### PR TITLE
Add Forensic Recognition Engine (PR-E) (#184)

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -38,6 +38,7 @@ from commands.CmdGraffiti import CmdGraffiti, CmdPress
 from commands.CmdCharacter import CmdLongdesc, CmdSkintone
 from commands.CmdCharacter import CmdShortdesc, CmdRemember, CmdForget, CmdRecall, CmdMemory
 from commands.CmdCommunication import CmdSay, CmdWhisper, CmdEmote, CmdDotPose
+from commands.forensics import CmdAutopsy
 from world.emote_templates import SOCIAL_COMMANDS
 from commands.CmdArmor import CmdArmor, CmdArmorRepair, CmdSlot, CmdUnslot
 from commands.shop import CmdBuy
@@ -243,6 +244,9 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         
         # Add shop commands
         self.add(CmdBuy())
+
+        # Add forensic command surfaces (PR-E)
+        self.add(CmdAutopsy())
 
 class AccountCmdSet(default_cmds.AccountCmdSet):
     """

--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -1,0 +1,127 @@
+"""Forensic command surfaces (PR-E).
+
+Player-facing commands that route through
+:mod:`world.forensics`'s canonical engine.
+
+Currently ships:
+
+* :class:`CmdAutopsy` — examine a corpse to recover signature axes
+  via an Intellect roll.  Two-tier (basic + ``/deep``) per the
+  PR-E scope lock.
+"""
+
+from __future__ import annotations
+
+from evennia import Command
+
+from typeclasses.corpse import Corpse
+from world.combat.constants import AUTOPSY_DC_BASIC, AUTOPSY_DC_DEEP_OFFSET
+from world.forensics import (
+    attempt_forensic_recognition,
+    extract_subject_from_corpse,
+    render_forensic_report,
+)
+from world.identity_utils import msg_room_identity
+
+
+class CmdAutopsy(Command):
+    """Forensic examination of a corpse.
+
+    Usage:
+      autopsy <corpse>
+      autopsy/deep <corpse>
+
+    Rolls Intellect vs a DC determined by ``AUTOPSY_DC_BASIC``
+    (or ``AUTOPSY_DC_BASIC + AUTOPSY_DC_DEEP_OFFSET`` with
+    ``/deep``).  Success reveals the corpse's preserved identity
+    signature: apparent height, build, keyword, and (deep only)
+    the type IDs of any disguise-essential items recovered.
+
+    Does **not** assign a name to the corpse unless the looker
+    already holds the corpse's apparent UID in their recognition
+    memory — that lookup is the responsibility of the recognition
+    pipeline, not the forensic engine, so this command never
+    leaks identities.
+
+    Results are cached per ``(observer, corpse)`` — a second
+    autopsy by the same character silently re-renders the cached
+    outcome rather than rolling again.  This rewards careful
+    single-pass examination and is consistent with the
+    disguise-pierce convention.
+    """
+
+    key = "autopsy"
+    aliases = ()
+    locks = "cmd:all()"
+    help_category = "Forensics"
+    switch_options = ("deep",)
+
+    def func(self):
+        caller = self.caller
+        if not self.args or not self.args.strip():
+            caller.msg("Usage: autopsy[/deep] <corpse>")
+            return
+
+        target = caller.search(self.args.strip(), location=caller.location)
+        if target is None:
+            return  # search() already messaged the caller
+
+        if not isinstance(target, Corpse):
+            caller.msg("You can only perform an autopsy on a corpse.")
+            return
+
+        deep = "deep" in self.switches
+        dc = AUTOPSY_DC_BASIC + (AUTOPSY_DC_DEEP_OFFSET if deep else 0)
+        depth = "detailed" if deep else "summary"
+
+        # Build the subject envelope.  Pre-PR-#183 corpses still in
+        # the live DB have no snapshot; render_forensic_report will
+        # produce a graceful "no further detail" message.
+        subject = extract_subject_from_corpse(target)
+
+        # Broadcast the activity to the room (per-observer rendering)
+        # before doing the roll, so observers see the investigator
+        # working regardless of outcome.  The corpse is rendered via
+        # ``get_display_name`` per-observer downstream of the
+        # template; we pre-format it for the actor.
+        corpse_name_for_caller = target.get_display_name(caller)
+        verb = "performs a deep autopsy on" if deep else "examines"
+        msg_room_identity(
+            location=caller.location,
+            template=f"{{actor}} {verb} {{corpse}}.",
+            char_refs={"actor": caller, "corpse": target},
+            exclude=[caller],
+        )
+
+        # Roll (and cache) the recognition attempt.  Result.success
+        # gates whether we render the report; revealed_uid lets us
+        # opportunistically enrich the report header if the looker
+        # already knows the UID.
+        result = attempt_forensic_recognition(
+            caller, subject, dc,
+            cache_owner=target, cache_attr="forensic_recognition_cache",
+        )
+
+        if not result.success:
+            caller.msg(
+                f"You examine {corpse_name_for_caller} but cannot determine "
+                f"anything conclusive."
+            )
+            return
+
+        report = render_forensic_report(subject, observer=caller, depth=depth)
+
+        # Recognition contract: only surface an assigned name if the
+        # looker already holds the UID.  The engine does not assign
+        # names on its own.
+        memory = getattr(caller, "recognition_memory", None) or {}
+        header = f"You examine {corpse_name_for_caller}."
+        if result.revealed_uid and result.revealed_uid in memory:
+            assigned = memory[result.revealed_uid].get("assigned_name")
+            if assigned:
+                header = (
+                    f"You examine {corpse_name_for_caller} and confirm the "
+                    f"remains are those of {assigned}."
+                )
+
+        caller.msg(f"{header}\n{report}")

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1369,12 +1369,158 @@ Corpses already preserve forensic data (original name, dbref, physical descripti
 
 **Disguise persistence.** Worn-item axes contribute to the signature at all non-skeletal stages, so looting a disguise-essential item (e.g. a balaclava) silently breaks both recognition paths just as it does for a living character.
 
-### Evidence and Investigation (Future)
+### Evidence and Investigation ✅ (Engine shipped — PR-E)
 
-When forensic investigation commands are built:
-- Evidence sources (fingerprints, DNA, etc.) link to `sleeve_uid`
-- Investigators see recognized names or sdescs when examining evidence
-- Creates detective gameplay: "The blood at the crime scene belongs to that tall man I saw earlier"
+The Forensic Recognition Engine (`world/forensics.py`) is the canonical
+access layer for all forensic evidence surfaces (corpses, blood pools,
+photos). It exposes:
+
+- `ForensicSubject` — source-agnostic envelope.
+- `attempt_forensic_recognition()` — Intellect roll vs DC with
+  permanent per-`(observer, evidence)` cache, mirroring
+  `attempt_disguise_pierce` semantics.
+- `render_forensic_report()` — depth ladder
+  (`summary` / `detailed` / `comparison`) over the preserved
+  signature.  **Never** assigns a name; surfacing a name remains the
+  exclusive responsibility of recognition-memory lookup.
+- `link_subjects()` — diagnostic primitive comparing two subjects
+  axis-by-axis (reserved for future linking gameplay; no command
+  exposes it).
+
+**Shipped consumer**: `commands/forensics.py:CmdAutopsy` (basic +
+`/deep`) routes corpses through the engine.
+
+**Data prep only**: blood pools have the `signature` / `apparent_uid`
+fields wired in `BloodPool.add_bleeding_incident` and the medical
+script, but no player-facing command consumes them yet.
+
+**Out of scope (deferred)**: photo capture/display (extractor stub
+raises `NotImplementedError`), multi-UID linking gameplay,
+sleeve-swap awareness (blocked on resleeving system).
+
+See the dedicated §"Forensic Recognition Engine" later in this
+document for the full surface, contracts, and DC tuning notes.
+
+---
+
+## Forensic Recognition Engine
+
+**Module**: `world/forensics.py` (PR-E, Issue #184).
+
+The Forensic Recognition Engine is the canonical access layer for
+identity recovery from *static evidence* — corpses today, blood
+pools and photos in follow-ups.  It complements
+`world.identity.attempt_disguise_pierce` (which handles *live*
+targets whose disguise an observer might see through) by keeping
+the recognition contract — *live UID is the only key that returns
+an assigned name* — invariant across evidence types.
+
+### Surface
+
+**Subject envelope**:
+
+- `ForensicSubject(signature, apparent_uid_at_death,
+  essential_item_type_ids, source_kind, source_ref)` — frozen
+  dataclass; consumers extract one per evidence object.
+
+**Extractors** (one per evidence surface):
+
+- `extract_subject_from_corpse(corpse)` — reads
+  `db.signature_at_death` + `db.apparent_uid_at_death`.
+- `extract_subject_from_blood_pool_incident(pool, incident)` —
+  reads `incident.get("signature")` / `incident.get("apparent_uid")`
+  so legacy incidents land as `signature=None` automatically.
+- `extract_subject_from_photo(photo)` — stub
+  (`NotImplementedError`); wire when photo typeclass lands.
+
+**Recognition (Surface A)**:
+
+- `attempt_forensic_recognition(looker, subject, dc, *,
+  cache_owner, cache_attr="forensic_recognition_cache")` —
+  returns `RecognitionResult(success, revealed_uid, from_cache)`.
+- Rolls `world.combat.dice.roll_stat(looker, "intellect", default=1)`
+  vs `dc`.  Cache key is `(looker.dbref, revealed_uid)` so a
+  signature change (looted disguise essential) naturally spawns a
+  fresh cache slot on the next examine.
+- Anonymous lookers (no dbref) re-roll every call; subjects
+  without a recoverable UID short-circuit to
+  `RecognitionResult(False, None, False)` without rolling.
+
+**Report rendering (Surface B)**:
+
+- `render_forensic_report(subject, *, observer, depth)` —
+  depth ladder: `"summary"` (height/build/keyword),
+  `"detailed"` (+ essential items), `"comparison"` (scaffold for
+  future linking gameplay).
+- Raises `ValueError` on invalid depth.
+- **Critically never assigns a name.**  Name surfacing remains
+  the exclusive responsibility of the recognition-memory lookup
+  performed by the consumer command.
+
+**Linking primitive**:
+
+- `link_subjects(a, b)` returns `LinkResult(shared_sleeve_uid,
+  shared_apparent_uid, shared_axes)` — diagnostic only, no
+  command exposes it yet.
+
+### Consumer: `autopsy` command
+
+`commands/forensics.py:CmdAutopsy` (keyed `autopsy`, switch
+`deep`, help category `Forensics`):
+
+- `autopsy <corpse>` — Intellect vs `AUTOPSY_DC_BASIC` → summary
+  report.
+- `autopsy/deep <corpse>` — Intellect vs
+  `AUTOPSY_DC_BASIC + AUTOPSY_DC_DEEP_OFFSET` → detailed report.
+- Pre-roll room broadcast via `msg_room_identity` so observers
+  see the investigation regardless of outcome.
+- Concatenates the recognized-name header only when the looker
+  already holds the revealed UID in `recognition_memory` with an
+  `assigned_name` set.
+
+### DC tuning (provisional)
+
+Constants live in `world/combat/constants.py`:
+
+```python
+AUTOPSY_DC_BASIC = 3
+AUTOPSY_DC_DEEP_OFFSET = 2  # /deep DC = BASIC + OFFSET
+```
+
+Flagged for balance tuning per the disguise-pierce precedent.
+Both are intentionally low for the shipping basic-Intellect
+target; raise alongside any future Investigation skill stat
+gating.
+
+### Cache strategy
+
+Per `(observer, evidence)` cache stored on the evidence object
+(`cache_owner.db.<cache_attr>` — defaults to
+`"forensic_recognition_cache"` for backward compatibility with
+the pre-PR-E corpse path).  Permanent across server restarts.
+A second examination by the same character silently re-renders
+the cached outcome rather than rolling again — rewards single
+careful examination and prevents Intellect re-roll abuse.
+
+### Recognition contract guarantees
+
+1. The engine never assigns a name on its own.
+2. Consumers may concatenate an `assigned_name` from the looker's
+   recognition memory **only after** confirming the revealed UID
+   is present in that memory.
+3. Subjects without a UID (pre-PR-#183 corpses, legacy blood
+   incidents) gracefully render "no further forensic detail"
+   instead of leaking a `sleeve_uid` or other internal hash.
+
+### Out of scope (deferred)
+
+- Photo capture/display gameplay.
+- Blood-pool forensic consumer command (data field is wired so
+  future consumers have something to read).
+- Multi-UID linking gameplay (`link_subjects` is a primitive).
+- Memory decay & active impersonation detection (spec L1668
+  Phase 5).
+- Sleeve-swap awareness (blocked on resleeving system).
 
 ---
 
@@ -1685,7 +1831,7 @@ For reference, the existing forensic data preserved by the system:
 
 **Corpses** (`typeclasses/corpse.py`): original character name/dbref, account dbref, death time, cause of death, medical conditions, wounds at death, physical description, longdesc data, skintone, gender. Decay stages: fresh (<1h), early (<1d), moderate (<3d), advanced (<1w), skeletal (>1w).
 
-`sleeve_uid` has been added to corpse forensic data (PR #133) — corpses participate in the recognition pipeline. Blood pool integration is still pending.
+`sleeve_uid` has been added to corpse forensic data (PR #133) — corpses participate in the recognition pipeline. PR-E adds a `signature` + `apparent_uid` field to each blood-pool incident (data prep only — no consumer command yet); see §"Forensic Recognition Engine" for the engine surface that will read them once a blood-pool examination command lands.
 
 ---
 

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -172,11 +172,11 @@ class Corpse(Item):
         Intellect re-rolls on every ``look`` from eventually surfacing
         an identity by chance.
 
-        Cache lives in ``self.db.forensic_recognition_cache`` as
-        ``{looker.dbref: bool}``.  Anonymous lookers (no dbref) are not
-        cached and re-roll on every call — this keeps the cache bounded
-        and avoids storing junk keys for tooling that walks corpses
-        without a real observer.
+        Thin wrapper over :func:`world.forensics.attempt_forensic_recognition`
+        (PR-E).  The engine owns the roll, cache, and apparent-UID
+        keying; this method preserves the stage-DC table and the
+        ``forensic_recognition_cache`` attribute name so the live
+        cache attribute slot continues to be reused.
 
         Args:
             looker: The character attempting recognition.
@@ -190,24 +190,20 @@ class Corpse(Item):
             # Stage has no defined DC — never recover.
             return False
 
-        cache = self.db.forensic_recognition_cache
-        if cache is None:
-            cache = {}
+        from world.forensics import (
+            attempt_forensic_recognition,
+            extract_subject_from_corpse,
+        )
 
-        looker_dbref = getattr(looker, "dbref", None)
-        if looker_dbref is not None and looker_dbref in cache:
-            return bool(cache[looker_dbref])
-
-        from world.combat.dice import roll_stat
-
-        roll = roll_stat(looker, "intellect", default=1)
-        success = roll >= dc
-
-        if looker_dbref is not None:
-            cache[looker_dbref] = success
-            self.db.forensic_recognition_cache = cache
-
-        return success
+        subject = extract_subject_from_corpse(self)
+        result = attempt_forensic_recognition(
+            looker,
+            subject,
+            dc,
+            cache_owner=self,
+            cache_attr="forensic_recognition_cache",
+        )
+        return result.success
 
     def _decay_display_name(self):
         """Return the decay-stage name used when no recognition matches."""

--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -491,7 +491,10 @@ class BloodPool(Object):
         # Add aliases for examination
         self.aliases.add(["blood", "stains", "pool", "evidence"])
         
-    def add_bleeding_incident(self, character_name, severity, sleeve_uid=None):
+    def add_bleeding_incident(
+        self, character_name, severity, sleeve_uid=None,
+        signature=None, apparent_uid=None,
+    ):
         """Add a new bleeding incident to this pool (like adding graffiti).
 
         Args:
@@ -500,12 +503,24 @@ class BloodPool(Object):
             severity: Numeric severity of the bleeding event.
             sleeve_uid: Optional sleeve UID for forensic identity tracking.
                 If provided, stored as the behind-the-scenes identifier.
+            signature: Optional 5-tuple from
+                :func:`world.identity.get_identity_signature` captured
+                at the moment of bleeding.  Forward-only data prep for
+                the Forensic Recognition Engine (PR-E); existing
+                incidents recorded before this argument was added
+                store ``None`` and forensic consumers treat them as
+                "signature unknown" via :py:meth:`dict.get`.
+            apparent_uid: Optional pre-computed apparent UID for the
+                donor at bleed-time.  Mirrors
+                ``corpse.db.apparent_uid_at_death``.
         """
         current_time = gametime.gametime()
-        
+
         incident = {
             'character': character_name,
             'sleeve_uid': sleeve_uid,
+            'signature': signature,
+            'apparent_uid': apparent_uid,
             'severity': severity,
             'timestamp': current_time,
             'age_hours': 0  # Will be calculated dynamically

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -728,3 +728,12 @@ CORPSE_DECAY_EARLY = 86400     # < 1 day - early decomposition
 CORPSE_DECAY_MODERATE = 259200 # < 3 days - moderate decomposition
 CORPSE_DECAY_ADVANCED = 604800 # < 1 week - advanced decomposition
 CORPSE_DECAY_COMPLETE = 1209600 # 2 weeks - complete decay and cleanup
+
+# Forensic Recognition Engine (PR-E) ----------------------------------
+# Intellect DC for the basic autopsy roll on a corpse.  Deep examination
+# rolls against ``AUTOPSY_DC_BASIC + AUTOPSY_DC_DEEP_OFFSET``.  Both
+# constants are provisional pending a balance pass — cf. the
+# disguise-pierce constants in ``world/identity.py`` (PR #134/#136),
+# which carry the same flag.
+AUTOPSY_DC_BASIC = 3
+AUTOPSY_DC_DEEP_OFFSET = 2

--- a/world/forensics.py
+++ b/world/forensics.py
@@ -1,0 +1,465 @@
+"""Forensic Recognition Engine (PR-E).
+
+Canonical access layer for forensic recovery across all evidence
+surfaces: corpses (shipped), blood-pool incidents (data prep only),
+and photographic evidence (stub — spec L1000 / L1015 / L1020).
+
+Two surfaces converge here:
+
+* **Identity recovery** — given an evidence source, attempt to match
+  the source's apparent UID against the looker's recognition memory
+  via a skill check (Surface A, previously embedded in
+  :meth:`typeclasses.corpse.Corpse._attempt_forensic_recognition`).
+* **Signature reconstruction** — given an evidence source, render the
+  preserved identity signature's axes (height/build/keyword/essential
+  items) into a human-readable forensic report without ever
+  surfacing an assigned name unless the looker already holds the UID
+  (Surface B, unlocked by PR #183's ``signature_at_death`` snapshot).
+
+The engine is source-agnostic: every consumer extracts a
+:class:`ForensicSubject` from its native object (corpse, blood-pool
+incident, photo) and routes through the same engine functions.  This
+keeps the recognition contract — *live UID is the only key that
+returns an assigned name* — invariant across evidence types and
+prevents per-surface drift as new consumers are added.
+
+This module is companion to :mod:`world.identity`'s disguise-piercing
+engine (``attempt_disguise_pierce`` at ~L1394) — both gate
+identity-leak vectors through skill rolls with permanent per-observer
+caches.  Disguise piercing handles *live* targets whose disguise an
+observer might see through; forensic recognition handles *static*
+evidence (corpses, blood, photos) where the source presentation may
+have drifted from the looker's stored memory.
+
+Out of scope (deferred per PR-E scope lock):
+
+* Photo capture/display gameplay (stub raises ``NotImplementedError``).
+* Blood-pool forensic *consumer* (the data field is wired in
+  :meth:`typeclasses.objects.BloodPool.add_bleeding_incident` so
+  future consumers have something to read, but no command surfaces it
+  yet).
+* Multi-UID linking gameplay (:func:`link_subjects` is a primitive
+  returning a diagnostic dataclass; no command exposes it).
+* Memory decay, active impersonation detection (spec L1668 Phase 5).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from world.identity import (
+    get_apparent_uid,
+    get_identity_signature,
+    render_signature_summary,
+)
+
+
+# ---------------------------------------------------------------------
+# Subject envelope
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ForensicSubject:
+    """Source-agnostic envelope for a piece of forensic evidence.
+
+    All engine functions consume this neutral shape so consumers don't
+    have to know whether the evidence came from a corpse, a blood
+    incident, or a photo.  Frozen so subjects can be used as cache
+    keys or compared for equality across consumers.
+
+    Attributes:
+        signature: The 5-tuple from :func:`world.identity.get_identity_signature`
+            captured at the moment the evidence was created, or
+            ``None`` if no snapshot is available (e.g. pre-PR-#183
+            corpses still in the live DB, or legacy blood incidents
+            recorded before the ``signature`` field was added).
+        apparent_uid_at_death: The hashed apparent UID at evidence
+            creation time.  Distinct from
+            ``signature[0]`` (the raw ``sleeve_uid``); this is the
+            disguise-aware UID used for recognition-memory lookup.
+            ``None`` if not captured.
+        essential_item_type_ids: Tuple of disguise-essential item
+            type IDs preserved on the evidence, or empty tuple.
+            Convenience accessor — also reachable via
+            ``signature[4]``.
+        source_kind: One of ``"corpse"``, ``"blood_pool"``,
+            ``"photo"``.  Used by renderers that want to phrase
+            reports per source type.
+        source_ref: The originating object (corpse / blood pool /
+            photo).  Held for cache-key generation; engine functions
+            never call methods on it.
+    """
+
+    signature: tuple | None
+    apparent_uid_at_death: str | None
+    essential_item_type_ids: tuple[str, ...]
+    source_kind: str
+    source_ref: Any = field(compare=False, hash=False)
+
+
+# ---------------------------------------------------------------------
+# Extractors — one per evidence surface
+# ---------------------------------------------------------------------
+
+
+def extract_subject_from_corpse(corpse) -> ForensicSubject:
+    """Build a :class:`ForensicSubject` from a corpse object.
+
+    Reads the death-time snapshot fields established by PR #183:
+
+    * ``corpse.db.signature_at_death`` — the full 5-tuple.
+    * ``corpse.db.apparent_uid_at_death`` — the hashed UID.
+
+    Pre-PR-#183 corpses still in the live DB have neither field
+    populated; the returned subject carries ``signature=None`` and
+    consumers should render a "no further detail" message.
+
+    Args:
+        corpse: A :class:`typeclasses.corpse.Corpse` instance (duck
+            typing accepted — only ``corpse.db.*`` is read).
+
+    Returns:
+        A populated :class:`ForensicSubject`.
+    """
+    signature = corpse.db.signature_at_death
+    apparent_uid = corpse.db.apparent_uid_at_death
+    essential = tuple(signature[4]) if signature is not None else ()
+    return ForensicSubject(
+        signature=signature,
+        apparent_uid_at_death=apparent_uid,
+        essential_item_type_ids=essential,
+        source_kind="corpse",
+        source_ref=corpse,
+    )
+
+
+def extract_subject_from_blood_pool_incident(
+    pool, incident: dict
+) -> ForensicSubject:
+    """Build a :class:`ForensicSubject` from one blood-pool incident.
+
+    Each entry in ``pool.db.bleeding_incidents`` is a dict.  The
+    ``"signature"`` key is read with :py:meth:`dict.get` so legacy
+    incidents recorded before PR-E land as ``signature=None``
+    automatically — no migration script required.
+
+    The legacy ``"sleeve_uid"`` field is honoured for
+    backward-compatible identity hashing when a full signature is
+    absent: we synthesise an apparent UID from a minimal sleeve-only
+    signature so consumers still see continuity.  This mirrors the
+    behaviour of :func:`world.identity.get_apparent_uid` for a bare
+    sleeve.
+
+    Args:
+        pool: The :class:`typeclasses.objects.BloodPool` the incident
+            belongs to.
+        incident: One incident dict from
+            ``pool.db.bleeding_incidents``.
+
+    Returns:
+        A populated :class:`ForensicSubject`.
+    """
+    signature = incident.get("signature")
+    apparent_uid = incident.get("apparent_uid")
+    essential = tuple(signature[4]) if signature is not None else ()
+    return ForensicSubject(
+        signature=signature,
+        apparent_uid_at_death=apparent_uid,
+        essential_item_type_ids=essential,
+        source_kind="blood_pool",
+        source_ref=(pool, incident.get("timestamp")),
+    )
+
+
+def extract_subject_from_photo(photo) -> ForensicSubject:
+    """Stub for photographic evidence (spec L1000 / L1015 / L1020).
+
+    Photo capture/display is out of scope for PR-E.  When the photo
+    typeclass lands, this function will read its preserved signature
+    snapshot (same shape as ``corpse.db.signature_at_death``) and
+    return a ``source_kind="photo"`` subject.
+
+    Args:
+        photo: Future photographic-evidence object.
+
+    Raises:
+        NotImplementedError: Always.  Wire the consumer in a follow-up
+            PR.
+    """
+    raise NotImplementedError(
+        "Photographic evidence extraction is not yet implemented; "
+        "see specs/IDENTITY_RECOGNITION_SPEC.md L1000 / L1015 / L1020."
+    )
+
+
+# ---------------------------------------------------------------------
+# Recognition engine — Surface A
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RecognitionResult:
+    """Outcome of an :func:`attempt_forensic_recognition` call.
+
+    Attributes:
+        success: ``True`` if the looker's roll met or exceeded the
+            DC (or a cached prior success replayed).
+        revealed_uid: The apparent UID that was matched against
+            memory, or ``None`` if the subject has no UID to match.
+            Callers can use this to look up the assigned name in
+            ``observer.recognition_memory``.
+        from_cache: ``True`` if the result was replayed from a prior
+            roll on the same ``(observer, subject)`` pair (silent
+            re-render per the cached-failure UX decision).
+    """
+
+    success: bool
+    revealed_uid: str | None
+    from_cache: bool
+
+
+def attempt_forensic_recognition(
+    looker,
+    subject: ForensicSubject,
+    dc: int,
+    *,
+    cache_owner,
+    cache_attr: str = "forensic_recognition_cache",
+) -> RecognitionResult:
+    """Roll Intellect vs ``dc`` to recover identity from evidence.
+
+    The roll outcome is cached permanently per
+    ``(looker.dbref, subject-key)`` on ``cache_owner.db.<cache_attr>``.
+    This rewards a single careful examination and prevents Intellect
+    re-rolls on every examine from eventually surfacing an identity
+    by chance.
+
+    Caching strategy mirrors the disguise-pierce convention
+    (:func:`world.identity.attempt_disguise_pierce`): permanent per
+    observer, keyed on the evidence's apparent UID so a signature
+    change (e.g. a disguise-essential item looted off a corpse,
+    invalidating the death-time UID) naturally produces a fresh
+    cache slot on the next examine.
+
+    Args:
+        looker: The character attempting recognition.  Must have a
+            ``dbref`` for the cache key; anonymous lookers re-roll
+            every call (bounded cache hygiene).
+        subject: The :class:`ForensicSubject` under examination.
+        dc: Intellect DC the looker must meet or exceed.
+        cache_owner: The object whose ``db.<cache_attr>`` holds the
+            per-observer roll cache.  Typically the corpse itself
+            (so the cache moves with the evidence); for blood-pool
+            incidents the pool object is appropriate.
+        cache_attr: Attribute name on ``cache_owner.db`` to use for
+            the cache dict.  Defaults to ``"forensic_recognition_cache"``
+            for backwards compatibility with corpse storage.
+
+    Returns:
+        :class:`RecognitionResult` describing the outcome.  If the
+        subject has no apparent UID (``apparent_uid_at_death is None``
+        and no signature[0]) the call returns
+        ``RecognitionResult(False, None, False)`` without rolling.
+    """
+    revealed_uid = subject.apparent_uid_at_death
+    if revealed_uid is None:
+        # Fall back to live re-derivation from the source where
+        # possible — kept for parity with the pre-PR-E corpse path
+        # that computed UIDs from the corpse itself rather than the
+        # death-time hash.  Also covers pre-PR-#183 corpses still in
+        # the live DB whose ``apparent_uid_at_death`` / ``signature_at_death``
+        # snapshot fields were never populated.
+        if subject.source_kind == "corpse":
+            try:
+                revealed_uid = get_apparent_uid(subject.source_ref)
+            except (AttributeError, TypeError, ValueError):
+                revealed_uid = None
+
+    if revealed_uid is None:
+        return RecognitionResult(success=False, revealed_uid=None, from_cache=False)
+
+    cache_db = getattr(cache_owner, "db", None)
+    cache = getattr(cache_db, cache_attr, None) if cache_db is not None else None
+    if cache is None:
+        cache = {}
+
+    looker_dbref = getattr(looker, "dbref", None)
+    cache_key = (looker_dbref, revealed_uid)
+    if looker_dbref is not None and cache_key in cache:
+        return RecognitionResult(
+            success=bool(cache[cache_key]),
+            revealed_uid=revealed_uid,
+            from_cache=True,
+        )
+
+    from world.combat.dice import roll_stat
+
+    roll = roll_stat(looker, "intellect", default=1)
+    success = roll >= dc
+
+    if looker_dbref is not None:
+        cache[cache_key] = success
+        setattr(cache_db, cache_attr, cache)
+
+    return RecognitionResult(
+        success=success, revealed_uid=revealed_uid, from_cache=False
+    )
+
+
+# ---------------------------------------------------------------------
+# Report renderer — Surface B
+# ---------------------------------------------------------------------
+
+
+_DEPTHS = ("summary", "detailed", "comparison")
+
+
+def render_forensic_report(
+    subject: ForensicSubject,
+    *,
+    observer,
+    depth: Literal["summary", "detailed", "comparison"] = "summary",
+) -> str:
+    """Render a human-readable forensic report from a subject.
+
+    Depth ladder:
+
+    * ``"summary"`` — height / build / keyword axes only.
+    * ``"detailed"`` — summary plus reconstructed essential-item
+      descriptors from :attr:`ForensicSubject.essential_item_type_ids`.
+    * ``"comparison"`` — primitive scaffold reserved for future
+      multi-subject linking gameplay; currently returns a placeholder
+      and is not wired to any command.
+
+    Critically, this function **never** assigns a name to the
+    subject.  The recognition contract requires that an assigned
+    name only appear when the observer already holds the UID in
+    their recognition memory; that lookup happens in the consumer
+    (the autopsy command), after which the consumer may concatenate
+    the recognized name with this report.
+
+    Args:
+        subject: The evidence subject to render.
+        observer: The character reading the report.  Reserved for
+            future observer-specific phrasing (per-observer
+            rendering hooks).  Currently unused but accepted to
+            keep the signature stable as renderers grow.
+        depth: One of ``"summary"`` / ``"detailed"`` / ``"comparison"``.
+
+    Returns:
+        A string suitable for ``observer.msg()``.
+
+    Raises:
+        ValueError: If ``depth`` is not a recognised level.
+    """
+    del observer  # Reserved; see docstring.
+    if depth not in _DEPTHS:
+        raise ValueError(
+            f"render_forensic_report: depth must be one of {_DEPTHS!r}, "
+            f"got {depth!r}"
+        )
+
+    if subject.signature is None:
+        return "The remains yield no further forensic detail."
+
+    summary = render_signature_summary(subject.signature)
+    height = summary["height_override"] or "indeterminate"
+    build = summary["build_override"] or "indeterminate"
+    keyword = summary["keyword_override"] or "indeterminate"
+
+    lines = [
+        "|wForensic Examination|n",
+        f"  Apparent height : {height}",
+        f"  Apparent build  : {build}",
+        f"  Keyword         : {keyword}",
+    ]
+
+    if depth in ("detailed", "comparison"):
+        essentials = subject.essential_item_type_ids
+        if essentials:
+            joined = ", ".join(essentials)
+            lines.append(f"  Worn essentials : {joined}")
+        else:
+            lines.append("  Worn essentials : none recovered")
+
+    if depth == "comparison":
+        # Placeholder for future multi-subject linking gameplay.
+        lines.append("  [Comparison rendering reserved for future linking gameplay.]")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------
+# Linking primitive
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LinkResult:
+    """Outcome of :func:`link_subjects`.
+
+    Attributes:
+        shared_sleeve_uid: ``True`` iff both subjects carry the same
+            raw ``sleeve_uid`` (i.e. genetically the same person).
+            Requires both subjects to have a captured signature.
+        shared_apparent_uid: ``True`` iff both subjects carry the
+            same ``apparent_uid_at_death`` (same disguised
+            presentation at the moment each was captured).
+        shared_axes: Tuple of signature-axis names that match
+            between the two subjects, drawn from ``("sleeve_uid",
+            "height_override", "build_override", "keyword_override",
+            "essential_item_type_ids")``.  Empty if either subject
+            lacks a signature.
+    """
+
+    shared_sleeve_uid: bool
+    shared_apparent_uid: bool
+    shared_axes: tuple[str, ...]
+
+
+_AXIS_NAMES = (
+    "sleeve_uid",
+    "height_override",
+    "build_override",
+    "keyword_override",
+    "essential_item_type_ids",
+)
+
+
+def link_subjects(a: ForensicSubject, b: ForensicSubject) -> LinkResult:
+    """Compare two subjects axis-by-axis (primitive, no gameplay).
+
+    Returned exclusively for engine-internal use and future linking
+    gameplay (spec L1020).  No command exposes this in PR-E.
+
+    Args:
+        a: First subject.
+        b: Second subject.
+
+    Returns:
+        A :class:`LinkResult` describing shared identity surfaces.
+    """
+    shared_apparent_uid = (
+        a.apparent_uid_at_death is not None
+        and a.apparent_uid_at_death == b.apparent_uid_at_death
+    )
+    if a.signature is None or b.signature is None:
+        return LinkResult(
+            shared_sleeve_uid=False,
+            shared_apparent_uid=shared_apparent_uid,
+            shared_axes=(),
+        )
+
+    shared_axes = tuple(
+        name
+        for name, va, vb in zip(_AXIS_NAMES, a.signature, b.signature)
+        if va == vb and va is not None
+    )
+    shared_sleeve_uid = "sleeve_uid" in shared_axes
+    return LinkResult(
+        shared_sleeve_uid=shared_sleeve_uid,
+        shared_apparent_uid=shared_apparent_uid,
+        shared_axes=shared_axes,
+    )

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -258,9 +258,27 @@ class MedicalScript(DefaultScript):
                 break
         
         sleeve_uid = self.obj.db.sleeve_uid if self.obj.db.sleeve_uid is not None else None
+
+        # Forensic Recognition Engine (PR-E) data prep: snapshot the
+        # bleeder's current identity signature alongside the legacy
+        # ``sleeve_uid`` field so future forensic consumers can
+        # reconstruct presentation axes at bleed-time.  Reads default
+        # to ``None`` for legacy incidents — no migration required.
+        signature = None
+        apparent_uid = None
+        try:
+            from world.identity import get_identity_signature, get_apparent_uid
+            signature = get_identity_signature(self.obj)
+            apparent_uid = get_apparent_uid(self.obj)
+        except (AttributeError, TypeError, ValueError):
+            pass
+
         if existing_pool:
             # Merge into existing pool (like graffiti entries)
-            existing_pool.add_bleeding_incident(self.obj.key, severity, sleeve_uid=sleeve_uid)
+            existing_pool.add_bleeding_incident(
+                self.obj.key, severity, sleeve_uid=sleeve_uid,
+                signature=signature, apparent_uid=apparent_uid,
+            )
         else:
             # Create new blood pool
             from evennia import create_object
@@ -271,7 +289,10 @@ class MedicalScript(DefaultScript):
                 key="blood stains",
                 location=self.obj.location
             )
