### PR TITLE
Add appear/persona verb cluster (Phase 3 surface)

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1260,6 +1260,7 @@ class CmdRemember(Command):
 
     Usage:
       remember <target> as <name>
+      remember me as <persona name>
 
     When you encounter someone for the first time, you see their short
     description (e.g. "a lanky man in a Black Trenchcoat").  Use this
@@ -1269,6 +1270,11 @@ class CmdRemember(Command):
     You can remember people by false or partial names.  Other characters
     won't know what name you've chosen.
 
+    The |wremember me as <name>|n form saves your *current* presentation
+    overrides (height, build, keyword) as a named persona that you can
+    restore later via |wappear <name>|n.  See also |wpersonas|n and
+    |wpersona <name>|n.
+
     To change an existing name, simply remember them again.
     To clear a remembered name, use the |wforget|n command.
 
@@ -1276,6 +1282,7 @@ class CmdRemember(Command):
       remember man as Jorge
       remember woman as Sketchy Lady
       remember 2nd man as Big J
+      remember me as Hooded Wanderer
     """
 
     key = "remember"
@@ -1302,6 +1309,11 @@ class CmdRemember(Command):
             caller.msg("What name do you want to remember them by?")
             return
 
+        # "remember me as <name>" branch — save a persona snapshot.
+        if target_str.lower() == "me":
+            self._remember_self_as_persona(caller, name)
+            return
+
         # Find the target
         target = caller.search(target_str)
         if not target:
@@ -1324,8 +1336,38 @@ class CmdRemember(Command):
             caller.msg("You can't remember that character.")
             return
 
+        # Cross-namespace uniqueness: a remembered name for someone else
+        # must not collide with one of our own persona names or a valid
+        # keyword (which would shadow `appear <keyword>`).
+        taken, reason = _name_is_taken(caller, name, allow_assigned_uid=sleeve_uid)
+        if taken:
+            caller.msg(reason)
+            return
+
         # Apply the assignment
         self._remember_target(caller, target, sleeve_uid, name)
+
+    def _remember_self_as_persona(self, caller, name):
+        """Save the caller's current overrides as a named persona."""
+        taken, reason = _name_is_taken(caller, name)
+        if taken:
+            caller.msg(reason)
+            return
+
+        personas = caller.db.personas
+        if personas is None:
+            personas = {}
+
+        entry = _build_persona_entry(caller, name)
+        personas[name] = entry
+        caller.db.personas = personas
+
+        # Echo a summary so the player can see what got captured.
+        summary = _persona_summary_line(entry)
+        caller.msg(
+            f"Saved persona |w{name}|n: {summary}\n"
+            f"Restore later with |wappear {name}|n."
+        )
 
     def _remember_target(self, caller, target, sleeve_uid, name):
         """Store a name assignment in the caller's recognition memory."""
@@ -1457,10 +1499,11 @@ def _format_relative_time(iso_timestamp):
 
 class CmdForget(Command):
     """
-    Forget the name you remembered for someone.
+    Forget the name you remembered for someone, or delete a saved persona.
 
     Usage:
       forget <target>
+      forget <persona name>
 
     Clears the name you assigned to someone.  They will appear as their
     description again until you remember them by a new name.
@@ -1469,9 +1512,15 @@ class CmdForget(Command):
     pass either their current description or the name you remembered
     them by.
 
+    If the argument matches one of your saved personas (see |wpersonas|n)
+    instead of a remembered person, the persona is deleted.  If that
+    persona is currently adopted, all your presentation overrides are
+    cleared at the same time (equivalent to |wstop appearing|n).
+
     Examples:
       forget man
       forget Jorge
+      forget Hooded Wanderer
     """
 
     key = "forget"
@@ -1506,11 +1555,45 @@ class CmdForget(Command):
 
         # Fall back to remembered-name lookup
         sleeve_uid, entry = _find_remembered_uid_by_name(caller, args)
-        if sleeve_uid is None:
-            caller.msg("You don't remember anyone by that name.")
+        if sleeve_uid is not None:
+            self._forget_remembered(caller, sleeve_uid, entry)
             return
 
-        self._forget_remembered(caller, sleeve_uid, entry)
+        # Final fallback: persona lookup.
+        if self._forget_persona(caller, args):
+            return
+
+        caller.msg("You don't remember anyone — or any persona — by that name.")
+
+    def _forget_persona(self, caller, name):
+        """Delete a saved persona by name.  Returns True on success."""
+        personas = caller.db.personas
+        if not personas:
+            return False
+
+        # Case-insensitive lookup; preserve stored casing for the message.
+        match_key = None
+        needle = name.lower()
+        for key in personas:
+            if key.lower() == needle:
+                match_key = key
+                break
+        if match_key is None:
+            return False
+
+        was_active = (caller.db.active_persona == match_key)
+        del personas[match_key]
+        caller.db.personas = personas
+
+        if was_active:
+            _clear_all_overrides(caller)
+            caller.msg(
+                f"Forgot persona |w{match_key}|n. "
+                f"It was active — your presentation overrides have been cleared."
+            )
+        else:
+            caller.msg(f"Forgot persona |w{match_key}|n.")
+        return True
 
     def _forget_visible(self, caller, target, sleeve_uid):
         """Forget a target who is currently present."""
@@ -1702,3 +1785,506 @@ class CmdMemory(Command):
             )
 
         caller.msg(str(table))
