### PR TITLE
Wire essential disguise items into identity signature (PR-C)

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -92,6 +92,46 @@ class Item(DefaultObject):
     
     # Plate size compatibility (small, medium, large, extra_large)
     plate_size = AttributeProperty("", autocreate=True)
+
+    # ===================================================================
+    # DISGUISE SYSTEM ATTRIBUTES
+    # ===================================================================
+    #
+    # Two-flag taxonomy for the Phase 3 disguise system. See
+    # ``specs/IDENTITY_RECOGNITION_SPEC.md`` §Disguise Items for the
+    # design rationale.
+    #
+    # ``is_disguise_item`` marks an item as belonging to the disguise
+    # taxonomy at all (carries a future Phase 5 perception-roll bonus).
+    # ``disguise_essential`` is the stronger flag: an essential item
+    # contributes to the wearer's identity signature, so equipping or
+    # removing it shifts their Apparent UID and produces a distinct
+    # recognition entry.  Non-essential disguise items contribute only
+    # visually through the existing distinguishing-feature derivation.
+    #
+    # ``disguise_type_id`` is the stable per-item-type identifier hashed
+    # into the signature.  Two balaclavas with the same
+    # ``disguise_type_id`` produce the same signature contribution, so
+    # the same physical disguise produces the same Apparent UID across
+    # different item instances.  Authors set this explicitly per
+    # essential item (e.g. ``"balaclava"``, ``"mask_full"``, ``"wig"``);
+    # leaving it empty on an essential item suppresses its signature
+    # contribution and emits a startup warning via the wearer's
+    # signature query path.
+
+    # Marks an item as part of the disguise taxonomy (perception-roll
+    # bonus in Phase 5; no behavioural effect today).
+    is_disguise_item = AttributeProperty(False, autocreate=True)
+
+    # Marks an essential disguise item: when worn, contributes its
+    # ``disguise_type_id`` to the wearer's identity signature.
+    disguise_essential = AttributeProperty(False, autocreate=True)
+
+    # Stable per-item-type identifier fed into the identity signature
+    # for essential disguise items.  Empty string means "no
+    # contribution"; treated as a soft warning when paired with
+    # ``disguise_essential = True``.
+    disguise_type_id = AttributeProperty("", autocreate=True)
     
     # Multiple style properties for combination states
     style_properties = AttributeProperty({}, autocreate=True)

--- a/world/identity.py
+++ b/world/identity.py
@@ -692,18 +692,50 @@ APPARENT_UID_HEX_LENGTH: int = _APPARENT_UID_DIGEST_BYTES * 2
 def get_essential_item_type_ids(char: Any) -> tuple[str, ...]:
     """Return the sorted tuple of equipped essential disguise item type IDs.
 
-    Stub for the foundation engine PR. Returns an empty tuple until
-    PR-C wires the ``disguise_essential`` item flag and the
-    disguise-item taxonomy. The signature shape stays stable; only its
-    content changes when items land.
+    Walks the character's worn items via
+    :meth:`typeclasses.clothing_mixin.ClothingMixin.get_worn_items`,
+    selects items flagged ``disguise_essential = True``, and returns
+    their ``disguise_type_id`` values as a sorted tuple.  This tuple is
+    the fifth element of :func:`get_identity_signature` and so feeds
+    directly into the wearer's Apparent UID.
+
+    Two essential items sharing the same ``disguise_type_id`` (e.g. two
+    balaclava instances) collapse to a single contribution: the sorted
+    tuple deduplicates intentionally so swapping one balaclava for
+    another does not shift the wearer's Apparent UID.
+
+    An essential item with an empty ``disguise_type_id`` is *skipped*
+    (no contribution) and a soft warning is emitted via
+    :func:`evennia.utils.logger.log_warn`; this catches authoring slips
+    without breaking recognition for the wearer.
+
+    Characters without :meth:`get_worn_items` (e.g. mocks, NPCs that
+    cannot wear clothing) yield an empty tuple.
 
     Args:
         char: The character whose equipped items are inspected.
 
     Returns:
-        Empty tuple until essential-item integration ships.
+        Sorted, deduplicated tuple of ``disguise_type_id`` strings.
     """
