### PR TITLE
Replace magic strings with constants and document tie-breaking

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -774,7 +774,8 @@ class Character(ObjectParent, DefaultCharacter):
         # Log warning if archiving a staff character (shouldn't happen normally)
         if self.account and self.account.is_superuser:
             try:
-                splattercast = ChannelDB.objects.get_channel("Splattercast")
+                from world.combat.constants import SPLATTERCAST_CHANNEL
+                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 splattercast.msg(f"WARNING: Archiving staff character {self.key} (Account: {self.account.key}, Reason: {reason})")
             except Exception:
                 pass
@@ -802,7 +803,8 @@ class Character(ObjectParent, DefaultCharacter):
             
             # Log the move
             try:
-                splattercast = ChannelDB.objects.get_channel("Splattercast")
+                from world.combat.constants import SPLATTERCAST_CHANNEL
+                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 splattercast.msg(f"ARCHIVE: Moved {self.key} from {current_location.key if current_location else 'None'} to Limbo")
             except Exception:
                 pass
@@ -1113,7 +1115,8 @@ class Character(ObjectParent, DefaultCharacter):
             self.medical_state.conditions):
             try:
                 from evennia.comms.models import ChannelDB
-                splattercast = ChannelDB.objects.get_channel("Splattercast")
+                from world.combat.constants import SPLATTERCAST_CHANNEL
+                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
                 
                 # Find stopped medical script and restart it
                 medical_scripts = self.scripts.get("medical_script")
@@ -1283,7 +1286,8 @@ class Character(ObjectParent, DefaultCharacter):
         Returns:
             bool: True if an aim state was actually cleared, False otherwise.
         """
-        splattercast = ChannelDB.objects.get_channel("Splattercast")
+        from world.combat.constants import SPLATTERCAST_CHANNEL
+        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         stopped_aiming_message_parts = []
         log_message_parts = []
         action_taken = False

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -297,6 +297,9 @@ DB_TARGET_DBREF = "target_dbref"
 DB_GRAPPLING_DBREF = "grappling_dbref"
 DB_GRAPPLED_BY_DBREF = "grappled_by_dbref"
 DB_IS_YIELDING = "is_yielding"
+DB_COMBAT_ACTION = "combat_action"
+DB_COMBAT_ACTION_TARGET = "combat_action_target"
+DB_INITIATIVE = "initiative"
 
 # Explosive/throwing weapon properties
 DB_IS_THROWING_WEAPON = "is_throwing_weapon"
@@ -400,6 +403,7 @@ COMBAT_ACTION_DISARM = "disarm"
 # Existing combat actions (for reference)
 COMBAT_ACTION_GRAPPLE_INITIATE = "grapple_initiate"
 COMBAT_ACTION_GRAPPLE_JOIN = "grapple_join"
+COMBAT_ACTION_GRAPPLE_TAKEOVER = "grapple_takeover"
 COMBAT_ACTION_RELEASE_GRAPPLE = "release_grapple"
 COMBAT_ACTION_ESCAPE_GRAPPLE = "escape_grapple"
 

--- a/world/combat/grappling.py
+++ b/world/combat/grappling.py
@@ -13,6 +13,7 @@ Functions:
 """
 
 from .constants import (
+    DB_CHAR, DB_IS_YIELDING,
     DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, 
     MSG_CANNOT_WHILE_GRAPPLED, MSG_CANNOT_GRAPPLE_SELF, MSG_ALREADY_GRAPPLING,
 )
@@ -71,9 +72,9 @@ def establish_grapple(combat_handler, grappler, victim):
     
     combatants_list = list(combat_handler.db.combatants)
     for entry in combatants_list:
-        if entry.get("char") == grappler:
+        if entry.get(DB_CHAR) == grappler:
             grappler_entry = entry
-        elif entry.get("char") == victim:
+        elif entry.get(DB_CHAR) == victim:
             victim_entry = entry
     
     if not grappler_entry or not victim_entry:
@@ -93,11 +94,11 @@ def establish_grapple(combat_handler, grappler, victim):
     
     # Establish the grapple
     for i, entry in enumerate(combatants_list):
