### PR TITLE
Fix combat handler state management bugs

### DIFF
--- a/commands/CmdThrow.py
+++ b/commands/CmdThrow.py
@@ -1652,10 +1652,17 @@ class CmdCatch(Command):
         if hasattr(obj.ndb, 'flight_thrower'):
             del obj.ndb.flight_thrower
         if hasattr(obj.ndb, 'flight_timer'):
+            # Cancel the pending flight timer so the object doesn't
+            # "arrive" or explode after being caught
+            try:
+                obj.ndb.flight_timer.cancel()
+            except Exception:
+                pass  # Timer may have already fired
             del obj.ndb.flight_timer
         
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} caught {obj} mid-flight")
+        if splattercast:
+            splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} caught {obj} mid-flight")
 
 
 class CmdRig(Command):

--- a/world/combat/grappling.py
+++ b/world/combat/grappling.py
@@ -15,7 +15,6 @@ Functions:
 from .constants import (
     DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, 
     MSG_CANNOT_WHILE_GRAPPLED, MSG_CANNOT_GRAPPLE_SELF, MSG_ALREADY_GRAPPLING,
-    MSG_GRAPPLE_AUTO_YIELD
 )
 from .utils import log_debug, get_display_name_safe, get_character_by_dbref, get_character_dbref
 from .proximity import establish_proximity, is_in_proximity
@@ -100,17 +99,14 @@ def establish_grapple(combat_handler, grappler, victim):
             combatants_list[i]["is_yielding"] = True
         elif entry.get("char") == victim:
             combatants_list[i][DB_GRAPPLED_BY_DBREF] = grappler.id
-            # Victim automatically yields when grappled (restraint mode)
-            combatants_list[i]["is_yielding"] = True
+            # Victim stays non-yielding so they auto-resist each turn
+            # (consistent with resolve_grapple_initiate behavior)
     
     # Save the updated list
     combat_handler.db.combatants = combatants_list
     
     # Ensure proximity (grappling requires proximity)
     establish_proximity(grappler, victim)
-    
-    # Notify victim they're auto-yielding
-    victim.msg(MSG_GRAPPLE_AUTO_YIELD)
     
     log_debug("GRAPPLE", "ESTABLISH", f"{grappler.key} grapples {victim.key}")
     

--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -27,7 +27,7 @@ from .constants import (
     DB_CHAR, DB_TARGET_DBREF, DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, DB_IS_YIELDING,
     NDB_COMBAT_HANDLER, NDB_PROXIMITY, NDB_SKIP_ROUND,
     DEBUG_PREFIX_HANDLER, DEBUG_SUCCESS, DEBUG_FAIL, DEBUG_ERROR, DEBUG_CLEANUP,
-    MSG_GRAPPLE_AUTO_ESCAPE_VIOLENT, MSG_GRAPPLE_AUTO_YIELD,
+    MSG_GRAPPLE_AUTO_ESCAPE_VIOLENT,
     COMBAT_ACTION_RETREAT, COMBAT_ACTION_ADVANCE, COMBAT_ACTION_CHARGE, COMBAT_ACTION_DISARM,
     COMBAT_ROUND_INTERVAL, STAGGER_DELAY_INTERVAL, MAX_STAGGER_DELAY
 )
@@ -762,6 +762,7 @@ class CombatHandler(DefaultScript):
                     if not is_action_target_valid and action_target_char:
                         char.msg(f"The target of your planned action ({action_target_char.key}) is no longer valid.")
                         splattercast.msg(f"{char.key}'s action_intent target {action_target_char.key} is invalid. Intent cleared, falling through.")
+                        current_char_combat_entry["combat_action"] = None
                     elif intent_type == "grapple" and is_action_target_valid:
                         # Handle grapple intent
                         can_grapple_target = (char.location == action_target_char.location)
@@ -785,6 +786,7 @@ class CombatHandler(DefaultScript):
                             if action_target_char not in proximity_set:
                                 char.msg(f"You need to be in melee proximity with {action_target_char.key} to grapple them. Try advancing or charging.")
                                 splattercast.msg(f"GRAPPLE FAIL (PROXIMITY): {char.key} not in proximity with {action_target_char.key}.")
+                                current_char_combat_entry["combat_action"] = None
                                 continue
 
                             attacker_roll = randint(1, max(1, get_numeric_stat(char, "motorics", 1)))
@@ -798,13 +800,9 @@ class CombatHandler(DefaultScript):
                                 if target_entry:
                                     target_entry[DB_GRAPPLED_BY_DBREF] = self._get_dbref(char)
                                 
-                                # Auto-yield both parties on successful grapple (restraint mode)
+                                # Auto-yield only the grappler (restraint intent)
+                                # Victim stays non-yielding so they auto-resist each turn
                                 current_char_combat_entry[DB_IS_YIELDING] = True
-                                if target_entry:
-                                    target_entry[DB_IS_YIELDING] = True
-                                
-                                # Notify victim they're auto-yielding
-                                action_target_char.msg(MSG_GRAPPLE_AUTO_YIELD)
                                 
                                 grapple_messages = get_combat_message("grapple", "hit", attacker=char, target=action_target_char)
                                 char.msg(grapple_messages.get("attacker_msg"))
@@ -826,6 +824,7 @@ class CombatHandler(DefaultScript):
                             char.msg(f"You can't reach {action_target_char.key} to grapple them from here.")
                             splattercast.msg(f"GRAPPLE FAIL (REACH): {char.key} cannot reach {action_target_char.key}.")
                         
+                        current_char_combat_entry["combat_action"] = None
                         continue
                     elif intent_type == "escape_grapple":
                         grappler = self.get_grappled_by_obj(current_char_combat_entry)
