### PR TITLE
Phase 3 disguise engine: identity signature, Apparent UID, lost-contact

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1330,22 +1330,27 @@ class CmdRemember(Command):
             caller.msg("You already know your own name.")
             return
 
-        # Target must have a sleeve_uid
-        sleeve_uid = target.sleeve_uid
-        if sleeve_uid is None:
+        # Target must have a derivable Apparent UID (requires a real
+        # sleeve_uid — pre-chargen shells return None).
+        from world.identity import get_apparent_uid
+
+        apparent_uid = get_apparent_uid(target)
+        if apparent_uid is None:
             caller.msg("You can't remember that character.")
             return
 
         # Cross-namespace uniqueness: a remembered name for someone else
         # must not collide with one of our own persona names or a valid
         # keyword (which would shadow `appear <keyword>`).
-        taken, reason = _name_is_taken(caller, name, allow_assigned_uid=sleeve_uid)
+        taken, reason = _name_is_taken(
+            caller, name, allow_assigned_uid=apparent_uid
+        )
         if taken:
             caller.msg(reason)
             return
 
         # Apply the assignment
-        self._remember_target(caller, target, sleeve_uid, name)
+        self._remember_target(caller, target, apparent_uid, name)
 
     def _remember_self_as_persona(self, caller, name):
         """Save the caller's current overrides as a named persona."""
@@ -1369,23 +1374,29 @@ class CmdRemember(Command):
             f"Restore later with |wappear {name}|n."
         )
 
-    def _remember_target(self, caller, target, sleeve_uid, name):
-        """Store a name assignment in the caller's recognition memory."""
+    def _remember_target(self, caller, target, apparent_uid, name):
+        """Store a name assignment in the caller's recognition memory.
+
+        The recognition entry is keyed on the target's current
+        Apparent UID, NOT on real ``sleeve_uid``.  A character under
+        a different disguise produces a different Apparent UID and
+        gets its own recognition entry.
+        """
         import time
 
         memory = caller.recognition_memory
         if memory is None:
             memory = {}
 
-        old_entry = memory.get(sleeve_uid, {})
+        old_entry = memory.get(apparent_uid, {})
         old_name = old_entry.get("assigned_name", "")
 
         # Build/update the recognition entry
         now = time.strftime("%Y-%m-%dT%H:%M:%S")
         location_name = caller.location.key if caller.location else "unknown"
 
-        if sleeve_uid in memory:
-            entry = memory[sleeve_uid]
+        if apparent_uid in memory:
+            entry = memory[apparent_uid]
             entry["assigned_name"] = name
             entry["last_seen"] = now
             entry["times_seen"] = entry.get("times_seen", 0) + 1
@@ -1393,6 +1404,8 @@ class CmdRemember(Command):
             if location_name not in entry.get("locations_seen", []):
                 entry.setdefault("locations_seen", []).append(location_name)
             entry["sdesc_at_last_encounter"] = target.get_sdesc()
+            # Re-encountering this UID clears any stale lost-contact flag.
+            entry["lost_contact"] = False
         else:
             entry = {
                 "assigned_name": name,
@@ -1408,10 +1421,11 @@ class CmdRemember(Command):
                 "tags": [],
                 "confidence": 1.0,
                 "relationship_valence": "neutral",
+                "lost_contact": False,
                 "recent_interactions": [],
             }
 
-        memory[sleeve_uid] = entry
+        memory[apparent_uid] = entry
         caller.recognition_memory = memory
 
         # Provide feedback using the newly assigned name
@@ -1427,20 +1441,20 @@ class CmdRemember(Command):
                 f"{target.get_sdesc()} as |w{name}|n."
             )
 
-    def _clear_assignment(self, caller, target, sleeve_uid):
+    def _clear_assignment(self, caller, target, apparent_uid):
         """Remove a name assignment from recognition memory.
 
         Retained for backward-compatible internal use; player-facing clear
         is now the |wforget|n command (:class:`CmdForget`).
         """
         memory = caller.recognition_memory
-        if not memory or sleeve_uid not in memory:
+        if not memory or apparent_uid not in memory:
             caller.msg("You don't have a name assigned to them.")
             return
 
-        old_name = memory[sleeve_uid].get("assigned_name", "")
+        old_name = memory[apparent_uid].get("assigned_name", "")
         # Clear the assigned name but keep the memory entry
-        memory[sleeve_uid]["assigned_name"] = ""
+        memory[apparent_uid]["assigned_name"] = ""
         caller.recognition_memory = memory
 
         sdesc = target.get_sdesc()
@@ -1459,11 +1473,13 @@ class CmdRemember(Command):
 
 
 def _find_remembered_uid_by_name(caller, name):
-    """Look up a sleeve_uid in caller's recognition_memory by assigned_name.
+    """Look up an Apparent UID in caller's recognition_memory by assigned_name.
 
     Case-insensitive match against ``assigned_name``.  Returns the first
