### PR TITLE
Replace hasattr/getattr/setattr on obj.db with direct attribute access

### DIFF
--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -183,9 +183,9 @@ class CmdHeal(Command):
                     target.ndb.unconsciousness_processed = False
                 
                 # Clear old test flags (backward compatibility)
-                if hasattr(target.db, '_test_death_state'):
+                if target.db._test_death_state is not None:
                     del target.db._test_death_state
-                if hasattr(target.db, '_test_unconscious_state'):
+                if target.db._test_unconscious_state is not None:
                     del target.db._test_unconscious_state
                 
                 # Remove any medical state restrictions (death/unconscious cmdsets)

--- a/commands/CmdArmor.py
+++ b/commands/CmdArmor.py
@@ -86,9 +86,7 @@ class CmdArmor(Command):
             return
         
         # Check if caller wants centered headers (default: True)
-        center_headers = getattr(caller.db, 'center_armor_headers', True)
-        if center_headers is None:
-            center_headers = True
+        center_headers = caller.db.center_armor_headers if caller.db.center_armor_headers is not None else True
         
         # Create armor status table with box-drawing characters
         table = BoxTable("Item", "Type", "Rating", "Durability", "Coverage")
@@ -307,9 +305,7 @@ class CmdArmor(Command):
                     })
         
         # Check if caller wants centered headers (default: True)
-        center_headers = getattr(caller.db, 'center_armor_headers', True)
-        if center_headers is None:
-            center_headers = True
+        center_headers = caller.db.center_armor_headers if caller.db.center_armor_headers is not None else True
         
         # Create coverage table with box-drawing characters
         table = BoxTable("Body Location", "Protected By", "Type", "Rating")
@@ -352,9 +348,7 @@ class CmdArmor(Command):
         from world.combat.constants import ARMOR_EFFECTIVENESS_MATRIX
         
         # Check if caller wants centered headers (default: True)
-        center_headers = getattr(caller.db, 'center_armor_headers', True)
-        if center_headers is None:
-            center_headers = True
+        center_headers = caller.db.center_armor_headers if caller.db.center_armor_headers is not None else True
         
         # Convert to percentage display format
         effectiveness_display = {}
@@ -456,9 +450,7 @@ class CmdArmor(Command):
         from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
         
         # Check if caller wants centered headers (default: True)
-        center_headers = getattr(caller.db, 'center_armor_headers', True)
-        if center_headers is None:
-            center_headers = True
+        center_headers = caller.db.center_armor_headers if caller.db.center_armor_headers is not None else True
         
         # Roman numeral conversion
         def to_roman(num):

--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -996,7 +996,7 @@ class CmdSkintone(Command):
 
     def _show_current_skintone(self, caller):
         """Show the caller's current skintone setting"""
-        skintone = getattr(caller.db, 'skintone', None)
+        skintone = caller.db.skintone
         if skintone:
             color_code = SKINTONE_PALETTE.get(skintone, "")
             if color_code:
@@ -1040,7 +1040,7 @@ class CmdSkintone(Command):
 
     def _clear_skintone(self, caller, target):
         """Clear skintone from target character"""
-        if hasattr(target.db, 'skintone'):
+        if target.db.skintone is not None:
             del target.db.skintone
             
         if target == caller:

--- a/commands/CmdClothing.py
+++ b/commands/CmdClothing.py
@@ -140,12 +140,12 @@ class CmdRemove(Command):
             return
         
         # STICKY GRENADE WARNING - Check for stuck grenades before removal
-        if hasattr(item.db, 'stuck_grenade') and item.db.stuck_grenade:
+        if item.db.stuck_grenade:
             grenade = item.db.stuck_grenade
             
             # Get remaining countdown time if any
             remaining = getattr(grenade.ndb, 'countdown_remaining', 0) if hasattr(grenade, 'ndb') else 0
-            stuck_location = getattr(grenade.db, 'stuck_to_location', 'unknown')
+            stuck_location = grenade.db.stuck_to_location if grenade.db.stuck_to_location is not None else 'unknown'
             
             # Send dramatic warning
             if remaining > 0:
@@ -185,7 +185,7 @@ class CmdRemove(Command):
         
         if success:
             # Message to room (only if no grenade warning was sent)
-            if not (hasattr(item.db, 'stuck_grenade') and item.db.stuck_grenade):
+            if not item.db.stuck_grenade:
                 caller.location.msg_contents(
                     f"{caller.get_display_name(None)} removes {item.key}.",
                     exclude=caller

--- a/commands/CmdGraffiti.py
+++ b/commands/CmdGraffiti.py
@@ -102,7 +102,7 @@ class CmdGraffiti(Command):
         can = can[0]  # Get first match
         
         # Check what type of aerosol contents the can has
-        aerosol_contents = getattr(can.db, 'aerosol_contents', None)
+        aerosol_contents = can.db.aerosol_contents
         if not aerosol_contents:
             self.caller.msg(f"You can't use {can.get_display_name(self.caller)} for spraying.")
             return
@@ -212,7 +212,7 @@ class CmdGraffiti(Command):
         for obj in self.caller.location.contents:
             if isinstance(obj, GraffitiObject):
                 graffiti_obj = obj
-            elif isinstance(obj, BloodPool) or (hasattr(obj.db, 'is_blood_pool') and obj.db.is_blood_pool):
+            elif isinstance(obj, BloodPool) or obj.db.is_blood_pool:
                 blood_pools.append(obj)
         
         # Check if there's anything to clean
@@ -245,7 +245,7 @@ class CmdGraffiti(Command):
                 if blood_pool.db.bleeding_incidents:
                     # Determine tool quality based on solvent can type
                     tool_quality = "basic"  # Default for spray cans
-                    if hasattr(solvent_can.db, 'quality'):
+                    if solvent_can.db.quality is not None:
                         tool_quality = solvent_can.db.quality
                     
                     cleaned_volume, clean_result = blood_pool.clean_with_solvent(self.caller, tool_quality)
@@ -362,7 +362,7 @@ class CmdPress(Command):
         spray_can = spray_can[0]  # Get first match
         
         # Check if it's an aerosol can with color-changing capability (spraypaint)
-        aerosol_contents = getattr(spray_can.db, 'aerosol_contents', None)
+        aerosol_contents = spray_can.db.aerosol_contents
         if not aerosol_contents:
             self.caller.msg(f"You can't press colors on {spray_can.get_display_name(self.caller)}.")
             return

--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -820,7 +820,7 @@ class CmdWrest(Command):
         combat_handler = getattr(self.caller.ndb, "combat_handler", None)
         if combat_handler:
             # Verify handler is still active
-            combatants = getattr(combat_handler.db, "combatants", None)
+            combatants = combat_handler.db.combatants
             if combatants:
                 # Check if caller is in the combatants list using correct field name
                 return any(entry.get(DB_CHAR) == self.caller for entry in combatants)
@@ -858,7 +858,7 @@ class CmdWrest(Command):
         # Check if target has a combat handler with grapple status
         combat_handler = getattr(target.ndb, "combat_handler", None)
         if combat_handler:
-            combatants = getattr(combat_handler.db, "combatants", None)
+            combatants = combat_handler.db.combatants
             if combatants:
                 # Find target's entry in combatants list
                 target_entry = next((entry for entry in combatants if entry.get(DB_CHAR) == target), None)
@@ -1040,10 +1040,10 @@ class CmdFrisk(Command):
             return
         
         # Get target's gender for pronouns
-        gender = getattr(target.db, 'gender', 'neutral')
+        gender = target.db.gender if target.db.gender is not None else 'neutral'
         # For corpses, try to get original gender
         if frisk_reason == "corpse":
-            gender = getattr(target.db, 'original_gender', gender)
+            gender = target.db.original_gender if target.db.original_gender is not None else gender
             
         pronoun_map = {
             'male': {'them': 'him', 'their': 'his', 'they': 'he'},
@@ -1096,12 +1096,12 @@ class CmdFrisk(Command):
         
         for item in all_items:
             # Check if item is worn (common patterns for worn items)
-            if hasattr(item.db, 'worn') and item.db.worn:
+            if item.db.worn:
                 worn_items.append(item)
             elif hasattr(item, 'worn') and item.worn:
                 worn_items.append(item)
             # Check if it's in a wear location
-            elif hasattr(item.db, 'wear_location') and item.db.wear_location:
+            elif item.db.wear_location:
                 worn_items.append(item)
             else:
                 carried_items.append(item)

--- a/commands/CmdMedical.py
+++ b/commands/CmdMedical.py
@@ -135,7 +135,7 @@ class CmdDamageTest(Command):
                         caller.msg(f"  - {organ_info}")
         except AttributeError:
             # Fallback to old db.medical_state format if property doesn't work
-            medical_state = getattr(caller.db, 'medical_state', {})
+            medical_state = caller.db.medical_state or {}
             if medical_state:
                 # Show current wounds
                 total_wounds = sum(len(wounds) for wounds in medical_state.get('wounds', {}).values())

--- a/commands/CmdThrow.py
+++ b/commands/CmdThrow.py
@@ -119,7 +119,7 @@ class CmdThrow(Command):
         self.obj_to_throw = obj
         
         # Check if this is a dedicated throwing weapon that should use attack command
-        if getattr(obj.db, DB_IS_THROWING_WEAPON, False):
+        if obj.db.is_throwing_weapon:
             # If targeting someone, invoke attack command instead
             if self.target_name:
                 self.caller.msg(f"You ready your {obj.key} to attack...")
@@ -188,7 +188,7 @@ class CmdThrow(Command):
         if hasattr(self.caller, 'ndb') and hasattr(self.caller.ndb, NDB_COMBAT_HANDLER):
             handler = getattr(self.caller.ndb, NDB_COMBAT_HANDLER)
             if handler:
-                combatants_list = getattr(handler.db, DB_COMBATANTS, [])
+                combatants_list = handler.db.combatants or []
                 combat_entry = next((e for e in combatants_list if e.get(DB_CHAR) == self.caller), None)
                 if combat_entry and combat_entry.get(DB_GRAPPLED_BY_DBREF):
                     self.caller.msg(MSG_THROW_GRAPPLED)
@@ -207,8 +207,8 @@ class CmdThrow(Command):
             if remaining is not None and remaining <= 0:
                 self.caller.msg(MSG_THROW_TIMER_EXPIRED)
                 # Apply damage to caller using medical system
-                blast_damage = getattr(obj.db, DB_BLAST_DAMAGE, 10)
-                damage_type = getattr(obj.db, 'damage_type', 'blast')  # Changed to 'blast' for explosive damage
+                blast_damage = obj.db.blast_damage if obj.db.blast_damage is not None else 10
+                damage_type = obj.db.damage_type if obj.db.damage_type is not None else 'blast'  # Changed to 'blast' for explosive damage
                 self.caller.take_damage(blast_damage, location="chest", injury_type=damage_type)
                 obj.delete()
                 return False
@@ -234,7 +234,7 @@ class CmdThrow(Command):
             if not destination:
                 return None, None
             # For sticky grenades, prefer most magnetic character, fallback to random
-            if hasattr(self, 'obj_to_throw') and getattr(self.obj_to_throw.db, 'is_sticky', False):
+            if hasattr(self, 'obj_to_throw') and self.obj_to_throw.db.is_sticky:
                 target = self.select_most_magnetic_target_in_room(destination, self.obj_to_throw)
                 if not target:  # No viable magnetic targets, select random
                     target = self.select_random_target_in_room(destination)
@@ -249,7 +249,7 @@ class CmdThrow(Command):
                 destination = self.get_destination_room(aim_direction)
                 if destination:
                     # For sticky grenades, prefer most magnetic character, fallback to random
-                    if hasattr(self, 'obj_to_throw') and getattr(self.obj_to_throw.db, 'is_sticky', False):
+                    if hasattr(self, 'obj_to_throw') and self.obj_to_throw.db.is_sticky:
                         target = self.select_most_magnetic_target_in_room(destination, self.obj_to_throw)
                         if not target:  # No viable magnetic targets, select random
                             target = self.select_random_target_in_room(destination)
@@ -259,7 +259,7 @@ class CmdThrow(Command):
             
             # Fallback to current room
             # For sticky grenades in current room, prefer most magnetic character, fallback to random
-            if hasattr(self, 'obj_to_throw') and getattr(self.obj_to_throw.db, 'is_sticky', False):
+            if hasattr(self, 'obj_to_throw') and self.obj_to_throw.db.is_sticky:
                 target = self.select_most_magnetic_target_in_room(self.caller.location, self.obj_to_throw)
                 if not target:  # No viable magnetic targets, select random
                     target = self.select_random_target_in_room(self.caller.location)
@@ -410,7 +410,7 @@ class CmdThrow(Command):
             return None
         
         # Get grenade magnetic strength for threshold checks
-        magnetic_strength = getattr(grenade.db, 'magnetic_strength', 5)
+        magnetic_strength = grenade.db.magnetic_strength if grenade.db.magnetic_strength is not None else 5
         magnetic_threshold = magnetic_strength - 3
         metal_threshold = magnetic_strength - 5
         
@@ -426,17 +426,17 @@ class CmdThrow(Command):
                 continue
             
             # Get armor properties (including plate carrier check)
-            metal_level = getattr(armor.db, 'metal_level', 0) or 0
-            magnetic_level = getattr(armor.db, 'magnetic_level', 0) or 0
+            metal_level = armor.db.metal_level or 0
+            magnetic_level = armor.db.magnetic_level or 0
             
             # Check if plate carrier - use installed plates' values
-            is_plate_carrier = getattr(armor.db, 'is_plate_carrier', False)
+            is_plate_carrier = bool(armor.db.is_plate_carrier)
             if is_plate_carrier:
-                installed_plates = getattr(armor.db, 'installed_plates', {})
+                installed_plates = armor.db.installed_plates or {}
                 for slot, plate_ref in installed_plates.items():
                     if plate_ref:
-                        plate_metal = getattr(plate_ref.db, 'metal_level', 0) or 0
-                        plate_magnetic = getattr(plate_ref.db, 'magnetic_level', 0) or 0
+                        plate_metal = plate_ref.db.metal_level or 0
+                        plate_magnetic = plate_ref.db.magnetic_level or 0
                         metal_level = max(metal_level, plate_metal)
                         magnetic_level = max(magnetic_level, plate_magnetic)
             
@@ -457,11 +457,11 @@ class CmdThrow(Command):
     
     def is_throwing_weapon(self, obj):
         """Check if object is a throwing weapon."""
-        return getattr(obj.db, DB_IS_THROWING_WEAPON, False)
+        return bool(obj.db.is_throwing_weapon)
     
     def is_explosive(self, obj):
         """Check if object is explosive."""
-        return getattr(obj.db, DB_IS_EXPLOSIVE, False)
+        return bool(obj.db.is_explosive)
     
     def handle_weapon_throw(self, obj, target, destination):
         """Handle throwing weapon combat mechanics."""
@@ -739,7 +739,7 @@ class CmdThrow(Command):
                     # Continue with landing even if weapon hit fails
             
             # Sticky grenade resolution (even for utility throws)
-            elif target and not is_weapon and getattr(obj.db, 'is_sticky', False):
+            elif target and not is_weapon and obj.db.is_sticky:
                 try:
                     splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Sticky grenade utility throw - routing to weapon hit logic")
                     self.resolve_weapon_hit(obj, target, thrower)
@@ -824,7 +824,7 @@ class CmdThrow(Command):
                 )
                 
                 # Check if this is a sticky grenade
-                is_sticky = getattr(weapon.db, 'is_sticky', False)
+                is_sticky = bool(weapon.db.is_sticky)
                 hit_location = "chest"  # Default hit location for throws
                 
                 if is_sticky:
@@ -880,9 +880,9 @@ class CmdThrow(Command):
                         # Continue to normal landing
                 
                 # Hit - apply damage (only for non-sticky or failed-stick weapons)
-                base_damage = getattr(weapon.db, 'damage', 1)
+                base_damage = weapon.db.damage if weapon.db.damage is not None else 1
                 total_damage = random.randint(1, 6) + base_damage
-                damage_type = getattr(weapon.db, 'damage_type', 'blunt')  # Get weapon damage type
+                damage_type = weapon.db.damage_type if weapon.db.damage_type is not None else 'blunt'  # Get weapon damage type
                 
                 target.take_damage(total_damage, location="chest", injury_type=damage_type)
                 
@@ -1027,7 +1027,7 @@ class CmdThrow(Command):
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: check_grenade_deflection called for {grenade} in {destination}")
             
             # Future-proofing: Skip deflection for impact grenades (explode on contact)
-            if getattr(grenade.db, 'impact_detonation', False):
+            if grenade.db.impact_detonation:
                 splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Impact grenade {grenade} cannot be deflected")
                 return False
             
@@ -1046,7 +1046,7 @@ class CmdThrow(Command):
             if hasattr(target, 'ndb') and hasattr(target.ndb, NDB_COMBAT_HANDLER):
                 handler = getattr(target.ndb, NDB_COMBAT_HANDLER)
                 if handler:
-                    combatants_list = getattr(handler.db, DB_COMBATANTS, [])
+                    combatants_list = handler.db.combatants or []
                     combat_entry = next((e for e in combatants_list if e.get(DB_CHAR) == target), None)
                     if combat_entry:
                         grappled_by = combat_entry.get(DB_GRAPPLED_BY_DBREF)
@@ -1080,7 +1080,7 @@ class CmdThrow(Command):
             
             # Base difficulty threshold (higher = easier)
             base_threshold = 10  # Moderate difficulty
-            weapon_bonus = getattr(melee_weapon.db, 'deflection_bonus', 0.0)  # Optional weapon property
+            weapon_bonus = melee_weapon.db.deflection_bonus if melee_weapon.db.deflection_bonus is not None else 0.0  # Optional weapon property
             
             # Convert weapon bonus to threshold modifier (0.30 bonus = +6 to threshold)
             threshold_modifier = int(weapon_bonus * 20)
@@ -1109,7 +1109,7 @@ class CmdThrow(Command):
     def is_melee_weapon(self, obj):
         """Check if object is a melee weapon suitable for deflection."""
         # Melee weapons are those that are NOT ranged (default is melee)
-        is_ranged = getattr(obj.db, 'is_ranged', False)
+        is_ranged = bool(obj.db.is_ranged)
         return not is_ranged
     
     def perform_grenade_deflection(self, grenade, deflector, weapon, original_thrower, current_location):
@@ -1278,17 +1278,18 @@ class CmdPull(Command):
                 return
         
         # Validate explosive
-        if not getattr(grenade.db, DB_IS_EXPLOSIVE, False):
+        if not grenade.db.is_explosive:
             self.caller.msg(MSG_PULL_NOT_EXPLOSIVE.format(object=grenade.key))
             return
         
         # Check if requires pin
-        if not getattr(grenade.db, DB_REQUIRES_PIN, True):
+        requires_pin = grenade.db.requires_pin if grenade.db.requires_pin is not None else True
+        if not requires_pin:
             self.caller.msg(MSG_PULL_NO_PIN_REQUIRED.format(object=grenade.key))
             return
         
         # Check if already pulled
-        if getattr(grenade.db, DB_PIN_PULLED, False):
+        if grenade.db.pin_pulled:
             self.caller.msg(MSG_PULL_ALREADY_PULLED.format(object=grenade.key))
             return
         
@@ -1298,10 +1299,10 @@ class CmdPull(Command):
     def pull_pin(self, grenade):
         """Pull the pin and start countdown."""
         # Set pin pulled flag
-        setattr(grenade.db, DB_PIN_PULLED, True)
+        grenade.db.pin_pulled = True
         
         # Get fuse time
-        fuse_time = getattr(grenade.db, DB_FUSE_TIME, 8)
+        fuse_time = grenade.db.fuse_time if grenade.db.fuse_time is not None else 8
         
         # Start countdown with robust ticker system
         setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, fuse_time)