@@ -852,6 +851,7 @@ class CombatHandler(DefaultScript):
                                 obs_msg = escape_messages.get("observer_msg")
                                 char.location.msg_contents(obs_msg, exclude=[char, grappler])
                                 splattercast.msg(f"ESCAPE FAIL: {char.key} failed to escape {grappler.key}.")
+                        current_char_combat_entry["combat_action"] = None
                         continue
 
             # Standard attack processing - get target and schedule attack with staggered timing
@@ -1275,7 +1275,22 @@ class CombatHandler(DefaultScript):
                     attacker.msg(kill_messages["attacker_msg"])
                 if "victim_msg" in kill_messages:
                     target.msg(kill_messages["victim_msg"])
-                attacker.location.msg_contents(kill_messages["observer_msg"], exclude=[attacker, target])
+                if "observer_msg" in kill_messages:
+                    # Send to attacker's room
+                    if attacker.location:
+                        attacker.location.msg_contents(
+                            kill_messages["observer_msg"],
+                            exclude=[attacker, target],
+                        )
+                    # Also send to target's room if it differs (cross-room combat)
+                    if (
+                        target.location
+                        and target.location != attacker.location
+                    ):
+                        target.location.msg_contents(
+                            kill_messages["observer_msg"],
+                            exclude=[attacker, target],
+                        )
                 
                 splattercast.msg(f"KILLING_BLOW: {attacker.key} delivered killing blow to {target.key} for {actual_damage} damage.")
                 

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -45,6 +45,24 @@ def debug_broadcast(message, prefix="DEBUG", status="INFO"):
         pass
 
 
+class _NullChannel:
+    """No-op channel stand-in when Splattercast is unavailable."""
+
+    def msg(self, *args, **kwargs):
+        pass
+
+
+def get_splattercast():
+    """
+    Safely retrieve the Splattercast debug channel.
+
+    Returns:
+        The channel object, or a no-op stand-in if unavailable.
+    """
+    channel = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    return channel if channel else _NullChannel()
+
+
 # ===================================================================
 # DICE & STATS
 # ===================================================================
@@ -565,7 +583,7 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
     )
     from random import randint
     
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     
     # Debug: Show what parameters were passed
     splattercast.msg(f"ADD_COMBATANT_PARAMS: char={char.key if char else None}, target={target.key if target else None}")
@@ -647,7 +665,7 @@ def remove_combatant(handler, char):
         NDB_COMBAT_HANDLER
     )
     
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     
     # Use the active working list if available (during round processing), otherwise use database
     active_list = getattr(handler, '_active_combatants_list', None)
@@ -809,18 +827,15 @@ def remove_combatant(handler, char):
                 if hasattr(other_char, 'msg'):
                     other_char.msg(f"|yYour target {char.get_display_name(other_char) if hasattr(char, 'get_display_name') else char.key} has left combat. Choose a new target if you wish to continue fighting.|n")
     
-    # Remove from combatants list
-    combatants = [e for e in combatants if e.get(DB_CHAR) != char]
+    # Remove from combatants list using in-place mutation so the active
+    # working list (handler._active_combatants_list) stays in sync.
+    combatants[:] = [e for e in combatants if e.get(DB_CHAR) != char]
     
-    # Update the appropriate list(s)
+    # Always persist to database
+    setattr(handler.db, DB_COMBATANTS, combatants)
     if active_list:
-        # Working with active list - it will be saved back at end of round
-        # But also update database in case something else queries it
-        setattr(handler.db, DB_COMBATANTS, combatants)
-        splattercast.msg(f"RMV_COMB: Updated both active list and database (active list will be saved at round end)")
+        splattercast.msg(f"RMV_COMB: Mutated active list in-place and synced to database")
     else:
-        # Working with database directly
-        setattr(handler.db, DB_COMBATANTS, combatants)
         splattercast.msg(f"RMV_COMB: Updated database directly")
     
     # Remove handler reference
@@ -878,8 +893,7 @@ def cleanup_combatant_state(char, entry, handler):
     if (hasattr(char, 'override_place') and 
         char.override_place == "locked in combat."):
         char.override_place = ""
-        from .constants import SPLATTERCAST_CHANNEL
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"CLEANUP_COMB: Cleared combat override_place for {char.key}")
     
     # No need to set charge flags to False after deletion - this was causing race conditions
@@ -896,9 +910,9 @@ def cleanup_all_combatants(handler):
     Args:
         handler: The combat handler instance
     """
-    from .constants import SPLATTERCAST_CHANNEL, DB_COMBATANTS, DB_CHAR, DEBUG_PREFIX_HANDLER, DEBUG_CLEANUP
+    from .constants import DB_COMBATANTS, DB_CHAR, DEBUG_PREFIX_HANDLER, DEBUG_CLEANUP
     
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     combatants = getattr(handler.db, DB_COMBATANTS, [])
     
     for entry in combatants:


### PR DESCRIPTION
## Summary
- Fix grapple yielding inconsistency across 3 code paths (only grappler yields, victim stays non-yielding for auto-resistance)
- Fix dict-based combat actions (grapple/escape_grapple) never being cleared after processing, causing infinite repetition
- Fix `remove_combatant` creating a new list instead of mutating in-place, causing the end-of-round save-back to overwrite removals
- Fix cross-room kill messages only sent to attacker's room, with null checks on locations and `observer_msg` key
- Fix caught objects still exploding because flight timer wasn't cancelled, only the ndb reference deleted
- Add `get_splattercast()` helper with no-op fallback to prevent crashes when Splattercast channel is unavailable

Fixes #28