+
+
+# ===================================================================
+# appear / stop appearing / personas / persona — disguise surface
+# ===================================================================
+#
+# Foundation cut for Phase 3 (Disguise System).  This layer ships the
+# *command surface* and *persistent storage* for presentation overrides
+# and saved personas only.  The signature engine, Apparent UID
+# derivation, sdesc-render consumption, item flags, and lifecycle hooks
+# all live in subsequent PRs — overrides set here are persisted but not
+# yet rendered into the sdesc.  See ``specs/IDENTITY_RECOGNITION_SPEC.md``
+# for the full Disguise System design.
+
+
+# -- Persona / override helpers ---------------------------------------
+
+
+def _override_axes(caller):
+    """Return the caller's three override axes as a dict."""
+    return {
+        "height_override": caller.db.height_override,
+        "build_override": caller.db.build_override,
+        "keyword_override": caller.db.keyword_override,
+    }
+
+
+def _has_any_override(caller):
+    """True if the caller has at least one active override axis."""
+    axes = _override_axes(caller)
+    return any(value is not None for value in axes.values())
+
+
+def _clear_all_overrides(caller):
+    """Wipe all override axes and the active-persona pointer."""
+    caller.db.height_override = None
+    caller.db.build_override = None
+    caller.db.keyword_override = None
+    caller.db.active_persona = None
+
+
+def _build_persona_entry(caller, name):
+    """Snapshot the caller's current overrides into a persona dict.
+
+    The shape matches the persona schema documented in the disguise
+    spec; ``essential_item_types`` and ``notes`` are reserved for the
+    Phase 3 engine PR but written empty now so the schema is stable.
+    """
+    import time
+
+    location_name = caller.location.key if caller.location else "unknown"
+    return {
+        "name": name,
+        "height_override": caller.db.height_override,
+        "build_override": caller.db.build_override,
+        "keyword_override": caller.db.keyword_override,
+        "saved_at": time.time(),
+        "saved_in": location_name,
+        "essential_item_types": [],
+        "notes": "",
+    }
+
+
+def _persona_summary_line(entry):
+    """Single-line summary of a persona's three axes for list/save echoes."""
+    parts = []
+    height = entry.get("height_override")
+    build = entry.get("build_override")
+    keyword = entry.get("keyword_override")
+    if height:
+        parts.append(f"height={height}")
+    if build:
+        parts.append(f"build={build}")
+    if keyword:
+        parts.append(f"keyword={keyword}")
+    if not parts:
+        return "(no overrides)"
+    return ", ".join(parts)
+
+
+def _format_relative_unixtime(unix_ts):
+    """Human-friendly 'X ago' string for a unix timestamp."""
+    import time
+    from evennia.utils.utils import time_format
+
+    if not unix_ts:
+        return "unknown"
+    try:
+        delta = time.time() - float(unix_ts)
+        if delta < 1:
+            return "just now"
+        return f"{time_format(int(delta), 4)} ago"
+    except (ValueError, TypeError):
+        return "unknown"
+
+
+def _name_is_taken(caller, name, allow_assigned_uid=None):
+    """Check whether *name* collides with any reserved identity namespace.
+
+    A persona name (or a remembered-as name) must be unique against:
+
+    * the keyword catalog (so ``appear <name>`` is unambiguous),
+    * the caller's recognition_memory ``assigned_name`` values
+      (so ``forget <name>`` is unambiguous), and
+    * the caller's existing persona names.
+
+    Args:
+        caller: The character whose namespaces are being checked.
+        name: The candidate name (case-insensitive).
+        allow_assigned_uid: When checking a remembered-as assignment,
+            the existing recognition entry for *that* sleeve_uid does
+            not count as a collision (re-naming the same person).
+
+    Returns:
+        Tuple ``(taken: bool, reason: str)``.  *reason* is a
+        player-facing message; empty string when ``taken`` is False.
+    """
+    from world.identity import get_all_keywords
+
+    needle = name.strip().lower()
+    if not needle:
+        return True, "Name cannot be blank."
+
+    if needle in {kw.lower() for kw in get_all_keywords()}:
+        return True, (
+            f"|r'{name}' is a reserved keyword.|n  Pick a different name "
+            f"so |wappear {name}|n stays unambiguous."
+        )
+
+    memory = caller.recognition_memory or {}
+    for uid, entry in memory.items():
+        assigned = (entry.get("assigned_name") or "").strip().lower()
+        if assigned and assigned == needle and uid != allow_assigned_uid:
+            return True, (
+                f"|rYou already remember someone else as '{name}'.|n  "
+                f"Pick a different name."
+            )
+
+    personas = caller.db.personas or {}
+    for persona_name in personas:
+        if persona_name.lower() == needle:
+            return True, (
+                f"|rYou already have a persona named '{persona_name}'.|n  "
+                f"Forget it first or pick a different name."
+            )
+
+    return False, ""
+
+
+def _nudge_axis(values, current, real, direction):
+    """Return the next axis value one step from current toward direction.
+
+    Args:
+        values: Ordered tuple of valid values (e.g. ``HEIGHTS``).
+        current: The current override value, or ``None`` to use *real*.
+        real: The character's real (un-overridden) axis value.
+        direction: ``+1`` (e.g. taller / fatter) or ``-1`` (shorter /
+            thinner).
+
+    Returns:
+        The new axis value, or ``None`` if the nudge would step off
+        either end of the scale.
+    """
+    base = current if current is not None else real
+    if base not in values:
+        return None
+    idx = values.index(base) + direction
+    if idx < 0 or idx >= len(values):
+        return None
+    return values[idx]
+
+
+def _describe_appearance(caller):
+    """Render the bare ``appear`` status display for the caller."""
+    real_height = caller.height
+    real_build = caller.build
+    real_keyword = caller.sdesc_keyword
+
+    h_over = caller.db.height_override
+    b_over = caller.db.build_override
+    k_over = caller.db.keyword_override
+    active = caller.db.active_persona
+
+    def _row(label, real, override):
+        if override is None:
+            return f"  {label:<8} {real or '(unset)'}"
+        return f"  {label:<8} |w{override}|n  |x(real: {real or 'unset'})|n"
+
+    lines = ["|cYour current appearance:|n"]
+    lines.append(_row("Height:", real_height, h_over))
+    lines.append(_row("Build:", real_build, b_over))
+    lines.append(_row("Keyword:", real_keyword, k_over))
+
+    if not _has_any_override(caller):
+        lines.append("")
+        lines.append("|xNo presentation overrides active.|n")
+    if active:
+        lines.append("")
+        lines.append(f"|y(Persona: {active})|n")
+    return "\n".join(lines)
+
+
+def _render_persona(entry):
+    """Multi-line render of a single persona entry for ``persona <name>``."""
+    name = entry.get("name", "(unnamed)")
+    when = _format_relative_unixtime(entry.get("saved_at"))
+    where = entry.get("saved_in") or "unknown"
+
+    lines = [f"|cPersona: |w{name}|n"]
+
+    h = entry.get("height_override")
+    b = entry.get("build_override")
+    k = entry.get("keyword_override")
+    lines.append(f"  Height:   {h if h is not None else '|x(unchanged)|n'}")
+    lines.append(f"  Build:    {b if b is not None else '|x(unchanged)|n'}")
+    lines.append(f"  Keyword:  {k if k is not None else '|x(unchanged)|n'}")
+    lines.append(f"  Saved:    {when} in {where}")
+    return "\n".join(lines)
+
+
+# -- Commands ---------------------------------------------------------
+
+
+class CmdAppear(Command):
+    """
+    Adopt a presentation override, restore a saved persona, or check status.
+
+    Usage:
+      appear                          - show current overrides and persona
+      appear taller | shorter         - nudge perceived height one step
+      appear thinner | fatter         - nudge perceived build one step
+      appear <keyword>                - present as the given keyword
+      appear <persona name>           - restore a saved persona
+
+    The |wappear|n command is your interface to *presentation overrides* —
+    per-axis changes to how others perceive you.  Each override stays
+    in effect until you change it, replace it, or use |wstop appearing|n.
+
+    Height and build nudges step one notch on a fixed scale.  If you're
+    already at the extreme of the scale in that direction, the command
+    refuses (some descriptors are simply unreachable for your real
+    sleeve — that's a tell).
+
+    A keyword override accepts any keyword from the full catalog
+    (gender restrictions don't apply to disguise).  Use |w@shortdesc|n
+    to introduce new keywords to the catalog.
+
+    A persona is a previously saved snapshot of all three override axes
+    (see |wremember me as <name>|n).  Adopting a persona overwrites all
+    three axes — including clearing axes the persona doesn't set.
+
+    Manually changing an axis after adopting a persona dissociates from
+    that persona; the persona itself is left intact.
+
+    Examples:
+      appear taller
+      appear thinner
+      appear droog
+      appear Hooded Wanderer
+    """
+
+    key = "appear"
+    locks = "cmd:all()"
+    help_category = "Character"
+
+    def func(self):
+        caller = self.caller
+        args = self.args.strip()
+
+        if not args:
+            caller.msg(_describe_appearance(caller))
+            return
+
+        # Resolution order: persona name > axis nudge > keyword.
+        personas = caller.db.personas or {}
+        for persona_name in personas:
+            if persona_name.lower() == args.lower():
+                self._adopt_persona(caller, persona_name, personas[persona_name])
+                return
+
+        lower = args.lower()
+        if lower in ("taller", "shorter"):
+            self._nudge_height(caller, +1 if lower == "taller" else -1)
+            return
+        if lower in ("thinner", "fatter"):
+            self._nudge_build(caller, +1 if lower == "fatter" else -1)
+            return
+
+        # Keyword override.
+        self._set_keyword_override(caller, args)
+
+    # -- axis handlers ---------------------------------------------------
+
+    def _nudge_height(self, caller, direction):
+        from world.identity import HEIGHTS
+
+        new = _nudge_axis(
+            HEIGHTS, caller.db.height_override, caller.height, direction
+        )
+        if new is None:
+            word = "taller" if direction > 0 else "shorter"
+            caller.msg(
+                f"You can't appear any {word} than that — your real frame "
+                f"won't sell it."
+            )
+            return
+        self._maybe_break_persona(caller)
+        caller.db.height_override = new
+        caller.msg(f"You now carry yourself as |w{new}|n.")
+
+    def _nudge_build(self, caller, direction):
+        from world.identity import BUILDS
+
+        new = _nudge_axis(
+            BUILDS, caller.db.build_override, caller.build, direction
+        )
+        if new is None:
+            word = "bulkier" if direction > 0 else "leaner"
+            caller.msg(
+                f"You can't appear any {word} than that — your real frame "
+                f"won't sell it."
+            )
+            return
+        self._maybe_break_persona(caller)
+        caller.db.build_override = new
+        caller.msg(f"You now carry yourself as |w{new}|n.")
+
+    def _set_keyword_override(self, caller, raw_keyword):
+        from world.identity import get_all_keywords
+
+        keyword = raw_keyword.lower()
+        if keyword not in {kw.lower() for kw in get_all_keywords()}:
+            caller.msg(
+                f"|r'{raw_keyword}' isn't a recognized keyword or persona.|n  "
+                f"Use |w@shortdesc|n to introduce new keywords to the "
+                f"catalog first."
+            )
+            return
+        self._maybe_break_persona(caller)
+        caller.db.keyword_override = keyword
+        caller.msg(f"You now present yourself as a |w{keyword}|n.")
+
+    # -- persona adoption ------------------------------------------------
+
+    def _adopt_persona(self, caller, name, entry):
+        """Clean swap: overwrite all three axes from the persona snapshot."""
+        caller.db.height_override = entry.get("height_override")
+        caller.db.build_override = entry.get("build_override")
+        caller.db.keyword_override = entry.get("keyword_override")
+        caller.db.active_persona = name
+
+        summary = _persona_summary_line(entry)
+        caller.msg(
+            f"You adopt the persona |w{name}|n.\n  {summary}"
+        )
+
+    def _maybe_break_persona(self, caller):
+        """Manual axis change dissociates from any active persona."""
+        active = caller.db.active_persona
+        if active:
+            caller.db.active_persona = None
+            caller.msg(
+                f"|x(Manual change — no longer presenting as persona "
+                f"'{active}'.)|n"
+            )
+
+
+class CmdStopAppearing(Command):
+    """
+    Drop all presentation overrides and return to your real appearance.
+
+    Usage:
+      stop appearing
+
+    Clears every active override (height, build, keyword) and any
+    adopted persona pointer.  You will be perceived as your real sleeve
+    again, modulo any disguise items you have equipped (those are
+    handled separately by the items themselves).
+
+    To delete a saved persona instead of just stepping out of it, use
+    |wforget <persona name>|n.
+    """
+
+    key = "stop appearing"
+    locks = "cmd:all()"
+    help_category = "Character"
+
+    def func(self):
+        caller = self.caller
+
+        if not _has_any_override(caller) and not caller.db.active_persona:
+            caller.msg("You aren't presenting as anything but yourself.")
+            return
+
+        _clear_all_overrides(caller)
+        caller.msg(
+            "You drop the act and present yourself as you really are."
+        )
+
+
+class CmdPersonas(Command):
+    """
+    List the personas you've saved.
+
+    Usage:
+      personas
+
+    Shows every persona you've stored via |wremember me as <name>|n,
+    most-recently-saved first.  An asterisk marks the persona you are
+    currently adopting (if any).
+
+    Use |wpersona <name>|n to inspect a single persona, |wappear <name>|n
+    to adopt one, and |wforget <name>|n to delete one.
+    """
+
+    key = "personas"
+    locks = "cmd:all()"
+    help_category = "Character"
+
+    def func(self):
+        caller = self.caller
+        if self.args.strip():
+            caller.msg("Usage: personas  (no arguments)")
+            return
+
+        personas = caller.db.personas or {}
+        if not personas:
+            caller.msg(
+                "You haven't saved any personas yet.  Use "
+                "|wremember me as <name>|n to save your current "
+                "presentation overrides as a persona."
+            )
+            return
+
+        # Recency sort, newest first.  Missing timestamps sort last.
+        ordered = sorted(
+            personas.items(),
+            key=lambda pair: pair[1].get("saved_at") or 0,
+            reverse=True,
+        )
+
+        active = caller.db.active_persona
+
+        from evennia.utils.evtable import EvTable
+
+        table = EvTable(
+            "|wPersona|n",
+            "|wOverrides|n",
+            "|wSaved|n",
+            border="cells",
+        )
+        for name, entry in ordered:
+            marker = "|g*|n " if name == active else "  "
+            table.add_row(
+                f"{marker}{name}",
+                _persona_summary_line(entry),
+                _format_relative_unixtime(entry.get("saved_at")),
+            )
+
+        caller.msg(str(table))
+
+
+class CmdPersona(Command):
+    """
+    Inspect a single saved persona.
+
+    Usage:
+      persona <name>
+
+    Shows the height/build/keyword overrides captured in the persona
+    and where/when it was saved.
+
+    Use |wpersonas|n to list every persona you've saved.
+    """
+
+    key = "persona"
+    locks = "cmd:all()"
+    help_category = "Character"
+
+    def func(self):
+        caller = self.caller
+        args = self.args.strip()
+
+        if not args:
+            caller.msg("Usage: persona <name>")
+            return
+
+        personas = caller.db.personas or {}
+        match = None
+        for name, entry in personas.items():
+            if name.lower() == args.lower():
+                match = (name, entry)
+                break
+
+        if match is None:
+            caller.msg(
+                f"You don't have a persona named '{args}'.  "
+                f"Try |wpersonas|n to see what you've saved."
+            )
+            return
+
+        caller.msg(_render_persona(match[1]))
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -187,6 +187,10 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdForget())
         self.add(CmdRecall())
         self.add(CmdMemory())
