### PR TITLE
Route admin command target lookup through identity pipeline (PR δ)

### DIFF
--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -1,6 +1,7 @@
 from evennia import Command
 from evennia.utils.search import search_object
 from evennia.utils import delay
+from commands._identity_targeting import resolve_admin_target
 from world.combat.messages import get_combat_message
 from evennia.comms.models import ChannelDB
 from world.weather import weather_system
@@ -117,12 +118,11 @@ class CmdHeal(Command):
             targets = [char]
             target_desc = char.key
         else:
-            # Normal name search
-            matches = search_object(target_name)
-            if not matches:
+            # Identity-aware lookup with admin global fallback.
+            target = resolve_admin_target(caller, target_name)
+            if not target:
                 caller.msg(f"|rNo character named '{target_name}' found.|n")
                 return
-            target = matches[0]
             targets = [target]
             target_desc = target.key
 
@@ -302,7 +302,7 @@ class CmdTestDeath(Command):
         
         # Determine target
         if target_name:
-            target = caller.search(target_name, global_search=True)
+            target = resolve_admin_target(caller, target_name)
             if not target:
                 caller.msg(f"Could not find '{target_name}'.")
                 return
@@ -524,7 +524,7 @@ class CmdTestUnconscious(Command):
         
         # Determine target
         if target_name:
-            target = caller.search(target_name, global_search=True)
+            target = resolve_admin_target(caller, target_name)
             if not target:
                 caller.msg(f"Could not find '{target_name}'.")
                 return
@@ -856,10 +856,11 @@ class CmdResetMedical(Command):
             
         else:
             # Reset specific character
-            target = caller.search(args, global_search=True)
+            target = resolve_admin_target(caller, args)
             if not target:
+                caller.msg(f"|rCould not find '{args}'.|n")
                 return
-                
+
             if hasattr(target, '_medical_state'):
                 delattr(target, '_medical_state')
             if target.db.medical_state:

--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1,5 +1,6 @@
 from evennia import Command
 from evennia.utils.search import search_object
