### PR TITLE
Fix ungrammatical articles for pluralia-tantum garments

### DIFF
--- a/commands/CmdClothing.py
+++ b/commands/CmdClothing.py
@@ -16,7 +16,7 @@ from world.combat.constants import (
     STYLE_STATE_UNZIPPED,
     STYLE_STATE_ZIPPED,
 )
-from world.grammar import get_article
+from world.grammar import with_article
 from world.identity_utils import msg_room_identity
 
 
@@ -56,8 +56,12 @@ def _snapshot_actor_names(caller, char_refs):
 
 
 def _articled(item_key: str) -> str:
-    """Return ``"a black balaclava"`` / ``"an axe handle"`` for *item_key*."""
-    return f"{get_article(item_key)} {item_key}"
+    """Return ``"a black balaclava"`` / ``"blue jeans"`` for *item_key*.
+
+    Pluralia-tantum nouns (``"blue jeans"``) are returned bare; all
+    other nouns receive the appropriate indefinite article.
+    """
+    return with_article(item_key)
 
 
 class CmdWear(Command):

--- a/specs/EMOTE_POSE_SPEC.md
+++ b/specs/EMOTE_POSE_SPEC.md
@@ -359,151 +359,19 @@ Multiple speech blocks are each tokenized independently. The language system hoo
 
 ---
 
-## Grammar Engine (`world/grammar.py`)
+## Grammar Engine
 
-A standalone utility module with no Evennia dependencies in its core functions. Imported by the emote system, the identity system, and any future system that needs English grammar processing.
+Verb conjugation, article handling (including pluralia tantum),
+pronoun transformation, possessive forms, capitalization, and
+default sdesc keywords are defined in their own dedicated
+specification:
 
-### Verb Conjugation
+- See [`GRAMMAR_ENGINE_SPEC.md`](GRAMMAR_ENGINE_SPEC.md) for the full
+  grammar engine specification.
 
