### PR TITLE
Decompose utils.py into debug, dice, and explosives modules

### DIFF
--- a/world/combat/actions.py
+++ b/world/combat/actions.py
@@ -31,9 +31,10 @@ from .constants import (
     MSG_DISARM_SUCCESS_ATTACKER, MSG_DISARM_SUCCESS_VICTIM,
     MSG_DISARM_SUCCESS_OBSERVER,
 )
+from .debug import log_combat_action
+from .dice import roll_stat
 from .utils import (
     get_numeric_stat, initialize_proximity_ndb,
-    roll_stat, log_combat_action,
     get_character_dbref,
 )
 from .proximity import is_in_proximity

--- a/world/combat/debug.py
+++ b/world/combat/debug.py
@@ -1,0 +1,127 @@
+"""
+Combat Debug & Logging Utilities
+
+Centralised helpers for broadcasting debug messages to the Splattercast
+channel.  Every module in the combat package that needs debug output
+should import from here rather than creating its own channel lookups.
+
+Extracted from ``world/combat/utils.py`` during Phase 2 refactoring.
+
+Functions:
+    debug_broadcast — fire-and-forget message to Splattercast
+    get_splattercast — safe channel retrieval (returns ``_NullChannel``
+                       when the channel is unavailable)
+    log_debug — structured ``PREFIX_ACTION: message (char)`` format
+    log_combat_action — higher-level action logger used by commands
+"""
+
+from __future__ import annotations
+
+from evennia.comms.models import ChannelDB
+
+from .constants import SPLATTERCAST_CHANNEL
+
+
+# ------------------------------------------------------------------
+# Channel helpers
+# ------------------------------------------------------------------
+
+class _NullChannel:
+    """No-op channel stand-in when Splattercast is unavailable."""
+
+    def msg(self, *args, **kwargs):  # noqa: D401
+        pass
+
+
+def get_splattercast():
+    """
+    Safely retrieve the Splattercast debug channel.
+
+    Returns:
+        The channel object, or a ``_NullChannel`` stand-in if
+        unavailable.
+    """
+    channel = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    return channel if channel else _NullChannel()
+
+
+# ------------------------------------------------------------------
+# Broadcasting helpers
+# ------------------------------------------------------------------
+
+def debug_broadcast(
+    message: str,
+    prefix: str = "DEBUG",
+    status: str = "INFO",
+) -> None:
+    """
+    Broadcast a debug message to the Splattercast channel.
+
+    Args:
+        message: Debug message to broadcast.
+        prefix: Prefix for the debug message (e.g. ``"STICKY_GRENADE"``).
+        status: Status level (``"INFO"``, ``"SUCCESS"``, ``"ERROR"``, …).
+    """
+    try:
+        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        if splattercast:
+            formatted_msg = f"{prefix}_{status}: {message}"
+            splattercast.msg(formatted_msg)
+    except Exception:
+        # Fail silently if channel not available
+        pass
+
+
+def log_debug(
+    prefix: str,
+    action: str,
+    message: str,
+    character=None,
+) -> None:
+    """
+    Send a standardised debug message to Splattercast.
+
+    Format: ``PREFIX_ACTION: message (character_key)``
+
+    Args:
+        prefix: Debug prefix (e.g. ``DEBUG_PREFIX_ATTACK``).
+        action: Action type (e.g. ``DEBUG_SUCCESS``).
+        message: The debug message.
+        character: Optional character for context.
+    """
+    try:
+        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        if splattercast:
+            char_context = f" ({character.key})" if character else ""
+            full_message = f"{prefix}_{action}: {message}{char_context}"
+            splattercast.msg(full_message)
+    except Exception:
+        # Fail silently if channel doesn't exist
+        pass
+
+
+def log_combat_action(
+    character,
+    action_type: str,
+    target=None,
+    success: bool = True,
+    details: str = "",
+) -> None:
+    """
+    Log a combat action with a standardised format.
+
+    Args:
+        character: The character performing the action.
+        action_type: Type of action (``"attack"``, ``"flee"``, …).
+        target: Optional target character.
+        success: Whether the action succeeded.
+        details: Additional details.
+    """
+    prefix = f"{action_type.upper()}_CMD"
+    action = "SUCCESS" if success else "FAIL"
+
+    target_info = f" on {target.key}" if target else ""
+    details_info = f" - {details}" if details else ""
+
+    message = f"{character.key}{target_info}{details_info}"
+    log_debug(prefix, action, message)

--- a/world/combat/dice.py
+++ b/world/combat/dice.py
@@ -1,0 +1,140 @@
+"""
+Combat Dice Rolling & Stat Access
+
+Pure functions for rolling dice against character stats.  These have no
+side-effects (no logging, no state mutation) and depend only on
+``random`` and ``constants``.
+
+Extracted from ``world/combat/utils.py`` during Phase 2 refactoring.
+
+Functions:
+    get_character_stat — safe stat value retrieval with fallback
+    roll_stat — single die roll against a character's stat
+    opposed_roll — opposed roll between two characters
+    roll_with_advantage — roll twice, take higher
+    roll_with_disadvantage — roll twice, take lower
+    standard_roll — single roll with consistent tuple interface
+"""
+
+from __future__ import annotations
+
+from random import randint
+
+from .constants import DEFAULT_MOTORICS, MIN_DICE_VALUE
+
+
+# ------------------------------------------------------------------
+# Stat access
+# ------------------------------------------------------------------
+
+def get_character_stat(character, stat_name: str, default: int = 1) -> int:
+    """
+    Safely get a character's stat value with fallback to *default*.
+
+    Args:
+        character: The character object.
+        stat_name: Name of the stat (e.g. ``"motorics"``, ``"grit"``).
+        default: Default value if stat is missing or invalid.
+
+    Returns:
+        The stat value, guaranteed to be a positive integer.
+    """
+    stat_value = getattr(character, stat_name, default)
+
+    # Ensure it's a valid number
+    if not isinstance(stat_value, (int, float)) or stat_value < 1:
+        return default
+
+    return int(stat_value)
+
+
+# ------------------------------------------------------------------
+# Rolling
+# ------------------------------------------------------------------
+
+def roll_stat(character, stat_name: str, default: int = DEFAULT_MOTORICS) -> int:
+    """
+    Roll a die based on a character's stat value.
+
+    Args:
+        character: The character object.
+        stat_name: Name of the stat to roll against.
+        default: Default stat value if missing.
+
+    Returns:
+        Random value from 1 to *stat_value*.
+    """
+    stat_value = get_character_stat(character, stat_name, default)
+    return randint(MIN_DICE_VALUE, max(MIN_DICE_VALUE, stat_value))
+
+
+def opposed_roll(
+    char1,
+    char2,
+    stat1: str = "motorics",
+    stat2: str = "motorics",
+) -> tuple[int, int, bool]:
+    """
+    Perform an opposed roll between two characters.
+
+    Args:
+        char1: First character.
+        char2: Second character.
+        stat1: Stat name for *char1*.
+        stat2: Stat name for *char2*.
+
+    Returns:
+        ``(char1_roll, char2_roll, char1_wins)`` — ties favour the
+        defender (*char2*).
+    """
+    roll1 = roll_stat(char1, stat1)
+    roll2 = roll_stat(char2, stat2)
+
+    return roll1, roll2, roll1 > roll2
+
+
+def roll_with_advantage(stat_value: int) -> tuple[int, int, int]:
+    """
+    Roll with advantage: roll twice, take the higher result.
+
+    Args:
+        stat_value: The stat value to roll against.
+
+    Returns:
+        ``(final_roll, roll1, roll2)`` for debugging.
+    """
+    roll1 = randint(1, max(1, stat_value))
+    roll2 = randint(1, max(1, stat_value))
+    final_roll = max(roll1, roll2)
+    return final_roll, roll1, roll2
+
+
+def roll_with_disadvantage(stat_value: int) -> tuple[int, int, int]:
+    """
+    Roll with disadvantage: roll twice, take the lower result.
+
+    Args:
+        stat_value: The stat value to roll against.
+
+    Returns:
+        ``(final_roll, roll1, roll2)`` for debugging.
+    """
+    roll1 = randint(1, max(1, stat_value))
+    roll2 = randint(1, max(1, stat_value))
+    final_roll = min(roll1, roll2)
+    return final_roll, roll1, roll2
+
+
+def standard_roll(stat_value: int) -> tuple[int, int, int]:
+    """
+    Standard single roll.
+
+    Args:
+        stat_value: The stat value to roll against.
+
+    Returns:
+        ``(final_roll, roll, roll)`` for a consistent interface with
+        advantage/disadvantage variants.
+    """
+    roll = randint(1, max(1, stat_value))
+    return roll, roll, roll

