### PR TITLE
Add real_sleeve_uid to recognition entries

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1394,6 +1394,7 @@ class CmdRemember(Command):
         # Build/update the recognition entry
         now = _recognition_now_iso()
         location_name = caller.location.key if caller.location else "unknown"
+        real_sleeve_uid = getattr(target, "sleeve_uid", None)
 
         if apparent_uid in memory:
             entry = memory[apparent_uid]
@@ -1406,6 +1407,12 @@ class CmdRemember(Command):
             entry["sdesc_at_last_encounter"] = target.get_sdesc()
             # Re-encountering this UID clears any stale lost-contact flag.
             entry["lost_contact"] = False
+            # Lazy backfill: schema gained `real_sleeve_uid` for reverse
+            # lookup; pre-schema entries don't have it.  Set when missing,
+            # leave alone when present (sleeve_uid never changes for a
+            # given underlying character).
+            if entry.get("real_sleeve_uid") is None and real_sleeve_uid:
+                entry["real_sleeve_uid"] = real_sleeve_uid
         else:
             entry = {
                 "assigned_name": name,
@@ -1423,6 +1430,7 @@ class CmdRemember(Command):
                 "relationship_valence": "neutral",
                 "lost_contact": False,
                 "recent_interactions": [],
+                "real_sleeve_uid": real_sleeve_uid,
             }
 
         memory[apparent_uid] = entry

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -264,6 +264,14 @@ recognition_memory = {
                                         # transition into a new signature ("unmasking").
                                         # Entry remains visible in `memory` and `recall`
                                         # but is annotated as out of contact.
+        "real_sleeve_uid": str | None,  # The target's actual `sleeve_uid` at the
+                                        # moment of writing. Written once per entry
+                                        # (sleeves don't change) and lazily backfilled
+                                        # by `bump_recognition_recency` and the
+                                        # unmasking-moments hook when missing. Enables
+                                        # `find_entries_by_real_sleeve_uid` reverse
+                                        # lookup used by the disguise-piercing
+                                        # recognition roll (see §Disguise Piercing).
         "linked_to": str | None,        # Apparent UID of a prior presentation the
                                         # observer witnessed transitioning into this one.
                                         # Populated by the unmasking-moments hook (see

--- a/world/identity.py
+++ b/world/identity.py
@@ -1254,9 +1254,63 @@ def bump_recognition_recency(
     entry["sdesc_at_last_encounter"] = target.get_sdesc()
     entry["lost_contact"] = False
 
+    # Lazy backfill of `real_sleeve_uid` for entries that pre-date the
+    # schema add (see :func:`_remember_target`).  Bump paths are the
+    # primary backfill surface because they run on every visible
+    # re-encounter; entries the observer never sees again retain their
+    # legacy shape (and are silently ineligible for disguise-piercing
+    # reverse lookup, which is acceptable per the pre-alpha decision).
+    if entry.get("real_sleeve_uid") is None:
+        real_sleeve_uid = getattr(target, "sleeve_uid", None)
+        if real_sleeve_uid:
+            entry["real_sleeve_uid"] = real_sleeve_uid
+
     # Reassign so the AttributeProperty persists the in-place mutation.
     observer.recognition_memory = memory
     return True
+
+
+def find_entries_by_real_sleeve_uid(
+    observer: Any, real_sleeve_uid: str
+) -> list[tuple[str, dict]]:
+    """Return all recognition entries belonging to a given underlying sleeve.
+
+    Reverse lookup over ``observer.recognition_memory``: returns the
+    list of ``(apparent_uid, entry)`` pairs whose ``real_sleeve_uid``
+    field matches the supplied value.  Used by disguise-piercing
+    recognition (PR-X3) to discover "have I previously remembered this
+    physical person under any presentation?" without walking every
+    entry by-hand at each call site.
+
+    Pre-schema entries (those without a ``real_sleeve_uid`` field —
+    see :func:`bump_recognition_recency` lazy backfill) are silently
+    skipped: they cannot be reverse-keyed by definition.  This is the
+    accepted cost of the lazy-backfill strategy (pre-alpha; legacy
+    entries simply remain pierce-ineligible until the observer re-
+    encounters the target through any writer path).
+
+    A ``real_sleeve_uid`` of ``None`` or empty string returns ``[]``
+    immediately; the caller must have already resolved the target's
+    actual sleeve to a non-empty value.
+
+    Args:
+        observer: Character whose recognition memory is searched.
+        real_sleeve_uid: The underlying sleeve UID to match against.
+
+    Returns:
+        List of ``(apparent_uid, entry)`` pairs in insertion order;
+        empty when no entries match or the observer has no memory.
+    """
+    if not real_sleeve_uid:
+        return []
+    memory = getattr(observer, "recognition_memory", None) or {}
+    if not memory:
+        return []
+    return [
+        (uid, entry)
+        for uid, entry in memory.items()
+        if entry.get("real_sleeve_uid") == real_sleeve_uid
+    ]
 
 
 # =========================================================================
@@ -1317,6 +1371,7 @@ def _build_link_entry(
     """
     del observer  # reserved for future per-observer customisation
     sdesc = target.get_sdesc() if hasattr(target, "get_sdesc") else ""
+    real_sleeve_uid = getattr(target, "sleeve_uid", None)
     return {
         "assigned_name": "",
         "first_seen": now_iso,
@@ -1334,6 +1389,7 @@ def _build_link_entry(
         "lost_contact": False,
         "recent_interactions": [],
         "linked_to": linked_to,
+        "real_sleeve_uid": real_sleeve_uid,
     }
 
 
@@ -1557,6 +1613,11 @@ def _broadcast_unmasking(
             entry["lost_contact"] = False
             if hasattr(char, "get_sdesc"):
                 entry["sdesc_at_last_encounter"] = char.get_sdesc()
+            # Lazy backfill of `real_sleeve_uid` (see _remember_target).
+            if entry.get("real_sleeve_uid") is None:
+                real_sleeve_uid = getattr(char, "sleeve_uid", None)
+                if real_sleeve_uid:
+                    entry["real_sleeve_uid"] = real_sleeve_uid
             observer.recognition_memory = memory
             _send_unmasking_message(
                 observer, char, "C", old_uid=old_uid, new_uid=new_uid
@@ -1575,6 +1636,14 @@ def _broadcast_unmasking(
             new_entry["sdesc_at_last_encounter"] = char.get_sdesc()
         if new_entry.get("linked_to") is None:
             new_entry["linked_to"] = old_uid
+        # Lazy backfill of `real_sleeve_uid` on both entries; cell D
+        # touches both, so backfill both opportunistically.
+        real_sleeve_uid = getattr(char, "sleeve_uid", None)
+        if real_sleeve_uid:
+            if new_entry.get("real_sleeve_uid") is None:
+                new_entry["real_sleeve_uid"] = real_sleeve_uid
+            if memory[old_uid].get("real_sleeve_uid") is None:
+                memory[old_uid]["real_sleeve_uid"] = real_sleeve_uid
         observer.recognition_memory = memory
         _send_unmasking_message(
             observer, char, "D", old_uid=old_uid, new_uid=new_uid

--- a/world/tests/_identity_helpers.py
+++ b/world/tests/_identity_helpers.py
@@ -74,15 +74,17 @@ def make_recognition_entry(
     times_seen: int = 1,
     lost_contact: bool = False,
     linked_to: str | None = None,
+    real_sleeve_uid: str | None = None,
 ) -> dict:
     """Build a recognition_memory entry dict matching the production schema.
 
     Defaults mirror what :meth:`commands.CmdCharacter.CmdRemember._remember_target`
     writes for a fresh first-meet, including the ``lost_contact`` field
-    introduced by the disguise engine PR and the ``linked_to`` chain
-    pointer added by the unmasking-moments broadcast (PR 3).  Tests that
-    need a particular field shape pass the relevant kwargs; everything
-    else takes a sensible default.
+    introduced by the disguise engine PR, the ``linked_to`` chain
+    pointer added by the unmasking-moments broadcast (PR 3), and the
+    ``real_sleeve_uid`` reverse-lookup field added by the recognition
+    schema refresh (PR-X2).  Tests that need a particular field shape
+    pass the relevant kwargs; everything else takes a sensible default.
     """
     return {
         "assigned_name": assigned_name,
@@ -103,4 +105,5 @@ def make_recognition_entry(
         "times_seen": times_seen,
         "lost_contact": lost_contact,
         "linked_to": linked_to,
+        "real_sleeve_uid": real_sleeve_uid,
     }

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -1741,3 +1741,208 @@ class TestBumpRecognitionRecency(TestCase):
         bump_recognition_recency(observer, target, "uid-known", now=now)
 
         self.assertEqual(memory["uid-known"]["location_last_seen"], "unknown")
+
+    def test_bump_backfills_real_sleeve_uid_when_missing(self):
+        """Bump path backfills `real_sleeve_uid` on legacy entries.
+
+        Pre-schema entries (written before PR-X2) lack the
+        ``real_sleeve_uid`` field; the bump path opportunistically
+        backfills it from ``target.sleeve_uid`` so the entry becomes
+        eligible for disguise-piercing reverse lookup.
+        """
+        from datetime import datetime, timedelta
+        from world.identity import (
+            RECOGNITION_BUMP_THROTTLE_SECONDS,
+            bump_recognition_recency,
+        )
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        stale = now - timedelta(
+            seconds=RECOGNITION_BUMP_THROTTLE_SECONDS + 60
+        )
+        memory = {
+            "uid-known": self._entry(
+                last_seen=stale.strftime(self.TS_FMT)
+            ),
+        }
+        # Note: legacy entry has no `real_sleeve_uid` key.
+        self.assertNotIn("real_sleeve_uid", memory["uid-known"])
+
+        observer = self._make_observer(memory)
+        target = self._make_target()
+        target.sleeve_uid = "sleeve-jorge-123"
+
+        bumped = bump_recognition_recency(
+            observer, target, "uid-known", now=now
+        )
+
+        self.assertTrue(bumped)
+        self.assertEqual(
+            memory["uid-known"]["real_sleeve_uid"], "sleeve-jorge-123"
+        )
+
+    def test_bump_preserves_existing_real_sleeve_uid(self):
+        """Bump must not overwrite an already-set `real_sleeve_uid`."""
+        from datetime import datetime, timedelta
+        from world.identity import (
+            RECOGNITION_BUMP_THROTTLE_SECONDS,
+            bump_recognition_recency,
+        )
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        stale = now - timedelta(
+            seconds=RECOGNITION_BUMP_THROTTLE_SECONDS + 60
+        )
+        memory = {
+            "uid-known": {
+                **self._entry(last_seen=stale.strftime(self.TS_FMT)),
+                "real_sleeve_uid": "sleeve-original",
+            },
+        }
+        observer = self._make_observer(memory)
+        target = self._make_target()
+        # Even if target reports a different sleeve_uid, the stored
+        # field must not change (it never changes for a given body).
+        target.sleeve_uid = "sleeve-different-somehow"
+
+        bump_recognition_recency(observer, target, "uid-known", now=now)
+
+        self.assertEqual(
+            memory["uid-known"]["real_sleeve_uid"], "sleeve-original"
+        )
+
+    def test_bump_handles_missing_target_sleeve_uid(self):
+        """No backfill when target has no sleeve_uid (pre-chargen)."""
+        from datetime import datetime, timedelta
+        from world.identity import (
+            RECOGNITION_BUMP_THROTTLE_SECONDS,
+            bump_recognition_recency,
+        )
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        stale = now - timedelta(
+            seconds=RECOGNITION_BUMP_THROTTLE_SECONDS + 60
+        )
+        memory = {
+            "uid-known": self._entry(
+                last_seen=stale.strftime(self.TS_FMT)
+            ),
+        }
+        observer = self._make_observer(memory)
+        target = self._make_target()
+        target.sleeve_uid = None
+
+        bump_recognition_recency(observer, target, "uid-known", now=now)
+
+        # No real_sleeve_uid added because target has none.
+        self.assertIsNone(memory["uid-known"].get("real_sleeve_uid"))
+
+
+class TestFindEntriesByRealSleeveUid(TestCase):
+    """Reverse-lookup helper used by disguise-piercing recognition.
+
+    Walks ``observer.recognition_memory`` and returns every entry
+    whose ``real_sleeve_uid`` matches.  Multiple matches are expected
+    in the disguise-piercing case (one body, many presentations).
+    Pre-schema entries (no field set) are silently skipped.
+    """
+
+    def test_returns_all_matching_entries(self):
+        from world.identity import find_entries_by_real_sleeve_uid
+
+        memory = {
+            "uid-bare": {
+                "assigned_name": "Bruce Wayne",
+                "real_sleeve_uid": "sleeve-bruce",
+            },
+            "uid-cape": {
+                "assigned_name": "the Bat",
+                "real_sleeve_uid": "sleeve-bruce",
+            },
+            "uid-shades": {
+                "assigned_name": "creep in shades",
+                "real_sleeve_uid": "sleeve-bruce",
+            },
+            "uid-other": {
+                "assigned_name": "Alfred",
+                "real_sleeve_uid": "sleeve-alfred",
+            },
+        }
+        observer = MagicMock()
+        observer.recognition_memory = memory
+
+        matches = find_entries_by_real_sleeve_uid(observer, "sleeve-bruce")
+
+        self.assertEqual(len(matches), 3)
+        uids = {uid for uid, _ in matches}
+        self.assertEqual(uids, {"uid-bare", "uid-cape", "uid-shades"})
+
+    def test_returns_empty_when_no_match(self):
+        from world.identity import find_entries_by_real_sleeve_uid
+
+        observer = MagicMock()
+        observer.recognition_memory = {
+            "uid-a": {"real_sleeve_uid": "sleeve-other"},
+        }
+
+        self.assertEqual(
+            find_entries_by_real_sleeve_uid(observer, "sleeve-missing"),
+            [],
+        )
+
+    def test_skips_entries_without_real_sleeve_uid(self):
+        """Legacy entries (pre-schema) are silently ignored."""
+        from world.identity import find_entries_by_real_sleeve_uid
+
+        observer = MagicMock()
+        observer.recognition_memory = {
+            "uid-legacy": {"assigned_name": "Old Entry"},  # no field
+            "uid-fresh": {
+                "assigned_name": "New Entry",
+                "real_sleeve_uid": "sleeve-bruce",
+            },
+        }
+
+        matches = find_entries_by_real_sleeve_uid(observer, "sleeve-bruce")
+
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0][0], "uid-fresh")
+
+    def test_empty_real_sleeve_uid_returns_empty(self):
+        """Empty/None lookup keys short-circuit immediately."""
+        from world.identity import find_entries_by_real_sleeve_uid
+
+        observer = MagicMock()
+        observer.recognition_memory = {
+            "uid-a": {"real_sleeve_uid": ""},
+        }
+
+        self.assertEqual(find_entries_by_real_sleeve_uid(observer, ""), [])
+        self.assertEqual(
+            find_entries_by_real_sleeve_uid(observer, None), []
+        )
+
+    def test_observer_without_memory_returns_empty(self):
+        from world.identity import find_entries_by_real_sleeve_uid
+
+        observer = MagicMock()
+        observer.recognition_memory = None
+
+        self.assertEqual(
+            find_entries_by_real_sleeve_uid(observer, "sleeve-x"), []
+        )
+
+    def test_does_not_match_on_apparent_uid(self):
+        """Match must be against `real_sleeve_uid` field, not the dict key."""
+        from world.identity import find_entries_by_real_sleeve_uid
+
+        observer = MagicMock()
+        observer.recognition_memory = {
+            "sleeve-bruce": {"real_sleeve_uid": "sleeve-other"},
+        }
+
+        # The dict key happens to equal what we're looking for, but the
+        # field value doesn't — must not match.
+        self.assertEqual(
+            find_entries_by_real_sleeve_uid(observer, "sleeve-bruce"), []
+        )


### PR DESCRIPTION
## Summary
- Records the target's actual `sleeve_uid` on every recognition entry write, enabling reverse lookup from a sleeve to all known presentations of that sleeve.
- Adds `find_entries_by_real_sleeve_uid(observer, real_sleeve_uid)` helper that returns all matching `(uid, entry)` pairs, skipping legacy entries without the field.
- Prerequisite schema work for the disguise-piercing recognition roll (next PR), which uses the reverse lookup to find a bare-face entry when the observer sees a familiar sleeve in an unfamiliar presentation.

## Changes
- `commands/CmdCharacter.py` — `_remember_target` writes `real_sleeve_uid` on both new entries and lazy backfills on existing ones.
- `world/identity.py`
  - `bump_recognition_recency` lazily backfills `real_sleeve_uid` from `target.sleeve_uid` when missing (preserves existing value).
  - `_build_link_entry` includes `real_sleeve_uid`.
  - `_broadcast_unmasking` cells C and D opportunistically backfill on both old and new entries.
  - New `find_entries_by_real_sleeve_uid` helper.
- `specs/IDENTITY_RECOGNITION_SPEC.md` — documents the new schema field.
- Tests — 3 new bump-recency backfill tests, new `TestFindEntriesByRealSleeveUid` class with 6 tests.

## Test plan
- `docker exec gelatinous evennia test --settings settings.py world.tests` — **783 passing** (was 774).