@@ -1345,12 +1346,12 @@ class CmdPull(Command):
                     from typeclasses.characters import Character
                     
                     # Check if grenade is stuck to armor
-                    is_stuck = isinstance(grenade.location, Item) and hasattr(grenade.db, 'stuck_to_armor')
+                    is_stuck = isinstance(grenade.location, Item) and grenade.db.stuck_to_armor is not None
                     
                     if is_stuck:
                         # Grenade stuck to armor - send dramatic warnings
                         armor = grenade.location
-                        stuck_location = getattr(grenade.db, 'stuck_to_location', 'unknown')
+                        stuck_location = grenade.db.stuck_to_location or 'unknown'
                         
                         # Check if armor is worn
                         if armor.location and isinstance(armor.location, Character):
@@ -1422,13 +1423,13 @@ class CmdPull(Command):
         """Handle grenade explosion."""
         try:
             # Check dud chance
-            dud_chance = getattr(grenade.db, DB_DUD_CHANCE, 0.0)
+            dud_chance = grenade.db.dud_chance if grenade.db.dud_chance is not None else 0.0
             if random.random() < dud_chance:
                 self.handle_dud(grenade)
                 return
             
             # Get blast damage
-            blast_damage = getattr(grenade.db, DB_BLAST_DAMAGE, 10)
+            blast_damage = grenade.db.blast_damage if grenade.db.blast_damage is not None else 10
             
             # Check if grenade is in someone's inventory when it explodes
             # Use typeclass check to distinguish characters (PCs and NPCs) from rooms
@@ -1448,7 +1449,7 @@ class CmdPull(Command):
             if holder:
                 # Explosion in hands - double damage and guaranteed hit
                 holder_damage = blast_damage * 2
-                damage_type = getattr(grenade.db, 'damage_type', 'blast')  # Explosive damage type
+                damage_type = grenade.db.damage_type if grenade.db.damage_type is not None else 'blast'  # Explosive damage type
                 holder.take_damage(holder_damage, location="chest", injury_type=damage_type)
                 holder.msg(f"|rThe {grenade.key} EXPLODES IN YOUR HANDS!|n You take {holder_damage} damage!")
                 
@@ -1463,7 +1464,7 @@ class CmdPull(Command):
                 for character in proximity_list:
                     if character != holder and hasattr(character, 'msg'):
                         reduced_damage = blast_damage // 2  # Half damage due to body shielding
-                        damage_type = getattr(grenade.db, 'damage_type', 'blast')
+                        damage_type = grenade.db.damage_type if grenade.db.damage_type is not None else 'blast'
                         character.take_damage(reduced_damage, location="chest", injury_type=damage_type)
                         character.msg(MSG_GRENADE_DAMAGE.format(grenade=grenade.key))
                         
@@ -1493,7 +1494,7 @@ class CmdPull(Command):
                         final_damage = int(blast_damage * modifier)
                         
                         if final_damage > 0:
-                            damage_type = getattr(grenade.db, 'damage_type', 'blast')
+                            damage_type = grenade.db.damage_type if grenade.db.damage_type is not None else 'blast'
                             character.take_damage(final_damage, location="chest", injury_type=damage_type)
                             character.msg(MSG_GRENADE_DAMAGE.format(grenade=grenade.key))
                             if character.location:
@@ -1525,7 +1526,7 @@ class CmdPull(Command):
     
     def handle_chain_reactions(self, exploding_grenade):
         """Handle chain reactions with other explosives."""
-        if not getattr(exploding_grenade.db, DB_CHAIN_TRIGGER, False):
+        if not exploding_grenade.db.chain_trigger:
             return
         
         # Find other explosives in proximity
@@ -1535,7 +1536,7 @@ class CmdPull(Command):
         
         for obj in proximity_list:
             if (hasattr(obj, 'db') and 
-                getattr(obj.db, DB_IS_EXPLOSIVE, False) and 
+                obj.db.is_explosive and 
                 obj != exploding_grenade):
                 
                         # Trigger chain explosion with new ticker system
@@ -1544,7 +1545,7 @@ class CmdPull(Command):
                                 MSG_GRENADE_CHAIN_TRIGGER.format(grenade=obj.key))
                         
                         # Set short timer and start ticker
-                        setattr(obj.db, DB_PIN_PULLED, True)
+                        obj.db.pin_pulled = True
                         setattr(obj.ndb, NDB_COUNTDOWN_REMAINING, 1)  # 1 second for chain reaction
                         self.start_grenade_ticker(obj)
 class CmdCatch(Command):
@@ -1734,12 +1735,12 @@ class CmdRig(Command):
                 return
         
         # Validate explosive
-        if not getattr(grenade.db, DB_IS_EXPLOSIVE, False):
+        if not grenade.db.is_explosive:
             self.caller.msg(MSG_RIG_NOT_EXPLOSIVE.format(object=grenade.key))
             return
         
         # Check if pin is NOT pulled (should be unpinned for rigging)
-        if getattr(grenade.db, DB_PIN_PULLED, False):
+        if grenade.db.pin_pulled:
             self.caller.msg(MSG_RIG_ALREADY_PINNED)
             return
         
@@ -1751,14 +1752,14 @@ class CmdRig(Command):
             return
         
         # Check if exit already rigged
-        existing_rigged = getattr(exit_obj.db, 'rigged_grenade', None)
+        existing_rigged = exit_obj.db.rigged_grenade
         if existing_rigged:
             self.caller.msg(MSG_RIG_EXIT_ALREADY_RIGGED)
             return
         
         # Check if return exit is already rigged too
         return_exit = self.find_return_exit_for_check(exit_obj)
-        if return_exit and getattr(return_exit.db, 'rigged_grenade', None):
+        if return_exit and return_exit.db.rigged_grenade:
             self.caller.msg(MSG_RIG_EXIT_ALREADY_RIGGED)
             return
         
@@ -1795,18 +1796,18 @@ class CmdRig(Command):
         grenade.move_to(self.caller.location, quiet=True)
         
         # Set up rigging on the main exit
-        setattr(exit_obj.db, 'rigged_grenade', grenade)
-        setattr(grenade.db, 'rigged_to_exit', exit_obj)
-        setattr(grenade.db, 'rigged_by', self.caller)  # Store who rigged it for immunity
+        exit_obj.db.rigged_grenade = grenade
+        grenade.db.rigged_to_exit = exit_obj
+        grenade.db.rigged_by = self.caller  # Store who rigged it for immunity
         
         # Add integration description for rigged grenade
         # Store original integration state if not already stored
-        if not hasattr(grenade.db, 'original_integrate'):
-            grenade.db.original_integrate = getattr(grenade.db, 'integrate', False)
-        if not hasattr(grenade.db, 'original_integration_desc'):
-            grenade.db.original_integration_desc = getattr(grenade.db, 'integration_desc', None)
-        if not hasattr(grenade.db, 'original_integration_priority'):
-            grenade.db.original_integration_priority = getattr(grenade.db, 'integration_priority', None)
+        if grenade.db.original_integrate is None:
+            grenade.db.original_integrate = grenade.db.integrate or False
+        if grenade.db.original_integration_desc is None:
+            grenade.db.original_integration_desc = grenade.db.integration_desc
+        if grenade.db.original_integration_priority is None:
+            grenade.db.original_integration_priority = grenade.db.integration_priority
         
         # Enable integration and set rigging description with priority
         grenade.db.integrate = True
@@ -1816,7 +1817,7 @@ class CmdRig(Command):
         # Find and rig the return exit too
         return_exit = self.find_return_exit(exit_obj)
         if return_exit:
-            setattr(return_exit.db, 'rigged_grenade', grenade)
+            return_exit.db.rigged_grenade = grenade
             splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: Also rigged return exit {return_exit} in {return_exit.location}")
         
@@ -1898,13 +1899,13 @@ def check_rigged_grenade(character, exit_obj):
     splattercast = ChannelDB.objects.get_channel("Splattercast")
     
     # Check if there's a rigged grenade on this exit
-    rigged_grenade = getattr(exit_obj.db, 'rigged_grenade', None)
+    rigged_grenade = exit_obj.db.rigged_grenade
     
     if not rigged_grenade:
         return False
     
     # Check if this character is the rigger (immunity)
-    rigger = getattr(rigged_grenade.db, 'rigged_by', None)
+    rigger = rigged_grenade.db.rigged_by
     
     if rigger and character == rigger:
         return False  # Rigger is immune to their own trap
@@ -1917,7 +1918,7 @@ def check_rigged_grenade(character, exit_obj):
     )
     
     # Pull the pin and start countdown timer when triggered
-    setattr(rigged_grenade.db, DB_PIN_PULLED, True)
+    rigged_grenade.db.pin_pulled = True
     fuse_time = 1  # Rigged grenades explode almost immediately
     setattr(rigged_grenade.ndb, NDB_COUNTDOWN_REMAINING, fuse_time)
     
@@ -1926,7 +1927,7 @@ def check_rigged_grenade(character, exit_obj):
     
     # FOR STICKY GRENADES: Find most magnetic target and attempt to stick
     # FOR REGULAR GRENADES: Just establish proximity with trigger character
-    is_sticky = getattr(rigged_grenade.db, 'is_sticky', False)
+    is_sticky = bool(rigged_grenade.db.is_sticky)
     sticky_target = None
     
     if is_sticky:
@@ -1969,14 +1970,14 @@ def check_rigged_grenade(character, exit_obj):
         """Handle rigged grenade explosion after timer."""
         try:
             # Check dud chance
-            dud_chance = getattr(rigged_grenade.db, DB_DUD_CHANCE, 0.0)
+            dud_chance = rigged_grenade.db.dud_chance if rigged_grenade.db.dud_chance is not None else 0.0
             if random.random() < dud_chance:
                 if rigged_grenade.location:
                     rigged_grenade.location.msg_contents(MSG_GRENADE_DUD_ROOM.format(grenade=rigged_grenade.key))
                 return
             
             # Get blast damage
-            blast_damage = getattr(rigged_grenade.db, DB_BLAST_DAMAGE, 10)
+            blast_damage = rigged_grenade.db.blast_damage if rigged_grenade.db.blast_damage is not None else 10
             
             # Room explosion
             if rigged_grenade.location:
@@ -1999,7 +2000,7 @@ def check_rigged_grenade(character, exit_obj):
                     final_damage = int(blast_damage * modifier)
                     
                     if final_damage > 0:
-                        damage_type = getattr(rigged_grenade.db, 'damage_type', 'blast')
+                        damage_type = rigged_grenade.db.damage_type if rigged_grenade.db.damage_type is not None else 'blast'
                         other_character.take_damage(final_damage, location="chest", injury_type=damage_type)
                         other_character.msg(MSG_GRENADE_DAMAGE.format(grenade=rigged_grenade.key))
                         if other_character.location:
@@ -2010,10 +2011,10 @@ def check_rigged_grenade(character, exit_obj):
                     # Note: Characters with 0.0 modifier (grapplers) take no damage and get no damage messages
             
             # Handle chain reactions if enabled
-            if getattr(rigged_grenade.db, DB_CHAIN_TRIGGER, False):
+            if rigged_grenade.db.chain_trigger:
                 for obj in proximity_list:
                     if (hasattr(obj, 'db') and 
-                        getattr(obj.db, DB_IS_EXPLOSIVE, False) and 
+                        obj.db.is_explosive and 
                         obj != rigged_grenade):
                         
                         # Trigger chain explosion
@@ -2022,7 +2023,7 @@ def check_rigged_grenade(character, exit_obj):
                                 MSG_GRENADE_CHAIN_TRIGGER.format(grenade=obj.key))
                         
                         # Start immediate explosion timer with new ticker system
-                        setattr(obj.db, DB_PIN_PULLED, True)
+                        obj.db.pin_pulled = True
                         setattr(obj.ndb, NDB_COUNTDOWN_REMAINING, 1)
                         start_standalone_grenade_ticker(obj)
             
@@ -2037,10 +2038,10 @@ def check_rigged_grenade(character, exit_obj):
     start_standalone_grenade_ticker(rigged_grenade, explode_rigged_grenade)
     
     # Clean up rigging from both exits
-    delattr(exit_obj.db, 'rigged_grenade')
+    exit_obj.db.rigged_grenade = None
     
     # Find and clean up return exit too
-    original_exit = getattr(rigged_grenade.db, 'rigged_to_exit', None)
+    original_exit = rigged_grenade.db.rigged_to_exit
     if original_exit and original_exit.destination:
         destination_room = original_exit.destination
         character_room = character.location
