### PR TITLE
Snapshot essential_item_types into personas; warn on adoption mismatch

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1872,10 +1872,15 @@ def _build_persona_entry(caller, name):
     """Snapshot the caller's current overrides into a persona dict.
 
     The shape matches the persona schema documented in the disguise
-    spec; ``essential_item_types`` and ``notes`` are reserved for the
-    Phase 3 engine PR but written empty now so the schema is stable.
+    spec.  ``essential_item_types`` captures the currently-equipped
+    essential disguise items (via :func:`get_essential_item_type_ids`)
+    so adoption can advise the player when the saved composition no
+    longer matches what's worn.  ``notes`` remains reserved for a
+    future player-annotation feature.
     """
     import time
+
+    from world.identity import get_essential_item_type_ids
 
     location_name = caller.location.key if caller.location else "unknown"
     return {
@@ -1885,7 +1890,7 @@ def _build_persona_entry(caller, name):
         "keyword_override": caller.db.keyword_override,
         "saved_at": time.time(),
         "saved_in": location_name,
-        "essential_item_types": [],
+        "essential_item_types": list(get_essential_item_type_ids(caller)),
         "notes": "",
     }
 
@@ -2172,7 +2177,39 @@ class CmdAppear(Command):
     # -- persona adoption ------------------------------------------------
 
     def _adopt_persona(self, caller, name, entry):
-        """Clean swap: overwrite all three axes from the persona snapshot."""
+        """Clean swap: overwrite all three axes from the persona snapshot.
+
+        If the persona's saved ``essential_item_types`` diverges from
+        the caller's currently-equipped essential disguise items, emit
+        a yellow advisory naming missing and extra type IDs before the
+        override swap.  Adoption is not refused — the player can choose
+        to proceed and accept the resulting Apparent UID divergence.
+        """
+        from world.identity import get_essential_item_type_ids
+
+        saved = tuple(entry.get("essential_item_types") or ())
+        current = get_essential_item_type_ids(caller)
+        missing = tuple(t for t in saved if t not in current)
+        extra = tuple(t for t in current if t not in saved)
+        if missing or extra:
+            advisory_lines = [
+                f"|y(Heads up: '{name}' was saved with a different set of "
+                f"essential disguise items than you have on now.)|n"
+            ]
+            if missing:
+                advisory_lines.append(
+                    f"|y  Missing: {', '.join(missing)}|n"
+                )
+            if extra:
+                advisory_lines.append(
+                    f"|y  Extra:   {', '.join(extra)}|n"
+                )
+            advisory_lines.append(
+                "|y  Your Apparent UID will not match the saved persona "
+                "exactly.|n"
+            )
+            caller.msg("\n".join(advisory_lines))
+
         caller.db.height_override = entry.get("height_override")
         caller.db.build_override = entry.get("build_override")
         caller.db.keyword_override = entry.get("keyword_override")

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -554,18 +554,20 @@ Because the identity engine is purely emergent from current state, players need 
 
 A persona is a **player-private snapshot** of presentation overrides, captured at the moment of saving and restorable later. Personas are designed in parallel to the planned identity/contact system — same recall, annotation, and (future) web-UI patterns.
 
-> **Status:** The surface verbs (`appear`, `stop appearing`, `personas`, `persona`, `remember me as <name>`, `forget <persona>`), the persona storage schema, the signature engine, Apparent UID derivation, `get_sdesc()` consumption of overrides, pronoun derivation under disguise via `get_apparent_gender`, and recognition-memory keying on Apparent UID are all **shipped**. Two tail items remain: populating the persona's `essential_item_types` snapshot from `get_essential_item_type_ids()` at save time (the field currently writes empty), and the `lost_contact` orphan-marking flag plus its `memory` / `recall` render annotation (the field exists on entries and defaults to `False`, but no code path currently flips it). Both tails are tracked in this spec's change-log below.
+> **Status:** The surface verbs (`appear`, `stop appearing`, `personas`, `persona`, `remember me as <name>`, `forget <persona>`), the persona storage schema, the signature engine, Apparent UID derivation, `get_sdesc()` consumption of overrides, pronoun derivation under disguise via `get_apparent_gender`, recognition-memory keying on Apparent UID, and the persona `essential_item_types` snapshot + adoption-time advisory are all **shipped**. One tail item remains: the `lost_contact` orphan-marking flag plus its `memory` / `recall` render annotation (the field exists on entries and defaults to `False`, but no code path currently flips it). The remaining tail is tracked in this spec's change-log below.
 
 **A persona stores:**
 - A **player-chosen name** (case-insensitive lookup, case-preserving display, player-private — never visible to other characters)
 - The **override values** active at save time (height, build, keyword) — `None` for axes that were unset
