### PR TITLE
Add disguise adjective and feature plumbing for sdesc red-flag (PR-D)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -118,7 +118,9 @@ The system selects the most visually prominent worn item. Prominence is determin
 
 Format: `"in {article} {item_sdesc}"` — e.g., `"in a leather jacket"`, `"in red power armor"`, `"in a tattered lab coat"`
 
-Items will need a `sdesc` or `worn_sdesc_short` attribute for this purpose — a brief, recognizable description suitable for the sdesc clause.
+Items use a `worn_sdesc_short` attribute for this clause — a brief, recognizable noun phrase. When unset, the selector falls back to the item's `key`.
+
+**Disguise items are deprioritised.** When a wearer has any non-disguise clothing, the feature selector partitions the worn items and prefers the non-disguise pool. The disguise pool is consulted only when nothing else is worn — the *naked-but-masked* carve-out. Without this carve-out, a lone balaclava would yield no feature clause; with it, observers still get `"a tall lean masked droog in a black balaclava"`. When real clothing is added, the feature shifts to that clothing and the balaclava's contribution falls back to the disguise adjective only (see [Disguise Adjective](#disguise-adjective)): `"a tall lean masked droog in a black trenchcoat"`.
 
 #### Hair-based Feature
 
@@ -128,7 +130,7 @@ Format: `"with {color} {style}"` — e.g., `"with red dreadlocks"`, `"with cropp
 
 If the character is bald or has no hair attribute set, this is skipped.
 
-If a head covering (hood, helmet, hat) is worn, hair is hidden and not used even as fallback.
+Head coverings suppress the hair fallback by setting `covers_hair = True` on the item; under coverage the chain falls through to "no feature" rather than describing hair the observer cannot see. Scope is feature-fallback only — longdesc gating lives with the existing clothing-coverage code.
 
 #### No Feature
 
@@ -604,6 +606,29 @@ Examples:
 - **Non-essential**: gloves, scarf, signature jacket, distinguishing hat
 
 The item taxonomy itself (which items exist, their categories, quality tiers) is designed in **Phase 3.5**, a separate cut after the foundation lands. The foundation only needs the two flags to function correctly with zero defined disguise items.
+
+### Disguise Adjective
+
+Disguise items can also flag themselves as a visible **red flag** in the wearer's sdesc through two additional attributes:
+
+- **`disguise_adjective`** (`str`): a single descriptor (`"masked"`, `"hooded"`, `"helmeted"`, …) injected between the physical descriptor and the keyword — e.g., `"a tall lean masked droog"`. Honoured **only** when the same item also has `is_disguise_item = True`; an adjective on a non-disguise item is skipped with a soft warning (red-flag style is reserved for the disguise taxonomy).
+- **`covers_hair`** (`bool`): when any worn item declares this, the hair fallback in the distinguishing-feature chain is suppressed. Scope is feature-fallback only; longdesc gating is handled by the existing clothing-coverage code.
+
+When more than one adjective is contributed, the wearer's sdesc shows the most identity-defining one. Priority ranks (lowest wins):
+
+| Adjective | Rank |
+|---|---|
+| `masked` | 1 |
+| `helmeted` | 2 |
+| `cowled` | 3 |
+| `hooded` | 4 |
+| `goggled` | 5 |
+| `veiled` | 6 |
+| `wigged` | 7 |
+
+Adjectives missing from the priority table are admitted at rank 999 with an alphabetical tiebreak — authors can ship new disguise types via item attribute alone, without editing the priority table.
+
+The adjective is **a visual-only red flag** and contributes nothing to the identity signature. Whether the wearer is recognised across encounters is governed entirely by the signature inputs (overrides + essential item type IDs); the adjective only governs how observers describe them. A `masked` wearer who removes the mask and dons an `helmeted` one shifts both adjective and signature simultaneously, but the adjective change alone (e.g., spec-future "rigid mask" item with the same `disguise_type_id` as a balaclava) would not affect recognition.
 
 ### Disguise Completeness
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -868,8 +868,18 @@ class Character(
 
         Priority chain (first non-empty wins):
           1. Wielded weapon or explosive
-          2. Outermost clothing item
-          3. Hair (colour/style)
+          2. Outermost clothing item.  Non-disguise items are preferred
+             over items flagged ``is_disguise_item = True``; the
+             disguise pool is consulted only when nothing else is worn
+             (the naked-but-masked carve-out — a lone balaclava still
+             reads as ``"in a black balaclava"`` rather than vanishing).
+             When chosen, the item's ``worn_sdesc_short`` is used in
+             preference to its ``key``.
+          3. Hair (colour/style) — suppressed when any worn item has
+             ``covers_hair = True``; under coverage we fall through to
+             "nothing" rather than describing hair the observer cannot
+             see.  Scope is feature-fallback only; longdesc gating
+             lives with the existing clothing-coverage code.
           4. ``None`` — no feature
 
         Returns:
@@ -889,21 +899,46 @@ class Character(
             if item is not None:
                 return format_wielded_feature(item.key)
 
-        # 2. Outermost clothing item (pick the first location with coverage)
+        # 2. Outermost clothing item (pick the first location with coverage).
+        # Partition disguise vs non-disguise so the clothing feature reads
+        # the wearer's "real" outfit when there is one, and only falls
+        # back to disguise items in the solo-disguise carve-out.
         coverage_map = self._build_clothing_coverage_map()
         if coverage_map:
-            # Deterministic: pick the first location alphabetically so the
-            # feature is stable between calls.
-            for _location in sorted(coverage_map):
-                item = coverage_map[_location]
-                if item is not None:
-                    return format_clothing_feature(item.key)
+            non_disguise: dict = {}
+            disguise: dict = {}
+            for _location, item in coverage_map.items():
+                if item is None:
+                    continue
+                if getattr(item, "is_disguise_item", False):
+                    disguise[_location] = item
+                else:
+                    non_disguise[_location] = item
+            chosen_pool = non_disguise or disguise
+            if chosen_pool:
+                # Deterministic: pick the first location alphabetically.
+                for _location in sorted(chosen_pool):
+                    item = chosen_pool[_location]
+                    label = (
+                        getattr(item, "worn_sdesc_short", "") or item.key
+                    )
+                    return format_clothing_feature(label)
 
-        # 3. Hair
-        hair_color = self.hair_color
-        hair_style = self.hair_style
-        if hair_color or hair_style:
-            return format_hair_feature(color=hair_color, style=hair_style)
+        # 3. Hair — suppressed when any worn item declares covers_hair.
+        suppress_hair = False
+        get_worn = getattr(self, "get_worn_items", None)
+        if get_worn is not None:
+            for worn in get_worn():
+                if getattr(worn, "covers_hair", False):
+                    suppress_hair = True
+                    break
+        if not suppress_hair:
+            hair_color = self.hair_color
+            hair_style = self.hair_style
+            if hair_color or hair_style:
+                return format_hair_feature(
+                    color=hair_color, style=hair_style
+                )
 
         # 4. Nothing
         return None
@@ -927,7 +962,11 @@ class Character(
         Returns:
             Sdesc string, e.g. ``"lanky man wielding a Kitchen Knife"``.
         """
-        from world.identity import compose_sdesc, get_physical_descriptor
+        from world.identity import (
+            compose_sdesc,
+            get_disguise_adjective,
+            get_physical_descriptor,
+        )
         from world.grammar import DEFAULT_SDESC_KEYWORDS
 
         # Override axes take precedence over real values.
@@ -942,7 +981,10 @@ class Character(
             keyword = DEFAULT_SDESC_KEYWORDS.get(self.gender, "person")
 
         feature = self.get_distinguishing_feature()
-        return compose_sdesc(descriptor, keyword, feature)
+        adjective = get_disguise_adjective(self)
+        return compose_sdesc(
+            descriptor, keyword, feature, disguise_adjective=adjective
+        )
 
     def get_display_name(self, looker=None, **kwargs):
         """Return the name of this character as seen by *looker*.

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -132,6 +132,33 @@ class Item(DefaultObject):
     # contribution"; treated as a soft warning when paired with
     # ``disguise_essential = True``.
     disguise_type_id = AttributeProperty("", autocreate=True)
+
+    # ``disguise_adjective`` is the visible "red flag" — when an item
+    # flagged ``is_disguise_item = True`` is worn, this adjective is
+    # injected into the wearer's sdesc between the physical descriptor
+    # and the keyword (e.g. ``"a tall lean masked droog"``).  Empty
+    # string means no contribution.  Authors set per item type
+    # (``"masked"``, ``"hooded"``, ``"helmeted"``, etc.).  Adjectives
+    # not in :data:`world.identity._DISGUISE_ADJECTIVE_PRIORITY` are
+    # admitted at the lowest priority rank, so new disguise types ship
+    # via item attribute alone without a code edit.  Honoured only when
+    # ``is_disguise_item`` is also ``True`` (red-flag style standard);
+    # otherwise skipped with a soft warning.
+    disguise_adjective = AttributeProperty("", autocreate=True)
+
+    # Brief noun phrase used by the distinguishing-feature clothing
+    # selector (e.g. ``"black balaclava"`` → ``"in a black balaclava"``).
+    # Empty string falls back to the item's ``key``.  See
+    # ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Distinguishing Feature
+    # Derivation".
+    worn_sdesc_short = AttributeProperty("", autocreate=True)
+
+    # When worn, suppresses the hair fallback in the distinguishing-
+    # feature chain.  A hooded character with red braids reads
+    # ``"a tall lean hooded droog"``, not ``"… with red braids"``.
+    # Scope is feature-fallback only; longdesc gating lives with the
+    # existing clothing-coverage code.
+    covers_hair = AttributeProperty(False, autocreate=True)
     
     # Multiple style properties for combination states
     style_properties = AttributeProperty({}, autocreate=True)

--- a/world/identity.py
+++ b/world/identity.py
@@ -645,6 +645,7 @@ def compose_sdesc(
     descriptor: str,
     keyword: str,
     feature: str | None = None,
+    disguise_adjective: str | None = None,
 ) -> str:
     """Assemble a short description string from its components.
 
@@ -659,15 +660,117 @@ def compose_sdesc(
         feature: Optional distinguishing feature clause (e.g.
             ``"in a Black Trenchcoat"``).  If ``None`` or empty,
             the sdesc has no feature suffix.
+        disguise_adjective: Optional disguise adjective injected
+            between descriptor and keyword (e.g. ``"masked"`` →
+            ``"lanky masked man"``).  If ``None`` or empty, the sdesc
+            shape is unchanged from its three-argument form.  See
+            :func:`get_disguise_adjective`.
 
     Returns:
-        Composed sdesc, e.g. ``"lanky man in a Black Trenchcoat"``
-        or ``"compact woman"`` (no article prefix).
+        Composed sdesc, e.g. ``"lanky man in a Black Trenchcoat"``,
+        ``"lanky masked man in a Black Trenchcoat"``, or
+        ``"compact woman"`` (no article prefix).
     """
-    base = f"{descriptor} {keyword}"
+    if disguise_adjective:
+        base = f"{descriptor} {disguise_adjective} {keyword}"
+    else:
+        base = f"{descriptor} {keyword}"
     if feature:
         return f"{base} {feature}"
     return base
+
+
+# =========================================================================
+# Disguise Adjective
+# =========================================================================
+#
+# See specs/IDENTITY_RECOGNITION_SPEC.md §"Disguise Adjective" for the
+# design rationale.  The adjective is the visible "red flag": when an
+# item flagged ``is_disguise_item = True`` is worn, its
+# ``disguise_adjective`` is injected into the wearer's sdesc so
+# observers can immediately tell someone is disguising themselves.
+
+#: Priority ranks for disguise adjectives, lowest rank wins.  The
+#: ranking captures *identity-defining-ness*: a mask hides the face
+#: more than a hood, so ``"masked"`` outranks ``"hooded"`` when both
+#: are worn.  Adjectives not in this table are admitted at rank 999
+#: (alphabetical tiebreak), so authors can ship new disguise types via
+#: item attribute alone without editing this table.
+_DISGUISE_ADJECTIVE_PRIORITY: dict[str, int] = {
+    "masked": 1,
+    "helmeted": 2,
+    "cowled": 3,
+    "hooded": 4,
+    "goggled": 5,
+    "veiled": 6,
+    "wigged": 7,
+}
+
+#: Sentinel rank for adjectives missing from the priority table.
+_DISGUISE_ADJECTIVE_UNKNOWN_RANK: int = 999
+
+
+def get_disguise_adjective(char: Any) -> str | None:
+    """Return the most-prominent disguise adjective for a character.
+
+    Walks the wearer's worn items via
+    :meth:`typeclasses.clothing_mixin.ClothingMixin.get_worn_items`,
+    collects non-empty ``disguise_adjective`` values from items also
+    flagged ``is_disguise_item = True``, and returns the highest-
+    priority adjective per :data:`_DISGUISE_ADJECTIVE_PRIORITY`.
+
+    Adjectives missing from the priority table are admitted at
+    :data:`_DISGUISE_ADJECTIVE_UNKNOWN_RANK` (alphabetical tiebreak),
+    so authors can ship new disguise types via item attribute alone.
+
+    Items with ``disguise_adjective`` set but ``is_disguise_item`` not
+    ``True`` are skipped with a soft warning: the adjective is a red-
+    flag style standard reserved for the disguise taxonomy.
+
+    Characters without :meth:`get_worn_items` (e.g. mocks, NPCs that
+    cannot wear clothing) yield ``None``.
+
+    Args:
+        char: The character whose worn items are inspected.
+
+    Returns:
+        The winning adjective string (e.g. ``"masked"``), or ``None``
+        when no eligible adjective is contributed.
+    """
+    get_worn = getattr(char, "get_worn_items", None)
+    if get_worn is None:
+        return None
+
+    candidates: list[str] = []
+    for item in get_worn():
+        adjective = getattr(item, "disguise_adjective", "") or ""
+        if not adjective:
+            continue
+        if not getattr(item, "is_disguise_item", False):
+            logger.log_warn(
+                f"Item {item!r} on {char!r} has disguise_adjective="
+                f"{adjective!r} but is_disguise_item is not True; "
+                f"skipping (disguise adjectives are reserved for the "
+                f"disguise taxonomy)."
+            )
+            continue
+        candidates.append(adjective)
+
+    if not candidates:
+        return None
+
+    # Sort by (priority rank, adjective) so unknowns tie-break
+    # alphabetically and the lowest rank (most identity-defining) wins.
+    candidates.sort(
+        key=lambda adj: (
+            _DISGUISE_ADJECTIVE_PRIORITY.get(
+                adj, _DISGUISE_ADJECTIVE_UNKNOWN_RANK
+            ),
+            adj,
+        )
+    )
+    return candidates[0]
+
 
 
 # =========================================================================

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -687,6 +687,43 @@ DEV_HOODIE = {
     # "tags": [("clothing", "type"), ("hoodie", "category"), ("developer_gear", "specialty")]
 }
 
+# Canonical disguise item — the foundational red-flag head-covering.
+# Demonstrates the full Phase 3 disguise surface in one prototype:
+#   * is_disguise_item       → marks it as belonging to the disguise taxonomy
+#   * disguise_essential     → contributes to the identity signature when worn
+#   * disguise_type_id       → the per-type hash key (multiple balaclavas are
+#                              indistinguishable; swapping one for another of
+#                              the same type does NOT shift Apparent UID)
+#   * disguise_adjective     → "masked" red-flag prefix in observer sdescs
+#   * worn_sdesc_short       → brief noun phrase used in the distinguishing-
+#                              feature clause (solo-disguise carve-out)
+#   * covers_hair            → suppresses hair fallback under the head covering
+BALACLAVA = {
+    "prototype_key": "BALACLAVA",
+    "key": "black balaclava",
+    "aliases": ["balaclava", "ski mask", "mask"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A heavy knit balaclava in matte black, woven tight enough to swallow detail. Only a narrow eye-slit interrupts the seamless coverage; the wearer's features collapse into shadow, and even hair colour is hidden by the snug pull of the fabric.",
+    "attrs": [
+        # Clothing attributes
+        ("coverage", ["head"]),
+        ("worn_desc", "A snug {color}black|n balaclava pulled tight over {their} head, devouring features and hair alike behind a narrow eye-slit"),
+        ("layer", 2),  # Regular clothing layer
+        ("color", "black"),
+        ("material", "wool"),
+        ("weight", 0.2),
+
+        # Disguise surface — see specs/IDENTITY_RECOGNITION_SPEC.md
+        # §"Disguise Items" and §"Disguise Adjective".
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "balaclava"),
+        ("disguise_adjective", "masked"),
+        ("worn_sdesc_short", "black balaclava"),
+        ("covers_hair", True),
+    ],
+}
+
 # Classic blue jeans with functional styling
 BLUE_JEANS = {
     "prototype_key": "BLUE_JEANS",

--- a/world/tests/test_character_identity.py
+++ b/world/tests/test_character_identity.py
@@ -34,9 +34,21 @@ from world.tests._identity_helpers import (
 
 
 def _make_item(key="Kitchen Knife"):
-    """Return a minimal mock item with a ``.key``."""
+    """Return a minimal mock item with a ``.key`` and disguise defaults.
+
+    Disguise-related attributes are pinned to falsy defaults so the
+    distinguishing-feature chain treats these as ordinary clothing
+    (not auto-truthy ``MagicMock`` placeholders that would, e.g.,
+    cause ``worn_sdesc_short`` to mask ``key``).
+    """
     item = MagicMock()
     item.key = key
+    item.is_disguise_item = False
+    item.disguise_essential = False
+    item.disguise_type_id = ""
+    item.disguise_adjective = ""
+    item.worn_sdesc_short = ""
+    item.covers_hair = False
     return item
 
 

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -664,6 +664,42 @@ class TestComposeSdesc(TestCase):
     def test_empty_feature_ignored(self) -> None:
         self.assertEqual(compose_sdesc("gaunt", "droog", ""), "gaunt droog")
 
+    # -- Disguise adjective param --
+
+    def test_disguise_adjective_injected_between_descriptor_and_keyword(
+        self,
+    ) -> None:
+        self.assertEqual(
+            compose_sdesc(
+                "lanky", "man", disguise_adjective="masked"
+            ),
+            "lanky masked man",
+        )
+
+    def test_disguise_adjective_with_feature(self) -> None:
+        self.assertEqual(
+            compose_sdesc(
+                "lanky",
+                "man",
+                "in a Black Trenchcoat",
+                disguise_adjective="masked",
+            ),
+            "lanky masked man in a Black Trenchcoat",
+        )
+
+    def test_none_adjective_unchanged(self) -> None:
+        """``None`` adjective preserves the three-arg shape exactly."""
+        self.assertEqual(
+            compose_sdesc("lanky", "man", "in a Black Trenchcoat", None),
+            "lanky man in a Black Trenchcoat",
+        )
+
+    def test_empty_adjective_unchanged(self) -> None:
+        self.assertEqual(
+            compose_sdesc("lanky", "man", disguise_adjective=""),
+            "lanky man",
+        )
+
     # -- End-to-end integration: descriptor lookup → compose --
 
     def test_end_to_end_from_table(self) -> None:
@@ -790,15 +826,34 @@ class _SignatureMockCharacter:
 class _FakeDisguiseItem:
     """Lightweight stand-in for ``typeclasses.items.Item`` in signature tests.
 
-    Mirrors the duck-typed surface ``get_essential_item_type_ids`` reads:
-    ``disguise_essential`` (bool) and ``disguise_type_id`` (str).
+    Mirrors the duck-typed surface read by the engine helpers:
+    ``disguise_essential`` / ``disguise_type_id`` (signature),
+    ``is_disguise_item`` / ``disguise_adjective`` (sdesc adjective),
+    ``worn_sdesc_short`` / ``covers_hair`` / ``key`` (distinguishing
+    feature).
     """
 
     def __init__(
-        self, *, disguise_essential: bool = False, disguise_type_id: str = ""
+        self,
+        *,
+        disguise_essential: bool = False,
+        disguise_type_id: str = "",
+        is_disguise_item: bool = False,
+        disguise_adjective: str = "",
+        worn_sdesc_short: str = "",
+        covers_hair: bool = False,
+        key: str = "fake item",
     ) -> None:
         self.disguise_essential = disguise_essential
         self.disguise_type_id = disguise_type_id
+        self.is_disguise_item = is_disguise_item
+        self.disguise_adjective = disguise_adjective
+        self.worn_sdesc_short = worn_sdesc_short
+        self.covers_hair = covers_hair
+        self.key = key
+
+    def __repr__(self) -> str:
+        return f"<_FakeDisguiseItem key={self.key!r}>"
 
 
 class TestGetEssentialItemTypeIds(TestCase):
@@ -978,6 +1033,148 @@ class TestEssentialItemsAffectSignatureAndUid(TestCase):
             )
         )
         self.assertNotEqual(balaclava_uid, wig_uid)
+
+
+class TestGetDisguiseAdjective(TestCase):
+    """``get_disguise_adjective`` resolves the most-prominent worn adjective."""
+
+    def test_no_worn_items_yields_none(self) -> None:
+        from world.identity import get_disguise_adjective
+
+        char = _SignatureMockCharacter()
+        self.assertIsNone(get_disguise_adjective(char))
+
+    def test_character_without_get_worn_items_yields_none(self) -> None:
+        """Defensive: NPCs/mocks lacking the wear API simply opt out."""
+        from world.identity import get_disguise_adjective
+
+        class _Bare:
+            pass
+
+        self.assertIsNone(get_disguise_adjective(_Bare()))
+
+    def test_single_disguise_item_returns_its_adjective(self) -> None:
+        from world.identity import get_disguise_adjective
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    is_disguise_item=True,
+                    disguise_adjective="masked",
+                    key="black balaclava",
+                )
+            ]
+        )
+        self.assertEqual(get_disguise_adjective(char), "masked")
+
+    def test_priority_table_lowest_rank_wins(self) -> None:
+        """``masked`` (rank 1) outranks ``hooded`` (rank 4)."""
+        from world.identity import get_disguise_adjective
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    is_disguise_item=True,
+                    disguise_adjective="hooded",
+                    key="grey hood",
+                ),
+                _FakeDisguiseItem(
+                    is_disguise_item=True,
+                    disguise_adjective="masked",
+                    key="black balaclava",
+                ),
+            ]
+        )
+        self.assertEqual(get_disguise_adjective(char), "masked")
+
+    def test_unknown_adjective_admitted_at_lowest_rank(self) -> None:
+        """Unknown adjectives still ship — they just lose to known ones."""
+        from world.identity import get_disguise_adjective
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    is_disguise_item=True,
+                    disguise_adjective="bedazzled",
+                    key="rhinestone visor",
+                ),
+                _FakeDisguiseItem(
+                    is_disguise_item=True,
+                    disguise_adjective="hooded",
+                    key="grey hood",
+                ),
+            ]
+        )
+        self.assertEqual(get_disguise_adjective(char), "hooded")
+
+    def test_unknown_adjective_alone_wins(self) -> None:
+        """A solo unknown adjective should still be picked, not dropped."""
+        from world.identity import get_disguise_adjective
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    is_disguise_item=True,
+                    disguise_adjective="bedazzled",
+                    key="rhinestone visor",
+                )
+            ]
+        )
+        self.assertEqual(get_disguise_adjective(char), "bedazzled")
+
+    def test_unknown_adjectives_tiebreak_alphabetically(self) -> None:
+        """Two unknowns at rank 999 → alphabetical first wins (deterministic)."""
+        from world.identity import get_disguise_adjective
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    is_disguise_item=True,
+                    disguise_adjective="zonked",
+                    key="z",
+                ),
+                _FakeDisguiseItem(
+                    is_disguise_item=True,
+                    disguise_adjective="bedazzled",
+                    key="b",
+                ),
+            ]
+        )
+        self.assertEqual(get_disguise_adjective(char), "bedazzled")
+
+    def test_non_disguise_item_with_adjective_skipped_with_warning(
+        self,
+    ) -> None:
+        """Adjective on non-disguise item is ignored (red-flag standard)."""
+        from world.identity import get_disguise_adjective
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    is_disguise_item=False,
+                    disguise_adjective="masked",
+                    key="ceremonial mask",
+                )
+            ]
+        )
+        with patch("world.identity.logger.log_warn") as mock_warn:
+            self.assertIsNone(get_disguise_adjective(char))
+            mock_warn.assert_called_once()
+
+    def test_empty_adjective_string_ignored(self) -> None:
+        """Items without a populated adjective contribute nothing."""
+        from world.identity import get_disguise_adjective
+
+        char = _SignatureMockCharacter(
+            worn_items=[
+                _FakeDisguiseItem(
+                    is_disguise_item=True,
+                    disguise_adjective="",
+                    key="plain hat",
+                )
+            ]
+        )
+        self.assertIsNone(get_disguise_adjective(char))
 
 
 class TestGetIdentitySignature(TestCase):


### PR DESCRIPTION
## Summary
- Disguise items can now inject a single `masked` / `hooded` / etc. adjective between the descriptor and keyword in observer sdescs (e.g. `a tall lean masked droog`).
- Adjective is a **visual-only red flag** — contributes nothing to the identity signature; recognition still keys solely on overrides + essential `disguise_type_id`s.
- Adds the supporting feature-clause work: `worn_sdesc_short` for brief noun phrases, `covers_hair` to suppress the hair fallback, and a partition rule that prefers non-disguise clothing as the feature source (with a naked-but-masked carve-out so a lone balaclava still reads as `in a black balaclava`).
- Ships a canonical `BALACLAVA` prototype demonstrating the full disguise surface end-to-end.

## Changes
- `typeclasses/items.py` — three new `AttributeProperty`s on `Item`: `disguise_adjective`, `worn_sdesc_short`, `covers_hair`.
- `world/identity.py` — `_DISGUISE_ADJECTIVE_PRIORITY` table (`masked > helmeted > cowled > hooded > goggled > veiled > wigged`); `get_disguise_adjective(char)` walks worn items, honours adjective only when `is_disguise_item=True` (skip + soft warn otherwise), admits unknown adjectives at rank 999 with alphabetical tiebreak so authors can ship new disguise types via item attribute alone. `compose_sdesc` gains an optional `disguise_adjective` kwarg (defaults to `None`; the `world/emote.py` short-form caller is intentionally left unchanged).
- `typeclasses/characters.py` — `get_distinguishing_feature` partitions worn items into non-disguise vs disguise pools and prefers the former; uses `worn_sdesc_short` when present, falls back to `item.key`; suppresses the hair fallback when any worn item declares `covers_hair=True`. `get_sdesc` threads the adjective through `compose_sdesc`.
- `world/tests/test_identity.py` — extend `_FakeDisguiseItem`; new `TestGetDisguiseAdjective` covers priority winner, unknown-rank-999 admission, alphabetical tiebreak, non-disguise skip+warn, empty/missing worn-items API. Extended `TestComposeSdesc` covers the new param.
- `world/tests/test_character_identity.py` — pin disguise attrs to falsy defaults on `_make_item` so `MagicMock` auto-attribute behaviour stops poisoning `worn_sdesc_short` lookups.
- `specs/IDENTITY_RECOGNITION_SPEC.md` — rewrite §"Distinguishing Feature Derivation" clothing + hair subsections to cover `worn_sdesc_short`, the disguise-skip carve-out, and `covers_hair`. Add new §"Disguise Adjective" subsection with the priority table, unknown-adjective contract, and the visual-only / signature-decoupled invariant.
- `world/prototypes.py` — canonical `BALACLAVA` prototype: `is_disguise_item`, `disguise_essential`, `disguise_type_id="balaclava"`, `disguise_adjective="masked"`, `worn_sdesc_short="black balaclava"`, `covers_hair=True`.

## Test Plan
- `docker exec gelatinous evennia test world` → **581/581 pass**.
- Live server reloaded post-merge for in-game smoke testing (spawn balaclava → wear → confirm `masked` adjective + hair feature suppressed + solo carve-out fires; add second clothing item → partition fires; remove balaclava → adjective drops, hair restored, recognition reverses).