### PR TITLE
Add disguise-piercing recognition roll

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -763,6 +763,34 @@ This is the bridge that keeps disguise legible after the fact. Without it, a sig
 
 Cell D falls back to the shorter `"You realize that {old_sdesc} and {new_sdesc} are the same person."` template if either `assigned_name` is blank (defensive — cell D by definition has both, but a future code path that drops one should still produce coherent prose). Cell B suppresses the message entirely if either sdesc is missing, rather than ship a malformed line.
 
+### Disguise Piercing
+
+When an observer sees a character whose current Apparent UID is **not** in their recognition memory, the display-name pipeline gives them one more chance: if they've previously remembered the same underlying sleeve under a *different* presentation (the "bare-face entry"), an opposed Intellect-vs-Resonance roll decides whether they see through the disguise.
+
+This is the standing complement to the eyewitness Unmasking Moments hook (§Unmasking Moments). Unmasking handles the case where the observer *witnesses* a transition; piercing handles the case where the observer encounters a familiar sleeve already wearing a disguise they did not see go on.
+
+**Trigger.** `Character.get_display_name(looker)` (and its richer sibling `get_look_header`) first try a direct `recognition_memory[apparent_uid]` lookup. On miss, they call `world.identity.attempt_display_pierce(looker, self, apparent_uid)` before falling back to the articled sdesc. The pierce wrapper:
+
+1. Calls `find_entries_by_real_sleeve_uid(looker, self.sleeve_uid)` to gather every entry the looker has for this underlying sleeve.
+2. Filters out the current `apparent_uid` (the disguised presentation can't pierce itself) and any candidate without an `assigned_name`.
+3. Returns `None` if no candidates remain.
+4. Picks the **first** candidate (insertion order — corresponds to the earliest presentation the looker remembered for this sleeve) and defers to `attempt_disguise_pierce` for the roll.
+
+**The roll.** `attempt_disguise_pierce(observer, target, apparent_uid, bare_entry)` rolls opposed `Intellect` (observer) vs `Resonance` (target) via `world.combat.dice.opposed_roll`, with:
+
+- **Familiarity bonus** added to the observer's effective total: `min(bare_entry["times_seen"], DISGUISE_PIERCE_FAMILIARITY_CAP)`. The cap (default 5) keeps a grizzled veteran from auto-piercing every disguise on Earth.
+- **Disguise penalty** added to the target's effective total: `DISGUISE_PIERCE_VECTOR_PENALTY * count_of_active_vectors`. Vectors are worn `disguise_essential` items plus the three string overrides (`height_override`, `build_override`, `keyword_override`); each contributes 1. Heavier disguises are harder to see through.
+
+Success condition: `(observer_roll + familiarity) > (target_roll + penalty)`. Ties favour the target (the disguise holds).
+
+**Caching.** The outcome is cached permanently per `(observer, target, apparent_uid)` triple on `observer.db.disguise_pierce_cache = {(target.dbref, apparent_uid): bool}`. This mirrors the corpse forensic-recovery contract (`typeclasses/corpse.py:_attempt_forensic_recognition`): one careful look determines the verdict, no re-roll abuse on every `look`. The cache key includes `apparent_uid` so changing the disguise (puts on a hat, swaps a coat) re-rolls; the previous presentation's cached outcome is irrelevant to the new one.
+
+Observers or targets without a `dbref` are not cached and re-roll on every call (keeps the cache bounded; no junk keys for tooling that walks characters without a real observer). The cache survives reloads (it's on `db`, not `ndb`) and persists across sessions — by design: a player who has decided "I do not recognise this person" should not be magically reset to undecided on a server restart.
+
+**Surface.** On success, the looker sees the bare-face entry's `assigned_name` in place of the articled sdesc — same surface as ordinary recognition. The `get_look_header` path further attaches the *current* (disguised) sdesc in parentheses, so the looker sees `"Bruce (a tall figure in a black coat)"` rather than the stranger fallback.
+
+**No auto-link.** Piercing surfaces a name but does **not** write `linked_to` on the disguised presentation's entry — there is no entry to link, by definition. If the looker subsequently runs `remember <pierced name>`, that command's normal flow creates a new entry for the disguised UID and (because the cell-D mirror in `_remember_target` runs) links it to the bare-face entry the looker matched against.
+
 ### Impersonation
 
 Impersonation is **emergent**, not mechanical. The system does not detect or prevent it.

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1032,6 +1032,16 @@ class Character(
                 if assigned:
                     return assigned
 
+        # Disguise piercing: looker doesn't know this presentation, but
+        # may have previously remembered the underlying sleeve under a
+        # different presentation.  Opposed Intellect-vs-Resonance roll
+        # (cached per presentation) decides whether they see through.
+        from world.identity import attempt_display_pierce
+
+        pierced_name = attempt_display_pierce(looker, self, apparent_uid)
+        if pierced_name is not None:
+            return pierced_name
+
         # Fall back to sdesc with indefinite article
         from world.grammar import with_article
 
@@ -1090,6 +1100,11 @@ class Character(
                     assigned = memory[apparent_uid].get("assigned_name")
                     if assigned:
                         name = assigned
+            # Disguise piercing — if not yet recognised, see through?
+            if name is None:
+                from world.identity import attempt_display_pierce
+
+                name = attempt_display_pierce(looker, self, apparent_uid)
             # Stranger: defer to the standard display name (article + sdesc)
             # without a parenthetical to avoid noisy duplication.
             if name is None:

--- a/world/identity.py
+++ b/world/identity.py
@@ -1314,6 +1314,193 @@ def find_entries_by_real_sleeve_uid(
 
 
 # =========================================================================
+# Disguise Piercing — Opposed recognition roll
+# =========================================================================
+#
+# When an observer looks at a target whose current Apparent UID is not in
+# their recognition memory, but the target's underlying ``sleeve_uid``
+# matches a *different* presentation they previously remembered (the
+# "bare-face entry"), the observer rolls Intellect against the target's
+# Resonance to "see through" the disguise.
+#
+# Modelled on the corpse-forensic-recovery pattern
+# (``typeclasses/corpse.py:_attempt_forensic_recognition``):
+# permanent per-``(observer, target, apparent_uid)`` cache so a single
+# careful look determines the verdict for that specific presentation;
+# entering a new disguise rolls again.
+#
+# Familiarity (``times_seen`` on the bare-face entry) buffs the
+# observer's roll; the number of disguise vectors the target is using
+# (worn ``disguise_essential`` items + active overrides) penalises it.
+
+#: Per-disguise-vector penalty applied to the observer's roll.
+DISGUISE_PIERCE_VECTOR_PENALTY = 1
+
+#: Soft cap on familiarity bonus (``min(times_seen, CAP)``) — keeps a
+#: grizzled veteran from auto-piercing every disguise on Earth.
+DISGUISE_PIERCE_FAMILIARITY_CAP = 5
+
+
+def _count_disguise_vectors(target: Any) -> int:
+    """Return the count of active disguise vectors on *target*.
+
+    A "vector" is anything that perturbs the Apparent UID away from the
+    bare sleeve: each worn ``disguise_essential`` item counts once, and
+    each of the three string overrides (``height_override``,
+    ``build_override``, ``keyword_override``) counts once when set.
+
+    Used by :func:`compute_disguise_pierce` to penalise the observer's
+    roll: heavier disguises are harder to see through.
+    """
+    vectors = 0
+    get_worn = getattr(target, "get_worn_items", None)
+    if callable(get_worn):
+        try:
+            worn = get_worn() or []
+        except (AttributeError, TypeError):
+            worn = []
+        vectors += sum(
+            1 for item in worn if getattr(item, "disguise_essential", False)
+        )
+    db = getattr(target, "db", None)
+    if db is not None:
+        for field in ("height_override", "build_override", "keyword_override"):
+            if getattr(db, field, None):
+                vectors += 1
+    return vectors
+
+
+def attempt_disguise_pierce(
+    observer: Any, target: Any, apparent_uid: str, bare_entry: dict
+) -> bool:
+    """Resolve (and cache) a disguise-piercing recognition roll.
+
+    Permanent per-``(observer, target, apparent_uid)`` cache stored on
+    ``observer.db.disguise_pierce_cache`` as
+    ``{(target.dbref, apparent_uid): bool}``.  An observer who fails to
+    pierce a specific presentation will keep failing until that
+    presentation changes; success sticks for that presentation.  This
+    mirrors the corpse forensic-recovery contract: one careful look
+    determines the verdict, no re-roll abuse on every ``look``.
+    Observers or targets without a ``dbref`` are not cached and re-roll
+    on every call (keeps the cache bounded, no junk keys for tooling).
+    Anonymous targets (no ``apparent_uid``) are likewise un-cached.
+
+    The roll is opposed ``Intellect`` (observer) vs ``Resonance``
+    (target), with:
+
+      * **Familiarity bonus** added to the observer: ``min(times_seen,
+        DISGUISE_PIERCE_FAMILIARITY_CAP)`` from the bare-face entry.
+      * **Disguise penalty** subtracted from the observer:
+        ``DISGUISE_PIERCE_VECTOR_PENALTY * count_of_active_vectors``
+        (worn ``disguise_essential`` items + active overrides).
+
+    Ties favour the target (the disguise holds).
+
+    Args:
+        observer: Character attempting recognition.
+        target: Character being observed (must have a ``sleeve_uid``).
+        apparent_uid: The target's *current* Apparent UID — the
+            disguised presentation being pierced.  Used as the cache
+            key so each new disguise gets a fresh roll.
+        bare_entry: The previously-remembered recognition entry for
+            this sleeve (from :func:`find_entries_by_real_sleeve_uid`);
+            its ``times_seen`` feeds the familiarity bonus.
+
+    Returns:
+        ``True`` if the observer pierces the disguise (caller should
+        surface the bare entry's ``assigned_name``), ``False`` otherwise.
+    """
+    from world.combat.dice import opposed_roll
+
+    observer_dbref = getattr(observer, "dbref", None)
+    target_dbref = getattr(target, "dbref", None)
+    cacheable = (
+        observer_dbref is not None
+        and target_dbref is not None
+        and bool(apparent_uid)
+    )
+
+    if cacheable:
+        cache = observer.db.disguise_pierce_cache
+        if cache is None:
+            cache = {}
+        key = (target_dbref, apparent_uid)
+        if key in cache:
+            return bool(cache[key])
+    else:
+        cache = None
+        key = None
+
+    obs_roll, tgt_roll, _ = opposed_roll(
+        observer, target, "intellect", "resonance"
+    )
+
+    familiarity = min(
+        int(bare_entry.get("times_seen", 0) or 0),
+        DISGUISE_PIERCE_FAMILIARITY_CAP,
+    )
+    penalty = _count_disguise_vectors(target) * DISGUISE_PIERCE_VECTOR_PENALTY
+
+    success = (obs_roll + familiarity) > (tgt_roll + penalty)
+
+    if cacheable:
+        cache[key] = success
+        observer.db.disguise_pierce_cache = cache
+
+    return success
+
+
+def attempt_display_pierce(
+    looker: Any, target: Any, apparent_uid: str | None
+) -> str | None:
+    """High-level pierce wrapper for the display-name pipeline.
+
+    Called from :meth:`Character.get_display_name` and
+    :meth:`Character.get_look_header` when the looker does not already
+    recognise the target's current Apparent UID.  Finds candidate
+    bare-face entries via reverse sleeve lookup, then defers to
+    :func:`attempt_disguise_pierce` for the actual opposed roll.
+
+    The first candidate (insertion order) wins; this corresponds to
+    "the earliest presentation the looker remembered for this sleeve".
+    The current (disguised) presentation is filtered out so we never
+    pierce a presentation against itself.
+
+    Args:
+        looker: The observer.
+        target: The character being looked at.
+        apparent_uid: ``target``'s current Apparent UID.
+
+    Returns:
+        The pierced ``assigned_name`` on success, or ``None`` when no
+        pierce occurs (missing memory, missing sleeve, no candidates,
+        or failed roll).
+    """
+    if looker is None or looker is target or not apparent_uid:
+        return None
+    memory = getattr(looker, "recognition_memory", None)
+    if not memory:
+        return None
+    real_sleeve = getattr(target, "sleeve_uid", None)
+    if not real_sleeve:
+        return None
+
+    candidates = [
+        (uid, entry)
+        for uid, entry in find_entries_by_real_sleeve_uid(looker, real_sleeve)
+        if uid != apparent_uid and entry.get("assigned_name")
+    ]
+    if not candidates:
+        return None
+
+    _bare_uid, bare_entry = candidates[0]
+    if attempt_disguise_pierce(looker, target, apparent_uid, bare_entry):
+        return bare_entry.get("assigned_name")
+    return None
+
+
+# =========================================================================
 # Unmasking Moments — Apparent UID transition broadcast
 # =========================================================================
 #

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -1946,3 +1946,325 @@ class TestFindEntriesByRealSleeveUid(TestCase):
         self.assertEqual(
             find_entries_by_real_sleeve_uid(observer, "sleeve-bruce"), []
         )
+
+
+class TestAttemptDisguisePierce(TestCase):
+    """Opposed Intellect-vs-Resonance roll with cache.
+
+    The cache is keyed on ``(target.dbref, apparent_uid)`` and stored
+    on ``observer.db.disguise_pierce_cache``.  Cached outcomes short-
+    circuit before the dice are touched.
+    """
+
+    def _make_observer(self):
+        observer = MagicMock()
+        observer.dbref = "#10"
+        observer.db.disguise_pierce_cache = None
+        return observer
+
+    def _make_target(self, with_overrides=False, worn_items=None):
+        target = MagicMock()
+        target.dbref = "#20"
+        target.db.height_override = "tall" if with_overrides else None
+        target.db.build_override = None
+        target.db.keyword_override = None
+        target.get_worn_items = MagicMock(return_value=worn_items or [])
+        return target
+
+    def test_cache_hit_true_short_circuits(self):
+        from world.identity import attempt_disguise_pierce
+
+        observer = self._make_observer()
+        target = self._make_target()
+        observer.db.disguise_pierce_cache = {("#20", "uid-cape"): True}
+        bare = {"times_seen": 0}
+
+        with patch("world.combat.dice.opposed_roll") as roll:
+            result = attempt_disguise_pierce(observer, target, "uid-cape", bare)
+
+        self.assertTrue(result)
+        roll.assert_not_called()
+
+    def test_cache_hit_false_short_circuits(self):
+        from world.identity import attempt_disguise_pierce
+
+        observer = self._make_observer()
+        target = self._make_target()
+        observer.db.disguise_pierce_cache = {("#20", "uid-cape"): False}
+        bare = {"times_seen": 99}
+
+        with patch("world.combat.dice.opposed_roll") as roll:
+            result = attempt_disguise_pierce(observer, target, "uid-cape", bare)
+
+        self.assertFalse(result)
+        roll.assert_not_called()
+
+    def test_success_caches_outcome(self):
+        from world.identity import attempt_disguise_pierce
+
+        observer = self._make_observer()
+        target = self._make_target()
+        bare = {"times_seen": 0}
+
+        with patch(
+            "world.combat.dice.opposed_roll", return_value=(10, 1, True)
+        ):
+            result = attempt_disguise_pierce(observer, target, "uid-cape", bare)
+
+        self.assertTrue(result)
+        self.assertEqual(
+            observer.db.disguise_pierce_cache, {("#20", "uid-cape"): True}
+        )
+
+    def test_failure_caches_outcome(self):
+        from world.identity import attempt_disguise_pierce
+
+        observer = self._make_observer()
+        target = self._make_target()
+        bare = {"times_seen": 0}
+
+        with patch(
+            "world.combat.dice.opposed_roll", return_value=(1, 10, False)
+        ):
+            result = attempt_disguise_pierce(observer, target, "uid-cape", bare)
+
+        self.assertFalse(result)
+        self.assertEqual(
+            observer.db.disguise_pierce_cache, {("#20", "uid-cape"): False}
+        )
+
+    def test_familiarity_bonus_lets_observer_win(self):
+        from world.identity import attempt_disguise_pierce
+
+        observer = self._make_observer()
+        target = self._make_target()
+        # Tie on raw rolls — observer's familiarity bonus should
+        # push them over the top.
+        bare = {"times_seen": 3}
+
+        with patch(
+            "world.combat.dice.opposed_roll", return_value=(5, 5, False)
+        ):
+            result = attempt_disguise_pierce(observer, target, "uid-cape", bare)
+
+        self.assertTrue(result)
+
+    def test_disguise_vectors_penalise_observer(self):
+        from world.identity import attempt_disguise_pierce
+
+        observer = self._make_observer()
+        item = MagicMock()
+        item.disguise_essential = True
+        target = self._make_target(with_overrides=True, worn_items=[item])
+        # Observer rolls 4, target rolls 2; vectors=2 (override + item)
+        # penalises observer's effective total to 2 vs target's 4. Fail.
+        bare = {"times_seen": 0}
+
+        with patch(
+            "world.combat.dice.opposed_roll", return_value=(4, 2, True)
+        ):
+            result = attempt_disguise_pierce(observer, target, "uid-cape", bare)
+
+        self.assertFalse(result)
+
+    def test_uncacheable_when_observer_lacks_dbref(self):
+        from world.identity import attempt_disguise_pierce
+
+        observer = self._make_observer()
+        observer.dbref = None
+        target = self._make_target()
+        bare = {"times_seen": 0}
+
+        with patch(
+            "world.combat.dice.opposed_roll", return_value=(10, 1, True)
+        ):
+            result = attempt_disguise_pierce(observer, target, "uid-cape", bare)
+
+        self.assertTrue(result)
+        # Cache must not have been written.
+        self.assertIsNone(observer.db.disguise_pierce_cache)
+
+    def test_familiarity_bonus_capped(self):
+        from world.identity import (
+            DISGUISE_PIERCE_FAMILIARITY_CAP,
+            attempt_disguise_pierce,
+        )
+
+        observer = self._make_observer()
+        target = self._make_target()
+        # Times_seen far above the cap — bonus must clip.  Set target's
+        # roll just above (observer_roll + CAP) so the observer fails
+        # even with bonus saturated.
+        bare = {"times_seen": 999}
+
+        with patch(
+            "world.combat.dice.opposed_roll",
+            return_value=(1, 1 + DISGUISE_PIERCE_FAMILIARITY_CAP + 1, False),
+        ):
+            result = attempt_disguise_pierce(observer, target, "uid-cape", bare)
+
+        self.assertFalse(result)
+
+
+class TestAttemptDisplayPierce(TestCase):
+    """End-to-end pierce wrapper used by Character.get_display_name."""
+
+    def _make_observer(self, memory=None):
+        observer = MagicMock()
+        observer.dbref = "#10"
+        observer.recognition_memory = memory or {}
+        observer.db.disguise_pierce_cache = None
+        return observer
+
+    def _make_target(self, sleeve_uid="sleeve-bruce"):
+        target = MagicMock()
+        target.dbref = "#20"
+        target.sleeve_uid = sleeve_uid
+        target.db.height_override = None
+        target.db.build_override = None
+        target.db.keyword_override = None
+        target.get_worn_items = MagicMock(return_value=[])
+        return target
+
+    def test_returns_none_when_looker_is_target(self):
+        from world.identity import attempt_display_pierce
+
+        target = self._make_target()
+        self.assertIsNone(attempt_display_pierce(target, target, "uid-cape"))
+
+    def test_returns_none_when_apparent_uid_missing(self):
+        from world.identity import attempt_display_pierce
+
+        observer = self._make_observer()
+        target = self._make_target()
+        self.assertIsNone(attempt_display_pierce(observer, target, None))
+
+    def test_returns_none_when_memory_empty(self):
+        from world.identity import attempt_display_pierce
+
+        observer = self._make_observer()
+        target = self._make_target()
+        self.assertIsNone(
+            attempt_display_pierce(observer, target, "uid-cape")
+        )
+
+    def test_returns_none_when_target_has_no_sleeve(self):
+        from world.identity import attempt_display_pierce
+
+        observer = self._make_observer(
+            memory={
+                "uid-bare": {
+                    "assigned_name": "Bruce",
+                    "real_sleeve_uid": "sleeve-bruce",
+                }
+            }
+        )
+        target = self._make_target(sleeve_uid=None)
+        self.assertIsNone(
+            attempt_display_pierce(observer, target, "uid-cape")
+        )
+
+    def test_returns_none_when_no_other_presentation_known(self):
+        from world.identity import attempt_display_pierce
+
+        # Only entry the looker has for this sleeve IS the current
+        # apparent_uid — nothing to pierce against.
+        observer = self._make_observer(
+            memory={
+                "uid-cape": {
+                    "assigned_name": "the Bat",
+                    "real_sleeve_uid": "sleeve-bruce",
+                }
+            }
+        )
+        target = self._make_target()
+        self.assertIsNone(
+            attempt_display_pierce(observer, target, "uid-cape")
+        )
+
+    def test_success_returns_bare_face_name(self):
+        from world.identity import attempt_display_pierce
+
+        observer = self._make_observer(
+            memory={
+                "uid-bare": {
+                    "assigned_name": "Bruce",
+                    "real_sleeve_uid": "sleeve-bruce",
+                    "times_seen": 3,
+                }
+            }
+        )
+        target = self._make_target()
+        with patch(
+            "world.combat.dice.opposed_roll", return_value=(10, 1, True)
+        ):
+            result = attempt_display_pierce(observer, target, "uid-cape")
+        self.assertEqual(result, "Bruce")
+
+    def test_failure_returns_none(self):
+        from world.identity import attempt_display_pierce
+
+        observer = self._make_observer(
+            memory={
+                "uid-bare": {
+                    "assigned_name": "Bruce",
+                    "real_sleeve_uid": "sleeve-bruce",
+                    "times_seen": 0,
+                }
+            }
+        )
+        target = self._make_target()
+        with patch(
+            "world.combat.dice.opposed_roll", return_value=(1, 10, False)
+        ):
+            result = attempt_display_pierce(observer, target, "uid-cape")
+        self.assertIsNone(result)
+
+    def test_picks_first_candidate_when_multiple_match(self):
+        from world.identity import attempt_display_pierce
+
+        # Dict insertion order preserved by Python 3.7+; bare-face
+        # entry comes first.
+        observer = self._make_observer(
+            memory={
+                "uid-bare": {
+                    "assigned_name": "Bruce",
+                    "real_sleeve_uid": "sleeve-bruce",
+                    "times_seen": 1,
+                },
+                "uid-shades": {
+                    "assigned_name": "creep in shades",
+                    "real_sleeve_uid": "sleeve-bruce",
+                    "times_seen": 1,
+                },
+            }
+        )
+        target = self._make_target()
+        with patch(
+            "world.combat.dice.opposed_roll", return_value=(10, 1, True)
+        ):
+            result = attempt_display_pierce(observer, target, "uid-cape")
+        self.assertEqual(result, "Bruce")
+
+    def test_skips_candidates_without_assigned_name(self):
+        from world.identity import attempt_display_pierce
+
+        observer = self._make_observer(
+            memory={
+                "uid-anon": {
+                    "assigned_name": None,
+                    "real_sleeve_uid": "sleeve-bruce",
+                },
+                "uid-bare": {
+                    "assigned_name": "Bruce",
+                    "real_sleeve_uid": "sleeve-bruce",
+                    "times_seen": 1,
+                },
+            }
+        )
+        target = self._make_target()
+        with patch(
+            "world.combat.dice.opposed_roll", return_value=(10, 1, True)
+        ):
+            result = attempt_display_pierce(observer, target, "uid-cape")
+        self.assertEqual(result, "Bruce")


### PR DESCRIPTION
## Summary
- Observers who have previously remembered a target under a different presentation now get an opposed Intellect-vs-Resonance roll to see through the current disguise, completing the standing complement to the eyewitness Unmasking Moments hook.
- Mirrors the corpse forensic-recovery contract: one careful look per `(observer, target, apparent_uid)` determines the verdict (permanent cache); changing the disguise re-rolls.

## Changes
- `world/identity.py`
  - `attempt_disguise_pierce(observer, target, apparent_uid, bare_entry)` — opposed Intellect vs Resonance, familiarity bonus from `times_seen` (capped at `DISGUISE_PIERCE_FAMILIARITY_CAP = 5`), disguise penalty of 1 per worn `disguise_essential` item + 1 per active override. Outcome cached on `observer.db.disguise_pierce_cache`.
  - `attempt_display_pierce(looker, target, apparent_uid)` — high-level wrapper for the display-name pipeline: reverse-sleeve lookup, filters out the current presentation, picks first candidate, defers to the roll.
- `typeclasses/characters.py` — `get_display_name` and `get_look_header` call the wrapper on Apparent-UID miss before falling back to articled sdesc.
- `specs/IDENTITY_RECOGNITION_SPEC.md` — new **Disguise Piercing** section documenting trigger, roll formula, caching contract, surface, and the no-auto-link decision.
- Tests — 17 new tests across `TestAttemptDisguisePierce` and `TestAttemptDisplayPierce`.

## Test plan
- `docker exec gelatinous evennia test --settings settings.py world.tests` — **800 passing** (was 783).

## Design notes
- **No auto-link**: piercing surfaces a name but does not write `linked_to` on the disguised presentation. There's no entry to link by definition. If the looker subsequently runs `remember <pierced-name>`, the existing cell-D mirror in `_remember_target` handles linking through the bare-face match.
- **Cache survives reloads**: stored on `db`, not `ndb`. A player who has decided "I do not recognise this person" should not be magically reset on server restart.
- **`dbref`-less observers/targets are uncached** (re-roll every call): keeps the cache bounded and avoids junk keys for tooling.