### PR TITLE
Propagate apparent UID and recognition memory to corpses

### DIFF
--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -63,19 +63,102 @@ class Corpse(Item):
         return min(1.0, elapsed / max_decay_time)
     
     def get_display_name(self, looker, **kwargs):
-        """Update display name based on current decay stage."""
+        """Return a display name, preferring recognition memory.
+
+        Looters and bystanders who already remember the deceased should
+        continue to see the assigned name on the corpse, exactly as
+        they would on the living character.  The lookup mirrors
+        :meth:`typeclasses.characters.Character.get_display_name`:
+
+        * ``looker is None`` (system context) → decay-stage fallback.
+        * Looker has an entry under this corpse's current Apparent UID
+          → return the entry's ``assigned_name``.
+        * Otherwise → decay-stage name (``"fresh corpse"`` etc.).
+
+        Disguise loss after death is handled by re-reading the
+        signature on every call (no cache): once a disguise-essential
+        item is looted, :func:`world.identity.get_apparent_uid`
+        recomputes against the corpse's remaining ``get_worn_items()``
+        contents and the recognition match silently falls away.
+        """
+        decay_name = self._decay_display_name()
+
+        if looker is None:
+            return decay_name
+
+        try:
+            from world.identity import get_apparent_uid
+            apparent_uid = get_apparent_uid(self)
+        except (AttributeError, TypeError, ValueError):
+            apparent_uid = None
+
+        if apparent_uid is not None and hasattr(looker, "recognition_memory"):
+            memory = looker.recognition_memory
+            if memory and apparent_uid in memory:
+                assigned = memory[apparent_uid].get("assigned_name")
+                if assigned:
+                    return assigned
+
+        return decay_name
+
+    def _decay_display_name(self):
+        """Return the decay-stage name used when no recognition matches."""
         stage = self.get_decay_stage()
-        
         decay_names = {
             "fresh": "fresh corpse",
-            "early": "pale corpse", 
+            "early": "pale corpse",
             "moderate": "decomposing remains",
             "advanced": "putrid remains",
-            "skeletal": "skeletal remains"
+            "skeletal": "skeletal remains",
         }
-        
         return decay_names.get(stage, 'corpse')
-    
+
+    # ------------------------------------------------------------------
+    # Disguise / identity signature surface
+    # ------------------------------------------------------------------
+
+    @property
+    def sleeve_uid(self):
+        """Expose the deceased's sleeve UID via the property surface.
+
+        :func:`world.identity.get_apparent_uid` reads
+        ``getattr(char, "sleeve_uid", None)`` rather than ``char.db.*``;
+        mirroring the Character property here lets the corpse flow
+        through the same identity pipeline without a separate code
+        path.
+        """
+        return self.db.sleeve_uid
+
+    def get_worn_items(self, location=None):
+        """Return disguise-essential items still on the corpse.
+
+        Corpses do not maintain a separate ``worn_items`` map — when a
+        character dies, their kit drops into ``corpse.contents`` (and is
+        treated as "still worn" for coverage purposes by
+        :meth:`_build_corpse_clothing_coverage_map`).  Mirroring
+        :meth:`typeclasses.clothing_mixin.ClothingMixin.get_worn_items`
+        here lets :func:`world.identity.get_essential_item_type_ids`
+        recompute the signature naturally as items are looted.
+
+        Only items flagged ``disguise_essential`` are returned — that is
+        all the signature pipeline consumes, and it avoids accidentally
+        treating loose loot in the corpse's inventory as worn clothing.
+
+        Args:
+            location: Accepted for signature parity with the mixin;
+                ignored because corpses have no per-location worn map.
+
+        Returns:
+            List of disguise-essential items currently in
+            ``self.contents``.
+        """
+        del location  # parity with ClothingMixin.get_worn_items signature
+        return [
+            item
+            for item in self.contents
+            if getattr(item, "disguise_essential", False)
+        ]
+
     def _get_preserved_longdesc_descriptions(self):
         """Get visible longdesc descriptions with clothing integration, like living characters."""
         if not self.db.longdesc_data:
@@ -501,8 +584,19 @@ class Corpse(Item):
         # Clear any cached appearance data since contents changed
         if hasattr(self.ndb, 'cached_appearance'):
             delattr(self.ndb, 'cached_appearance')
