### PR TITLE
Add harvest command for organ extraction from corpses (#188)

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -38,7 +38,7 @@ from commands.CmdGraffiti import CmdGraffiti, CmdPress
 from commands.CmdCharacter import CmdLongdesc, CmdSkintone
 from commands.CmdCharacter import CmdShortdesc, CmdRemember, CmdForget, CmdRecall, CmdMemory
 from commands.CmdCommunication import CmdSay, CmdWhisper, CmdEmote, CmdDotPose
-from commands.forensics import CmdAutopsy
+from commands.forensics import CmdAutopsy, CmdHarvest
 from world.emote_templates import SOCIAL_COMMANDS
 from commands.CmdArmor import CmdArmor, CmdArmorRepair, CmdSlot, CmdUnslot
 from commands.shop import CmdBuy
@@ -247,6 +247,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
 
         # Add forensic command surfaces (PR-E)
         self.add(CmdAutopsy())
+        self.add(CmdHarvest())
 
 class AccountCmdSet(default_cmds.AccountCmdSet):
     """

--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -10,20 +10,31 @@ Currently ships:
   wounds, organ inventory, and worn essentials.  Single-tier
   (the legacy ``/deep`` switch was dropped in PR #186 in favour of
   the unified five-section report).
+* :class:`CmdHarvest` — extract a named organ from a corpse via a
+  Motorics roll, spawning a :class:`typeclasses.items.Organ` item
+  into the harvester's inventory and marking the organ ``absent`` on
+  subsequent autopsies (PR #188).
 """
 
 from __future__ import annotations
 
-from evennia import Command
+from evennia import Command, create_object
 
 from typeclasses.corpse import Corpse
-from world.combat.constants import AUTOPSY_DC_BASIC
+from world.combat.constants import (
+    AUTOPSY_DC_BASIC,
+    HARVEST_CRIT_FAIL,
+    HARVEST_DC_BASIC,
+    ORGAN_CONDITION_BY_DECAY,
+)
+from world.combat.dice import roll_stat
 from world.forensics import (
     attempt_forensic_recognition,
     extract_subject_from_corpse,
     render_forensic_report,
 )
 from world.identity_utils import msg_room_identity
+from world.medical.constants import ORGANS
 
 
 class CmdAutopsy(Command):
@@ -134,3 +145,258 @@ class CmdAutopsy(Command):
                 )
 
         caller.msg(f"{header}\n{report}")
