### PR TITLE
Fix combat state management bugs

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -947,8 +947,6 @@ class Character(ObjectParent, DefaultCharacter):
         self.db.death_processed = True
         
         # Also set NDB flag for backwards compatibility
-        if not hasattr(self, 'ndb'):
-            self.ndb = {}
         self.ndb.death_processed = True
         
         # Note: death_count is NOT incremented here - it will be incremented in the 

--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -642,7 +642,7 @@ class CombatHandler(DefaultScript):
                     splattercast.msg(f"GRAPPLE_ERROR: {char.key} is grappled by themselves! Clearing invalid state.")
                     current_char_combat_entry[DB_GRAPPLED_BY_DBREF] = None
                     grappler = None
-                elif not any(e[DB_CHAR] == grappler for e in combatants_list):
+                elif not any(e.get(DB_CHAR) == grappler for e in combatants_list):
                     splattercast.msg(f"GRAPPLE_ERROR: {char.key} is grappled by {grappler.key} who is not in combat! Clearing invalid state.")
                     current_char_combat_entry[DB_GRAPPLED_BY_DBREF] = None
                     grappler = None
@@ -668,7 +668,7 @@ class CombatHandler(DefaultScript):
                 if escaper_roll > grappler_roll:
                     # Success - clear grapple
                     current_char_combat_entry[DB_GRAPPLED_BY_DBREF] = None
-                    grappler_entry = next((e for e in combatants_list if e[DB_CHAR] == grappler), None)
+                    grappler_entry = next((e for e in combatants_list if e.get(DB_CHAR) == grappler), None)
                     if grappler_entry:
                         grappler_entry[DB_GRAPPLING_DBREF] = None
                     
@@ -751,7 +751,7 @@ class CombatHandler(DefaultScript):
                     
                     # Validate target
                     is_action_target_valid = False
-                    if action_target_char and any(e[DB_CHAR] == action_target_char for e in combatants_list):
+                    if action_target_char and any(e.get(DB_CHAR) == action_target_char for e in combatants_list):
                         if action_target_char.location and action_target_char.location in (self.db.managed_rooms or []):
                             is_action_target_valid = True
                     
@@ -792,7 +792,7 @@ class CombatHandler(DefaultScript):
                             if attacker_roll > defender_roll:
                                 # Store dbrefs for persistence
                                 current_char_combat_entry[DB_GRAPPLING_DBREF] = self._get_dbref(action_target_char)
-                                target_entry = next((e for e in combatants_list if e[DB_CHAR] == action_target_char), None)
+                                target_entry = next((e for e in combatants_list if e.get(DB_CHAR) == action_target_char), None)
                                 if target_entry:
                                     target_entry[DB_GRAPPLED_BY_DBREF] = self._get_dbref(char)
                                 
@@ -825,14 +825,14 @@ class CombatHandler(DefaultScript):
                         continue
                     elif intent_type == "escape_grapple":
                         grappler = self.get_grappled_by_obj(current_char_combat_entry)
-                        if grappler and any(e[DB_CHAR] == grappler for e in combatants_list):
+                        if grappler and any(e.get(DB_CHAR) == grappler for e in combatants_list):
                             escaper_roll = randint(1, max(1, get_numeric_stat(char, "motorics", 1)))
                             grappler_roll = randint(1, max(1, get_numeric_stat(grappler, "motorics", 1)))
                             splattercast.msg(f"ESCAPE ATTEMPT: {char.key} (roll {escaper_roll}) vs {grappler.key} (roll {grappler_roll}).")
 
                             if escaper_roll > grappler_roll:
                                 current_char_combat_entry[DB_GRAPPLED_BY_DBREF] = None
-                                grappler_entry = next((e for e in combatants_list if e[DB_CHAR] == grappler), None)
+                                grappler_entry = next((e for e in combatants_list if e.get(DB_CHAR) == grappler), None)
                                 if grappler_entry:
                                     grappler_entry[DB_GRAPPLING_DBREF] = None
                                 escape_messages = get_combat_message("grapple", "escape_hit", attacker=char, target=grappler)
@@ -1541,7 +1541,7 @@ class CombatHandler(DefaultScript):
         
         # Check if target is still in combat
         combatants_list = self.db.combatants or []
-        if not any(e[DB_CHAR] == target for e in combatants_list):
+        if not any(e.get(DB_CHAR) == target for e in combatants_list):
             char.msg(f"|r{target.key} is no longer in combat.|n")
             return
         
@@ -1599,7 +1599,9 @@ class CombatHandler(DefaultScript):
                 # Check if targeted by others in the same room (excluding the victim and the advance target)
                 is_targeted_by_others_not_victim = False
                 for e in combatants_list:
-                    other_char = e[DB_CHAR]
+                    other_char = e.get(DB_CHAR)
+                    if not other_char:
+                        continue
                     if (other_char != char and other_char != grappled_victim and other_char != target and
                         other_char.location == char.location):  # Only check same-room combatants
                         if self.get_target_obj(e) == char:
