### PR TITLE
Factor IdentityBearerMixin from Corpse (#192)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1369,6 +1369,31 @@ Corpses already preserve forensic data (original name, dbref, physical descripti
 
 **Disguise persistence.** Worn-item axes contribute to the signature at all non-skeletal stages, so looting a disguise-essential item (e.g. a balaclava) silently breaks both recognition paths just as it does for a living character.
 
+#### Identity-Bearer Mixin
+
+The two-pass recognition algorithm above is factored into
+`typeclasses.identity_bearer.IdentityBearerMixin` so multiple
+typeclasses can share the same recognition surface without
+duplicating the implementation.  `Corpse` inherits the mixin
+unchanged; the upcoming `SeveredHead` super-item (severed-head v2)
+will inherit the same mixin so heads recognise on-sight identically
+to corpses.
+
+**Contract** (duck-typed; subclass must supply):
+
+| Member | Contract |
+|---|---|
+| `self.db.signature_at_death` | 5-tuple identity signature at bodily-separation moment. `None` on legacy objects. |
+| `self.db.apparent_uid_at_death` | Hashed apparent UID matching the signature. |
+| `get_decay_stage() -> str` | One of `fresh` / `early` / `moderate` / `advanced` / `skeletal`. |
+| `_decay_display_name() -> str` | Fallback name when no recognition match (`"fresh corpse"`, `"fresh head"`, …). |
+
+Subclasses may override `_FORENSIC_RECOGNITION_DC` to tune per-stage
+DCs.  The default `{"moderate": 3, "advanced": 5}` matches the
+original `Corpse` behaviour; `fresh` and `early` are deliberately
+absent so forensic-recovery rolls never fire at those stages
+(natural recognition covers them via the unchanged degraded UID).
+
 ### Evidence and Investigation ✅ (Engine shipped — PR-E)
 
 The Forensic Recognition Engine (`world/forensics.py`) is the canonical

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -3,9 +3,10 @@
 # =============================================================================
 
 from .items import Item
+from .identity_bearer import IdentityBearerMixin
 import time
 
-class Corpse(Item):
+class Corpse(IdentityBearerMixin, Item):
     """
     A corpse object that preserves forensic data and uses just-in-time decay.
     Decay is calculated on-demand when the corpse is looked at or referenced,
@@ -106,148 +107,6 @@ class Corpse(Item):
         """
         return self.db.medical_state_at_death
 
-    def get_display_name(self, looker, **kwargs):
-        """Return a display name, preferring recognition memory.
-
-        Looters and bystanders who already remember the deceased should
-        continue to see the assigned name on the corpse, exactly as
-        they would on the living character.  The lookup mirrors
-        :meth:`typeclasses.characters.Character.get_display_name`:
-
-        * ``looker is None`` (system context) → decay-stage fallback.
-        * Stage is ``skeletal`` → decay-stage name (hard cutoff;
-          neither natural recognition nor a forensic skill check can
-          recover an identity from bones; recognizable clothing is
-          deduced by the player through item inspection, not surfaced
-          through the corpse name).
-        * Otherwise, two-pass recognition:
-
-          1. **Natural recognition.**  Compute the *decay-degraded*
-             apparent UID via :func:`world.identity.get_apparent_uid_for_decay`
-             (which blanks the body-identity axis at ``moderate`` and
-             ``advanced`` stages).  If the looker's memory has that UID,
-             return its ``assigned_name``.  At ``fresh`` and ``early``
-             the degraded UID equals the fresh UID, so this path covers
-             ordinary recognition through light decay.
-          2. **Forensic recovery.**  If the degraded lookup missed,
-             compute the *fresh-equivalent* UID via
-             :func:`world.identity.get_apparent_uid`.  If memory has
-             that UID **and** the looker passes an Intellect roll
-             against the stage DC (see :meth:`_attempt_forensic_recognition`),
-             return its ``assigned_name``.  The roll outcome is cached
-             permanently per ``(looker, this corpse)``.
-
-        * Else → decay-stage name (``"fresh corpse"`` etc.).
-
-        Disguise loss after death is handled by re-reading the
-        signature on every call (no cache): once a disguise-essential
-        item is looted, both UID computations see the new
-        ``get_worn_items()`` view and the recognition match silently
-        falls away.
-        """
-        del kwargs  # Evennia passes look context we don't need.
-        decay_name = self._decay_display_name()
-        stage = self.get_decay_stage()
-
-        if looker is None:
-            return decay_name
-
-        if stage == "skeletal":
-            # Hard cutoff: no recognition path returns a name for a
-            # skeleton.  The sleeve_uid is still queryable
-            # programmatically (forensic tooling, admin commands) but
-            # not surfaced through the display name.
-            return decay_name
-
-        memory = getattr(looker, "recognition_memory", None)
-        if not memory:
-            return decay_name
-
-        # Pass 1: natural recognition against the decay-degraded UID.
-        try:
-            from world.identity import (
-                get_apparent_uid,
-                get_apparent_uid_for_decay,
-            )
-            degraded_uid = get_apparent_uid_for_decay(self, stage)
-        except (AttributeError, TypeError, ValueError):
-            degraded_uid = None
-
-        if degraded_uid is not None and degraded_uid in memory:
-            assigned = memory[degraded_uid].get("assigned_name")
-            if assigned:
-                return assigned
-
-        # Pass 2: forensic recovery against the fresh-equivalent UID.
-        try:
-            fresh_uid = get_apparent_uid(self)
-        except (AttributeError, TypeError, ValueError):
-            fresh_uid = None
-
-        if (
-            fresh_uid is not None
-            and fresh_uid != degraded_uid
-            and fresh_uid in memory
-        ):
-            if self._attempt_forensic_recognition(looker, stage):
-                assigned = memory[fresh_uid].get("assigned_name")
-                if assigned:
-                    return assigned
-
-        return decay_name
-
-    # Intellect DC by decay stage for forensic recognition recovery.
-    # Stages absent from this map never roll: ``fresh`` / ``early`` don't
-    # need recovery (the degraded UID still matches memory), and
-    # ``skeletal`` is hard-cutoff in :meth:`get_display_name` before this
-    # table is consulted.
-    _FORENSIC_RECOGNITION_DC = {
-        "moderate": 3,
-        "advanced": 5,
-    }
-
-    def _attempt_forensic_recognition(self, looker, stage):
-        """Resolve (and cache) a forensic-recognition Intellect roll.
-
-        Per-observer, per-corpse, permanent: a looker who fails the roll
-        the first time they examine this corpse will keep failing, and a
-        looker who passes will keep recognising it across subsequent
-        looks.  This rewards a single careful examination and prevents
-        Intellect re-rolls on every ``look`` from eventually surfacing
-        an identity by chance.
-
-        Thin wrapper over :func:`world.forensics.attempt_forensic_recognition`
-        (PR-E).  The engine owns the roll, cache, and apparent-UID
-        keying; this method preserves the stage-DC table and the
-        ``forensic_recognition_cache`` attribute name so the live
-        cache attribute slot continues to be reused.
-
-        Args:
-            looker: The character attempting recognition.
-            stage: The corpse's current decay stage (used for DC).
-
-        Returns:
-            ``True`` if the looker recovers the identity, else ``False``.
-        """
-        dc = self._FORENSIC_RECOGNITION_DC.get(stage)
-        if dc is None:
-            # Stage has no defined DC — never recover.
-            return False
-
-        from world.forensics import (
-            attempt_forensic_recognition,
-            extract_subject_from_corpse,
-        )
-
-        subject = extract_subject_from_corpse(self)
-        result = attempt_forensic_recognition(
-            looker,
-            subject,
-            dc,
-            cache_owner=self,
-            cache_attr="forensic_recognition_cache",
-        )
-        return result.success
 
     def _decay_display_name(self):
         """Return the decay-stage name used when no recognition matches."""

--- a/typeclasses/identity_bearer.py
+++ b/typeclasses/identity_bearer.py
@@ -1,0 +1,174 @@
+"""Identity-bearer mixin.
+
+Shared recognition / forensic-recovery surface for objects that carry
+a death-time identity snapshot — :class:`typeclasses.corpse.Corpse`
+and (post PR-#193) :class:`typeclasses.items.SeveredHead`.
+
+The mixin is deliberately decoupled from any concrete typeclass; it
+relies on a small duck-typed contract that subclasses must satisfy:
+
+============================  ===========================================
+Required member                Contract
+============================  ===========================================
+``self.db.signature_at_death`` 5-tuple identity signature captured at
+                               the moment of bodily separation (death
+                               for a corpse, sever for a head).  May be
+                               ``None`` on pre-snapshot legacy objects;
+                               recognition then never succeeds.
+``self.db.apparent_uid_at_death`` Hashed apparent UID matching
+                               ``signature_at_death``.  May be ``None``.
+``get_decay_stage(self) -> str`` Returns one of ``"fresh"``, ``"early"``,
+                               ``"moderate"``, ``"advanced"``,
+                               ``"skeletal"``.  ``"skeletal"`` is the
+                               hard cutoff — no recognition path beyond
+                               it.
+``_decay_display_name(self) -> str`` Fallback display name when no
+                               recognition match is found
+                               (e.g. ``"fresh corpse"``, ``"early head"``).
+============================  ===========================================
+
+Subclasses may override ``_FORENSIC_RECOGNITION_DC`` to tune per-stage
+Intellect DCs for the forensic-recovery roll.  The default mirrors
+:class:`typeclasses.corpse.Corpse`'s pre-mixin behaviour.
+
+The recognition flow is two-pass:
+
+1. **Natural recognition** against the *decay-degraded* apparent UID.
+   At ``fresh`` and ``early`` stages the degraded UID equals the fresh
+   UID, so this path covers ordinary recognition through light decay.
+   At ``moderate`` and ``advanced`` the body-identity axis is blanked,
+   so only loose-feature memory matches survive.
+2. **Forensic recovery** against the *fresh-equivalent* UID, gated by
+   a per-observer cached Intellect roll keyed off
+   :data:`_FORENSIC_RECOGNITION_DC`.  Per-observer-per-bearer-permanent
+   — a failed roll on first contact sticks.
+
+See ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Identity-Bearer Mixin"
+for the broader design rationale.
+"""
+
+from __future__ import annotations
+
+
+class IdentityBearerMixin:
+    """Two-pass recognition + forensic-recovery for snapshot-bearing objects.
+
+    Mix into a typeclass whose instances expose the contract above.
+    Provides :meth:`get_display_name` and the
+    :meth:`_attempt_forensic_recognition` helper.  Subclasses still own
+    ``get_decay_stage`` and ``_decay_display_name``.
+    """
+
+    #: Intellect DC by decay stage for forensic-recognition recovery.
+    #: Stages absent from this map never roll: ``fresh`` / ``early``
+    #: don't need recovery (the degraded UID still matches memory), and
+    #: ``skeletal`` is hard-cutoff in :meth:`get_display_name` before
+    #: this table is consulted.  Override in subclasses to tune.
+    _FORENSIC_RECOGNITION_DC = {
+        "moderate": 3,
+        "advanced": 5,
+    }
+
+    def get_display_name(self, looker, **kwargs):
+        """Return a display name, preferring recognition memory.
+
+        Mirrors the corpse-recognition contract: observers who already
+        remember the deceased / severed party see the assigned name;
+        strangers and the system see the decay-stage fallback.
+
+        * ``looker is None`` → decay-stage fallback.
+        * ``get_decay_stage() == "skeletal"`` → hard cutoff; return
+          decay-stage fallback regardless of recognition memory.
+        * Otherwise two-pass: natural (degraded UID) then forensic
+          (fresh UID + Intellect roll).
+        """
+        del kwargs  # Evennia passes look context we don't need.
+        decay_name = self._decay_display_name()
+        stage = self.get_decay_stage()
+
+        if looker is None:
+            return decay_name
+
+        if stage == "skeletal":
+            return decay_name
+
+        memory = getattr(looker, "recognition_memory", None)
+        if not memory:
+            return decay_name
+
+        # Pass 1: natural recognition against the decay-degraded UID.
+        try:
+            from world.identity import (
+                get_apparent_uid,
+                get_apparent_uid_for_decay,
+            )
+            degraded_uid = get_apparent_uid_for_decay(self, stage)
+        except (AttributeError, TypeError, ValueError):
+            degraded_uid = None
+
+        if degraded_uid is not None and degraded_uid in memory:
+            assigned = memory[degraded_uid].get("assigned_name")
+            if assigned:
+                return assigned
+
+        # Pass 2: forensic recovery against the fresh-equivalent UID.
+        try:
+            fresh_uid = get_apparent_uid(self)
+        except (AttributeError, TypeError, ValueError):
+            fresh_uid = None
+
+        if (
+            fresh_uid is not None
+            and fresh_uid != degraded_uid
+            and fresh_uid in memory
+        ):
+            if self._attempt_forensic_recognition(looker, stage):
+                assigned = memory[fresh_uid].get("assigned_name")
+                if assigned:
+                    return assigned
+
+        return decay_name
+
+    def _attempt_forensic_recognition(self, looker, stage):
+        """Resolve (and cache) a forensic-recognition Intellect roll.
+
+        Per-observer, per-bearer, permanent: a looker who fails the roll
+        the first time they examine this bearer will keep failing, and
+        a looker who passes will keep recognising it across subsequent
+        looks.  Rewards a single careful examination and prevents
+        Intellect re-rolls on every ``look`` from eventually surfacing
+        an identity by chance.
+
+        Thin wrapper over
+        :func:`world.forensics.attempt_forensic_recognition`.  The
+        engine owns the roll and the cache; this method preserves the
+        stage-DC table and the cache-attribute slot so subclasses
+        sharing the slot (e.g. corpse → severed head migration) reuse
+        the same cache entries.
+
+        Args:
+            looker: The character attempting recognition.
+            stage: The bearer's current decay stage (used for DC).
+
+        Returns:
+            ``True`` if the looker recovers the identity, else ``False``.
+        """
+        dc = self._FORENSIC_RECOGNITION_DC.get(stage)
+        if dc is None:
+            # Stage has no defined DC — never recover.
+            return False
+
+        from world.forensics import (
+            attempt_forensic_recognition,
+            extract_subject_from_corpse,
+        )
+
+        subject = extract_subject_from_corpse(self)
+        result = attempt_forensic_recognition(
+            looker,
+            subject,
+            dc,
+            cache_owner=self,
+            cache_attr="forensic_recognition_cache",
+        )
+        return result.success

--- a/world/tests/test_identity_bearer_mixin.py
+++ b/world/tests/test_identity_bearer_mixin.py
@@ -1,0 +1,208 @@
+"""Contract tests for :class:`typeclasses.identity_bearer.IdentityBearerMixin`.
+
+Exercises the mixin in isolation via a minimal stand-in typeclass
+``_FakeBearer`` that satisfies the duck-typed contract:
+
+* ``self.db.signature_at_death`` / ``self.db.apparent_uid_at_death``
+* ``get_decay_stage()``
+* ``_decay_display_name()``
+
+Validates the recognition pipeline end-to-end without dragging in
+:class:`typeclasses.corpse.Corpse`'s clothing / account / decay
+infrastructure.  The full corpse integration is covered by
+``test_corpse_decay_recognition`` and stays green as the regression
+guard for the mixin's behaviour in production.
+
+Run via::
+
+    docker exec gelatinous evennia test --settings settings.py \\
+        world.tests.test_identity_bearer_mixin
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from typeclasses.identity_bearer import IdentityBearerMixin
+
+
+# ---------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------
+
+
+class _FakeDB:
+    """Tiny attribute bag stand-in for ``obj.db``."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _FakeBearer(IdentityBearerMixin):
+    """Minimal mixin host.
+
+    Holds just enough state for the recognition pipeline; subclasses /
+    callers control the decay stage explicitly via ``stage``.
+    """
+
+    def __init__(
+        self,
+        *,
+        signature=("uid-A", None, None, None, ()),
+        apparent_uid="uid-A",
+        stage: str = "fresh",
+        decay_label: str = "fresh bearer",
+    ):
+        self.db = _FakeDB(
+            signature_at_death=signature,
+            apparent_uid_at_death=apparent_uid,
+        )
+        self._stage = stage
+        self._decay_label = decay_label
+
+    def get_decay_stage(self) -> str:
+        return self._stage
+
+    def _decay_display_name(self) -> str:
+        return self._decay_label
+
+
+class _FakeLooker:
+    """Recognition-memory bag with a deterministic dbref."""
+
+    def __init__(self, *, memory: dict | None = None, dbref: str = "#42"):
+        self.recognition_memory = memory or {}
+        self.dbref = dbref
+
+
+# ---------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------
+
+
+class TestIdentityBearerMixin(TestCase):
+    """End-to-end recognition contract enforcement."""
+
+    def test_system_looker_returns_decay_name(self):
+        """``looker is None`` short-circuits to the decay fallback."""
+        bearer = _FakeBearer(decay_label="fresh thing")
+        self.assertEqual(bearer.get_display_name(None), "fresh thing")
+
+    def test_skeletal_is_hard_cutoff(self):
+        """Skeletal stage suppresses recognition unconditionally."""
+        bearer = _FakeBearer(
+            stage="skeletal", decay_label="skeletal thing",
+        )
+        looker = _FakeLooker(
+            memory={"uid-A": {"assigned_name": "Alice"}},
+        )
+        self.assertEqual(
+            bearer.get_display_name(looker), "skeletal thing",
+        )
+
+    def test_looker_without_memory_returns_decay_name(self):
+        """No ``recognition_memory`` → decay fallback."""
+        bearer = _FakeBearer(decay_label="fresh thing")
+        looker = _FakeLooker(memory=None)
+        self.assertEqual(
+            bearer.get_display_name(looker), "fresh thing",
+        )
+
+    def test_natural_recognition_through_fresh_stage(self):
+        """Fresh stage: degraded UID equals fresh UID; memory hits."""
+        bearer = _FakeBearer()
+        looker = _FakeLooker(
+            memory={"uid-A": {"assigned_name": "Alice"}},
+        )
+        with patch(
+            "world.identity.get_apparent_uid_for_decay",
+            return_value="uid-A",
+        ), patch(
+            "world.identity.get_apparent_uid", return_value="uid-A",
+        ):
+            self.assertEqual(bearer.get_display_name(looker), "Alice")
+
+    def test_forensic_recovery_on_pass(self):
+        """Degraded UID misses, fresh UID hits, Intellect roll passes."""
+        bearer = _FakeBearer(
+            stage="moderate", decay_label="moderate thing",
+        )
+        looker = _FakeLooker(
+            memory={"uid-A": {"assigned_name": "Alice"}},
+        )
+        with patch(
+            "world.identity.get_apparent_uid_for_decay",
+            return_value="uid-degraded",
+        ), patch(
+            "world.identity.get_apparent_uid", return_value="uid-A",
+        ), patch(
+            "typeclasses.identity_bearer.IdentityBearerMixin"
+            "._attempt_forensic_recognition",
+            return_value=True,
+        ):
+            self.assertEqual(bearer.get_display_name(looker), "Alice")
+
+    def test_forensic_recovery_on_fail(self):
+        """Degraded UID misses, fresh UID hits, Intellect roll fails."""
+        bearer = _FakeBearer(
+            stage="moderate", decay_label="moderate thing",
+        )
+        looker = _FakeLooker(
+            memory={"uid-A": {"assigned_name": "Alice"}},
+        )
+        with patch(
+            "world.identity.get_apparent_uid_for_decay",
+            return_value="uid-degraded",
+        ), patch(
+            "world.identity.get_apparent_uid", return_value="uid-A",
+        ), patch(
+            "typeclasses.identity_bearer.IdentityBearerMixin"
+            "._attempt_forensic_recognition",
+            return_value=False,
+        ):
+            self.assertEqual(
+                bearer.get_display_name(looker), "moderate thing",
+            )
+
+    def test_forensic_dc_table_skips_undefined_stages(self):
+        """Stages absent from ``_FORENSIC_RECOGNITION_DC`` never roll.
+
+        ``fresh`` and ``early`` are deliberately omitted from the DC
+        table because the degraded UID still equals the fresh UID at
+        those stages — natural recognition handles them.  If forensic
+        recovery is somehow reached at those stages it must return
+        ``False`` without consulting the forensics engine.
+        """
+        bearer = _FakeBearer(stage="early")
+        looker = _FakeLooker()
+        # ``early`` is intentionally missing from the DC table.
+        self.assertNotIn("early", bearer._FORENSIC_RECOGNITION_DC)
+        with patch(
+            "world.forensics.attempt_forensic_recognition",
+        ) as engine:
+            result = bearer._attempt_forensic_recognition(looker, "early")
+        self.assertFalse(result)
+        engine.assert_not_called()
+
+    def test_apparent_uid_helper_exception_falls_through(self):
+        """Helper exceptions degrade gracefully to the decay fallback.
+
+        Mirrors the production guard against malformed signatures in
+        the legacy DB — bearer rendering must never raise into the
+        room broadcast pipeline.
+        """
+        bearer = _FakeBearer(decay_label="fresh thing")
+        looker = _FakeLooker(
+            memory={"uid-A": {"assigned_name": "Alice"}},
+        )
+        with patch(
+            "world.identity.get_apparent_uid_for_decay",
+            side_effect=TypeError("malformed"),
+        ), patch(
+            "world.identity.get_apparent_uid",
+            side_effect=ValueError("malformed"),
+        ):
+            self.assertEqual(
+                bearer.get_display_name(looker), "fresh thing",
+            )


### PR DESCRIPTION
## Summary
- Extract identity/recognition behaviour from `Corpse` into a reusable `IdentityBearerMixin` (typeclasses/identity_bearer.py) so upcoming `SeveredHead` super-item can share two-pass recognition + forensic-recovery logic without duplication.
- `Corpse` now inherits the mixin; lifted method bodies removed from `typeclasses/corpse.py`. Decay-stage hooks (`get_decay_stage`, `_decay_display_name`) remain on `Corpse` and are the contract subclasses must implement.
- Add 8 mixin-contract tests in `world/tests/test_identity_bearer_mixin.py` using lightweight `_FakeBearer` / `_FakeLooker` / `_FakeDB` doubles; existing corpse recognition/decay tests remain green as the regression guard for the inherited path.
- Update `specs/IDENTITY_RECOGNITION_SPEC.md` with an "Identity-Bearer Mixin" subsection documenting the contract.

## Why
PR-A of the 3-PR severed-head super-item rollout (PR-B adds `SeveredHead` typeclass + sever routing, PR-C widens autopsy/harvest gates). Mixin extraction is mergeable on its own and unblocks PR-B without functional change to corpses.

## Tests
`docker exec gelatinous evennia test --settings settings.py world commands typeclasses` → 1038 passing (1030 prior + 8 new).

Closes #192