### PR TITLE
Add Phase 3.5 disguise prototype catalog (Class A + B)

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -724,6 +724,324 @@ BALACLAVA = {
     ],
 }
 
+# =========================================================================
+# Disguise Catalog — Phase 3.5
+# =========================================================================
+#
+# See specs/IDENTITY_RECOGNITION_SPEC.md §"Disguise Item Taxonomy".
+#
+# Two classes of disguise items:
+#
+# Class A — Visibly-obfuscating: carry a non-empty ``disguise_adjective``
+#   that is injected into the wearer's sdesc as a red-flag prefix
+#   ("masked", "hooded"). Observers see the disguise itself.
+#
+# Class B — Silent obfuscators: carry ``disguise_adjective=""`` so they
+#   shift the Apparent UID without announcing themselves in the sdesc.
+#   Wigs, contacts, and sunglasses fall here — disguise works precisely
+#   because it does not call attention to itself.
+#
+# Both classes share ``is_disguise_item=True`` and
+# ``disguise_essential=True``; the per-type ``disguise_type_id`` ensures
+# same-type swaps (BALACLAVA ↔ SKI_MASK) do not shift the Apparent UID
+# while cross-type swaps do.
+
+# --- Class A: Visibly-obfuscating ----------------------------------------
+
+# A second balaclava variant; shares ``disguise_type_id="balaclava"`` so
+# swapping a BALACLAVA for a SKI_MASK is invisible to observers.
+SKI_MASK = {
+    "prototype_key": "SKI_MASK",
+    "key": "wool ski mask",
+    "aliases": ["ski mask", "mask", "balaclava"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A pull-on ski mask of coarse charcoal wool with three cut-outs — two for the eyes and one for the mouth — leaving everything between in featureless shadow. The weave is dense enough to obscure hair colour and jawline alike.",
+    "attrs": [
+        ("coverage", ["head", "face"]),
+        ("worn_desc", "A coarse {color}charcoal|n ski mask drawn tight over {their} head, three ragged cut-outs the only break in featureless wool"),
+        ("layer", 2),
+        ("color", "charcoal"),
+        ("material", "wool"),
+        ("weight", 0.2),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "balaclava"),
+        ("disguise_adjective", "masked"),
+        ("worn_sdesc_short", "wool ski mask"),
+        ("covers_hair", True),
+    ],
+}
+
+# Pale-blue surgical mask — covers nose and mouth, leaves eyes and hair
+# untouched.
+SURGICAL_MASK = {
+    "prototype_key": "SURGICAL_MASK",
+    "key": "pale-blue surgical mask",
+    "aliases": ["surgical mask", "mask", "medical mask"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A standard pleated surgical mask in pale clinic-blue, looped over the ears with thin elastic. The pleats expand to cover nose, mouth and chin, leaving only the eyes and brow exposed.",
+    "attrs": [
+        ("coverage", ["face"]),
+        ("worn_desc", "A pleated {color}pale-blue|n surgical mask hooked over {their} ears, smothering nose and mouth in clinical fabric"),
+        ("layer", 2),
+        ("color", "pale-blue"),
+        ("material", "polypropylene"),
+        ("weight", 0.05),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "face_mask"),
+        ("disguise_adjective", "masked"),
+        ("worn_sdesc_short", "surgical mask"),
+        ("covers_hair", False),
+    ],
+}
+
+# Industrial half-face respirator — heavy rubber and twin filter cans.
+RESPIRATOR = {
+    "prototype_key": "RESPIRATOR",
+    "key": "industrial respirator",
+    "aliases": ["respirator", "gas mask", "mask"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A bulky half-face respirator moulded from matte-black rubber, twin filter cans jutting from the cheeks like stubby tusks. The harness straps cinch tight across the back of the skull and around the crown.",
+    "attrs": [
+        ("coverage", ["face"]),
+        ("worn_desc", "A bulky {color}black|n industrial respirator strapped to {their} face, twin filter cans jutting like stubby tusks"),
+        ("layer", 2),
+        ("color", "black"),
+        ("material", "rubber"),
+        ("weight", 0.6),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "respirator"),
+        ("disguise_adjective", "masked"),
+        ("worn_sdesc_short", "industrial respirator"),
+        ("covers_hair", False),
+    ],
+}
+
+# Slim domino mask — covers the eyes only, classic costume-party shape.
+DOMINO_MASK = {
+    "prototype_key": "DOMINO_MASK",
+    "key": "black domino mask",
+    "aliases": ["domino mask", "mask", "eye mask"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A slim domino mask cut from black satin, shaped to cover the brow and the upper cheeks while leaving the lower face entirely free. A thin elastic loops behind the head; two almond-shaped slits frame the eyes.",
+    "attrs": [
+        ("coverage", ["left_eye", "right_eye"]),
+        ("worn_desc", "A slim {color}black|n satin domino mask hugging the upper half of {their} face, two almond slits framing {their} eyes"),
+        ("layer", 2),
+        ("color", "black"),
+        ("material", "satin"),
+        ("weight", 0.05),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "domino_mask"),
+        ("disguise_adjective", "masked"),
+        ("worn_sdesc_short", "domino mask"),
+        ("covers_hair", False),
+    ],
+}
+
+# Bandana worn outlaw-style across the lower face.
+FACE_BANDANA = {
+    "prototype_key": "FACE_BANDANA",
+    "key": "red face bandana",
+    "aliases": ["bandana", "face bandana", "kerchief"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A square of red cotton bandana, knotted outlaw-style across the lower face. The triangle of cloth covers nose, mouth and chin; the knot bunches behind the ears at the nape.",
+    "attrs": [
+        ("coverage", ["face"]),
+        ("worn_desc", "A {color}red|n cotton bandana knotted outlaw-style across the lower half of {their} face"),
+        ("layer", 2),
+        ("color", "red"),
+        ("material", "cotton"),
+        ("weight", 0.1),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "face_bandana"),
+        ("disguise_adjective", "masked"),
+        ("worn_sdesc_short", "face bandana"),
+        ("covers_hair", False),
+    ],
+}
+
+# A standalone hood worn raised — separate from the DEV_HOODIE garment so
+# the disguise hook can fire on a discrete wear/remove cycle without
+# requiring a full hoodie style transition.
+HOODIE_HOOD_UP = {
+    "prototype_key": "HOODIE_HOOD_UP",
+    "key": "drawn hood",
+    "aliases": ["hood", "drawn hood"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A loose dark-grey hood, deep enough to swallow most of the wearer's face in shadow when raised. The drawstrings hang loose against the chest, and the lining is unbleached cotton softened by long use.",
+    "attrs": [
+        ("coverage", ["head"]),
+        ("worn_desc", "A loose {color}dark-grey|n hood drawn forward over {their} head, casting {their} face into shadow"),
+        ("layer", 3),
+        ("color", "dark-grey"),
+        ("material", "cotton"),
+        ("weight", 0.3),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "hood"),
+        ("disguise_adjective", "hooded"),
+        ("worn_sdesc_short", "drawn hood"),
+        ("covers_hair", True),
+    ],
+}
+
+# --- Class B: Silent obfuscators -----------------------------------------
+#
+# These items shift the wearer's Apparent UID — making them unrecognisable
+# to observers who only know the bare-faced form — but contribute no
+# adjective to the rendered sdesc.  See PR #129 for the wig precedent.
+
+BLACK_WIG = {
+    "prototype_key": "BLACK_WIG",
+    "key": "black wig",
+    "aliases": ["wig", "black wig"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A shoulder-length wig of glossy jet-black synthetic hair, cut to a blunt fringe. The mesh cap is fine enough to pass for a natural hairline at conversational distance.",
+    "attrs": [
+        ("coverage", ["head"]),
+        ("worn_desc", "A glossy {color}black|n shoulder-length wig with a blunt fringe"),
+        ("layer", 2),
+        ("color", "black"),
+        ("material", "synthetic"),
+        ("weight", 0.15),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "wig"),
+        ("disguise_adjective", ""),
+        ("worn_sdesc_short", "black wig"),
+        ("covers_hair", True),
+    ],
+}
+
+BLOND_WIG = {
+    "prototype_key": "BLOND_WIG",
+    "key": "blond wig",
+    "aliases": ["wig", "blond wig", "blonde wig"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A chin-length blond wig in honey-gold synthetic fibre, layered for volume. The cap is mesh-lined and the parting has been hand-stitched to mimic a real scalp.",
+    "attrs": [
+        ("coverage", ["head"]),
+        ("worn_desc", "A honey-{color}blond|n chin-length wig layered for volume"),
+        ("layer", 2),
+        ("color", "gold"),
+        ("material", "synthetic"),
+        ("weight", 0.15),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "wig"),
+        ("disguise_adjective", ""),
+        ("worn_sdesc_short", "blond wig"),
+        ("covers_hair", True),
+    ],
+}
+
+BROWN_WIG = {
+    "prototype_key": "BROWN_WIG",
+    "key": "brown wig",
+    "aliases": ["wig", "brown wig"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A mid-length brown wig in walnut-toned synthetic fibre, parted off-centre. The cap is a soft stretch mesh and the ends have been heat-set into a loose wave.",
+    "attrs": [
+        ("coverage", ["head"]),
+        ("worn_desc", "A walnut-{color}brown|n mid-length wig parted off-centre with loose waves"),
+        ("layer", 2),
+        ("color", "brown"),
+        ("material", "synthetic"),
+        ("weight", 0.15),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "wig"),
+        ("disguise_adjective", ""),
+        ("worn_sdesc_short", "brown wig"),
+        ("covers_hair", True),
+    ],
+}
+
+# Cosmetic contact lenses — change apparent eye colour silently.
+COLORED_CONTACTS = {
+    "prototype_key": "COLORED_CONTACTS",
+    "key": "colored contact lenses",
+    "aliases": ["contacts", "lenses", "contact lenses"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A blister-pack pair of cosmetic contact lenses in vivid emerald green. The pigment ring covers the iris completely; pupils show through unaltered.",
+    "attrs": [
+        ("coverage", ["left_eye", "right_eye"]),
+        ("worn_desc", "Cosmetic contact lenses tinting {their} eyes vivid emerald"),
+        ("layer", 1),
+        ("color", "emerald"),
+        ("material", "hydrogel"),
+        ("weight", 0.01),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "contacts"),
+        ("disguise_adjective", ""),
+        ("worn_sdesc_short", "colored contacts"),
+        ("covers_hair", False),
+    ],
+}
+
+# Mirrorshade aviators — opaque chrome lenses, classic shape.
+MIRRORSHADES = {
+    "prototype_key": "MIRRORSHADES",
+    "key": "chrome mirrorshades",
+    "aliases": ["mirrorshades", "shades", "sunglasses", "glasses"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A pair of mirrorshade aviators with a chrome-coated finish so dense the lenses throw back the room as a warped silver pane. The frames are thin gunmetal wire, the bridge a single arched bar.",
+    "attrs": [
+        ("coverage", ["left_eye", "right_eye"]),
+        ("worn_desc", "A pair of {color}chrome|n mirrorshades reflecting the room as a warped silver pane"),
+        ("layer", 2),
+        ("color", "chrome"),
+        ("material", "metal"),
+        ("weight", 0.08),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "mirrorshades"),
+        ("disguise_adjective", ""),
+        ("worn_sdesc_short", "mirrorshades"),
+        ("covers_hair", False),
+    ],
+}
+
+AVIATOR_SUNGLASSES = {
+    "prototype_key": "AVIATOR_SUNGLASSES",
+    "key": "aviator sunglasses",
+    "aliases": ["aviators", "sunglasses", "glasses", "shades"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A pair of aviator sunglasses with teardrop-shaped smoke-tinted lenses and a thin gold frame. The lenses are dark enough to obscure the eyes but translucent enough to read intent through.",
+    "attrs": [
+        ("coverage", ["left_eye", "right_eye"]),
+        ("worn_desc", "A pair of {color}gold|n-framed aviator sunglasses with teardrop smoke-tinted lenses"),
+        ("layer", 2),
+        ("color", "gold"),
+        ("material", "metal"),
+        ("weight", 0.08),
+
+        ("is_disguise_item", True),
+        ("disguise_essential", True),
+        ("disguise_type_id", "sunglasses"),
+        ("disguise_adjective", ""),
+        ("worn_sdesc_short", "aviator sunglasses"),
+        ("covers_hair", False),
+    ],
+}
+
 # Classic blue jeans with functional styling
 BLUE_JEANS = {
     "prototype_key": "BLUE_JEANS",

--- a/world/tests/test_disguise_prototypes.py
+++ b/world/tests/test_disguise_prototypes.py
@@ -1,0 +1,364 @@
+"""Tests for the Phase 3.5 disguise prototype catalog.
+
+Verifies that each disguise prototype in :mod:`world.prototypes` carries
+the attribute surface required by the disguise engine
+(:mod:`world.identity`), splits cleanly into Class A (visibly-obfuscating
+with a non-empty ``disguise_adjective``) and Class B (silent obfuscators
+with ``disguise_adjective=""``), and behaves correctly under same-type vs
+cross-type swaps.
+
+See ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Disguise Item Taxonomy"
+and the PR-3.5 plan for the catalog rationale.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world import prototypes
+from world.identity import (
+    get_apparent_uid,
+    get_disguise_adjective,
+    get_essential_item_type_ids,
+)
+from world.tests._identity_helpers import prepare_mock_for_apparent_uid
+from world.tests.test_identity import (
+    _FakeDisguiseItem,
+    _SignatureMockCharacter,
+)
+
+
+# Class A — visibly-obfuscating: must carry a non-empty
+# ``disguise_adjective``.
+CLASS_A_PROTOTYPES: tuple[str, ...] = (
+    "BALACLAVA",
+    "SKI_MASK",
+    "SURGICAL_MASK",
+    "RESPIRATOR",
+    "DOMINO_MASK",
+    "FACE_BANDANA",
+    "HOODIE_HOOD_UP",
+)
+
+# Class B — silent obfuscators: must carry ``disguise_adjective=""``.
+CLASS_B_PROTOTYPES: tuple[str, ...] = (
+    "BLACK_WIG",
+    "BLOND_WIG",
+    "BROWN_WIG",
+    "COLORED_CONTACTS",
+    "MIRRORSHADES",
+    "AVIATOR_SUNGLASSES",
+)
+
+ALL_DISGUISE_PROTOTYPES: tuple[str, ...] = (
+    CLASS_A_PROTOTYPES + CLASS_B_PROTOTYPES
+)
+
+# Items that must have ``covers_hair=True``.
+COVERS_HAIR_PROTOTYPES: frozenset[str] = frozenset(
+    {
+        "BALACLAVA",
+        "SKI_MASK",
+        "HOODIE_HOOD_UP",
+        "BLACK_WIG",
+        "BLOND_WIG",
+        "BROWN_WIG",
+    }
+)
+
+
+def _attrs_dict(prototype_name: str) -> dict:
+    """Return the prototype's ``attrs`` list flattened to a dict."""
+    proto = getattr(prototypes, prototype_name)
+    return dict(proto["attrs"])
+
+
+def _fake_item_from_prototype(prototype_name: str) -> _FakeDisguiseItem:
+    """Construct an :class:`_FakeDisguiseItem` from the prototype attrs.
+
+    Uses the same duck-typed surface the engine reads at runtime, so the
+    fake faithfully exercises ``get_essential_item_type_ids``,
+    ``get_disguise_adjective``, and the distinguishing-feature chain.
+    """
+    attrs = _attrs_dict(prototype_name)
+    proto = getattr(prototypes, prototype_name)
+    return _FakeDisguiseItem(
+        disguise_essential=attrs.get("disguise_essential", False),
+        disguise_type_id=attrs.get("disguise_type_id", ""),
+        is_disguise_item=attrs.get("is_disguise_item", False),
+        disguise_adjective=attrs.get("disguise_adjective", ""),
+        worn_sdesc_short=attrs.get("worn_sdesc_short", ""),
+        covers_hair=attrs.get("covers_hair", False),
+        key=proto["key"],
+    )
+
+
+class TestDisguisePrototypeStructure(TestCase):
+    """Each prototype defines the disguise attribute surface correctly."""
+
+    def test_all_prototypes_exist(self) -> None:
+        for name in ALL_DISGUISE_PROTOTYPES:
+            with self.subTest(prototype=name):
+                self.assertTrue(
+                    hasattr(prototypes, name),
+                    f"Missing disguise prototype: {name}",
+                )
+
+    def test_all_prototypes_are_disguise_items(self) -> None:
+        for name in ALL_DISGUISE_PROTOTYPES:
+            with self.subTest(prototype=name):
+                attrs = _attrs_dict(name)
+                self.assertIs(
+                    attrs.get("is_disguise_item"),
+                    True,
+                    f"{name} must set is_disguise_item=True",
+                )
+
+    def test_all_prototypes_are_essential(self) -> None:
+        for name in ALL_DISGUISE_PROTOTYPES:
+            with self.subTest(prototype=name):
+                attrs = _attrs_dict(name)
+                self.assertIs(
+                    attrs.get("disguise_essential"),
+                    True,
+                    f"{name} must set disguise_essential=True",
+                )
+
+    def test_all_prototypes_define_type_id(self) -> None:
+        for name in ALL_DISGUISE_PROTOTYPES:
+            with self.subTest(prototype=name):
+                attrs = _attrs_dict(name)
+                type_id = attrs.get("disguise_type_id", "")
+                self.assertTrue(
+                    isinstance(type_id, str) and type_id,
+                    f"{name} must define a non-empty disguise_type_id",
+                )
+
+    def test_all_prototypes_define_worn_sdesc_short(self) -> None:
+        for name in ALL_DISGUISE_PROTOTYPES:
+            with self.subTest(prototype=name):
+                attrs = _attrs_dict(name)
+                short = attrs.get("worn_sdesc_short", "")
+                self.assertTrue(
+                    isinstance(short, str) and short,
+                    f"{name} must define a non-empty worn_sdesc_short",
+                )
+
+    def test_prototype_keys_match_dict_names(self) -> None:
+        for name in ALL_DISGUISE_PROTOTYPES:
+            with self.subTest(prototype=name):
+                proto = getattr(prototypes, name)
+                self.assertEqual(proto["prototype_key"], name)
+
+    def test_typeclass_is_item(self) -> None:
+        for name in ALL_DISGUISE_PROTOTYPES:
+            with self.subTest(prototype=name):
+                proto = getattr(prototypes, name)
+                self.assertEqual(
+                    proto["typeclass"], "typeclasses.items.Item"
+                )
+
+
+class TestClassAVisiblyObfuscating(TestCase):
+    """Class A items carry a non-empty disguise_adjective."""
+
+    def test_class_a_have_non_empty_adjective(self) -> None:
+        for name in CLASS_A_PROTOTYPES:
+            with self.subTest(prototype=name):
+                attrs = _attrs_dict(name)
+                adjective = attrs.get("disguise_adjective", "")
+                self.assertTrue(
+                    isinstance(adjective, str) and adjective,
+                    f"{name} (Class A) must have non-empty "
+                    f"disguise_adjective; got {adjective!r}",
+                )
+
+    def test_class_a_adjective_drives_get_disguise_adjective(self) -> None:
+        for name in CLASS_A_PROTOTYPES:
+            with self.subTest(prototype=name):
+                attrs = _attrs_dict(name)
+                expected = attrs["disguise_adjective"]
+                char = _SignatureMockCharacter(
+                    worn_items=[_fake_item_from_prototype(name)]
+                )
+                self.assertEqual(
+                    get_disguise_adjective(char), expected
+                )
+
+
+class TestClassBSilentObfuscators(TestCase):
+    """Class B items carry an empty disguise_adjective but still flip UID."""
+
+    def test_class_b_have_empty_adjective(self) -> None:
+        for name in CLASS_B_PROTOTYPES:
+            with self.subTest(prototype=name):
+                attrs = _attrs_dict(name)
+                adjective = attrs.get("disguise_adjective", "")
+                self.assertEqual(
+                    adjective,
+                    "",
+                    f"{name} (Class B) must have empty "
+                    f"disguise_adjective; got {adjective!r}",
+                )
+
+    def test_class_b_contributes_no_adjective(self) -> None:
+        for name in CLASS_B_PROTOTYPES:
+            with self.subTest(prototype=name):
+                char = _SignatureMockCharacter(
+                    worn_items=[_fake_item_from_prototype(name)]
+                )
+                self.assertIsNone(get_disguise_adjective(char))
+
+    def test_class_b_still_shifts_apparent_uid(self) -> None:
+        """Wearing a silent obfuscator must change the Apparent UID."""
+        for name in CLASS_B_PROTOTYPES:
+            with self.subTest(prototype=name):
+                bare = _SignatureMockCharacter()
+                disguised = _SignatureMockCharacter(
+                    worn_items=[_fake_item_from_prototype(name)]
+                )
+                prepare_mock_for_apparent_uid(bare)
+                prepare_mock_for_apparent_uid(disguised)
+                bare_uid = get_apparent_uid(bare)
+                disguised_uid = get_apparent_uid(disguised)
+                self.assertIsNotNone(bare_uid)
+                self.assertIsNotNone(disguised_uid)
+                self.assertNotEqual(
+                    bare_uid,
+                    disguised_uid,
+                    f"{name} (Class B) must shift the Apparent UID "
+                    f"despite having no adjective",
+                )
+
+
+class TestCoversHairFlag(TestCase):
+    """Items in COVERS_HAIR_PROTOTYPES set covers_hair=True; others False."""
+
+    def test_covers_hair_set_correctly(self) -> None:
+        for name in ALL_DISGUISE_PROTOTYPES:
+            with self.subTest(prototype=name):
+                attrs = _attrs_dict(name)
+                covers = bool(attrs.get("covers_hair", False))
+                expected = name in COVERS_HAIR_PROTOTYPES
+                self.assertEqual(
+                    covers,
+                    expected,
+                    f"{name} covers_hair={covers}, expected {expected}",
+                )
+
+
+class TestSameTypeSwapApparentUidStable(TestCase):
+    """Swapping items of the same disguise_type_id must not shift UID."""
+
+    def test_balaclava_to_ski_mask_uid_unchanged(self) -> None:
+        with_balaclava = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("BALACLAVA")]
+        )
+        with_ski_mask = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("SKI_MASK")]
+        )
+        prepare_mock_for_apparent_uid(with_balaclava)
+        prepare_mock_for_apparent_uid(with_ski_mask)
+        self.assertEqual(
+            get_apparent_uid(with_balaclava),
+            get_apparent_uid(with_ski_mask),
+            "BALACLAVA and SKI_MASK share disguise_type_id='balaclava'; "
+            "swapping must not shift Apparent UID.",
+        )
+
+    def test_wig_swap_uid_unchanged(self) -> None:
+        with_black = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("BLACK_WIG")]
+        )
+        with_blond = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("BLOND_WIG")]
+        )
+        prepare_mock_for_apparent_uid(with_black)
+        prepare_mock_for_apparent_uid(with_blond)
+        self.assertEqual(
+            get_apparent_uid(with_black),
+            get_apparent_uid(with_blond),
+            "All wigs share disguise_type_id='wig'; swapping must not "
+            "shift Apparent UID.",
+        )
+
+    def test_sunglasses_swap_uid_unchanged_within_type(self) -> None:
+        """MIRRORSHADES and AVIATOR_SUNGLASSES are distinct types.
+
+        They obfuscate the same body slot (eyes) but model different
+        ``disguise_type_id`` values, so their swap *should* shift the
+        UID.  This test guards the inverse: same type → same UID, by
+        comparing two AVIATOR_SUNGLASSES instances.
+        """
+        a = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("AVIATOR_SUNGLASSES")]
+        )
+        b = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("AVIATOR_SUNGLASSES")]
+        )
+        prepare_mock_for_apparent_uid(a)
+        prepare_mock_for_apparent_uid(b)
+        self.assertEqual(get_apparent_uid(a), get_apparent_uid(b))
+
+
+class TestCrossTypeSwapApparentUidShifts(TestCase):
+    """Swapping to a different disguise_type_id must shift the UID."""
+
+    def test_balaclava_to_hood_uid_shifts(self) -> None:
+        with_balaclava = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("BALACLAVA")]
+        )
+        with_hood = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("HOODIE_HOOD_UP")]
+        )
+        prepare_mock_for_apparent_uid(with_balaclava)
+        prepare_mock_for_apparent_uid(with_hood)
+        self.assertNotEqual(
+            get_apparent_uid(with_balaclava),
+            get_apparent_uid(with_hood),
+        )
+
+    def test_mirrorshades_to_aviators_uid_shifts(self) -> None:
+        """Different sunglass types model as different disguise_type_id."""
+        with_mirror = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("MIRRORSHADES")]
+        )
+        with_aviators = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("AVIATOR_SUNGLASSES")]
+        )
+        prepare_mock_for_apparent_uid(with_mirror)
+        prepare_mock_for_apparent_uid(with_aviators)
+        self.assertNotEqual(
+            get_apparent_uid(with_mirror),
+            get_apparent_uid(with_aviators),
+        )
+
+    def test_contacts_to_sunglasses_uid_shifts(self) -> None:
+        with_contacts = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("COLORED_CONTACTS")]
+        )
+        with_aviators = _SignatureMockCharacter(
+            worn_items=[_fake_item_from_prototype("AVIATOR_SUNGLASSES")]
+        )
+        prepare_mock_for_apparent_uid(with_contacts)
+        prepare_mock_for_apparent_uid(with_aviators)
+        self.assertNotEqual(
+            get_apparent_uid(with_contacts),
+            get_apparent_uid(with_aviators),
+        )
+
+
+class TestEssentialTypeIdsFromCatalog(TestCase):
+    """get_essential_item_type_ids reads each prototype's type_id."""
+
+    def test_each_prototype_contributes_its_type_id(self) -> None:
+        for name in ALL_DISGUISE_PROTOTYPES:
+            with self.subTest(prototype=name):
+                attrs = _attrs_dict(name)
+                expected = (attrs["disguise_type_id"],)
+                char = _SignatureMockCharacter(
+                    worn_items=[_fake_item_from_prototype(name)]
+                )
+                self.assertEqual(
+                    get_essential_item_type_ids(char), expected
+                )


