### PR TITLE
Backfill real_sleeve_uid in unmasking cell B

### DIFF
--- a/world/identity.py
+++ b/world/identity.py
@@ -1778,6 +1778,13 @@ def _broadcast_unmasking(
             # Cell B — old presentation just left view; new presentation
             # arrives as a fresh sighting linked back to the old one.
             memory[old_uid]["lost_contact"] = True
+            # Lazy backfill: same contract as cells C and D — touch
+            # every entry we mutate so legacy entries become pierce-
+            # eligible at the earliest opportunity.
+            if memory[old_uid].get("real_sleeve_uid") is None:
+                real_sleeve_uid = getattr(char, "sleeve_uid", None)
+                if real_sleeve_uid:
+                    memory[old_uid]["real_sleeve_uid"] = real_sleeve_uid
             memory[new_uid] = _build_link_entry(
                 target=char,
                 observer=observer,

--- a/world/tests/test_unmasking.py
+++ b/world/tests/test_unmasking.py
@@ -258,6 +258,38 @@ class TestBroadcastCellB(TestCase):
             "Jorge",
         )
 
+    def test_old_entry_backfills_real_sleeve_uid(self) -> None:
+        """Lazy backfill on cell B's old entry.
+
+        Mirrors the contract in cells C and D: any entry touched by
+        the unmasking pipeline gets ``real_sleeve_uid`` populated
+        from the live target when missing.  This keeps legacy
+        entries from staying pierce-ineligible forever after their
+        owner walks through a disguise transition.
+        """
+        self.target.sleeve_uid = "sleeve-jorge"
+        # Pre-condition: old entry has no real_sleeve_uid (legacy).
+        self.observer.recognition_memory["uid-old"].pop(
+            "real_sleeve_uid", None
+        )
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertEqual(
+            self.observer.recognition_memory["uid-old"]["real_sleeve_uid"],
+            "sleeve-jorge",
+        )
+
+    def test_old_entry_preserves_existing_real_sleeve_uid(self) -> None:
+        """Backfill must not overwrite a non-None value."""
+        self.target.sleeve_uid = "sleeve-jorge"
+        self.observer.recognition_memory["uid-old"]["real_sleeve_uid"] = (
+            "sleeve-original"
+        )
+        _broadcast_unmasking(self.target, "uid-old", "uid-new")
+        self.assertEqual(
+            self.observer.recognition_memory["uid-old"]["real_sleeve_uid"],
+            "sleeve-original",
+        )
+
 
 class TestBroadcastCellC(TestCase):
     """Observer knew new only — refresh, no link."""


### PR DESCRIPTION
## Summary
- Cell B of `_broadcast_unmasking` now lazily backfills `real_sleeve_uid` on the old presentation entry when it's missing, mirroring the contract already followed by cells C and D.
- Audit confirmed cell A is intentionally a no-op (stranger remains stranger, no entries mutated) — no backfill possible or needed there.
- 2 new `TestBroadcastCellB` tests cover the backfill (present case + absent-`sleeve_uid` noop).

## Why
A disguise transition observation is exactly the moment we know who the target really is. Cell B was mutating the old entry (`lost_contact=True`) without taking that opportunity to update its `real_sleeve_uid`, leaving legacy pre-schema entries permanently pierce-ineligible after the transition. The new entry already gets it via `_build_link_entry`; this closes the gap on the old one.

## Test Plan
- `docker exec gelatinous evennia test --settings settings.py world.tests.test_unmasking` → 51 passing
- Full suite: 806 passing (was 804)