--- a/world/combat/explosives.py
+++ b/world/combat/explosives.py
@@ -1,0 +1,519 @@
+"""
+Explosive & Grenade Utilities
+
+Functions for sticky-grenade adhesion mechanics, human-shield logic
+during explosions, and helpers for traversing the location hierarchy
+to find the blast room.
+
+Extracted from ``world/combat/utils.py`` during Phase 2 refactoring.
+
+Functions:
+    check_grenade_human_shield — grapple-based shield damage modifiers
+    send_grenade_shield_messages — notify participants of shield event
+    calculate_stick_chance — magnetic adhesion probability
+    get_explosion_room — resolve room through item/character hierarchy
+    establish_stick — create bidirectional grenade↔armor bond
+    get_stuck_grenades_on_character — find all stuck grenades on worn items
+    get_outermost_armor_at_location — highest-layer armor at body slot
+    break_stick — sever grenade↔armor magnetic bond
+"""
+
+from __future__ import annotations
+
+from .constants import (
+    DB_CHAR,
+    DB_COMBATANTS,
+    DB_GRAPPLING_DBREF,
+    NDB_COMBAT_HANDLER,
+)
+from .debug import debug_broadcast, get_splattercast
+from .utils import get_character_by_dbref, get_display_name_safe
+
+
+# ------------------------------------------------------------------
+# Human-shield mechanics
+# ------------------------------------------------------------------
+
+def check_grenade_human_shield(proximity_list, combat_handler=None):
+    """
+    Check for human-shield mechanics in grenade explosions.
+
+    For characters in *proximity_list* who are grappling someone,
+    implement simplified human-shield mechanics:
+
+    * Grappler automatically uses victim as blast shield → no damage.
+    * Victim takes double damage.
+
+    Args:
+        proximity_list: List of characters in blast radius.
+        combat_handler: Optional combat handler for grapple state
+            checking.
+
+    Returns:
+        ``dict`` of ``{char: damage_multiplier}`` where multiplier is
+        ``0.0`` for grapplers and ``2.0`` for victims.
+    """
+    splattercast = get_splattercast()
+    damage_modifiers: dict = {}
+
+    # If no combat handler provided, try to find one from the characters
+    if not combat_handler and proximity_list:
+        for char in proximity_list:
+            if hasattr(char.ndb, NDB_COMBAT_HANDLER):
+                combat_handler = getattr(char.ndb, NDB_COMBAT_HANDLER)
+                break
+
+    if not combat_handler:
+        splattercast.msg(
+            "GRENADE_SHIELD: No combat handler found, skipping human shield checks"
+        )
+        return damage_modifiers
+
+    # Get current combatants list for grapple state checking
+    combatants_list = combat_handler.db.combatants or []
+
+    for char in proximity_list:
+        # Find this character's combat entry
+        char_entry = next(
+            (e for e in combatants_list if e.get(DB_CHAR) == char), None
+        )
+        if not char_entry:
+            continue
+
+        # Check if this character is grappling someone
+        grappling_dbref = char_entry.get(DB_GRAPPLING_DBREF)
+        if grappling_dbref:
+            victim = get_character_by_dbref(grappling_dbref)
+            if victim and victim in proximity_list:
+                # Both grappler and victim are in blast radius
+                damage_modifiers[char] = 0.0   # Grappler takes no damage
+                damage_modifiers[victim] = 2.0  # Victim takes double damage
+
+                # Send human shield messages
+                send_grenade_shield_messages(char, victim)
+
+                splattercast.msg(
+                    f"GRENADE_SHIELD: {char.key} using {victim.key} as blast shield"
+                )
+
+    return damage_modifiers
+
+
+def send_grenade_shield_messages(grappler, victim) -> None:
+    """
+    Send human-shield messages specific to grenade explosions.
+
+    Args:
+        grappler: The character using *victim* as shield.
+        victim: The character being used as shield.
+    """
+    grappler_msg = (
+        f"|yYou instinctively position {get_display_name_safe(victim)} "
+        f"between yourself and the explosion!|n"
+    )
+    victim_msg = (
+        f"|RYou are forced to absorb the full blast as "
+        f"{get_display_name_safe(grappler)} uses you as a shield!|n"
+    )
+    observer_msg = (
+        f"|y{get_display_name_safe(grappler)} uses "
+        f"{get_display_name_safe(victim)} as a human shield against "
+        f"the explosion!|n"
+    )
+
+    grappler.msg(grappler_msg)
+    victim.msg(victim_msg)
+
+    # Send to observers in the same location
+    if grappler.location:
+        grappler.location.msg_contents(
+            observer_msg, exclude=[grappler, victim]
+        )
+
+
+# ------------------------------------------------------------------
+# Sticky-grenade adhesion
+# ------------------------------------------------------------------
+
+def calculate_stick_chance(grenade, armor) -> int:
+    """
+    Calculate the chance that a sticky grenade will adhere to armor.
+
+    Stick criteria:
+
+    1. Check armor base metal / magnetic levels.
+    2. If armor is a plate carrier, check installed plates for highest
+       values.
+    3. Threshold check: ``magnetic_level >= (grenade_strength - 3)``
+       AND ``metal_level >= (grenade_strength - 5)``.
+    4. If threshold met: ``chance = 40 + (metal_level * 5) +
+       (magnetic_level * 5)``.
+    5. Maximum 95 % (always a 5 % chance to fail).
+
+    Args:
+        grenade: The sticky grenade object with ``magnetic_strength``.
+        armor: The armor ``Item`` with ``metal_level`` and
+            ``magnetic_level``.
+
+    Returns:
+        Percentage chance to stick (0–95), or 0 if thresholds not met.
+    """
+    from typeclasses.items import Item
+
+    # Validate inputs
+    if not grenade or not armor:
+        return 0
+
+    # Get grenade magnetic strength (default 5 if not set)
+    magnetic_strength = (
+        grenade.db.magnetic_strength
+        if grenade.db.magnetic_strength is not None
+        else 5
+    )
+
+    # Get armor base properties (default 0 if not set)
+    metal_level = (
+        armor.db.metal_level if armor.db.metal_level is not None else 0
+    )
+    magnetic_level = (
+        armor.db.magnetic_level if armor.db.magnetic_level is not None else 0
+    )
+
+    # PLATE CARRIER CHECK: If this is a plate carrier, check installed plates
+    is_plate_carrier = armor.db.is_plate_carrier
+    if is_plate_carrier:
+        installed_plates = armor.db.installed_plates or {}
+
+        # Check all installed plates and use highest metal/magnetic values
+        for slot, plate_ref in installed_plates.items():
+            if plate_ref:
+                plate_metal = (
+                    plate_ref.db.metal_level
+                    if plate_ref.db.metal_level is not None
+                    else 0
+                )
+                plate_magnetic = (
+                    plate_ref.db.magnetic_level
+                    if plate_ref.db.magnetic_level is not None
+                    else 0
+                )
+
+                metal_level = max(metal_level, plate_metal)
+                magnetic_level = max(magnetic_level, plate_magnetic)
+
+                debug_broadcast(
+                    f"Plate carrier check: {armor.key} slot {slot} has "
+                    f"{plate_ref.key} (metal={plate_metal}, "
+                    f"magnetic={plate_magnetic})",
+                    prefix="STICKY_GRENADE",
+                    status="PLATE_CHECK",
+                )
+
+        debug_broadcast(
+            f"Plate carrier final values: metal={metal_level}, "
+            f"magnetic={magnetic_level}",
+            prefix="STICKY_GRENADE",
+            status="PLATE_FINAL",
+        )
+
+    # Calculate thresholds
+    magnetic_threshold = magnetic_strength - 3
+    metal_threshold = magnetic_strength - 5
+
+    # Check if thresholds are met
+    if magnetic_level < magnetic_threshold or metal_level < metal_threshold:
+        debug_broadcast(
+            f"Stick failed threshold: {grenade.key} vs {armor.key} "
+            f"(magnetic {magnetic_level}/{magnetic_threshold}, "
+            f"metal {metal_level}/{metal_threshold})",
+            prefix="STICKY_GRENADE",
+            status="THRESHOLD_FAIL",
+        )
+        return 0
+
+    # Calculate base chance
+    chance = 40 + (metal_level * 5) + (magnetic_level * 5)
+
+    # Cap at 95% (always 5% failure chance)
+    chance = min(chance, 95)
+
+    debug_broadcast(
+        f"Stick chance: {grenade.key} vs {armor.key} = {chance}% "
+        f"(metal={metal_level}, magnetic={magnetic_level}, "
+        f"strength={magnetic_strength})",
+        prefix="STICKY_GRENADE",
+        status="CALC",
+    )
+
+    return chance
+
+
+def get_explosion_room(grenade):
+    """
+    Get the room where a grenade will explode, handling armor hierarchy.
+
+    Traverses the location hierarchy to find the room:
+
+    * ``grenade.location = armor`` → ``armor.location = character/room``
+    * ``grenade.location = character`` → ``character.location = room``
+    * ``grenade.location = room`` → room itself
+
+    Args:
+        grenade: The grenade object.
+
+    Returns:
+        Room object or ``None`` if grenade has no valid explosion
+        location.
+    """
+    from typeclasses.characters import Character
+    from typeclasses.items import Item
+    from typeclasses.rooms import Room
+
+    if not grenade or not grenade.location:
+        debug_broadcast(
+            "Explosion room lookup failed: grenade has no location",
+            prefix="STICKY_GRENADE",
+            status="ERROR",
+        )
+        return None
+
+    location = grenade.location
+
+    # If grenade is in/on an Item (armor), go up one level
+    if isinstance(location, Item):
+        debug_broadcast(
+            f"Grenade {grenade.key} stuck to armor {location.key}, "
+            f"checking armor location",
+            prefix="STICKY_GRENADE",
+            status="HIERARCHY",
+        )
+        location = location.location
+
+    # If we're now at a Character, go up one more level to room
+    if isinstance(location, Character):
+        debug_broadcast(
+            f"Grenade on character {location.key}, getting their room",
+            prefix="STICKY_GRENADE",
+            status="HIERARCHY",
+        )
+        location = location.location
+
+    # Validate we have a room
+    if isinstance(location, Room):
+        debug_broadcast(
+            f"Explosion room for {grenade.key}: {location.key}",
+            prefix="STICKY_GRENADE",
+            status="SUCCESS",
+        )
+        return location
+
+    debug_broadcast(
+        f"Explosion room lookup failed: final location is "
+        f"{type(location).__name__}",
+        prefix="STICKY_GRENADE",
+        status="ERROR",
+    )
+    return None
+
+
+def establish_stick(grenade, armor, hit_location: str) -> bool:
+    """
+    Establish bidirectional sticky-grenade relationship.
+
+    Sets up the magnetic bond between grenade and armor:
+
+    * ``grenade.location = armor`` (physical containment)
+    * ``grenade.db.stuck_to_armor = armor`` (reference)
+    * ``grenade.db.stuck_to_location = hit_location`` (body part)
+    * ``armor.db.stuck_grenade = grenade`` (bidirectional reference)
+
+    Args:
+        grenade: The sticky grenade object.
+        armor: The armor ``Item`` object.
+        hit_location: Body location string (e.g. ``"chest"``).
+
+    Returns:
+        ``True`` if stick established successfully.
+    """
+    from typeclasses.items import Item
+
+    # Validate inputs
+    if not grenade or not armor or not isinstance(armor, Item):
+        debug_broadcast(
+            "Stick establishment failed: invalid inputs",
+            prefix="STICKY_GRENADE",
+            status="ERROR",
+        )
+        return False
+
+    # Break any existing stick first
+    if grenade.db.stuck_to_armor:
+        old_armor = grenade.db.stuck_to_armor
+        if old_armor and old_armor.db.stuck_grenade is not None:
+            old_armor.db.stuck_grenade = None
+
+    # Establish new stick — grenade moves to armor
+    grenade.location = armor
+
+    # Set grenade attributes
+    grenade.db.stuck_to_armor = armor
+    grenade.db.stuck_to_location = hit_location
+
+    # Set armor attribute (bidirectional reference)
+    armor.db.stuck_grenade = grenade
+
+    debug_broadcast(
+        f"Stick established: {grenade.key} -> {armor.key} at "
+        f"{hit_location}",
+        prefix="STICKY_GRENADE",
+        status="SUCCESS",
+    )
+
+    return True
+
+
+def get_stuck_grenades_on_character(character) -> list[tuple]:
+    """
+    Get all sticky grenades currently stuck to a character's armor.
+
+    Searches all worn items for stuck grenades.
+
+    Args:
+        character: The ``Character`` object to check.
+
+    Returns:
+        List of ``(grenade, armor, location)`` tuples for each stuck
+        grenade.
+    """
+    from typeclasses.characters import Character
+    from typeclasses.items import Item
+
+    if not isinstance(character, Character):
+        return []
+
+    stuck_grenades: list[tuple] = []
+
+    # Check all items in character's inventory
+    for item in character.contents:
+        if not isinstance(item, Item):
+            continue
+
+        # Check if this item has a stuck grenade
+        if item.db.stuck_grenade:
+            grenade = item.db.stuck_grenade
+            location = (
+                grenade.db.stuck_to_location
+                if grenade.db.stuck_to_location is not None
+                else "unknown"
+            )
+            stuck_grenades.append((grenade, item, location))
+
+            debug_broadcast(
+                f"Found stuck grenade: {grenade.key} on {item.key} "
+                f"({location})",
+                prefix="STICKY_GRENADE",
+                status="FOUND",
+            )
+
+    return stuck_grenades
+
+
+def get_outermost_armor_at_location(character, hit_location: str):
+    """
+    Get the outermost armor piece at a specific body location.
+
+    Searches worn items for highest layer number at the hit location.
+
+    Args:
+        character: The ``Character`` object.
+        hit_location: Body location string (e.g. ``"chest"``).
+
+    Returns:
+        The outermost armor ``Item`` at that location, or ``None`` if
+        no armor covers it.
+    """
+    from typeclasses.characters import Character
+    from typeclasses.items import Item
+
+    if not isinstance(character, Character):
+        return None
+
+    outermost_armor = None
+    highest_layer = -1
+
+    # Check all worn items
+    for item in character.contents:
+        if not isinstance(item, Item):
+            continue
+
+        # Check if item covers this location
+        coverage = item.db.coverage or []
+        if not coverage or hit_location not in coverage:
+            continue
+
+        # Check layer
+        layer = item.db.layer if item.db.layer is not None else 0
+        if layer > highest_layer:
+            highest_layer = layer
+            outermost_armor = item
+
+    if outermost_armor:
+        debug_broadcast(
+            f"Outermost armor at {hit_location}: {outermost_armor.key} "
+            f"(layer {highest_layer})",
+            prefix="STICKY_GRENADE",
+            status="FOUND",
+        )
+    else:
+        debug_broadcast(
+            f"No armor found at {hit_location}",
+            prefix="STICKY_GRENADE",
+            status="NOT_FOUND",
+        )
+
+    return outermost_armor
+
+
+def break_stick(grenade) -> bool:
+    """
+    Break the magnetic bond between grenade and armor.
+
+    Cleans up all bidirectional references.  The grenade's location is
+    **not** changed — the caller must handle that separately.
+
+    Args:
+        grenade: The sticky grenade object.
+
+    Returns:
+        ``True`` if stick was broken, ``False`` if no stick existed.
+    """
+    if not grenade:
+        return False
+
+    # Check if grenade is stuck
+    if not grenade.db.stuck_to_armor:
+        return False
+
+    armor = grenade.db.stuck_to_armor
+    location = (
+        grenade.db.stuck_to_location
+        if grenade.db.stuck_to_location is not None
+        else "unknown"
+    )
+
+    # Clear armor's reference to grenade
+    if armor and armor.db.stuck_grenade is not None:
+        armor.db.stuck_grenade = None
+
+    # Clear grenade's references
+    grenade.db.stuck_to_armor = None
+    grenade.db.stuck_to_location = None
+
+    debug_broadcast(
+        f"Stick broken: {grenade.key} from "
+        f"{armor.key if armor else 'unknown'} at {location}",
+        prefix="STICKY_GRENADE",
+        status="BREAK",
+    )
+
+    return True

