### PR TITLE
Add SeveredHead super-item carrying identity and decay (#194)

### DIFF
--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -614,8 +614,17 @@ class CmdSever(Command):
         severed_list.append(location_arg)
         target.db.severed_locations = severed_list
 
+        # Route ``head`` to the super-item typeclass so the head
+        # carries identity / decay / trimmed snapshot state forward
+        # for downstream autopsy and harvest.  All other severable
+        # locations spawn a plain Appendage.
+        if location_arg == "head":
+            appendage_typeclass = "typeclasses.items.SeveredHead"
+        else:
+            appendage_typeclass = "typeclasses.items.Appendage"
+
         appendage = create_object(
-            "typeclasses.items.Appendage",
+            appendage_typeclass,
             key=f"{condition} {readable_name}",
             location=caller,
         )

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1746,11 +1746,48 @@ review alongside the harvest economy work.
 
 ### Out of scope (deferred past PR #190)
 
-- Severed-head super-item carrying full identity signature.
 - Limb-attached worn-item retention (severing an arm with a watch
   on does **not** transfer the watch to the appendage in v1).
 - Reattachment / cybernetic limb prosthetics.
 - Per-organ unbundling from severed limbs.
+
+### Severed-Head Super-Item ✅ (Shipped — PR #194)
+
+`sever head from <corpse>` produces a `typeclasses.items.SeveredHead`
+rather than the generic `Appendage` used for limbs.  `SeveredHead`
+inherits `IdentityBearerMixin` (alongside its `Appendage` base) so
+the head is a first-class forensic peer of the source corpse:
+
+- **Identity carry-forward**: `db.signature_at_death` and
+  `db.apparent_uid_at_death` are copied verbatim from the corpse, so
+  the two-pass recognition algorithm (live UID → snapshot UID via
+  forensic-recovery roll) works against a disembodied head with the
+  same semantics it does against a corpse.
+- **Shared decay clock**: `db.creation_time`, `db.death_time`,
+  `db.death_cause` are copied so the head ages on the same timeline
+  as the corpse it came from.  `get_decay_stage()` maps the elapsed
+  time onto `fresh` / `early` / `moderate` / `advanced` / `skeletal`
+  using the standard `CORPSE_DECAY_*` thresholds.
+- **Trimmed medical snapshot**: `db.medical_state_at_death` retains
+  only the organs whose `container == "head"` (brain, eyes, ears,
+  etc.); body-wide fields (`conditions`, `blood_level`, `pain_level`,
+  `consciousness`) are blanked because reporting them off a
+  disembodied head would lie.  Head-container entries from the
+  corpse's `removed_organs` list are carried over so pre-sever
+  harvests stay visible.
+- **Worn-items contract**: `get_worn_items()` returns `[]` — heads
+  carry no clothing in v1 (renderer compatibility shim).
+- **Severing a SeveredHead is refused**: heads are terminal; the
+  `CmdSever` isinstance gate remains `Corpse`-only.
+
+PR-C will widen `CmdAutopsy` and `CmdHarvest` isinstance gates to
+accept `SeveredHead` so the head can be examined and its
+head-container organs harvested through the same forensic surface
+as a corpse.
+
+**Deferred** (not blocking PR-C): the snapshot represents the
+*body's* identity at sever time, not consciousness; sleeve-swap
+awareness on the head awaits the resleeving system.
 
 ---
 

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1,5 +1,6 @@
 from evennia import DefaultObject, AttributeProperty
 from world.combat.constants import DEFAULT_CLOTHING_LAYER
+from .identity_bearer import IdentityBearerMixin
 
 # ANSI Color definitions for clothing descriptions
 COLOR_DEFINITIONS = {
@@ -1067,3 +1068,200 @@ class Appendage(Item):
         self.db.source_corpse_dbref = corpse.dbref
         readable = location_name.replace("_", " ")
         self.key = f"{condition} {readable}"
+
+
+def apply_severed_head_overlay(head, corpse):
+    """Copy identity / decay / trimmed snapshot from ``corpse`` onto ``head``.
+
+    Extracted from :meth:`SeveredHead.configure_from_sever` so unit
+    tests can exercise the overlay logic against plain-Python stubs
+    without instantiating an Evennia typeclass (whose metaclass would
+    bind ``super()`` to the concrete class and reject duck-typed
+    ``self`` substitutes).
+
+    Contract — after this call ``head.db`` has:
+
+    * ``signature_at_death`` / ``apparent_uid_at_death`` copied verbatim
+      from the source corpse (IdentityBearerMixin contract).
+    * ``creation_time`` / ``death_time`` / ``death_cause`` shared with
+      the corpse so the head ages on the same decay clock.
+    * ``medical_state_at_death`` = trimmed snapshot — only organs whose
+      ``container == "head"``; body-wide fields (conditions, blood,
+      pain, consciousness) blanked because they describe the whole
+      body and would lie if reported off a disembodied head.  Organs
+      are deep-copied to prevent aliasing with the corpse snapshot.
+    * ``removed_organs`` filtered to the head-container subset of the
+      corpse's removed-organ list (so pre-sever harvests stay visible).
+    """
+    # IdentityBearerMixin contract — copy snapshotted identity.
+    head.db.signature_at_death = corpse.db.signature_at_death
+    head.db.apparent_uid_at_death = corpse.db.apparent_uid_at_death
+
+    # Shared decay clock — head ages with the corpse.
+    head.db.creation_time = corpse.db.creation_time
+    head.db.death_time = corpse.db.death_time
+    head.db.death_cause = corpse.db.death_cause
+
+    # Trimmed head-container medical snapshot.
+    corpse_snapshot = corpse.get_medical_snapshot() or {}
+    organs = corpse_snapshot.get("organs") or {}
+    head_organs = {
+        name: dict(data)
+        for name, data in organs.items()
+        if (data.get("container") or "") == "head"
+    }
+    head.db.medical_state_at_death = {
+        "organs": head_organs,
+        "conditions": [],
+        "blood_level": None,
+        "pain_level": None,
+        "consciousness": None,
+    }
+
+    # Head-container subset of removed_organs.
+    corpse_removed = corpse.db.removed_organs or ()
+    head.db.removed_organs = [
+        name for name in corpse_removed if name in head_organs
+    ]
+
+
+class SeveredHead(IdentityBearerMixin, Appendage):
+    """A severed head — super-item spawned by ``sever head from <corpse>``.
+
+    Sibling of :class:`Appendage` but additionally inherits
+    :class:`typeclasses.identity_bearer.IdentityBearerMixin` so the
+    head carries the same two-pass recognition + forensic-recovery
+    surface as a :class:`typeclasses.corpse.Corpse`.  Investigators
+    can autopsy the head, harvest brain/eyes from it, and recognise
+    its identity through decay exactly as they could the source
+    corpse — within the limits of the head-container partition.
+
+    Decay clock is shared with the source corpse: ``creation_time``
+    is copied at severance, so a head that left a moderate-decay
+    corpse is itself moderate-decay.  ``death_time`` is likewise
+    copied so the autopsy "time since death" reads consistently.
+
+    Attributes (``self.db``):
+        Inherited from :class:`Appendage` —
+            ``location_name`` (always ``"head"``), ``condition``,
+            ``source_signature``, ``source_apparent_uid``,
+            ``source_corpse_dbref``.
+        IdentityBearerMixin contract —
+            ``signature_at_death``, ``apparent_uid_at_death``.
+        Decay clock —
+            ``creation_time``, ``death_time``, ``death_cause``.
+        Trimmed snapshot —
+            ``medical_state_at_death`` (head-container organs only,
+            other fields blanked) and ``removed_organs`` (head-
+            container subset of the source corpse's removals).
+
+    Severing a SeveredHead is refused at the :class:`commands.forensics.CmdSever`
+    gate (Corpse-only ``isinstance`` check) — heads are terminal.
+    """
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.location_name = "head"
+        # IdentityBearerMixin contract — populated by configure_from_sever.
+        self.db.signature_at_death = None
+        self.db.apparent_uid_at_death = None
+        # Decay clock — copied from source corpse at severance so the
+        # head and corpse age together.  Default to creation time of
+        # this object until configure_from_sever overwrites.
+        import time
+        self.db.creation_time = time.time()
+        self.db.death_time = time.time()
+        self.db.death_cause = "unknown"
+        # Trimmed head-container medical snapshot — set by
+        # configure_from_sever.  Conformant with the dict shape
+        # :meth:`typeclasses.corpse.Corpse.get_medical_snapshot`
+        # returns so harvest / autopsy code can consume both via
+        # ``get_medical_snapshot``.
+        self.db.medical_state_at_death = None
+        self.db.removed_organs = []
+        # ``severed_locations`` is unused on a head (you cannot sever
+        # the head off a head), but harvest/autopsy code paths may
+        # read it defensively — keep it present and empty.
+        self.db.severed_locations = []
+
+    # ------------------------------------------------------------------
+    # IdentityBearerMixin contract — decay surface
+    # ------------------------------------------------------------------
+
+    # Decay tier thresholds, in seconds since ``creation_time``.  Same
+    # ladder the corpse uses (see ``world/combat/constants.py``
+    # ``CORPSE_DECAY_*``).  Copied locally so we don't need a Corpse
+    # instance to consult.
+    _DECAY_STAGES = (
+        ("fresh", 3600),
+        ("early", 86400),
+        ("moderate", 259200),
+        ("advanced", 604800),
+    )
+
+    def get_decay_stage(self):
+        """Return the current decay tier; mirrors Corpse semantics."""
+        import time
+        elapsed = time.time() - (self.db.creation_time or time.time())
+        for stage, threshold in self._DECAY_STAGES:
+            if elapsed < threshold:
+                return stage
+        return "skeletal"
+
+    def _decay_display_name(self):
+        """Fallback display when no recognition memory matches."""
+        stage = self.get_decay_stage()
+        return {
+            "fresh": "fresh severed head",
+            "early": "pale severed head",
+            "moderate": "decomposing severed head",
+            "advanced": "putrid severed head",
+            "skeletal": "skull",
+        }.get(stage, "severed head")
+
+    def get_medical_snapshot(self):
+        """Return the trimmed head-container medical snapshot, if any.
+
+        Same contract as :meth:`typeclasses.corpse.Corpse.get_medical_snapshot`;
+        consumed by :class:`commands.forensics.CmdHarvest` and
+        :class:`commands.forensics.CmdAutopsy` once PR-C widens their
+        isinstance gates.
+        """
+        return self.db.medical_state_at_death
+
+    def get_worn_items(self, location=None):
+        """Heads carry no worn clothing — return ``[]``.
+
+        Renderer compatibility shim for any code path that calls
+        :func:`world.identity.get_essential_item_type_ids` against a
+        severed head (the identity signature is the snapshotted one,
+        not a re-derived live signature).
+        """
+        del location  # parity with ClothingMixin.get_worn_items signature
+        return []
+
+    # ------------------------------------------------------------------
+    # Sever-time configuration
+    # ------------------------------------------------------------------
+
+    def configure_from_sever(self, *, location_name, condition, corpse):
+        """Populate identity + decay + trimmed snapshot fields at sever.
+
+        Overrides :meth:`Appendage.configure_from_sever` to additionally
+        copy the corpse's identity / death / decay state and to build
+        the trimmed head-container medical snapshot.
+
+        ``location_name`` is expected to be ``"head"`` — the caller
+        (:class:`commands.forensics.CmdSever`) routes only heads here.
+        We don't assert it, to keep the surface duck-typed and to leave
+        future container types (severed face? severed neck?) the door
+        open.
+        """
+        # Inherited bookkeeping: location_name, condition, source_*
+        # provenance, display key.
+        super().configure_from_sever(
+            location_name=location_name, condition=condition, corpse=corpse,
+        )
+        # Identity / decay / trimmed snapshot overlay (unit-testable).
+        apply_severed_head_overlay(self, corpse)
+

--- a/world/tests/test_cmd_sever.py
+++ b/world/tests/test_cmd_sever.py
@@ -342,3 +342,37 @@ class CmdSeverTests(TestCase):
         ):
             _make_cmd(caller=caller, args="left_arm from corpse").func()
         self.assertIn("left_arm", corpse.db.severed_locations)
+
+    # ----- head routing → SeveredHead super-item (PR #194) -----
+
+    def test_head_routes_to_severed_head_typeclass(self):
+        """Severing the head spawns ``typeclasses.items.SeveredHead``,
+        not the plain ``Appendage`` other locations get.
+        """
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ) as mk:
+            _make_cmd(caller=caller, args="head from corpse").func()
+        args, kwargs = mk.call_args
+        # First positional arg is the typeclass path.
+        self.assertEqual(args[0], "typeclasses.items.SeveredHead")
+        self.assertIn("head", kwargs["key"])
+
+    def test_non_head_still_routes_to_appendage(self):
+        """Non-head severable locations still spawn plain Appendage."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ) as mk:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+        args, _ = mk.call_args
+        self.assertEqual(args[0], "typeclasses.items.Appendage")

--- a/world/tests/test_severed_head.py
+++ b/world/tests/test_severed_head.py
@@ -1,0 +1,239 @@
+"""Unit tests for :class:`typeclasses.items.SeveredHead` (PR #194).
+
+The SeveredHead super-item carries identity / decay / trimmed
+snapshot state forward from the source corpse so PR-C's widened
+autopsy and harvest gates can treat it as a forensic peer of the
+corpse.  These tests lock the sever-time overlay contract and the
+decay surface without spinning up a full Evennia typeclass instance.
+
+The overlay body lives in :func:`typeclasses.items.apply_severed_head_overlay`
+(a module-level helper) so the test can drive it against a plain stub
+``self``; the ``SeveredHead.configure_from_sever`` method is a thin
+wrapper that chains ``super().configure_from_sever`` then delegates
+to that helper.  Decay-stage methods are class-attribute lookups
+plus pure arithmetic, so they're exercised via
+``SeveredHead.<method>.__func__(stub)`` calls where ``stub`` owns the
+required ``db`` shape plus a borrowed ``_DECAY_STAGES`` class attribute.
+
+Run via::
+
+    evennia test world.tests.test_severed_head
+"""
+
+from __future__ import annotations
+
+import time
+from unittest import TestCase
+
+from typeclasses.items import SeveredHead, apply_severed_head_overlay
+
+
+class _DB:
+    pass
+
+
+class _FakeHead:
+    """Stub stand-in for a ``SeveredHead`` instance.
+
+    Carries the ``db`` shape and the borrowed ``_DECAY_STAGES`` class
+    attribute that the unbound decay methods need.  ``configure_from_sever``
+    is intentionally absent — overlay tests drive
+    :func:`apply_severed_head_overlay` directly.
+    """
+
+    _DECAY_STAGES = SeveredHead._DECAY_STAGES
+    # Bind the unbound function so ``self.get_decay_stage()`` works
+    # (needed because ``_decay_display_name`` does a bound call).
+    get_decay_stage = SeveredHead.get_decay_stage
+
+    def __init__(self):
+        self.db = _DB()
+        self.db.creation_time = time.time()
+        self.db.death_time = time.time()
+        self.db.death_cause = "unknown"
+        self.db.medical_state_at_death = None
+        self.db.removed_organs = []
+        self.db.signature_at_death = None
+        self.db.apparent_uid_at_death = None
+
+
+class _FakeCorpse:
+    def __init__(
+        self,
+        *,
+        signature=("sleeve-9", "tall", "lean", "hooded", ("balaclava",)),
+        apparent_uid="hash-xyz",
+        creation_time=None,
+        death_time=None,
+        death_cause="gunshot",
+        snapshot=None,
+        removed_organs=None,
+        dbref="#777",
+    ):
+        self.dbref = dbref
+        self.db = _DB()
+        self.db.signature_at_death = signature
+        self.db.apparent_uid_at_death = apparent_uid
+        self.db.creation_time = creation_time or (time.time() - 100)
+        self.db.death_time = death_time or self.db.creation_time
+        self.db.death_cause = death_cause
+        self.db.medical_state_at_death = snapshot
+        self.db.removed_organs = list(removed_organs or ())
+
+    def get_medical_snapshot(self):
+        return self.db.medical_state_at_death
+
+
+def _full_snapshot():
+    def org(hp, container):
+        return {"current_hp": hp, "max_hp": hp, "container": container}
+    return {
+        "organs": {
+            "brain": org(10, "head"),
+            "left_eye": org(10, "head"),
+            "right_eye": org(10, "head"),
+            "heart": org(15, "chest"),
+            "liver": org(20, "abdomen"),
+            "left_humerus": org(25, "left_arm"),
+        },
+        "conditions": ["shock"],
+        "blood_level": 3500,
+        "pain_level": 9,
+        "consciousness": False,
+    }
+
+
+class SeveredHeadOverlayTests(TestCase):
+    """Drive :func:`apply_severed_head_overlay` against a stub head."""
+
+    def setUp(self):
+        self.head = _FakeHead()
+        self.corpse = _FakeCorpse(snapshot=_full_snapshot())
+
+    def _overlay(self):
+        apply_severed_head_overlay(self.head, self.corpse)
+
+    def test_identity_snapshot_copied(self):
+        self._overlay()
+        self.assertEqual(
+            self.head.db.signature_at_death,
+            self.corpse.db.signature_at_death,
+        )
+        self.assertEqual(
+            self.head.db.apparent_uid_at_death,
+            self.corpse.db.apparent_uid_at_death,
+        )
+
+    def test_decay_clock_shared_with_corpse(self):
+        self._overlay()
+        self.assertEqual(
+            self.head.db.creation_time, self.corpse.db.creation_time
+        )
+        self.assertEqual(
+            self.head.db.death_time, self.corpse.db.death_time
+        )
+        self.assertEqual(
+            self.head.db.death_cause, self.corpse.db.death_cause
+        )
+
+    def test_trimmed_snapshot_filters_to_head_container(self):
+        self._overlay()
+        organs = self.head.db.medical_state_at_death["organs"]
+        self.assertEqual(
+            set(organs.keys()), {"brain", "left_eye", "right_eye"}
+        )
+
+    def test_trimmed_snapshot_blanks_body_wide_fields(self):
+        self._overlay()
+        snap = self.head.db.medical_state_at_death
+        self.assertEqual(snap["conditions"], [])
+        self.assertIsNone(snap["blood_level"])
+        self.assertIsNone(snap["pain_level"])
+        self.assertIsNone(snap["consciousness"])
+
+    def test_removed_organs_carries_head_subset_only(self):
+        self.corpse.db.removed_organs = ["left_eye", "heart"]
+        self._overlay()
+        self.assertEqual(self.head.db.removed_organs, ["left_eye"])
+
+    def test_snapshot_organs_are_independent_copies(self):
+        """Mutating the head's snapshot must not bleed into the corpse."""
+        self._overlay()
+        self.head.db.medical_state_at_death["organs"]["brain"][
+            "current_hp"
+        ] = 0
+        self.assertEqual(
+            self.corpse.db.medical_state_at_death["organs"]["brain"][
+                "current_hp"
+            ],
+            10,
+        )
+
+    def test_no_corpse_snapshot_yields_empty_organs(self):
+        self.corpse.db.medical_state_at_death = None
+        self._overlay()
+        snap = self.head.db.medical_state_at_death
+        self.assertEqual(snap["organs"], {})
+
+    def test_get_medical_snapshot_returns_trimmed_dict(self):
+        """The accessor is a thin ``self.db.medical_state_at_death`` read."""
+        self._overlay()
+        result = SeveredHead.get_medical_snapshot(self.head)
+        self.assertIs(result, self.head.db.medical_state_at_death)
+
+    def test_non_head_organs_excluded_even_if_missing_container(self):
+        """Organs with no ``container`` key are excluded (defensive)."""
+        snapshot = _full_snapshot()
+        snapshot["organs"]["mystery_organ"] = {"current_hp": 1, "max_hp": 1}
+        self.corpse.db.medical_state_at_death = snapshot
+        self._overlay()
+        organs = self.head.db.medical_state_at_death["organs"]
+        self.assertNotIn("mystery_organ", organs)
+
+    def test_overlay_preserves_corpse_snapshot_keys(self):
+        """Sanity: the overlay shouldn't mutate the corpse snapshot dict."""
+        original_keys = set(
+            self.corpse.db.medical_state_at_death["organs"].keys()
+        )
+        self._overlay()
+        self.assertEqual(
+            set(self.corpse.db.medical_state_at_death["organs"].keys()),
+            original_keys,
+        )
+
+
+class SeveredHeadDecayContractTests(TestCase):
+    """Spot-check the decay surface used by IdentityBearerMixin."""
+
+    def _make_head_at_age(self, age_seconds):
+        head = _FakeHead()
+        head.db.creation_time = time.time() - age_seconds
+        return head
+
+    def test_fresh_under_hour(self):
+        head = self._make_head_at_age(60)
+        self.assertEqual(SeveredHead.get_decay_stage(head), "fresh")
+
+    def test_early_under_day(self):
+        head = self._make_head_at_age(7200)
+        self.assertEqual(SeveredHead.get_decay_stage(head), "early")
+
+    def test_skeletal_after_advanced_threshold(self):
+        # 604800s = advanced cap; bump past it.
+        head = self._make_head_at_age(604800 + 10)
+        self.assertEqual(SeveredHead.get_decay_stage(head), "skeletal")
+
+    def test_decay_display_name_per_stage(self):
+        head = self._make_head_at_age(60)
+        self.assertEqual(
+            SeveredHead._decay_display_name(head), "fresh severed head"
+        )
+        head.db.creation_time = time.time() - (604800 + 10)
+        self.assertEqual(SeveredHead._decay_display_name(head), "skull")
+
+    def test_get_worn_items_is_empty(self):
+        head = _FakeHead()
+        self.assertEqual(SeveredHead.get_worn_items(head), [])
+        self.assertEqual(
+            SeveredHead.get_worn_items(head, location="head"), []
+        )


### PR DESCRIPTION
## Summary

PR-B of the severed-head super-item rollout (after PR-A's
`IdentityBearerMixin` factoring in #193).

- New `typeclasses.items.SeveredHead(IdentityBearerMixin, Appendage)`
  super-item, spawned by `sever head from <corpse>` instead of the
  generic `Appendage` used for limbs.
- Copies the source corpse's identity signature, apparent UID, decay
  clock (`creation_time` / `death_time` / `death_cause`), and a
  trimmed head-container medical snapshot (organs filtered to
  `container == "head"`; body-wide fields blanked).  Pre-sever
  head-organ harvests carry over via `removed_organs`.
- `get_worn_items()` returns `[]` (renderer compatibility shim).
- `CmdSever` routes `location == "head"` to `SeveredHead`, all other
  locations stay on `Appendage`.  Severing a `SeveredHead` is
  refused — the `Corpse`-only isinstance gate is unchanged.

The overlay body lives in module-level
`apply_severed_head_overlay(head, corpse)` so unit tests can drive
it against plain Python stubs without spinning up Evennia
typeclass instances.

## Tests

- `world/tests/test_severed_head.py` (NEW, 15 tests):
  10 overlay tests covering identity carry-forward, shared decay
  clock, head-container filter, body-wide field blanking,
  removed-organs subset, organ deep-copy isolation, empty-snapshot
  handling, missing-container defensiveness, corpse non-mutation;
  5 decay-contract tests covering stage thresholds, display-name
  mapping, and the empty `get_worn_items` shim.
- `world/tests/test_cmd_sever.py` (+2 tests): head-location routes
  to `SeveredHead` typeclass; non-head locations still route to
  `Appendage`.

Full suite: **1055 passing** (1038 baseline + 17 new — 15 in
`test_severed_head.py`, 2 in `test_cmd_sever.py`).

## Spec

`specs/IDENTITY_RECOGNITION_SPEC.md`: removed the "Severed-head
super-item" bullet from §"Out of scope (deferred past PR #190)";
added new §"Severed-Head Super-Item ✅ (Shipped — PR #194)"
documenting the carry-forward contract and pointing at PR-C for
the autopsy/harvest gate widening.

Closes #194.