### PR TITLE
Demote KeywordManager to ServerConfig-backed module data

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -36,20 +36,6 @@ from evennia.settings_default import *
 INSTALLED_APPS = INSTALLED_APPS + ["world"]  # type: ignore[name-defined]
 
 ######################################################################
-# Global Scripts
-######################################################################
-
-# Auto-managed singleton scripts.  Evennia recreates these if they
-# are deleted, preventing stale-reference tracebacks on reload.
-GLOBAL_SCRIPTS = {
-    "keyword_manager": {
-        "typeclass": "world.identity.KeywordManager",
-        "desc": "Manages approved sdesc keywords",
-        "persistent": True,
-    },
-}
-
-######################################################################
 # Security Middleware
 ######################################################################
 

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -635,7 +635,7 @@ Pronouns must follow the disguise. A character presenting as "a woman" should be
 
 **Derivation rule:**
 
-1. If the character has an active `keyword_override`, look the override up in the runtime keyword catalog (`KeywordManager` script's `db.feminine_keywords` / `db.masculine_keywords` / `db.neutral_keywords`, falling back to the `_DEFAULT_FEMININE_KEYWORDS` / `_DEFAULT_MASCULINE_KEYWORDS` / `_DEFAULT_NEUTRAL_KEYWORDS` frozensets in `world/identity.py` when the script is unavailable).
+1. If the character has an active `keyword_override`, look the override up in the runtime keyword catalog (`ServerConfig` entries under keys `identity.feminine_keywords` / `identity.masculine_keywords` / `identity.neutral_keywords`, falling back to the `_DEFAULT_FEMININE_KEYWORDS` / `_DEFAULT_MASCULINE_KEYWORDS` / `_DEFAULT_NEUTRAL_KEYWORDS` frozensets in `world/identity.py` when a key is unset).
    - Match in the feminine list → render as `she/her/hers`.
    - Match in the masculine list → render as `he/him/his`.
    - Match in the neutral list, **or no match anywhere** (e.g. a custom `@shortdesc` keyword such as `ronin` or `wraith`, which carries no gender metadata in `KeywordEvent`) → render as `they/them/theirs` (singular they).
@@ -1027,7 +1027,7 @@ The identity test suite mixes two patterns:
 - **Fast unit tests** (`world/tests/test_identity.py`, `test_identity_commands.py`, `test_unmasking.py`, `test_character_identity.py`, `test_corpse_identity.py`) use `unittest.TestCase` with fake observer/target/room objects defined per-module. Most pierce/unmasking/recognition logic is covered this way for speed and isolation. Shared schema helpers live in `world/tests/_identity_helpers.py` (notably `make_recognition_entry`, which keeps fake entries in sync with the production schema).
 - **End-to-end integration tests** (`world/tests/test_pierce_integration.py`, `test_unmasking_integration.py`) use `evennia.utils.test_resources.EvenniaTest` with real `Character` typeclasses, real `recognition_memory`, and real persistent attributes. These catch regressions that mock-based suites cannot — typeclass wiring, `AttributeProperty` round-trips, and hooks like `at_post_move` that depend on real Evennia object lifecycle.
 
-**`evennia test` uses the live development database.** Tests that touch the keyword catalog must patch `world.identity._get_keyword_manager` to return a deterministic stub; otherwise they pick up live `KeywordEvent` rows and become non-reproducible. The `attempt_disguise_pierce` path performs a local import of `world.combat.dice.opposed_roll` — patches must target `world.combat.dice.opposed_roll`, not `world.identity.opposed_roll`.
+**`evennia test` uses the live development database.** Tests that touch the keyword catalog must patch `world.identity.ServerConfig.objects.conf` to return a deterministic value (typically `None` to force the default-frozenset fallback); otherwise they pick up live `KeywordEvent` rows and become non-reproducible. The `attempt_disguise_pierce` path performs a local import of `world.combat.dice.opposed_roll` — patches must target `world.combat.dice.opposed_roll`, not `world.identity.opposed_roll`.
 
 Run a single module:
 
@@ -1559,7 +1559,7 @@ Sites that broadcast **only** non-character text (item names, constant prose) ar
   - `appear` (status), `appear taller | shorter`, `appear thinner | fatter | bulkier | leaner`, `appear <keyword>`, `appear <persona name>`
   - `stop appearing` (clears all overrides + active-persona pointer)
 - Sdesc descriptor recomposition via existing `get_physical_descriptor(height, build)` table — **shipped** (wired into `typeclasses/characters.py:get_sdesc`)
-- Pronoun derivation under disguise via `get_apparent_gender(char)` helper consulting `keyword_override` against `KeywordManager` gender lists — **shipped** (`world/identity.py:get_apparent_gender`; consumed in `world/emote.py`)
+- Pronoun derivation under disguise via `get_apparent_gender(char)` helper consulting `keyword_override` against the `ServerConfig`-backed gender lists — **shipped** (`world/identity.py:get_apparent_gender`; consumed in `world/emote.py`)
 - DB attributes for active overrides on character — **shipped**: `db.height_override`, `db.build_override`, `db.keyword_override`, `db.active_persona`, `db.personas`
 - `db.disguise_essential` flag on items — contributes to identity signature when worn — **shipped** (signature wiring in `world/identity.py:get_essential_item_type_ids`; concrete item prototypes ship in Phase 3.5)
 - `db.is_disguise_item` flag on items — Phase 5 perception bonus hook (defined but inert in Phase 3) — **shipped (flag schema only)**

--- a/world/identity.py
+++ b/world/identity.py
@@ -6,7 +6,8 @@ physical descriptor lookup, keyword validation, hair options, distinguishing
 feature formatting, and short description (sdesc) composition.
 
 This module has no Evennia dependencies in its core functions (except for
-:class:`KeywordManager`, which is an Evennia Script, and
+the runtime keyword list storage, which is backed by Evennia's
+:class:`~evennia.server.models.ServerConfig`, and
 :class:`~world.models.KeywordEvent`, a Django model).
 
 See specs/IDENTITY_RECOGNITION_SPEC.md for the full specification.
@@ -17,8 +18,7 @@ from __future__ import annotations
 import hashlib
 from typing import TYPE_CHECKING, Any
 
-from django.core.exceptions import ObjectDoesNotExist
-from evennia.scripts.scripts import DefaultScript
+from evennia.server.models import ServerConfig
 from evennia.utils import logger
 
 from world.grammar import GENDER_MAP, with_article
@@ -130,8 +130,9 @@ def get_physical_descriptor(height: str, build: str) -> str:
 # Keyword Lists
 # =========================================================================
 
-#: Default feminine keywords — seeds for the :class:`KeywordManager` script.
-#: At runtime, use :func:`get_feminine_keywords` instead.
+#: Default feminine keywords — seeds the ``identity.feminine_keywords``
+#: :class:`ServerConfig` entry on first mutation.  At runtime, use
+#: :func:`get_feminine_keywords` instead.
 _DEFAULT_FEMININE_KEYWORDS: frozenset[str] = frozenset({
     "female", "girl", "lass", "woman", "matron", "grandma", "hag", "granny",
     "madam", "tomboy", "chick", "gal", "chica", "vixen",
@@ -139,8 +140,9 @@ _DEFAULT_FEMININE_KEYWORDS: frozenset[str] = frozenset({
     "chola", "devotchka",
 })
 
-#: Default masculine keywords — seeds for the :class:`KeywordManager` script.
-#: At runtime, use :func:`get_masculine_keywords` instead.
+#: Default masculine keywords — seeds the ``identity.masculine_keywords``
+#: :class:`ServerConfig` entry on first mutation.  At runtime, use
+#: :func:`get_masculine_keywords` instead.
 _DEFAULT_MASCULINE_KEYWORDS: frozenset[str] = frozenset({
     "male", "boy", "lad", "man", "patron", "grandpa", "geezer", "gramps",
     "gentleman", "guy", "fellow", "dude", "playa",
@@ -148,8 +150,9 @@ _DEFAULT_MASCULINE_KEYWORDS: frozenset[str] = frozenset({
     "cholo", "droog",
 })
 
-#: Default neutral keywords — seeds for the :class:`KeywordManager` script.
-#: At runtime, use :func:`get_neutral_keywords` instead.
+#: Default neutral keywords — seeds the ``identity.neutral_keywords``
+#: :class:`ServerConfig` entry on first mutation.  At runtime, use
+#: :func:`get_neutral_keywords` instead.
 _DEFAULT_NEUTRAL_KEYWORDS: frozenset[str] = frozenset({
     "person", "kid", "urchin", "human", "citizen", "elder", "fossil",
     "fleshbag", "denizen", "neut", "snack", "walker", "chum",
@@ -243,125 +246,83 @@ def validate_custom_keyword(keyword: str) -> tuple[bool, str]:
 
 
 # =========================================================================
-# KeywordManager Script  (runtime keyword list storage)
+# Approved Keyword Storage  (backed by ServerConfig)
 # =========================================================================
 
-_KEYWORD_MANAGER_KEY = "keyword_manager"
+#: ServerConfig keys for the three runtime-mutable keyword lists.  Stored
+#: as picklable :class:`set` of lowercase strings.  When unset (fresh
+#: install, test environment), the getters fall back to the module-level
+#: ``_DEFAULT_*`` frozensets.
+_SERVERCONFIG_KEY_FEMININE = "identity.feminine_keywords"
+_SERVERCONFIG_KEY_MASCULINE = "identity.masculine_keywords"
+_SERVERCONFIG_KEY_NEUTRAL = "identity.neutral_keywords"
+
+_GENDER_LIST_TO_KEY: dict[str, str] = {
+    "feminine": _SERVERCONFIG_KEY_FEMININE,
+    "masculine": _SERVERCONFIG_KEY_MASCULINE,
+    "neutral": _SERVERCONFIG_KEY_NEUTRAL,
+}
 
 
-def _get_keyword_manager() -> "KeywordManager":
-    """Return the singleton :class:`KeywordManager` script.
+def _read_keyword_set(conf_key: str, default: frozenset[str]) -> frozenset[str]:
+    """Read a keyword set from :class:`ServerConfig`, falling back to default.
 
-    Looks up the script by key in the database.  Evennia's
-    ``GLOBAL_SCRIPTS`` registry (configured in
-    ``server/conf/settings.py``) guarantees the script exists at
-    server startup and recreates it if it is ever deleted.
+    Args:
+        conf_key: ServerConfig key (see ``_SERVERCONFIG_KEY_*``).
+        default: Frozenset returned when the key is unset.
 
     Returns:
-        The keyword manager script instance.
-
-    Raises:
-        ``ScriptDB.DoesNotExist``: If the script has not been created
-            yet (e.g. during unit tests that bypass server startup).
+        Frozenset of keyword strings.
     """
-    from evennia.scripts.models import ScriptDB
-
-    return ScriptDB.objects.get(db_key=_KEYWORD_MANAGER_KEY)
-
-
-class KeywordManager(DefaultScript):
-    """Global script that stores the approved keyword lists.
-
-    Managed by Evennia's ``GLOBAL_SCRIPTS`` registry (configured in
-    ``server/conf/settings.py``).  Access via :func:`_get_keyword_manager`.
-    Stores three mutable sets on ``db`` attributes:
-
-    * ``db.feminine_keywords`` — :class:`set` of feminine keywords
-    * ``db.masculine_keywords`` — :class:`set` of masculine keywords
-    * ``db.neutral_keywords`` — :class:`set` of neutral keywords
-
-    These are seeded from the module-level ``_DEFAULT_*`` frozensets on
-    first creation and may be modified at runtime via
-    :func:`add_approved_keyword` / :func:`remove_approved_keyword`.
-    """
-
-    def at_script_creation(self) -> None:
-        self.key = _KEYWORD_MANAGER_KEY
-        self.persistent = True
-        self.db.feminine_keywords = set(_DEFAULT_FEMININE_KEYWORDS)  # type: ignore[attr-defined]
-        self.db.masculine_keywords = set(_DEFAULT_MASCULINE_KEYWORDS)  # type: ignore[attr-defined]
-        self.db.neutral_keywords = set(_DEFAULT_NEUTRAL_KEYWORDS)  # type: ignore[attr-defined]
+    stored = ServerConfig.objects.conf(conf_key)
+    if stored is None:
+        return default
+    return frozenset(stored)
 
 
 # =========================================================================
-# Keyword Getters  (read from KeywordManager, fall back to defaults)
+# Keyword Getters  (read from ServerConfig, fall back to defaults)
 # =========================================================================
 
 
 def get_feminine_keywords() -> frozenset[str]:
     """Return the current set of approved feminine keywords.
 
-    Reads from the :class:`KeywordManager` script via
-    ``GLOBAL_SCRIPTS``.  Falls back to
-    :data:`_DEFAULT_FEMININE_KEYWORDS` during tests or early startup.
+    Reads from :class:`~evennia.server.models.ServerConfig` under key
+    ``identity.feminine_keywords``.  Falls back to
+    :data:`_DEFAULT_FEMININE_KEYWORDS` when the key is unset (fresh
+    install or test environment).
 
     Returns:
         Frozenset of feminine keyword strings.
     """
-    try:
-        mgr = _get_keyword_manager()
-        kws: set[str] | None = mgr.db.feminine_keywords
-        if kws is not None:
-            return frozenset(kws)
-    except ObjectDoesNotExist:
-        pass
-    except Exception:
-        logger.log_trace("Unexpected error reading KeywordManager")
-    return _DEFAULT_FEMININE_KEYWORDS
+    return _read_keyword_set(_SERVERCONFIG_KEY_FEMININE, _DEFAULT_FEMININE_KEYWORDS)
 
 
 def get_masculine_keywords() -> frozenset[str]:
     """Return the current set of approved masculine keywords.
 
-    Reads from the :class:`KeywordManager` script via
-    ``GLOBAL_SCRIPTS``.  Falls back to
-    :data:`_DEFAULT_MASCULINE_KEYWORDS` during tests or early startup.
+    Reads from :class:`~evennia.server.models.ServerConfig` under key
+    ``identity.masculine_keywords``.  Falls back to
+    :data:`_DEFAULT_MASCULINE_KEYWORDS` when the key is unset.
 
     Returns:
         Frozenset of masculine keyword strings.
     """
-    try:
-        mgr = _get_keyword_manager()
-        kws: set[str] | None = mgr.db.masculine_keywords
-        if kws is not None:
-            return frozenset(kws)
-    except ObjectDoesNotExist:
-        pass
-    except Exception:
-        logger.log_trace("Unexpected error reading KeywordManager")
-    return _DEFAULT_MASCULINE_KEYWORDS
+    return _read_keyword_set(_SERVERCONFIG_KEY_MASCULINE, _DEFAULT_MASCULINE_KEYWORDS)
 
 
 def get_neutral_keywords() -> frozenset[str]:
     """Return the current set of approved neutral keywords.
 
-    Reads from the :class:`KeywordManager` script via
-    ``GLOBAL_SCRIPTS``.  Falls back to
-    :data:`_DEFAULT_NEUTRAL_KEYWORDS` during tests or early startup.
+    Reads from :class:`~evennia.server.models.ServerConfig` under key
+    ``identity.neutral_keywords``.  Falls back to
+    :data:`_DEFAULT_NEUTRAL_KEYWORDS` when the key is unset.
 
     Returns:
         Frozenset of neutral keyword strings.
     """
-    try:
-        mgr = _get_keyword_manager()
-        kws: set[str] | None = mgr.db.neutral_keywords
-        if kws is not None:
-            return frozenset(kws)
-    except ObjectDoesNotExist:
-        pass
-    except Exception:
-        logger.log_trace("Unexpected error reading KeywordManager")
-    return _DEFAULT_NEUTRAL_KEYWORDS
+    return _read_keyword_set(_SERVERCONFIG_KEY_NEUTRAL, _DEFAULT_NEUTRAL_KEYWORDS)
 
 
 def get_all_keywords() -> frozenset[str]:
@@ -409,6 +370,26 @@ def log_custom_keyword(
     )
 
 
+def _load_gender_keyword_set(gender_list: str) -> set[str]:
+    """Return a fresh mutable :class:`set` of the current keywords for *gender_list*.
+
+    Reads the live :class:`~evennia.server.models.ServerConfig` value, or
+    seeds from the module-level defaults when unset.  The returned set is
+    a fresh copy — mutating it does not affect storage until written back
+    via ``ServerConfig.objects.conf(key, new_set)``.
+    """
+    defaults = {
+        "feminine": _DEFAULT_FEMININE_KEYWORDS,
+        "masculine": _DEFAULT_MASCULINE_KEYWORDS,
+        "neutral": _DEFAULT_NEUTRAL_KEYWORDS,
+    }[gender_list]
+    conf_key = _GENDER_LIST_TO_KEY[gender_list]
+    stored = ServerConfig.objects.conf(conf_key)
+    if stored is None:
+        return set(defaults)
+    return set(stored)
+
+
 def add_approved_keyword(
     keyword: str,
     gender_list: str,
@@ -417,8 +398,8 @@ def add_approved_keyword(
     """Add a keyword to an approved gender list.
 
     Creates a :class:`~world.models.KeywordEvent` with event type
-    ``admin_add`` and adds the keyword to the :class:`KeywordManager`
-    script's set for the given gender list.
+    ``admin_add`` and persists the updated keyword set via
+    :class:`~evennia.server.models.ServerConfig`.
 
     Args:
         keyword: Keyword to add (lowercase).
@@ -429,24 +410,15 @@ def add_approved_keyword(
     Returns:
         ``(True, "")`` on success, or ``(False, reason)`` on failure.
     """
-    attr_map = {
-        "feminine": "feminine_keywords",
-        "masculine": "masculine_keywords",
-        "neutral": "neutral_keywords",
-    }
-    attr_name = attr_map.get(gender_list)
-    if attr_name is None:
+    if gender_list not in _GENDER_LIST_TO_KEY:
         return False, f"Invalid gender list {gender_list!r}."
 
-    mgr = _get_keyword_manager()
-    kw_set: set[str] | None = getattr(mgr.db, attr_name)
-    if kw_set is None:
-        kw_set = set()
+    kw_set = _load_gender_keyword_set(gender_list)
     if keyword in kw_set:
         return False, f"'{keyword}' is already in the {gender_list} list."
 
     kw_set.add(keyword)
-    setattr(mgr.db, attr_name, kw_set)
+    ServerConfig.objects.conf(_GENDER_LIST_TO_KEY[gender_list], kw_set)
 
     from world.models import KeywordEvent
 
@@ -467,8 +439,8 @@ def remove_approved_keyword(
     """Remove a keyword from an approved gender list.
 
     Creates a :class:`~world.models.KeywordEvent` with event type
-    ``admin_remove`` and removes the keyword from the
-    :class:`KeywordManager` script's set for the given gender list.
+    ``admin_remove`` and persists the updated keyword set via
+    :class:`~evennia.server.models.ServerConfig`.
 
     Args:
         keyword: Keyword to remove (lowercase).
@@ -479,22 +451,15 @@ def remove_approved_keyword(
     Returns:
         ``(True, "")`` on success, or ``(False, reason)`` on failure.
     """
-    attr_map = {
-        "feminine": "feminine_keywords",
-        "masculine": "masculine_keywords",
-        "neutral": "neutral_keywords",
-    }
-    attr_name = attr_map.get(gender_list)
-    if attr_name is None:
+    if gender_list not in _GENDER_LIST_TO_KEY:
         return False, f"Invalid gender list {gender_list!r}."
 
-    mgr = _get_keyword_manager()
-    kw_set: set[str] | None = getattr(mgr.db, attr_name)
-    if kw_set is None or keyword not in kw_set:
+    kw_set = _load_gender_keyword_set(gender_list)
+    if keyword not in kw_set:
         return False, f"'{keyword}' is not in the {gender_list} list."
 
     kw_set.discard(keyword)
-    setattr(mgr.db, attr_name, kw_set)
+    ServerConfig.objects.conf(_GENDER_LIST_TO_KEY[gender_list], kw_set)
 
     from world.models import KeywordEvent
 
@@ -973,7 +938,7 @@ def get_apparent_gender(char: Any) -> str:
     Derivation rule:
 
     1. If the character has an active ``keyword_override``, look it up
-       in the runtime keyword catalog (KeywordManager script, falling
+       in the runtime keyword catalog (``ServerConfig`` entries, falling
        back to the module-level default frozensets).
 
        * Match in the feminine list → ``"female"``

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -12,8 +12,6 @@ All test cases match the specification in
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from django.core.exceptions import ObjectDoesNotExist
-
 from world.identity import (
     BUILDS,
     HAIR_COLORS,
@@ -249,17 +247,17 @@ class TestKeywordLists(TestCase):
 class TestGetValidKeywords(TestCase):
     """Tests for ``get_valid_keywords`` and ``is_valid_keyword``.
 
-    The getter functions read from the live ``KeywordManager`` script
-    when one exists.  We patch ``_get_keyword_manager`` to raise
-    ``ObjectDoesNotExist`` (the expected missing-script path) so the
-    getters fall back to code-level ``_DEFAULT_*`` frozensets, keeping
-    these routing tests independent of live DB state.
+    The getter functions read from :class:`ServerConfig` when set.  We
+    patch ``ServerConfig.objects.conf`` to return ``None`` (the
+    unset-key path) so the getters fall back to code-level
+    ``_DEFAULT_*`` frozensets, keeping these routing tests independent
+    of live DB state.
     """
 
     def setUp(self) -> None:
         patcher = patch(
-            "world.identity._get_keyword_manager",
-            side_effect=ObjectDoesNotExist,
+            "world.identity.ServerConfig.objects.conf",
+            return_value=None,
         )
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -321,130 +319,100 @@ class TestGetValidKeywords(TestCase):
 
 
 class TestKeywordGetterFallback(TestCase):
-    """Verify that keyword getters handle all script states correctly.
+    """Verify that keyword getters handle all ``ServerConfig`` states.
 
-    Each getter has three code paths:
+    Each getter has two code paths:
 
-    1. Script exists and has keywords → return the script's data.
-    2. ``ObjectDoesNotExist`` → silent fallback to ``_DEFAULT_*``.
-    3. Unexpected error → ``log_trace`` + fallback to ``_DEFAULT_*``.
-
-    A fourth edge case (script exists but ``db`` attribute is ``None``)
-    also falls back to defaults without logging.
+    1. Key is set in :class:`ServerConfig` → return the stored data
+       (coerced to ``frozenset``).
+    2. Key is unset (``ServerConfig.objects.conf`` returns ``None``) →
+       fall back to the module-level ``_DEFAULT_*`` frozenset.
     """
 
-    # -- Happy path: script provides keywords --------------------------
+    # -- Happy path: ServerConfig provides keywords --------------------
 
-    def test_feminine_returns_script_keywords(self) -> None:
-        mock_mgr = MagicMock()
-        mock_mgr.db.feminine_keywords = {"queen", "duchess"}
-        with patch("world.identity._get_keyword_manager", return_value=mock_mgr):
+    def test_feminine_returns_serverconfig_keywords(self) -> None:
+        with patch(
+            "world.identity.ServerConfig.objects.conf",
+            return_value={"queen", "duchess"},
+        ):
             result = get_feminine_keywords()
         self.assertEqual(result, frozenset({"queen", "duchess"}))
 
-    def test_masculine_returns_script_keywords(self) -> None:
-        mock_mgr = MagicMock()
-        mock_mgr.db.masculine_keywords = {"king", "duke"}
-        with patch("world.identity._get_keyword_manager", return_value=mock_mgr):
+    def test_masculine_returns_serverconfig_keywords(self) -> None:
+        with patch(
+            "world.identity.ServerConfig.objects.conf",
+            return_value={"king", "duke"},
+        ):
             result = get_masculine_keywords()
         self.assertEqual(result, frozenset({"king", "duke"}))
 
-    def test_neutral_returns_script_keywords(self) -> None:
-        mock_mgr = MagicMock()
-        mock_mgr.db.neutral_keywords = {"citizen", "clone"}
-        with patch("world.identity._get_keyword_manager", return_value=mock_mgr):
+    def test_neutral_returns_serverconfig_keywords(self) -> None:
+        with patch(
+            "world.identity.ServerConfig.objects.conf",
+            return_value={"citizen", "clone"},
+        ):
             result = get_neutral_keywords()
         self.assertEqual(result, frozenset({"citizen", "clone"}))
 
-    # -- Missing script: silent fallback to defaults -------------------
+    # -- Unset key: fallback to defaults -------------------------------
 
-    def test_feminine_falls_back_when_script_missing(self) -> None:
+    def test_feminine_falls_back_when_unset(self) -> None:
         with patch(
-            "world.identity._get_keyword_manager",
-            side_effect=ObjectDoesNotExist,
+            "world.identity.ServerConfig.objects.conf",
+            return_value=None,
         ):
             self.assertEqual(get_feminine_keywords(), _DEFAULT_FEMININE_KEYWORDS)
 
-    def test_masculine_falls_back_when_script_missing(self) -> None:
+    def test_masculine_falls_back_when_unset(self) -> None:
         with patch(
-            "world.identity._get_keyword_manager",
-            side_effect=ObjectDoesNotExist,
+            "world.identity.ServerConfig.objects.conf",
+            return_value=None,
         ):
             self.assertEqual(get_masculine_keywords(), _DEFAULT_MASCULINE_KEYWORDS)
 
-    def test_neutral_falls_back_when_script_missing(self) -> None:
+    def test_neutral_falls_back_when_unset(self) -> None:
         with patch(
-            "world.identity._get_keyword_manager",
-            side_effect=ObjectDoesNotExist,
+            "world.identity.ServerConfig.objects.conf",
+            return_value=None,
         ):
             self.assertEqual(get_neutral_keywords(), _DEFAULT_NEUTRAL_KEYWORDS)
 
-    # -- Unexpected error: log + fallback ------------------------------
+    # -- Per-key routing: only the right key is read -------------------
 
-    def test_feminine_logs_and_falls_back_on_unexpected_error(self) -> None:
-        with (
-            patch(
-                "world.identity._get_keyword_manager",
-                side_effect=RuntimeError("connection lost"),
-            ),
-            patch("world.identity.logger") as mock_logger,
+    def test_getters_pass_distinct_serverconfig_keys(self) -> None:
+        """Each getter must query its own gender-specific key."""
+        captured: list[str] = []
+
+        def fake_conf(key, *args, **kwargs):
+            captured.append(key)
+            return None
+
+        with patch(
+            "world.identity.ServerConfig.objects.conf",
+            side_effect=fake_conf,
         ):
-            result = get_feminine_keywords()
-        self.assertEqual(result, _DEFAULT_FEMININE_KEYWORDS)
-        mock_logger.log_trace.assert_called_once()
+            get_feminine_keywords()
+            get_masculine_keywords()
+            get_neutral_keywords()
 
-    def test_masculine_logs_and_falls_back_on_unexpected_error(self) -> None:
+        self.assertEqual(
+            captured,
+            [
+                "identity.feminine_keywords",
+                "identity.masculine_keywords",
+                "identity.neutral_keywords",
+            ],
+        )
+
+    # -- Unset path does NOT log ---------------------------------------
+
+    def test_unset_path_does_not_log(self) -> None:
+        """The unset path is the normal fresh-install state and silent."""
         with (
             patch(
-                "world.identity._get_keyword_manager",
-                side_effect=RuntimeError("connection lost"),
-            ),
-            patch("world.identity.logger") as mock_logger,
-        ):
-            result = get_masculine_keywords()
-        self.assertEqual(result, _DEFAULT_MASCULINE_KEYWORDS)
-        mock_logger.log_trace.assert_called_once()
-
-    def test_neutral_logs_and_falls_back_on_unexpected_error(self) -> None:
-        with (
-            patch(
-                "world.identity._get_keyword_manager",
-                side_effect=RuntimeError("connection lost"),
-            ),
-            patch("world.identity.logger") as mock_logger,
-        ):
-            result = get_neutral_keywords()
-        self.assertEqual(result, _DEFAULT_NEUTRAL_KEYWORDS)
-        mock_logger.log_trace.assert_called_once()
-
-    # -- None attribute: fallback without logging ----------------------
-
-    def test_feminine_falls_back_when_attribute_is_none(self) -> None:
-        mock_mgr = MagicMock()
-        mock_mgr.db.feminine_keywords = None
-        with patch("world.identity._get_keyword_manager", return_value=mock_mgr):
-            self.assertEqual(get_feminine_keywords(), _DEFAULT_FEMININE_KEYWORDS)
-
-    def test_masculine_falls_back_when_attribute_is_none(self) -> None:
-        mock_mgr = MagicMock()
-        mock_mgr.db.masculine_keywords = None
-        with patch("world.identity._get_keyword_manager", return_value=mock_mgr):
-            self.assertEqual(get_masculine_keywords(), _DEFAULT_MASCULINE_KEYWORDS)
-
-    def test_neutral_falls_back_when_attribute_is_none(self) -> None:
-        mock_mgr = MagicMock()
-        mock_mgr.db.neutral_keywords = None
-        with patch("world.identity._get_keyword_manager", return_value=mock_mgr):
-            self.assertEqual(get_neutral_keywords(), _DEFAULT_NEUTRAL_KEYWORDS)
-
-    # -- Missing-script path does NOT log ------------------------------
-
-    def test_missing_script_does_not_log(self) -> None:
-        """ObjectDoesNotExist is expected — should not produce a log entry."""
-        with (
-            patch(
-                "world.identity._get_keyword_manager",
-                side_effect=ObjectDoesNotExist,
+                "world.identity.ServerConfig.objects.conf",
+                return_value=None,
             ),
             patch("world.identity.logger") as mock_logger,
         ):


### PR DESCRIPTION
## Summary
- Replaces the `KeywordManager` `DefaultScript` with `evennia.server.models.ServerConfig` as the runtime store for the three approved-keyword sets, retaining every feature (live `@keywords add/remove/list/summary`, `KeywordEvent` audit log, disguise gender gating, full-catalog bypass, persona uniqueness, custom-keyword introduction).
- Eliminates the three-layer fallback gymnastics in the getters: `ServerConfig.objects.conf(key)` returns `None` for unset keys, which the helpers cleanly translate into the `_DEFAULT_*` frozenset. The `try/except ObjectDoesNotExist` plus broad `except Exception` (an AGENTS.md violation) and the `setattr/getattr` on `mgr.db` (another AGENTS.md violation) are all gone.
- Drops `GLOBAL_SCRIPTS['keyword_manager']` from `server/conf/settings.py`; rewrites 16 script-flavored fallback tests as 8 ServerConfig-targeted tests covering the two remaining code paths plus per-getter key routing; refreshes spec L638, L1030, L1562.

## Test Plan
- `docker exec gelatinous evennia test --settings settings.py world.tests.test_identity world.tests.test_identity_commands` → 299 OK.
- `docker exec gelatinous evennia test --settings settings.py world commands typeclasses` → 921 OK.

## Post-Deploy
- The orphan `keyword_manager` script will linger in the live DB; remove it manually with `@scripts/delete keyword_manager` after `evennia reload`.

Closes #167.