-        
-        # Debug logging removed to reduce noise
+
+        # If a disguise-essential item was looted, the corpse's
+        # signature has shifted: the previously-snapshot
+        # ``apparent_uid_at_death`` is now stale and observers who only
+        # remember the disguised UID should silently stop recognising
+        # the corpse.  We do *not* recompute and store a new UID here:
+        # :func:`world.identity.get_apparent_uid` re-derives lazily from
+        # the live ``get_worn_items()`` view on every display, so a
+        # stored value would only drift.  Clearing the snapshot is
+        # enough to signal "the death-time presentation is gone".
+        if getattr(moved_obj, "disguise_essential", False):
+            if self.db.apparent_uid_at_death is not None:
+                self.db.apparent_uid_at_death = None
     
     def _update_decay_descriptions(self):
         """Update descriptions based on current decay stage."""

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -510,9 +510,28 @@ class DeathProgressionScript(DefaultScript):
         corpse.db.death_time = time.time()
         corpse.db.physical_description = character.db.desc if character.db.desc is not None else 'A person.'
         
-        # Store identity data for identity-aware corpse description
-        corpse.db.sleeve_uid = character.db.sleeve_uid
+        # Store identity data for identity-aware corpse description.
+        # ``sleeve_uid`` is an AttributeProperty under category="identity", so
+        # ``character.db.sleeve_uid`` is always None — must read the property.
+        corpse.db.sleeve_uid = character.sleeve_uid
         corpse.db.sdesc_at_death = character.get_sdesc() if hasattr(character, 'get_sdesc') else character.key
+
+        # Snapshot the wearer's identity-signature axes at the moment of
+        # death so the corpse's Apparent UID matches the disguise the
+        # character died in.  Worn items move to ``corpse.contents`` via
+        # the normal drop/transfer hooks and are re-evaluated lazily by
+        # :meth:`Corpse.get_worn_items` whenever the signature is read.
+        corpse.db.height_override = character.db.height_override
+        corpse.db.build_override = character.db.build_override
+        corpse.db.keyword_override = character.db.keyword_override
+        # Record the original Apparent UID so observers who recognised
+        # the deceased can still match the corpse before any loot
+        # disturbs its presentation.
+        try:
+            from world.identity import get_apparent_uid
+            corpse.db.apparent_uid_at_death = get_apparent_uid(character)
+        except (AttributeError, TypeError, ValueError):
+            corpse.db.apparent_uid_at_death = None
         
         # Preserve character appearance data for proper corpse display
         corpse.db.original_gender = getattr(character, 'gender', 'neutral')

