### PR TITLE
Add sever command for limb detachment from corpses (#190)

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -38,7 +38,7 @@ from commands.CmdGraffiti import CmdGraffiti, CmdPress
 from commands.CmdCharacter import CmdLongdesc, CmdSkintone
 from commands.CmdCharacter import CmdShortdesc, CmdRemember, CmdForget, CmdRecall, CmdMemory
 from commands.CmdCommunication import CmdSay, CmdWhisper, CmdEmote, CmdDotPose
-from commands.forensics import CmdAutopsy, CmdHarvest
+from commands.forensics import CmdAutopsy, CmdHarvest, CmdSever
 from world.emote_templates import SOCIAL_COMMANDS
 from commands.CmdArmor import CmdArmor, CmdArmorRepair, CmdSlot, CmdUnslot
 from commands.shop import CmdBuy
@@ -248,6 +248,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         # Add forensic command surfaces (PR-E)
         self.add(CmdAutopsy())
         self.add(CmdHarvest())
+        self.add(CmdSever())
 
 class AccountCmdSet(default_cmds.AccountCmdSet):
     """

--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -14,6 +14,11 @@ Currently ships:
   Motorics roll, spawning a :class:`typeclasses.items.Organ` item
   into the harvester's inventory and marking the organ ``absent`` on
   subsequent autopsies (PR #188).
+* :class:`CmdSever` — remove a limb (or the head) from a corpse via
+  a Motorics roll, spawning a :class:`typeclasses.items.Appendage`
+  item.  The severed location is appended to
+  ``corpse.db.severed_locations`` so :class:`CmdHarvest` correctly
+  refuses to extract organs that left with the limb (PR #190).
 """
 
 from __future__ import annotations
@@ -26,6 +31,9 @@ from world.combat.constants import (
     HARVEST_CRIT_FAIL,
     HARVEST_DC_BASIC,
     ORGAN_CONDITION_BY_DECAY,
+    SEVER_CRIT_FAIL,
+    SEVER_DC_BASIC,
+    SEVERABLE_CONTAINERS,
 )
 from world.combat.dice import roll_stat
 from world.forensics import (
@@ -395,6 +403,234 @@ class CmdHarvest(Command):
             location=caller.location,
             template=(
                 f"{{actor}} extracts the {condition} {readable_name} "
+                f"from {{corpse}}."
+            ),
+            char_refs={"actor": caller, "corpse": target},
+            exclude=[caller],
+        )
+
+
+# ---------------------------------------------------------------------
+# CmdSever (PR #190)
+# ---------------------------------------------------------------------
+
+
+def _severable_locations(corpse) -> list[str]:
+    """Return body-location identifiers still detachable from *corpse*.
+
+    A location is severable when **all** of the following hold:
+
+    * It is present in :data:`world.combat.constants.SEVERABLE_CONTAINERS`
+      (the limb partition + ``head``).
+    * The death-time medical snapshot mentions at least one organ
+      housed in that container (so we know the corpse had the limb
+      in the first place — bare anatomy without organs is treated
+      as not severable to avoid spawning items for missing
+      structures).
+    * The location is not already in ``corpse.db.severed_locations``.
+
+    Returns an empty list if the snapshot is missing.
+    """
+    snapshot = corpse.get_medical_snapshot()
+    if snapshot is None:
+        return []
+    organs = snapshot.get("organs") or {}
+    present_containers = {
+        (data.get("container") or "")
+        for data in organs.values()
+    }
+    severed = set(corpse.db.severed_locations or ())
+    out = [
+        loc for loc in SEVERABLE_CONTAINERS
+        if loc in present_containers and loc not in severed
+    ]
+    out.sort()
+    return out
+
+
+class CmdSever(Command):
+    """Detach a limb (or the head) from a corpse.
+
+    Usage:
+      sever <location> from <corpse>
+      sever <corpse>            (lists severable locations)
+
+    Rolls Motorics vs ``SEVER_DC_BASIC``.  On success an
+    :class:`~typeclasses.items.Appendage` item is spawned into the
+    severer's inventory and the location is appended to
+    ``corpse.db.severed_locations``.  Subsequent ``harvest`` attempts
+    targeting organs whose container matches the severed location are
+    refused — the contained organs went with the limb (v1 does not
+    spawn separate organ items for the contained anatomy; a future
+    butchery pass may unbundle them).
+
+    A natural roll of ``SEVER_CRIT_FAIL`` botches the cut: no item,
+    no bookkeeping mutation, just a "mangled" message.  Unlike
+    organ harvest crit-fail (which destroys the organ), limb
+    botches are recoverable — try again.
+
+    Refused outright when:
+
+    * The corpse is skeletal (no soft tissue left to cut through).
+    * The corpse predates PR #186 and has no medical snapshot.
+    * The named location is not in
+      :data:`world.combat.constants.SEVERABLE_CONTAINERS`.
+    * The snapshot mentions no organs in that container (the corpse
+      never had that limb).
+    * The location is already in ``corpse.db.severed_locations``.
+
+    Appendage freshness tracks the source corpse's decay stage via
+    :data:`world.combat.constants.ORGAN_CONDITION_BY_DECAY`.
+    """
+
+    key = "sever"
+    aliases = ()
+    locks = "cmd:all()"
+    help_category = "Forensics"
+
+    def func(self):  # noqa: C901 — straight-line guard-clause flow
+        caller = self.caller
+        raw = (self.args or "").strip()
+        if not raw:
+            caller.msg("Usage: sever <location> from <corpse>")
+            return
+
+        if " from " in raw:
+            location_arg, _, corpse_arg = raw.partition(" from ")
+            location_arg = location_arg.strip().lower().replace(" ", "_")
+            corpse_arg = corpse_arg.strip()
+        else:
+            location_arg = ""
+            corpse_arg = raw
+
+        target = caller.search(corpse_arg, location=caller.location)
+        if target is None:
+            return
+
+        if not isinstance(target, Corpse):
+            caller.msg("You can only sever limbs from a corpse.")
+            return
+
+        if target.get_decay_stage() == "skeletal":
+            caller.msg(
+                "The remains are too far decomposed — only bone is left."
+            )
+            return
+
+        snapshot = target.get_medical_snapshot()
+        if snapshot is None:
+            caller.msg(
+                "These remains predate forensic record-keeping; no "
+                "internal examination is possible."
+            )
+            return
+
+        severable = _severable_locations(target)
+
+        if not location_arg:
+            if not severable:
+                caller.msg(
+                    f"There are no limbs left to sever on "
+                    f"{target.get_display_name(caller)}."
+                )
+                return
+            readable = ", ".join(loc.replace("_", " ") for loc in severable)
+            caller.msg(
+                f"Severable locations on {target.get_display_name(caller)}:"
+                f" {readable}.\nUsage: sever <location> from <corpse>"
+            )
+            return
+
+        # Specific location requested.
+        if location_arg not in SEVERABLE_CONTAINERS:
+            caller.msg(
+                f"You cannot sever the {location_arg.replace('_', ' ')} "
+                f"— it is not a detachable body location."
+            )
+            return
+
+        organs = snapshot.get("organs") or {}
+        present = any(
+            (data.get("container") or "") == location_arg
+            for data in organs.values()
+        )
+        if not present:
+            caller.msg(
+                f"{target.get_display_name(caller)} has no "
+                f"{location_arg.replace('_', ' ')} to sever."
+            )
+            return
+
+        if location_arg in (target.db.severed_locations or ()):
+            caller.msg(
+                f"The {location_arg.replace('_', ' ')} has already been "
+                f"severed from these remains."
+            )
+            return
+
+        # Pre-roll broadcast.
+        readable_name = location_arg.replace("_", " ")
+        corpse_display = target.get_display_name(caller)
+        msg_room_identity(
+            location=caller.location,
+            template=(
+                f"{{actor}} begins severing the {readable_name} "
+                f"from {{corpse}}."
+            ),
+            char_refs={"actor": caller, "corpse": target},
+            exclude=[caller],
+        )
+
+        roll = roll_stat(caller, "motorics")
+
+        if roll == SEVER_CRIT_FAIL:
+            caller.msg(
+                f"Your cut goes wide — you mangle the {readable_name} "
+                f"but fail to detach it."
+            )
+            msg_room_identity(
+                location=caller.location,
+                template=(
+                    f"{{actor}} mangles the {readable_name} on "
+                    f"{{corpse}} but fails to sever it."
+                ),
+                char_refs={"actor": caller, "corpse": target},
+                exclude=[caller],
+            )
+            return
+
+        if roll < SEVER_DC_BASIC:
+            caller.msg(
+                f"You hack at {corpse_display} but cannot detach the "
+                f"{readable_name} cleanly. The limb remains attached."
+            )
+            return
+
+        # Success.
+        condition = ORGAN_CONDITION_BY_DECAY.get(
+            target.get_decay_stage(), "damaged"
+        )
+        severed_list = list(target.db.severed_locations or ())
+        severed_list.append(location_arg)
+        target.db.severed_locations = severed_list
+
+        appendage = create_object(
+            "typeclasses.items.Appendage",
+            key=f"{condition} {readable_name}",
+            location=caller,
+        )
+        appendage.configure_from_sever(
+            location_name=location_arg, condition=condition, corpse=target,
+        )
+
+        caller.msg(
+            f"You sever the {readable_name} from {corpse_display} — "
+            f"the limb is {condition}."
+        )
+        msg_room_identity(
+            location=caller.location,
+            template=(
+                f"{{actor}} severs the {condition} {readable_name} "
                 f"from {{corpse}}."
             ),
             char_refs={"actor": caller, "corpse": target},

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1634,6 +1634,101 @@ intentionally — both are "basic forensic competency" gates.
 
 ---
 
+## Surgical Sever (PR #190)
+
+`sever <location> from <corpse>` detaches a limb (or the head) from
+a corpse, spawning a :class:`typeclasses.items.Appendage` item into
+the severer's inventory.  Sibling to PR-188 harvest; shares the
+forensic-chain provenance pattern and the death-time medical
+snapshot as the single source of truth for what anatomy the corpse
+had.
+
+### Command contract
+
+- **Roll**: Motorics vs `SEVER_DC_BASIC`.  Natural `SEVER_CRIT_FAIL`
+  (= 1) mangles the cut but leaves state intact — no item, no
+  bookkeeping mutation.  Crit-fail is **non-destructive** (unlike
+  harvest, which destroys the organ); limbs are coarser anatomy
+  and the realistic failure-mode is hacking a mess, not destroying
+  the limb beyond recovery.
+- **Ambiguous form** (`sever <corpse>`) lists severable locations.
+- **Pre-roll refusals** (no Motorics roll spent):
+  - Skeletal corpse / pre-PR-#186 corpse.
+  - Location not in
+    :data:`world.combat.constants.SEVERABLE_CONTAINERS`.
+  - Snapshot contains no organs in that container (the corpse
+    never had that limb).
+  - Location already in `corpse.db.severed_locations`.
+- **Pre-roll broadcast** via `msg_room_identity`.
+- **On success**: append location to `severed_locations`, spawn
+  `Appendage` item with `configure_from_sever`.
+
+### Severable partition
+
+The canonical limb partition from
+:meth:`world.medical.core.Organ._is_limb_container` plus `head`:
+
+```python
+SEVERABLE_CONTAINERS = frozenset({
+    "head",
+    "left_arm", "right_arm",
+    "left_hand", "right_hand",
+    "left_thigh", "right_thigh",
+    "left_shin", "right_shin",
+    "left_foot", "right_foot",
+})
+```
+
+`head` is internal anatomy in the medical model but is severable as
+a discrete item per the PR-190 contract.  A v2 super-item carrying
+the full identity signature on the severed head (so it can be
+recognized / autopsied independently of the source corpse) remains
+deferred.
+
+### Appendage typeclass
+
+`typeclasses.items.Appendage` extends `Item`; carries the same
+forensic-chain fields as `Organ` (`source_signature`,
+`source_apparent_uid`, `source_corpse_dbref`) plus:
+
+| Attribute | Source |
+|---|---|
+| `db.location_name` | Canonical container key (e.g. `left_arm`) |
+| `db.condition` | `ORGAN_CONDITION_BY_DECAY[stage]` at severance |
+
+Display key renders `"<condition> <location>"` (underscores → spaces).
+
+### Harvest interaction
+
+`CmdHarvest` already filters its harvestable-organs list with
+`organ_data["container"] not in corpse.db.severed_locations`.  Once
+PR-190 ships, severing an arm correctly causes subsequent
+harvest attempts on contained organs (e.g. `left_humerus`) to
+refuse with "went with the severed left_arm".  V1 does **not**
+spawn separate organ items for the anatomy bundled inside the
+limb — a future butchery pass may unbundle.
+
+### DC tuning (provisional)
+
+```python
+SEVER_DC_BASIC = 3
+SEVER_CRIT_FAIL = 1
+```
+
+Matches `HARVEST_DC_BASIC` / `AUTOPSY_DC_BASIC` — all three are
+basic forensic / surgical competency gates.  Flagged for balance
+review alongside the harvest economy work.
+
+### Out of scope (deferred past PR #190)
+
+- Severed-head super-item carrying full identity signature.
+- Limb-attached worn-item retention (severing an arm with a watch
+  on does **not** transfer the watch to the appendage in v1).
+- Reattachment / cybernetic limb prosthetics.
+- Per-organ unbundling from severed limbs.
+
+---
+
 ## New Character Attributes
 
 ### On Character (sleeve-level)

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1015,3 +1015,55 @@ class Organ(Item):
         self.db.source_corpse_dbref = corpse.dbref
         readable = organ_name.replace("_", " ")
         self.key = f"{condition} {readable}"
+
+
+class Appendage(Item):
+    """A severed limb (or head) detached from a corpse via ``sever``.
+
+    Sibling typeclass to :class:`Organ`; carries the same
+    forensic-chain provenance fields so investigators (and future
+    black-market gameplay) can trace a found appendage back to its
+    source corpse signature without re-querying the corpse.
+
+    Attributes (``self.db``):
+        location_name: Canonical body-location identifier
+            (e.g. ``"left_arm"``, ``"head"``) — matches the
+            ``container`` keys used in
+            :data:`world.medical.constants.ORGANS`.
+        condition: Freshness descriptor at severance, derived from
+            the source corpse's decay stage via
+            :data:`world.combat.constants.ORGAN_CONDITION_BY_DECAY`.
+        source_signature: Copy of source corpse's
+            ``signature_at_death``.
+        source_apparent_uid: Copy of source corpse's
+            ``apparent_uid_at_death``.
+        source_corpse_dbref: Audit pointer to the source corpse;
+            not guaranteed resolvable after decay.
+
+    The display name renders as ``"<condition> <location>"``
+    (underscores → spaces), e.g. ``"pristine left arm"``.
+    """
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.location_name = ""
+        self.db.condition = "pristine"
+        self.db.source_signature = None
+        self.db.source_apparent_uid = None
+        self.db.source_corpse_dbref = None
+
+    def configure_from_sever(self, *, location_name, condition, corpse):
+        """Populate forensic-chain fields immediately after spawn.
+
+        Args:
+            location_name (str): Canonical body-location identifier.
+            condition (str): Freshness descriptor.
+            corpse: The source :class:`typeclasses.corpse.Corpse`.
+        """
+        self.db.location_name = location_name
+        self.db.condition = condition
+        self.db.source_signature = corpse.db.signature_at_death
+        self.db.source_apparent_uid = corpse.db.apparent_uid_at_death
+        self.db.source_corpse_dbref = corpse.dbref
+        readable = location_name.replace("_", " ")
+        self.key = f"{condition} {readable}"

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -771,3 +771,28 @@ ORGAN_CONDITION_BY_DECAY = {
     "advanced": "putrid",
     "skeletal": "refuse",
 }
+
+# Surgical Sever (PR #190) --------------------------------------------
+# Motorics DC for removing a limb (or the head) from a corpse via
+# ``sever <location> from <corpse>``.  A natural ``SEVER_CRIT_FAIL``
+# botches the cut — no item is spawned and no bookkeeping mutates,
+# unlike the harvest crit-fail which destroys the organ.  The
+# asymmetry is deliberate: limbs are coarser anatomy and the
+# failure-mode is "you hacked a mess into the corpse" rather than
+# "you ruptured a delicate organ".
+SEVER_DC_BASIC = 3
+SEVER_CRIT_FAIL = 1
+
+# Severable body locations: the limb partition from
+# :meth:`world.medical.core.Organ._is_limb_container` plus ``head``
+# (the head is internal anatomy but severable as a discrete item per
+# the PR #190 contract; a future v2 severed-head super-item carrying
+# the full identity signature is documented as deferred).
+SEVERABLE_CONTAINERS = frozenset({
+    "head",
+    "left_arm", "right_arm",
+    "left_hand", "right_hand",
+    "left_thigh", "right_thigh",
+    "left_shin", "right_shin",
+    "left_foot", "right_foot",
+})

--- a/world/tests/test_cmd_sever.py
+++ b/world/tests/test_cmd_sever.py
@@ -1,0 +1,344 @@
+"""Unit tests for :class:`commands.forensics.CmdSever` (PR #190).
+
+Mirrors the harvest test strategy: lightweight fakes + Corpse symbol
+swap so ``isinstance(target, Corpse)`` accepts our stand-in.
+
+Coverage matrix:
+
+* Usage / argument parsing.
+* Non-corpse rejection.
+* Skeletal short-circuit.
+* Pre-PR-#186 snapshot-less refusal.
+* Ambiguous form lists severable locations (filters non-severable
+  containers and already-severed).
+* Non-severable container rejection (e.g. ``chest``).
+* Snapshot-missing-location rejection.
+* Already-severed rejection.
+* Mid-range fail vs crit-fail vs success — bookkeeping correctness.
+* Condition tracks decay.
+* Forward-compat: after sever-arm, harvest cannot target organs in
+  that arm (verified at the harvest gate, exercised here by reading
+  the post-sever ``severed_locations`` state).
+
+Run via::
+
+    evennia test world.tests.test_cmd_sever
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from commands import forensics as cmd_module
+from commands.forensics import CmdSever
+from world.combat.constants import (
+    ORGAN_CONDITION_BY_DECAY,
+    SEVER_CRIT_FAIL,
+    SEVER_DC_BASIC,
+)
+
+
+# ---------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------
+
+
+class _DB:
+    pass
+
+
+class _FakeRoom:
+    def __init__(self):
+        self.contents = []
+
+
+class _CorpseStandIn:
+    pass
+
+
+class _FakeCorpse(_CorpseStandIn):
+    def __init__(
+        self,
+        *,
+        key="the corpse of Jorge",
+        display=None,
+        decay_stage="fresh",
+        snapshot=None,
+        removed_organs=None,
+        severed_locations=None,
+        dbref="#101",
+    ):
+        self.key = key
+        self.dbref = dbref
+        self.db = _DB()
+        self.db.signature_at_death = (
+            "sleeve-1", "tall", "lean", "hooded", ("balaclava",),
+        )
+        self.db.apparent_uid_at_death = "abc123"
+        self.db.medical_state_at_death = snapshot
+        self.db.removed_organs = list(removed_organs or ())
+        self.db.severed_locations = list(severed_locations or ())
+        self._display = display or key
+        self._decay_stage = decay_stage
+
+    def get_display_name(self, looker=None, **kwargs):
+        del looker, kwargs
+        return self._display
+
+    def get_decay_stage(self):
+        return self._decay_stage
+
+    def get_medical_snapshot(self):
+        return self.db.medical_state_at_death
+
+
+def _snapshot_with_limbs():
+    """Snapshot with a representative slice of containers."""
+    def org(hp, container):
+        return {"current_hp": hp, "max_hp": hp, "container": container}
+    return {
+        "organs": {
+            "heart": org(15, "chest"),
+            "liver": org(20, "abdomen"),
+            "brain": org(10, "head"),
+            "left_humerus": org(25, "left_arm"),
+            "right_humerus": org(25, "right_arm"),
+            "left_femur": org(25, "left_thigh"),
+            "right_femur": org(25, "right_thigh"),
+        },
+        "conditions": [],
+        "blood_level": 5000,
+        "pain_level": 0,
+        "consciousness": True,
+    }
+
+
+def _make_caller(*, location=None):
+    caller = MagicMock()
+    caller.key = "Alice"
+    caller.dbref = "#42"
+    caller.location = location or _FakeRoom()
+    caller.recognition_memory = {}
+    caller.msg = MagicMock()
+    caller.search = MagicMock()
+    caller.motorics = 10
+    return caller
+
+
+def _make_cmd(*, caller, args):
+    cmd = CmdSever()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.switches = ()
+    return cmd
+
+
+class CmdSeverTests(TestCase):
+    def setUp(self):
+        self._patcher = patch.object(cmd_module, "Corpse", _CorpseStandIn)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    # ----- argument handling -----
+
+    def test_no_args_prints_usage(self):
+        caller = _make_caller()
+        _make_cmd(caller=caller, args="").func()
+        self.assertIn("Usage", caller.msg.call_args[0][0])
+
+    def test_non_corpse_rejected(self):
+        caller = _make_caller()
+        caller.search.return_value = MagicMock()
+        _make_cmd(caller=caller, args="left_arm from rock").func()
+        caller.msg.assert_called_with(
+            "You can only sever limbs from a corpse."
+        )
+
+    # ----- decay / snapshot gates -----
+
+    def test_skeletal_short_circuit(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            decay_stage="skeletal", snapshot=_snapshot_with_limbs()
+        )
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="left_arm from corpse").func()
+        self.assertIn("decomposed", caller.msg.call_args[0][0])
+
+    def test_no_snapshot_refused(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=None)
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="left_arm from corpse").func()
+        self.assertIn("predate", caller.msg.call_args[0][0])
+
+    # ----- ambiguous form -----
+
+    def test_ambiguous_lists_severable(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="corpse").func()
+        msg = caller.msg.call_args[0][0]
+        # Limb partition + head present
+        for loc in ("head", "left arm", "right arm", "left thigh"):
+            self.assertIn(loc, msg)
+        # Internal containers excluded
+        self.assertNotIn("chest", msg)
+        self.assertNotIn("abdomen", msg)
+
+    def test_ambiguous_with_nothing_left(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            snapshot=_snapshot_with_limbs(),
+            severed_locations=[
+                "head", "left_arm", "right_arm",
+                "left_thigh", "right_thigh",
+            ],
+        )
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="corpse").func()
+        self.assertIn("no limbs left", caller.msg.call_args[0][0])
+
+    # ----- per-location refusals -----
+
+    def test_non_severable_container_rejected(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="chest from corpse").func()
+        self.assertIn(
+            "not a detachable", caller.msg.call_args[0][0]
+        )
+
+    def test_missing_limb_in_snapshot(self):
+        caller = _make_caller()
+        # Snapshot only has chest organs — no limbs at all.
+        snap = {
+            "organs": {
+                "heart": {
+                    "current_hp": 15, "max_hp": 15, "container": "chest",
+                },
+            },
+        }
+        corpse = _FakeCorpse(snapshot=snap)
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="left_arm from corpse").func()
+        self.assertIn("no left arm", caller.msg.call_args[0][0])
+
+    def test_already_severed_rejected(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            snapshot=_snapshot_with_limbs(),
+            severed_locations=["left_arm"],
+        )
+        caller.search.return_value = corpse
+        _make_cmd(caller=caller, args="left_arm from corpse").func()
+        self.assertIn(
+            "already been severed", caller.msg.call_args[0][0]
+        )
+
+    # ----- roll outcomes -----
+
+    def test_roll_fail_leaves_state_intact(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        fail_roll = SEVER_DC_BASIC - 1
+        self.assertGreater(fail_roll, SEVER_CRIT_FAIL)
+        with patch.object(cmd_module, "roll_stat", return_value=fail_roll), \
+                patch.object(cmd_module, "create_object") as mk:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            mk.assert_not_called()
+        self.assertEqual(corpse.db.severed_locations, [])
+
+    def test_crit_fail_no_mutation_no_item(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_CRIT_FAIL
+        ), patch.object(cmd_module, "create_object") as mk:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            mk.assert_not_called()
+        # Unlike harvest crit-fail, sever crit-fail does NOT destroy
+        # anything — state is fully intact.
+        self.assertEqual(corpse.db.severed_locations, [])
+        self.assertEqual(
+            corpse.db.medical_state_at_death["organs"][
+                "left_humerus"]["current_hp"],
+            25,
+        )
+
+    def test_success_spawns_appendage_and_appends(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        fake_app = MagicMock()
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=fake_app
+        ) as mk:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            mk.assert_called_once()
+            kwargs = mk.call_args.kwargs
+            self.assertEqual(kwargs["location"], caller)
+            self.assertIn("left arm", kwargs["key"])
+        fake_app.configure_from_sever.assert_called_once_with(
+            location_name="left_arm",
+            condition=ORGAN_CONDITION_BY_DECAY["fresh"],
+            corpse=corpse,
+        )
+        self.assertEqual(corpse.db.severed_locations, ["left_arm"])
+
+    def test_success_condition_tracks_decay(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            snapshot=_snapshot_with_limbs(), decay_stage="advanced"
+        )
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC + 5
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ) as mk:
+            _make_cmd(caller=caller, args="head from corpse").func()
+        self.assertIn(
+            ORGAN_CONDITION_BY_DECAY["advanced"], mk.call_args.kwargs["key"]
+        )
+
+    def test_location_accepts_spaces(self):
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ):
+            _make_cmd(caller=caller, args="left arm from corpse").func()
+        self.assertEqual(corpse.db.severed_locations, ["left_arm"])
+
+    # ----- forward-compat with harvest -----
+
+    def test_sever_then_harvest_gate_state(self):
+        """After severing an arm, the gate that harvest reads — the
+        ``severed_locations`` list — contains the arm.  CmdHarvest's
+        ``_harvestable_organs`` exclusion is tested in
+        ``test_cmd_harvest``; this test just locks the post-sever
+        state contract those tests depend on.
+        """
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ):
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+        self.assertIn("left_arm", corpse.db.severed_locations)


### PR DESCRIPTION
## Summary
- New `sever <location> from <corpse>` command detaches limbs (arms/hands/thighs/shins/feet) and the head from corpses via a Motorics roll vs `SEVER_DC_BASIC`.
- Spawns a `typeclasses.items.Appendage` item carrying full forensic provenance (`source_signature`, `source_apparent_uid`, `source_corpse_dbref`) and decay-derived condition.
- Tracks severed parts in `corpse.db.severed_locations`; `harvest` is now gated so organs whose container has been severed cannot be extracted independently (they went with the limb).

## Design notes
- Sever crit-fail (`SEVER_CRIT_FAIL`) is **non-destructive** — recoverable retry. Asymmetric with harvest crit-fail (which zeros organ HP), because limb anatomy is coarser.
- Severable set = limb partition from `world/medical/core.py::Organ._is_limb_container` + `head` carve-out (identity-carrying severed-head super-item deferred to v2).
- v1 does not unbundle organs contained within a severed limb into separate items; future butchery pass may.
- Refuses on skeletal corpses, pre-#186 corpses (no medical snapshot), unknown locations, locations with no organs in snapshot, and already-severed locations.

## Testing
- `docker exec gelatinous evennia test --settings settings.py world commands typeclasses` → **1030 tests pass** (15 new sever tests on top of the 1015 baseline from #189).

## Spec
- `specs/IDENTITY_RECOGNITION_SPEC.md` updated with new "Surgical Sever (PR #190)" section.