### PR TITLE
PR-G: Species-aware naming + decay-modulated keys + parenthetical recognition (#202)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1891,6 +1891,106 @@ renderer independent of registry growth in subsequent PRs.
 and organs; decay-modulated keys; recognition reveal as parenthetical;
 static default descriptions per organ × condition tier.
 
+### Species Anatomy Overlay (PR-G ✅ — PR #202)
+
+PR-G introduces a thin **species registry** at `world/anatomy/species.py`
+that owns the player-facing vocabulary for body locations, severed
+parts, and whole-corpse names — keyed by species and decay stage.  The
+registry is consulted by every species-aware rendering path
+(`Corpse`, `Appendage`, `SeveredHead`, `Organ`, wound-display
+`get_location_display_name`) so naming conventions stay consistent and
+new species can be added by registering a single dict.
+
+**Registry shape** (`SPECIES_DEFINITIONS[species]`):
+
+| Key                    | Purpose                                              |
+|------------------------|------------------------------------------------------|
+| `display_name`         | Glance-level species tag (e.g. `"human"`).           |
+| `location_display`     | Canonical body-location → readable string mapping.   |
+| `decay_part_prefixes`  | Decay-stage → severed-part template (`{species} {part}`). |
+| `decay_corpse_names`   | Decay-stage → whole-corpse name string.              |
+
+**Three pure-function helpers** (state-free, callable per
+`get_display_name` invocation):
+
+```python
+get_species_location_display(species, location) -> str
+get_species_part_name(species, location, decay_stage) -> str
+get_species_corpse_name(species, decay_stage) -> str
+```
+
+Unknown species fall back to the `"human"` definition; unknown
+locations fall back to underscore-stripped passthrough; unknown decay
+stages fall back to the `"fresh"` template.
+
+**Provenance propagation**:
+
+* `Character.at_object_creation` sets `db.species = "human"` (default).
+* `_create_corpse_from_character` copies `character.db.species` →
+  `corpse.db.species` and seeds the corpse's initial key with
+  `get_species_corpse_name(species, "fresh")`.
+* `Appendage.configure_from_sever` and `Organ.configure_from_harvest`
+  copy `corpse.db.species` → `db.source_species`.
+* `SeveredHead` inherits the propagation via its super-call.
+
+### Display-Name Conventions (PR-G ✅)
+
+**Decay-tier vocabulary** — universal across corpses and severed parts:
+
+| Stage     | Part display           | Corpse display       |
+|-----------|------------------------|----------------------|
+| fresh     | `human <part>`         | `human corpse`       |
+| early     | `human <part>`         | `human corpse`       |
+| moderate  | `rotting <part>`       | `rotting corpse`     |
+| advanced  | `rotting <part>`       | `rotting corpse`     |
+| skeletal  | `skeletal <part>`      | `skeletal remains`   |
+
+Fresh / early stages cleanly identify species; moderate / advanced
+obscure species (just "rotting"); skeletal abandons species entirely
+and the corpse switches from "corpse" to "remains" — a deliberate
+vocabulary shift that signals decay irreversibility.
+
+**Recognition-parenthetical format** — `IdentityBearerMixin.get_display_name`:
+
+When an observer's recognition memory matches the bearer's UID (either
+natural recognition on the degraded UID or forensic recovery on the
+fresh UID), the returned display name is:
+
+```
+<decay name> (<assigned name>)
+```
+
+Examples: `"human corpse (Jorge)"`, `"rotting corpse (Jorge)"`,
+`"rotting head (Mira)"`.  The decay name still leads so the
+recognising observer retains glance-level awareness of decay state;
+the parenthetical surfaces the remembered identity.  Living
+characters are unaffected — they don't pass through
+`IdentityBearerMixin`.  Skeletal stage retains its hard cutoff (no
+recognition reveal under any circumstance).
+
+### Organ Default Descriptions (PR-G ✅)
+
+`world/medical/constants.py` ships an `ORGAN_DISPLAY` table sibling
+to `ORGANS`, carrying display names and condition-keyed prose for
+every harvestable organ (26 entries × 3 conditions: pristine /
+damaged / putrid).  The prose is short, clinical, and physically
+anchored — enough to ground the player in the organ's current state
+without `look` requiring a custom `db.desc`.
+
+`Organ.return_appearance` prepends the condition-keyed prose to the
+base appearance output, so a freshly harvested heart reads:
+
+```
+A dense, dark-red heart, its muscle firm and the great vessels
+stumped cleanly above.
+```
+
+Two lookup helpers (`get_organ_display_name`,
+`get_organ_default_description`) provide defensive fallbacks: unknown
+organs return the underscore-stripped key; unknown conditions
+(`refuse` — skeletal-stage harvest, refused at the command gate)
+return empty so callers render nothing rather than asserting.
+
 ---
 
 ## New Character Attributes

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -125,6 +125,10 @@ class Character(
             import uuid
             self.sleeve_uid = str(uuid.uuid4())
 
+        # Initialize species for anatomy/decay naming (PR-G)
+        if self.db.species is None:
+            self.db.species = "human"
+
         # Initialize medical system - replaces legacy HP system
         self._initialize_medical_state()
 

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -109,16 +109,17 @@ class Corpse(IdentityBearerMixin, Item):
 
 
     def _decay_display_name(self):
-        """Return the decay-stage name used when no recognition matches."""
+        """Return the decay-stage name used when no recognition matches.
+
+        PR-G: delegates to the species registry so corpse fallback
+        names share vocabulary with the rest of the species-aware
+        naming surface (severed limbs, organs, organ-display prose).
+        """
+        from world.anatomy import get_species_corpse_name
+
         stage = self.get_decay_stage()
-        decay_names = {
-            "fresh": "fresh corpse",
-            "early": "pale corpse",
-            "moderate": "decomposing remains",
-            "advanced": "putrid remains",
-            "skeletal": "skeletal remains",
-        }
-        return decay_names.get(stage, 'corpse')
+        species = self.db.species or "human"
+        return get_species_corpse_name(species, stage)
 
     # ------------------------------------------------------------------
     # Disguise / identity signature surface
@@ -607,30 +608,37 @@ class Corpse(IdentityBearerMixin, Item):
     
     def _update_decay_descriptions(self):
         """Update descriptions based on current decay stage."""
+        from world.anatomy import get_species_corpse_name
+
         stage = self.get_decay_stage()
         decay_factor = self.get_decay_factor()
         
         # Base physical description
         base_desc = self.db.physical_description or "A lifeless body."
-        
-        # Update aliases to match decay stage so players can reference the corpse correctly
-        decay_names = {
-            "fresh": "fresh corpse",
-            "early": "pale corpse", 
-            "moderate": "decomposing remains",
-            "advanced": "putrid remains",
-            "skeletal": "skeletal remains"
-        }
-        
-        stage_name = decay_names.get(stage, 'corpse')
+
+        # PR-G: derive the player-facing corpse name from the species
+        # registry rather than hardcoded per-stage strings.  This keeps
+        # non-human corpses (when they exist) consistent and lets the
+        # registry own the decay vocabulary in one place.
+        species = self.db.species or "human"
+        stage_name = get_species_corpse_name(species, stage)
+
+        # Update the corpse's primary key so glance-level rendering
+        # (room contents, inventory listings) reflects the current
+        # decay tier.  Recognition memory (handled by
+        # IdentityBearerMixin.get_display_name) overrides this when an
+        # observer has assigned a name to the corpse.
+        if self.key != stage_name:
+            self.key = stage_name
+
         # Update aliases to include the current decay stage name
         # Don't use clear() as it wipes out Evennia's multi-match tracking
         # Instead, get current aliases and add our decay-related ones
         current_aliases = set(self.aliases.all())
-        
+
         # Define the aliases we want for this decay stage
         desired_aliases = {stage_name, "corpse", "remains", "body"}
-        
+
         # Add any missing aliases
         for alias in desired_aliases:
             if alias not in current_aliases:

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -491,18 +491,28 @@ class DeathProgressionScript(DefaultScript):
     def _create_corpse_from_character(self, character):
         """Create a corpse object that preserves forensic data from the character."""
         from evennia import create_object
+        from world.anatomy import get_species_corpse_name
         import time
-        
+
+        # Determine source species (default to human) so the corpse's
+        # decay-modulated key reflects the deceased's anatomy.
+        species = character.db.species or "human"
+        initial_key = get_species_corpse_name(species, "fresh")
+
         # Create corpse object using specialized Corpse typeclass
         corpse = create_object(
             typeclass="typeclasses.corpse.Corpse",
-            key="fresh corpse",  # Anonymous corpse name
+            key=initial_key,  # Species-aware, decay-modulated anonymous name
             location=character.location
         )
-        
+
         # The Corpse typeclass automatically sets up most properties in at_object_creation()
         # Just need to transfer the specific forensic data from this character
-        
+
+        # Propagate species to the corpse so decay updates and any organ /
+        # severed-part creation downstream can stay species-consistent.
+        corpse.db.species = species
+
         # Transfer forensic data for investigation
         corpse.db.original_character_name = character.key
         corpse.db.original_character_dbref = character.dbref

--- a/typeclasses/identity_bearer.py
+++ b/typeclasses/identity_bearer.py
@@ -73,14 +73,19 @@ class IdentityBearerMixin:
         """Return a display name, preferring recognition memory.
 
         Mirrors the corpse-recognition contract: observers who already
-        remember the deceased / severed party see the assigned name;
-        strangers and the system see the decay-stage fallback.
+        remember the deceased / severed party see the decay-stage name
+        followed by the assigned name in parentheses (PR-G); strangers
+        and the system see only the decay-stage fallback.
 
         * ``looker is None`` → decay-stage fallback.
         * ``get_decay_stage() == "skeletal"`` → hard cutoff; return
           decay-stage fallback regardless of recognition memory.
         * Otherwise two-pass: natural (degraded UID) then forensic
-          (fresh UID + Intellect roll).
+          (fresh UID + Intellect roll).  A successful match returns
+          ``"<decay name> (<assigned name>)"`` — e.g.
+          ``"rotting corpse (Jorge)"`` — so the recognising observer
+          still sees decay state at a glance while having the
+          remembered identity surfaced.
         """
         del kwargs  # Evennia passes look context we don't need.
         decay_name = self._decay_display_name()
@@ -109,7 +114,7 @@ class IdentityBearerMixin:
         if degraded_uid is not None and degraded_uid in memory:
             assigned = memory[degraded_uid].get("assigned_name")
             if assigned:
-                return assigned
+                return f"{decay_name} ({assigned})"
 
         # Pass 2: forensic recovery against the fresh-equivalent UID.
         try:
@@ -125,7 +130,7 @@ class IdentityBearerMixin:
             if self._attempt_forensic_recognition(looker, stage):
                 assigned = memory[fresh_uid].get("assigned_name")
                 if assigned:
-                    return assigned
+                    return f"{decay_name} ({assigned})"
 
         return decay_name
 

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -996,6 +996,11 @@ class Organ(Item):
         self.db.source_signature = None
         self.db.source_apparent_uid = None
         self.db.source_corpse_dbref = None
+        # PR-G: species provenance, used to render condition-aware
+        # default descriptions and (in future) species-specific organ
+        # variants.  Defaults to ``"human"`` so direct-spawned organs
+        # without ``configure_from_harvest`` still look sensible.
+        self.db.source_species = "human"
 
     def configure_from_harvest(self, *, organ_name, condition, corpse):
         """Populate forensic-chain fields immediately after spawn.
@@ -1005,17 +1010,46 @@ class Organ(Item):
             condition (str): Freshness descriptor.
             corpse: The source :class:`typeclasses.corpse.Corpse`.
 
-        Sets the display key to ``"<condition> <organ_name>"`` with
-        underscores in the organ name replaced by spaces so the
-        canonical ``"left_kidney"`` reads as ``"pristine left kidney"``.
+        Sets the display key to ``"<condition> <display_name>"`` using
+        the player-facing organ display name from
+        :data:`world.medical.constants.ORGAN_DISPLAY` (falling back to
+        the underscore-stripped canonical key).
         """
+        from world.medical.constants import get_organ_display_name
+
         self.db.organ_name = organ_name
         self.db.condition = condition
         self.db.source_signature = corpse.db.signature_at_death
         self.db.source_apparent_uid = corpse.db.apparent_uid_at_death
         self.db.source_corpse_dbref = corpse.dbref
-        readable = organ_name.replace("_", " ")
+        # PR-G: species inheritance for condition-aware prose.
+        self.db.source_species = corpse.db.species or "human"
+        readable = get_organ_display_name(organ_name)
         self.key = f"{condition} {readable}"
+
+    def return_appearance(self, looker, **kwargs):
+        """Render condition-keyed default prose above any base desc.
+
+        PR-G: every harvested organ now ships with a clinical default
+        description per condition (pristine / damaged / putrid).  We
+        prepend that prose to the standard ``return_appearance`` output
+        so the player sees the organ's current state at a glance even
+        when no custom ``db.desc`` has been set.
+
+        Refuse-stage organs (skeletal harvest, which the command gate
+        refuses anyway) and organs not registered in
+        :data:`world.medical.constants.ORGAN_DISPLAY` fall through to
+        the base appearance without a prefix.
+        """
+        from world.medical.constants import get_organ_default_description
+
+        base = super().return_appearance(looker, **kwargs)
+        prose = get_organ_default_description(
+            self.db.organ_name or "", self.db.condition or "",
+        )
+        if prose:
+            return f"{prose}\n{base}" if base else prose
+        return base
 
 
 class Appendage(Item):
@@ -1052,6 +1086,11 @@ class Appendage(Item):
         self.db.source_signature = None
         self.db.source_apparent_uid = None
         self.db.source_corpse_dbref = None
+        # PR-G: species provenance for decay-aware naming.  Defaults to
+        # ``"human"`` so legacy code paths and tests that spawn a bare
+        # Appendage without going through ``configure_from_sever`` still
+        # render a sensible key.
+        self.db.source_species = "human"
         # PR #198 wound + longdesc carry-forward: populated by
         # ``configure_from_sever`` via ``apply_wound_and_longdesc_overlay``.
         # Default to empty containers so renderer code paths can iterate
@@ -1067,13 +1106,26 @@ class Appendage(Item):
             condition (str): Freshness descriptor.
             corpse: The source :class:`typeclasses.corpse.Corpse`.
         """
+        from world.anatomy import get_species_part_name
+
         self.db.location_name = location_name
         self.db.condition = condition
         self.db.source_signature = corpse.db.signature_at_death
         self.db.source_apparent_uid = corpse.db.apparent_uid_at_death
         self.db.source_corpse_dbref = corpse.dbref
-        readable = location_name.replace("_", " ")
-        self.key = f"{condition} {readable}"
+        # PR-G: inherit species from corpse so the appendage's
+        # decay-modulated key matches its origin anatomy.
+        species = corpse.db.species or "human"
+        self.db.source_species = species
+        # Read the corpse's current decay stage for naming.  The
+        # ``condition`` parameter is the organ-condition mapping
+        # (pristine / damaged / putrid / refuse) — useful for harvest
+        # bookkeeping but coarser than the underlying decay tier.
+        try:
+            decay_stage = corpse.get_decay_stage()
+        except AttributeError:
+            decay_stage = "fresh"
+        self.key = get_species_part_name(species, location_name, decay_stage)
         # PR #198: pull this location's wound + longdesc prose off the
         # corpse onto ourselves.  The corpse-side mutation
         # (delete-from-source + synthesized stump wound) is handled by
@@ -1388,15 +1440,21 @@ class SeveredHead(IdentityBearerMixin, Appendage):
         return "skeletal"
 
     def _decay_display_name(self):
-        """Fallback display when no recognition memory matches."""
+        """Fallback display when no recognition memory matches.
+
+        PR-G: delegates to the species registry so head names drift
+        through the decay tiers in lockstep with the rest of the
+        species-aware naming surface (corpse, severed limbs, organs).
+        Skeletal heads render as "skeletal head" rather than a bespoke
+        "skull" — gameplay-consistent with the unified vocabulary —
+        though the species table can override this later if a "skull"
+        alias is wanted as a search keyword.
+        """
+        from world.anatomy import get_species_part_name
+
+        species = self.db.source_species or "human"
         stage = self.get_decay_stage()
-        return {
-            "fresh": "fresh severed head",
-            "early": "pale severed head",
-            "moderate": "decomposing severed head",
-            "advanced": "putrid severed head",
-            "skeletal": "skull",
-        }.get(stage, "severed head")
+        return get_species_part_name(species, "head", stage)
 
     def get_medical_snapshot(self):
         """Return the trimmed head-container medical snapshot, if any.

--- a/world/anatomy/__init__.py
+++ b/world/anatomy/__init__.py
@@ -1,0 +1,29 @@
+"""Anatomy package.
+
+Species-overlay data and helpers for body-location display, decay-tier
+naming, and per-organ presentation prose.  Currently ships only the
+``human`` species; the registry is structured as a minimal overlay so
+non-humans can be added without refactoring corpse / severed-item /
+organ rendering code.
+
+Public surface:
+
+* :data:`world.anatomy.species.SPECIES_DEFINITIONS`
+* :func:`world.anatomy.species.get_species_part_name`
+* :func:`world.anatomy.species.get_species_corpse_name`
+* :func:`world.anatomy.species.get_species_location_display`
+"""
+
+from .species import (
+    SPECIES_DEFINITIONS,
+    get_species_corpse_name,
+    get_species_location_display,
+    get_species_part_name,
+)
+
+__all__ = (
+    "SPECIES_DEFINITIONS",
+    "get_species_corpse_name",
+    "get_species_location_display",
+    "get_species_part_name",
+)

--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -1,0 +1,212 @@
+"""Species anatomy overlay (PR #202 / PR-G).
+
+A minimal data + helpers layer that names body parts, corpses, and
+locations by species and decay stage.  Designed as a *minimal overlay*
+rather than a full anatomical refactor: humans are the assumed default,
+and the only species shipped at the time of writing; non-humans will
+register here when they exist, and severed items / organs / corpses
+will pick up the new vocabulary automatically because every rendering
+path consults these helpers.
+
+Design notes
+============
+
+* **Decay-tier vocabulary** (per the PR-G design discussion):
+
+    +-----------+----------------------------------------+
+    | Stage     | Display                                |
+    +===========+========================================+
+    | fresh     | ``{species} {part}`` / ``{species} corpse`` |
+    | early     | ``{species} {part}`` / ``{species} corpse`` |
+    | moderate  | ``rotting {part}`` / ``rotting corpse`` |
+    | advanced  | ``rotting {part}`` / ``rotting corpse`` |
+    | skeletal  | ``skeletal {part}`` / ``skeletal remains`` |
+    +-----------+----------------------------------------+
+
+  Fresh/early stages reveal species cleanly; moderate/advanced
+  obfuscate ("rotting" alone, no species clue); skeletal abandons
+  species for the universal "skeletal" tag.  Players who want more
+  precision than these glance-level tags must ``look`` for the full
+  description (which still carries decay prose) or ``autopsy`` (which
+  rolls Intellect for forensic recovery).
+
+* **No species in skeletal/rotting stages**: deliberate gameplay
+  signal — late decay obscures species at a glance.  Once a body has
+  rotted past recognition or reduced to bone, the casual observer
+  can't tell a human from a synth without close examination.
+
+* **Per-character override hook**: characters (or any object with a
+  ``db.species`` attribute) consult this registry through their
+  species key.  Unknown species fall back to the ``human`` definition
+  rather than crashing — this keeps the system robust as new species
+  are added incrementally.
+
+* **No state stored on the helpers**: every call is a pure lookup
+  against :data:`SPECIES_DEFINITIONS`.  This lets rendering code call
+  the helpers on every ``get_display_name`` / ``return_appearance``
+  invocation without performance concerns and lets decay drift propagate
+  naturally as time passes (the source data — ``get_decay_stage()`` —
+  is what changes, not the registry).
+"""
+
+from __future__ import annotations
+
+#: Species registry.  Keys are stable species identifiers (lowercase,
+#: underscore-separated for multi-word species like ``"glitch_synth"``);
+#: values are dicts whose schema is documented inline below.
+SPECIES_DEFINITIONS = {
+    "human": {
+        # Glance-level species tag, used in fresh/early-stage display
+        # ("a human corpse", "a human left arm").  Omitted from moderate/
+        # advanced/skeletal stages by the decay-prefix template.
+        "display_name": "human",
+
+        # Per-location display strings.  Keys are canonical body-
+        # location identifiers (matching ``container`` values in
+        # ``world.medical.constants.ORGANS`` and the ``location`` field
+        # of wound records).  Values are the player-facing strings —
+        # underscored canonical keys (``"left_arm"``) become spaced
+        # display strings (``"left arm"``).
+        "location_display": {
+            "head": "head",
+            "face": "face",
+            "neck": "neck",
+            "chest": "chest",
+            "abdomen": "abdomen",
+            "back": "back",
+            "groin": "groin",
+            "left_arm": "left arm",
+            "right_arm": "right arm",
+            "left_hand": "left hand",
+            "right_hand": "right hand",
+            "left_thigh": "left thigh",
+            "right_thigh": "right thigh",
+            "left_shin": "left shin",
+            "right_shin": "right shin",
+            "left_foot": "left foot",
+            "right_foot": "right foot",
+            "left_eye": "left eye",
+            "right_eye": "right eye",
+            "left_ear": "left ear",
+            "right_ear": "right ear",
+        },
+
+        # Decay-tier prefix templates for severed body parts.  Rendered
+        # by :func:`get_species_part_name` with ``{species}`` and
+        # ``{part}`` substitution.  Note "rotting" and "skeletal" drop
+        # the species token deliberately (see module docstring).
+        "decay_part_prefixes": {
+            "fresh":    "{species} {part}",
+            "early":    "{species} {part}",
+            "moderate": "rotting {part}",
+            "advanced": "rotting {part}",
+            "skeletal": "skeletal {part}",
+        },
+
+        # Decay-tier corpse-name templates.  Rendered by
+        # :func:`get_species_corpse_name`.  Skeletal abandons "corpse"
+        # for "remains" — a fully skeletonized body isn't a corpse in
+        # the colloquial sense and the change in vocabulary signals
+        # the irreversibility of that decay tier.
+        "decay_corpse_names": {
+            "fresh":    "human corpse",
+            "early":    "human corpse",
+            "moderate": "rotting corpse",
+            "advanced": "rotting corpse",
+            "skeletal": "skeletal remains",
+        },
+    },
+}
+
+
+def _resolve_species(species: str | None) -> dict:
+    """Return the species definition, falling back to ``human``.
+
+    Centralized so every helper degrades gracefully on unknown / None
+    species inputs without scattering ``.get(..., SPECIES_DEFINITIONS["human"])``
+    boilerplate.
+    """
+    if not species:
+        return SPECIES_DEFINITIONS["human"]
+    return SPECIES_DEFINITIONS.get(species, SPECIES_DEFINITIONS["human"])
+
+
+def get_species_location_display(species: str | None, location: str) -> str:
+    """Return the display string for a body location under a species.
+
+    Unmapped locations fall back to the raw token with underscores
+    replaced by spaces — robust against ad-hoc anatomy keys that
+    haven't been added to the registry yet (e.g. a future ``"tail"``
+    or ``"third_arm"``).
+
+    Args:
+        species: Species identifier (e.g. ``"human"``); ``None`` /
+            unknown species fall back to ``"human"``.
+        location: Canonical body-location identifier
+            (e.g. ``"left_arm"``).
+
+    Returns:
+        Display string suitable for embedding in player-facing prose.
+    """
+    spec = _resolve_species(species)
+    mapping = spec.get("location_display") or {}
+    if location in mapping:
+        return mapping[location]
+    return (location or "").replace("_", " ")
+
+
+def get_species_part_name(
+    species: str | None, location: str, decay_stage: str
+) -> str:
+    """Return the decay-modulated display name for a severed body part.
+
+    Used by :class:`typeclasses.items.Appendage`,
+    :class:`typeclasses.items.SeveredHead`, and any other detached
+    body-part typeclass to render decay-aware glance names like
+    ``"human left arm"`` (fresh) → ``"rotting left arm"`` (moderate)
+    → ``"skeletal left arm"`` (skeletal).
+
+    The output deliberately omits any article — callers compose with
+    ``"a "`` / ``"the "`` per their context.
+
+    Args:
+        species: Species identifier; unknown / None → human.
+        location: Canonical body-location identifier.
+        decay_stage: One of ``fresh`` / ``early`` / ``moderate`` /
+            ``advanced`` / ``skeletal``.  Unknown stages fall back to
+            the ``fresh`` template.
+
+    Returns:
+        Display string ready for use as ``self.key`` or in look output.
+    """
+    spec = _resolve_species(species)
+    prefixes = spec.get("decay_part_prefixes") or {}
+    template = prefixes.get(decay_stage) or prefixes.get("fresh") or "{part}"
+    part = get_species_location_display(species, location)
+    species_display = spec.get("display_name", "")
+    return template.format(species=species_display, part=part)
+
+
+def get_species_corpse_name(
+    species: str | None, decay_stage: str
+) -> str:
+    """Return the decay-modulated display name for a whole corpse.
+
+    Used by :class:`typeclasses.corpse.Corpse` to render decay-aware
+    glance names like ``"human corpse"`` → ``"rotting corpse"`` →
+    ``"skeletal remains"``.
+
+    Args:
+        species: Species identifier; unknown / None → human.
+        decay_stage: One of ``fresh`` / ``early`` / ``moderate`` /
+            ``advanced`` / ``skeletal``.  Unknown stages fall back to
+            the ``fresh`` template.
+
+    Returns:
+        Display string ready for use as ``corpse.key``.
+    """
+    spec = _resolve_species(species)
+    names = spec.get("decay_corpse_names") or {}
+    if decay_stage in names:
+        return names[decay_stage]
+    return names.get("fresh", "corpse")

--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -390,6 +390,270 @@ ORGANS = {
 }
 
 # ===================================================================
+# ORGAN DISPLAY METADATA (PR #202 / PR-G)
+# ===================================================================
+#
+# Augments :data:`ORGANS` with player-facing display names and
+# condition-keyed default descriptions.  Kept as a sibling table
+# rather than inlined into ``ORGANS`` to keep the gameplay-mechanics
+# dict (max_hp, vital, capacity, ...) readable and to make this
+# prose-heavy block easy to translate / rewrite in isolation.
+#
+# Schema (per organ):
+#   display_name: Player-facing noun phrase (no article).  Underscored
+#       canonical keys (``"left_eye"``) become spaced display strings.
+#   default_descriptions: condition → prose mapping.  Conditions are
+#       :data:`world.combat.constants.ORGAN_CONDITION_BY_DECAY` outputs
+#       (``pristine`` / ``damaged`` / ``putrid``).  ``refuse`` is not
+#       represented — skeletal-stage corpses refuse harvest at the
+#       command gate, so no Organ instance reaches that condition.
+#
+# Default descriptions are short (≤ 1 sentence) and clinical, with
+# enough physicality to anchor the player's senses.  They are rendered
+# **above** any wound carry-forward prose (see
+# :meth:`typeclasses.items.Organ.return_appearance`).
+
+ORGAN_DISPLAY = {
+    "brain": {
+        "display_name": "brain",
+        "default_descriptions": {
+            "pristine": "A glistening pinkish-grey mass, folded into intricate gyri and slick with cerebrospinal fluid.",
+            "damaged": "A dulled brain, its folds slack and its tissue weeping a thin pinkish serum where the surface has dried.",
+            "putrid": "A swollen, blackening brain, its folds collapsed into a fetid grey-green slurry.",
+        },
+    },
+    "left_eye": {
+        "display_name": "left eye",
+        "default_descriptions": {
+            "pristine": "A clear left eye, its iris sharp and the sclera still wetly bright.",
+            "damaged": "A clouded left eye, the cornea milky and the surface beginning to slacken in its socket-cup.",
+            "putrid": "A collapsed left eye, gone soft and weeping a dark serum from its ruptured sclera.",
+        },
+    },
+    "right_eye": {
+        "display_name": "right eye",
+        "default_descriptions": {
+            "pristine": "A clear right eye, its iris sharp and the sclera still wetly bright.",
+            "damaged": "A clouded right eye, the cornea milky and the surface beginning to slacken in its socket-cup.",
+            "putrid": "A collapsed right eye, gone soft and weeping a dark serum from its ruptured sclera.",
+        },
+    },
+    "left_ear": {
+        "display_name": "left ear",
+        "default_descriptions": {
+            "pristine": "A neatly excised left ear, its cartilage springy and the skin still naturally toned.",
+            "damaged": "A discoloured left ear, the cartilage gone rubbery and the skin mottled with patches of grey.",
+            "putrid": "A blackening left ear, its cartilage slumping inward and the flesh beginning to slough.",
+        },
+    },
+    "right_ear": {
+        "display_name": "right ear",
+        "default_descriptions": {
+            "pristine": "A neatly excised right ear, its cartilage springy and the skin still naturally toned.",
+            "damaged": "A discoloured right ear, the cartilage gone rubbery and the skin mottled with patches of grey.",
+            "putrid": "A blackening right ear, its cartilage slumping inward and the flesh beginning to slough.",
+        },
+    },
+    "tongue": {
+        "display_name": "tongue",
+        "default_descriptions": {
+            "pristine": "A thick, pink tongue, its surface roughened with taste buds and still glossy with saliva.",
+            "damaged": "A greyed tongue, the surface dried into a leathery rasp and the root beginning to split.",
+            "putrid": "A blackened tongue, swollen and weeping, its papillae lost to a uniform decaying slime.",
+        },
+    },
+    "jaw": {
+        "display_name": "jaw",
+        "default_descriptions": {
+            "pristine": "A clean jawbone, its teeth seated firmly and the hinge surfaces still slick with synovial fluid.",
+            "damaged": "A discoloured jaw, several teeth loosened in their sockets and the bone surface beginning to dull.",
+            "putrid": "A foul jaw, the gum-line sloughed away and the bone stained with seeping decay.",
+        },
+    },
+    "heart": {
+        "display_name": "heart",
+        "default_descriptions": {
+            "pristine": "A dense, dark-red heart, its muscle firm and the great vessels stumped cleanly above.",
+            "damaged": "A slackened heart, its chambers flaccid and the surface beginning to discolour to a dull brown.",
+            "putrid": "A swollen, greenish heart, its chambers ruptured and weeping a foul dark fluid.",
+        },
+    },
+    "left_lung": {
+        "display_name": "left lung",
+        "default_descriptions": {
+            "pristine": "A spongy, pink left lung, its surface marbled with fine vasculature and still elastic to the touch.",
+            "damaged": "A mottled left lung, gone purplish and limp, its alveoli collapsed into a doughy mass.",
+            "putrid": "A blackening left lung, its tissue dissolving into a frothy, fetid pulp.",
+        },
+    },
+    "right_lung": {
+        "display_name": "right lung",
+        "default_descriptions": {
+            "pristine": "A spongy, pink right lung, its surface marbled with fine vasculature and still elastic to the touch.",
+            "damaged": "A mottled right lung, gone purplish and limp, its alveoli collapsed into a doughy mass.",
+            "putrid": "A blackening right lung, its tissue dissolving into a frothy, fetid pulp.",
+        },
+    },
+    "liver": {
+        "display_name": "liver",
+        "default_descriptions": {
+            "pristine": "A glossy, mahogany-red liver, dense and faintly warm to the touch.",
+            "damaged": "A dulled liver, its lobes gone slack and the surface mottled with greyish patches.",
+            "putrid": "A swollen, blackening liver, its capsule split and weeping a viscous brown-green fluid.",
+        },
+    },
+    "left_kidney": {
+        "display_name": "left kidney",
+        "default_descriptions": {
+            "pristine": "A firm, bean-shaped left kidney, its capsule taut and the surface a deep reddish-brown.",
+            "damaged": "A softened left kidney, the capsule loose and the cortex beginning to break down into a grainy paste.",
+            "putrid": "A foul-smelling left kidney, its tissue dissolving into a dark, weeping mass.",
+        },
+    },
+    "right_kidney": {
+        "display_name": "right kidney",
+        "default_descriptions": {
+            "pristine": "A firm, bean-shaped right kidney, its capsule taut and the surface a deep reddish-brown.",
+            "damaged": "A softened right kidney, the capsule loose and the cortex beginning to break down into a grainy paste.",
+            "putrid": "A foul-smelling right kidney, its tissue dissolving into a dark, weeping mass.",
+        },
+    },
+    "stomach": {
+        "display_name": "stomach",
+        "default_descriptions": {
+            "pristine": "A pale, muscular stomach, its rugae visible through the thin serosa and a faint acidic tang clinging to it.",
+            "damaged": "A slackened stomach, its walls thinned and the lining beginning to slough into the lumen.",
+            "putrid": "A bloated, blackening stomach, its walls ruptured and weeping a foul digestive slurry.",
+        },
+    },
+    "spine": {
+        "display_name": "spine",
+        "default_descriptions": {
+            "pristine": "A clean length of spine, its vertebrae articulated and the cord still glistening within the canal.",
+            "damaged": "A discoloured spine, the intervertebral discs flattened and the cord gone grey within its sheath.",
+            "putrid": "A fouled spine, the cord liquefied and seeping from between the slumping vertebrae.",
+        },
+    },
+    "left_humerus": {
+        "display_name": "left humerus",
+        "default_descriptions": {
+            "pristine": "A clean left humerus, its surface ivory-pale and the joint ends still slick with cartilage.",
+            "damaged": "A discoloured left humerus, the cartilage caps cracking and dried tissue clinging to the shaft.",
+            "putrid": "A stained left humerus, the marrow weeping from the medullary cavity and the surface fouled with rot.",
+        },
+    },
+    "right_humerus": {
+        "display_name": "right humerus",
+        "default_descriptions": {
+            "pristine": "A clean right humerus, its surface ivory-pale and the joint ends still slick with cartilage.",
+            "damaged": "A discoloured right humerus, the cartilage caps cracking and dried tissue clinging to the shaft.",
+            "putrid": "A stained right humerus, the marrow weeping from the medullary cavity and the surface fouled with rot.",
+        },
+    },
+    "left_metacarpals": {
+        "display_name": "left metacarpals",
+        "default_descriptions": {
+            "pristine": "A neat cluster of left metacarpals, still articulated and the joint surfaces pearly white.",
+            "damaged": "A loosened set of left metacarpals, several bones disarticulated and the cartilage gone leathery.",
+            "putrid": "A fouled jumble of left metacarpals, stained dark and stuck together with putrefying tissue.",
+        },
+    },
+    "right_metacarpals": {
+        "display_name": "right metacarpals",
+        "default_descriptions": {
+            "pristine": "A neat cluster of right metacarpals, still articulated and the joint surfaces pearly white.",
+            "damaged": "A loosened set of right metacarpals, several bones disarticulated and the cartilage gone leathery.",
+            "putrid": "A fouled jumble of right metacarpals, stained dark and stuck together with putrefying tissue.",
+        },
+    },
+    "left_femur": {
+        "display_name": "left femur",
+        "default_descriptions": {
+            "pristine": "A heavy left femur, its shaft smooth and the femoral head a perfect glistening sphere.",
+            "damaged": "A discoloured left femur, hairline fractures spidering the shaft and the joint caps cracking.",
+            "putrid": "A stained left femur, the marrow weeping from the medullary cavity and the surface slick with rot.",
+        },
+    },
+    "right_femur": {
+        "display_name": "right femur",
+        "default_descriptions": {
+            "pristine": "A heavy right femur, its shaft smooth and the femoral head a perfect glistening sphere.",
+            "damaged": "A discoloured right femur, hairline fractures spidering the shaft and the joint caps cracking.",
+            "putrid": "A stained right femur, the marrow weeping from the medullary cavity and the surface slick with rot.",
+        },
+    },
+    "left_tibia": {
+        "display_name": "left tibia",
+        "default_descriptions": {
+            "pristine": "A long, clean left tibia, its anterior crest sharp and the periosteum still glossy.",
+            "damaged": "A discoloured left tibia, the periosteum stripped in patches and the bone dulled to a greyish ivory.",
+            "putrid": "A foul left tibia, the marrow seeping at both ends and the shaft mottled with putrid stains.",
+        },
+    },
+    "right_tibia": {
+        "display_name": "right tibia",
+        "default_descriptions": {
+            "pristine": "A long, clean right tibia, its anterior crest sharp and the periosteum still glossy.",
+            "damaged": "A discoloured right tibia, the periosteum stripped in patches and the bone dulled to a greyish ivory.",
+            "putrid": "A foul right tibia, the marrow seeping at both ends and the shaft mottled with putrid stains.",
+        },
+    },
+    "left_metatarsals": {
+        "display_name": "left metatarsals",
+        "default_descriptions": {
+            "pristine": "A neat row of left metatarsals, still articulated and the joint surfaces gleaming white.",
+            "damaged": "A loosened set of left metatarsals, several bones disarticulated and the cartilage gone leathery.",
+            "putrid": "A fouled set of left metatarsals, stained dark and stuck together with putrefying tissue.",
+        },
+    },
+    "right_metatarsals": {
+        "display_name": "right metatarsals",
+        "default_descriptions": {
+            "pristine": "A neat row of right metatarsals, still articulated and the joint surfaces gleaming white.",
+            "damaged": "A loosened set of right metatarsals, several bones disarticulated and the cartilage gone leathery.",
+            "putrid": "A fouled set of right metatarsals, stained dark and stuck together with putrefying tissue.",
+        },
+    },
+    "pelvis": {
+        "display_name": "pelvis",
+        "default_descriptions": {
+            "pristine": "A broad, intact pelvis, its iliac wings flared and the joint surfaces still smooth.",
+            "damaged": "A discoloured pelvis, the sacroiliac joints loosened and the bone surface beginning to dull.",
+            "putrid": "A stained pelvis, the bone fouled with seeping decay and the joint surfaces sloughing away.",
+        },
+    },
+}
+
+
+def get_organ_display_name(organ_name):
+    """Return the player-facing display name for an organ.
+
+    Falls back to the underscore-stripped canonical key when the
+    organ isn't registered in :data:`ORGAN_DISPLAY` — defensive
+    against new organs added to :data:`ORGANS` before their display
+    metadata lands.
+    """
+    entry = ORGAN_DISPLAY.get(organ_name)
+    if entry and entry.get("display_name"):
+        return entry["display_name"]
+    return (organ_name or "").replace("_", " ")
+
+
+def get_organ_default_description(organ_name, condition):
+    """Return the default prose for an organ at a given condition.
+
+    Returns an empty string when the organ has no registered prose
+    or the condition isn't one of pristine / damaged / putrid (e.g.
+    ``refuse``).  Callers should treat empty as "render nothing"
+    rather than asserting.
+    """
+    entry = ORGAN_DISPLAY.get(organ_name)
+    if not entry:
+        return ""
+    descs = entry.get("default_descriptions") or {}
+    return descs.get(condition, "")
+
+# ===================================================================
 # INJURY TYPES AND MEDICAL CONDITIONS  
 # ===================================================================
 

--- a/world/medical/wounds/constants.py
+++ b/world/medical/wounds/constants.py
@@ -22,15 +22,23 @@ INJURY_SEVERITY_MAP = {
     "Critical": "grievous",
 }
 
-# Body location display mapping for wounds (dynamic - will adapt to character's anatomy)
+# Body location display mapping for wounds (species-aware via the
+# anatomy registry).
 def get_location_display_name(location, character=None):
     """
-    Get the display name for a body location based on character's anatomy.
-    
+    Get the display name for a body location based on character's species.
+
+    PR-G: delegates to :func:`world.anatomy.get_species_location_display`
+    so naming stays consistent with severed limbs, organs, and corpses.
+    The previous ``character.location_display_names`` per-instance
+    override branch was dead code (no production code path ever set
+    the attribute) and has been removed.
+
     Args:
         location (str): Body location key
-        character: Character object (optional)
-        
+        character: Character object (optional) — used to read
+            ``db.species``; falls back to ``"human"`` when absent.
+
     Returns:
         str: Human-readable location name
     """
@@ -38,35 +46,13 @@ def get_location_display_name(location, character=None):
     if isinstance(location, str) is False and isinstance(character, str):
         # Swap arguments - old calling convention passed (character, location)
         character, location = location, character
-    
-    # Check if character has custom location names
-    if character and hasattr(character, 'location_display_names'):
-        custom_name = character.location_display_names.get(location)
-        if custom_name:
-            return custom_name
-    
-    # Default humanoid mappings (fallback)
-    default_mappings = {
-        "head": "head",
-        "face": "face", 
-        "chest": "chest",
-        "abdomen": "abdomen",
-        "back": "back",
-        "left_arm": "left arm",
-        "right_arm": "right arm",
-        "left_hand": "left hand", 
-        "right_hand": "right hand",
-        "left_thigh": "left thigh",
-        "right_thigh": "right thigh",
-        "left_shin": "left shin",
-        "right_shin": "right shin",
-        "left_foot": "left foot",
-        "right_foot": "right foot",
-        "neck": "neck",
-        "groin": "groin",
-    }
-    
-    return default_mappings.get(location, location)
+
+    from world.anatomy import get_species_location_display
+
+    species = None
+    if character is not None:
+        species = getattr(character.db, "species", None)
+    return get_species_location_display(species, location)
 
 # Wound transition thresholds (days since injury)
 WOUND_TRANSITION_DAYS = {

--- a/world/tests/test_corpse_decay_recognition.py
+++ b/world/tests/test_corpse_decay_recognition.py
@@ -93,11 +93,13 @@ class _FakeDecayCorpse:
         self.contents = list(contents or [])
         self.ndb = type("_NDB", (), {})()
         self._stage = stage
+        # PR-G: match the species-aware vocabulary produced by
+        # ``world.anatomy.get_species_corpse_name(species="human", ...)``.
         self._decay_names = {
-            "fresh": "fresh corpse",
-            "early": "pale corpse",
-            "moderate": "decomposing remains",
-            "advanced": "putrid remains",
+            "fresh": "human corpse",
+            "early": "human corpse",
+            "moderate": "rotting corpse",
+            "advanced": "rotting corpse",
             "skeletal": "skeletal remains",
         }
 
@@ -245,7 +247,9 @@ class TestNaturalRecognitionLightDecay(TestCase):
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
         )
-        self.assertEqual(corpse.get_display_name(observer), "Jorge")
+        self.assertEqual(
+            corpse.get_display_name(observer), "human corpse (Jorge)"
+        )
 
     def test_early_recognition_returns_assigned_name(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="early")
@@ -253,19 +257,21 @@ class TestNaturalRecognitionLightDecay(TestCase):
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
         )
-        self.assertEqual(corpse.get_display_name(observer), "Jorge")
+        self.assertEqual(
+            corpse.get_display_name(observer), "human corpse (Jorge)"
+        )
 
     def test_none_looker_returns_decay_name(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
         self.assertEqual(
-            corpse.get_display_name(None), "decomposing remains",
+            corpse.get_display_name(None), "rotting corpse",
         )
 
     def test_stranger_sees_decay_name(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
         observer = _FakeObserver(memory={})
         self.assertEqual(
-            corpse.get_display_name(observer), "decomposing remains",
+            corpse.get_display_name(observer), "rotting corpse",
         )
 
 
@@ -285,7 +291,7 @@ class TestForensicRecovery(TestCase):
         )
         # DC 3 for moderate; force a passing roll.
         with patch("world.combat.dice.roll_stat", return_value=3):
-            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+            self.assertEqual(corpse.get_display_name(observer), "rotting corpse (Jorge)")
 
     def test_moderate_fail_returns_decay_name(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
@@ -296,7 +302,7 @@ class TestForensicRecovery(TestCase):
         # DC 3 for moderate; force a failing roll.
         with patch("world.combat.dice.roll_stat", return_value=2):
             self.assertEqual(
-                corpse.get_display_name(observer), "decomposing remains",
+                corpse.get_display_name(observer), "rotting corpse",
             )
 
     def test_advanced_pass_returns_assigned_name(self):
@@ -307,7 +313,7 @@ class TestForensicRecovery(TestCase):
         )
         # DC 5 for advanced.
         with patch("world.combat.dice.roll_stat", return_value=5):
-            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+            self.assertEqual(corpse.get_display_name(observer), "rotting corpse (Jorge)")
 
     def test_advanced_fail_returns_decay_name(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="advanced")
@@ -317,7 +323,7 @@ class TestForensicRecovery(TestCase):
         )
         with patch("world.combat.dice.roll_stat", return_value=4):
             self.assertEqual(
-                corpse.get_display_name(observer), "putrid remains",
+                corpse.get_display_name(observer), "rotting corpse",
             )
 
 
@@ -338,13 +344,13 @@ class TestForensicCache(TestCase):
         # First look: forced failure.
         with patch("world.combat.dice.roll_stat", return_value=1):
             self.assertEqual(
-                corpse.get_display_name(observer), "decomposing remains",
+                corpse.get_display_name(observer), "rotting corpse",
             )
         # Second look: even a guaranteed-pass roll must not re-roll —
         # the cached failure persists.
         with patch("world.combat.dice.roll_stat", return_value=99) as mocked:
             self.assertEqual(
-                corpse.get_display_name(observer), "decomposing remains",
+                corpse.get_display_name(observer), "rotting corpse",
             )
             mocked.assert_not_called()
 
@@ -355,10 +361,10 @@ class TestForensicCache(TestCase):
             memory={fresh_uid: {"assigned_name": "Jorge"}},
         )
         with patch("world.combat.dice.roll_stat", return_value=10):
