### PR TITLE
Route combat command targeting through identity pipeline

### DIFF
--- a/commands/_identity_targeting.py
+++ b/commands/_identity_targeting.py
@@ -1,0 +1,256 @@
+"""
+Identity-aware character target resolution for commands.
+
+Centralises the two non-trivial targeting patterns that the
+identity-recognition system imposes on commands:
+
+1. **Same-room character lookup** with proper identity filtering and
+   Builder-by-key fallback within the candidate scope.  Use
+   :func:`resolve_character_target`.
+
+2. **Cross-room scan** across an explicit list of rooms (typically a
+   combat handler's ``managed_rooms``).  Use
+   :func:`resolve_character_in_rooms`.
+
+3. **Admin dual-path** — local identity match first, then a global
+   key-based search as fallback so staff retain cross-room reach.  Use
+   :func:`resolve_admin_target`.
+
+This module is the canonical entry point referenced by
+``specs/IDENTITY_RECOGNITION_SPEC.md`` §Command Authoring Rule.  New
+commands SHOULD prefer these helpers over hand-rolled substring loops
+or ``caller.search(name, location=..., candidates=...)`` patterns,
+both of which bypass the identity filter (see
+``typeclasses/characters.py:1201–1206``).
+
+All helpers handle the magic ``me`` / ``self`` / ``myself`` tokens by
+returning the caller directly when ``allow_self=True``; otherwise they
+return ``None`` so the calling command can emit a cannot-target-self
+message in its own voice.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from evennia.utils.utils import inherits_from  # noqa: F401  (kept for future)
+
+from world.combat.constants import PERM_BUILDER
+from world.search import identity_match_characters
+
+_CHARACTER_PATH = "typeclasses.characters.Character"
+_SELF_TOKENS = frozenset({"me", "self", "myself"})
+
+
+def _is_character(obj) -> bool:
+    """Duck-type check: anything exposing ``get_sdesc`` participates in
+    the identity system and is treated as a character for targeting
+    purposes.  Matches the convention used by ``world.search._has_identity``
+    and keeps the helper compatible with both production typeclasses
+    and the ``MagicMock(spec=Character)`` fixtures used by the test
+    suite (where ``inherits_from`` cannot resolve a real MRO).
+    """
+    get_sdesc = getattr(obj, "get_sdesc", None)
+    return callable(get_sdesc)
+
+
+def _is_self_token(query: str) -> bool:
+    return query.strip().lower() in _SELF_TOKENS
+
+
+def _builder_key_matches(caller, query: str, candidates: Iterable) -> list:
+    """Return characters in *candidates* whose ``.key`` or aliases
+    substring-match *query*.
+
+    Only intended as a Builder-tier fallback when the identity pipeline
+    finds no matches.  Real-key matching for ordinary players would
+    defeat the recognition system, so callers must gate this on a
+    Builder permission check.
+    """
+    needle = query.strip().lower()
+    matches: list = []
+    for obj in candidates:
+        if obj is caller:
+            continue
+        if not _is_character(obj):
+            continue
+        if needle in obj.key.lower():
+            matches.append(obj)
+            continue
+        aliases = obj.aliases.all() if hasattr(obj.aliases, "all") else []
+        if any(needle in alias.lower() for alias in aliases):
+            matches.append(obj)
+    return matches
+
+
+def resolve_character_target(
+    caller,
+    query: str,
+    candidates: Optional[Iterable] = None,
+    *,
+    allow_self: bool = False,
+) -> Optional[object]:
+    """Resolve a character target via the identity pipeline.
+
+    Args:
+        caller: The searching character.
+        query: Raw player input (the target string).
+        candidates: Iterable of objects to search.  Defaults to
+            ``caller.location.contents`` when ``None``.
+        allow_self: When ``True``, the magic tokens ``me`` / ``self``
+            / ``myself`` resolve to *caller*; otherwise they yield
+            ``None``.
+
+    Returns:
+        - A single character on a unique match.
+        - ``None`` when no match is found, the query is empty, or
+          (with ``allow_self=False``) the caller is the only match.
+        - ``None`` on ambiguity (multiple matches) **after sending a
+          disambiguation message to caller**.  Callers should treat
+          ``None`` as "stop processing" and return immediately.
+
+    The Builder-by-key fallback only fires when the identity pipeline
+    returns no matches AND the caller has Builder+ permission.  This
+    preserves staff ergonomics without exposing real keys to ordinary
+    players.
+    """
+    if not query:
+        return None
+
+    stripped = query.strip()
+    if not stripped:
+        return None
+
+    if _is_self_token(stripped):
+        return caller if allow_self else None
+
+    if candidates is None:
+        location = caller.location
+        candidates = list(location.contents) if location else []
+    else:
+        candidates = list(candidates)
+
+    matches = identity_match_characters(caller, stripped, candidates)
+
+    if not matches and caller.check_permstring(PERM_BUILDER):
+        matches = _builder_key_matches(caller, stripped, candidates)
+
+    if not matches:
+        return None
+
+    if len(matches) > 1:
+        caller.msg(
+            f"Multiple targets match '{stripped}'. Please be more specific."
+        )
+        return None
+
+    return matches[0]
+
+
+def resolve_character_in_rooms(
+    caller,
+    query: str,
+    rooms: Iterable,
+    *,
+    allow_self: bool = False,
+) -> Optional[object]:
+    """Resolve a character target across an explicit list of rooms.
+
+    Searches each room in order, returning the first room that yields
+    a unique match.  Used by cross-room combat commands (advance,
+    charge) that scan a handler's ``managed_rooms``.
+
+    Args:
+        caller: The searching character.
+        query: Raw player input.
+        rooms: Iterable of room objects to scan.  Order matters — the
+            caller's own room should typically come first.
+        allow_self: See :func:`resolve_character_target`.
+
+    Returns:
+        First unique character match across *rooms*, or ``None``.  On
+        ambiguity within a room, sends the disambiguation message and
+        returns ``None`` (does not fall through to subsequent rooms).
+    """
+    if not query:
+        return None
+
+    stripped = query.strip()
+    if not stripped:
+        return None
+
+    if _is_self_token(stripped):
+        return caller if allow_self else None
+
+    is_builder = caller.check_permstring(PERM_BUILDER)
+
+    for room in rooms:
+        if not room:
+            continue
+        candidates = list(room.contents)
+        matches = identity_match_characters(caller, stripped, candidates)
+        if not matches and is_builder:
+            matches = _builder_key_matches(caller, stripped, candidates)
+        if not matches:
+            continue
+        if len(matches) > 1:
+            caller.msg(
+                f"Multiple targets match '{stripped}' in "
+                f"{room.key}. Please be more specific."
+            )
+            return None
+        return matches[0]
+
+    return None
+
+
+def resolve_admin_target(caller, query: str) -> Optional[object]:
+    """Dual-path character resolution for admin commands.
+
+    Phase 1: identity match in the caller's current room (so disguised
+    or sdesc-referenced neighbours resolve naturally).
+
+    Phase 2: global key search via :func:`evennia.search_object`,
+    filtered to Character instances.  Provides cross-room reach for
+    staff tooling (``@heal``, ``@longdesc``, ``@testdeath``, etc.).
+
+    Args:
+        caller: The staff character issuing the command.
+        query: Raw input string.
+
+    Returns:
+        First match, or ``None`` if nothing resolves.  On ambiguity in
+        the global phase, sends a disambiguation message and returns
+        ``None``.
+    """
+    if not query:
+        return None
+
+    stripped = query.strip()
+    if not stripped:
+        return None
+
+    if _is_self_token(stripped):
+        return caller
+
+    # Phase 1: local identity match (includes Builder-by-key fallback).
+    local = resolve_character_target(caller, stripped)
+    if local is not None:
+        return local
+
+    # Phase 2: global key search.
+    from evennia import search_object
+
+    results = [obj for obj in search_object(stripped) if _is_character(obj)]
+
+    if not results:
+        return None
+
+    if len(results) > 1:
+        caller.msg(
+            f"Multiple characters match '{stripped}' globally. "
+            f"Please be more specific (e.g. use a dbref)."
+        )
+        return None
+
+    return results[0]

--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -25,6 +25,7 @@ from world.combat.constants import (
     NDB_PROXIMITY, NDB_COMBAT_HANDLER, NDB_AIMING_AT, NDB_AIMED_AT_BY,
     NDB_AIMING_DIRECTION, SPLATTERCAST_CHANNEL,
 )
+from commands._identity_targeting import resolve_character_target
 from world.combat.handler import get_or_create_combat
 from world.combat.messages import get_combat_message
 from world.combat.proximity import establish_proximity
@@ -112,15 +113,14 @@ class CmdAttack(Command):
 
         potential_targets = [
             obj for obj in target_room.contents
-            if inherits_from(obj, "typeclasses.characters.Character") and
-               obj != caller and  # Exclude caller from potential targets (defense-in-depth)
-               (target_search_name.lower() in obj.key.lower() or
-                any(target_search_name.lower() in alias.lower() for alias in (obj.aliases.all() if hasattr(obj.aliases, "all") else [])))
+            if inherits_from(obj, "typeclasses.characters.Character")
         ]
-        if not potential_targets:
+        target = resolve_character_target(
+            caller, target_search_name, candidates=potential_targets
+        )
+        if not target:
             caller.msg(f"You don't see '{target_search_name}' {(f'in the {aiming_direction} direction' if aiming_direction else 'here')}.")
             return
-        target = potential_targets[0]
 
         if target == caller:
             caller.msg(MSG_SELF_TARGET)

--- a/commands/combat/movement.py
+++ b/commands/combat/movement.py
@@ -35,6 +35,7 @@ from world.combat.constants import (
 # Re-export CmdJump and apply_gravity_to_items for backward compatibility.
 # Canonical location: commands.combat.jump
 from commands.combat.jump import CmdJump, apply_gravity_to_items  # noqa: F401
+from commands._identity_targeting import resolve_character_in_rooms
 from world.combat.utils import (
     get_highest_opponent_stat, get_numeric_stat, filter_valid_opponents,
     standard_roll, clear_aim_state,
@@ -522,39 +523,16 @@ class CmdAdvance(Command):
         # Determine target
         target = None
         if args:
-            target = caller.search(args, location=caller.location, quiet=True)
-            # Handle case where search returns a list
-            if isinstance(target, list):
-                if len(target) == 1:
-                    target = target[0]
-                elif len(target) > 1:
-                    caller.msg(f"Multiple targets match '{args}'. Please be more specific.")
-                    return
-                else:
-                    target = None
-                    
-            if not target:
-                # Try searching in adjacent combat rooms
-                managed_rooms = handler.db.managed_rooms or []
-                for room in managed_rooms:
-                    if room != caller.location:
-                        potential_target = caller.search(args, location=room, quiet=True)
-                        # Handle list results for adjacent rooms too
-                        if isinstance(potential_target, list):
-                            if len(potential_target) == 1:
-                                target = potential_target[0]
-                                break
-                            elif len(potential_target) > 1:
-                                caller.msg(f"Multiple targets match '{args}' in {room.key}. Please be more specific.")
-                                return
-                        elif potential_target:
-                            target = potential_target
-                            break
-                            
+            managed_rooms = handler.db.managed_rooms or []
+            rooms_to_scan = [caller.location] + [
+                r for r in managed_rooms if r and r != caller.location
+            ]
+            target = resolve_character_in_rooms(caller, args, rooms_to_scan)
+
             if not target:
                 caller.msg(f"You cannot find '{args}' to advance on.")
                 return
-                
+
             if target == caller:
                 caller.msg(MSG_ADVANCE_SELF_TARGET)
                 return
@@ -635,35 +613,14 @@ class CmdCharge(Command):
         if grappling_victim_obj:
             if args:
                 # Caller specified a target while grappling
-                target_search = caller.search(args, location=caller.location, quiet=True)
-                # Handle case where search returns a list
-                if isinstance(target_search, list):
-                    if len(target_search) == 1:
-                        target_search = target_search[0]
-                    elif len(target_search) > 1:
-                        caller.msg(f"Multiple targets match '{args}'. Please be more specific.")
-                        return
-                    else:
-                        target_search = None
-                        
-                if not target_search:
-                    # Try searching in adjacent combat rooms
-                    managed_rooms = handler.db.managed_rooms or []
-                    for room in managed_rooms:
-                        if room != caller.location:
-                            potential_target = caller.search(args, location=room, quiet=True)
-                            # Handle list results for adjacent rooms too
-                            if isinstance(potential_target, list):
-                                if len(potential_target) == 1:
-                                    target_search = potential_target[0]
-                                    break
-                                elif len(potential_target) > 1:
-                                    caller.msg(f"Multiple targets match '{args}' in {room.key}. Please be more specific.")
-                                    return
-                            elif potential_target:
-                                target_search = potential_target
-                                break
-                
+                managed_rooms = handler.db.managed_rooms or []
+                rooms_to_scan = [caller.location] + [
+                    r for r in managed_rooms if r and r != caller.location
+                ]
+                target_search = resolve_character_in_rooms(
+                    caller, args, rooms_to_scan
+                )
+
                 if target_search == grappling_victim_obj:
                     # Trying to charge the person they're grappling
                     caller.msg(f"You cannot charge {grappling_victim_obj.get_display_name(caller)} while you are grappling them! Release the grapple first or choose a different target.")
@@ -687,39 +644,16 @@ class CmdCharge(Command):
         # Determine target
         target = None
         if args:
-            target = caller.search(args, location=caller.location, quiet=True)
-            # Handle case where search returns a list
-            if isinstance(target, list):
-                if len(target) == 1:
-                    target = target[0]
-                elif len(target) > 1:
-                    caller.msg(f"Multiple targets match '{args}'. Please be more specific.")
-                    return
-                else:
-                    target = None
-                    
-            if not target:
-                # Try searching in adjacent combat rooms
-                managed_rooms = handler.db.managed_rooms or []
-                for room in managed_rooms:
-                    if room != caller.location:
-                        potential_target = caller.search(args, location=room, quiet=True)
-                        # Handle list results for adjacent rooms too
-                        if isinstance(potential_target, list):
-                            if len(potential_target) == 1:
-                                target = potential_target[0]
-                                break
-                            elif len(potential_target) > 1:
-                                caller.msg(f"Multiple targets match '{args}' in {room.key}. Please be more specific.")
-                                return
-                        elif potential_target:
-                            target = potential_target
-                            break
-                            
+            managed_rooms = handler.db.managed_rooms or []
+            rooms_to_scan = [caller.location] + [
+                r for r in managed_rooms if r and r != caller.location
+            ]
+            target = resolve_character_in_rooms(caller, args, rooms_to_scan)
+
             if not target:
                 caller.msg(f"You cannot find '{args}' to charge.")
                 return
-                
+
             if target == caller:
                 caller.msg(MSG_CHARGE_SELF_TARGET)
                 return

--- a/commands/combat/special_actions.py
+++ b/commands/combat/special_actions.py
@@ -16,6 +16,7 @@ import random
 
 from evennia import Command
 from evennia.comms.models import ChannelDB
+from evennia.utils.utils import inherits_from
 
 from world.combat.constants import (
     MSG_GRAPPLE_WHO, MSG_GRAPPLE_NO_TARGET, MSG_CANNOT_GRAPPLE_SELF, MSG_CANNOT_GRAPPLE_TARGET,
@@ -37,6 +38,7 @@ from world.combat.constants import (
 from world.combat.utils import log_combat_action, initialize_proximity_ndb, get_display_name_safe
 from world.grammar import capitalize_first
 from world.identity_utils import msg_room_identity
+from commands._identity_targeting import resolve_character_target
 
 
 class CmdGrapple(Command):
@@ -75,22 +77,14 @@ class CmdGrapple(Command):
             return
         # --- END SELF-TARGET CHECK ---
 
-        # --- Target searching (similar to CmdAttack) ---
-        search_name = self.args.strip().lower()
-        candidates = caller.location.contents
-        matches = [
-            obj for obj in candidates
-            if obj != caller and  # Exclude caller from potential targets (defense-in-depth)
-               (search_name in obj.key.lower()
-                or any(search_name in alias.lower() for alias in (obj.aliases.all() if hasattr(obj.aliases, "all") else [])))
-        ]
+        # --- Target searching (identity-aware) ---
+        search_name = self.args.strip()
+        target = resolve_character_target(caller, search_name)
 
-        if not matches:
+        if not target:
             caller.msg(MSG_GRAPPLE_NO_TARGET)
             log_combat_action(caller, "grapple_fail", details=f"tried to grapple '{search_name}' but found no valid target in the room")
             return
-
-        target = matches[0]
 
         if target == caller:
             caller.msg(MSG_CANNOT_GRAPPLE_SELF)
@@ -449,26 +443,30 @@ class CmdAim(Command):
             # Clear directional aim override_place
             caller.override_place = ""
 
-        # Try to find target in current room first
-        target = caller.search(args, location=caller.location, quiet=True)
-        
-        # Debug: Show what search found
-        splattercast.msg(f"AIM_DEBUG: caller.search('{args}') returned: {target} (type: {type(target)})")
-        
-        # Handle search results - caller.search can return None, empty list, or list with objects
-        if target:
-            # If search returns a list, take the first match
-            if isinstance(target, (list, tuple)):
-                if len(target) > 0:
-                    target = target[0]
-                    splattercast.msg(f"AIM_DEBUG: Found target from list: {target.key}")
+        # Try to find target in current room.  Character targets resolve
+        # via the identity pipeline (assigned names + sdescs); if nothing
+        # matches, fall back to a scoped search so exits remain detectable
+        # for direction-aim mode.
+        target = resolve_character_target(caller, args)
+
+        if target is None:
+            exit_search = caller.search(args, location=caller.location, quiet=True)
+            if exit_search:
+                if isinstance(exit_search, (list, tuple)):
+                    target = exit_search[0] if exit_search else None
                 else:
+                    target = exit_search
+                # Reject characters from this fallback — identity already
+                # had its chance and rejected them.  Only exits / non-char
+                # objects should slip through.
+                if target is not None and inherits_from(
+                    target, "typeclasses.characters.Character"
+                ):
                     target = None
-                    splattercast.msg(f"AIM_DEBUG: Empty list returned, no target")
-            else:
-                splattercast.msg(f"AIM_DEBUG: Found single target: {target.key}")
-        else:
-            splattercast.msg(f"AIM_DEBUG: No target found by search")
+
+        splattercast.msg(
+            f"AIM_DEBUG: target resolution for '{args}' returned: {target}"
+        )
         
         if target and hasattr(target, 'key'):
             # Check if the "target" is actually an exit - if so, treat as direction aiming

--- a/world/tests/test_combat_command_identity.py
+++ b/world/tests/test_combat_command_identity.py
@@ -1,0 +1,390 @@
+"""
+Tests for combat-command identity targeting (PR \u03b1).
+
+Covers the new ``commands._identity_targeting`` helper module which is
+the canonical entry point used by combat commands (attack/kill,
+grapple, aim, advance, charge) to resolve character targets via the
+identity recognition pipeline.
+
+Tests exercise the helper directly (since the helper IS the conversion)
+with mock characters and rooms.  The four cases per command from the
+test matrix collapse into helper-level cases:
+
+  - **recognised name match** — assigned_name in recognition_memory
+  - **sdesc substring match** — keyword from get_sdesc composition
+  - **real-key rejection** — non-Builder cannot target by .key
+  - **ambiguity** — multiple matches send disambiguation, return None
+
+Cross-room commands (advance, charge) additionally exercise
+``resolve_character_in_rooms``.
+
+Run via::
+
+    evennia test world.tests.test_combat_command_identity
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock
+
+from commands._identity_targeting import (
+    resolve_character_in_rooms,
+    resolve_character_target,
+)
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
+
+
+# ===================================================================
+# Mock factory (mirrors test_identity_search._make_character)
+# ===================================================================
+
+
+def _make_character(
+    *,
+    key="Jorge Jackson",
+    sex="male",
+    height="tall",
+    build="lean",
+    sdesc_keyword=None,
+    sleeve_uid="uid-default",
+    recognition_memory=None,
+    is_builder=False,
+    aliases=None,
+):
+    """Build a mock character with identity attributes."""
+    from typeclasses.characters import Character
+
+    char = MagicMock(spec=Character)
+    char.key = key
+    char.sex = sex
+    char.height = height
+    char.build = build
+    char.sdesc_keyword = sdesc_keyword
+    char.hair_color = None
+    char.hair_style = None
+    char.sleeve_uid = sleeve_uid
+    char.recognition_memory = (
+        recognition_memory if recognition_memory is not None else {}
+    )
+    char.hands = {"left": None, "right": None}
+    char.worn_items = {}
+
+    def _coverage_map():
+        return {}
+
+    char._build_clothing_coverage_map = _coverage_map
+
+    char.get_distinguishing_feature = (
+        lambda: Character.get_distinguishing_feature(char)
+    )
+    char.get_sdesc = lambda: Character.get_sdesc(char)
+    char.get_display_name = (
+        lambda looker=None, **kw: Character.get_display_name(
+            char, looker, **kw
+        )
+    )
+
+    sex_val = (sex or "ambiguous").lower().strip()
+    if sex_val in ("male", "man", "masculine", "m"):
+        type(char).gender = PropertyMock(return_value="male")
+    elif sex_val in ("female", "woman", "feminine", "f"):
+        type(char).gender = PropertyMock(return_value="female")
+    else:
+        type(char).gender = PropertyMock(return_value="neutral")
+
+    # aliases mock
+    alias_list = aliases or []
+    char.aliases = MagicMock()
+    char.aliases.all = lambda: alias_list
+
+    # Permission check (Builder gate for the helper's key fallback)
+    char.check_permstring = lambda perm: is_builder
+
+    # msg sink (helpers send disambiguation messages here)
+    char.msg = MagicMock()
+
+    prepare_mock_for_apparent_uid(char)
+    return char
+
+
+def _make_room(contents):
+    """Build a minimal mock room exposing .contents and .key."""
+    room = MagicMock()
+    room.contents = contents
+    room.key = "Test Room"
+    return room
+
+
+# ===================================================================
+# Tests: resolve_character_target — same-room resolution
+# ===================================================================
+
+
+class TestResolveCharacterTarget(TestCase):
+    """Same-room identity-aware target resolution."""
+
+    def setUp(self):
+        self.caller = _make_character(
+            key="Alice Smith",
+            sex="female",
+            height="short",
+            build="athletic",
+            sleeve_uid="uid-caller",
+        )
+        self.jorge = _make_character(
+            key="Jorge Jackson",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-jorge",
+        )
+        self.maria = _make_character(
+            key="Maria Santos",
+            sex="female",
+            height="short",
+            build="athletic",
+            sdesc_keyword="woman",
+            sleeve_uid="uid-maria",
+        )
+        self.candidates = [self.caller, self.jorge, self.maria]
+        self.room = _make_room(self.candidates)
+        self.caller.location = self.room
+
+    def test_recognised_name_match(self):
+        """Assigned name resolves to the right character."""
+        self.caller.recognition_memory = {
+            apparent_uid_for(self.jorge): {
+                "assigned_name": "Jorge",
+                "lost_contact": False,
+            },
+        }
+        result = resolve_character_target(self.caller, "jorge")
+        self.assertIs(result, self.jorge)
+
+    def test_sdesc_substring_match(self):
+        """Sdesc keyword resolves."""
+        result = resolve_character_target(self.caller, "man")
+        self.assertIs(result, self.jorge)
+
+    def test_real_key_rejected_for_non_builder(self):
+        """Non-builders cannot target by .key."""
+        # 'jackson' is in Jorge's .key but not in his sdesc.
+        result = resolve_character_target(self.caller, "jackson")
+        self.assertIsNone(result)
+
+    def test_real_key_allowed_for_builder(self):
+        """Builders fall back to .key matching."""
+        self.caller.check_permstring = lambda perm: True
+        result = resolve_character_target(self.caller, "jackson")
+        self.assertIs(result, self.jorge)
+
+    def test_ambiguity_returns_none_and_messages_caller(self):
+        """Multiple matches produce disambiguation message + None."""
+        second_man = _make_character(
+            key="Bob Brown",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-bob",
+        )
+        self.room.contents = [self.caller, self.jorge, second_man]
+        result = resolve_character_target(
+            self.caller, "man", candidates=self.room.contents
+        )
+        self.assertIsNone(result)
+        self.caller.msg.assert_called_once()
+        message = self.caller.msg.call_args[0][0]
+        self.assertIn("Multiple targets match", message)
+
+    def test_empty_query_returns_none(self):
+        self.assertIsNone(resolve_character_target(self.caller, ""))
+        self.assertIsNone(resolve_character_target(self.caller, "   "))
+
+    def test_caller_excluded_from_results(self):
+        """Caller is never a valid identity match for themselves."""
+        # Caller's own sdesc contains 'compact'/'woman'. Without
+        # exclusion 'woman' would match both caller and Maria.
+        result = resolve_character_target(self.caller, "compact")
+        # Only the non-caller match (Maria) survives.
+        self.assertIs(result, self.maria)
+
+    def test_self_token_blocked_by_default(self):
+        """'me'/'self'/'myself' yield None unless allow_self=True."""
+        for token in ("me", "self", "myself", "ME", "Self"):
+            self.assertIsNone(resolve_character_target(self.caller, token))
+
+    def test_self_token_resolves_when_allowed(self):
+        for token in ("me", "self", "myself"):
+            self.assertIs(
+                resolve_character_target(self.caller, token, allow_self=True),
+                self.caller,
+            )
+
+    def test_explicit_candidates_override_location(self):
+        """Passing candidates= bypasses location.contents."""
+        # Caller's room is empty in this test.
+        empty_room = _make_room([])
+        self.caller.location = empty_room
+        result = resolve_character_target(
+            self.caller, "man", candidates=[self.jorge]
+        )
+        self.assertIs(result, self.jorge)
+
+
+# ===================================================================
+# Tests: resolve_character_in_rooms — cross-room scan (advance/charge)
+# ===================================================================
+
+
+class TestResolveCharacterInRooms(TestCase):
+    """Cross-room scan used by advance/charge."""
+
+    def setUp(self):
+        self.caller = _make_character(
+            key="Alice Smith",
+            sex="female",
+            height="short",
+            build="athletic",
+            sleeve_uid="uid-caller",
+        )
+        self.jorge = _make_character(
+            key="Jorge Jackson",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-jorge",
+        )
+        self.viktor = _make_character(
+            key="Viktor Kozlov",
+            sex="male",
+            height="above-average",
+            build="stocky",
+            sdesc_keyword="droog",
+            sleeve_uid="uid-viktor",
+        )
+        self.local_room = _make_room([self.caller])
+        self.adjacent_room = _make_room([self.jorge, self.viktor])
+        self.caller.location = self.local_room
+
+    def test_finds_target_in_adjacent_room(self):
+        """Caller in empty room, target in adjacent — resolves."""
+        result = resolve_character_in_rooms(
+            self.caller, "man", [self.local_room, self.adjacent_room]
+        )
+        self.assertIs(result, self.jorge)
+
+    def test_local_room_takes_priority(self):
+        """Match in caller's own room is returned before adjacent."""
+        local_match = _make_character(
+            key="Carl Other",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-carl",
+        )
+        self.local_room.contents = [self.caller, local_match]
+        result = resolve_character_in_rooms(
+            self.caller, "man", [self.local_room, self.adjacent_room]
+        )
+        self.assertIs(result, local_match)
+
+    def test_no_match_in_any_room(self):
+        result = resolve_character_in_rooms(
+            self.caller, "zephyr", [self.local_room, self.adjacent_room]
+        )
+        self.assertIsNone(result)
+
+    def test_ambiguity_in_one_room_does_not_fall_through(self):
+        """Ambiguous match in a room messages caller and stops scan."""
+        second_man = _make_character(
+            key="Bob Brown",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-bob",
+        )
+        self.adjacent_room.contents = [self.jorge, second_man]
+        result = resolve_character_in_rooms(
+            self.caller, "man", [self.local_room, self.adjacent_room]
+        )
+        self.assertIsNone(result)
+        self.caller.msg.assert_called_once()
+        message = self.caller.msg.call_args[0][0]
+        self.assertIn("Multiple targets match", message)
+        self.assertIn("Test Room", message)
+
+    def test_empty_query_returns_none(self):
+        self.assertIsNone(
+            resolve_character_in_rooms(
+                self.caller, "", [self.local_room, self.adjacent_room]
+            )
+        )
+
+    def test_skips_falsy_rooms(self):
+        """None entries in the room list don't crash."""
+        result = resolve_character_in_rooms(
+            self.caller, "man", [None, self.adjacent_room]
+        )
+        self.assertIs(result, self.jorge)
+
+    def test_builder_key_fallback_works_cross_room(self):
+        """Builder caller can match by .key in an adjacent room."""
+        self.caller.check_permstring = lambda perm: True
+        result = resolve_character_in_rooms(
+            self.caller, "kozlov", [self.local_room, self.adjacent_room]
+        )
+        self.assertIs(result, self.viktor)
+
+
+# ===================================================================
+# Tests: integration — Character.search override still feeds helper
+# ===================================================================
+
+
+class TestHelperRespectsIdentityPipeline(TestCase):
+    """Sanity: helper produces same answers as direct identity_match_characters."""
+
+    def setUp(self):
+        self.caller = _make_character(sleeve_uid="uid-caller", sex="female")
+        self.jorge = _make_character(
+            key="Jorge",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-jorge",
+        )
+
+    def test_ordinal_query_passes_through(self):
+        """Ordinals in queries are handled by identity_match_characters."""
+        twin1 = _make_character(
+            key="Twin One",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-t1",
+        )
+        twin2 = _make_character(
+            key="Twin Two",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-t2",
+        )
+        candidates = [self.caller, twin1, twin2]
+        room = _make_room(candidates)
+        self.caller.location = room
+        # '2nd man' yields the second match — should not trigger
+        # ambiguity message.
+        result = resolve_character_target(self.caller, "2nd man")
+        self.assertIs(result, twin2)
+        self.caller.msg.assert_not_called()


