### PR TITLE
Synthesize harvested-organ wound on corpse for carry-forward (#200)

### DIFF
--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -393,6 +393,29 @@ class CmdHarvest(Command):
         # parity with crit-fail branch; future per-organ HP tweaks rely
         # on this contract.
 
+        # PR #200 (PR-F): synthesize a ``harvested``-type wound on the
+        # corpse at the organ's *container* location.  Targeting the
+        # container (not the organ name) lets PR-D's wound + longdesc
+        # carry-forward overlay move this wound onto severed limbs /
+        # heads automatically when those locations are later severed.
+        # Harvests of organs whose container is unseverable (chest,
+        # abdomen, back) leave the wound on the corpse permanently —
+        # which is the correct narrative for torso excisions.
+        wounds = list(target.db.wounds_at_death or ())
+        wounds.append({
+            "injury_type": "harvested",
+            "location": organ_data.get("container") or organ_arg,
+            "severity": "Critical",
+            "stage": "old",
+            "organ": organ_arg,
+            "organ_damage": {
+                "current_hp": 0,
+                "max_hp": 0,
+                "container": organ_data.get("container") or organ_arg,
+            },
+        })
+        target.db.wounds_at_death = wounds
+
         organ_item = create_object(
             "typeclasses.items.Organ",
             key=f"{condition} {readable_name}",

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1844,6 +1844,53 @@ the corpse retains its wounds and longdesc unchanged.
 (rather than a whole limb) is harvested; decay-tier modulation of
 inherited longdesc prose on the severed item itself.
 
+### Harvested-Organ Wounds (PR-F ✅ — PR #200)
+
+When `CmdHarvest` succeeds, the corpse gains a synthesized
+`harvested`-type wound at the organ's **container** location.
+Targeting the container (not the organ name) lets the existing
+PR-D wound + longdesc carry-forward overlay
+(`apply_wound_and_longdesc_overlay`) move the wound onto a severed
+limb / head automatically when that container is later severed —
+no harvest-specific code is needed in the overlay layer.
+
+**Synthesized wound contract**:
+`{injury_type: "harvested", location: <container>, severity: "Critical",
+stage: "old", organ: <organ_name>, organ_damage: {current_hp: 0,
+max_hp: 0, container: <container>}}`. Appended to
+`corpse.db.wounds_at_death` after `removed_organs.append`. Templates
+in `world/medical/wounds/messages/harvested.py` (fresh / old / treated
+/ healing / scarred / destroyed stages) render via the standard
+`get_wound_description` pipeline using `{location}` and `{organ}`
+tokens.
+
+**Carry-forward behavior**:
+- **Severable container** (head, hands, arms, thighs, shins, feet) —
+  harvested wound rides with the severed item when that location is
+  later severed. A harvested-eye wound at `head` flows through the
+  head-cluster fan-out; a harvested-metacarpal wound at `right_hand`
+  moves to the severed right hand.
+- **Unseverable container** (chest, abdomen, back) — wound stays on
+  the corpse permanently. A harvested-heart wound at `chest` cannot
+  travel because no sever operation targets the chest; the autopsy
+  forever records the excision.
+
+**Crit-fail behavior**: silent — no wound synthesized. The
+`destroyed` organ-status in the autopsy snapshot already conveys
+the destruction, and crit-fail is operator error not external
+trauma. Successful harvest leaves a clean surgical trace; crit-fail
+leaves an internal mess that doesn't manifest as an external wound.
+
+**Rendering helper change**: `world/medical/wounds/wound_descriptions.py`
+adds an `organ_display` key to `format_vars` (humanizes `left_eye`
+→ `left eye`) so templates using `{organ}` render readable prose.
+Cheap str-level transform — no `ORGANS` registry lookup, to keep the
+renderer independent of registry growth in subsequent PRs.
+
+**Deferred** (PR-G): species-aware naming for corpses, severed items,
+and organs; decay-modulated keys; recognition reveal as parenthetical;
+static default descriptions per organ × condition tier.
+
 ---
 
 ## New Character Attributes

--- a/world/medical/wounds/messages/__init__.py
+++ b/world/medical/wounds/messages/__init__.py
@@ -10,3 +10,4 @@ from . import stab
 from . import blunt
 from . import generic
 from . import severed
+from . import harvested

--- a/world/medical/wounds/messages/harvested.py
+++ b/world/medical/wounds/messages/harvested.py
@@ -1,0 +1,69 @@
+"""
+Harvested-organ wound descriptions.
+
+These render on a corpse where an organ has been surgically extracted
+via :class:`commands.forensics.CmdHarvest`.  The wound record is
+synthesized by the success branch of ``CmdHarvest.func`` immediately
+after the organ is moved off the corpse, with ``injury_type='harvested'``
+and the canonical body-location name of the organ's *container*
+(e.g. ``head`` for an eye harvest, ``right_hand`` for a metacarpal
+harvest, ``chest`` for a heart harvest).
+
+Targeting the **container** rather than the organ name lets PR-D's
+existing wound + longdesc carry-forward overlay
+(:func:`typeclasses.items.apply_wound_and_longdesc_overlay`) move the
+wound onto a subsequently severed limb / head without any extra
+plumbing.  Wounds at unseverable containers (chest, abdomen, back)
+stay on the corpse permanently.
+
+Stages:
+    fresh: Used immediately after harvest (the cut is recent prose-wise).
+    old:   Used on long-dead corpses; the excision has dried, sunken.
+
+All templates expect the ``{location}`` and ``{organ}`` tokens, which
+resolve through :func:`world.medical.wounds.constants.get_location_display_name`
+and the new ``organ_display`` derivation in
+:func:`world.medical.wounds.wound_descriptions.get_wound_description`
+respectively.
+"""
+
+WOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|RA precise incision marks where the {organ} was extracted "
+        "from the {location}, the cavity still wet and red|n",
+        "|RThe {location} bears a surgical opening where the {organ} "
+        "was excised, the edges of the cut still glistening|n",
+        "|RWhere the {organ} used to sit inside the {location}, only "
+        "a hollow, blood-slick pocket remains|n",
+        "|RA careful cut along the {location} has exposed the empty "
+        "socket where the {organ} was lifted free|n",
+    ],
+    "old": [
+        "|rA dried incision marks where the {organ} was excised from "
+        "the {location}, the cavity sunken and dark|n",
+        "|rThe {location} bears a healed-over surgical opening where "
+        "the {organ} was removed, the edges crusted brown|n",
+        "|rWhere the {organ} used to sit inside the {location}, only "
+        "a shrunken, empty pocket remains|n",
+        "|rA puckered seam along the {location} marks the long-ago "
+        "extraction of the {organ}|n",
+    ],
+    # Aliases so the renderer's defensive stage fallbacks don't fall
+    # through to a different injury_type's templates.
+    "treated": [
+        "|rThe surgical opening on the {location} where the {organ} was "
+        "removed has been crudely bandaged|n",
+    ],
+    "healing": [
+        "|rThe extraction site on the {location} shows callused, "
+        "knotted scar tissue where the {organ} was lifted free|n",
+    ],
+    "scarred": [
+        "|rA smooth, pale scar runs along the {location}, marking where "
+        "the {organ} was excised long ago|n",
+    ],
+    "destroyed": [
+        "|RThe {location} has been torn open, the {organ} ruined and "
+        "ripped out in a violent extraction|n",
+    ],
+}

