### PR TITLE
Carry wounds and longdesc forward to severed items (#198)

### DIFF
--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from evennia import Command, create_object
 
 from typeclasses.corpse import Corpse
-from typeclasses.items import SeveredHead
+from typeclasses.items import SeveredHead, apply_sever_to_corpse
 from world.combat.constants import (
     AUTOPSY_DC_BASIC,
     HARVEST_CRIT_FAIL,
@@ -638,6 +638,13 @@ class CmdSever(Command):
         appendage.configure_from_sever(
             location_name=location_arg, condition=condition, corpse=target,
         )
+
+        # PR #198: mirror the appendage-side wound/longdesc overlay by
+        # clearing that prose off the corpse and synthesizing a stump
+        # wound at the canonical severed location.  Handles the
+        # head-cluster fan-out internally (head sever also clears
+        # face / neck / eyes / ears prose).
+        apply_sever_to_corpse(target, location_arg)
 
         caller.msg(
             f"You sever the {readable_name} from {corpse_display} — "

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1792,6 +1792,58 @@ remains `Corpse`-only.
 *body's* identity at sever time, not consciousness; sleeve-swap
 awareness on the head awaits the resleeving system.
 
+### Wound + Longdesc Carry-Forward (PR-D ✅ — PR #198)
+
+When `CmdSever` succeeds, the severed appendage (or head) inherits
+the corpse's per-location wounds and free-form longdesc prose, and
+the corpse's matching prose is cleared and replaced with a
+synthesized stump wound — keeping a single source of truth for "what
+happened to that body part" and letting both autopsy and the severed
+item render the same narrative.
+
+**Move semantics** (not copy): pre-existing wounds at the severed
+location(s) are removed from the corpse and reassigned to the
+severed item. The corpse keeps only the synthesized stump wound at
+the sever location. This prevents double-reporting in autopsy.
+
+**Head cluster**: severing the head moves wounds and longdesc for
+the entire head cluster — `{head, face, neck, left_eye, right_eye,
+left_ear, right_ear}` (see `SEVERED_HEAD_LOCATIONS` in
+`world/combat/constants.py`). Limbs use a single-location move.
+
+**Stump wound contract**: synthesized as
+`{injury_type: "severed", location: <sever_loc>, severity: "Critical",
+stage: "old", organ: None, organ_damage: {current_hp: 0, max_hp: 0,
+container: <sever_loc>}}` and appended to `corpse.db.wounds_at_death`.
+Rendering flows through the standard
+`world.medical.wounds.get_wound_description()` pipeline using new
+templates in `world/medical/wounds/messages/severed.py` (fresh / old /
+treated / healing / scarred / destroyed stages all defined, with `old`
+being the canonical autopsy form).
+
+**Severed-item rendering**: `Appendage.return_appearance` (and the
+`SeveredHead` override) renders the base condition prose, then any
+carried longdesc verbatim per location (no decay modulation — once
+written into death prose, it ages with the host item's overall decay
+clock, not its own), then any inherited wounds via
+`get_wound_description`. This keeps a severed hand with a tattoo
+description on it readable as "a severed left hand — tattoo prose —
+old slash wound" regardless of where the hand ends up.
+
+**Helpers** (`typeclasses/items.py`):
+- `apply_wound_and_longdesc_overlay(item, corpse, locations)` —
+  moves the listed locations' wounds and longdesc from corpse → item.
+- `apply_sever_to_corpse(corpse, location)` — wraps the overlay for
+  the limb / head-cluster case and stamps the stump wound onto the
+  corpse.
+
+**Failure modes**: on a failed sever roll, neither helper is called;
+the corpse retains its wounds and longdesc unchanged.
+
+**Deferred**: per-organ wound carry-forward when only an organ
+(rather than a whole limb) is harvested; decay-tier modulation of
+inherited longdesc prose on the severed item itself.
+
 ---
 
 ## New Character Attributes

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1052,6 +1052,12 @@ class Appendage(Item):
         self.db.source_signature = None
         self.db.source_apparent_uid = None
         self.db.source_corpse_dbref = None
+        # PR #198 wound + longdesc carry-forward: populated by
+        # ``configure_from_sever`` via ``apply_wound_and_longdesc_overlay``.
+        # Default to empty containers so renderer code paths can iterate
+        # without ``None`` checks.
+        self.db.wounds_at_death = []
+        self.db.longdesc_data = {}
 
     def configure_from_sever(self, *, location_name, condition, corpse):
         """Populate forensic-chain fields immediately after spawn.
@@ -1068,6 +1074,179 @@ class Appendage(Item):
         self.db.source_corpse_dbref = corpse.dbref
         readable = location_name.replace("_", " ")
         self.key = f"{condition} {readable}"
+        # PR #198: pull this location's wound + longdesc prose off the
+        # corpse onto ourselves.  The corpse-side mutation
+        # (delete-from-source + synthesized stump wound) is handled by
+        # :func:`commands.forensics._apply_sever_to_corpse` so this
+        # helper stays a pure copy and is independently unit-testable.
+        apply_wound_and_longdesc_overlay(self, corpse, (location_name,))
+
+    def return_appearance(self, looker, **kwargs):
+        """Compose appearance from base desc + carried longdesc + wounds.
+
+        PR #198: severed limbs and heads carry forward the source
+        corpse's per-location longdesc prose and wound records.  We
+        render them after the base ``return_appearance`` output so the
+        condition-keyed line (e.g. ``"fresh left arm"``) still leads.
+
+        Longdesc text is shown verbatim — the ``condition`` prefix in
+        the key already conveys decay state, so we deliberately skip
+        the decay-modulation pass that
+        :class:`typeclasses.corpse.Corpse` applies to its preserved
+        longdescs.  Wound descriptions render at ``stage="old"`` to
+        match the corpse's own preserved-wound contract.
+        """
+        base = super().return_appearance(looker, **kwargs)
+        parts = [base] if base else []
+
+        longdescs = self.db.longdesc_data or {}
+        if longdescs:
+            try:
+                from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
+            except ImportError:
+                ANATOMICAL_DISPLAY_ORDER = list(longdescs.keys())
+            seen = set()
+            for loc in ANATOMICAL_DISPLAY_ORDER:
+                text = longdescs.get(loc)
+                if text and loc not in seen:
+                    parts.append(text)
+                    seen.add(loc)
+            # Any longdesc locations not in the canonical order
+            # (defensive — preserves prose for nonstandard anatomy).
+            for loc, text in longdescs.items():
+                if text and loc not in seen:
+                    parts.append(text)
+                    seen.add(loc)
+
+        wounds = self.db.wounds_at_death or []
+        if wounds:
+            try:
+                from world.medical.wounds import get_wound_description
+            except ImportError:
+                get_wound_description = None
+            if get_wound_description is not None:
+                for wound in wounds:
+                    try:
+                        rendered = get_wound_description(
+                            injury_type=wound.get("injury_type", "generic"),
+                            location=wound.get(
+                                "location", self.db.location_name or ""
+                            ),
+                            severity=wound.get("severity", "Moderate"),
+                            stage="old",
+                            organ=wound.get("organ"),
+                            character=self,
+                        )
+                    except (KeyError, ValueError, AttributeError):
+                        continue
+                    if rendered:
+                        parts.append(rendered)
+
+        return "\n".join(p for p in parts if p)
+
+
+def apply_wound_and_longdesc_overlay(appendage, corpse, locations):
+    """Copy wounds + longdesc prose for ``locations`` from corpse → appendage.
+
+    Extracted as a module-level helper (matching the
+    :func:`apply_severed_head_overlay` pattern) so unit tests can
+    exercise the overlay against plain-Python stubs without
+    instantiating an Evennia typeclass.
+
+    The overlay is a **pure copy** — the caller (:func:`commands.forensics._apply_sever_to_corpse`)
+    is responsible for the symmetric corpse-side delete + stump-wound
+    synthesis.  Wound dict entries are shallow-copied (one level) to
+    prevent the appendage and corpse from sharing list/dict identity
+    on subsequent mutations.
+
+    Args:
+        appendage: Object whose ``db`` should receive ``wounds_at_death``
+            and ``longdesc_data`` for the given locations.
+        corpse: Source :class:`typeclasses.corpse.Corpse`-like object
+            whose ``db.wounds_at_death`` and ``db.longdesc_data`` are
+            read.
+        locations: Iterable of body-location names.  Wounds whose
+            ``location`` field is in this set are copied; longdesc
+            entries whose key is in this set are copied.
+    """
+    locs = frozenset(locations)
+
+    src_wounds = corpse.db.wounds_at_death or []
+    appendage.db.wounds_at_death = [
+        dict(wound) for wound in src_wounds
+        if wound.get("location") in locs
+    ]
+
+    src_longdescs = corpse.db.longdesc_data or {}
+    appendage.db.longdesc_data = {
+        loc: text for loc, text in src_longdescs.items() if loc in locs
+    }
+
+
+def apply_sever_to_corpse(corpse, location_arg, *, head_locations=None):
+    """Mutate ``corpse`` to reflect a successful sever at ``location_arg``.
+
+    Symmetric counterpart to :func:`apply_wound_and_longdesc_overlay`:
+    where the overlay copies prose onto the severed item, this helper
+    removes that prose from the source corpse and synthesizes a stump
+    wound at the canonical severed location.
+
+    For ``location_arg == "head"`` the full
+    :data:`world.combat.constants.SEVERED_HEAD_LOCATIONS` cluster is
+    cleared from the corpse's ``longdesc_data`` and ``wounds_at_death``
+    (face, neck, eyes, ears all visually leave with the head).  For
+    any other limb, only that single location is cleared.  In every
+    case exactly one synthesized ``severed``-type wound is appended at
+    ``location_arg`` so the corpse renders, e.g., *"the left shoulder
+    ends in a ragged stump"*.
+
+    Args:
+        corpse: The source corpse to mutate in place.
+        location_arg: Canonical severed-location identifier
+            (member of :data:`world.combat.constants.SEVERABLE_CONTAINERS`).
+        head_locations: Override for the head-cluster set; defaults to
+            :data:`world.combat.constants.SEVERED_HEAD_LOCATIONS`.
+            Exposed for test injection.
+    """
+    if head_locations is None:
+        from world.combat.constants import SEVERED_HEAD_LOCATIONS
+        head_locations = SEVERED_HEAD_LOCATIONS
+
+    if location_arg == "head":
+        locs = frozenset(head_locations)
+    else:
+        locs = frozenset({location_arg})
+
+    # Drop longdesc prose for the cleared locations.
+    src_longdescs = corpse.db.longdesc_data or {}
+    if src_longdescs:
+        corpse.db.longdesc_data = {
+            loc: text for loc, text in src_longdescs.items()
+            if loc not in locs
+        }
+
+    # Wounds at the cleared locations move to the severed item; drop
+    # them from the corpse to avoid double-counting in autopsy.
+    src_wounds = corpse.db.wounds_at_death or []
+    remaining = [
+        wound for wound in src_wounds
+        if wound.get("location") not in locs
+    ]
+    # Synthesized stump wound — single entry at the canonical sever
+    # location, regardless of head-cluster size.
+    remaining.append({
+        "injury_type": "severed",
+        "location": location_arg,
+        "severity": "Critical",
+        "stage": "old",
+        "organ": None,
+        "organ_damage": {
+            "current_hp": 0,
+            "max_hp": 0,
+            "container": location_arg,
+        },
+    })
+    corpse.db.wounds_at_death = remaining
 
 
 def apply_severed_head_overlay(head, corpse):
@@ -1258,10 +1437,22 @@ class SeveredHead(IdentityBearerMixin, Appendage):
         open.
         """
         # Inherited bookkeeping: location_name, condition, source_*
-        # provenance, display key.
+        # provenance, display key.  The Appendage super-call also
+        # invokes :func:`apply_wound_and_longdesc_overlay` for the
+        # single ``"head"`` location; we re-invoke it below with the
+        # full head-cluster set so face / neck / eyes / ears prose
+        # also follows the severed head.
         super().configure_from_sever(
             location_name=location_name, condition=condition, corpse=corpse,
         )
         # Identity / decay / trimmed snapshot overlay (unit-testable).
         apply_severed_head_overlay(self, corpse)
+        # Re-apply wound + longdesc overlay across the full head-cluster
+        # (overrides the head-only set the Appendage super-call laid
+        # down).  Per PR #198: face, neck, eyes, ears all visually leave
+        # with the head.
+        from world.combat.constants import SEVERED_HEAD_LOCATIONS
+        apply_wound_and_longdesc_overlay(
+            self, corpse, SEVERED_HEAD_LOCATIONS,
+        )
 

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -796,3 +796,15 @@ SEVERABLE_CONTAINERS = frozenset({
     "left_shin", "right_shin",
     "left_foot", "right_foot",
 })
+
+# Body locations bundled with the severed-head super-item.  When the
+# head is severed (PR #198), the longdesc text and wound records for
+# all of these locations move from the corpse onto the SeveredHead,
+# since they are visually and anatomically part of the head cluster.
+# The corpse loses prose for every location in this set and gains a
+# single synthesized ``severed`` wound at ``head``.
+SEVERED_HEAD_LOCATIONS = frozenset({
+    "head", "face", "neck",
+    "left_eye", "right_eye",
+    "left_ear", "right_ear",
+})

--- a/world/medical/wounds/messages/__init__.py
+++ b/world/medical/wounds/messages/__init__.py
@@ -9,3 +9,4 @@ from . import cut
 from . import stab
 from . import blunt
 from . import generic
+from . import severed

--- a/world/medical/wounds/messages/severed.py
+++ b/world/medical/wounds/messages/severed.py
@@ -1,0 +1,46 @@
+"""
+Severed wound descriptions.
+
+These render on a corpse where a limb has been removed (PR #198).
+The wound record is synthesized by
+:func:`commands.forensics._apply_sever_to_corpse` immediately after
+``CmdSever`` succeeds, with ``injury_type='severed'`` and the
+canonical body-location name (e.g. ``left_arm``, ``head``).
+
+Stages:
+    fresh: Used immediately after sever (the cut is recent prose-wise).
+    old:   Used on long-dead corpses; the stump is dried / desiccated.
+
+All templates expect the ``{location}`` token, which resolves through
+:func:`world.medical.wounds.constants.get_location_display_name` and
+yields readable strings like ``"left arm"`` or ``"head"``.
+"""
+
+WOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|RThe {location} has been severed, leaving a ragged, weeping stump|n",
+        "|RWhere the {location} once attached, only a wet, raw stump remains|n",
+        "|RThe {location} is gone — cleaved away at the joint, the wound still glistening|n",
+        "|RA crude amputation has removed the {location}, leaving torn flesh exposed|n",
+    ],
+    "old": [
+        "|rThe {location} has been severed, leaving a darkened, crusted stump|n",
+        "|rWhere the {location} once attached, only dried, ragged tissue remains|n",
+        "|rThe {location} is missing — the stump long since congealed and stiff|n",
+        "|rA stump marks where the {location} used to be, the wound long dry|n",
+    ],
+    # Aliases so the renderer's defensive stage fallbacks don't fall
+    # through to a different injury_type's templates.
+    "treated": [
+        "|rThe stump where the {location} used to be has been crudely bandaged|n",
+    ],
+    "healing": [
+        "|rThe stump where the {location} used to be shows callused, knotted scar tissue|n",
+    ],
+    "scarred": [
+        "|rA smooth, pale scar marks where the {location} was severed long ago|n",
+    ],
+    "destroyed": [
+        "|RThe {location} has been violently torn away, leaving a mangled, ruined stump|n",
+    ],
+}

--- a/world/tests/test_cmd_sever.py
+++ b/world/tests/test_cmd_sever.py
@@ -67,6 +67,8 @@ class _FakeCorpse(_CorpseStandIn):
         snapshot=None,
         removed_organs=None,
         severed_locations=None,
+        wounds_at_death=None,
+        longdesc_data=None,
         dbref="#101",
     ):
         self.key = key
