### PR TITLE
Fix medical system critical bugs

### DIFF
--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -302,7 +302,7 @@ class InfectionCondition(MedicalCondition):
         self.severity = max(0, self.severity - severity_reduction)
         
         # Stop progression when treated
-        self.progression_chance = 0
+        self.base_progression_chance = 0
 
 
 def create_condition_from_damage(damage_amount, damage_type, location=None):

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -238,7 +238,10 @@ class Organ:
             "current_hp": self.current_hp,
             "max_hp": self.max_hp,
             "conditions": self.conditions.copy(),
-            "container": self.container
+            "container": self.container,
+            "wound_stage": self.wound_stage,
+            "injury_type": self.injury_type,
+            "wound_timestamp": self.wound_timestamp
         }
         
     @classmethod
@@ -256,6 +259,9 @@ class Organ:
         organ.current_hp = data.get("current_hp", organ.max_hp)
         organ.max_hp = data.get("max_hp", organ.max_hp)
         organ.conditions = data.get("conditions", [])
+        organ.wound_stage = data.get("wound_stage")
+        organ.injury_type = data.get("injury_type")
+        organ.wound_timestamp = data.get("wound_timestamp")
         return organ
 
 

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -886,7 +886,7 @@ def apply_medical_effects(item, user, target, **kwargs):
     
     elif medical_type == "oxygen":
         # Oxygen therapy - improves consciousness and breathing
-        medical_state.consciousness = min(100, medical_state.consciousness + 15)
+        medical_state.consciousness = min(1.0, medical_state.consciousness + 0.15)
         breathing_conditions = [c for c in medical_state.conditions 
                                if hasattr(c, 'condition_type') and c.condition_type in ["breathing_difficulty", "suffocation"]]
         for condition in breathing_conditions[:2]:
@@ -899,7 +899,7 @@ def apply_medical_effects(item, user, target, **kwargs):
     elif medical_type == "anesthetic":
         # Anesthetic gas - reduces pain and consciousness
         medical_state.pain_level = max(0, medical_state.pain_level - 25)
-        medical_state.consciousness = max(0, medical_state.consciousness - 10)
+        medical_state.consciousness = max(0.0, medical_state.consciousness - 0.10)
         
         result_msg = "Anesthetic inhaled. Pain reduced but consciousness lowered."
     
@@ -916,7 +916,7 @@ def apply_medical_effects(item, user, target, **kwargs):
     
     elif medical_type == "gas":
         # Medical gas treatment - various effects
-        medical_state.consciousness = min(100, medical_state.consciousness + 5)
+        medical_state.consciousness = min(1.0, medical_state.consciousness + 0.05)
         result_msg = "Medical gas inhaled. Minor therapeutic effects applied."
     
     elif medical_type == "vapor":
@@ -946,7 +946,7 @@ def apply_medical_effects(item, user, target, **kwargs):
     elif medical_type in ["medicinal_plant", "dried_medicine"]:
         # Dried medicinal substances - concentrated effects
         medical_state.pain_level = max(0, medical_state.pain_level - 12)
-        medical_state.consciousness = min(100, medical_state.consciousness + 3)
+        medical_state.consciousness = min(1.0, medical_state.consciousness + 0.03)
         
         result_msg = "Dried medicine smoked. Concentrated therapeutic effects applied."
     else:


### PR DESCRIPTION
## Summary
- Fix consciousness scale mismatch: `apply_medical_effects` was using 0-100 values (e.g., +15, -10) but `MedicalState.consciousness` is 0.0-1.0. Oxygen therapy was setting consciousness to 100x the max. Converted all values to proper 0.0-1.0 scale.
- Fix infection treatment: `apply_treatment()` was setting `self.progression_chance` (non-existent) instead of `self.base_progression_chance` — antibiotics had no effect on infection progression.
- Fix wound state persistence: `Organ.to_dict()` omitted `wound_stage`, `injury_type`, and `wound_timestamp`, so wound data was lost on every server reload.

Fixes #25