-    return ()
+    get_worn = getattr(char, "get_worn_items", None)
+    if get_worn is None:
+        return ()
+
+    type_ids: set[str] = set()
+    for item in get_worn():
+        if not getattr(item, "disguise_essential", False):
+            continue
+        type_id = getattr(item, "disguise_type_id", "") or ""
+        if not type_id:
+            logger.log_warn(
+                f"Essential disguise item {item!r} on {char!r} has empty "
+                f"disguise_type_id; skipping signature contribution."
+            )
+            continue
+        type_ids.add(type_id)
+
+    return tuple(sorted(type_ids))
 
 
 def get_identity_signature(char: Any) -> tuple:

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -764,6 +764,7 @@ class _SignatureMockCharacter:
         keyword_override: str | None = None,
         sex: str = "male",
         gender: str | None = None,
+        worn_items: list | None = None,
     ) -> None:
         self.sleeve_uid = sleeve_uid
         self.sex = sex
@@ -779,6 +780,204 @@ class _SignatureMockCharacter:
 
         self.recognition_memory: dict = {}
         self.key = "Jorge"
+        self._worn_items = worn_items or []
+
+    def get_worn_items(self, location: str | None = None) -> list:
+        """Mirror :meth:`ClothingMixin.get_worn_items` for signature tests."""
+        return list(self._worn_items)
+
+
+class _FakeDisguiseItem:
+    """Lightweight stand-in for ``typeclasses.items.Item`` in signature tests.
+
+    Mirrors the duck-typed surface ``get_essential_item_type_ids`` reads:
+    ``disguise_essential`` (bool) and ``disguise_type_id`` (str).
+    """
+
+    def __init__(
+        self, *, disguise_essential: bool = False, disguise_type_id: str = ""
+    ) -> None:
+        self.disguise_essential = disguise_essential
+        self.disguise_type_id = disguise_type_id
+
+
+class TestGetEssentialItemTypeIds(TestCase):
+    """Essential disguise items contribute their type IDs to the signature."""
+
+    def test_no_worn_items_yields_empty_tuple(self) -> None:
+        from world.identity import get_essential_item_type_ids
+
+        char = _SignatureMockCharacter()
+        self.assertEqual(get_essential_item_type_ids(char), ())
+
+    def test_non_essential_items_are_ignored(self) -> None:
+        """A worn item without ``disguise_essential`` contributes nothing."""
+        from world.identity import get_essential_item_type_ids
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    disguise_essential=False, disguise_type_id="balaclava"
+                ),
+            ]
+        )
+        self.assertEqual(get_essential_item_type_ids(char), ())
+
+    def test_essential_item_contributes_type_id(self) -> None:
+        from world.identity import get_essential_item_type_ids
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="balaclava"
+                ),
+            ]
+        )
+        self.assertEqual(get_essential_item_type_ids(char), ("balaclava",))
+
+    def test_duplicate_type_ids_collapse(self) -> None:
+        """Two balaclavas → one signature contribution (set semantics)."""
+        from world.identity import get_essential_item_type_ids
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="balaclava"
+                ),
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="balaclava"
+                ),
+            ]
+        )
+        self.assertEqual(get_essential_item_type_ids(char), ("balaclava",))
+
+    def test_multiple_distinct_types_are_sorted(self) -> None:
+        from world.identity import get_essential_item_type_ids
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="wig"
+                ),
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="balaclava"
+                ),
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="mask_full"
+                ),
+            ]
+        )
+        self.assertEqual(
+            get_essential_item_type_ids(char),
+            ("balaclava", "mask_full", "wig"),
+        )
+
+    def test_essential_with_empty_type_id_is_skipped_and_warns(self) -> None:
+        """Authoring slip: essential flag set but no type_id → warn + skip."""
+        from world.identity import get_essential_item_type_ids
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id=""
+                ),
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="wig"
+                ),
+            ]
+        )
+        with patch("world.identity.logger.log_warn") as mock_warn:
+            result = get_essential_item_type_ids(char)
+        self.assertEqual(result, ("wig",))
+        mock_warn.assert_called_once()
+
+    def test_character_without_get_worn_items_yields_empty_tuple(self) -> None:
+        """NPCs that cannot wear clothing must not crash signature derivation."""
+        from world.identity import get_essential_item_type_ids
+
+        class _BareChar:
+            pass
+
+        self.assertEqual(get_essential_item_type_ids(_BareChar()), ())
+
+
+class TestEssentialItemsAffectSignatureAndUid(TestCase):
+    """Integration: equipping essential items shifts signature + Apparent UID."""
+
+    def test_essential_item_appears_in_signature_tuple(self) -> None:
+        from world.identity import get_identity_signature
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="balaclava"
+                ),
+            ]
+        )
+        sig = get_identity_signature(char)
+        self.assertEqual(sig[4], ("balaclava",))
+
+    def test_essential_item_changes_apparent_uid(self) -> None:
+        from world.identity import get_apparent_uid
+
+        bare = get_apparent_uid(_SignatureMockCharacter())
+        disguised = get_apparent_uid(
+            _SignatureMockCharacter(
+                worn_items=[
+                    _FakeDisguiseItem(
+                        disguise_essential=True, disguise_type_id="balaclava"
+                    ),
+                ]
+            )
+        )
+        self.assertNotEqual(bare, disguised)
+
+    def test_two_balaclavas_hash_identically(self) -> None:
+        """Swapping one balaclava for another must not shift the UID."""
+        from world.identity import get_apparent_uid
+
+        a = get_apparent_uid(
+            _SignatureMockCharacter(
+                worn_items=[
+                    _FakeDisguiseItem(
+                        disguise_essential=True, disguise_type_id="balaclava"
+                    ),
+                ]
+            )
+        )
+        b = get_apparent_uid(
+            _SignatureMockCharacter(
+                worn_items=[
+                    _FakeDisguiseItem(
+                        disguise_essential=True, disguise_type_id="balaclava"
+                    ),
+                ]
+            )
+        )
+        self.assertEqual(a, b)
+
+    def test_different_essential_types_produce_different_uids(self) -> None:
+        from world.identity import get_apparent_uid
+
+        balaclava_uid = get_apparent_uid(
+            _SignatureMockCharacter(
+                worn_items=[
+                    _FakeDisguiseItem(
+                        disguise_essential=True, disguise_type_id="balaclava"
+                    ),
+                ]
+            )
+        )
+        wig_uid = get_apparent_uid(
+            _SignatureMockCharacter(
+                worn_items=[
+                    _FakeDisguiseItem(
+                        disguise_essential=True, disguise_type_id="wig"
+                    ),
+                ]
+            )
+        )
+        self.assertNotEqual(balaclava_uid, wig_uid)
 
 
 class TestGetIdentitySignature(TestCase):


### PR DESCRIPTION
## Summary
- Add `is_disguise_item`, `disguise_essential`, `disguise_type_id` AttributeProperties on `Item` for the Phase 3 disguise taxonomy
- Replace the `get_essential_item_type_ids` stub with a real implementation: walk `char.get_worn_items()`, filter `disguise_essential`, dedupe + sort `disguise_type_id` values, warn on essential-but-empty
- New unit tests (`TestGetEssentialItemTypeIds`) and integration tests (`TestEssentialItemsAffectSignatureAndUid`) covering signature shape, Apparent UID shift, two-balaclava equivalence, distinct-type divergence, and the bare-character fallback

## Why
Closes the last engine gap from the disguise foundation PR (#116): essential disguise items now actually shift the wearer's Apparent UID, so two impostors wearing the same balaclava read as the same anonymous stranger to an observer, while swapping balaclava → wig produces a distinct recognition entry.

## Tests
`docker exec gelatinous evennia test world.tests` → 568/568 OK