-Converts base-form verbs to third-person singular present tense.
-
-```python
-def conjugate_third_person(verb: str) -> str:
-    """Convert base-form verb to third-person singular present.
-
-    Args:
-        verb: Base form ("lean", "catch", "try").
-
-    Returns:
-        Conjugated form ("leans", "catches", "tries").
-    """
-```
-
-**Irregular table** (checked first):
-
-| Base Form | Third Person |
-|---|---|
-| be | is |
-| have | has |
-
-**Regular rules** (applied in order after irregular table check):
-
-| # | Rule | Pattern | Example |
-|---|---|---|---|
-| 1 | Sibilant | Ends in -s, -sh, -ch, -x, -z | pass → passes, push → pushes, catch → catches, fix → fixes, buzz → buzzes |
-| 2 | -O ending | Ends in -o | go → goes, do → does, echo → echoes |
-| 3 | Consonant + Y | Ends in [consonant] + y | try → tries, carry → carries, fly → flies |
-| 4 | Default | Everything else | lean → leans, run → runs, play → plays, say → says |
-
-The function checks the irregular table first, then applies regular rules in order. Unknown words always receive regular treatment — the system never refuses to conjugate.
-
-The irregular table is intentionally minimal. English third-person singular present tense is remarkably regular — only `be` and `have` are truly irregular for this conjugation. The table is easily extensible if edge cases emerge.
-
-### Article Handling
-
-Uses the `inflect` library for phoneme-aware article selection:
-
-```python
-import inflect
-
-_engine = inflect.engine()
-
-def get_article(noun_phrase: str, definite: bool = False) -> str:
-    """Get the appropriate article for a noun phrase.
-
-    Args:
-        noun_phrase: The noun phrase ("lanky man", "athletic dame").
-        definite: If True, return "the". If False, return "a"/"an".
-
-    Returns:
-        Article string: "a", "an", or "the".
-    """
-    if definite:
-        return "the"
-    result = _engine.a(noun_phrase)  # Returns "a lanky man" or "an athletic dame"
-    return result.split(" ", 1)[0]   # Extract just the article
-```
-
-**Context rules** (applied by the rendering pipeline, not the grammar engine):
-
-- **Indefinite** (default for sdescs): `"a lanky man"`, `"an athletic dame"`
-- **Definite** (for targeting / repeated reference): `"the lanky man"`
-- **None** (for assigned names and "You"): `"Jorge"` — no article
-
-### Pronoun Transformation
-
-```python
-def transform_pronoun(
-    pronoun: str,
-    target_person: str,
-    gender: str = "neutral",
-) -> str:
-    """Transform a first-person pronoun to the target perspective.
-
-    Args:
-        pronoun: First-person pronoun ("I", "me", "my", "mine", "myself").
-        target_person: "second" (actor self-view) or "third" (observer view).
-        gender: "male", "female", or "neutral". Only used for third person.
-
-    Returns:
-        Transformed pronoun string.
-    """
-```
-
-**Gender mapping** from character `sex` attribute:
-
-```python
-GENDER_MAP = {
-    "male": "male",
-    "female": "female",
-    "ambiguous": "neutral",
-    "neutral": "neutral",
-    "nonbinary": "neutral",
-    "other": "neutral",
-}
-```
-
-See Appendix B for the complete transformation tables.
-
-### Possessive and Objective Forms
-
-For display names used by the identity system and emote rendering:
-
-```python
-def possessive(name: str) -> str:
-    """Form the possessive of a name or noun phrase.
-
-    Args:
-        name: "Jorge", "a lanky man", "you".
-
-    Returns:
-        "Jorge's", "a lanky man's", "your".
-    """
-```
-
-| Input | Output | Notes |
-|---|---|---|
-| `"Jorge"` | `"Jorge's"` | Standard possessive |
-| `"a lanky man"` | `"a lanky man's"` | Sdesc possessive |
-| `"you"` | `"your"` | Pronoun — lookup table |
-| `"he"` | `"his"` | Pronoun — lookup table |
-| `"she"` | `"her"` | Pronoun — lookup table |
-| `"they"` | `"their"` | Pronoun — lookup table |
-
-Pronoun possessives are handled by a lookup table. All other inputs receive `'s` appended.
-
-### Subject-Verb Agreement
-
-The conjugation function pairs with the subject reference:
-
-| Subject | Verb Form | Example |
-|---|---|---|
-| "You" (actor self-view) | Base form | "You lean back." |
-| Named character | Third-person singular | "Jorge leans back." |
-| Sdesc (singular) | Third-person singular | "A lanky man leans back." |
-
-The rendering pipeline handles this: if the observer is the actor, use the base form; otherwise, use `conjugate_third_person()`.
-
+The pronoun transformation tables are still listed in Appendix B of
+this document for convenient reference from the rendering pipeline
+below.
 ---
 
 ## Per-Observer Rendering Pipeline

