### PR TITLE
Fix critical one-liner bugs in typeclasses and commands

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -539,7 +539,6 @@ class CmdTempPlace(Command):
         # Ensure description ends with proper punctuation
         if not description.endswith(('.', '!', '?')):
             description += '.'
-            description += '.'
         
         # Set the temp_place
         caller.temp_place = description

--- a/commands/CmdFixCharacterOwnership.py
+++ b/commands/CmdFixCharacterOwnership.py
@@ -85,11 +85,6 @@ class CmdFixCharacterOwnership(Command):
             else:
                 caller.msg(f"|gFixed {fixed_count} character(s).|n")
             
-            if fixed_count == 0:
-                caller.msg("|yNo characters needed fixing.|n")
-            else:
-                caller.msg(f"|gFixed {fixed_count} character(s).|n")
-            
             # Show verification
             all_playable = account.characters.all()
             caller.msg(f"|yaccount.characters now returns {len(all_playable)} character(s):|n")

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -40,7 +40,7 @@ class Character(ObjectParent, DefaultCharacter):
     tokens = AttributeProperty(0, category="shop", autocreate=True)
     
     # Death tracking system
-    death_count = AttributeProperty(1, category='mortality', autocreate=True)
+    death_count = AttributeProperty(0, category='mortality', autocreate=True)
     
     # Appearance attributes - stored in db but no auto-creation for optional features
     # skintone is set via @skintone command and stored as db.skintone
@@ -632,8 +632,6 @@ class Character(ObjectParent, DefaultCharacter):
             return
             
         # Mark unconsciousness as processed
-        if not hasattr(self, 'ndb'):
-            self.ndb = {}
         self.ndb.unconsciousness_processed = True
         
         # Set unconscious placement description

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -532,12 +532,17 @@ class DeathProgressionScript(DefaultScript):
                         }
                         corpse.db.wounds_at_death.append(wound_record)
                     
-                    splattercast.msg(f"DEATH_WOUNDS_PRESERVED: {len(wound_data)} wounds preserved on corpse for {character.key}")
+                    try:
+                        splattercast = ChannelDB.objects.get_channel("Splattercast")
+                        splattercast.msg(f"DEATH_WOUNDS_PRESERVED: {len(wound_data)} wounds preserved on corpse for {character.key}")
+                    except Exception:
+                        pass
             except Exception as e:
                 # Don't fail death progression if wound preservation fails
                 try:
+                    splattercast = ChannelDB.objects.get_channel("Splattercast")
                     splattercast.msg(f"DEATH_WOUNDS_ERROR: Failed to preserve wounds for {character.key}: {e}")
-                except:
+                except Exception:
                     pass
         
         # Transfer character description data


### PR DESCRIPTION
## Summary
- Fix `death_count` default from 1 to 0 — new characters no longer start with a phantom death
- Remove `self.ndb = {}` that destroyed Evennia's NAttributeHandler, breaking all subsequent `ndb` access
- Fix `splattercast` NameError in death wound preservation by getting the channel before using it
- Remove duplicate `description += '.'` in CmdTempPlace that appended `..` instead of `.`
- Remove duplicate result message block in CmdFixCharacterOwnership that printed output twice

Fixes #23