@@ -2049,9 +2050,8 @@ def check_rigged_grenade(character, exit_obj):
         for obj in destination_room.contents:
             if (hasattr(obj, 'destination') and 
                 obj.destination == character_room and
-                hasattr(obj.db, 'rigged_grenade') and
-                getattr(obj.db, 'rigged_grenade') == rigged_grenade):
-                delattr(obj.db, 'rigged_grenade')
+                obj.db.rigged_grenade == rigged_grenade):
+                obj.db.rigged_grenade = None
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: Cleaned up return exit rigging on {obj}")
                 break
@@ -2188,7 +2188,7 @@ def explode_standalone_grenade(grenade):
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: explode_standalone_grenade called for {grenade}")
         
         # Debug: Check dud chance
-        dud_chance = getattr(grenade.db, DB_DUD_CHANCE, 0.0)
+        dud_chance = grenade.db.dud_chance if grenade.db.dud_chance is not None else 0.0
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Dud chance: {dud_chance}")
         if random.random() < dud_chance:
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Grenade {grenade} is a dud")
@@ -2201,7 +2201,7 @@ def explode_standalone_grenade(grenade):
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Grenade {grenade} is not a dud, proceeding with explosion")
         
         # Get blast damage
-        blast_damage = getattr(grenade.db, DB_BLAST_DAMAGE, 10)
+        blast_damage = grenade.db.blast_damage if grenade.db.blast_damage is not None else 10
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Blast damage: {blast_damage}")
         
         # Check if grenade is in someone's inventory when it explodes
@@ -2250,13 +2250,13 @@ def explode_standalone_grenade(grenade):
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Handling explosion in holder's hands: {holder}")
             # Explosion in hands - double damage and guaranteed hit
             holder_damage = blast_damage * 2
-            damage_type = getattr(grenade.db, 'damage_type', 'blast')  # Explosive damage type
+            damage_type = grenade.db.damage_type if grenade.db.damage_type is not None else 'blast'  # Explosive damage type
             holder.take_damage(holder_damage, location="chest", injury_type=damage_type)
             
             # Different messages for sticky vs normal grenades
             if stuck_to_armor:
                 # Sticky grenade stuck to armor they're wearing
-                stuck_location = getattr(grenade.db, 'stuck_to_location', 'body')
+                stuck_location = grenade.db.stuck_to_location or 'body'
                 holder.msg(f"|R*** CATASTROPHIC EXPLOSION! ***|n\nThe {grenade.key} magnetically clamped to your {stuck_to_armor.key} DETONATES against your {stuck_location}!\nYou take {holder_damage} damage!")
                 
                 # Announce to the room
@@ -2280,7 +2280,7 @@ def explode_standalone_grenade(grenade):
             for character in proximity_list:
                 if character != holder and hasattr(character, 'msg'):
                     reduced_damage = blast_damage // 2  # Half damage due to body shielding
-                    damage_type = getattr(grenade.db, 'damage_type', 'blast')
+                    damage_type = grenade.db.damage_type if grenade.db.damage_type is not None else 'blast'
                     character.take_damage(reduced_damage, location="chest", injury_type=damage_type)
                     character.msg(MSG_GRENADE_DAMAGE.format(grenade=grenade.key))
                     
@@ -2317,7 +2317,7 @@ def explode_standalone_grenade(grenade):
                     final_damage = int(blast_damage * modifier)
                     
                     if final_damage > 0:
-                        damage_type = getattr(grenade.db, 'damage_type', 'blast')
+                        damage_type = grenade.db.damage_type if grenade.db.damage_type is not None else 'blast'
                         character.take_damage(final_damage, location="chest", injury_type=damage_type)
                         character.msg(MSG_GRENADE_DAMAGE.format(grenade=grenade.key))
                         if character.location:
@@ -2328,10 +2328,10 @@ def explode_standalone_grenade(grenade):
                     # Note: Characters with 0.0 modifier (grapplers) take no damage and get no damage messages
         
         # Handle chain reactions
-        if getattr(grenade.db, DB_CHAIN_TRIGGER, False):
+        if grenade.db.chain_trigger:
             for obj in proximity_list:
                 if (hasattr(obj, 'db') and 
-                    getattr(obj.db, DB_IS_EXPLOSIVE, False) and 
+                    obj.db.is_explosive and 
                     obj != grenade):
                     
                     # Trigger chain explosion
@@ -2340,7 +2340,7 @@ def explode_standalone_grenade(grenade):
                             MSG_GRENADE_CHAIN_TRIGGER.format(grenade=obj.key))
                     
                     # Start chain reaction with new ticker system
-                    setattr(obj.db, DB_PIN_PULLED, True)
+                    obj.db.pin_pulled = True
                     setattr(obj.ndb, NDB_COUNTDOWN_REMAINING, 1)
                     start_standalone_grenade_ticker(obj)
         
@@ -2360,11 +2360,11 @@ def check_auto_defuse(character):
         
         for obj in character.location.contents:
             # Check if object is an explosive
-            if not getattr(obj.db, DB_IS_EXPLOSIVE, False):
+            if not obj.db.is_explosive:
                 continue
                 
             # Check if grenade is live (pin pulled and timer active)
-            pin_pulled = getattr(obj.db, DB_PIN_PULLED, False)
+            pin_pulled = obj.db.pin_pulled
             if not pin_pulled:
                 continue
                 
@@ -2460,7 +2460,7 @@ def handle_auto_defuse_success(character, grenade):
         
         # Clear countdown state
         setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0)
-        setattr(grenade.db, DB_PIN_PULLED, False)  # Grenade is now safe
+        grenade.db.pin_pulled = False  # Grenade is now safe
         
         # Success messages (more dramatic than manual defuse)
         character.msg(f"SUCCESS! You instinctively defuse the {grenade.key} just in time!")
@@ -2526,14 +2526,14 @@ def trigger_auto_defuse_explosion(grenade):
     
     try:
         # Check dud chance
-        dud_chance = getattr(grenade.db, DB_DUD_CHANCE, 0.0)
+        dud_chance = grenade.db.dud_chance if grenade.db.dud_chance is not None else 0.0
         if random.random() < dud_chance:
             if grenade.location:
                 grenade.location.msg_contents(MSG_GRENADE_DUD_ROOM.format(grenade=grenade.key))
             return
         
         # Get blast damage
-        blast_damage = getattr(grenade.db, DB_BLAST_DAMAGE, 10)
+        blast_damage = grenade.db.blast_damage if grenade.db.blast_damage is not None else 10
         
         # Room explosion
         if grenade.location:
@@ -2556,7 +2556,7 @@ def trigger_auto_defuse_explosion(grenade):
                 final_damage = int(blast_damage * modifier)
                 
                 if final_damage > 0:
-                    damage_type = getattr(grenade.db, 'damage_type', 'blast')
+                    damage_type = grenade.db.damage_type if grenade.db.damage_type is not None else 'blast'
                     character.take_damage(final_damage, location="chest", injury_type=damage_type)
                     character.msg(MSG_GRENADE_DAMAGE.format(grenade=grenade.key))
                     if character.location:
@@ -2567,10 +2567,10 @@ def trigger_auto_defuse_explosion(grenade):
                 # Note: Characters with 0.0 modifier (grapplers) take no damage and get no damage messages
         
         # Handle chain reactions if enabled
-        if getattr(grenade.db, DB_CHAIN_TRIGGER, False):
+        if grenade.db.chain_trigger:
             for obj in proximity_list:
                 if (hasattr(obj, 'db') and 
-                    getattr(obj.db, DB_IS_EXPLOSIVE, False) and 
+                    obj.db.is_explosive and 
                     obj != grenade):
                     
                     # Trigger chain explosion
@@ -2648,7 +2648,7 @@ class CmdDefuse(Command):
         
         for obj in all_candidates:
             if (grenade_name.lower() in obj.key.lower() and 
-                getattr(obj.db, DB_IS_EXPLOSIVE, False)):
+                obj.db.is_explosive):
                 
                 # Check if caller is already in this object's proximity
                 obj_proximity = getattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, [])
@@ -2668,11 +2668,11 @@ class CmdDefuse(Command):
         # Check both room contents AND character inventory for physical candidates
         for obj in all_candidates:
             if (grenade_name.lower() in obj.key.lower() and 
-                getattr(obj.db, DB_IS_EXPLOSIVE, False)):
+                obj.db.is_explosive):
                 
                 # Check if grenade is live (either pin pulled OR rigged to exit)
-                pin_pulled = getattr(obj.db, DB_PIN_PULLED, False)
-                is_rigged = getattr(obj.db, 'rigged_to_exit', None) is not None
+                pin_pulled = obj.db.pin_pulled
+                is_rigged = obj.db.rigged_to_exit is not None
                 
                 if pin_pulled or is_rigged:
                     physical_candidates.append(obj)
@@ -2743,13 +2743,13 @@ class CmdDefuse(Command):
     def validate_grenade_for_defuse(self, grenade):
         """Validate that grenade can be defused."""
         # Must be explosive
-        if not getattr(grenade.db, DB_IS_EXPLOSIVE, False):
+        if not grenade.db.is_explosive:
             self.caller.msg(f"The {grenade.key} is not an explosive device.")
             return False
         
         # Must be live (pin pulled OR rigged)
-        pin_pulled = getattr(grenade.db, DB_PIN_PULLED, False)
-        is_rigged = getattr(grenade.db, 'rigged_to_exit', None) is not None
+        pin_pulled = grenade.db.pin_pulled
+        is_rigged = grenade.db.rigged_to_exit is not None
         
         if not (pin_pulled or is_rigged):
             self.caller.msg(f"The {grenade.key} is not armed - no need to defuse it.")
@@ -2786,7 +2786,7 @@ class CmdDefuse(Command):
         setattr(grenade.ndb, 'defuse_attempted_by', attempted_by)
         
         # Check if this is a rigged grenade (different difficulty calculation)
-        is_rigged = getattr(grenade.db, 'rigged_to_exit', None) is not None
+        is_rigged = grenade.db.rigged_to_exit is not None
         
         if is_rigged:
             # Rigged grenades: base difficulty only (no time pressure)
@@ -2853,7 +2853,7 @@ class CmdDefuse(Command):
         
         # Clear countdown state
         setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0)
-        setattr(grenade.db, DB_PIN_PULLED, False)  # Grenade is now safe
+        grenade.db.pin_pulled = False  # Grenade is now safe
         
         # Clean up rigging if this was a rigged grenade
         self.cleanup_rigging(grenade)
@@ -2898,13 +2898,13 @@ class CmdDefuse(Command):
     
     def cleanup_rigging(self, grenade):
         """Clean up rigging references when grenade is defused."""
-        rigged_to_exit = getattr(grenade.db, 'rigged_to_exit', None)
+        rigged_to_exit = grenade.db.rigged_to_exit
         if rigged_to_exit:
             splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
             
             # Clean up main exit
-            if hasattr(rigged_to_exit.db, 'rigged_grenade'):
-                delattr(rigged_to_exit.db, 'rigged_grenade')
+            if rigged_to_exit.db.rigged_grenade is not None:
+                rigged_to_exit.db.rigged_grenade = None
                 if splattercast:
                     splattercast.msg(f"DEFUSE_CLEANUP: Removed rigging from {rigged_to_exit}")
             
@@ -2916,43 +2916,39 @@ class CmdDefuse(Command):
                 for obj in destination_room.contents:
                     if (hasattr(obj, 'destination') and 
                         obj.destination == grenade_room and
-                        hasattr(obj.db, 'rigged_grenade') and
-                        getattr(obj.db, 'rigged_grenade') == grenade):
-                        delattr(obj.db, 'rigged_grenade')
+                        obj.db.rigged_grenade is not None and
+                        obj.db.rigged_grenade == grenade):
+                        obj.db.rigged_grenade = None
                         if splattercast:
                             splattercast.msg(f"DEFUSE_CLEANUP: Removed rigging from return exit {obj}")
                         break
             
             # Clean up grenade's rigging reference
-            delattr(grenade.db, 'rigged_to_exit')
-            if hasattr(grenade.db, 'rigged_by'):
-                delattr(grenade.db, 'rigged_by')
+            grenade.db.rigged_to_exit = None
+            if grenade.db.rigged_by is not None:
+                grenade.db.rigged_by = None
             
             # Restore original integration state
-            if hasattr(grenade.db, 'original_integrate'):
+            if grenade.db.original_integrate is not None:
                 grenade.db.integrate = grenade.db.original_integrate
-                delattr(grenade.db, 'original_integrate')
+                grenade.db.original_integrate = None
             else:
                 # Default: disable integration for regular grenades
                 grenade.db.integrate = False
                 
-            if hasattr(grenade.db, 'original_integration_desc'):
-                if grenade.db.original_integration_desc is not None:
-                    grenade.db.integration_desc = grenade.db.original_integration_desc
-                else:
-                    # Remove integration_desc if it wasn't set originally
-                    if hasattr(grenade.db, 'integration_desc'):
-                        delattr(grenade.db, 'integration_desc')
-                delattr(grenade.db, 'original_integration_desc')
+            if grenade.db.original_integration_desc is not None:
+                grenade.db.integration_desc = grenade.db.original_integration_desc
+                grenade.db.original_integration_desc = None
+            else:
+                # Remove integration_desc if it wasn't set originally
+                grenade.db.integration_desc = None
                 
-            if hasattr(grenade.db, 'original_integration_priority'):
-                if grenade.db.original_integration_priority is not None:
-                    grenade.db.integration_priority = grenade.db.original_integration_priority
-                else:
-                    # Remove integration_priority if it wasn't set originally
-                    if hasattr(grenade.db, 'integration_priority'):
-                        delattr(grenade.db, 'integration_priority')
-                delattr(grenade.db, 'original_integration_priority')
+            if grenade.db.original_integration_priority is not None:
+                grenade.db.integration_priority = grenade.db.original_integration_priority
+                grenade.db.original_integration_priority = None
+            else:
+                # Remove integration_priority if it wasn't set originally
+                grenade.db.integration_priority = None
             
             # Announce trap disarmament
             self.caller.msg("You also disarm the trap rigging mechanism.")
@@ -3009,14 +3005,14 @@ class CmdDefuse(Command):
         
         try:
             # Check dud chance
-            dud_chance = getattr(grenade.db, DB_DUD_CHANCE, 0.0)
+            dud_chance = grenade.db.dud_chance if grenade.db.dud_chance is not None else 0.0
             if random.random() < dud_chance:
                 if grenade.location:
                     grenade.location.msg_contents(MSG_GRENADE_DUD_ROOM.format(grenade=grenade.key))
                 return
             
             # Get blast damage
-            blast_damage = getattr(grenade.db, DB_BLAST_DAMAGE, 10)
+            blast_damage = grenade.db.blast_damage if grenade.db.blast_damage is not None else 10
             
             # Room explosion
             if grenade.location:
@@ -3039,7 +3035,7 @@ class CmdDefuse(Command):
                     final_damage = int(blast_damage * modifier)
                     
                     if final_damage > 0:
-                        damage_type = getattr(grenade.db, 'damage_type', 'blast')
+                        damage_type = grenade.db.damage_type if grenade.db.damage_type is not None else 'blast'
                         character.take_damage(final_damage, location="chest", injury_type=damage_type)
                         character.msg(MSG_GRENADE_DAMAGE.format(grenade=grenade.key))
                         if character.location:
@@ -3050,10 +3046,10 @@ class CmdDefuse(Command):
                     # Note: Characters with 0.0 modifier (grapplers) take no damage and get no damage messages
             
             # Handle chain reactions if enabled
-            if getattr(grenade.db, DB_CHAIN_TRIGGER, False):
+            if grenade.db.chain_trigger:
                 for obj in proximity_list:
                     if (hasattr(obj, 'db') and 
-                        getattr(obj.db, DB_IS_EXPLOSIVE, False) and 
+                        obj.db.is_explosive and 
                         obj != grenade):
                         
                         # Trigger chain explosion
@@ -3121,7 +3117,7 @@ class CmdScan(Command):
             return
         
         # Validate explosive
-        if not getattr(explosive.db, DB_IS_EXPLOSIVE, False):
+        if not explosive.db.is_explosive:
             caller.msg(f"{explosive.key} is not an explosive device.")
             return
         
