### PR TITLE
Reconcile chargen spec with shipped deferred-keyword design

### DIFF
--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -21,7 +21,6 @@ from world.identity import (
     BUILDS,
     HAIR_COLORS,
     HAIR_STYLES,
-    get_valid_keywords,
 )
 
 

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1452,16 +1452,28 @@ Several systems route through `get_display_name(looker)` or `msg_room_identity` 
 
 ## Character Creation Updates
 
-Character creation (both in-game `create` and web-based) must be updated to include identity attribute selection:
+Character creation (both in-game `create` and web-based) includes a
+short identity-attribute selection block between sex selection and
+G.R.I.M. distribution:
 
-### New Chargen Steps
+### Chargen Identity Steps
 
 1. **Height selection** — short, below-average, average, above-average, tall
 2. **Build selection** — slight, lean, athletic, average, stocky, heavyset
 3. **Hair color selection** — from approved list, or bald/none
 4. **Hair style selection** — from approved list (contextual based on color choice), or bald/none
-5. **Keyword selection** — gender-gated list from the keyword table
-6. **Preview** — Show the assembled sdesc: `"You will appear as 'a lanky man with red dreadlocks' to strangers."`
+5. **Preview** — confirmation screen showing the assembled sdesc, e.g. `"You will appear as 'a lanky man with red dreadlocks' to strangers."`
+
+**Sdesc keyword is _not_ chosen during chargen.** New characters get a
+gender-appropriate default (`DEFAULT_SDESC_KEYWORDS[gender]` —
+`"man"` / `"woman"` / `"person"`) via the lazy fallback in
+`Character.get_sdesc()` (`typeclasses/characters.py`). Players
+customize their keyword at any time post-chargen via the
+`@shortdesc` command, which presents the gender-gated approved list
+and accepts custom alpha-only keywords (logged as
+`KeywordEvent(event_type="custom_set")`). This keeps the chargen
+flow short and defers a writing decision until the player has
+context for what a keyword is.
 
 ### Sleeve UID Assignment
 


### PR DESCRIPTION
## Summary
- `specs/IDENTITY_RECOGNITION_SPEC.md` §New Chargen Steps documented a 6-step flow with step 5 = "Keyword selection — gender-gated list from the keyword table". Shipped reality (Phase 1c, commit `88e7c56`) is a deliberate 4-identity-step flow (height, build, hair color, hair style); sdesc keyword is intentionally deferred to post-chargen `@shortdesc`, with `DEFAULT_SDESC_KEYWORDS[gender]` supplied lazily by `Character.get_sdesc()`.
- Rewrites the spec section to describe the actual flow + the lazy-default + `@shortdesc` post-chargen path.
- Drops the dead `get_valid_keywords` import at `commands/charcreate.py:24` — imported but never called, a leftover from the original Phase 1c design before the deferred-keyword decision.

## Test Plan
- `docker exec gelatinous evennia test --settings settings.py world commands typeclasses` → 921 OK.

Closes #169.