+        self.add(CmdCharacter.CmdAppear())
+        self.add(CmdCharacter.CmdStopAppearing())
+        self.add(CmdCharacter.CmdPersonas())
+        self.add(CmdCharacter.CmdPersona())
 
         # Add identity-aware communication commands (override Evennia defaults)
         self.add(CmdSay())

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -497,31 +497,47 @@ The composed sdesc descriptor (`gaunt`, `burly`, etc.) is recomputed from the ov
 - Voice (deferred to future communication-system integration)
 - The character's real `sleeve_uid` (the underlying body identity)
 
-### Bookmarks — Player-Facing Persona Recall
+### Personas — Player-Facing Persona Recall
 
-Because the identity engine is purely emergent from current state, players need an ergonomic layer to **remember and restore** disguise combinations they have discovered and want to reuse. Bookmarks fill this role.
+Because the identity engine is purely emergent from current state, players need an ergonomic layer to **remember and restore** disguise combinations they have discovered and want to reuse. Personas fill this role.
 
-A bookmark is a **player-private snapshot** of a disguise combination, captured at the moment of bookmarking and restorable later. Bookmarks are designed in parallel to the planned identity/contact system — same recall, annotation, and (future) web-UI patterns.
+A persona is a **player-private snapshot** of presentation overrides, captured at the moment of saving and restorable later. Personas are designed in parallel to the planned identity/contact system — same recall, annotation, and (future) web-UI patterns.
 
