### PR TITLE
Fix web security issues

### DIFF
--- a/commands/unloggedin_email.py
+++ b/commands/unloggedin_email.py
@@ -37,20 +37,16 @@ class CmdEmailConnect(MuxCommand):
         email = arglist[0].lower().strip()
         password = arglist[1]
 
-        # Look up account by email
+        # Look up account by email and verify password.
+        # Use a generic error message for both "no account" and "wrong password"
+        # to prevent user enumeration attacks.
         try:
             account = AccountDB.objects.filter(email__iexact=email).first()
         except AccountDB.DoesNotExist:
             account = None
-        
-        if not account:
-            session.msg(f"No account found with email '{email}'.")
-            session.msg("Use 'create' to make a new account.")
-            return
-            
-        # Verify password
-        if not account.check_password(password):
-            session.msg("Incorrect password.")
+
+        if not account or not account.check_password(password):
+            session.msg("Invalid email or password.")
             return
 
         # Check IP and/or name bans

--- a/server/conf/mssp.py
+++ b/server/conf/mssp.py
@@ -20,23 +20,23 @@ needed on the Evennia side.
 
 MSSPTable = {
     # Required fields
-    "NAME": "Mygame",  # usually the same as SERVERNAME
+    "NAME": "Gelatinous Monster",
     # Generic
     "CRAWL DELAY": "-1",  # limit how often crawler may update the listing. -1 for no limit
-    "HOSTNAME": "",  # telnet hostname
-    "PORT": ["4000"],  # telnet port - most important port should be *last* in list!
+    "HOSTNAME": "play.gel.monster",  # telnet hostname
+    "PORT": ["23"],  # telnet port - most important port should be *last* in list!
     "CODEBASE": "Evennia",
     "CONTACT": "",  # email for contacting the mud
     "CREATED": "",  # year MUD was created
     "ICON": "",  # url to icon 32x32 or larger; <32kb.
     "IP": "",  # current or new IP address
-    "LANGUAGE": "",  # name of language used, e.g. English
+    "LANGUAGE": "English",  # name of language used, e.g. English
     "LOCATION": "",  # full English name of server country
     "MINIMUM AGE": "0",  # set to 0 if not applicable
-    "WEBSITE": "",  # http:// address to your game website
+    "WEBSITE": "https://gel.monster",  # http:// address to your game website
     # Categorisation
     "FAMILY": "Evennia",
-    "GENRE": "None",  # Adult, Fantasy, Historical, Horror, Modern, None, or Science Fiction
+    "GENRE": "Science Fiction",  # Adult, Fantasy, Historical, Horror, Modern, None, or Science Fiction
     # Gameplay: Adventure, Educational, Hack and Slash, None,
     # Player versus Player, Player versus Environment,
     # Roleplaying, Simulation, Social or Strategy
@@ -45,7 +45,7 @@ MSSPTable = {
     "GAMESYSTEM": "Custom",  # D&D, d20 System, World of Darkness, etc. Use Custom if homebrew
     # Subgenre: LASG, Medieval Fantasy, World War II, Frankenstein,
     # Cyberpunk, Dragonlance, etc. Or None if not applicable.
-    "SUBGENRE": "None",
+    "SUBGENRE": "Cyberpunk",
     # World
     "AREAS": "0",
     "HELPFILES": "0",
@@ -96,9 +96,9 @@ MSSPTable = {
     "PLAYER GUILDS": "0",
     "EQUIPMENT SYSTEM": "None",  # "None", "Level", "Skill", "Both"
     "MULTIPLAYING": "None",  # "None", "Restricted", "Full"
-    "PLAYERKILLING": "None",  # "None", "Restricted", "Full"
+    "PLAYERKILLING": "Full",  # "None", "Restricted", "Full"
     "QUEST SYSTEM": "None",  # "None", "Immortal Run", "Automated", "Integrated"
-    "ROLEPLAYING": "None",  # "None", "Accepted", "Encouraged", "Enforced"
+    "ROLEPLAYING": "Enforced",  # "None", "Accepted", "Encouraged", "Enforced"
     "TRAINING SYSTEM": "None",  # "None", "Level", "Skill", "Both"
     # World originality: "All Stock", "Mostly Stock", "Mostly Original", "All Original"
     "WORLD ORIGINALITY": "All Original",

--- a/web/templates/website/header_only.html
+++ b/web/templates/website/header_only.html
@@ -74,13 +74,17 @@ Uses iframe-specific menu that removes Forum link to prevent double headers.
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
     
     <script>
-        // Send height updates to parent iframe for responsive sizing
+        // Send height updates to parent iframe for responsive sizing.
+        // Target origin is restricted to the configured Discourse URL
+        // to prevent leaking auth state to arbitrary embedding domains.
+        const TARGET_ORIGIN = '{{ discourse_url|default:"" }}';
         function updateHeight() {
+            if (!TARGET_ORIGIN) return;  // Don't post if no origin configured
             const height = document.body.scrollHeight;
             window.parent.postMessage({
                 type: 'gel-header-height',
                 height: height
-            }, '*');
+            }, TARGET_ORIGIN);
         }
         
         // Send height on load and when window resizes

--- a/web/website/urls.py
+++ b/web/website/urls.py
@@ -8,6 +8,7 @@ so it can reroute to all website pages.
 
 from django.urls import path
 from django.views.generic import RedirectView, TemplateView
+from django.conf import settings
 
 from evennia.web.website.urls import urlpatterns as evennia_website_urlpatterns
 from web.website.views.characters import (
@@ -30,8 +31,11 @@ urlpatterns = [
     # robots.txt - served as plain text for search engine crawlers
     path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain"), name="robots-txt"),
 
-    # Forum redirect - gel.monster/forum/ -> forum.gel.monster
-    path("forum/", RedirectView.as_view(url="https://forum.gel.monster", permanent=False), name="forum-redirect"),
+    # Forum redirect - uses DISCOURSE_URL from settings, falls back to homepage
+    path("forum/", RedirectView.as_view(
+        url=getattr(settings, 'DISCOURSE_URL', '') or '/',
+        permanent=False,
+    ), name="forum-redirect"),
     
     # Header-only endpoint for iframe embedding (optional - for forum integration)
     path("header-only/", header_only, name="header-only"),

--- a/web/website/views/discourse_logout.py
+++ b/web/website/views/discourse_logout.py
@@ -15,7 +15,9 @@ SETUP INSTRUCTIONS:
    https://yoursite.com/sso/discourse/logout/
 
 SECURITY:
+- Requires authentication (anonymous requests are ignored)
 - Validates Referer header to prevent logout CSRF attacks
+- Rejects requests with missing Referer when DISCOURSE_URL is configured
 - CSRF-exempt is required per DiscourseConnect spec (simple GET redirect)
 - Only logs out current session (non-destructive)
 
@@ -37,44 +39,61 @@ from django.conf import settings
 def discourse_logout(request):
     """
     Official DiscourseConnect logout endpoint.
-    
+
     Called by Discourse's logout_redirect setting when a user logs out.
     Logs out the Django session and redirects to configured landing page.
-    
+
     This follows the standard DiscourseConnect logout flow as documented
     in the official Discourse SSO documentation.
-    
-    Security: Checks Referer header to prevent logout CSRF attacks.
-    
+
+    Security:
+        - Only processes logout for authenticated users
+        - Validates Referer header against DISCOURSE_URL
+        - Rejects requests with missing or mismatched Referer
+
     Configuration:
         DISCOURSE_URL (required): Your Discourse forum URL
         DISCOURSE_LOGOUT_REDIRECT (optional): Where to redirect after logout
     """
+    redirect_url = getattr(settings, 'DISCOURSE_LOGOUT_REDIRECT', '/')
+
+    # If user is not authenticated, just redirect — nothing to log out
+    if not request.user.is_authenticated:
+        return redirect(redirect_url)
+
     # Verify request is coming from configured Discourse forum
     # This prevents malicious sites from forcing users to logout via embedded links
     referer = request.META.get('HTTP_REFERER', '')
-    discourse_url = getattr(settings, 'DISCOURSE_URL', None)
-    
-    if not discourse_url:
-        # If DISCOURSE_URL is not configured, log a warning but allow logout
-        # This makes the endpoint fail-safe rather than fail-closed
+    discourse_url = getattr(settings, 'DISCOURSE_URL', '')
+
+    if discourse_url:
+        # Require a valid Referer from the configured Discourse instance.
+        # A missing Referer is rejected because attackers can trivially strip
+        # it (e.g. <meta name="referrer" content="no-referrer">).
+        if not referer or not referer.startswith(discourse_url):
+            return HttpResponseForbidden(
+                "Invalid logout request. "
+                "Please log out through your account page."
+            )
+    else:
+        # DISCOURSE_URL not configured — refuse to process the logout.
+        # Fail-closed: without a URL to validate against, we can't verify
+        # the request origin.
         try:
             from evennia.utils import logger
             logger.log_warn(
                 "DISCOURSE_URL not configured in settings. "
-                "Set DISCOURSE_URL in your Django settings for Referer validation."
+                "Discourse logout endpoint is non-functional until configured."
             )
         except ImportError:
-            pass  # Not in an Evennia environment
-    elif referer and not referer.startswith(discourse_url):
-        # Referer exists but doesn't match our Discourse forum
+            pass
         return HttpResponseForbidden(
-            "Invalid logout request. Please log out through your account page."
+            "Discourse logout is not configured. "
+            "Please log out through your account page."
         )
-    
+
     # Log the user out of Django
     logout(request)
-    
+
     # Redirect to configured landing page (default: home page)
-    redirect_url = getattr(settings, 'DISCOURSE_LOGOUT_REDIRECT', '/')
     return redirect(redirect_url)

--- a/web/website/views/discourse_session_sync.py
+++ b/web/website/views/discourse_session_sync.py
@@ -30,8 +30,8 @@ from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
 
 
-@require_http_methods(["GET"])
 @login_required
+@require_http_methods(["GET"])
 def discourse_session_sync(request):
     """
     Redirect logged-in Django user to Discourse to establish session.
@@ -47,8 +47,13 @@ def discourse_session_sync(request):
     Returns:
         HttpResponseRedirect: Redirect to Discourse SSO endpoint
     """
-    discourse_url = getattr(settings, 'DISCOURSE_URL', 'https://forum.gel.monster')
-    
+    discourse_url = getattr(settings, 'DISCOURSE_URL', '')
+
+    if not discourse_url:
+        # DISCOURSE_URL not configured — redirect home instead of to a
+        # hardcoded external domain.
+        return HttpResponseRedirect('/')
+
     # Redirect to Discourse's SSO endpoint
     # Discourse will then initiate the SSO flow back to our discourse_sso view
     sso_url = f"{discourse_url}/session/sso"

--- a/web/website/views/discourse_sso.py
+++ b/web/website/views/discourse_sso.py
@@ -77,8 +77,8 @@ def sign_payload(payload):
     ).hexdigest()
 
 
-@require_http_methods(["GET"])
 @login_required
+@require_http_methods(["GET"])
 def discourse_sso(request):
     """
     Handle SSO authentication request from Discourse.

--- a/web/website/views/header_only.py
+++ b/web/website/views/header_only.py
@@ -10,22 +10,23 @@ This endpoint is optional and only useful if you're embedding the header elsewhe
 
 from django.shortcuts import render
 from django.views.decorators.cache import cache_control
+from django.conf import settings
 
 
 @cache_control(max_age=300, private=True)  # Cache for 5 minutes, private to prevent shared cache leaking auth state
 def header_only(request):
     """
     Render just the navbar for iframe embedding on external sites.
-    
+
     This minimal view provides the Django header with full functionality
     (authentication state, dropdowns, etc.) without page chrome.
-    
+
     The header detects it's in an iframe context and adjusts link behavior
     to prevent navigation issues.
-    
+
     Cache is set to 5 minutes to improve load performance while still
     reflecting authentication state changes reasonably quickly.
-    
+
     Optional: Only useful if you're embedding the header elsewhere (e.g., forum).
     """
     context = {
@@ -36,6 +37,7 @@ def header_only(request):
         'register_enabled': True,
         'rest_api_enabled': request.user.is_staff if request.user.is_authenticated else False,
         'is_iframe': True,  # Signal to template that this is iframe context
+        'discourse_url': getattr(settings, 'DISCOURSE_URL', ''),
     }
-    
+
     return render(request, 'website/header_only.html', context)

--- a/web/website/views/logout_with_discourse.py
+++ b/web/website/views/logout_with_discourse.py
@@ -34,10 +34,10 @@ def get_discourse_user_id(user):
     Get Discourse user ID for a Django user.
     For DiscourseConnect, this is the external_id which is the Django user ID.
     """
-    discourse_url = getattr(settings, 'DISCOURSE_URL', 'https://forum.gel.monster')
+    discourse_url = getattr(settings, 'DISCOURSE_URL', '')
     api_key = getattr(settings, 'DISCOURSE_API_KEY', None)
-    
-    if not api_key:
+
+    if not discourse_url or not api_key:
         return None
     
     # Use the by-external endpoint to find user by Django user ID
@@ -66,12 +66,12 @@ def logout_discourse_user(discourse_user_id):
     if not discourse_user_id:
         return False
     
-    discourse_url = getattr(settings, 'DISCOURSE_URL', 'https://forum.gel.monster')
+    discourse_url = getattr(settings, 'DISCOURSE_URL', '')
     api_key = getattr(settings, 'DISCOURSE_API_KEY', None)
-    
-    if not api_key:
+
+    if not discourse_url or not api_key:
         return False
-    
+
     url = f"{discourse_url}/admin/users/{discourse_user_id}/log_out"
     headers = {
         'Api-Key': api_key,
@@ -86,8 +86,8 @@ def logout_discourse_user(discourse_user_id):
         return False
 
 
-@require_http_methods(["GET", "POST"])
 @login_required
+@require_http_methods(["GET", "POST"])
 def logout_with_discourse(request):
     """
     Log out from Django and optionally from Discourse.


### PR DESCRIPTION
## Summary

Fixes #30

Addresses security issues in the web layer affecting authentication, session management, and information disclosure.

## Changes

### High Priority
- **Logout CSRF hardened** (`discourse_logout.py`): Reject requests with missing Referer header (attackers can strip it trivially), require authentication before processing logout, fail-closed when `DISCOURSE_URL` is not configured
- **Header iframe postMessage restricted** (`header_only.html`, `header_only.py`): Target origin changed from wildcard `'*'` to the configured `DISCOURSE_URL`, preventing arbitrary embedding domains from receiving auth state
- **Telnet user enumeration fixed** (`unloggedin_email.py`): Combined "no account" and "wrong password" into generic "Invalid email or password" message

### Medium Priority
- **Hardcoded Discourse URLs removed**: Replaced `'https://forum.gel.monster'` fallback defaults in `logout_with_discourse.py`, `discourse_session_sync.py`, and `urls.py` with `settings.DISCOURSE_URL` lookups (empty string default, fail gracefully)

### Low Priority
- **Decorator ordering fixed** (`discourse_sso.py`, `logout_with_discourse.py`, `discourse_session_sync.py`): `@login_required` now wraps `@require_http_methods` so unauthenticated requests get a login redirect instead of HTTP 405
- **MSSP metadata updated** (`mssp.py`): NAME → "Gelatinous Monster", HOSTNAME → "play.gel.monster", PORT → 23, GENRE → "Science Fiction", SUBGENRE → "Cyberpunk", WEBSITE → "https://gel.monster"

## Not addressed (out of scope)
- Rate limiting on login/registration (requires middleware or external tooling)
- `ALLOWED_HOSTS` with infrastructure hostnames (lives in `secret_settings.py`)
- Email enumeration on `create` command (MUD users expect to be told if email is taken)