### PR TITLE
Phase 2 Φ₂: Route armor plate broadcasts through per-observer rendering

### DIFF
--- a/commands/CmdArmor.py
+++ b/commands/CmdArmor.py
@@ -14,6 +14,7 @@ from world.combat.constants import (
     ANATOMICAL_DISPLAY_ORDER,
     ARMOR_EFFECTIVENESS_MATRIX,
 )
+from world.identity_utils import msg_room_identity
 
 
 def _get_center_headers(caller):
@@ -1456,9 +1457,13 @@ class CmdSlot(Command):
 
         # Location message
         if caller.location:
-            caller.location.msg_contents(
-                f"{caller.key} installs an armor plate into"
-                f" their {carrier.key}.",
+            msg_room_identity(
+                location=caller.location,
+                template=(
+                    f"{{actor}} installs an armor plate into"
+                    f" their {carrier.key}."
+                ),
+                char_refs={"actor": caller},
                 exclude=[caller],
             )
 
@@ -1511,9 +1516,13 @@ class CmdSlot(Command):
 
         # Location message
         if caller.location:
-            caller.location.msg_contents(
-                f"{caller.key} removes an armor plate from"
-                f" their {carrier.key}.",
+            msg_room_identity(
+                location=caller.location,
+                template=(
+                    f"{{actor}} removes an armor plate from"
+                    f" their {carrier.key}."
+                ),
+                char_refs={"actor": caller},
                 exclude=[caller],
             )
 
@@ -1560,9 +1569,13 @@ class CmdSlot(Command):
 
         # Location message
         if caller.location:
-            caller.location.msg_contents(
-                f"{caller.key} performs a tactical plate swap on"
-                f" their {old_carrier.key}.",
+            msg_room_identity(
+                location=caller.location,
+                template=(
+                    f"{{actor}} performs a tactical plate swap on"
+                    f" their {old_carrier.key}."
+                ),
+                char_refs={"actor": caller},
                 exclude=[caller],
             )
 
@@ -1805,7 +1818,11 @@ class CmdUnslot(Command):
             f" slot of your {carrier.key}."
         )
         if caller.location:
-            caller.location.msg_contents(
-                f"{caller.key} removes a plate from their {carrier.key}.",
+            msg_room_identity(
+                location=caller.location,
+                template=(
+                    f"{{actor}} removes a plate from their {carrier.key}."
+                ),
+                char_refs={"actor": caller},
                 exclude=[caller],
             )

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1531,7 +1531,7 @@ The helper and most rendering surfaces shipped in earlier work; a per-surface au
 | Φ | Scope | Files | Status |
 |---|---|---|---|
 | Φ₁ | Consumption verbs (inject / apply / bandage / eat / drink / inhale / smoke) | `commands/CmdConsumption.py` (14 sites) | ✅ Shipped |
-| Φ₂ | Armor put-on / take-off / repair | `commands/CmdArmor.py` (~7 sites) | 🟡 Pending |
+| Φ₂ | Armor put-on / take-off / repair | `commands/CmdArmor.py` (~7 sites) | ✅ Shipped |
 | Φ₃ | Movement + jump announcements | `commands/combat/movement.py` (~5), `commands/combat/jump.py` (~2) | 🟡 Pending |
 | Φ₄ | Capstone: throw, shop, spawnmob, explosives | `commands/CmdThrow.py`, `commands/shop.py`, `commands/CmdSpawnMob.py`, `commands/CmdExplosives.py`, `commands/explosion_utils.py`, `world/combat/explosives.py` (~11 sites) | 🟡 Pending |
 

--- a/world/tests/test_armor_rendering.py
+++ b/world/tests/test_armor_rendering.py
@@ -1,0 +1,300 @@
+"""
+Tests for Phase 2 per-observer rendering in CmdSlot / CmdUnslot.
+
+Verifies the plate install / remove / swap / unslot flows route their
+room broadcasts through :func:`msg_room_identity` so each observer sees
+the actor rendered according to their own recognition memory.
+
+Tool-degradation broadcasts in ``CmdArmorRepair`` are intentionally
+*not* converted: those strings reference only the tool's ``.key`` (no
+character) and add no value under per-observer rendering.
+
+Run via::
+
+    evennia test world.tests.test_armor_rendering
+
+Aligns with ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Phase 2 —
+Consistency" Conversion Status.
+"""
+
+from contextlib import ExitStack
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
+
+
+# ===================================================================
+# Mock builders
+# ===================================================================
+
+
+def _make_character(
+    *,
+    key,
+    sex="male",
+    height="tall",
+    build="lean",
+    sdesc_keyword="man",
+    sleeve_uid,
+    recognition_memory=None,
+):
+    from typeclasses.characters import Character
+
+    char = MagicMock(spec=Character)
+    char.key = key
+    char.sex = sex
+    char.height = height
+    char.build = build
+    char.sdesc_keyword = sdesc_keyword
+    char.hair_color = None
+    char.hair_style = None
+    char.sleeve_uid = sleeve_uid
+    char.recognition_memory = (
+        recognition_memory if recognition_memory is not None else {}
+    )
+    char.hands = {"left": None, "right": None}
+    char.worn_items = {}
+    char._build_clothing_coverage_map = lambda: {}
+
+    char.get_distinguishing_feature = (
+        lambda: Character.get_distinguishing_feature(char)
+    )
+    char.get_sdesc = lambda: Character.get_sdesc(char)
+    char.get_display_name = (
+        lambda looker=None, **kw: Character.get_display_name(
+            char, looker, **kw
+        )
+    )
+
+    sex_val = (sex or "ambiguous").lower().strip()
+    if sex_val in ("male", "man", "masculine", "m"):
+        type(char).gender = PropertyMock(return_value="male")
+    elif sex_val in ("female", "woman", "feminine", "f"):
+        type(char).gender = PropertyMock(return_value="female")
+    else:
+        type(char).gender = PropertyMock(return_value="neutral")
+
+    prepare_mock_for_apparent_uid(char)
+    return char
+
+
+def _make_room(contents):
+    room = MagicMock()
+    room.contents = contents
+    return room
+
+
+def _make_carrier(key="plate carrier", slots=("front", "back")):
+    carrier = MagicMock(spec=["key", "is_plate_carrier", "plate_slots",
+                              "installed_plates"])
+    carrier.key = key
+    carrier.is_plate_carrier = True
+    carrier.plate_slots = list(slots)
+    carrier.installed_plates = {}
+    return carrier
+
+
+def _make_plate(key="ceramic plate"):
+    plate = MagicMock(spec=["key", "aliases", "is_armor_plate", "move_to"])
+    plate.key = key
+    plate.is_armor_plate = True
+    plate.aliases = MagicMock()
+    plate.aliases.all = lambda: []
+    plate.move_to = MagicMock()
+    return plate
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+
+def _observer_text(observer):
+    if not observer.msg.call_args:
+        return ""
+    args = observer.msg.call_args
+    return args.kwargs.get("text") or (args.args[0] if args.args else "")
+
+
+# ===================================================================
+# Tests
+# ===================================================================
+
+
+class TestArmorPerObserverRendering(TestCase):
+    """CmdSlot / CmdUnslot broadcasts render per-observer."""
+
+    def setUp(self):
+        self.actor = _make_character(
+            key="Jorge Jackson",
+            sleeve_uid="uid-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        self.knower = _make_character(
+            key="Alice",
+            sex="female",
+            sleeve_uid="uid-alice",
+            recognition_memory={
+                apparent_uid_for(self.actor): {"assigned_name": "Jorge"},
+            },
+        )
+        self.stranger = _make_character(
+            key="Bob",
+            sleeve_uid="uid-bob",
+            recognition_memory={},
+        )
+
+        self.room = _make_room([self.actor, self.knower, self.stranger])
+        self.actor.location = self.room
+
+        self.carrier = _make_carrier(key="plate carrier")
+        self.plate = _make_plate(key="ceramic plate")
+
+    def _make_cmd(self, cls):
+        cmd = cls()
+        cmd.caller = self.actor
+        return cmd
+
+    # ---- install --------------------------------------------------
+
+    def test_install_plate_broadcast(self):
+        from commands.CmdArmor import CmdSlot
+
+        cmd = self._make_cmd(CmdSlot)
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(cmd, "_find_plate_by_name",
+                             return_value=self.plate)
+            )
+            stack.enter_context(
+                patch.object(cmd, "_find_carrier_by_name",
+                             return_value=self.carrier)
+            )
+            stack.enter_context(
+                patch(
+                    "commands.CmdArmor._calculate_total_carrier_rating",
+                    return_value=5,
+                )
+            )
+            cmd._install_plate(self.actor, "ceramic", "carrier", None)
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("plate carrier", ktext)
+        self.assertIn("installs", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+        self.assertIn("plate carrier", stext)
+
+    # ---- remove ---------------------------------------------------
+
+    def test_remove_plate_broadcast(self):
+        from commands.CmdArmor import CmdSlot
+
+        # Pre-install plate so _remove_plate can find it
+        self.carrier.installed_plates = {"front": self.plate}
+
+        cmd = self._make_cmd(CmdSlot)
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(cmd, "_find_carrier_by_name",
+                             return_value=self.carrier)
+            )
+            stack.enter_context(
+                patch(
+                    "commands.CmdArmor._calculate_total_carrier_rating",
+                    return_value=0,
+                )
+            )
+            cmd._remove_plate(self.actor, "ceramic", "carrier")
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("plate carrier", ktext)
+        self.assertIn("removes", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+
+    # ---- swap -----------------------------------------------------
+
+    def test_swap_plates_broadcast(self):
+        from commands.CmdArmor import CmdSlot
+
+        new_plate = _make_plate(key="steel plate")
+        self.carrier.installed_plates = {"front": self.plate}
+
+        cmd = self._make_cmd(CmdSlot)
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(
+                    cmd, "_find_installed_plate",
+                    return_value=(self.plate, self.carrier, "front"),
+                )
+            )
+            stack.enter_context(
+                patch.object(cmd, "_find_plate_by_name",
+                             return_value=new_plate)
+            )
+            stack.enter_context(
+                patch(
+                    "commands.CmdArmor._calculate_total_carrier_rating",
+                    return_value=5,
+                )
+            )
+            cmd._swap_plates(self.actor, "ceramic", "steel")
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("plate carrier", ktext)
+        self.assertIn("tactical plate swap", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+
+    # ---- unslot ---------------------------------------------------
+
+    def test_unslot_broadcast(self):
+        from commands.CmdArmor import CmdUnslot
+
+        cmd = self._make_cmd(CmdUnslot)
+        cmd._do_remove_plate(
+            self.actor, self.plate, self.carrier, "front"
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("plate carrier", ktext)
+        self.assertIn("removes", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+
+    # ---- caller exclusion ----------------------------------------
+
+    def test_actor_excluded_from_broadcast(self):
+        """Actor receives only first-person msgs, not the room broadcast."""
+        from commands.CmdArmor import CmdUnslot
+
+        cmd = self._make_cmd(CmdUnslot)
+        cmd._do_remove_plate(
+            self.actor, self.plate, self.carrier, "front"
+        )
+
+        actor_texts = [
+            (c.args[0] if c.args else c.kwargs.get("text", ""))
+            for c in self.actor.msg.call_args_list
+        ]
+        # Actor's first-person message uses "You remove"
+        self.assertTrue(
+            any("You remove" in t for t in actor_texts),
+            f"Actor missing first-person remove msg: {actor_texts}",
+        )
+        # Actor must NOT receive the third-person broadcast
+        self.assertFalse(
+            any("Jorge Jackson removes a plate" in t for t in actor_texts),
+            f"Actor unexpectedly received broadcast: {actor_texts}",
+        )


### PR DESCRIPTION
## Summary
- Converts the four character-naming `msg_contents()` sites in `commands/CmdArmor.py` — `_install_plate`, `_remove_plate`, `_swap_plates` (CmdSlot), `_do_remove_plate` (CmdUnslot) — to `msg_room_identity`.
- Adds `world/tests/test_armor_rendering.py` — 5 cases covering install / remove / swap / unslot broadcasts plus the actor-exclusion guard.
- Bumps `specs/IDENTITY_RECOGNITION_SPEC.md` §"Phase 2 — Consistency" Conversion Status row Φ₂ to ✅.

## Skipped (intentionally)
The three `repair_tool.location.msg_contents(...)` sites in `CmdArmorRepair._degrade_repair_tool` / `_damage_repair_tool` reference only the tool's `.key` (no character) and are deliberately left as raw broadcasts per the AGENTS.md Class B/C rule.

## Scope
Second of four PRs under #155 / #157:
- Φ₁ Consumption — ✅ (#156)
- **Φ₂ Armor** (this PR) — ✅
- Φ₃ Movement + Jump
- Φ₄ Misc capstone (throw, shop, spawnmob, explosives) — flips roadmap row back to ✅

## Tests
`docker exec gelatinous evennia test --settings settings.py world.tests` → 904 passed (was 899; +5 new).