@@ -79,6 +81,14 @@ class _FakeCorpse(_CorpseStandIn):
         self.db.medical_state_at_death = snapshot
         self.db.removed_organs = list(removed_organs or ())
         self.db.severed_locations = list(severed_locations or ())
+        # PR #198 corpse-side state read by apply_sever_to_corpse.
+        self.db.wounds_at_death = list(wounds_at_death or ())
+        self.db.longdesc_data = dict(longdesc_data or {})
+        # PR #198 decay clock fields touched by apply_severed_head_overlay.
+        import time
+        self.db.creation_time = time.time()
+        self.db.death_time = time.time()
+        self.db.death_cause = "gunshot"
         self._display = display or key
         self._decay_stage = decay_stage
 
@@ -376,3 +386,87 @@ class CmdSeverTests(TestCase):
             _make_cmd(caller=caller, args="left_arm from corpse").func()
         args, _ = mk.call_args
         self.assertEqual(args[0], "typeclasses.items.Appendage")
+
+    # ----- wound + longdesc carry-forward (PR #198) -----
+
+    def test_successful_sever_clears_corpse_longdesc(self):
+        """After a limb sever, the corpse's longdesc for that location
+        is removed (it moved to the appendage)."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            snapshot=_snapshot_with_limbs(),
+            longdesc_data={
+                "left_arm": "a pale freckled arm",
+                "chest": "a broad chest",
+            },
+        )
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ):
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+        self.assertNotIn("left_arm", corpse.db.longdesc_data)
+        self.assertIn("chest", corpse.db.longdesc_data)
+
+    def test_successful_sever_appends_stump_wound(self):
+        """After a limb sever, the corpse gains a synthesized
+        ``severed``-type wound at the severed location."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ):
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+        stump_wounds = [
+            w for w in corpse.db.wounds_at_death
+            if w.get("injury_type") == "severed"
+        ]
+        self.assertEqual(len(stump_wounds), 1)
+        self.assertEqual(stump_wounds[0]["location"], "left_arm")
+
+    def test_head_sever_clears_full_head_cluster(self):
+        """Severing the head clears longdesc for the entire
+        SEVERED_HEAD_LOCATIONS cluster, not just ``head``."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            snapshot=_snapshot_with_limbs(),
+            longdesc_data={
+                "head": "a shaven scalp",
+                "face": "sharp features",
+                "neck": "a thick neck",
+                "left_eye": "a milky eye",
+                "chest": "a broad chest",
+            },
+        )
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ):
+            _make_cmd(caller=caller, args="head from corpse").func()
+        self.assertEqual(set(corpse.db.longdesc_data.keys()), {"chest"})
+
+    def test_failed_sever_does_not_clear_longdesc(self):
+        """Sub-DC rolls must not mutate corpse longdesc."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(
+            snapshot=_snapshot_with_limbs(),
+            longdesc_data={"left_arm": "a pale arm"},
+        )
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC - 1
+        ), patch.object(
+            cmd_module, "create_object"
+        ):
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+        # Longdesc untouched on failure.
+        self.assertEqual(
+            corpse.db.longdesc_data, {"left_arm": "a pale arm"}
+        )