@@ -1764,9 +1766,9 @@ class CombatHandler(DefaultScript):
                     if grappled_victim:
                         # Release the grapple - update the actual combatants list
                         for combatant_entry in combatants_list:
-                            if combatant_entry[DB_CHAR] == char:
+                            if combatant_entry.get(DB_CHAR) == char:
                                 combatant_entry[DB_GRAPPLING_DBREF] = None
-                            elif combatant_entry[DB_CHAR] == grappled_victim:
+                            elif combatant_entry.get(DB_CHAR) == grappled_victim:
                                 combatant_entry[DB_GRAPPLED_BY_DBREF] = None
                         
                         # Announce grapple release
@@ -1804,6 +1806,8 @@ class CombatHandler(DefaultScript):
                     splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_CHARGE: {char.key} failed charge against ranged weapon user {target.key}, bonus attack triggered.")
                 
                 # Apply charge failure penalty
+                # TODO: charge_penalty is set but never read — implement penalty
+                # mechanic (e.g., reduced dodge or accuracy next round) or remove
                 char.ndb.charge_penalty = True
                 char.msg("|rYour failed charge leaves you off-balance!|n")
                 splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_CHARGE: {char.key} failed charge on {target.key}, penalty applied.")
@@ -1846,9 +1850,9 @@ class CombatHandler(DefaultScript):
                     if grappled_victim:
                         # Release the grapple - update the actual combatants list
                         for combatant_entry in combatants_list:
-                            if combatant_entry[DB_CHAR] == char:
+                            if combatant_entry.get(DB_CHAR) == char:
                                 combatant_entry[DB_GRAPPLING_DBREF] = None
-                            elif combatant_entry[DB_CHAR] == grappled_victim:
+                            elif combatant_entry.get(DB_CHAR) == grappled_victim:
                                 combatant_entry[DB_GRAPPLED_BY_DBREF] = None
                         
                         # Announce grapple release (victim might be in different room now)
@@ -1896,6 +1900,8 @@ class CombatHandler(DefaultScript):
                     splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_CHARGE: {char.key} failed cross-room charge on {target.key}.")
                 
                 # Apply charge failure penalty
+                # TODO: charge_penalty is set but never read — implement penalty
+                # mechanic (e.g., reduced dodge or accuracy next round) or remove
                 char.ndb.charge_penalty = True
                 char.msg("|rYour failed charge leaves you off-balance!|n")
 

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -657,8 +657,7 @@ def remove_combatant(handler, char):
         char: The character to remove from combat
     """
     from .constants import (
-        SPLATTERCAST_CHANNEL, DB_COMBATANTS, DB_CHAR, DB_TARGET_DBREF, 
-        NDB_COMBAT_HANDLER
+        DB_COMBATANTS, DB_CHAR, DB_TARGET_DBREF
     )
     
     splattercast = get_splattercast()
@@ -685,7 +684,9 @@ def remove_combatant(handler, char):
     for other_entry in combatants:
         if other_entry.get(DB_TARGET_DBREF) == get_character_dbref(char):
             other_entry[DB_TARGET_DBREF] = None
-            other_char = other_entry[DB_CHAR]
+            other_char = other_entry.get(DB_CHAR)
+            if not other_char:
+                continue
             splattercast.msg(f"RMV_COMB: Cleared {other_char.key}'s target_dbref (was {char.key})")
             
             # Attempt smart auto-retargeting: find someone who is actively attacking this character
@@ -834,10 +835,6 @@ def remove_combatant(handler, char):
     else:
         splattercast.msg(f"RMV_COMB: Updated database directly")
     
-    # Remove handler reference
-    if hasattr(char.ndb, NDB_COMBAT_HANDLER) and getattr(char.ndb, NDB_COMBAT_HANDLER) == handler:
-        delattr(char.ndb, NDB_COMBAT_HANDLER)
-    
     splattercast.msg(f"{char.key} removed from combat.")
     # TODO: Add narrative combat exit message (weapon lowering, stepping back, etc.)
     
@@ -863,6 +860,9 @@ def cleanup_combatant_state(char, entry, handler):
     # Clear proximity relationships
     clear_all_proximity(char)
     
+    # Clear aim state (aiming_at, aimed_at_by, aiming_direction)
+    clear_aim_state(char)
+    
     # Break grapples
     grappling = get_combatant_grappling_target(entry, handler)
     grappled_by = get_combatant_grappled_by(entry, handler)
@@ -885,12 +885,18 @@ def cleanup_combatant_state(char, entry, handler):
     if hasattr(char.ndb, NDB_COMBAT_HANDLER):
         delattr(char.ndb, NDB_COMBAT_HANDLER)
     
-    # Clear combat override_place (only if it's the generic combat state)
+    # Clear combat-related override_place values.
+    # Combat sets several variants: "locked in combat.", "locked in a deadly showdown.",
+    # "aiming carefully at {name}.", "aiming carefully to the {direction}."
+    # We must NOT clear non-combat overrides like "unconscious and motionless." or
+    # "lying motionless and deceased." which belong to the medical/death systems.
+    combat_override_prefixes = ("locked in combat", "locked in a deadly showdown", "aiming carefully")
     if (hasattr(char, 'override_place') and 
-        char.override_place == "locked in combat."):
-        char.override_place = ""
+        char.override_place and
+        any(char.override_place.startswith(prefix) for prefix in combat_override_prefixes)):
         splattercast = get_splattercast()
-        splattercast.msg(f"CLEANUP_COMB: Cleared combat override_place for {char.key}")
+        splattercast.msg(f"CLEANUP_COMB: Cleared combat override_place '{char.override_place}' for {char.key}")
+        char.override_place = ""
     
     # No need to set charge flags to False after deletion - this was causing race conditions
     # The delattr above already removed them, setting them to False recreates them
@@ -952,9 +958,9 @@ def update_all_combatant_handler_references(handler):
     Args:
         handler: The combat handler instance all combatants should reference
     """
