### PR TITLE
Fix critical command bugs causing crashes and wrong behavior

### DIFF
--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -221,7 +221,8 @@ class CmdHeal(Command):
                 for i in range(conditions_to_heal):
                     if matching_conditions:
                         condition_key = matching_conditions.pop(0)
-                        medical_state.conditions.pop(condition_key, None)
+                        if condition_key in medical_state.conditions:
+                            medical_state.conditions.remove(condition_key)
                 
                 # Stop medical script if no conditions remain
                 if not medical_state.conditions:

--- a/commands/CmdBug.py
+++ b/commands/CmdBug.py
@@ -8,7 +8,7 @@ input validation, and privacy-conscious reporting.
 
 from evennia.commands.default.muxcommand import MuxCommand
 from django.conf import settings
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import requests
 import json
 
@@ -120,8 +120,7 @@ class CmdBug(MuxCommand):
     def get_time_until_reset(self, account):
         """Get human-readable time until rate limit resets."""
         now = datetime.now(timezone.utc)
-        tomorrow = datetime(now.year, now.month, now.day, tzinfo=timezone.utc)
-        tomorrow = tomorrow.replace(day=tomorrow.day + 1)
+        tomorrow = datetime(now.year, now.month, now.day, tzinfo=timezone.utc) + timedelta(days=1)
         
         delta = tomorrow - now
         hours = delta.seconds // 3600

--- a/commands/CmdMedical.py
+++ b/commands/CmdMedical.py
@@ -183,8 +183,8 @@ class CmdMedicalInfo(Command):
             if len(parts) == 1:
                 # Could be either target or info type
                 search_result = caller.search(parts[0], quiet=True)
-                if search_result and not isinstance(search_result, list):
-                    target = search_result
+                if search_result and len(search_result) == 1:
+                    target = search_result[0]
                     info_type = "summary"
                 else:
                     # Not a valid target, treat as info type

--- a/commands/CmdSpawnMob.py
+++ b/commands/CmdSpawnMob.py
@@ -62,7 +62,5 @@ class CmdSpawnMob(Command):
         mob.intellect = roll_stat()
         mob.motorics = roll_stat()
 
-        mob.at_object_creation()
-
         caller.msg(f"You manifest {mob_name} into the world.")
         caller.location.msg_contents(f"{mob_name} flickers into existence, vacant and twitching.", exclude=caller)

--- a/commands/combat/movement.py
+++ b/commands/combat/movement.py
@@ -275,7 +275,8 @@ class CmdFlee(Command):
                 # This shouldn't happen if ndb.combat_handler is properly managed
                 caller.msg("Your combat state seems confused. Moving freely.")
                 splattercast.msg(f"{DEBUG_PREFIX_FLEE}_ERROR: {caller.key} has combat handler but no entry.")
-                super().at_traverse(caller, choice(available_exits).destination)
+                destination = choice(available_exits).destination
+                caller.move_to(destination)
                 return
                 
             # Check if grappled - can't flee while grappled
@@ -360,6 +361,9 @@ class CmdFlee(Command):
             else:
                 clear_aim_state(caller)
             
+            # Capture old location before moving for departure message
+            old_location = caller.location
+            
             # Move to the chosen exit
             caller.move_to(destination, quiet=True)
             
@@ -375,8 +379,7 @@ class CmdFlee(Command):
             caller.location.msg_contents(f"|y{caller.get_display_name(caller.location)} has arrived, fleeing from combat.|n", exclude=[caller])
             
             # Message the room they left
-            if caller.location != destination:  # Safety check
-                old_location = caller.location
+            if old_location and old_location != destination:
                 old_location.msg_contents(f"|y{caller.get_display_name(old_location)} flees {chosen_exit.key}!|n")
             
             splattercast.msg(f"{DEBUG_PREFIX_FLEE}_SUCCESS: {caller.key} successfully fled via {chosen_exit.key} to {destination.key}.")


### PR DESCRIPTION
## Summary
- Fix `CmdFlee` crash: `super().at_traverse()` called on `Command` which has no such method — replaced with `caller.move_to()`
- Fix `CmdFlee` departure message never sent: capture `old_location` before `move_to()` so the old room sees the flee message
- Fix `CmdBug` crash on month-end dates: `replace(day=day+1)` fails on Jan 31 etc. — use `timedelta(days=1)` instead
- Fix `CmdMedical` target lookup: `quiet=True` search returns a list, check `len() == 1` and index `[0]`
- Fix `CmdSpawnMob` stats overwritten: remove redundant `at_object_creation()` that Evennia already called during `create_object`
- Fix `CmdAdmin` heal TypeError: `list.pop(key, None)` is dict syntax — use `list.remove()` instead

Fixes #24