### PR TITLE
Code quality improvements

### DIFF
--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -1,5 +1,6 @@
 from evennia import Command
 from evennia.utils.search import search_object
+from evennia.utils import delay
 from world.combat.messages import get_combat_message
 from evennia.comms.models import ChannelDB
 from world.weather import weather_system
@@ -397,16 +398,7 @@ class CmdTestDeath(Command):
                 # Import condition classes
                 from world.medical.conditions import ConsciousnessSuppressionCondition, PainCondition, BleedingCondition
                 
-                def delayed_message(func, delay_time):
-                    """Helper to delay message functions"""
-                    import time
-                    import threading
-                    def delayed_func():
-                        time.sleep(delay_time)
-                        func()
-                    thread = threading.Thread(target=delayed_func)
-                    thread.daemon = True
-                    thread.start()
+                # Use Evennia's delay() for Twisted-safe deferred execution
                 
                 # Create a fatal combination using consciousness suppression and moderate damage
                 # This simulates a more controlled death like drug overdose or poisoning
@@ -470,7 +462,7 @@ class CmdTestDeath(Command):
                         target.location.msg_contents(f"|R{target.key} begins bleeding from everywhere at once - eyes weeping blood, crimson pouring from nose and mouth as their skin becomes a canvas of seeping red.|n", exclude=[target])
                 
                 # Schedule the dramatic message - only one needed
-                delayed_message(show_bleeding_onset, 3)
+                delay(3, show_bleeding_onset)
                 
                 # Multiple severe arterial bleeding conditions will cause rapid death
                 # 5 x 10% blood loss per tick = 50% blood loss per tick = death in 2 ticks

--- a/commands/CmdBug.py
+++ b/commands/CmdBug.py
@@ -170,7 +170,7 @@ class CmdBug(MuxCommand):
             try:
                 git_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
                 possible_paths.append(os.path.join(git_dir, '.git', 'refs', 'heads', 'master'))
-            except:
+            except Exception:
                 pass
             
             # Try each possible path

--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -211,7 +211,7 @@ class ConsumptionCommand(Command):
                 has_bleeding = any(condition.condition_type == "minor_bleeding" 
                                  for condition in getattr(target.medical_state, 'conditions', []))
                 return blood_level < 100 or has_bleeding
-            except:
+            except Exception:
                 return False
                 
         elif medical_type == "wound_care":
@@ -221,7 +221,7 @@ class ConsumptionCommand(Command):
                 has_bleeding = any(condition.condition_type == "minor_bleeding" 
                                  for condition in getattr(target.medical_state, 'conditions', []))
                 return has_bleeding
-            except:
+            except Exception:
                 return False
                 
         elif medical_type in ["pain_relief", "antiseptic"]:

--- a/commands/CmdGraffiti.py
+++ b/commands/CmdGraffiti.py
@@ -1,24 +1,7 @@
 """
 Spray Commands
 
-Unified spray command that         # Parse command patterns to determine intent
-        args_stripped = self.args.strip()
-        args_lower = args_stripped.lower()
-        
-        if args_lower.startswith("here with "):
-            # User wants to clean - get the can name
-            can_name = args_stripped[10:].strip()
-            intent = "clean"
-            message = None
-        elif " with " in args_stripped:
-            # User wants to spray paint - parse message and can name
-            message_part, can_part = args_stripped.rsplit(" with ", 1)
-            message = message_part.strip().strip('"'')  # Remove quotes if present
-            can_name = can_part.strip()
-            intent = "spraypaint"
-        else:
-            self.caller.msg("Usage: spray "<message>" with <can> OR spray here with <can>")
-            return painting and solvent cleaning
+Unified spray command for spray painting and solvent cleaning
 based on the type of can used and syntax provided.
 """
 

--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -545,10 +545,6 @@ class CmdGet(Command):
         caller.msg(f"You don't see a '{itemname}' here.")
         return None
 