--- a/world/combat/grappling.py
+++ b/world/combat/grappling.py
@@ -17,7 +17,8 @@ from .constants import (
     DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, 
     MSG_CANNOT_WHILE_GRAPPLED, MSG_CANNOT_GRAPPLE_SELF, MSG_ALREADY_GRAPPLING,
 )
-from .utils import log_debug, get_display_name_safe, get_character_by_dbref, get_character_dbref
+from .debug import log_debug
+from .utils import get_display_name_safe, get_character_by_dbref, get_character_dbref
 from .proximity import establish_proximity
 
 
@@ -255,7 +256,8 @@ def resolve_grapple_initiate(char_entry, combatants_list, handler):
         DB_CHAR, DB_TARGET_DBREF,
         DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, DB_IS_YIELDING
     )
-    from .utils import get_numeric_stat, get_splattercast
+    from .debug import get_splattercast
+    from .utils import get_numeric_stat
     from random import randint
     
     splattercast = get_splattercast()
@@ -363,7 +365,8 @@ def resolve_grapple_join(char_entry, combatants_list, handler):
         NDB_PROXIMITY, DB_CHAR,
         DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, DB_IS_YIELDING
     )
-    from .utils import get_numeric_stat, get_splattercast
+    from .debug import get_splattercast
+    from .utils import get_numeric_stat
     from random import randint
     
     splattercast = get_splattercast()
