### PR TITLE
Potential fix for code scanning alert no. 8: URL redirection from remote source

### DIFF
--- a/web/website/views/discourse_sso.py
+++ b/web/website/views/discourse_sso.py
@@ -153,6 +153,10 @@ def discourse_sso(request):
     return_sso_url = params.get('return_sso_url', [None])[0]
     if not return_sso_url:
         return HttpResponseBadRequest("Missing return_sso_url in payload")
+
+    # Sanitize return_sso_url for safe redirection
+    # Remove any backslashes, which can allow bypass of validation in some browsers
+    return_sso_url = return_sso_url.replace('\\', '')
     
     # Validate the return URL to prevent open redirect attacks
     # Extract allowed hosts from DISCOURSE_URL setting


### PR DESCRIPTION
Potential fix for [https://github.com/daiimus/gelatinous/security/code-scanning/8](https://github.com/daiimus/gelatinous/security/code-scanning/8)

**General approach:**  
Ensure any user-supplied value that may eventually form part of a redirect is thoroughly sanitized and validated before use. For redirect URLs, specifically remove any backslashes (`\`) from the supplied URL before running the `url_has_allowed_host_and_scheme` check, as browsers may treat backslashes as forward slashes and thus open up validation bypasses. This mirrors best practice from Django's own documentation and mitigates edge-case browser "quirks".

**Detailed fix:**  
Within the `discourse_sso` view—after extracting `return_sso_url` from the parameters (line 153) and before any validation or construction of the redirect—a line should be added to strip out any `\` from `return_sso_url`:
```python
return_sso_url = return_sso_url.replace('\\', '')
```
This should happen immediately after line 153 (after assignment and None check)—i.e., after confirming it's not None (line 154-155). After this, the usual validation (`url_has_allowed_host_and_scheme`) and later use of the cleaned variable can proceed as before.

**Lines to change:**  
- In `web/website/views/discourse_sso.py`:
    - Insert stripping of backslashes after extracting and confirming `return_sso_url` is present and before validation.
- No new imports are required (Python `str.replace` is native).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