--- a/world/tests/test_corpse_identity.py
+++ b/world/tests/test_corpse_identity.py
@@ -1,0 +1,278 @@
+"""
+Tests for Corpse Apparent UID Propagation (PR 2 of disguise completion).
+
+Verifies that:
+
+1. A freshly created corpse exposes a ``sleeve_uid`` property that
+   matches the deceased character's real sleeve UID — so
+   :func:`world.identity.get_apparent_uid` flows through the same
+   pipeline used for living characters.
+2. :meth:`typeclasses.corpse.Corpse.get_worn_items` returns only
+   disguise-essential items currently in ``corpse.contents``, mirroring
+   :meth:`typeclasses.clothing_mixin.ClothingMixin.get_worn_items` so
+   the identity signature recomputes naturally as loot is removed.
+3. The death-time snapshot writes ``apparent_uid_at_death`` and the
+   identity override axes, matching what ``get_apparent_uid`` would
+   compute for the living character at the moment of death.
+4. :meth:`Corpse.get_display_name` consults the observer's
+   ``recognition_memory`` using the *current* Apparent UID (so looting
+   a balaclava off the corpse breaks the recognition silently).
+5. :meth:`Corpse.at_object_leave` clears the stale
+   ``apparent_uid_at_death`` snapshot when a disguise-essential item
+   is removed.
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_corpse_identity
+
+These are pure unit tests built on lightweight fakes — no Evennia
+database is required.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.identity import get_apparent_uid
+
+from world.tests.test_identity import _FakeDisguiseItem
+
+
+# ---------------------------------------------------------------------
+# Lightweight fakes (mirroring _SignatureMockCharacter, but corpse-shaped)
+# ---------------------------------------------------------------------
+
+
+class _FakeCorpse:
+    """Duck-typed stand-in for :class:`typeclasses.corpse.Corpse`.
+
+    Re-implements just the surface that PR 2 adds — the ``sleeve_uid``
+    property, the ``get_worn_items`` view over ``contents``, the
+    recognition-aware ``get_display_name``, and the
+    ``at_object_leave`` snapshot invalidation — so the tests can run
+    without spinning up Evennia's typeclass machinery.
+    """
+
+    def __init__(
+        self,
+        *,
+        sleeve_uid: str | None = "uid-jorge",
+        height_override: str | None = None,
+        build_override: str | None = None,
+        keyword_override: str | None = None,
+        contents: list | None = None,
+        apparent_uid_at_death: str | None = None,
+    ) -> None:
+        class _DB:
+            pass
+
+        self.db = _DB()
+        self.db.sleeve_uid = sleeve_uid
+        self.db.height_override = height_override
+        self.db.build_override = build_override
+        self.db.keyword_override = keyword_override
+        self.db.apparent_uid_at_death = apparent_uid_at_death
+        self.contents = list(contents or [])
+        self.key = "fresh corpse"
+        self._decay_name = "fresh corpse"
+        self.ndb = type("_NDB", (), {})()
+
+    # --- methods mirroring the production typeclass --------------------
+
+    @property
+    def sleeve_uid(self):
+        return self.db.sleeve_uid
+
+    def get_worn_items(self, location=None):
+        del location
+        return [
+            item
+            for item in self.contents
+            if getattr(item, "disguise_essential", False)
+        ]
+
+    def _decay_display_name(self):
+        return self._decay_name
+
+    def get_display_name(self, looker, **kwargs):
+        decay = self._decay_display_name()
+        if looker is None:
+            return decay
+        apparent_uid = get_apparent_uid(self)
+        if apparent_uid is not None and hasattr(looker, "recognition_memory"):
+            memory = looker.recognition_memory
+            if memory and apparent_uid in memory:
+                assigned = memory[apparent_uid].get("assigned_name")
+                if assigned:
+                    return assigned
+        return decay
+
+    def at_object_leave(self, moved_obj, target_location, **kwargs):
+        if getattr(moved_obj, "disguise_essential", False):
+            if self.db.apparent_uid_at_death is not None:
+                self.db.apparent_uid_at_death = None
+
+
+class _FakeObserver:
+    """Minimal observer with a ``recognition_memory`` dict."""
+
+    def __init__(self, memory: dict | None = None) -> None:
+        self.recognition_memory = memory or {}
+
+
+# ---------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------
+
+
+class TestCorpseSleeveUidProperty(TestCase):
+    """The ``sleeve_uid`` property must flow into the identity engine."""
+
+    def test_sleeve_uid_property_reflects_db(self):
+        corpse = _FakeCorpse(sleeve_uid="uid-victor")
+        self.assertEqual(corpse.sleeve_uid, "uid-victor")
+
+    def test_get_apparent_uid_on_corpse_is_not_none(self):
+        corpse = _FakeCorpse(sleeve_uid="uid-victor")
+        self.assertIsNotNone(get_apparent_uid(corpse))
+
+    def test_get_apparent_uid_returns_none_when_sleeve_uid_missing(self):
+        corpse = _FakeCorpse(sleeve_uid=None)
+        self.assertIsNone(get_apparent_uid(corpse))
+
+
+class TestCorpseWornItemsView(TestCase):
+    """``get_worn_items`` returns only disguise-essential contents."""
+
+    def test_no_contents_returns_empty(self):
+        corpse = _FakeCorpse(contents=[])
+        self.assertEqual(corpse.get_worn_items(), [])
+
+    def test_filters_out_non_essential_items(self):
+        balaclava = _FakeDisguiseItem(
+            disguise_essential=True, disguise_type_id="balaclava",
+        )
+        loose_loot = _FakeDisguiseItem(
+            disguise_essential=False, disguise_type_id="",
+        )
+        corpse = _FakeCorpse(contents=[balaclava, loose_loot])
+        worn = corpse.get_worn_items()
+        self.assertEqual(worn, [balaclava])
+
+
+class TestCorpseSignatureMatchesLivingCharacter(TestCase):
+    """Apparent UID derived from corpse matches the living character's."""
+
+    def test_signature_axes_propagate_to_corpse(self):
+        from world.tests.test_identity import _SignatureMockCharacter
+
+        balaclava = _FakeDisguiseItem(
+            disguise_essential=True, disguise_type_id="balaclava",
+        )
+        living = _SignatureMockCharacter(
+            sleeve_uid="uid-jorge",
+            height_override="tall",
+            build_override="lean",
+            keyword_override=None,
+            worn_items=[balaclava],
+        )
+        living_uid = get_apparent_uid(living)
+
+        # Death-time snapshot mirrors the character's signature axes
+        # plus the disguise-essential items dropping into contents.
+        corpse = _FakeCorpse(
+            sleeve_uid="uid-jorge",
+            height_override="tall",
+            build_override="lean",
+            keyword_override=None,
+            contents=[balaclava],
+        )
+        corpse_uid = get_apparent_uid(corpse)
+
+        self.assertEqual(living_uid, corpse_uid)
+        self.assertIsNotNone(living_uid)
+
+    def test_looting_essential_item_shifts_uid(self):
+        balaclava = _FakeDisguiseItem(
+            disguise_essential=True, disguise_type_id="balaclava",
+        )
+        corpse = _FakeCorpse(sleeve_uid="uid-jorge", contents=[balaclava])
+        uid_before = get_apparent_uid(corpse)
+
+        corpse.contents.remove(balaclava)
+        uid_after = get_apparent_uid(corpse)
+
+        self.assertNotEqual(uid_before, uid_after)
+
+
+class TestCorpseDisplayNameRecognition(TestCase):
+    """Corpse display name honours observer recognition memory."""
+
+    def test_none_looker_returns_decay_name(self):
+        corpse = _FakeCorpse(sleeve_uid="uid-jorge")
+        self.assertEqual(corpse.get_display_name(None), "fresh corpse")
+
+    def test_stranger_sees_decay_name(self):
+        corpse = _FakeCorpse(sleeve_uid="uid-jorge")
+        observer = _FakeObserver(memory={})
+        self.assertEqual(
+            corpse.get_display_name(observer), "fresh corpse",
+        )
+
+    def test_recogniser_sees_assigned_name(self):
+        corpse = _FakeCorpse(sleeve_uid="uid-jorge")
+        apparent_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={apparent_uid: {"assigned_name": "Jorge"}},
+        )
+        self.assertEqual(corpse.get_display_name(observer), "Jorge")
+
+    def test_looting_essential_item_breaks_recognition(self):
+        balaclava = _FakeDisguiseItem(
+            disguise_essential=True, disguise_type_id="balaclava",
+        )
+        corpse = _FakeCorpse(
+            sleeve_uid="uid-jorge", contents=[balaclava],
+        )
+        disguised_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={disguised_uid: {"assigned_name": "BalaclavaDude"}},
+        )
+        # While the corpse still "wears" the balaclava, recognition holds.
+        self.assertEqual(
+            corpse.get_display_name(observer), "BalaclavaDude",
+        )
+
+        # Looter removes the balaclava.
+        corpse.contents.remove(balaclava)
+        # Signature has shifted; the observer's old recognition
+        # silently falls away.
+        self.assertEqual(
+            corpse.get_display_name(observer), "fresh corpse",
+        )
+
+
+class TestCorpseAtObjectLeave(TestCase):
+    """``at_object_leave`` clears the death-time UID snapshot on loot."""
+
+    def test_non_essential_leave_preserves_snapshot(self):
+        corpse = _FakeCorpse(
+            sleeve_uid="uid-jorge",
+            apparent_uid_at_death="deadbeef00112233",
+        )
+        loose = _FakeDisguiseItem(disguise_essential=False)
+        corpse.at_object_leave(loose, None)
+        self.assertEqual(
+            corpse.db.apparent_uid_at_death, "deadbeef00112233",
+        )
+
+    def test_essential_leave_clears_snapshot(self):
+        corpse = _FakeCorpse(
+            sleeve_uid="uid-jorge",
+            apparent_uid_at_death="deadbeef00112233",
+        )
+        balaclava = _FakeDisguiseItem(
+            disguise_essential=True, disguise_type_id="balaclava",
+        )
+        corpse.at_object_leave(balaclava, None)
+        self.assertIsNone(corpse.db.apparent_uid_at_death)