-    matching ``(sleeve_uid, entry)`` tuple, or ``(None, None)`` if no
-    match.
+    matching ``(apparent_uid, entry)`` tuple, or ``(None, None)`` if no
+    match.  The returned UID is the recognition_memory dict key (an
+    Apparent UID derived from the target's identity signature at the
+    time the entry was written), not the target's real ``sleeve_uid``.
     """
     memory = caller.recognition_memory
     if not memory:
@@ -1546,17 +1562,19 @@ class CmdForget(Command):
                 target = target[0] if target else None
 
         if target and isinstance(target, Character):
-            sleeve_uid = target.sleeve_uid
-            if sleeve_uid is None:
+            from world.identity import get_apparent_uid
+
+            apparent_uid = get_apparent_uid(target)
+            if apparent_uid is None:
                 caller.msg("You can't forget that character.")
                 return
-            self._forget_visible(caller, target, sleeve_uid)
+            self._forget_visible(caller, target, apparent_uid)
             return
 
         # Fall back to remembered-name lookup
-        sleeve_uid, entry = _find_remembered_uid_by_name(caller, args)
-        if sleeve_uid is not None:
-            self._forget_remembered(caller, sleeve_uid, entry)
+        apparent_uid, entry = _find_remembered_uid_by_name(caller, args)
+        if apparent_uid is not None:
+            self._forget_remembered(caller, apparent_uid, entry)
             return
 
         # Final fallback: persona lookup.
@@ -1595,19 +1613,24 @@ class CmdForget(Command):
             caller.msg(f"Forgot persona |w{match_key}|n.")
         return True
 
-    def _forget_visible(self, caller, target, sleeve_uid):
-        """Forget a target who is currently present."""
+    def _forget_visible(self, caller, target, apparent_uid):
+        """Forget a target who is currently present.
+
+        Keyed on the target's *Apparent UID* (derived from their current
+        identity signature), so forgetting under a disguise only forgets
+        the disguised persona — the real-form entry is untouched.
+        """
         memory = caller.recognition_memory
-        if not memory or sleeve_uid not in memory:
+        if not memory or apparent_uid not in memory:
             caller.msg("You don't have a name remembered for them.")
             return
 
-        old_name = memory[sleeve_uid].get("assigned_name", "")
+        old_name = memory[apparent_uid].get("assigned_name", "")
         if not old_name:
             caller.msg("You don't have a name remembered for them.")
             return
 
-        memory[sleeve_uid]["assigned_name"] = ""
+        memory[apparent_uid]["assigned_name"] = ""
         caller.recognition_memory = memory
 
         caller.msg(
@@ -1615,8 +1638,12 @@ class CmdForget(Command):
             f"They will now appear as their description."
         )
 
-    def _forget_remembered(self, caller, sleeve_uid, entry):
-        """Forget someone by remembered name; they may not be present."""
+    def _forget_remembered(self, caller, apparent_uid, entry):
+        """Forget someone by remembered name; they may not be present.
+
+        ``apparent_uid`` is the recognition_memory dict key (an Apparent
+        UID derived from the target's signature at recording time).
+        """
         old_name = entry.get("assigned_name", "")
         sdesc = entry.get("sdesc_at_last_encounter", "someone")
         location = entry.get("location_last_seen", "somewhere")
@@ -1624,7 +1651,7 @@ class CmdForget(Command):
         when = _format_relative_time(last_seen)
 
         memory = caller.recognition_memory
-        memory[sleeve_uid]["assigned_name"] = ""
+        memory[apparent_uid]["assigned_name"] = ""
         caller.recognition_memory = memory
 
         caller.msg(
@@ -1675,19 +1702,20 @@ class CmdRecall(Command):
             if isinstance(target, list):
                 target = target[0] if target else None
 
-        sleeve_uid = None
         entry = None
 
         if target and isinstance(target, Character):
-            sleeve_uid = target.sleeve_uid
-            if sleeve_uid is None:
+            from world.identity import get_apparent_uid
+
+            apparent_uid = get_apparent_uid(target)
+            if apparent_uid is None:
                 caller.msg("You can't recall anything about that character.")
                 return
             memory = caller.recognition_memory or {}
-            entry = memory.get(sleeve_uid)
+            entry = memory.get(apparent_uid)
         else:
             # Fall back to remembered-name lookup
-            sleeve_uid, entry = _find_remembered_uid_by_name(caller, args)
+            _apparent_uid, entry = _find_remembered_uid_by_name(caller, args)
 
         if entry is None:
             caller.msg("You don't recognize that person.")
@@ -1696,22 +1724,33 @@ class CmdRecall(Command):
         self._render_entry(caller, entry)
 
     def _render_entry(self, caller, entry):
-        """Format and send a recognition_memory entry to the caller."""
+        """Format and send a recognition_memory entry to the caller.
+
+        Adds a ``(lost contact)`` annotation when the stored entry's
+        ``lost_contact`` flag is True (set by the periodic prune scan;
+        cleared on re-encounter).  Old entries that predate the flag
+        default to False.
+        """
         assigned_name = entry.get("assigned_name", "")
         sdesc_first = entry.get("sdesc_at_first_encounter", "(unknown)")
         location_first = entry.get("location_first_seen", "(unknown)")
         first_seen = entry.get("first_seen", "")
         times_seen = entry.get("times_seen", 0)
+        lost_contact = entry.get("lost_contact", False)
 
         when = _format_relative_time(first_seen)
 
         if assigned_name:
             header = f"You remember them as: |w{assigned_name}|n"
+            if lost_contact:
+                header += " |y(lost contact)|n"
         else:
             header = (
                 "You've encountered them before but don't have a "
                 "name for them."
             )
+            if lost_contact:
+                header += " |y(lost contact)|n"
 
         lines = [
             header,
@@ -1777,8 +1816,11 @@ class CmdMemory(Command):
             border="cells",
         )
         for _uid, entry in named:
+            name_cell = entry.get("assigned_name", "")
+            if entry.get("lost_contact", False):
+                name_cell = f"{name_cell} |y(lost contact)|n"
             table.add_row(
-                entry.get("assigned_name", ""),
+                name_cell,
                 entry.get("sdesc_at_last_encounter", "(unknown)"),
                 entry.get("location_last_seen", "(unknown)"),
                 _format_relative_time(entry.get("last_seen", "")),
@@ -1895,8 +1937,8 @@ def _name_is_taken(caller, name, allow_assigned_uid=None):
         caller: The character whose namespaces are being checked.
         name: The candidate name (case-insensitive).
         allow_assigned_uid: When checking a remembered-as assignment,
-            the existing recognition entry for *that* sleeve_uid does
-            not count as a collision (re-naming the same person).
+            the existing recognition entry for *that* Apparent UID does
+            not count as a collision (re-naming the same persona).
 
     Returns:
         Tuple ``(taken: bool, reason: str)``.  *reason* is a

--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -1054,11 +1054,19 @@ class CmdFrisk(Command):
             caller.msg(f"{target.get_display_name(caller)} is too lively to frisk. They need to be unconscious, dead, or a corpse.")
             return
         
-        # Get target's gender for pronouns
-        gender = target.db.gender if target.db.gender is not None else 'neutral'
-        # For corpses, try to get original gender
+        # Get target's gender for pronouns. Living targets follow the
+        # apparent presentation (disguises shift pronouns); corpses
+        # use the body's original gender snapshot if recorded.
         if frisk_reason == "corpse":
-            gender = target.db.original_gender if target.db.original_gender is not None else gender
+            gender = (
+                target.db.original_gender
+                if target.db.original_gender is not None
+                else "neutral"
+            )
+        else:
+            from world.identity import get_apparent_gender
+
+            gender = get_apparent_gender(target)
             
         pronoun_map = {
             'male': {'them': 'him', 'their': 'his', 'they': 'he'},

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -30,7 +30,32 @@ def at_server_start():
     This is called every time the server starts up, regardless of
     how it was shut down.
     """
-    pass
+    # One-time recognition_memory schema migration (engine PR).
+    #
+    # Wipes any pre-engine-PR recognition_memory entries that were
+    # keyed on real ``sleeve_uid`` (36-char UUID) instead of the new
+    # 16-char Apparent UID, or that lack the post-engine-PR
+    # ``lost_contact`` field. Idempotent — once all entries pass the
+    # shape check, this is a no-op.
+    #
+    # TODO: Remove this call (and the helper in world/identity.py)
+    # after the engine-PR deployment is verified clean across all
+    # production characters.
+    try:
+        from world.identity import wipe_all_legacy_recognition_memory
+
+        wiped = wipe_all_legacy_recognition_memory()
+        if wiped:
+            from evennia.utils import logger
+
+            logger.log_info(
+                f"identity: engine-PR migration wiped {wiped} legacy "
+                f"recognition_memory entries"
+            )
+    except Exception:
+        from evennia.utils import logger
+
+        logger.log_trace("identity: legacy recognition_memory wipe failed")
 
 
 def at_server_stop():

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -911,11 +911,18 @@ class Character(
     def get_sdesc(self):
         """Return the composed short description for this character.
 
+        Consumes the active presentation overrides
+        (``db.height_override``, ``db.build_override``,
+        ``db.keyword_override``) when set; otherwise falls back to the
+        character's real ``height`` / ``build`` / ``sdesc_keyword``.
+        This is the engine-PR consumption point that makes the
+        ``appear`` command's overrides actually visible to observers.
+
         The sdesc has no leading article — callers prepend ``a``/``an``/
         ``the`` as needed via :func:`world.grammar.get_article`.
 
-        If height/build/keyword are not yet set (pre-chargen character),
-        falls back to ``self.key``.
+        If height/build are not yet set (pre-chargen character), falls
+        back to ``self.key``.
 
         Returns:
             Sdesc string, e.g. ``"lanky man wielding a Kitchen Knife"``.
@@ -923,13 +930,14 @@ class Character(
         from world.identity import compose_sdesc, get_physical_descriptor
         from world.grammar import DEFAULT_SDESC_KEYWORDS
 
-        height = self.height
-        build = self.build
+        # Override axes take precedence over real values.
+        height = self.db.height_override or self.height
+        build = self.db.build_override or self.build
         if not height or not build:
             return self.key
 
         descriptor = get_physical_descriptor(height, build)
-        keyword = self.sdesc_keyword
+        keyword = self.db.keyword_override or self.sdesc_keyword
         if not keyword:
             keyword = DEFAULT_SDESC_KEYWORDS.get(self.gender, "person")
 
@@ -942,9 +950,15 @@ class Character(
         Resolution order:
           1. ``looker is self`` → ``self.key`` (own real name)
           2. *looker* has an assigned name in ``recognition_memory``
-             for this character's ``sleeve_uid`` → that assigned name
+             keyed on this character's current Apparent UID → that
+             assigned name
           3. Otherwise → composed sdesc with indefinite article
              (e.g. ``"a lanky man in a Black Trenchcoat"``)
+
+        The Apparent UID is derived from the target's full identity
+        signature (real ``sleeve_uid`` + active overrides + essential
+        items), so the same physical body produces different
+        recognition entries under different disguises.
 
         If *looker* is ``None`` (system / log context), returns
         ``self.key``.
@@ -964,12 +978,14 @@ class Character(
         if looker is self:
             return self.key
 
-        # Check if looker has a recognized name for this sleeve
-        sleeve_uid = self.sleeve_uid
-        if sleeve_uid is not None and hasattr(looker, "recognition_memory"):
+        # Check if looker has a recognized name for this Apparent UID.
+        from world.identity import get_apparent_uid
+
+        apparent_uid = get_apparent_uid(self)
+        if apparent_uid is not None and hasattr(looker, "recognition_memory"):
             memory = looker.recognition_memory
-            if memory and sleeve_uid in memory:
-                entry = memory[sleeve_uid]
+            if memory and apparent_uid in memory:
+                entry = memory[apparent_uid]
                 assigned = entry.get("assigned_name")
                 if assigned:
                     return assigned

--- a/world/emote.py
+++ b/world/emote.py
@@ -26,7 +26,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Sequence
 
 from world.grammar import (
-    GENDER_MAP,
     capitalize_first,
     conjugate_third_person,
     transform_pronoun,
@@ -730,9 +729,13 @@ def render_for_observer(
         Fully rendered emote string for this observer.
     """
     is_actor = observer is actor
-    gender = GENDER_MAP.get(
-        getattr(actor, "sex", "ambiguous") or "ambiguous", "neutral"
-    )
+    # Pronouns must follow the disguise: derive from the actor's
+    # apparent gender (which inspects active keyword_override against
+    # the keyword catalog) rather than from the underlying ``sex``
+    # attribute. See spec §"Pronouns Under Disguise".
+    from world.identity import get_apparent_gender
+
+    gender = get_apparent_gender(actor)
 
     parts: list[str] = []
     actor_named = False

--- a/world/identity.py
+++ b/world/identity.py
@@ -14,13 +14,14 @@ See specs/IDENTITY_RECOGNITION_SPEC.md for the full specification.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import hashlib
+from typing import TYPE_CHECKING, Any
 
 from django.core.exceptions import ObjectDoesNotExist
 from evennia.scripts.scripts import DefaultScript
 from evennia.utils import logger
 
-from world.grammar import get_article
+from world.grammar import GENDER_MAP, get_article
 
 if TYPE_CHECKING:
     from evennia.accounts.models import AccountDB
@@ -667,3 +668,261 @@ def compose_sdesc(
     if feature:
         return f"{base} {feature}"
     return base
+
+
+# =========================================================================
+# Identity Signature, Apparent UID, Apparent Gender
+# =========================================================================
+#
+# See specs/IDENTITY_RECOGNITION_SPEC.md §"Identity Signature & Apparent
+# UID" and §"Pronouns Under Disguise" for the full design rationale.
+
+#: Length in bytes of the blake2b digest backing the Apparent UID.
+#: Eight bytes → 16-character lowercase hex string. The 64-bit collision
+#: space is comfortable for per-observer recognition memory, where keys
+#: are bounded by encounter count.
+_APPARENT_UID_DIGEST_BYTES: int = 8
+
+#: Length in characters of an Apparent UID hex string.  Used by the
+#: startup wipe migration as a shape check for legacy entries (real
+#: ``sleeve_uid`` values are 36-character UUID strings).
+APPARENT_UID_HEX_LENGTH: int = _APPARENT_UID_DIGEST_BYTES * 2
+
+
+def get_essential_item_type_ids(char: Any) -> tuple[str, ...]:
+    """Return the sorted tuple of equipped essential disguise item type IDs.
+
+    Stub for the foundation engine PR. Returns an empty tuple until
+    PR-C wires the ``disguise_essential`` item flag and the
+    disguise-item taxonomy. The signature shape stays stable; only its
+    content changes when items land.
+
+    Args:
+        char: The character whose equipped items are inspected.
+
+    Returns:
+        Empty tuple until essential-item integration ships.
+    """
+    return ()
+
+
+def get_identity_signature(char: Any) -> tuple:
+    """Compute the identity signature tuple for a character.
+
+    The signature is the input to :func:`get_apparent_uid`.  It captures
+    every observable identity input that can shift recognition:
+
+    * The character's real ``sleeve_uid`` (acts as a per-character salt
+      — two impostors with identical disguises still produce different
+      Apparent UIDs).
+    * The active presentation overrides on each axis (height, build,
+      keyword), each ``None`` when unset.
+    * The sorted tuple of equipped essential disguise item type IDs
+      (empty until PR-C lands; see :func:`get_essential_item_type_ids`).
+
+    Re-evaluated on every call from current state — there is no
+    cache. Performance optimisation is intentionally deferred.
+
+    Args:
+        char: The character whose signature is computed.
+
+    Returns:
+        Five-tuple
+        ``(sleeve_uid, height_override, build_override, keyword_override,
+        essential_item_type_ids)``.
+    """
+    sleeve_uid = getattr(char, "sleeve_uid", None)
+    db = getattr(char, "db", None)
+    height_override = db.height_override if db is not None else None
+    build_override = db.build_override if db is not None else None
+    keyword_override = db.keyword_override if db is not None else None
+    return (
+        sleeve_uid,
+        height_override,
+        build_override,
+        keyword_override,
+        get_essential_item_type_ids(char),
+    )
+
+
+def get_apparent_uid(char: Any) -> str | None:
+    """Compute the Apparent UID for a character's current presentation.
+
+    Deterministic 16-character lowercase hex digest of the identity
+    signature — same signature, same UID, every time, across processes
+    (unlike Python's salted builtin ``hash()``).
+
+    Returns ``None`` when the signature has no real ``sleeve_uid``
+    (pre-chargen character or other transient state). Callers MUST
+    treat ``None`` as "no recognition possible" and skip memory
+    lookups; storing entries under ``None`` would conflate distinct
+    pre-chargen shells.
+
+    Args:
+        char: The character whose Apparent UID is computed.
+
+    Returns:
+        16-character hex string, or ``None`` when ``sleeve_uid`` is
+        unset.
+    """
+    signature = get_identity_signature(char)
+    if signature[0] is None:
+        return None
+    signature_bytes = repr(signature).encode("utf-8")
+    return hashlib.blake2b(
+        signature_bytes, digest_size=_APPARENT_UID_DIGEST_BYTES
+    ).hexdigest()
+
+
+def get_apparent_gender(char: Any) -> str:
+    """Return the grammar gender presented by a character's current look.
+
+    Pronouns must follow the disguise: a character presenting as "a
+    woman" should be referenced with feminine pronouns by observers
+    who do not know the real identity, regardless of the underlying
+    ``sex`` attribute.
+
+    Derivation rule:
+
+    1. If the character has an active ``keyword_override``, look it up
+       in the runtime keyword catalog (KeywordManager script, falling
+       back to the module-level default frozensets).
+
+       * Match in the feminine list → ``"female"``
+       * Match in the masculine list → ``"male"``
+       * Match in the neutral list, **or no match anywhere** (custom
+         ``@shortdesc`` keyword carrying no gender metadata) →
+         ``"neutral"``.
+
+    2. Otherwise, fall through to the character's real grammar gender
+       via :data:`world.grammar.GENDER_MAP` (no behaviour change for
+       undisguised characters).
+
+    There is no explicit ``gender_override`` axis in Phase 3; players
+    select pronouns implicitly by choosing a keyword from the desired
+    gender list.  Custom keywords always render neutral by design.
+
+    Args:
+        char: The character whose apparent gender is computed.
+
+    Returns:
+        One of ``"male"``, ``"female"``, ``"neutral"``.
+    """
+    db = getattr(char, "db", None)
+    keyword_override = db.keyword_override if db is not None else None
+
+    if keyword_override:
+        keyword_lc = keyword_override.lower()
+        if keyword_lc in get_feminine_keywords():
+            return "female"
+        if keyword_lc in get_masculine_keywords():
+            return "male"
+        # Neutral list match OR unknown custom keyword → neutral.
+        return "neutral"
+
+    # No override → use real grammar gender.
+    real_gender = getattr(char, "gender", None)
+    if real_gender in ("male", "female", "neutral"):
+        return real_gender
+    sex_value = getattr(char, "sex", None)
+    if sex_value:
+        return GENDER_MAP.get(sex_value, "neutral")
+    return "neutral"
+
+
+# =========================================================================
+# Recognition Memory Migration
+# =========================================================================
+
+
+def _is_legacy_recognition_entry(uid: Any, entry: Any) -> bool:
+    """Return True if a recognition entry pre-dates the engine PR schema.
+
+    Legacy entries are keyed on real ``sleeve_uid`` (a 36-character
+    UUID string) instead of on the new 16-character Apparent UID, or
+    are missing the post-engine-PR ``lost_contact`` field.
+
+    Args:
+        uid: The dict key from ``recognition_memory``.
+        entry: The corresponding value (usually a dict).
+
+    Returns:
+        ``True`` if the entry should be wiped.
+    """
+    if not isinstance(uid, str) or len(uid) != APPARENT_UID_HEX_LENGTH:
+        return True
+    if not isinstance(entry, dict):
+        return True
+    if "lost_contact" not in entry:
+        return True
+    return False
+
+
+def wipe_legacy_recognition_memory(char: Any) -> int:
+    """Wipe legacy recognition_memory entries on a single character.
+
+    Idempotent shape-check: any entry whose key length does not match
+    :data:`APPARENT_UID_HEX_LENGTH` or whose value lacks the
+    ``lost_contact`` field is removed.  After the engine-PR
+    deployment, all surviving entries pass the shape check and this
+    function becomes a no-op for that character.
+
+    The spec is explicit (see §"Memory Data Model" — *One-time wipe*)
+    that there is no migration recompute — players rebuild recognition
+    organically under the new keying.
+
+    .. todo:: Remove this function and its caller after the engine-PR
+       deployment is verified clean across all production characters.
+
+    Args:
+        char: The character whose ``recognition_memory`` is inspected.
+
+    Returns:
+        The number of entries wiped (``0`` if already clean).
+    """
+    memory = getattr(char, "recognition_memory", None)
+    if not memory:
+        return 0
+    legacy_keys = [
+        uid for uid, entry in memory.items()
+        if _is_legacy_recognition_entry(uid, entry)
+    ]
+    if not legacy_keys:
+        return 0
+    new_memory = {
+        uid: entry for uid, entry in memory.items() if uid not in legacy_keys
+    }
+    char.recognition_memory = new_memory
+    logger.log_info(
+        f"identity: wiped {len(legacy_keys)} legacy recognition_memory "
+        f"entries on {getattr(char, 'key', '<unknown>')}"
+    )
+    return len(legacy_keys)
+
+
+def wipe_all_legacy_recognition_memory() -> int:
+    """Wipe legacy recognition_memory entries across all Character objects.
+
+    Intended to be called once at server startup as a one-shot
+    migration. Idempotent — safe to call repeatedly; subsequent calls
+    are no-ops once all entries pass the shape check.
+
+    .. todo:: Remove this function and its server-startup hook after
+       the engine-PR deployment is verified clean across all
+       production characters.
+
+    Returns:
+        Total number of entries wiped across all characters.
+    """
+    from typeclasses.characters import Character
+
+    total = 0
+    for char in Character.objects.all():
+        try:
+            total += wipe_legacy_recognition_memory(char)
+        except Exception:
+            logger.log_trace(
+                f"identity: failed to wipe recognition_memory on "
+                f"{getattr(char, 'key', '<unknown>')}"
+            )
+    return total

--- a/world/search.py
+++ b/world/search.py
@@ -164,18 +164,20 @@ def _match_assigned_name(
         query: The normalized query string.
 
     Returns:
-        ``True`` if the searcher's assigned name for *target*'s sleeve
-        matches *query*.
+        ``True`` if the searcher's assigned name for *target*'s current
+        Apparent UID matches *query*.
     """
-    sleeve_uid = getattr(target, "sleeve_uid", None)
-    if sleeve_uid is None:
+    from world.identity import get_apparent_uid
+
+    apparent_uid = get_apparent_uid(target)
+    if apparent_uid is None:
         return False
 
     memory = getattr(searcher, "recognition_memory", None)
-    if not memory or sleeve_uid not in memory:
+    if not memory or apparent_uid not in memory:
         return False
 
-    assigned = memory[sleeve_uid].get("assigned_name", "")
+    assigned = memory[apparent_uid].get("assigned_name", "")
     if not assigned:
         return False
 

--- a/world/tests/_identity_helpers.py
+++ b/world/tests/_identity_helpers.py
@@ -1,0 +1,103 @@
+"""
+Shared identity-test helpers.
+
+Centralises the derivation of recognition_memory dict keys and the
+shape of recognition_memory entries so the 7 identity-adjacent test
+modules (``test_identity_commands``, ``test_emote``, ``test_emote_templates``,
+``test_identity_search``, ``test_communication``, ``test_character_identity``,
+``test_identity``) stay aligned with the production engine in
+``world/identity.py``.
+
+Two reasons to import from here instead of seeding literal UIDs:
+
+1. **Schema stability.**  When the identity signature gains new inputs
+   (e.g. PR-C wires equipped essential disguise items), every test
+   re-derives its expected key automatically.
+
+2. **Mock hygiene.**  ``MagicMock(spec=Character)`` auto-creates truthy
+   stand-ins for ``char.db.height_override`` etc., which silently
+   poisons the signature.  :func:`prepare_mock_for_apparent_uid` clears
+   those axes to ``None`` so the derived UID is a deterministic function
+   of ``sleeve_uid`` alone (until PR-C adds essential items).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from world.identity import get_apparent_uid
+
+
+def prepare_mock_for_apparent_uid(char: Any) -> None:
+    """Zero out ``db.*_override`` axes on a mock character.
+
+    ``MagicMock`` returns a fresh ``MagicMock`` for any attribute
+    access, including ``char.db.height_override``.  Those non-``None``
+    sentinels feed directly into :func:`world.identity.get_identity_signature`
+    and produce wildly different Apparent UIDs than the production
+    engine would compute for an undisguised character.
+
+    Call this once per test character that participates in recognition
+    lookups; safe to call multiple times.
+    """
+    char.db.height_override = None
+    char.db.build_override = None
+    char.db.keyword_override = None
+
+
+def apparent_uid_for(char: Any) -> str:
+    """Return the Apparent UID for *char*, asserting it is non-``None``.
+
+    Wraps :func:`world.identity.get_apparent_uid` so test fixtures fail
+    loudly (rather than silently storing a ``None`` key) when a mock
+    character is missing its ``sleeve_uid``.
+    """
+    prepare_mock_for_apparent_uid(char)
+    uid = get_apparent_uid(char)
+    if uid is None:
+        raise AssertionError(
+            f"apparent_uid_for({char!r}) returned None; mock is missing "
+            f"sleeve_uid."
+        )
+    return uid
+
+
+def make_recognition_entry(
+    *,
+    assigned_name: str = "",
+    sdesc_at_first_encounter: str = "a tall lean man",
+    sdesc_at_last_encounter: str | None = None,
+    location_first_seen: str = "Test Room",
+    location_last_seen: str | None = None,
+    first_seen: str = "2025-01-01T00:00:00",
+    last_seen: str | None = None,
+    times_seen: int = 1,
+    lost_contact: bool = False,
+) -> dict:
+    """Build a recognition_memory entry dict matching the production schema.
+
+    Defaults mirror what :meth:`commands.CmdCharacter.CmdRemember._remember_target`
+    writes for a fresh first-meet, including the ``lost_contact`` field
+    introduced by the disguise engine PR.  Tests that need a particular
+    field shape pass the relevant kwargs; everything else takes a
+    sensible default.
+    """
+    return {
+        "assigned_name": assigned_name,
+        "sdesc_at_first_encounter": sdesc_at_first_encounter,
+        "sdesc_at_last_encounter": (
+            sdesc_at_last_encounter
+            if sdesc_at_last_encounter is not None
+            else sdesc_at_first_encounter
+        ),
+        "location_first_seen": location_first_seen,
+        "location_last_seen": (
+            location_last_seen
+            if location_last_seen is not None
+            else location_first_seen
+        ),
+        "first_seen": first_seen,
+        "last_seen": last_seen if last_seen is not None else first_seen,
+        "times_seen": times_seen,
+        "lost_contact": lost_contact,
+    }

--- a/world/tests/test_character_identity.py
+++ b/world/tests/test_character_identity.py
@@ -22,6 +22,10 @@ from world.identity import (
     get_physical_descriptor,
 )
 from world.grammar import DEFAULT_SDESC_KEYWORDS, get_article
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
 
 
 # ===================================================================
@@ -101,6 +105,7 @@ def _make_character(
     else:
         type(char).gender = PropertyMock(return_value="neutral")
 
+    prepare_mock_for_apparent_uid(char)
     return char
 
 
@@ -378,8 +383,9 @@ class TestGetDisplayName(TestCase):
             key="Looker",
             sleeve_uid="uid-looker-3",
             recognition_memory={
-                "uid-target-3": {
+                apparent_uid_for(target): {
                     "assigned_name": "Big J",
+                    "lost_contact": False,
                 }
             },
         )
@@ -399,8 +405,9 @@ class TestGetDisplayName(TestCase):
             key="Looker",
             sleeve_uid="uid-looker-4",
             recognition_memory={
-                "uid-target-4": {
+                apparent_uid_for(target): {
                     "assigned_name": "",
+                    "lost_contact": False,
                 }
             },
         )
@@ -488,7 +495,10 @@ class TestGetDisplayName(TestCase):
             key="Friend",
             sleeve_uid="uid-friend",
             recognition_memory={
-                "uid-target-multi": {"assigned_name": "Jorge"},
+                apparent_uid_for(target): {
+                    "assigned_name": "Jorge",
+                    "lost_contact": False,
+                },
             },
         )
         stranger = _make_character(
@@ -518,7 +528,10 @@ class TestFlashCloneInheritance(TestCase):
             key="Jorge Jackson",
             sleeve_uid="uid-parent",
             recognition_memory={
-                "uid-somebody": {"assigned_name": "Somebody"},
+                "uid-somebody": {
+                    "assigned_name": "Somebody",
+                    "lost_contact": False,
+                },
             },
         )
         # Simulate what create_flash_clone should do:
@@ -551,7 +564,10 @@ class TestFlashCloneInheritance(TestCase):
             key="Observer",
             sleeve_uid="uid-observer",
             recognition_memory={
-                "uid-shared-body": {"assigned_name": "Big J"},
+                apparent_uid_for(parent): {
+                    "assigned_name": "Big J",
+                    "lost_contact": False,
+                },
             },
         )
         self.assertEqual(parent.get_display_name(observer), "Big J")

--- a/world/tests/test_communication.py
+++ b/world/tests/test_communication.py
@@ -19,6 +19,11 @@ from unittest.mock import MagicMock, PropertyMock, call
 
 from world.identity_utils import msg_room_identity
 
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
+
 
 # ===================================================================
 # Helpers — lightweight character / room stand-in
@@ -87,6 +92,7 @@ def _make_character(
     else:
         type(char).gender = PropertyMock(return_value="neutral")
 
+    prepare_mock_for_apparent_uid(char)
     return char
 
 
@@ -139,8 +145,8 @@ class TestMsgRoomIdentity(TestCase):
             build="average",
             sleeve_uid="uid-alice",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
-                "uid-maria": {"assigned_name": "Maria"},
+                apparent_uid_for(self.jorge): {"assigned_name": "Jorge"},
+                apparent_uid_for(self.maria): {"assigned_name": "Maria"},
             },
         )
         # Observer who knows neither
@@ -334,7 +340,7 @@ class TestCmdSay(TestCase):
             key="Alice", sex="female", height="average",
             build="average", sleeve_uid="uid-alice",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
+                apparent_uid_for(jorge): {"assigned_name": "Jorge"},
             },
         )
         self._run_say(jorge, "Hello!", [jorge, observer])