@@ -3131,7 +3127,7 @@ class CmdScan(Command):
             return
         
         # Validate detonator type
-        if not hasattr(detonator.db, 'device_type') or detonator.db.device_type != "remote_detonator":
+        if not detonator.db.device_type or detonator.db.device_type != "remote_detonator":
             caller.msg(f"{detonator.key} is not a remote detonator.")
             return
         
@@ -3219,7 +3215,7 @@ class CmdDetonate(Command):
             return
         
         # Validate detonator type
-        if not hasattr(detonator.db, 'device_type') or detonator.db.device_type != "remote_detonator":
+        if not detonator.db.device_type or detonator.db.device_type != "remote_detonator":
             caller.msg(f"{detonator.key} is not a remote detonator.")
             return
         
@@ -3271,13 +3267,13 @@ class CmdDetonate(Command):
         explosive = explosive[0]
         
         # Check if already detonating
-        if getattr(explosive.db, DB_PIN_PULLED, False):
+        if explosive.db.pin_pulled:
             caller.msg(f"|y{explosive.key} is already detonating!|n")
             return
         
         # Pull the pin remotely
-        setattr(explosive.db, DB_PIN_PULLED, True)
-        fuse_time = getattr(explosive.db, DB_FUSE_TIME, 8)
+        explosive.db.pin_pulled = True
+        fuse_time = explosive.db.fuse_time if explosive.db.fuse_time is not None else 8
         setattr(explosive.ndb, NDB_COUNTDOWN_REMAINING, fuse_time)
         
         # Start countdown using CmdPull's grenade ticker system
@@ -3344,13 +3340,13 @@ class CmdDetonate(Command):
             explosive = explosive[0]
             
             # Skip if already detonating
-            if getattr(explosive.db, DB_PIN_PULLED, False):
+            if explosive.db.pin_pulled:
                 already_active_count += 1
                 continue
             
             # Pull the pin remotely
-            setattr(explosive.db, DB_PIN_PULLED, True)
-            fuse_time = getattr(explosive.db, DB_FUSE_TIME, 8)
+            explosive.db.pin_pulled = True
+            fuse_time = explosive.db.fuse_time if explosive.db.fuse_time is not None else 8
             setattr(explosive.ndb, NDB_COUNTDOWN_REMAINING, fuse_time)
             
             # Start countdown
@@ -3444,7 +3440,7 @@ class CmdDetonateList(Command):
             # Find wielded detonator
             if hasattr(caller, 'hands') and caller.hands:
                 for held_item in caller.hands.values():
-                    if (held_item and hasattr(held_item.db, 'device_type') and 
+                    if (held_item and held_item.db.device_type and 
                         held_item.db.device_type == "remote_detonator"):
                         detonator = held_item
                         break
@@ -3469,7 +3465,7 @@ class CmdDetonateList(Command):
                 return
         
         # Validate detonator type
-        if not hasattr(detonator.db, 'device_type') or detonator.db.device_type != "remote_detonator":
+        if not detonator.db.device_type or detonator.db.device_type != "remote_detonator":
             caller.msg(f"{detonator.key} is not a remote detonator.")
             return
         
@@ -3508,20 +3504,20 @@ class CmdDetonateList(Command):
             explosive = explosive[0]
             
             # Get status
-            if getattr(explosive.db, DB_PIN_PULLED, False):
+            if explosive.db.pin_pulled:
                 countdown = getattr(explosive.ndb, NDB_COUNTDOWN_REMAINING, 0)
-                if getattr(explosive.db, 'stuck_to_armor', None):
+                if explosive.db.stuck_to_armor is not None:
                     status = f"|RSTUCK|n"
                 else:
                     status = f"|YACTIVE|n"
                 fuse_str = f"|R{countdown}s left!|n"
-            elif getattr(explosive.db, 'rigged_to_exit', None) is not None:
+            elif explosive.db.rigged_to_exit is not None:
                 status = f"|yTRAP|n"
-                fuse_time = getattr(explosive.db, DB_FUSE_TIME, 8)
+                fuse_time = explosive.db.fuse_time if explosive.db.fuse_time is not None else 8
                 fuse_str = f"{fuse_time}s (trap)"
             else:
                 status = f"|gREADY|n"
-                fuse_time = getattr(explosive.db, DB_FUSE_TIME, 8)
+                fuse_time = explosive.db.fuse_time if explosive.db.fuse_time is not None else 8
                 fuse_str = f"{fuse_time}s"
             
             # Get location
@@ -3531,7 +3527,7 @@ class CmdDetonateList(Command):
                 loc_str = "Your inventory"
             elif hasattr(explosive.location, 'key'):
                 # Check if stuck to armor
-                if getattr(explosive.db, 'stuck_to_armor', None):
+                if explosive.db.stuck_to_armor is not None:
                     stuck_to = explosive.db.stuck_to_armor
                     if hasattr(stuck_to, 'location') and hasattr(stuck_to.location, 'key'):
                         loc_str = f"On {stuck_to.location.key}"
@@ -3602,7 +3598,7 @@ class CmdClearDetonator(Command):
             
             detonator = None
             for held_item in caller.hands.values():
-                if (held_item and hasattr(held_item.db, 'device_type') and 
+                if (held_item and held_item.db.device_type and 
                     held_item.db.device_type == "remote_detonator"):
                     detonator = held_item
                     break
@@ -3633,7 +3629,7 @@ class CmdClearDetonator(Command):
             return
         
         # Validate detonator type
-        if not hasattr(detonator.db, 'device_type') or detonator.db.device_type != "remote_detonator":
+        if not detonator.db.device_type or detonator.db.device_type != "remote_detonator":
             caller.msg(f"{detonator.key} is not a remote detonator.")
             return
         
@@ -3704,9 +3700,9 @@ class CmdClearDetonator(Command):
         from evennia.utils.search import search_object
         for explosive_dbref in list(detonator.db.scanned_explosives):
             explosive = search_object(f"#{explosive_dbref}")
-            if explosive and len(explosive) > 0:
+                if explosive and len(explosive) > 0:
                 explosive_obj = explosive[0]
-                if hasattr(explosive_obj.db, 'scanned_by_detonator'):
+                if explosive_obj.db.scanned_by_detonator is not None:
                     explosive_obj.db.scanned_by_detonator = None
         
         # Clear detonator list

--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -81,12 +81,12 @@ class CmdAttack(Command):
         splattercast.msg(f"WEAPON_DETECT: {caller.key} hands={hands}, weapon_obj={weapon_obj.key if weapon_obj else 'None'}")
         if weapon_obj:
             splattercast.msg(f"WEAPON_DETECT: {weapon_obj.key} has db={hasattr(weapon_obj, 'db')}, "
-                           f"db.is_ranged={getattr(weapon_obj.db, 'is_ranged', 'MISSING') if hasattr(weapon_obj, 'db') else 'NO_DB'}, "
-                           f"db.weapon_type={getattr(weapon_obj.db, 'weapon_type', 'MISSING') if hasattr(weapon_obj, 'db') else 'NO_DB'}")
+                           f"db.is_ranged={weapon_obj.db.is_ranged if weapon_obj.db.is_ranged is not None else 'MISSING' if hasattr(weapon_obj, 'db') else 'NO_DB'}, "
+                           f"db.weapon_type={weapon_obj.db.weapon_type if weapon_obj.db.weapon_type is not None else 'MISSING' if hasattr(weapon_obj, 'db') else 'NO_DB'}")
         
-        is_ranged_weapon = weapon_obj and hasattr(weapon_obj, "db") and getattr(weapon_obj.db, "is_ranged", False)
+        is_ranged_weapon = weapon_obj and hasattr(weapon_obj, "db") and weapon_obj.db.is_ranged
         weapon_name_for_msg = weapon_obj.key if weapon_obj else "your fists"
-        weapon_type_for_msg = (str(weapon_obj.db.weapon_type).lower() if weapon_obj and hasattr(weapon_obj, "db") and hasattr(weapon_obj.db, "weapon_type") and weapon_obj.db.weapon_type else "unarmed")
+        weapon_type_for_msg = (str(weapon_obj.db.weapon_type).lower() if weapon_obj and hasattr(weapon_obj, "db") and weapon_obj.db.weapon_type else "unarmed")
         
         splattercast.msg(f"WEAPON_FINAL: {caller.key} is_ranged={is_ranged_weapon}, weapon_type={weapon_type_for_msg}")
         # --- END WEAPON IDENTIFICATION ---
@@ -136,7 +136,7 @@ class CmdAttack(Command):
             validation_error = target.validate_attack_target()
             if validation_error:
                 # Target is invalid - show glitch effect for holographic
-                if getattr(target.db, 'is_holographic', False):
+                if target.db.is_holographic:
                     caller.msg(f"|yYour attack passes through {target.key}'s holographic form with a shimmer of static.|n")
                     target.location.msg_contents(
                         f"|y{caller.key}'s attack passes through {target.key}'s flickering projection.|n",
@@ -151,7 +151,7 @@ class CmdAttack(Command):
         # Check if caller is grappled and trying to attack their grappler
         caller_handler = getattr(caller.ndb, "combat_handler", None)
         if caller_handler:
-            combatants_list = getattr(caller_handler.db, "combatants", None)
+            combatants_list = caller_handler.db.combatants
             if combatants_list:  # Add None check to prevent iteration errors
                 caller_entry = next((e for e in combatants_list if e["char"] == caller), None)
                 if caller_entry:
@@ -276,7 +276,7 @@ class CmdAttack(Command):
                 
                 # Clear any existing combat action when attacking (prevents stuck charge actions)
                 # Use copy-modify-save pattern to ensure changes persist
-                combatants_copy = getattr(final_handler.db, "combatants", [])
+                combatants_copy = final_handler.db.combatants or []
                 caller_entry_copy = next((e for e in combatants_copy if e.get("char") == caller), None)
                 if caller_entry_copy:
                     caller_entry_copy["combat_action"] = None
@@ -287,7 +287,7 @@ class CmdAttack(Command):
                     caller_entry_copy["is_yielding"] = False
                     
                     # Save the modified combatants list back
-                    setattr(final_handler.db, "combatants", combatants_copy)
+                    final_handler.db.combatants = combatants_copy
                     
                     if was_yielding:
                         # Check if caller is grappled (being grappled by someone)
@@ -403,7 +403,7 @@ class CmdAttack(Command):
                 # Get target's weapon for their defensive initiate message
                 target_weapon = get_wielded_weapon(target)
                 target_weapon_type = "unarmed"
-                if target_weapon and hasattr(target_weapon, 'db') and hasattr(target_weapon.db, 'weapon_type'):
+                if target_weapon and hasattr(target_weapon, 'db') and target_weapon.db.weapon_type is not None:
                     target_weapon_type = target_weapon.db.weapon_type
                 
                 # Get target's initiate message (defensive reaction)

--- a/commands/combat/movement.py
+++ b/commands/combat/movement.py
@@ -105,7 +105,7 @@ class CmdFlee(Command):
         all_exits = [ex for ex in caller.location.exits if ex.access(caller, 'traverse')]
         available_exits = [
             ex for ex in all_exits 
-            if ex.destination and not getattr(ex.destination.db, "is_sky_room", False)
+            if ex.destination and not ex.destination.db.is_sky_room
         ]
         
         # Debug log if sky rooms were filtered out
@@ -142,7 +142,7 @@ class CmdFlee(Command):
                             if other_entry and other_h.get_target_obj(other_entry) == caller:
                                 other_hands = getattr(char_in_dest, "hands", {})
                                 other_weapon_obj = next((item for hand, item in other_hands.items() if item), None)
-                                other_is_ranged = other_weapon_obj and hasattr(other_weapon_obj.db, "is_ranged") and other_weapon_obj.db.is_ranged
+                                other_is_ranged = other_weapon_obj and other_weapon_obj.db.is_ranged
                                 if other_is_ranged:
                                     is_this_exit_safe_from_ranged_targeters = False
                                     splattercast.msg(f"{DEBUG_PREFIX_FLEE}_PRE_CHECK_UNSAFE_EXIT: {caller.key} - exit {potential_exit.key} to {destination_room.key} is unsafe. Reason: {char_in_dest.key} is a ranged targeter in combat handler {other_h.key}.")
@@ -289,7 +289,7 @@ class CmdFlee(Command):
             # Attempt to disengage from combat
             # Get all opponents targeting the caller
             opponents_targeting_caller = []
-            combatants_list = getattr(original_handler_at_flee_start.db, "combatants", [])
+            combatants_list = original_handler_at_flee_start.db.combatants or []
             if combatants_list:
                 for entry in combatants_list:
                     if entry["char"] != caller:
@@ -335,12 +335,12 @@ class CmdFlee(Command):
                         if char_in_dest == caller or not hasattr(char_in_dest, "ndb"):
                             continue
                         other_handler = getattr(char_in_dest.ndb, "combat_handler", None)
-                        if other_handler and getattr(other_handler.db, "combat_is_running", False):
-                            other_entry = next((e for e in getattr(other_handler.db, "combatants", []) if e["char"] == char_in_dest), None)
+                        if other_handler and other_handler.db.combat_is_running:
+                            other_entry = next((e for e in (other_handler.db.combatants or []) if e["char"] == char_in_dest), None)
                             if other_entry and original_handler_at_flee_start.get_target_obj(other_entry) == caller:
                                 other_hands = getattr(char_in_dest, "hands", {})
                                 other_weapon = next((item for hand, item in other_hands.items() if item), None)
-                                if other_weapon and getattr(other_weapon.db, "is_ranged", False):
+                                if other_weapon and other_weapon.db.is_ranged:
                                     is_safe = False
                                     break
                     if is_safe:
@@ -548,7 +548,7 @@ class CmdAdvance(Command):
                     
             if not target:
                 # Try searching in adjacent combat rooms
-                managed_rooms = getattr(handler.db, "managed_rooms", [])
+                managed_rooms = handler.db.managed_rooms or []
                 for room in managed_rooms:
                     if room != caller.location:
                         potential_target = caller.search(args, location=room, quiet=True)
@@ -661,7 +661,7 @@ class CmdCharge(Command):
                         
                 if not target_search:
                     # Try searching in adjacent combat rooms
-                    managed_rooms = getattr(handler.db, "managed_rooms", [])
+                    managed_rooms = handler.db.managed_rooms or []
                     for room in managed_rooms:
                         if room != caller.location:
                             potential_target = caller.search(args, location=room, quiet=True)
@@ -713,7 +713,7 @@ class CmdCharge(Command):
                     
             if not target:
                 # Try searching in adjacent combat rooms
-                managed_rooms = getattr(handler.db, "managed_rooms", [])
+                managed_rooms = handler.db.managed_rooms or []
                 for room in managed_rooms:
                     if room != caller.location:
                         potential_target = caller.search(args, location=room, quiet=True)
@@ -854,7 +854,7 @@ class CmdJump(Command):
         # Check if caller is being grappled (can't sacrifice while restrained)
         handler = getattr(self.caller.ndb, "combat_handler", None)
         if handler:
-            combatants_list = getattr(handler.db, "combatants", [])
+            combatants_list = handler.db.combatants or []
             caller_entry = next((e for e in combatants_list if e.get("char") == self.caller), None)
             if caller_entry:
                 from world.combat.grappling import get_grappled_by
@@ -877,7 +877,7 @@ class CmdJump(Command):
         explosive = explosive[0]  # Take first match
         
         # Validate it's an explosive
-        if not getattr(explosive.db, "is_explosive", False):
+        if not explosive.db.is_explosive:
             self.caller.msg(f"{explosive.key} is not an explosive device.")
             return
         
@@ -896,7 +896,7 @@ class CmdJump(Command):
         explosive.ndb.current_hero = self.caller
         
         # Determine explosive state for delayed revelation
-        is_armed = getattr(explosive.db, "pin_pulled", False)
+        is_armed = explosive.db.pin_pulled
         remaining_time = getattr(explosive.ndb, "countdown_remaining", None)
         has_active_countdown = remaining_time is not None and remaining_time > 0
         
@@ -946,7 +946,7 @@ class CmdJump(Command):
         handler = getattr(self.caller.ndb, "combat_handler", None)
         grappled_victim_preview = None
         if handler:
-            combatants_list = getattr(handler.db, "combatants", [])
+            combatants_list = handler.db.combatants or []
             caller_entry = next((e for e in combatants_list if e.get("char") == self.caller), None)
             if caller_entry:
                 from world.combat.grappling import get_grappling_target
@@ -963,7 +963,7 @@ class CmdJump(Command):
             )
         
         # Get blast damage for real explosions
-        blast_damage = getattr(explosive.db, "blast_damage", 10)
+        blast_damage = explosive.db.blast_damage if explosive.db.blast_damage is not None else 10
         
         # Delayed revelation function
         def reveal_outcome():
@@ -984,7 +984,7 @@ class CmdJump(Command):
                 shield_used = False
                 
                 if handler:
-                    combatants_list = getattr(handler.db, "combatants", [])
+                    combatants_list = handler.db.combatants or []
                     caller_entry = next((e for e in combatants_list if e.get("char") == self.caller), None)
                     if caller_entry:
                         from world.combat.grappling import get_grappling_target
@@ -1002,7 +1002,7 @@ class CmdJump(Command):
                     
                     # Cruel damage distribution using medical system
                     victim_alive_before = not grappled_victim.is_dead()
-                    explosive_damage_type = getattr(explosive.db, "damage_type", "blast")
+                    explosive_damage_type = explosive.db.damage_type if explosive.db.damage_type is not None else "blast"
                     grappled_victim.take_damage(blast_damage * 2, location="chest", injury_type=explosive_damage_type)  # Victim takes double damage from shrapnel
                     victim_alive_after = not grappled_victim.is_dead()
                     
@@ -1020,7 +1020,7 @@ class CmdJump(Command):
                     splattercast.msg(f"JUMP_SACRIFICE_CRUEL: {self.caller.key} used {grappled_victim.key} as blast shield - victim took {blast_damage * 2}, hero took {hero_damage}")
                 else:
                     # Standard heroic sacrifice: hero takes ALL damage, others protected
-                    explosive_damage_type = getattr(explosive.db, "damage_type", "blast")
+                    explosive_damage_type = explosive.db.damage_type if explosive.db.damage_type is not None else "blast"
                     self.caller.take_damage(blast_damage, location="chest", injury_type=explosive_damage_type)
                     splattercast.msg(f"JUMP_SACRIFICE_HEROIC: {self.caller.key} absorbed {blast_damage} damage, protecting all others")
                 
@@ -1102,7 +1102,7 @@ class CmdJump(Command):
         # Check if caller is being grappled (can't jump while restrained)
         handler = getattr(self.caller.ndb, "combat_handler", None)
         if handler:
-            combatants_list = getattr(handler.db, "combatants", [])
+            combatants_list = handler.db.combatants or []
             caller_entry = next((e for e in combatants_list if e.get("char") == self.caller), None)
             if caller_entry:
                 from world.combat.grappling import get_grappled_by, get_grappling_target
@@ -1128,7 +1128,7 @@ class CmdJump(Command):
             return
         
         # Validate it's an edge
-        if not getattr(exit_obj.db, "is_edge", False):
+        if not exit_obj.db.is_edge:
             self.caller.msg(f"The {self.direction} exit is not an edge you can jump from.")
             return
         
@@ -1140,7 +1140,7 @@ class CmdJump(Command):
         # Check if caller is grappled (can't jump while grappled)
         handler = getattr(self.caller.ndb, "combat_handler", None)
         if handler:
-            caller_entry = next((e for e in getattr(handler.db, "combatants", []) if e.get("char") == self.caller), None)
+            caller_entry = next((e for e in (handler.db.combatants or []) if e.get("char") == self.caller), None)
             if caller_entry:
                 grappler_obj = handler.get_grappled_by_obj(caller_entry)
                 if grappler_obj:
@@ -1174,7 +1174,7 @@ class CmdJump(Command):
                 grappled_victim.msg(f"|r{self.caller.key} drags you off the {self.direction} edge!|n")
                 
                 # Apply bodyshield damage even without sky room using medical system
-                base_damage = getattr(exit_obj.db, "fall_damage", 8)
+                base_damage = exit_obj.db.fall_damage if exit_obj.db.fall_damage is not None else 8
                 victim_damage = max(1, int(base_damage * 1.2))  # Victim takes 120% damage
                 grappler_damage = max(1, int(base_damage * 0.3))  # Grappler takes 30% due to bodyshield
                 
@@ -1186,7 +1186,7 @@ class CmdJump(Command):
                 splattercast.msg(f"JUMP_EDGE_BODYSHIELD_DIRECT: {self.caller.key} used {grappled_victim.key} as bodyshield in direct fall - victim took {victim_damage}, grappler took {grappler_damage}")
             else:
                 # Normal fall damage without bodyshield using medical system
-                base_damage = getattr(exit_obj.db, "fall_damage", 8)
+                base_damage = exit_obj.db.fall_damage if exit_obj.db.fall_damage is not None else 8
                 self.caller.take_damage(base_damage, location="chest", injury_type="blunt")
                 self.caller.msg(f"|rYou land hard and take {base_damage} damage from the fall!|n")
             
@@ -1259,7 +1259,7 @@ class CmdJump(Command):
         # Check if caller is being grappled (can't jump while restrained)
         handler = getattr(self.caller.ndb, "combat_handler", None)
         if handler:
-            combatants_list = getattr(handler.db, "combatants", [])
+            combatants_list = handler.db.combatants or []
             caller_entry = next((e for e in combatants_list if e.get("char") == self.caller), None)
             if caller_entry:
                 from world.combat.grappling import get_grappled_by, get_grappling_target
@@ -1291,12 +1291,12 @@ class CmdJump(Command):
             return
         
         # Validate it's a gap
-        if not getattr(exit_obj.db, "is_gap", False):
+        if not exit_obj.db.is_gap:
             self.caller.msg(f"The {self.direction} exit is not a gap you can jump across.")
             return
         
         # Determine destination - use gap_destination if set, otherwise use exit destination
-        gap_destination_id = getattr(exit_obj.db, "gap_destination", None)
+        gap_destination_id = exit_obj.db.gap_destination
         if gap_destination_id:
             # Convert gap_destination ID to actual room object
             if isinstance(gap_destination_id, (str, int)):
@@ -1314,7 +1314,7 @@ class CmdJump(Command):
         # Check if caller is grappled (can't jump while grappled)
         handler = getattr(self.caller.ndb, "combat_handler", None)
         if handler:
-            caller_entry = next((e for e in getattr(handler.db, "combatants", []) if e.get("char") == self.caller), None)
+            caller_entry = next((e for e in (handler.db.combatants or []) if e.get("char") == self.caller), None)
             if caller_entry:
                 grappler_obj = handler.get_grappled_by_obj(caller_entry)
                 if grappler_obj:
@@ -1323,7 +1323,7 @@ class CmdJump(Command):
         
         # Gap jumping requires Motorics check vs gap difficulty
         caller_motorics = get_numeric_stat(self.caller, "motorics")
-        gap_difficulty = getattr(exit_obj.db, "gap_difficulty", 10)  # Default hard difficulty
+        gap_difficulty = exit_obj.db.gap_difficulty if exit_obj.db.gap_difficulty is not None else 10  # Default hard difficulty
         
         motorics_roll, _, _ = standard_roll(caller_motorics)
         success = motorics_roll >= gap_difficulty
@@ -1439,10 +1439,10 @@ class CmdJump(Command):
                         aliases_match = any(alias.lower() == opposite_direction for alias in obj.aliases.all())
                     direction_matches = key_matches or aliases_match
                     splattercast.msg(f"JUMP_GAP_DEBUG: Object {obj} direction matches check: {direction_matches} (key: {key_matches}, aliases: {aliases_match})")
-                    if hasattr(obj.db, 'is_edge'):
-                        splattercast.msg(f"JUMP_GAP_DEBUG: Object {obj} is_edge: {getattr(obj.db, 'is_edge', False)}")
+                    if obj.db.is_edge is not None:
+                        splattercast.msg(f"JUMP_GAP_DEBUG: Object {obj} is_edge: {obj.db.is_edge}")
                 if (hasattr(obj, 'key') and hasattr(obj, 'destination') and
-                    hasattr(obj.db, 'is_edge') and getattr(obj.db, 'is_edge', False)):
+                    obj.db.is_edge):
                     # Check if direction matches
                     key_matches = obj.key.lower() == opposite_direction
                     aliases_match = False
