### PR TITLE
Phase 2 Φ₅: per-observer move announcements

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1413,13 +1413,13 @@ The distinguishing feature is not stored — it is computed on access from worn 
 
 ## Impact on Existing Systems
 
-The table below tracks the original Phase 2 audit surface. Most rows have been resolved by the Phase 2 sweep (PRs #156, #158, #160, #162) and are kept here with ✅ markers for historical reference. The remaining 🟡 row is genuine future work.
+The table below tracks the original Phase 2 audit surface. All rows have been resolved by the Phase 2 sweep (PRs #156, #158, #160, #162, #166) and are kept here with ✅ markers for historical reference.
 
 | System | File(s) | Status | Notes |
 |---|---|---|---|
 | Combat message templates | `world/combat/messages/__init__.py` | ✅ | Module exposes `observer_template` + `char_refs` for `msg_room_identity`; legacy `observer_msg` retained for back-compat |
 | Shield messages | `world/combat/attack.py:232-268` | ✅ | First-person msgs use `get_display_name_safe(target, observer)`; observer broadcast at line 263 uses `msg_room_identity` with three char_refs |
-| Normal movement (Evennia defaults) | Evennia `announce_move_from/to` | 🟡 | Still use `.key`; no per-observer override written. Future work |
+| Normal movement (Evennia defaults) | `typeclasses/characters.py` (`Character.announce_move_from/to`) | ✅ | Per-observer override routes broadcasts through `msg_room_identity`; honors caller `msg=`/`mapping=` by delegating to `super()`. Phase 2 Φ₅, PR #166 |
 | Communication (say/whisper/emote) | `commands/CmdCommunication.py` | ✅ | Custom `CmdSay` / `CmdWhisper` / `CmdEmote` overrides ship per-observer rendering |
 | Death curtain filter | `typeclasses/characters.py:155-222` | n/a | Uses verb-substring matching (`' says, "'`, `' tells you'`, etc.) in `_is_social_message`, not `.key`. Intentional design; out of per-observer-rendering scope |
 | CmdAttack target resolution | `commands/combat/core_actions.py:118` | ✅ | Uses `resolve_character_target(...)` — recognition-aware |
@@ -1443,6 +1443,7 @@ Several systems route through `get_display_name(looker)` or `msg_room_identity` 
 - Consumption commands (`commands/CmdConsumption.py`) — Phase 2 Φ₁, PR #156
 - Armor commands (`commands/CmdArmor.py`) — Phase 2 Φ₂, PR #158
 - Spawnmob manifest, shop purchase, human-shield grenade — Phase 2 Φ₄, PR #162
+- Normal exit traversal announcements (`Character.announce_move_from/to` in `typeclasses/characters.py`) — Phase 2 Φ₅, PR #166
 - Medical commands (`commands/CmdMedical.py`)
 - Clothing commands (`commands/CmdClothing.py`)
 - Most inventory/interaction commands
@@ -1519,7 +1520,7 @@ Per-phase detail below.
 
 ### Phase 2 — Consistency
 
-**Status: ✅ Shipped (PRs #156, #158, #160, #162).** Helper plus per-surface conversion sweep complete; see Conversion Status table below.
+**Status: ✅ Shipped (PRs #156, #158, #160, #162, #166).** Helper plus per-surface conversion sweep complete; see Conversion Status table below.
 
 **Scope:** Patch all `.key` usage across the codebase.
 
@@ -1543,6 +1544,7 @@ The helper and most rendering surfaces shipped in earlier work; a per-surface au
 | Φ₂ | Armor put-on / take-off / repair | `commands/CmdArmor.py` (~7 sites) | ✅ Shipped |
 | Φ₃ | Movement flee announcements | `commands/combat/movement.py` (5 sites) | ✅ Shipped |
 | Φ₄ | Capstone: spawnmob, shop, human-shield grenade | `commands/CmdSpawnMob.py` (1 site), `commands/shop.py` (1 site), `world/combat/explosives.py` (1 site) | ✅ Shipped |
+| Φ₅ | Normal exit traversal announcements | `typeclasses/characters.py` (`announce_move_from/to` overrides) | ✅ Shipped |
 
 Sites that broadcast **only** non-character text (item names, constant prose) are intentionally left as raw `msg_contents` since per-observer rendering adds no value there. `commands/combat/jump.py` was audited during Φ₃ and its 3 `msg_contents` sites (sacrifice dud, false-heroics, gravity item-fall) are all item-only and remain raw under this rule. During Φ₄, the bulk of broadcasts in `commands/CmdThrow.py` (5 sites), `commands/CmdExplosives.py` (7 sites), and `commands/explosion_utils.py` (13 sites) were similarly audited and confirmed item-only (grenade/object names, prose, direction strings) — they remain raw. The 3 character-naming sites (spawnmob manifest, shop purchase, human-shield grenade) shipped in Φ₄ closing the sweep.
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1118,6 +1118,103 @@ class Character(
 
         return f"{name} ({with_article(sdesc)})"
 
+    def announce_move_from(
+        self, destination, msg=None, mapping=None, **kwargs
+    ):
+        """Broadcast our departure to the source room, per-observer.
+
+        Overrides Evennia's default, which interpolates the mover's
+        name in a way that effectively renders ``self.key`` for every
+        observer regardless of their recognition memory.  Routes the
+        broadcast through :func:`world.identity_utils.msg_room_identity`
+        so each observer sees the mover rendered according to their
+        own recognition memory (assigned name, sdesc, or distinguishing
+        feature as appropriate).
+
+        Honors caller-provided ``msg``/``mapping`` by delegating to
+        ``super()`` — this preserves any future customization a caller
+        might want to layer on top of the default announcement.
+
+        See ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Phase 2 —
+        Consistency" (Φ₅) for the broader sweep.
+
+        Args:
+            destination: Room the mover is heading to.
+            msg: Optional caller-provided message template; when set,
+                we delegate to ``super()`` to preserve customization.
+            mapping: Optional caller-provided template mapping; when
+                set, we delegate to ``super()`` for the same reason.
+            **kwargs: Forwarded to ``super()`` on the delegation path
+                (e.g. ``move_type``).
+        """
+        if msg is not None or mapping is not None:
+            return super().announce_move_from(
+                destination, msg=msg, mapping=mapping, **kwargs
+            )
+        if not self.location:
+            return
+        origin_name = (
+            self.location.get_display_name(self)
+            if self.location
+            else "somewhere"
+        )
+        dest_name = (
+            destination.get_display_name(self) if destination else "somewhere"
+        )
+        template = (
+            f"{{actor}} is leaving {origin_name}, heading for {dest_name}."
+        )
+        msg_room_identity(
+            self.location,
+            template,
+            {"actor": self},
+            exclude=[self],
+        )
+
+    def announce_move_to(
+        self, source_location, msg=None, mapping=None, **kwargs
+    ):
+        """Broadcast our arrival to the destination room, per-observer.
+
+        Overrides Evennia's default for the same reason as
+        :meth:`announce_move_from` — to ensure observers see the
+        mover rendered according to their own recognition memory.
+
+        See ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Phase 2 —
+        Consistency" (Φ₅) for the broader sweep.
+
+        Args:
+            source_location: Room the mover came from (may be ``None``
+                for fresh spawns / teleports without a prior location).
+            msg: Optional caller-provided message template; when set,
+                we delegate to ``super()`` to preserve customization.
+            mapping: Optional caller-provided template mapping; when
+                set, we delegate to ``super()`` for the same reason.
+            **kwargs: Forwarded to ``super()`` on the delegation path
+                (e.g. ``move_type``).
+        """
+        if msg is not None or mapping is not None:
+            return super().announce_move_to(
+                source_location, msg=msg, mapping=mapping, **kwargs
+            )
+        if not self.location:
+            return
+        origin_name = (
+            source_location.get_display_name(self)
+            if source_location
+            else "somewhere"
+        )
+        dest_name = self.location.get_display_name(self)
+        template = (
+            f"{{actor}} arrives to {dest_name} from {origin_name}."
+        )
+        msg_room_identity(
+            self.location,
+            template,
+            {"actor": self},
+            exclude=[self],
+        )
+
     def at_post_move(self, source_location, **kwargs):
         """Hook called after this character lands in a new location.
 

--- a/world/tests/test_movement_announcements.py
+++ b/world/tests/test_movement_announcements.py
@@ -1,0 +1,255 @@
+"""
+Tests for Phase 2 Φ₅ per-observer rendering of normal exit-traversal
+move announcements.
+
+Covers ``Character.announce_move_from`` and
+``Character.announce_move_to`` overrides on
+``typeclasses/characters.py``, which take over the default Evennia
+broadcast so that observers in source/destination rooms see the
+mover's name resolved through their own recognition memory.
+
+Run via::
+
+    evennia test world.tests.test_movement_announcements
+
+Aligns with ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Phase 2 —
+Consistency" (Φ₅) and §"Impact on Existing Systems".
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from world.tests._identity_helpers import (
+    apparent_uid_for,
+    prepare_mock_for_apparent_uid,
+)
+
+
+def _make_character(
+    *,
+    key,
+    sex="male",
+    height="tall",
+    build="lean",
+    sdesc_keyword="man",
+    sleeve_uid,
+    recognition_memory=None,
+):
+    from typeclasses.characters import Character
+
+    char = MagicMock(spec=Character)
+    char.key = key
+    char.sex = sex
+    char.height = height
+    char.build = build
+    char.sdesc_keyword = sdesc_keyword
+    char.hair_color = None
+    char.hair_style = None
+    char.sleeve_uid = sleeve_uid
+    char.recognition_memory = (
+        recognition_memory if recognition_memory is not None else {}
+    )
+    char.hands = {"left": None, "right": None}
+    char.worn_items = {}
+    char._build_clothing_coverage_map = lambda: {}
+
+    char.get_distinguishing_feature = (
+        lambda: Character.get_distinguishing_feature(char)
+    )
+    char.get_sdesc = lambda: Character.get_sdesc(char)
+    char.get_display_name = (
+        lambda looker=None, **kw: Character.get_display_name(
+            char, looker, **kw
+        )
+    )
+
+    sex_val = (sex or "ambiguous").lower().strip()
+    if sex_val in ("male", "man", "masculine", "m"):
+        type(char).gender = PropertyMock(return_value="male")
+    elif sex_val in ("female", "woman", "feminine", "f"):
+        type(char).gender = PropertyMock(return_value="female")
+    else:
+        type(char).gender = PropertyMock(return_value="neutral")
+
+    prepare_mock_for_apparent_uid(char)
+    return char
+
+
+def _make_room(contents, *, name="a room"):
+    room = MagicMock()
+    room.contents = contents
+    room.get_display_name = lambda looker=None, **kw: name
+    return room
+
+
+def _observer_text(observer):
+    if not observer.msg.call_args:
+        return ""
+    args = observer.msg.call_args
+    return args.kwargs.get("text") or (args.args[0] if args.args else "")
+
+
+class TestAnnounceMoveFromPerObserver(TestCase):
+    """``Character.announce_move_from`` renders the mover per-observer."""
+
+    def setUp(self):
+        self.mover = _make_character(
+            key="Jorge Jackson",
+            sleeve_uid="uid-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        self.knower = _make_character(
+            key="Alice",
+            sex="female",
+            sleeve_uid="uid-alice",
+            recognition_memory={
+                apparent_uid_for(self.mover): {"assigned_name": "Jorge"},
+            },
+        )
+        self.stranger = _make_character(
+            key="Bob",
+            sleeve_uid="uid-bob",
+            recognition_memory={},
+        )
+        self.origin = _make_room(
+            [self.mover, self.knower, self.stranger], name="the bar"
+        )
+        self.destination = _make_room([], name="the street")
+        self.mover.location = self.origin
+
+    def _call(self, **kwargs):
+        from typeclasses.characters import Character
+
+        return Character.announce_move_from(
+            self.mover, self.destination, **kwargs
+        )
+
+    def test_knower_sees_assigned_name(self):
+        self._call()
+        text = _observer_text(self.knower)
+        self.assertIn("Jorge", text)
+        self.assertIn("leaving the bar", text)
+        self.assertIn("heading for the street", text)
+
+    def test_stranger_sees_sdesc(self):
+        self._call()
+        text = _observer_text(self.stranger)
+        self.assertIn("gaunt man", text)
+        self.assertIn("leaving the bar", text)
+
+    def test_mover_is_excluded(self):
+        self._call()
+        self.assertEqual(_observer_text(self.mover), "")
+
+    def test_sdesc_capitalized_at_sentence_start(self):
+        """Stranger sees 'A gaunt man' not 'a gaunt man' at sentence start."""
+        # Drop knower so we only examine stranger output cleanly.
+        self.origin.contents = [self.mover, self.stranger]
+        self._call()
+        text = _observer_text(self.stranger)
+        self.assertIn("A gaunt man", text)
+
+    def test_caller_msg_delegates_to_super(self):
+        """When caller passes ``msg=``, we delegate to super() and skip our path."""
+        from typeclasses.characters import Character
+
+        with patch.object(
+            Character.__mro__[1], "announce_move_from", create=True
+        ) as mock_super:
+            Character.announce_move_from(
+                self.mover, self.destination, msg="custom"
+            )
+            mock_super.assert_called_once()
+        # Our broadcast should not have fired on any observer.
+        self.assertEqual(_observer_text(self.knower), "")
+        self.assertEqual(_observer_text(self.stranger), "")
+
+    def test_missing_location_short_circuits(self):
+        """No location → silent early-return; no exceptions, no broadcast."""
+        self.mover.location = None
+        # Should not raise.
+        self._call()
+
+
+class TestAnnounceMoveToPerObserver(TestCase):
+    """``Character.announce_move_to`` renders the mover per-observer."""
+
+    def setUp(self):
+        self.mover = _make_character(
+            key="Jorge Jackson",
+            sleeve_uid="uid-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        self.knower = _make_character(
+            key="Alice",
+            sex="female",
+            sleeve_uid="uid-alice",
+            recognition_memory={
+                apparent_uid_for(self.mover): {"assigned_name": "Jorge"},
+            },
+        )
+        self.stranger = _make_character(
+            key="Bob",
+            sleeve_uid="uid-bob",
+            recognition_memory={},
+        )
+        self.origin = _make_room([], name="the bar")
+        self.destination = _make_room(
+            [self.mover, self.knower, self.stranger], name="the street"
+        )
+        self.mover.location = self.destination
+
+    def _call(self, **kwargs):
+        from typeclasses.characters import Character
+
+        return Character.announce_move_to(
+            self.mover, self.origin, **kwargs
+        )
+
+    def test_knower_sees_assigned_name(self):
+        self._call()
+        text = _observer_text(self.knower)
+        self.assertIn("Jorge", text)
+        self.assertIn("arrives to the street", text)
+        self.assertIn("from the bar", text)
+
+    def test_stranger_sees_sdesc(self):
+        self._call()
+        text = _observer_text(self.stranger)
+        self.assertIn("gaunt man", text)
+        self.assertIn("arrives to the street", text)
+
+    def test_mover_is_excluded(self):
+        self._call()
+        self.assertEqual(_observer_text(self.mover), "")
+
+    def test_sdesc_capitalized_at_sentence_start(self):
+        self.destination.contents = [self.mover, self.stranger]
+        self._call()
+        text = _observer_text(self.stranger)
+        self.assertIn("A gaunt man", text)
+
+    def test_source_location_none_falls_back(self):
+        """When source_location is None (fresh spawn), use 'somewhere'."""
+        from typeclasses.characters import Character
+
+        Character.announce_move_to(self.mover, None)
+        text = _observer_text(self.knower)
+        self.assertIn("from somewhere", text)
+
+    def test_caller_mapping_delegates_to_super(self):
+        from typeclasses.characters import Character
+
+        with patch.object(
+            Character.__mro__[1], "announce_move_to", create=True
+        ) as mock_super:
+            Character.announce_move_to(
+                self.mover, self.origin, mapping={"actor": "x"}
+            )
+            mock_super.assert_called_once()
+        self.assertEqual(_observer_text(self.knower), "")
+        self.assertEqual(_observer_text(self.stranger), "")


### PR DESCRIPTION
Closes #165.

## Summary
- Override `Character.announce_move_from` / `announce_move_to` to route departure/arrival broadcasts through `msg_room_identity`, so each observer sees the mover rendered against **their own** recognition memory instead of Evennia's default `.key`.
- Honor caller-provided `msg=`/`mapping=` by delegating to `super()` — preserves customization.
- Mover excluded (they already get Evennia's first-person `"You move to..."`).
- New test module `world/tests/test_movement_announcements.py` (12 tests) covering knower/stranger rendering, mover exclusion, sentence-start capitalization, super() delegation, and edge cases.
- Spec: flips the last 🟡 row in §"Impact on Existing Systems" to ✅, adds Φ₅ row to Conversion Status, retitles intro, extends §"Systems Already Correct".

## Coverage Notes
- NPCs are `Character` subclasses → inherit the fix automatically.
- Items/corpses move with `quiet=True` → these hooks never fire for them.
- Exit drag flow already routed through `msg_room_identity` directly; grappler's own `announce_move_*` now inherits the per-observer rendering.

## Tests
- 12 new Φ₅ tests green.
- Full suite: **914 → 926 tests, all green.**

The Phase 2 per-observer rendering sweep is now fully closed.