### PR TITLE
Bump recognition recency passively when observing remembered targets

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -230,17 +230,26 @@ recognition_memory = {
 
         # Temporal context
         "first_seen": str,              # ISO timestamp of first encounter
-        "last_seen": str,               # ISO timestamp of most recent encounter
-        "times_seen": int,              # Total encounter count
+        "last_seen": str,               # ISO timestamp of most recent perception.
+                                        # Bumped passively on room entry (see
+                                        # §Memory Architecture) and on every
+                                        # explicit `remember`. Throttled to one
+                                        # write per RECOGNITION_BUMP_THROTTLE_SECONDS
+                                        # per UID per observer.
+        "times_seen": int,              # Count of explicit `remember` invocations
+                                        # for this entry. Does NOT track passive
+                                        # perception — see `last_seen` for recency.
 
         # Spatial context
         "location_first_seen": str,     # Room name/key where first encountered
-        "location_last_seen": str,      # Room name/key where last seen
+        "location_last_seen": str,      # Room name/key where last perceived
+                                        # (passive bump on room entry + explicit `remember`)
         "locations_seen": [str],        # All locations where encountered
 
         # Appearance snapshot
         "sdesc_at_first_encounter": str,  # What they looked like initially
         "sdesc_at_last_encounter": str,   # What they looked like most recently
+                                          # (passive bump on room entry + explicit `remember`)
 
         # Player-authored
         "notes": str,                   # Free-text notes (player-written)
@@ -269,7 +278,9 @@ recognition_memory = {
 
 This is stored as a db attribute on the Character (`recognition_memory` AttributeProperty), keyed by **Apparent UID**. See §Memory Architecture for the storage-location rationale and the planned migration to brain-organ storage. The `recent_interactions` list should be capped (e.g., last 20 interactions per entry) to prevent unbounded growth, with older interactions eligible for summarization or archival.
 
-**Orphaned entries (`lost_contact`):** A recognition entry whose Apparent UID has not matched any observable character within a configurable window (deferred to balance pass; provisional default: 30 in-game days, defined as `LOST_CONTACT_THRESHOLD_SECONDS` in `world/identity.py`) is marked `lost_contact = True`. The entry stays visible in `memory` and `recall` (player-authored notes are valuable lore even when the trail goes cold) and is rendered with a "(lost contact)" annotation. The flip is performed lazily at render time by `world/identity.py:mark_lost_contact_entries`, invoked from the `memory` and `recall` commands via `commands/CmdCharacter._refresh_lost_contact` immediately before iterating recognition memory; there is no background scan. The inverse — clearing the flag back to `False` on re-meet — is handled by the recognition writer in `_remember_target`. A future player command may allow explicit pruning of lost-contact entries; auto-pruning is intentionally **not** done.
+**Orphaned entries (`lost_contact`):** A recognition entry whose Apparent UID has not matched any observable character within a configurable window (deferred to balance pass; provisional default: 30 in-game days, defined as `LOST_CONTACT_THRESHOLD_SECONDS` in `world/identity.py`) is marked `lost_contact = True`. The entry stays visible in `memory` and `recall` (player-authored notes are valuable lore even when the trail goes cold) and is rendered with a "(lost contact)" annotation. The flip is performed lazily at render time by `world/identity.py:mark_lost_contact_entries`, invoked from the `memory` and `recall` commands via `commands/CmdCharacter._refresh_lost_contact` immediately before iterating recognition memory; there is no background scan. The inverse — clearing the flag back to `False` on re-meet — is handled by `world/identity.py:bump_recognition_recency` (passive perception path) and by the recognition writer in `_remember_target` (explicit `remember` path). A future player command may allow explicit pruning of lost-contact entries; auto-pruning is intentionally **not** done.
+
+**Passive recency on perception:** Recency fields on existing recognition entries (`last_seen`, `location_last_seen`, `sdesc_at_last_encounter`) are refreshed without an explicit `remember` whenever the observer perceives a target whose Apparent UID is already in their memory. This is implemented by `world/identity.py:bump_recognition_recency`, invoked from `Character.at_post_move` via `_refresh_recognition_recency`: on every room entry the observer scans the new room's contents and bumps each known UID. Writes are throttled to one bump per `RECOGNITION_BUMP_THROTTLE_SECONDS` (provisional 300s = 5 minutes) per UID per observer, so extended co-location does not spam AttributeProperty writes. The helper is **strictly opt-in for already-remembered UIDs** — it never creates entries; entry creation remains the exclusive responsibility of the `remember` command. The `times_seen` counter is intentionally **not** incremented by passive perception; it counts explicit `remember` invocations only. Stealth/sneaking/hidden mechanics are a known future delta — when those land, they will need to suppress this hook for hidden targets.
 
 ### Remembering Names
 
@@ -1138,7 +1149,8 @@ Players should be prompted to customize their sdesc on next login if defaults we
 - `db.is_disguise_item` flag on items — Phase 5 perception bonus hook (defined but inert in Phase 3) — **shipped (flag schema only)**
 - Hook `get_sdesc()` / `get_display_name()` to consume override axes and Apparent UID — **shipped** (`typeclasses/characters.py:946,989`)
 - Recognition memory re-keyed on Apparent UID — **shipped**
-- Orphaned-entry handling: `lost_contact` boolean flag + render annotation in `memory` / `recall`; never auto-pruned — **shipped**. Lazy evaluation at render time: `world/identity.py:mark_lost_contact_entries` is invoked by `commands/CmdCharacter._refresh_lost_contact` from `CmdMemory.func` and `CmdRecall.func`, flipping `lost_contact = True` for entries whose Apparent UID is not currently visible and whose `last_seen` is older than `LOST_CONTACT_THRESHOLD_SECONDS` (`world/identity.py`; provisional 30 in-game days, balance-pass tuning value). The inverse — clearing back to `False` — is handled by the existing recognition writer in `_remember_target` on re-meet. Render annotation `|y(lost contact)|n` appears next to the assigned name in both `memory` (table cell) and `recall` (entry header).
+- Orphaned-entry handling: `lost_contact` boolean flag + render annotation in `memory` / `recall`; never auto-pruned — **shipped**. Lazy evaluation at render time: `world/identity.py:mark_lost_contact_entries` is invoked by `commands/CmdCharacter._refresh_lost_contact` from `CmdMemory.func` and `CmdRecall.func`, flipping `lost_contact = True` for entries whose Apparent UID is not currently visible and whose `last_seen` is older than `LOST_CONTACT_THRESHOLD_SECONDS` (`world/identity.py`; provisional 30 in-game days, balance-pass tuning value). The inverse — clearing back to `False` — is handled by the existing recognition writer in `_remember_target` on re-meet **and** by the passive recency bumper `world/identity.py:bump_recognition_recency` whenever a remembered observer perceives a remembered target. Render annotation `|y(lost contact)|n` appears next to the assigned name in both `memory` (table cell) and `recall` (entry header).
+- Passive recognition recency on perception — **shipped**. `world/identity.py:bump_recognition_recency` refreshes `last_seen` / `location_last_seen` / `sdesc_at_last_encounter` (but not `times_seen`) for already-remembered targets, throttled by `RECOGNITION_BUMP_THROTTLE_SECONDS` (300s). Wired into `typeclasses/characters.py:Character.at_post_move` via `_refresh_recognition_recency`, which iterates the new room's `Character` contents and bumps each remembered target. Stealth/sneaking/hidden suppression is a known future-work delta.
 - Full keyword catalog available regardless of character gender (override bypasses gender filter) — **shipped via `appear <keyword>` validation**
 - Available to **all characters** (no access level restriction)
 - Persona layer (player-private ergonomics) — **shipped (`appear-persona-cluster`)**:

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1042,6 +1042,61 @@ class Character(
         article = get_article(sdesc)
         return f"{article} {sdesc}"
 
+    def at_post_move(self, source_location, **kwargs):
+        """Hook called after this character lands in a new location.
+
+        Extends the default Evennia behavior with a passive recognition
+        recency pass so that walking into a room with someone whose
+        Apparent UID is already in our memory refreshes their
+        ``last_seen`` (and friends).  See
+        :func:`world.identity.bump_recognition_recency` for the
+        per-target contract.
+
+        Args:
+            source_location: Location we just left (may be ``None``).
+            **kwargs: Forwarded to the parent hook (e.g. ``move_type``).
+        """
+        super().at_post_move(source_location, **kwargs)
+        self._refresh_recognition_recency()
+
+    def _refresh_recognition_recency(self):
+        """Bump recognition recency for every visible character we know.
+
+        Iterates the current room's contents, computes each
+        character's Apparent UID, and calls
+        :func:`world.identity.bump_recognition_recency`.  The helper
+        is a no-op for UIDs we have never explicitly remembered, so
+        this method only mutates entries that already exist.
+
+        Per-target failures are caught and logged — a single bad
+        recognition entry must never break room entry.
+        """
+        if self.location is None:
+            return
+        memory = self.recognition_memory
+        if not memory:
+            return
+
+        from evennia.utils import logger
+
+        from world.identity import bump_recognition_recency, get_apparent_uid
+
+        for obj in self.location.contents:
+            if obj is self:
+                continue
+            if not isinstance(obj, Character):
+                continue
+            try:
+                apparent_uid = get_apparent_uid(obj)
+                if apparent_uid is None:
+                    continue
+                bump_recognition_recency(self, obj, apparent_uid)
+            except (AttributeError, TypeError, ValueError):
+                logger.log_trace(
+                    f"Recognition recency bump failed for "
+                    f"observer={self!r} target={obj!r}; continuing."
+                )
+
     def search(
         self,
         searchdata,

--- a/world/identity.py
+++ b/world/identity.py
@@ -1062,3 +1062,105 @@ def mark_lost_contact_entries(
     return flipped
 
 
+#: Minimum seconds between passive recency bumps for the same Apparent UID
+#: per observer.  Prevents room ping-pong (or extended co-location across
+#: many ``at_post_move`` calls) from spamming AttributeProperty writes.
+#: 300s = 5 minutes; tunable in a balance pass.
+RECOGNITION_BUMP_THROTTLE_SECONDS: int = 300
+
+
+def bump_recognition_recency(
+    observer: Any,
+    target: Any,
+    apparent_uid: Any,
+    *,
+    now: Any = None,
+) -> bool:
+    """Refresh the recency fields on an existing recognition entry.
+
+    Passive perception model: when ``observer`` perceives ``target``
+    (currently invoked from ``Character.at_post_move`` for everyone in
+    the new room), this helper updates the *recency* fields on the
+    matching ``recognition_memory`` entry so ``memory`` / ``recall``
+    reflect the latest sighting and so
+    :func:`mark_lost_contact_entries` compares against last actual
+    sighting rather than last explicit ``remember`` invocation.
+
+    **Strictly opt-in for already-remembered UIDs.**  If
+    ``apparent_uid`` is not already a key in
+    ``observer.recognition_memory`` this helper is a no-op; it never
+    creates entries.  Entry creation remains the exclusive
+    responsibility of
+    :meth:`commands.CmdCharacter.CmdRemember._remember_target`.  This
+    guards against a target whom the observer has never named ever
+    appearing in their memory by way of passive perception.
+
+    Throttle: writes are skipped when the existing ``last_seen`` is
+    less than :data:`RECOGNITION_BUMP_THROTTLE_SECONDS` ago.  Missing
+    or malformed ``last_seen`` is treated as stale and the entry is
+    bumped immediately (with a warning logged for the malformed
+    case).
+
+    Fields written on a successful bump:
+
+    * ``last_seen`` — current ISO timestamp
+    * ``location_last_seen`` — observer's current room key
+    * ``sdesc_at_last_encounter`` — fresh snapshot of ``target.get_sdesc()``
+    * ``lost_contact`` — cleared to ``False`` (re-sighting clears the flag)
+
+    The ``times_seen`` counter is intentionally **not** incremented;
+    it tracks explicit ``remember`` invocations only — see the
+    spec's data-model block for the field-by-field semantics.
+
+    Args:
+        observer: Character whose ``recognition_memory`` is updated.
+        target: Character being perceived; used to snapshot the fresh
+            sdesc.
+        apparent_uid: Apparent UID computed for ``target`` from the
+            observer's vantage point.
+        now: Optional :class:`datetime.datetime` for tests; defaults
+            to ``datetime.utcnow()`` when omitted.
+
+    Returns:
+        ``True`` when the entry was bumped; ``False`` when the helper
+        was a no-op (UID not in memory, or throttle window not
+        elapsed).
+    """
+    from datetime import datetime
+
+    memory = getattr(observer, "recognition_memory", None) or {}
+    entry = memory.get(apparent_uid)
+    if entry is None:
+        return False
+
+    now_dt = now if now is not None else datetime.utcnow()
+    last_seen_iso = entry.get("last_seen") or ""
+    if last_seen_iso:
+        try:
+            then = datetime.strptime(
+                last_seen_iso, _RECOGNITION_TIMESTAMP_FMT
+            )
+        except ValueError:
+            logger.log_warn(
+                f"recognition_memory entry on {observer!r} "
+                f"(uid={apparent_uid}) has unparseable "
+                f"last_seen={last_seen_iso!r}; bumping anyway."
+            )
+        else:
+            elapsed = (now_dt - then).total_seconds()
+            if elapsed < RECOGNITION_BUMP_THROTTLE_SECONDS:
+                return False
+
+    location_name = (
+        observer.location.key if observer.location is not None else "unknown"
+    )
+
+    entry["last_seen"] = now_dt.strftime(_RECOGNITION_TIMESTAMP_FMT)
+    entry["location_last_seen"] = location_name
+    entry["sdesc_at_last_encounter"] = target.get_sdesc()
+    entry["lost_contact"] = False
+
+    # Reassign so the AttributeProperty persists the in-place mutation.
+    observer.recognition_memory = memory
+    return True
+

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -1465,3 +1465,259 @@ class TestMarkLostContactEntries(TestCase):
 
         self.assertEqual(flipped, 0)
         self.assertFalse(memory["uid-empty"]["lost_contact"])
+
+
+# ===================================================================
+# bump_recognition_recency — passive perception recency refresh
+# ===================================================================
+
+
+class TestBumpRecognitionRecency(TestCase):
+    """Passive perception updates recency fields on existing entries."""
+
+    TS_FMT = "%Y-%m-%dT%H:%M:%S"
+
+    def _make_observer(self, memory, *, location_key="Plaza"):
+        observer = MagicMock()
+        observer.recognition_memory = memory
+        observer.location.key = location_key
+        return observer
+
+    def _make_target(self, *, sdesc="a tall lean droog"):
+        target = MagicMock()
+        target.get_sdesc.return_value = sdesc
+        return target
+
+    def _entry(self, *, last_seen, lost_contact=False, sdesc="old sdesc"):
+        return {
+            "assigned_name": "Spartacus",
+            "last_seen": last_seen,
+            "times_seen": 3,
+            "location_last_seen": "OldRoom",
+            "sdesc_at_last_encounter": sdesc,
+            "lost_contact": lost_contact,
+        }
+
+    def test_bump_updates_recency_fields(self):
+        from datetime import datetime, timedelta
+        from world.identity import (
+            RECOGNITION_BUMP_THROTTLE_SECONDS,
+            bump_recognition_recency,
+        )
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        stale = now - timedelta(
+            seconds=RECOGNITION_BUMP_THROTTLE_SECONDS + 60
+        )
+        memory = {
+            "uid-known": self._entry(last_seen=stale.strftime(self.TS_FMT)),
+        }
+        observer = self._make_observer(memory, location_key="NewRoom")
+        target = self._make_target(sdesc="a tall lean masked droog")
+
+        result = bump_recognition_recency(
+            observer, target, "uid-known", now=now
+        )
+
+        self.assertTrue(result)
+        entry = memory["uid-known"]
+        self.assertEqual(entry["last_seen"], now.strftime(self.TS_FMT))
+        self.assertEqual(entry["location_last_seen"], "NewRoom")
+        self.assertEqual(
+            entry["sdesc_at_last_encounter"], "a tall lean masked droog"
+        )
+        self.assertFalse(entry["lost_contact"])
+
+    def test_bump_clears_lost_contact_flag(self):
+        from datetime import datetime, timedelta
+        from world.identity import (
+            RECOGNITION_BUMP_THROTTLE_SECONDS,
+            bump_recognition_recency,
+        )
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        stale = now - timedelta(
+            seconds=RECOGNITION_BUMP_THROTTLE_SECONDS + 60
+        )
+        memory = {
+            "uid-lost": self._entry(
+                last_seen=stale.strftime(self.TS_FMT), lost_contact=True
+            ),
+        }
+        observer = self._make_observer(memory)
+        target = self._make_target()
+
+        bump_recognition_recency(observer, target, "uid-lost", now=now)
+
+        self.assertFalse(memory["uid-lost"]["lost_contact"])
+
+    def test_bump_does_not_increment_times_seen(self):
+        """times_seen counts explicit `remember`, not perceptions."""
+        from datetime import datetime, timedelta
+        from world.identity import (
+            RECOGNITION_BUMP_THROTTLE_SECONDS,
+            bump_recognition_recency,
+        )
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        stale = now - timedelta(
+            seconds=RECOGNITION_BUMP_THROTTLE_SECONDS + 60
+        )
+        memory = {
+            "uid-known": self._entry(last_seen=stale.strftime(self.TS_FMT)),
+        }
+        observer = self._make_observer(memory)
+        target = self._make_target()
+
+        bump_recognition_recency(observer, target, "uid-known", now=now)
+
+        self.assertEqual(memory["uid-known"]["times_seen"], 3)
+
+    def test_throttle_blocks_recent_bump(self):
+        """Bump within throttle window is a no-op."""
+        from datetime import datetime, timedelta
+        from world.identity import (
+            RECOGNITION_BUMP_THROTTLE_SECONDS,
+            bump_recognition_recency,
+        )
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        recent = now - timedelta(
+            seconds=RECOGNITION_BUMP_THROTTLE_SECONDS - 60
+        )
+        recent_iso = recent.strftime(self.TS_FMT)
+        memory = {
+            "uid-known": self._entry(last_seen=recent_iso),
+        }
+        observer = self._make_observer(memory, location_key="NewRoom")
+        target = self._make_target(sdesc="changed sdesc")
+
+        result = bump_recognition_recency(
+            observer, target, "uid-known", now=now
+        )
+
+        self.assertFalse(result)
+        # Fields preserved exactly.
+        self.assertEqual(memory["uid-known"]["last_seen"], recent_iso)
+        self.assertEqual(memory["uid-known"]["location_last_seen"], "OldRoom")
+        self.assertEqual(
+            memory["uid-known"]["sdesc_at_last_encounter"], "old sdesc"
+        )
+
+    def test_unknown_uid_is_noop_and_does_not_create_entry(self):
+        """Helper never creates entries — guards against retroactive memory."""
+        from datetime import datetime
+        from world.identity import bump_recognition_recency
+
+        memory = {"uid-known": self._entry(last_seen="2025-01-01T00:00:00")}
+        before = dict(memory)
+        observer = self._make_observer(memory)
+        target = self._make_target()
+
+        result = bump_recognition_recency(
+            observer,
+            target,
+            "uid-stranger",
+            now=datetime(2026, 1, 1, 12, 0, 0),
+        )
+
+        self.assertFalse(result)
+        self.assertEqual(memory, before)
+        self.assertNotIn("uid-stranger", memory)
+
+    def test_empty_memory_is_noop(self):
+        from datetime import datetime
+        from world.identity import bump_recognition_recency
+
+        observer = MagicMock()
+        observer.recognition_memory = {}
+        target = self._make_target()
+
+        result = bump_recognition_recency(
+            observer, target, "uid-anything", now=datetime(2026, 1, 1)
+        )
+
+        self.assertFalse(result)
+        self.assertEqual(observer.recognition_memory, {})
+
+    def test_observer_without_memory_attr_is_noop(self):
+        from datetime import datetime
+        from world.identity import bump_recognition_recency
+
+        observer = MagicMock()
+        observer.recognition_memory = None
+        target = self._make_target()
+
+        result = bump_recognition_recency(
+            observer, target, "uid-anything", now=datetime(2026, 1, 1)
+        )
+
+        self.assertFalse(result)
+
+    def test_missing_last_seen_bumps_immediately(self):
+        """No prior timestamp → treat as stale, bump now."""
+        from datetime import datetime
+        from world.identity import bump_recognition_recency
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        memory = {
+            "uid-known": {
+                "assigned_name": "X",
+                "times_seen": 1,
+                "lost_contact": False,
+            },
+        }
+        observer = self._make_observer(memory)
+        target = self._make_target()
+
+        result = bump_recognition_recency(
+            observer, target, "uid-known", now=now
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(
+            memory["uid-known"]["last_seen"], now.strftime(self.TS_FMT)
+        )
+
+    def test_malformed_last_seen_logs_warning_and_bumps(self):
+        from datetime import datetime
+        from world.identity import bump_recognition_recency
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        memory = {
+            "uid-bad": self._entry(last_seen="not-a-timestamp"),
+        }
+        observer = self._make_observer(memory)
+        target = self._make_target()
+
+        with patch("world.identity.logger") as mock_logger:
+            result = bump_recognition_recency(
+                observer, target, "uid-bad", now=now
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(
+            memory["uid-bad"]["last_seen"], now.strftime(self.TS_FMT)
+        )
+        mock_logger.log_warn.assert_called_once()
+
+    def test_observer_without_location_uses_unknown(self):
+        from datetime import datetime
+        from world.identity import bump_recognition_recency
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        memory = {
+            "uid-known": {
+                "assigned_name": "X",
+                "times_seen": 1,
+                "lost_contact": False,
+            },
+        }
+        observer = MagicMock()
+        observer.recognition_memory = memory
+        observer.location = None
+        target = self._make_target()
+
+        bump_recognition_recency(observer, target, "uid-known", now=now)
+
+        self.assertEqual(memory["uid-known"]["location_last_seen"], "unknown")

--- a/world/tests/test_identity_commands.py
+++ b/world/tests/test_identity_commands.py
@@ -1777,3 +1777,131 @@ class TestCmdForgetPersona(TestCase):
         self._run(caller, "Nobody")
         msg = caller.msg.call_args[0][0]
         self.assertIn("don't remember anyone", msg)
+
+
+# ===================================================================
+# Passive recognition recency on room entry
+# ===================================================================
+
+
+class TestPassiveRecencyOnMove(TestCase):
+    """Walking into a room with a known target refreshes recency.
+
+    Exercises ``Character._refresh_recognition_recency`` end-to-end:
+    iterates the room's contents, computes Apparent UIDs, and calls
+    :func:`world.identity.bump_recognition_recency` for known UIDs.
+    """
+
+    def _bind_refresh(self, observer):
+        """Bind the real _refresh_recognition_recency to a mock character."""
+        from typeclasses.characters import Character
+
+        observer._refresh_recognition_recency = (
+            lambda: Character._refresh_recognition_recency(observer)
+        )
+
+    def _make_room(self, contents):
+        """Build a stand-in location with the given contents list."""
+        room = MagicMock()
+        room.key = "Plaza"
+        room.contents = contents
+        return room
+
+    def test_entry_with_known_target_bumps_recency(self):
+        """Known UID in room → last_seen advances after refresh."""
+        from datetime import datetime, timedelta
+        from world.identity import RECOGNITION_BUMP_THROTTLE_SECONDS
+
+        target = _make_character(
+            key="Jorge", sleeve_uid="uid-jorge"
+        )
+        target_uid = apparent_uid_for(target)
+
+        stale = datetime.utcnow() - timedelta(
+            seconds=RECOGNITION_BUMP_THROTTLE_SECONDS + 60
+        )
+        stale_iso = stale.strftime("%Y-%m-%dT%H:%M:%S")
+        memory = {
+            target_uid: {
+                "assigned_name": "Jorge",
+                "last_seen": stale_iso,
+                "times_seen": 1,
+                "location_last_seen": "OldRoom",
+                "sdesc_at_last_encounter": "old sdesc",
+                "lost_contact": False,
+            },
+        }
+        observer = _make_character(
+            key="Watcher",
+            sleeve_uid="uid-watcher",
+            recognition_memory=memory,
+        )
+        observer.location = self._make_room([observer, target])
+        self._bind_refresh(observer)
+
+        observer._refresh_recognition_recency()
+
+        self.assertNotEqual(memory[target_uid]["last_seen"], stale_iso)
+        self.assertEqual(memory[target_uid]["location_last_seen"], "Plaza")
+        # times_seen unchanged — this is passive perception, not remember.
+        self.assertEqual(memory[target_uid]["times_seen"], 1)
+
+    def test_entry_with_unknown_target_does_not_create_memory(self):
+        """Stranger in room → memory dict unchanged."""
+        target = _make_character(
+            key="Stranger", sleeve_uid="uid-stranger"
+        )
+        observer = _make_character(
+            key="Watcher",
+            sleeve_uid="uid-watcher",
+            recognition_memory={},
+        )
+        observer.location = self._make_room([observer, target])
+        self._bind_refresh(observer)
+
+        observer._refresh_recognition_recency()
+
+        self.assertEqual(observer.recognition_memory, {})
+
+    def test_disguised_target_does_not_bump_stale_uid(self):
+        """Target whose Apparent UID changed → no bump on the old UID."""
+        from datetime import datetime, timedelta
+        from world.identity import RECOGNITION_BUMP_THROTTLE_SECONDS
+
+        # We remember the target under an old UID, but their current
+        # Apparent UID is different (e.g. they put on a hood).
+        target = _make_character(
+            key="Jorge", sleeve_uid="uid-jorge"
+        )
+        current_uid = apparent_uid_for(target)
+        old_uid = "uid-jorge-undisguised-different"
+        self.assertNotEqual(current_uid, old_uid)
+
+        stale = datetime.utcnow() - timedelta(
+            seconds=RECOGNITION_BUMP_THROTTLE_SECONDS + 60
+        )
+        stale_iso = stale.strftime("%Y-%m-%dT%H:%M:%S")
+        memory = {
+            old_uid: {
+                "assigned_name": "Jorge",
+                "last_seen": stale_iso,
+                "times_seen": 1,
+                "location_last_seen": "OldRoom",
+                "sdesc_at_last_encounter": "old sdesc",
+                "lost_contact": False,
+            },
+        }
+        observer = _make_character(
+            key="Watcher",
+            sleeve_uid="uid-watcher",
+            recognition_memory=memory,
+        )
+        observer.location = self._make_room([observer, target])
+        self._bind_refresh(observer)
+
+        observer._refresh_recognition_recency()
+
+        # Old UID untouched — current sighting doesn't match it.
+        self.assertEqual(memory[old_uid]["last_seen"], stale_iso)
+        # Current UID was not added — helper never creates entries.
+        self.assertNotIn(current_uid, memory)


### PR DESCRIPTION
## Summary
- Add `bump_recognition_recency` helper in `world/identity.py` that refreshes `last_seen`, `location_last_seen`, and `sdesc_at_last_encounter` on already-remembered entries, throttled by `RECOGNITION_BUMP_THROTTLE_SECONDS` (300s). `times_seen` remains remember-counted only.
- Wire the helper into `Character.at_post_move` via `_refresh_recognition_recency`, iterating the new room's `Character` contents and bumping each remembered target. Per-target failures are caught with narrow exceptions and logged.
- Update `specs/IDENTITY_RECOGNITION_SPEC.md` data model and Phase 3 change-log to document the passive-recency model and credit `bump_recognition_recency` for clearing `lost_contact` on re-perception.

## Why
Previously only `CmdRemember._remember_target` wrote recency fields, so `last_seen` drifted from reality whenever a player saw a remembered target without re-issuing `remember`. This caused `lost_contact` to misfire on actively-observed characters.

## Tests
- `world/tests/test_identity.py::TestBumpRecognitionRecency` (10 cases) — module 154 → 164.
- `world/tests/test_identity_commands.py::TestPassiveRecencyOnMove` (3 cases) — module 75 → 78.
- Full `world` suite: 620 tests passing (+13).