+
+
+# ---------------------------------------------------------------------
+# CmdHarvest (PR #188)
+# ---------------------------------------------------------------------
+
+
+def _harvestable_organs(corpse) -> list[str]:
+    """Return organ names that are still extractable from *corpse*.
+
+    Filters the death-time medical snapshot against three gates:
+
+    1. Organ must declare ``can_be_harvested: True`` in
+       :data:`world.medical.constants.ORGANS`.
+    2. Organ must not already be in ``corpse.db.removed_organs``.
+    3. Organ's container must not be in ``corpse.db.severed_locations``
+       (a severed limb takes its contained organs with it; PR #189
+       will produce the severed limb item itself).
+    4. Organ must still have ``current_hp > 0`` in the snapshot
+       (destroyed organs are not recoverable as items).
+
+    Returns an empty list if the snapshot is missing.
+    """
+    snapshot = corpse.get_medical_snapshot()
+    if snapshot is None:
+        return []
+    removed = set(corpse.db.removed_organs or ())
+    severed = set(corpse.db.severed_locations or ())
+    organs = snapshot.get("organs") or {}
+    out: list[str] = []
+    for name, organ_data in organs.items():
+        spec = ORGANS.get(name) or {}
+        if not spec.get("can_be_harvested"):
+            continue
+        if name in removed:
+            continue
+        if organ_data.get("container") in severed:
+            continue
+        if (organ_data.get("current_hp") or 0) <= 0:
+            continue
+        out.append(name)
+    return out
+
+
+class CmdHarvest(Command):
+    """Extract a named organ from a corpse.
+
+    Usage:
+      harvest <organ> from <corpse>
+      harvest <corpse>          (lists harvestable organs)
+
+    Rolls Motorics vs ``HARVEST_DC_BASIC``.  On success an
+    :class:`~typeclasses.items.Organ` item is spawned into the
+    harvester's inventory, the organ is appended to the corpse's
+    ``removed_organs`` list, and the death-time medical snapshot is
+    mutated in place so subsequent autopsies render the organ as
+    *absent*.  A natural roll of ``HARVEST_CRIT_FAIL`` destroys the
+    organ instead — the snapshot's ``current_hp`` is zeroed and no
+    item is produced.
+
+    Refused outright when:
+
+    * The corpse is skeletal (no soft tissue remains).
+    * The corpse predates PR #186 and has no medical snapshot.
+    * The named organ is missing, undeclared as harvestable, or
+      flagged ``cannot_be_destroyed`` (spine).
+    * The organ has already been harvested, lives inside a severed
+      limb container, or is destroyed.
+
+    The freshness of the spawned organ tracks the corpse's decay stage
+    via :data:`world.combat.constants.ORGAN_CONDITION_BY_DECAY`:
+    fresh / early → ``pristine``; moderate → ``damaged``; advanced →
+    ``putrid``; skeletal → refused outright.
+    """
+
+    key = "harvest"
+    aliases = ()
+    locks = "cmd:all()"
+    help_category = "Forensics"
+
+    def func(self):  # noqa: C901 — straight-line guard-clause flow
+        caller = self.caller
+        raw = (self.args or "").strip()
+        if not raw:
+            caller.msg("Usage: harvest <organ> from <corpse>")
+            return
+
+        # Split on ' from ' once; if absent, treat the whole arg as a
+        # corpse and surface the harvestable-organ list.
+        if " from " in raw:
+            organ_arg, _, corpse_arg = raw.partition(" from ")
+            organ_arg = organ_arg.strip().lower().replace(" ", "_")
+            corpse_arg = corpse_arg.strip()
+        else:
+            organ_arg = ""
+            corpse_arg = raw
+
+        target = caller.search(corpse_arg, location=caller.location)
+        if target is None:
+            return  # search() already messaged
+
+        if not isinstance(target, Corpse):
+            caller.msg("You can only harvest organs from a corpse.")
+            return
+
+        if target.get_decay_stage() == "skeletal":
+            caller.msg(
+                "The remains are too far decomposed — only bone is left."
+            )
+            return
+
+        snapshot = target.get_medical_snapshot()
+        if snapshot is None:
+            caller.msg(
+                "These remains predate forensic record-keeping; no "
+                "internal examination is possible."
+            )
+            return
+
+        harvestable = _harvestable_organs(target)
+
+        if not organ_arg:
+            # Ambiguous form — list options.
+            if not harvestable:
+                caller.msg(
+                    f"There are no harvestable organs left in "
+                    f"{target.get_display_name(caller)}."
+                )
+                return
+            readable = ", ".join(o.replace("_", " ") for o in harvestable)
+            caller.msg(
+                f"Harvestable organs in {target.get_display_name(caller)}: "
+                f"{readable}.\nUsage: harvest <organ> from <corpse>"
+            )
+            return
+
+        # Specific organ requested.  Validate against the snapshot
+        # *and* the ORGANS spec to produce useful error messages.
+        organs = snapshot.get("organs") or {}
+        if organ_arg not in organs:
+            caller.msg(
+                f"There is no {organ_arg.replace('_', ' ')} in "
+                f"{target.get_display_name(caller)}."
+            )
+            return
+
+        spec = ORGANS.get(organ_arg) or {}
+        if spec.get("cannot_be_destroyed"):
+            caller.msg(
+                f"The {organ_arg.replace('_', ' ')} is too deeply "
+                f"integrated to extract."
+            )
+            return
+        if not spec.get("can_be_harvested"):
+            caller.msg(
+                f"The {organ_arg.replace('_', ' ')} cannot be harvested."
+            )
+            return
+
+        organ_data = organs[organ_arg]
+        if organ_arg in (target.db.removed_organs or ()):
+            caller.msg(
+                f"The {organ_arg.replace('_', ' ')} has already been "
+                f"removed from these remains."
+            )
+            return
+        if organ_data.get("container") in (target.db.severed_locations or ()):
+            caller.msg(
+                f"The {organ_arg.replace('_', ' ')} went with the "
+                f"severed {organ_data.get('container')}."
+            )
+            return
+        if (organ_data.get("current_hp") or 0) <= 0:
+            caller.msg(
+                f"The {organ_arg.replace('_', ' ')} is already destroyed."
+            )
+            return
+
+        # Pre-roll broadcast — observers see the surgical attempt
+        # regardless of outcome.
+        readable_name = organ_arg.replace("_", " ")
+        corpse_display = target.get_display_name(caller)
+        msg_room_identity(
+            location=caller.location,
+            template=(
+                f"{{actor}} begins extracting the {readable_name} "
+                f"from {{corpse}}."
+            ),
+            char_refs={"actor": caller, "corpse": target},
+            exclude=[caller],
+        )
+
+        roll = roll_stat(caller, "motorics")
+
+        if roll == HARVEST_CRIT_FAIL:
+            # Critical fail destroys the organ in place — no item
+            # spawned, but the snapshot must be mutated and re-saved
+            # so autopsies render the organ as ``destroyed``.
+            organ_data["current_hp"] = 0
+            target.db.medical_state_at_death = snapshot
+            caller.msg(
+                f"Your hand slips — the {readable_name} ruptures and is "
+                f"destroyed beyond recovery."
+            )
+            msg_room_identity(
+                location=caller.location,
+                template=(
+                    f"{{actor}}'s extraction goes wrong; the "
+                    f"{readable_name} ruptures inside {{corpse}}."
+                ),
+                char_refs={"actor": caller, "corpse": target},
+                exclude=[caller],
+            )
+            return
+
+        if roll < HARVEST_DC_BASIC:
+            caller.msg(
+                f"You probe at {corpse_display} but cannot extract the "
+                f"{readable_name} cleanly. The organ remains in place."
+            )
+            return
+
+        # Success: mutate snapshot, append to removed_organs, spawn item.
+        condition = ORGAN_CONDITION_BY_DECAY.get(
+            target.get_decay_stage(), "damaged"
+        )
+        removed_list = list(target.db.removed_organs or ())
+        removed_list.append(organ_arg)
+        target.db.removed_organs = removed_list
+        target.db.medical_state_at_death = snapshot  # re-save no-op for
+        # parity with crit-fail branch; future per-organ HP tweaks rely
+        # on this contract.
+
+        organ_item = create_object(
+            "typeclasses.items.Organ",
+            key=f"{condition} {readable_name}",
+            location=caller,
+        )
+        organ_item.configure_from_harvest(
+            organ_name=organ_arg, condition=condition, corpse=target,
+        )
+
+        caller.msg(
+            f"You extract the {readable_name} from {corpse_display} — "
+            f"the organ is {condition}."
+        )
+        msg_room_identity(
+            location=caller.location,
+            template=(
+                f"{{actor}} extracts the {condition} {readable_name} "
+                f"from {{corpse}}."
+            ),
+            char_refs={"actor": caller, "corpse": target},
+            exclude=[caller],
+        )

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1553,6 +1553,87 @@ careful examination and prevents Intellect re-roll abuse.
 
 ---
 