@@ -469,7 +472,8 @@ def resolve_grapple_takeover(char_entry, combatants_list, handler):
         DB_CHAR,
         DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, DB_IS_YIELDING, DB_TARGET_DBREF
     )
-    from .utils import get_numeric_stat, get_splattercast
+    from .debug import get_splattercast
+    from .utils import get_numeric_stat
     from random import randint
     
     splattercast = get_splattercast()
@@ -581,7 +585,7 @@ def resolve_release_grapple(char_entry, combatants_list, handler):
         handler: The combat handler instance
     """
     from .constants import DB_CHAR, DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF
-    from .utils import get_splattercast
+    from .debug import get_splattercast
     
     splattercast = get_splattercast()
     char = char_entry.get(DB_CHAR)
@@ -637,7 +641,7 @@ def validate_and_cleanup_grapple_state(handler):
         handler: The combat handler instance
     """
     from .constants import DB_CHAR, DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF
-    from .utils import get_splattercast
+    from .debug import get_splattercast
     
     splattercast = get_splattercast()
     combatants_list = list(handler.db.combatants or [])

--- a/world/combat/movement_resolution.py
+++ b/world/combat/movement_resolution.py
@@ -22,10 +22,10 @@ from .constants import (
     DB_IS_YIELDING, DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF,
     NDB_PROXIMITY_UNIVERSAL,
 )
