### PR TITLE
Add per-item disguise_weight to scale pierce penalty

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -636,6 +636,7 @@ A disguise item is a clothing/equipment item with two declarative properties:
 
 - **`is_disguise_item`** (`bool`): marks the item as belonging to the disguise taxonomy. Disguise items provide a future Phase 5 perception-roll bonus to the disguiser.
 - **`disguise_essential`** (`bool`): marks the item as identity-essential. Essential items contribute to the identity signature (their type is hashed into the Apparent UID); non-essential items contribute only visually through the existing distinguishing-feature derivation.
+- **`disguise_weight`** (`int`, default `1`): per-item pierce-penalty weight. When worn (and `disguise_essential = True`), the item counts as this many vectors in the `_count_disguise_vectors` calculation. Heavy concealment (full prosthetic mask, hooded robe) can scale piercing difficulty independently of how many items are involved; `0` lets an essential item pin the identity signature without making piercing harder. Negative values are clamped to `0`; non-numeric values fall back to `1`. No effect on non-essential items.
 
 Examples:
 - **Essential**: balaclava, full mask, cowl, wig, contacts, prosthetic face, voice modulator (when voice integration lands)
@@ -779,7 +780,7 @@ This is the standing complement to the eyewitness Unmasking Moments hook (§Unma
 **The roll.** `attempt_disguise_pierce(observer, target, apparent_uid, bare_entry)` rolls opposed `Intellect` (observer) vs `Resonance` (target) via `world.combat.dice.opposed_roll`, with:
 
 - **Familiarity bonus** added to the observer's effective total: `min(bare_entry["times_seen"], DISGUISE_PIERCE_FAMILIARITY_CAP)`. The cap (default 5) keeps a grizzled veteran from auto-piercing every disguise on Earth.
-- **Disguise penalty** added to the target's effective total: `DISGUISE_PIERCE_VECTOR_PENALTY * count_of_active_vectors`. Vectors are worn `disguise_essential` items plus the three string overrides (`height_override`, `build_override`, `keyword_override`); each contributes 1. Heavier disguises are harder to see through.
+- **Disguise penalty** added to the target's effective total: `DISGUISE_PIERCE_VECTOR_PENALTY * count_of_active_vectors`. Vectors are worn `disguise_essential` items (each contributing its `disguise_weight`, default `1`) plus the three string overrides (`height_override`, `build_override`, `keyword_override`), each contributing `1`. Heavier disguises are harder to see through; an item with `disguise_weight = 3` (e.g. a full prosthetic mask) triples its contribution, while `disguise_weight = 0` lets a cosmetic essential pin the identity signature without affecting the pierce roll.
 
 Success condition: `(observer_roll + familiarity) > (target_roll + penalty)`. Ties favour the target (the disguise holds).
 

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -133,6 +133,17 @@ class Item(DefaultObject):
     # ``disguise_essential = True``.
     disguise_type_id = AttributeProperty("", autocreate=True)
 
+    # Per-item pierce-penalty weight.  Counts as this many disguise
+    # vectors when worn (and ``disguise_essential = True``) in
+    # :func:`world.identity._count_disguise_vectors`.  Default ``1``
+    # preserves the original flat-1-per-essential-item contract; bump
+    # higher for heavy concealment (a full prosthetic mask, an
+    # all-covering hooded robe) and drop to ``0`` for cosmetic
+    # essentials that should still pin the identity signature but
+    # shouldn't make piercing harder.  No effect on non-essential
+    # items.
+    disguise_weight = AttributeProperty(1, autocreate=True)
+
     # ``disguise_adjective`` is the visible "red flag" — when an item
     # flagged ``is_disguise_item = True`` is worn, this adjective is
     # injected into the wearer's sdesc between the physical descriptor

--- a/world/identity.py
+++ b/world/identity.py
@@ -1345,9 +1345,15 @@ def _count_disguise_vectors(target: Any) -> int:
     """Return the count of active disguise vectors on *target*.
 
     A "vector" is anything that perturbs the Apparent UID away from the
-    bare sleeve: each worn ``disguise_essential`` item counts once, and
-    each of the three string overrides (``height_override``,
-    ``build_override``, ``keyword_override``) counts once when set.
+    bare sleeve.  Each of the three string overrides
+    (``height_override``, ``build_override``, ``keyword_override``)
+    counts once when set.  Each worn ``disguise_essential`` item
+    contributes its ``disguise_weight`` (default ``1``) so heavy
+    concealment (full prosthetic mask, hooded robe) can scale piercing
+    difficulty independently of how many items are involved.  A
+    weight of ``0`` lets an essential item still pin the identity
+    signature without making piercing harder.  Missing or non-numeric
+    weights fall back to ``1``.
 
     Used by :func:`compute_disguise_pierce` to penalise the observer's
     roll: heavier disguises are harder to see through.
@@ -1359,9 +1365,19 @@ def _count_disguise_vectors(target: Any) -> int:
             worn = get_worn() or []
         except (AttributeError, TypeError):
             worn = []
-        vectors += sum(
-            1 for item in worn if getattr(item, "disguise_essential", False)
-        )
+        for item in worn:
+            if not getattr(item, "disguise_essential", False):
+                continue
+            raw_weight = getattr(item, "disguise_weight", 1)
+            try:
+                weight = int(raw_weight)
+            except (TypeError, ValueError):
+                weight = 1
+            # Guard against negative or absurd weights; clamp to a
+            # non-negative integer so the penalty stays well-defined.
+            if weight < 0:
+                weight = 0
+            vectors += weight
     db = getattr(target, "db", None)
     if db is not None:
         for field in ("height_override", "build_override", "keyword_override"):

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -863,6 +863,7 @@ class _FakeDisguiseItem:
         worn_sdesc_short: str = "",
         covers_hair: bool = False,
         key: str = "fake item",
+        disguise_weight: int = 1,
     ) -> None:
         self.disguise_essential = disguise_essential
         self.disguise_type_id = disguise_type_id
@@ -871,6 +872,7 @@ class _FakeDisguiseItem:
         self.worn_sdesc_short = worn_sdesc_short
         self.covers_hair = covers_hair
         self.key = key
+        self.disguise_weight = disguise_weight
 
     def __repr__(self) -> str:
         return f"<_FakeDisguiseItem key={self.key!r}>"
@@ -2268,3 +2270,194 @@ class TestAttemptDisplayPierce(TestCase):
         ):
             result = attempt_display_pierce(observer, target, "uid-cape")
         self.assertEqual(result, "Bruce")
+
+
+# =========================================================================
+# _count_disguise_vectors — per-item disguise_weight support
+# =========================================================================
+
+
+class TestCountDisguiseVectors(TestCase):
+    """The pierce penalty weights each essential item by its
+    ``disguise_weight`` (default ``1``).  Non-essential items and
+    overrides are unaffected.  Backward-compatible: any item or fake
+    that omits the attribute behaves exactly as before.
+    """
+
+    def _make_target(self, worn=(), **overrides):
+        target = _SignatureMockCharacter(worn_items=list(worn))
+        # _SignatureMockCharacter ships with db.*_override = None; only
+        # set what the caller asks for so the no-override baseline is
+        # clean.
+        for field, value in overrides.items():
+            setattr(target.db, field, value)
+        return target
+
+    def test_no_essential_items_returns_zero(self) -> None:
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target()
+        self.assertEqual(_count_disguise_vectors(target), 0)
+
+    def test_default_weight_essential_items_count_one_each(self) -> None:
+        """Items with no explicit ``disguise_weight`` use the default
+        ``1`` — preserving the original contract."""
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target(
+            worn=[
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="balaclava"
+                ),
+                _FakeDisguiseItem(
+                    disguise_essential=True, disguise_type_id="trenchcoat"
+                ),
+            ]
+        )
+        self.assertEqual(_count_disguise_vectors(target), 2)
+
+    def test_explicit_default_weight_matches_implicit(self) -> None:
+        """Setting ``disguise_weight=1`` explicitly is a no-op."""
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target(
+            worn=[
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="balaclava",
+                    disguise_weight=1,
+                ),
+            ]
+        )
+        self.assertEqual(_count_disguise_vectors(target), 1)
+
+    def test_heavy_concealment_weight_scales_penalty(self) -> None:
+        """A full prosthetic mask weighted at 3 contributes 3 vectors."""
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target(
+            worn=[
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="prosthetic_mask",
+                    disguise_weight=3,
+                ),
+            ]
+        )
+        self.assertEqual(_count_disguise_vectors(target), 3)
+
+    def test_zero_weight_essential_item_pins_signature_without_penalty(
+        self,
+    ) -> None:
+        """Weight ``0`` lets an essential item still pin the identity
+        signature elsewhere while contributing no pierce penalty."""
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target(
+            worn=[
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="signature_pendant",
+                    disguise_weight=0,
+                ),
+            ]
+        )
+        self.assertEqual(_count_disguise_vectors(target), 0)
+
+    def test_non_essential_item_weight_is_ignored(self) -> None:
+        """``disguise_weight`` on a non-essential item is ignored."""
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target(
+            worn=[
+                _FakeDisguiseItem(
+                    disguise_essential=False,
+                    disguise_type_id="shirt",
+                    disguise_weight=5,
+                ),
+            ]
+        )
+        self.assertEqual(_count_disguise_vectors(target), 0)
+
+    def test_negative_weight_clamps_to_zero(self) -> None:
+        """A negative weight is clamped to ``0`` rather than reducing
+        other items' contributions or going below zero."""
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target(
+            worn=[
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="oddity",
+                    disguise_weight=-7,
+                ),
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="balaclava",
+                    disguise_weight=1,
+                ),
+            ]
+        )
+        self.assertEqual(_count_disguise_vectors(target), 1)
+
+    def test_non_numeric_weight_falls_back_to_one(self) -> None:
+        """A malformed weight ('heavy', None) falls back to ``1`` —
+        never silently zero, so a bad attribute doesn't accidentally
+        let a disguise through unpenalised."""
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target(
+            worn=[
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="oddity",
+                    disguise_weight="heavy",  # type: ignore[arg-type]
+                ),
+            ]
+        )
+        self.assertEqual(_count_disguise_vectors(target), 1)
+
+    def test_mixed_weights_sum_correctly(self) -> None:
+        """Multiple items with varying weights sum their contributions."""
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target(
+            worn=[
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="prosthetic_mask",
+                    disguise_weight=3,
+                ),
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="signature_pendant",
+                    disguise_weight=0,
+                ),
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="trenchcoat",
+                    # default weight 1
+                ),
+            ]
+        )
+        self.assertEqual(_count_disguise_vectors(target), 4)
+
+    def test_overrides_add_one_each_regardless_of_item_weight(self) -> None:
+        """The three string overrides each contribute exactly ``1``,
+        independent of any item weights."""
+        from world.identity import _count_disguise_vectors
+
+        target = self._make_target(
+            worn=[
+                _FakeDisguiseItem(
+                    disguise_essential=True,
+                    disguise_type_id="prosthetic_mask",
+                    disguise_weight=3,
+                ),
+            ],
+            height_override="tall",
+            build_override="slight",
+            keyword_override="stranger",
+        )
+        # 3 (mask) + 1 + 1 + 1 (overrides) = 6
+        self.assertEqual(_count_disguise_vectors(target), 6)


### PR DESCRIPTION
## Summary
Adds `disguise_weight` (default `1`) on `Item` typeclass; `_count_disguise_vectors` now sums per-item weights instead of a flat `1` per worn essential item. Lets disguise designers scale pierce difficulty per item rather than per-count.

## Semantics
| Weight | Effect |
|---|---|
| `1` (default) | Preserves the original flat-1 contract |
| `> 1` | Heavy concealment (full prosthetic mask = 3, hooded robe + chin-mask = 4) contributes that many vectors |
| `0` | Cosmetic essential — still pins the identity signature, no pierce penalty |
| `< 0` | Clamped to `0` (well-defined floor) |
| Non-numeric | Falls back to `1` (a malformed attribute must never silently let a disguise through unpenalised) |

No effect on non-essential items.

## Backward Compatibility
`getattr(item, "disguise_weight", 1)` — any pre-PR item, prototype, or test mock without the attribute still contributes `1`. All 816 pre-PR tests continue to pass.

## Test Plan
- `docker exec gelatinous evennia test --settings settings.py world.tests.test_identity.TestCountDisguiseVectors` → 10 passing
- Full suite: 826 passing (was 816)

## Spec
Documents the new attribute on the disguise-item schema and in the Disguise Piercing penalty section.