### PR TITLE
Phase 2 Φ₁: Route consumption verb broadcasts through per-observer rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -590,6 +590,45 @@ class CmdExample(Command):
             self.send_failure_messages(caller, target)
 ```
 
+### Per-Observer Rendering
+
+Any room broadcast that names a character (actor, target, or both) **must**
+route through `world.identity_utils.msg_room_identity` instead of
+`location.msg_contents()`. This ensures each observer sees the actor /
+target rendered according to **their own recognition memory** — assigned
+names for known characters, sdesc fallback for strangers — rather than
+the raw `.key`.
+
+**Use `msg_room_identity` when** the broadcast string references a
+character. Pre-interpolate non-character tokens (item names, body parts)
+into the template via f-string; the helper's `char_refs` dict is
+character-only.
+
+```python
+from world.identity_utils import msg_room_identity
+
+# First-person to actor (caller IS the observer — get_display_name is fine)
+caller.msg(f"You inject {item.get_display_name(caller)} into "
+           f"{target.get_display_name(caller)}.")
+target.msg(f"{caller.get_display_name(target)} injects "
+           f"{item.get_display_name(target)} into you.")
+
+# Third-party broadcast: per-observer rendering
+msg_room_identity(
+    location=caller.location,
+    template=f"{{actor}} injects {item.key} into {{target}}.",
+    char_refs={"actor": caller, "target": target},
+    exclude=[caller, target],
+)
+```
+
+**Skip the helper when** the broadcast contains **only** non-character
+text (e.g. `"A {item.key} falls to the ground."`, constant ambient
+prose). Per-observer rendering adds no value there.
+
+See `specs/IDENTITY_RECOGNITION_SPEC.md` §"Per-Observer Rendering" and
+§"Phase 2 — Consistency" Conversion Status for the active sweep.
+
 ### Command Integration Points
 
 **Handler Interaction:**

--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -7,6 +7,7 @@ Implements the universal consumption system with inject, apply, bandage, etc.
 
 from evennia import Command
 from commands._identity_targeting import resolve_character_target
+from world.identity_utils import msg_room_identity
 from world.medical.utils import (
     is_medical_item, can_be_used, get_medical_type, get_stat_requirement,
     calculate_treatment_success, apply_medical_effects, use_item
@@ -283,16 +284,20 @@ class CmdInject(ConsumptionCommand):
         # Execute injection
         if is_self:
             caller.msg(f"You inject {item.get_display_name(caller)} into your arm.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} injects {item.get_display_name()}.",
-                exclude=caller
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} injects {item.key}.",
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
         else:
             caller.msg(f"You inject {item.get_display_name(caller)} into {target.get_display_name(caller)}.")
             target.msg(f"{caller.get_display_name(target)} injects {item.get_display_name(target)} into you.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} injects {item.get_display_name()} into {target.get_display_name()}.",
-                exclude=[caller, target]
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} injects {item.key} into {{target}}.",
+                char_refs={"actor": caller, "target": target},
+                exclude=[caller, target],
             )
             
         # Apply treatment effects
@@ -391,16 +396,20 @@ class CmdApply(ConsumptionCommand):
         # Execute application
         if is_self:
             caller.msg(f"You carefully apply {item.get_display_name(caller)} to your wounds.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} applies {item.get_display_name()} to their wounds.",
-                exclude=caller
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} applies {item.key} to their wounds.",
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
         else:
             caller.msg(f"You carefully apply {item.get_display_name(caller)} to {target.get_display_name(caller)}'s wounds.")
             target.msg(f"{caller.get_display_name(target)} applies {item.get_display_name(target)} to your wounds.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} applies {item.get_display_name()} to {target.get_display_name()}'s wounds.",
-                exclude=[caller, target]
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} applies {item.key} to {{target}}'s wounds.",
+                char_refs={"actor": caller, "target": target},
+                exclude=[caller, target],
             )
             
         # Apply treatment effects
@@ -518,16 +527,20 @@ class CmdBandage(ConsumptionCommand):
         location_desc = f" {self.body_location}" if self.body_location else ""
         if is_self:
             caller.msg(f"You bandage your{location_desc} wounds with {item.get_display_name(caller)}.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} bandages their{location_desc} wounds.",
-                exclude=caller
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} bandages their{location_desc} wounds.",
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
         else:
             caller.msg(f"You bandage {target.get_display_name(caller)}'s{location_desc} wounds with {item.get_display_name(caller)}.")
             target.msg(f"{caller.get_display_name(target)} bandages your{location_desc} wounds.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} bandages {target.get_display_name()}'s{location_desc} wounds.",
-                exclude=[caller, target]
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} bandages {{target}}'s{location_desc} wounds.",
+                char_refs={"actor": caller, "target": target},
+                exclude=[caller, target],
             )
             
         # Apply treatment effects with body location
@@ -589,16 +602,20 @@ class CmdEat(ConsumptionCommand):
         # Execute eating
         if is_self:
             caller.msg(f"You swallow {item.get_display_name(caller)}.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} swallows {item.get_display_name()}.",
-                exclude=caller
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} swallows {item.key}.",
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
         else:
             caller.msg(f"You help {target.get_display_name(caller)} swallow {item.get_display_name(caller)}.")
             target.msg(f"{caller.get_display_name(target)} helps you swallow {item.get_display_name(target)}.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} helps {target.get_display_name()} swallow {item.get_display_name()}.",
-                exclude=[caller, target]
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} helps {{target}} swallow {item.key}.",
+                char_refs={"actor": caller, "target": target},
+                exclude=[caller, target],
             )
             
         # Apply effects
@@ -664,16 +681,20 @@ class CmdDrink(ConsumptionCommand):
         # Execute drinking
         if is_self:
             caller.msg(f"You drink {item.get_display_name(caller)}.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} drinks {item.get_display_name()}.",
-                exclude=caller
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} drinks {item.key}.",
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
         else:
             caller.msg(f"You help {target.get_display_name(caller)} drink {item.get_display_name(caller)}.")
             target.msg(f"{caller.get_display_name(target)} helps you drink {item.get_display_name(target)}.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} helps {target.get_display_name()} drink {item.get_display_name()}.",
-                exclude=[caller, target]
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} helps {{target}} drink {item.key}.",
+                char_refs={"actor": caller, "target": target},
+                exclude=[caller, target],
             )
             
         # Apply effects
@@ -746,16 +767,20 @@ class CmdInhale(ConsumptionCommand):
         # Execute inhalation
         if is_self:
             caller.msg(f"You breathe in {item.get_display_name(caller)} deeply.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} inhales {item.get_display_name()}.",
-                exclude=caller
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} inhales {item.key}.",
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
         else:
             caller.msg(f"You help {target.get_display_name(caller)} inhale {item.get_display_name(caller)}.")
             target.msg(f"{caller.get_display_name(target)} helps you inhale {item.get_display_name(target)}.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} helps {target.get_display_name()} inhale {item.get_display_name()}.",
-                exclude=[caller, target]
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} helps {{target}} inhale {item.key}.",
+                char_refs={"actor": caller, "target": target},
+                exclude=[caller, target],
             )
             
         # Apply treatment effects
@@ -824,16 +849,20 @@ class CmdSmoke(ConsumptionCommand):
         # Execute smoking
         if is_self:
             caller.msg(f"You light and smoke {item.get_display_name(caller)}, inhaling the medicinal smoke.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} lights and smokes {item.get_display_name()}, creating aromatic smoke.",
-                exclude=caller
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} lights and smokes {item.key}, creating aromatic smoke.",
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
         else:
             caller.msg(f"You help {target.get_display_name(caller)} smoke {item.get_display_name(caller)}.")
             target.msg(f"{caller.get_display_name(target)} helps you smoke {item.get_display_name(target)}.")
-            caller.location.msg_contents(
-                f"{caller.get_display_name()} helps {target.get_display_name()} smoke {item.get_display_name()}.",
-                exclude=[caller, target]
+            msg_room_identity(
+                location=caller.location,
+                template=f"{{actor}} helps {{target}} smoke {item.key}.",
+                char_refs={"actor": caller, "target": target},
+                exclude=[caller, target],
             )
             
         # Apply treatment effects

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1484,7 +1484,7 @@ Players should be prompted to customize their sdesc on next login if defaults we
 | Phase | Scope | Status |
 |---|---|---|
 | 1 | Foundation (sdesc, recognition, chargen, grammar) | ✅ Shipped |
-| 2 | Per-observer rendering consistency | ✅ Shipped |
+| 2 | Per-observer rendering consistency | 🟡 In progress — helper shipped; per-surface `msg_contents()` → `msg_room_identity` sweep underway (Φ₁ Consumption ✅; Φ₂ Armor, Φ₃ Movement+Jump, Φ₄ Misc pending) |
 | 3 | Disguise foundation (signature engine, `appear`, personas, unmasking) | ✅ Shipped |
 | 3.5 | Disguise item taxonomy | 🟡 Partially shipped — prototypes live, cohesion polish pending |
 | 4 | Cybernetics (digital memory, ID exchange) | ⛔ Not started (gated on cyberware system) |
@@ -1523,6 +1523,19 @@ Per-phase detail below.
 - Target resolution with sdescs, assigned names, and ordinals
 - `sdesc_short` attribute on items
 - Distinguishing feature auto-derivation from worn items
+
+**Conversion Status — `msg_contents()` → `msg_room_identity()` sweep:**
+
+The helper and most rendering surfaces shipped in earlier work; a per-surface audit identified 14 command-layer files still emitting raw `msg_contents()` broadcasts with character `.key` references. Conversion is split across four PRs:
+
+| Φ | Scope | Files | Status |
+|---|---|---|---|
+| Φ₁ | Consumption verbs (inject / apply / bandage / eat / drink / inhale / smoke) | `commands/CmdConsumption.py` (14 sites) | ✅ Shipped |
+| Φ₂ | Armor put-on / take-off / repair | `commands/CmdArmor.py` (~7 sites) | 🟡 Pending |
+| Φ₃ | Movement + jump announcements | `commands/combat/movement.py` (~5), `commands/combat/jump.py` (~2) | 🟡 Pending |
+| Φ₄ | Capstone: throw, shop, spawnmob, explosives | `commands/CmdThrow.py`, `commands/shop.py`, `commands/CmdSpawnMob.py`, `commands/CmdExplosives.py`, `commands/explosion_utils.py`, `world/combat/explosives.py` (~11 sites) | 🟡 Pending |
+
+Sites that broadcast **only** non-character text (item names, constant prose) are intentionally left as raw `msg_contents` since per-observer rendering adds no value. The roadmap row flips back to ✅ Shipped when Φ₄ lands.
 
 ### Phase 3 — Disguise (Foundation)
 

--- a/world/tests/test_consumption_rendering.py
+++ b/world/tests/test_consumption_rendering.py
@@ -1,0 +1,417 @@
+"""
+Tests for Phase 2 per-observer rendering in CmdConsumption.
+
+Verifies the inject / apply / bandage / eat / drink / inhale / smoke
+verbs route their room broadcasts through :func:`msg_room_identity`
+so that each observer sees the actor (and optional target) rendered
+according to their own recognition memory.
+
+Run via::
+
+    evennia test world.tests.test_consumption_rendering
+
+Aligns with ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Phase 2 —
+Consistency" Conversion Status.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
+
+
+# ===================================================================
+# Mock builders (mirrors world/tests/test_communication.py)
+# ===================================================================
+
+
+def _make_character(
+    *,
+    key,
+    sex="male",
+    height="tall",
+    build="lean",
+    sdesc_keyword="man",
+    sleeve_uid,
+    recognition_memory=None,
+):
+    """Build a mock character with identity methods bound."""
+    from typeclasses.characters import Character
+
+    char = MagicMock(spec=Character)
+    char.key = key
+    char.sex = sex
+    char.height = height
+    char.build = build
+    char.sdesc_keyword = sdesc_keyword
+    char.hair_color = None
+    char.hair_style = None
+    char.sleeve_uid = sleeve_uid
+    char.recognition_memory = (
+        recognition_memory if recognition_memory is not None else {}
+    )
+    char.hands = {"left": None, "right": None}
+    char.worn_items = {}
+    char._build_clothing_coverage_map = lambda: {}
+
+    char.get_distinguishing_feature = (
+        lambda: Character.get_distinguishing_feature(char)
+    )
+    char.get_sdesc = lambda: Character.get_sdesc(char)
+    char.get_display_name = (
+        lambda looker=None, **kw: Character.get_display_name(
+            char, looker, **kw
+        )
+    )
+
+    sex_val = (sex or "ambiguous").lower().strip()
+    if sex_val in ("male", "man", "masculine", "m"):
+        type(char).gender = PropertyMock(return_value="male")
+    elif sex_val in ("female", "woman", "feminine", "f"):
+        type(char).gender = PropertyMock(return_value="female")
+    else:
+        type(char).gender = PropertyMock(return_value="neutral")
+
+    prepare_mock_for_apparent_uid(char)
+    return char
+
+
+def _make_room(contents):
+    room = MagicMock()
+    room.contents = contents
+    return room
+
+
+def _make_item(key="medkit"):
+    """Non-character item (no msg attribute, deliberately empty spec)."""
+    item = MagicMock(spec=["key", "get_display_name", "delete"])
+    item.key = key
+    # Stub get_display_name so caller-side first-person msgs don't blow up.
+    item.get_display_name = lambda looker=None: key
+    return item
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+
+def _observer_text(observer):
+    """Pull the text= kwarg or first positional arg from observer.msg()."""
+    if not observer.msg.call_args:
+        return ""
+    args = observer.msg.call_args
+    return args.kwargs.get("text") or (args.args[0] if args.args else "")
+
+
+def _run_consumption_cmd(
+    cmd_cls,
+    *,
+    caller,
+    target,
+    item,
+    args="medkit",
+    body_location=None,
+    is_medical=True,
+    medical_type="pain_relief",
+    cmdstring=None,
+):
+    """Invoke a consumption command's func() with stubbed parsing/effects.
+
+    Patches :meth:`ConsumptionCommand.get_item_and_target`,
+    :meth:`check_medical_requirements`, :meth:`execute_treatment`,
+    and module-level ``is_medical_item`` / ``get_medical_type`` so the
+    test runs the room-broadcast branch end-to-end without touching
+    the medical state machine or the live DB.
+
+    ``CmdBandage`` uses its own ``parse()`` pipeline and ``caller.search``
+    instead of ``get_item_and_target``; this helper handles both flows.
+    """
+    cmd = cmd_cls()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.cmdstring = cmdstring or cmd_cls.key
+    cmd.body_location = body_location
+
+    # CmdBandage uses its own parsed attrs + caller.search
+    is_bandage = cmd_cls.__name__ == "CmdBandage"
+    if is_bandage:
+        cmd.item_name = "medkit"
+        cmd.target_name = None if caller is target else "target"
+        caller.search = MagicMock(return_value=[item])
+
+    parse_result = {
+        "item": item,
+        "target": target,
+        "body_location": body_location,
+        "errors": [],
+    }
+
+    patches = [
+        patch.object(cmd, "check_medical_requirements", return_value=[]),
+        patch.object(cmd, "execute_treatment", return_value="ok"),
+        patch(
+            "commands.CmdConsumption.is_medical_item",
+            return_value=is_medical,
+        ),
+        patch(
+            "commands.CmdConsumption.get_medical_type",
+            return_value=medical_type,
+        ),
+    ]
+    if not is_bandage:
+        patches.insert(
+            0, patch.object(cmd, "get_item_and_target", return_value=parse_result)
+        )
+    else:
+        # Bandage resolves target via resolve_character_target when not self
+        patches.append(
+            patch(
+                "commands.CmdConsumption.resolve_character_target",
+                return_value=target,
+            )
+        )
+
+    # Apply all patches via nested context
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        cmd.func()
+
+
+# ===================================================================
+# Tests
+# ===================================================================
+
+
+class TestConsumptionPerObserverRendering(TestCase):
+    """Each consumption verb broadcasts per-observer-rendered text."""
+
+    def setUp(self):
+        self.actor = _make_character(
+            key="Jorge Jackson",
+            sleeve_uid="uid-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        self.patient = _make_character(
+            key="Maria Santos",
+            sex="female",
+            sleeve_uid="uid-maria",
+            height="short",
+            build="athletic",
+            sdesc_keyword="woman",
+        )
+        self.knower = _make_character(
+            key="Alice",
+            sex="female",
+            sleeve_uid="uid-alice",
+            recognition_memory={
+                apparent_uid_for(self.actor): {"assigned_name": "Jorge"},
+                apparent_uid_for(self.patient): {"assigned_name": "Maria"},
+            },
+        )
+        self.stranger = _make_character(
+            key="Bob",
+            sleeve_uid="uid-bob",
+            recognition_memory={},
+        )
+
+        self.item = _make_item("medkit")
+        self.room = _make_room(
+            [self.actor, self.patient, self.knower, self.stranger]
+        )
+        self.actor.location = self.room
+        self.patient.location = self.room
+
+        # Patient needs a medical_state for the requirement passthrough,
+        # though we patch check_medical_requirements anyway.
+        self.actor.medical_state = MagicMock()
+        self.patient.medical_state = MagicMock()
+        self.actor.is_unconscious = lambda: False
+        self.patient.is_unconscious = lambda: False
+
+    # ---- inject --------------------------------------------------
+
+    def test_inject_self_broadcast(self):
+        from commands.CmdConsumption import CmdInject
+
+        _run_consumption_cmd(
+            CmdInject,
+            caller=self.actor,
+            target=self.actor,
+            item=self.item,
+        )
+
+        self.assertIn("Jorge", _observer_text(self.knower))
+        self.assertIn("medkit", _observer_text(self.knower))
+        self.assertIn("gaunt man", _observer_text(self.stranger))
+
+    def test_inject_other_broadcast(self):
+        from commands.CmdConsumption import CmdInject
+
+        _run_consumption_cmd(
+            CmdInject,
+            caller=self.actor,
+            target=self.patient,
+            item=self.item,
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("Maria", ktext)
+        self.assertIn("medkit", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+        self.assertIn("compact woman", stext)
+
+    # ---- apply ---------------------------------------------------
+
+    def test_apply_other_broadcast(self):
+        from commands.CmdConsumption import CmdApply
+
+        _run_consumption_cmd(
+            CmdApply,
+            caller=self.actor,
+            target=self.patient,
+            item=self.item,
+            medical_type="wound_care",
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("Maria", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+        self.assertIn("compact woman", stext)
+
+    # ---- bandage -------------------------------------------------
+
+    def test_bandage_self_broadcast(self):
+        from commands.CmdConsumption import CmdBandage
+
+        _run_consumption_cmd(
+            CmdBandage,
+            caller=self.actor,
+            target=self.actor,
+            item=self.item,
+            body_location="left arm",
+            medical_type="wound_care",
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("left arm", ktext)
+        self.assertIn("gaunt man", _observer_text(self.stranger))
+
+    # ---- eat -----------------------------------------------------
+
+    def test_eat_self_broadcast(self):
+        from commands.CmdConsumption import CmdEat
+
+        _run_consumption_cmd(
+            CmdEat,
+            caller=self.actor,
+            target=self.actor,
+            item=self.item,
+            is_medical=False,
+            medical_type="food",
+        )
+
+        self.assertIn("Jorge", _observer_text(self.knower))
+        self.assertIn("medkit", _observer_text(self.knower))
+        self.assertIn("gaunt man", _observer_text(self.stranger))
+
+    # ---- drink ---------------------------------------------------
+
+    def test_drink_other_broadcast(self):
+        from commands.CmdConsumption import CmdDrink
+
+        _run_consumption_cmd(
+            CmdDrink,
+            caller=self.actor,
+            target=self.patient,
+            item=self.item,
+            is_medical=False,
+            medical_type="water",
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("Maria", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+        self.assertIn("compact woman", stext)
+
+    # ---- inhale --------------------------------------------------
+
+    def test_inhale_self_broadcast(self):
+        from commands.CmdConsumption import CmdInhale
+
+        _run_consumption_cmd(
+            CmdInhale,
+            caller=self.actor,
+            target=self.actor,
+            item=self.item,
+            medical_type="oxygen",
+        )
+
+        self.assertIn("Jorge", _observer_text(self.knower))
+        self.assertIn("gaunt man", _observer_text(self.stranger))
+
+    # ---- smoke ---------------------------------------------------
+
+    def test_smoke_other_broadcast(self):
+        from commands.CmdConsumption import CmdSmoke
+
+        _run_consumption_cmd(
+            CmdSmoke,
+            caller=self.actor,
+            target=self.patient,
+            item=self.item,
+            medical_type="herb",
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("Maria", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+        self.assertIn("compact woman", stext)
+
+    # ---- exclusion / first-person guard --------------------------
+
+    def test_actor_and_patient_excluded_from_room_broadcast(self):
+        """Actor and patient receive their own first/second-person msgs."""
+        from commands.CmdConsumption import CmdInject
+
+        _run_consumption_cmd(
+            CmdInject,
+            caller=self.actor,
+            target=self.patient,
+            item=self.item,
+        )
+
+        actor_texts = [
+            (c.args[0] if c.args else c.kwargs.get("text", ""))
+            for c in self.actor.msg.call_args_list
+        ]
+        self.assertTrue(
+            any("You inject" in t for t in actor_texts),
+            f"Actor missing first-person inject msg: {actor_texts}",
+        )
+
+        patient_texts = [
+            (c.args[0] if c.args else c.kwargs.get("text", ""))
+            for c in self.patient.msg.call_args_list
+        ]
+        self.assertTrue(
+            any("into you" in t for t in patient_texts),
+            f"Patient missing second-person msg: {patient_texts}",
+        )


### PR DESCRIPTION
## Summary
- Converts all 14 `msg_contents()` sites in `commands/CmdConsumption.py` (inject / apply / bandage / eat / drink / inhale / smoke) to `msg_room_identity` so each observer sees the actor (and optional target) rendered against their own recognition memory.
- Adds `world/tests/test_consumption_rendering.py` — 9 cases exercising self / other broadcasts plus the actor-and-patient exclusion guard, all using identity-aware mocks (`prepare_mock_for_apparent_uid`, `apparent_uid_for`).
- Documents the per-observer rendering pattern in `AGENTS.md` under Command System.
- Updates `specs/IDENTITY_RECOGNITION_SPEC.md` §"Phase 2 — Consistency" with a Conversion Status checklist and drops the roadmap row from ✅ to 🟡 until Φ₄ lands.

## Scope
First of four PRs tracked under #155:
- **Φ₁ Consumption** (this PR) — ✅
- Φ₂ Armor (`CmdArmor`, ~7 sites)
- Φ₃ Movement + Jump (`commands/combat/movement.py`, `commands/combat/jump.py`, ~7 sites)
- Φ₄ Misc capstone (throw, shop, spawnmob, explosives, ~11 sites) — flips roadmap row back to ✅

## Why
Raw `msg_contents()` calls leak `character.key` into the room broadcast, defeating the recognition memory system: strangers see "Jorge" instead of "a gaunt man", and acquaintances under assigned names see the player's real key. `msg_room_identity` resolves each placeholder per observer.

## Tests
`docker exec gelatinous evennia test --settings settings.py world.tests` → 899 passed (was 890; +9 new).