### PR TITLE
Add unmasking-moments hook for apparent-UID transitions

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1746,21 +1746,28 @@ class CmdRecall(Command):
             entry = memory.get(apparent_uid)
         else:
             # Fall back to remembered-name lookup
-            _apparent_uid, entry = _find_remembered_uid_by_name(caller, args)
+            apparent_uid, entry = _find_remembered_uid_by_name(caller, args)
 
         if entry is None:
             caller.msg("You don't recognize that person.")
             return
 
-        self._render_entry(caller, entry)
+        self._render_entry(caller, entry, apparent_uid)
 
-    def _render_entry(self, caller, entry):
+    def _render_entry(self, caller, entry, apparent_uid=None):
         """Format and send a recognition_memory entry to the caller.
 
         Adds a ``(lost contact)`` annotation when the stored entry's
         ``lost_contact`` flag is True (set by the periodic prune scan;
         cleared on re-encounter).  Old entries that predate the flag
         default to False.
+
+        When ``apparent_uid`` is provided and the entry is part of a
+        linked-presentation chain (built up by the unmasking-moments
+        broadcast), an ``Also known as: ...`` line lists the assigned
+        names of every other named presentation in the chain — letting
+        the player see at a glance which of their remembered names refer
+        to the same underlying sleeve.
         """
         assigned_name = entry.get("assigned_name", "")
         sdesc_first = entry.get("sdesc_at_first_encounter", "(unknown)")
@@ -1789,6 +1796,17 @@ class CmdRecall(Command):
             f"Location: {location_first}",
             f"When: {when} (seen {times_seen} time{'s' if times_seen != 1 else ''})",
         ]
+
+        if apparent_uid is not None:
+            from world.identity import get_linked_aliases
+
+            memory = caller.recognition_memory or {}
+            aliases = get_linked_aliases(memory, apparent_uid)
+            if aliases:
+                lines.append(
+                    f"Also known as: |w{'|n, |w'.join(aliases)}|n"
+                )
+
         caller.msg("\n".join(lines))
 
 
@@ -1841,6 +1859,7 @@ class CmdMemory(Command):
         )
 
         from evennia.utils.evtable import EvTable
+        from world.identity import get_linked_aliases
 
         table = EvTable(
             "|wName|n",
@@ -1849,10 +1868,13 @@ class CmdMemory(Command):
             "|wWhen|n",
             border="cells",
         )
-        for _uid, entry in named:
+        for uid, entry in named:
             name_cell = entry.get("assigned_name", "")
             if entry.get("lost_contact", False):
                 name_cell = f"{name_cell} |y(lost contact)|n"
+            aliases = get_linked_aliases(memory, uid)
+            if aliases:
+                name_cell = f"{name_cell}\n|x(aka {', '.join(aliases)})|n"
             table.add_row(
                 name_cell,
                 entry.get("sdesc_at_last_encounter", "(unknown)"),
@@ -1896,10 +1918,13 @@ def _has_any_override(caller):
 
 def _clear_all_overrides(caller):
     """Wipe all override axes and the active-persona pointer."""
-    caller.db.height_override = None
-    caller.db.build_override = None
-    caller.db.keyword_override = None
-    caller.db.active_persona = None
+    from world.identity import apply_signature_change
+
+    with apply_signature_change(caller, source="stop_appearing"):
+        caller.db.height_override = None
+        caller.db.build_override = None
+        caller.db.keyword_override = None
+        caller.db.active_persona = None
 
 
 def _build_persona_entry(caller, name):
@@ -2160,7 +2185,7 @@ class CmdAppear(Command):
     # -- axis handlers ---------------------------------------------------
 
     def _nudge_height(self, caller, direction):
-        from world.identity import HEIGHTS
+        from world.identity import HEIGHTS, apply_signature_change
 
         new = _nudge_axis(
             HEIGHTS, caller.db.height_override, caller.height, direction
@@ -2173,11 +2198,12 @@ class CmdAppear(Command):
             )
             return
         self._maybe_break_persona(caller)
-        caller.db.height_override = new
+        with apply_signature_change(caller, source="override:height"):
+            caller.db.height_override = new
         caller.msg(f"You now carry yourself as |w{new}|n.")
 
     def _nudge_build(self, caller, direction):
-        from world.identity import BUILDS
+        from world.identity import BUILDS, apply_signature_change
 
         new = _nudge_axis(
             BUILDS, caller.db.build_override, caller.build, direction
@@ -2190,11 +2216,12 @@ class CmdAppear(Command):
             )
             return
         self._maybe_break_persona(caller)
-        caller.db.build_override = new
+        with apply_signature_change(caller, source="override:build"):
+            caller.db.build_override = new
         caller.msg(f"You now carry yourself as |w{new}|n.")
 
     def _set_keyword_override(self, caller, raw_keyword):
-        from world.identity import get_all_keywords
+        from world.identity import apply_signature_change, get_all_keywords
 
         keyword = raw_keyword.lower()
         if keyword not in {kw.lower() for kw in get_all_keywords()}:
@@ -2205,7 +2232,8 @@ class CmdAppear(Command):
             )
             return
         self._maybe_break_persona(caller)
-        caller.db.keyword_override = keyword
+        with apply_signature_change(caller, source="override:keyword"):
+            caller.db.keyword_override = keyword
         caller.msg(f"You now present yourself as a |w{keyword}|n.")
 
     # -- persona adoption ------------------------------------------------
