### PR TITLE
Replace assign with remember/forget/recall/memory verb cluster

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1254,32 +1254,31 @@ def _apply_keyword(caller, keyword):
     return None  # Exit menu after setting
 
 
-class CmdAssign(Command):
+class CmdRemember(Command):
     """
-    Assign a name to someone you can see.
+    Remember someone you can see by a name of your choosing.
 
     Usage:
-      assign <target> as <name>
+      remember <target> as <name>
 
     When you encounter someone for the first time, you see their short
     description (e.g. "a lanky man in a Black Trenchcoat").  Use this
-    command to assign them a name — any name you choose.  From then on
-    you'll see that name instead of their sdesc.
+    command to remember them by a name — any name you choose.  From then
+    on you'll see that name instead of their sdesc.
 
-    You can assign false or partial names.  Other characters won't know
-    what name you've assigned.
+    You can remember people by false or partial names.  Other characters
+    won't know what name you've chosen.
 
-    To change an existing assignment, simply assign again.
-    To clear an assignment, use:  assign <target> as clear
+    To change an existing name, simply remember them again.
+    To clear a remembered name, use the |wforget|n command.
 
     Examples:
-      assign man as Jorge
-      assign woman as Sketchy Lady
-      assign 2nd man as Big J
-      assign jorge as clear
+      remember man as Jorge
+      remember woman as Sketchy Lady
+      remember 2nd man as Big J
     """
 
-    key = "assign"
+    key = "remember"
     locks = "cmd:all()"
     help_category = "Character"
 
@@ -1288,7 +1287,7 @@ class CmdAssign(Command):
         args = self.args.strip()
 
         if not args or " as " not in args:
-            caller.msg("Usage: assign <target> as <name>")
+            caller.msg("Usage: remember <target> as <name>")
             return
 
         # Split on first " as " to allow names with spaces
@@ -1297,10 +1296,10 @@ class CmdAssign(Command):
         name = parts[1].strip()
 
         if not target_str:
-            caller.msg("Who do you want to assign a name to?")
+            caller.msg("Who do you want to remember?")
             return
         if not name:
-            caller.msg("What name do you want to assign?")
+            caller.msg("What name do you want to remember them by?")
             return
 
         # Find the target
@@ -1311,10 +1310,10 @@ class CmdAssign(Command):
         # Must be a character (not an item/exit)
         from typeclasses.characters import Character
         if not isinstance(target, Character):
-            caller.msg("You can only assign names to characters.")
+            caller.msg("You can only remember characters by name.")
             return
 
-        # Can't assign a name to yourself
+        # Can't remember yourself by another name
         if target is caller:
             caller.msg("You already know your own name.")
             return
@@ -1322,18 +1321,13 @@ class CmdAssign(Command):
         # Target must have a sleeve_uid
         sleeve_uid = target.sleeve_uid
         if sleeve_uid is None:
-            caller.msg("You can't assign a name to that character.")
-            return
-
-        # Handle "clear" to remove assignment
-        if name.lower() == "clear":
-            self._clear_assignment(caller, target, sleeve_uid)
+            caller.msg("You can't remember that character.")
             return
 
         # Apply the assignment
-        self._set_assignment(caller, target, sleeve_uid, name)
+        self._remember_target(caller, target, sleeve_uid, name)
 
-    def _set_assignment(self, caller, target, sleeve_uid, name):
+    def _remember_target(self, caller, target, sleeve_uid, name):
         """Store a name assignment in the caller's recognition memory."""
         import time
 
@@ -1392,7 +1386,11 @@ class CmdAssign(Command):
             )
 
     def _clear_assignment(self, caller, target, sleeve_uid):
-        """Remove a name assignment from recognition memory."""
+        """Remove a name assignment from recognition memory.
+
+        Retained for backward-compatible internal use; player-facing clear
+        is now the |wforget|n command (:class:`CmdForget`).
+        """
         memory = caller.recognition_memory
         if not memory or sleeve_uid not in memory:
             caller.msg("You don't have a name assigned to them.")
@@ -1411,3 +1409,296 @@ class CmdAssign(Command):
             )
         else:
             caller.msg("No name was assigned to clear.")