@@ -407,16 +413,16 @@ class TestCmdWhisper(TestCase):
 
     def test_actor_sees_own_whisper(self):
         """Actor sees 'You whisper to <target>, \"...\"'."""
+        maria = _make_character(
+            key="Maria Santos", sex="female", height="short",
+            build="athletic", sdesc_keyword="woman", sleeve_uid="uid-maria",
+        )
         jorge = _make_character(
             key="Jorge", sex="male", height="tall",
             build="lean", sdesc_keyword="man", sleeve_uid="uid-jorge",
             recognition_memory={
-                "uid-maria": {"assigned_name": "Maria"},
+                apparent_uid_for(maria): {"assigned_name": "Maria"},
             },
-        )
-        maria = _make_character(
-            key="Maria Santos", sex="female", height="short",
-            build="athletic", sdesc_keyword="woman", sleeve_uid="uid-maria",
         )
         self._run_whisper(
             jorge, "Maria = Meet me later.",
@@ -596,7 +602,7 @@ class TestCmdEmote(TestCase):
             key="Alice", sex="female", height="average",
             build="average", sleeve_uid="uid-alice",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
+                apparent_uid_for(jorge): {"assigned_name": "Jorge"},
             },
         )
         self._run_emote(jorge, "waves.", [jorge, observer])