@@ -1510,7 +1510,7 @@ class CmdJump(Command):
         self.caller.msg(f"|rYou leap for the {self.direction} gap but don't make it far enough... you're falling!|n")
         
         # Calculate fall damage
-        fall_distance = getattr(exit_obj.db, "fall_distance", None)
+        fall_distance = exit_obj.db.fall_distance
         if fall_distance is None:
             # If no fall_distance configured, use gravity system's result
             fall_distance = 1  # Default fallback, will be updated by gravity system
@@ -1555,7 +1555,7 @@ class CmdJump(Command):
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         
         # For edge descent failure, apply damage but stay in current room
-        fall_damage = getattr(exit_obj.db, "fall_damage", 8)  # Default moderate damage
+        fall_damage = exit_obj.db.fall_damage if exit_obj.db.fall_damage is not None else 8  # Default moderate damage
         
         self.caller.take_damage(fall_damage, location="chest", injury_type="blunt")
         
@@ -1577,7 +1577,7 @@ class CmdJump(Command):
         splattercast.msg(f"SKY_ROOM_DEBUG: Looking for exit '{direction}' from {origin.key}, found: {exit_obj}")
         
         if exit_obj:
-            sky_room_id = getattr(exit_obj[0].db, "sky_room", None)
+            sky_room_id = exit_obj[0].db.sky_room
             splattercast.msg(f"SKY_ROOM_DEBUG: Exit {exit_obj[0].key} has sky_room: {sky_room_id}")
             
             if sky_room_id:
@@ -1614,7 +1614,7 @@ class CmdJump(Command):
             splattercast.msg(f"SKY_ROOM_DEBUG: Found reverse exit: {reverse_exit}")
             
             if reverse_exit:
-                sky_room_id = getattr(reverse_exit[0].db, "sky_room", None)
+                sky_room_id = reverse_exit[0].db.sky_room
                 splattercast.msg(f"SKY_ROOM_DEBUG: Reverse exit {reverse_exit[0].key} has sky_room: {sky_room_id}")
                 
                 if sky_room_id:
@@ -1639,7 +1639,7 @@ class CmdJump(Command):
     def get_fall_room_for_gap(self, intended_destination, exit_obj):
         """Get the fall room for a failed gap jump."""
         # Check if exit specifies a fall room
-        fall_room_id = getattr(exit_obj.db, "fall_room", None)
+        fall_room_id = exit_obj.db.fall_room
         if fall_room_id:
             # Convert string/int ID to actual room object
             if isinstance(fall_room_id, (str, int)):
@@ -1665,18 +1665,18 @@ class CmdJump(Command):
             splattercast.msg(f"JUMP_EDGE_BODYSHIELD_RESTORE: Restored bodyshield victim {grappled_victim.key} for fall damage calculation")
         
         # Get fall distance for story counting (stories = fall difficulty multiplier)
-        fall_distance = getattr(exit_obj.db, "fall_distance", None)
+        fall_distance = exit_obj.db.fall_distance
         if fall_distance is None:
             # If no fall_distance configured, use default
             fall_distance = 1  # Default 1 story
-        base_edge_difficulty = getattr(exit_obj.db, "edge_difficulty", 8)  # Base difficulty
+        base_edge_difficulty = exit_obj.db.edge_difficulty if exit_obj.db.edge_difficulty is not None else 8  # Base difficulty
         
         # Calculate landing difficulty based on fall distance
         # Each story adds difficulty - falling farther = harder to land safely
         landing_difficulty = base_edge_difficulty + (fall_distance * 2)  # +2 per story
         
         # Get fall damage (scaled by fall distance)
-        base_fall_damage = getattr(exit_obj.db, "fall_damage", 8)  # Base damage
+        base_fall_damage = exit_obj.db.fall_damage if exit_obj.db.fall_damage is not None else 8  # Base damage
         fall_damage = base_fall_damage * fall_distance  # Scale with distance
         
         splattercast.msg(f"JUMP_EDGE_FALL: {self.caller.key} falling {fall_distance} stories, landing difficulty:{landing_difficulty}, potential damage:{fall_damage}")
@@ -1708,7 +1708,7 @@ class CmdJump(Command):
             # Update fall damage based on actual distance fallen
             actual_fall_damage = base_fall_damage * actual_fall_distance
             if not success:
-                fall_room_id = getattr(exit_obj.db, "fall_room", None)
+                fall_room_id = exit_obj.db.fall_room
                 if fall_room_id:
                     if isinstance(fall_room_id, (str, int)):
                         fall_rooms = search_object(f"#{fall_room_id}")
@@ -1877,7 +1877,7 @@ class CmdJump(Command):
         
         while rooms_fallen < max_depth:
             # Check if this room is marked as ground level
-            if getattr(current_room.db, "is_ground", False):
+            if current_room.db.is_ground:
                 splattercast.msg(f"GRAVITY_GROUND: Found ground room {current_room.key} after {rooms_fallen} rooms")
                 return current_room, rooms_fallen
             
@@ -1924,7 +1924,7 @@ def apply_gravity_to_items(room):
     splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
     
     # Check if this is a sky room
-    is_sky_room = getattr(room.db, "is_sky_room", False)
+    is_sky_room = room.db.is_sky_room
     if not is_sky_room:
         splattercast.msg(f"GRAVITY_ITEMS: {room.key} is not a sky room, skipping gravity check")
         return  # Nothing to do if not a sky room

--- a/commands/shop.py
+++ b/commands/shop.py
@@ -190,7 +190,7 @@ class CmdBuy(Command):
         """
         # Check for merchant NPCs in the room
         for obj in buyer.location.contents:
-            if hasattr(obj, 'db') and getattr(obj.db, 'is_merchant', False):
+            if hasattr(obj, 'db') and obj.db.is_merchant:
                 # Found a merchant - send them a message
                 from world.shop.utils import format_currency
                 obj.msg(f"{buyer.get_display_name(obj)} purchases {item.get_display_name(obj)} for {format_currency(price)}.")

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1149,7 +1149,7 @@ class Character(ObjectParent, DefaultCharacter):
         # Clear death processing flags (both ndb and db)
         if hasattr(self.ndb, 'death_processed'):
             self.ndb.death_processed = False
-        if hasattr(self.db, 'death_processed'):
+        if self.db.death_processed is not None:
             del self.db.death_processed
         
         # Notify revival
@@ -1191,7 +1191,7 @@ class Character(ObjectParent, DefaultCharacter):
             None if valid target, or str with error message if invalid
         """
         # Holographic merchants cannot be attacked
-        if getattr(self.db, 'is_holographic', False):
+        if self.db.is_holographic:
             return "A holographic merchant cannot be attacked - target validation failed"
         
         # Character is a valid attack target
@@ -2066,7 +2066,7 @@ class Character(ObjectParent, DefaultCharacter):
             
         # Apply skintone coloring only if requested (for longdescs only)
         if apply_skintone:
-            skintone = getattr(self.db, 'skintone', None)
+            skintone = self.db.skintone
             if skintone:
                 from world.combat.constants import SKINTONE_PALETTE
                 color_code = SKINTONE_PALETTE.get(skintone)

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -21,7 +21,7 @@ class Corpse(Item):
         self.db.creation_time = time.time()
         
         # Preserve original descriptions for decay calculations
-        self.db.base_description = getattr(self.db, 'desc', '')
+        self.db.base_description = self.db.desc if self.db.desc is not None else ''
         self.db.base_longdesc = {}
         
         # Forensic data (set by death progression script)
@@ -146,12 +146,12 @@ class Corpse(Item):
         clothing_items = []
         for item in self.contents:
             # Check if item appears to be clothing (has coverage attribute)
-            if hasattr(item.db, 'coverage') and item.db.coverage:
+            if item.db.coverage:
                 clothing_items.append(item)
         
         # For each clothing item, map its coverage to body locations
         for item in clothing_items:
