### PR TITLE
Phase 2 Φ₃: per-observer rendering for movement flee broadcasts

### DIFF
--- a/commands/combat/movement.py
+++ b/commands/combat/movement.py
@@ -40,6 +40,7 @@ from world.combat.utils import (
     get_highest_opponent_stat, get_numeric_stat, filter_valid_opponents,
     standard_roll, clear_aim_state,
 )
+from world.identity_utils import msg_room_identity
 
 
 class CmdFlee(Command):
@@ -247,11 +248,20 @@ class CmdFlee(Command):
             
             # Messages
             caller.msg(f"|gYou successfully flee {chosen_exit.key} to {destination.key}!|n")
-            caller.location.msg_contents(f"|y{caller.get_display_name(caller.location)} has arrived, fleeing from an aimer.|n", exclude=[caller])
+            msg_room_identity(
+                location=caller.location,
+                template="|y{actor} has arrived, fleeing from an aimer.|n",
+                char_refs={"actor": caller},
+                exclude=[caller],
+            )
             
             # Message the room they left
             if hasattr(caller, 'previous_location') and caller.previous_location:
-                caller.previous_location.msg_contents(f"|y{caller.get_display_name(caller.previous_location)} flees {chosen_exit.key}!|n")
+                msg_room_identity(
+                    location=caller.previous_location,
+                    template=f"|y{{actor}} flees {chosen_exit.key}!|n",
+                    char_refs={"actor": caller},
+                )
             
             splattercast.msg(f"{DEBUG_PREFIX_FLEE}_SUCCESS: {caller.key} successfully fled after breaking aim via {chosen_exit.key} to {destination.key}.")
             return
@@ -301,9 +311,11 @@ class CmdFlee(Command):
                     caller.msg(f"|rYou try to flee but {blocking_opponent.get_display_name(caller) if blocking_opponent else 'your opponents'} block your escape!|n")
                     if blocking_opponent:
                         blocking_opponent.msg(f"|gYou successfully block {caller.get_display_name(blocking_opponent)}'s attempt to flee!|n")