### PR DESCRIPTION
## Summary
PR 2 of 3 in the disguise completion plan. Closes the gap where corpses dropped out of the identity-recognition pipeline entirely.

- Fix pre-existing bug in `death_progression.py:514`: `character.db.sleeve_uid` was always `None` because `sleeve_uid` is an `AttributeProperty` (category `identity`), so the death snapshot was silently storing `None`. Read the property instead.
- Snapshot identity-signature axes (`height_override`, `build_override`, `keyword_override`) and the live Apparent UID at the moment of death (`db.apparent_uid_at_death`) so observers can recognise the corpse in the disguise its owner died wearing.
- Add `Corpse.sleeve_uid` property and `Corpse.get_worn_items()` that filters `corpse.contents` to `disguise_essential` items, so `world.identity.get_apparent_uid(corpse)` flows through the same pipeline used for living characters.
- Make `Corpse.get_display_name` consult observer `recognition_memory` against the corpse's current Apparent UID. Looting a balaclava off the corpse silently shifts the UID and the recognition match falls away naturally.
- `Corpse.at_object_leave` clears the stale `apparent_uid_at_death` snapshot when a disguise-essential item leaves the corpse.

## Tests
- New `world/tests/test_corpse_identity.py` (13 tests, all green)
- Full world suite: 689 tests passing (up from 676 baseline; +13 new)
- Live reload verified