--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -52,10 +52,17 @@ def get_wound_description(injury_type, location, severity="Moderate", stage="fre
     
     # Build format variables
     location_display = get_location_display_name(location, character)
+    # Humanize the organ token the same way location is humanized so
+    # templates using {organ} render "left eye" instead of "left_eye".
+    # Cheap str-level transform — organ-spec lookup is intentionally
+    # avoided here to keep this renderer independent of the ORGANS
+    # registry (the registry can grow species-specific entries in PR-G
+    # without rippling into the wound-description pipeline).
+    organ_display = (organ or "").replace("_", " ") if organ else ""
     format_vars = {
         'severity': INJURY_SEVERITY_MAP.get(severity, severity.lower()),
         'location': location_display,
-        'organ': organ or "",
+        'organ': organ_display,
         'injury_type': injury_type
     }
     

--- a/world/tests/test_cmd_harvest.py
+++ b/world/tests/test_cmd_harvest.py
@@ -83,6 +83,11 @@ class _FakeCorpse(_CorpseStandIn):
         self.db.medical_state_at_death = snapshot
         self.db.removed_organs = list(removed_organs or ())
         self.db.severed_locations = list(severed_locations or ())
+        # PR-F (#200): CmdHarvest synthesizes a ``harvested``-type wound
+        # on the corpse at the organ's container.  Seed the slot so the
+        # success branch's ``list(target.db.wounds_at_death or ())``
+        # round-trip preserves any pre-existing wounds from death.
+        self.db.wounds_at_death = []
         self._display = display or key
         self._decay_stage = decay_stage
 
@@ -355,3 +360,111 @@ class CmdHarvestTests(TestCase):
             _make_cmd(caller=caller, args="left kidney from corpse").func()
             mk.assert_called_once()
         self.assertEqual(corpse.db.removed_organs, ["left_kidney"])
+
+    # ----- PR-F (#200) — harvested wound synthesis -----
+
+    def test_success_synthesizes_harvested_wound_at_container(self):
+        """A successful heart harvest stamps a ``harvested`` wound at chest."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=HARVEST_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ):
+            _make_cmd(caller=caller, args="heart from corpse").func()
+        self.assertEqual(len(corpse.db.wounds_at_death), 1)
+        wound = corpse.db.wounds_at_death[0]
+        self.assertEqual(wound["injury_type"], "harvested")
+        # Location is the *container*, not the organ name.
+        self.assertEqual(wound["location"], "chest")
+        self.assertEqual(wound["organ"], "heart")
+        self.assertEqual(wound["severity"], "Critical")
+        self.assertEqual(wound["stage"], "old")
+        self.assertEqual(wound["organ_damage"]["container"], "chest")
+        self.assertEqual(wound["organ_damage"]["current_hp"], 0)
+
+    def test_eye_harvest_targets_head_container(self):
+        """Eye harvest must target ``head`` so PR-D head-cluster carry-forward triggers."""
+        caller = _make_caller()
+        # Snapshot needs left_eye for the eye harvest path.
+        snap = _snapshot_with()
+        snap["organs"]["left_eye"] = {
+            "current_hp": 10, "max_hp": 10, "container": "head",
+        }
+        corpse = _FakeCorpse(snapshot=snap)
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=HARVEST_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ):
+            _make_cmd(caller=caller, args="left eye from corpse").func()
+        self.assertEqual(len(corpse.db.wounds_at_death), 1)
+        wound = corpse.db.wounds_at_death[0]
+        self.assertEqual(wound["location"], "head")
+        self.assertEqual(wound["organ"], "left_eye")
+
+    def test_miss_does_not_synthesize_wound(self):
+        """Below-DC rolls leave wounds_at_death untouched."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=HARVEST_DC_BASIC - 1
+        ), patch.object(cmd_module, "create_object"):
+            _make_cmd(caller=caller, args="heart from corpse").func()
+        self.assertEqual(corpse.db.wounds_at_death, [])
+
+    def test_crit_fail_does_not_synthesize_wound(self):
+        """Crit-fail destroys the organ silently — no harvested wound prose."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=HARVEST_CRIT_FAIL
+        ), patch.object(cmd_module, "create_object"):
+            _make_cmd(caller=caller, args="heart from corpse").func()
+        self.assertEqual(corpse.db.wounds_at_death, [])
+        # And the destruction signal lives on the snapshot, not in
+        # the wounds list — confirm the snapshot was zeroed.
+        self.assertEqual(
+            corpse.db.medical_state_at_death["organs"]["heart"]["current_hp"],
+            0,
+        )
+
+    def test_harvest_preserves_pre_existing_wounds(self):
+        """The new wound is appended, not replacing pre-existing wounds."""
+        caller = _make_caller()
+        corpse = _FakeCorpse(snapshot=_snapshot_with())
+        # Seed a pre-existing wound that came from combat death.
+        existing = {
+            "injury_type": "bullet",
+            "location": "chest",
+            "severity": "Critical",
+            "stage": "old",
+            "organ": "heart",
+            "organ_damage": {
+                "current_hp": 0, "max_hp": 15, "container": "chest",
+            },
+        }
+        corpse.db.wounds_at_death = [existing]
+        caller.search.return_value = corpse
+        with patch.object(
+            cmd_module, "roll_stat", return_value=HARVEST_DC_BASIC
+        ), patch.object(
+            cmd_module, "create_object", return_value=MagicMock()
+        ):
+            _make_cmd(caller=caller, args="liver from corpse").func()
+        self.assertEqual(len(corpse.db.wounds_at_death), 2)
+        # Existing bullet wound preserved.
+        self.assertIn(existing, corpse.db.wounds_at_death)
+        # New harvested wound at liver's container.
+        harvested = [
+            w for w in corpse.db.wounds_at_death
+            if w["injury_type"] == "harvested"
+        ]
+        self.assertEqual(len(harvested), 1)
+        self.assertEqual(harvested[0]["location"], "abdomen")
+        self.assertEqual(harvested[0]["organ"], "liver")

--- a/world/tests/test_cmd_harvest_severed_head.py
+++ b/world/tests/test_cmd_harvest_severed_head.py
@@ -69,6 +69,10 @@ class _FakeSeveredHead(_SeveredHeadStandIn):
         self.db.medical_state_at_death = snapshot
         self.db.removed_organs = list(removed_organs or ())
         self.db.severed_locations = []
+        # PR-F (#200): CmdHarvest synthesizes a ``harvested`` wound
+        # on the target at the organ's container.  Seed the slot so
+        # the wound-append round-trip works against the SeveredHead.
+        self.db.wounds_at_death = []
         self._display = display or key
         self._decay_stage = decay_stage
 

--- a/world/tests/test_sever_overlay.py
+++ b/world/tests/test_sever_overlay.py
@@ -260,3 +260,130 @@ class ApplySeverToCorpseTests(TestCase):
         self.assertEqual(
             corpse.db.wounds_at_death[0]["injury_type"], "severed",
         )
+
+
+# ---------------------------------------------------------------------
+# PR-F (#200) — harvested-organ wound carry-forward via PR-D overlay
+# ---------------------------------------------------------------------
+
+
+def _harvested_wound(location, organ):
+    """Build a harvested wound dict shaped like CmdHarvest synthesizes."""
+    return {
+        "injury_type": "harvested",
+        "location": location,
+        "severity": "Critical",
+        "stage": "old",
+        "organ": organ,
+        "organ_damage": {
+            "current_hp": 0, "max_hp": 0, "container": location,
+        },
+    }
+
+
+class HarvestedWoundCarryForwardTests(TestCase):
+    """Integration: harvested wounds piggyback PR-D's existing overlay.
+
+    The contract verified here is that ``CmdHarvest`` synthesizes
+    wounds at the organ's *container* location (PR-F design), so the
+    pre-existing PR-D ``apply_wound_and_longdesc_overlay`` and
+    ``apply_sever_to_corpse`` helpers move them correctly without
+    any harvest-specific code in the overlay layer.
+    """
+
+    def test_harvested_hand_wound_moves_to_severed_right_hand(self):
+        """harvest right metacarpals → sever right hand → wound rides along."""
+        corpse = _FakeCorpse(wounds=[
+            _harvested_wound("right_hand", "right_metacarpals"),
+            _wound("chest"),  # unrelated
+        ])
+        appendage = _FakeAppendage()
+        # Simulate the configure_from_sever overlay call.
+        apply_wound_and_longdesc_overlay(appendage, corpse, ("right_hand",))
+        # Then simulate the corpse-side mutation.
+        apply_sever_to_corpse(corpse, "right_hand")
+
+        # Severed item carries the harvested wound.
+        appendage_wounds = appendage.db.wounds_at_death
+        self.assertEqual(len(appendage_wounds), 1)
+        self.assertEqual(appendage_wounds[0]["injury_type"], "harvested")
+        self.assertEqual(appendage_wounds[0]["organ"], "right_metacarpals")
+
+        # Corpse no longer carries it (moved, not copied).
+        corpse_harvested = [
+            w for w in corpse.db.wounds_at_death
+            if w["injury_type"] == "harvested"
+        ]
+        self.assertEqual(corpse_harvested, [])
+        # Stump wound now exists at right_hand on the corpse.
+        stumps = [
+            w for w in corpse.db.wounds_at_death
+            if w["injury_type"] == "severed" and w["location"] == "right_hand"
+        ]
+        self.assertEqual(len(stumps), 1)
+        # Unrelated chest wound survives.
+        chest_wounds = [
+            w for w in corpse.db.wounds_at_death if w["location"] == "chest"
+        ]
+        self.assertEqual(len(chest_wounds), 1)
+
+    def test_harvested_eye_wound_moves_with_head_cluster(self):
+        """harvest left eye → sever head → harvested wound rides cluster."""
+        corpse = _FakeCorpse(wounds=[
+            _harvested_wound("head", "left_eye"),
+            _wound("abdomen"),  # unrelated, unseverable container
+        ])
+        head_item = _FakeAppendage()
+        apply_wound_and_longdesc_overlay(
+            head_item, corpse, SEVERED_HEAD_LOCATIONS,
+        )
+        apply_sever_to_corpse(corpse, "head")
+
+        # Severed head carries the harvested-eye wound.
+        head_wounds = head_item.db.wounds_at_death
+        harvested = [
+            w for w in head_wounds if w["injury_type"] == "harvested"
+        ]
+        self.assertEqual(len(harvested), 1)
+        self.assertEqual(harvested[0]["organ"], "left_eye")
+
+        # Corpse no longer carries the harvested-eye wound.
+        corpse_harvested = [
+            w for w in corpse.db.wounds_at_death
+            if w["injury_type"] == "harvested"
+        ]
+        self.assertEqual(corpse_harvested, [])
+        # Abdomen wound (unseverable container) survives on corpse.
+        abd_wounds = [
+            w for w in corpse.db.wounds_at_death if w["location"] == "abdomen"
+        ]
+        self.assertEqual(len(abd_wounds), 1)
+
+    def test_harvested_torso_wound_stays_on_corpse_after_limb_sever(self):
+        """A harvested-liver wound at abdomen survives a left-arm sever.
+
+        Demonstrates the design intent: wounds at unseverable
+        containers (chest / abdomen / back) remain on the corpse
+        permanently — limb severs only move wounds whose location
+        matches the severed location.
+        """
+        corpse = _FakeCorpse(wounds=[
+            _harvested_wound("abdomen", "liver"),
+            _wound("left_arm"),
+        ])
+        appendage = _FakeAppendage()
+        apply_wound_and_longdesc_overlay(appendage, corpse, ("left_arm",))
+        apply_sever_to_corpse(corpse, "left_arm")
+
+        # Severed left arm has only the left_arm bullet wound, no liver.
+        appendage_organs = [
+            w.get("organ") for w in appendage.db.wounds_at_death
+        ]
+        self.assertNotIn("liver", appendage_organs)
+        # Corpse still has the harvested-liver wound at abdomen.
+        liver_wounds = [
+            w for w in corpse.db.wounds_at_death
+            if w.get("organ") == "liver"
+        ]
+        self.assertEqual(len(liver_wounds), 1)
+        self.assertEqual(liver_wounds[0]["location"], "abdomen")

--- a/world/tests/test_wound_descriptions_harvested.py
+++ b/world/tests/test_wound_descriptions_harvested.py
@@ -1,0 +1,96 @@
+"""Unit tests for the ``harvested`` injury type (PR #200 / PR-F).
+
+Synthesized by :class:`commands.forensics.CmdHarvest` after a
+successful organ extraction and rendered through the standard
+:func:`world.medical.wounds.get_wound_description` pipeline so the
+same templates flow to corpse autopsies and (via PR-D's overlay) to
+severed-item ``return_appearance`` output when the harvested organ's
+container is subsequently severed.
+
+Run via::
+
+    evennia test world.tests.test_wound_descriptions_harvested
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.medical.wounds import get_wound_description
+
+
+class HarvestedWoundRenderingTests(TestCase):
+
+    def test_eye_harvest_old_stage_renders_extraction_prose(self):
+        out = get_wound_description(
+            injury_type="harvested",
+            location="head",
+            severity="Critical",
+            stage="old",
+            organ="left_eye",
+        )
+        lowered = out.lower()
+        # Templates evoke surgical / excision / extraction prose at the
+        # head location with the organ token present.
+        self.assertIn("head", lowered)
+        self.assertIn("left eye", lowered)
+        self.assertTrue(
+            any(
+                token in lowered
+                for token in (
+                    "incision", "extracted", "excised", "removed",
+                    "extraction", "lifted", "puckered",
+                )
+            ),
+            f"Expected extraction prose; got {out!r}",
+        )
+
+    def test_heart_harvest_chest_location(self):
+        out = get_wound_description(
+            injury_type="harvested",
+            location="chest",
+            severity="Critical",
+            stage="old",
+            organ="heart",
+        )
+        lowered = out.lower()
+        self.assertIn("chest", lowered)
+        self.assertIn("heart", lowered)
+
+    def test_fresh_stage_renders(self):
+        out = get_wound_description(
+            injury_type="harvested",
+            location="abdomen",
+            severity="Critical",
+            stage="fresh",
+            organ="liver",
+        )
+        lowered = out.lower()
+        self.assertIn("abdomen", lowered)
+        self.assertIn("liver", lowered)
+
+    def test_organ_token_humanized(self):
+        """Underscored organ keys (left_eye) render as 'left eye'."""
+        out = get_wound_description(
+            injury_type="harvested",
+            location="head",
+            severity="Critical",
+            stage="old",
+            organ="right_eye",
+        )
+        # Should NOT contain the raw underscored token.
+        self.assertNotIn("right_eye", out)
+        # Should contain the humanized form.
+        self.assertIn("right eye", out.lower())
+
+    def test_unknown_location_falls_back_to_raw_token(self):
+        """No crash + raw token survives the format pipeline."""
+        out = get_wound_description(
+            injury_type="harvested",
+            location="gizzard",  # not in default mappings
+            severity="Critical",
+            stage="old",
+            organ="bezoar",
+        )
+        self.assertIn("gizzard", out.lower())
+        self.assertIn("bezoar", out.lower())


### PR DESCRIPTION
## Summary
- When `CmdHarvest` succeeds, the corpse gains a synthesized `harvested`-type wound at the organ's **container** location (not organ name). This lets PR-D's existing wound + longdesc carry-forward overlay move the wound onto severed limbs / heads automatically when those locations are later severed — no harvest-specific overlay code needed.
- Wounds at unseverable containers (chest / abdomen / back) remain on the corpse permanently, which is the correct narrative for torso excisions.
- Crit-fail stays silent: the `destroyed` organ-status in the autopsy snapshot already conveys the destruction, and crit-fail is operator error rather than external trauma worth narrating as a wound.

## Changes
- `world/medical/wounds/messages/harvested.py` — NEW. Stage templates (`fresh`/`old`/`treated`/`healing`/`scarred`/`destroyed`) using `{location}` and `{organ}` tokens, flowing through the standard `get_wound_description()` pipeline.
- `world/medical/wounds/messages/__init__.py` — imports new module.
- `world/medical/wounds/wound_descriptions.py` — add `organ_display` to `format_vars` so `{organ}` renders humanized (`left eye`, not `left_eye`). Cheap str-level transform; no `ORGANS` registry coupling.
- `commands/forensics.py` — `CmdHarvest` success branch synthesizes and appends the wound to `corpse.db.wounds_at_death`.
- `specs/IDENTITY_RECOGNITION_SPEC.md` — new §"Harvested-Organ Wounds (PR-F)" under existing PR-D section.

## Carry-forward matrix
| Container | Severable? | Behavior |
|---|---|---|
| `head` | Yes | Harvested wound rides head-cluster fan-out on sever. |
| `left_hand`/`right_hand`/limbs/feet | Yes | Harvested wound moves to severed item. |
| `chest`/`abdomen`/`back` | No | Wound stays on corpse permanently. |

## Tests
- `world/tests/test_wound_descriptions_harvested.py` — NEW. 5 render tests across stages, `{organ}` humanization, unmapped-location fallback.
- `world/tests/test_cmd_harvest.py` — +5 synthesis tests: wound at correct container, eye→head, miss leaves untouched, crit-fail leaves untouched, pre-existing wounds preserved.
- `world/tests/test_sever_overlay.py` — +3 carry-forward integration tests: harvested hand wound → severed hand, harvested eye → head cluster, harvested liver wound stays on corpse after limb sever.
- `world/tests/test_cmd_harvest_severed_head.py` — `_FakeSeveredHead` fixture seeded with `wounds_at_death`.
- **Full suite: 1102 passing** (1089 baseline + 13 new).

## Out of scope (deferred to PR-G)
- Species-aware naming for corpses, severed items, organs.
- Decay-modulated keys and parenthetical recognition reveal.
- Static default descriptions per organ × condition tier.

Closes #200.