-        # Edge case fallback — just add to inventory
-        item.location = caller
-        caller.msg(f"You pick up {item.key} and stow it.")
-
 
 class CmdGive(Command):
     """

--- a/commands/CmdThrow.py
+++ b/commands/CmdThrow.py
@@ -673,7 +673,7 @@ class CmdThrow(Command):
                         try:
                             obj.move_to(origin)
                             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Moved {obj} back to origin {origin} as fallback")
-                        except:
+                        except Exception:
                             pass  # If even fallback fails, give up gracefully
             
             # Clean up flight data with defensive checks
@@ -710,7 +710,7 @@ class CmdThrow(Command):
                         obj.move_to(flight_origin)
                         if splattercast:
                             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Emergency moved {obj} back to origin {flight_origin}")
-            except:
+            except Exception:
                 pass  # If all else fails, give up gracefully
     
     def get_arrival_direction(self, origin, destination):
@@ -1413,7 +1413,7 @@ class CmdPull(Command):
                     splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Ticker error for {grenade.key}: {e} - triggering explosion")
                 try:
                     explode_standalone_grenade(grenade)
-                except:
+                except Exception:
                     pass  # If even explosion fails, give up gracefully
         
         # Start the ticker
@@ -2125,7 +2125,7 @@ def start_standalone_grenade_ticker(grenade, explosion_callback=None):
                     explosion_callback()
                 else:
                     explode_standalone_grenade(grenade)
-            except:
+            except Exception:
                 pass  # If even explosion fails, give up gracefully
     
     # Start the ticker

--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -280,7 +280,7 @@ def create_character_from_template(account, template, sex="ambiguous"):
     try:
         splattercast = ChannelDB.objects.get_channel("Splattercast")
         splattercast.msg(f"CHARCREATE_SEX_SET: {char.key} sex set to '{sex}', current value: '{char.sex}', gender property: '{char.gender}'")
-    except:
+    except Exception:
         pass
     
     # Set defaults
@@ -359,7 +359,7 @@ def create_flash_clone(account, old_character):
     try:
         splattercast = ChannelDB.objects.get_channel("Splattercast")
         splattercast.msg(f"FLASH_CLONE_SEX_INHERIT: {char.key} inherited sex '{old_character.sex}' from {old_character.key}, current value: '{char.sex}', gender property: '{char.gender}'")
-    except:
+    except Exception:
         pass
     
     # INHERIT: death_count from old character
@@ -683,7 +683,7 @@ def respawn_finalize_template(caller, raw_string, **kwargs):
         try:
             splattercast = ChannelDB.objects.get_channel("Splattercast")
             splattercast.msg(f"CHARCREATE_ERROR: {e}")
-        except:
+        except Exception:
             pass
         return "respawn_welcome"
 
@@ -753,7 +753,7 @@ def respawn_flash_clone(caller, raw_string, **kwargs):
         try:
             splattercast = ChannelDB.objects.get_channel("Splattercast")
             splattercast.msg(f"FLASH_CLONE_ERROR: {e}")
-        except:
+        except Exception:
             pass
         return "respawn_welcome"
 
@@ -964,11 +964,11 @@ def first_char_grim(caller, raw_string, **kwargs):
         # Commands: grit, resonance, intellect, motorics, reset, done
         # Ignore: single digits (from sex selection) or other garbage
         valid_commands = ['grit', 'g', 'resonance', 'r', 'res', 'intellect', 'i', 'int', 
-                         'motorics', 'm', 'mot', 'reset', 'done', 'd', 'finish', 'finalize']
+                         'motorics', 'm', 'mot', 'reset', 're', 'done', 'd', 'finish', 'finalize']
         
         if command in valid_commands:
             # Reset command
-            if command in ["reset", "r"]:
+            if command in ["reset", "re"]:
                 caller.ndb.charcreate_data['grit'] = 75
                 caller.ndb.charcreate_data['resonance'] = 75
                 caller.ndb.charcreate_data['intellect'] = 75
@@ -1197,7 +1197,7 @@ def first_char_finalize(caller, raw_string, **kwargs):
         try:
             splattercast = ChannelDB.objects.get_channel("Splattercast")
             splattercast.msg(f"CHARCREATE_ERROR: {e}")
-        except:
+        except Exception:
             pass
         return "first_char_confirm"
 

--- a/commands/combat/movement.py
+++ b/commands/combat/movement.py
@@ -929,7 +929,7 @@ class CmdJump(Command):
                     try:
                         timer.cancel()  # Cancel the utils.delay timer
                         splattercast.msg(f"JUMP_SACRIFICE: Cancelled original grenade timer on {explosive.key}")
-                    except:
+                    except Exception:
                         splattercast.msg(f"JUMP_SACRIFICE: Failed to cancel original grenade timer on {explosive.key}")
                 delattr(explosive.ndb, "grenade_timer")
             

--- a/server/conf/connection_screens.py
+++ b/server/conf/connection_screens.py
@@ -61,37 +61,3 @@ Enter |whelp|n for more info. |wlook|n will re-show this screen.
 
 |b█▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒█|n
 """