-            coverage = getattr(item.db, 'coverage', [])
+            coverage = item.db.coverage or []
             for location in coverage:
                 # Use outermost item (last one wins for now - could be enhanced)
                 coverage_map[location] = item
@@ -171,7 +171,7 @@ class Corpse(Item):
         wound_descriptions = []
         
         # Get preserved wound data
-        wounds_at_death = getattr(self.db, 'wounds_at_death', [])
+        wounds_at_death = self.db.wounds_at_death or []
         if not wounds_at_death:
             return wound_descriptions
         
@@ -216,7 +216,7 @@ class Corpse(Item):
         self._current_item_context = clothing_item
         
         # Try to get worn description first
-        worn_desc = getattr(clothing_item.db, 'worn_desc', None)
+        worn_desc = clothing_item.db.worn_desc
         if worn_desc:
             # Process template variables like living characters do
             processed_desc = self._process_corpse_description_variables(worn_desc)
@@ -240,7 +240,7 @@ class Corpse(Item):
             return self._apply_decay_to_description(corpse_desc)
         
         # Fallback to item description
-        item_desc = getattr(clothing_item.db, 'desc', None)
+        item_desc = clothing_item.db.desc
         if item_desc:
             # Process template variables
             processed_desc = self._process_corpse_description_variables(item_desc)
@@ -352,14 +352,14 @@ class Corpse(Item):
         processed_desc = description
         
         # Get preserved character data
-        original_gender = getattr(self.db, 'original_gender', 'neutral')
-        original_skintone = getattr(self.db, 'original_skintone', None)
+        original_gender = self.db.original_gender if self.db.original_gender is not None else 'neutral'
+        original_skintone = self.db.original_skintone
         
         # Process color templates FIRST (before other processing)
         if hasattr(self, '_current_item_context'):
             # If we have item context, use the item's color
             item = getattr(self, '_current_item_context', None)
-            if item and hasattr(item.db, 'color') and item.db.color:
+            if item and item.db.color:
                 # Get the proper color code from COLOR_DEFINITIONS
                 try:
                     from typeclasses.items import COLOR_DEFINITIONS

--- a/typeclasses/curtain_of_death.py
+++ b/typeclasses/curtain_of_death.py
@@ -272,7 +272,7 @@ class DeathCurtain:
         """Called when the animation completes."""
         # Send a single, vivid death message that incorporates the cause
         if self.location:
-            death_cause = getattr(self.character.db, 'death_cause', None)
+            death_cause = self.character.db.death_cause
             
             if death_cause:
                 # Create vivid death descriptions based on cause

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -497,17 +497,17 @@ class DeathProgressionScript(DefaultScript):
         corpse.db.original_character_dbref = character.dbref
         corpse.db.original_account_dbref = character.account.dbref if character.account else None
         corpse.db.death_time = time.time()
-        corpse.db.physical_description = getattr(character.db, 'desc', 'A person.')
+        corpse.db.physical_description = character.db.desc if character.db.desc is not None else 'A person.'
         
         # Preserve character appearance data for proper corpse display
         corpse.db.original_gender = getattr(character, 'gender', 'neutral')
-        corpse.db.original_skintone = getattr(character.db, 'skintone', None)
+        corpse.db.original_skintone = character.db.skintone
         
         # Transfer medical/death data if available
         if hasattr(character, 'medical_state') and character.medical_state:
             corpse.db.death_cause = character.get_death_cause()
             corpse.db.medical_conditions = character.medical_state.get_condition_summary()
-            corpse.db.blood_type = getattr(character.db, 'blood_type', 'unknown')
+            corpse.db.blood_type = character.db.blood_type if character.db.blood_type is not None else 'unknown'
             
             # Transfer wound data for corpse wound descriptions
             try:
@@ -690,7 +690,7 @@ class DeathProgressionScript(DefaultScript):
         
         # Archive the dead character (also handles any lingering sessions)
         character.archive_character(reason="death")
-        character.db.death_cause = getattr(character.db, 'death_cause', 'unknown')
+        character.db.death_cause = character.db.death_cause if character.db.death_cause is not None else 'unknown'
 
     def _initiate_new_character_creation(self, account, old_character, session):
         """Start the character creation process for the account after death."""

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -56,8 +56,8 @@ class Exit(DefaultExit):
         # --- SKY ROOM RESTRICTION CHECK ---
         # Block normal traversal to/from sky rooms - these are transit-only spaces
         # Exception: Allow jump command system to use sky rooms for aerial transit
-        current_room_is_sky = getattr(traversing_object.location.db, "is_sky_room", False)
-        target_room_is_sky = getattr(target_location.db, "is_sky_room", False)
+        current_room_is_sky = traversing_object.location.db.is_sky_room
+        target_room_is_sky = target_location.db.is_sky_room
         is_jump_movement = getattr(traversing_object.ndb, "jump_movement_allowed", False)
         
         if (current_room_is_sky or target_room_is_sky) and not is_jump_movement:
@@ -74,8 +74,8 @@ class Exit(DefaultExit):
         
         # --- EDGE/GAP RESTRICTION CHECK ---
         # Block normal traversal of edge and gap exits - these require jump command
-        is_edge = getattr(self.db, "is_edge", False)
-        is_gap = getattr(self.db, "is_gap", False)
+        is_edge = self.db.is_edge
+        is_gap = self.db.is_gap
         
         if is_edge or is_gap:
             if is_edge and is_gap:
@@ -179,7 +179,7 @@ class Exit(DefaultExit):
         handler = getattr(traversing_object.ndb, "combat_handler", None)
         is_being_dragged = False
         if handler:
-            combatants = getattr(handler.db, "combatants", None)
+            combatants = handler.db.combatants
             if combatants:
                 try:
                     is_being_dragged = any(e.get(DB_CHAR) == traversing_object and 
@@ -225,7 +225,7 @@ class Exit(DefaultExit):
 
         if handler:
             # Character is in combat - check if handler is still valid
-            combatants_list = getattr(handler.db, "combatants", None)
+            combatants_list = handler.db.combatants
             if combatants_list is None:
                 # Handler has been cleaned up but character still has reference
                 splattercast.msg(f"TRAVERSAL: {traversing_object.key} has stale combat_handler reference. Clearing and allowing move.")
@@ -359,7 +359,7 @@ class Exit(DefaultExit):
 
                 # No longer need to manually find and update entries here, as add_combatant handles it.
                 
-                new_handler_combatants = getattr(new_handler.db, "combatants", None)
+                new_handler_combatants = new_handler.db.combatants
                 if new_handler_combatants and len(new_handler_combatants) > 1 and not new_handler.is_active:
                     splattercast.msg(f"DRAG: New handler {new_handler.key} has {len(new_handler_combatants)} combatants, ensuring it starts if not already active.")
                     new_handler.start()
@@ -452,8 +452,8 @@ class Exit(DefaultExit):
             str: Atmospheric description or empty string
         """
         # Check for edge/gap exits first (specialized descriptions)
-        is_edge = getattr(self.db, "is_edge", False)
-        is_gap = getattr(self.db, "is_gap", False)
+        is_edge = self.db.is_edge
+        is_gap = self.db.is_gap
         
         if is_edge and is_gap:
             return "A jagged gap torn in reality, requiring a leap of faith to cross."

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -512,12 +512,12 @@ class Item(DefaultObject):
         Handles cleanup for remote detonator explosive tracking.
         """
         # If this item is an explosive scanned by a detonator, remove it from the detonator's list
-        if hasattr(self.db, 'scanned_by_detonator') and self.db.scanned_by_detonator:
+        if self.db.scanned_by_detonator:
             from evennia.utils.search import search_object
             detonator = search_object(f"#{self.db.scanned_by_detonator}")
             if detonator and len(detonator) > 0:
                 detonator_obj = detonator[0]
-                if hasattr(detonator_obj.db, 'scanned_explosives'):
+                if detonator_obj.db.scanned_explosives is not None:
                     try:
                         detonator_obj.db.scanned_explosives.remove(self.id)
                     except ValueError:
@@ -809,14 +809,14 @@ class RemoteDetonator(Item):
             return False, f"{explosive.key} is already scanned by this detonator."
         
         # Handle override: remove from previous detonator if any
-        if hasattr(explosive.db, 'scanned_by_detonator') and explosive.db.scanned_by_detonator:
+        if explosive.db.scanned_by_detonator:
             old_detonator_dbref = explosive.db.scanned_by_detonator
             from evennia.utils.search import search_object
             old_detonator = search_object(f"#{old_detonator_dbref}")
             
             if old_detonator and len(old_detonator) > 0:
                 old_det = old_detonator[0]
-                if hasattr(old_det.db, 'scanned_explosives'):
+                if old_det.db.scanned_explosives is not None:
                     try:
                         old_det.db.scanned_explosives.remove(explosive.id)
                     except ValueError:
@@ -852,7 +852,7 @@ class RemoteDetonator(Item):
         explosive = search_object(f"#{explosive_dbref}")
         if explosive and len(explosive) > 0:
             explosive_obj = explosive[0]
-            if hasattr(explosive_obj.db, 'scanned_by_detonator'):
+            if explosive_obj.db.scanned_by_detonator is not None:
                 explosive_obj.db.scanned_by_detonator = None
         
         return True
@@ -880,7 +880,7 @@ class RemoteDetonator(Item):
                 explosive = search_object(f"#{explosive_dbref}")
                 if explosive and len(explosive) > 0:
                     explosive_obj = explosive[0]
-                    if hasattr(explosive_obj.db, 'scanned_by_detonator'):
+                    if explosive_obj.db.scanned_by_detonator is not None:
                         explosive_obj.db.scanned_by_detonator = None
         
         super().at_delete()

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -294,11 +294,11 @@ class Room(ObjectParent, DefaultRoom):
                 continue
             
             # Check if item should be integrated
-            is_integrate = getattr(obj.db, "integrate", False)
+            is_integrate = obj.db.integrate
             
             if is_integrate:
                 # Regular @integrate objects use their configured priority
-                priority = getattr(obj.db, "integration_priority", 5)
+                priority = obj.db.integration_priority if obj.db.integration_priority is not None else 5
                 # Safety check: ensure priority is not None
                 if priority is None:
                     priority = 5
@@ -344,7 +344,7 @@ class Room(ObjectParent, DefaultRoom):
             str: Integration content for this object
         """
         # Check for sensory contributions (primary content source)
-        sensory_contributions = getattr(obj.db, "sensory_contributions", {})
+        sensory_contributions = obj.db.sensory_contributions or {}
         
         if sensory_contributions:
             # Collect available sensory content
@@ -367,12 +367,12 @@ class Room(ObjectParent, DefaultRoom):
                 return " ".join(content_parts)
         
         # Fall back to basic integration description if no sensory data
-        integration_desc = getattr(obj.db, "integration_desc", "")
+        integration_desc = obj.db.integration_desc if obj.db.integration_desc is not None else ""
         if integration_desc:
             return integration_desc
         
         # Last resort: use the object's short_desc or key
-        return getattr(obj.db, "integration_fallback", f"{obj.key} is here")
+        return obj.db.integration_fallback if obj.db.integration_fallback is not None else f"{obj.key} is here"
     
     def get_display_characters(self, looker, **kwargs):
         """
@@ -514,7 +514,7 @@ class Room(ObjectParent, DefaultRoom):
                  obj.is_typeclass("typeclasses.objects.GraffitiObject") or 
                  obj.is_typeclass("typeclasses.objects.BloodPool") or
                  obj.is_typeclass("typeclasses.shopkeeper.ShopContainer")) and 
-                getattr(obj.db, "integrate", False)):
+                obj.db.integrate):
                 continue
             
             # Skip objects the looker can't see
@@ -689,13 +689,13 @@ class Room(ObjectParent, DefaultRoom):
             if destination:
                 destination_is_sky = destination.is_sky_room
             
-            if destination_is_sky and not (getattr(exit_obj.db, "is_edge", False) or getattr(exit_obj.db, "is_gap", False)):
+            if destination_is_sky and not (exit_obj.db.is_edge or exit_obj.db.is_gap):
                 continue  # Skip pure sky rooms
             
             # Check for edge/gap first (highest priority)
-            if getattr(exit_obj.db, "is_edge", False):
+            if exit_obj.db.is_edge:
                 exit_groups['edges'].append((direction, alias))
-            elif getattr(exit_obj.db, "is_gap", False):
+            elif exit_obj.db.is_gap:
                 exit_groups['gaps'].append((direction, alias))
             # Check destination type
             elif destination and hasattr(destination, 'type') and destination.type:

--- a/world/combat/grappling.py
+++ b/world/combat/grappling.py
@@ -674,7 +674,7 @@ def validate_and_cleanup_grapple_state(handler):
     )
     
     splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-    combatants_list = list(getattr(handler.db, "combatants", []))
+    combatants_list = list(handler.db.combatants or [])
     cleanup_needed = False
     
     splattercast.msg(f"GRAPPLE_VALIDATE: Starting grapple state validation for handler {handler.key}")
@@ -778,7 +778,7 @@ def validate_and_cleanup_grapple_state(handler):
     if cleanup_needed:
         # Use the same pattern as set_target(): get fresh copy, apply changes, save back
         # Don't overwrite the entire list as it may contain mid-round target changes
-        fresh_combatants = getattr(handler.db, "combatants", [])
+        fresh_combatants = handler.db.combatants or []
         
         # Apply grapple cleanup changes to the fresh copy
         for modified_entry in combatants_list:
@@ -791,7 +791,7 @@ def validate_and_cleanup_grapple_state(handler):
                     fresh_entry[DB_GRAPPLING_DBREF] = modified_entry.get(DB_GRAPPLING_DBREF)
                     fresh_entry[DB_GRAPPLED_BY_DBREF] = modified_entry.get(DB_GRAPPLED_BY_DBREF)
         
-        setattr(handler.db, "combatants", fresh_combatants)
+        handler.db.combatants = fresh_combatants
         splattercast.msg(f"GRAPPLE_CLEANUP: Grapple state cleanup completed for handler {handler.key}. Changes saved.")
     else:
         splattercast.msg(f"GRAPPLE_VALIDATE: All grapple states valid for handler {handler.key}.")

--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -69,8 +69,8 @@ def get_or_create_combat(location):
 
     for handler_script in active_handlers:
         # Ensure it's our CombatHandler type and has managed_rooms
-        if hasattr(handler_script, "db") and hasattr(handler_script.db, DB_MANAGED_ROOMS):
-            if location in getattr(handler_script.db, DB_MANAGED_ROOMS, []):
+        if hasattr(handler_script, "db") and handler_script.db.managed_rooms is not None:
+            if location in (handler_script.db.managed_rooms or []):
                 splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_GET: Location {location.key} is already managed by active handler {handler_script.key} (on {handler_script.obj.key}). Returning it.")
                 return handler_script
     
@@ -81,10 +81,10 @@ def get_or_create_combat(location):
             if script.is_active: # Should have been caught by the loop above if it managed this location
                 splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_GET: Found active handler {script.key} directly on {location.key} (missed by global check or manages only self). Returning it.")
                 # Ensure it knows it manages this location
-                managed_rooms = getattr(script.db, DB_MANAGED_ROOMS, [])
+                managed_rooms = script.db.managed_rooms or []
                 if location not in managed_rooms:
                     managed_rooms.append(location)
-                    setattr(script.db, DB_MANAGED_ROOMS, managed_rooms)
+                    script.db.managed_rooms = managed_rooms
                 return script
             else:
                 splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_GET: Found inactive handler {script.key} on {location.key}. Attempting cleanup.")
@@ -150,13 +150,13 @@ class CombatHandler(DefaultScript):
         self.persistent = True
         
         # Initialize database attributes using constants
-        setattr(self.db, DB_COMBATANTS, [])
-        setattr(self.db, "round", 0)
-        setattr(self.db, DB_MANAGED_ROOMS, [self.obj])  # Initially manages only its host room
-        setattr(self.db, DB_COMBAT_RUNNING, False)
+        self.db.combatants = []
+        self.db.round = 0
+        self.db.managed_rooms = [self.obj]  # Initially manages only its host room
+        self.db.combat_is_running = False
         
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        managed_rooms = getattr(self.db, DB_MANAGED_ROOMS, [])
+        managed_rooms = self.db.managed_rooms or []
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_CREATE: New handler {self.key} created on {self.obj.key}, initially managing: {[r.key for r in managed_rooms]}. Combat logic initially not running.")
 
     def start(self):