@@ -653,7 +659,7 @@ class TestCmdEmote(TestCase):
             key="Bob", sex="male", height="average",
             build="average", sleeve_uid="uid-bob",
             recognition_memory={
-                "uid-maria": {"assigned_name": "Maria"},
+                apparent_uid_for(maria): {"assigned_name": "Maria"},
             },
         )
         # Jorge emotes referencing Maria by her sdesc (short+stocky = "squat")
@@ -725,16 +731,16 @@ class TestCmdEmote(TestCase):
 
     def test_emote_actor_sees_char_ref_via_own_memory(self):
         """Actor's char ref rendering uses their own recognition memory."""
+        maria = _make_character(
+            key="Maria Santos", sex="female", height="short",
+            build="stocky", sdesc_keyword="woman", sleeve_uid="uid-maria",
+        )
         jorge = _make_character(
             key="Jorge Jackson", sex="male", height="tall",
             build="lean", sdesc_keyword="man", sleeve_uid="uid-jorge",
             recognition_memory={
-                "uid-maria": {"assigned_name": "Maria"},
+                apparent_uid_for(maria): {"assigned_name": "Maria"},
             },
-        )
-        maria = _make_character(
-            key="Maria Santos", sex="female", height="short",
-            build="stocky", sdesc_keyword="woman", sleeve_uid="uid-maria",
         )
         # Jorge emotes referencing Maria by descriptor+keyword
         self._run_emote(
@@ -840,7 +846,7 @@ class TestCmdDotPose(TestCase):
             build="average",
             sleeve_uid="uid-alice",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
+                apparent_uid_for(jorge): {"assigned_name": "Jorge"},
             },
         )
         self._run_dot_pose(jorge, ".lean back.", [jorge, observer])
