### PR TITLE
Remove 'wigged' from disguise adjective priority catalog

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -635,7 +635,6 @@ Adjective selection is implemented in `world/identity.py:get_disguise_adjective`
 | `hooded` | 4 |
 | `goggled` | 5 |
 | `veiled` | 6 |
-| `wigged` | 7 |
 
 Adjectives missing from the priority table are admitted at rank 999 with an alphabetical tiebreak — authors can ship new disguise types via item attribute alone, without editing the priority table.
 

--- a/world/identity.py
+++ b/world/identity.py
@@ -703,7 +703,6 @@ _DISGUISE_ADJECTIVE_PRIORITY: dict[str, int] = {
     "hooded": 4,
     "goggled": 5,
     "veiled": 6,
-    "wigged": 7,
 }
 
 #: Sentinel rank for adjectives missing from the priority table.


### PR DESCRIPTION
## Summary
- Drop the `"wigged": 7` entry from `_DISGUISE_ADJECTIVE_PRIORITY` in `world/identity.py`.
- Remove the matching `| wigged | 7 |` row from the priority table in `specs/IDENTITY_RECOGNITION_SPEC.md`.

## Why
Retiring `wigged` as an explicitly-ranked disguise adjective. The remaining catalog (`masked`, `helmeted`, `cowled`, `hooded`, `goggled`, `veiled`) covers the desired disguise surfaces; wigs are a costume detail rather than an identity-defining red flag and don't warrant a dedicated priority slot.

## Behavioral notes
- Items that still set `disguise_adjective="wigged"` would be admitted at rank 999 (alphabetical tiebreak) — the engine's unknown-adjective fallback path remains intact. No prototypes ship `"wigged"`, so there is no live impact.
- The unrelated `disguise_type_id="wig"` example in `typeclasses/items.py` and the spec's "essential items" example list are concept references (item type ID, not adjective) and remain untouched.

## Tests
- Full `world` suite: 626 tests passing (no change).