### PR TITLE
Rework autopsy: unified report + death-time medical snapshot (#186)

### DIFF
--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -1,13 +1,15 @@
-"""Forensic command surfaces (PR-E).
+"""Forensic command surfaces.
 
 Player-facing commands that route through
 :mod:`world.forensics`'s canonical engine.
 
 Currently ships:
 
-* :class:`CmdAutopsy` — examine a corpse to recover signature axes
-  via an Intellect roll.  Two-tier (basic + ``/deep``) per the
-  PR-E scope lock.
+* :class:`CmdAutopsy` — examine a corpse to recover the preserved
+  identity signature, fuzzy time-of-death, apparent cause of death,
+  wounds, organ inventory, and worn essentials.  Single-tier
+  (the legacy ``/deep`` switch was dropped in PR #186 in favour of
+  the unified five-section report).
 """
 
 from __future__ import annotations
@@ -15,7 +17,7 @@ from __future__ import annotations
 from evennia import Command
 
 from typeclasses.corpse import Corpse
-from world.combat.constants import AUTOPSY_DC_BASIC, AUTOPSY_DC_DEEP_OFFSET
+from world.combat.constants import AUTOPSY_DC_BASIC
 from world.forensics import (
     attempt_forensic_recognition,
     extract_subject_from_corpse,
@@ -29,13 +31,13 @@ class CmdAutopsy(Command):
 
     Usage:
       autopsy <corpse>
-      autopsy/deep <corpse>
 
-    Rolls Intellect vs a DC determined by ``AUTOPSY_DC_BASIC``
-    (or ``AUTOPSY_DC_BASIC + AUTOPSY_DC_DEEP_OFFSET`` with
-    ``/deep``).  Success reveals the corpse's preserved identity
-    signature: apparent height, build, keyword, and (deep only)
-    the type IDs of any disguise-essential items recovered.
+    Rolls Intellect vs ``AUTOPSY_DC_BASIC``.  On success the corpse's
+    preserved death-time signature is rendered — apparent height,
+    build, keyword, fuzzy time of death, cause of death, wounds
+    grouped by body location, organ inventory (with harvested /
+    severed organs marked ``absent`` per PR-186 Q3), and any
+    disguise-essential items still worn on the remains.
 
     Does **not** assign a name to the corpse unless the looker
     already holds the corpse's apparent UID in their recognition
@@ -48,18 +50,22 @@ class CmdAutopsy(Command):
     outcome rather than rolling again.  This rewards careful
     single-pass examination and is consistent with the
     disguise-pierce convention.
+
+    Skeletal remains are too far decomposed for forensic
+    examination; pre-PR-#186 corpses still in the live DB lack
+    the death-time medical snapshot and report an empty internal
+    examination instead.
     """
 
     key = "autopsy"
     aliases = ()
     locks = "cmd:all()"
     help_category = "Forensics"
-    switch_options = ("deep",)
 
     def func(self):
         caller = self.caller
         if not self.args or not self.args.strip():
-            caller.msg("Usage: autopsy[/deep] <corpse>")
+            caller.msg("Usage: autopsy <corpse>")
             return
 
         target = caller.search(self.args.strip(), location=caller.location)
@@ -70,9 +76,15 @@ class CmdAutopsy(Command):
             caller.msg("You can only perform an autopsy on a corpse.")
             return
 
-        deep = "deep" in self.switches
-        dc = AUTOPSY_DC_BASIC + (AUTOPSY_DC_DEEP_OFFSET if deep else 0)
-        depth = "detailed" if deep else "summary"
+        # Skeletal-stage guard: no soft tissue, no signature axes worth
+        # recovering.  Cheaper to short-circuit here than to render a
+        # report full of "absent" lines.
+        if target.get_decay_stage() == "skeletal":
+            caller.msg(
+                "The remains are too far decomposed for forensic "
+                "examination — only bone is left."
+            )
+            return
 
         # Build the subject envelope.  Pre-PR-#183 corpses still in
         # the live DB have no snapshot; render_forensic_report will
@@ -81,14 +93,11 @@ class CmdAutopsy(Command):
 
         # Broadcast the activity to the room (per-observer rendering)
         # before doing the roll, so observers see the investigator
-        # working regardless of outcome.  The corpse is rendered via
-        # ``get_display_name`` per-observer downstream of the
-        # template; we pre-format it for the actor.
+        # working regardless of outcome.
         corpse_name_for_caller = target.get_display_name(caller)
-        verb = "performs a deep autopsy on" if deep else "examines"
         msg_room_identity(
             location=caller.location,
-            template=f"{{actor}} {verb} {{corpse}}.",
+            template="{actor} examines {corpse}.",
             char_refs={"actor": caller, "corpse": target},
             exclude=[caller],
         )
@@ -98,7 +107,7 @@ class CmdAutopsy(Command):
         # opportunistically enrich the report header if the looker
         # already knows the UID.
         result = attempt_forensic_recognition(
-            caller, subject, dc,
+            caller, subject, AUTOPSY_DC_BASIC,
             cache_owner=target, cache_attr="forensic_recognition_cache",
         )
 
@@ -109,7 +118,7 @@ class CmdAutopsy(Command):
             )
             return
 
-        report = render_forensic_report(subject, observer=caller, depth=depth)
+        report = render_forensic_report(subject, observer=caller)
 
         # Recognition contract: only surface an assigned name if the
         # looker already holds the UID.  The engine does not assign

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1379,16 +1379,19 @@ photos). It exposes:
 - `attempt_forensic_recognition()` — Intellect roll vs DC with
   permanent per-`(observer, evidence)` cache, mirroring
   `attempt_disguise_pierce` semantics.