-        if entry.get("char") == grappler:
+        if entry.get(DB_CHAR) == grappler:
             combatants_list[i][DB_GRAPPLING_DBREF] = get_character_dbref(victim)
             # Grappler starts in restraint mode (yielding)
-            combatants_list[i]["is_yielding"] = True
-        elif entry.get("char") == victim:
+            combatants_list[i][DB_IS_YIELDING] = True
+        elif entry.get(DB_CHAR) == victim:
             combatants_list[i][DB_GRAPPLED_BY_DBREF] = get_character_dbref(grappler)
             # Victim stays non-yielding so they auto-resist each turn
             # (consistent with resolve_grapple_initiate behavior)
@@ -137,18 +138,18 @@ def break_grapple(combat_handler, grappler=None, victim=None):
     # --- Infer the missing side so both are always cleared ---
     if grappler and not victim:
         for entry in combatants_list:
-            if entry.get("char") == grappler and entry.get(DB_GRAPPLING_DBREF):
+            if entry.get(DB_CHAR) == grappler and entry.get(DB_GRAPPLING_DBREF):
                 victim = get_character_by_dbref(entry.get(DB_GRAPPLING_DBREF))
                 break
     elif victim and not grappler:
         for entry in combatants_list:
-            if entry.get("char") == victim and entry.get(DB_GRAPPLED_BY_DBREF):
+            if entry.get(DB_CHAR) == victim and entry.get(DB_GRAPPLED_BY_DBREF):
                 grappler = get_character_by_dbref(entry.get(DB_GRAPPLED_BY_DBREF))
                 break
     
     # Clear both sides of the grapple
     for i, entry in enumerate(combatants_list):
-        char = entry.get("char")
+        char = entry.get(DB_CHAR)
         
         if grappler and char == grappler:
             if entry.get(DB_GRAPPLING_DBREF):
@@ -186,7 +187,7 @@ def is_grappling(combat_handler, character):
         bool: True if character is grappling someone
     """
     for entry in combat_handler.db.combatants:
-        if entry.get("char") == character:
+        if entry.get(DB_CHAR) == character:
             return bool(entry.get(DB_GRAPPLING_DBREF))
     return False
 
@@ -203,7 +204,7 @@ def is_grappled(combat_handler, character):
         bool: True if character is being grappled
     """
     for entry in combat_handler.db.combatants:
-        if entry.get("char") == character:
+        if entry.get(DB_CHAR) == character:
             return bool(entry.get(DB_GRAPPLED_BY_DBREF))
     return False
 