-
-
-# Keep the old static version as fallback (though the function above will take precedence)
-CONNECTION_SCREEN = """
-
-|b█▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒█
-█▒▒▒▒▒▒▒▒▒ |g{} SYSTEM |n :::: SIGNAL {} |b▒▒▒▒▒▒▒▒▒▒█
-█▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒█|n
-
-[ WARNING: Signal instability detected. ]
-[ Color bars desaturated. ]
-[ Anomalous resonance detected at 7.8Hz. ] 
-
-YEAR: 198|u█|n (ENDLESS BROADCAST)
-LOCATION: PARTS UNKNOWN
- 
->> Streets: Flowing.
->> Airwaves: Distorted.
->> Flesh: Grainy.
->> Memory: OFFLINE.
-
-__ Connect : |wconnect <email@address.com> <password>|n
-__ Create  : |wcreate <email@address.com> <password>|n
-
-Use your email address to connect or create a new account.
-Character creation happens after login.
-Enter |whelp|n for more info. |wlook|n will re-show this screen.
-
-|w>>> END OF TE▒T PATTERN. BROADCAST WI▒L NOT RESUME WITHOUT PROMPT.|n
-
-|b█▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒█|n
-""".format(
-    settings.SERVERNAME, utils.get_evennia_version("short")
-)

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -302,7 +302,7 @@ class Character(ObjectParent, DefaultCharacter):
                             installed = getattr(item, 'installed_plates', {})
                             debug_broadcast(f"PLATE_CARRIER detected: {item.key} for {location}, installed_plates={list(installed.keys())}", 
                                            "ARMOR_CALC", "DEBUG")
-                        except:
+                        except Exception:
                             pass
                         # Expand plate carrier into multiple sequential layers
                         carrier_layers = self._expand_plate_carrier_layers(item, location)
@@ -314,7 +314,7 @@ class Character(ObjectParent, DefaultCharacter):
                             for layer in carrier_layers:
                                 debug_broadcast(f"  Layer {layer['layer']}: {layer['item'].key} ({layer['armor_type']}, rating={layer['armor_rating']})", 
                                                "ARMOR_CALC", "DEBUG")
-                        except:
+                        except Exception:
                             pass
                         armor_layers.extend(carrier_layers)
                     else:
@@ -431,7 +431,7 @@ class Character(ObjectParent, DefaultCharacter):
                                "ARMOR_CALC", "DEBUG")
                 debug_broadcast(f"PLATE_LOOP: slot_coverage={slot_coverage}", 
                                "ARMOR_CALC", "DEBUG")
-            except:
+            except Exception:
                 pass
             
             for slot_name, plate in installed_plates.items():
@@ -458,7 +458,7 @@ class Character(ObjectParent, DefaultCharacter):
                     from world.combat.utils import debug_broadcast
                     debug_broadcast(f"PLATE_COVERAGE: slot={slot_name}, protects={protected_locations}, location={location}, match={location in protected_locations}", 
                                    "ARMOR_CALC", "DEBUG")
-                except:
+                except Exception:
                     pass
                 if location not in protected_locations:
                     continue
@@ -627,7 +627,7 @@ class Character(ObjectParent, DefaultCharacter):
             try:
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 splattercast.msg(f"UNCONSCIOUS_SKIP: {self.key} already processed unconsciousness, skipping")
-            except:
+            except Exception:
                 pass
             return
             
@@ -646,7 +646,7 @@ class Character(ObjectParent, DefaultCharacter):
             try:
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 splattercast.msg(f"UNCONSCIOUS_COMBAT: {self.key} unconsciousness message deferred - in active combat")
-            except:
+            except Exception:
                 pass
             
             # Safety fallback - trigger message after 5 seconds if combat doesn't handle it
@@ -655,7 +655,7 @@ class Character(ObjectParent, DefaultCharacter):
                     try:
                         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                         splattercast.msg(f"UNCONSCIOUS_FALLBACK: {self.key} triggering fallback unconsciousness message")
-                    except:
+                    except Exception:
                         pass
                     self._show_unconsciousness_message()
                     self.ndb.unconsciousness_pending = False
@@ -776,7 +776,7 @@ class Character(ObjectParent, DefaultCharacter):
             try:
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"WARNING: Archiving staff character {self.key} (Account: {self.account.key}, Reason: {reason})")
-            except:
+            except Exception:
                 pass
         
         # Set account's last_character for respawn flow
@@ -804,7 +804,7 @@ class Character(ObjectParent, DefaultCharacter):
             try:
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"ARCHIVE: Moved {self.key} from {current_location.key if current_location else 'None'} to Limbo")
-            except:
+            except Exception:
                 pass
         
         # Disconnect any active sessions
@@ -939,7 +939,7 @@ class Character(ObjectParent, DefaultCharacter):
             try:
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 splattercast.msg(f"AT_DEATH_SKIP: {self.key} already processed death (db flag), skipping")
-            except:
+            except Exception:
                 pass
             return
             
@@ -981,7 +981,7 @@ class Character(ObjectParent, DefaultCharacter):
             try:
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 splattercast.msg(f"AT_DEATH_COMBAT: {self.key} death curtain deferred - in active combat")
-            except:
+            except Exception:
                 pass
             
             # Safety fallback - trigger curtain after 5 seconds if combat doesn't handle it