-            blood_pool.add_bleeding_incident(self.obj.key, severity, sleeve_uid=sleeve_uid)
+            blood_pool.add_bleeding_incident(
+                self.obj.key, severity, sleeve_uid=sleeve_uid,
+                signature=signature, apparent_uid=apparent_uid,
+            )
 
 
 def start_medical_script(character):

--- a/world/tests/test_blood_pool_incident.py
+++ b/world/tests/test_blood_pool_incident.py
@@ -1,0 +1,129 @@
+"""Tests for :meth:`typeclasses.objects.BloodPool.add_bleeding_incident`.
+
+PR-E adds two forward-only data-prep arguments (``signature`` and
+``apparent_uid``) to the bleeding-incident dict so the Forensic
+Recognition Engine has fully populated subjects to consume once a
+blood-pool command surface lands.
+
+Coverage:
+
+* Modern call path stores both new fields on the incident.
+* Legacy call path (only ``character_name`` / ``severity`` /
+  ``sleeve_uid``) still works and leaves the new fields as ``None`` so
+  forensic consumers can ``.get("signature")`` without raising.
+* The engine extractor (:func:`world.forensics.extract_subject_from_blood_pool_incident`)
+  consumes both shapes correctly, closing the data-prep loop.
+
+Run via::
+
+    evennia test world.tests.test_blood_pool_incident
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.forensics import extract_subject_from_blood_pool_incident
+
+
+class _DB:
+    """Bare attribute holder mimicking ``obj.db``."""
+
+
+def _make_pool():
+    """Construct a stand-in BloodPool object that exercises the
+    incident-list append path without booting Evennia.
+
+    We bind the real
+    :meth:`typeclasses.objects.BloodPool.add_bleeding_incident` to a
+    bare object that supplies the attributes the method touches:
+    ``db.bleeding_incidents``, ``db.total_volume``, ``db.last_updated``,
+    and ``_update_description``.
+    """
+    from typeclasses.objects import BloodPool
+
+    pool = MagicMock()
+    pool.db = _DB()
+    pool.db.bleeding_incidents = None
+    pool.db.total_volume = 0
+    pool.db.last_updated = None
+    pool._update_description = MagicMock()
+    # Bind the unbound method so it operates on our stand-in.
+    pool.add_bleeding_incident = (
+        BloodPool.add_bleeding_incident.__get__(pool, type(pool))
+    )
+    return pool
+
+
+class TestAddBleedingIncidentModern(TestCase):
+    def test_signature_and_apparent_uid_stored(self):
+        pool = _make_pool()
+        sig = ("sleeve-1", "tall", "lean", "hooded", ("balaclava",))
+        with patch("typeclasses.objects.gametime") as fake_time:
+            fake_time.gametime.return_value = 1000.0
+            pool.add_bleeding_incident(
+                character_name="Jorge",
+                severity=5,
+                sleeve_uid="sleeve-1",
+                signature=sig,
+                apparent_uid="abc123",
+            )
+        incidents = pool.db.bleeding_incidents
+        self.assertEqual(len(incidents), 1)
+        entry = incidents[0]
+        self.assertEqual(entry["signature"], sig)
+        self.assertEqual(entry["apparent_uid"], "abc123")
+        self.assertEqual(entry["sleeve_uid"], "sleeve-1")
+        self.assertEqual(entry["severity"], 5)
+        self.assertEqual(entry["character"], "Jorge")
+
+
+class TestAddBleedingIncidentLegacy(TestCase):
+    def test_legacy_call_leaves_new_fields_none(self):
+        pool = _make_pool()
+        with patch("typeclasses.objects.gametime") as fake_time:
+            fake_time.gametime.return_value = 1000.0
+            pool.add_bleeding_incident(
+                character_name="Jorge",
+                severity=3,
+                sleeve_uid="sleeve-1",
+            )
+        entry = pool.db.bleeding_incidents[0]
+        self.assertIsNone(entry["signature"])
+        self.assertIsNone(entry["apparent_uid"])
+
+
+class TestForensicExtractorClosesTheLoop(TestCase):
+    """Verify the extractor consumes both call shapes."""
+
+    def test_modern_incident_round_trips_through_extractor(self):
+        pool = _make_pool()
+        sig = ("sleeve-1", "tall", "lean", "hooded", ("balaclava",))
+        with patch("typeclasses.objects.gametime") as fake_time:
+            fake_time.gametime.return_value = 1000.0
+            pool.add_bleeding_incident(
+                character_name="Jorge", severity=5,
+                sleeve_uid="sleeve-1", signature=sig, apparent_uid="abc123",
+            )
+        subject = extract_subject_from_blood_pool_incident(
+            pool, pool.db.bleeding_incidents[0],
+        )
+        self.assertEqual(subject.signature, sig)
+        self.assertEqual(subject.apparent_uid_at_death, "abc123")
+        self.assertEqual(subject.essential_item_type_ids, ("balaclava",))
+        self.assertEqual(subject.source_kind, "blood_pool")
+
+    def test_legacy_incident_round_trips_as_unknown_signature(self):
+        pool = _make_pool()
+        with patch("typeclasses.objects.gametime") as fake_time:
+            fake_time.gametime.return_value = 1000.0
+            pool.add_bleeding_incident(
+                character_name="Jorge", severity=3, sleeve_uid="sleeve-1",
+            )
+        subject = extract_subject_from_blood_pool_incident(
+            pool, pool.db.bleeding_incidents[0],
+        )
+        self.assertIsNone(subject.signature)
+        self.assertIsNone(subject.apparent_uid_at_death)
+        self.assertEqual(subject.essential_item_type_ids, ())

--- a/world/tests/test_cmd_autopsy.py
+++ b/world/tests/test_cmd_autopsy.py
@@ -1,0 +1,303 @@
+"""Unit tests for :class:`commands.forensics.CmdAutopsy` (PR-E).
+
+Exercises the command surface end-to-end with lightweight fakes so no
+Evennia DB is required.  The command itself is thin glue over
+:mod:`world.forensics`; these tests focus on the *contract* layer:
+
+* Usage / argument handling.
+* Non-corpse target rejection.
+* Basic vs ``/deep`` DC routing and depth selection.
+* Cache-hit silent re-render (per PR-E scope lock #4).
+* Recognition-memory name surfacing *only* when the looker holds the
+  revealed UID (regression: command must never auto-assign names).
+* Room broadcast routes through :func:`world.identity_utils.msg_room_identity`.
+
+To bypass ``isinstance(target, Corpse)`` without patching the builtin
+(which causes infinite recursion against mock.call internals), we
+substitute the ``commands.forensics.Corpse`` symbol with a stand-in
+base class that our fake corpse inherits from, then patch it in for
+the duration of the test.
+
+Run via::
+
+    evennia test world.tests.test_cmd_autopsy
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from commands import forensics as cmd_module
+from commands.forensics import CmdAutopsy
+from world.combat.constants import AUTOPSY_DC_BASIC, AUTOPSY_DC_DEEP_OFFSET
+from world.forensics import RecognitionResult
+
+
+# ---------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------
+
+
+class _DB:
+    """Bare attribute holder mimicking ``obj.db``."""
+
+
+class _FakeRoom:
+    def __init__(self):
+        self.contents = []
+
+
+class _CorpseStandIn:
+    """Stand-in for :class:`typeclasses.corpse.Corpse` (isinstance target)."""
+
+
+class _FakeCorpse(_CorpseStandIn):
+    """Minimal corpse surface the command needs."""
+
+    def __init__(self, *, key="the corpse of Jorge", display=None):
+        self.key = key
+        self.db = _DB()
+        self.db.signature_at_death = (
+            "sleeve-1", "tall", "lean", "hooded", ("balaclava",),
+        )
+        self.db.apparent_uid_at_death = "abc123"
+        self.db.forensic_recognition_cache = None
+        self._display = display or key
+
+    def get_display_name(self, looker=None, **kwargs):  # noqa: D401
+        del looker, kwargs
+        return self._display
+
+
+def _make_caller(*, key="Alice", dbref="#42", memory=None, location=None):
+    caller = MagicMock()
+    caller.key = key
+    caller.dbref = dbref
+    caller.location = location or _FakeRoom()
+    caller.recognition_memory = memory or {}
+    caller.msg = MagicMock()
+    caller.search = MagicMock()
+    return caller
+
+
+def _make_cmd(*, caller, target, args="corpse", switches=()):
+    cmd = CmdAutopsy()
+    cmd.caller = caller
+    cmd.args = " " + args
+    cmd.switches = list(switches)
+    caller.search.return_value = target
+    return cmd
+
+
+def _patch_corpse():
+    """Patch the command-module's Corpse symbol with our stand-in."""
+    return patch.object(cmd_module, "Corpse", _CorpseStandIn)
+
+
+# ---------------------------------------------------------------------
+# Arg handling
+# ---------------------------------------------------------------------
+
+
+class TestCmdAutopsyArgs(TestCase):
+    def test_no_args_prints_usage(self):
+        caller = _make_caller()
+        cmd = CmdAutopsy()
+        cmd.caller = caller
+        cmd.args = ""
+        cmd.switches = []
+        cmd.func()
+        caller.msg.assert_called_once()
+        self.assertIn("Usage:", caller.msg.call_args[0][0])
+        caller.search.assert_not_called()
+
+    def test_search_miss_returns_silently(self):
+        """Evennia's ``caller.search`` already messages on miss."""
+        caller = _make_caller()
+        caller.search.return_value = None
+        cmd = CmdAutopsy()
+        cmd.caller = caller
+        cmd.args = " ghost"
+        cmd.switches = []
+        cmd.func()
+        caller.msg.assert_not_called()
+
+
+# ---------------------------------------------------------------------
+# Target validation
+# ---------------------------------------------------------------------
+
+
+class TestCmdAutopsyTargetValidation(TestCase):
+    def test_non_corpse_rejected(self):
+        caller = _make_caller()
+        not_a_corpse = object()  # NOT a Corpse instance
+        caller.search.return_value = not_a_corpse
+        cmd = CmdAutopsy()
+        cmd.caller = caller
+        cmd.args = " rock"
+        cmd.switches = []
+        with _patch_corpse():
+            cmd.func()
+        caller.msg.assert_called_once()
+        self.assertIn("corpse", caller.msg.call_args[0][0].lower())
+
+
+# ---------------------------------------------------------------------
+# DC / depth dispatch
+# ---------------------------------------------------------------------
+
+
+class TestCmdAutopsyDispatch(TestCase):
+    def _run(self, *, switches, roll=99):
+        caller = _make_caller()
+        corpse = _FakeCorpse()
+        cmd = _make_cmd(caller=caller, target=corpse, switches=switches)
+        with _patch_corpse(), \
+                patch.object(cmd_module, "msg_room_identity") as broadcast, \
+                patch("world.combat.dice.roll_stat", return_value=roll):
+            cmd.func()
+        return caller, corpse, broadcast
+
+    def test_basic_uses_summary_depth(self):
+        caller, _, broadcast = self._run(switches=[])
+        self.assertTrue(caller.msg.called)
+        rendered = caller.msg.call_args[0][0]
+        self.assertNotIn("Worn essentials", rendered)
+        broadcast.assert_called_once()
+        template = broadcast.call_args.kwargs["template"]
+        self.assertIn("examines", template)
+        self.assertNotIn("deep autopsy", template)
+
+    def test_deep_uses_detailed_depth(self):
+        caller, _, broadcast = self._run(switches=["deep"])
+        rendered = caller.msg.call_args[0][0]
+        self.assertIn("Worn essentials", rendered)
+        template = broadcast.call_args.kwargs["template"]
+        self.assertIn("deep autopsy", template)
+
+    def test_dc_constants_distinct(self):
+        """Sanity: /deep DC must exceed basic so tuning is meaningful."""
+        self.assertGreater(
+            AUTOPSY_DC_BASIC + AUTOPSY_DC_DEEP_OFFSET, AUTOPSY_DC_BASIC,
+        )
+
+
+# ---------------------------------------------------------------------
+# Failure path
+# ---------------------------------------------------------------------
+
+
+class TestCmdAutopsyFailure(TestCase):
+    def test_failed_roll_emits_inconclusive_message(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse()
+        cmd = _make_cmd(caller=caller, target=corpse)
+        with _patch_corpse(), \
+                patch.object(cmd_module, "msg_room_identity"), \
+                patch("world.combat.dice.roll_stat", return_value=0):
+            cmd.func()
+        out = caller.msg.call_args[0][0]
+        self.assertIn("cannot determine", out)
+
+
+# ---------------------------------------------------------------------
+# Cache replay
+# ---------------------------------------------------------------------
+
+
+class TestCmdAutopsyCacheReplay(TestCase):
+    def test_second_call_replays_without_reroll(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse()
+        cmd1 = _make_cmd(caller=caller, target=corpse)
+        with _patch_corpse(), \
+                patch.object(cmd_module, "msg_room_identity"), \
+                patch("world.combat.dice.roll_stat", return_value=99):
+            cmd1.func()
+        first_render = caller.msg.call_args[0][0]
+        caller.msg.reset_mock()
+
+        cmd2 = _make_cmd(caller=caller, target=corpse)
+        with _patch_corpse(), \
+                patch.object(cmd_module, "msg_room_identity"), \
+                patch(
+                    "world.combat.dice.roll_stat", return_value=0,
+                ) as mocked_roll:
+            cmd2.func()
+            mocked_roll.assert_not_called()
+        second_render = caller.msg.call_args[0][0]
+        # Cache hit: identical output, no reroll.
+        self.assertEqual(first_render, second_render)
+
+
+# ---------------------------------------------------------------------
+# Name-disclosure contract
+# ---------------------------------------------------------------------
+
+
+class TestCmdAutopsyNameDisclosure(TestCase):
+    def _run_with_result(self, *, memory, result):
+        caller = _make_caller(memory=memory)
+        corpse = _FakeCorpse()
+        cmd = _make_cmd(caller=caller, target=corpse)
+        with _patch_corpse(), \
+                patch.object(cmd_module, "msg_room_identity"), \
+                patch.object(
+                    cmd_module, "attempt_forensic_recognition",
+                    return_value=result,
+                ):
+            cmd.func()
+        return caller.msg.call_args[0][0]
+
+    def test_no_name_surfaced_when_uid_absent_from_memory(self):
+        result = RecognitionResult(
+            success=True, revealed_uid="abc123", from_cache=False,
+        )
+        rendered = self._run_with_result(memory={}, result=result)
+        self.assertNotIn("remains are those of", rendered)
+
+    def test_name_surfaces_when_uid_present_in_memory(self):
+        memory = {"abc123": {"assigned_name": "Jorge Jackson"}}
+        result = RecognitionResult(
+            success=True, revealed_uid="abc123", from_cache=False,
+        )
+        rendered = self._run_with_result(memory=memory, result=result)
+        self.assertIn("Jorge Jackson", rendered)
+        self.assertIn("remains are those of", rendered)
+
+    def test_no_name_when_uid_in_memory_but_no_assigned_name(self):
+        """Memory entry without ``assigned_name`` must not leak a name."""
+        memory = {"abc123": {"sdesc": "the hooded one"}}
+        result = RecognitionResult(
+            success=True, revealed_uid="abc123", from_cache=False,
+        )
+        rendered = self._run_with_result(memory=memory, result=result)
+        self.assertNotIn("remains are those of", rendered)
+
+
+# ---------------------------------------------------------------------
+# Room broadcast
+# ---------------------------------------------------------------------
+
+
+class TestCmdAutopsyBroadcast(TestCase):
+    def test_broadcast_excludes_caller_and_uses_per_observer_helper(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse()
+        cmd = _make_cmd(caller=caller, target=corpse)
+        with _patch_corpse(), \
+                patch.object(
+                    cmd_module, "msg_room_identity",
+                ) as broadcast, \
+                patch("world.combat.dice.roll_stat", return_value=99):
+            cmd.func()
+        broadcast.assert_called_once()
+        kwargs = broadcast.call_args.kwargs
+        self.assertEqual(kwargs["location"], caller.location)
+        self.assertEqual(kwargs["exclude"], [caller])
+        self.assertIn("actor", kwargs["char_refs"])
+        self.assertIn("corpse", kwargs["char_refs"])
+        self.assertIs(kwargs["char_refs"]["actor"], caller)
+        self.assertIs(kwargs["char_refs"]["corpse"], corpse)

--- a/world/tests/test_corpse_decay_recognition.py
+++ b/world/tests/test_corpse_decay_recognition.py
@@ -88,6 +88,7 @@ class _FakeDecayCorpse:
         self.db.build_override = build_override
         self.db.keyword_override = keyword_override
         self.db.apparent_uid_at_death = None
+        self.db.signature_at_death = None
         self.db.forensic_recognition_cache = None
         self.contents = list(contents or [])
         self.ndb = type("_NDB", (), {})()

--- a/world/tests/test_forensics.py
+++ b/world/tests/test_forensics.py
@@ -1,0 +1,381 @@
+"""Unit tests for the Forensic Recognition Engine (PR-E).
+
+Covers :mod:`world.forensics`:
+
+* :class:`ForensicSubject` extraction from corpse / blood-pool
+  incident; ``NotImplementedError`` for photo stub.
+* :func:`attempt_forensic_recognition` — roll, cache hit/miss, cache
+  re-roll on UID change, anonymous-looker handling.
+* :func:`render_forensic_report` — depth ladder output shape; safe
+  None-signature handling; never includes assigned names.
+* :func:`link_subjects` — shared-axes detection.
+
+Built on lightweight fakes so no Evennia DB is required.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.forensics import (
+    ForensicSubject,
+    LinkResult,
+    RecognitionResult,
+    attempt_forensic_recognition,
+    extract_subject_from_blood_pool_incident,
+    extract_subject_from_corpse,
+    extract_subject_from_photo,
+    link_subjects,
+    render_forensic_report,
+)
+
+
+# ---------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------
+
+
+class _DB:
+    """Bare attribute holder mimicking ``obj.db``."""
+
+
+class _FakeCorpse:
+    """Minimal corpse surface for forensic extraction."""
+
+    def __init__(
+        self,
+        *,
+        signature=None,
+        apparent_uid=None,
+        sleeve_uid="uid-jorge",
+        dbref="#1",
+    ) -> None:
+        self.db = _DB()
+        self.db.signature_at_death = signature
+        self.db.apparent_uid_at_death = apparent_uid
+        self.db.sleeve_uid = sleeve_uid
+        self.db.forensic_recognition_cache = None
+        self.db.height_override = signature[1] if signature else None
+        self.db.build_override = signature[2] if signature else None
+        self.db.keyword_override = signature[3] if signature else None
+        self.contents = []
+        self.dbref = dbref
+
+    @property
+    def sleeve_uid(self):
+        return self.db.sleeve_uid
+
+    def get_worn_items(self, location=None):
+        del location
+        return []
+
+
+class _FakePool:
+    pass
+
+
+class _FakeObserver:
+    def __init__(self, *, dbref="#42", intellect=1, memory=None):
+        self.dbref = dbref
+        self.intellect = intellect
+        self.recognition_memory = memory or {}
+
+
+# ---------------------------------------------------------------------
+# ForensicSubject extraction
+# ---------------------------------------------------------------------
+
+
+class TestExtractFromCorpse(TestCase):
+    def test_full_snapshot_propagates(self):
+        sig = ("sleeve-1", "tall", "lean", "hooded", ("balaclava",))
+        corpse = _FakeCorpse(signature=sig, apparent_uid="abc123")
+        subject = extract_subject_from_corpse(corpse)
+        self.assertEqual(subject.signature, sig)
+        self.assertEqual(subject.apparent_uid_at_death, "abc123")
+        self.assertEqual(subject.essential_item_type_ids, ("balaclava",))
+        self.assertEqual(subject.source_kind, "corpse")
+        self.assertIs(subject.source_ref, corpse)
+
+    def test_missing_snapshot_yields_none_signature(self):
+        corpse = _FakeCorpse(signature=None, apparent_uid=None)
+        subject = extract_subject_from_corpse(corpse)
+        self.assertIsNone(subject.signature)
+        self.assertIsNone(subject.apparent_uid_at_death)
+        self.assertEqual(subject.essential_item_type_ids, ())
+
+    def test_empty_essentials_tuple(self):
+        sig = ("sleeve-1", None, None, None, ())
+        corpse = _FakeCorpse(signature=sig)
+        subject = extract_subject_from_corpse(corpse)
+        self.assertEqual(subject.essential_item_type_ids, ())
+
+
+class TestExtractFromBloodPoolIncident(TestCase):
+    def test_modern_incident_with_signature(self):
+        sig = ("sleeve-1", "tall", "lean", "hooded", ("balaclava",))
+        incident = {
+            "character": "someone",
+            "sleeve_uid": "sleeve-1",
+            "signature": sig,
+            "apparent_uid": "deadbeef",
+            "severity": 5,
+            "timestamp": 100.0,
+        }
+        pool = _FakePool()
+        subject = extract_subject_from_blood_pool_incident(pool, incident)
+        self.assertEqual(subject.signature, sig)
+        self.assertEqual(subject.apparent_uid_at_death, "deadbeef")
+        self.assertEqual(subject.essential_item_type_ids, ("balaclava",))
+        self.assertEqual(subject.source_kind, "blood_pool")
+
+    def test_legacy_incident_without_signature_field(self):
+        incident = {
+            "character": "someone",
+            "sleeve_uid": "sleeve-1",
+            "severity": 5,
+            "timestamp": 100.0,
+        }
+        pool = _FakePool()
+        subject = extract_subject_from_blood_pool_incident(pool, incident)
+        self.assertIsNone(subject.signature)
+        self.assertIsNone(subject.apparent_uid_at_death)
+        self.assertEqual(subject.essential_item_type_ids, ())
+
+
+class TestExtractFromPhotoStub(TestCase):
+    def test_raises_not_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            extract_subject_from_photo(object())
+
+
+# ---------------------------------------------------------------------
+# Recognition engine
+# ---------------------------------------------------------------------
+
+
+class TestAttemptForensicRecognition(TestCase):
+    def _subject(self, *, apparent_uid="abc123"):
+        sig = ("sleeve-1", "tall", "lean", "hooded", ())
+        return ForensicSubject(
+            signature=sig,
+            apparent_uid_at_death=apparent_uid,
+            essential_item_type_ids=(),
+            source_kind="corpse",
+            source_ref=_FakeCorpse(signature=sig, apparent_uid=apparent_uid),
+        )
+
+    def test_success_passes_roll(self):
+        owner = _FakeCorpse()
+        observer = _FakeObserver()
+        with patch("world.combat.dice.roll_stat", return_value=5):
+            result = attempt_forensic_recognition(
+                observer, self._subject(), dc=3, cache_owner=owner,
+            )
+        self.assertIsInstance(result, RecognitionResult)
+        self.assertTrue(result.success)
+        self.assertEqual(result.revealed_uid, "abc123")
+        self.assertFalse(result.from_cache)
+
+    def test_failure_at_dc(self):
+        owner = _FakeCorpse()
+        observer = _FakeObserver()
+        with patch("world.combat.dice.roll_stat", return_value=2):
+            result = attempt_forensic_recognition(
+                observer, self._subject(), dc=3, cache_owner=owner,
+            )
+        self.assertFalse(result.success)
+
+    def test_cache_hit_skips_reroll(self):
+        owner = _FakeCorpse()
+        observer = _FakeObserver()
+        with patch("world.combat.dice.roll_stat", return_value=1):
+            first = attempt_forensic_recognition(
+                observer, self._subject(), dc=3, cache_owner=owner,
+            )
+        with patch("world.combat.dice.roll_stat", return_value=99) as mocked:
+            second = attempt_forensic_recognition(
+                observer, self._subject(), dc=3, cache_owner=owner,
+            )
+            mocked.assert_not_called()
+        self.assertFalse(first.success)
+        self.assertFalse(second.success)
+        self.assertTrue(second.from_cache)
+
+    def test_cache_reroll_when_uid_changes(self):
+        """Disguise loss → new apparent UID → fresh cache slot."""
+        owner = _FakeCorpse()
+        observer = _FakeObserver()
+        subject_v1 = self._subject(apparent_uid="uid-v1")
+        subject_v2 = self._subject(apparent_uid="uid-v2")
+        with patch("world.combat.dice.roll_stat", return_value=1):
+            attempt_forensic_recognition(
+                observer, subject_v1, dc=3, cache_owner=owner,
+            )
+        with patch("world.combat.dice.roll_stat", return_value=99) as mocked:
+            result = attempt_forensic_recognition(
+                observer, subject_v2, dc=3, cache_owner=owner,
+            )
+            mocked.assert_called_once()
+        self.assertTrue(result.success)
+        self.assertFalse(result.from_cache)
+
+    def test_anonymous_looker_does_not_cache(self):
+        owner = _FakeCorpse()
+        observer = _FakeObserver(dbref=None)
+        with patch("world.combat.dice.roll_stat", return_value=1):
+            attempt_forensic_recognition(
+                observer, self._subject(), dc=3, cache_owner=owner,
+            )
+        # Second call must re-roll because nothing was stored.
+        with patch("world.combat.dice.roll_stat", return_value=99) as mocked:
+            result = attempt_forensic_recognition(
+                observer, self._subject(), dc=3, cache_owner=owner,
+            )
+            mocked.assert_called_once()
+        self.assertTrue(result.success)
+
+    def test_subject_without_uid_short_circuits(self):
+        owner = _FakeCorpse()
+        observer = _FakeObserver()
+        subject = ForensicSubject(
+            signature=None,
+            apparent_uid_at_death=None,
+            essential_item_type_ids=(),
+            source_kind="corpse",
+            source_ref=None,
+        )
+        with patch("world.combat.dice.roll_stat") as mocked:
+            result = attempt_forensic_recognition(
+                observer, subject, dc=3, cache_owner=owner,
+            )
+            mocked.assert_not_called()
+        self.assertFalse(result.success)
+        self.assertIsNone(result.revealed_uid)
+
+
+# ---------------------------------------------------------------------
+# Report renderer
+# ---------------------------------------------------------------------
+
+
+class TestRenderForensicReport(TestCase):
+    def _subject(self, sig=None, essentials=()):
+        return ForensicSubject(
+            signature=sig,
+            apparent_uid_at_death=None,
+            essential_item_type_ids=essentials,
+            source_kind="corpse",
+            source_ref=None,
+        )
+
+    def test_summary_lists_three_axes(self):
+        sig = ("sleeve-1", "tall", "lean", "hooded", ())
+        out = render_forensic_report(
+            self._subject(sig=sig), observer=None, depth="summary",
+        )
+        self.assertIn("tall", out)
+        self.assertIn("lean", out)
+        self.assertIn("hooded", out)
+        self.assertNotIn("Worn essentials", out)
+
+    def test_detailed_includes_essentials(self):
+        sig = ("sleeve-1", "tall", "lean", "hooded", ("balaclava", "trenchcoat"))
+        out = render_forensic_report(
+            self._subject(sig=sig, essentials=("balaclava", "trenchcoat")),
+            observer=None, depth="detailed",
+        )
+        self.assertIn("balaclava", out)
+        self.assertIn("trenchcoat", out)
+
+    def test_detailed_with_no_essentials(self):
+        sig = ("sleeve-1", "tall", "lean", "hooded", ())
+        out = render_forensic_report(
+            self._subject(sig=sig), observer=None, depth="detailed",
+        )
+        self.assertIn("none recovered", out)
+
+    def test_none_signature_returns_graceful_message(self):
+        out = render_forensic_report(
+            self._subject(sig=None), observer=None, depth="summary",
+        )
+        self.assertIn("no further forensic detail", out)
+
+    def test_invalid_depth_raises(self):
+        sig = ("sleeve-1", None, None, None, ())
+        with self.assertRaises(ValueError):
+            render_forensic_report(
+                self._subject(sig=sig), observer=None, depth="bogus",
+            )
+
+    def test_indeterminate_axes_rendered(self):
+        sig = ("sleeve-1", None, None, None, ())
+        out = render_forensic_report(
+            self._subject(sig=sig), observer=None, depth="summary",
+        )
+        self.assertIn("indeterminate", out)
+
+    def test_report_never_contains_assigned_name(self):
+        """Recognition contract: renderer must not surface names."""
+        sig = ("sleeve-1", "tall", "lean", "hooded", ())
+        out = render_forensic_report(
+            self._subject(sig=sig), observer=None, depth="detailed",
+        )
+        # The renderer has no access to recognition memory at all.
+        self.assertNotIn("Jorge", out)
+
+
+# ---------------------------------------------------------------------
+# Linking primitive
+# ---------------------------------------------------------------------
+
+
+class TestLinkSubjects(TestCase):
+    def _subject(self, sig, apparent_uid=None):
+        return ForensicSubject(
+            signature=sig,
+            apparent_uid_at_death=apparent_uid,
+            essential_item_type_ids=tuple(sig[4]) if sig else (),
+            source_kind="corpse",
+            source_ref=None,
+        )
+
+    def test_identical_signatures_share_all_axes(self):
+        sig = ("sleeve-1", "tall", "lean", "hooded", ("balaclava",))
+        result = link_subjects(self._subject(sig), self._subject(sig))
+        self.assertIsInstance(result, LinkResult)
+        self.assertTrue(result.shared_sleeve_uid)
+        self.assertEqual(len(result.shared_axes), 5)
+
+    def test_same_sleeve_different_disguise(self):
+        sig_a = ("sleeve-1", "tall", "lean", "hooded", ())
+        sig_b = ("sleeve-1", "short", "wide", "masked", ())
+        result = link_subjects(self._subject(sig_a), self._subject(sig_b))
+        self.assertTrue(result.shared_sleeve_uid)
+        self.assertIn("sleeve_uid", result.shared_axes)
+
+    def test_disjoint_subjects(self):
+        sig_a = ("sleeve-1", "tall", None, None, ())
+        sig_b = ("sleeve-2", "short", None, None, ())
+        result = link_subjects(self._subject(sig_a), self._subject(sig_b))
+        self.assertFalse(result.shared_sleeve_uid)
+        self.assertNotIn("sleeve_uid", result.shared_axes)
+
+    def test_none_signature_returns_empty_axes(self):
+        sig = ("sleeve-1", "tall", None, None, ())
+        result = link_subjects(self._subject(None), self._subject(sig))
+        self.assertEqual(result.shared_axes, ())
+        self.assertFalse(result.shared_sleeve_uid)
+
+    def test_shared_apparent_uid_detected_without_signature(self):
+        a = ForensicSubject(
+            signature=None, apparent_uid_at_death="abc",
+            essential_item_type_ids=(), source_kind="corpse", source_ref=None,
+        )
+        b = ForensicSubject(
+            signature=None, apparent_uid_at_death="abc",
+            essential_item_type_ids=(), source_kind="corpse", source_ref=None,
+        )
+        result = link_subjects(a, b)
+        self.assertTrue(result.shared_apparent_uid)


### PR DESCRIPTION
## Summary
- Introduces a unified Forensic Recognition Engine at `world/forensics.py` so corpses, blood-pool incidents, and future photos all route identity recovery and signature reconstruction through one canonical layer.
- Refactors `Corpse._attempt_forensic_recognition` into a thin engine wrapper (cache slot preserved), wires `BloodPool` incidents to carry forward-only signature + apparent UID snapshots, and adds `CmdAutopsy` (basic + `/deep` at DC+2) which only surfaces assigned names when the observer already holds the UID.
- Closes #184.

## Tests
`docker exec gelatinous evennia test --settings settings.py world commands typeclasses` — 987 passing.

## Spec
`specs/IDENTITY_RECOGNITION_SPEC.md` updated with the "Forensic Recognition Engine" section; L1372 flipped to ✅.