+from .dice import roll_with_disadvantage, standard_roll
 from .utils import (
     get_numeric_stat, initialize_proximity_ndb,
     is_wielding_ranged_weapon, clear_aim_state,
-    roll_with_disadvantage, standard_roll,
     get_character_by_dbref,
 )
 from .proximity import (

--- a/world/combat/proximity.py
+++ b/world/combat/proximity.py
@@ -13,7 +13,7 @@ Functions:
 """
 
 from .constants import NDB_PROXIMITY
-from .utils import log_debug
+from .debug import log_debug
 
 
 def initialize_proximity(character):
@@ -159,7 +159,7 @@ def proximity_opposed_roll(character, stat_name="motorics"):
     Returns:
         tuple: (highest_roll, highest_opponent, all_rolls)
     """
-    from .utils import roll_stat
+    from .dice import roll_stat
     
     proximity_list = get_proximity_list(character)
     if not proximity_list:

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -2,219 +2,83 @@
 Combat System Utilities
 
 Shared utility functions used throughout the combat system.
-Extracted from repeated patterns in the codebase to improve
-maintainability and consistency.
+Organised following Python best practices while maintaining
+Evennia conventions and backward compatibility.
 
-Functions:
-- Dice rolling and stat validation
-- Debug logging helpers
-- Character attribute access
-- NDB state management
-- Proximity validation
-- Message formatting
+Functions remaining in this module:
+    - Character state management (proximity, aim)
+    - Weapon & item helpers
+    - Message formatting
+    - Validation helpers
+    - Stat management helpers
+    - Combatant management (add, remove, cleanup)
+
+Functions extracted to dedicated modules (re-exported here for
+backward compatibility):
+    - ``debug``  — debug_broadcast, get_splattercast, log_debug,
+      log_combat_action, _NullChannel
+    - ``dice``   — get_character_stat, roll_stat, opposed_roll,
+      roll_with_advantage, roll_with_disadvantage, standard_roll
+    - ``explosives`` — check_grenade_human_shield,
+      send_grenade_shield_messages, calculate_stick_chance,
+      get_explosion_room, establish_stick,
+      get_stuck_grenades_on_character, get_outermost_armor_at_location,
+      break_stick
 """
 
+from __future__ import annotations
+
 from random import randint
-from evennia.comms.models import ChannelDB
+
 from .constants import (
-    DEFAULT_MOTORICS, MIN_DICE_VALUE, SPLATTERCAST_CHANNEL,
-    DEBUG_TEMPLATE, NDB_PROXIMITY, COLOR_NORMAL,
-    DB_COMBAT_ACTION, DB_COMBAT_ACTION_TARGET, DB_INITIATIVE,
-    WEAPON_TYPE_UNARMED, DB_CHAR, DB_TARGET_DBREF, DB_IS_YIELDING
+    COLOR_NORMAL,
+    DB_CHAR,
+    DB_COMBAT_ACTION,
+    DB_COMBAT_ACTION_TARGET,
+    DB_INITIATIVE,
+    DB_IS_YIELDING,
+    DB_TARGET_DBREF,
+    DEFAULT_MOTORICS,
+    NDB_PROXIMITY,
+    WEAPON_TYPE_UNARMED,
 )
+from .debug import get_splattercast, log_debug
 
 
 # ===================================================================
-# DEBUG & LOGGING
+# BACKWARD-COMPATIBLE RE-EXPORTS
+#
+# External consumers (commands/, typeclasses/, world/medical/, …)
+# import these symbols from ``world.combat.utils``.  The canonical
+# definitions now live in their own modules, but we re-export them
+# here so every ``from world.combat.utils import X`` keeps working.
 # ===================================================================
 
-def debug_broadcast(message, prefix="DEBUG", status="INFO"):
-    """
-    Broadcast debug message to Splattercast channel.
-    
-    Args:
-        message (str): Debug message to broadcast
-        prefix (str): Prefix for the debug message
-        status (str): Status level (INFO, SUCCESS, ERROR, etc.)
-    """
-    try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        if splattercast:
-            formatted_msg = f"{prefix}_{status}: {message}"
-            splattercast.msg(formatted_msg)
-    except Exception:
-        # Fail silently if channel not available
-        pass
-
-
-class _NullChannel:
-    """No-op channel stand-in when Splattercast is unavailable."""
-
-    def msg(self, *args, **kwargs):
-        pass
-
-
-def get_splattercast():
-    """
-    Safely retrieve the Splattercast debug channel.
-
-    Returns:
-        The channel object, or a no-op stand-in if unavailable.
-    """
-    channel = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-    return channel if channel else _NullChannel()
-
-
-# ===================================================================
-# DICE & STATS
-# ===================================================================
-
-def get_character_stat(character, stat_name, default=1):
-    """
-    Safely get a character's stat value with fallback to default.
-    
-    Args:
-        character: The character object
-        stat_name (str): Name of the stat (e.g., 'motorics', 'grit')
-        default (int): Default value if stat is missing or invalid
-        
-    Returns:
-        int: The stat value, guaranteed to be a positive integer
-    """
-    stat_value = getattr(character, stat_name, default)
-    
-    # Ensure it's a valid number
-    if not isinstance(stat_value, (int, float)) or stat_value < 1:
-        return default
-    
-    return int(stat_value)
-
-
-def roll_stat(character, stat_name, default=DEFAULT_MOTORICS):
-    """
-    Roll a die based on a character's stat value.
-    
-    Args:
-        character: The character object
-        stat_name (str): Name of the stat to roll against
-        default (int): Default stat value if missing
-        
-    Returns:
-        int: Random value from 1 to stat_value
-    """
-    stat_value = get_character_stat(character, stat_name, default)
-    return randint(MIN_DICE_VALUE, max(MIN_DICE_VALUE, stat_value))
-
-
-def opposed_roll(char1, char2, stat1="motorics", stat2="motorics"):
-    """
-    Perform an opposed roll between two characters.
-    
-    Args:
-        char1: First character
-        char2: Second character  
-        stat1 (str): Stat name for first character
-        stat2 (str): Stat name for second character
-        
-    Returns:
-        tuple: (char1_roll, char2_roll, char1_wins)
-    """
-    roll1 = roll_stat(char1, stat1)
-    roll2 = roll_stat(char2, stat2)
-    
-    return roll1, roll2, roll1 > roll2
-
-
-def roll_with_advantage(stat_value):
-    """
-    Roll with advantage: roll twice, take the higher result.
-    
-    Args:
-        stat_value (int): The stat value to roll against
-        
-    Returns:
-        tuple: (final_roll, roll1, roll2) for debugging
-    """
-    roll1 = randint(1, max(1, stat_value))
-    roll2 = randint(1, max(1, stat_value))
-    final_roll = max(roll1, roll2)
-    return final_roll, roll1, roll2
-
-
-def roll_with_disadvantage(stat_value):
-    """
-    Roll with disadvantage: roll twice, take the lower result.
-    
-    Args:
-        stat_value (int): The stat value to roll against
-        
-    Returns:
-        tuple: (final_roll, roll1, roll2) for debugging
-    """
-    roll1 = randint(1, max(1, stat_value))
-    roll2 = randint(1, max(1, stat_value))
-    final_roll = min(roll1, roll2)
-    return final_roll, roll1, roll2
-
-
-def standard_roll(stat_value):
-    """
-    Standard single roll.
-    
-    Args:
-        stat_value (int): The stat value to roll against
-        
-    Returns:
-        tuple: (final_roll, roll, roll) for consistent interface
-    """
-    roll = randint(1, max(1, stat_value))
-    return roll, roll, roll
-
-
-# ===================================================================
-# DEBUG LOGGING
-# ===================================================================
-
-def log_debug(prefix, action, message, character=None):
-    """
-    Send a standardized debug message to Splattercast.
-    
-    Args:
-        prefix (str): Debug prefix (e.g., DEBUG_PREFIX_ATTACK)
-        action (str): Action type (e.g., DEBUG_SUCCESS)
-        message (str): The debug message
-        character: Optional character for context
-    """
-    try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        if splattercast:
-            char_context = f" ({character.key})" if character else ""
-            full_message = f"{prefix}_{action}: {message}{char_context}"
-            splattercast.msg(full_message)
-    except Exception:
-        # Fail silently if channel doesn't exist
-        pass
-
-
-def log_combat_action(character, action_type, target=None, success=True, details=""):
-    """
-    Log a combat action with standardized format.
-    
-    Args:
-        character: The character performing the action
-        action_type (str): Type of action (attack, flee, etc.)
-        target: Optional target character
-        success (bool): Whether the action succeeded
-        details (str): Additional details
-    """
-    prefix = f"{action_type.upper()}_CMD"
-    action = "SUCCESS" if success else "FAIL"
-    
-    target_info = f" on {target.key}" if target else ""
-    details_info = f" - {details}" if details else ""
-    
-    message = f"{character.key}{target_info}{details_info}"
-    log_debug(prefix, action, message)
+from .debug import (  # noqa: F401 — re-export
+    _NullChannel,
+    debug_broadcast,
+    get_splattercast,
+    log_combat_action,
+    log_debug,
+)
+from .dice import (  # noqa: F401 — re-export
+    get_character_stat,
+    opposed_roll,
+    roll_stat,
+    roll_with_advantage,
+    roll_with_disadvantage,
+    standard_roll,
+)
+from .explosives import (  # noqa: F401 — re-export
+    break_stick,
+    calculate_stick_chance,
+    check_grenade_human_shield,
+    establish_stick,
+    get_explosion_room,
+    get_outermost_armor_at_location,
+    get_stuck_grenades_on_character,
+    send_grenade_shield_messages,
+)
 
 
 # ===================================================================
@@ -253,7 +117,7 @@ def clear_character_proximity(character):
         
         # Clear this character's proximity
         character.ndb.in_proximity_with.clear()
-        log_debug("PROXIMITY", "CLEAR", f"Cleared all proximity", character)
+        log_debug("PROXIMITY", "CLEAR", "Cleared all proximity", character)
 
 
 # ===================================================================
@@ -527,7 +391,7 @@ def clear_aim_state(character):
     if hasattr(character.ndb, "aimed_at_by"):
         del character.ndb.aimed_at_by
     
-    log_debug("AIM", "CLEAR", f"Cleared aim state", character)
+    log_debug("AIM", "CLEAR", "Cleared aim state", character)
 
 
 def clear_mutual_aim(char1, char2):
@@ -833,9 +697,9 @@ def remove_combatant(handler, char):
     # Always persist to database
     handler.db.combatants = combatants
     if active_list:
-        splattercast.msg(f"RMV_COMB: Mutated active list in-place and synced to database")
+        splattercast.msg("RMV_COMB: Mutated active list in-place and synced to database")
     else:
-        splattercast.msg(f"RMV_COMB: Updated database directly")
+        splattercast.msg("RMV_COMB: Updated database directly")
     
     splattercast.msg(f"{char.key} removed from combat.")
     # TODO: Add narrative combat exit message (weapon lowering, stepping back, etc.)
@@ -1178,475 +1042,3 @@ def resolve_bonus_attack(handler, attacker, target):
     
     # Log the bonus attack
     splattercast.msg(f"BONUS_ATTACK: {attacker.key} made bonus attack against {target.key}.")
-
-
-# ===================================================================
-# DAMAGE SYSTEM
-# ===================================================================
-
-def check_grenade_human_shield(proximity_list, combat_handler=None):
-    """
-    Check for human shield mechanics in grenade explosions.
-    
-    For characters in the proximity list who are grappling someone,
-    implement simplified human shield mechanics:
-    - Grappler automatically uses victim as blast shield
-    - Grappler takes no damage 
-    - Victim takes double damage
-    
-    Args:
-        proximity_list: List of characters in blast radius
-        combat_handler: Optional combat handler for grapple state checking
-        
-    Returns:
-        dict: Modified damage assignments {char: damage_multiplier}
-             where damage_multiplier is 0.0 for grapplers, 2.0 for victims
-    """
-    from .constants import DB_CHAR, DB_GRAPPLING_DBREF, DB_COMBATANTS, NDB_COMBAT_HANDLER
-    
-    splattercast = get_splattercast()
-    damage_modifiers = {}
-    
-    # If no combat handler provided, try to find one from the characters
-    if not combat_handler and proximity_list:
-        for char in proximity_list:
-            if hasattr(char.ndb, NDB_COMBAT_HANDLER):
-                combat_handler = getattr(char.ndb, NDB_COMBAT_HANDLER)
-                break
-    
-    if not combat_handler:
-        splattercast.msg("GRENADE_SHIELD: No combat handler found, skipping human shield checks")
-        return damage_modifiers
-    
-    # Get current combatants list for grapple state checking
-    combatants_list = combat_handler.db.combatants or []
-    
-    for char in proximity_list:
-        # Find this character's combat entry
-        char_entry = next((e for e in combatants_list if e.get(DB_CHAR) == char), None)
-        if not char_entry:
-            continue
-            
-        # Check if this character is grappling someone
-        grappling_dbref = char_entry.get(DB_GRAPPLING_DBREF)
-        if grappling_dbref:
-            victim = get_character_by_dbref(grappling_dbref)
-            if victim and victim in proximity_list:
-                # Both grappler and victim are in blast radius - apply shield mechanics
-                damage_modifiers[char] = 0.0  # Grappler takes no damage
-                damage_modifiers[victim] = 2.0  # Victim takes double damage
-                
-                # Send human shield messages
-                send_grenade_shield_messages(char, victim)
-                
-                splattercast.msg(f"GRENADE_SHIELD: {char.key} using {victim.key} as blast shield")
-    
-    return damage_modifiers
-
-
-def send_grenade_shield_messages(grappler, victim):
-    """
-    Send human shield messages specific to grenade explosions.
-    
-    Args:
-        grappler: The character using victim as shield
-        victim: The character being used as shield
-    """
-    # Grenade-specific shield messages
-    grappler_msg = f"|yYou instinctively position {get_display_name_safe(victim)} between yourself and the explosion!|n"
-    victim_msg = f"|RYou are forced to absorb the full blast as {get_display_name_safe(grappler)} uses you as a shield!|n"
-    observer_msg = f"|y{get_display_name_safe(grappler)} uses {get_display_name_safe(victim)} as a human shield against the explosion!|n"
-    
-    # Send messages
-    grappler.msg(grappler_msg)
-    victim.msg(victim_msg)
-    
-    # Send to observers in the same location (exclude the two participants)
-    if grappler.location:
-        grappler.location.msg_contents(observer_msg, exclude=[grappler, victim])
-
-
-# ===================================================================
-# STICKY GRENADE HELPERS
-# ===================================================================
-
-def calculate_stick_chance(grenade, armor):
-    """
-    Calculate the chance that a sticky grenade will adhere to armor.
-    
-    Stick Criteria:
-    1. Check armor base metal/magnetic levels
-    2. If armor is a plate carrier, check installed plates for highest values
-    3. Threshold check: magnetic_level >= (grenade_strength - 3) AND 
-                       metal_level >= (grenade_strength - 5)
-    4. If threshold met: chance = 40 + (metal_level * 5) + (magnetic_level * 5)
-    5. Maximum 95% chance (always 5% chance to fail)
-    
-    Args:
-        grenade: The sticky grenade object with magnetic_strength attribute
-        armor: The armor Item with metal_level and magnetic_level attributes
-    
-    Returns:
-        int: Percentage chance to stick (0-95), or 0 if thresholds not met
-        
-    Example:
-        # Steel plate (metal=10, magnetic=10) vs medium grenade (strength=5)
-        # Thresholds: magnetic >= 2, metal >= 0 (both pass)
-        # Chance: 40 + (10*5) + (10*5) = 140 -> capped at 95%
-        
-        # Cloth vest (metal=0, magnetic=0) vs any grenade
-        # Thresholds: fail -> 0% chance
-        
-        # Plate carrier with steel plate installed
-        # Checks both carrier properties AND installed plate properties
-    """
-    from typeclasses.items import Item
-    
-    # Validate inputs
-    if not grenade or not armor:
-        return 0
-    
-    # Get grenade magnetic strength (default 5 if not set)
-    magnetic_strength = grenade.db.magnetic_strength if grenade.db.magnetic_strength is not None else 5
-    
-    # Get armor base properties (default 0 if not set)
-    metal_level = armor.db.metal_level if armor.db.metal_level is not None else 0
-    magnetic_level = armor.db.magnetic_level if armor.db.magnetic_level is not None else 0
-    
-    # PLATE CARRIER CHECK: If this is a plate carrier, check installed plates
-    is_plate_carrier = armor.db.is_plate_carrier
-    if is_plate_carrier:
-        installed_plates = armor.db.installed_plates or {}
-        
-        # Check all installed plates and use highest metal/magnetic values
-        for slot, plate_ref in installed_plates.items():
-            if plate_ref:
-                # Get plate properties
-                plate_metal = plate_ref.db.metal_level if plate_ref.db.metal_level is not None else 0
-                plate_magnetic = plate_ref.db.magnetic_level if plate_ref.db.magnetic_level is not None else 0
-                
-                # Use highest values between carrier and plates
-                metal_level = max(metal_level, plate_metal)
-                magnetic_level = max(magnetic_level, plate_magnetic)
-                
-                debug_broadcast(
-                    f"Plate carrier check: {armor.key} slot {slot} has {plate_ref.key} "
-                    f"(metal={plate_metal}, magnetic={plate_magnetic})",
-                    prefix="STICKY_GRENADE",
-                    status="PLATE_CHECK"
-                )
-        
-        debug_broadcast(
-            f"Plate carrier final values: metal={metal_level}, magnetic={magnetic_level}",
-            prefix="STICKY_GRENADE",
-            status="PLATE_FINAL"
-        )
-    
-    # Calculate thresholds
-    magnetic_threshold = magnetic_strength - 3
-    metal_threshold = magnetic_strength - 5
-    
-    # Check if thresholds are met
-    if magnetic_level < magnetic_threshold or metal_level < metal_threshold:
-        debug_broadcast(
-            f"Stick failed threshold: {grenade.key} vs {armor.key} "
-            f"(magnetic {magnetic_level}/{magnetic_threshold}, "
-            f"metal {metal_level}/{metal_threshold})",
-            prefix="STICKY_GRENADE",
-            status="THRESHOLD_FAIL"
-        )
-        return 0
-    
-    # Calculate base chance
-    chance = 40 + (metal_level * 5) + (magnetic_level * 5)
-    
-    # Cap at 95% (always 5% failure chance)
-    chance = min(chance, 95)
-    
-    debug_broadcast(
-        f"Stick chance: {grenade.key} vs {armor.key} = {chance}% "
-        f"(metal={metal_level}, magnetic={magnetic_level}, strength={magnetic_strength})",
-        prefix="STICKY_GRENADE",
-        status="CALC"
-    )
-    
-    return chance
-
-
-def get_explosion_room(grenade):
-    """
-    Get the room where a grenade will explode, handling armor hierarchy.
-    
-    This traverses the location hierarchy to find the room:
-    - grenade.location = armor -> armor.location = character/room
-    - grenade.location = character -> character.location = room
-    - grenade.location = room -> room itself
-    
-    Args:
-        grenade: The grenade object
-    
-    Returns:
-        Room object or None if grenade has no valid explosion location
-        
-    Example:
-        # Stuck to worn armor: grenade -> armor -> character -> room
-        room = get_explosion_room(grenade)  # Returns room
-        
-        # On ground: grenade -> room
-        room = get_explosion_room(grenade)  # Returns room
-    """
-    from typeclasses.characters import Character
-    from typeclasses.rooms import Room
-    from typeclasses.items import Item
-    
-    if not grenade or not grenade.location:
-        debug_broadcast(
-            f"Explosion room lookup failed: grenade has no location",
-            prefix="STICKY_GRENADE",
-            status="ERROR"
-        )
-        return None
-    
-    location = grenade.location
-    
-    # If grenade is in/on an Item (armor), go up one level
-    if isinstance(location, Item):
-        debug_broadcast(
-            f"Grenade {grenade.key} stuck to armor {location.key}, checking armor location",
-            prefix="STICKY_GRENADE",
-            status="HIERARCHY"
-        )
-        location = location.location
-    
-    # If we're now at a Character, go up one more level to room
-    if isinstance(location, Character):
-        debug_broadcast(
-            f"Grenade on character {location.key}, getting their room",
-            prefix="STICKY_GRENADE",
-            status="HIERARCHY"
-        )
-        location = location.location
-    
-    # Validate we have a room
-    if isinstance(location, Room):
-        debug_broadcast(
-            f"Explosion room for {grenade.key}: {location.key}",
-            prefix="STICKY_GRENADE",
-            status="SUCCESS"
-        )
-        return location
-    
-    debug_broadcast(
-        f"Explosion room lookup failed: final location is {type(location).__name__}",
-        prefix="STICKY_GRENADE",
-        status="ERROR"
-    )
-    return None
-
-
-def establish_stick(grenade, armor, hit_location):
-    """
-    Establish bidirectional sticky grenade relationship.
-    
-    Sets up the magnetic bond between grenade and armor:
-    - grenade.location = armor (physical containment)
-    - grenade.db.stuck_to_armor = armor (reference)
-    - grenade.db.stuck_to_location = hit_location (body part)
-    - armor.db.stuck_grenade = grenade (bidirectional reference)
-    
-    Args:
-        grenade: The sticky grenade object
-        armor: The armor Item object
-        hit_location: String indicating body location (e.g., "chest", "head")
-    
-    Returns:
-        bool: True if stick established successfully
-        
-    Example:
-        if establish_stick(grenade, steel_vest, "chest"):
-            # Grenade is now magnetically bonded to vest
-            # Will move with vest when removed
-    """
-    from typeclasses.items import Item
-    
-    # Validate inputs
-    if not grenade or not armor or not isinstance(armor, Item):
-        debug_broadcast(
-            f"Stick establishment failed: invalid inputs",
-            prefix="STICKY_GRENADE",
-            status="ERROR"
-        )
-        return False
-    
-    # Break any existing stick first
-    if grenade.db.stuck_to_armor:
-        old_armor = grenade.db.stuck_to_armor
-        if old_armor and old_armor.db.stuck_grenade is not None:
-            old_armor.db.stuck_grenade = None
-    
-    # Establish new stick - grenade moves to armor
-    grenade.location = armor
-    
-    # Set grenade attributes
-    grenade.db.stuck_to_armor = armor
-    grenade.db.stuck_to_location = hit_location
-    
-    # Set armor attribute (bidirectional reference)
-    armor.db.stuck_grenade = grenade
-    
-    debug_broadcast(
-        f"Stick established: {grenade.key} -> {armor.key} at {hit_location}",
-        prefix="STICKY_GRENADE",
-        status="SUCCESS"
-    )
-    
-    return True
-
-
-def get_stuck_grenades_on_character(character):
-    """
-    Get all sticky grenades currently stuck to a character's armor.
-    
-    Searches all worn items for stuck grenades.
-    
-    Args:
-        character: The Character object to check
-    
-    Returns:
-        list: List of tuples (grenade, armor, location) for each stuck grenade
-        
-    Example:
-        stuck = get_stuck_grenades_on_character(bob)
-        for grenade, armor, location in stuck:
-            print(f"{grenade.key} stuck to {armor.key} at {location}")
-    """
-    from typeclasses.characters import Character
-    from typeclasses.items import Item
-    
-    if not isinstance(character, Character):
-        return []
-    
-    stuck_grenades = []
-    
-    # Check all items in character's inventory
-    for item in character.contents:
-        if not isinstance(item, Item):
-            continue
-        
-        # Check if this item has a stuck grenade
-        if item.db.stuck_grenade:
-            grenade = item.db.stuck_grenade
-            location = grenade.db.stuck_to_location if grenade.db.stuck_to_location is not None else 'unknown'
-            stuck_grenades.append((grenade, item, location))
-            
-            debug_broadcast(
-                f"Found stuck grenade: {grenade.key} on {item.key} ({location})",
-                prefix="STICKY_GRENADE",
-                status="FOUND"
-            )
-    
-    return stuck_grenades
-
-
-def get_outermost_armor_at_location(character, hit_location):
-    """
-    Get the outermost armor piece at a specific body location.
-    
-    Searches worn items for highest layer number at the hit location.
-    
-    Args:
-        character: The Character object
-        hit_location: Body location string (e.g., "chest", "head", "left_arm")
-    
-    Returns:
-        Item: The outermost armor at that location, or None if no armor
-        
-    Example:
-        # Character wearing shirt (layer 1) and vest (layer 3) on chest
-        armor = get_outermost_armor_at_location(bob, "chest")
-        # Returns vest (higher layer)
-    """
-    from typeclasses.characters import Character
-    from typeclasses.items import Item
-    
-    if not isinstance(character, Character):
-        return None
-    
-    outermost_armor = None
-    highest_layer = -1
-    
-    # Check all worn items
-    for item in character.contents:
-        if not isinstance(item, Item):
-            continue
-        
-        # Check if item covers this location
-        coverage = item.db.coverage or []
-        if not coverage or hit_location not in coverage:
-            continue
-        
-        # Check layer
-        layer = item.db.layer if item.db.layer is not None else 0
-        if layer > highest_layer:
-            highest_layer = layer
-            outermost_armor = item
-    
-    if outermost_armor:
-        debug_broadcast(
-            f"Outermost armor at {hit_location}: {outermost_armor.key} (layer {highest_layer})",
-            prefix="STICKY_GRENADE",
-            status="FOUND"
-        )
-    else:
-        debug_broadcast(
-            f"No armor found at {hit_location}",
-            prefix="STICKY_GRENADE",
-            status="NOT_FOUND"
-        )
-    
-    return outermost_armor
-
-
-def break_stick(grenade):
-    """
-    Break the magnetic bond between grenade and armor.
-    
-    Cleans up all bidirectional references. Grenade location is NOT changed
-    (caller must handle that separately if needed).
-    
-    Args:
-        grenade: The sticky grenade object
-    
-    Returns:
-        bool: True if stick was broken, False if no stick existed
-        
-    Example:
-        if break_stick(grenade):
-            # Magnetic bond broken
-            grenade.location = room  # Move to room
-    """
-    if not grenade:
-        return False
-    
-    # Check if grenade is stuck
-    if not grenade.db.stuck_to_armor:
-        return False
-    
-    armor = grenade.db.stuck_to_armor
-    location = grenade.db.stuck_to_location if grenade.db.stuck_to_location is not None else 'unknown'
-    
-    # Clear armor's reference to grenade
-    if armor and armor.db.stuck_grenade is not None:
-        armor.db.stuck_grenade = None
-    
-    # Clear grenade's references
-    grenade.db.stuck_to_armor = None
-    grenade.db.stuck_to_location = None
-    
-    debug_broadcast(
-        f"Stick broken: {grenade.key} from {armor.key if armor else 'unknown'} at {location}",
-        prefix="STICKY_GRENADE",
-        status="BREAK"
-    )
-    
-    return True


### PR DESCRIPTION
## Summary

- Extract 19 functions from `utils.py` into 3 focused modules: `debug.py` (5 functions, 127 lines), `dice.py` (6 functions, 140 lines), `explosives.py` (8 functions, 519 lines)
- Reduce `utils.py` from 1,652 to 1,044 lines (36% reduction) while maintaining full backward compatibility via re-exports
- Update internal combat package imports (`proximity.py`, `grappling.py`, `actions.py`, `movement_resolution.py`) to use canonical imports from new modules

## Details

**New modules:**

| Module | Functions | Lines | Dependencies |
|--------|-----------|-------|-------------|
| `debug.py` | `debug_broadcast`, `get_splattercast`, `log_debug`, `log_combat_action`, `_NullChannel` | 127 | constants |
| `dice.py` | `get_character_stat`, `roll_stat`, `opposed_roll`, `roll_with_advantage`, `roll_with_disadvantage`, `standard_roll` | 140 | constants |
| `explosives.py` | `check_grenade_human_shield`, `send_grenade_shield_messages`, `calculate_stick_chance`, `get_explosion_room`, `establish_stick`, `get_stuck_grenades_on_character`, `get_outermost_armor_at_location`, `break_stick` | 519 | constants, debug, utils |

**Backward compatibility:** Re-exports in `utils.py` ensure all external consumers (`commands/`, `typeclasses/`, `world/medical/`) continue working with zero changes.

**No circular imports:** `debug` and `dice` are leaf nodes (only depend on `constants`). `explosives` depends on `constants`, `debug`, and `utils` — never on `handler.py`.

## Verification

- All 8 modified/new files pass `python3 -m py_compile`
- Import dependency graph verified: no circular imports
- No changes needed to external consumer files

Fixes #52