-            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+            self.assertEqual(corpse.get_display_name(observer), "rotting corpse (Jorge)")
         # Cached success: a forced-fail roll must not be consulted.
         with patch("world.combat.dice.roll_stat", return_value=1) as mocked:
-            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+            self.assertEqual(corpse.get_display_name(observer), "rotting corpse (Jorge)")
             mocked.assert_not_called()
 
     def test_cache_is_keyed_by_dbref(self):
@@ -372,11 +378,11 @@ class TestForensicCache(TestCase):
         with patch("world.combat.dice.roll_stat", return_value=1):
             self.assertEqual(
                 corpse.get_display_name(observer_a),
-                "decomposing remains",
+                "rotting corpse",
             )
         # B independently passes (different dbref → fresh roll).
         with patch("world.combat.dice.roll_stat", return_value=99):
-            self.assertEqual(corpse.get_display_name(observer_b), "Jorge")
+            self.assertEqual(corpse.get_display_name(observer_b), "rotting corpse (Jorge)")
 
     def test_anonymous_looker_rerolls_each_call(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
@@ -389,11 +395,11 @@ class TestForensicCache(TestCase):
         with patch("world.combat.dice.roll_stat", return_value=1):
             self.assertEqual(
                 corpse.get_display_name(observer),
-                "decomposing remains",
+                "rotting corpse",
             )
         # Re-roll happens because nothing was stored.
         with patch("world.combat.dice.roll_stat", return_value=99) as mocked:
-            self.assertEqual(corpse.get_display_name(observer), "Jorge")
+            self.assertEqual(corpse.get_display_name(observer), "rotting corpse (Jorge)")
             mocked.assert_called_once()
 
 
@@ -441,7 +447,7 @@ class TestWornItemDisguiseThroughDecay(TestCase):
         # Advanced DC = 5; pass.
         with patch("world.combat.dice.roll_stat", return_value=5):
             self.assertEqual(
-                corpse.get_display_name(observer), "BalaclavaDude",
+                corpse.get_display_name(observer), "rotting corpse (BalaclavaDude)",
             )
 
 

--- a/world/tests/test_identity_bearer_mixin.py
+++ b/world/tests/test_identity_bearer_mixin.py
@@ -121,7 +121,9 @@ class TestIdentityBearerMixin(TestCase):
         ), patch(
             "world.identity.get_apparent_uid", return_value="uid-A",
         ):