@@ -222,7 +223,7 @@ def validate_grapple_action(combat_handler, character, action_name):
     """
     # Check if being grappled
     for entry in combat_handler.db.combatants:
-        if entry.get("char") == character:
+        if entry.get(DB_CHAR) == character:
             grappled_by_dbref = entry.get(DB_GRAPPLED_BY_DBREF)
             if grappled_by_dbref:
                 grappler = get_grappled_by(combat_handler, entry)
@@ -281,6 +282,7 @@ def resolve_grapple_initiate(char_entry, combatants_list, handler):
     
     if attacker_roll > defender_roll:
         # Success
+        # NOTE: Strict > means ties favor the defender. This is intentional.
         char_entry[DB_GRAPPLING_DBREF] = get_character_dbref(target)
         target_entry[DB_GRAPPLED_BY_DBREF] = get_character_dbref(char)
         
@@ -406,6 +408,7 @@ def resolve_grapple_join(char_entry, combatants_list, handler):
     
     if new_grappler_roll > current_grappler_roll:
         # New grappler wins - they take over the grapple
+        # NOTE: Strict > means ties favor the current grappler (defender). This is intentional.
         char_entry[DB_GRAPPLING_DBREF] = get_character_dbref(target)
         char_entry[DB_IS_YIELDING] = True
         
@@ -510,6 +513,7 @@ def resolve_grapple_takeover(char_entry, combatants_list, handler):
     
     if new_grappler_roll > current_grappler_roll:
         # Success: Force target to release victim, then establish new grapple
+        # NOTE: Strict > means ties favor the current grappler (defender). This is intentional.
         
         # Step 1: Break the existing grapple (A releases B)
         target_entry[DB_GRAPPLING_DBREF] = None

--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -24,10 +24,14 @@ from .constants import (
     COMBAT_SCRIPT_KEY, SPLATTERCAST_CHANNEL,
     DB_COMBATANTS, DB_COMBAT_RUNNING, DB_MANAGED_ROOMS,
     DB_CHAR, DB_TARGET_DBREF, DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, DB_IS_YIELDING,
+    DB_COMBAT_ACTION, DB_COMBAT_ACTION_TARGET, DB_INITIATIVE,
     NDB_COMBAT_HANDLER, NDB_PROXIMITY, NDB_SKIP_ROUND,
     DEBUG_PREFIX_HANDLER, DEBUG_SUCCESS, DEBUG_FAIL, DEBUG_ERROR, DEBUG_CLEANUP,
     MSG_GRAPPLE_AUTO_ESCAPE_VIOLENT,
     COMBAT_ACTION_RETREAT, COMBAT_ACTION_ADVANCE, COMBAT_ACTION_CHARGE, COMBAT_ACTION_DISARM,
+    COMBAT_ACTION_GRAPPLE_INITIATE, COMBAT_ACTION_GRAPPLE_JOIN, COMBAT_ACTION_GRAPPLE_TAKEOVER,
+    COMBAT_ACTION_RELEASE_GRAPPLE, COMBAT_ACTION_ESCAPE_GRAPPLE,
+    WEAPON_TYPE_UNARMED,
     COMBAT_ROUND_INTERVAL, STAGGER_DELAY_INTERVAL, MAX_STAGGER_DELAY
 )
 from .utils import (
@@ -554,7 +558,7 @@ class CombatHandler(DefaultScript):
             splattercast.msg(f"AT_REPEAT: Handler {self.key}. All combatants yielding but active grapples present. Combat continues in restraint mode.")
 
         # Sort combatants by initiative for processing
-        initiative_order = sorted(combatants_list, key=lambda e: e.get("initiative", 0), reverse=True)
+        initiative_order = sorted(combatants_list, key=lambda e: e.get(DB_INITIATIVE, 0), reverse=True)
         
         for combat_entry in initiative_order:
             char = combat_entry.get(DB_CHAR)
@@ -609,13 +613,13 @@ class CombatHandler(DefaultScript):
                     splattercast.msg(f"AT_REPEAT_START_TURN_CLEANUP: {char.key} has charge_attack_bonus_active - will be consumed during attack.")
 
             # Get combat action for this character
-            combat_action = current_char_combat_entry.get("combat_action")
+            combat_action = current_char_combat_entry.get(DB_COMBAT_ACTION)
             splattercast.msg(f"AT_REPEAT: {char.key} combat_action: {combat_action}")
 
             # Check if character is yielding first
             if current_char_combat_entry.get(DB_IS_YIELDING, False):
                 # Exception: Allow certain actions even when yielding
-                if combat_action in ["release_grapple", COMBAT_ACTION_ADVANCE, COMBAT_ACTION_RETREAT, COMBAT_ACTION_CHARGE]:
+                if combat_action in [COMBAT_ACTION_RELEASE_GRAPPLE, COMBAT_ACTION_ADVANCE, COMBAT_ACTION_RETREAT, COMBAT_ACTION_CHARGE]:
                     splattercast.msg(f"{char.key} is yielding but can still perform {combat_action} action.")
                     # Fall through to normal action processing
                 else:
@@ -667,6 +671,7 @@ class CombatHandler(DefaultScript):
 
                 if escaper_roll > grappler_roll:
                     # Success - clear grapple
+                    # NOTE: Strict > means ties favor the grappler (defender). This is intentional.
                     current_char_combat_entry[DB_GRAPPLED_BY_DBREF] = None
                     grappler_entry = next((e for e in combatants_list if e.get(DB_CHAR) == grappler), None)
                     if grappler_entry:
@@ -709,41 +714,41 @@ class CombatHandler(DefaultScript):
                 splattercast.msg(f"AT_REPEAT: {char.key} has action_intent: {combat_action}")
                 
                 if isinstance(combat_action, str):
-                    if combat_action == "grapple_initiate":
+                    if combat_action == COMBAT_ACTION_GRAPPLE_INITIATE:
                         self._resolve_grapple_initiate(current_char_combat_entry, combatants_list)
-                        current_char_combat_entry["combat_action"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
                         continue
-                    elif combat_action == "grapple_join":
+                    elif combat_action == COMBAT_ACTION_GRAPPLE_JOIN:
                         self._resolve_grapple_join(current_char_combat_entry, combatants_list)
-                        current_char_combat_entry["combat_action"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
                         continue
-                    elif combat_action == "grapple_takeover":
+                    elif combat_action == COMBAT_ACTION_GRAPPLE_TAKEOVER:
                         self._resolve_grapple_takeover(current_char_combat_entry, combatants_list)
-                        current_char_combat_entry["combat_action"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
                         continue
-                    elif combat_action == "release_grapple":
+                    elif combat_action == COMBAT_ACTION_RELEASE_GRAPPLE:
                         self._resolve_release_grapple(current_char_combat_entry, combatants_list)
-                        current_char_combat_entry["combat_action"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
                         continue
                     elif combat_action == COMBAT_ACTION_RETREAT:
                         self._resolve_retreat(char, current_char_combat_entry)
-                        current_char_combat_entry["combat_action"] = None
-                        current_char_combat_entry["combat_action_target"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION_TARGET] = None
                         continue
                     elif combat_action == COMBAT_ACTION_ADVANCE:
                         self._resolve_advance(char, current_char_combat_entry)
-                        current_char_combat_entry["combat_action"] = None
-                        current_char_combat_entry["combat_action_target"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION_TARGET] = None
                         continue
                     elif combat_action == COMBAT_ACTION_CHARGE:
                         self._resolve_charge(char, current_char_combat_entry, combatants_list)
-                        current_char_combat_entry["combat_action"] = None
-                        current_char_combat_entry["combat_action_target"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION_TARGET] = None
                         continue
                     elif combat_action == COMBAT_ACTION_DISARM:
                         self._resolve_disarm(char, current_char_combat_entry)
-                        current_char_combat_entry["combat_action"] = None
-                        current_char_combat_entry["combat_action_target"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION_TARGET] = None
                         continue
                 elif isinstance(combat_action, dict):
                     intent_type = combat_action.get("type")
@@ -758,7 +763,7 @@ class CombatHandler(DefaultScript):
                     if not is_action_target_valid and action_target_char:
                         char.msg(f"The target of your planned action ({action_target_char.key}) is no longer valid.")
                         splattercast.msg(f"{char.key}'s action_intent target {action_target_char.key} is invalid. Intent cleared, falling through.")
-                        current_char_combat_entry["combat_action"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
                     elif intent_type == "grapple" and is_action_target_valid:
                         # Handle grapple intent
                         can_grapple_target = (char.location == action_target_char.location)
@@ -782,7 +787,7 @@ class CombatHandler(DefaultScript):
                             if action_target_char not in proximity_set:
                                 char.msg(f"You need to be in melee proximity with {action_target_char.key} to grapple them. Try advancing or charging.")
                                 splattercast.msg(f"GRAPPLE FAIL (PROXIMITY): {char.key} not in proximity with {action_target_char.key}.")
-                                current_char_combat_entry["combat_action"] = None
+                                current_char_combat_entry[DB_COMBAT_ACTION] = None
                                 continue
 
                             attacker_roll = randint(1, max(1, get_numeric_stat(char, "motorics", 1)))
@@ -791,6 +796,7 @@ class CombatHandler(DefaultScript):
 
                             if attacker_roll > defender_roll:
                                 # Store dbrefs for persistence
+                                # NOTE: Strict > means ties favor the defender. This is intentional.
                                 current_char_combat_entry[DB_GRAPPLING_DBREF] = self._get_dbref(action_target_char)
                                 target_entry = next((e for e in combatants_list if e.get(DB_CHAR) == action_target_char), None)
                                 if target_entry:
@@ -820,10 +826,10 @@ class CombatHandler(DefaultScript):
                             char.msg(f"You can't reach {action_target_char.key} to grapple them from here.")
                             splattercast.msg(f"GRAPPLE FAIL (REACH): {char.key} cannot reach {action_target_char.key}.")
                         
-                        current_char_combat_entry["combat_action"] = None
-                        current_char_combat_entry["combat_action_target"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION_TARGET] = None
                         continue
-                    elif intent_type == "escape_grapple":
+                    elif intent_type == COMBAT_ACTION_ESCAPE_GRAPPLE:
                         grappler = self.get_grappled_by_obj(current_char_combat_entry)
                         if grappler and any(e.get(DB_CHAR) == grappler for e in combatants_list):
                             escaper_roll = randint(1, max(1, get_numeric_stat(char, "motorics", 1)))
@@ -832,6 +838,7 @@ class CombatHandler(DefaultScript):
 
                             if escaper_roll > grappler_roll:
                                 current_char_combat_entry[DB_GRAPPLED_BY_DBREF] = None
+                                # NOTE: Strict > means ties favor the grappler (defender). This is intentional.
                                 grappler_entry = next((e for e in combatants_list if e.get(DB_CHAR) == grappler), None)
                                 if grappler_entry:
                                     grappler_entry[DB_GRAPPLING_DBREF] = None
@@ -848,8 +855,8 @@ class CombatHandler(DefaultScript):
                                 obs_msg = escape_messages.get("observer_msg")
                                 char.location.msg_contents(obs_msg, exclude=[char, grappler])
                                 splattercast.msg(f"ESCAPE FAIL: {char.key} failed to escape {grappler.key}.")
-                        current_char_combat_entry["combat_action"] = None
-                        current_char_combat_entry["combat_action_target"] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION] = None
+                        current_char_combat_entry[DB_COMBAT_ACTION_TARGET] = None
                         continue
 
             # Standard attack processing - get target and schedule attack with staggered timing
@@ -867,7 +874,7 @@ class CombatHandler(DefaultScript):
                 splattercast.msg(f"AT_REPEAT: {char.key} has no valid target for attack.")
 
             # Clear the combat action after processing
-            current_char_combat_entry["combat_action"] = None
+            current_char_combat_entry[DB_COMBAT_ACTION] = None
 
         # Save the modified combatants list to the database FIRST to persist
         # combat_action changes and grapple state from round processing.
@@ -1003,15 +1010,15 @@ class CombatHandler(DefaultScript):
         
         # Find both characters in combatants list
         for entry in combatants_list:
-            if entry["char"] == char1:
+            if entry[DB_CHAR] == char1:
                 char1_entry = entry
-            elif entry["char"] == char2:
+            elif entry[DB_CHAR] == char2:
                 char2_entry = entry
         
         # Both must be in combat and targeting each other
         if char1_entry and char2_entry:
-            char1_target_dbref = char1_entry.get("target_dbref")
-            char2_target_dbref = char2_entry.get("target_dbref") 
+            char1_target_dbref = char1_entry.get(DB_TARGET_DBREF)
+            char2_target_dbref = char2_entry.get(DB_TARGET_DBREF) 
             char1_dbref = self._get_dbref(char1)
             char2_dbref = self._get_dbref(char2)
             
@@ -1229,6 +1236,7 @@ class CombatHandler(DefaultScript):
         
         if attacker_roll > target_roll:
             # Hit - calculate damage
+            # NOTE: Strict > means ties favor the defender. This is intentional.
             damage = randint(1, 6)  # Base damage
             if weapon:
                 # Add weapon damage if applicable
@@ -1258,7 +1266,7 @@ class CombatHandler(DefaultScript):
             splattercast.msg(f"PRECISION_TARGET: {attacker.key} margin={success_margin}, precision={precision_roll + precision_skill}, hit {hit_location}:{target_organ}")
             
             # Determine weapon type for messages
-            weapon_type = "unarmed"
+            weapon_type = WEAPON_TYPE_UNARMED
             if weapon and hasattr(weapon, 'db') and weapon.db.weapon_type:
                 weapon_type = weapon.db.weapon_type
             
@@ -1330,7 +1338,7 @@ class CombatHandler(DefaultScript):
                 
         else:
             # Miss - get miss messages from the message system
-            weapon_type = "unarmed"
+            weapon_type = WEAPON_TYPE_UNARMED
             if weapon and hasattr(weapon, 'db') and weapon.db.weapon_type:
                 weapon_type = weapon.db.weapon_type
                 
@@ -1506,6 +1514,7 @@ class CombatHandler(DefaultScript):
         
         if char_roll > opponent_roll:
             # Success - break proximity with opponents but maintain with grappled victim
+            # NOTE: Strict > means ties favor the opponent (defender). This is intentional.
             for opponent in opponents:
                 if is_in_proximity(char, opponent):
                     break_proximity(char, opponent)
@@ -1533,7 +1542,7 @@ class CombatHandler(DefaultScript):
         from .constants import SPLATTERCAST_CHANNEL, DEBUG_PREFIX_HANDLER, DB_COMBATANTS, DB_IS_YIELDING
         
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        target = entry.get("combat_action_target")
+        target = entry.get(DB_COMBAT_ACTION_TARGET)
         
         if not target:
             char.msg("|rNo target specified for advance action.|n")
@@ -1567,6 +1576,7 @@ class CombatHandler(DefaultScript):
             
             if char_roll > target_roll:
                 # Success - establish proximity
+                # NOTE: Strict > means ties favor the target (defender). This is intentional.
                 establish_proximity(char, target)
                 
                 char.msg(f"|gYou successfully advance to melee range with {target.key}.|n")
@@ -1639,6 +1649,7 @@ class CombatHandler(DefaultScript):
             
             if char_roll > target_roll:
                 # Success - move to target's room
+                # NOTE: Strict > means ties favor the target (defender). This is intentional.
                 old_location = char.location
                 
                 # Clear aim states before moving (consistent with traversal)
@@ -1710,14 +1721,14 @@ class CombatHandler(DefaultScript):
         from .constants import SPLATTERCAST_CHANNEL, DEBUG_PREFIX_HANDLER
         
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        target = entry.get("combat_action_target")
+        target = entry.get(DB_COMBAT_ACTION_TARGET)
         
         if not target:
             char.msg("|rNo target specified for charge action.|n")
             return
         
         # Validate target is still in combat
-        if not any(e["char"] == target for e in combatants_list):
+        if not any(e[DB_CHAR] == target for e in combatants_list):
             char.msg(f"|r{target.key} is no longer in combat.|n")
             return
         
@@ -1733,9 +1744,9 @@ class CombatHandler(DefaultScript):
             # Clear the charge action since it's not needed
             combatants_list = list(self.db.combatants)
             for combat_entry in combatants_list:
-                if combat_entry["char"] == char:
-                    combat_entry["combat_action"] = None
-                    combat_entry["combat_action_target"] = None
+                if combat_entry[DB_CHAR] == char:
+                    combat_entry[DB_COMBAT_ACTION] = None
+                    combat_entry[DB_COMBAT_ACTION_TARGET] = None
                     break
             self.db.combatants = combatants_list
             
@@ -1758,6 +1769,7 @@ class CombatHandler(DefaultScript):
             
             if charge_roll > resist_roll:
                 # Success - establish proximity and charge bonus
+                # NOTE: Strict > means ties favor the target (defender). This is intentional.
                 
                 # Check if charger is grappling someone and release them
                 if entry.get(DB_GRAPPLING_DBREF):
@@ -1840,6 +1852,7 @@ class CombatHandler(DefaultScript):
             
             if charge_roll > resist_roll:
                 # Success - move and establish proximity
+                # NOTE: Strict > means ties favor the target (defender). This is intentional.
                 exit_to_use = exits_to_target[0]
                 char.move_to(target_room)
                 
@@ -1917,7 +1930,7 @@ class CombatHandler(DefaultScript):
         )
         
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        target = entry.get("combat_action_target")
+        target = entry.get(DB_COMBAT_ACTION_TARGET)
         
         if not target:
             char.msg("|rNo target specified for disarm action.|n")
@@ -1929,7 +1942,7 @@ class CombatHandler(DefaultScript):
             return
         
         combatants_list = self.db.combatants or []
-        if not any(e["char"] == target for e in combatants_list):
+        if not any(e[DB_CHAR] == target for e in combatants_list):
             char.msg(f"|r{target.key} is no longer in combat.|n")
             return
         

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -18,7 +18,9 @@ from random import randint
 from evennia.comms.models import ChannelDB
 from .constants import (
     DEFAULT_MOTORICS, MIN_DICE_VALUE, SPLATTERCAST_CHANNEL,
-    DEBUG_TEMPLATE, NDB_PROXIMITY, COLOR_NORMAL
+    DEBUG_TEMPLATE, NDB_PROXIMITY, COLOR_NORMAL,
+    DB_COMBAT_ACTION, DB_COMBAT_ACTION_TARGET, DB_INITIATIVE,
+    WEAPON_TYPE_UNARMED, DB_CHAR, DB_TARGET_DBREF, DB_IS_YIELDING
 )
 
 
@@ -605,15 +607,15 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
     target_dbref = get_character_dbref(target)
     entry = {
         DB_CHAR: char,
-        "initiative": randint(1, 20) + get_numeric_stat(char, "motorics", 0),
+        DB_INITIATIVE: randint(1, 20) + get_numeric_stat(char, "motorics", 0),
         DB_TARGET_DBREF: target_dbref,
         DB_GRAPPLING_DBREF: get_character_dbref(initial_grappling),
         DB_GRAPPLED_BY_DBREF: get_character_dbref(initial_grappled_by),
         DB_IS_YIELDING: initial_is_yielding,
-        "combat_action": None
+        DB_COMBAT_ACTION: None
     }
     
-    splattercast.msg(f"ADD_COMBATANT_ENTRY: {char.key} -> target_dbref={target_dbref}, initiative={entry['initiative']}")
+    splattercast.msg(f"ADD_COMBATANT_ENTRY: {char.key} -> target_dbref={target_dbref}, initiative={entry[DB_INITIATIVE]}")
     
     combatants.append(entry)
     handler.db.combatants = combatants
@@ -628,7 +630,7 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
     else:
         splattercast.msg(f"ADD_COMB: {char.key} already has override_place: '{char.override_place}' - not overriding")
     
-    splattercast.msg(f"ADD_COMB: {char.key} added to combat in {handler.key} with initiative {entry['initiative']}.")
+    splattercast.msg(f"ADD_COMB: {char.key} added to combat in {handler.key} with initiative {entry[DB_INITIATIVE]}.")
     
     # Establish proximity for grappled pairs when adding to new handler
     from .proximity import establish_proximity
@@ -764,22 +766,22 @@ def remove_combatant(handler, char):
                 handler.set_target(other_char, new_target)
                 
                 # CRITICAL: Update the working list (combatants parameter) if we're using it
-                other_char_entry_working = next((e for e in combatants if e.get("char") == other_char), None)
+                other_char_entry_working = next((e for e in combatants if e.get(DB_CHAR) == other_char), None)
                 if other_char_entry_working:
-                    other_char_entry_working["target_dbref"] = get_character_dbref(new_target)
-                    other_char_entry_working["combat_action"] = None
-                    other_char_entry_working["combat_action_target"] = None 
-                    other_char_entry_working["is_yielding"] = False
-                    splattercast.msg(f"RMV_COMB: Updated working list for {other_char.key} -> target_dbref={other_char_entry_working['target_dbref']}")
+                    other_char_entry_working[DB_TARGET_DBREF] = get_character_dbref(new_target)
+                    other_char_entry_working[DB_COMBAT_ACTION] = None
+                    other_char_entry_working[DB_COMBAT_ACTION_TARGET] = None 
+                    other_char_entry_working[DB_IS_YIELDING] = False
+                    splattercast.msg(f"RMV_COMB: Updated working list for {other_char.key} -> target_dbref={other_char_entry_working[DB_TARGET_DBREF]}")
                 
                 # Also update database to ensure persistence (same as attack command)
                 combatants_copy = handler.db.combatants or []
-                other_char_entry_copy = next((e for e in combatants_copy if e.get("char") == other_char), None)
+                other_char_entry_copy = next((e for e in combatants_copy if e.get(DB_CHAR) == other_char), None)
                 if other_char_entry_copy:
-                    other_char_entry_copy["target_dbref"] = get_character_dbref(new_target)
-                    other_char_entry_copy["combat_action"] = None
-                    other_char_entry_copy["combat_action_target"] = None 
-                    other_char_entry_copy["is_yielding"] = False
+                    other_char_entry_copy[DB_TARGET_DBREF] = get_character_dbref(new_target)
+                    other_char_entry_copy[DB_COMBAT_ACTION] = None
+                    other_char_entry_copy[DB_COMBAT_ACTION_TARGET] = None 
+                    other_char_entry_copy[DB_IS_YIELDING] = False
                     
                     # Save the modified combatants list back (same as attack command)
                     handler.db.combatants = combatants_copy
@@ -788,7 +790,7 @@ def remove_combatant(handler, char):
                 # Get weapon info for initiate message
                 from .messages import get_combat_message
                 weapon_obj = get_wielded_weapon(other_char)
-                weapon_type = "unarmed"
+                weapon_type = WEAPON_TYPE_UNARMED
                 if weapon_obj and hasattr(weapon_obj, 'db') and weapon_obj.db.weapon_type is not None:
                     weapon_type = weapon_obj.db.weapon_type
                 
@@ -933,7 +935,7 @@ def cleanup_all_combatants(handler):
 
 def get_combatant_target(entry, handler):
     """Get the target object for a combatant entry."""
-    target_dbref = entry.get("target_dbref")
+    target_dbref = entry.get(DB_TARGET_DBREF)
     return get_character_by_dbref(target_dbref)
 
 
@@ -998,7 +1000,7 @@ def validate_character_handler_reference(char):
         
         # Check if character is actually in the handler's combatants list
         combatants = handler.db.combatants or []
-        char_in_handler = any(entry.get('char') == char for entry in combatants)
+        char_in_handler = any(entry.get(DB_CHAR) == char for entry in combatants)
         
         if not char_in_handler:
             return False, handler, "Character not found in handler's combatants list"


### PR DESCRIPTION
## Summary

- Replace ~72 magic string instances across 5 files with centralized constants from `world/combat/constants.py`
- Add 4 new constants: `DB_COMBAT_ACTION`, `DB_COMBAT_ACTION_TARGET`, `DB_INITIATIVE`, `COMBAT_ACTION_GRAPPLE_TAKEOVER`
- Document tie-breaking behavior (ties favor defender) at all 11 contested roll sites

## Changes by file

| File | Replacements | Details |
|------|-------------|---------|
| `constants.py` | +4 new constants | New combatant entry field and action constants |
| `handler.py` | 41 string → constant | combat_action, combat_action_target, initiative, char, target_dbref, is_yielding, grapple actions, unarmed |
| `utils.py` | 17 string → constant | Same fields in add/remove combatant, get_combatant_target, validate |
| `grappling.py` | 11 string → constant | `"char"` ×10 → `DB_CHAR`, `"is_yielding"` ×1 → `DB_IS_YIELDING` |
| `characters.py` | 4 string → constant | `"Splattercast"` → `SPLATTERCAST_CHANNEL` |

## Tie-breaking documentation

Added `# NOTE: Strict > means ties favor the defender. This is intentional.` comments at all contested roll comparison sites in `handler.py` (8 sites) and `grappling.py` (3 sites).

Fixes #44