@@ -990,7 +990,7 @@ class Character(ObjectParent, DefaultCharacter):
                     try:
                         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                         splattercast.msg(f"AT_DEATH_FALLBACK: {self.key} triggering fallback death curtain")
-                    except:
+                    except Exception:
                         pass
                     show_death_curtain(self)
                     self.ndb.death_curtain_pending = False
@@ -1143,7 +1143,7 @@ class Character(ObjectParent, DefaultCharacter):
             except Exception as e:
                 try:
                     splattercast.msg(f"REVIVAL_ERROR: Failed to restart medical script for {self.key}: {e}")
-                except:
+                except Exception:
                     pass
         
         # Clear death processing flags (both ndb and db)
@@ -1177,7 +1177,7 @@ class Character(ObjectParent, DefaultCharacter):
         try:
             splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
             splattercast.msg(f"FINAL_DEATH: {self.key} has entered permanent death state")
-        except:
+        except Exception:
             pass
 
     def validate_attack_target(self):

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -204,7 +204,7 @@ class Corpse(Item):
                     from evennia.comms.models import ChannelDB
                     splattercast = ChannelDB.objects.get_channel("Splattercast")
                     splattercast.msg(f"CORPSE_WOUND_ERROR: Failed to generate wound description for {self.key}: {e}")
-                except:
+                except Exception:
                     pass
                 continue
         
@@ -681,7 +681,7 @@ class Corpse(Item):
             from evennia.comms.models import ChannelDB
             splattercast = ChannelDB.objects.get_channel("Splattercast")
             splattercast.msg(f"CORPSE_DECAY: {self.key} completely decayed and removed from {self.location}")
-        except:
+        except Exception:
             pass
             
         # Remove the corpse

--- a/typeclasses/curtain_of_death.py
+++ b/typeclasses/curtain_of_death.py
@@ -307,7 +307,7 @@ class DeathCurtain:
                 from evennia.comms.models import ChannelDB
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"DEATH_CURTAIN: Death progression started for {self.character.key}, script: {script}")
-            except:
+            except Exception:
                 pass
                 
         except Exception as e:
@@ -316,7 +316,7 @@ class DeathCurtain:
                 from evennia.comms.models import ChannelDB
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"DEATH_CURTAIN_ERROR: Failed to start death progression for {self.character.key}: {e}")
-            except:
+            except Exception:
                 pass
 
 

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -142,7 +142,7 @@ class DeathProgressionScript(DefaultScript):
                 f"interval: {DEATH_PROGRESSION_CHECK_INTERVAL}s, "
                 f"messages: {DEATH_PROGRESSION_MESSAGE_COUNT})"
             )
-        except:
+        except Exception:
             pass
         
     def at_start(self):
@@ -160,7 +160,7 @@ class DeathProgressionScript(DefaultScript):
                 f"DEATH_PROGRESSION: Started for {character.key} - "
                 f"{duration_minutes:.1f} minute revival window"
             )
-        except:
+        except Exception:
             pass
             
         # Send initial dying message
@@ -174,7 +174,7 @@ class DeathProgressionScript(DefaultScript):
             try:
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script (invalid character)")
-            except:
+            except Exception:
                 pass
             self.stop()
             self.delete()
@@ -187,7 +187,7 @@ class DeathProgressionScript(DefaultScript):
         try:
             splattercast = ChannelDB.objects.get_channel("Splattercast")
             splattercast.msg(f"DEATH_PROGRESSION: at_repeat for {character.key}, elapsed: {elapsed:.1f}s")
-        except:
+        except Exception:
             pass
         
         # Check if medical conditions have been resolved and character should be revived
@@ -243,7 +243,7 @@ class DeathProgressionScript(DefaultScript):
             elapsed = time.time() - self.db.start_time
             splattercast.msg(f"MEDICAL_REVIVAL: {character.key} revived by medical treatment after {elapsed:.1f}s")
             splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script for {character.key} (medical revival)")
-        except:
+        except Exception:
             pass
             
         # Medical revival messages
@@ -329,7 +329,7 @@ class DeathProgressionScript(DefaultScript):
         try:
             splattercast = ChannelDB.objects.get_channel("Splattercast")
             splattercast.msg(f"DEATH_PROGRESSION: {character.key} at {interval}s (msg {message_index + 1}/{len(messages_list)}) - {minutes_remaining}m remaining")
-        except:
+        except Exception:
             pass
             
     def _get_progression_messages(self):
@@ -433,7 +433,7 @@ class DeathProgressionScript(DefaultScript):
             splattercast = ChannelDB.objects.get_channel("Splattercast")
             splattercast.msg(f"DEATH_PROGRESSION: {character.key} completed - corpse created, character transitioned")
             splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script for {character.key}")