-**A bookmark stores:**
-- A **player-chosen name** (1–32 chars, case-insensitive lookup, case-preserving display, player-private — never visible to other characters)
-- The **override values** active at bookmark time (height, build, keyword)
-- The **types of essential disguise items** equipped at bookmark time
-- A **freeform notes field** for player annotations (e.g., *"met Marcus at the docks, he thinks I work for Diaz"*)
-- A **created-at timestamp**
+> **Status (current PR — `appear-persona-cluster`):** The surface verbs (`appear`, `stop appearing`, `personas`, `persona`, `remember me as <name>`, `forget <persona>`) and the persona storage schema are shipped. The signature engine, Apparent UID derivation, essential-item integration, and `get_sdesc()` consumption of overrides are deferred to follow-up Phase 3 PRs. Until those land, override axes are written to character DB but do not yet affect what observers perceive.
 
-**Bookmarks do NOT generate identities.** They are pure recall aids. When a player restores a bookmark, the system applies the captured overrides and notifies the player which essential items they need to equip (or are missing). The resulting Apparent UID is derived by the engine from the restored state, not from the bookmark itself. Two bookmarks with identical override + item-type composition yield the same Apparent UID — they are just labels in the player's memory.
+**A persona stores:**
+- A **player-chosen name** (case-insensitive lookup, case-preserving display, player-private — never visible to other characters)
+- The **override values** active at save time (height, build, keyword) — `None` for axes that were unset
+- The **types of essential disguise items** equipped at save time *(reserved field, populated when the engine PR lands; written empty in the foundation cut)*
+- A **freeform notes field** for player annotations *(reserved field, currently always empty)*
+- A **created-at timestamp** and the **room name** where it was saved
 
-**Bookmark cap:** `min(Resonance × 2, 10)`. (Tunable; this gating is ergonomic, not load-bearing — expected to change.) Players at cap must delete a bookmark before saving a new one. Existing bookmarks remain usable if Resonance drops below the threshold; only new saves are blocked.
+**Personas do NOT generate identities.** They are pure recall aids. When a player adopts a persona, the system applies the captured overrides as a **clean swap** — overwriting all three axes including any unset axes (so adoption produces an exact replay of the saved state, never a merge). The resulting Apparent UID, once the engine PR lands, will be derived from the restored state, not from the persona itself. Two personas with identical overrides + item-type composition will yield the same Apparent UID — they are just labels in the player's memory.
 
-**Operations** (exact syntax to be settled in a future commands discussion):
-- Save current state as a bookmark
-- List bookmarks (player-private; never visible to others)
-- Restore a bookmark (apply overrides + report missing items)
-- Annotate a bookmark with notes
-- Delete a bookmark
+**Cap:** No cap in the surface PR. The previously-floated `min(Resonance × 2, 10)` gating is held for the engine PR or later balance pass.
 
-**Bookmark name collision** within a single character is rejected. Players must delete an existing bookmark before reusing the name. (`appear edit`-style in-place modification is deferred to a future iteration.)
+**Player surface (current grammar — locked):**
+- `appear` — show current overrides + active persona
+- `appear taller | shorter` — nudge perceived height one step on the `HEIGHTS` scale; refuses at the extremes (an unreachable axis value is itself a tell)
+- `appear thinner | fatter` — same on the `BUILDS` scale
+- `appear <keyword>` — present as the given keyword; validated against the full keyword catalog (gender filter does not apply to disguise). New keywords are introduced via `@shortdesc`, not via `appear`.
+- `appear <persona name>` — restore a saved persona (clean swap)
+- `stop appearing` — clear all overrides and any adopted-persona pointer; the only canonical clear verb (no aliases)
+- `remember me as <persona name>` — snapshot current overrides as a persona; allowed even with no axes set (intentional — supports saving a baseline)
+- `forget <persona name>` — delete a persona; if it was the currently-adopted persona, also clears all overrides
+- `personas` — list saved personas, recency-sorted (newest first); the active persona, if any, is marked with `*`
+- `persona <name>` — inspect a single persona's snapshot
+
+**Resolution order for `appear <arg>`:** persona name → axis nudge keyword (`taller`/`shorter`/`thinner`/`fatter`) → keyword catalog. Persona names take precedence so a player can always reach their own personas; cross-namespace uniqueness (below) prevents real ambiguity.
+
+**Manual axis change after persona adoption** dissociates the active-persona pointer (with an explicit message) but leaves the persona definition intact. The player can re-adopt it later with `appear <name>`.
+
+**Cross-namespace uniqueness** is enforced when saving a persona name *or* assigning a recognition name via `remember <target> as <name>`. A name is rejected if it collides with:
+- the keyword catalog (so `appear <name>` stays unambiguous)
+- any of the caller's existing recognition `assigned_name`s (so `forget <name>` stays unambiguous)
+- any of the caller's existing persona names
+
+The collision check is case-insensitive and presents the offending namespace in the error message.
 
 ### Disguise Items
 
@@ -551,15 +567,15 @@ A disguise's effectiveness scales with the player's investment:
 
 ### Disguise Persistence
 
-Override and bookmark state lives in DB attributes — persists across server restarts, reloads, and crashes. There is no "session" concept; a character who logs out mid-disguise logs back in still disguised.
+Override and persona state lives in DB attributes — persists across server restarts, reloads, and crashes. There is no "session" concept; a character who logs out mid-disguise logs back in still disguised.
 
-Bookmarks persist indefinitely until explicitly deleted, regardless of whether the character is currently using their overrides.
+Personas persist indefinitely until explicitly deleted, regardless of whether the character is currently using their overrides.
 
 ### Breaking and Degrading Disguise
 
 Because disguise is continuous, "breaking" simply means changing signature inputs.
 
-**Voluntary `appear reset`:** Clears all overrides. If no essential items are equipped, the Apparent UID returns to the real `sleeve_uid` and observers who know the real identity auto-recognize. If essential items are still equipped, the signature still differs from real — only the override contribution is removed.
+**Voluntary `stop appearing`:** Clears all overrides and any active-persona pointer. If no essential items are equipped, the Apparent UID returns to the real `sleeve_uid` and observers who know the real identity auto-recognize. If essential items are still equipped, the signature still differs from real — only the override contribution is removed.
 
 **Death:** All active overrides clear; the corpse stores both `real_sleeve_uid` and a snapshot of the identity signature active at time of death (for forensic gameplay — investigators can reconstruct what the character looked like when they died).
 