+
+
+# ===================================================================
+# forget / recall / memory — observer-memory verb cluster
+# ===================================================================
+
+
+def _find_remembered_uid_by_name(caller, name):
+    """Look up a sleeve_uid in caller's recognition_memory by assigned_name.
+
+    Case-insensitive match against ``assigned_name``.  Returns the first
+    matching ``(sleeve_uid, entry)`` tuple, or ``(None, None)`` if no
+    match.
+    """
+    memory = caller.recognition_memory
+    if not memory:
+        return None, None
+    needle = name.lower()
+    for uid, entry in memory.items():
+        assigned = (entry.get("assigned_name") or "").lower()
+        if assigned and assigned == needle:
+            return uid, entry
+    return None, None
+
+
+def _format_relative_time(iso_timestamp):
+    """Return a human-friendly 'X ago' string for an ISO timestamp.
+
+    Falls back to the raw timestamp if parsing fails.
+    """
+    import time
+    from datetime import datetime
+    from evennia.utils.utils import time_format
+
+    if not iso_timestamp:
+        return "unknown"
+    try:
+        then = datetime.strptime(iso_timestamp, "%Y-%m-%dT%H:%M:%S")
+        delta = time.time() - then.timestamp()
+        if delta < 1:
+            return "just now"
+        return f"{time_format(int(delta), 4)} ago"
+    except (ValueError, TypeError):
+        return iso_timestamp
+
+
+class CmdForget(Command):
+    """
+    Forget the name you remembered for someone.
+
+    Usage:
+      forget <target>
+
+    Clears the name you assigned to someone.  They will appear as their
+    description again until you remember them by a new name.
+
+    You can forget someone whether or not they're currently present —
+    pass either their current description or the name you remembered
+    them by.
+
+    Examples:
+      forget man
+      forget Jorge
+    """
+
+    key = "forget"
+    locks = "cmd:all()"
+    help_category = "Character"
+
+    def func(self):
+        caller = self.caller
+        args = self.args.strip()
+
+        if not args:
+            caller.msg("Forget who?")
+            return
+
+        from typeclasses.characters import Character
+
+        # Try visible-target resolution first (silent on failure so we can
+        # fall back to remembered-name lookup).
+        target = caller.search(args, quiet=True)
+        if target:
+            # caller.search with quiet=True returns a list
+            if isinstance(target, list):
+                target = target[0] if target else None
+
+        if target and isinstance(target, Character):
+            sleeve_uid = target.sleeve_uid
+            if sleeve_uid is None:
+                caller.msg("You can't forget that character.")
+                return
+            self._forget_visible(caller, target, sleeve_uid)
+            return
+
+        # Fall back to remembered-name lookup
+        sleeve_uid, entry = _find_remembered_uid_by_name(caller, args)
+        if sleeve_uid is None:
+            caller.msg("You don't remember anyone by that name.")
+            return
+
+        self._forget_remembered(caller, sleeve_uid, entry)
+
+    def _forget_visible(self, caller, target, sleeve_uid):
+        """Forget a target who is currently present."""
+        memory = caller.recognition_memory
+        if not memory or sleeve_uid not in memory:
+            caller.msg("You don't have a name remembered for them.")
+            return
+
+        old_name = memory[sleeve_uid].get("assigned_name", "")
+        if not old_name:
+            caller.msg("You don't have a name remembered for them.")
+            return
+
+        memory[sleeve_uid]["assigned_name"] = ""
+        caller.recognition_memory = memory
+
+        caller.msg(
+            f"You forget the name '{old_name}'. "
+            f"They will now appear as their description."
+        )
+
+    def _forget_remembered(self, caller, sleeve_uid, entry):
+        """Forget someone by remembered name; they may not be present."""
+        old_name = entry.get("assigned_name", "")
+        sdesc = entry.get("sdesc_at_last_encounter", "someone")
+        location = entry.get("location_last_seen", "somewhere")
+        last_seen = entry.get("last_seen", "")
+        when = _format_relative_time(last_seen)
+
+        memory = caller.recognition_memory
+        memory[sleeve_uid]["assigned_name"] = ""
+        caller.recognition_memory = memory
+
+        caller.msg(
+            f"You forget the name '{old_name}'. "
+            f"(Last seen: {sdesc} in {location}, {when}.)"
+        )
+
+
+class CmdRecall(Command):
+    """
+    Recall what you remember about someone.
+
+    Usage:
+      recall <target>
+
+    Shows the name you remembered them by, what they looked like when
+    you first met them, where, when, and how many times you've seen
+    them.
+
+    The target may be someone currently present (by description or by
+    remembered name) or someone you've remembered before but isn't
+    here now (by remembered name).
+
+    To see everyone you've remembered, use the |wmemory|n command.
+
+    Examples:
+      recall man
+      recall Jorge
+    """
+
+    key = "recall"
+    locks = "cmd:all()"
+    help_category = "Character"
+
+    def func(self):
+        caller = self.caller
+        args = self.args.strip()
+
+        if not args:
+            caller.msg("Recall who? (Try |wmemory|n to see everyone you remember.)")
+            return
+
+        from typeclasses.characters import Character
+
+        # Try visible-target resolution first
+        target = caller.search(args, quiet=True)
+        if target:
+            if isinstance(target, list):
+                target = target[0] if target else None
+
+        sleeve_uid = None
+        entry = None
+
+        if target and isinstance(target, Character):
+            sleeve_uid = target.sleeve_uid
+            if sleeve_uid is None:
+                caller.msg("You can't recall anything about that character.")
+                return
+            memory = caller.recognition_memory or {}
+            entry = memory.get(sleeve_uid)
+        else:
+            # Fall back to remembered-name lookup
+            sleeve_uid, entry = _find_remembered_uid_by_name(caller, args)
+
+        if entry is None:
+            caller.msg("You don't recognize that person.")
+            return
+
+        self._render_entry(caller, entry)
+
+    def _render_entry(self, caller, entry):
+        """Format and send a recognition_memory entry to the caller."""
+        assigned_name = entry.get("assigned_name", "")
+        sdesc_first = entry.get("sdesc_at_first_encounter", "(unknown)")
+        location_first = entry.get("location_first_seen", "(unknown)")
+        first_seen = entry.get("first_seen", "")
+        times_seen = entry.get("times_seen", 0)
+
+        when = _format_relative_time(first_seen)
+
+        if assigned_name:
+            header = f"You remember them as: |w{assigned_name}|n"
+        else:
+            header = (
+                "You've encountered them before but don't have a "
+                "name for them."
+            )
+
+        lines = [
+            header,
+            f"First seen: {sdesc_first}",
+            f"Location: {location_first}",
+            f"When: {when} (seen {times_seen} time{'s' if times_seen != 1 else ''})",
+        ]
+        caller.msg("\n".join(lines))
+
+
+class CmdMemory(Command):
+    """
+    List everyone you remember by name.
+
+    Usage:
+      memory
+
+    Shows a table of every person you've remembered, sorted by who
+    you've seen most recently.  People you've forgotten (cleared with
+    |wforget|n) are not listed, even though their record is preserved.
+
+    Use |wrecall <name>|n to inspect a specific entry.
+    """
+
+    key = "memory"
+    locks = "cmd:all()"
+    help_category = "Character"
+
+    def func(self):
+        caller = self.caller
+        args = self.args.strip()
+
+        if args:
+            caller.msg("Usage: memory  (no arguments)")
+            return
+
+        memory = caller.recognition_memory or {}
+
+        # Filter to entries with a non-blank assigned_name
+        named = [
+            (uid, entry)
+            for uid, entry in memory.items()
+            if (entry.get("assigned_name") or "").strip()
+        ]
+
+        if not named:
+            caller.msg("You don't remember anyone yet.")
+            return
+
+        # Sort by last_seen descending (recency).  Missing values sort last.
+        named.sort(
+            key=lambda pair: pair[1].get("last_seen") or "",
+            reverse=True,
+        )
+
+        from evennia.utils.evtable import EvTable
+
+        table = EvTable(
+            "|wName|n",
+            "|wLast seen as|n",
+            "|wWhere|n",
+            "|wWhen|n",
+            border="cells",
+        )
+        for _uid, entry in named:
+            table.add_row(
+                entry.get("assigned_name", ""),
+                entry.get("sdesc_at_last_encounter", "(unknown)"),
+                entry.get("location_last_seen", "(unknown)"),
+                _format_relative_time(entry.get("last_seen", "")),
+            )
+
+        caller.msg(str(table))

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -36,7 +36,7 @@ from commands.CmdExplosives import (
 )
 from commands.CmdGraffiti import CmdGraffiti, CmdPress
 from commands.CmdCharacter import CmdLongdesc, CmdSkintone