-- The **types of essential disguise items** equipped at save time *(reserved field; population from `get_essential_item_type_ids()` is the remaining persona tail item — see change-log below)*
+- The **types of essential disguise items** equipped at save time, captured via `get_essential_item_type_ids()` (sorted, deduplicated)
 - A **freeform notes field** for player annotations *(reserved field, currently always empty)*
 - A **created-at timestamp** and the **room name** where it was saved
 
 **Pronouns are not stored separately.** Restoring a persona restores its `keyword_override`, and pronouns derive from that keyword via the rule in §Pronouns Under Disguise. A persona that captured a feminine keyword automatically restores feminine pronouns when adopted; a persona that captured a custom keyword automatically restores neutral pronouns. No persona field is needed for gender.
 
 **Personas do NOT generate identities.** They are pure recall aids. When a player adopts a persona, the system applies the captured overrides as a **clean swap** — overwriting all three axes including any unset axes (so adoption produces an exact replay of the saved state, never a merge). The resulting Apparent UID is derived from the restored state, not from the persona itself. Two personas with identical overrides + item-type composition will yield the same Apparent UID — they are just labels in the player's memory.
+
+**Adoption-time essential-item advisory.** When the player runs `appear <persona>`, the system diffs the persona's saved `essential_item_types` against the player's currently-equipped essential disguise items and emits a yellow heads-up listing missing and extra type IDs when they diverge. Adoption is **not refused** — the player can choose to proceed and accept the resulting Apparent UID divergence. The advisory exists because unlike real life, it's easy in-game to forget which items pair with which persona; the warning is a recall aid, not a gate. This may be revisited later as the player grows more accustomed to the disguise system.
 
 **Cap:** No cap in the surface PR. The previously-floated `min(Resonance × 2, 10)` gating is held for the engine PR or later balance pass.
 
@@ -1148,7 +1150,7 @@ Players should be prompted to customize their sdesc on next login if defaults we
   - `forget <persona name>` — delete a persona; clears overrides and `db.active_persona` if it was active
   - Cross-namespace uniqueness enforced (keyword catalog ∩ recognition names ∩ persona names)
   - No cap (deferred to balance pass)
-  - Persona `essential_item_types` snapshot — **tail item (not yet shipped)**; `_build_persona_entry` currently writes `[]` instead of capturing `get_essential_item_type_ids(caller)` at save time. Planned implementation also adds an adoption-time advisory: when the player runs `appear <persona>`, the system diffs the saved `essential_item_types` against currently-equipped essential items and emits a yellow heads-up listing missing and extra type IDs. Adoption is not refused — the player can choose to proceed and accept the resulting Apparent UID divergence.
+  - Persona `essential_item_types` snapshot + adoption-time advisory — **shipped** (`commands/CmdCharacter.py:_build_persona_entry,_adopt_persona`); `_build_persona_entry` captures `get_essential_item_type_ids(caller)` at save time, and `_adopt_persona` emits a yellow advisory when the saved composition diverges from currently-equipped essentials. Adoption proceeds regardless.
 - Lifecycle integration *(future)*:
   - Death: clears overrides; corpse stores `real_sleeve_uid` + `last_active_signature` snapshot
   - Sleeve swap (flash clone / resleeving): salt is `real_sleeve_uid`, so personas don't carry across bodies; persona records remain on the player