-- `render_forensic_report()` — depth ladder
-  (`summary` / `detailed` / `comparison`) over the preserved
-  signature.  **Never** assigns a name; surfacing a name remains the
-  exclusive responsibility of recognition-memory lookup.
+- `render_forensic_report()` — single-tier five-section renderer
+  (identity axes + fuzzy time-of-death + cause of death + wounds +
+  organ inventory + worn essentials) over the preserved signature
+  and death-time medical snapshot.  **Never** assigns a name;
+  surfacing a name remains the exclusive responsibility of
+  recognition-memory lookup.  (The legacy depth ladder
+  `summary`/`detailed`/`comparison` was dropped in PR #186.)
 - `link_subjects()` — diagnostic primitive comparing two subjects
   axis-by-axis (reserved for future linking gameplay; no command
   exposes it).
 
-**Shipped consumer**: `commands/forensics.py:CmdAutopsy` (basic +
-`/deep`) routes corpses through the engine.
+**Shipped consumer**: `commands/forensics.py:CmdAutopsy` (single-tier)
+routes corpses through the engine.
 
 **Data prep only**: blood pools have the `signature` / `apparent_uid`
 fields wired in `BloodPool.add_bleeding_incident` and the medical
@@ -1448,11 +1451,24 @@ an assigned name* — invariant across evidence types.
 
 **Report rendering (Surface B)**:
 
-- `render_forensic_report(subject, *, observer, depth)` —
-  depth ladder: `"summary"` (height/build/keyword),
-  `"detailed"` (+ essential items), `"comparison"` (scaffold for
-  future linking gameplay).
-- Raises `ValueError` on invalid depth.
+- `render_forensic_report(subject, *, observer)` — single-tier
+  five-section report (PR #186):
+  1. Identity axes (height / build / keyword).
+  2. Apparent time of death — fuzzy bucket from
+     `AUTOPSY_TIME_BUCKETS` (aligned with `CORPSE_DECAY_*`).
+  3. Apparent cause of death — `corpse.db.death_cause`.
+  4. Wounds — enumerated by body location from
+     `corpse.db.wounds_at_death`.
+  5. Organ inventory — from `corpse.get_medical_snapshot()`;
+     harvested / severed organs render as `absent` per the
+     no-surgeon-attribution rule (PR-186 Q3).  Pre-PR-#186
+     corpses with no snapshot emit a single "no internal
+     examination possible" marker.
+  6. Worn essentials — disguise-essential item type IDs folded
+     into the unified report (formerly `/deep`-only).
+- Pre-PR-#183 subjects (`signature is None`) collapse to a single
+  "no further forensic detail" line so identity axes never leak as
+  blank fields.
 - **Critically never assigns a name.**  Name surfacing remains
   the exclusive responsibility of the recognition-memory lookup
   performed by the consumer command.
@@ -1465,13 +1481,14 @@ an assigned name* — invariant across evidence types.
 
 ### Consumer: `autopsy` command
 
-`commands/forensics.py:CmdAutopsy` (keyed `autopsy`, switch
-`deep`, help category `Forensics`):
+`commands/forensics.py:CmdAutopsy` (keyed `autopsy`, no switches,
+help category `Forensics`):
 
-- `autopsy <corpse>` — Intellect vs `AUTOPSY_DC_BASIC` → summary
-  report.
-- `autopsy/deep <corpse>` — Intellect vs
-  `AUTOPSY_DC_BASIC + AUTOPSY_DC_DEEP_OFFSET` → detailed report.
+- `autopsy <corpse>` — Intellect vs `AUTOPSY_DC_BASIC` → unified
+  five-section report (identity axes, fuzzy ToD, cause, wounds,
+  organ inventory, worn essentials).
+- Skeletal corpses short-circuit with a "too far decomposed" message
+  before rolling.
 - Pre-roll room broadcast via `msg_room_identity` so observers
   see the investigation regardless of outcome.
 - Concatenates the recognized-name header only when the looker
@@ -1484,13 +1501,20 @@ Constants live in `world/combat/constants.py`:
 
 ```python
 AUTOPSY_DC_BASIC = 3
-AUTOPSY_DC_DEEP_OFFSET = 2  # /deep DC = BASIC + OFFSET
+# AUTOPSY_DC_DEEP_OFFSET removed in PR #186 alongside the /deep tier.
+AUTOPSY_TIME_BUCKETS = (
+    (CORPSE_DECAY_FRESH,    "recently deceased"),
+    (CORPSE_DECAY_EARLY,    "dead for hours"),
+    (CORPSE_DECAY_MODERATE, "dead for a day or more"),
+    (CORPSE_DECAY_ADVANCED, "dead for several days"),
+    (float("inf"),          "long dead"),
+)
 ```
 
 Flagged for balance tuning per the disguise-pierce precedent.
-Both are intentionally low for the shipping basic-Intellect
-target; raise alongside any future Investigation skill stat
-gating.
+`AUTOPSY_DC_BASIC` is intentionally low for the shipping
+basic-Intellect target; raise alongside any future Investigation
+skill stat gating.
 
 ### Cache strategy
 
@@ -1521,6 +1545,11 @@ careful examination and prevents Intellect re-roll abuse.
 - Memory decay & active impersonation detection (spec L1668
   Phase 5).
 - Sleeve-swap awareness (blocked on resleeving system).
+- Skeletal-bone harvest (cracked-bone marrow extraction) — deferred
+  past PR-186; skeletal corpses currently refuse autopsy and harvest.
+- Severed-head super-item carrying full identity signature —
+  deferred to v2 of the sever workflow (PR-188 ships limb sever
+  only).
 
 ---
 

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -33,6 +33,27 @@ class Corpse(Item):
         self.db.medical_conditions = []
         self.db.physical_description = ""
         self.db.longdesc_data = {}
+
+        # Death-time medical snapshot (PR #186 / Issue #186).  Set by
+        # :meth:`typeclasses.death_progression.DeathProgression._create_corpse_from_character`
+        # to ``character.medical_state.to_dict()``.  Read via
+        # :meth:`get_medical_snapshot`.  Surgical commands (harvest /
+        # sever) mutate this in place; the autopsy report renders from
+        # it.  Pre-PR-186 corpses still in the live DB carry ``None``;
+        # consumers degrade gracefully.  Two PR-186 sibling lists track
+        # what has been physically removed from the corpse since death:
+        #
+        # * ``removed_organs``: list of organ names that the
+        #   :class:`commands.surgery.CmdHarvest` flow has extracted.
+        # * ``severed_locations``: list of body-location names that
+        #   :class:`commands.surgery.CmdSever` has removed.
+        #
+        # Both lists are initialised empty so the harvest/sever code
+        # can ``append`` without a None-guard, and the autopsy report
+        # uniformly renders "absent" for any organ present in either.
+        self.db.medical_state_at_death = None
+        self.db.removed_organs = []
+        self.db.severed_locations = []
         
         # Preserve character appearance data for proper display
         self.db.original_skintone = None
@@ -61,7 +82,30 @@ class Corpse(Item):
         elapsed = time.time() - self.db.creation_time
         max_decay_time = self.db.decay_stages["advanced"]  # 1 week
         return min(1.0, elapsed / max_decay_time)
-    
+
+    def get_medical_snapshot(self):
+        """Return the death-time medical-state snapshot, if any.
+
+        The snapshot is :meth:`world.medical.core.MedicalState.to_dict`
+        captured at the moment of corpse creation (see
+        :meth:`typeclasses.death_progression.DeathProgression._create_corpse_from_character`).
+
+        Pre-PR-#186 corpses still in the live DB return ``None``;
+        consumers should degrade gracefully (autopsy renders identity
+        axes only, harvest/sever refuse with a "no internal
+        examination possible" message).
+
+        Surgical commands mutate the returned dict in place and then
+        re-assign it to ``self.db.medical_state_at_death`` to persist;
+        callers must respect that mutation contract — do not treat the
+        dict as read-only.
+
+        Returns:
+            dict | None: The serialized medical state, or ``None`` if
+            no snapshot was captured.
+        """
+        return self.db.medical_state_at_death
+
     def get_display_name(self, looker, **kwargs):
         """Return a display name, preferring recognition memory.
 

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -564,6 +564,34 @@ class DeathProgressionScript(DefaultScript):
             corpse.db.death_cause = character.get_death_cause()
             corpse.db.medical_conditions = character.medical_state.get_condition_summary()
             corpse.db.blood_type = character.db.blood_type if character.db.blood_type is not None else 'unknown'
+
+            # Snapshot the full medical state at death so forensic
+            # consumers (autopsy, harvest, sever) can render organ
+            # inventory and the upcoming surgical commands can mutate
+            # the snapshot in place without touching live medical
+            # systems.  ``MedicalState.to_dict()`` is the canonical
+            # serialization; pre-PR-186 corpses carry None and degrade
+            # gracefully in :func:`world.forensics.render_forensic_report`.
+            try:
+                corpse.db.medical_state_at_death = character.medical_state.to_dict()
+                try:
+                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    organ_count = len(corpse.db.medical_state_at_death.get("organs", {}))
+                    splattercast.msg(
+                        f"DEATH_MEDICAL_SNAPSHOT: {organ_count} organs preserved "
+                        f"on corpse for {character.key}"
+                    )
+                except Exception:
+                    pass
+            except Exception as snapshot_err:
+                try:
+                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    splattercast.msg(
+                        f"DEATH_MEDICAL_SNAPSHOT_ERROR: Failed to snapshot "
+                        f"medical state for {character.key}: {snapshot_err}"
+                    )
+                except Exception:
+                    pass
             
             # Transfer wound data for corpse wound descriptions
             try:

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -730,10 +730,24 @@ CORPSE_DECAY_ADVANCED = 604800 # < 1 week - advanced decomposition
 CORPSE_DECAY_COMPLETE = 1209600 # 2 weeks - complete decay and cleanup
 
 # Forensic Recognition Engine (PR-E) ----------------------------------
-# Intellect DC for the basic autopsy roll on a corpse.  Deep examination
-# rolls against ``AUTOPSY_DC_BASIC + AUTOPSY_DC_DEEP_OFFSET``.  Both
-# constants are provisional pending a balance pass — cf. the
-# disguise-pierce constants in ``world/identity.py`` (PR #134/#136),
-# which carry the same flag.
+# Intellect DC for the autopsy roll on a corpse.  PR #186 dropped the
+# two-tier ``/deep`` switch in favour of a single richer report (cause
+# of death, fuzzy time of death, wound enumeration, organ inventory,
+# worn essentials) rendered on any successful roll.  Flagged for
+# balance tuning per the disguise-pierce precedent in
+# ``world/identity.py`` (PR #134/#136).
 AUTOPSY_DC_BASIC = 3
-AUTOPSY_DC_DEEP_OFFSET = 2
+
+# Fuzzy time-of-death buckets surfaced in the autopsy report.  Each
+# tuple is ``(max_seconds_since_death, display_string)``; the first
+# tuple whose threshold the elapsed time falls under wins.  A trailing
+# entry with ``float('inf')`` provides the long-dead fallback.  Tuned
+# to align with ``CORPSE_DECAY_*`` thresholds above so the report
+# narrative tracks the decay model without exposing exact times.
+AUTOPSY_TIME_BUCKETS = (
+    (CORPSE_DECAY_FRESH, "recently deceased"),
+    (CORPSE_DECAY_EARLY, "dead for hours"),
+    (CORPSE_DECAY_MODERATE, "dead for a day or more"),
+    (CORPSE_DECAY_ADVANCED, "dead for several days"),
+    (float("inf"), "long dead"),
+)

--- a/world/forensics.py
+++ b/world/forensics.py
@@ -45,9 +45,11 @@ Out of scope (deferred per PR-E scope lock):
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any
 
+from world.combat.constants import AUTOPSY_TIME_BUCKETS
 from world.identity import (
     get_apparent_uid,
     get_identity_signature,
@@ -313,25 +315,180 @@ def attempt_forensic_recognition(
 # ---------------------------------------------------------------------
 
 
-_DEPTHS = ("summary", "detailed", "comparison")
+def _fuzzy_time_of_death(corpse) -> str:
+    """Return a fuzzy time-of-death string from a corpse's death_time.
+
+    Drives the autopsy report's "Apparent time of death" line.  The
+    buckets are tuned to align with the decay-stage thresholds in
+    ``world/combat/constants.py`` so the narrative tracks the corpse
+    model without leaking exact seconds.  Pre-PR-#183 corpses without
+    a ``death_time`` return ``"unknown"``.
+
+    Args:
+        corpse: A :class:`typeclasses.corpse.Corpse` instance (duck
+            typed — only ``corpse.db.death_time`` is read).
+
+    Returns:
+        One of the strings in :data:`world.combat.constants.AUTOPSY_TIME_BUCKETS`,
+        or ``"unknown"`` if the corpse has no death-time stamp.
+    """
+    death_time = getattr(getattr(corpse, "db", None), "death_time", None)
+    if death_time is None:
+        return "unknown"
+    try:
+        elapsed = time.time() - float(death_time)
+    except (TypeError, ValueError):
+        return "unknown"
+    if elapsed < 0:
+        elapsed = 0
+    for threshold, label in AUTOPSY_TIME_BUCKETS:
+        if elapsed < threshold:
+            return label
+    return AUTOPSY_TIME_BUCKETS[-1][1]
+
+
+def _render_wound_lines(corpse) -> list[str]:
+    """Render wound enumeration lines for the autopsy report.
+
+    Reads ``corpse.db.wounds_at_death`` (the existing PR #133 snapshot)
+    and groups entries by body location, using
+    :func:`world.medical.wounds.get_wound_description` for severity
+    prose and
+    :func:`world.medical.wounds.get_location_display_name` for the
+    location label.  Returns an empty list when no wounds were
+    snapshotted (pre-PR-#133 corpses, peaceful deaths) so the caller
+    can omit the section header cleanly.
+
+    Args:
+        corpse: A :class:`typeclasses.corpse.Corpse` instance.
+
+    Returns:
+        A list of report lines (without the section header).  Empty
+        if there are no wounds to render.
+    """
+    wounds = getattr(getattr(corpse, "db", None), "wounds_at_death", None) or []
+    if not wounds:
+        return []
+
+    try:
+        from world.medical.wounds import (
+            get_location_display_name,
+            get_wound_description,
+        )
+    except ImportError:
+        return []
+
+    grouped: dict[str, list[str]] = {}
+    for wound in wounds:
+        location = wound.get("location") or "unknown"
+        try:
+            descr = get_wound_description(
+                injury_type=wound.get("injury_type", "unknown"),
+                location=location,
+                severity=wound.get("severity", "Moderate"),
+                stage=wound.get("stage", "fresh"),
+                organ=wound.get("organ"),
+            )
+        except (TypeError, ValueError, KeyError):
+            descr = (
+                f"{wound.get('severity', 'unspecified')} "
+                f"{wound.get('injury_type', 'wound')}"
+            )
+        grouped.setdefault(location, []).append(descr)
+
+    lines: list[str] = []
+    for location, descrs in grouped.items():
+        try:
+            label = get_location_display_name(location)
+        except (TypeError, ValueError, KeyError):
+            label = location.replace("_", " ")
+        for descr in descrs:
+            lines.append(f"  {label}: {descr}")
+    return lines
+
+
+def _render_organ_lines(corpse) -> list[str]:
+    """Render the organ-inventory section of the autopsy report.
+
+    Reads ``corpse.get_medical_snapshot()`` (PR #186) and per-organ
+    status from the serialized :class:`world.medical.core.MedicalState`.
+    Organs whose name appears in ``corpse.db.removed_organs`` (harvest
+    target) or whose ``container`` appears in
+    ``corpse.db.severed_locations`` (sever target) render as
+    ``"absent"`` per the no-surgeon-attribution rule (PR-186 Q3).
+
+    A snapshot of ``None`` (pre-PR-#186 corpse) yields an empty list,
+    letting the caller print a "no internal examination possible"
+    marker instead.
+
+    Args:
+        corpse: A :class:`typeclasses.corpse.Corpse` instance.
+
+    Returns:
+        A list of report lines (without the section header).  Empty
+        when no snapshot is available.
+    """
+    snapshot = None
+    getter = getattr(corpse, "get_medical_snapshot", None)
+    if callable(getter):
+        snapshot = getter()
+    if not snapshot:
+        return []
+
+    removed = set(
+        getattr(getattr(corpse, "db", None), "removed_organs", None) or []
+    )
+    severed = set(
+        getattr(getattr(corpse, "db", None), "severed_locations", None) or []
+    )
+
+    lines: list[str] = []
+    organs = snapshot.get("organs") or {}
+    for name, organ in organs.items():
+        if name in removed or organ.get("container") in severed:
+            status = "absent"
+        else:
+            current_hp = organ.get("current_hp", 0)
+            max_hp = organ.get("max_hp", 1) or 1
+            ratio = current_hp / max_hp
+            if current_hp <= 0:
+                status = "destroyed"
+            elif ratio < 0.5:
+                status = "damaged"
+            else:
+                status = "intact"
+        lines.append(f"  {name}: {status}")
+    return lines
 
 
 def render_forensic_report(
     subject: ForensicSubject,
     *,
     observer,
-    depth: Literal["summary", "detailed", "comparison"] = "summary",
 ) -> str:
-    """Render a human-readable forensic report from a subject.
+    """Render a human-readable autopsy report from a subject.
 
-    Depth ladder:
+    The single-tier report (PR #186 dropped the ``/deep`` switch)
+    composes up to five sections, omitting any that have no data:
 
-    * ``"summary"`` — height / build / keyword axes only.
-    * ``"detailed"`` — summary plus reconstructed essential-item
-      descriptors from :attr:`ForensicSubject.essential_item_type_ids`.
-    * ``"comparison"`` — primitive scaffold reserved for future
-      multi-subject linking gameplay; currently returns a placeholder
-      and is not wired to any command.
+    1. **Identity axes** — height / build / keyword from the preserved
+       :func:`world.identity.get_identity_signature`.
+    2. **Apparent time of death** — fuzzy bucket from
+       :func:`_fuzzy_time_of_death`.
+    3. **Apparent cause of death** — ``corpse.db.death_cause``.
+    4. **Wounds** — enumerated by body location via
+       :func:`_render_wound_lines`.
+    5. **Organ inventory** — from
+       :meth:`typeclasses.corpse.Corpse.get_medical_snapshot` via
+       :func:`_render_organ_lines`; harvested / severed organs render
+       as ``"absent"`` (PR-186 Q3 — no surgeon attribution).
+    6. **Worn essentials** — disguise-essential item type IDs from
+       :attr:`ForensicSubject.essential_item_type_ids`.  Folded into
+       the unified report (formerly ``/deep``-only).
+
+    Pre-PR-#183 subjects with ``signature=None`` collapse to a single
+    "no further forensic detail" line so identity-axes never leak as
+    blank fields.
 
     Critically, this function **never** assigns a name to the
     subject.  The recognition contract requires that an assigned
@@ -346,20 +503,11 @@ def render_forensic_report(
             future observer-specific phrasing (per-observer
             rendering hooks).  Currently unused but accepted to
             keep the signature stable as renderers grow.
-        depth: One of ``"summary"`` / ``"detailed"`` / ``"comparison"``.
 
     Returns:
         A string suitable for ``observer.msg()``.
-
-    Raises:
-        ValueError: If ``depth`` is not a recognised level.
     """
     del observer  # Reserved; see docstring.
-    if depth not in _DEPTHS:
-        raise ValueError(
-            f"render_forensic_report: depth must be one of {_DEPTHS!r}, "
-            f"got {depth!r}"
-        )
 
     if subject.signature is None:
         return "The remains yield no further forensic detail."
@@ -369,24 +517,42 @@ def render_forensic_report(
     build = summary["build_override"] or "indeterminate"
     keyword = summary["keyword_override"] or "indeterminate"
 
-    lines = [
+    lines: list[str] = [
         "|wForensic Examination|n",
         f"  Apparent height : {height}",
         f"  Apparent build  : {build}",
         f"  Keyword         : {keyword}",
     ]
 
-    if depth in ("detailed", "comparison"):
-        essentials = subject.essential_item_type_ids
-        if essentials:
-            joined = ", ".join(essentials)
-            lines.append(f"  Worn essentials : {joined}")
-        else:
-            lines.append("  Worn essentials : none recovered")
+    corpse = subject.source_ref if subject.source_kind == "corpse" else None
 
-    if depth == "comparison":
-        # Placeholder for future multi-subject linking gameplay.
-        lines.append("  [Comparison rendering reserved for future linking gameplay.]")
+    if corpse is not None:
+        tod = _fuzzy_time_of_death(corpse)
+        lines.append(f"  Time of death   : {tod}")
+
+        cause = getattr(getattr(corpse, "db", None), "death_cause", None)
+        if cause:
+            lines.append(f"  Cause of death  : {cause}")
+
+        wound_lines = _render_wound_lines(corpse)
+        if wound_lines:
+            lines.append("|wWounds|n")
+            lines.extend(wound_lines)
+
+        organ_lines = _render_organ_lines(corpse)
+        if organ_lines:
+            lines.append("|wOrgan Inventory|n")
+            lines.extend(organ_lines)
+        elif getattr(corpse, "get_medical_snapshot", lambda: None)() is None:
+            lines.append(
+                "  (No internal examination possible — pre-mortem records "
+                "unavailable.)"
+            )
+
+    essentials = subject.essential_item_type_ids
+    if essentials:
+        joined = ", ".join(essentials)
+        lines.append(f"  Worn essentials : {joined}")
 
     return "\n".join(lines)
 

--- a/world/tests/test_cmd_autopsy.py
+++ b/world/tests/test_cmd_autopsy.py
@@ -1,4 +1,4 @@
-"""Unit tests for :class:`commands.forensics.CmdAutopsy` (PR-E).
+"""Unit tests for :class:`commands.forensics.CmdAutopsy` (PR-E + PR #186).
 
 Exercises the command surface end-to-end with lightweight fakes so no
 Evennia DB is required.  The command itself is thin glue over
@@ -6,11 +6,13 @@ Evennia DB is required.  The command itself is thin glue over
 
 * Usage / argument handling.
 * Non-corpse target rejection.
-* Basic vs ``/deep`` DC routing and depth selection.
+* Skeletal-corpse short-circuit (PR #186).
 * Cache-hit silent re-render (per PR-E scope lock #4).
 * Recognition-memory name surfacing *only* when the looker holds the
   revealed UID (regression: command must never auto-assign names).
 * Room broadcast routes through :func:`world.identity_utils.msg_room_identity`.
+* Five-section report assertions (ToD bucket, cause, wounds, organ
+  status including absent-on-harvested/severed).
 
 To bypass ``isinstance(target, Corpse)`` without patching the builtin
 (which causes infinite recursion against mock.call internals), we
@@ -25,12 +27,17 @@ Run via::
 
 from __future__ import annotations
 
+import time
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from commands import forensics as cmd_module
 from commands.forensics import CmdAutopsy
-from world.combat.constants import AUTOPSY_DC_BASIC, AUTOPSY_DC_DEEP_OFFSET
+from world.combat.constants import (
+    AUTOPSY_DC_BASIC,
+    AUTOPSY_TIME_BUCKETS,
+    CORPSE_DECAY_EARLY,
+)
 from world.forensics import RecognitionResult
 
 
@@ -55,7 +62,19 @@ class _CorpseStandIn:
 class _FakeCorpse(_CorpseStandIn):
     """Minimal corpse surface the command needs."""
 
-    def __init__(self, *, key="the corpse of Jorge", display=None):
+    def __init__(
+        self,
+        *,
+        key="the corpse of Jorge",
+        display=None,
+        decay_stage="fresh",
+        snapshot=None,
+        removed_organs=None,
+        severed_locations=None,
+        wounds=None,
+        death_cause="multiple gunshot wounds",
+        death_time=None,
+    ):
         self.key = key
         self.db = _DB()
         self.db.signature_at_death = (
@@ -63,11 +82,26 @@ class _FakeCorpse(_CorpseStandIn):
         )
         self.db.apparent_uid_at_death = "abc123"
         self.db.forensic_recognition_cache = None
+        self.db.death_cause = death_cause
+        self.db.death_time = (
+            death_time if death_time is not None else time.time() - 60
+        )
+        self.db.wounds_at_death = wounds or []
+        self.db.removed_organs = removed_organs or []
+        self.db.severed_locations = severed_locations or []
         self._display = display or key
+        self._decay_stage = decay_stage
+        self._snapshot = snapshot
 
     def get_display_name(self, looker=None, **kwargs):  # noqa: D401
         del looker, kwargs
         return self._display
+
+    def get_decay_stage(self):
+        return self._decay_stage
+
+    def get_medical_snapshot(self):
+        return self._snapshot
 
 
 def _make_caller(*, key="Alice", dbref="#42", memory=None, location=None):
@@ -143,16 +177,30 @@ class TestCmdAutopsyTargetValidation(TestCase):
         caller.msg.assert_called_once()
         self.assertIn("corpse", caller.msg.call_args[0][0].lower())
 
+    def test_skeletal_corpse_short_circuits(self):
+        """Skeletal corpses refuse autopsy with a dedicated message."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(decay_stage="skeletal")
+        cmd = _make_cmd(caller=caller, target=corpse)
+        with _patch_corpse(), \
+                patch.object(cmd_module, "msg_room_identity") as broadcast, \
+                patch("world.combat.dice.roll_stat") as mocked_roll:
+            cmd.func()
+        mocked_roll.assert_not_called()
+        broadcast.assert_not_called()
+        out = caller.msg.call_args[0][0]
+        self.assertIn("decomposed", out.lower())
+
 
 # ---------------------------------------------------------------------
-# DC / depth dispatch
+# Single-tier dispatch (PR #186 dropped /deep)
 # ---------------------------------------------------------------------
 
 
 class TestCmdAutopsyDispatch(TestCase):
-    def _run(self, *, switches, roll=99):
+    def _run(self, *, switches=(), roll=99, corpse=None):
         caller = _make_caller()
-        corpse = _FakeCorpse()
+        corpse = corpse or _FakeCorpse()
         cmd = _make_cmd(caller=caller, target=corpse, switches=switches)
         with _patch_corpse(), \
                 patch.object(cmd_module, "msg_room_identity") as broadcast, \
@@ -160,28 +208,97 @@ class TestCmdAutopsyDispatch(TestCase):
             cmd.func()
         return caller, corpse, broadcast
 
-    def test_basic_uses_summary_depth(self):
-        caller, _, broadcast = self._run(switches=[])
+    def test_unified_report_includes_essentials(self):
+        """No more /deep gating — essentials always render on success."""
+        caller, _, broadcast = self._run()
         self.assertTrue(caller.msg.called)
         rendered = caller.msg.call_args[0][0]
-        self.assertNotIn("Worn essentials", rendered)
+        self.assertIn("Worn essentials", rendered)
         broadcast.assert_called_once()
         template = broadcast.call_args.kwargs["template"]
         self.assertIn("examines", template)
         self.assertNotIn("deep autopsy", template)
 
-    def test_deep_uses_detailed_depth(self):
-        caller, _, broadcast = self._run(switches=["deep"])
-        rendered = caller.msg.call_args[0][0]
-        self.assertIn("Worn essentials", rendered)
-        template = broadcast.call_args.kwargs["template"]
-        self.assertIn("deep autopsy", template)
+    def test_dc_basic_constant_low_enough_to_tune(self):
+        """Sanity: AUTOPSY_DC_BASIC remains reachable by base Intellect."""
+        self.assertGreater(AUTOPSY_DC_BASIC, 0)
+        self.assertLess(AUTOPSY_DC_BASIC, 10)
 
-    def test_dc_constants_distinct(self):
-        """Sanity: /deep DC must exceed basic so tuning is meaningful."""
-        self.assertGreater(
-            AUTOPSY_DC_BASIC + AUTOPSY_DC_DEEP_OFFSET, AUTOPSY_DC_BASIC,
+
+# ---------------------------------------------------------------------
+# Report sections (PR #186)
+# ---------------------------------------------------------------------
+
+
+class TestCmdAutopsyReportSections(TestCase):
+    def _run(self, *, corpse):
+        caller = _make_caller()
+        cmd = _make_cmd(caller=caller, target=corpse)
+        with _patch_corpse(), \
+                patch.object(cmd_module, "msg_room_identity"), \
+                patch("world.combat.dice.roll_stat", return_value=99):
+            cmd.func()
+        return caller.msg.call_args[0][0]
+
+    def test_fresh_corpse_emits_recent_time_of_death_bucket(self):
+        corpse = _FakeCorpse(death_time=time.time() - 30)
+        rendered = self._run(corpse=corpse)
+        self.assertIn(AUTOPSY_TIME_BUCKETS[0][1], rendered)
+
+    def test_older_corpse_falls_into_later_bucket(self):
+        corpse = _FakeCorpse(death_time=time.time() - CORPSE_DECAY_EARLY - 1)
+        rendered = self._run(corpse=corpse)
+        self.assertIn(AUTOPSY_TIME_BUCKETS[2][1], rendered)
+
+    def test_cause_of_death_rendered(self):
+        corpse = _FakeCorpse(death_cause="blunt force trauma")
+        rendered = self._run(corpse=corpse)
+        self.assertIn("blunt force trauma", rendered)
+
+    def test_no_snapshot_emits_pre_mortem_unavailable_marker(self):
+        corpse = _FakeCorpse(snapshot=None)
+        rendered = self._run(corpse=corpse)
+        self.assertIn("No internal examination possible", rendered)
+
+    def test_organ_status_intact_damaged_destroyed(self):
+        snapshot = {
+            "organs": {
+                "heart": {"current_hp": 10, "max_hp": 10, "container": "torso"},
+                "liver": {"current_hp": 2, "max_hp": 10, "container": "torso"},
+                "left_lung": {
+                    "current_hp": 0, "max_hp": 10, "container": "torso",
+                },
+            }
+        }
+        corpse = _FakeCorpse(snapshot=snapshot)
+        rendered = self._run(corpse=corpse)
+        self.assertIn("heart: intact", rendered)
+        self.assertIn("liver: damaged", rendered)
+        self.assertIn("left_lung: destroyed", rendered)
+
+    def test_removed_organ_renders_as_absent(self):
+        snapshot = {
+            "organs": {
+                "heart": {"current_hp": 10, "max_hp": 10, "container": "torso"},
+            }
+        }
+        corpse = _FakeCorpse(snapshot=snapshot, removed_organs=["heart"])
+        rendered = self._run(corpse=corpse)
+        self.assertIn("heart: absent", rendered)
+
+    def test_severed_location_marks_contained_organs_absent(self):
+        snapshot = {
+            "organs": {
+                "left_hand_bones": {
+                    "current_hp": 8, "max_hp": 8, "container": "left_arm",
+                },
+            }
+        }
+        corpse = _FakeCorpse(
+            snapshot=snapshot, severed_locations=["left_arm"],
         )
+        rendered = self._run(corpse=corpse)
+        self.assertIn("left_hand_bones: absent", rendered)
 
 
 # ---------------------------------------------------------------------
@@ -301,3 +418,4 @@ class TestCmdAutopsyBroadcast(TestCase):
         self.assertIn("corpse", kwargs["char_refs"])
         self.assertIs(kwargs["char_refs"]["actor"], caller)
         self.assertIs(kwargs["char_refs"]["corpse"], corpse)
+

--- a/world/tests/test_corpse_medical_snapshot.py
+++ b/world/tests/test_corpse_medical_snapshot.py
@@ -1,0 +1,120 @@
+"""Tests for the death-time medical-state snapshot (PR #186).
+
+Verifies that :meth:`typeclasses.death_progression.DeathProgressionScript
+._create_corpse_from_character` captures the live character's full
+:class:`world.medical.core.MedicalState` via ``to_dict()`` and persists
+it on ``corpse.db.medical_state_at_death`` so the upcoming surgical
+commands (autopsy / harvest / sever) all have a single source of
+truth for the death-moment organ inventory.
+
+Also exercises :meth:`typeclasses.corpse.Corpse.get_medical_snapshot`
+as the canonical accessor — consumers must route through the helper
+rather than reading the raw ``db`` attribute so the contract is
+re-checkable in one place.
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_corpse_medical_snapshot
+"""
+
+from __future__ import annotations
+
+from evennia import create_object
+from evennia.utils.test_resources import EvenniaTest
+
+from typeclasses.characters import Character
+from typeclasses.death_progression import DeathProgressionScript
+
+
+class TestCorpseMedicalSnapshot(EvenniaTest):
+    """Snapshot write + round-trip via ``get_medical_snapshot``."""
+
+    character_typeclass = Character
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.victim = self.char1
+        self.victim.sleeve_uid = "sleeve-medical-001"
+        # Touch the medical state so the lazy initializer runs and
+        # populates the default organ set.  Reading the property is
+        # sufficient — :class:`world.medical.core.MedicalState`'s
+        # constructor wires the default organ table.
+        _ = self.victim.medical_state
+
+        self.script = DeathProgressionScript()
+
+    def _make_corpse(self):
+        return self.script._create_corpse_from_character(self.victim)
+
+    # ------------------------------------------------------------------
+    # Snapshot is written at corpse creation
+    # ------------------------------------------------------------------
+
+    def test_snapshot_persisted_on_corpse(self) -> None:
+        corpse = self._make_corpse()
+        try:
+            snapshot = corpse.db.medical_state_at_death
+            # Evennia wraps persisted dicts in ``_SaverDict``; the
+            # surface is dict-compatible but not a plain ``dict``
+            # subclass, so test the mapping protocol instead of the
+            # concrete type.
+            self.assertIsNotNone(snapshot)
+            self.assertIn("organs", snapshot)
+            self.assertGreater(len(snapshot["organs"]), 0)
+        finally:
+            corpse.delete()
+
+    def test_get_medical_snapshot_returns_persisted_dict(self) -> None:
+        """The accessor must surface the same data the db attribute holds."""
+        corpse = self._make_corpse()
+        try:
+            via_helper = corpse.get_medical_snapshot()
+            via_db = corpse.db.medical_state_at_death
+            self.assertIsNotNone(via_helper)
+            # ``_SaverDict`` instances compare equal field-by-field via
+            # the mapping protocol; identity is not guaranteed across
+            # repeated attribute reads.
+            self.assertEqual(dict(via_helper), dict(via_db))
+        finally:
+            corpse.delete()
+
+    def test_snapshot_matches_live_to_dict_at_death(self) -> None:
+        """The captured dict equals what the live ``to_dict`` returned."""
+        expected = self.victim.medical_state.to_dict()
+        corpse = self._make_corpse()
+        try:
+            self.assertEqual(corpse.db.medical_state_at_death, expected)
+        finally:
+            corpse.delete()
+
+    def test_sibling_lists_initialised_empty(self) -> None:
+        """Surgical-state lists must exist as empty containers so the
+        upcoming harvest / sever commands can append without guards."""
+        corpse = self._make_corpse()
+        try:
+            self.assertEqual(corpse.db.removed_organs, [])
+            self.assertEqual(corpse.db.severed_locations, [])
+        finally:
+            corpse.delete()
+
+    # ------------------------------------------------------------------
+    # Edge cases
+    # ------------------------------------------------------------------
+
+    def test_bare_character_still_yields_organ_inventory(self) -> None:
+        """A pristine character (no overrides applied) snapshots a
+        complete default organ table — the snapshot does not depend on
+        disguise state."""
+        bare = create_object(Character, key="Bare", location=self.room1)
+        bare.sleeve_uid = "sleeve-bare-medical-002"
+        _ = bare.medical_state
+        try:
+            corpse = self.script._create_corpse_from_character(bare)
+            try:
+                snapshot = corpse.get_medical_snapshot()
+                self.assertIsNotNone(snapshot)
+                self.assertIn("heart", snapshot["organs"])
+            finally:
+                corpse.delete()
+        finally:
+            bare.delete()

--- a/world/tests/test_forensics.py
+++ b/world/tests/test_forensics.py
@@ -6,8 +6,9 @@ Covers :mod:`world.forensics`:
   incident; ``NotImplementedError`` for photo stub.
 * :func:`attempt_forensic_recognition` — roll, cache hit/miss, cache
   re-roll on UID change, anonymous-looker handling.
-* :func:`render_forensic_report` — depth ladder output shape; safe
-  None-signature handling; never includes assigned names.
+* :func:`render_forensic_report` — single-tier unified output (PR
+  #186); identity axes always render; ``signature=None`` falls back to
+  graceful message; never includes assigned names.
 * :func:`link_subjects` — shared-axes detection.
 
 Built on lightweight fakes so no Evennia DB is required.
@@ -273,46 +274,39 @@ class TestRenderForensicReport(TestCase):
     def test_summary_lists_three_axes(self):
         sig = ("sleeve-1", "tall", "lean", "hooded", ())
         out = render_forensic_report(
-            self._subject(sig=sig), observer=None, depth="summary",
+            self._subject(sig=sig), observer=None,
         )
         self.assertIn("tall", out)
         self.assertIn("lean", out)
         self.assertIn("hooded", out)
-        self.assertNotIn("Worn essentials", out)
 
-    def test_detailed_includes_essentials(self):
+    def test_essentials_always_rendered_when_present(self):
+        """PR #186 dropped the depth ladder — essentials always render."""
         sig = ("sleeve-1", "tall", "lean", "hooded", ("balaclava", "trenchcoat"))
         out = render_forensic_report(
             self._subject(sig=sig, essentials=("balaclava", "trenchcoat")),
-            observer=None, depth="detailed",
+            observer=None,
         )
         self.assertIn("balaclava", out)
         self.assertIn("trenchcoat", out)
 
-    def test_detailed_with_no_essentials(self):
+    def test_no_essentials_omits_section(self):
         sig = ("sleeve-1", "tall", "lean", "hooded", ())
         out = render_forensic_report(
-            self._subject(sig=sig), observer=None, depth="detailed",
+            self._subject(sig=sig), observer=None,
         )
-        self.assertIn("none recovered", out)
+        self.assertNotIn("Worn essentials", out)
 
     def test_none_signature_returns_graceful_message(self):
         out = render_forensic_report(
-            self._subject(sig=None), observer=None, depth="summary",
+            self._subject(sig=None), observer=None,
         )
         self.assertIn("no further forensic detail", out)
-
-    def test_invalid_depth_raises(self):
-        sig = ("sleeve-1", None, None, None, ())
-        with self.assertRaises(ValueError):
-            render_forensic_report(
-                self._subject(sig=sig), observer=None, depth="bogus",
-            )
 
     def test_indeterminate_axes_rendered(self):
         sig = ("sleeve-1", None, None, None, ())
         out = render_forensic_report(
-            self._subject(sig=sig), observer=None, depth="summary",
+            self._subject(sig=sig), observer=None,
         )
         self.assertIn("indeterminate", out)
 
@@ -320,7 +314,7 @@ class TestRenderForensicReport(TestCase):
         """Recognition contract: renderer must not surface names."""
         sig = ("sleeve-1", "tall", "lean", "hooded", ())
         out = render_forensic_report(
-            self._subject(sig=sig), observer=None, depth="detailed",
+            self._subject(sig=sig), observer=None,
         )
         # The renderer has no access to recognition memory at all.
         self.assertNotIn("Jorge", out)


### PR DESCRIPTION
## Summary

Reworks the autopsy command in preparation for the upcoming `harvest`
(PR-187) and `sever` (PR-188) surgical commands. Drops the `/deep`
two-tier ladder in favour of a single unified Intellect check that
surfaces a richer five-section forensic report, and lays in the
death-time medical-state snapshot that the two follow-ups will mutate.

Closes #186.

## Changes

- **`typeclasses/death_progression.py`** — snapshot
  `character.medical_state.to_dict()` onto
  `corpse.db.medical_state_at_death` at corpse creation (try/except
  with Splattercast diagnostics so it cannot block corpse creation).
- **`typeclasses/corpse.py`** — initialise `medical_state_at_death`,
  `removed_organs`, `severed_locations`; add `get_medical_snapshot()`
  accessor.
- **`world/combat/constants.py`** — drop `AUTOPSY_DC_DEEP_OFFSET`;
  add `AUTOPSY_TIME_BUCKETS` aligned to `CORPSE_DECAY_*` thresholds.
- **`world/forensics.py`** — rewrite `render_forensic_report` as the
  unified five-section renderer (identity / fuzzy ToD / cause /
  wounds / organs / essentials). Removed or severed organs render as
  `absent` (no surgeon attribution per PR-186 Q3).
- **`commands/forensics.py`** — `CmdAutopsy` loses the `/deep` switch
  + branch; gains a skeletal-corpse short-circuit. Cache contract is
  unchanged — it still gates the identity-name surface only; the
  report body always renders on success.
- **`specs/IDENTITY_RECOGNITION_SPEC.md`** — refresh
  §Forensic Recognition Engine; document the new constants and
  defer-list entries (skeletal-bone harvest, severed-head super-item).
- Tests: `test_cmd_autopsy.py` rewritten (drops `/deep`, adds
  skeletal / ToD-bucket / cause / wound / organ-status assertions);
  `test_forensics.py` depth-ladder cases replaced with unified-render
  cases; **new** `test_corpse_medical_snapshot.py` covers the
  snapshot write + helper round-trip + sibling-list init.

## Tests

`docker exec gelatinous evennia test --settings settings.py world commands typeclasses`
→ **998 passing**.

## Deferred (spec-notes only)

- Skeletal-bone harvest (cracked-bone marrow extraction) — past PR-186.
- Severed-head super-item carrying full identity signature — v2 of
  the sever workflow.
- Sleeve-swap awareness — blocked on the resleeving system.