-from commands.CmdCharacter import CmdShortdesc, CmdAssign
+from commands.CmdCharacter import CmdShortdesc, CmdRemember, CmdForget, CmdRecall, CmdMemory
 from commands.CmdCommunication import CmdSay, CmdWhisper, CmdEmote, CmdDotPose
 from world.emote_templates import SOCIAL_COMMANDS
 from commands.CmdArmor import CmdArmor, CmdArmorRepair, CmdSlot, CmdUnslot
@@ -183,7 +183,10 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         
         # Add identity system commands
         self.add(CmdShortdesc())
-        self.add(CmdAssign())
+        self.add(CmdRemember())
+        self.add(CmdForget())
+        self.add(CmdRecall())
+        self.add(CmdMemory())
 
         # Add identity-aware communication commands (override Evennia defaults)
         self.add(CmdSay())

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -253,31 +253,54 @@ recognition_memory = {
 
 This is stored as a db attribute on the brain organ, keyed by `sleeve_uid`. The `recent_interactions` list should be capped (e.g., last 20 interactions per entry) to prevent unbounded growth, with older interactions eligible for summarization or archival.
 
-### Assigning Names
+### Remembering Names
 
-**`assign` command:**
-
-```
-assign <target> as <name>
-assign <target> = <name>
-```
-
-Stores the name in the assigner's brain recognition memory for the target's apparent `sleeve_uid`. Any name is valid — false names are always possible. Reassignment overwrites.
+**`remember` command:**
 
 ```
-> assign tall man as Jorge
-You will now remember this person as "Jorge".
-
-> assign 2nd lanky dude as Sketchy Pete
-You will now remember this person as "Sketchy Pete".
+remember <target> as <name>
 ```
 
-If the target is already recognized under a different name:
+Stores the name in the rememberer's brain recognition memory for the target's apparent `sleeve_uid`. Any name is valid — false names are always possible. Re-remembering overwrites.
 
 ```
-> assign Jorge as Johnny Twoshoes
-You update your memory: the person you knew as "Jorge" is now "Johnny Twoshoes".
+> remember tall man as Jorge
+You will now recognize a tall lanky man as Jorge.
+
+> remember 2nd lanky dude as Sketchy Pete
+You will now recognize a lanky man with a leather jacket as Sketchy Pete.
 ```
+
+If the target is already remembered under a different name:
+
+```
+> remember Jorge as Johnny Twoshoes
+You now know Jorge (previously 'Jorge') as Johnny Twoshoes.
+```
+
+**`forget` command:**
+
+```
+forget <target>
+```
+
+Clears the assigned name on a recognition entry. The entry itself is preserved (sdesc snapshots, locations, `times_seen`, etc.) so future `remember` calls extend the existing history rather than starting fresh. Targets resolve against currently-visible characters first, then against previously-remembered names — you can `forget` someone who isn't present.
+
+**`recall` command:**
+
+```
+recall <target>
+```
+
+Inspects a single recognition entry: assigned name (if any), what they looked like at first encounter, where, when, and how many times you've seen them. Same target resolution as `forget`.
+
+**`memory` command:**
+
+```
+memory
+```
+
+Lists every person you've remembered by name, sorted by recency (most recently seen first). Forgotten entries are not listed even though their record is preserved.
 
 **Digital ID exchange (Phase 4 — Cybernetics):**
 
@@ -296,7 +319,7 @@ Recognition data lives on the brain organ object (`world/medical/constants.py` d
 **Storage:** A new db attribute on the brain organ: `db.recognition_memory` (dict).
 
 **Properties:**
-- Populated by explicit player action (`assign` command)
+- Populated by explicit player action (`remember` command)
 - Future: auto-populated by Resonance-driven proximity detection
 - Lost if the brain is destroyed (brain destruction = death, so this is moot for the current character, but matters for brain transplant scenarios)
 - Brain damage (non-fatal) carries a risk of partial memory loss — individual entries can be degraded or lost. This is a future enhancement once the memory pool is rich enough to make partial loss meaningful.
@@ -563,11 +586,11 @@ A disguised character (overrides: `tall man` + essential cowl + non-essential ca
 
 ### Recognition Interactions
 
-- **Stranger meets disguised character:** Observer sees the disguised sdesc; no auto-recognition. Observer can `assign` a name, which binds to the current Apparent UID.
+- **Stranger meets disguised character:** Observer sees the disguised sdesc; no auto-recognition. Observer can `remember` them by a name, which binds to the current Apparent UID.
 - **Observer who knew real identity meets the disguised character:** Observer's recognition memory is keyed on the *real* `sleeve_uid`; the disguise has a different Apparent UID; no auto-recognition. The observer sees the disguised sdesc as a stranger.
 - **Observer meets the same disguised character a second time, same signature:** Auto-recognition fires (same Apparent UID); observer sees the previously-assigned name.
 - **Observer meets the same disguised character a second time, different signature** (e.g., one essential item swapped): Different Apparent UID; observer sees a stranger.
-- **Two characters wearing identical overrides + items:** Visual collision (sdesc strings match), but Apparent UIDs differ (different salts). Each observer's recognition is per-UID; impersonation is *visual*, not *systemic*. An impostor *looks* the same but does not auto-resolve to the original's assigned name. Successful name-fooling requires either acquiring the original's salt (future adversarial-identity mechanic — e.g., through stolen contact cards) or the observer manually `assign`ing the same name to the impostor's distinct UID.
+- **Two characters wearing identical overrides + items:** Visual collision (sdesc strings match), but Apparent UIDs differ (different salts). Each observer's recognition is per-UID; impersonation is *visual*, not *systemic*. An impostor *looks* the same but does not auto-resolve to the original's assigned name. Successful name-fooling requires either acquiring the original's salt (future adversarial-identity mechanic — e.g., through stolen contact cards) or the observer manually `remember`ing the same name onto the impostor's distinct UID.
 
 ### Impersonation
 
@@ -575,7 +598,7 @@ Impersonation is **emergent**, not mechanical. The system does not detect or pre
 
 Two characters can create overrides + ensembles with identical descriptors, keywords, and similar clothing — they will look the same in the sdesc but have different Apparent UIDs (different salts). This means:
 
-- **Strangers** seeing both at different times would have no way to distinguish them visually. A character who met "Natasha" on Monday and meets a different `short woman in a black cape` on Friday would naturally assume it's the same person — until they `assign` a name and discover the recognition system creates a *new* entry instead of matching the old one.
+- **Strangers** seeing both at different times would have no way to distinguish them visually. A character who met "Natasha" on Monday and meets a different `short woman in a black cape` on Friday would naturally assume it's the same person — until they `remember` them by a name and discover the recognition system creates a *new* entry instead of matching the old one.
 - **People who tagged the original signature** are not fooled by a visual look-alike — the UIDs don't match. The impostor appears as a stranger who happens to look similar.
 - **Investigation gameplay** emerges naturally: if a witness meets two different UIDs with matching sdescs, that's a clue that one of them is an impostor. Which one is "real" requires further investigation.
 
@@ -892,7 +915,7 @@ Players should be prompted to customize their sdesc on next login if defaults we
 - `recognition_memory` on brain organ
 - `Character.get_display_name(looker)` override
 - `@shortdesc` command
-- `assign` command
+- `remember` / `forget` / `recall` / `memory` commands
 - Grammar engine (articles, possessive, objective, self-perception)
 - Chargen updates
 - Flash clone `sleeve_uid` inheritance

--- a/world/tests/test_identity_commands.py
+++ b/world/tests/test_identity_commands.py
@@ -1,5 +1,6 @@
 """
-Tests for Identity Phase 1c commands: ``@shortdesc`` and ``assign``.
+Tests for Identity Phase 1c commands: ``@shortdesc`` and the memory
+verb cluster (``remember``, ``forget``, ``recall``, ``memory``).
 
 Tests the command logic and helper functions using mocks.
 Run via::
@@ -238,16 +239,16 @@ class TestShortdescMenuHelpers(TestCase):
 
 
 # ===================================================================
-# assign command
+# remember command
 # ===================================================================
 
 
-class TestAssignCommand(TestCase):
-    """Test the assign command's internal logic."""
+class TestRememberCommand(TestCase):
+    """Test the remember command's internal logic."""
 
-    def test_set_assignment_creates_memory(self):
-        """Assigning a name creates a recognition memory entry."""
-        from commands.CmdCharacter import CmdAssign
+    def test_remember_target_creates_memory(self):
+        """Remembering someone creates a recognition memory entry."""
+        from commands.CmdCharacter import CmdRemember
 
         caller = _make_character(key="Observer", sleeve_uid="uid-observer")
         target = _make_character(
@@ -258,17 +259,17 @@ class TestAssignCommand(TestCase):
             sdesc_keyword="man",
         )
 
-        cmd = CmdAssign()
+        cmd = CmdRemember()
         cmd.caller = caller
-        cmd._set_assignment(caller, target, "uid-target", "Big J")
+        cmd._remember_target(caller, target, "uid-target", "Big J")
 
         memory = caller.recognition_memory
         self.assertIn("uid-target", memory)
         self.assertEqual(memory["uid-target"]["assigned_name"], "Big J")
         self.assertEqual(memory["uid-target"]["times_seen"], 1)
 
-    def test_display_name_changes_after_assign(self):
-        """After assigning, get_display_name returns the assigned name."""
+    def test_display_name_changes_after_remember(self):
+        """After remembering, get_display_name returns the chosen name."""
         caller = _make_character(key="Observer", sleeve_uid="uid-observer")
         target = _make_character(
             key="Jorge",
@@ -278,61 +279,18 @@ class TestAssignCommand(TestCase):
             sdesc_keyword="man",
         )
 
-        # Before assignment — stranger
+        # Before — stranger
         self.assertEqual(target.get_display_name(caller), "a gaunt man")
 
-        # Manually set recognition memory (simulating what assign does)
+        # Manually set recognition memory (simulating what remember does)
         caller.recognition_memory = {
             "uid-target": {"assigned_name": "Big J"},
         }
         self.assertEqual(target.get_display_name(caller), "Big J")
 
-    def test_clear_assignment(self):
-        """Clearing an assignment removes the assigned_name."""
-        from commands.CmdCharacter import CmdAssign
-
-        caller = _make_character(
-            key="Observer",
-            sleeve_uid="uid-observer",
-            recognition_memory={
-                "uid-target": {
-                    "assigned_name": "Big J",
-                    "first_seen": "2026-01-01T00:00:00",
-                    "last_seen": "2026-01-01T00:00:00",
-                    "times_seen": 1,
-                    "location_first_seen": "Test Room",
-                    "location_last_seen": "Test Room",
-                    "locations_seen": ["Test Room"],
-                    "sdesc_at_first_encounter": "gaunt man",
-                    "sdesc_at_last_encounter": "gaunt man",
-                    "notes": "",
-                    "tags": [],
-                    "confidence": 1.0,
-                    "relationship_valence": "neutral",
-                    "recent_interactions": [],
-                },
-            },
-        )
-        target = _make_character(
-            key="Jorge",
-            sleeve_uid="uid-target",
-            height="tall",
-            build="lean",
-            sdesc_keyword="man",
-        )
-
-        cmd = CmdAssign()
-        cmd.caller = caller
-        cmd._clear_assignment(caller, target, "uid-target")
-
-        memory = caller.recognition_memory
-        # Entry still exists but assigned_name is empty
-        self.assertIn("uid-target", memory)
-        self.assertEqual(memory["uid-target"]["assigned_name"], "")
-
-    def test_reassign_updates_name(self):
-        """Re-assigning updates the name and increments times_seen."""
-        from commands.CmdCharacter import CmdAssign
+    def test_re_remember_updates_name(self):
+        """Re-remembering updates the name and increments times_seen."""
+        from commands.CmdCharacter import CmdRemember
 
         caller = _make_character(
             key="Observer",
@@ -364,32 +322,17 @@ class TestAssignCommand(TestCase):
             sdesc_keyword="man",
         )
 
-        cmd = CmdAssign()
+        cmd = CmdRemember()
         cmd.caller = caller
-        cmd._set_assignment(caller, target, "uid-target", "Jorge")
+        cmd._remember_target(caller, target, "uid-target", "Jorge")
 
         memory = caller.recognition_memory
         self.assertEqual(memory["uid-target"]["assigned_name"], "Jorge")
         self.assertEqual(memory["uid-target"]["times_seen"], 4)
 
-    def test_clear_nonexistent_assignment(self):
-        """Clearing when no assignment exists gives feedback."""
-        from commands.CmdCharacter import CmdAssign
-
-        caller = _make_character(key="Observer", sleeve_uid="uid-observer")
-        target = _make_character(key="Jorge", sleeve_uid="uid-target")
-
-        cmd = CmdAssign()
-        cmd.caller = caller
-        cmd._clear_assignment(caller, target, "uid-target")
-
-        caller.msg.assert_called()
-        msg_text = caller.msg.call_args[0][0]
-        self.assertIn("don't have a name", msg_text)
-
-    def test_assign_preserves_existing_fields(self):
-        """Re-assigning preserves notes, tags, etc."""
-        from commands.CmdCharacter import CmdAssign
+    def test_remember_preserves_existing_fields(self):
+        """Re-remembering preserves notes, tags, etc."""
+        from commands.CmdCharacter import CmdRemember
 
         caller = _make_character(
             key="Observer",
@@ -421,21 +364,336 @@ class TestAssignCommand(TestCase):
             sdesc_keyword="man",
         )
 
-        cmd = CmdAssign()
+        cmd = CmdRemember()
         cmd.caller = caller
-        cmd._set_assignment(caller, target, "uid-target", "J-Dog")
+        cmd._remember_target(caller, target, "uid-target", "J-Dog")
 
         memory = caller.recognition_memory
         entry = memory["uid-target"]
-        # Name updated
         self.assertEqual(entry["assigned_name"], "J-Dog")
-        # Existing fields preserved
         self.assertEqual(entry["notes"], "Seems dangerous")
         self.assertEqual(entry["tags"], ["ally"])
         self.assertEqual(entry["confidence"], 0.8)
         self.assertEqual(entry["relationship_valence"], "friendly")
-        # first_seen unchanged
         self.assertEqual(entry["first_seen"], "2026-01-01T00:00:00")
+
+
+# ===================================================================
+# forget command
+# ===================================================================
+
+
+def _seed_memory(uid="uid-target", name="Big J"):
+    """Build a populated recognition_memory dict for a single target."""
+    return {
+        uid: {
+            "assigned_name": name,
+            "first_seen": "2026-01-01T00:00:00",
+            "last_seen": "2026-01-01T00:00:00",
+            "times_seen": 2,
+            "location_first_seen": "The Grit",
+            "location_last_seen": "Back Alley",
+            "locations_seen": ["The Grit", "Back Alley"],
+            "sdesc_at_first_encounter": "a gaunt man",
+            "sdesc_at_last_encounter": "a gaunt man in a hood",
+            "notes": "",
+            "tags": [],
+            "confidence": 1.0,
+            "relationship_valence": "neutral",
+            "recent_interactions": [],
+        },
+    }
+
+
+class TestForgetCommand(TestCase):
+    """Test the forget command."""
+
+    def test_forget_visible_target_clears_name(self):
+        """forget <visible target> blanks assigned_name, preserves entry."""
+        from commands.CmdCharacter import CmdForget
+
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=_seed_memory(),
+        )
+        target = _make_character(
+            key="Jorge",
+            sleeve_uid="uid-target",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd._forget_visible(caller, target, "uid-target")
+
+        memory = caller.recognition_memory
+        self.assertIn("uid-target", memory)
+        self.assertEqual(memory["uid-target"]["assigned_name"], "")
+        # History preserved
+        self.assertEqual(memory["uid-target"]["times_seen"], 2)
+        self.assertEqual(
+            memory["uid-target"]["sdesc_at_first_encounter"], "a gaunt man"
+        )
+
+    def test_forget_remembered_name_when_target_absent(self):
+        """forget <remembered name> works without target object."""
+        from commands.CmdCharacter import CmdForget, _find_remembered_uid_by_name
+
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=_seed_memory(),
+        )
+
+        sleeve_uid, entry = _find_remembered_uid_by_name(caller, "big j")
+        self.assertEqual(sleeve_uid, "uid-target")
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd._forget_remembered(caller, sleeve_uid, entry)
+
+        memory = caller.recognition_memory
+        self.assertEqual(memory["uid-target"]["assigned_name"], "")
+        # Output message references snapshot data
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("Big J", msg_text)
+        self.assertIn("Back Alley", msg_text)
+
+    def test_forget_unknown_name(self):
+        """forget <unknown name> with empty memory rejects gracefully."""
+        from commands.CmdCharacter import _find_remembered_uid_by_name
+
+        caller = _make_character(key="Observer", sleeve_uid="uid-observer")
+        sleeve_uid, entry = _find_remembered_uid_by_name(caller, "ghost")
+        self.assertIsNone(sleeve_uid)
+        self.assertIsNone(entry)
+
+    def test_forget_visible_with_no_assigned_name(self):
+        """forget on someone with a blank assigned_name reports correctly."""
+        from commands.CmdCharacter import CmdForget
+
+        memory = _seed_memory()
+        memory["uid-target"]["assigned_name"] = ""
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=memory,
+        )
+        target = _make_character(
+            key="Jorge",
+            sleeve_uid="uid-target",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd._forget_visible(caller, target, "uid-target")
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("don't have a name", msg_text)
+
+
+# ===================================================================
+# recall command
+# ===================================================================
+
+
+class TestRecallCommand(TestCase):
+    """Test the recall command."""
+
+    def test_recall_renders_full_entry(self):
+        """recall outputs assigned name, first sdesc, location, when, count."""
+        from commands.CmdCharacter import CmdRecall
+
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=_seed_memory(),
+        )
+
+        cmd = CmdRecall()
+        cmd.caller = caller
+        cmd._render_entry(caller, caller.recognition_memory["uid-target"])
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("Big J", msg_text)
+        self.assertIn("a gaunt man", msg_text)
+        self.assertIn("The Grit", msg_text)
+        self.assertIn("seen 2 times", msg_text)
+
+    def test_recall_blank_assigned_name_shows_unnamed_message(self):
+        """Entry with blank assigned_name renders the 'no name' header."""
+        from commands.CmdCharacter import CmdRecall
+
+        memory = _seed_memory()
+        memory["uid-target"]["assigned_name"] = ""
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=memory,
+        )
+
+        cmd = CmdRecall()
+        cmd.caller = caller
+        cmd._render_entry(caller, memory["uid-target"])
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("don't have a name", msg_text)
+        # Snapshot still rendered
+        self.assertIn("a gaunt man", msg_text)
+
+    def test_recall_singular_seen_count(self):
+        """times_seen of 1 renders 'time' (singular), not 'times'."""
+        from commands.CmdCharacter import CmdRecall
+
+        memory = _seed_memory()
+        memory["uid-target"]["times_seen"] = 1
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=memory,
+        )
+
+        cmd = CmdRecall()
+        cmd.caller = caller
+        cmd._render_entry(caller, memory["uid-target"])
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("seen 1 time", msg_text)
+        self.assertNotIn("seen 1 times", msg_text)
+
+
+# ===================================================================
+# memory command
+# ===================================================================
+
+
+class TestMemoryCommand(TestCase):
+    """Test the memory command."""
+
+    def test_memory_empty(self):
+        """memory with no entries reports the empty state."""
+        from commands.CmdCharacter import CmdMemory
+
+        caller = _make_character(key="Observer", sleeve_uid="uid-observer")
+        cmd = CmdMemory()
+        cmd.caller = caller
+        cmd.args = ""
+        cmd.func()
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("don't remember anyone", msg_text)
+
+    def test_memory_lists_named_entries(self):
+        """memory lists each entry with a non-blank assigned_name."""
+        from commands.CmdCharacter import CmdMemory
+
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory={
+                "uid-a": {
+                    "assigned_name": "Alice",
+                    "last_seen": "2026-05-10T00:00:00",
+                    "sdesc_at_last_encounter": "a tall woman",
+                    "location_last_seen": "Bar",
+                },
+                "uid-b": {
+                    "assigned_name": "Bob",
+                    "last_seen": "2026-05-12T00:00:00",
+                    "sdesc_at_last_encounter": "a short man",
+                    "location_last_seen": "Alley",
+                },
+            },
+        )
+        cmd = CmdMemory()
+        cmd.caller = caller
+        cmd.args = ""
+        cmd.func()
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("Alice", msg_text)
+        self.assertIn("Bob", msg_text)
+
+    def test_memory_excludes_blank_names(self):
+        """Entries with blank assigned_name are excluded from listing."""
+        from commands.CmdCharacter import CmdMemory
+
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory={
+                "uid-a": {
+                    "assigned_name": "Alice",
+                    "last_seen": "2026-05-10T00:00:00",
+                    "sdesc_at_last_encounter": "a tall woman",
+                    "location_last_seen": "Bar",
+                },
+                "uid-b": {
+                    "assigned_name": "",  # forgotten
+                    "last_seen": "2026-05-12T00:00:00",
+                    "sdesc_at_last_encounter": "a short man",
+                    "location_last_seen": "Alley",
+                },
+            },
+        )
+        cmd = CmdMemory()
+        cmd.caller = caller
+        cmd.args = ""
+        cmd.func()
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("Alice", msg_text)
+        self.assertNotIn("a short man", msg_text)
+
+    def test_memory_recency_sort(self):
+        """Entries sort by last_seen descending."""
+        from commands.CmdCharacter import CmdMemory
+
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory={
+                "uid-old": {
+                    "assigned_name": "Older",
+                    "last_seen": "2026-01-01T00:00:00",
+                    "sdesc_at_last_encounter": "x",
+                    "location_last_seen": "y",
+                },
+                "uid-new": {
+                    "assigned_name": "Newer",
+                    "last_seen": "2026-12-01T00:00:00",
+                    "sdesc_at_last_encounter": "x",
+                    "location_last_seen": "y",
+                },
+            },
+        )
+        cmd = CmdMemory()
+        cmd.caller = caller
+        cmd.args = ""
+        cmd.func()
+
+        msg_text = caller.msg.call_args[0][0]
+        # Newer should appear before Older in the rendered table
+        self.assertLess(msg_text.index("Newer"), msg_text.index("Older"))
+
+    def test_memory_rejects_arguments(self):
+        """memory with args returns a usage hint."""
+        from commands.CmdCharacter import CmdMemory
+
+        caller = _make_character(key="Observer", sleeve_uid="uid-observer")
+        cmd = CmdMemory()
+        cmd.caller = caller
+        cmd.args = "something"
+        cmd.func()
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("Usage: memory", msg_text)
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- Renames `assign` to `remember` (hard rename — no backward-compatible alias) and adds three companion verbs that round out the observer-memory surface area.
- Pure syntax cleanup: no schema changes, existing `recognition_memory` entries already capture every field the new verbs need.
- 14 new tests; 35 in the identity command suite total; 507 in the full world suite — all green.

## New Surface Area
| Verb | Purpose |
|------|---------|
| `remember <target> as <name>` | Rename of the old `assign` command |
| `forget <target>` | Clears `assigned_name`; preserves entry (UID, sdesc snapshots, history). Resolves against visible characters and previously-remembered names. |
| `recall <target>` | Single-entry inspection: name, first-encounter sdesc, location, when, times seen. |
| `memory` | Dump-all listing sorted by recency, formatted with EvTable. Forgotten entries excluded. |

## Notable Decisions
- **Hard rename**: muscle memory for `assign` will get "Command not found." Acceptable cost.
- **`forget` preserves the entry**: only `assigned_name` is blanked. Sdesc snapshots, locations, and `times_seen` remain so re-`remember`ing extends the record rather than starting fresh.
- **`recall` and `forget` both resolve remembered-by-name targets even when absent**: memory management shouldn't require the person to be standing in front of you.
- **`recall` uses first-encounter snapshot**: shows what they looked like when you first met them. Future iteration will build on this.
- **`memory` is a pure list verb**: no subcommands. `recall <name>` covers single-entry inspection.
- **Relative time formatting**: uses `evennia.utils.utils.time_format(seconds, style=4)`.