### PR TITLE
Wire corpse decay into apparent-UID recognition

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1047,7 +1047,27 @@ Corpses already preserve forensic data (original name, dbref, physical descripti
 - `sleeve_uid` is propagated to the corpse — **shipped** (PR #133).
 - Looking at a corpse: investigator sees recognized name or sdesc based on their memory — **shipped**. The corpse's `get_display_name` routes through the observer's recognition memory keyed on the corpse's apparent UID (derived from `sleeve_uid` plus whatever the corpse is still wearing).
 - Worn-item changes on the corpse re-derive the apparent presentation — **shipped** via `at_object_leave` invalidation, so stripping a body changes its signature exactly like stripping a live character.
-- Corpse decay interacts with recognition: at advanced decay, the physical features become unrecognizable (already described in existing decay stage text). Wiring decay stage into the apparent-UID pipeline is **pending** — the hook exists; the policy for "when does decay break recognition" has not been chosen.
+- Corpse decay interacts with recognition via the **decay-aware recognition** policy below — **shipped** (PR B).
+
+#### Decay-Aware Recognition
+
+`Corpse.get_display_name` runs a two-pass lookup against the observer's recognition memory, gated by the corpse's current decay stage:
+
+| Stage | Threshold | Body axis (`sleeve_uid`) | Natural recognition | Forensic recovery |
+|---|---|---|---|---|
+| `fresh` | < 1 h | preserved | Works | n/a |
+| `early` | < 1 d | preserved | Works | n/a |
+| `moderate` | < 3 d | blanked | Fails | Intellect ≥ 3 |
+| `advanced` | < 1 w | blanked | Fails | Intellect ≥ 5 |
+| `skeletal` | ≥ 1 w | n/a | Blocked | Blocked |
+
+**Pass 1 — natural recognition.** `world.identity.get_apparent_uid_for_decay(corpse, stage)` mirrors `get_apparent_uid` but blanks the `sleeve_uid` axis at `moderate` and `advanced`. Worn items and override axes are preserved, so a recognizable jacket continues to anchor the signature through light decay; a fresh memory keyed to `(sleeve_uid + jacket)` simply no longer matches once the body axis is blanked. At `fresh` and `early` the degraded UID equals the fresh UID, so ordinary recognition works.
+
+**Pass 2 — forensic recovery.** If the degraded lookup misses but `get_apparent_uid(corpse)` (the fresh-equivalent UID) is in memory, the looker rolls Intellect (`world.combat.dice.roll_stat(looker, "intellect", default=1)`) against the stage DC. On success the assigned name is returned; on failure the decay name is returned. The roll outcome is cached permanently in `corpse.db.forensic_recognition_cache = {looker.dbref: bool}` — a single careful examination per `(observer, corpse)` pair determines the verdict, which prevents re-roll abuse on every `look`. Anonymous lookers (no dbref) are not cached and re-roll on each call.
+
+**Skeletal hard cutoff.** The skeletal stage short-circuits both passes and returns the decay name even with a guaranteed-pass roll. Programmatic `sleeve_uid` queries (admin commands, future forensic tooling) continue to work — only the display-name path is blocked.
+
+**Disguise persistence.** Worn-item axes contribute to the signature at all non-skeletal stages, so looting a disguise-essential item (e.g. a balaclava) silently breaks both recognition paths just as it does for a living character.
 
 ### Evidence and Investigation (Future)
 

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -71,35 +71,143 @@ class Corpse(Item):
         :meth:`typeclasses.characters.Character.get_display_name`:
 
         * ``looker is None`` (system context) → decay-stage fallback.
-        * Looker has an entry under this corpse's current Apparent UID
-          → return the entry's ``assigned_name``.
-        * Otherwise → decay-stage name (``"fresh corpse"`` etc.).
+        * Stage is ``skeletal`` → decay-stage name (hard cutoff;
+          neither natural recognition nor a forensic skill check can
+          recover an identity from bones; recognizable clothing is
+          deduced by the player through item inspection, not surfaced
+          through the corpse name).
+        * Otherwise, two-pass recognition:
+
+          1. **Natural recognition.**  Compute the *decay-degraded*
+             apparent UID via :func:`world.identity.get_apparent_uid_for_decay`
+             (which blanks the body-identity axis at ``moderate`` and
+             ``advanced`` stages).  If the looker's memory has that UID,
+             return its ``assigned_name``.  At ``fresh`` and ``early``
+             the degraded UID equals the fresh UID, so this path covers
+             ordinary recognition through light decay.
+          2. **Forensic recovery.**  If the degraded lookup missed,
+             compute the *fresh-equivalent* UID via
+             :func:`world.identity.get_apparent_uid`.  If memory has
+             that UID **and** the looker passes an Intellect roll
+             against the stage DC (see :meth:`_attempt_forensic_recognition`),
+             return its ``assigned_name``.  The roll outcome is cached
+             permanently per ``(looker, this corpse)``.
+
+        * Else → decay-stage name (``"fresh corpse"`` etc.).
 
         Disguise loss after death is handled by re-reading the
         signature on every call (no cache): once a disguise-essential
-        item is looted, :func:`world.identity.get_apparent_uid`
-        recomputes against the corpse's remaining ``get_worn_items()``
-        contents and the recognition match silently falls away.
+        item is looted, both UID computations see the new
+        ``get_worn_items()`` view and the recognition match silently
+        falls away.
         """
+        del kwargs  # Evennia passes look context we don't need.
         decay_name = self._decay_display_name()
+        stage = self.get_decay_stage()
 
         if looker is None:
             return decay_name
 
-        try:
-            from world.identity import get_apparent_uid
-            apparent_uid = get_apparent_uid(self)
-        except (AttributeError, TypeError, ValueError):
-            apparent_uid = None
+        if stage == "skeletal":
+            # Hard cutoff: no recognition path returns a name for a
+            # skeleton.  The sleeve_uid is still queryable
+            # programmatically (forensic tooling, admin commands) but
+            # not surfaced through the display name.
+            return decay_name
 
-        if apparent_uid is not None and hasattr(looker, "recognition_memory"):
-            memory = looker.recognition_memory
-            if memory and apparent_uid in memory:
-                assigned = memory[apparent_uid].get("assigned_name")
+        memory = getattr(looker, "recognition_memory", None)
+        if not memory:
+            return decay_name
+
+        # Pass 1: natural recognition against the decay-degraded UID.
+        try:
+            from world.identity import (
+                get_apparent_uid,
+                get_apparent_uid_for_decay,
+            )
+            degraded_uid = get_apparent_uid_for_decay(self, stage)
+        except (AttributeError, TypeError, ValueError):
+            degraded_uid = None
+
+        if degraded_uid is not None and degraded_uid in memory:
+            assigned = memory[degraded_uid].get("assigned_name")
+            if assigned:
+                return assigned
+
+        # Pass 2: forensic recovery against the fresh-equivalent UID.
+        try:
+            fresh_uid = get_apparent_uid(self)
+        except (AttributeError, TypeError, ValueError):
+            fresh_uid = None
+
+        if (
+            fresh_uid is not None
+            and fresh_uid != degraded_uid
+            and fresh_uid in memory
+        ):
+            if self._attempt_forensic_recognition(looker, stage):
+                assigned = memory[fresh_uid].get("assigned_name")
                 if assigned:
                     return assigned
 
         return decay_name
+
+    # Intellect DC by decay stage for forensic recognition recovery.
+    # Stages absent from this map never roll: ``fresh`` / ``early`` don't
+    # need recovery (the degraded UID still matches memory), and
+    # ``skeletal`` is hard-cutoff in :meth:`get_display_name` before this
+    # table is consulted.
+    _FORENSIC_RECOGNITION_DC = {
+        "moderate": 3,
+        "advanced": 5,
+    }
+
+    def _attempt_forensic_recognition(self, looker, stage):
+        """Resolve (and cache) a forensic-recognition Intellect roll.
+
+        Per-observer, per-corpse, permanent: a looker who fails the roll
+        the first time they examine this corpse will keep failing, and a
+        looker who passes will keep recognising it across subsequent
+        looks.  This rewards a single careful examination and prevents
+        Intellect re-rolls on every ``look`` from eventually surfacing
+        an identity by chance.
+
+        Cache lives in ``self.db.forensic_recognition_cache`` as
+        ``{looker.dbref: bool}``.  Anonymous lookers (no dbref) are not
+        cached and re-roll on every call — this keeps the cache bounded
+        and avoids storing junk keys for tooling that walks corpses
+        without a real observer.
+
+        Args:
+            looker: The character attempting recognition.
+            stage: The corpse's current decay stage (used for DC).
+
+        Returns:
+            ``True`` if the looker recovers the identity, else ``False``.
+        """
+        dc = self._FORENSIC_RECOGNITION_DC.get(stage)
+        if dc is None:
+            # Stage has no defined DC — never recover.
+            return False
+
+        cache = self.db.forensic_recognition_cache
+        if cache is None:
+            cache = {}
+
+        looker_dbref = getattr(looker, "dbref", None)
+        if looker_dbref is not None and looker_dbref in cache:
+            return bool(cache[looker_dbref])
+
+        from world.combat.dice import roll_stat
+
+        roll = roll_stat(looker, "intellect", default=1)
+        success = roll >= dc
+
+        if looker_dbref is not None:
+            cache[looker_dbref] = success
+            self.db.forensic_recognition_cache = cache
+
+        return success
 
     def _decay_display_name(self):
         """Return the decay-stage name used when no recognition matches."""

--- a/world/identity.py
+++ b/world/identity.py
@@ -906,6 +906,62 @@ def get_apparent_uid(char: Any) -> str | None:
     ).hexdigest()
 
 
+# Decay stages at which a corpse's body-identity axis (``sleeve_uid``) is
+# no longer recoverable by an unaided observer.  Stages strictly listed
+# here cause :func:`get_apparent_uid_for_decay` to blank the sleeve_uid
+# in the signature tuple, producing a UID that no living-character
+# memory will match — natural recognition fails, only forensic recovery
+# (see :meth:`typeclasses.corpse.Corpse._attempt_forensic_recognition`)
+# can restore the original match.
+#
+# Earlier stages (fresh, early) leave the signature untouched.  The
+# ``skeletal`` stage is handled separately as a hard cutoff in
+# :meth:`Corpse.get_display_name` — no recognition path returns a name
+# for a skeleton, with or without forensics.
+_DECAY_SUPPRESS_SLEEVE_UID_STAGES = frozenset({"moderate", "advanced"})
+
+
+def get_apparent_uid_for_decay(char: Any, stage: str) -> str | None:
+    """Compute the Apparent UID a decayed body presents to an unaided observer.
+
+    Same hashing pipeline as :func:`get_apparent_uid`, but with the
+    body-identity axis (``sleeve_uid``) blanked when the decay stage is
+    advanced enough that an unaided observer cannot resolve the face /
+    build / skin signature.  The non-body axes (overrides, worn items)
+    are preserved so a recognizable disguise / costume still contributes
+    to a partial match — but partial-match UIDs will not collide with
+    memory entries written from the fresh, sleeve-keyed presentation.
+
+    Callers compare the result against the observer's recognition memory
+    first; if it misses, they may fall back to the un-degraded
+    :func:`get_apparent_uid` and gate the recovery on a forensic skill
+    check (see :meth:`typeclasses.corpse.Corpse._attempt_forensic_recognition`).
+
+    Args:
+        char: The decaying character / corpse.
+        stage: One of ``"fresh"``, ``"early"``, ``"moderate"``,
+            ``"advanced"``, ``"skeletal"`` (matches
+            :meth:`typeclasses.corpse.Corpse.get_decay_stage`).  Unknown
+            stages are treated as ``"fresh"`` (no suppression) to fail
+            safe toward recognition rather than silently break it.
+
+    Returns:
+        16-character hex digest, or ``None`` when the underlying
+        signature has no real ``sleeve_uid`` to hash (matching the
+        ``None`` semantics of :func:`get_apparent_uid`).
+    """
+    signature = get_identity_signature(char)
+    if signature[0] is None:
+        return None
+    if stage in _DECAY_SUPPRESS_SLEEVE_UID_STAGES:
+        # Blank the sleeve_uid axis; preserve overrides and worn items.
+        signature = (None,) + signature[1:]
+    signature_bytes = repr(signature).encode("utf-8")
+    return hashlib.blake2b(
+        signature_bytes, digest_size=_APPARENT_UID_DIGEST_BYTES
+    ).hexdigest()
+
+
 def get_apparent_gender(char: Any) -> str:
     """Return the grammar gender presented by a character's current look.
 

--- a/world/tests/test_corpse_decay_recognition.py
+++ b/world/tests/test_corpse_decay_recognition.py
@@ -1,0 +1,486 @@
+"""
+Tests for Phase 3.6 PR B — decay-aware corpse recognition.
+
+Verifies the two-pass recognition flow on
+:meth:`typeclasses.corpse.Corpse.get_display_name`:
+
+1. **Decay-degraded UID path** — at ``moderate`` and ``advanced`` decay
+   stages, :func:`world.identity.get_apparent_uid_for_decay` blanks the
+   ``sleeve_uid`` axis, producing a UID that no fresh-keyed memory entry
+   matches.  At ``fresh`` and ``early`` the degraded UID equals the
+   fresh UID (natural recognition keeps working through light decay).
+2. **Forensic recovery path** — when the degraded lookup misses but the
+   fresh UID is in memory, an Intellect roll against the stage DC may
+   recover the assigned name.  The roll outcome is cached permanently
+   per ``(looker.dbref, corpse)`` so a single careful examination
+   determines the verdict for that observer.
+3. **Skeletal hard cutoff** — the skeletal stage suppresses both
+   recognition paths in the display name (programmatic
+   ``sleeve_uid`` queries continue to work for forensic tooling).
+4. **Worn-item disguise persistence** — items in ``corpse.contents``
+   keep contributing to the signature at non-skeletal stages, so a
+   recognizable jacket still anchors recognition through decay; a fresh
+   memory keyed to ``(sleeve_uid + jacket)`` only resurfaces via
+   forensic recovery once the body itself is no longer readable.
+5. **Living-character regression guard** —
+   :func:`world.identity.get_apparent_uid` is unchanged for living
+   characters (the new helper is additive).
+
+Run via::
+
+    docker exec gelatinous evennia test --settings settings.py \\
+        world.tests.test_corpse_decay_recognition
+
+These are pure unit tests built on lightweight fakes that bind the
+production :class:`typeclasses.corpse.Corpse` methods to a duck-typed
+instance — no Evennia database is required.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from typeclasses.corpse import Corpse
+from world.identity import (
+    get_apparent_uid,
+    get_apparent_uid_for_decay,
+)
+from world.tests.test_identity import _FakeDisguiseItem
+
+
+# ---------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------
+
+
+class _FakeDecayCorpse:
+    """Duck-typed corpse that binds production ``Corpse`` methods.
+
+    Holds the minimum ``db`` / ``contents`` / ``ndb`` surface that the
+    production :meth:`Corpse.get_display_name` and
+    :meth:`Corpse._attempt_forensic_recognition` touch, plus a
+    test-controlled ``_stage`` so we can pin the decay stage without
+    juggling ``creation_time`` arithmetic.
+    """
+
+    # Bind production methods so tests exercise the real implementation.
+    get_display_name = Corpse.get_display_name
+    _attempt_forensic_recognition = Corpse._attempt_forensic_recognition
+    _FORENSIC_RECOGNITION_DC = Corpse._FORENSIC_RECOGNITION_DC
+
+    def __init__(
+        self,
+        *,
+        sleeve_uid: str | None = "uid-jorge",
+        height_override: str | None = None,
+        build_override: str | None = None,
+        keyword_override: str | None = None,
+        contents: list | None = None,
+        stage: str = "fresh",
+    ) -> None:
+        class _DB:
+            pass
+
+        self.db = _DB()
+        self.db.sleeve_uid = sleeve_uid
+        self.db.height_override = height_override
+        self.db.build_override = build_override
+        self.db.keyword_override = keyword_override
+        self.db.apparent_uid_at_death = None
+        self.db.forensic_recognition_cache = None
+        self.contents = list(contents or [])
+        self.ndb = type("_NDB", (), {})()
+        self._stage = stage
+        self._decay_names = {
+            "fresh": "fresh corpse",
+            "early": "pale corpse",
+            "moderate": "decomposing remains",
+            "advanced": "putrid remains",
+            "skeletal": "skeletal remains",
+        }
+
+    @property
+    def sleeve_uid(self):
+        return self.db.sleeve_uid
+
+    def get_worn_items(self, location=None):
+        del location
+        return [
+            item
+            for item in self.contents
+            if getattr(item, "disguise_essential", False)
+        ]
+
+    def get_decay_stage(self):
+        return self._stage
+
+    def _decay_display_name(self):
+        return self._decay_names[self._stage]
+
+
+class _FakeObserver:
+    """Minimal observer with ``recognition_memory`` and ``dbref``."""
+
+    def __init__(
+        self,
+        *,
+        memory: dict | None = None,
+        dbref: str | None = "#42",
+        intellect: int = 1,
+    ) -> None:
+        self.recognition_memory = memory or {}
+        self.dbref = dbref
+        self.intellect = intellect
+
+
+# ---------------------------------------------------------------------
+# Decay-degraded UID helper (world.identity.get_apparent_uid_for_decay)
+# ---------------------------------------------------------------------
+
+
+class TestGetApparentUidForDecay(TestCase):
+    """The new helper degrades the UID per stage, no roll involved."""
+
+    def test_fresh_stage_matches_fresh_uid(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge")
+        self.assertEqual(
+            get_apparent_uid_for_decay(corpse, "fresh"),
+            get_apparent_uid(corpse),
+        )
+
+    def test_early_stage_matches_fresh_uid(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge")
+        self.assertEqual(
+            get_apparent_uid_for_decay(corpse, "early"),
+            get_apparent_uid(corpse),
+        )
+
+    def test_moderate_stage_differs_from_fresh_uid(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge")
+        self.assertNotEqual(
+            get_apparent_uid_for_decay(corpse, "moderate"),
+            get_apparent_uid(corpse),
+        )
+
+    def test_advanced_stage_differs_from_fresh_uid(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge")
+        self.assertNotEqual(
+            get_apparent_uid_for_decay(corpse, "advanced"),
+            get_apparent_uid(corpse),
+        )
+
+    def test_returns_none_when_sleeve_uid_missing(self):
+        corpse = _FakeDecayCorpse(sleeve_uid=None)
+        self.assertIsNone(get_apparent_uid_for_decay(corpse, "moderate"))
+
+    def test_worn_items_still_affect_degraded_uid(self):
+        balaclava = _FakeDisguiseItem(
+            disguise_essential=True, disguise_type_id="balaclava",
+        )
+        bare = _FakeDecayCorpse(sleeve_uid="uid-jorge")
+        clothed = _FakeDecayCorpse(
+            sleeve_uid="uid-jorge", contents=[balaclava],
+        )
+        self.assertNotEqual(
+            get_apparent_uid_for_decay(bare, "moderate"),
+            get_apparent_uid_for_decay(clothed, "moderate"),
+        )
+
+
+# ---------------------------------------------------------------------
+# Skeletal hard cutoff
+# ---------------------------------------------------------------------
+
+
+class TestSkeletalHardCutoff(TestCase):
+    """Skeletal corpses never surface a recognised name."""
+
+    def test_skeletal_blocks_natural_recognition(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="skeletal")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        self.assertEqual(
+            corpse.get_display_name(observer), "skeletal remains",
+        )
+
+    def test_skeletal_blocks_forensic_recovery(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="skeletal")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+            intellect=99,
+        )
+        # Even with a guaranteed-pass roll, skeletal short-circuits
+        # before forensic recovery is attempted.
+        with patch(
+            "world.combat.dice.roll_stat", return_value=99,
+        ):
+            self.assertEqual(
+                corpse.get_display_name(observer), "skeletal remains",
+            )
+
+    def test_sleeve_uid_still_queryable_on_skeleton(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="skeletal")
+        # Programmatic forensic queries still see the sleeve UID; only
+        # the *display name* path is blocked.
+        self.assertEqual(corpse.sleeve_uid, "uid-jorge")
+        self.assertIsNotNone(get_apparent_uid(corpse))
+
+
+# ---------------------------------------------------------------------
+# Natural recognition through light decay
+# ---------------------------------------------------------------------
+
+
+class TestNaturalRecognitionLightDecay(TestCase):
+    """Fresh and early stages keep ordinary recognition working."""
+
+    def test_fresh_recognition_returns_assigned_name(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="fresh")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        self.assertEqual(corpse.get_display_name(observer), "Jorge")
+
+    def test_early_recognition_returns_assigned_name(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="early")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        self.assertEqual(corpse.get_display_name(observer), "Jorge")
+
+    def test_none_looker_returns_decay_name(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
+        self.assertEqual(
+            corpse.get_display_name(None), "decomposing remains",
+        )
+
+    def test_stranger_sees_decay_name(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
+        observer = _FakeObserver(memory={})
+        self.assertEqual(
+            corpse.get_display_name(observer), "decomposing remains",
+        )
+
+
+# ---------------------------------------------------------------------
+# Forensic recovery (Intellect roll vs stage DC, with caching)
+# ---------------------------------------------------------------------
+
+
+class TestForensicRecovery(TestCase):
+    """Moderate / advanced require an Intellect roll to recover identity."""
+
+    def test_moderate_pass_returns_assigned_name(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        # DC 3 for moderate; force a passing roll.
+        with patch("world.combat.dice.roll_stat", return_value=3):
+            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+
+    def test_moderate_fail_returns_decay_name(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        # DC 3 for moderate; force a failing roll.
+        with patch("world.combat.dice.roll_stat", return_value=2):
+            self.assertEqual(
+                corpse.get_display_name(observer), "decomposing remains",
+            )
+
+    def test_advanced_pass_returns_assigned_name(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="advanced")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        # DC 5 for advanced.
+        with patch("world.combat.dice.roll_stat", return_value=5):
+            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+
+    def test_advanced_fail_returns_decay_name(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="advanced")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        with patch("world.combat.dice.roll_stat", return_value=4):
+            self.assertEqual(
+                corpse.get_display_name(observer), "putrid remains",
+            )
+
+
+# ---------------------------------------------------------------------
+# Forensic cache stickiness
+# ---------------------------------------------------------------------
+
+
+class TestForensicCache(TestCase):
+    """Roll outcome is cached permanently per (looker.dbref, corpse)."""
+
+    def test_failure_sticks_across_rerolls(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        # First look: forced failure.
+        with patch("world.combat.dice.roll_stat", return_value=1):
+            self.assertEqual(
+                corpse.get_display_name(observer), "decomposing remains",
+            )
+        # Second look: even a guaranteed-pass roll must not re-roll —
+        # the cached failure persists.
+        with patch("world.combat.dice.roll_stat", return_value=99) as mocked:
+            self.assertEqual(
+                corpse.get_display_name(observer), "decomposing remains",
+            )
+            mocked.assert_not_called()
+
+    def test_success_sticks_across_rerolls(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        with patch("world.combat.dice.roll_stat", return_value=10):
+            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+        # Cached success: a forced-fail roll must not be consulted.
+        with patch("world.combat.dice.roll_stat", return_value=1) as mocked:
+            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+            mocked.assert_not_called()
+
+    def test_cache_is_keyed_by_dbref(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
+        fresh_uid = get_apparent_uid(corpse)
+        memory = {fresh_uid: {"assigned_name": "Jorge"}}
+        observer_a = _FakeObserver(memory=memory, dbref="#42")
+        observer_b = _FakeObserver(memory=memory, dbref="#43")
+
+        # A fails, locked in.
+        with patch("world.combat.dice.roll_stat", return_value=1):
+            self.assertEqual(
+                corpse.get_display_name(observer_a),
+                "decomposing remains",
+            )
+        # B independently passes (different dbref → fresh roll).
+        with patch("world.combat.dice.roll_stat", return_value=99):
+            self.assertEqual(corpse.get_display_name(observer_b), "Jorge")
+
+    def test_anonymous_looker_rerolls_each_call(self):
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
+        fresh_uid = get_apparent_uid(corpse)
+        # No dbref → must not be cached.
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+            dbref=None,
+        )
+        with patch("world.combat.dice.roll_stat", return_value=1):
+            self.assertEqual(
+                corpse.get_display_name(observer),
+                "decomposing remains",
+            )
+        # Re-roll happens because nothing was stored.
+        with patch("world.combat.dice.roll_stat", return_value=99) as mocked:
+            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+            mocked.assert_called_once()
+
+
+# ---------------------------------------------------------------------
+# Worn-item disguise interaction with decay
+# ---------------------------------------------------------------------
+
+
+class TestWornItemDisguiseThroughDecay(TestCase):
+    """Disguise items keep contributing to the UID through decay stages."""
+
+    def test_jacket_does_not_resurface_past_skeletal(self):
+        balaclava = _FakeDisguiseItem(
+            disguise_essential=True, disguise_type_id="balaclava",
+        )
+        corpse = _FakeDecayCorpse(
+            sleeve_uid="uid-jorge",
+            contents=[balaclava],
+            stage="skeletal",
+        )
+        # Memory keyed to the live-disguise (sleeve + balaclava) UID.
+        disguised_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={disguised_uid: {"assigned_name": "BalaclavaDude"}},
+            intellect=99,
+        )
+        with patch("world.combat.dice.roll_stat", return_value=99):
+            self.assertEqual(
+                corpse.get_display_name(observer), "skeletal remains",
+            )
+
+    def test_jacket_recovers_via_forensics_at_advanced(self):
+        balaclava = _FakeDisguiseItem(
+            disguise_essential=True, disguise_type_id="balaclava",
+        )
+        corpse = _FakeDecayCorpse(
+            sleeve_uid="uid-jorge",
+            contents=[balaclava],
+            stage="advanced",
+        )
+        disguised_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={disguised_uid: {"assigned_name": "BalaclavaDude"}},
+        )
+        # Advanced DC = 5; pass.
+        with patch("world.combat.dice.roll_stat", return_value=5):
+            self.assertEqual(
+                corpse.get_display_name(observer), "BalaclavaDude",
+            )
+
+
+# ---------------------------------------------------------------------
+# Living-character regression guard
+# ---------------------------------------------------------------------
+
+
+class TestLivingCharacterRegressionGuard(TestCase):
+    """``get_apparent_uid`` is unchanged for living characters."""
+
+    def test_living_uid_matches_freshly_dead_corpse_uid(self):
+        from world.tests.test_identity import _SignatureMockCharacter
+
+        living = _SignatureMockCharacter(
+            sleeve_uid="uid-jorge",
+            height_override=None,
+            build_override=None,
+            keyword_override=None,
+            worn_items=[],
+        )
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="fresh")
+        self.assertEqual(get_apparent_uid(living), get_apparent_uid(corpse))
+
+    def test_living_uid_unaffected_by_decay_helper(self):
+        from world.tests.test_identity import _SignatureMockCharacter
+
+        living = _SignatureMockCharacter(
+            sleeve_uid="uid-jorge",
+            height_override=None,
+            build_override=None,
+            keyword_override=None,
+            worn_items=[],
+        )
+        # The decay helper would degrade *if* invoked on a living
+        # character with an "advanced" stage — but the production path
+        # only invokes it for corpses, and the standard helper stays
+        # intact.
+        self.assertIsNotNone(get_apparent_uid(living))
+        self.assertNotEqual(
+            get_apparent_uid(living),
+            get_apparent_uid_for_decay(living, "advanced"),
+        )


### PR DESCRIPTION
## Summary
- Adds two-pass corpse recognition: natural lookup against a decay-degraded UID, then forensic recovery against the fresh UID gated by an Intellect roll vs stage DC.
- Caches the forensic roll outcome permanently per ``(looker.dbref, corpse)`` so a single examination decides the verdict — no re-roll abuse on every ``look``.
- Skeletal stage hard-cuts both recognition paths in the display name; programmatic ``sleeve_uid`` queries still work for forensic tooling.

## Stage / DC table

| Stage | Body axis | Natural | Forensic (Intellect) |
|---|---|---|---|
| fresh / early | preserved | works | n/a |
| moderate | blanked | fails | DC 3 |
| advanced | blanked | fails | DC 5 |
| skeletal | n/a | blocked | blocked |

## Files
- ``world/identity.py`` — new ``get_apparent_uid_for_decay(char, stage)`` mirrors ``get_apparent_uid`` but blanks the ``sleeve_uid`` axis at moderate / advanced stages.
- ``typeclasses/corpse.py`` — rewrites ``get_display_name`` for the two-pass flow; adds ``_attempt_forensic_recognition`` with cached Intellect roll.
- ``world/tests/test_corpse_decay_recognition.py`` — 25 new unit tests covering degraded-UID behavior, skeletal cutoff, forensic pass/fail, cache stickiness (per-dbref + anonymous re-roll), worn-item disguise interaction, and a living-character regression guard.
- ``specs/IDENTITY_RECOGNITION_SPEC.md`` — Decay-Aware Recognition subsection under §Forensic Integration.

## Tests
- ``docker exec gelatinous evennia test --settings settings.py world.tests.test_corpse_decay_recognition`` — 25 passing.
- ``docker exec gelatinous evennia test --settings settings.py world`` — 766 passing (741 + 25 new), no regressions.