### PR TITLE
Snapshot pre-mutation sdesc and article-grammar clothing broadcasts (PR-E)

### DIFF
--- a/commands/CmdClothing.py
+++ b/commands/CmdClothing.py
@@ -6,6 +6,7 @@
 # - CmdZip/CmdUnzip: Closure management
 #
 from evennia import Command
+from evennia.utils.utils import iter_to_str
 
 from world.combat.constants import (
     STYLE_ADJUSTABLE,
@@ -15,7 +16,49 @@ from world.combat.constants import (
     STYLE_STATE_UNZIPPED,
     STYLE_STATE_ZIPPED,
 )
+from world.grammar import get_article
 from world.identity_utils import msg_room_identity
+
+
+def _snapshot_actor_names(caller, char_refs):
+    """Capture per-observer display names for *char_refs* before mutation.
+
+    Returns a ``pre_resolved_refs`` mapping suitable for
+    :func:`world.identity_utils.msg_room_identity` of the shape
+    ``{placeholder: {observer: display_name}}``.
+
+    This is the snapshot idiom for actions that mutate the actor's own
+    sdesc inputs (clothing, future ``wield``/``appear``).  Without it,
+    observers receive the broadcast describing the actor's *post-action*
+    sdesc, which produces nonsense like "a lithe masked droog in a
+    black balaclava puts on a black balaclava" — the message describes
+    the actor as if the action had already taken effect on their
+    appearance.  See specs/IDENTITY_RECOGNITION_SPEC.md
+    §"Action Broadcast Sdesc Stability".
+
+    Defensive: snapshots every placeholder in *char_refs* so future
+    multi-actor templates (e.g. forced equip with ``{actor}`` and
+    ``{victim}``) get stable names too, not only the placeholder we
+    know mutates today.
+    """
+    location = caller.location
+    if location is None:
+        return {}
+    observers = [
+        obs
+        for obs in location.contents
+        if obs is not caller and hasattr(obs, "msg")
+    ]
+    return {
+        placeholder: {obs: char.get_display_name(obs) for obs in observers}
+        for placeholder, char in char_refs.items()
+    }
+
+
+def _articled(item_key: str) -> str:
+    """Return ``"a black balaclava"`` / ``"an axe handle"`` for *item_key*."""
+    return f"{get_article(item_key)} {item_key}"
+
 
 class CmdWear(Command):
     """
@@ -71,17 +114,21 @@ class CmdWear(Command):
             caller.msg(f"You're already wearing {item.key}.")
             return
         
-        # Attempt to wear the item
+        # Attempt to wear the item.  Snapshot observer names BEFORE
+        # mutating worn_items so the broadcast describes the actor as
+        # they appeared at the moment they began the action.
+        char_refs = {"actor": caller}
+        pre_resolved = _snapshot_actor_names(caller, char_refs)
         success, message = caller.wear_item(item)
         caller.msg(message)
-        
+
         if success:
-            # Message to room
             msg_room_identity(
                 location=caller.location,
-                template=f"{{actor}} puts on {item.key}.",
-                char_refs={"actor": caller},
+                template=f"{{actor}} puts on {_articled(item.key)}.",
+                char_refs=char_refs,
                 exclude=[caller],
+                pre_resolved_refs=pre_resolved,
             )
 
 
@@ -120,20 +167,28 @@ class CmdRemove(Command):
             if not worn_items:
                 caller.msg("You're not wearing anything.")
                 return
-            
+
+            # Snapshot observer names BEFORE mutating worn state so the
+            # broadcast describes the actor as they appeared at the
+            # moment they began the action.
+            char_refs = {"actor": caller}
+            pre_resolved = _snapshot_actor_names(caller, char_refs)
+
             removed_items = []
             for item in worn_items:
                 success, message = caller.remove_item(item)
                 if success:
                     removed_items.append(item.key)
-            
+
             if removed_items:
                 caller.msg(f"You remove: {', '.join(removed_items)}")
+                articled = iter_to_str([_articled(key) for key in removed_items])
                 msg_room_identity(
                     location=caller.location,
-                    template="{actor} removes several items.",
-                    char_refs={"actor": caller},
+                    template=f"{{actor}} removes {articled}.",
+                    char_refs=char_refs,
                     exclude=[caller],
+                    pre_resolved_refs=pre_resolved,
                 )
             else:
                 caller.msg("You couldn't remove anything.")
@@ -154,6 +209,10 @@ class CmdRemove(Command):
             return
         
         # STICKY GRENADE WARNING - Check for stuck grenades before removal
+        # Snapshot actor names BEFORE remove_item mutates worn state.
+        char_refs = {"actor": caller}
+        pre_resolved = _snapshot_actor_names(caller, char_refs)
+
         if item.db.stuck_grenade is not None:
             grenade = item.db.stuck_grenade
             
@@ -186,16 +245,17 @@ class CmdRemove(Command):
                     f"The grenade will remain stuck to the armor.\n"
                 )
             
-            # Warn the room
+            # Warn the room (possessive form: "their X" stays as-is)
             msg_room_identity(
                 location=caller.location,
                 template=(
                     f"|R{{actor}} carefully removes their {item.key} - "
-                    f"the magnetically attached {grenade.key} moves "
+                    f"the magnetically attached {_articled(grenade.key)} moves "
                     f"with it!|n"
                 ),
-                char_refs={"actor": caller},
+                char_refs=char_refs,
                 exclude=[caller],
+                pre_resolved_refs=pre_resolved,
             )
         
         # Remove the item
@@ -207,9 +267,10 @@ class CmdRemove(Command):
             if item.db.stuck_grenade is None:
                 msg_room_identity(
                     location=caller.location,
-                    template=f"{{actor}} removes {item.key}.",
-                    char_refs={"actor": caller},
+                    template=f"{{actor}} removes {_articled(item.key)}.",
+                    char_refs=char_refs,
                     exclude=[caller],
+                    pre_resolved_refs=pre_resolved,
                 )
 
 
@@ -280,6 +341,13 @@ class CmdRollUp(Command):
             caller.msg(f"That wouldn't change anything about the {item.key}.")
             return
         
+        # Snapshot observer names BEFORE the style change so the
+        # broadcast describes the actor as they appeared at the
+        # moment they began the action (rolling/unrolling can
+        # change worn_sdesc_short and thus the sdesc).
+        char_refs = {"actor": caller}
+        pre_resolved = _snapshot_actor_names(caller, char_refs)
+
         # Apply the style change
         success = item.set_style_property(STYLE_ADJUSTABLE, target_state)
         
@@ -288,17 +356,19 @@ class CmdRollUp(Command):
                 caller.msg(f"You roll up the {item.key}.")
                 msg_room_identity(
                     location=caller.location,
-                    template=f"{{actor}} rolls up {item.key}.",
-                    char_refs={"actor": caller},
+                    template=f"{{actor}} rolls up {_articled(item.key)}.",
+                    char_refs=char_refs,
                     exclude=[caller],
+                    pre_resolved_refs=pre_resolved,
                 )
             else:
                 caller.msg(f"You unroll the {item.key}.")
                 msg_room_identity(
                     location=caller.location,
-                    template=f"{{actor}} unrolls {item.key}.",
-                    char_refs={"actor": caller},
+                    template=f"{{actor}} unrolls {_articled(item.key)}.",
+                    char_refs=char_refs,
                     exclude=[caller],
+                    pre_resolved_refs=pre_resolved,
                 )
         else:
             caller.msg(f"You can't {action} the {item.key}.")
@@ -391,6 +461,13 @@ class CmdZip(Command):
             caller.msg(f"That wouldn't change anything about the {item.key}.")
             return
         
+        # Snapshot observer names BEFORE the style change so the
+        # broadcast describes the actor as they appeared at the
+        # moment they began the action (zipping/buttoning can
+        # change worn_sdesc_short and thus the sdesc).
+        char_refs = {"actor": caller}
+        pre_resolved = _snapshot_actor_names(caller, char_refs)
+
         # Apply the style change
         success = item.set_style_property(STYLE_CLOSURE, target_state)
         
@@ -398,9 +475,10 @@ class CmdZip(Command):
             caller.msg(f"You {action} the {item.key}.")
             msg_room_identity(
                 location=caller.location,
-                template=f"{{actor}} {action_past} {item.key}.",
-                char_refs={"actor": caller},
+                template=f"{{actor}} {action_past} {_articled(item.key)}.",
+                char_refs=char_refs,
                 exclude=[caller],
+                pre_resolved_refs=pre_resolved,
             )
         else:
             caller.msg(f"You can't {action} the {item.key}.")

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -748,7 +748,14 @@ This affects every system that sends messages to rooms: combat, movement, commun
 A centralized helper replaces direct `msg_contents()` calls for any message referencing characters:
 
 ```python
-def msg_room_identity(location, template, char_refs, exclude=None):
+def msg_room_identity(
+    location,
+    template,
+    char_refs,
+    exclude=None,
+    pre_resolved_refs=None,
+    **kwargs,
+):
     """Send identity-aware message to all observers in a room.
 
     Args:
@@ -757,15 +764,12 @@ def msg_room_identity(location, template, char_refs, exclude=None):
         char_refs: Dict mapping placeholder names to Character objects.
             e.g., {"actor": attacker_obj, "target": target_obj}
         exclude: Characters to exclude from receiving the message.
+        pre_resolved_refs: Optional snapshot mapping of the shape
+            ``{placeholder: {observer: display_name}}``.  When set,
+            an observer's entry under a placeholder is used verbatim
+            instead of calling ``char.get_display_name(observer)``.
+            See "Action Broadcast Sdesc Stability" below.
     """
-    for observer in location.contents_get(exclude=exclude):
-        if not hasattr(observer, "msg"):
-            continue
-        resolved = template
-        for placeholder, char in char_refs.items():
-            display_name = char.get_display_name(observer)
-            resolved = resolved.replace(f"{{{placeholder}}}", display_name)
-        observer.msg(resolved)
 ```
 
 Usage:
@@ -789,6 +793,87 @@ With 20 observers and 2 character references: 40 dict lookups + 40 string replac
 **NPC memory storage**: An NPC that has encountered 500 unique characters stores a dict with 500 keys. Each entry is ~500 bytes of metadata. Total: ~250KB per well-traveled NPC. Acceptable.
 
 **Scaling concern**: The real cost is not runtime performance but **refactoring scope**. Every `msg_contents()` call and every `.key` reference in message strings across the codebase must be converted to use `msg_room_identity` or route through `get_display_name`. This is a large, methodical effort (Phase 2).
+
+### Action Broadcast Sdesc Stability
+
+A subtle hazard arises whenever the action being broadcast *mutates the
+actor's own sdesc inputs*.  The canonical example is a disguise item:
+
+```python
+char_refs = {"actor": caller}
+caller.wear_item(item)        # mutates worn_items, changing the sdesc
+msg_room_identity(
+    location=caller.location,
+    template=f"{{actor}} puts on {item.key}.",
+    char_refs=char_refs,
+    exclude=[caller],
+)
+```
+
+By the time `msg_room_identity` calls `caller.get_display_name(observer)`,
+the worn-items mutation has already taken effect.  The actor's sdesc now
+includes the disguise's `disguise_adjective` and `worn_sdesc_short`
+feature, producing a broadcast like:
+
+> *a lithe masked droog in a black balaclava puts on a black balaclava.*
+
+The action message describes the actor as if the action had already
+landed on their appearance — the actor cannot be the subject of the
+"puts on a balaclava" sentence while *already wearing* the balaclava.
+
+**Snapshot idiom.**  Capture per-observer display names *before* mutating
+state, then pass them via `pre_resolved_refs`:
+
+```python
+char_refs = {"actor": caller}
+pre_resolved = {
+    placeholder: {
+        obs: char.get_display_name(obs)
+        for obs in caller.location.contents
+        if obs is not caller and hasattr(obs, "msg")
+    }
+    for placeholder, char in char_refs.items()
+}
+caller.wear_item(item)
+msg_room_identity(
+    location=caller.location,
+    template=f"{{actor}} puts on {item.key}.",
+    char_refs=char_refs,
+    exclude=[caller],
+    pre_resolved_refs=pre_resolved,
+)
+```
+
+The snapshot is **defensive**: every placeholder in `char_refs` is
+captured, not only the one known to mutate today.  This protects future
+multi-actor templates (e.g. a forced-equip command with both
+`{actor}` and `{victim}`) without requiring per-call audits.
+
+**When to apply the snapshot idiom.**  Any command whose body mutates
+attributes that feed into `compose_sdesc` *for an actor referenced by
+the broadcast template*:
+
+- `wear` / `remove` (clothing changes feature partition and
+  disguise adjective)
+- `rollup` / `unroll`, `zip` / `unzip` (style changes can swap
+  `worn_sdesc_short`)
+- Future: `wield` / `unwield` if weapons ever feed sdesc; `appear`
+  command overrides; transformation effects.
+
+Commands that mutate non-broadcast actors (e.g. an admin command
+forcing another character's sdesc) need the snapshot for *that*
+character, not the caller — `_snapshot_actor_names` snapshots every
+placeholder defensively for exactly this reason.
+
+**Article grammar.**  The same neutral-introduction broadcasts that
+benefit from the snapshot also need indefinite-article grammar on the
+item being acted upon: `"puts on a black balaclava"` not
+`"puts on black balaclava"`.  Use `world.grammar.get_article` (or the
+`_articled` helper in `commands/CmdClothing.py`) when interpolating an
+item key into the template; for lists of items use
+`evennia.utils.utils.iter_to_str` over `[_articled(k) for k in keys]`.
+Error messages and possessive forms (`"the X"`, `"their X"`) are left
+untouched — only neutral introductions need the article fix.
 
 ---
 

--- a/typeclasses/clothing_mixin.py
+++ b/typeclasses/clothing_mixin.py
@@ -7,6 +7,8 @@ coverage queries, and the clothing coverage map builder for Character objects.
 Extracted from typeclasses/characters.py in Phase 4 refactoring.
 """
 
+from world.grammar import get_article
+
 
 class ClothingMixin:
     """
@@ -207,7 +209,7 @@ class ClothingMixin:
 
             location_items.insert(insert_index, item)
 
-        return True, f"You put on {item.key}."
+        return True, f"You put on {get_article(item.key)} {item.key}."
 
     def remove_item(self, item):
         """
@@ -286,7 +288,7 @@ class ClothingMixin:
                     if not items:
                         del self.worn_items[location]
 
-        return True, f"You remove {item.key}."
+        return True, f"You remove {get_article(item.key)} {item.key}."
 
     def is_item_worn(self, item):
         """

--- a/world/identity_utils.py
+++ b/world/identity_utils.py
@@ -26,6 +26,7 @@ def msg_room_identity(
     template: str,
     char_refs: dict[str, "Character"],
     exclude: list | None = None,
+    pre_resolved_refs: dict[str, dict] | None = None,
     **kwargs,
 ) -> None:
     """Send an identity-aware message to all observers in a room.
@@ -44,6 +45,20 @@ def msg_room_identity(
         exclude: Characters/objects to exclude from receiving the
             message.  Typically the actor and/or target who receive
             separate first-person messages.
+        pre_resolved_refs: Optional pre-computed display-name snapshots,
+            shaped ``{placeholder: {observer: display_name_str}}``.
+            When an observer has an entry under a placeholder, that
+            string is used verbatim instead of calling
+            ``char.get_display_name(observer)``.  This is the snapshot
+            idiom used by actions whose effect mutates the actor's own
+            sdesc inputs (e.g. putting on a disguise item) — the
+            command captures pre-mutation names *before* mutating
+            state, then passes them here so the broadcast describes
+            the actor as they appeared at the moment they began the
+            action.  See specs/IDENTITY_RECOGNITION_SPEC.md
+            §"Action Broadcast Sdesc Stability".  Missing placeholder
+            keys or missing observer keys silently fall through to
+            the live ``get_display_name`` lookup.
         **kwargs: Extra keyword arguments passed through to each
             ``observer.msg()`` call (e.g. ``type="say"``).
 
@@ -60,6 +75,7 @@ def msg_room_identity(
     Observer B (knows neither): ``"A lanky man attacks a wiry droog with a knife!"``
     """
     exclude_set = set(exclude) if exclude else set()
+    pre_resolved_refs = pre_resolved_refs or {}
 
     # Determine which placeholder appears first in the template
     # so we can capitalize its display name for proper sentence casing.
@@ -81,7 +97,14 @@ def msg_room_identity(
 
         resolved = template
         for placeholder, char in char_refs.items():
-            display_name = char.get_display_name(observer)
+            snapshot_for_placeholder = pre_resolved_refs.get(placeholder)
+            if (
+                snapshot_for_placeholder is not None
+                and observer in snapshot_for_placeholder
+            ):
+                display_name = snapshot_for_placeholder[observer]
+            else:
+                display_name = char.get_display_name(observer)
             if placeholder == first_placeholder:
                 display_name = capitalize_first(display_name)
             resolved = resolved.replace(f"{{{placeholder}}}", display_name)

--- a/world/tests/test_clothing_broadcast.py
+++ b/world/tests/test_clothing_broadcast.py
@@ -1,0 +1,146 @@
+"""
+Tests for clothing broadcast snapshot + article grammar (PR-E).
+
+Covers the helper utilities ``_snapshot_actor_names`` and ``_articled``
+in :mod:`commands.CmdClothing` that ensure room broadcasts for
+``wear`` / ``remove`` / ``rollup`` / ``zip`` describe the actor's
+*pre-mutation* sdesc and use indefinite-article grammar for item names.
+
+See ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Action Broadcast Sdesc
+Stability".
+
+Run via::
+
+    evennia test world.tests.test_clothing_broadcast
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from evennia.utils.utils import iter_to_str
+
+from commands.CmdClothing import _articled, _snapshot_actor_names
+
+
+class TestArticled(TestCase):
+    """Indefinite-article grammar for item keys."""
+
+    def test_consonant_initial(self):
+        self.assertEqual(_articled("black balaclava"), "a black balaclava")
+
+    def test_vowel_initial(self):
+        self.assertEqual(_articled("axe handle"), "an axe handle")
+
+    def test_silent_h_uses_an(self):
+        # get_article handles "hour" as vowel-sound
+        self.assertEqual(_articled("hour glass"), "an hour glass")
+
+
+class TestArticledIterToStr(TestCase):
+    """`iter_to_str` over articled keys produces natural lists."""
+
+    def test_single(self):
+        self.assertEqual(
+            iter_to_str([_articled("jacket")]),
+            "a jacket",
+        )
+
+    def test_two(self):
+        self.assertEqual(
+            iter_to_str([_articled("jacket"), _articled("axe")]),
+            "a jacket and an axe",
+        )
+
+    def test_three(self):
+        self.assertEqual(
+            iter_to_str([
+                _articled("jacket"),
+                _articled("axe"),
+                _articled("balaclava"),
+            ]),
+            "a jacket, an axe, and a balaclava",
+        )
+
+
+class TestSnapshotActorNames(TestCase):
+    """Pre-mutation observer-name capture for char_refs."""
+
+    def _observer(self, name):
+        obs = MagicMock()
+        obs.msg = MagicMock()  # has msg attr
+        obs._test_name = name
+        return obs
+
+    def _itemobj(self):
+        # An object without a msg attribute — must be skipped.
+        item = MagicMock(spec=[])
+        return item
+
+    def test_snapshot_excludes_caller(self):
+        caller = MagicMock()
+        caller.msg = MagicMock()
+        alice = self._observer("alice")
+        bob = self._observer("bob")
+        room = MagicMock()
+        room.contents = [caller, alice, bob]
+        caller.location = room
+
+        # actor.get_display_name returns observer-specific names
+        caller.get_display_name = MagicMock(
+            side_effect=lambda obs: f"PRE-{obs._test_name}"
+        )
+
+        snapshot = _snapshot_actor_names(caller, {"actor": caller})
+
+        self.assertIn("actor", snapshot)
+        self.assertEqual(
+            snapshot["actor"],
+            {alice: "PRE-alice", bob: "PRE-bob"},
+        )
+        # Caller never asked for own display name
+        for call in caller.get_display_name.call_args_list:
+            self.assertNotIn(caller, call.args)
+
+    def test_snapshot_skips_non_msg_contents(self):
+        caller = MagicMock()
+        caller.msg = MagicMock()
+        alice = self._observer("alice")
+        item = self._itemobj()  # no msg attr
+        room = MagicMock()
+        room.contents = [caller, alice, item]
+        caller.location = room
+        caller.get_display_name = MagicMock(
+            side_effect=lambda obs: f"PRE-{obs._test_name}"
+        )
+
+        snapshot = _snapshot_actor_names(caller, {"actor": caller})
+
+        self.assertEqual(snapshot["actor"], {alice: "PRE-alice"})
+
+    def test_snapshot_defensive_for_all_char_refs(self):
+        """Snapshot every placeholder, not only 'actor'."""
+        caller = MagicMock()
+        caller.msg = MagicMock()
+        victim = MagicMock()
+        victim.msg = MagicMock()
+        observer = self._observer("alice")
+        room = MagicMock()
+        room.contents = [caller, victim, observer]
+        caller.location = room
+
+        caller.get_display_name = MagicMock(return_value="PRE-actor")
+        victim.get_display_name = MagicMock(return_value="PRE-victim")
+
+        snapshot = _snapshot_actor_names(
+            caller, {"actor": caller, "victim": victim}
+        )
+
+        self.assertEqual(set(snapshot.keys()), {"actor", "victim"})
+        self.assertEqual(snapshot["actor"][observer], "PRE-actor")
+        self.assertEqual(snapshot["victim"][observer], "PRE-victim")
+
+    def test_snapshot_empty_when_no_location(self):
+        caller = MagicMock()
+        caller.location = None
+        snapshot = _snapshot_actor_names(caller, {"actor": caller})
+        self.assertEqual(snapshot, {})

--- a/world/tests/test_communication.py
+++ b/world/tests/test_communication.py
@@ -273,8 +273,129 @@ class TestMsgRoomIdentity(TestCase):
 
 
 # ===================================================================
-# Tests: CmdSay
+# Tests: msg_room_identity pre_resolved_refs (snapshot idiom)
 # ===================================================================
+
+
+class TestMsgRoomIdentityPreResolved(TestCase):
+    """Tests for the pre_resolved_refs snapshot kwarg.
+
+    The snapshot idiom is documented in
+    ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Action Broadcast Sdesc
+    Stability".  Used by clothing commands (and future wield/appear)
+    to broadcast pre-mutation sdescs.
+    """
+
+    def setUp(self):
+        self.jorge = _make_character(
+            key="Jorge Jackson",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-jorge",
+        )
+        self.alice = _make_character(
+            key="Alice Smith",
+            sex="female",
+            height="average",
+            build="average",
+            sleeve_uid="uid-alice",
+            recognition_memory={
+                apparent_uid_for(self.jorge): {"assigned_name": "Jorge"},
+            },
+        )
+        self.bob = _make_character(
+            key="Bob Doe",
+            sex="male",
+            height="average",
+            build="average",
+            sleeve_uid="uid-bob",
+            recognition_memory={},
+        )
+
+    def _msg_text(self, observer):
+        call = observer.msg.call_args
+        return call[1].get(
+            "text",
+            call[0][0] if call[0] else None,
+        )
+
+    def test_snapshot_used_when_observer_present(self):
+        """Snapshot string is used verbatim, get_display_name is not called."""
+        room = _make_room([self.jorge, self.alice, self.bob])
+        snapshot = {
+            "actor": {
+                self.alice: "PRE-Jorge",
+                self.bob: "PRE-sdesc",
+            }
+        }
+        # Spy on get_display_name to assert it is bypassed.
+        self.jorge.get_display_name = MagicMock(
+            side_effect=AssertionError(
+                "get_display_name must not be called when snapshot present"
+            )
+        )
+
+        msg_room_identity(
+            location=room,
+            template="{actor} puts on a balaclava.",
+            char_refs={"actor": self.jorge},
+            exclude=[self.jorge],
+            pre_resolved_refs=snapshot,
+        )
+
+        self.assertIn("PRE-Jorge", self._msg_text(self.alice))
+        self.assertIn("PRE-sdesc", self._msg_text(self.bob))
+
+    def test_snapshot_missing_observer_falls_back(self):
+        """Observers absent from snapshot fall back to live get_display_name."""
+        room = _make_room([self.jorge, self.alice, self.bob])
+        # Only Alice has a snapshot entry; Bob must fall back.
+        snapshot = {"actor": {self.alice: "PRE-Jorge"}}
+
+        msg_room_identity(
+            location=room,
+            template="{actor} puts on a balaclava.",
+            char_refs={"actor": self.jorge},
+            exclude=[self.jorge],
+            pre_resolved_refs=snapshot,
+        )
+
+        self.assertIn("PRE-Jorge", self._msg_text(self.alice))
+        # Bob has no snapshot entry → live sdesc lookup
+        self.assertIn("gaunt man", self._msg_text(self.bob))
+
+    def test_snapshot_missing_placeholder_falls_back(self):
+        """Placeholders absent from snapshot mapping use live names."""
+        room = _make_room([self.jorge, self.alice])
+        # Empty snapshot — entire mapping has no entries for "actor"
+        msg_room_identity(
+            location=room,
+            template="{actor} puts on a balaclava.",
+            char_refs={"actor": self.jorge},
+            exclude=[self.jorge],
+            pre_resolved_refs={},
+        )
+        self.assertIn("Jorge", self._msg_text(self.alice))
+
+    def test_first_placeholder_capitalization_preserved(self):
+        """Snapshot string at sentence start receives capitalize_first()."""
+        room = _make_room([self.jorge, self.bob])
+        snapshot = {"actor": {self.bob: "a lithe man"}}
+
+        msg_room_identity(
+            location=room,
+            template="{actor} puts on a balaclava.",
+            char_refs={"actor": self.jorge},
+            exclude=[self.jorge],
+            pre_resolved_refs=snapshot,
+        )
+
+        self.assertTrue(
+            self._msg_text(self.bob).startswith("A lithe man "),
+            self._msg_text(self.bob),
+        )
 
 
 class TestCmdSay(TestCase):


### PR DESCRIPTION
## Summary
Two coupled bugs surfaced in disguise smoke testing:

1. **Action broadcasts described post-mutation sdesc.** Donning a balaclava produced *"a lithe masked droog in a black balaclava puts on a black balaclava"* — the message described the actor as if the action had already taken effect on their appearance.
2. **Item names lacked indefinite articles** in neutral introductions: *"puts on black balaclava"* instead of *"puts on a black balaclava"*.

## Fix Surface
- **`world/identity_utils.msg_room_identity`** — new `pre_resolved_refs` kwarg (shape `{placeholder: {observer: display_name}}`) that bypasses live `get_display_name` when present, with fall-through on missing placeholder/observer keys.
- **`commands/CmdClothing`** — `_snapshot_actor_names` helper captures pre-mutation per-observer names *defensively* across all `char_refs` placeholders (not only known mutators), preparing for future multi-actor templates like forced-equip. `_articled` wraps `world.grammar.get_article`. Wired into `CmdWear`, `CmdRemove` (single + `remove all` + stuck-grenade), `CmdRollUp`, `CmdZip`. `remove all` now lists items via `iter_to_str` instead of *"removes several items"*.
- **`typeclasses/clothing_mixin`** — actor self-messages get `get_article`'d.
- **`specs/IDENTITY_RECOGNITION_SPEC.md`** — new section *Action Broadcast Sdesc Stability* documents the snapshot idiom and article rule; `msg_room_identity` code block updated to new signature.

## Tests
- 4 new tests in `test_communication.TestMsgRoomIdentityPreResolved`: snapshot precedence over `get_display_name`, missing-observer fall-back, missing-placeholder fall-back, first-placeholder capitalization preserved.
- 10 new tests in `test_clothing_broadcast`: `_articled` (consonant/vowel/silent-h), `iter_to_str` over articled keys (1/2/3+), `_snapshot_actor_names` (excludes caller, skips non-msg contents, defensive across all placeholders, empty-when-no-location).
- Full `world` suite: **595/595 pass**.

## Scope Notes
Error messages and possessive forms (`"the X"`, `"their X"`) intentionally left untouched — only neutral introductions need the article fix. Combat sweep (CmdAttack, etc.) deferred to a follow-up.

## Smoke Test
Verified in-game: balaclava donning now reads *"A lithe droog puts on a black balaclava."* to observers without recognition memory, and the actor's sdesc transitions cleanly across observers post-broadcast.