-        except:
+        except Exception:
             pass
             
         # Stop and delete the script to clean up completely
@@ -466,7 +466,7 @@ class DeathProgressionScript(DefaultScript):
             try:
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"DEATH_COMPLETION: {character.key} -> Corpse created, character transitioned")
-            except:
+            except Exception:
                 pass
                 
         except Exception as e:
@@ -474,7 +474,7 @@ class DeathProgressionScript(DefaultScript):
             try:
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"DEATH_COMPLETION_ERROR: {character.key} - {e}")
-            except:
+            except Exception:
                 pass
 
     def _create_corpse_from_character(self, character):
@@ -580,7 +580,7 @@ class DeathProgressionScript(DefaultScript):
                 splattercast.msg(f"DEATH_ITEMS_TRANSFERRED: {len(transferred_items)} items moved to corpse: {', '.join(transferred_items)}")
             else:
                 splattercast.msg(f"DEATH_ITEMS_TRANSFERRED: No items found on {character.key} to transfer")
-        except:
+        except Exception:
             pass
         
         # Set corpse description
@@ -610,7 +610,7 @@ class DeathProgressionScript(DefaultScript):
             try:
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"DEATH_MEDICAL_CLEANUP: Found {script_count} medical scripts for {character.key}")
-            except:
+            except Exception:
                 pass
             
             for script in medical_scripts:
@@ -630,7 +630,7 @@ class DeathProgressionScript(DefaultScript):
                             splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: Script #{script_id} for {character.key} still exists after delete!")
                         else:
                             splattercast.msg(f"DEATH_MEDICAL_CLEANUP: Successfully deleted script #{script_id} for {character.key}")
-                    except:
+                    except Exception:
                         pass
                 except Exception as e:
                     try:
@@ -638,7 +638,7 @@ class DeathProgressionScript(DefaultScript):
                         splattercast.msg(f"DEATH_MEDICAL_CLEANUP_ERROR: {character.key} - {e}")
                         import traceback
                         splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
-                    except:
+                    except Exception:
                         pass
         except Exception as e:
             try:
@@ -646,7 +646,7 @@ class DeathProgressionScript(DefaultScript):
                 splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: {character.key} - {e}")
                 import traceback
                 splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
-            except:
+            except Exception:
                 pass
         
         # Move character to limbo/OOC room (Evennia's default limbo is #2)
@@ -660,7 +660,7 @@ class DeathProgressionScript(DefaultScript):
             try:
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"DEATH_TELEPORT_SUCCESS: {character.key} moved from {old_location} to {limbo_room}")
-            except:
+            except Exception:
                 pass
                 
         except Exception as e:
@@ -668,7 +668,7 @@ class DeathProgressionScript(DefaultScript):
             try:
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"DEATH_TELEPORT_ERROR: {character.key} - {e}")
-            except:
+            except Exception:
                 pass
         
         # Unpuppet character from account
@@ -685,7 +685,7 @@ class DeathProgressionScript(DefaultScript):
                 try:
                     splattercast = ChannelDB.objects.get_channel("Splattercast")
                     splattercast.msg(f"DEATH_UNPUPPET: {character.key} unpuppeted from {account.key}")
-                except:
+                except Exception:
                     pass
         
         # Archive the dead character (also handles any lingering sessions)
@@ -713,7 +713,7 @@ class DeathProgressionScript(DefaultScript):
             try:
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"CHARCREATE_IMPORT_ERROR: {e}")
-            except:
+            except Exception:
                 pass
         account.msg("")
         
@@ -740,7 +740,7 @@ def start_death_progression(character):
         try:
             splattercast = ChannelDB.objects.get_channel("Splattercast")
             splattercast.msg(f"DEATH_PROGRESSION: Existing script found for {character.key}")
-        except:
+        except Exception:
             pass
         return existing_script
         
@@ -748,7 +748,7 @@ def start_death_progression(character):
     try:
         splattercast = ChannelDB.objects.get_channel("Splattercast")
         splattercast.msg(f"DEATH_PROGRESSION: Creating new script for {character.key}")
-    except:
+    except Exception:
         pass
         
     # Create script using the same pattern as medical script
@@ -757,7 +757,7 @@ def start_death_progression(character):
     try:
         splattercast = ChannelDB.objects.get_channel("Splattercast")
         splattercast.msg(f"DEATH_PROGRESSION: Script created and started: {script} for {character.key}")
-    except:
+    except Exception:
         pass
         
     return script

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -99,7 +99,7 @@ class Room(ObjectParent, DefaultRoom):
                     for item in list(corpse.contents):
                         try:
                             item.move_to(self, quiet=True)
-                        except:
+                        except Exception:
                             pass
                     
                     # Log and delete
