### PR TITLE
Fix web registration broken without Turnstile configuration

### DIFF
--- a/web/website/forms.py
+++ b/web/website/forms.py
@@ -210,14 +210,14 @@ class TurnstileAccountForm(EvenniaAccountForm):
     # This is populated by the Turnstile JavaScript widget
     cf_turnstile_response = forms.CharField(
         widget=forms.HiddenInput(),
-        required=True,
+        required=False,
         error_messages={
             'required': 'CAPTCHA verification is required. Please complete the verification.'
         }
     )
     
     def __init__(self, *args, **kwargs):
-        """Override email field to make it required."""
+        """Override email field to make it required, conditionally require Turnstile."""
         super().__init__(*args, **kwargs)
         # Make email required and update help text
         self.fields['email'].required = True


### PR DESCRIPTION
## Summary
- Fix registration form: `cf_turnstile_response` was `required=True` but the Turnstile widget is only rendered when `TURNSTILE_SITE_KEY` is configured. Without it, the hidden field is never included in POST data, so Django form validation always fails and registration is impossible.
- Set `required=False` — the view already handles server-side Turnstile verification conditionally (only when `TURNSTILE_SECRET_KEY` is set).
- Note: The respawn template bug (random stats mismatch) listed in #26 was already fixed in an earlier commit that persists templates in the Django session.

Fixes #26