### PR TITLE
Fix Mermaid parse error in Recognition Pipeline diagram

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -179,11 +179,11 @@ graph TD
     D --> E[Get looker's recognition_memory]
     E --> F{Apparent UID in recognition_memory?}
     F -->|Yes, has assigned_name| G[Return stored assigned_name]
-    F -->|Yes, no assigned_name<br/>(forgotten entry)| H[Return target's sdesc]
+    F -->|"Yes, no assigned_name (forgotten entry)"| H["Return target's sdesc"]
     F -->|No| H
     G --> I{Staff cyberware active?}
     H --> I
-    I -->|Yes| J["Append ' [real_name]'"]
+    I -->|Yes| J["Append ' (real_name)'"]
     I -->|No| K[Return as-is]
 ```
 


### PR DESCRIPTION
## Summary

GitHub's Mermaid renderer was failing on the Recognition Pipeline diagram in ``specs/IDENTITY_RECOGNITION_SPEC.md`` with:

```
Parse error on line 8:
...o assigned_name<br/>(forgotten entry)| H
-----------------------^
Expecting ..., got 'PS'
```

The F-->H edge label stacked two illegal constructs: HTML ``<br/>`` (unsupported in edge labels) and bare parentheses (require quoting). The token ``PS`` is paren-start.

## Fixes

1. **Edge label quoted, ``<br/>`` removed** — ``F -->|"Yes, no assigned_name (forgotten entry)"| H``
2. **H node label quoted** — apostrophe in ``Return target's sdesc`` now needs quoting since the upstream edge is quoted
3. **Precautionary: ``[real_name]`` -> ``(real_name)`` in J node** — inner ``]`` in a ``[...]`` label is a known fragility even when double-quoted

## Out of Scope

- No code, no tests, no behavior change
- Other unquoted apostrophe-containing node labels (E, G, etc.) left alone — they were rendering before the line-182 break and are minimal-change-safe