@@ -107,11 +107,11 @@ class Room(ObjectParent, DefaultRoom):
                         from evennia.comms.models import ChannelDB
                         splattercast = ChannelDB.objects.get_channel("Splattercast")
                         splattercast.msg(f"CORPSE_DECAY_JIT: {corpse.key} decayed on room entry to {self.key}")
-                    except:
+                    except Exception:
                         pass
                     
                     corpse.delete()
-            except:
+            except Exception:
                 pass  # Corpse may have been deleted or be in invalid state
     
     # Override the appearance template to use our custom footer for exits

--- a/web/website/views/accounts.py
+++ b/web/website/views/accounts.py
@@ -14,6 +14,9 @@ from evennia.web.website.views.accounts import (
 )
 from web.website.forms import TurnstileAccountForm
 
+import logging
+logger = logging.getLogger("web")
+
 
 class TurnstileAccountCreateView(EvenniaAccountCreateView):
     """
@@ -99,7 +102,7 @@ class TurnstileAccountCreateView(EvenniaAccountCreateView):
             # If no secret key configured, log warning
             # This shouldn't happen as we check before calling this method,
             # but handle gracefully just in case
-            print("WARNING: TURNSTILE_SECRET_KEY not configured - skipping verification")
+            logger.warning("TURNSTILE_SECRET_KEY not configured - skipping verification")
             return True  # Allow registration to proceed
         
         # Cloudflare Turnstile verification endpoint
@@ -122,7 +125,7 @@ class TurnstileAccountCreateView(EvenniaAccountCreateView):
             
         except Exception as e:
             # Log error and fail verification
-            print(f"Turnstile verification error: {e}")
+            logger.error("Turnstile verification error: %s", e)
             return False
     
     def get_client_ip(self):

--- a/web/website/views/characters.py
+++ b/web/website/views/characters.py
@@ -232,7 +232,7 @@ class CharacterCreateView(EvenniaCharacterCreateView):
                     f"location set to None for invisibility. "
                     f"Will be restored to {character.db.prelogout_location.key} on telnet login."
                 )
-            except:
+            except Exception:
                 pass
             
             # Clear last_character after successful respawn
@@ -349,7 +349,7 @@ class CharacterCreateView(EvenniaCharacterCreateView):
                     f"location set to None for invisibility. "
                     f"Will be restored to {character.db.prelogout_location.key} on telnet login."
                 )
-            except:
+            except Exception:
                 pass
             
             messages.success(

--- a/world/combat/grappling.py
+++ b/world/combat/grappling.py
@@ -633,13 +633,6 @@ def resolve_release_grapple(char_entry, combatants_list, handler):
     # The yielding state reflects the original intent when combat/grapple was initiated
     # If they want to become violent again, they need to explicitly take a hostile action
     
-    # Check if target is still grappled by someone else for validation
-    still_grappled = any(
-        e.get(DB_GRAPPLING_DBREF) == get_character_dbref(grappling_target)
-        for e in combatants_list
-        if e.get(DB_CHAR) != char
-    )
-    
     char.msg(f"|gYou release your grapple on {grappling_target.key}.|n")
     grappling_target.msg(f"|g{char.key} releases their grapple on you.|n")
     

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -720,7 +720,7 @@ def remove_combatant(handler, char):
                     try:
                         target_obj = next((e.get(DB_CHAR) for e in combatants if get_character_dbref(e.get(DB_CHAR)) == potential_target_dbref), None)
                         target_name = target_obj.key if target_obj else f"dbref#{potential_target_dbref}"
-                    except:
+                    except Exception:
                         target_name = f"dbref#{potential_target_dbref}"
                     splattercast.msg(f"RMV_COMB: Skipping {potential_target_char.key} for auto-retarget - attacking {target_name}, not {other_char.key} (friendly fire prevention)")
                     continue

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -307,80 +307,6 @@ class MedicalState:
             self.organs[organ_name] = Organ(organ_name)
         return self.organs[organ_name]
         
-    def add_condition(self, condition_type, location=None, severity="minor", **kwargs):
-        """
-        Add a new medical condition using the ticker-based system.
-        
-        Args:
-            condition_type (str): Type of condition
-            location (str, optional): Affected body location
-            severity (str): Condition severity
-            **kwargs: Additional condition properties
-            
-        Returns:
-            MedicalCondition: The created condition
-        """
-        # Import the new condition creation function
-        from .conditions import create_condition_from_damage
-        
-        # Map condition types to injury types for new system
-        injury_type_map = {
-            "bleeding": "bullet",  # Bleeding usually from trauma
-            "fracture": "blunt",   # Fractures from blunt trauma
-            "burn": "burn",        # Burns
-            "infection": "generic" # Infections (generic for now)
-        }
-        injury_type = injury_type_map.get(condition_type, "bullet")
-        
-        # Convert string severities to numeric damage for new system
-        if isinstance(severity, str):
-            severity_map = {"minor": 3, "moderate": 6, "severe": 12, "critical": 20}
-            numeric_severity = severity_map.get(severity.lower(), 3)
-        else:
-            numeric_severity = severity
-        
-        # Create conditions using new ticker-based system
-        new_conditions = create_condition_from_damage(
-            damage_amount=numeric_severity * 5,  # Scale to match damage amounts
-            injury_type=injury_type,
-            location=location or "chest"
-        )
-        
-        # Add created conditions and start their tickers
-        created_condition = None
-        for condition in new_conditions:
-            self.conditions.append(condition)
-            # Start ticker if character is available
-            if hasattr(self, 'character') and self.character:
-                try:
-                    from world.combat.constants import SPLATTERCAST_CHANNEL
-                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-                    splattercast.msg(f"CONDITION_CREATE: Starting {condition.condition_type} for {self.character.key}")
-                    condition.start_condition(self.character)
-                except:
-                    pass
-            else:
-                try:
-                    from world.combat.constants import SPLATTERCAST_CHANNEL
-                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-                    splattercast.msg(f"CONDITION_CREATE: No character reference available for {condition.condition_type}")
-                except:
-                    pass
-            created_condition = condition  # Return the last created condition
-            
-        self._cache_dirty = True
-        return created_condition
-        
-    def remove_condition(self, condition):
-        """Remove a medical condition."""
-        if condition in self.conditions:
-            self.conditions.remove(condition)
-            self._cache_dirty = True
-            
-    def get_conditions_by_type(self, condition_type):
-        """Get all conditions of a specific type."""
-        return [c for c in self.conditions if hasattr(c, 'condition_type') and c.condition_type == condition_type]
-        
     def get_conditions_by_location(self, location):
         """Get all conditions affecting a specific body location."""
         return [c for c in self.conditions if c.location == location]
@@ -590,7 +516,7 @@ class MedicalState:
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 char_name = character.key if character else "unknown"
                 splattercast.msg(f"ADD_CONDITION: {char_name} is archived, not adding {condition.condition_type}")
-            except:
+            except Exception:
                 pass
             return
             
@@ -601,7 +527,7 @@ class MedicalState:
                 from world.combat.constants import SPLATTERCAST_CHANNEL
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 splattercast.msg(f"ADD_CONDITION: Added {condition.condition_type} severity {condition.severity}")
-            except:
+            except Exception:
                 pass
             
             # Start ticker if condition requires it
@@ -614,7 +540,7 @@ class MedicalState:
                         from world.combat.constants import SPLATTERCAST_CHANNEL
                         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                         splattercast.msg(f"ADD_CONDITION: Starting ticker for {condition.condition_type} on {character.key}")
-                    except:
+                    except Exception:
                         pass
                     condition.start_condition(character)
                 else:
@@ -622,7 +548,7 @@ class MedicalState:
                         from world.combat.constants import SPLATTERCAST_CHANNEL
                         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                         splattercast.msg(f"ADD_CONDITION: No character reference found for {condition.condition_type}")
-                    except:
+                    except Exception:
                         pass
             
             # Save medical state after adding condition to ensure persistence

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -166,7 +166,7 @@ class MedicalScript(DefaultScript):
         try:
             splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
             splattercast.msg(f"MEDICAL_SCRIPT_STOP: Medical script stopped for {self.obj.key}")
-        except:
+        except Exception:
             pass
     
     def _send_medical_messages(self, bleeding_severity, pain_severity, infection_severity=0):
@@ -319,7 +319,7 @@ def start_medical_script(character):
     try:
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         splattercast.msg(f"START_MEDICAL_SCRIPT: Checking for existing script on {character.key}")
-    except:
+    except Exception:
         pass
         
     # Don't create scripts for dead characters
@@ -327,7 +327,7 @@ def start_medical_script(character):
         try:
             splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
             splattercast.msg(f"START_MEDICAL_SCRIPT: {character.key} is dead, not creating medical script")
-        except:
+        except Exception:
             pass
         return None
         
@@ -337,7 +337,7 @@ def start_medical_script(character):
         try:
             splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
             splattercast.msg(f"START_MEDICAL_SCRIPT: Found existing script for {character.key}")
-        except:
+        except Exception:
             pass
         return existing_script.first() if existing_script else None
     
@@ -345,7 +345,7 @@ def start_medical_script(character):
     try:
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         splattercast.msg(f"START_MEDICAL_SCRIPT: Creating new script for {character.key}")
-    except:
+    except Exception:
         pass
         
     script = character.scripts.add(MedicalScript)
@@ -353,7 +353,7 @@ def start_medical_script(character):
     try:
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         splattercast.msg(f"START_MEDICAL_SCRIPT: Script created: {script}")
-    except:
+    except Exception:
         pass
         
     return script
@@ -369,7 +369,7 @@ def stop_medical_script(character):
     try:
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         splattercast.msg(f"STOP_MEDICAL_SCRIPT: Looking for medical scripts on {character.key}")
-    except:
+    except Exception:
         pass
     
     # Find and delete all medical scripts (active or stopped)
@@ -379,7 +379,7 @@ def stop_medical_script(character):
             try:
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 splattercast.msg(f"STOP_MEDICAL_SCRIPT: Found script {script}, deleting it")
-            except:
+            except Exception:
                 pass
             script.stop()
             script.delete()
@@ -387,5 +387,5 @@ def stop_medical_script(character):
         try:
             splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
             splattercast.msg(f"STOP_MEDICAL_SCRIPT: No medical scripts found on {character.key}")
-        except:
+        except Exception:
             pass

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -966,7 +966,7 @@ def apply_medical_effects(item, user, target, **kwargs):
             splattercast.msg(f"REVIVAL_DEBUG: {target.key} blood_level={blood_level:.1f}%, is_dead={is_dead}")
         else:
             splattercast.msg(f"REVIVAL_DEBUG: {target.key} has no medical_state")
-    except:
+    except Exception:
         pass
     
     if death_scripts:
@@ -980,7 +980,7 @@ def apply_medical_effects(item, user, target, **kwargs):
                         from evennia.comms.models import ChannelDB
                         splattercast = ChannelDB.objects.get_channel("Splattercast")
                         splattercast.msg(f"REVIVAL_DEBUG: Checking revival conditions for {target.key}")
-                    except:
+                    except Exception:
                         pass
                     
                     if script._check_medical_revival_conditions(target):
@@ -994,7 +994,7 @@ def apply_medical_effects(item, user, target, **kwargs):
                             from evennia.comms.models import ChannelDB
                             splattercast = ChannelDB.objects.get_channel("Splattercast")
                             splattercast.msg(f"REVIVAL_DEBUG: {target.key} does not meet revival conditions")
-                        except:
+                        except Exception:
                             pass
         except Exception as e:
             # Don't let revival check errors break medical treatment
@@ -1002,7 +1002,7 @@ def apply_medical_effects(item, user, target, **kwargs):
                 from evennia.comms.models import ChannelDB
                 splattercast = ChannelDB.objects.get_channel("Splattercast")
                 splattercast.msg(f"REVIVAL_CHECK_ERROR: {target.key}: {e}")
-            except:
+            except Exception:
                 pass
     
     return result_msg


### PR DESCRIPTION
## Summary

Fixes #31 (targeted items — larger refactoring deferred)

Addresses safe, mechanical code quality improvements identified during code review. Large architectural changes (god class decomposition, deduplication of explosion routines) are deferred as they require more careful planning.

## Changes

### Dead code removal (114 lines)
- **`world/medical/core.py`**: Removed 3 duplicate method definitions (`add_condition`, `remove_condition`, `get_conditions_by_type`) in `MedicalState` — Python uses the last definition, making the first versions dead code
- **`commands/CmdInventory.py`**: Removed unreachable code after `return None`
- **`world/combat/grappling.py`**: Removed unused `still_grappled` variable
- **`server/conf/connection_screens.py`**: Removed static `CONNECTION_SCREEN` variable shadowed by the `connection_screen()` function

### Bare except clauses (75 replacements across 15 files)
- Replaced all `except:` with `except Exception:` to avoid catching `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`
- Affected files: characters.py, death_progression.py, CmdThrow.py, charcreate.py, medical/script.py, medical/core.py, medical/utils.py, rooms.py, and 7 others

### Threading anti-pattern
- **`commands/CmdAdmin.py`**: Replaced `threading.Thread` + `time.sleep()` with `evennia.utils.delay()` for Twisted-safe deferred execution in the `@murder` command

### Miscellaneous
- **`commands/CmdGraffiti.py`**: Fixed garbled module docstring (had code fragments from a `func()` body mixed in)
- **`commands/charcreate.py`**: Fixed shortcut collision where `r` matched `reset` before `resonance`; now `r` → resonance, `re` → reset
- **`web/website/views/accounts.py`**: Replaced `print()` with `logging.getLogger("web")` for structured log output

## Not addressed (deferred)
- God class decomposition of `characters.py` (2117 lines)
- Deduplication of explosion routines in `CmdThrow.py` (~200 lines x5)
- Deduplication in `CmdAim` and inline handler grapple/escape logic
- Test suite creation
- Console.log cleanup in JS templates
- Kill/hit message color inversion