+## Surgical Harvest (PR #188)
+
+`harvest <organ> from <corpse>` extracts a named organ from a
+corpse, spawning a :class:`typeclasses.items.Organ` item into the
+harvester's inventory.  Builds on the PR-186 death-time medical
+snapshot — the snapshot is the single source of truth for organ
+state, and the harvest command mutates it in place so subsequent
+autopsies render the removed organ as `absent`.
+
+### Command contract
+
+- **Roll**: Motorics vs `HARVEST_DC_BASIC`.  Natural
+  `HARVEST_CRIT_FAIL` (= 1) destroys the organ — zeroes
+  `current_hp` in the snapshot, no item produced.
+- **Ambiguous form** (`harvest <corpse>`) lists currently
+  harvestable organ names instead of erroring opaquely.
+- **Pre-roll refusals** (no Motorics roll spent):
+  - Skeletal corpse — no soft tissue remains.
+  - Pre-PR-#186 corpse — `get_medical_snapshot() is None`.
+  - Organ not present in the snapshot.
+  - Organ flagged `cannot_be_destroyed` (spine).
+  - Organ not flagged `can_be_harvested` (lungs, brain, eyes, etc.).
+  - Organ already in `corpse.db.removed_organs`.
+  - Organ's container in `corpse.db.severed_locations` (PR #189
+    sever-limb takes contained organs with it).
+  - Organ `current_hp <= 0` ("already destroyed").
+- **Pre-roll broadcast**: room sees the extraction attempt via
+  `msg_room_identity` regardless of outcome.
+- **On success**: append to `removed_organs`, re-save snapshot,
+  spawn `Organ` item with `configure_from_harvest`.
+- **Organ freshness** tracks the source corpse's decay stage via
+  `ORGAN_CONDITION_BY_DECAY`: fresh / early → `pristine`;
+  moderate → `damaged`; advanced → `putrid`.  Skeletal is gated
+  out at the decay check.
+
+### Organ typeclass
+
+`typeclasses.items.Organ` extends `Item` and carries:
+
+| Attribute | Source |
+|---|---|
+| `db.organ_name` | Canonical key from `ORGANS` |
+| `db.condition` | `ORGAN_CONDITION_BY_DECAY[stage]` at extraction |
+| `db.source_signature` | Copy of `corpse.db.signature_at_death` |
+| `db.source_apparent_uid` | Copy of `corpse.db.apparent_uid_at_death` |
+| `db.source_corpse_dbref` | Audit pointer; not resolution-guaranteed |
+
+The display key is rendered `"<condition> <organ name>"`
+(underscores → spaces) at spawn time via
+`configure_from_harvest`.
+
+### DC tuning (provisional)
+
+```python
+HARVEST_DC_BASIC = 3
+HARVEST_CRIT_FAIL = 1
+ORGAN_CONDITION_BY_DECAY = {
+    "fresh": "pristine", "early": "pristine",
+    "moderate": "damaged", "advanced": "putrid",
+    "skeletal": "refuse",
+}
+```
+
+Flagged for balance review once the black-market organ-trade
+gameplay loop lands.  `HARVEST_DC_BASIC` matches `AUTOPSY_DC_BASIC`
+intentionally — both are "basic forensic competency" gates.
+
+### Out of scope (deferred to later PRs)
+
+- Sever-limb command (PR #189) — will populate
+  `corpse.db.severed_locations` which the harvest gate already
+  honours.
+- Black-market organ economy / NPC fences.
+- Organ implantation / replacement surgery.
+- Snapshot persistence across corpse deletion (lost when the
+  corpse decays out — `source_corpse_dbref` becomes stale but the
+  forensic-chain copy of the signature on the organ item
+  survives).
+
+---
+
 ## New Character Attributes
 
 ### On Character (sleeve-level)

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -955,3 +955,63 @@ class RemoteDetonator(Item):
                         explosive_obj.db.scanned_by_detonator = None
         
         super().at_delete()
+
+
+class Organ(Item):
+    """A harvested organ extracted from a corpse via ``harvest``.
+
+    Surfaces the forensic-chain provenance (source corpse signature)
+    so downstream gameplay — implantation, black-market trade,
+    investigation — can reason about origin without re-querying the
+    source corpse (which may have decayed away by the time the organ
+    changes hands).
+
+    Attributes (``self.db``):
+        organ_name: Canonical organ identifier from
+            :data:`world.medical.constants.ORGANS`
+            (e.g. ``"heart"``, ``"liver"``).
+        condition: Freshness descriptor at extraction time, derived
+            from the source corpse's decay stage via
+            :data:`world.combat.constants.ORGAN_CONDITION_BY_DECAY`.
+        source_signature: Copy of the source corpse's
+            ``signature_at_death`` tuple (forensic chain).
+        source_apparent_uid: Copy of the source corpse's
+            ``apparent_uid_at_death`` (forensic chain).
+        source_corpse_dbref: ``#NNN`` ref of the source corpse, for
+            audit / debugging — not guaranteed resolvable (the corpse
+            may have decayed and been deleted).
+
+    The display name is rendered ``"<condition> <organ_name>"``
+    (e.g. ``"pristine heart"``) at ``at_object_creation`` time; callers
+    that need the raw organ identifier should read ``db.organ_name``.
+    """
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        # Defaults — the harvest command overwrites these immediately
+        # after spawn via ``configure_from_harvest``.
+        self.db.organ_name = ""
+        self.db.condition = "pristine"
+        self.db.source_signature = None
+        self.db.source_apparent_uid = None
+        self.db.source_corpse_dbref = None
+
+    def configure_from_harvest(self, *, organ_name, condition, corpse):
+        """Populate forensic-chain fields immediately after spawn.
+
+        Args:
+            organ_name (str): Canonical organ identifier.
+            condition (str): Freshness descriptor.
+            corpse: The source :class:`typeclasses.corpse.Corpse`.
+
+        Sets the display key to ``"<condition> <organ_name>"`` with
+        underscores in the organ name replaced by spaces so the
+        canonical ``"left_kidney"`` reads as ``"pristine left kidney"``.
+        """
+        self.db.organ_name = organ_name
+        self.db.condition = condition
+        self.db.source_signature = corpse.db.signature_at_death
+        self.db.source_apparent_uid = corpse.db.apparent_uid_at_death
+        self.db.source_corpse_dbref = corpse.dbref
+        readable = organ_name.replace("_", " ")
+        self.key = f"{condition} {readable}"

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -751,3 +751,23 @@ AUTOPSY_TIME_BUCKETS = (
     (CORPSE_DECAY_ADVANCED, "dead for several days"),
     (float("inf"), "long dead"),
 )
+
+# Surgical Harvest (PR #188) ------------------------------------------
+# Motorics DC for extracting an organ from a corpse via
+# ``harvest <organ> from <corpse>``.  A roll of exactly ``1`` (natural
+# botch) destroys the target organ instead of producing an item.  Tuned
+# against the same baseline as ``AUTOPSY_DC_BASIC``; flagged for
+# balance review once organ-trade gameplay lands.
+HARVEST_DC_BASIC = 3
+HARVEST_CRIT_FAIL = 1
+
+# Decay-stage → freshness condition surfaced on harvested ``Organ``
+# items and gated for refusal at the skeletal stage (no soft tissue
+# remains).  Mirrors the corpse decay model in :mod:`typeclasses.corpse`.
+ORGAN_CONDITION_BY_DECAY = {
+    "fresh": "pristine",
+    "early": "pristine",
+    "moderate": "damaged",
+    "advanced": "putrid",
+    "skeletal": "refuse",
+}

--- a/world/tests/test_cmd_harvest.py
+++ b/world/tests/test_cmd_harvest.py
@@ -1,0 +1,357 @@
+"""Unit tests for :class:`commands.forensics.CmdHarvest` (PR #188).
+
+Exercises the harvest command end-to-end with lightweight fakes so no
+Evennia DB is required.  Mirrors the strategy used in
+:mod:`world.tests.test_cmd_autopsy`: substitute the
+``commands.forensics.Corpse`` symbol with a stand-in base class so the
+``isinstance(target, Corpse)`` guard accepts our fake without patching
+the ``isinstance`` builtin (which causes infinite recursion against
+``mock.call`` internals).
+
+Coverage matrix:
+
+* Usage / argument parsing.
+* Non-corpse rejection.
+* Skeletal-corpse short-circuit.
+* Pre-PR-#186 snapshot-less corpse refusal.
+* Ambiguous ``harvest <corpse>`` lists harvestable organs.
+* Snapshot organ missing / spec missing / spine refusal.
+* Already-removed / inside-severed-limb / destroyed refusal.
+* Roll-fail (mid-range) leaves snapshot untouched.
+* Critical-fail (natural 1) zeroes ``current_hp`` in snapshot.
+* Success spawns an Organ via ``create_object``, mutates snapshot,
+  appends to ``removed_organs``.
+
+Run via::
+
+    evennia test world.tests.test_cmd_harvest
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from commands import forensics as cmd_module
+from commands.forensics import CmdHarvest
+from world.combat.constants import (
+    HARVEST_CRIT_FAIL,
+    HARVEST_DC_BASIC,
+    ORGAN_CONDITION_BY_DECAY,
+)
+
+
+# ---------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------
+
+
+class _DB:
+    """Bare attribute holder mimicking ``obj.db``."""
+
+
+class _FakeRoom:
+    def __init__(self):
+        self.contents = []
+
+
+class _CorpseStandIn:
+    """Stand-in for :class:`typeclasses.corpse.Corpse` (isinstance target)."""
+
+
+class _FakeCorpse(_CorpseStandIn):
+    """Minimal corpse surface the harvest command needs."""
+
+    def __init__(
+        self,
+        *,
+        key="the corpse of Jorge",
+        display=None,
+        decay_stage="fresh",
+        snapshot=None,
+        removed_organs=None,
+        severed_locations=None,
+        dbref="#101",
+    ):
+        self.key = key
+        self.dbref = dbref
+        self.db = _DB()
+        self.db.signature_at_death = (
+            "sleeve-1", "tall", "lean", "hooded", ("balaclava",),
+        )
+        self.db.apparent_uid_at_death = "abc123"
+        self.db.medical_state_at_death = snapshot
+        self.db.removed_organs = list(removed_organs or ())
+        self.db.severed_locations = list(severed_locations or ())
+        self._display = display or key
+        self._decay_stage = decay_stage
+
+    def get_display_name(self, looker=None, **kwargs):  # noqa: D401
+        del looker, kwargs
+        return self._display
+
+    def get_decay_stage(self):
+        return self._decay_stage
+
+    def get_medical_snapshot(self):
+        return self.db.medical_state_at_death
+
+
+def _snapshot_with(*, heart_hp=15, liver_hp=20, kidney_hp=15):
+    """Return a minimal MedicalState.to_dict()-shaped snapshot."""
+    return {
+        "organs": {
+            "heart": {
+                "current_hp": heart_hp, "max_hp": 15, "container": "chest",
+            },
+            "liver": {
+                "current_hp": liver_hp, "max_hp": 20, "container": "abdomen",
+            },
+            "left_kidney": {
+                "current_hp": kidney_hp, "max_hp": 15, "container": "abdomen",
+            },
+            "spine": {
+                "current_hp": 25, "max_hp": 25, "container": "back",
+            },
+            "left_lung": {
+                "current_hp": 20, "max_hp": 20, "container": "chest",
+            },
+        },
+        "conditions": [],
+        "blood_level": 5000,
+        "pain_level": 0,
+        "consciousness": True,
+    }
+
+
+def _make_caller(*, key="Alice", dbref="#42", location=None):
+    caller = MagicMock()
+    caller.key = key
+    caller.dbref = dbref
+    caller.location = location or _FakeRoom()
+    caller.recognition_memory = {}
+    caller.msg = MagicMock()
+    caller.search = MagicMock()
+    caller.motorics = 10
+    return caller
+
+
+def _make_cmd(*, caller, args):
+    cmd = CmdHarvest()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.switches = ()
+    return cmd
+
+
+# ---------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------
+
+
+class CmdHarvestTests(TestCase):
+    def setUp(self):
+        # Swap the Corpse symbol so our fake passes isinstance.
+        self._patcher = patch.object(cmd_module, "Corpse", _CorpseStandIn)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    # ----- argument handling -----
+
+    def test_no_args_prints_usage(self):
+        caller = _make_caller()
+        _make_cmd(caller=caller, args="").func()
+        caller.msg.assert_called_once()
+        self.assertIn("Usage", caller.msg.call_args[0][0])
+
+    def test_non_corpse_rejected(self):
+        caller = _make_caller()
+        caller.search.return_value = MagicMock()  # not a _CorpseStandIn
+        _make_cmd(caller=caller, args="heart from rock").func()
+        caller.msg.assert_called_with(
+            "You can only harvest organs from a corpse."
+        )
+
+    # ----- decay / snapshot gates -----
+
+    def test_skeletal_short_circuit(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(decay_stage="skeletal", snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="heart from corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("decomposed", msg)
+
+    def test_no_snapshot_refused(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=None)
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="heart from corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("predate", msg)
+
+    # ----- ambiguous form -----
+
+    def test_ambiguous_lists_harvestable(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("heart", msg)
+        self.assertIn("liver", msg)
+        self.assertIn("left kidney", msg)
+        # spine is cannot_be_destroyed; lung is can_be_harvested=False
+        self.assertNotIn("spine", msg)
+        self.assertNotIn("lung", msg)
+
+    def test_ambiguous_with_nothing_left(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            snapshot=_snapshot_with(),
+            removed_organs=["heart", "liver", "left_kidney"],
+        )
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("no harvestable organs", msg)
+
+    # ----- per-organ refusals -----
+
+    def test_missing_organ_refused(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="gallbladder from corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("no gallbladder", msg)
+
+    def test_spine_refused(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="spine from corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("too deeply integrated", msg)
+
+    def test_lung_refused_not_harvestable(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="left_lung from corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("cannot be harvested", msg)
+
+    def test_already_removed_refused(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            snapshot=_snapshot_with(), removed_organs=["heart"],
+        )
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="heart from corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("already been removed", msg)
+
+    def test_inside_severed_limb_refused(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            snapshot=_snapshot_with(), severed_locations=["chest"],
+        )
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="heart from corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("went with the severed chest", msg)
+
+    def test_destroyed_organ_refused(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with(heart_hp=0))
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="heart from corpse").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("already destroyed", msg)
+
+    # ----- roll outcomes -----
+
+    def test_roll_fail_leaves_state_intact(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        # Force a mid-range fail (above crit-fail, below DC).
+        fail_roll = HARVEST_DC_BASIC - 1
+        self.assertGreater(fail_roll, HARVEST_CRIT_FAIL)
+        with patch.object(cmd_module, "roll_stat", return_value=fail_roll), \
+                patch.object(cmd_module, "create_object") as mk:
+            _make_cmd(caller=caller, args="heart from corpse").func()
+            mk.assert_not_called()
+        self.assertEqual(corpse.db.removed_organs, [])
+        self.assertEqual(
+            corpse.db.medical_state_at_death["organs"]["heart"]["current_hp"],
+            15,
+        )
+
+    def test_crit_fail_destroys_organ(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=HARVEST_CRIT_FAIL
+        ), patch.object(cmd_module, "create_object") as mk:
+            _make_cmd(caller=caller, args="heart from corpse").func()
+            mk.assert_not_called()
+        self.assertEqual(
+            corpse.db.medical_state_at_death["organs"]["heart"]["current_hp"],
+            0,
+        )
+        self.assertEqual(corpse.db.removed_organs, [])
+
+    def test_success_spawns_organ_and_mutates_snapshot(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with(), decay_stage="fresh")
+        caller.search.return_value = corpse
+        fake_organ = MagicMock()
+        with patch.object(
+            cmd_module, "roll_stat", return_value=HARVEST_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=fake_organ
+        ) as mk:
+            _make_cmd(caller=caller, args="heart from corpse").func()
+            mk.assert_called_once()
+            kwargs = mk.call_args.kwargs
+            self.assertEqual(kwargs["location"], caller)
+            self.assertIn("heart", kwargs["key"])
+        fake_organ.configure_from_harvest.assert_called_once_with(
+            organ_name="heart",
+            condition=ORGAN_CONDITION_BY_DECAY["fresh"],
+            corpse=corpse,
+        )
+        self.assertEqual(corpse.db.removed_organs, ["heart"])
+
+    def test_success_condition_tracks_decay(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with(), decay_stage="advanced")
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=HARVEST_DC_BASIC + 5
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ) as mk:
+            _make_cmd(caller=caller, args="liver from corpse").func()
+        self.assertIn(
+            ORGAN_CONDITION_BY_DECAY["advanced"], mk.call_args.kwargs["key"]
+        )
+
+    def test_organ_name_accepts_spaces(self):
+        """``harvest left kidney from corpse`` → underscore-normalized."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=HARVEST_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ) as mk:
+            _make_cmd(caller=caller, args="left kidney from corpse").func()
+            mk.assert_called_once()
+        self.assertEqual(corpse.db.removed_organs, ["left_kidney"])


### PR DESCRIPTION
## Summary

Implements `harvest <organ> from <corpse>` on top of the PR-186 death-time medical snapshot. Motorics roll vs `HARVEST_DC_BASIC`; natural 1 destroys the organ. Success spawns an `Organ` item with forensic-chain provenance and mutates the corpse snapshot in place so subsequent autopsies render the organ as `absent`.

Closes #188.

## Surfaces

- `world/combat/constants.py` — `HARVEST_DC_BASIC=3`, `HARVEST_CRIT_FAIL=1`, `ORGAN_CONDITION_BY_DECAY`
- `typeclasses/items.py::Organ` — typeclass with `configure_from_harvest(organ_name, condition, corpse)`; carries `organ_name`, `condition`, `source_signature`, `source_apparent_uid`, `source_corpse_dbref`
- `commands/forensics.py::CmdHarvest` — motorics roll, ambiguous-form listing, full pre-roll guard suite, per-observer room broadcasts via `msg_room_identity`
- `commands/default_cmdsets.py` — registers `CmdHarvest`
- `specs/IDENTITY_RECOGNITION_SPEC.md` — new "Surgical Harvest (PR #188)" section

## Guards (pre-roll, no DC spent)

- Skeletal corpse / no medical snapshot
- Organ missing / `cannot_be_destroyed` (spine) / `can_be_harvested=False` (lungs etc.)
- Already in `removed_organs`
- Container in `severed_locations` (forward-compat with PR #189)
- `current_hp <= 0`

## Tests

1015 pass (998 baseline + 17 new in `world/tests/test_cmd_harvest.py`):

- Argument parsing (usage, non-corpse rejection, space-in-organ-name normalization)
- All pre-roll refusal branches
- Ambiguous form lists harvestable organs (filters spine, lungs)
- Mid-range fail vs crit-fail vs success — snapshot mutation correctness
- Condition tracks decay stage (fresh→pristine, advanced→putrid)

## Deferred

- PR #189 sever-limb (will populate `severed_locations` — gate already in place)
- Organ economy / NPC fences / implantation