-    from .constants import SPLATTERCAST_CHANNEL, DB_COMBATANTS, DB_CHAR, NDB_COMBAT_HANDLER
+    from .constants import DB_COMBATANTS, DB_CHAR, NDB_COMBAT_HANDLER
     
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     combatants = handler.db.combatants or []
     
     updated_count = 0
@@ -1029,11 +1035,11 @@ def get_combatants_safe(handler):
     Returns:
         list: The combatants list, or an empty list if None/missing
     """
-    from .constants import DB_COMBATANTS, SPLATTERCAST_CHANNEL, DEBUG_PREFIX_HANDLER
+    from .constants import DB_COMBATANTS, DEBUG_PREFIX_HANDLER
     
     combatants = handler.db.combatants
     if combatants is None:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_WARNING: {DB_COMBATANTS} was None for handler {handler.key}, initializing to empty list.")
         combatants = []
         # Only set the attribute if the handler has been saved to the database
@@ -1088,11 +1094,11 @@ def detect_and_remove_orphaned_combatants(handler):
         list: List of orphaned combatants that were removed
     """
     from .constants import (
-        SPLATTERCAST_CHANNEL, DB_COMBATANTS, DB_CHAR, DB_TARGET_DBREF,
+        DB_COMBATANTS, DB_CHAR, DB_TARGET_DBREF,
         DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, DB_IS_YIELDING
     )
     
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     combatants = handler.db.combatants or []
     orphaned_chars = []
     
@@ -1153,9 +1159,9 @@ def resolve_bonus_attack(handler, attacker, target):
         attacker: The character making the bonus attack
         target: The target of the bonus attack
     """
-    from .constants import SPLATTERCAST_CHANNEL, DB_COMBATANTS, DB_CHAR
+    from .constants import DB_COMBATANTS, DB_CHAR
     
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     
     # Find the attacker's combat entry
     combatants_list = handler.db.combatants or []
@@ -1194,9 +1200,9 @@ def check_grenade_human_shield(proximity_list, combat_handler=None):
         dict: Modified damage assignments {char: damage_multiplier}
              where damage_multiplier is 0.0 for grapplers, 2.0 for victims
     """
-    from .constants import SPLATTERCAST_CHANNEL, DB_CHAR, DB_GRAPPLING_DBREF, DB_COMBATANTS, NDB_COMBAT_HANDLER
+    from .constants import DB_CHAR, DB_GRAPPLING_DBREF, DB_COMBATANTS, NDB_COMBAT_HANDLER
     
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     damage_modifiers = {}
     
     # If no combat handler provided, try to find one from the characters


### PR DESCRIPTION
## Summary

Fixes #42

- **Aim state cleanup**: `cleanup_combatant_state()` now calls `clear_aim_state()` to clear `aiming_at`/`aimed_at_by`/`aiming_direction` NDB attributes when characters leave combat.
- **Splattercast crash prevention**: Replaced 5 direct `ChannelDB.objects.get_channel()` calls with safe `get_splattercast()` wrapper that returns a `_NullChannel` fallback when the channel is missing.
- **charge_penalty documentation**: Added TODO comments to the write-only `charge_penalty` NDB assignments flagging them as unimplemented.
- **override_place cleanup broadened**: Now matches all combat-related prefixes (`"locked in combat"`, `"locked in a deadly showdown"`, `"aiming carefully"`) instead of only the exact string `"locked in combat."`.
- **Dead guard removal**: Removed `if not hasattr(self, 'ndb'): self.ndb = {}` from `at_death()` — all Evennia typeclassed objects always have `ndb`.
- **Safe dict access**: Replaced all 12 unsafe `entry[DB_CHAR]` accesses with `entry.get(DB_CHAR)` across `handler.py` and `utils.py` to prevent `KeyError` on malformed entries.
- **Duplicate cleanup removal**: Removed redundant handler-ref deletion in `remove_combatant()` that was already handled by `cleanup_combatant_state()`.