@@ -171,18 +171,18 @@ class CombatHandler(DefaultScript):
 
         # Use super().is_active to check Evennia's ticker status
         evennia_ticker_is_active = super().is_active
-        combat_is_running = getattr(self.db, DB_COMBAT_RUNNING, False)
+        combat_is_running = self.db.combat_is_running
 
         if combat_is_running and evennia_ticker_is_active:
             splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_START: Handler {self.key} on {self.obj.key} - combat logic and Evennia ticker are already active. Skipping redundant start.")
             return
 
-        managed_rooms = getattr(self.db, DB_MANAGED_ROOMS, [])
+        managed_rooms = self.db.managed_rooms or []
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_START: Handler {self.key} on {self.obj.key} (managing {[r.key for r in managed_rooms]}) - ensuring combat logic is running and ticker is scheduled.")
         
         if not combat_is_running:
             splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_START_DETAIL: Setting {DB_COMBAT_RUNNING} = True for {self.key}.")
-            setattr(self.db, DB_COMBAT_RUNNING, True)
+            self.db.combat_is_running = True
         
         if not evennia_ticker_is_active:
             splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_START_DETAIL: Evennia ticker for {self.key} is not active (super().is_active=False). Calling force_repeat().")
@@ -210,7 +210,7 @@ class CombatHandler(DefaultScript):
         
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         
-        combat_was_running = getattr(self.db, DB_COMBAT_RUNNING, False)
+        combat_was_running = self.db.combat_is_running
         
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_{DEBUG_CLEANUP}: Handler {self.key} stopping combat logic. Was running: {combat_was_running}, cleanup_combatants: {cleanup_combatants}")
 
@@ -218,7 +218,7 @@ class CombatHandler(DefaultScript):
             self._cleanup_all_combatants()
         
         # Determine if we should delete the script BEFORE modifying db attributes
-        combatants = getattr(self.db, DB_COMBATANTS, [])
+        combatants = self.db.combatants or []
         should_delete_script = False
         if not combatants and self.pk:
             splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_{DEBUG_CLEANUP}: Handler {self.key} is empty and persistent. Marking for deletion.")
@@ -251,7 +251,7 @@ class CombatHandler(DefaultScript):
         
         # Only reach here if handler was NOT deleted
         # Now it's safe to modify db attributes (self.pk is still valid)
-        setattr(self.db, DB_COMBAT_RUNNING, False)
+        self.db.combat_is_running = False
         self.db.round = 0
         
         # Stop the ticker if the script is saved to the database
@@ -304,10 +304,10 @@ class CombatHandler(DefaultScript):
         Args:
             room_to_add: The room to add to managed rooms
         """
-        managed_rooms = getattr(self.db, DB_MANAGED_ROOMS, [])
+        managed_rooms = self.db.managed_rooms or []
         if room_to_add not in managed_rooms:
             managed_rooms.append(room_to_add)
-            setattr(self.db, DB_MANAGED_ROOMS, managed_rooms)
+            self.db.managed_rooms = managed_rooms
 
     def merge_handler(self, other_handler):
         """
@@ -332,8 +332,8 @@ class CombatHandler(DefaultScript):
             return
         
         # Get combatants from both handlers
-        our_combatants = getattr(self.db, DB_COMBATANTS, [])
-        their_combatants = getattr(other_handler.db, DB_COMBATANTS, [])
+        our_combatants = self.db.combatants or []
+        their_combatants = other_handler.db.combatants or []
         
         # Merge combatants lists
         for entry in their_combatants:
@@ -342,15 +342,15 @@ class CombatHandler(DefaultScript):
                 our_combatants.append(entry)
         
         # Merge managed rooms
-        our_rooms = getattr(self.db, DB_MANAGED_ROOMS, [])
-        their_rooms = getattr(other_handler.db, DB_MANAGED_ROOMS, [])
+        our_rooms = self.db.managed_rooms or []
+        their_rooms = other_handler.db.managed_rooms or []
         for room in their_rooms:
             if room not in our_rooms:
                 our_rooms.append(room)
         
         # Update our state
-        setattr(self.db, DB_COMBATANTS, our_combatants)
-        setattr(self.db, DB_MANAGED_ROOMS, our_rooms)
+        self.db.combatants = our_combatants
+        self.db.managed_rooms = our_rooms
         
         # CRITICAL FIX: Update ALL combatants' handler references after merge
         # This ensures both existing and newly merged combatants point to the correct handler
@@ -433,13 +433,13 @@ class CombatHandler(DefaultScript):
         Handles attacks, misses, deaths, and round progression across managed rooms.
         """
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        if not getattr(self.db, DB_COMBAT_RUNNING, False):
+        if not self.db.combat_is_running:
             splattercast.msg(f"AT_REPEAT: Handler {self.key} on {self.obj.key} combat logic is not running ({DB_COMBAT_RUNNING}=False). Returning.")
             return
 
         if not super().is_active:
              splattercast.msg(f"AT_REPEAT: Handler {self.key} on {self.obj.key} Evennia script.is_active=False. Marking {DB_COMBAT_RUNNING}=False and returning.")
-             setattr(self.db, DB_COMBAT_RUNNING, False)
+             self.db.combat_is_running = False
              return
 
         # Convert SaverList to regular list to avoid corruption during modifications
@@ -486,7 +486,7 @@ class CombatHandler(DefaultScript):
             self._active_combatants_list = combatants_list
 
         valid_combatants_entries = []
-        managed_rooms = getattr(self.db, DB_MANAGED_ROOMS, [])
+        managed_rooms = self.db.managed_rooms or []
         for entry in combatants_list:
             char = entry.get(DB_CHAR)
             if not char:
@@ -522,7 +522,7 @@ class CombatHandler(DefaultScript):
             else:
                 splattercast.msg(f"AT_REPEAT: Handler {self.key}. Waiting for combatants to join...")
                 # Save the list back before returning
-                setattr(self.db, DB_COMBATANTS, combatants_list)
+                self.db.combatants = combatants_list
                 self._active_combatants_list = None  # Clear active list tracking
                 return
 
@@ -756,7 +756,7 @@ class CombatHandler(DefaultScript):
                     # Validate target
                     is_action_target_valid = False
                     if action_target_char and any(e[DB_CHAR] == action_target_char for e in combatants_list):
-                        if action_target_char.location and action_target_char.location in getattr(self.db, DB_MANAGED_ROOMS, []):
+                        if action_target_char.location and action_target_char.location in (self.db.managed_rooms or []):
                             is_action_target_valid = True
                     
                     if not is_action_target_valid and action_target_char:
@@ -873,7 +873,7 @@ class CombatHandler(DefaultScript):
 
         # Check for dead or unconscious combatants after all attacks are processed
         # NOTE: Keep _active_combatants_list alive so remove_combatant can use it for auto-retargeting
-        remaining_combatants = getattr(self.db, DB_COMBATANTS, [])
+        remaining_combatants = self.db.combatants or []
         incapacitated_combatants = []
         
         for entry in remaining_combatants:
@@ -894,7 +894,7 @@ class CombatHandler(DefaultScript):
         self._active_combatants_list = None
 
         # Check if combat should continue
-        remaining_combatants = getattr(self.db, DB_COMBATANTS, [])
+        remaining_combatants = self.db.combatants or []
         if not remaining_combatants:
             splattercast.msg(f"AT_REPEAT: No combatants remain in handler {self.key}. Stopping.")
             self._active_combatants_list = None  # Clear active list tracking
@@ -920,7 +920,7 @@ class CombatHandler(DefaultScript):
         if active_list:
             combatants_list = active_list
         else:
-            combatants_list = getattr(self.db, DB_COMBATANTS, [])
+            combatants_list = self.db.combatants or []
         
         entry = next((e for e in combatants_list if e.get(DB_CHAR) == char), None)
         if entry:
@@ -935,7 +935,7 @@ class CombatHandler(DefaultScript):
         # 1. Get a copy of the combatants list
         # 2. Modify the copy
         # 3. Save the entire modified copy back
-        combatants = getattr(self.db, DB_COMBATANTS, [])
+        combatants = self.db.combatants or []
         db_entry = next((e for e in combatants if e.get(DB_CHAR) == char), None)
         
         if db_entry:
@@ -955,12 +955,12 @@ class CombatHandler(DefaultScript):
                     splattercast.msg(f"SET_TARGET: Updated both DB and active list for {char.key}")
             
             # Save the modified copy back (following utils.py pattern)
-            setattr(self.db, DB_COMBATANTS, combatants)
+            self.db.combatants = combatants
             
             if target:
                 splattercast.msg(f"SET_TARGET: {char.key} target changed from {old_target_dbref} to {new_target_dbref} ({target.key})")
                 # Verify the change was saved
-                verification_list = getattr(self.db, DB_COMBATANTS, [])
+                verification_list = self.db.combatants or []
                 verification_entry = next((e for e in verification_list if e.get(DB_CHAR) == char), None)
                 if verification_entry:
                     actual_dbref = verification_entry.get(DB_TARGET_DBREF)
@@ -997,7 +997,7 @@ class CombatHandler(DefaultScript):
         Check if two characters are targeting each other in active combat.
         Used to restore proximity after server reloads.
         """
-        combatants_list = getattr(self.db, DB_COMBATANTS, [])
+        combatants_list = self.db.combatants or []
         char1_entry = None
         char2_entry = None
         
@@ -1058,12 +1058,12 @@ class CombatHandler(DefaultScript):
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         
         # Validate that combat is still active
-        if not getattr(self.db, DB_COMBAT_RUNNING, False):
+        if not self.db.combat_is_running:
             splattercast.msg(f"DELAYED_ATTACK: Combat ended before {attacker.key}'s attack on {target.key} could execute.")
             return
             
         # Validate that both characters are still in combat
-        current_combatants = getattr(self.db, DB_COMBATANTS, [])
+        current_combatants = self.db.combatants or []
         attacker_still_in_combat = any(e.get(DB_CHAR) == attacker for e in current_combatants)
         target_still_in_combat = any(e.get(DB_CHAR) == target for e in current_combatants)
         
@@ -1115,7 +1115,7 @@ class CombatHandler(DefaultScript):
             return "blunt"  # Unarmed attacks are blunt trauma
         
         # Get damage_type from weapon, default to "blunt" if not specified
-        damage_type = getattr(weapon.db, 'damage_type', 'blunt')
+        damage_type = weapon.db.damage_type if weapon.db.damage_type is not None else 'blunt'
         return damage_type
 
     def _process_attack(self, attacker, target, attacker_entry, combatants_list):
@@ -1259,7 +1259,7 @@ class CombatHandler(DefaultScript):
             
             # Determine weapon type for messages
             weapon_type = "unarmed"
-            if weapon and hasattr(weapon, 'db') and hasattr(weapon.db, 'weapon_type'):
+            if weapon and hasattr(weapon, 'db') and weapon.db.weapon_type:
                 weapon_type = weapon.db.weapon_type
             
             # Apply damage first to determine if this is a killing blow
@@ -1331,7 +1331,7 @@ class CombatHandler(DefaultScript):
         else:
             # Miss - get miss messages from the message system
             weapon_type = "unarmed"
-            if weapon and hasattr(weapon, 'db') and hasattr(weapon.db, 'weapon_type'):
+            if weapon and hasattr(weapon, 'db') and weapon.db.weapon_type:
                 weapon_type = weapon.db.weapon_type
                 
             miss_messages = get_combat_message(weapon_type, "miss", attacker=attacker, target=target, item=weapon)
@@ -1540,7 +1540,7 @@ class CombatHandler(DefaultScript):
             return
         
         # Check if target is still in combat
-        combatants_list = getattr(self.db, DB_COMBATANTS, [])
+        combatants_list = self.db.combatants or []
         if not any(e[DB_CHAR] == target for e in combatants_list):
             char.msg(f"|r{target.key} is no longer in combat.|n")
             return
@@ -1581,7 +1581,7 @@ class CombatHandler(DefaultScript):
                 splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_ADVANCE: {char.key} failed to advance on {target.key}.")
         else:
             # Different room - check if it's a managed room and try to move there
-            managed_rooms = getattr(self.db, DB_MANAGED_ROOMS, [])
+            managed_rooms = self.db.managed_rooms or []
             target_room = target.location
             
             if target_room not in managed_rooms:
@@ -1810,7 +1810,7 @@ class CombatHandler(DefaultScript):
                 splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_CHARGE: {char.key} failed charge on {target.key}, penalty applied.")
         else:
             # Different room charge - move to target's room
-            managed_rooms = getattr(self.db, DB_MANAGED_ROOMS, [])
+            managed_rooms = self.db.managed_rooms or []
             if target.location not in managed_rooms:
                 char.msg(f"|r{target.key} is not in a room you can charge to.|n")
                 return
@@ -1924,7 +1924,7 @@ class CombatHandler(DefaultScript):
             char.msg(f"|r{target.key} is no longer in the same room.|n")
             return
         
-        combatants_list = getattr(self.db, "combatants", [])
+        combatants_list = self.db.combatants or []
         if not any(e["char"] == target for e in combatants_list):
             char.msg(f"|r{target.key} is no longer in combat.|n")
             return
@@ -1947,7 +1947,7 @@ class CombatHandler(DefaultScript):
         # Find weapon to disarm (prioritize weapons, then any held item)
         weapon_hand = None
         for hand, item in hands.items():
-            if item and hasattr(item.db, "weapon_type") and item.db.weapon_type:
+            if item and item.db.weapon_type:
                 weapon_hand = hand
                 break
         

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -285,7 +285,7 @@ def is_wielding_ranged_weapon(character):
     # Use the same hands detection logic as core_actions.py
     hands = getattr(character, "hands", {})
     for hand, weapon in hands.items():
-        if weapon and hasattr(weapon, 'db') and getattr(weapon.db, 'is_ranged', False):
+        if weapon and hasattr(weapon, 'db') and weapon.db.is_ranged:
             return True
     
     return False
@@ -325,11 +325,7 @@ def get_weapon_damage(weapon, default=0):
     if not weapon or not hasattr(weapon, 'db'):
         return default
     
-    damage = getattr(weapon.db, "damage", default)
-    
-    # Handle None explicitly since some weapons might have damage=None
-    if damage is None:
-        return default
+    damage = weapon.db.damage if weapon.db.damage is not None else default
     
     # Ensure it's numeric and non-negative
     if not isinstance(damage, (int, float)) or damage < 0:
@@ -594,7 +590,7 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
         target = None
     
     # Check if already in combat
-    combatants = getattr(handler.db, DB_COMBATANTS, [])
+    combatants = handler.db.combatants or []
     for entry in combatants:
         if entry.get(DB_CHAR) == char:
             splattercast.msg(f"ADD_COMB: {char.key} is already in combat.")
@@ -620,7 +616,7 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
     splattercast.msg(f"ADD_COMBATANT_ENTRY: {char.key} -> target_dbref={target_dbref}, initiative={entry['initiative']}")
     
     combatants.append(entry)
-    setattr(handler.db, DB_COMBATANTS, combatants)
+    handler.db.combatants = combatants
     
     # Set the character's handler reference
     setattr(char.ndb, NDB_COMBAT_HANDLER, handler)
@@ -644,7 +640,7 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
         splattercast.msg(f"ADD_COMB: Established proximity between {char.key} and grappler {initial_grappled_by.key}.")
     
     # Start combat if not already running
-    if not getattr(handler.db, DB_COMBAT_RUNNING, False):
+    if not handler.db.combat_is_running:
         handler.start()
     
     # Validate grapple state after adding new combatant
@@ -673,7 +669,7 @@ def remove_combatant(handler, char):
         combatants = active_list
         splattercast.msg(f"RMV_COMB: Using active working list with {len(combatants)} entries")
     else:
-        combatants = getattr(handler.db, DB_COMBATANTS, [])
+        combatants = handler.db.combatants or []
         splattercast.msg(f"RMV_COMB: Using database list with {len(combatants)} entries")
         
     entry = next((e for e in combatants if e.get(DB_CHAR) == char), None)