--- a/world/tests/test_identity_commands.py
+++ b/world/tests/test_identity_commands.py
@@ -56,6 +56,11 @@ def _make_character(
     char.hands = {"left": None, "right": None}
     char.worn_items = {}
 
+    # get_worn_items: empty by default so get_essential_item_type_ids()
+    # produces an empty tuple.  Tests that need essentials override
+    # this via _equip_essential_items() below.
+    char.get_worn_items = MagicMock(return_value=[])
+
     def _coverage_map():
         coverage = {}
         if char.worn_items:
@@ -917,6 +922,22 @@ def _make_disguise_character(**overrides):
     return char
 
 
+def _equip_essential_items(char, type_ids):
+    """Make ``char.get_worn_items()`` return mocks for the given type IDs.
+
+    Each fake worn item has ``disguise_essential = True`` and a
+    ``disguise_type_id`` from the list.  Pass an empty list to reset.
+    """
+    items = []
+    for type_id in type_ids:
+        item = MagicMock()
+        item.disguise_essential = True
+        item.disguise_type_id = type_id
+        items.append(item)
+    char.get_worn_items = MagicMock(return_value=items)
+    return char
+
+
 # ===================================================================
 # CmdAppear — bare status display
 # ===================================================================
@@ -1418,6 +1439,147 @@ class TestCmdRememberMeAs(TestCase):
         self.assertEqual(len(caller.db.personas), 1)
         msg = caller.msg.call_args[0][0]
         self.assertIn("already have a persona", msg)
+
+    def test_captures_essential_item_types_when_equipped(self):
+        """Saving with essentials worn populates essential_item_types."""
+        caller = _make_disguise_character(
+            db_attrs={"keyword_override": "wanderer"},
+        )
+        _equip_essential_items(caller, ["balaclava", "trenchcoat"])
+        with patch(
+            "world.identity.get_all_keywords",
+            return_value=frozenset({"man", "wanderer"}),
+        ):
+            self._run(caller, "me as Hooded Wanderer")
+
+        entry = caller.db.personas["Hooded Wanderer"]
+        # Sorted, deduplicated.
+        self.assertEqual(
+            entry["essential_item_types"], ["balaclava", "trenchcoat"]
+        )
+
+    def test_dedupes_duplicate_essential_item_types(self):
+        """Two balaclavas collapse to one entry in the snapshot."""
+        caller = _make_disguise_character()
+        _equip_essential_items(
+            caller, ["balaclava", "balaclava", "trenchcoat"]
+        )
+        with patch(
+            "world.identity.get_all_keywords", return_value=frozenset({"man"})
+        ):
+            self._run(caller, "me as Dupes")
+
+        entry = caller.db.personas["Dupes"]
+        self.assertEqual(
+            entry["essential_item_types"], ["balaclava", "trenchcoat"]
+        )
+
+    def test_empty_essential_items_yields_empty_list(self):
+        """No essentials → empty list (existing behavior preserved)."""
+        caller = _make_disguise_character()
+        with patch(
+            "world.identity.get_all_keywords", return_value=frozenset({"man"})
+        ):
+            self._run(caller, "me as Bare")
+        self.assertEqual(caller.db.personas["Bare"]["essential_item_types"], [])
+
+
+# ===================================================================
+# CmdAppear — persona adoption essential-item advisory
+# ===================================================================
+
+
+class TestCmdAppearPersonaEssentialAdvisory(TestCase):
+    """``appear <persona>`` warns when essential item composition diverges."""
+
+    def _run(self, caller, args):
+        from commands.CmdCharacter import CmdAppear
+
+        cmd = CmdAppear()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.func()
+
+    def _persona(self, name, essential_item_types):
+        return {
+            "name": name,
+            "height_override": None,
+            "build_override": None,
+            "keyword_override": None,
+            "saved_at": 1000.0,
+            "saved_in": "Bar",
+            "essential_item_types": list(essential_item_types),
+            "notes": "",
+        }
+
+    def test_warns_on_missing_items(self):
+        persona = self._persona("Hooded", ["balaclava", "trenchcoat"])
+        caller = _make_disguise_character(
+            db_attrs={"personas": {"Hooded": persona}},
+        )
+        # Strip everything — both items missing.
+        _equip_essential_items(caller, [])
+
+        self._run(caller, "Hooded")
+
+        all_msgs = " ".join(
+            ca[0][0] for ca in caller.msg.call_args_list
+        )
+        self.assertIn("Heads up", all_msgs)
+        self.assertIn("Missing", all_msgs)
+        self.assertIn("balaclava", all_msgs)
+        self.assertIn("trenchcoat", all_msgs)
+        # Adoption proceeded anyway.
+        self.assertEqual(caller.db.active_persona, "Hooded")
+
+    def test_warns_on_extra_items(self):
+        persona = self._persona("Plain", [])
+        caller = _make_disguise_character(
+            db_attrs={"personas": {"Plain": persona}},
+        )
+        # Wearing a balaclava the persona didn't have.
+        _equip_essential_items(caller, ["balaclava"])
+
+        self._run(caller, "Plain")
+
+        all_msgs = " ".join(
+            ca[0][0] for ca in caller.msg.call_args_list
+        )
+        self.assertIn("Heads up", all_msgs)
+        self.assertIn("Extra", all_msgs)
+        self.assertIn("balaclava", all_msgs)
+        self.assertEqual(caller.db.active_persona, "Plain")
+
+    def test_no_warning_on_exact_match(self):
+        persona = self._persona("Hooded", ["balaclava"])
+        caller = _make_disguise_character(
+            db_attrs={"personas": {"Hooded": persona}},
+        )
+        _equip_essential_items(caller, ["balaclava"])
+
+        self._run(caller, "Hooded")
+
+        all_msgs = " ".join(
+            ca[0][0] for ca in caller.msg.call_args_list
+        )
+        self.assertNotIn("Heads up", all_msgs)
+        self.assertNotIn("Missing", all_msgs)
+        self.assertNotIn("Extra", all_msgs)
+        self.assertEqual(caller.db.active_persona, "Hooded")
+
+    def test_no_warning_when_both_empty(self):
+        """No essentials saved, none worn → silent adoption."""
+        persona = self._persona("Plain", [])
+        caller = _make_disguise_character(
+            db_attrs={"personas": {"Plain": persona}},
+        )
+
+        self._run(caller, "Plain")
+
+        all_msgs = " ".join(
+            ca[0][0] for ca in caller.msg.call_args_list
+        )
+        self.assertNotIn("Heads up", all_msgs)
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- `_build_persona_entry` now captures `get_essential_item_type_ids(caller)` at save time instead of writing `[]`. The field's intent finally matches its content.
- `_adopt_persona` diffs the persona's saved composition against the player's currently-equipped essentials and emits a yellow heads-up listing missing and extra type IDs when they diverge. Adoption is **not refused** — the warning is a recall aid, not a gate. Rationale: unlike real life, it's easy to forget which items pair with which persona in-game.

## Spec
- §Personas status callout: drop the `essential_item_types` tail (only `lost_contact` remains).
- New paragraph under §Personas documenting the adoption-time advisory.
- Change-log bullet: mark `essential_item_types` snapshot as shipped.

## Tests
- 3 new `TestCmdRememberMeAs` cases (essentials worn, dedupe across multiples, empty list).
- New `TestCmdAppearPersonaEssentialAdvisory` class with 4 cases (missing, extra, exact match, both empty).
- `_make_character` now binds `get_worn_items` to return `[]` by default; new `_equip_essential_items()` helper for tests that need essentials.

## Verification
- `evennia test world` → 595/595 passing (was 588 → +7 new).
- Live reload completed cleanly.

## Compatibility note
Existing live personas (saved before this PR) have `essential_item_types: []` baked in. Players reusing those won't see warnings even if they had essentials equipped at save time. This is acceptable — we don't retroactively reconstruct historical state.