### PR DESCRIPTION
## Summary
- Expands the disguise catalog from a single `BALACLAVA` to the full Phase 3.5 inventory documented in `IDENTITY_RECOGNITION_SPEC.md`
- Establishes the **Class A / Class B** taxonomy: visibly-obfuscating vs silent obfuscators
- Adds 20 tests verifying structure, adjective semantics, covers_hair flag, and same-type / cross-type Apparent UID swap behavior

## New Prototypes

### Class A — Visibly-obfuscating (carry a non-empty `disguise_adjective`)
| Prototype | type_id | adjective | covers_hair |
|---|---|---|---|
| `SKI_MASK` | balaclava | masked | yes |
| `SURGICAL_MASK` | face_mask | masked | no |
| `RESPIRATOR` | respirator | masked | no |
| `DOMINO_MASK` | domino_mask | masked | no |
| `FACE_BANDANA` | face_bandana | masked | no |
| `HOODIE_HOOD_UP` | hood | hooded | yes |

### Class B — Silent obfuscators (`disguise_adjective=""`; shift UID without announcing themselves)
| Prototype | type_id | covers_hair |
|---|---|---|
| `BLACK_WIG` | wig | yes |
| `BLOND_WIG` | wig | yes |
| `BROWN_WIG` | wig | yes |
| `COLORED_CONTACTS` | contacts | no |
| `MIRRORSHADES` | mirrorshades | no |
| `AVIATOR_SUNGLASSES` | sunglasses | no |

All twelve carry `is_disguise_item=True` and `disguise_essential=True`. Per-type `disguise_type_id` ensures same-type swaps leave the Apparent UID stable while cross-type swaps shift it.

## Tests
`world/tests/test_disguise_prototypes.py` — 20 new tests covering:
- Structural invariants (`is_disguise_item`, `disguise_essential`, type_id, `worn_sdesc_short`, `prototype_key`, typeclass)
- Class A non-empty / Class B empty `disguise_adjective` semantics
- `covers_hair` flag matrix
- Same-type-swap UID stability (`BALACLAVA` ↔ `SKI_MASK`; wig swaps)
- Cross-type-swap UID shift (`BALACLAVA` → `HOODIE_HOOD_UP`; `MIRRORSHADES` ↔ `AVIATOR_SUNGLASSES`)
- Each prototype's `type_id` flows through `get_essential_item_type_ids` unchanged

World suite: **656 → 676 tests, all green**.

## Part of
Phase 3.5 disguise system completion (PR 1 of 3). Follow-ups:
- PR 2: corpse Apparent UID propagation
- PR 3: "Unmasking Moments" signature-change hook