--- a/world/tests/test_sever_overlay.py
+++ b/world/tests/test_sever_overlay.py
@@ -1,0 +1,262 @@
+"""Unit tests for the PR #198 wound + longdesc carry-forward overlay.
+
+Two module-level helpers in :mod:`typeclasses.items` are exercised:
+
+* :func:`apply_wound_and_longdesc_overlay` — copies a corpse's
+  wound records and longdesc prose for a given set of body locations
+  onto a severed item (Appendage or SeveredHead).
+* :func:`apply_sever_to_corpse` — symmetric counterpart: clears the
+  same prose off the corpse and synthesizes a ``severed``-type stump
+  wound at the canonical severed location.  Handles the head-cluster
+  fan-out (``head`` sever also clears face / neck / eyes / ears).
+
+Both helpers are pure: they operate on the duck-typed ``db`` surface
+and are independently testable against plain-Python stubs without
+instantiating an Evennia typeclass.
+
+Run via::
+
+    evennia test world.tests.test_sever_overlay
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from typeclasses.items import (
+    apply_sever_to_corpse,
+    apply_wound_and_longdesc_overlay,
+)
+from world.combat.constants import SEVERED_HEAD_LOCATIONS
+
+
+class _DB:
+    """Bare attribute container — matches Evennia ``obj.db`` surface."""
+
+
+class _FakeAppendage:
+    def __init__(self):
+        self.db = _DB()
+        self.db.wounds_at_death = []
+        self.db.longdesc_data = {}
+
+
+class _FakeCorpse:
+    def __init__(self, *, wounds=None, longdescs=None):
+        self.db = _DB()
+        self.db.wounds_at_death = list(wounds or [])
+        self.db.longdesc_data = dict(longdescs or {})
+
+
+def _wound(location, injury_type="bullet", severity="Severe"):
+    """Build a wound dict matching the death_progression snapshot shape."""
+    return {
+        "injury_type": injury_type,
+        "location": location,
+        "severity": severity,
+        "stage": "old",
+        "organ": None,
+        "organ_damage": {
+            "current_hp": 0, "max_hp": 10, "container": location,
+        },
+    }
+
+
+# ---------------------------------------------------------------------
+# apply_wound_and_longdesc_overlay
+# ---------------------------------------------------------------------
+
+
+class ApplyWoundAndLongdescOverlayTests(TestCase):
+    """Pure-copy overlay: corpse → severed item, no source mutation."""
+
+    def test_single_location_wounds_copied(self):
+        corpse = _FakeCorpse(wounds=[
+            _wound("left_arm"),
+            _wound("chest"),
+            _wound("left_arm", injury_type="cut"),
+        ])
+        appendage = _FakeAppendage()
+        apply_wound_and_longdesc_overlay(appendage, corpse, ("left_arm",))
+        locations = [w["location"] for w in appendage.db.wounds_at_death]
+        self.assertEqual(locations, ["left_arm", "left_arm"])
+        injury_types = [w["injury_type"] for w in appendage.db.wounds_at_death]
+        self.assertEqual(injury_types, ["bullet", "cut"])
+
+    def test_single_location_longdesc_copied(self):
+        corpse = _FakeCorpse(longdescs={
+            "left_arm": "a pale, freckled forearm",
+            "chest": "a broad chest with old burn scars",
+        })
+        appendage = _FakeAppendage()
+        apply_wound_and_longdesc_overlay(appendage, corpse, ("left_arm",))
+        self.assertEqual(
+            appendage.db.longdesc_data,
+            {"left_arm": "a pale, freckled forearm"},
+        )
+
+    def test_head_cluster_locations_all_copied(self):
+        corpse = _FakeCorpse(
+            wounds=[
+                _wound("head"),
+                _wound("face"),
+                _wound("left_eye"),
+                _wound("chest"),  # should NOT carry
+            ],
+            longdescs={
+                "head": "a shaven scalp",
+                "face": "sharp angular features",
+                "neck": "a thick muscular neck",
+                "left_eye": "a milky, blind left eye",
+                "chest": "a broad chest",  # should NOT carry
+            },
+        )
+        appendage = _FakeAppendage()
+        apply_wound_and_longdesc_overlay(
+            appendage, corpse, SEVERED_HEAD_LOCATIONS,
+        )
+        wound_locs = {w["location"] for w in appendage.db.wounds_at_death}
+        self.assertEqual(wound_locs, {"head", "face", "left_eye"})
+        self.assertEqual(
+            set(appendage.db.longdesc_data.keys()),
+            {"head", "face", "neck", "left_eye"},
+        )
+
+    def test_empty_corpse_state_yields_empty_appendage_state(self):
+        corpse = _FakeCorpse()
+        appendage = _FakeAppendage()
+        apply_wound_and_longdesc_overlay(appendage, corpse, ("left_arm",))
+        self.assertEqual(appendage.db.wounds_at_death, [])
+        self.assertEqual(appendage.db.longdesc_data, {})
+
+    def test_wound_dicts_are_independent_copies(self):
+        wound = _wound("left_arm")
+        corpse = _FakeCorpse(wounds=[wound])
+        appendage = _FakeAppendage()
+        apply_wound_and_longdesc_overlay(appendage, corpse, ("left_arm",))
+        appendage.db.wounds_at_death[0]["severity"] = "MUTATED"
+        # Original corpse wound dict must not have been mutated.
+        self.assertEqual(corpse.db.wounds_at_death[0]["severity"], "Severe")
+
+    def test_none_db_collections_treated_as_empty(self):
+        corpse = _FakeCorpse()
+        corpse.db.wounds_at_death = None
+        corpse.db.longdesc_data = None
+        appendage = _FakeAppendage()
+        apply_wound_and_longdesc_overlay(appendage, corpse, ("left_arm",))
+        self.assertEqual(appendage.db.wounds_at_death, [])
+        self.assertEqual(appendage.db.longdesc_data, {})
+
+
+# ---------------------------------------------------------------------
+# apply_sever_to_corpse
+# ---------------------------------------------------------------------
+
+
+class ApplySeverToCorpseTests(TestCase):
+    """Symmetric corpse-side mutation after a successful sever."""
+
+    def test_limb_sever_drops_location_longdesc(self):
+        corpse = _FakeCorpse(longdescs={
+            "left_arm": "a pale arm",
+            "chest": "a broad chest",
+        })
+        apply_sever_to_corpse(corpse, "left_arm")
+        self.assertNotIn("left_arm", corpse.db.longdesc_data)
+        self.assertIn("chest", corpse.db.longdesc_data)
+
+    def test_limb_sever_drops_location_wounds(self):
+        corpse = _FakeCorpse(wounds=[
+            _wound("left_arm"),
+            _wound("chest"),
+        ])
+        apply_sever_to_corpse(corpse, "left_arm")
+        locations = [w["location"] for w in corpse.db.wounds_at_death]
+        # Original left_arm wound gone; chest survives; one new
+        # synthesized severed-stump wound at left_arm appended.
+        self.assertEqual(locations.count("left_arm"), 1)
+        self.assertIn("chest", locations)
+        stump = next(
+            w for w in corpse.db.wounds_at_death
+            if w["location"] == "left_arm"
+        )
+        self.assertEqual(stump["injury_type"], "severed")
+
+    def test_limb_sever_appends_single_stump_wound(self):
+        corpse = _FakeCorpse()
+        apply_sever_to_corpse(corpse, "right_thigh")
+        stumps = [
+            w for w in corpse.db.wounds_at_death
+            if w["injury_type"] == "severed"
+        ]
+        self.assertEqual(len(stumps), 1)
+        self.assertEqual(stumps[0]["location"], "right_thigh")
+        self.assertEqual(stumps[0]["severity"], "Critical")
+
+    def test_head_sever_clears_full_cluster_longdescs(self):
+        corpse = _FakeCorpse(longdescs={
+            "head": "a shaven scalp",
+            "face": "sharp features",
+            "neck": "a thick neck",
+            "left_eye": "a milky eye",
+            "right_eye": "a clear eye",
+            "left_ear": "a torn ear",
+            "right_ear": "a normal ear",
+            "chest": "a broad chest",  # survives
+        })
+        apply_sever_to_corpse(corpse, "head")
+        self.assertEqual(set(corpse.db.longdesc_data.keys()), {"chest"})
+
+    def test_head_sever_clears_full_cluster_wounds(self):
+        corpse = _FakeCorpse(wounds=[
+            _wound("head"),
+            _wound("face"),
+            _wound("left_eye"),
+            _wound("neck"),
+            _wound("chest"),  # survives
+        ])
+        apply_sever_to_corpse(corpse, "head")
+        # All head-cluster wounds removed; chest survives; ONE
+        # synthesized stump wound at "head".
+        remaining_originals = [
+            w for w in corpse.db.wounds_at_death
+            if w["injury_type"] != "severed"
+        ]
+        self.assertEqual(
+            [w["location"] for w in remaining_originals], ["chest"]
+        )
+        stumps = [
+            w for w in corpse.db.wounds_at_death
+            if w["injury_type"] == "severed"
+        ]
+        self.assertEqual(len(stumps), 1)
+        self.assertEqual(stumps[0]["location"], "head")
+
+    def test_head_locations_override_accepted(self):
+        """Test injection: caller can pass a custom head-cluster set."""
+        corpse = _FakeCorpse(longdescs={"head": "a head", "face": "a face"})
+        apply_sever_to_corpse(
+            corpse, "head", head_locations=frozenset({"head"}),
+        )
+        # Only "head" cleared, "face" survives.
+        self.assertNotIn("head", corpse.db.longdesc_data)
+        self.assertIn("face", corpse.db.longdesc_data)
+
+    def test_stump_wound_has_organ_damage_block(self):
+        """Forensic shape — autopsy code may read organ_damage defensively."""
+        corpse = _FakeCorpse()
+        apply_sever_to_corpse(corpse, "left_hand")
+        stump = corpse.db.wounds_at_death[-1]
+        self.assertEqual(stump["organ_damage"]["container"], "left_hand")
+        self.assertEqual(stump["organ_damage"]["current_hp"], 0)
+
+    def test_none_db_collections_handled(self):
+        corpse = _FakeCorpse()
+        corpse.db.wounds_at_death = None
+        corpse.db.longdesc_data = None
+        apply_sever_to_corpse(corpse, "left_arm")
+        # No crash; stump wound was still appended.
+        self.assertEqual(len(corpse.db.wounds_at_death), 1)
+        self.assertEqual(
+            corpse.db.wounds_at_death[0]["injury_type"], "severed",
+        )

--- a/world/tests/test_wound_descriptions_severed.py
+++ b/world/tests/test_wound_descriptions_severed.py
@@ -1,0 +1,68 @@
+"""Unit tests for the ``severed`` injury type (PR #198).
+
+Synthesized by :func:`typeclasses.items.apply_sever_to_corpse` after
+a successful sever, and rendered through the standard
+:func:`world.medical.wounds.get_wound_description` pipeline so the
+same templates flow to corpse autopsies and to severed-item
+``return_appearance`` output.
+
+Run via::
+
+    evennia test world.tests.test_wound_descriptions_severed
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.medical.wounds import get_wound_description
+
+
+class SeveredWoundRenderingTests(TestCase):
+
+    def test_limb_severed_old_stage_renders_stump(self):
+        out = get_wound_description(
+            injury_type="severed",
+            location="left_arm",
+            severity="Critical",
+            stage="old",
+        )
+        lowered = out.lower()
+        self.assertIn("left arm", lowered)
+        # Templates evoke stump / severed / missing / ragged-tissue prose.
+        self.assertTrue(
+            any(
+                token in lowered
+                for token in ("stump", "severed", "missing", "ragged", "once attached")
+            ),
+            f"Expected stump/severed prose; got {out!r}",
+        )
+
+    def test_head_severed_renders_head_in_prose(self):
+        out = get_wound_description(
+            injury_type="severed",
+            location="head",
+            severity="Critical",
+            stage="old",
+        )
+        self.assertIn("head", out.lower())
+
+    def test_fresh_stage_also_renders(self):
+        out = get_wound_description(
+            injury_type="severed",
+            location="right_thigh",
+            severity="Critical",
+            stage="fresh",
+        )
+        self.assertIn("right thigh", out.lower())
+
+    def test_unknown_location_falls_back_to_raw_token(self):
+        """No crash + raw token survives the format pipeline."""
+        out = get_wound_description(
+            injury_type="severed",
+            location="tail",  # not in default mappings
+            severity="Critical",
+            stage="old",
+        )
+        # ``get_location_display_name`` returns the raw key if unmapped.
+        self.assertIn("tail", out.lower())


### PR DESCRIPTION
## Summary
- When `CmdSever` succeeds, the severed appendage (or head) inherits the corpse's per-location wounds and longdesc prose; the corpse loses prose at the cleared location(s) and gains a synthesized `severed`-type stump wound.
- Head severs move the full `{head, face, neck, left_eye, right_eye, left_ear, right_ear}` cluster (`SEVERED_HEAD_LOCATIONS`); limbs move a single location. Wounds are **moved** (not copied) so autopsy never double-reports.
- New `severed` injury-type templates flow through the standard `world.medical.wounds.get_wound_description()` pipeline, so corpse autopsies and severed-item `return_appearance` render from the same source of truth.

## Changes
- `world/medical/wounds/messages/severed.py` — new stump templates (fresh/old/treated/healing/scarred/destroyed) keyed on `{location}`.
- `world/medical/wounds/messages/__init__.py` — imports new module.
- `world/combat/constants.py` — `SEVERED_HEAD_LOCATIONS` frozenset.
- `typeclasses/items.py` — `apply_wound_and_longdesc_overlay(item, corpse, locations)` and `apply_sever_to_corpse(corpse, location)` helpers; `Appendage.return_appearance` renders base + longdesc + wounds; `SeveredHead.configure_from_sever` re-applies overlay with full head cluster.
- `commands/forensics.py` — `CmdSever.func` calls `apply_sever_to_corpse(target, location_arg)` after `configure_from_sever`.
- `specs/IDENTITY_RECOGNITION_SPEC.md` — new §"Wound + Longdesc Carry-Forward (PR-D)".

## Tests
- `world/tests/test_sever_overlay.py` — 14 unit tests covering helper behavior, head-cluster expansion, failure-mode guards, and stump-wound contract.
- `world/tests/test_wound_descriptions_severed.py` — 4 rendering tests across stages and locations.
- `world/tests/test_cmd_sever.py` — extended `_FakeCorpse` and 4 new tests (clears longdesc, appends stump, head clears full cluster, failed roll preserves state).
- **Full suite: 1089 passing** (1067 baseline + 22 new).

Closes #198.