### PR TITLE
Add 'contacts' to pluralia-tantum noun set

### DIFF
--- a/world/grammar.py
+++ b/world/grammar.py
@@ -132,7 +132,7 @@ _PLURALIA_TANTUM_NOUNS: frozenset[str] = frozenset({
     "slippers", "heels", "loafers", "moccasins", "mittens",
     # eyewear
     "glasses", "goggles", "spectacles", "binoculars",
-    "sunglasses", "shades",
+    "sunglasses", "shades", "contacts",
     # tools
     "scissors", "pliers", "tweezers", "tongs", "shears", "clippers",
     # other

--- a/world/tests/test_grammar.py
+++ b/world/tests/test_grammar.py
@@ -192,6 +192,11 @@ class TestIsPluraliaTantum(TestCase):
     def test_pluralia_tantum_scissors(self) -> None:
         self.assertTrue(is_pluralia_tantum("scissors"))
 
+    def test_pluralia_tantum_contacts(self) -> None:
+        """Contact lenses idiomatically take no indefinite article."""
+        self.assertTrue(is_pluralia_tantum("contacts"))
+        self.assertTrue(is_pluralia_tantum("colored contacts"))
+
     def test_not_pluralia_tantum_trenchcoat(self) -> None:
         self.assertFalse(is_pluralia_tantum("Black Trenchcoat"))
 


### PR DESCRIPTION
## Summary
- Adds `\"contacts\"` to the eyewear group in `_PLURALIA_TANTUM_NOUNS` (`world/grammar.py`).
- Adds `test_pluralia_tantum_contacts` covering both bare and adjective-prefixed forms.

## Why
`COLORED_CONTACTS.worn_sdesc_short = \"colored contacts\"` rendered as `\"in a colored contacts\"` in the distinguishing-feature line. Other eyewear (sunglasses, shades, mirrorshades, aviator sunglasses) already render bare via the existing pluralia-tantum handling — contacts were the only outlier.

## Tests
- `evennia test world.tests.test_grammar` → 109/109 OK
- Full suite → 922/922 OK

Closes #172.