### PR TITLE
Widen autopsy and harvest to accept SeveredHead (#196)

### DIFF
--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from evennia import Command, create_object
 
 from typeclasses.corpse import Corpse
+from typeclasses.items import SeveredHead
 from world.combat.constants import (
     AUTOPSY_DC_BASIC,
     HARVEST_CRIT_FAIL,
@@ -91,8 +92,11 @@ class CmdAutopsy(Command):
         if target is None:
             return  # search() already messaged the caller
 
-        if not isinstance(target, Corpse):
-            caller.msg("You can only perform an autopsy on a corpse.")
+        if not isinstance(target, (Corpse, SeveredHead)):
+            caller.msg(
+                "You can only perform an autopsy on a corpse or a "
+                "severed head."
+            )
             return
 
         # Skeletal-stage guard: no soft tissue, no signature axes worth
@@ -254,8 +258,11 @@ class CmdHarvest(Command):
         if target is None:
             return  # search() already messaged
 
-        if not isinstance(target, Corpse):
-            caller.msg("You can only harvest organs from a corpse.")
+        if not isinstance(target, (Corpse, SeveredHead)):
+            caller.msg(
+                "You can only harvest organs from a corpse or a "
+                "severed head."
+            )
             return
 
         if target.get_decay_stage() == "skeletal":

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1780,12 +1780,15 @@ the head is a first-class forensic peer of the source corpse:
 - **Severing a SeveredHead is refused**: heads are terminal; the
   `CmdSever` isinstance gate remains `Corpse`-only.
 
-PR-C will widen `CmdAutopsy` and `CmdHarvest` isinstance gates to
-accept `SeveredHead` so the head can be examined and its
-head-container organs harvested through the same forensic surface
-as a corpse.
+**Accepted targets ✅ (PR #196)**: `CmdAutopsy` and `CmdHarvest`
+accept either a `Corpse` or a `SeveredHead` — the isinstance gate
+is `(Corpse, SeveredHead)`.  Autopsy on a head renders the standard
+five-section report against the trimmed head-container snapshot
+(brain / eyes / ears / etc.); harvest extracts head-container organs
+honoring the carry-forward `removed_organs` list.  `CmdSever`
+remains `Corpse`-only.
 
-**Deferred** (not blocking PR-C): the snapshot represents the
+**Deferred** (post PR-C): the snapshot represents the
 *body's* identity at sever time, not consciousness; sleeve-swap
 awareness on the head awaits the resleeving system.
 

--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -240,35 +240,42 @@ ORGANS = {
     "brain": {
         "container": "head", "max_hp": 10, "hit_weight": "very_rare",
         "vital": True, "capacity": "consciousness", "contribution": "total",
-        "special": "damage_always_scars", "can_scar": True, "can_heal": False
+        "special": "damage_always_scars", "can_scar": True, "can_heal": False,
+        "can_be_harvested": True
     },
     "left_eye": {
         "container": "head", "max_hp": 10, "hit_weight": "rare",
         "capacity": "sight", "contribution": "major", "disfiguring_if_lost": True,
-        "damage_always_scars": True, "vulnerable_to_blunt": False
+        "damage_always_scars": True, "vulnerable_to_blunt": False,
+        "can_be_harvested": True
     },
     "right_eye": {
         "container": "head", "max_hp": 10, "hit_weight": "rare",
         "capacity": "sight", "contribution": "major", "disfiguring_if_lost": True,
-        "damage_always_scars": True, "vulnerable_to_blunt": False
+        "damage_always_scars": True, "vulnerable_to_blunt": False,
+        "can_be_harvested": True
     },
     "left_ear": {
         "container": "head", "max_hp": 12, "hit_weight": "rare",
-        "capacity": "hearing", "contribution": "major", "disfiguring_if_lost": True
+        "capacity": "hearing", "contribution": "major", "disfiguring_if_lost": True,
+        "can_be_harvested": True
     },
     "right_ear": {
         "container": "head", "max_hp": 12, "hit_weight": "rare",
-        "capacity": "hearing", "contribution": "major", "disfiguring_if_lost": True
+        "capacity": "hearing", "contribution": "major", "disfiguring_if_lost": True,
+        "can_be_harvested": True
     },
     "tongue": {
         "container": "head", "max_hp": 20, "hit_weight": "rare",
         "capacities": ["talking", "eating"], "talking_contribution": "major",
-        "eating_contribution": "major", "disfiguring_if_lost": True
+        "eating_contribution": "major", "disfiguring_if_lost": True,
+        "can_be_harvested": True
     },
     "jaw": {
         "container": "head", "max_hp": 10, "hit_weight": "rare",
         "capacities": ["talking", "eating"], "talking_contribution": "major",
-        "eating_contribution": "moderate", "disfiguring_if_lost": True, "can_scar": False
+        "eating_contribution": "moderate", "disfiguring_if_lost": True, "can_scar": False,
+        "can_be_harvested": True
     },
 
     # CHEST CONTAINER → VITAL ORGANS INSIDE  

--- a/world/tests/test_cmd_autopsy_severed_head.py
+++ b/world/tests/test_cmd_autopsy_severed_head.py
@@ -1,0 +1,214 @@
+"""Unit tests for ``CmdAutopsy`` widened to SeveredHead (PR #196).
+
+PR-C widens the ``CmdAutopsy`` isinstance gate from ``Corpse`` only
+to ``(Corpse, SeveredHead)`` so a disembodied head can be examined
+via the same forensic surface as a corpse.  These tests lock the
+widened gate and confirm the trimmed head-container snapshot flows
+through the same renderer as a full-body autopsy.
+
+The pattern mirrors :mod:`world.tests.test_cmd_autopsy`: we patch the
+``commands.forensics.Corpse`` *and* ``SeveredHead`` symbols with
+stand-in base classes, then point our fakes at those stand-ins so
+the ``isinstance(target, (Corpse, SeveredHead))`` gate accepts them
+without spinning up Evennia typeclass instances.
+
+Run via::
+
+    evennia test world.tests.test_cmd_autopsy_severed_head
+"""
+
+from __future__ import annotations
+
+import time
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from commands import forensics as cmd_module
+from commands.forensics import CmdAutopsy
+
+
+class _DB:
+    pass
+
+
+class _FakeRoom:
+    def __init__(self):
+        self.contents = []
+
+
+class _CorpseStandIn:
+    pass
+
+
+class _SeveredHeadStandIn:
+    pass
+
+
+class _FakeSeveredHead(_SeveredHeadStandIn):
+    """Mirrors the surface CmdAutopsy / render_forensic_report read.
+
+    Field defaults match the post-``configure_from_sever`` shape
+    laid down by :func:`typeclasses.items.apply_severed_head_overlay`:
+    trimmed snapshot, blanked body-wide fields, no wounds list.
+    """
+
+    def __init__(
+        self,
+        *,
+        key="the severed head of Jorge",
+        display=None,
+        decay_stage="fresh",
+        snapshot=None,
+        removed_organs=None,
+        death_cause="multiple gunshot wounds",
+        death_time=None,
+    ):
+        self.key = key
+        self.db = _DB()
+        self.db.signature_at_death = (
+            "sleeve-9", "tall", "lean", "hooded", ("balaclava",),
+        )
+        self.db.apparent_uid_at_death = "head-xyz"
+        self.db.forensic_recognition_cache = None
+        self.db.death_cause = death_cause
+        self.db.death_time = (
+            death_time if death_time is not None else time.time() - 60
+        )
+        # SeveredHead intentionally has no wounds_at_death; the
+        # renderer's defensive ``getattr`` returns None → empty list.
+        self.db.removed_organs = removed_organs or []
+        self.db.severed_locations = []  # heads are terminal
+        self._display = display or key
+        self._decay_stage = decay_stage
+        self._snapshot = snapshot
+
+    def get_display_name(self, looker=None, **kwargs):
+        del looker, kwargs
+        return self._display
+
+    def get_decay_stage(self):
+        return self._decay_stage
+
+    def get_medical_snapshot(self):
+        return self._snapshot
+
+
+def _make_caller(*, key="Alice", dbref="#42", memory=None, location=None):
+    caller = MagicMock()
+    caller.key = key
+    caller.dbref = dbref
+    caller.location = location or _FakeRoom()
+    caller.recognition_memory = memory or {}
+    caller.msg = MagicMock()
+    caller.search = MagicMock()
+    return caller
+
+
+def _make_cmd(*, caller, target, args="head", switches=()):
+    cmd = CmdAutopsy()
+    cmd.caller = caller
+    cmd.args = " " + args
+    cmd.switches = list(switches)
+    caller.search.return_value = target
+    return cmd
+
+
+def _patch_gate():
+    """Patch both Corpse and SeveredHead symbols on the command module."""
+    return patch.multiple(
+        cmd_module,
+        Corpse=_CorpseStandIn,
+        SeveredHead=_SeveredHeadStandIn,
+    )
+
+
+def _head_snapshot():
+    def org(hp, container="head"):
+        return {"current_hp": hp, "max_hp": hp, "container": container}
+    return {
+        "organs": {
+            "brain": org(10),
+            "left_eye": org(10),
+            "right_eye": org(10),
+        },
+        "conditions": [],
+        "blood_level": None,
+        "pain_level": None,
+        "consciousness": None,
+    }
+
+
+class TestCmdAutopsyAcceptsSeveredHead(TestCase):
+    """The widened isinstance gate accepts SeveredHead."""
+
+    def _run(self, *, head=None, roll=99):
+        caller = _make_caller()
+        head = head or _FakeSeveredHead(snapshot=_head_snapshot())
+        cmd = _make_cmd(caller=caller, target=head)
+        with _patch_gate(), \
+                patch.object(cmd_module, "msg_room_identity") as broadcast, \
+                patch("world.combat.dice.roll_stat", return_value=roll):
+            cmd.func()
+        return caller, head, broadcast
+
+    def test_severed_head_passes_gate(self):
+        """A SeveredHead is no longer rejected with the corpse-only message."""
+        caller, _, broadcast = self._run()
+        # Successful autopsy renders the standard report sections.
+        rendered = caller.msg.call_args[0][0]
+        self.assertNotIn("can only perform", rendered)
+        self.assertIn("Worn essentials", rendered)
+        broadcast.assert_called_once()
+
+    def test_organ_section_shows_head_container_only(self):
+        caller, _, _ = self._run()
+        rendered = caller.msg.call_args[0][0]
+        self.assertIn("brain: intact", rendered)
+        self.assertIn("left_eye: intact", rendered)
+        self.assertIn("right_eye: intact", rendered)
+        # Non-head organs are not present in the trimmed snapshot.
+        self.assertNotIn("heart", rendered)
+        self.assertNotIn("liver", rendered)
+
+    def test_cause_of_death_carried_through(self):
+        head = _FakeSeveredHead(
+            snapshot=_head_snapshot(), death_cause="decapitation",
+        )
+        caller, _, _ = self._run(head=head)
+        rendered = caller.msg.call_args[0][0]
+        self.assertIn("decapitation", rendered)
+
+    def test_removed_organ_renders_as_absent_on_head(self):
+        head = _FakeSeveredHead(
+            snapshot=_head_snapshot(), removed_organs=["brain"],
+        )
+        caller, _, _ = self._run(head=head)
+        rendered = caller.msg.call_args[0][0]
+        self.assertIn("brain: absent", rendered)
+
+    def test_skeletal_head_short_circuits(self):
+        head = _FakeSeveredHead(decay_stage="skeletal")
+        caller, _, broadcast = self._run(head=head)
+        broadcast.assert_not_called()
+        out = caller.msg.call_args[0][0]
+        self.assertIn("decomposed", out.lower())
+
+
+class TestCmdAutopsyStillRejectsArbitrary(TestCase):
+    """Widening must not allow arbitrary non-forensic objects through."""
+
+    def test_plain_object_still_rejected(self):
+        caller = _make_caller()
+        not_a_remain = object()
+        caller.search.return_value = not_a_remain
+        cmd = CmdAutopsy()
+        cmd.caller = caller
+        cmd.args = " rock"
+        cmd.switches = []
+        with _patch_gate():
+            cmd.func()
+        caller.msg.assert_called_once()
+        # Updated message mentions both surfaces.
+        msg = caller.msg.call_args[0][0].lower()
+        self.assertIn("corpse", msg)
+        self.assertIn("severed head", msg)

--- a/world/tests/test_cmd_harvest.py
+++ b/world/tests/test_cmd_harvest.py
@@ -170,9 +170,9 @@ class CmdHarvestTests(TestCase):
         caller = _make_caller()
         caller.search.return_value = MagicMock()  # not a _CorpseStandIn
         _make_cmd(caller=caller, args="heart from rock").func()
-        caller.msg.assert_called_with(
-            "You can only harvest organs from a corpse."
-        )
+        msg = caller.msg.call_args[0][0].lower()
+        self.assertIn("corpse", msg)
+        self.assertIn("severed head", msg)
 
     # ----- decay / snapshot gates -----
 

--- a/world/tests/test_cmd_harvest_severed_head.py
+++ b/world/tests/test_cmd_harvest_severed_head.py
@@ -1,0 +1,204 @@
+"""Unit tests for ``CmdHarvest`` widened to SeveredHead (PR #196).
+
+PR-C widens the ``CmdHarvest`` isinstance gate from ``Corpse`` only
+to ``(Corpse, SeveredHead)`` so head-container organs (brain, eyes,
+ears, …) can be harvested from a disembodied head with the same
+flow as from a full corpse.
+
+The pattern mirrors :mod:`world.tests.test_cmd_harvest`: we patch the
+``commands.forensics.Corpse`` *and* ``SeveredHead`` symbols with
+stand-in base classes, then point our fakes at those stand-ins.
+
+Run via::
+
+    evennia test world.tests.test_cmd_harvest_severed_head
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from commands import forensics as cmd_module
+from commands.forensics import CmdHarvest
+
+
+class _DB:
+    pass
+
+
+class _FakeRoom:
+    def __init__(self):
+        self.contents = []
+
+
+class _CorpseStandIn:
+    pass
+
+
+class _SeveredHeadStandIn:
+    pass
+
+
+class _FakeSeveredHead(_SeveredHeadStandIn):
+    """Mirrors the surface CmdHarvest reads off a SeveredHead.
+
+    Matches the post-``configure_from_sever`` shape: trimmed snapshot
+    containing only head-container organs, empty ``severed_locations``
+    (heads are terminal), ``removed_organs`` carry-forward already
+    applied.
+    """
+
+    def __init__(
+        self,
+        *,
+        key="the severed head of Jorge",
+        display=None,
+        decay_stage="fresh",
+        snapshot=None,
+        removed_organs=None,
+        dbref="#202",
+    ):
+        self.key = key
+        self.dbref = dbref
+        self.db = _DB()
+        self.db.signature_at_death = (
+            "sleeve-9", "tall", "lean", "hooded", ("balaclava",),
+        )
+        self.db.apparent_uid_at_death = "head-xyz"
+        self.db.medical_state_at_death = snapshot
+        self.db.removed_organs = list(removed_organs or ())
+        self.db.severed_locations = []
+        self._display = display or key
+        self._decay_stage = decay_stage
+
+    def get_display_name(self, looker=None, **kwargs):
+        del looker, kwargs
+        return self._display
+
+    def get_decay_stage(self):
+        return self._decay_stage
+
+    def get_medical_snapshot(self):
+        return self.db.medical_state_at_death
+
+
+def _head_snapshot(*, brain_hp=10, left_eye_hp=10, right_eye_hp=10):
+    """Trimmed head-container snapshot (mirrors apply_severed_head_overlay)."""
+    return {
+        "organs": {
+            "brain": {
+                "current_hp": brain_hp, "max_hp": 10, "container": "head",
+            },
+            "left_eye": {
+                "current_hp": left_eye_hp, "max_hp": 10, "container": "head",
+            },
+            "right_eye": {
+                "current_hp": right_eye_hp, "max_hp": 10, "container": "head",
+            },
+        },
+        "conditions": [],
+        "blood_level": None,
+        "pain_level": None,
+        "consciousness": None,
+    }
+
+
+def _make_caller(*, key="Alice", dbref="#42", location=None):
+    caller = MagicMock()
+    caller.key = key
+    caller.dbref = dbref
+    caller.location = location or _FakeRoom()
+    caller.recognition_memory = {}
+    caller.msg = MagicMock()
+    caller.search = MagicMock()
+    caller.motorics = 10
+    return caller
+
+
+def _make_cmd(*, caller, args):
+    cmd = CmdHarvest()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.switches = ()
+    return cmd
+
+
+class CmdHarvestSeveredHeadTests(TestCase):
+    def setUp(self):
+        self._patcher = patch.multiple(
+            cmd_module,
+            Corpse=_CorpseStandIn,
+            SeveredHead=_SeveredHeadStandIn,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_severed_head_passes_isinstance_gate(self):
+        """Ambiguous form on a head lists head-container organs."""
+        caller = _make_caller()
+        head = _FakeSeveredHead(snapshot=_head_snapshot())
+        caller.search.return_value = head
+        _make_cmd(caller=caller, args="head").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertNotIn("can only harvest", msg)
+        self.assertIn("brain", msg)
+        self.assertIn("left eye", msg)
+        self.assertIn("right eye", msg)
+
+    def test_already_removed_head_organ_refused(self):
+        """Head-organ harvest respects carry-forward ``removed_organs``."""
+        caller = _make_caller()
+        head = _FakeSeveredHead(
+            snapshot=_head_snapshot(), removed_organs=["brain"],
+        )
+        caller.search.return_value = head
+        _make_cmd(caller=caller, args="brain from head").func()
+        msg = caller.msg.call_args[0][0].lower()
+        self.assertTrue(
+            "already" in msg or "no brain" in msg,
+            f"unexpected refusal message: {msg!r}",
+        )
+
+    def test_non_head_organ_not_present_on_head(self):
+        """A non-head organ name finds nothing on the trimmed snapshot."""
+        caller = _make_caller()
+        head = _FakeSeveredHead(snapshot=_head_snapshot())
+        caller.search.return_value = head
+        _make_cmd(caller=caller, args="heart from head").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("no heart", msg)
+
+    def test_successful_brain_harvest_spawns_organ(self):
+        """Success: ``create_object`` called and snapshot mutated."""
+        caller = _make_caller()
+        head = _FakeSeveredHead(snapshot=_head_snapshot())
+        caller.search.return_value = head
+        with patch.object(cmd_module, "create_object") as mock_create, \
+                patch.object(cmd_module, "msg_room_identity"), \
+                patch.object(cmd_module, "roll_stat", return_value=99):
+            mock_create.return_value = MagicMock()
+            _make_cmd(caller=caller, args="brain from head").func()
+        mock_create.assert_called_once()
+        self.assertIn("brain", head.db.removed_organs)
+
+    def test_skeletal_head_short_circuits_harvest(self):
+        caller = _make_caller()
+        head = _FakeSeveredHead(
+            decay_stage="skeletal", snapshot=_head_snapshot(),
+        )
+        caller.search.return_value = head
+        _make_cmd(caller=caller, args="brain from head").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("decomposed", msg)
+
+    def test_no_snapshot_head_refuses_harvest(self):
+        """A SeveredHead without a snapshot (legacy) refuses harvest."""
+        caller = _make_caller()
+        head = _FakeSeveredHead(snapshot=None)
+        caller.search.return_value = head
+        _make_cmd(caller=caller, args="brain from head").func()
+        msg = caller.msg.call_args[0][0]
+        self.assertIn("predate", msg)


### PR DESCRIPTION
## Summary

PR-C of the severed-head super-item rollout (final), completing the
work started in PR-A (#192/#193 — IdentityBearerMixin extraction)
and PR-B (#194/#195 — SeveredHead typeclass).

- `commands/forensics.py::CmdAutopsy` — isinstance gate widened from
  `Corpse` to `(Corpse, SeveredHead)`; refusal message updated to
  name both surfaces.
- `commands/forensics.py::CmdHarvest` — same widening.
- `commands/forensics.py::CmdSever` — **unchanged**; heads remain
  terminal (Corpse-only gate intentional).
- `world/medical/constants.py::ORGANS` — added `can_be_harvested: True`
  to the seven head-container organs (brain, left_eye, right_eye,
  left_ear, right_ear, tongue, jaw) so the widened harvest gate has
  real organs to extract.  Without this the harvest surface accepted
  a head but `_harvestable_organs` returned `[]`.

`world/forensics.py` was audited — `extract_subject_from_corpse`,
`render_forensic_report`, `_render_wound_lines`, `_render_organ_lines`,
and `_fuzzy_time_of_death` were all already duck-typed against
`getattr(target.db, ..., None)` and require no changes.  SeveredHead
intentionally has no `wounds_at_death` (the wound section omits
cleanly via the defensive `getattr`).

## Tests

- `world/tests/test_cmd_autopsy_severed_head.py` (NEW, 6 tests):
  SeveredHead passes the gate; organ section shows head-container
  organs only; cause-of-death carry-forward; removed_organs renders
  as absent; skeletal head short-circuits; non-forensic objects
  still refused with both-surfaces message.
- `world/tests/test_cmd_harvest_severed_head.py` (NEW, 6 tests):
  ambiguous form lists head-container organs; already-removed
  carry-forward refused; non-head organ surfaces as 'no <organ>';
  successful brain harvest spawns Organ + appends to removed_organs;
  skeletal head short-circuits; snapshot-less legacy head refuses.
- `world/tests/test_cmd_harvest.py` — updated `test_non_corpse_rejected`
  to match the new both-surfaces refusal message.

Full suite: **1067 passing** (1055 baseline + 12 new).

## Spec

`specs/IDENTITY_RECOGNITION_SPEC.md` §"Severed-Head Super-Item":
added "Accepted targets ✅ (PR #196)" paragraph documenting the
widened gates; collapsed the prior PR-C-deferral paragraph into
a "Deferred (post PR-C)" note covering sleeve-swap awareness.

Closes #196.