@@ -2219,7 +2247,10 @@ class CmdAppear(Command):
         override swap.  Adoption is not refused — the player can choose
         to proceed and accept the resulting Apparent UID divergence.
         """
-        from world.identity import get_essential_item_type_ids
+        from world.identity import (
+            apply_signature_change,
+            get_essential_item_type_ids,
+        )
 
         saved = tuple(entry.get("essential_item_types") or ())
         current = get_essential_item_type_ids(caller)
@@ -2244,10 +2275,11 @@ class CmdAppear(Command):
             )
             caller.msg("\n".join(advisory_lines))
 
-        caller.db.height_override = entry.get("height_override")
-        caller.db.build_override = entry.get("build_override")
-        caller.db.keyword_override = entry.get("keyword_override")
-        caller.db.active_persona = name
+        with apply_signature_change(caller, source=f"persona:{name}"):
+            caller.db.height_override = entry.get("height_override")
+            caller.db.build_override = entry.get("build_override")
+            caller.db.keyword_override = entry.get("keyword_override")
+            caller.db.active_persona = name
 
         summary = _persona_summary_line(entry)
         caller.msg(

--- a/typeclasses/clothing_mixin.py
+++ b/typeclasses/clothing_mixin.py
@@ -191,23 +191,36 @@ class ClothingMixin:
 
             return False, error_msg
 
-        # No conflicts - proceed with wearing
-        for location in item_coverage:
-            if location not in self.worn_items:
-                self.worn_items[location] = []
+        # No conflicts - proceed with wearing.  If the item contributes to
+        # the identity signature, wrap the mutation so observers in the
+        # room get an unmasking-moment broadcast for any UID transition.
+        from world.identity import apply_signature_change
 
-            # Add item to location, maintaining layer order (outer first)
-            location_items = self.worn_items[location]
+        is_essential = getattr(item, "disguise_essential", False)
 
-            # Find insertion point based on layer
-            insert_index = 0
-            for i, worn_item in enumerate(location_items):
-                if item.layer <= worn_item.layer:
-                    insert_index = i + 1
-                else:
-                    break
+        def _do_wear():
+            for location in item_coverage:
+                if location not in self.worn_items:
+                    self.worn_items[location] = []
 
-            location_items.insert(insert_index, item)
+                # Add item to location, maintaining layer order (outer first)
+                location_items = self.worn_items[location]
+
+                # Find insertion point based on layer
+                insert_index = 0
+                for i, worn_item in enumerate(location_items):
+                    if item.layer <= worn_item.layer:
+                        insert_index = i + 1
+                    else:
+                        break
+
+                location_items.insert(insert_index, item)
+
+        if is_essential:
+            with apply_signature_change(self, source="wear_item"):
+                _do_wear()
+        else:
+            _do_wear()
 
         return True, f"You put on {with_article(item.key)}."
 
@@ -279,14 +292,26 @@ class ClothingMixin:
 
             return False, error_msg
 
-        # No blocking - proceed with removal
-        if self.worn_items:
-            for location, items in list(self.worn_items.items()):
-                if item in items:
-                    items.remove(item)
-                    # Clean up empty lists
-                    if not items:
-                        del self.worn_items[location]
+        # No blocking - proceed with removal.  Wrap signature-contributing
+        # items so the unmasking-moment broadcast fires for observers.
+        from world.identity import apply_signature_change
+
+        is_essential = getattr(item, "disguise_essential", False)
+
+        def _do_remove():
+            if self.worn_items:
+                for location, items in list(self.worn_items.items()):
+                    if item in items:
+                        items.remove(item)
+                        # Clean up empty lists
+                        if not items:
+                            del self.worn_items[location]
+
+        if is_essential:
+            with apply_signature_change(self, source="remove_item"):
+                _do_remove()
+        else:
+            _do_remove()
 
         return True, f"You remove {with_article(item.key)}."
 

--- a/world/identity.py
+++ b/world/identity.py
@@ -1161,3 +1161,372 @@ def bump_recognition_recency(
     observer.recognition_memory = memory
     return True
 
+
+# =========================================================================
+# Unmasking Moments — Apparent UID transition broadcast
+# =========================================================================
+#
+# The "unmasking moment" is the event of a character's Apparent UID
+# shifting (puts on or removes a disguise-essential item, applies an
+# override, etc.) while other characters can perceive them.  For each
+# in-room conscious observer, the broadcast pipeline updates their
+# recognition memory according to a 4-cell matrix keyed on whether
+# they previously knew the old UID, the new UID, both, or neither.
+#
+# See specs/IDENTITY_RECOGNITION_SPEC.md (Unmasking Moments) for the
+# end-to-end behavioural contract.
+
+#: Hard cap on link-chain traversal to bound work on malformed data.
+#: Linked chains are uncapped per design (no per-chain user-facing
+#: limit), but the walker still terminates if it visits this many
+#: distinct UIDs without exhausting the chain — a safety net against
+#: corrupted entries, not a UX constraint.
+_LINKED_CHAIN_MAX_HOPS: int = 64
+
+
+def _build_link_entry(
+    *,
+    target: Any,
+    observer: Any,
+    linked_to: str | None,
+    now_iso: str,
+    location_name: str,
+) -> dict:
+    """Build a fresh recognition-memory entry for an auto-linked sighting.
+
+    Mirrors the shape written by
+    :meth:`commands.CmdCharacter.CmdRemember._remember_target` but with
+    ``assigned_name=""`` (the observer has not chosen to name this
+    presentation) and ``linked_to`` pointing at the prior UID we just
+    saw transition away from.
+
+    Pulled out as a helper so the broadcast pipeline and the test suite
+    agree on entry shape; the field set must stay in lock-step with
+    ``_identity_helpers.make_recognition_entry`` and the production
+    ``_remember_target``.
+
+    Args:
+        target: The character whose UID just transitioned.
+        observer: The character whose memory is being updated.
+        linked_to: Apparent UID of the prior presentation, or ``None``.
+        now_iso: ISO timestamp string to stamp ``first_seen`` /
+            ``last_seen``.
+        location_name: Room key for ``location_first_seen`` /
+            ``location_last_seen``.
+
+    Returns:
+        Recognition-memory entry dict ready to be stored under the new
+        Apparent UID.
+    """
+    del observer  # reserved for future per-observer customisation
+    sdesc = target.get_sdesc() if hasattr(target, "get_sdesc") else ""
+    return {
+        "assigned_name": "",
+        "first_seen": now_iso,
+        "last_seen": now_iso,
+        "times_seen": 1,
+        "location_first_seen": location_name,
+        "location_last_seen": location_name,
+        "locations_seen": [location_name],
+        "sdesc_at_first_encounter": sdesc,
+        "sdesc_at_last_encounter": sdesc,
+        "notes": "",
+        "tags": [],
+        "confidence": 1.0,
+        "relationship_valence": "neutral",
+        "lost_contact": False,
+        "recent_interactions": [],
+        "linked_to": linked_to,
+    }
+
+
+def _collect_unmasking_observers(char: Any) -> list:
+    """Return the list of characters eligible to witness an unmasking.
+
+    Filters in this order:
+
+    1. Must share ``char.location`` (visual perception is room-local).
+    2. Must not be ``char`` themselves (you don't witness your own
+       unmasking through recognition memory — you know who you are).
+    3. Must have a ``recognition_memory`` attribute (excludes items,
+       exits, mobs without the identity surface).
+    4. Must not be unconscious — perception requires awareness.
+
+    Characters lacking :meth:`is_unconscious` are treated as conscious
+    (matches the conservative default used elsewhere in the codebase).
+
+    Args:
+        char: The character whose unmasking is being broadcast.
+
+    Returns:
+        List of observer characters, in iteration order of
+        ``char.location.contents`` (stable per Evennia's storage).
+    """
+    location = getattr(char, "location", None)
+    if location is None:
+        return []
+    contents = getattr(location, "contents", None) or []
+
+    observers: list = []
+    for candidate in contents:
+        if candidate is char:
+            continue
+        if not hasattr(candidate, "recognition_memory"):
+            continue
+        is_unconscious = getattr(candidate, "is_unconscious", None)
+        if callable(is_unconscious):
+            try:
+                if is_unconscious():
+                    continue
+            except (AttributeError, TypeError, ValueError):
+                # Defensive: a broken medical surface should not stop
+                # the broadcast for everyone in the room.
+                logger.log_trace(
+                    f"is_unconscious() raised for {candidate!r}; "
+                    f"treating as conscious for unmasking broadcast."
+                )
+        observers.append(candidate)
+    return observers
+
+
+def _send_unmasking_message(observer: Any, char: Any, cell: str) -> None:
+    """Stub hook for per-cell narrative observer messages.
+
+    PR 3 ships the recognition-memory bookkeeping only.  Narrative
+    flavor text ("Someone's features shift subtly", etc.) is intentionally
+    deferred to a follow-up PR once the engine is observed in play.
+
+    Call sites pass the matrix cell label (``"B"`` / ``"C"`` / ``"D"``)
+    so the future implementation can branch on what the observer knew
+    going in.  Cell ``"A"`` never reaches this hook (no-op short-circuit
+    in :func:`_broadcast_unmasking`).
+    """
+    del observer, char, cell  # TODO(disguise/flavor): write per-cell messages
+
+
+def _broadcast_unmasking(
+    char: Any,
+    old_uid: str | None,
+    new_uid: str | None,
+    source: str | None = None,
+) -> None:
+    """Update every eligible observer's recognition memory for a UID flip.
+
+    Implements the 4-cell matrix:
+
+    * **A** (knew neither): no-op.
+    * **B** (knew old, not new): old entry → ``lost_contact=True``;
+      auto-create new entry with ``linked_to=old_uid``.
+    * **C** (not old, knew new): refresh new entry's ``last_seen`` and
+      clear ``lost_contact``; no link formed (we never met the old
+      presentation, so there's nothing to chain).
+    * **D** (knew both): old entry → ``lost_contact=True``; new entry
+      refreshed; ``linked_to`` set on the new entry (if not already)
+      pointing at ``old_uid``.  Existing ``assigned_name`` on either
+      side is preserved untouched.
+
+    ``old_uid`` or ``new_uid`` being ``None`` (pre-chargen, missing
+    sleeve_uid) short-circuits the entire broadcast — there is nothing
+    meaningful to record.
+
+    Args:
+        char: The character whose UID just changed.
+        old_uid: Apparent UID before the mutation.
+        new_uid: Apparent UID after the mutation.
+        source: Free-form provenance tag (``"wear:balaclava"`` etc.)
+            forwarded to the flavor-text hook for future use.
+    """
+    if old_uid is None or new_uid is None:
+        return
+    if old_uid == new_uid:
+        return
+
+    import time
+
+    now_iso = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+    for observer in _collect_unmasking_observers(char):
+        memory = getattr(observer, "recognition_memory", None)
+        if memory is None:
+            memory = {}
+
+        knew_old = old_uid in memory
+        knew_new = new_uid in memory
+        location_name = (
+            observer.location.key
+            if getattr(observer, "location", None) is not None
+            else "unknown"
+        )
+
+        if not knew_old and not knew_new:
+            # Cell A — stranger remains a stranger.
+            continue
+
+        if knew_old and not knew_new:
+            # Cell B — old presentation just left view; new presentation
+            # arrives as a fresh sighting linked back to the old one.
+            memory[old_uid]["lost_contact"] = True
+            memory[new_uid] = _build_link_entry(
+                target=char,
+                observer=observer,
+                linked_to=old_uid,
+                now_iso=now_iso,
+                location_name=location_name,
+            )
+            observer.recognition_memory = memory
+            _send_unmasking_message(observer, char, "B")
+            continue
+
+        if not knew_old and knew_new:
+            # Cell C — we never met the old presentation; just refresh
+            # the new one as we would on any re-sighting.
+            entry = memory[new_uid]
+            entry["last_seen"] = now_iso
+            entry["location_last_seen"] = location_name
+            entry["lost_contact"] = False
+            if hasattr(char, "get_sdesc"):
+                entry["sdesc_at_last_encounter"] = char.get_sdesc()
+            observer.recognition_memory = memory
+            _send_unmasking_message(observer, char, "C")
+            continue
+
+        # Cell D — observer knew both presentations independently.
+        # Refresh both, link new → old if not already linked, but never
+        # rewrite assigned_name (player-authored data is sacrosanct).
+        memory[old_uid]["lost_contact"] = True
+        new_entry = memory[new_uid]
+        new_entry["last_seen"] = now_iso
+        new_entry["location_last_seen"] = location_name
+        new_entry["lost_contact"] = False
+        if hasattr(char, "get_sdesc"):
+            new_entry["sdesc_at_last_encounter"] = char.get_sdesc()
+        if new_entry.get("linked_to") is None:
+            new_entry["linked_to"] = old_uid
+        observer.recognition_memory = memory
+        _send_unmasking_message(observer, char, "D")
+
+    del source  # reserved for future debug/flavor routing
+
+
+class apply_signature_change:
+    """Context manager wrapping any mutation of a character's identity signature.
+
+    Captures the Apparent UID on enter, yields to the caller for the
+    mutation, then captures the post-mutation UID on exit and fires
+    :func:`_broadcast_unmasking` if it changed.
+
+    Use at every site that writes a signature input:
+
+    * ``db.height_override`` / ``db.build_override`` / ``db.keyword_override``
+    * Wearing or removing a ``disguise_essential`` item
+    * Bulk persona application
+
+    Exceptions raised inside the ``with`` block propagate normally and
+    suppress the broadcast — a failed mutation should not pretend the
+    UID changed.
+
+    Usage::
+
+        with apply_signature_change(char, source="override:height"):
+            char.db.height_override = "tall"
+
+    Args:
+        char: The character whose signature is being mutated.
+        source: Optional free-form tag describing the mutation, passed
+            through to the flavor-text hook (currently unused).
+    """
+
+    def __init__(self, char: Any, source: str | None = None) -> None:
+        self.char = char
+        self.source = source
+        self._old_uid: str | None = None
+
+    def __enter__(self) -> "apply_signature_change":
+        self._old_uid = get_apparent_uid(self.char)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if exc_type is not None:
+            # Mutation failed; do not broadcast.
+            return False
+        new_uid = get_apparent_uid(self.char)
+        _broadcast_unmasking(
+            self.char, self._old_uid, new_uid, source=self.source
+        )
+        return False
+
+
+def walk_linked_chain(
+    memory: dict, start_uid: str, max_hops: int = _LINKED_CHAIN_MAX_HOPS
+) -> list[str]:
+    """Walk a recognition-memory ``linked_to`` chain from ``start_uid``.
+
+    Returns the list of UIDs reachable from (and including)
+    ``start_uid``, in traversal order, with cycle detection.  A UID
+    encountered twice terminates the walk silently — corrupted data
+    must not hang the engine.
+
+    The ``max_hops`` cap is a defensive safety net against pathological
+    data only; per design there is no user-facing chain-length limit.
+
+    Args:
+        memory: A ``recognition_memory`` dict.
+        start_uid: UID to begin the walk from.  Returns ``[]`` if not
+            present in ``memory``.
+        max_hops: Defensive cap on distinct UIDs visited.
+
+    Returns:
+        List of UIDs visited in walk order, starting with ``start_uid``.
+    """
+    if start_uid not in memory:
+        return []
+    chain: list[str] = []
+    seen: set = set()
+    current: str | None = start_uid
+    while current is not None and current in memory:
+        if current in seen:
+            logger.log_warn(
+                f"recognition_memory linked_to cycle detected at "
+                f"uid={current!r}; truncating chain walk."
+            )
+            break
+        seen.add(current)
+        chain.append(current)
+        if len(chain) >= max_hops:
+            break
+        current = memory[current].get("linked_to")
+    return chain
+
+
+def get_linked_aliases(memory: dict, uid: str) -> list[str]:
+    """Return assigned names from entries linked to ``uid`` (excluding self).
+
+    Walks the chain via :func:`walk_linked_chain`, skips the starting
+    UID, and collects non-blank ``assigned_name`` values from every
+    other entry in the chain.
+
+    Used by ``recall`` / ``memory`` to render "Also known as: …" lines
+    so the player can see when the engine has observed a body
+    transition between two named presentations.
+
+    Args:
+        memory: A ``recognition_memory`` dict.
+        uid: The starting UID whose chain is inspected.
+
+    Returns:
+        List of assigned names found on linked entries (excluding the
+        entry at ``uid`` itself), in traversal order.  Blank names are
+        omitted.
+    """
+    aliases: list[str] = []
+    for chain_uid in walk_linked_chain(memory, uid):
+        if chain_uid == uid:
+            continue
+        entry = memory.get(chain_uid)
+        if entry is None:
+            continue
+        name = (entry.get("assigned_name") or "").strip()
+        if name:
+            aliases.append(name)
+    return aliases
+

--- a/world/tests/_identity_helpers.py
+++ b/world/tests/_identity_helpers.py
@@ -73,14 +73,16 @@ def make_recognition_entry(
     last_seen: str | None = None,
     times_seen: int = 1,
     lost_contact: bool = False,
+    linked_to: str | None = None,
 ) -> dict:
     """Build a recognition_memory entry dict matching the production schema.
 
     Defaults mirror what :meth:`commands.CmdCharacter.CmdRemember._remember_target`
     writes for a fresh first-meet, including the ``lost_contact`` field
-    introduced by the disguise engine PR.  Tests that need a particular
-    field shape pass the relevant kwargs; everything else takes a
-    sensible default.
+    introduced by the disguise engine PR and the ``linked_to`` chain
+    pointer added by the unmasking-moments broadcast (PR 3).  Tests that
+    need a particular field shape pass the relevant kwargs; everything
+    else takes a sensible default.
     """
     return {
         "assigned_name": assigned_name,
@@ -100,4 +102,5 @@ def make_recognition_entry(
         "last_seen": last_seen if last_seen is not None else first_seen,
         "times_seen": times_seen,
         "lost_contact": lost_contact,
+        "linked_to": linked_to,
     }

--- a/world/tests/test_identity_commands.py
+++ b/world/tests/test_identity_commands.py
@@ -854,7 +854,111 @@ class TestLostContactRenderAnnotation(TestCase):
 # ===================================================================
 
 
-class TestShortdescCustomKeyword(TestCase):
+class TestAlsoKnownAsRendering(TestCase):
+    """``recall`` and ``memory`` surface linked-chain aliases (PR 3)."""
+
+    def _seed_linked_pair(self, observer):
+        """Seed two linked entries on *observer*'s memory.
+
+        ``uid-hood`` (named "The Hood") links back to ``uid-jorge``
+        (named "Jorge") — the shape produced by Cell D / Cell B of the
+        unmasking broadcast.
+        """
+        observer.recognition_memory = {
+            "uid-jorge": {
+                "assigned_name": "Jorge",
+                "first_seen": "2026-01-01T00:00:00",
+                "last_seen": "2026-01-01T00:00:00",
+                "times_seen": 3,
+                "location_first_seen": "Plaza",
+                "location_last_seen": "Plaza",
+                "locations_seen": ["Plaza"],
+                "sdesc_at_first_encounter": "a tall lean man",
+                "sdesc_at_last_encounter": "a tall lean man",
+                "notes": "",
+                "tags": [],
+                "confidence": 1.0,
+                "relationship_valence": "neutral",
+                "recent_interactions": [],
+                "lost_contact": True,
+                "linked_to": None,
+            },
+            "uid-hood": {
+                "assigned_name": "The Hood",
+                "first_seen": "2026-01-02T00:00:00",
+                "last_seen": "2026-01-02T00:00:00",
+                "times_seen": 1,
+                "location_first_seen": "Alley",
+                "location_last_seen": "Alley",
+                "locations_seen": ["Alley"],
+                "sdesc_at_first_encounter": "a hooded figure",
+                "sdesc_at_last_encounter": "a hooded figure",
+                "notes": "",
+                "tags": [],
+                "confidence": 1.0,
+                "relationship_valence": "neutral",
+                "recent_interactions": [],
+                "lost_contact": False,
+                "linked_to": "uid-jorge",
+            },
+        }
+
+    def test_recall_renders_also_known_as_for_linked_entry(self):
+        from commands.CmdCharacter import CmdRecall
+
+        caller = _make_character(key="Observer", sleeve_uid="uid-observer")
+        self._seed_linked_pair(caller)
+
+        cmd = CmdRecall()
+        cmd.caller = caller
+        cmd._render_entry(
+            caller, caller.recognition_memory["uid-hood"], "uid-hood"
+        )
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertIn("Also known as", msg_text)
+        self.assertIn("Jorge", msg_text)
+
+    def test_recall_omits_also_known_as_when_no_chain(self):
+        from commands.CmdCharacter import CmdRecall
+
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=_seed_memory(),
+        )
+
+        cmd = CmdRecall()
+        cmd.caller = caller
+        cmd._render_entry(
+            caller, caller.recognition_memory["uid-target"], "uid-target"
+        )
+
+        msg_text = caller.msg.call_args[0][0]
+        self.assertNotIn("Also known as", msg_text)
+
+    def test_memory_table_shows_aka_for_linked_entries(self):
+        from commands.CmdCharacter import CmdMemory
+
+        caller = _make_character(key="Observer", sleeve_uid="uid-observer")
+        self._seed_linked_pair(caller)
+
+        cmd = CmdMemory()
+        cmd.caller = caller
+        cmd.args = ""
+        cmd.func()
+
+        msg_text = caller.msg.call_args[0][0]
+        # The Hood row should annotate Jorge as a linked alias.  The
+        # table cell wraps "(aka Jorge)" across whitespace, so assert
+        # on both fragments independently rather than the joined string.
+        self.assertIn("aka", msg_text)
+        self.assertIn("Jorge", msg_text)
+        # And the Hood entry itself should still be present.
+        self.assertIn("The Hood", msg_text)
+
+
+
     """Test that @shortdesc accepts arbitrary valid custom keywords."""
 
     def test_custom_keyword_accepted(self):

--- a/world/tests/test_unmasking.py
+++ b/world/tests/test_unmasking.py
@@ -1,0 +1,658 @@
+"""Tests for the unmasking-moments broadcast pipeline.
+
+Covers the engine added in PR 3:
+
+* :class:`world.identity.apply_signature_change` — context manager that
+  detects UID transitions and dispatches :func:`_broadcast_unmasking`.
+* :func:`_broadcast_unmasking` — the 4-cell A/B/C/D matrix that updates
+  in-room observers' recognition memory.
+* :func:`_collect_unmasking_observers` — same-room, conscious, has-memory
+  filter.
+* :func:`walk_linked_chain` / :func:`get_linked_aliases` — chain
+  traversal helpers (with cycle and max-hops defenses).
+
+These tests exercise the engine directly without going through CmdSets;
+wiring tests live alongside the relevant command/mixin modules.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.identity import (
+    _broadcast_unmasking,
+    _build_link_entry,
+    _collect_unmasking_observers,
+    _LINKED_CHAIN_MAX_HOPS,
+    apply_signature_change,
+    get_linked_aliases,
+    walk_linked_chain,
+)
+from world.tests._identity_helpers import make_recognition_entry
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeRoom:
+    """Minimal stand-in for a location with ``contents`` and a ``key``."""
+
+    def __init__(self, key: str = "Test Room") -> None:
+        self.key = key
+        self.contents: list = []
+
+
+class _FakeObserver:
+    """Stand-in for an in-room character that can observe an unmasking.
+
+    Mirrors the duck-typed surface read by
+    :func:`_collect_unmasking_observers` (``recognition_memory``,
+    ``is_unconscious``, ``location``) and the broadcast pipeline
+    (``recognition_memory`` writeback).
+    """
+
+    def __init__(
+        self,
+        *,
+        key: str = "Observer",
+        location: _FakeRoom | None = None,
+        recognition_memory: dict | None = None,
+        unconscious: bool = False,
+        is_unconscious_raises: bool = False,
+    ) -> None:
+        self.key = key
+        self.location = location
+        self.recognition_memory = (
+            recognition_memory if recognition_memory is not None else {}
+        )
+        self._unconscious = unconscious
+        self._is_unconscious_raises = is_unconscious_raises
+        if location is not None:
+            location.contents.append(self)
+
+    def is_unconscious(self) -> bool:
+        if self._is_unconscious_raises:
+            raise AttributeError("simulated broken medical surface")
+        return self._unconscious
+
+
+class _FakeTarget:
+    """The character whose Apparent UID transitions.
+
+    Implements just enough surface for the broadcast pipeline:
+    ``location``, ``get_sdesc``, ``key``.
+    """
+
+    def __init__(
+        self,
+        *,
+        key: str = "Jorge",
+        location: _FakeRoom | None = None,
+        sdesc: str = "a tall lean man",
+    ) -> None:
+        self.key = key
+        self.location = location
+        self._sdesc = sdesc
+        if location is not None:
+            location.contents.append(self)
+
+    def get_sdesc(self) -> str:
+        return self._sdesc
+
+
+class _FakeNonCharacter:
+    """An item-like object in the room: no ``recognition_memory`` attr."""
+
+    def __init__(self, location: _FakeRoom) -> None:
+        self.key = "rock"
+        location.contents.append(self)
+
+
+# ---------------------------------------------------------------------------
+# _collect_unmasking_observers
+# ---------------------------------------------------------------------------
+
+
+class TestCollectUnmaskingObservers(TestCase):
+    """Eligibility filter for in-room observers."""
+
+    def test_returns_empty_when_target_has_no_location(self) -> None:
+        target = _FakeTarget(location=None)
+        self.assertEqual(_collect_unmasking_observers(target), [])
+
+    def test_excludes_self(self) -> None:
+        room = _FakeRoom()
+        target = _FakeTarget(location=room)
+        target.recognition_memory = {}  # self has memory too
+        self.assertEqual(_collect_unmasking_observers(target), [])
+
+    def test_excludes_objects_without_recognition_memory(self) -> None:
+        room = _FakeRoom()
+        target = _FakeTarget(location=room)
+        _FakeNonCharacter(room)
+        self.assertEqual(_collect_unmasking_observers(target), [])
+
+    def test_excludes_unconscious_observers(self) -> None:
+        room = _FakeRoom()
+        target = _FakeTarget(location=room)
+        awake = _FakeObserver(location=room, key="awake")
+        _FakeObserver(location=room, key="asleep", unconscious=True)
+        observers = _collect_unmasking_observers(target)
+        self.assertEqual(observers, [awake])
+
+    def test_treats_broken_is_unconscious_as_conscious(self) -> None:
+        """A raising ``is_unconscious`` must not nuke the broadcast."""
+        room = _FakeRoom()
+        target = _FakeTarget(location=room)
+        broken = _FakeObserver(
+            location=room, key="broken", is_unconscious_raises=True
+        )
+        observers = _collect_unmasking_observers(target)
+        self.assertEqual(observers, [broken])
+
+    def test_returns_multiple_in_iteration_order(self) -> None:
+        room = _FakeRoom()
+        target = _FakeTarget(location=room)
+        a = _FakeObserver(location=room, key="a")
+        b = _FakeObserver(location=room, key="b")
+        c = _FakeObserver(location=room, key="c")
+        self.assertEqual(_collect_unmasking_observers(target), [a, b, c])
+
+
+# ---------------------------------------------------------------------------
+# _broadcast_unmasking — 4-cell matrix
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcastUnmaskingShortCircuits(TestCase):
+    """Pre-matrix bailouts: ``None`` UIDs and unchanged UIDs."""
+
+    def _setup_observer_with_known(self, old_uid: str) -> _FakeObserver:
+        room = _FakeRoom()
+        target = _FakeTarget(location=room)
+        observer = _FakeObserver(
+            location=room,
+            recognition_memory={
+                old_uid: make_recognition_entry(assigned_name="Jorge")
+            },
+        )
+        self.target = target
+        return observer
+
+    def test_none_old_uid_short_circuits(self) -> None:
+        observer = self._setup_observer_with_known("uid-old")
+        before = dict(observer.recognition_memory)
+        _broadcast_unmasking(self.target, None, "uid-new")
+        self.assertEqual(observer.recognition_memory, before)
+
+    def test_none_new_uid_short_circuits(self) -> None:
+        observer = self._setup_observer_with_known("uid-old")
+        before = dict(observer.recognition_memory)
+        _broadcast_unmasking(self.target, "uid-old", None)
+        self.assertEqual(observer.recognition_memory, before)
+
+    def test_unchanged_uid_short_circuits(self) -> None:
+        observer = self._setup_observer_with_known("uid-same")
+        before_entry = dict(observer.recognition_memory["uid-same"])
+        _broadcast_unmasking(self.target, "uid-same", "uid-same")
+        self.assertEqual(
+            observer.recognition_memory["uid-same"], before_entry
+        )
+
+
+class TestBroadcastCellA(TestCase):
+    """Observer knew neither old nor new UID — no-op."""
+
+    def test_strangers_remain_strangers(self) -> None:
+        room = _FakeRoom()
+        target = _FakeTarget(location=room)
+        observer = _FakeObserver(location=room, recognition_memory={})
+        _broadcast_unmasking(target, "uid-old", "uid-new")
+        self.assertEqual(observer.recognition_memory, {})
+
+
+class TestBroadcastCellB(TestCase):
+    """Observer knew old only — mark lost, auto-create linked new entry."""
+
+    def setUp(self) -> None:
+        self.room = _FakeRoom("Alley")
+        self.target = _FakeTarget(location=self.room, sdesc="a hooded figure")
+        self.observer = _FakeObserver(
+            location=self.room,
+            recognition_memory={
+                "uid-old": make_recognition_entry(
+                    assigned_name="Jorge",
+                    sdesc_at_first_encounter="a tall lean man",
+                )
+            },
+        )
+
+    def test_old_entry_marked_lost_contact(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertTrue(
+            self.observer.recognition_memory["uid-old"]["lost_contact"]
+        )
+
+    def test_new_entry_created_with_link_back(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        new_entry = self.observer.recognition_memory["uid-new"]
+        self.assertEqual(new_entry["linked_to"], "uid-old")
+        self.assertEqual(new_entry["assigned_name"], "")
+        self.assertEqual(new_entry["sdesc_at_last_encounter"], "a hooded figure")
+        self.assertEqual(new_entry["location_first_seen"], "Alley")
+
+    def test_assigned_name_on_old_preserved(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertEqual(
+            self.observer.recognition_memory["uid-old"]["assigned_name"],
+            "Jorge",
+        )
+
+
+class TestBroadcastCellC(TestCase):
+    """Observer knew new only — refresh, no link."""
+
+    def setUp(self) -> None:
+        self.room = _FakeRoom("Bar")
+        self.target = _FakeTarget(location=self.room, sdesc="a tall lean man")
+        self.observer = _FakeObserver(
+            location=self.room,
+            recognition_memory={
+                "uid-new": make_recognition_entry(
+                    assigned_name="Jorge",
+                    location_first_seen="Plaza",
+                    location_last_seen="Plaza",
+                    lost_contact=True,
+                )
+            },
+        )
+
+    def test_lost_contact_cleared(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertFalse(
+            self.observer.recognition_memory["uid-new"]["lost_contact"]
+        )
+
+    def test_last_seen_refreshed(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        entry = self.observer.recognition_memory["uid-new"]
+        self.assertEqual(entry["location_last_seen"], "Bar")
+        self.assertEqual(entry["sdesc_at_last_encounter"], "a tall lean man")
+
+    def test_no_link_formed(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertIsNone(
+            self.observer.recognition_memory["uid-new"]["linked_to"]
+        )
+
+    def test_old_uid_not_added(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertNotIn("uid-old", self.observer.recognition_memory)
+
+
+class TestBroadcastCellD(TestCase):
+    """Observer knew both — link new→old, refresh new, mark old lost."""
+
+    def setUp(self) -> None:
+        self.room = _FakeRoom("Dock")
+        self.target = _FakeTarget(location=self.room, sdesc="a hooded figure")
+        self.observer = _FakeObserver(
+            location=self.room,
+            recognition_memory={
+                "uid-old": make_recognition_entry(assigned_name="Jorge"),
+                "uid-new": make_recognition_entry(
+                    assigned_name="The Hood",
+                    lost_contact=True,
+                ),
+            },
+        )
+
+    def test_both_assigned_names_preserved(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertEqual(
+            self.observer.recognition_memory["uid-old"]["assigned_name"],
+            "Jorge",
+        )
+        self.assertEqual(
+            self.observer.recognition_memory["uid-new"]["assigned_name"],
+            "The Hood",
+        )
+
+    def test_old_marked_lost_new_refreshed(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertTrue(
+            self.observer.recognition_memory["uid-old"]["lost_contact"]
+        )
+        self.assertFalse(
+            self.observer.recognition_memory["uid-new"]["lost_contact"]
+        )
+
+    def test_link_set_when_absent(self) -> None:
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertEqual(
+            self.observer.recognition_memory["uid-new"]["linked_to"],
+            "uid-old",
+        )
+
+    def test_existing_link_not_overwritten(self) -> None:
+        self.observer.recognition_memory["uid-new"]["linked_to"] = "uid-other"
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertEqual(
+            self.observer.recognition_memory["uid-new"]["linked_to"],
+            "uid-other",
+        )
+
+
+# ---------------------------------------------------------------------------
+# apply_signature_change context manager
+# ---------------------------------------------------------------------------
+
+
+class TestApplySignatureChange(TestCase):
+    """Context manager dispatch correctness."""
+
+    def test_no_broadcast_when_uid_unchanged(self) -> None:
+        target = _FakeTarget(location=_FakeRoom())
+        with patch(
+            "world.identity.get_apparent_uid", side_effect=["uid-x", "uid-x"]
+        ), patch("world.identity._broadcast_unmasking") as bc:
+            with apply_signature_change(target, source="test"):
+                pass
+        bc.assert_called_once_with(target, "uid-x", "uid-x", source="test")
+
+    def test_broadcast_called_with_old_and_new(self) -> None:
+        target = _FakeTarget(location=_FakeRoom())
+        with patch(
+            "world.identity.get_apparent_uid",
+            side_effect=["uid-old", "uid-new"],
+        ), patch("world.identity._broadcast_unmasking") as bc:
+            with apply_signature_change(target, source="wear:hood"):
+                pass
+        bc.assert_called_once_with(
+            target, "uid-old", "uid-new", source="wear:hood"
+        )
+
+    def test_exception_suppresses_broadcast(self) -> None:
+        target = _FakeTarget(location=_FakeRoom())
+        with patch(
+            "world.identity.get_apparent_uid",
+            side_effect=["uid-old", "uid-new"],
+        ), patch("world.identity._broadcast_unmasking") as bc:
+            with self.assertRaises(RuntimeError):
+                with apply_signature_change(target):
+                    raise RuntimeError("mutation failed")
+        bc.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# walk_linked_chain / get_linked_aliases
+# ---------------------------------------------------------------------------
+
+
+class TestWalkLinkedChain(TestCase):
+    """Chain traversal with cycle and max-hops defenses."""
+
+    def test_missing_start_returns_empty(self) -> None:
+        self.assertEqual(walk_linked_chain({}, "uid-missing"), [])
+
+    def test_single_entry_returns_just_self(self) -> None:
+        memory = {"uid-1": make_recognition_entry(linked_to=None)}
+        self.assertEqual(walk_linked_chain(memory, "uid-1"), ["uid-1"])
+
+    def test_multi_link_walk(self) -> None:
+        memory = {
+            "uid-3": make_recognition_entry(linked_to="uid-2"),
+            "uid-2": make_recognition_entry(linked_to="uid-1"),
+            "uid-1": make_recognition_entry(linked_to=None),
+        }
+        self.assertEqual(
+            walk_linked_chain(memory, "uid-3"),
+            ["uid-3", "uid-2", "uid-1"],
+        )
+
+    def test_cycle_terminates(self) -> None:
+        memory = {
+            "uid-a": make_recognition_entry(linked_to="uid-b"),
+            "uid-b": make_recognition_entry(linked_to="uid-a"),
+        }
+        chain = walk_linked_chain(memory, "uid-a")
+        self.assertEqual(chain, ["uid-a", "uid-b"])
+
+    def test_max_hops_caps_walk(self) -> None:
+        memory = {}
+        for i in range(_LINKED_CHAIN_MAX_HOPS + 10):
+            memory[f"uid-{i}"] = make_recognition_entry(
+                linked_to=f"uid-{i + 1}"
+            )
+        # Last entry: dangling pointer to a uid not in memory — ensures
+        # walk terminates by max_hops, not by missing-link fallthrough.
+        chain = walk_linked_chain(memory, "uid-0")
+        self.assertEqual(len(chain), _LINKED_CHAIN_MAX_HOPS)
+
+    def test_dangling_link_terminates_silently(self) -> None:
+        memory = {
+            "uid-1": make_recognition_entry(linked_to="uid-missing"),
+        }
+        self.assertEqual(walk_linked_chain(memory, "uid-1"), ["uid-1"])
+
+
+class TestGetLinkedAliases(TestCase):
+    """Chain-derived alias names for ``Also known as`` rendering."""
+
+    def test_no_chain_returns_empty(self) -> None:
+        memory = {"uid-1": make_recognition_entry(assigned_name="Jorge")}
+        self.assertEqual(get_linked_aliases(memory, "uid-1"), [])
+
+    def test_excludes_starting_entry_name(self) -> None:
+        memory = {
+            "uid-2": make_recognition_entry(
+                assigned_name="The Hood", linked_to="uid-1"
+            ),
+            "uid-1": make_recognition_entry(assigned_name="Jorge"),
+        }
+        # Starting from uid-2 (named "The Hood"), we should see Jorge but
+        # not "The Hood" itself.
+        self.assertEqual(get_linked_aliases(memory, "uid-2"), ["Jorge"])
+
+    def test_skips_blank_assigned_names(self) -> None:
+        memory = {
+            "uid-3": make_recognition_entry(
+                assigned_name="Outer", linked_to="uid-2"
+            ),
+            "uid-2": make_recognition_entry(
+                assigned_name="", linked_to="uid-1"
+            ),
+            "uid-1": make_recognition_entry(assigned_name="Inner"),
+        }
+        self.assertEqual(get_linked_aliases(memory, "uid-3"), ["Inner"])
+
+
+# ---------------------------------------------------------------------------
+# _build_link_entry
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLinkEntry(TestCase):
+    """Auto-created link-entry shape parity with ``make_recognition_entry``."""
+
+    def test_required_fields_present(self) -> None:
+        target = _FakeTarget(sdesc="a hooded figure")
+        observer = _FakeObserver()
+        entry = _build_link_entry(
+            target=target,
+            observer=observer,
+            linked_to="uid-prev",
+            now_iso="2025-01-02T03:04:05",
+            location_name="Alley",
+        )
+        for field in (
+            "assigned_name",
+            "first_seen",
+            "last_seen",
+            "times_seen",
+            "location_first_seen",
+            "location_last_seen",
+            "sdesc_at_first_encounter",
+            "sdesc_at_last_encounter",
+            "lost_contact",
+            "linked_to",
+        ):
+            self.assertIn(field, entry, f"missing field: {field}")
+
+    def test_assigned_name_starts_blank(self) -> None:
+        target = _FakeTarget(sdesc="a hooded figure")
+        observer = _FakeObserver()
+        entry = _build_link_entry(
+            target=target,
+            observer=observer,
+            linked_to=None,
+            now_iso="2025-01-02T03:04:05",
+            location_name="Alley",
+        )
+        self.assertEqual(entry["assigned_name"], "")
+
+    def test_linked_to_passed_through(self) -> None:
+        target = _FakeTarget(sdesc="a hooded figure")
+        observer = _FakeObserver()
+        entry = _build_link_entry(
+            target=target,
+            observer=observer,
+            linked_to="uid-prev",
+            now_iso="2025-01-02T03:04:05",
+            location_name="Alley",
+        )
+        self.assertEqual(entry["linked_to"], "uid-prev")
+
+
+# ---------------------------------------------------------------------------
+# Wiring tests — confirm apply_signature_change is invoked at each site
+# ---------------------------------------------------------------------------
+
+
+class _WiringMixinHost:
+    """Minimal host for :class:`ClothingMixin` exercising wear/remove only.
+
+    The mixin reads ``self.worn_items`` (dict mapping location → list of
+    items) and ``self.hands`` (dict mapping hand → held item).  We don't
+    need an Evennia Character — just the duck-typed surface.
+    """
+
+    def __init__(self) -> None:
+        self.worn_items: dict = {}
+        self.hands: dict = {}
+        self.location = None  # broadcast no-ops when no location
+
+
+class _WiringFakeItem:
+    """Wearable item stand-in for clothing-mixin wiring tests."""
+
+    def __init__(
+        self,
+        *,
+        disguise_essential: bool,
+        layer: int = 2,
+        coverage: tuple[str, ...] = ("torso",),
+        key: str = "fake-garment",
+    ) -> None:
+        self.disguise_essential = disguise_essential
+        self.layer = layer
+        self._coverage = coverage
+        self.key = key
+        self.location = None
+
+    def is_wearable(self) -> bool:
+        return True
+
+    def get_current_coverage(self) -> tuple[str, ...]:
+        return self._coverage
+
+    def move_to(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class TestClothingMixinWiring(TestCase):
+    """``wear_item`` / ``remove_item`` invoke broadcast only for essentials."""
+
+    def _build_host_with_item(self, item: _WiringFakeItem):
+        from typeclasses.clothing_mixin import ClothingMixin
+
+        class _Host(_WiringMixinHost, ClothingMixin):
+            pass
+
+        host = _Host()
+        item.location = host  # treat as in inventory
+        return host
+
+    def test_wear_essential_invokes_broadcast(self) -> None:
+        item = _WiringFakeItem(disguise_essential=True, key="balaclava")
+        host = self._build_host_with_item(item)
+        with patch(
+            "world.identity.get_apparent_uid",
+            side_effect=["uid-bare", "uid-masked"],
+        ), patch("world.identity._broadcast_unmasking") as bc:
+            ok, _msg = host.wear_item(item)
+        self.assertTrue(ok)
+        bc.assert_called_once()
+
+    def test_wear_non_essential_skips_broadcast(self) -> None:
+        item = _WiringFakeItem(disguise_essential=False, key="shirt")
+        host = self._build_host_with_item(item)
+        with patch("world.identity._broadcast_unmasking") as bc:
+            ok, _msg = host.wear_item(item)
+        self.assertTrue(ok)
+        bc.assert_not_called()
+
+    def test_remove_essential_invokes_broadcast(self) -> None:
+        item = _WiringFakeItem(disguise_essential=True, key="balaclava")
+        host = self._build_host_with_item(item)
+        host.wear_item(item)  # establish worn state without patches
+        with patch(
+            "world.identity.get_apparent_uid",
+            side_effect=["uid-masked", "uid-bare"],
+        ), patch("world.identity._broadcast_unmasking") as bc:
+            ok, _msg = host.remove_item(item)
+        self.assertTrue(ok)
+        bc.assert_called_once()
+
+    def test_remove_non_essential_skips_broadcast(self) -> None:
+        item = _WiringFakeItem(disguise_essential=False, key="shirt")
+        host = self._build_host_with_item(item)
+        host.wear_item(item)
+        with patch("world.identity._broadcast_unmasking") as bc:
+            ok, _msg = host.remove_item(item)
+        self.assertTrue(ok)
+        bc.assert_not_called()
+
+
+class TestOverrideHelperWiring(TestCase):
+    """``_clear_all_overrides`` runs the mutation inside the context manager."""
+
+    def test_clear_all_overrides_uses_context_manager(self) -> None:
+        from commands.CmdCharacter import _clear_all_overrides
+
+        class _DB:
+            height_override = "tall"
+            build_override = "lean"
+            keyword_override = "hood"
+            active_persona = "Bandit"
+
+        class _Caller:
+            db = _DB()
+            location = None
+
+        caller = _Caller()
+        with patch(
+            "world.identity.get_apparent_uid",
+            side_effect=["uid-disguised", "uid-real"],
+        ), patch("world.identity._broadcast_unmasking") as bc:
+            _clear_all_overrides(caller)
+
+        # All four axes wiped.
+        self.assertIsNone(caller.db.height_override)
+        self.assertIsNone(caller.db.build_override)
+        self.assertIsNone(caller.db.keyword_override)
+        self.assertIsNone(caller.db.active_persona)
+        bc.assert_called_once()


### PR DESCRIPTION
## Summary

Completes the disguise system by closing the gap between
`specs/IDENTITY_RECOGNITION_SPEC.md` and the live engine: when a
character's Apparent UID changes, every conscious in-room observer's
recognition memory is now updated according to a 4-cell matrix, and
linked presentations surface in `recall` / `memory` as
"Also known as: …" annotations.

This is PR 3 of 3, following #132 (disguise prototype catalog) and
#133 (corpse apparent-UID propagation).

## What changed

**`world/identity.py`** — new engine surface:

- `apply_signature_change(char, source=None)` — context manager that
  captures the Apparent UID on enter / exit and dispatches a broadcast
  if it changed.  Exceptions inside the `with` block suppress the
  broadcast (a failed mutation should not pretend the UID flipped).
- `_broadcast_unmasking(char, old_uid, new_uid, source=None)` —
  implements the 4-cell A/B/C/D matrix.  Short-circuits on `None` UIDs
  or unchanged UID.
- `_collect_unmasking_observers(char)` — same-room, not-self,
  has-recognition-memory, not-unconscious; defensive `try/except` so a
  broken `is_unconscious()` doesn't nuke the broadcast for everyone.
- `_build_link_entry(...)` — entry factory mirroring `_remember_target`
  shape, blank `assigned_name`, configurable `linked_to`.
- `_send_unmasking_message(observer, char, cell)` — stub hook for
  future per-cell flavor text (deferred to a follow-up).
- `walk_linked_chain(memory, start_uid, max_hops=64)` — cycle-detecting
  forward walker; 64-hop defensive cap (no user-facing chain limit).
- `get_linked_aliases(memory, uid)` — collects non-blank
  `assigned_name`s along the chain, excluding the starting entry.

**Wiring (6 sites):**

- `commands/CmdCharacter.py`: `_clear_all_overrides`, `_nudge_height`,
  `_nudge_build`, `_set_keyword_override`, `_adopt_persona`
- `typeclasses/clothing_mixin.py`: `wear_item` / `remove_item` — only
  when the item is `disguise_essential=True`

**Rendering:**

- `CmdRecall._render_entry` now accepts an `apparent_uid` argument and
  appends `Also known as: <names>` for linked entries.
- `CmdMemory` table cell shows `(aka …)` under each name with linked
  ancestors.

**Schema:**

- `_identity_helpers.make_recognition_entry` gains a `linked_to=None`
  kwarg for test parity (production already reads via
  `.get("linked_to")`).

## Broadcast matrix

| Cell | Observer knew | Action |
|------|---------------|--------|
| A | neither | no-op |
| B | old only | old → `lost_contact=True`; auto-create new with `linked_to=old`, blank `assigned_name` |
| C | new only | refresh `last_seen` / clear `lost_contact` on new; no link |
| D | both | old → `lost_contact=True`; refresh new; set `new.linked_to=old` if currently `None`; both `assigned_name` values preserved |

## Tests

- `world/tests/test_unmasking.py` (new, 41 tests): observer filter
  (6), short-circuits (3), cells A/B/C/D (10), `apply_signature_change`
  (3), chain walker (6), aliases (3), entry factory (3), wiring (7).
- `world/tests/test_identity_commands.py::TestAlsoKnownAsRendering`
  (3 tests): recall renders chain, recall omits when no chain, memory
  table shows `aka`.
- Full world suite: **689 → 733** passing (+44).

## Deferred

`_send_unmasking_message` is currently a no-op stub.  Narrative flavor
text per matrix cell (e.g. "Someone's features shift subtly") is
deferred to a follow-up PR once the bookkeeping engine has been
observed in play.

## Refs

- spec: `specs/IDENTITY_RECOGNITION_SPEC.md` (Unmasking Moments)
- precedes: PR #132, #133