@@ -1073,7 +1079,7 @@ class TestCmdDotPose(TestCase):
             build="average",
             sleeve_uid="uid-bob",
             recognition_memory={
-                "uid-maria": {"assigned_name": "Maria"},
+                apparent_uid_for(maria): {"assigned_name": "Maria"},
             },
         )
         self._run_dot_pose(

--- a/world/tests/test_emote.py
+++ b/world/tests/test_emote.py
@@ -36,6 +36,11 @@ from world.emote import (
     tokenize_emote,
 )
 
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
+
 
 # ===================================================================
 # Helpers — lightweight character / room stand-in
@@ -111,6 +116,7 @@ def _make_character(
     else:
         char.locks.check_lockstring.return_value = False
 
+    prepare_mock_for_apparent_uid(char)
     return char
 
 
@@ -348,7 +354,7 @@ class TestTokenizer(TestCase):
         )
         # Actor knows Maria
         self.actor.recognition_memory = {
-            "uid-maria": {"assigned_name": "Maria"},
+            apparent_uid_for(maria): {"assigned_name": "Maria"},
         }
         tokens = tokenize_dot_pose(
             "nod at Maria", self.actor, [self.actor, maria]
@@ -496,7 +502,7 @@ class TestRendererActorView(TestCase):
             sleeve_uid="uid-maria",
         )
         self.actor.recognition_memory = {
-            "uid-maria": {"assigned_name": "Maria"},
+            apparent_uid_for(maria): {"assigned_name": "Maria"},
         }
         tokens = tokenize_dot_pose(
             "nod at Maria.", self.actor, [self.actor, maria]
@@ -529,7 +535,7 @@ class TestRendererObserverKnown(TestCase):
             build="average",
             sleeve_uid="uid-alice",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
+                apparent_uid_for(self.actor): {"assigned_name": "Jorge"},
             },
         )
 
@@ -773,7 +779,7 @@ class TestCharacterReferences(TestCase):
         )
         # Actor knows Maria
         self.actor.recognition_memory = {
-            "uid-maria": {"assigned_name": "Maria"},
+            apparent_uid_for(self.maria): {"assigned_name": "Maria"},
         }
 
     def test_char_ref_observer_sees_sdesc(self) -> None:
@@ -804,8 +810,8 @@ class TestCharacterReferences(TestCase):
             build="average",
             sleeve_uid="uid-alice",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
-                "uid-maria": {"assigned_name": "Maria"},
+                apparent_uid_for(self.actor): {"assigned_name": "Jorge"},
+                apparent_uid_for(self.maria): {"assigned_name": "Maria"},
             },
         )
         tokens = tokenize_dot_pose(
@@ -864,7 +870,7 @@ class TestSpecExamples(TestCase):
             build="average",
             sleeve_uid="uid-alice",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
+                apparent_uid_for(self.actor): {"assigned_name": "Jorge"},
             },
         )
         self.observer_unknown = _make_character(
@@ -999,7 +1005,7 @@ class TestRenderDotPose(TestCase):
             build="average",
             sleeve_uid="uid-alice",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
+                apparent_uid_for(self.actor): {"assigned_name": "Jorge"},
             },
         )
 
@@ -1077,7 +1083,7 @@ class TestBuildCharCandidates(TestCase):
             sleeve_uid="uid-maria",
         )
         actor.recognition_memory = {
-            "uid-maria": {"assigned_name": "Maria"},
+            apparent_uid_for(maria): {"assigned_name": "Maria"},
         }
         candidates = build_char_candidates(actor, [actor, maria])
         names = [name for name, _char, _rc in candidates]
@@ -1319,7 +1325,7 @@ class TestRenderEmoteForObserver(TestCase):
             build="average",
             sleeve_uid="uid-bob",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
+                apparent_uid_for(self.actor): {"assigned_name": "Jorge"},
             },
         )
         tokens = tokenize_emote("waves.", self.actor, [])