+from commands._identity_targeting import resolve_admin_target
 from world.combat.constants import (
     PERM_BUILDER, PERM_DEVELOPER,
     BOX_TOP_LEFT, BOX_TOP_RIGHT, BOX_BOTTOM_LEFT, BOX_BOTTOM_RIGHT,
@@ -615,41 +616,14 @@ class CmdLongdesc(Command):
         remaining_args = args
 
         if caller.locks.check_lockstring(caller, f"dummy:perm({PERM_BUILDER}) or perm_above({PERM_BUILDER})"):
-            # Staff can target other characters
+            # Staff can target other characters via identity-aware lookup
+            # (same-room sdesc/recognition match) with global key fallback.
             parts = args.split(None, 1)
             if len(parts) >= 1:
-                # Try different search approaches
-                potential_target = caller.search(parts[0], global_search=True, quiet=True)
-                
-                if not potential_target:
-                    # Try searching without global_search
-                    potential_target = caller.search(parts[0], quiet=True)
-                
-                if not potential_target:
-                    # Try searching in the same location as the caller
-                    if caller.location:
-                        potential_target = caller.location.search(parts[0], quiet=True)
-                        
-                        # If not found in location, try searching the location's contents more broadly
-                        if not potential_target:
-                            for obj in caller.location.contents:
-                                if obj.key.lower() == parts[0].lower():
-                                    potential_target = obj
-                                    break
-                
-                if potential_target:
-                    # If it's a list, get the first item
-                    if isinstance(potential_target, list):
-                        if potential_target:
-                            actual_target = potential_target[0]
-                        else:
-                            actual_target = None
-                    else:
-                        actual_target = potential_target
-                    
-                    if actual_target and hasattr(actual_target, 'longdesc'):
-                        target_char = actual_target
-                        remaining_args = parts[1] if len(parts) > 1 else ""
+                actual_target = resolve_admin_target(caller, parts[0])
+                if actual_target and hasattr(actual_target, 'longdesc'):
+                    target_char = actual_target
+                    remaining_args = parts[1] if len(parts) > 1 else ""
 
         if not target_char:
             target_char = caller
@@ -739,8 +713,7 @@ class CmdLongdesc(Command):
         if caller.locks.check_lockstring(caller, f"dummy:perm({PERM_BUILDER}) or perm_above({PERM_BUILDER})"):
             parts = args.split(None, 1)
             if len(parts) >= 1:
-                # Use quiet=True to prevent "Could not find" messages
-                potential_target = caller.search(parts[0], global_search=True, quiet=True)
+                potential_target = resolve_admin_target(caller, parts[0])
                 if potential_target and hasattr(potential_target, 'longdesc'):
                     target_char = potential_target
                     location = parts[1] if len(parts) > 1 else ""
@@ -1010,22 +983,12 @@ class CmdSkintone(Command):
             target.msg(f"{caller.name} has cleared your skintone setting.")
 
     def _find_character(self, caller, character_name):
-        """Find a character by name for staff targeting"""
-        # Use Evennia's search system to find the character
-        results = search_object(character_name, typeclass="typeclasses.characters.Character")
-        
-        if not results:
-            return None
-        elif len(results) > 1:
-            # Multiple matches - try to find exact match
-            exact_matches = [obj for obj in results if obj.name.lower() == character_name.lower()]
-            if len(exact_matches) == 1:
-                return exact_matches[0]
-            else:
-                caller.msg(f"Multiple characters match '{character_name}': {', '.join(obj.name for obj in results)}")
-                return None
-        else:
-            return results[0]
+        """Find a character by name for staff targeting.
+
+        Uses the identity-aware admin lookup: local sdesc/recognition
+        match in caller's room first, then global key search fallback.
+        """
+        return resolve_admin_target(caller, character_name)
 
 
 # ===================================================================

--- a/world/tests/test_admin_command_identity.py
+++ b/world/tests/test_admin_command_identity.py
@@ -1,0 +1,340 @@
+"""
+Tests for admin command identity targeting (PR δ).
+
+Verifies that staff commands ``@heal``, ``@testdeath``,
+``@testunconscious``, ``@resetmedical``, ``@longdesc`` (set & clear),
+and ``@skintone`` route character-target resolution through
+``commands._identity_targeting.resolve_admin_target``.
+
+The helper applies the admin dual-path: identity-aware match in the
+caller's local room first, then a global key search fallback so staff
+retain cross-room reach.
+
+The helper itself is exhaustively tested in
+``test_combat_command_identity``; here we assert call-site wiring
+only: helper invocation, found-vs-None branching, and that legacy
+``caller.search(..., global_search=True)`` / ``search_object`` direct
+calls are no longer used for the target lookup.
+
+Run via::
+
+    evennia test world.tests.test_admin_command_identity
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+
+# ===================================================================
+# CmdHeal — name-target branch (here / dbref branches untouched)
+# ===================================================================
+
+
+class TestCmdHealIdentity(TestCase):
+    """``@heal <name>`` uses identity-aware admin lookup."""
+
+    def _make_cmd(self, args="man"):
+        from commands.CmdAdmin import CmdHeal
+
+        cmd = CmdHeal()
+        cmd.args = args
+        cmd.caller = MagicMock()
+        cmd.caller.location = MagicMock()
+        cmd.caller.location.key = "Room"
+        return cmd
+
+    @patch("commands.CmdAdmin.resolve_admin_target")
+    def test_heal_uses_admin_helper(self, mock_resolve):
+        target = MagicMock()
+        target.key = "Jorge"
+        target.medical_state = None  # short-circuit after lookup
+        mock_resolve.return_value = target
+        cmd = self._make_cmd(args="man")
+        cmd.func()
+        mock_resolve.assert_called_with(cmd.caller, "man")
+
+    @patch("commands.CmdAdmin.resolve_admin_target")
+    def test_heal_target_not_found_messages_caller(self, mock_resolve):
+        mock_resolve.return_value = None
+        cmd = self._make_cmd(args="ghost")
+        cmd.func()
+        msg_calls = [c.args[0] for c in cmd.caller.msg.call_args_list]
+        self.assertTrue(any("ghost" in m for m in msg_calls))
+
+    @patch("commands.CmdAdmin.resolve_admin_target")
+    def test_heal_here_skips_helper(self, mock_resolve):
+        """``@heal here`` uses location.contents directly, not the helper."""
+        cmd = self._make_cmd(args="here")
+        cmd.caller.location.contents = []  # empty -> no targets msg
+        cmd.func()
+        mock_resolve.assert_not_called()
+
+
+# ===================================================================
+# CmdTestDeath — same admin pattern
+# ===================================================================
+
+
+class TestCmdTestDeathIdentity(TestCase):
+    def _make_cmd(self, args="man"):
+        from commands.CmdAdmin import CmdTestDeath
+
+        cmd = CmdTestDeath()
+        cmd.args = args
+        cmd.caller = MagicMock()
+        return cmd
+
+    @patch("commands.CmdAdmin.resolve_admin_target")
+    def test_testdeath_uses_admin_helper(self, mock_resolve):
+        target = MagicMock(spec=["key"])  # no is_dead → short-circuit
+        target.key = "Jorge"
+        mock_resolve.return_value = target
+        cmd = self._make_cmd(args="man")
+        cmd.func()
+        mock_resolve.assert_called_with(cmd.caller, "man")
+
+    @patch("commands.CmdAdmin.resolve_admin_target")
+    def test_testdeath_not_found_messages_caller(self, mock_resolve):
+        mock_resolve.return_value = None
+        cmd = self._make_cmd(args="ghost")
+        cmd.func()
+        msg_calls = [c.args[0] for c in cmd.caller.msg.call_args_list]
+        self.assertTrue(any("ghost" in m for m in msg_calls))
+
+
+# ===================================================================
+# CmdTestUnconscious — same admin pattern
+# ===================================================================
+
+
+class TestCmdTestUnconsciousIdentity(TestCase):
+    def _make_cmd(self, args="man"):
+        from commands.CmdAdmin import CmdTestUnconscious
+
+        cmd = CmdTestUnconscious()
+        cmd.args = args
+        cmd.caller = MagicMock()
+        return cmd
+
+    @patch("commands.CmdAdmin.resolve_admin_target")
+    def test_testunconscious_uses_admin_helper(self, mock_resolve):
+        target = MagicMock(spec=["key"])
+        target.key = "Jorge"
+        mock_resolve.return_value = target
+        cmd = self._make_cmd(args="man")
+        cmd.func()
+        mock_resolve.assert_called_with(cmd.caller, "man")
+
+    @patch("commands.CmdAdmin.resolve_admin_target")
+    def test_testunconscious_not_found_messages_caller(self, mock_resolve):
+        mock_resolve.return_value = None
+        cmd = self._make_cmd(args="ghost")
+        cmd.func()
+        msg_calls = [c.args[0] for c in cmd.caller.msg.call_args_list]
+        self.assertTrue(any("ghost" in m for m in msg_calls))
+
+
+# ===================================================================
+# CmdResetMedical — specific-character branch
+# ===================================================================
+
+
+class TestCmdResetMedicalIdentity(TestCase):
+    def _make_cmd(self, args="man"):
+        from commands.CmdAdmin import CmdResetMedical
+
+        cmd = CmdResetMedical()
+        cmd.args = args
+        cmd.caller = MagicMock()
+        return cmd
+
+    @patch("commands.CmdAdmin.resolve_admin_target")
+    def test_resetmedical_uses_admin_helper(self, mock_resolve):
+        target = MagicMock()  # full mock; we only assert helper call
+        target.key = "Jorge"
+        mock_resolve.return_value = target
+        cmd = self._make_cmd(args="man")
+        try:
+            cmd.func()
+        except Exception:
+            pass
+        mock_resolve.assert_called_with(cmd.caller, "man")
+
+    @patch("commands.CmdAdmin.resolve_admin_target")
+    def test_resetmedical_not_found_messages_caller(self, mock_resolve):
+        mock_resolve.return_value = None
+        cmd = self._make_cmd(args="ghost")
+        cmd.func()
+        msg_calls = [c.args[0] for c in cmd.caller.msg.call_args_list]
+        self.assertTrue(any("ghost" in m for m in msg_calls))
+
+
+# ===================================================================
+# CmdLongdesc — set and clear paths both use helper for staff target
+# ===================================================================
+
+
+class TestCmdLongdescIdentity(TestCase):
+    """``@longdesc`` set + clear use admin helper for staff targeting."""
+
+    def _make_set_cmd(self, args='man head "scarred"'):
+        from commands.CmdCharacter import CmdLongdesc
+
+        cmd = CmdLongdesc()
+        cmd.key = "@longdesc"
+        cmd.args = args
+        cmd.cmdstring = "@longdesc"
+        cmd.caller = MagicMock()
+        cmd.caller.locks.check_lockstring = lambda *a, **kw: True
+        cmd.caller.location = MagicMock()
+        return cmd
+
+    def _make_clear_cmd(self, args="man head"):
+        from commands.CmdCharacter import CmdLongdesc
+
+        cmd = CmdLongdesc()
+        cmd.key = "@longdesc"
+        cmd.args = args
+        cmd.cmdstring = "@longdesc"
+        cmd.caller = MagicMock()
+        cmd.caller.locks.check_lockstring = lambda *a, **kw: True
+        cmd.caller.location = MagicMock()
+        return cmd
+
+    @patch("commands.CmdCharacter.resolve_admin_target")
+    def test_longdesc_set_uses_admin_helper(self, mock_resolve):
+        target = MagicMock()
+        target.longdesc = MagicMock()  # has longdesc attr
+        mock_resolve.return_value = target
+        cmd = self._make_set_cmd()
+        # Call the func; we only care that the helper was invoked
+        # with the first token of args.
+        try:
+            cmd.func()
+        except Exception:
+            pass
+        mock_resolve.assert_called_with(cmd.caller, "man")
+
+    @patch("commands.CmdCharacter.resolve_admin_target")
+    def test_longdesc_set_no_target_falls_back_to_self(self, mock_resolve):
+        """Helper returns None → command continues with caller as target."""
+        mock_resolve.return_value = None
+        cmd = self._make_set_cmd(args='man head "scarred"')
+        try:
+            cmd.func()
+        except Exception:
+            pass
+        # Helper was called; no AttributeError from missing target_char.
+        mock_resolve.assert_called()
+
+    @patch("commands.CmdCharacter.resolve_admin_target")
+    def test_longdesc_clear_uses_admin_helper(self, mock_resolve):
+        target = MagicMock()
+        target.longdesc = MagicMock()
+        mock_resolve.return_value = target
+        cmd = self._make_clear_cmd(args="man head")
+        # Force the clear path: @longdesc with no quotes is clear.
+        try:
+            cmd.func()
+        except Exception:
+            pass
+        # The clear path will be entered if cmdstring contains 'clear'
+        # or there are no quotes; either way the helper should be
+        # consulted at least once by the set OR clear path.
+        mock_resolve.assert_called()
+
+
+# ===================================================================
+# CmdSkintone._find_character — admin helper
+# ===================================================================
+
+
+class TestCmdSkintoneIdentity(TestCase):
+    @patch("commands.CmdCharacter.resolve_admin_target")
+    def test_find_character_delegates_to_admin_helper(self, mock_resolve):
+        from commands.CmdCharacter import CmdSkintone
+
+        cmd = CmdSkintone()
+        caller = MagicMock()
+        target = MagicMock()
+        mock_resolve.return_value = target
+        result = cmd._find_character(caller, "man")
+        mock_resolve.assert_called_once_with(caller, "man")
+        self.assertIs(result, target)
+
+    @patch("commands.CmdCharacter.resolve_admin_target")
+    def test_find_character_returns_none_when_helper_returns_none(
+        self, mock_resolve
+    ):
+        from commands.CmdCharacter import CmdSkintone
+
+        cmd = CmdSkintone()
+        caller = MagicMock()
+        mock_resolve.return_value = None
+        result = cmd._find_character(caller, "ghost")
+        self.assertIsNone(result)
+
+
+# ===================================================================
+# resolve_admin_target — local-first, then global-key fallback
+# ===================================================================
+
+
+class TestResolveAdminTargetDualPath(TestCase):
+    """Direct unit tests for the admin dual-path helper."""
+
+    @patch("commands._identity_targeting.resolve_character_target")
+    def test_local_match_wins(self, mock_local):
+        from commands._identity_targeting import resolve_admin_target
+
+        caller = MagicMock()
+        target = MagicMock(get_sdesc=lambda: "tall man")
+        mock_local.return_value = target
+        result = resolve_admin_target(caller, "man")
+        self.assertIs(result, target)
+        mock_local.assert_called_once_with(caller, "man")
+
+    @patch("evennia.search_object")
+    @patch("commands._identity_targeting.resolve_character_target")
+    def test_falls_back_to_global_search_when_no_local_match(
+        self, mock_local, mock_search
+    ):
+        from commands._identity_targeting import resolve_admin_target
+
+        caller = MagicMock()
+        global_target = MagicMock(get_sdesc=lambda: "tall man")
+        mock_local.return_value = None
+        mock_search.return_value = [global_target]
+        result = resolve_admin_target(caller, "Jorge")
+        self.assertIs(result, global_target)
+
+    @patch("evennia.search_object")
+    @patch("commands._identity_targeting.resolve_character_target")
+    def test_global_ambiguity_messages_caller(self, mock_local, mock_search):
+        from commands._identity_targeting import resolve_admin_target
+
+        caller = MagicMock()
+        mock_local.return_value = None
+        mock_search.return_value = [
+            MagicMock(get_sdesc=lambda: "a"),
+            MagicMock(get_sdesc=lambda: "b"),
+        ]
+        result = resolve_admin_target(caller, "Smith")
+        self.assertIsNone(result)
+        caller.msg.assert_called_once()
+        message = caller.msg.call_args[0][0]
+        self.assertIn("Multiple", message)
+
+    def test_self_token_returns_caller(self):
+        from commands._identity_targeting import resolve_admin_target
+
+        caller = MagicMock()
+        for token in ("me", "self", "myself", "ME"):
+            self.assertIs(resolve_admin_target(caller, token), caller)
+
+    def test_empty_query_returns_none(self):
+        from commands._identity_targeting import resolve_admin_target
+
+        caller = MagicMock()
+        self.assertIsNone(resolve_admin_target(caller, ""))
+        self.assertIsNone(resolve_admin_target(caller, "   "))


### PR DESCRIPTION
## Summary
- Converts staff commands (`@heal`, `@testdeath`, `@testunconscious`, `@resetmedical`, `@longdesc` set/clear, `@skintone`) character-target resolution to the canonical identity pipeline via `commands._identity_targeting.resolve_admin_target`.
- **Closes the 5-PR identity-conversion series** (ε spec, α combat, β inventory, γ medical, **δ admin**).
- Net delta across the series: **831 → 890 tests** (+59).

## Admin dual-path
`resolve_admin_target` applies a two-phase lookup:
1. **Local identity match** in caller's room — sdesc keywords and recognised names work naturally on neighbours.
2. **Global key search fallback** — staff retain cross-room reach for off-screen targets.

## Changes
- `commands/CmdAdmin.py` — CmdHeal name branch, CmdTestDeath, CmdTestUnconscious, CmdResetMedical specific-character branch
- `commands/CmdCharacter.py` — CmdLongdesc set + clear staff-target lookup, CmdSkintone._find_character

## Preserved as-is
- `@heal here` / `@heal <room#>` still iterate `location.contents`.
- `CmdFixCharacterOwnership` left on raw `search_object` — it is a low-level repair tool that must operate on real keys.

## Tests
- New: `world/tests/test_admin_command_identity.py` (19 cases)
  - `@heal` name/here/not-found
  - `@testdeath`, `@testunconscious`, `@resetmedical` helper invocation + not-found messaging
  - `@longdesc` set + clear staff target lookup
  - `CmdSkintone._find_character` delegation
  - `resolve_admin_target` direct unit tests (local-first, global fallback, ambiguity, self tokens, empty query)
- Full suite: **871 → 890**, all pass.

## Behavior
- Staff can now `@heal man` and `@longdesc man head "scarred"` using sdesc keywords for adjacent characters.
- Off-screen targets continue to resolve via global key search (e.g. `@heal Jorge` from anywhere).
- Ambiguity in global phase produces a clear disambiguation message instructing staff to use a dbref.