@@ -582,7 +598,7 @@ A disguised character (overrides: `tall man` + essential cowl + non-essential ca
 3. The Apparent UID recomputes to a new value.
 4. The observer's recognition no longer auto-resolves: "Batman" was tagged against the *previous* UID. They now see the new sdesc as a stranger — `"a tall man in a black cape"` — and may deduce the connection from context, but the system does not auto-link the two identities.
 5. If the cowl is re-equipped, the signature returns to its prior value and the observer's "Batman" tag fires again.
-6. If the disguised character then does `appear reset`, both overrides and the cowl effect are discarded — the Apparent UID returns to the real `sleeve_uid` (or wherever the remaining signature inputs lead). Observers who knew the real identity may now auto-recognize the character.
+6. If the disguised character then does `stop appearing`, both overrides and the active-persona pointer are cleared — the Apparent UID returns to the real `sleeve_uid` (or wherever the remaining signature inputs lead, modulo any still-equipped essential items). Observers who knew the real identity may now auto-recognize the character.
 
 ### Recognition Interactions
 
@@ -629,7 +645,7 @@ These are designed into the architecture but not implemented yet:
 - **Pharmaceutical / biomod items**: Consumable or implanted modifications that override `@longdesc` and contribute to the identity signature (extending the signature function with body-mod inputs). Closes the last gap: with body mods, even direct `look` reveals a different person. Pharmaceuticals would be temporary (wears off over time), potentially expensive/rare, and could carry side effects (stat penalties, addiction).
 - **Photos / identity artifacts**: Captured signature snapshots usable as recipes (own personas) or investigation tools (others'). Salt-acquisition mechanics enable true impersonation gameplay. Ties into Phase 4 (cybernetics) where digital identity data becomes hackable and forgeable.
 - **Voice modulation**: Integration with say/whisper/communication so voice becomes part of the identity signature for observers who can hear but not see (or in addition to visual identification).
-- **Web UI integration**: Bookmarks designed to mirror the planned identity/contact archive system; eventual web UI surface for managing bookmarks, photos, and contact memory in one place.
+- **Web UI integration**: Personas designed to mirror the planned identity/contact archive system; eventual web UI surface for managing personas, photos, and contact memory in one place.
 - **Salt-acquisition mechanics for true impersonation**: Stolen contact cards, hacked digital identities, and other adversarial means by which an impostor can acquire the original's salt and become auto-recognized as them.
 
 ---
@@ -938,30 +954,33 @@ Players should be prompted to customize their sdesc on next login if defaults we
 
 ### Phase 3 — Disguise (Foundation)
 
-**Scope:** Identity signature engine, the `appear` command (per-axis overrides), disguise item flags, bookmark layer, and lifecycle integration.
+**Scope:** Identity signature engine, the `appear` / persona verb cluster (per-axis overrides + persona snapshots), disguise item flags, and lifecycle integration. Shipped incrementally across multiple PRs.
 
 **Build in Phase 3:**
 - Identity signature tuple: `(real_sleeve_uid, height_override, build_override, keyword_override, sorted(essential_item_types))`
 - Apparent UID derivation: `hash(real_sleeve_uid + override_signature)` — deterministic, recomputed on access (no caching in foundation cut)
-- Per-axis `appear` command grammar: `appear taller/shorter/average`, `appear bulkier/leaner/athletic`, `appear man/woman/[keyword]`, `appear reset`, bare `appear` (status)
+- Per-axis `appear` command grammar — **shipped (`appear-persona-cluster`)**:
+  - `appear` (status), `appear taller | shorter`, `appear thinner | fatter`, `appear <keyword>`, `appear <persona name>`
+  - `stop appearing` (clears all overrides + active-persona pointer)
 - Sdesc descriptor recomposition via existing `get_physical_descriptor(height, build)` table
 - Resonance check stub on each axis override (always succeeds; call point exists for Phase 5 tuning)
-- DB attributes for active overrides (height/build/keyword override fields on character)
-- `db.disguise_essential` flag on items — contributes to identity signature when worn
-- `db.is_disguise_item` flag on items — Phase 5 perception bonus hook (defined but inert in Phase 3)
-- Hook `get_sdesc()` / `get_display_name()` to use Apparent UID
-- Full keyword catalog available regardless of character gender (override bypasses gender filter)
+- DB attributes for active overrides on character — **shipped**: `db.height_override`, `db.build_override`, `db.keyword_override`, `db.active_persona`, `db.personas`
+- `db.disguise_essential` flag on items — contributes to identity signature when worn *(deferred)*
+- `db.is_disguise_item` flag on items — Phase 5 perception bonus hook (defined but inert in Phase 3) *(deferred)*
+- Hook `get_sdesc()` / `get_display_name()` to consume override axes and Apparent UID *(deferred — overrides are written but not yet rendered)*
+- Full keyword catalog available regardless of character gender (override bypasses gender filter) — **shipped via `appear <keyword>` validation**
 - Available to **all characters** (no access level restriction)
-- Bookmark layer (player-private ergonomics):
-  - `appear bookmark <name>` — capture current overrides + essential item types + freeform notes + timestamp
-  - `appear as <bookmark>` — apply captured overrides (does not auto-equip items; notes which essentials are missing)
-  - `appear bookmarks` — list saved bookmarks
-  - `appear forget <bookmark>` — delete bookmark
-  - Cap: `min(Resonance × 2, 10)` (placeholder fluff, will retune)
-  - Name collision: rejected (no `appear edit` in foundation)
-- Lifecycle integration:
+- Persona layer (player-private ergonomics) — **shipped (`appear-persona-cluster`)**:
+  - `remember me as <name>` — capture current overrides as a persona (verb-symmetric with `remember <target> as <name>`)
+  - `appear <persona name>` — adopt a persona (clean swap; overwrites all axes including unset ones)
+  - `personas` — list saved personas, recency-sorted; active persona marked with `*`
+  - `persona <name>` — inspect a single persona
+  - `forget <persona name>` — delete a persona; clears overrides if it was active
+  - Cross-namespace uniqueness enforced (keyword catalog ∩ recognition names ∩ persona names)
+  - No cap (deferred to engine PR / balance pass)
+- Lifecycle integration *(deferred to engine PR)*:
   - Death: clears overrides; corpse stores `real_sleeve_uid` + `last_active_signature` snapshot
-  - Sleeve swap (flash clone / resleeving): salt is `real_sleeve_uid`, so personas don't carry across bodies; bookmarks remain on the player
+  - Sleeve swap (flash clone / resleeving): salt is `real_sleeve_uid`, so personas don't carry across bodies; persona records remain on the player
   - Item destruction: removing/destroying essential item changes signature → Apparent UID changes → observers see stranger
 - No observer-side disguise metadata — recognition system stays transparent to disguise mechanics
 - No auto-equip / auto-remove on persona swap — disguise emerges from observable state
@@ -976,8 +995,8 @@ Players should be prompted to customize their sdesc on next login if defaults we
 - Forcible strip via grapple (needs grapple system integration)
 - Photo / recording mechanic (capture full signature for later impersonation; future phase)
 - Pharma / voice-modulation override axes (future phase)
-- `appear edit <bookmark>` (deferred)
-- Web-UI maximal bookmark capture (deferred)
+- `appear edit <persona>` (deferred — players currently delete + re-save)
+- Web-UI maximal persona capture (deferred)
 
 ### Phase 3.5 — Disguise Item Taxonomy
 

--- a/world/tests/test_identity_commands.py
+++ b/world/tests/test_identity_commands.py
@@ -861,3 +861,609 @@ class TestLogCustomKeyword(TestCase):
                 log_custom_keyword("wraith", "Bob")
 
         self.assertEqual(mock_create.call_count, 2)
+
+
+# ===================================================================
+# Disguise — appear / persona cluster helpers
+# ===================================================================
+
+
+def _make_disguise_character(**overrides):
+    """``_make_character`` plus pre-zeroed disguise/persona ``db`` attrs.
+
+    The new commands rely on ``caller.db.height_override is None`` style
+    checks; bare ``MagicMock`` access would yield a child mock instead
+    of ``None``.  We seed the relevant ``db`` slots and the ``personas``
+    dict so each test starts from a clean baseline.
+    """
+    db_overrides = overrides.pop("db_attrs", {})
+    char = _make_character(**overrides)
+
+    # Persona/override storage attrs default to None / empty dict.
+    defaults = {
+        "height_override": None,
+        "build_override": None,
+        "keyword_override": None,
+        "active_persona": None,
+        "personas": None,
+    }
+    defaults.update(db_overrides)
+    for attr, value in defaults.items():
+        setattr(char.db, attr, value)
+    return char
+
+
+# ===================================================================
+# CmdAppear — bare status display
+# ===================================================================
+
+
+class TestCmdAppearStatus(TestCase):
+    """``appear`` with no args renders current overrides + persona."""
+
+    def _run(self, caller):
+        from commands.CmdCharacter import CmdAppear
+
+        cmd = CmdAppear()
+        cmd.caller = caller
+        cmd.args = ""
+        cmd.func()
+        return caller.msg.call_args[0][0]
+
+    def test_no_overrides_reports_clean_state(self):
+        caller = _make_disguise_character(
+            height="tall", build="lean", sdesc_keyword="man"
+        )
+        msg = self._run(caller)
+        self.assertIn("tall", msg)
+        self.assertIn("lean", msg)
+        self.assertIn("man", msg)
+        self.assertIn("No presentation overrides active", msg)
+
+    def test_active_persona_appears_in_status(self):
+        caller = _make_disguise_character(
+            height="tall", build="lean", sdesc_keyword="man",
+            db_attrs={
+                "height_override": "average",
+                "active_persona": "Hooded Wanderer",
+            },
+        )
+        msg = self._run(caller)
+        self.assertIn("average", msg)
+        self.assertIn("Hooded Wanderer", msg)
+        self.assertIn("real:", msg)
+
+
+# ===================================================================
+# CmdAppear — axis nudges
+# ===================================================================
+
+
+class TestCmdAppearAxes(TestCase):
+    """``appear taller/shorter/thinner/fatter`` step the axis."""
+
+    def _run(self, caller, args):
+        from commands.CmdCharacter import CmdAppear
+
+        cmd = CmdAppear()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.func()
+
+    def test_taller_steps_height_up(self):
+        from world.identity import HEIGHTS
+
+        caller = _make_disguise_character(height="average")
+        self._run(caller, "taller")
+        expected = HEIGHTS[HEIGHTS.index("average") + 1]
+        self.assertEqual(caller.db.height_override, expected)
+
+    def test_shorter_steps_height_down(self):
+        from world.identity import HEIGHTS
+
+        caller = _make_disguise_character(height="average")
+        self._run(caller, "shorter")
+        expected = HEIGHTS[HEIGHTS.index("average") - 1]
+        self.assertEqual(caller.db.height_override, expected)
+
+    def test_taller_at_max_refuses(self):
+        from world.identity import HEIGHTS
+
+        caller = _make_disguise_character(height=HEIGHTS[-1])
+        self._run(caller, "taller")
+        self.assertIsNone(caller.db.height_override)
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("can't appear any taller", msg)
+
+    def test_fatter_steps_build_up(self):
+        from world.identity import BUILDS
+
+        caller = _make_disguise_character(build="average")
+        self._run(caller, "fatter")
+        expected = BUILDS[BUILDS.index("average") + 1]
+        self.assertEqual(caller.db.build_override, expected)
+
+    def test_thinner_steps_build_down(self):
+        from world.identity import BUILDS
+
+        caller = _make_disguise_character(build="average")
+        self._run(caller, "thinner")
+        expected = BUILDS[BUILDS.index("average") - 1]
+        self.assertEqual(caller.db.build_override, expected)
+
+
+# ===================================================================
+# CmdAppear — keyword override
+# ===================================================================
+
+
+class TestCmdAppearKeyword(TestCase):
+    """``appear <keyword>`` validates against the catalog."""
+
+    def _run(self, caller, args):
+        from commands.CmdCharacter import CmdAppear
+
+        cmd = CmdAppear()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.func()
+
+    def test_valid_keyword_sets_override(self):
+        caller = _make_disguise_character()
+        with patch(
+            "world.identity.get_all_keywords",
+            return_value=frozenset({"man", "droog", "person"}),
+        ):
+            self._run(caller, "droog")
+        self.assertEqual(caller.db.keyword_override, "droog")
+
+    def test_unknown_keyword_rejected(self):
+        caller = _make_disguise_character()
+        with patch(
+            "world.identity.get_all_keywords",
+            return_value=frozenset({"man", "person"}),
+        ):
+            self._run(caller, "wraith")
+        self.assertIsNone(caller.db.keyword_override)
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("isn't a recognized keyword", msg)
+        self.assertIn("@shortdesc", msg)
+
+
+# ===================================================================
+# CmdAppear — persona resolution
+# ===================================================================
+
+
+class TestCmdAppearPersona(TestCase):
+    """``appear <persona name>`` adopts a saved snapshot."""
+
+    def test_persona_overrides_keyword_resolution(self):
+        from commands.CmdCharacter import CmdAppear
+
+        persona_entry = {
+            "name": "Hooded Wanderer",
+            "height_override": "tall",
+            "build_override": None,
+            "keyword_override": "wanderer",
+            "saved_at": 1000.0,
+            "saved_in": "Bar",
+            "essential_item_types": [],
+            "notes": "",
+        }
+        caller = _make_disguise_character(
+            db_attrs={"personas": {"Hooded Wanderer": persona_entry}},
+        )
+
+        cmd = CmdAppear()
+        cmd.caller = caller
+        cmd.args = "hooded wanderer"  # case-insensitive
+        cmd.func()
+
+        self.assertEqual(caller.db.height_override, "tall")
+        self.assertIsNone(caller.db.build_override)
+        self.assertEqual(caller.db.keyword_override, "wanderer")
+        self.assertEqual(caller.db.active_persona, "Hooded Wanderer")
+
+    def test_persona_adoption_clears_unset_axes(self):
+        """Adoption is a clean swap, not a merge."""
+        from commands.CmdCharacter import CmdAppear
+
+        persona_entry = {
+            "name": "Plain",
+            "height_override": None,
+            "build_override": None,
+            "keyword_override": None,
+            "saved_at": 1000.0,
+            "saved_in": "Bar",
+            "essential_item_types": [],
+            "notes": "",
+        }
+        caller = _make_disguise_character(
+            db_attrs={
+                "height_override": "tall",
+                "build_override": "fat",
+                "keyword_override": "droog",
+                "personas": {"Plain": persona_entry},
+            },
+        )
+
+        cmd = CmdAppear()
+        cmd.caller = caller
+        cmd.args = "Plain"
+        cmd.func()
+
+        self.assertIsNone(caller.db.height_override)
+        self.assertIsNone(caller.db.build_override)
+        self.assertIsNone(caller.db.keyword_override)
+        self.assertEqual(caller.db.active_persona, "Plain")
+
+
+# ===================================================================
+# CmdAppear — manual change clears active persona
+# ===================================================================
+
+
+class TestCmdAppearManualClearsPersona(TestCase):
+    """Manual axis change after adoption dissociates from the persona."""
+
+    def test_height_nudge_clears_active_persona(self):
+        from commands.CmdCharacter import CmdAppear
+
+        caller = _make_disguise_character(
+            height="average",
+            db_attrs={"active_persona": "Hooded Wanderer"},
+        )
+        cmd = CmdAppear()
+        cmd.caller = caller
+        cmd.args = "taller"
+        cmd.func()
+
+        self.assertIsNone(caller.db.active_persona)
+        # Two msgs sent: persona-break and confirmation.
+        all_msgs = " ".join(
+            call_args[0][0] for call_args in caller.msg.call_args_list
+        )
+        self.assertIn("Hooded Wanderer", all_msgs)
+        self.assertIn("Manual change", all_msgs)
+
+    def test_keyword_override_clears_active_persona(self):
+        from commands.CmdCharacter import CmdAppear
+
+        caller = _make_disguise_character(
+            db_attrs={"active_persona": "Hooded Wanderer"},
+        )
+        with patch(
+            "world.identity.get_all_keywords",
+            return_value=frozenset({"droog"}),
+        ):
+            cmd = CmdAppear()
+            cmd.caller = caller
+            cmd.args = "droog"
+            cmd.func()
+
+        self.assertIsNone(caller.db.active_persona)
+        self.assertEqual(caller.db.keyword_override, "droog")
+
+
+# ===================================================================
+# CmdStopAppearing
+# ===================================================================
+
+
+class TestCmdStopAppearing(TestCase):
+    """``stop appearing`` clears overrides and persona pointer."""
+
+    def _run(self, caller):
+        from commands.CmdCharacter import CmdStopAppearing
+
+        cmd = CmdStopAppearing()
+        cmd.caller = caller
+        cmd.args = ""
+        cmd.func()
+
+    def test_clears_all_axes(self):
+        caller = _make_disguise_character(
+            db_attrs={
+                "height_override": "tall",
+                "build_override": "fat",
+                "keyword_override": "droog",
+                "active_persona": "Hooded Wanderer",
+            },
+        )
+        self._run(caller)
+        self.assertIsNone(caller.db.height_override)
+        self.assertIsNone(caller.db.build_override)
+        self.assertIsNone(caller.db.keyword_override)
+        self.assertIsNone(caller.db.active_persona)
+
+    def test_no_overrides_reports_no_op(self):
+        caller = _make_disguise_character()
+        self._run(caller)
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("aren't presenting", msg)
+
+
+# ===================================================================
+# CmdPersonas — list view
+# ===================================================================
+
+
+class TestCmdPersonas(TestCase):
+    """``personas`` lists saved personas, recency-sorted."""
+
+    def _run(self, caller, args=""):
+        from commands.CmdCharacter import CmdPersonas
+
+        cmd = CmdPersonas()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.func()
+        return caller.msg.call_args[0][0]
+
+    def test_empty_state_explains_remember_me_as(self):
+        caller = _make_disguise_character()
+        msg = self._run(caller)
+        self.assertIn("haven't saved any personas", msg)
+        self.assertIn("remember me as", msg)
+
+    def test_lists_personas_recency_sorted(self):
+        caller = _make_disguise_character(
+            db_attrs={
+                "personas": {
+                    "Old": {
+                        "name": "Old",
+                        "height_override": "tall",
+                        "build_override": None,
+                        "keyword_override": None,
+                        "saved_at": 100.0,
+                        "saved_in": "X",
+                    },
+                    "New": {
+                        "name": "New",
+                        "height_override": "short",
+                        "build_override": None,
+                        "keyword_override": None,
+                        "saved_at": 2000.0,
+                        "saved_in": "Y",
+                    },
+                },
+            },
+        )
+        msg = self._run(caller)
+        self.assertIn("Old", msg)
+        self.assertIn("New", msg)
+        self.assertLess(msg.index("New"), msg.index("Old"))
+
+    def test_active_persona_marked_with_asterisk(self):
+        caller = _make_disguise_character(
+            db_attrs={
+                "active_persona": "Hooded",
+                "personas": {
+                    "Hooded": {
+                        "name": "Hooded",
+                        "height_override": None,
+                        "build_override": None,
+                        "keyword_override": "wanderer",
+                        "saved_at": 100.0,
+                        "saved_in": "Bar",
+                    },
+                },
+            },
+        )
+        msg = self._run(caller)
+        self.assertIn("*", msg)
+        self.assertIn("Hooded", msg)
+
+    def test_rejects_arguments(self):
+        caller = _make_disguise_character()
+        msg = self._run(caller, args="something")
+        self.assertIn("Usage: personas", msg)
+
+
+# ===================================================================
+# CmdPersona — single inspect
+# ===================================================================
+
+
+class TestCmdPersona(TestCase):
+    """``persona <name>`` inspects one saved persona."""
+
+    def _run(self, caller, args):
+        from commands.CmdCharacter import CmdPersona
+
+        cmd = CmdPersona()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.func()
+        return caller.msg.call_args[0][0]
+
+    def test_no_args_shows_usage(self):
+        caller = _make_disguise_character()
+        msg = self._run(caller, "")
+        self.assertIn("Usage: persona", msg)
+
+    def test_unknown_persona_rejected(self):
+        caller = _make_disguise_character()
+        msg = self._run(caller, "Ghost")
+        self.assertIn("don't have a persona named 'Ghost'", msg)
+
+    def test_known_persona_renders(self):
+        caller = _make_disguise_character(
+            db_attrs={
+                "personas": {
+                    "Hooded Wanderer": {
+                        "name": "Hooded Wanderer",
+                        "height_override": "tall",
+                        "build_override": None,
+                        "keyword_override": "wanderer",
+                        "saved_at": 100.0,
+                        "saved_in": "The Grit",
+                    },
+                },
+            },
+        )
+        msg = self._run(caller, "hooded wanderer")  # case-insensitive
+        self.assertIn("Hooded Wanderer", msg)
+        self.assertIn("tall", msg)
+        self.assertIn("wanderer", msg)
+        self.assertIn("The Grit", msg)
+
+
+# ===================================================================
+# CmdRemember — `me as <name>` persona snapshot
+# ===================================================================
+
+
+class TestCmdRememberMeAs(TestCase):
+    """``remember me as <name>`` saves a persona snapshot."""
+
+    def _run(self, caller, args):
+        from commands.CmdCharacter import CmdRemember
+
+        cmd = CmdRemember()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.func()
+
+    def test_saves_snapshot_of_current_overrides(self):
+        caller = _make_disguise_character(
+            db_attrs={
+                "height_override": "tall",
+                "keyword_override": "wanderer",
+            },
+        )
+        with patch(
+            "world.identity.get_all_keywords",
+            return_value=frozenset({"man", "wanderer"}),
+        ):
+            self._run(caller, "me as Hooded Wanderer")
+
+        personas = caller.db.personas
+        self.assertIn("Hooded Wanderer", personas)
+        entry = personas["Hooded Wanderer"]
+        self.assertEqual(entry["height_override"], "tall")
+        self.assertEqual(entry["keyword_override"], "wanderer")
+        self.assertIsNone(entry["build_override"])
+        self.assertIn("essential_item_types", entry)
+        self.assertEqual(entry["essential_item_types"], [])
+
+    def test_allowed_with_no_active_overrides(self):
+        """Per locked decision: allowed even with no axes set."""
+        caller = _make_disguise_character()
+        with patch(
+            "world.identity.get_all_keywords",
+            return_value=frozenset({"man"}),
+        ):
+            self._run(caller, "me as Empty")
+        self.assertIn("Empty", caller.db.personas)
+
+    def test_collides_with_keyword_rejected(self):
+        caller = _make_disguise_character()
+        with patch(
+            "world.identity.get_all_keywords",
+            return_value=frozenset({"droog"}),
+        ):
+            self._run(caller, "me as droog")
+        self.assertTrue(
+            caller.db.personas is None or "droog" not in (caller.db.personas or {})
+        )
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("reserved keyword", msg)
+
+    def test_collides_with_existing_persona_rejected(self):
+        caller = _make_disguise_character(
+            db_attrs={
+                "personas": {
+                    "Hooded": {
+                        "name": "Hooded",
+                        "height_override": None,
+                        "build_override": None,
+                        "keyword_override": None,
+                        "saved_at": 100.0,
+                        "saved_in": "X",
+                    },
+                },
+            },
+        )
+        with patch(
+            "world.identity.get_all_keywords", return_value=frozenset()
+        ):
+            self._run(caller, "me as hooded")
+        # Still only the original entry.
+        self.assertEqual(len(caller.db.personas), 1)
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("already have a persona", msg)
+
+
+# ===================================================================
+# CmdForget — persona fallback
+# ===================================================================
+
+
+class TestCmdForgetPersona(TestCase):
+    """``forget <persona name>`` deletes a persona; clears overrides if active."""
+
+    def _run(self, caller, args):
+        from commands.CmdCharacter import CmdForget
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd.args = args
+        # caller.search returns nothing so we fall through to persona path.
+        caller.search = MagicMock(return_value=None)
+        cmd.func()
+
+    def test_inactive_persona_deleted(self):
+        caller = _make_disguise_character(
+            db_attrs={
+                "personas": {
+                    "Hooded": {
+                        "name": "Hooded",
+                        "height_override": "tall",
+                        "build_override": None,
+                        "keyword_override": None,
+                        "saved_at": 100.0,
+                        "saved_in": "X",
+                    },
+                },
+            },
+        )
+        self._run(caller, "Hooded")
+        self.assertEqual(caller.db.personas, {})
+        # Overrides were never set on caller; nothing to clear.
+        self.assertIsNone(caller.db.height_override)
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("Forgot persona", msg)
+
+    def test_active_persona_clears_overrides(self):
+        caller = _make_disguise_character(
+            db_attrs={
+                "active_persona": "Hooded",
+                "height_override": "tall",
+                "keyword_override": "wanderer",
+                "personas": {
+                    "Hooded": {
+                        "name": "Hooded",
+                        "height_override": "tall",
+                        "build_override": None,
+                        "keyword_override": "wanderer",
+                        "saved_at": 100.0,
+                        "saved_in": "X",
+                    },
+                },
+            },
+        )
+        self._run(caller, "Hooded")
+        self.assertEqual(caller.db.personas, {})
+        self.assertIsNone(caller.db.height_override)
+        self.assertIsNone(caller.db.keyword_override)
+        self.assertIsNone(caller.db.active_persona)
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("It was active", msg)
+
+    def test_unknown_name_falls_through_to_error(self):
+        caller = _make_disguise_character()
+        self._run(caller, "Nobody")
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("don't remember anyone", msg)


### PR DESCRIPTION
## Summary
- Ships the player-facing verbs for the Phase 3 disguise system: `appear`, `stop appearing`, `personas`, `persona`, plus the persona-snapshot branch of `remember` (`remember me as <name>`) and the persona-deletion branch of `forget`.
- Override axes (`db.height_override`, `db.build_override`, `db.keyword_override`) and persona storage (`db.personas`, `db.active_persona`) are written to character DB. Engine wiring — signature tuple, Apparent UID, essential-item integration, `get_sdesc()` consumption, lifecycle hooks — is intentionally deferred to follow-up Phase 3 PRs. Until those land, overrides exist on the character but do not yet alter what observers perceive.
- Updates `IDENTITY_RECOGNITION_SPEC.md`: renames the bookmark layer to personas, locks the surface grammar, and annotates the Phase 3 roadmap with shipped vs. deferred items.

## Player surface (locked)
- `appear` — show current overrides + active persona
- `appear taller | shorter` / `appear thinner | fatter` — nudge one step on `HEIGHTS`/`BUILDS`; refuses at extremes (an unreachable axis is itself a tell)
- `appear <keyword>` — validated against the full keyword catalog; new keywords introduced via `@shortdesc`
- `appear <persona name>` — clean swap (overwrites all axes including unset ones)
- `stop appearing` — clear all overrides + active-persona pointer (no aliases)
- `remember me as <name>` — snapshot current overrides as a persona; allowed even with no axes set
- `forget <persona name>` — delete a persona; clears overrides if it was the active one
- `personas` — recency-sorted list, active persona marked with `*`
- `persona <name>` — inspect a single persona

Resolution order for `appear <arg>`: persona → axis nudge → keyword. Manual axis change after persona adoption dissociates the active-persona pointer (with explicit message) but leaves the persona definition intact.

## Cross-namespace uniqueness
Persona names and `remember <target> as <name>` assignments reject collisions against the keyword catalog, the caller's existing recognition `assigned_name`s, and the caller's existing persona names — so `appear <arg>` and `forget <arg>` stay unambiguous. Case-insensitive; the offending namespace is named in the error.

## Tests
- 29 new tests in `world.tests.test_identity_commands` covering all four new commands plus the extended `remember`/`forget` branches: status display, axis nudges, axis-extreme refusal, keyword validation, persona adoption (case-insensitive, clean-swap semantics), manual-change persona dissociation, `stop appearing` no-op + clear, persona listing (recency sort, active marker, empty state), persona inspect, persona snapshot creation, persona collisions, persona deletion (active vs. inactive).
- `evennia test world.tests.test_identity_commands`: 64 passing.
- `evennia test world`: 536 passing.

## Out of scope (next PRs)
Signature tuple, Apparent UID derivation, `get_sdesc()` consumption of overrides, `db.disguise_essential` / `db.is_disguise_item` flags, resonance check stubs, lifecycle hooks (death, sleeve swap, item destruction).