### PR DESCRIPTION
## Summary
- Closes the user-reported bug where `kill` (and `attack`) could be used against disguised/unrecognised characters by their real key.
- Introduces `commands/_identity_targeting.py` as the canonical helper module called out by the new spec rule (PR #150).
- Converts six bypass call sites across `core_actions.py`, `special_actions.py`, and `movement.py` to route character target resolution through `resolve_character_target` / `resolve_character_in_rooms`.

## Helper API
- `resolve_character_target(caller, query, candidates=None, *, allow_self=False)` — same-room (or pre-scoped) identity lookup with Builder-by-key fallback.
- `resolve_character_in_rooms(caller, query, rooms, *, allow_self=False)` — cross-room scan (caller's room first, then `managed_rooms`).
- `resolve_admin_target(caller, query)` — dual-path local-identity / global-key for upcoming admin conversions (PR \u03b4).

## Commands converted
| Command | File | Pattern |
|---|---|---|
| attack / kill | `commands/combat/core_actions.py` | manual key/alias substring loop |
| grapple | `commands/combat/special_actions.py` | manual key/alias substring loop |
| aim | `commands/combat/special_actions.py` | `caller.search(location=)` (exit fallback preserved) |
| advance | `commands/combat/movement.py` | `caller.search(location=)` + cross-room scan |
| charge | `commands/combat/movement.py` | same as advance, plus grappling-branch target |

`aim` keeps its exit-detection behaviour for direction-aim mode: identity helper runs first for characters, then a scoped fallback search picks up exits (and rejects characters from the fallback so a real-key character cannot sneak through).

## Tests
- New `world/tests/test_combat_command_identity.py` (18 cases):
  - **resolve_character_target**: recognised name, sdesc substring, real-key rejection (non-Builder), Builder fallback, ambiguity disambiguation, caller exclusion, self-token gating, explicit candidates override.
  - **resolve_character_in_rooms**: adjacent-room match, local-room priority, no-match, ambiguity stops scan, falsy-room handling, Builder cross-room fallback.
  - **integration**: ordinal queries pass through cleanly.
- Suite: **831 \u2192 849** (+18). Full `world.tests` passes.

## Behavioural notes
- Builder+ callers retain the ability to target by `.key` within the candidate scope, matching the existing `Character.search` override convention.
- Ambiguity sends `"Multiple targets match '<query>'..."` to caller and returns `None`; commands treat that as "stop processing".
- Magic tokens (`me`/`self`/`myself`) are blocked by default; combat commands already had their own self-target messages and are unaffected.

Per `specs/IDENTITY_RECOGNITION_SPEC.md` \u00a7Command Authoring Rule (introduced in PR #150).