-                    caller.location.msg_contents(
-                        f"|y{caller.get_display_name(caller.location)} tries to flee but is blocked by their opponents!|n",
-                        exclude=[caller] + opponents_targeting_caller
+                    msg_room_identity(
+                        location=caller.location,
+                        template="|y{actor} tries to flee but is blocked by their opponents!|n",
+                        char_refs={"actor": caller},
+                        exclude=[caller] + opponents_targeting_caller,
                     )
                     splattercast.msg(f"{DEBUG_PREFIX_FLEE}_DISENGAGE_FAIL: {caller.key} failed to disengage from combat.")
                     
@@ -364,11 +376,20 @@ class CmdFlee(Command):
             
             # Messages
             caller.msg(f"|gYou successfully flee {chosen_exit.key} to {destination.key}!|n")
-            caller.location.msg_contents(f"|y{caller.get_display_name(caller.location)} has arrived, fleeing from combat.|n", exclude=[caller])
+            msg_room_identity(
+                location=caller.location,
+                template="|y{actor} has arrived, fleeing from combat.|n",
+                char_refs={"actor": caller},
+                exclude=[caller],
+            )
             
             # Message the room they left
             if old_location and old_location != destination:
-                old_location.msg_contents(f"|y{caller.get_display_name(old_location)} flees {chosen_exit.key}!|n")
+                msg_room_identity(
+                    location=old_location,
+                    template=f"|y{{actor}} flees {chosen_exit.key}!|n",
+                    char_refs={"actor": caller},
+                )
             
             splattercast.msg(f"{DEBUG_PREFIX_FLEE}_SUCCESS: {caller.key} successfully fled via {chosen_exit.key} to {destination.key}.")
             

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1532,10 +1532,10 @@ The helper and most rendering surfaces shipped in earlier work; a per-surface au
 |---|---|---|---|
 | Φ₁ | Consumption verbs (inject / apply / bandage / eat / drink / inhale / smoke) | `commands/CmdConsumption.py` (14 sites) | ✅ Shipped |
 | Φ₂ | Armor put-on / take-off / repair | `commands/CmdArmor.py` (~7 sites) | ✅ Shipped |
-| Φ₃ | Movement + jump announcements | `commands/combat/movement.py` (~5), `commands/combat/jump.py` (~2) | 🟡 Pending |
+| Φ₃ | Movement flee announcements | `commands/combat/movement.py` (5 sites) | ✅ Shipped |
 | Φ₄ | Capstone: throw, shop, spawnmob, explosives | `commands/CmdThrow.py`, `commands/shop.py`, `commands/CmdSpawnMob.py`, `commands/CmdExplosives.py`, `commands/explosion_utils.py`, `world/combat/explosives.py` (~11 sites) | 🟡 Pending |
 
-Sites that broadcast **only** non-character text (item names, constant prose) are intentionally left as raw `msg_contents` since per-observer rendering adds no value. The roadmap row flips back to ✅ Shipped when Φ₄ lands.
+Sites that broadcast **only** non-character text (item names, constant prose) are intentionally left as raw `msg_contents` since per-observer rendering adds no value there. `commands/combat/jump.py` was audited during Φ₃ and its 3 `msg_contents` sites (sacrifice dud, false-heroics, gravity item-fall) are all item-only and remain raw under this rule. The roadmap row flips back to ✅ Shipped when Φ₄ lands.
 
 ### Phase 3 — Disguise (Foundation)
 

--- a/world/tests/test_movement_rendering.py
+++ b/world/tests/test_movement_rendering.py
@@ -1,0 +1,211 @@
+"""
+Tests for Phase 2 per-observer rendering in movement commands.
+
+Verifies CmdFlee's three broadcast templates (arrived-after-aimer-flee,
+arrived-after-combat-flee, flee-blocked-by-opponents, plus the
+left-room flee announcements) render per-observer correctly.
+
+Jump-related ``msg_contents`` sites are item-only (no character refs)
+and intentionally left as raw broadcasts.
+
+Run via::
+
+    evennia test world.tests.test_movement_rendering
+
+Aligns with ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Phase 2 —
+Consistency" Conversion Status.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock
+
+from world.identity_utils import msg_room_identity
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
+
+
+def _make_character(
+    *,
+    key,
+    sex="male",
+    height="tall",
+    build="lean",
+    sdesc_keyword="man",
+    sleeve_uid,
+    recognition_memory=None,
+):
+    from typeclasses.characters import Character
+
+    char = MagicMock(spec=Character)
+    char.key = key
+    char.sex = sex
+    char.height = height
+    char.build = build
+    char.sdesc_keyword = sdesc_keyword
+    char.hair_color = None
+    char.hair_style = None
+    char.sleeve_uid = sleeve_uid
+    char.recognition_memory = (
+        recognition_memory if recognition_memory is not None else {}
+    )
+    char.hands = {"left": None, "right": None}
+    char.worn_items = {}
+    char._build_clothing_coverage_map = lambda: {}
+
+    char.get_distinguishing_feature = (
+        lambda: Character.get_distinguishing_feature(char)
+    )
+    char.get_sdesc = lambda: Character.get_sdesc(char)
+    char.get_display_name = (
+        lambda looker=None, **kw: Character.get_display_name(
+            char, looker, **kw
+        )
+    )
+
+    sex_val = (sex or "ambiguous").lower().strip()
+    if sex_val in ("male", "man", "masculine", "m"):
+        type(char).gender = PropertyMock(return_value="male")
+    elif sex_val in ("female", "woman", "feminine", "f"):
+        type(char).gender = PropertyMock(return_value="female")
+    else:
+        type(char).gender = PropertyMock(return_value="neutral")
+
+    prepare_mock_for_apparent_uid(char)
+    return char
+
+
+def _make_room(contents):
+    room = MagicMock()
+    room.contents = contents
+    return room
+
+
+def _observer_text(observer):
+    if not observer.msg.call_args:
+        return ""
+    args = observer.msg.call_args
+    return args.kwargs.get("text") or (args.args[0] if args.args else "")
+
+
+class TestMovementPerObserverRendering(TestCase):
+    """CmdFlee broadcast templates render per-observer."""
+
+    def setUp(self):
+        self.fleer = _make_character(
+            key="Jorge Jackson",
+            sleeve_uid="uid-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        self.knower = _make_character(
+            key="Alice",
+            sex="female",
+            sleeve_uid="uid-alice",
+            recognition_memory={
+                apparent_uid_for(self.fleer): {"assigned_name": "Jorge"},
+            },
+        )
+        self.stranger = _make_character(
+            key="Bob",
+            sleeve_uid="uid-bob",
+            recognition_memory={},
+        )
+
+    # ---- arrived-after-flee (destination room) ------------------
+
+    def test_arrived_fleeing_aimer_broadcast(self):
+        """Destination room sees per-observer 'has arrived, fleeing from an aimer'."""
+        dest_room = _make_room([self.fleer, self.knower, self.stranger])
+
+        msg_room_identity(
+            location=dest_room,
+            template="|y{actor} has arrived, fleeing from an aimer.|n",
+            char_refs={"actor": self.fleer},
+            exclude=[self.fleer],
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("fleeing from an aimer", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+        self.assertIn("fleeing from an aimer", stext)
+        # Fleer themselves excluded
+        self.assertEqual(_observer_text(self.fleer), "")
+
+    def test_arrived_fleeing_combat_broadcast(self):
+        dest_room = _make_room([self.fleer, self.knower, self.stranger])
+
+        msg_room_identity(
+            location=dest_room,
+            template="|y{actor} has arrived, fleeing from combat.|n",
+            char_refs={"actor": self.fleer},
+            exclude=[self.fleer],
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("fleeing from combat", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+
+    # ---- left-room flee announcement -----------------------------
+
+    def test_flees_via_exit_broadcast(self):
+        """Origin room sees per-observer 'flees <exit>' after departure."""
+        # Fleer has already moved; not in origin room contents
+        origin_room = _make_room([self.knower, self.stranger])
+
+        msg_room_identity(
+            location=origin_room,
+            template="|y{actor} flees north!|n",
+            char_refs={"actor": self.fleer},
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("flees north", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+        self.assertIn("flees north", stext)
+
+    # ---- flee blocked --------------------------------------------
+
+    def test_flee_blocked_broadcast(self):
+        """Room sees per-observer 'tries to flee but is blocked'."""
+        # In this scenario the fleer is still in the room.
+        room = _make_room([self.fleer, self.knower, self.stranger])
+
+        msg_room_identity(
+            location=room,
+            template="|y{actor} tries to flee but is blocked by their opponents!|n",
+            char_refs={"actor": self.fleer},
+            exclude=[self.fleer],
+        )
+
+        ktext = _observer_text(self.knower)
+        self.assertIn("Jorge", ktext)
+        self.assertIn("tries to flee", ktext)
+        stext = _observer_text(self.stranger)
+        self.assertIn("gaunt man", stext)
+        self.assertIn("tries to flee", stext)
+
+    # ---- capitalization at sentence start ------------------------
+
+    def test_stranger_sdesc_capitalized_at_sentence_start(self):
+        """First placeholder must be capitalized for proper sentence casing."""
+        room = _make_room([self.fleer, self.stranger])
+
+        msg_room_identity(
+            location=room,
+            template="|y{actor} flees north!|n",
+            char_refs={"actor": self.fleer},
+            exclude=[self.fleer],
+        )
+
+        stext = _observer_text(self.stranger)
+        # Stranger sees "A gaunt man" (capitalized A), not "a gaunt man"
+        self.assertIn("A gaunt man", stext)


### PR DESCRIPTION
Closes #159.

## Summary
- Converts 5 character-naming `msg_contents` broadcasts in `commands/combat/movement.py` (CmdFlee arrival/departure/blocked messages) to `msg_room_identity`, so each observer sees the actor rendered via their own recognition memory instead of the raw `.key`.
- Audits `commands/combat/jump.py`: all 3 `msg_contents` sites are item-only (sacrifice dud, false-heroics, gravity item-fall) and remain raw under the AGENTS.md skip rule for item-only broadcasts.
- Adds `world/tests/test_movement_rendering.py` (5 cases).
- Updates `specs/IDENTITY_RECOGNITION_SPEC.md` Conversion Status table: Φ₃ row → ✅ Shipped; jump.py audit outcome noted inline.

## Sites converted (commands/combat/movement.py)
| Line | Context | Notes |
|------|---------|-------|
| 250 | Arrival-from-aimer announcement to new room | `location=new_room` |
| 254 | Flee-through-exit announcement to previous room | f-string for `exit.key` |
| 304 | Blocked-by-opponents announcement | `exclude=[caller] + opponents_targeting_caller` |
| 367 | Arrival-from-combat announcement to new room | `location=new_room` |
| 371 | Flee-through-exit announcement to old location | f-string for `exit.key` |

`CmdAdvance` / `CmdRetreat` / `CmdCharge` have no direct character-naming broadcasts (queued via combat handler) — nothing to convert.

## Tests
- `world/tests/test_movement_rendering.py`: 5 new cases (arrival-from-aimer, arrival-from-combat, flee-through-exit, blocked-by-opponents with exclude semantics, sentence-start capitalization).
- Full `world.tests` suite: **909 passing** (was 904).

## Spec / docs
- `specs/IDENTITY_RECOGNITION_SPEC.md` §"Phase 2 — Consistency" Conversion Status table: Φ₃ row → ✅ Shipped.
- Φ₄ (capstone: throw, shop, spawnmob, explosives, ~11 sites) remains the final PR before roadmap row 2 flips back to ✅.