-            self.assertEqual(bearer.get_display_name(looker), "Alice")
+            self.assertEqual(
+                bearer.get_display_name(looker), "fresh bearer (Alice)"
+            )
 
     def test_forensic_recovery_on_pass(self):
         """Degraded UID misses, fresh UID hits, Intellect roll passes."""
@@ -141,7 +143,9 @@ class TestIdentityBearerMixin(TestCase):
             "._attempt_forensic_recognition",
             return_value=True,
         ):
-            self.assertEqual(bearer.get_display_name(looker), "Alice")
+            self.assertEqual(
+                bearer.get_display_name(looker), "moderate thing (Alice)"
+            )
 
     def test_forensic_recovery_on_fail(self):
         """Degraded UID misses, fresh UID hits, Intellect roll fails."""

--- a/world/tests/test_organ_display.py
+++ b/world/tests/test_organ_display.py
@@ -1,0 +1,98 @@
+"""Tests for organ display metadata (PR #202 / PR-G).
+
+Covers :data:`world.medical.constants.ORGAN_DISPLAY` and the two
+lookup helpers (``get_organ_display_name``,
+``get_organ_default_description``).  Schema + coverage checks plus a
+spot-check on the Organ typeclass key formatting at harvest time.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.medical.constants import (
+    ORGAN_DISPLAY,
+    ORGANS,
+    get_organ_default_description,
+    get_organ_display_name,
+)
+
+
+class TestOrganDisplayCoverage(TestCase):
+    """Every harvestable organ must have display metadata registered."""
+
+    def test_every_harvestable_organ_has_display_entry(self):
+        missing = []
+        for organ_name, data in ORGANS.items():
+            if data.get("can_be_harvested"):
+                if organ_name not in ORGAN_DISPLAY:
+                    missing.append(organ_name)
+        self.assertEqual(
+            missing, [],
+            f"Harvestable organs missing ORGAN_DISPLAY entries: {missing}",
+        )
+
+    def test_every_display_entry_has_required_keys(self):
+        for organ_name, entry in ORGAN_DISPLAY.items():
+            self.assertIn(
+                "display_name", entry,
+                f"{organ_name} missing display_name",
+            )
+            self.assertIn(
+                "default_descriptions", entry,
+                f"{organ_name} missing default_descriptions",
+            )
+
+    def test_every_display_entry_covers_three_conditions(self):
+        required_conditions = {"pristine", "damaged", "putrid"}
+        for organ_name, entry in ORGAN_DISPLAY.items():
+            descs = entry.get("default_descriptions", {})
+            missing = required_conditions - set(descs.keys())
+            self.assertEqual(
+                missing, set(),
+                f"{organ_name} missing conditions: {missing}",
+            )
+
+    def test_descriptions_are_non_empty_strings(self):
+        for organ_name, entry in ORGAN_DISPLAY.items():
+            for condition, prose in entry["default_descriptions"].items():
+                self.assertIsInstance(
+                    prose, str,
+                    f"{organ_name}/{condition} prose is not a string",
+                )
+                self.assertGreater(
+                    len(prose.strip()), 0,
+                    f"{organ_name}/{condition} prose is empty",
+                )
+
+
+class TestOrganDisplayHelpers(TestCase):
+    def test_get_display_name_known_organ(self):
+        self.assertEqual(get_organ_display_name("heart"), "heart")
+        self.assertEqual(
+            get_organ_display_name("left_kidney"), "left kidney"
+        )
+
+    def test_get_display_name_unknown_organ_falls_back(self):
+        # Unregistered organs fall back to underscore-stripped key.
+        self.assertEqual(
+            get_organ_display_name("flux_capacitor"), "flux capacitor"
+        )
+
+    def test_get_default_description_returns_prose(self):
+        prose = get_organ_default_description("heart", "pristine")
+        self.assertTrue(prose)
+        self.assertIn("heart", prose.lower())
+
+    def test_get_default_description_unknown_organ_returns_empty(self):
+        self.assertEqual(
+            get_organ_default_description("flux_capacitor", "pristine"),
+            "",
+        )
+
+    def test_get_default_description_unknown_condition_returns_empty(self):
+        # ``refuse`` (skeletal-stage harvest) is intentionally absent —
+        # the harvest command refuses skeletal corpses upstream.
+        self.assertEqual(
+            get_organ_default_description("heart", "refuse"), ""
+        )

--- a/world/tests/test_severed_head.py
+++ b/world/tests/test_severed_head.py
@@ -55,6 +55,9 @@ class _FakeHead:
         self.db.removed_organs = []
         self.db.signature_at_death = None
         self.db.apparent_uid_at_death = None
+        # PR-G: species drives decay-aware naming via the anatomy
+        # registry; stub defaults to human to match production behaviour.
+        self.db.source_species = "human"
 
 
 class _FakeCorpse:
@@ -226,10 +229,10 @@ class SeveredHeadDecayContractTests(TestCase):
     def test_decay_display_name_per_stage(self):
         head = self._make_head_at_age(60)
         self.assertEqual(
-            SeveredHead._decay_display_name(head), "fresh severed head"
+            SeveredHead._decay_display_name(head), "human head"
         )
         head.db.creation_time = time.time() - (604800 + 10)
-        self.assertEqual(SeveredHead._decay_display_name(head), "skull")
+        self.assertEqual(SeveredHead._decay_display_name(head), "skeletal head")
 
     def test_get_worn_items_is_empty(self):
         head = _FakeHead()

--- a/world/tests/test_species_anatomy.py
+++ b/world/tests/test_species_anatomy.py
@@ -1,0 +1,146 @@
+"""Tests for the species anatomy overlay (PR #202 / PR-G).
+
+Covers :mod:`world.anatomy.species` — the data registry and the three
+pure-function helpers (``get_species_location_display``,
+``get_species_part_name``, ``get_species_corpse_name``).  These helpers
+are state-free and consumed by every species-aware rendering path,
+so we exercise them directly rather than through the typeclass
+integration paths (which have their own targeted suites).
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.anatomy import (
+    SPECIES_DEFINITIONS,
+    get_species_corpse_name,
+    get_species_location_display,
+    get_species_part_name,
+)
+
+
+class TestSpeciesRegistry(TestCase):
+    """Sanity-check the shape of :data:`SPECIES_DEFINITIONS`."""
+
+    def test_human_species_registered(self):
+        self.assertIn("human", SPECIES_DEFINITIONS)
+
+    def test_human_has_required_keys(self):
+        human = SPECIES_DEFINITIONS["human"]
+        for key in (
+            "display_name",
+            "location_display",
+            "decay_part_prefixes",
+            "decay_corpse_names",
+        ):
+            self.assertIn(key, human, f"human species missing '{key}'")
+
+    def test_decay_stages_complete(self):
+        """Every decay stage must have prefix + corpse-name templates."""
+        human = SPECIES_DEFINITIONS["human"]
+        stages = {"fresh", "early", "moderate", "advanced", "skeletal"}
+        self.assertEqual(set(human["decay_part_prefixes"].keys()), stages)
+        self.assertEqual(set(human["decay_corpse_names"].keys()), stages)
+
+
+class TestLocationDisplay(TestCase):
+    def test_known_location(self):
+        self.assertEqual(
+            get_species_location_display("human", "left_arm"), "left arm"
+        )
+
+    def test_underscore_passthrough_for_unknown_location(self):
+        # Defensive — unmapped locations still render readably.
+        self.assertEqual(
+            get_species_location_display("human", "third_arm"), "third arm"
+        )
+
+    def test_unknown_species_falls_back_to_human(self):
+        self.assertEqual(
+            get_species_location_display("synth", "head"), "head"
+        )
+
+    def test_none_species_falls_back_to_human(self):
+        self.assertEqual(
+            get_species_location_display(None, "chest"), "chest"
+        )
+
+
+class TestPartName(TestCase):
+    def test_fresh_includes_species(self):
+        self.assertEqual(
+            get_species_part_name("human", "left_arm", "fresh"),
+            "human left arm",
+        )
+
+    def test_early_includes_species(self):
+        self.assertEqual(
+            get_species_part_name("human", "head", "early"),
+            "human head",
+        )
+
+    def test_moderate_drops_species(self):
+        self.assertEqual(
+            get_species_part_name("human", "left_arm", "moderate"),
+            "rotting left arm",
+        )
+
+    def test_advanced_drops_species(self):
+        self.assertEqual(
+            get_species_part_name("human", "chest", "advanced"),
+            "rotting chest",
+        )
+
+    def test_skeletal_uses_skeletal_prefix(self):
+        self.assertEqual(
+            get_species_part_name("human", "left_femur", "skeletal"),
+            "skeletal left femur",
+        )
+
+    def test_unknown_stage_falls_back_to_fresh(self):
+        # Unknown decay stage → fresh template.
+        self.assertEqual(
+            get_species_part_name("human", "head", "wibbly"),
+            "human head",
+        )
+
+
+class TestCorpseName(TestCase):
+    def test_fresh_corpse(self):
+        self.assertEqual(
+            get_species_corpse_name("human", "fresh"), "human corpse"
+        )
+
+    def test_early_corpse(self):
+        self.assertEqual(
+            get_species_corpse_name("human", "early"), "human corpse"
+        )
+
+    def test_moderate_corpse(self):
+        self.assertEqual(
+            get_species_corpse_name("human", "moderate"), "rotting corpse"
+        )
+
+    def test_advanced_corpse(self):
+        self.assertEqual(
+            get_species_corpse_name("human", "advanced"), "rotting corpse"
+        )
+
+    def test_skeletal_corpse_uses_remains_vocabulary(self):
+        # Deliberate signal of decay irreversibility — "remains" not
+        # "corpse".
+        self.assertEqual(
+            get_species_corpse_name("human", "skeletal"),
+            "skeletal remains",
+        )
+
+    def test_unknown_stage_falls_back_to_fresh(self):
+        self.assertEqual(
+            get_species_corpse_name("human", "wibbly"), "human corpse"
+        )
+
+    def test_unknown_species_falls_back_to_human(self):
+        self.assertEqual(
+            get_species_corpse_name("synth", "fresh"), "human corpse"
+        )


### PR DESCRIPTION
## Summary

Closes #202.

Introduces a species-anatomy overlay so corpses, severed limbs, severed heads, and harvested organs share one decay-aware naming vocabulary keyed by species. Recognition reveals now render as `<decay name> (<assigned name>)` — preserving glance-level decay state while surfacing the remembered identity. Every harvestable organ ships with a clinical default description per condition.

## Highlights

- **`world/anatomy/species.py`** — new `SPECIES_DEFINITIONS` registry + three pure-function helpers (`get_species_location_display`, `get_species_part_name`, `get_species_corpse_name`). Unknown species/locations/stages degrade gracefully.
- **Species propagation** — `Character.at_object_creation` defaults `db.species = "human"`; `_create_corpse_from_character` copies it to the corpse; `Appendage.configure_from_sever`, `Organ.configure_from_harvest`, and `SeveredHead` propagate `source_species` from corpse → severed item.
- **Decay-tier vocabulary** — `fresh`/`early` → `human <part>` / `human corpse`; `moderate`/`advanced` → `rotting <part>` / `rotting corpse`; `skeletal` → `skeletal <part>` / `skeletal remains` (deliberate "remains" vocabulary for irreversibility).
- **Recognition parenthetical** — `IdentityBearerMixin.get_display_name` now returns `"rotting corpse (Jorge)"` instead of bare `"Jorge"` on match. Skeletal hard-cutoff retained.
- **`ORGAN_DISPLAY`** — 26 harvestable organs × 3 conditions (pristine/damaged/putrid) of clinical prose; `Organ.return_appearance` prepends it to the base output.
- **Dead-code removal** — `character.location_display_names` branch in `world/medical/wounds/constants.py`.

## Tests

- **29 new tests** (`test_species_anatomy.py`, `test_organ_display.py`) covering registry shape, helper behaviour, organ-display coverage + non-empty prose invariant.
- **Fixture sweep** of `test_corpse_decay_recognition.py`, `test_identity_bearer_mixin.py`, `test_severed_head.py` for new vocabulary and parenthetical format.
- **1102 → 1131 tests passing** (`evennia test world commands typeclasses`).

## Spec

- New sections in `specs/IDENTITY_RECOGNITION_SPEC.md` — *Species Anatomy Overlay*, *Display-Name Conventions*, *Organ Default Descriptions*.