### PR TITLE
Fix look me/self/here failure for non-Builder characters

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -895,10 +895,11 @@ Currently, players type character names to target them. With the recognition sys
 
 When a player types a targeting string (e.g., `attack jorge` or `attack tall man`):
 
-1. **Assigned names** — Check the player's recognition memory for any character in the room whose assigned name matches the input
-2. **sdescs** — Match against visible characters' sdescs (partial matching, case-insensitive)
-3. **Ordinals** — `"2nd tall man"` uses the existing ordinal system (`get_search_query_replacement`)
-4. **Real keys** — Fall through to standard Evennia search (matches `.key` and aliases)
+1. **Magic keywords** — `me` / `self` resolve to the caller; `here` resolves to the caller's location. These short-circuit *before* the identity filter so they always work, regardless of permissions. (Without this shortcut the identity filter strips the caller from `super().search('me')` results because `is_identity_match(self, self, 'me')` is False, breaking `look me` for non-Builders.)
+2. **Assigned names** — Check the player's recognition memory for any character in the room whose assigned name matches the input
+3. **sdescs** — Match against visible characters' sdescs (partial matching, case-insensitive)
+4. **Ordinals** — `"2nd tall man"` uses the existing ordinal system (`get_search_query_replacement`)
+5. **Real keys** — Fall through to standard Evennia search (matches `.key` and aliases)
 
 ### Implementation Approach
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1192,6 +1192,10 @@ class Character(
           - ``candidates`` or ``location`` is explicitly provided
           - ``attribute_name`` is set
 
+        **Magic keywords** (always short-circuit, all permissions):
+          - ``me`` / ``self`` → the caller
+          - ``here`` → the caller's location
+
         **Identity pipeline** (local room search):
           1. Try identity matching (assigned names → sdescs) against
              room occupants.
@@ -1207,6 +1211,26 @@ class Character(
         """
         from world.combat.constants import PERM_BUILDER
         from world.search import identity_match_characters, is_identity_match
+
+        # ----------------------------------------------------------
+        # Magic keyword shortcut: ``me`` / ``self`` / ``here``
+        # ----------------------------------------------------------
+        # Evennia's DefaultObject.search resolves these tokens to the
+        # caller / caller.location.  Our identity filter would then
+        # strip the caller (because ``is_identity_match(self, self,
+        # "me")`` is False) and return ``Could not find 'me'.`` for
+        # any non-Builder.  Short-circuit before the identity pipeline
+        # so these tokens always resolve, regardless of permissions.
+        # See ``specs/IDENTITY_RECOGNITION_SPEC.md`` §Target Resolution.
+        if isinstance(searchdata, str):
+            stripped = searchdata.strip().lower()
+            if stripped in ("me", "self"):
+                return [self] if quiet else self
+            if stripped == "here":
+                loc = self.location
+                if quiet:
+                    return [loc] if loc else []
+                return loc
 
         # ----------------------------------------------------------
         # Bypass: let Evennia handle non-local or privileged searches

--- a/world/tests/test_identity_commands.py
+++ b/world/tests/test_identity_commands.py
@@ -2040,3 +2040,79 @@ class TestGetLookHeader(TestCase):
         # Sanity: sdesc collapses to key.
         self.assertEqual(target.get_sdesc(), "Newbie")
         self.assertEqual(target.get_look_header(looker), "Friend")
+
+
+# ===================================================================
+# Magic-keyword regressions: forget me / recall me
+# ===================================================================
+
+
+class TestForgetRecallMeAreHarmless(TestCase):
+    """Regression tests for the ``me``/``self``/``here`` shortcut.
+
+    After the shortcut, ``caller.search('me', quiet=True)`` returns
+    ``[caller]`` instead of ``[]`` — which routes ``forget me`` and
+    ``recall me`` into the visible-Character branch of those commands
+    where they previously fell through to the remembered-name path.
+
+    Both endpoints must remain harmless: no state mutation, a sensible
+    user-facing message, no exception.
+
+    See ``specs/IDENTITY_RECOGNITION_SPEC.md`` §Target Resolution
+    (Magic Keywords).
+    """
+
+    def _bind_search(self, char):
+        """Wire ``char.search`` to call the real Character.search."""
+        from typeclasses.characters import Character
+
+        char.search = lambda *a, **kw: Character.search(char, *a, **kw)
+        char.check_permstring = MagicMock(return_value=False)
+
+    def test_forget_me_is_harmless(self):
+        """``forget me`` reports no-name-remembered, mutates nothing."""
+        from commands.CmdCharacter import CmdForget
+
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+        )
+        self._bind_search(caller)
+
+        before = dict(caller.recognition_memory)
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd.args = "me"
+        cmd.func()
+
+        # No state corruption
+        self.assertEqual(caller.recognition_memory, before)
+        # Some message was emitted (no exception)
+        caller.msg.assert_called()
+
+    def test_recall_me_is_harmless(self):
+        """``recall me`` emits a 'don't recognize' message, no exception."""
+        from commands.CmdCharacter import CmdRecall
+
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+        )
+        self._bind_search(caller)
+
+        cmd = CmdRecall()
+        cmd.caller = caller
+        cmd.args = "me"
+        cmd.func()
+
+        caller.msg.assert_called()
+        msg_text = caller.msg.call_args[0][0]
+        # Either "don't recognize" (entry None branch) or
+        # "can't recall anything" (None apparent_uid branch).
+        # Both are acceptable harmless outcomes.
+        self.assertTrue(
+            "don't recognize" in msg_text
+            or "can't recall" in msg_text,
+            f"Unexpected message: {msg_text!r}",
+        )

--- a/world/tests/test_identity_search.py
+++ b/world/tests/test_identity_search.py
@@ -703,3 +703,115 @@ class TestParseOrdinalEvennia(TestCase):
         self.assertTrue(
             is_identity_match(searcher, jorge, "1.man")
         )
+
+
+# ===================================================================
+# Tests: Magic keyword shortcuts (me / self / here)
+# ===================================================================
+
+
+class TestCharacterSearchMagicKeywords(TestCase):
+    """Verify ``me``/``self``/``here`` short-circuit before identity filter.
+
+    Regression coverage for the latent bug where non-Builder characters
+    got ``Could not find 'me'.`` from ``look me`` because the identity
+    filter stripped them from their own search results.
+
+    See ``specs/IDENTITY_RECOGNITION_SPEC.md`` §Target Resolution
+    (Magic Keywords).
+    """
+
+    def setUp(self):
+        """Build a searcher with a real bound Character.search."""
+        from typeclasses.characters import Character
+
+        self.searcher = _make_character(
+            key="Alice Smith",
+            sex="female",
+            sleeve_uid="uid-searcher",
+        )
+
+        self.room = MagicMock()
+        self.room.contents = [self.searcher]
+        self.searcher.location = self.room
+
+        self.searcher.search = (
+            lambda *a, **kw: Character.search(self.searcher, *a, **kw)
+        )
+        self.searcher.msg = MagicMock()
+        # Default: not a builder (the bug only manifests for non-builders)
+        self.searcher.check_permstring = MagicMock(return_value=False)
+
+    # -- "me" --
+
+    def test_search_me_returns_self(self):
+        """``search('me')`` returns the caller (non-quiet scalar)."""
+        result = self.searcher.search("me")
+        self.assertIs(result, self.searcher)
+
+    def test_search_me_quiet_returns_list_with_self(self):
+        """``search('me', quiet=True)`` returns ``[caller]``."""
+        result = self.searcher.search("me", quiet=True)
+        self.assertEqual(result, [self.searcher])
+
+    def test_search_me_case_insensitive(self):
+        """``ME``/``Me`` resolve identically to ``me``."""
+        self.assertIs(self.searcher.search("ME"), self.searcher)
+        self.assertIs(self.searcher.search("Me"), self.searcher)
+
+    def test_search_me_strips_whitespace(self):
+        """``'  me  '`` still resolves to caller."""
+        self.assertIs(self.searcher.search("  me  "), self.searcher)
+
+    # -- "self" --
+
+    def test_search_self_returns_self(self):
+        """``search('self')`` returns the caller."""
+        result = self.searcher.search("self")
+        self.assertIs(result, self.searcher)
+
+    def test_search_self_case_insensitive(self):
+        """``SELF`` resolves to caller."""
+        self.assertIs(self.searcher.search("SELF"), self.searcher)
+
+    # -- "here" --
+
+    def test_search_here_returns_location(self):
+        """``search('here')`` returns the caller's location."""
+        result = self.searcher.search("here")
+        self.assertIs(result, self.room)
+
+    def test_search_here_quiet_returns_list_with_location(self):
+        """``search('here', quiet=True)`` returns ``[location]``."""
+        result = self.searcher.search("here", quiet=True)
+        self.assertEqual(result, [self.room])
+
+    def test_search_here_when_no_location_quiet_returns_empty_list(self):
+        """No location + quiet → ``[]`` (matches Evennia search contract)."""
+        self.searcher.location = None
+        result = self.searcher.search("here", quiet=True)
+        self.assertEqual(result, [])
+
+    def test_search_here_when_no_location_nonquiet_returns_none(self):
+        """No location + non-quiet → ``None``."""
+        self.searcher.location = None
+        result = self.searcher.search("here")
+        self.assertIsNone(result)
+
+    # -- Regression: the original bug --
+
+    def test_me_works_for_non_builder(self):
+        """Regression: non-Builder ``look me`` must NOT return None.
+
+        Previously the identity filter stripped the caller from
+        ``super().search('me')`` results because
+        ``is_identity_match(self, self, 'me')`` returns False, and
+        only Builders bypassed that filter.  This test guards against
+        that regression.
+        """
+        # Explicitly assert we're testing the non-builder path
+        self.assertFalse(self.searcher.check_permstring("Builder"))
+        result = self.searcher.search("me")
+        self.assertIs(result, self.searcher)
+        # No "Could not find" message should fire
+        self.searcher.msg.assert_not_called()


### PR DESCRIPTION
## Summary
- Add a magic-keyword shortcut to `Character.search` so `me`/`self`/`here` resolve to the caller / caller's location for **all** characters, not just Builders.
- Without this, non-Builder players got `Could not find 'me'.` from `look me` because the identity filter stripped the caller from `super().search('me')` results (`is_identity_match(self, self, 'me')` is False, and only Builders bypassed the filter — masking the bug from staff).
- Latent pre-existing bug; not a regression from #128/#129. Reproducible on any freshly-created non-builder character.

## Changes
- **`typeclasses/characters.py`** — short-circuit `me`/`self`/`here` at the top of `Character.search`, before bypass logic. Returns `[self]`/`self` for `me`/`self`, `[location]`/`location` (or `[]`/`None`) for `here`, matching Evennia's `DefaultObject.search` return-shape contract (list when `quiet=True`, scalar otherwise).
- **`world/tests/test_identity_search.py`** — new `TestCharacterSearchMagicKeywords` class with 8 tests covering `me`/`self`/`here`, case-insensitivity, whitespace, quiet/non-quiet shapes, no-location edge case, and a non-Builder regression guard.
- **`world/tests/test_identity_commands.py`** — new `TestForgetRecallMeAreHarmless` class with 2 regression tests confirming `forget me` and `recall me` remain harmless after the shortcut routes them into the visible-Character branch instead of the remembered-name fallback.
- **`specs/IDENTITY_RECOGNITION_SPEC.md`** — Target Resolution priority list now documents the magic-keyword shortcut as step 1.

## Disguise & Recognition Audit
Verified the shortcut does not interfere with identity systems:
- `CmdRemember` `remember me as <name>` already short-circuits `me` *before* `caller.search` (CmdCharacter.py:1313) — unchanged.
- `CmdForget` `forget me` → `_forget_visible(caller, caller, ...)` → `apparent_uid not in memory` → `"You don't have a name remembered for them."` — harmless.
- `CmdRecall` `recall me` → `caller.recognition_memory[own_uid]` is None → `"You don't recognize that person."` — harmless.
- `CmdAppear`, `bump_recognition_recency`, `get_apparent_uid`, `get_sdesc`, `get_display_name`, `get_look_header` — none call `caller.search` for self-resolution.
- Builder bypass and dbref/global/candidates/location bypasses untouched.

## Test Results
- `evennia test world.tests.test_identity_search` — 70 passed (was 60; +10)
- `evennia test world.tests.test_identity_commands` — 86 passed (was 84; +2)
- `evennia test world` — **639 passed** (was 626; +13)

## Live Verification
Reloaded production. Probed Laszlo XLIV (#2017, non-Builder):
```
me=[Laszlo XLIV]    # was [] before fix
self=[Laszlo XLIV]  # was [] before fix
here=[]             # location is None (offline); correct shape
is_builder=False
```