--- a/specs/GRAMMAR_ENGINE_SPEC.md
+++ b/specs/GRAMMAR_ENGINE_SPEC.md
@@ -1,0 +1,288 @@
+# Grammar Engine Specification
+
+## Overview
+
+The Grammar Engine (`world/grammar.py`) is a standalone utility module providing
+English grammar processing — verb conjugation, article handling, pronoun
+transformation, possessive formation, and capitalization.
+
+It has **no Evennia dependencies in its core functions**. It is imported by
+the emote system, the identity system, the clothing system, the combat
+system, and any future system that needs English grammar processing.
+
+This spec is the canonical reference for the engine. The Emote/Pose,
+Identity/Recognition, and Clothing specs all delegate grammar concerns here.
+
+---
+
+## Verb Conjugation
+
+Converts base-form verbs to third-person singular present tense.
+
+```python
+def conjugate_third_person(verb: str) -> str:
+    """Convert base-form verb to third-person singular present.
+
+    Args:
+        verb: Base form ("lean", "catch", "try").
+
+    Returns:
+        Conjugated form ("leans", "catches", "tries").
+    """
+```
+
+**Irregular table** (checked first):
+
+| Base Form | Third Person |
+|---|---|
+| be | is |
+| have | has |
+
+**Regular rules** (applied in order after irregular table check):
+
+| # | Rule | Pattern | Example |
+|---|---|---|---|
+| 1 | Sibilant | Ends in -s, -sh, -ch, -x, -z | pass → passes, push → pushes, catch → catches, fix → fixes, buzz → buzzes |
+| 2 | -O ending | Ends in -o | go → goes, do → does, echo → echoes |
+| 3 | Consonant + Y | Ends in [consonant] + y | try → tries, carry → carries, fly → flies |
+| 4 | Default | Everything else | lean → leans, run → runs, play → plays, say → says |
+
+The function checks the irregular table first, then applies regular rules
+in order. Unknown words always receive regular treatment — the system never
+refuses to conjugate.
+
+The irregular table is intentionally minimal. English third-person singular
+present tense is remarkably regular — only `be` and `have` are truly
+irregular for this conjugation. The table is easily extensible if edge
+cases emerge.
+
+---
+
+## Article Handling
+
+The engine exposes two article-related helpers:
+
+- `get_article(noun_phrase, definite=False)` — returns just the article
+  string (`"a"`, `"an"`, or `"the"`).
+- `with_article(noun_phrase, definite=False)` — returns the noun phrase
+  prefixed with its article, or bare for indefinite pluralia tantum.
+
+`with_article` is the canonical helper for callers that want a complete
+noun phrase. `get_article` remains for callers that need just the article
+token.
+
+### Phoneme-aware article selection
+
+```python
+import inflect
+
+_engine = inflect.engine()
+
+def get_article(noun_phrase: str, definite: bool = False) -> str:
+    """Get the appropriate article for a noun phrase.
+
+    Args:
+        noun_phrase: The noun phrase ("lanky man", "athletic dame").
+        definite: If True, return "the". If False, return "a"/"an".
+
+    Returns:
+        Article string: "a", "an", or "the".
+    """
+    if definite:
+        return "the"
+    result = _engine.a(noun_phrase)  # "a lanky man" or "an athletic dame"
+    return result.split(" ", 1)[0]   # Extract just the article
+```
+
+**Context rules** (applied by callers, not the grammar engine):
+
+- **Indefinite** (default for sdescs): `"a lanky man"`, `"an athletic dame"`
+- **Definite** (for targeting / repeated reference): `"the lanky man"`
+- **None** (for assigned names and "You"): `"Jorge"` — no article
+
+### Pluralia tantum
+
+Some English nouns exist only — or idiomatically, in sdesc context — in
+plural form and reject the indefinite article: `"blue jeans"` is
+grammatical, `"*a blue jeans"` is not. The engine maintains a curated
+frozenset of such nouns and exposes a detector:
+
+```python
+def is_pluralia_tantum(noun_phrase: str) -> bool:
+    """Return True if the head noun of *noun_phrase* is pluralia tantum."""
+```
+
+**Categories covered:**
+
+| Category | Examples |
+|---|---|
+| True pluralia tantum garments | jeans, pants, trousers, shorts, leggings, overalls |
+| Paired-noun garments (idiomatic plural) | boots, shoes, gloves, socks, sneakers |
+| Eyewear | glasses, goggles, sunglasses, binoculars |
+| Two-bladed/handled tools | scissors, pliers, tweezers, tongs, shears |
+
+**Head-noun rule.** Detection inspects only the *head* of the noun
+phrase — the last token before the first prepositional break (`" in "`,
+`" with "`, `" wielding "`, `" wearing "`, `" holding "`). This means
+sdesc-style phrases such as `"stocky droog in blue jeans"` are judged
+on the wearer (`"droog"`), not the garment (`"jeans"`), so the wearer
+still correctly receives `"a"`.
+
+**Why not `inflect.singular_noun`?** The `inflect` library's plural
+detection is unreliable for pluralia tantum: it returns `"jean"` for
+`"jeans"`. An explicit curated set is the only correct approach.
+
+### Article composition
+
+```python
+def with_article(noun_phrase: str, definite: bool = False) -> str:
+    """Return *noun_phrase* prefixed with the appropriate article.
+
+    Pluralia-tantum nouns receive no indefinite article — "blue jeans"
+    is returned bare, never "*a blue jeans". The definite article "the"
+    is grammatical with both singular and plural nouns and is applied
+    uniformly when *definite* is True.
+    """
+```
+
+| Input | `definite=False` | `definite=True` |
+|---|---|---|
+| `"Black Trenchcoat"` | `"a Black Trenchcoat"` | `"the Black Trenchcoat"` |
+| `"Orange Jumpsuit"` | `"an Orange Jumpsuit"` | `"the Orange Jumpsuit"` |
+| `"blue jeans"` | `"blue jeans"` | `"the blue jeans"` |
+| `"black leather combat boots"` | `"black leather combat boots"` | `"the black leather combat boots"` |
+| `"stocky droog in blue jeans"` | `"a stocky droog in blue jeans"` | `"the stocky droog in blue jeans"` |
+
+### Per-item override (deferred)
+
+A future enhancement could allow individual prototypes to override
+pluralia-tantum classification via an item attribute (e.g. for an
+ironic singular `"Pair O' Jeans"` artifact). This is **deferred** until
+a real one-off case demands it; the centralized set is sufficient for
+all current prototypes.
+
+---
+
+## Pronoun Transformation
+
+```python
+def transform_pronoun(
+    pronoun: str,
+    target_person: str,
+    gender: str = "neutral",
+) -> str:
+    """Transform a first-person pronoun to the target perspective.
+
+    Args:
+        pronoun: First-person pronoun ("I", "me", "my", "mine", "myself").
+        target_person: "second" (actor self-view) or "third" (observer view).
+        gender: "male", "female", or "neutral". Only used for third person.
+
+    Returns:
+        Transformed pronoun string.
+    """
+```
+
+**Gender mapping** from character `sex` attribute:
+
+```python
+GENDER_MAP = {
+    "male": "male",
+    "female": "female",
+    "ambiguous": "neutral",
+    "neutral": "neutral",
+    "nonbinary": "neutral",
+    "other": "neutral",
+}
+```
+
+See `EMOTE_POSE_SPEC.md` Appendix B for the complete transformation tables.
+
+---
+
+## Possessive Forms
+
+For display names used by the identity system and emote rendering:
+
+```python
+def possessive(name: str) -> str:
+    """Form the possessive of a name or noun phrase.
+
+    Args:
+        name: "Jorge", "a lanky man", "you".
+
+    Returns:
+        "Jorge's", "a lanky man's", "your".
+    """
+```
+
+| Input | Output | Notes |
+|---|---|---|
+| `"Jorge"` | `"Jorge's"` | Standard possessive |
+| `"a lanky man"` | `"a lanky man's"` | Sdesc possessive |
+| `"you"` | `"your"` | Pronoun — lookup table |
+| `"he"` | `"his"` | Pronoun — lookup table |
+| `"she"` | `"her"` | Pronoun — lookup table |
+| `"they"` | `"their"` | Pronoun — lookup table |
+
+Pronoun possessives are handled by a lookup table. All other inputs
+receive `'s` appended.
+
+---
+
+## Subject-Verb Agreement
+
+The conjugation function pairs with the subject reference:
+
+| Subject | Verb Form | Example |
+|---|---|---|
+| "You" (actor self-view) | Base form | "You lean back." |
+| Named character | Third-person singular | "Jorge leans back." |
+| Sdesc (singular) | Third-person singular | "A lanky man leans back." |
+
+The rendering pipeline handles this: if the observer is the actor, use
+the base form; otherwise, use `conjugate_third_person()`.
+
+---
+
+## Capitalization
+
+```python
+def capitalize_first(text: str) -> str:
+    """Capitalise the first alphabetic character of a string."""
+```
+
+Unlike `str.capitalize()`, this preserves the case of all subsequent
+characters and handles leading non-alpha characters (e.g. opening
+quotes). Used by the emote pipeline for sentence-initial rendering.
+
+---
+
+## Default Sdesc Keywords
+
+```python
+DEFAULT_SDESC_KEYWORDS = {
+    "male": "man",
+    "female": "woman",
+    "neutral": "person",
+}
+```
+
+Fallback keyword assigned to new characters based on grammar gender,
+when no explicit keyword has been chosen via `@shortdesc`. Keyed by the
+output of `GENDER_MAP`, not the raw `sex` attribute.
+
+---
+
+## Testing
+
+All grammar functions are unit-tested in `world/tests/test_grammar.py`
+with no Evennia dependencies. Run via:
+
+```
+evennia test world.tests.test_grammar
+```
+
+Test classes: `TestVerbConjugation`, `TestArticles`,
+`TestIsPluraliaTantum`, `TestWithArticle`,
+`TestPronounTransformation`, `TestPossessive`, `TestCapitalizeFirst`.

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1033,14 +1033,13 @@ class Character(
                     return assigned
 
         # Fall back to sdesc with indefinite article
-        from world.grammar import get_article
+        from world.grammar import with_article
 
         sdesc = self.get_sdesc()
         # If sdesc fell back to self.key, return it as-is (no article)
         if sdesc == self.key:
             return self.key
-        article = get_article(sdesc)
-        return f"{article} {sdesc}"
+        return with_article(sdesc)
 
     def get_look_header(self, looker=None, **kwargs):
         """Return the appearance-header form of this character's name.
@@ -1100,10 +1099,9 @@ class Character(
         if sdesc == self.key:
             return name
 
-        from world.grammar import get_article
+        from world.grammar import with_article
 
-        article = get_article(sdesc)
-        return f"{name} ({article} {sdesc})"
+        return f"{name} ({with_article(sdesc)})"
 
     def at_post_move(self, source_location, **kwargs):
         """Hook called after this character lands in a new location.

--- a/typeclasses/clothing_mixin.py
+++ b/typeclasses/clothing_mixin.py
@@ -7,7 +7,7 @@ coverage queries, and the clothing coverage map builder for Character objects.
 Extracted from typeclasses/characters.py in Phase 4 refactoring.
 """
 
-from world.grammar import get_article
+from world.grammar import with_article
 
 
 class ClothingMixin:
@@ -209,7 +209,7 @@ class ClothingMixin:
 
             location_items.insert(insert_index, item)
 
-        return True, f"You put on {get_article(item.key)} {item.key}."
+        return True, f"You put on {with_article(item.key)}."
 
     def remove_item(self, item):
         """
@@ -288,7 +288,7 @@ class ClothingMixin:
                     if not items:
                         del self.worn_items[location]
 
-        return True, f"You remove {get_article(item.key)} {item.key}."
+        return True, f"You remove {with_article(item.key)}."
 
     def is_item_worn(self, item):
         """

--- a/world/grammar.py
+++ b/world/grammar.py
@@ -9,7 +9,7 @@ This is a standalone utility module with no Evennia dependencies in its
 core functions. It is imported by the emote system, the identity system,
 and any future system that needs English grammar processing.
 
-See specs/EMOTE_POSE_SPEC.md §Grammar Engine for the full specification.
+See specs/GRAMMAR_ENGINE_SPEC.md for the full specification.
 """
 
 from __future__ import annotations
@@ -110,6 +110,94 @@ def get_article(noun_phrase: str, definite: bool = False) -> str:
         return "the"
     result = _engine.a(noun_phrase)  # e.g. "a lanky man" or "an athletic dame"
     return result.split(" ", 1)[0]   # Extract just the article
+
+
+#: Pluralia-tantum nouns: English nouns that exist only (or idiomatically)
+#: in plural form and therefore reject the indefinite article "a/an".
+#: A bare noun phrase ("blue jeans") is grammatical; "*a blue jeans" is not.
+#:
+#: Categories:
+#:   - True pluralia tantum garments (jeans, trousers, ...)
+#:   - Paired-noun garments idiomatically referenced as plurals in sdescs
+#:     (boots, gloves, ...)
+#:   - Eyewear (glasses, goggles, ...)
+#:   - Two-bladed/handled tools (scissors, pliers, ...)
+_PLURALIA_TANTUM_NOUNS: frozenset[str] = frozenset({
+    # garments (true pluralia tantum)
+    "jeans", "pants", "trousers", "shorts", "briefs", "leggings",
+    "tights", "overalls", "pyjamas", "pajamas", "knickers",
+    "bloomers", "slacks", "chaps", "dungarees", "coveralls",
+    # paired-noun garments
+    "boots", "shoes", "gloves", "socks", "sneakers", "sandals",
+    "slippers", "heels", "loafers", "moccasins", "mittens",
+    # eyewear
+    "glasses", "goggles", "spectacles", "binoculars",
+    "sunglasses", "shades",
+    # tools
+    "scissors", "pliers", "tweezers", "tongs", "shears", "clippers",
+    # other
+    "trunks",
+})
+
+#: Prepositions that introduce a non-head modifier in a noun phrase.
+#: When detecting whether a noun phrase is pluralia tantum we only
+#: inspect the head phrase preceding the first such break — so
+#: ``"stocky droog in blue jeans"`` is judged on ``"stocky droog"``.
+_PREP_BREAKS: tuple[str, ...] = (
+    " in ", " with ", " wielding ", " wearing ", " holding ",
+)
+
+
+def is_pluralia_tantum(noun_phrase: str) -> bool:
+    """Return ``True`` if the head noun of *noun_phrase* is pluralia tantum.
+
+    The head noun is the last token of the phrase preceding the first
+    prepositional break (``" in "``, ``" with "``, etc.).  This means
+    sdesc-style phrases such as ``"stocky droog in blue jeans"`` are
+    judged on the wearer ("droog"), not on the garment ("jeans").
+
+    Args:
+        noun_phrase: A noun phrase such as ``"blue jeans"``,
+            ``"Black Trenchcoat"``, or ``"stocky droog in blue jeans"``.
+
+    Returns:
+        ``True`` if the head noun is in :data:`_PLURALIA_TANTUM_NOUNS`,
+        ``False`` otherwise.
+    """
+    lower = noun_phrase.strip().lower()
+    for prep in _PREP_BREAKS:
+        idx = lower.find(prep)
+        if idx >= 0:
+            lower = lower[:idx]
+            break
+    tokens = lower.split()
+    return bool(tokens) and tokens[-1] in _PLURALIA_TANTUM_NOUNS
+
+
+def with_article(noun_phrase: str, definite: bool = False) -> str:
+    """Return *noun_phrase* prefixed with the appropriate article.
+
+    Pluralia-tantum nouns receive no indefinite article — ``"blue jeans"``
+    is returned bare, never ``"*a blue jeans"``.  The definite article
+    ``"the"`` is grammatical with both singular and plural nouns and is
+    applied uniformly when *definite* is ``True``.
+
+    Args:
+        noun_phrase: A noun phrase to which an article should be
+            prepended (e.g. ``"Black Trenchcoat"``, ``"blue jeans"``).
+        definite: If ``True``, prepend ``"the"``.  If ``False``,
+            prepend ``"a"``/``"an"`` for singular nouns and nothing for
+            pluralia tantum.
+
+    Returns:
+        The noun phrase with its article (or bare, for indefinite
+        pluralia tantum).
+    """
+    if definite:
+        return f"the {noun_phrase}"
+    if is_pluralia_tantum(noun_phrase):
+        return noun_phrase
+    return f"{get_article(noun_phrase)} {noun_phrase}"
 
 
 # ---------------------------------------------------------------------------

--- a/world/identity.py
+++ b/world/identity.py
@@ -21,7 +21,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from evennia.scripts.scripts import DefaultScript
 from evennia.utils import logger
 
-from world.grammar import GENDER_MAP, get_article
+from world.grammar import GENDER_MAP, with_article
 
 if TYPE_CHECKING:
     from evennia.accounts.models import AccountDB
@@ -566,8 +566,7 @@ def format_wielded_feature(item_name: str) -> str:
     Returns:
         Feature clause, e.g. ``"wielding a Kitchen Knife"``.
     """
-    article = get_article(item_name)
-    return f"wielding {article} {item_name}"
+    return f"wielding {with_article(item_name)}"
 
 
 def format_clothing_feature(item_name: str) -> str:
@@ -579,8 +578,7 @@ def format_clothing_feature(item_name: str) -> str:
     Returns:
         Feature clause, e.g. ``"in a Black Trenchcoat"``.
     """
-    article = get_article(item_name)
-    return f"in {article} {item_name}"
+    return f"in {with_article(item_name)}"
 
 
 def format_hair_feature(

--- a/world/tests/test_grammar.py
+++ b/world/tests/test_grammar.py
@@ -17,8 +17,10 @@ from world.grammar import (
     capitalize_first,
     conjugate_third_person,
     get_article,
+    is_pluralia_tantum,
     possessive,
     transform_pronoun,
+    with_article,
 )
 
 
@@ -168,6 +170,84 @@ class TestArticles(TestCase):
 
     def test_definite_ignores_phonetics(self) -> None:
         self.assertEqual(get_article("athletic dame", definite=True), "the")
+
+
+# -----------------------------------------------------------------------
+# Pluralia-Tantum Detection
+# -----------------------------------------------------------------------
+
+
+class TestIsPluraliaTantum(TestCase):
+    """Tests for ``is_pluralia_tantum``."""
+
+    def test_pluralia_tantum_jeans(self) -> None:
+        self.assertTrue(is_pluralia_tantum("blue jeans"))
+
+    def test_pluralia_tantum_boots(self) -> None:
+        self.assertTrue(is_pluralia_tantum("black leather combat boots"))
+
+    def test_pluralia_tantum_glasses(self) -> None:
+        self.assertTrue(is_pluralia_tantum("aviator sunglasses"))
+
+    def test_pluralia_tantum_scissors(self) -> None:
+        self.assertTrue(is_pluralia_tantum("scissors"))
+
+    def test_not_pluralia_tantum_trenchcoat(self) -> None:
+        self.assertFalse(is_pluralia_tantum("Black Trenchcoat"))
+
+    def test_pluralia_tantum_ignores_prep_phrase(self) -> None:
+        """Head noun is the wearer, not the garment."""
+        self.assertFalse(is_pluralia_tantum("stocky droog in blue jeans"))
+
+    def test_pluralia_tantum_case_insensitive(self) -> None:
+        self.assertTrue(is_pluralia_tantum("Blue JEANS"))
+
+
+# -----------------------------------------------------------------------
+# Article Composition
+# -----------------------------------------------------------------------
+
+
+class TestWithArticle(TestCase):
+    """Tests for ``with_article``."""
+
+    def test_with_article_pluralia_tantum_indefinite(self) -> None:
+        """Pluralia-tantum nouns receive no indefinite article."""
+        self.assertEqual(with_article("blue jeans"), "blue jeans")
+
+    def test_with_article_pluralia_tantum_definite(self) -> None:
+        self.assertEqual(
+            with_article("blue jeans", definite=True), "the blue jeans"
+        )
+
+    def test_with_article_singular_a(self) -> None:
+        self.assertEqual(
+            with_article("Black Trenchcoat"), "a Black Trenchcoat"
+        )
+
+    def test_with_article_singular_an(self) -> None:
+        self.assertEqual(
+            with_article("Orange Jumpsuit"), "an Orange Jumpsuit"
+        )
+
+    def test_with_article_definite(self) -> None:
+        self.assertEqual(
+            with_article("Black Trenchcoat", definite=True),
+            "the Black Trenchcoat",
+        )
+
+    def test_with_article_full_sdesc_with_garment(self) -> None:
+        """Regression: look-header sdesc with prep-phrase still gets 'a'."""
+        self.assertEqual(
+            with_article("stocky droog in blue jeans"),
+            "a stocky droog in blue jeans",
+        )
+
+    def test_with_article_starts_with_vowel_pluralia_tantum(self) -> None:
+        """Pluralia tantum overrides phoneme-based 'an' selection."""
+        self.assertEqual(
+            with_article("orange overalls"), "orange overalls"
+        )
 
 
 # -----------------------------------------------------------------------

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -505,6 +505,13 @@ class TestFormatWieldedFeature(TestCase):
             "wielding an Assault Rifle",
         )
 
+    def test_pluralia_tantum_scissors(self) -> None:
+        """Pluralia-tantum tools wield bare, no indefinite article."""
+        self.assertEqual(
+            format_wielded_feature("scissors"),
+            "wielding scissors",
+        )
+
 
 class TestFormatClothingFeature(TestCase):
     """Tests for ``format_clothing_feature``."""
@@ -519,6 +526,19 @@ class TestFormatClothingFeature(TestCase):
         self.assertEqual(
             format_clothing_feature("Orange Jumpsuit"),
             "in an Orange Jumpsuit",
+        )
+
+    def test_pluralia_tantum_jeans(self) -> None:
+        """Pluralia-tantum garments worn bare, no indefinite article."""
+        self.assertEqual(
+            format_clothing_feature("blue jeans"),
+            "in blue jeans",
+        )
+
+    def test_pluralia_tantum_boots(self) -> None:
+        self.assertEqual(
+            format_clothing_feature("black leather combat boots"),
+            "in black leather combat boots",
         )
 
 


### PR DESCRIPTION
## Summary
- Fixes `\"a blue jeans\"` / `\"You put on a blue jeans.\"` and similar ungrammatical output for pluralia-tantum garments (jeans, pants, boots, gloves, sunglasses, scissors, ...).
- Adds `is_pluralia_tantum()` and `with_article()` helpers to `world/grammar.py` backed by a curated frozenset of pluralia-tantum nouns.
- Extracts the grammar engine spec into a dedicated `specs/GRAMMAR_ENGINE_SPEC.md`.

## Approach
- **Head-noun detection**: `is_pluralia_tantum` splits on prepositional breaks (`\" in \"`, `\" with \"`, `\" wielding \"`, `\" wearing \"`, `\" holding \"`) and inspects only the head noun. So `\"stocky droog in blue jeans\"` is judged on `\"droog\"` and still receives `\"a\"`.
- **Centralized**: pluralia-tantum classification is a property of English nouns, not items, so it lives in `world/grammar.py` rather than per-prototype attributes. A per-item override can be layered on later if a one-off case demands it.
- **Terse messages**: wear/remove messages now read `\"You put on blue jeans.\"` (no forced \"pair of\" idiom).
- **`get_article` retained** for back-compat; `with_article` is the canonical helper.

## Migrated call sites
| File | Site |
|---|---|
| `world/identity.py` | `format_wielded_feature`, `format_clothing_feature` |
| `typeclasses/clothing_mixin.py` | wear / remove messages |
| `commands/CmdClothing.py` | `_articled` helper |
| `typeclasses/characters.py` | `get_display_name`, `get_look_header` |

## Tests
- `world/tests/test_grammar.py` — `TestIsPluraliaTantum` (7), `TestWithArticle` (7)
- `world/tests/test_identity.py` — 3 new (jeans/boots clothing, scissors wielded)
- **Full world suite: 656 passing** (was 639 + 17 new)

## Spec changes
- Created `specs/GRAMMAR_ENGINE_SPEC.md` (engine now serves emote, identity, clothing, and combat systems).
- Replaced §Grammar Engine in `EMOTE_POSE_SPEC.md` with a stub link.

## Live verification
With_article on the live container after reload:
- `with_article(\"blue jeans\")` → `\"blue jeans\"`
- `with_article(\"blue jeans\", definite=True)` → `\"the blue jeans\"`
- `with_article(\"black leather combat boots\")` → `\"black leather combat boots\"`
- `with_article(\"stocky droog in blue jeans\")` → `\"a stocky droog in blue jeans\"` (head-noun rule)
- `with_article(\"Orange Jumpsuit\")` → `\"an Orange Jumpsuit\"` (singular unaffected)