@@ -1336,7 +1342,7 @@ class TestRenderEmoteForObserver(TestCase):
             build="average",
             sleeve_uid="uid-bob",
             recognition_memory={
-                "uid-maria": {"assigned_name": "Maria"},
+                apparent_uid_for(self.maria): {"assigned_name": "Maria"},
             },
         )
         tokens = tokenize_emote(
@@ -1599,7 +1605,7 @@ class TestOrdinalCharRefsInEmotes(TestCase):
             build="average",
             sleeve_uid="uid-bob",
             recognition_memory={
-                "uid-viktor": {"assigned_name": "Vik"},
+                apparent_uid_for(self.viktor): {"assigned_name": "Vik"},
             },
         )
         tokens = tokenize_dot_pose(

--- a/world/tests/test_emote_templates.py
+++ b/world/tests/test_emote_templates.py
@@ -22,6 +22,10 @@ from world.emote_templates import (
     _actor_verb,
     _make_social_cmd,
 )
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
 
 
 # ===================================================================
@@ -91,6 +95,7 @@ def _make_character(
     else:
         type(char).gender = PropertyMock(return_value="neutral")
 
+    prepare_mock_for_apparent_uid(char)
     return char
 
 
@@ -371,8 +376,14 @@ class TestSocialCmdTargeted(TestCase):
             build="average",
             sleeve_uid="uid-alice",
             recognition_memory={
-                "uid-jorge": {"assigned_name": "Jorge"},
-                "uid-maria": {"assigned_name": "Maria"},
+                apparent_uid_for(self.jorge): {
+                    "assigned_name": "Jorge",
+                    "lost_contact": False,
+                },
+                apparent_uid_for(self.maria): {
+                    "assigned_name": "Maria",
+                    "lost_contact": False,
+                },
             },
         )
         self.observer_knows_neither = _make_character(

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -740,3 +740,262 @@ class TestValidateCustomKeyword(TestCase):
     def test_reject_empty(self) -> None:
         valid, reason = validate_custom_keyword("")
         self.assertFalse(valid)
+
+
+# =====================================================================
+# Disguise engine: signature, Apparent UID, gender derivation, wipe
+# =====================================================================
+
+
+class _SignatureMockCharacter:
+    """Minimal stand-in for a Character used by signature/UID tests.
+
+    Avoids ``MagicMock`` because its auto-attribute behaviour silently
+    produces non-``None`` ``db.*_override`` values that poison the
+    signature.  This explicit class makes the unset state obvious and
+    makes the tests fail loudly when a new signature input is added.
+    """
+
+    def __init__(
+        self,
+        sleeve_uid: str | None = "uid-jorge",
+        height_override: str | None = None,
+        build_override: str | None = None,
+        keyword_override: str | None = None,
+        sex: str = "male",
+        gender: str | None = None,
+    ) -> None:
+        self.sleeve_uid = sleeve_uid
+        self.sex = sex
+        self.gender = gender
+
+        class _DB:
+            pass
+
+        self.db = _DB()
+        self.db.height_override = height_override
+        self.db.build_override = build_override
+        self.db.keyword_override = keyword_override
+
+        self.recognition_memory: dict = {}
+        self.key = "Jorge"
+
+
+class TestGetIdentitySignature(TestCase):
+    """Signature is the deterministic input tuple for Apparent UID derivation."""
+
+    def test_undisguised_signature_shape(self) -> None:
+        """Signature is a 5-tuple ending with an empty essential-items tuple."""
+        from world.identity import get_identity_signature
+
+        char = _SignatureMockCharacter()
+        sig = get_identity_signature(char)
+        self.assertEqual(len(sig), 5)
+        self.assertEqual(sig[0], "uid-jorge")
+        self.assertIsNone(sig[1])
+        self.assertIsNone(sig[2])
+        self.assertIsNone(sig[3])
+        # Essential-item tuple is empty until PR-C wires the flag.
+        self.assertEqual(sig[4], ())
+
+    def test_overrides_change_signature(self) -> None:
+        from world.identity import get_identity_signature
+
+        bare = get_identity_signature(_SignatureMockCharacter())
+        disguised = get_identity_signature(
+            _SignatureMockCharacter(
+                height_override="short",
+                build_override="stocky",
+                keyword_override="woman",
+            )
+        )
+        self.assertNotEqual(bare, disguised)
+        self.assertEqual(disguised[1], "short")
+        self.assertEqual(disguised[2], "stocky")
+        self.assertEqual(disguised[3], "woman")
+
+    def test_signature_is_pure_function_of_state(self) -> None:
+        """Two calls on the same state yield the same signature (no caching artefacts)."""
+        from world.identity import get_identity_signature
+
+        char = _SignatureMockCharacter(keyword_override="hooded")
+        self.assertEqual(get_identity_signature(char), get_identity_signature(char))
+
+
+class TestGetApparentUid(TestCase):
+    """Apparent UID is a deterministic 16-char hex digest of the signature."""
+
+    def test_uid_is_sixteen_hex_chars(self) -> None:
+        from world.identity import APPARENT_UID_HEX_LENGTH, get_apparent_uid
+
+        uid = get_apparent_uid(_SignatureMockCharacter())
+        self.assertIsNotNone(uid)
+        self.assertEqual(len(uid), APPARENT_UID_HEX_LENGTH)
+        self.assertEqual(len(uid), 16)
+        int(uid, 16)  # Raises ValueError if not valid hex.
+
+    def test_uid_is_deterministic(self) -> None:
+        """Same signature → same UID across calls (unlike salted ``hash()``)."""
+        from world.identity import get_apparent_uid
+
+        char1 = _SignatureMockCharacter(sleeve_uid="uid-x", keyword_override="man")
+        char2 = _SignatureMockCharacter(sleeve_uid="uid-x", keyword_override="man")
+        self.assertEqual(get_apparent_uid(char1), get_apparent_uid(char2))
+
+    def test_uid_changes_with_disguise(self) -> None:
+        """Adopting any override produces a distinct UID from the bare form."""
+        from world.identity import get_apparent_uid
+
+        bare = get_apparent_uid(_SignatureMockCharacter())
+        disguised = get_apparent_uid(
+            _SignatureMockCharacter(keyword_override="woman")
+        )
+        self.assertNotEqual(bare, disguised)
+
+    def test_uid_includes_sleeve_salt(self) -> None:
+        """Two impostors with identical disguises still get distinct UIDs."""
+        from world.identity import get_apparent_uid
+
+        a = _SignatureMockCharacter(sleeve_uid="uid-A", keyword_override="hooded")
+        b = _SignatureMockCharacter(sleeve_uid="uid-B", keyword_override="hooded")
+        self.assertNotEqual(get_apparent_uid(a), get_apparent_uid(b))
+
+    def test_uid_none_when_no_sleeve(self) -> None:
+        """Pre-chargen shells (no sleeve_uid) produce ``None``, never a digest."""
+        from world.identity import get_apparent_uid
+
+        self.assertIsNone(
+            get_apparent_uid(_SignatureMockCharacter(sleeve_uid=None))
+        )
+
+
+class TestGetApparentGender(TestCase):
+    """Gender derivation follows keyword override → real grammar gender."""
+
+    def test_no_override_uses_real_gender(self) -> None:
+        from world.identity import get_apparent_gender
+
+        char = _SignatureMockCharacter(sex="male", gender="male")
+        self.assertEqual(get_apparent_gender(char), "male")
+
+    def test_no_override_falls_back_to_sex_when_no_gender(self) -> None:
+        """When ``gender`` is unset, fall back through GENDER_MAP[sex]."""
+        from world.identity import get_apparent_gender
+
+        char = _SignatureMockCharacter(sex="female", gender=None)
+        self.assertEqual(get_apparent_gender(char), "female")
+
+    def test_feminine_override_returns_female(self) -> None:
+        from world.identity import get_apparent_gender
+
+        char = _SignatureMockCharacter(sex="male", keyword_override="woman")
+        self.assertEqual(get_apparent_gender(char), "female")
+
+    def test_masculine_override_returns_male(self) -> None:
+        from world.identity import get_apparent_gender
+
+        char = _SignatureMockCharacter(sex="female", keyword_override="man")
+        self.assertEqual(get_apparent_gender(char), "male")
+
+    def test_neutral_keyword_override_returns_neutral(self) -> None:
+        from world.identity import get_apparent_gender
+
+        char = _SignatureMockCharacter(sex="male", keyword_override="figure")
+        self.assertEqual(get_apparent_gender(char), "neutral")
+
+    def test_custom_keyword_override_returns_neutral(self) -> None:
+        """Custom ``@shortdesc`` keywords carry no gender metadata → neutral."""
+        from world.identity import get_apparent_gender
+
+        char = _SignatureMockCharacter(
+            sex="male", gender="male", keyword_override="zaibatsu-runner"
+        )
+        self.assertEqual(get_apparent_gender(char), "neutral")
+
+
+class TestLegacyRecognitionWipe(TestCase):
+    """Idempotent shape-check wipe of pre-engine-PR recognition entries."""
+
+    def _entry(self, **overrides) -> dict:
+        base = {
+            "assigned_name": "Big J",
+            "first_seen": "2025-01-01T00:00:00",
+            "last_seen": "2025-01-01T00:00:00",
+            "times_seen": 1,
+            "lost_contact": False,
+        }
+        base.update(overrides)
+        return base
+
+    def test_legacy_uuid_key_is_wiped(self) -> None:
+        """36-char UUID-style keys are pre-engine and must be wiped."""
+        from world.identity import wipe_legacy_recognition_memory
+
+        char = _SignatureMockCharacter()
+        char.recognition_memory = {
+            "12345678-1234-1234-1234-123456789012": self._entry(),
+        }
+        wiped = wipe_legacy_recognition_memory(char)
+        self.assertEqual(wiped, 1)
+        self.assertEqual(char.recognition_memory, {})
+
+    def test_missing_lost_contact_field_is_wiped(self) -> None:
+        """16-char key but missing ``lost_contact`` field → still legacy."""
+        from world.identity import wipe_legacy_recognition_memory
+
+        char = _SignatureMockCharacter()
+        # 16-char key, but entry pre-dates the lost_contact field.
+        legacy = self._entry()
+        del legacy["lost_contact"]
+        char.recognition_memory = {"abcdef0123456789": legacy}
+        wiped = wipe_legacy_recognition_memory(char)
+        self.assertEqual(wiped, 1)
+        self.assertEqual(char.recognition_memory, {})
+
+    def test_modern_entry_is_preserved(self) -> None:
+        """16-char key + ``lost_contact`` field present → no-op."""
+        from world.identity import wipe_legacy_recognition_memory
+
+        char = _SignatureMockCharacter()
+        char.recognition_memory = {"abcdef0123456789": self._entry()}
+        wiped = wipe_legacy_recognition_memory(char)
+        self.assertEqual(wiped, 0)
+        self.assertIn("abcdef0123456789", char.recognition_memory)
+
+    def test_wipe_is_idempotent(self) -> None:
+        """A second call after a successful wipe is a no-op."""
+        from world.identity import wipe_legacy_recognition_memory
+
+        char = _SignatureMockCharacter()
+        char.recognition_memory = {
+            "12345678-1234-1234-1234-123456789012": self._entry(),
+            "abcdef0123456789": self._entry(),
+        }
+        first = wipe_legacy_recognition_memory(char)
+        second = wipe_legacy_recognition_memory(char)
+        self.assertEqual(first, 1)
+        self.assertEqual(second, 0)
+
+    def test_wipe_handles_empty_memory(self) -> None:
+        from world.identity import wipe_legacy_recognition_memory
+
+        char = _SignatureMockCharacter()
+        char.recognition_memory = {}
+        self.assertEqual(wipe_legacy_recognition_memory(char), 0)
+
+    def test_wipe_handles_none_memory(self) -> None:
+        """A character with no recognition_memory attribute is handled gracefully."""
+        from world.identity import wipe_legacy_recognition_memory
+
+        char = _SignatureMockCharacter()
+        char.recognition_memory = None
+        self.assertEqual(wipe_legacy_recognition_memory(char), 0)
+
+    def test_non_dict_entry_value_is_wiped(self) -> None:
+        """A corrupt non-dict value at a 16-char key is still legacy."""
+        from world.identity import wipe_legacy_recognition_memory
+
+        char = _SignatureMockCharacter()
+        char.recognition_memory = {"abcdef0123456789": "corrupt-string"}
+        self.assertEqual(wipe_legacy_recognition_memory(char), 1)
+        self.assertEqual(char.recognition_memory, {})

--- a/world/tests/test_identity_commands.py
+++ b/world/tests/test_identity_commands.py
@@ -14,6 +14,11 @@ All test cases match the specification in
 from unittest import TestCase
 from unittest.mock import MagicMock, PropertyMock, patch, call
 
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
+
 
 # ===================================================================
 # Helpers — lightweight character stand-in
@@ -85,6 +90,7 @@ def _make_character(
         location.key = "Test Room"
     char.location = location
 
+    prepare_mock_for_apparent_uid(char)
     return char
 
 
@@ -258,15 +264,16 @@ class TestRememberCommand(TestCase):
             build="lean",
             sdesc_keyword="man",
         )
+        target_uid = apparent_uid_for(target)
 
         cmd = CmdRemember()
         cmd.caller = caller
-        cmd._remember_target(caller, target, "uid-target", "Big J")
+        cmd._remember_target(caller, target, target_uid, "Big J")
 
         memory = caller.recognition_memory
-        self.assertIn("uid-target", memory)
-        self.assertEqual(memory["uid-target"]["assigned_name"], "Big J")
-        self.assertEqual(memory["uid-target"]["times_seen"], 1)
+        self.assertIn(target_uid, memory)
+        self.assertEqual(memory[target_uid]["assigned_name"], "Big J")
+        self.assertEqual(memory[target_uid]["times_seen"], 1)
 
     def test_display_name_changes_after_remember(self):
         """After remembering, get_display_name returns the chosen name."""
@@ -278,13 +285,14 @@ class TestRememberCommand(TestCase):
             build="lean",
             sdesc_keyword="man",
         )
+        target_uid = apparent_uid_for(target)
 
         # Before — stranger
         self.assertEqual(target.get_display_name(caller), "a gaunt man")
 
         # Manually set recognition memory (simulating what remember does)
         caller.recognition_memory = {
-            "uid-target": {"assigned_name": "Big J"},
+            target_uid: {"assigned_name": "Big J"},
         }
         self.assertEqual(target.get_display_name(caller), "Big J")
 
@@ -292,11 +300,19 @@ class TestRememberCommand(TestCase):
         """Re-remembering updates the name and increments times_seen."""
         from commands.CmdCharacter import CmdRemember
 
+        target = _make_character(
+            key="Jorge",
+            sleeve_uid="uid-target",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        target_uid = apparent_uid_for(target)
         caller = _make_character(
             key="Observer",
             sleeve_uid="uid-observer",
             recognition_memory={
-                "uid-target": {
+                target_uid: {
                     "assigned_name": "Big J",
                     "first_seen": "2026-01-01T00:00:00",
                     "last_seen": "2026-01-01T00:00:00",
@@ -311,9 +327,23 @@ class TestRememberCommand(TestCase):
                     "confidence": 1.0,
                     "relationship_valence": "neutral",
                     "recent_interactions": [],
+                    "lost_contact": False,
                 },
             },
         )
+
+        cmd = CmdRemember()
+        cmd.caller = caller
+        cmd._remember_target(caller, target, target_uid, "Jorge")
+
+        memory = caller.recognition_memory
+        self.assertEqual(memory[target_uid]["assigned_name"], "Jorge")
+        self.assertEqual(memory[target_uid]["times_seen"], 4)
+
+    def test_remember_preserves_existing_fields(self):
+        """Re-remembering preserves notes, tags, etc."""
+        from commands.CmdCharacter import CmdRemember
+
         target = _make_character(
             key="Jorge",
             sleeve_uid="uid-target",
@@ -321,24 +351,12 @@ class TestRememberCommand(TestCase):
             build="lean",
             sdesc_keyword="man",
         )
-
-        cmd = CmdRemember()
-        cmd.caller = caller
-        cmd._remember_target(caller, target, "uid-target", "Jorge")
-
-        memory = caller.recognition_memory
-        self.assertEqual(memory["uid-target"]["assigned_name"], "Jorge")
-        self.assertEqual(memory["uid-target"]["times_seen"], 4)
-
-    def test_remember_preserves_existing_fields(self):
-        """Re-remembering preserves notes, tags, etc."""
-        from commands.CmdCharacter import CmdRemember
-
+        target_uid = apparent_uid_for(target)
         caller = _make_character(
             key="Observer",
             sleeve_uid="uid-observer",
             recognition_memory={
-                "uid-target": {
+                target_uid: {
                     "assigned_name": "Big J",
                     "first_seen": "2026-01-01T00:00:00",
                     "last_seen": "2026-01-01T00:00:00",
@@ -353,23 +371,17 @@ class TestRememberCommand(TestCase):
                     "confidence": 0.8,
                     "relationship_valence": "friendly",
                     "recent_interactions": [],
+                    "lost_contact": False,
                 },
             },
-        )
-        target = _make_character(
-            key="Jorge",
-            sleeve_uid="uid-target",
-            height="tall",
-            build="lean",
-            sdesc_keyword="man",
         )
 
         cmd = CmdRemember()
         cmd.caller = caller
-        cmd._remember_target(caller, target, "uid-target", "J-Dog")
+        cmd._remember_target(caller, target, target_uid, "J-Dog")
 
         memory = caller.recognition_memory
-        entry = memory["uid-target"]
+        entry = memory[target_uid]
         self.assertEqual(entry["assigned_name"], "J-Dog")
         self.assertEqual(entry["notes"], "Seems dangerous")
         self.assertEqual(entry["tags"], ["ally"])
@@ -401,6 +413,7 @@ def _seed_memory(uid="uid-target", name="Big J"):
             "confidence": 1.0,
             "relationship_valence": "neutral",
             "recent_interactions": [],
+            "lost_contact": False,
         },
     }
 
@@ -412,11 +425,6 @@ class TestForgetCommand(TestCase):
         """forget <visible target> blanks assigned_name, preserves entry."""
         from commands.CmdCharacter import CmdForget
 
-        caller = _make_character(
-            key="Observer",
-            sleeve_uid="uid-observer",
-            recognition_memory=_seed_memory(),
-        )
         target = _make_character(
             key="Jorge",
             sleeve_uid="uid-target",
@@ -424,39 +432,54 @@ class TestForgetCommand(TestCase):
             build="lean",
             sdesc_keyword="man",
         )
+        target_uid = apparent_uid_for(target)
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=_seed_memory(uid=target_uid),
+        )
 
         cmd = CmdForget()
         cmd.caller = caller
-        cmd._forget_visible(caller, target, "uid-target")
+        cmd._forget_visible(caller, target, target_uid)
 
         memory = caller.recognition_memory
-        self.assertIn("uid-target", memory)
-        self.assertEqual(memory["uid-target"]["assigned_name"], "")
+        self.assertIn(target_uid, memory)
+        self.assertEqual(memory[target_uid]["assigned_name"], "")
         # History preserved
-        self.assertEqual(memory["uid-target"]["times_seen"], 2)
+        self.assertEqual(memory[target_uid]["times_seen"], 2)
         self.assertEqual(
-            memory["uid-target"]["sdesc_at_first_encounter"], "a gaunt man"
+            memory[target_uid]["sdesc_at_first_encounter"], "a gaunt man"
         )
 
     def test_forget_remembered_name_when_target_absent(self):
         """forget <remembered name> works without target object."""
         from commands.CmdCharacter import CmdForget, _find_remembered_uid_by_name
 
+        # Build a target only to derive its apparent UID for seeding.
+        target = _make_character(
+            key="Jorge",
+            sleeve_uid="uid-target",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        target_uid = apparent_uid_for(target)
         caller = _make_character(
             key="Observer",
             sleeve_uid="uid-observer",
-            recognition_memory=_seed_memory(),
+            recognition_memory=_seed_memory(uid=target_uid),
         )
 
         sleeve_uid, entry = _find_remembered_uid_by_name(caller, "big j")
-        self.assertEqual(sleeve_uid, "uid-target")
+        self.assertEqual(sleeve_uid, target_uid)
 
         cmd = CmdForget()
         cmd.caller = caller
         cmd._forget_remembered(caller, sleeve_uid, entry)
 
         memory = caller.recognition_memory
-        self.assertEqual(memory["uid-target"]["assigned_name"], "")
+        self.assertEqual(memory[target_uid]["assigned_name"], "")
         # Output message references snapshot data
         msg_text = caller.msg.call_args[0][0]
         self.assertIn("Big J", msg_text)
@@ -475,13 +498,6 @@ class TestForgetCommand(TestCase):
         """forget on someone with a blank assigned_name reports correctly."""
         from commands.CmdCharacter import CmdForget
 
-        memory = _seed_memory()
-        memory["uid-target"]["assigned_name"] = ""
-        caller = _make_character(
-            key="Observer",
-            sleeve_uid="uid-observer",
-            recognition_memory=memory,
-        )
         target = _make_character(
             key="Jorge",
             sleeve_uid="uid-target",
@@ -489,10 +505,18 @@ class TestForgetCommand(TestCase):
             build="lean",
             sdesc_keyword="man",
         )
+        target_uid = apparent_uid_for(target)
+        memory = _seed_memory(uid=target_uid)
+        memory[target_uid]["assigned_name"] = ""
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=memory,
+        )
 
         cmd = CmdForget()
         cmd.caller = caller
-        cmd._forget_visible(caller, target, "uid-target")
+        cmd._forget_visible(caller, target, target_uid)
 
         msg_text = caller.msg.call_args[0][0]
         self.assertIn("don't have a name", msg_text)

--- a/world/tests/test_identity_search.py
+++ b/world/tests/test_identity_search.py
@@ -22,6 +22,11 @@ from world.search import (
     strip_leading_article,
 )
 
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
+
 
 # ===================================================================
 # Helpers — lightweight character / object stand-in
@@ -90,6 +95,7 @@ def _make_character(
     else:
         type(char).gender = PropertyMock(return_value="neutral")
 
+    prepare_mock_for_apparent_uid(char)
     return char
 
 
@@ -269,7 +275,10 @@ class TestIdentityMatchCharacters(TestCase):
     def test_match_by_assigned_name(self):
         """Assigned name 'Jorge' matches."""
         self.searcher.recognition_memory = {
-            "uid-jorge": {"assigned_name": "Jorge"},
+            apparent_uid_for(self.jorge): {
+                "assigned_name": "Jorge",
+                "lost_contact": False,
+            },
         }
         result = identity_match_characters(
             self.searcher, "jorge", self.candidates
@@ -279,7 +288,10 @@ class TestIdentityMatchCharacters(TestCase):
     def test_assigned_name_takes_priority(self):
         """Assigned name matches come before sdesc matches."""
         self.searcher.recognition_memory = {
-            "uid-jorge": {"assigned_name": "Big Guy"},
+            apparent_uid_for(self.jorge): {
+                "assigned_name": "Big Guy",
+                "lost_contact": False,
+            },
         }
         # "Big" would not match Jorge's sdesc, but matches assigned name
         result = identity_match_characters(
@@ -394,7 +406,10 @@ class TestIdentityMatchCharacters(TestCase):
     def test_assigned_name_partial_match(self):
         """Partial assigned name match works (substring)."""
         self.searcher.recognition_memory = {
-            "uid-jorge": {"assigned_name": "Jorge Jackson"},
+            apparent_uid_for(self.jorge): {
+                "assigned_name": "Jorge Jackson",
+                "lost_contact": False,
+            },
         }
         result = identity_match_characters(
             self.searcher, "jorge", self.candidates
@@ -404,7 +419,10 @@ class TestIdentityMatchCharacters(TestCase):
     def test_assigned_name_no_double_count(self):
         """A character matched by assigned name is not also added by sdesc."""
         self.searcher.recognition_memory = {
-            "uid-jorge": {"assigned_name": "gaunt man"},
+            apparent_uid_for(self.jorge): {
+                "assigned_name": "gaunt man",
+                "lost_contact": False,
+            },
         }
         # "gaunt man" matches both assigned name AND sdesc —
         # should only appear once
@@ -447,7 +465,10 @@ class TestIsIdentityMatch(TestCase):
 
     def test_assigned_name_match_returns_true(self):
         self.searcher.recognition_memory = {
-            "uid-jorge": {"assigned_name": "Jorge"},
+            apparent_uid_for(self.jorge): {
+                "assigned_name": "Jorge",
+                "lost_contact": False,
+            },
         }
         self.assertTrue(
             is_identity_match(self.searcher, self.jorge, "jorge")


### PR DESCRIPTION
## Summary

Implements the recognition engine described in spec PR #115:

- **Identity signature** (`get_identity_signature`): five-tuple of `(sleeve_uid, height_override, build_override, keyword_override, essential_item_type_ids)`. Essential-item slot is empty until PR-C.
- **Apparent UID** (`get_apparent_uid`): deterministic 16-char `blake2b` digest of the signature; returns `None` for pre-chargen shells. Two impostors with identical disguises still produce distinct UIDs because the real `sleeve_uid` is part of the signature.
- **Apparent gender** (`get_apparent_gender`): keyword override → catalog reverse-lookup → real grammar gender. Custom `@shortdesc` keywords always render neutral. Pronouns now follow the disguise everywhere they're rendered (`world/emote.py`, `commands/CmdInventory.py` frisk path).
- **Recognition re-keying**: `recognition_memory` is keyed on Apparent UID instead of real `sleeve_uid` everywhere — `get_display_name`, `world/search` assigned-name match, and the full `remember`/`forget`/`recall`/`memory` cluster. A character under disguise produces a distinct entry from their real form.
- **`lost_contact` field**: added to memory entries, surfaced in `recall` and `memory` output as `(lost contact)`. The periodic prune job that flips this flag is deferred — the engine PR adds the field + render only.
- **Idempotent legacy wipe**: `wipe_all_legacy_recognition_memory` runs on `at_server_start` and removes any entry whose key length ≠ 16 or whose value lacks `lost_contact`. Becomes a no-op once migrated; carries a TODO to be removed after deployment is verified clean.

## Test scaffolding

Shared helper module `world/tests/_identity_helpers.py` exposes:
- `apparent_uid_for(char)` — derives the UID for a mock character
- `prepare_mock_for_apparent_uid(char)` — zeroes `db.*_override` axes so `MagicMock` auto-attributes don't poison the signature
- `make_recognition_entry(...)` — builds an entry dict with the post-engine schema (incl. `lost_contact`)

Six identity-adjacent test modules migrated to use it. New tests in `test_identity.py` cover: signature shape, UID determinism, sleeve-salt distinctness, gender derivation across all override paths, and wipe migration idempotency.

## Out of scope (PR-C)

- Wiring the `disguise_essential` item flag and equip/remove lifecycle hooks into `get_essential_item_type_ids` (currently returns `()`).
- Periodic `lost_contact` scan job and balance-pass threshold.

## Test plan

```
docker exec gelatinous evennia test world commands typeclasses
# 557/557 tests pass
```

Smoke-tested locally via `evennia reload`; no fresh tracebacks.