### PR TITLE
Fix PR-G: populate db.desc the Evennia-standard way (#204)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1968,28 +1968,67 @@ characters are unaffected — they don't pass through
 `IdentityBearerMixin`.  Skeletal stage retains its hard cutoff (no
 recognition reveal under any circumstance).
 
-### Organ Default Descriptions (PR-G ✅)
+### Organ Default Descriptions (PR-G ✅ — corrected in PR #204)
 
 `world/medical/constants.py` ships an `ORGAN_DISPLAY` table sibling
 to `ORGANS`, carrying display names and condition-keyed prose for
 every harvestable organ (26 entries × 3 conditions: pristine /
 damaged / putrid).  The prose is short, clinical, and physically
 anchored — enough to ground the player in the organ's current state
-without `look` requiring a custom `db.desc`.
+without staff ever setting a custom `db.desc`.
 
-`Organ.return_appearance` prepends the condition-keyed prose to the
-base appearance output, so a freshly harvested heart reads:
+`Organ.configure_from_harvest` populates `self.db.desc` from the
+condition-keyed prose at harvest time, the Evennia-standard way.  The
+engine's default `return_appearance` renderer then slots the prose
+into the look output naturally — no custom override required.  A
+freshly harvested heart reads:
 
 ```
 A dense, dark-red heart, its muscle firm and the great vessels
 stumped cleanly above.
 ```
 
+> **Historical note (PR-G → PR #204):** the original PR-G shipped
+> with an `Organ.return_appearance` override that prepended prose to
+> the engine output. That bypassed Evennia's normal renderer and
+> produced a "You see nothing special" line alongside the floating
+> prose. PR #204 deleted the override and moved the prose into
+> `db.desc` at harvest time, matching the convention used by every
+> other Item subclass in `typeclasses/items.py`.
+
 Two lookup helpers (`get_organ_display_name`,
 `get_organ_default_description`) provide defensive fallbacks: unknown
 organs return the underscore-stripped key; unknown conditions
 (`refuse` — skeletal-stage harvest, refused at the command gate)
-return empty so callers render nothing rather than asserting.
+return empty so `configure_from_harvest` leaves `db.desc` untouched
+(engine default applies) rather than overwriting with an empty
+string.
+
+### Severed Part Default Descriptions (PR #204 ✅)
+
+Parallel to the organ table, `world/anatomy/severed_parts.py` ships
+`SEVERED_PART_DESCRIPTIONS` — a species-keyed prose table for every
+entry in `world.combat.constants.SEVERABLE_CONTAINERS` (11 locations
+for humans: `head`, both arms / hands / thighs / shins / feet × 3
+conditions = 33 prose strings).  Same vocabulary register as the
+organ table — short, clinical, physically anchored.
+
+`Appendage.configure_from_sever` populates `self.db.desc` from the
+condition-keyed prose at sever-time.  `SeveredHead` inherits this
+behaviour via its `super().configure_from_sever(...)` call, so a
+severed head also reads with a populated default desc.
+
+`Appendage.return_appearance` is retained: it composes wound +
+longdesc carry-forward (PR-D / PR-F) dynamically on top of the
+engine-rendered base.  Since `super().return_appearance(...)` now
+includes the seeded `db.desc` in its output, both surfaces coexist
+cleanly — the default prose anchors the look, and the dynamic prose
+(wounds, transferred longdesc) follows.
+
+A single helper (`get_severed_part_description`) provides the same
+defensive fallback contract as the organ helper: unknown species fall
+back to human; unknown locations / conditions return empty so the
+configure step leaves `db.desc` untouched.
 
 ---
 

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1014,8 +1014,19 @@ class Organ(Item):
         the player-facing organ display name from
         :data:`world.medical.constants.ORGAN_DISPLAY` (falling back to
         the underscore-stripped canonical key).
+
+        PR #204: also seeds ``self.db.desc`` from the condition-keyed
+        default description so the Evennia-standard ``return_appearance``
+        renderer slots it into the look output naturally — no custom
+        ``return_appearance`` override required.  Organs without a
+        registered description (or with the ``refuse`` condition, which
+        the harvest command gate refuses upstream anyway) leave
+        ``db.desc`` untouched so the engine default applies.
         """
-        from world.medical.constants import get_organ_display_name
+        from world.medical.constants import (
+            get_organ_default_description,
+            get_organ_display_name,
+        )
 
         self.db.organ_name = organ_name
         self.db.condition = condition
@@ -1026,30 +1037,13 @@ class Organ(Item):
         self.db.source_species = corpse.db.species or "human"
         readable = get_organ_display_name(organ_name)
         self.key = f"{condition} {readable}"
-
-    def return_appearance(self, looker, **kwargs):
-        """Render condition-keyed default prose above any base desc.
-
-        PR-G: every harvested organ now ships with a clinical default
-        description per condition (pristine / damaged / putrid).  We
-        prepend that prose to the standard ``return_appearance`` output
-        so the player sees the organ's current state at a glance even
-        when no custom ``db.desc`` has been set.
-
-        Refuse-stage organs (skeletal harvest, which the command gate
-        refuses anyway) and organs not registered in
-        :data:`world.medical.constants.ORGAN_DISPLAY` fall through to
-        the base appearance without a prefix.
-        """
-        from world.medical.constants import get_organ_default_description
-
-        base = super().return_appearance(looker, **kwargs)
-        prose = get_organ_default_description(
-            self.db.organ_name or "", self.db.condition or "",
-        )
+        # PR #204: populate db.desc the Evennia-standard way so the
+        # engine renderer handles it (rather than overriding
+        # return_appearance to prepend prose).  Conditional: leave the
+        # engine default in place when no prose is registered.
+        prose = get_organ_default_description(organ_name, condition)
         if prose:
-            return f"{prose}\n{base}" if base else prose
-        return base
+            self.db.desc = prose
 
 
 class Appendage(Item):
@@ -1126,6 +1120,16 @@ class Appendage(Item):
         except AttributeError:
             decay_stage = "fresh"
         self.key = get_species_part_name(species, location_name, decay_stage)
+        # PR #204: populate db.desc the Evennia-standard way so the
+        # engine renderer handles it.  ``Appendage.return_appearance``
+        # still composes wound + longdesc carry-forward dynamically on
+        # top of the engine-rendered base (which now includes our
+        # seeded desc), so both surfaces coexist cleanly.  Conditional:
+        # leave the engine default in place when no prose is registered.
+        from world.anatomy import get_severed_part_description
+        prose = get_severed_part_description(species, location_name, condition)
+        if prose:
+            self.db.desc = prose
         # PR #198: pull this location's wound + longdesc prose off the
         # corpse onto ourselves.  The corpse-side mutation
         # (delete-from-source + synthesized stump wound) is handled by

--- a/world/anatomy/__init__.py
+++ b/world/anatomy/__init__.py
@@ -1,10 +1,11 @@
 """Anatomy package.
 
 Species-overlay data and helpers for body-location display, decay-tier
-naming, and per-organ presentation prose.  Currently ships only the
-``human`` species; the registry is structured as a minimal overlay so
-non-humans can be added without refactoring corpse / severed-item /
-organ rendering code.
+naming, per-organ presentation prose, and per-severed-part default
+descriptions.  Currently ships only the ``human`` species; the
+registry is structured as a minimal overlay so non-humans can be
+added without refactoring corpse / severed-item / organ rendering
+code.
 
 Public surface:
 
@@ -12,8 +13,14 @@ Public surface:
 * :func:`world.anatomy.species.get_species_part_name`
 * :func:`world.anatomy.species.get_species_corpse_name`
 * :func:`world.anatomy.species.get_species_location_display`
+* :data:`world.anatomy.severed_parts.SEVERED_PART_DESCRIPTIONS`
+* :func:`world.anatomy.severed_parts.get_severed_part_description`
 """
 
+from .severed_parts import (
+    SEVERED_PART_DESCRIPTIONS,
+    get_severed_part_description,
+)
 from .species import (
     SPECIES_DEFINITIONS,
     get_species_corpse_name,
@@ -22,7 +29,9 @@ from .species import (
 )
 
 __all__ = (
+    "SEVERED_PART_DESCRIPTIONS",
     "SPECIES_DEFINITIONS",
+    "get_severed_part_description",
     "get_species_corpse_name",
     "get_species_location_display",
     "get_species_part_name",

--- a/world/anatomy/severed_parts.py
+++ b/world/anatomy/severed_parts.py
@@ -1,0 +1,230 @@
+"""Severed body-part default descriptions (PR #204).
+
+Sibling table to :data:`world.medical.constants.ORGAN_DISPLAY`, but
+keyed by species and severable body-location.  Consumed by
+:meth:`typeclasses.items.Appendage.configure_from_sever` (and via
+super-call by :class:`typeclasses.items.SeveredHead`) to seed
+``self.db.desc`` at sever-time so the standard Evennia renderer
+slots the prose into the look output naturally.
+
+Design notes
+============
+
+* **Separate file from** :mod:`world.anatomy.species` — that module
+  owns the structural species registry (location names, decay
+  templates).  Prose belongs in its own file so the structural data
+  stays scannable and the prose-heavy block stays easy to translate
+  or rewrite in isolation (mirrors the
+  :data:`world.medical.constants.ORGAN_DISPLAY` separation from
+  :data:`world.medical.constants.ORGANS`).
+
+* **Species-keyed** so non-humans (when they exist) can register
+  their own anatomy prose without crowding the human entries.
+  Unknown species fall back to ``"human"`` via
+  :func:`get_severed_part_description`.
+
+* **Three conditions only** — ``pristine`` / ``damaged`` / ``putrid``,
+  matching the :data:`world.combat.constants.ORGAN_CONDITION_BY_DECAY`
+  map.  The ``refuse`` condition (skeletal-stage corpses) is
+  intentionally absent: skeletal corpses refuse severance at the
+  command gate, so no Appendage instance ever reaches that condition.
+
+* **Same vocabulary register as** :data:`world.medical.constants.ORGAN_DISPLAY`
+  — short, clinical, physically anchored, single sentence.  Anchors
+  the player's senses without depending on a custom ``db.desc``
+  ever being set by a staff member.
+"""
+
+from __future__ import annotations
+
+
+#: Severed-part description registry.  Keys: species identifier (lower-case)
+#: → location identifier → condition → prose.  Locations match
+#: :data:`world.combat.constants.SEVERABLE_CONTAINERS`.
+SEVERED_PART_DESCRIPTIONS = {
+    "human": {
+        "head": {
+            "pristine": (
+                "A severed human head, the features still composed and "
+                "the stump-cut at the neck clean and weeping a thin "
+                "rim of blood."
+            ),
+            "damaged": (
+                "A discoloured severed head, the skin gone waxy and "
+                "the stump-cut at the neck dried into a dark, "
+                "leathery rim."
+            ),
+            "putrid": (
+                "A bloated severed head, the features distorted and "
+                "the flesh sloughing in soft, fetid patches."
+            ),
+        },
+        "left_arm": {
+            "pristine": (
+                "A severed left arm, the muscle firm and the shoulder "
+                "stump cut cleanly through cartilage and bone."
+            ),
+            "damaged": (
+                "A discoloured left arm, the skin mottled and the "
+                "shoulder stump dried into a dark, ragged crust."
+            ),
+            "putrid": (
+                "A bloated left arm, the flesh sloughing from the bone "
+                "and the shoulder stump weeping a foul dark fluid."
+            ),
+        },
+        "right_arm": {
+            "pristine": (
+                "A severed right arm, the muscle firm and the shoulder "
+                "stump cut cleanly through cartilage and bone."
+            ),
+            "damaged": (
+                "A discoloured right arm, the skin mottled and the "
+                "shoulder stump dried into a dark, ragged crust."
+            ),
+            "putrid": (
+                "A bloated right arm, the flesh sloughing from the bone "
+                "and the shoulder stump weeping a foul dark fluid."
+            ),
+        },
+        "left_hand": {
+            "pristine": (
+                "A severed left hand, the fingers still loosely curled "
+                "and the wrist-cut clean across the carpal bones."
+            ),
+            "damaged": (
+                "A discoloured left hand, the fingers stiffened into a "
+                "claw and the wrist-cut dried into a dark rim."
+            ),
+            "putrid": (
+                "A bloated left hand, the skin sloughing from the "
+                "fingers and the wrist-cut weeping a foul dark fluid."
+            ),
+        },
+        "right_hand": {
+            "pristine": (
+                "A severed right hand, the fingers still loosely curled "
+                "and the wrist-cut clean across the carpal bones."
+            ),
+            "damaged": (
+                "A discoloured right hand, the fingers stiffened into a "
+                "claw and the wrist-cut dried into a dark rim."
+            ),
+            "putrid": (
+                "A bloated right hand, the skin sloughing from the "
+                "fingers and the wrist-cut weeping a foul dark fluid."
+            ),
+        },
+        "left_thigh": {
+            "pristine": (
+                "A severed left thigh, the heavy muscle firm and the "
+                "hip-cut clean through the femoral head."
+            ),
+            "damaged": (
+                "A discoloured left thigh, the skin gone mottled and the "
+                "hip-cut dried into a dark, crusted rim."
+            ),
+            "putrid": (
+                "A bloated left thigh, the flesh sloughing from the femur "
+                "and the hip-cut weeping a foul dark fluid."
+            ),
+        },
+        "right_thigh": {
+            "pristine": (
+                "A severed right thigh, the heavy muscle firm and the "
+                "hip-cut clean through the femoral head."
+            ),
+            "damaged": (
+                "A discoloured right thigh, the skin gone mottled and the "
+                "hip-cut dried into a dark, crusted rim."
+            ),
+            "putrid": (
+                "A bloated right thigh, the flesh sloughing from the femur "
+                "and the hip-cut weeping a foul dark fluid."
+            ),
+        },
+        "left_shin": {
+            "pristine": (
+                "A severed left shin, the calf muscle firm and the "
+                "knee-cut clean across the joint surfaces."
+            ),
+            "damaged": (
+                "A discoloured left shin, the skin gone leathery and the "
+                "knee-cut dried into a dark rim."
+            ),
+            "putrid": (
+                "A bloated left shin, the flesh sloughing from the tibia "
+                "and the knee-cut weeping a foul dark fluid."
+            ),
+        },
+        "right_shin": {
+            "pristine": (
+                "A severed right shin, the calf muscle firm and the "
+                "knee-cut clean across the joint surfaces."
+            ),
+            "damaged": (
+                "A discoloured right shin, the skin gone leathery and the "
+                "knee-cut dried into a dark rim."
+            ),
+            "putrid": (
+                "A bloated right shin, the flesh sloughing from the tibia "
+                "and the knee-cut weeping a foul dark fluid."
+            ),
+        },
+        "left_foot": {
+            "pristine": (
+                "A severed left foot, the toes still loosely splayed and "
+                "the ankle-cut clean across the tarsal bones."
+            ),
+            "damaged": (
+                "A discoloured left foot, the toes stiffened and the "
+                "ankle-cut dried into a dark, crusted rim."
+            ),
+            "putrid": (
+                "A bloated left foot, the skin sloughing from the toes and "
+                "the ankle-cut weeping a foul dark fluid."
+            ),
+        },
+        "right_foot": {
+            "pristine": (
+                "A severed right foot, the toes still loosely splayed and "
+                "the ankle-cut clean across the tarsal bones."
+            ),
+            "damaged": (
+                "A discoloured right foot, the toes stiffened and the "
+                "ankle-cut dried into a dark, crusted rim."
+            ),
+            "putrid": (
+                "A bloated right foot, the skin sloughing from the toes and "
+                "the ankle-cut weeping a foul dark fluid."
+            ),
+        },
+    },
+}
+
+
+def get_severed_part_description(species, location, condition):
+    """Return condition-keyed prose for a severed body part.
+
+    Args:
+        species: Species identifier (e.g. ``"human"``); ``None`` /
+            unknown species fall back to ``"human"``.
+        location: Canonical body-location identifier
+            (e.g. ``"left_arm"``).
+        condition: Freshness descriptor — ``"pristine"`` /
+            ``"damaged"`` / ``"putrid"``.
+
+    Returns:
+        Prose string (single sentence, no trailing newline) or an
+        empty string when the species / location / condition tuple
+        isn't registered.  Callers should treat empty as "no default
+        desc available, fall back to whatever Evennia does next"
+        rather than asserting.
+    """
+    species_table = SEVERED_PART_DESCRIPTIONS.get(species)
+    if species_table is None:
+        species_table = SEVERED_PART_DESCRIPTIONS.get("human", {})
+    location_table = species_table.get(location)
+    if not location_table:
+        return ""
+    return location_table.get(condition, "")

--- a/world/tests/test_organ_display.py
+++ b/world/tests/test_organ_display.py
@@ -96,3 +96,127 @@ class TestOrganDisplayHelpers(TestCase):
         self.assertEqual(
             get_organ_default_description("heart", "refuse"), ""
         )
+
+
+class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
+    """PR #204: ``configure_from_harvest`` must seed ``db.desc``.
+
+    Verifies the Evennia-standard contract: the engine's normal
+    ``return_appearance`` renderer picks up ``db.desc`` and slots it
+    into the look output.  No custom ``return_appearance`` override
+    is required (or wanted).
+    """
+
+    def _fake_corpse(self, species="human"):
+        """Minimal duck-typed corpse for ``configure_from_harvest``."""
+
+        class _DB:
+            pass
+
+        corpse = type("FakeCorpse", (), {})()
+        corpse.db = _DB()
+        corpse.db.signature_at_death = ("uid", "tall", "lean", "hooded", ())
+        corpse.db.apparent_uid_at_death = "hash-abc"
+        corpse.db.species = species
+        corpse.dbref = "#42"
+        return corpse
+
+    def _fake_organ(self):
+        """Stub with a ``db`` namespace; binds the unbound configure method."""
+        from typeclasses.items import Organ
+
+        class _DB:
+            pass
+
+        organ = type("FakeOrgan", (), {})()
+        organ.db = _DB()
+        organ.db.organ_name = ""
+        organ.db.condition = "pristine"
+        organ.db.source_signature = None
+        organ.db.source_apparent_uid = None
+        organ.db.source_corpse_dbref = None
+        organ.db.source_species = "human"
+        organ.db.desc = None
+        # Track key assignment.
+        organ.key = ""
+        organ.configure_from_harvest = (
+            Organ.configure_from_harvest.__get__(organ)
+        )
+        return organ
+
+    def test_registered_organ_populates_desc(self):
+        organ = self._fake_organ()
+        organ.configure_from_harvest(
+            organ_name="heart", condition="pristine",
+            corpse=self._fake_corpse(),
+        )
+        self.assertTrue(organ.db.desc)
+        self.assertIn("heart", organ.db.desc.lower())
+
+    def test_damaged_condition_uses_damaged_prose(self):
+        organ = self._fake_organ()
+        organ.configure_from_harvest(
+            organ_name="liver", condition="damaged",
+            corpse=self._fake_corpse(),
+        )
+        self.assertTrue(organ.db.desc)
+        # Damaged prose typically signals decay-onset vocabulary.
+        self.assertIn("liver", organ.db.desc.lower())
+
+    def test_putrid_condition_uses_putrid_prose(self):
+        organ = self._fake_organ()
+        organ.configure_from_harvest(
+            organ_name="brain", condition="putrid",
+            corpse=self._fake_corpse(),
+        )
+        self.assertTrue(organ.db.desc)
+        self.assertIn("brain", organ.db.desc.lower())
+
+    def test_unknown_organ_leaves_desc_untouched(self):
+        organ = self._fake_organ()
+        organ.configure_from_harvest(
+            organ_name="flux_capacitor", condition="pristine",
+            corpse=self._fake_corpse(),
+        )
+        # Falls through to engine default — we do NOT set an empty
+        # string, so the original ``None`` survives.
+        self.assertIsNone(organ.db.desc)
+
+    def test_refuse_condition_leaves_desc_untouched(self):
+        organ = self._fake_organ()
+        organ.configure_from_harvest(
+            organ_name="heart", condition="refuse",
+            corpse=self._fake_corpse(),
+        )
+        # ``refuse`` has no registered prose; preserve engine default.
+        self.assertIsNone(organ.db.desc)
+
+    def test_key_still_assigned_alongside_desc(self):
+        # Regression guard: the desc plumbing must not skip the
+        # display-key assignment that the rest of the system reads.
+        organ = self._fake_organ()
+        organ.configure_from_harvest(
+            organ_name="heart", condition="pristine",
+            corpse=self._fake_corpse(),
+        )
+        self.assertEqual(organ.key, "pristine heart")
+
+
+class TestOrganHasNoReturnAppearanceOverride(TestCase):
+    """PR #204: the PR-G return_appearance override is gone.
+
+    Asserts the override no longer exists on ``Organ`` so the engine's
+    default renderer handles look output (consuming ``db.desc``
+    naturally).  Guards against accidental re-introduction.
+    """
+
+    def test_organ_does_not_define_return_appearance(self):
+        from typeclasses.items import Organ
+
+        # ``return_appearance`` should be inherited, not defined on
+        # Organ itself.  ``__dict__`` check skips inherited members.
+        self.assertNotIn(
+            "return_appearance", Organ.__dict__,
+            "Organ must not override return_appearance; populate db.desc "
+            "in configure_from_harvest instead.",
+        )

--- a/world/tests/test_severed_part_descriptions.py
+++ b/world/tests/test_severed_part_descriptions.py
@@ -1,0 +1,188 @@
+"""Tests for severed-part default descriptions (PR #204).
+
+Covers :data:`world.anatomy.severed_parts.SEVERED_PART_DESCRIPTIONS`
+and the lookup helper, plus the
+:meth:`typeclasses.items.Appendage.configure_from_sever` contract that
+``self.db.desc`` is populated at sever-time so the standard Evennia
+renderer slots the prose into the look output naturally.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.anatomy import (
+    SEVERED_PART_DESCRIPTIONS,
+    get_severed_part_description,
+)
+from world.combat.constants import SEVERABLE_CONTAINERS
+
+
+class TestSeveredPartCoverage(TestCase):
+    """Every severable location must have prose for all 3 conditions."""
+
+    def test_human_table_registered(self):
+        self.assertIn("human", SEVERED_PART_DESCRIPTIONS)
+
+    def test_every_severable_location_has_human_entry(self):
+        human = SEVERED_PART_DESCRIPTIONS["human"]
+        missing = sorted(SEVERABLE_CONTAINERS - set(human.keys()))
+        self.assertEqual(
+            missing, [],
+            f"Severable locations missing from human prose table: {missing}",
+        )
+
+    def test_every_human_entry_covers_three_conditions(self):
+        required_conditions = {"pristine", "damaged", "putrid"}
+        for location, entry in SEVERED_PART_DESCRIPTIONS["human"].items():
+            missing = required_conditions - set(entry.keys())
+            self.assertEqual(
+                missing, set(),
+                f"{location} missing conditions: {missing}",
+            )
+
+    def test_descriptions_are_non_empty_strings(self):
+        for location, entry in SEVERED_PART_DESCRIPTIONS["human"].items():
+            for condition, prose in entry.items():
+                self.assertIsInstance(
+                    prose, str,
+                    f"{location}/{condition} prose is not a string",
+                )
+                self.assertGreater(
+                    len(prose.strip()), 0,
+                    f"{location}/{condition} prose is empty",
+                )
+
+
+class TestSeveredPartHelper(TestCase):
+    def test_returns_prose_for_known_tuple(self):
+        prose = get_severed_part_description("human", "left_arm", "pristine")
+        self.assertTrue(prose)
+        self.assertIn("left arm", prose.lower())
+
+    def test_returns_empty_for_unknown_location(self):
+        self.assertEqual(
+            get_severed_part_description("human", "tentacle", "pristine"),
+            "",
+        )
+
+    def test_returns_empty_for_unknown_condition(self):
+        # ``refuse`` is the harvest-only condition; severance never
+        # produces it, but a defensive caller might pass it anyway.
+        self.assertEqual(
+            get_severed_part_description("human", "left_arm", "refuse"),
+            "",
+        )
+
+    def test_unknown_species_falls_back_to_human(self):
+        prose = get_severed_part_description("synth", "head", "pristine")
+        # Falls back to the human entry, which is registered.
+        self.assertTrue(prose)
+
+    def test_none_species_falls_back_to_human(self):
+        prose = get_severed_part_description(None, "head", "pristine")
+        self.assertTrue(prose)
+
+
+class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
+    """PR #204: ``configure_from_sever`` must seed ``db.desc``.
+
+    Same Evennia-standard contract as Organ: the engine renderer
+    handles ``db.desc``; ``Appendage.return_appearance`` composes
+    additional dynamic prose (wound + longdesc carry-forward) on top
+    of the engine-rendered base.
+    """
+
+    def _fake_corpse(self, species="human", stage="fresh"):
+        class _DB:
+            pass
+
+        corpse = type("FakeCorpse", (), {})()
+        corpse.db = _DB()
+        corpse.db.signature_at_death = ("uid", "tall", "lean", "hooded", ())
+        corpse.db.apparent_uid_at_death = "hash-abc"
+        corpse.db.species = species
+        corpse.dbref = "#42"
+        # Per-location longdesc / wounds tables consumed by the
+        # carry-forward overlay; empty is fine for desc-only tests.
+        corpse.db.longdesc = {}
+        corpse.db.longdesc_data = {}
+        corpse.db.wounds = []
+        corpse.db.wounds_at_death = []
+        corpse.db.severed_locations = []
+        corpse._stage = stage
+
+        def get_decay_stage():
+            return corpse._stage
+
+        corpse.get_decay_stage = get_decay_stage
+        return corpse
+
+    def _fake_appendage(self):
+        from typeclasses.items import Appendage
+
+        class _DB:
+            pass
+
+        app = type("FakeAppendage", (), {})()
+        app.db = _DB()
+        app.db.location_name = ""
+        app.db.condition = "pristine"
+        app.db.source_signature = None
+        app.db.source_apparent_uid = None
+        app.db.source_corpse_dbref = None
+        app.db.source_species = "human"
+        app.db.wounds_at_death = []
+        app.db.longdesc_data = {}
+        app.db.desc = None
+        app.key = ""
+        app.configure_from_sever = (
+            Appendage.configure_from_sever.__get__(app)
+        )
+        return app
+
+    def test_pristine_left_arm_populates_desc(self):
+        app = self._fake_appendage()
+        app.configure_from_sever(
+            location_name="left_arm", condition="pristine",
+            corpse=self._fake_corpse(),
+        )
+        self.assertTrue(app.db.desc)
+        self.assertIn("left arm", app.db.desc.lower())
+
+    def test_damaged_right_thigh_populates_desc(self):
+        app = self._fake_appendage()
+        app.configure_from_sever(
+            location_name="right_thigh", condition="damaged",
+            corpse=self._fake_corpse(stage="moderate"),
+        )
+        self.assertTrue(app.db.desc)
+        self.assertIn("right thigh", app.db.desc.lower())
+
+    def test_putrid_head_populates_desc(self):
+        app = self._fake_appendage()
+        app.configure_from_sever(
+            location_name="head", condition="putrid",
+            corpse=self._fake_corpse(stage="advanced"),
+        )
+        self.assertTrue(app.db.desc)
+        self.assertIn("head", app.db.desc.lower())
+
+    def test_unknown_location_leaves_desc_untouched(self):
+        app = self._fake_appendage()
+        app.configure_from_sever(
+            location_name="tentacle", condition="pristine",
+            corpse=self._fake_corpse(),
+        )
+        # No registered prose → engine default preserved.
+        self.assertIsNone(app.db.desc)
+
+    def test_key_still_assigned_alongside_desc(self):
+        # Regression guard for the species-aware key path.
+        app = self._fake_appendage()
+        app.configure_from_sever(
+            location_name="left_arm", condition="pristine",
+            corpse=self._fake_corpse(),
+        )
+        # Fresh corpse → "human left arm" via species helper.
+        self.assertEqual(app.key, "human left arm")


### PR DESCRIPTION
## Summary

Closes #204.

PR-G shipped organ default descriptions via an ``Organ.return_appearance`` override that prepended prose to the engine's look output — bypassing Evennia's renderer entirely. ``db.desc`` was never set, so look showed the default "You see nothing special" line alongside the raw prose floating above the formatted block.

This PR brings ``Organ`` in line with every other Item subclass in the codebase (set ``db.desc``, let Evennia render) and extends the same pattern to severed body parts.

## Changes

- **New ``world/anatomy/severed_parts.py``** — ``SEVERED_PART_DESCRIPTIONS`` table covering all 11 ``SEVERABLE_CONTAINERS`` × 3 conditions (33 prose strings for ``human``) + ``get_severed_part_description`` helper with empty-string fallback.
- **``Organ.configure_from_harvest``** — sets ``self.db.desc`` from ``get_organ_default_description`` at harvest time. Conditional: unregistered organs / ``refuse`` condition leave engine default in place.
- **``Organ.return_appearance``** — **deleted**. Engine default renderer handles look output via ``db.desc`` natively.
- **``Appendage.configure_from_sever``** — sets ``self.db.desc`` from the severed-parts helper. ``SeveredHead`` inherits via ``super().configure_from_sever(...)``.
- **``Appendage.return_appearance``** — **retained**. Wound + longdesc carry-forward (PR-D / PR-F) is legitimate dynamic composition; it now layers on top of the engine-rendered base (which includes the seeded ``db.desc``).
- **Spec** — corrected *Organ Default Descriptions* section + new *Severed Part Default Descriptions* section.

## Tests

- 7 new tests in ``test_organ_display.py`` covering ``configure_from_harvest`` desc population + regression guard that Organ doesn't override ``return_appearance``.
- 14 new tests in ``test_severed_part_descriptions.py`` covering table coverage, helper fallback behaviour, and Appendage desc population.
- **1131 → 1152 tests passing.**