@@ -695,7 +691,7 @@ def remove_combatant(handler, char):
             # Attempt smart auto-retargeting: find someone who is actively attacking this character
             # For melee weapons, prioritize targets in proximity; for ranged weapons, any attacker is fine
             other_char_weapon = get_wielded_weapon(other_char)
-            other_char_is_ranged = other_char_weapon and hasattr(other_char_weapon, "db") and getattr(other_char_weapon.db, "is_ranged", False)
+            other_char_is_ranged = other_char_weapon and hasattr(other_char_weapon, "db") and other_char_weapon.db.is_ranged
             
             new_target = None
             proximity_attackers = []  # Attackers in proximity (for melee priority)
@@ -776,7 +772,7 @@ def remove_combatant(handler, char):
                     splattercast.msg(f"RMV_COMB: Updated working list for {other_char.key} -> target_dbref={other_char_entry_working['target_dbref']}")
                 
                 # Also update database to ensure persistence (same as attack command)
-                combatants_copy = getattr(handler.db, "combatants", [])
+                combatants_copy = handler.db.combatants or []
                 other_char_entry_copy = next((e for e in combatants_copy if e.get("char") == other_char), None)
                 if other_char_entry_copy:
                     other_char_entry_copy["target_dbref"] = get_character_dbref(new_target)
@@ -785,14 +781,14 @@ def remove_combatant(handler, char):
                     other_char_entry_copy["is_yielding"] = False
                     
                     # Save the modified combatants list back (same as attack command)
-                    setattr(handler.db, "combatants", combatants_copy)
+                    handler.db.combatants = combatants_copy
                     splattercast.msg(f"RMV_COMB: Updated database using attack command pattern for {other_char.key}")
                 
                 # Get weapon info for initiate message
                 from .messages import get_combat_message
                 weapon_obj = get_wielded_weapon(other_char)
                 weapon_type = "unarmed"
-                if weapon_obj and hasattr(weapon_obj, 'db') and hasattr(weapon_obj.db, 'weapon_type'):
+                if weapon_obj and hasattr(weapon_obj, 'db') and weapon_obj.db.weapon_type is not None:
                     weapon_type = weapon_obj.db.weapon_type
                 
                 # Send initiate messages (same as attack command)
@@ -832,7 +828,7 @@ def remove_combatant(handler, char):
     combatants[:] = [e for e in combatants if e.get(DB_CHAR) != char]
     
     # Always persist to database
-    setattr(handler.db, DB_COMBATANTS, combatants)
+    handler.db.combatants = combatants
     if active_list:
         splattercast.msg(f"RMV_COMB: Mutated active list in-place and synced to database")
     else:
@@ -913,7 +909,7 @@ def cleanup_all_combatants(handler):
     from .constants import DB_COMBATANTS, DB_CHAR, DEBUG_PREFIX_HANDLER, DEBUG_CLEANUP
     
     splattercast = get_splattercast()
-    combatants = getattr(handler.db, DB_COMBATANTS, [])
+    combatants = handler.db.combatants or []
     
     for entry in combatants:
         char = entry.get(DB_CHAR)
@@ -921,7 +917,7 @@ def cleanup_all_combatants(handler):
             cleanup_combatant_state(char, entry, handler)
     
     # Clear the combatants list
-    setattr(handler.db, DB_COMBATANTS, [])
+    handler.db.combatants = []
     splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_{DEBUG_CLEANUP}: All combatants cleaned up for {handler.key}.")
 
 
@@ -959,7 +955,7 @@ def update_all_combatant_handler_references(handler):
     from .constants import SPLATTERCAST_CHANNEL, DB_COMBATANTS, DB_CHAR, NDB_COMBAT_HANDLER
     
     splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-    combatants = getattr(handler.db, DB_COMBATANTS, [])
+    combatants = handler.db.combatants or []
     
     updated_count = 0
     for entry in combatants:
@@ -991,11 +987,11 @@ def validate_character_handler_reference(char):
     # Check if handler still exists and is valid
     try:
         # Try to access handler attributes to verify it's still valid
-        if not hasattr(handler, 'db') or not hasattr(handler.db, 'combatants'):
+        if not hasattr(handler, 'db') or handler.db.combatants is None:
             return False, None, "Handler missing required attributes"
         
         # Check if character is actually in the handler's combatants list
-        combatants = getattr(handler.db, 'combatants', [])
+        combatants = handler.db.combatants or []
         char_in_handler = any(entry.get('char') == char for entry in combatants)
         
         if not char_in_handler:
@@ -1035,7 +1031,7 @@ def get_combatants_safe(handler):
     """
     from .constants import DB_COMBATANTS, SPLATTERCAST_CHANNEL, DEBUG_PREFIX_HANDLER
     
-    combatants = getattr(handler.db, DB_COMBATANTS, [])
+    combatants = handler.db.combatants
     if combatants is None:
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_WARNING: {DB_COMBATANTS} was None for handler {handler.key}, initializing to empty list.")
@@ -1043,7 +1039,7 @@ def get_combatants_safe(handler):
         # Only set the attribute if the handler has been saved to the database
         # Otherwise we get "needs to have a value for field 'id'" errors
         if hasattr(handler, 'id') and handler.id:
-            setattr(handler.db, DB_COMBATANTS, combatants)
+            handler.db.combatants = combatants
         else:
             splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_WARNING: Handler {handler.key} not yet saved to DB, cannot set {DB_COMBATANTS}.")
     return combatants
@@ -1097,7 +1093,7 @@ def detect_and_remove_orphaned_combatants(handler):
     )
     
     splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-    combatants = getattr(handler.db, DB_COMBATANTS, [])
+    combatants = handler.db.combatants or []
     orphaned_chars = []
     
     if not combatants:
@@ -1162,7 +1158,7 @@ def resolve_bonus_attack(handler, attacker, target):
     splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
     
     # Find the attacker's combat entry
-    combatants_list = getattr(handler.db, DB_COMBATANTS, [])
+    combatants_list = handler.db.combatants or []
     attacker_entry = next((e for e in combatants_list if e.get(DB_CHAR) == attacker), None)
     
     if not attacker_entry:
@@ -1215,7 +1211,7 @@ def check_grenade_human_shield(proximity_list, combat_handler=None):
         return damage_modifiers
     
     # Get current combatants list for grapple state checking
-    combatants_list = getattr(combat_handler.db, DB_COMBATANTS, [])
+    combatants_list = combat_handler.db.combatants or []
     
     for char in proximity_list:
         # Find this character's combat entry
@@ -1303,23 +1299,23 @@ def calculate_stick_chance(grenade, armor):
         return 0
     
     # Get grenade magnetic strength (default 5 if not set)
-    magnetic_strength = getattr(grenade.db, 'magnetic_strength', 5)
+    magnetic_strength = grenade.db.magnetic_strength if grenade.db.magnetic_strength is not None else 5
     
     # Get armor base properties (default 0 if not set)
-    metal_level = getattr(armor.db, 'metal_level', 0)
-    magnetic_level = getattr(armor.db, 'magnetic_level', 0)
+    metal_level = armor.db.metal_level if armor.db.metal_level is not None else 0
+    magnetic_level = armor.db.magnetic_level if armor.db.magnetic_level is not None else 0
     
     # PLATE CARRIER CHECK: If this is a plate carrier, check installed plates
-    is_plate_carrier = getattr(armor.db, 'is_plate_carrier', False)
+    is_plate_carrier = armor.db.is_plate_carrier
     if is_plate_carrier:
-        installed_plates = getattr(armor.db, 'installed_plates', {})
+        installed_plates = armor.db.installed_plates or {}
         
         # Check all installed plates and use highest metal/magnetic values
         for slot, plate_ref in installed_plates.items():
             if plate_ref:
                 # Get plate properties
-                plate_metal = getattr(plate_ref.db, 'metal_level', 0)
-                plate_magnetic = getattr(plate_ref.db, 'magnetic_level', 0)
+                plate_metal = plate_ref.db.metal_level if plate_ref.db.metal_level is not None else 0
+                plate_magnetic = plate_ref.db.magnetic_level if plate_ref.db.magnetic_level is not None else 0
                 
                 # Use highest values between carrier and plates
                 metal_level = max(metal_level, plate_metal)
@@ -1475,9 +1471,9 @@ def establish_stick(grenade, armor, hit_location):
         return False
     
     # Break any existing stick first
-    if hasattr(grenade.db, 'stuck_to_armor') and grenade.db.stuck_to_armor:
+    if grenade.db.stuck_to_armor:
         old_armor = grenade.db.stuck_to_armor
-        if old_armor and hasattr(old_armor.db, 'stuck_grenade'):
+        if old_armor and old_armor.db.stuck_grenade is not None:
             old_armor.db.stuck_grenade = None
     
     # Establish new stick - grenade moves to armor
@@ -1530,9 +1526,9 @@ def get_stuck_grenades_on_character(character):
             continue
         
         # Check if this item has a stuck grenade
-        if hasattr(item.db, 'stuck_grenade') and item.db.stuck_grenade:
+        if item.db.stuck_grenade:
             grenade = item.db.stuck_grenade
-            location = getattr(grenade.db, 'stuck_to_location', 'unknown')
+            location = grenade.db.stuck_to_location if grenade.db.stuck_to_location is not None else 'unknown'
             stuck_grenades.append((grenade, item, location))
             
             debug_broadcast(
@@ -1577,12 +1573,12 @@ def get_outermost_armor_at_location(character, hit_location):
             continue
         
         # Check if item covers this location
-        coverage = getattr(item.db, 'coverage', [])
+        coverage = item.db.coverage or []
         if not coverage or hit_location not in coverage:
             continue
         
         # Check layer
-        layer = getattr(item.db, 'layer', 0)
+        layer = item.db.layer if item.db.layer is not None else 0
         if layer > highest_layer:
             highest_layer = layer
             outermost_armor = item
@@ -1625,14 +1621,14 @@ def break_stick(grenade):
         return False
     
     # Check if grenade is stuck
-    if not hasattr(grenade.db, 'stuck_to_armor') or not grenade.db.stuck_to_armor:
+    if not grenade.db.stuck_to_armor:
         return False
     
     armor = grenade.db.stuck_to_armor
-    location = getattr(grenade.db, 'stuck_to_location', 'unknown')
+    location = grenade.db.stuck_to_location if grenade.db.stuck_to_location is not None else 'unknown'
     
     # Clear armor's reference to grenade
-    if armor and hasattr(armor.db, 'stuck_grenade'):
+    if armor and armor.db.stuck_grenade is not None:
         armor.db.stuck_grenade = None
     
     # Clear grenade's references

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -44,7 +44,7 @@ class MedicalCondition:
         
         # Don't add conditions to archived characters (permanently dead)
         # Dying characters can still be resuscitated, so they should keep conditions
-        if getattr(character.db, 'archived', False):
+        if character.db.archived:
             splattercast.msg(f"CONDITION_START: {character.key} is archived, not adding {self.condition_type}")
             return
         

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -584,7 +584,7 @@ class MedicalState:
         # Don't add conditions if character is archived (permanently dead)
         # Dying characters can still be resuscitated, so they should keep conditions
         character = self._get_character_reference()
-        if character and getattr(character.db, 'archived', False):
+        if character and character.db.archived:
             try:
                 from world.combat.constants import SPLATTERCAST_CHANNEL
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
@@ -725,7 +725,7 @@ class MedicalState:
                 medical_state.conditions.append(condition)
                 # Re-start condition ticker if character is available and not archived
                 # Archived characters are permanently dead; dying characters can still be resuscitated
-                if character and not getattr(character.db, 'archived', False):
+                if character and not character.db.archived:
                     condition.start_condition(character)
                     
             except Exception as e:

--- a/world/medical/wounds/longdesc_hooks.py
+++ b/world/medical/wounds/longdesc_hooks.py
@@ -195,7 +195,7 @@ def _create_compound_wound_description_for_location(location, wounds, character=
     # Determine if we need skintone coloring
     skintone_color = ""
     if character and fresh_count == 0:  # No fresh wounds, use skintone
-        skintone = getattr(character.db, 'skintone', None)
+        skintone = character.db.skintone
         if skintone:
             try:
                 from world.combat.constants import SKINTONE_PALETTE

--- a/world/medical/wounds/longdesc_integration.py
+++ b/world/medical/wounds/longdesc_integration.py
@@ -198,7 +198,7 @@ def update_character_longdesc_with_wounds(character):
     # 5. Preserve other longdesc content
     
     # For now, store wound display for testing
-    if hasattr(character.db, 'wound_display'):
+    if character.db.wound_display is not None:
         character.db.wound_display = wound_display
     
     return True
@@ -219,7 +219,7 @@ def remove_all_wound_descriptions(character):
     # This would remove all wound-related text from the longdesc
     
     # For now, clear stored wound display
-    if hasattr(character.db, 'wound_display'):
+    if character.db.wound_display is not None:
         character.db.wound_display = ""
     
     return True

--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -61,7 +61,7 @@ def get_wound_description(injury_type, location, severity="Moderate", stage="fre
     
     # Add skintone if character provided and stage requires it
     if character and stage in ["treated", "healing", "scarred"]:
-        skintone = getattr(character.db, 'skintone', None)
+        skintone = character.db.skintone
         if skintone:
             try:
                 from world.combat.constants import SKINTONE_PALETTE

--- a/world/shop/utils.py
+++ b/world/shop/utils.py
@@ -130,7 +130,7 @@ def validate_purchase(buyer, price):
         ...     character.msg(msg)
         ...     return
     """
-    buyer_tokens = getattr(buyer.db, "tokens", 0)
+    buyer_tokens = buyer.db.tokens if buyer.db.tokens is not None else 0
     
     if buyer_tokens < price:
         shortage = price - buyer_tokens
@@ -150,7 +150,7 @@ def deduct_tokens(character, amount):
     Returns:
         bool: True if successful, False if insufficient funds
     """
-    current = getattr(character.db, "tokens", 0)
+    current = character.db.tokens if character.db.tokens is not None else 0
     if current < amount:
         return False
     character.db.tokens = current - amount
@@ -165,5 +165,5 @@ def add_tokens(character, amount):
         character: Character object
         amount (int): Amount to add
     """
-    current = getattr(character.db, "tokens", 0)
+    current = character.db.tokens if character.db.tokens is not None else 0
     character.db.tokens = current + amount


### PR DESCRIPTION
## Summary

Fixes #29

- Replaces ~290 instances of `hasattr()`/`getattr()`/`setattr()` on `obj.db` with idiomatic Evennia direct attribute access across 27 files
- Evennia's `db` handler returns `None` for missing attributes, making these Python builtins unnecessary and potentially misleading
- Preserves valid `hasattr(obj, 'db')` checks (which test whether the object itself has a db handler)

## Transformation rules applied

| Pattern | Replacement |
|---------|-------------|
| `hasattr(x.db, 'attr')` | `x.db.attr is not None` |
| `hasattr(x.db, 'attr') and x.db.attr` | `x.db.attr` |
| `getattr(x.db, 'attr', None)` | `x.db.attr` |
| `getattr(x.db, 'attr', False)` (boolean ctx) | `x.db.attr` |
| `getattr(x.db, 'attr', 0)` | `x.db.attr if x.db.attr is not None else 0` |
| `getattr(x.db, 'attr', [])` | `x.db.attr or []` |
| `getattr(x.db, 'attr', 'default')` | `x.db.attr if x.db.attr is not None else 'default'` |
| `setattr(x.db, 'attr', val)` | `x.db.attr = val` |

## Files changed (27)

**commands/** (11 files): CmdAdmin, CmdArmor, CmdCharacter, CmdClothing, CmdGraffiti, CmdInventory, CmdMedical, CmdThrow, shop, combat/core_actions, combat/movement

**typeclasses/** (7 files): characters, corpse, curtain_of_death, death_progression, exits, items, rooms

**world/** (9 files): combat/grappling, combat/handler, combat/utils, medical/conditions, medical/core, medical/wounds/longdesc_hooks, medical/wounds/longdesc_integration, medical/wounds/wound_descriptions, shop/utils