### PR TITLE
Invalidate disguise_pierce_cache on forget (#210)

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1643,6 +1643,12 @@ class CmdForget(Command):
         Keyed on the target's *Apparent UID* (derived from their current
         identity signature), so forgetting under a disguise only forgets
         the disguised persona — the real-form entry is untouched.
+
+        Also invalidates every cached pierce verdict for any
+        presentation of the target's sleeve (issue #210): without this,
+        a cached ``True`` in ``observer.db.disguise_pierce_cache``
+        survives forget and the rendering pipeline keeps surfacing the
+        forgotten name through any disguise.
         """
         memory = caller.recognition_memory
         if not memory or apparent_uid not in memory:
@@ -1657,6 +1663,19 @@ class CmdForget(Command):
         memory[apparent_uid]["assigned_name"] = ""
         caller.recognition_memory = memory
 
+        # Drop stale pierce-cache verdicts for this sleeve so the next
+        # look re-evaluates against the now-nameless memory.  Prefer
+        # the entry's stored ``real_sleeve_uid`` (covers all backfilled
+        # presentations); fall back to the target's live sleeve_uid
+        # for pre-schema entries.
+        from world.identity import invalidate_pierce_cache_for_sleeve
+
+        entry_sleeve = memory[apparent_uid].get("real_sleeve_uid")
+        live_sleeve = getattr(target, "sleeve_uid", None)
+        sleeve_uid = entry_sleeve or live_sleeve
+        if sleeve_uid:
+            invalidate_pierce_cache_for_sleeve(caller, sleeve_uid)
+
         caller.msg(
             f"You forget the name '{old_name}'. "
             f"They will now appear as their description."
@@ -1667,6 +1686,14 @@ class CmdForget(Command):
 
         ``apparent_uid`` is the recognition_memory dict key (an Apparent
         UID derived from the target's signature at recording time).
+
+        Also invalidates pierce-cache entries for the sleeve (issue
+        #210); pre-schema entries (no ``real_sleeve_uid``) skip
+        invalidation since there is no other handle on the sleeve when
+        the target is absent.  The pierce candidate filter in
+        :func:`world.identity.attempt_display_pierce` still guards
+        rendering correctness in that degraded case — it requires a
+        truthy ``assigned_name``, which the forget just cleared.
         """
         old_name = entry.get("assigned_name", "")
         sdesc = entry.get("sdesc_at_last_encounter", "someone")
@@ -1677,6 +1704,12 @@ class CmdForget(Command):
         memory = caller.recognition_memory
         memory[apparent_uid]["assigned_name"] = ""
         caller.recognition_memory = memory
+
+        from world.identity import invalidate_pierce_cache_for_sleeve
+
+        sleeve_uid = entry.get("real_sleeve_uid")
+        if sleeve_uid:
+            invalidate_pierce_cache_for_sleeve(caller, sleeve_uid)
 
         caller.msg(
             f"You forget the name '{old_name}'. "

--- a/world/identity.py
+++ b/world/identity.py
@@ -1484,6 +1484,77 @@ def attempt_disguise_pierce(
     return success
 
 
+def invalidate_pierce_cache_for_sleeve(
+    observer: Any, real_sleeve_uid: str | None
+) -> int:
+    """Drop pierce-cache entries for every presentation of ``real_sleeve_uid``.
+
+    Walks :attr:`observer.recognition_memory` to collect every
+    ``apparent_uid`` belonging to the supplied sleeve (via the
+    ``real_sleeve_uid`` field populated by :func:`_remember_target`
+    and the unmasking-moments lazy backfill), then removes any
+    ``(target_dbref, apparent_uid)`` key from
+    ``observer.db.disguise_pierce_cache`` whose ``apparent_uid``
+    matches.
+
+    Used by ``CmdForget`` (see ``commands/CmdCharacter.py``) so the
+    cognitive act of forgetting a person also discards every cached
+    pierce verdict for any disguise that person has worn.  Without
+    this invalidation, :func:`attempt_disguise_pierce` short-circuits
+    on a cached ``True`` and surfaces the bare-face entry's
+    ``assigned_name`` from any *other* (still-named) entry sharing the
+    sleeve — leaving forgotten targets perpetually recognized through
+    disguises.  See issue #210.
+
+    Sleeve-wide scope matches the semantics of forget: the player is
+    declaring "I no longer know this person", not "I no longer know
+    this particular presentation".  Per-``apparent_uid`` invalidation
+    would leave stale ``True`` verdicts the moment the target swaps
+    any signature axis.
+
+    Pre-schema memory entries (missing ``real_sleeve_uid``) are
+    silently skipped — same contract as
+    :func:`find_entries_by_real_sleeve_uid`.  A missing or empty
+    ``real_sleeve_uid`` argument is a no-op.  Missing or empty cache
+    is a no-op.
+
+    Args:
+        observer: Character whose pierce cache is pruned.
+        real_sleeve_uid: The underlying sleeve UID whose
+            presentations should be invalidated.
+
+    Returns:
+        Count of cache entries removed.
+    """
+    if not real_sleeve_uid:
+        return 0
+    cache = observer.db.disguise_pierce_cache
+    if not cache:
+        return 0
+
+    matching_uids = {
+        apparent_uid
+        for apparent_uid, _entry in find_entries_by_real_sleeve_uid(
+            observer, real_sleeve_uid
+        )
+    }
+    if not matching_uids:
+        return 0
+
+    keys_to_drop = [
+        key for key in cache
+        if isinstance(key, tuple) and len(key) == 2
+        and key[1] in matching_uids
+    ]
+    for key in keys_to_drop:
+        del cache[key]
+
+    if keys_to_drop:
+        observer.db.disguise_pierce_cache = cache
+
+    return len(keys_to_drop)
+
+
 def attempt_display_pierce(
     looker: Any, target: Any, apparent_uid: str | None
 ) -> str | None:

--- a/world/tests/test_identity_commands.py
+++ b/world/tests/test_identity_commands.py
@@ -704,6 +704,326 @@ class TestForgetCommand(TestCase):
 
 
 # ===================================================================
+# forget — pierce-cache invalidation (issue #210)
+# ===================================================================
+
+
+def _seed_memory_with_sleeve(
+    *, uid="uid-target", name="Big J", real_sleeve_uid="sleeve-jorge"
+):
+    """``_seed_memory`` variant that populates ``real_sleeve_uid``.
+
+    Mirrors entries written by the post-schema ``_remember_target``
+    builder.  Tests for pierce-cache invalidation rely on the
+    backfilled sleeve field to drive
+    :func:`world.identity.find_entries_by_real_sleeve_uid`.
+    """
+    memory = _seed_memory(uid=uid, name=name)
+    memory[uid]["real_sleeve_uid"] = real_sleeve_uid
+    return memory
+
+
+class TestForgetInvalidatesPierceCache(TestCase):
+    """``forget`` drops cached pierce verdicts for the target's sleeve.
+
+    Regression coverage for issue #210: a cached ``True`` in
+    ``observer.db.disguise_pierce_cache`` survived ``forget`` and
+    ``attempt_disguise_pierce`` short-circuited on it, leaving
+    forgotten targets perpetually recognized through any disguise.
+
+    Scope: sleeve-wide.  Every cached ``apparent_uid`` belonging to
+    the forgotten target's sleeve drops, not just the current
+    presentation.
+    """
+
+    def _make_caller_with_cache(self, *, memory, cache):
+        caller = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=memory,
+        )
+        caller.db.disguise_pierce_cache = cache
+        return caller
+
+    def test_forget_visible_drops_pierce_cache_for_target_sleeve(self):
+        """All cached presentations for the forgotten sleeve are removed."""
+        from commands.CmdCharacter import CmdForget
+
+        target = _make_character(
+            key="Jorge",
+            sleeve_uid="sleeve-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        target.dbref = "#101"
+        bare_uid = apparent_uid_for(target)
+        memory = _seed_memory_with_sleeve(
+            uid=bare_uid, real_sleeve_uid="sleeve-jorge"
+        )
+        # A second masked presentation for the same sleeve.
+        memory["uid-jorge-masked"] = {
+            "assigned_name": "",
+            "real_sleeve_uid": "sleeve-jorge",
+            "first_seen": "2026-01-02T00:00:00",
+            "last_seen": "2026-01-02T00:00:00",
+            "times_seen": 1,
+            "linked_to": bare_uid,
+        }
+        cache = {
+            ("#101", bare_uid): True,
+            ("#101", "uid-jorge-masked"): True,
+        }
+        caller = self._make_caller_with_cache(memory=memory, cache=cache)
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd._forget_visible(caller, target, bare_uid)
+
+        self.assertEqual(caller.db.disguise_pierce_cache, {})
+
+    def test_forget_visible_preserves_other_sleeve_cache(self):
+        """Forgetting one sleeve must not touch unrelated cached pierces."""
+        from commands.CmdCharacter import CmdForget
+
+        target = _make_character(
+            key="Jorge",
+            sleeve_uid="sleeve-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        target.dbref = "#101"
+        bare_uid = apparent_uid_for(target)
+        memory = _seed_memory_with_sleeve(
+            uid=bare_uid, real_sleeve_uid="sleeve-jorge"
+        )
+        # Unrelated second sleeve in memory + cache.
+        memory["uid-other-bare"] = {
+            "assigned_name": "Maria",
+            "real_sleeve_uid": "sleeve-maria",
+            "first_seen": "2026-01-03T00:00:00",
+            "last_seen": "2026-01-03T00:00:00",
+            "times_seen": 1,
+        }
+        cache = {
+            ("#101", bare_uid): True,
+            ("#202", "uid-other-bare"): True,
+        }
+        caller = self._make_caller_with_cache(memory=memory, cache=cache)
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd._forget_visible(caller, target, bare_uid)
+
+        self.assertEqual(
+            caller.db.disguise_pierce_cache,
+            {("#202", "uid-other-bare"): True},
+        )
+
+    def test_forget_remembered_clears_cache_via_entry_sleeve(self):
+        """Absent-target path uses ``entry['real_sleeve_uid']`` for scope."""
+        from commands.CmdCharacter import (
+            CmdForget,
+            _find_remembered_uid_by_name,
+        )
+
+        # Build a target only to derive its apparent UID for seeding.
+        target = _make_character(
+            key="Jorge",
+            sleeve_uid="sleeve-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        bare_uid = apparent_uid_for(target)
+        memory = _seed_memory_with_sleeve(
+            uid=bare_uid, real_sleeve_uid="sleeve-jorge"
+        )
+        memory["uid-jorge-masked"] = {
+            "assigned_name": "",
+            "real_sleeve_uid": "sleeve-jorge",
+            "first_seen": "2026-01-02T00:00:00",
+            "last_seen": "2026-01-02T00:00:00",
+            "times_seen": 1,
+        }
+        cache = {
+            ("#101", bare_uid): True,
+            ("#101", "uid-jorge-masked"): True,
+        }
+        caller = self._make_caller_with_cache(memory=memory, cache=cache)
+
+        sleeve_uid, entry = _find_remembered_uid_by_name(caller, "big j")
+        self.assertEqual(sleeve_uid, bare_uid)
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd._forget_remembered(caller, sleeve_uid, entry)
+
+        self.assertEqual(caller.db.disguise_pierce_cache, {})
+
+    def test_forget_remembered_pre_schema_entry_skips_invalidation(self):
+        """Entry without ``real_sleeve_uid`` leaves cache untouched.
+
+        Pre-schema memory entries cannot be reverse-keyed by sleeve, so
+        invalidation has no anchor.  Forget still succeeds (clears the
+        assigned_name) — the pierce candidate filter in
+        :func:`world.identity.attempt_display_pierce` guards rendering
+        correctness in that case (it requires a truthy
+        ``assigned_name``, which the forget just cleared).
+        """
+        from commands.CmdCharacter import CmdForget
+
+        bare_uid = "uid-jorge-bare"
+        memory = _seed_memory(uid=bare_uid)
+        # Pre-schema entry — no real_sleeve_uid.
+        cache = {("#101", bare_uid): True}
+        caller = self._make_caller_with_cache(memory=memory, cache=cache)
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd._forget_remembered(caller, bare_uid, memory[bare_uid])
+
+        # Cache untouched; assigned_name cleared.
+        self.assertEqual(
+            caller.db.disguise_pierce_cache, {("#101", bare_uid): True}
+        )
+        self.assertEqual(memory[bare_uid]["assigned_name"], "")
+
+    def test_forget_visible_falls_back_to_live_sleeve_for_pre_schema_entry(self):
+        """Visible-target path can still invalidate via ``target.sleeve_uid``.
+
+        Even when the memory entry pre-dates the ``real_sleeve_uid``
+        schema, the visible target itself exposes its sleeve and the
+        invalidator can run.
+        """
+        from commands.CmdCharacter import CmdForget
+
+        target = _make_character(
+            key="Jorge",
+            sleeve_uid="sleeve-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        target.dbref = "#101"
+        bare_uid = apparent_uid_for(target)
+        memory = _seed_memory(uid=bare_uid)  # no real_sleeve_uid
+        # Add a second presentation that HAS the field — so the
+        # invalidator has something to find via reverse lookup.
+        memory["uid-jorge-masked"] = {
+            "assigned_name": "",
+            "real_sleeve_uid": "sleeve-jorge",
+            "first_seen": "2026-01-02T00:00:00",
+            "last_seen": "2026-01-02T00:00:00",
+            "times_seen": 1,
+        }
+        cache = {("#101", "uid-jorge-masked"): True}
+        caller = self._make_caller_with_cache(memory=memory, cache=cache)
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd._forget_visible(caller, target, bare_uid)
+
+        self.assertEqual(caller.db.disguise_pierce_cache, {})
+
+    def test_forget_with_empty_cache_no_crash(self):
+        """No cache present is a no-op (not an error)."""
+        from commands.CmdCharacter import CmdForget
+
+        target = _make_character(
+            key="Jorge",
+            sleeve_uid="sleeve-jorge",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+        )
+        bare_uid = apparent_uid_for(target)
+        memory = _seed_memory_with_sleeve(
+            uid=bare_uid, real_sleeve_uid="sleeve-jorge"
+        )
+        caller = self._make_caller_with_cache(memory=memory, cache=None)
+
+        cmd = CmdForget()
+        cmd.caller = caller
+        cmd._forget_visible(caller, target, bare_uid)
+
+        self.assertIsNone(caller.db.disguise_pierce_cache)
+
+
+# ===================================================================
+# invalidate_pierce_cache_for_sleeve — direct unit coverage
+# ===================================================================
+
+
+class TestInvalidatePierceCacheForSleeve(TestCase):
+    """Direct unit coverage for the helper."""
+
+    def _make_observer(self, *, memory, cache):
+        observer = _make_character(
+            key="Observer",
+            sleeve_uid="uid-observer",
+            recognition_memory=memory,
+        )
+        observer.db.disguise_pierce_cache = cache
+        return observer
+
+    def test_returns_zero_for_empty_sleeve_uid(self):
+        from world.identity import invalidate_pierce_cache_for_sleeve
+
+        observer = self._make_observer(memory={}, cache={})
+        self.assertEqual(
+            invalidate_pierce_cache_for_sleeve(observer, ""), 0
+        )
+        self.assertEqual(
+            invalidate_pierce_cache_for_sleeve(observer, None), 0
+        )
+
+    def test_returns_zero_for_empty_cache(self):
+        from world.identity import invalidate_pierce_cache_for_sleeve
+
+        observer = self._make_observer(memory={}, cache=None)
+        self.assertEqual(
+            invalidate_pierce_cache_for_sleeve(observer, "sleeve-x"), 0
+        )
+
+    def test_returns_zero_when_sleeve_has_no_memory_entries(self):
+        from world.identity import invalidate_pierce_cache_for_sleeve
+
+        cache = {("#101", "uid-other"): True}
+        observer = self._make_observer(memory={}, cache=cache)
+        self.assertEqual(
+            invalidate_pierce_cache_for_sleeve(observer, "sleeve-x"), 0
+        )
+        # Cache untouched.
+        self.assertEqual(
+            observer.db.disguise_pierce_cache,
+            {("#101", "uid-other"): True},
+        )
+
+    def test_drops_matching_keys_and_returns_count(self):
+        from world.identity import invalidate_pierce_cache_for_sleeve
+
+        memory = {
+            "uid-a": {"real_sleeve_uid": "sleeve-x", "assigned_name": "A"},
+            "uid-b": {"real_sleeve_uid": "sleeve-x", "assigned_name": ""},
+            "uid-c": {"real_sleeve_uid": "sleeve-y", "assigned_name": "C"},
+        }
+        cache = {
+            ("#10", "uid-a"): True,
+            ("#10", "uid-b"): False,
+            ("#11", "uid-c"): True,
+        }
+        observer = self._make_observer(memory=memory, cache=cache)
+        dropped = invalidate_pierce_cache_for_sleeve(observer, "sleeve-x")
+        self.assertEqual(dropped, 2)
+        self.assertEqual(
+            observer.db.disguise_pierce_cache,
+            {("#11", "uid-c"): True},
+        )
+
+
+# ===================================================================
 # recall command
 # ===================================================================
 


### PR DESCRIPTION
## Summary
- `CmdForget` now drops every cached pierce verdict for the forgotten target's `real_sleeve_uid`, not just the assigned name on the current `apparent_uid`. Without this, `attempt_disguise_pierce` short-circuited on a cached `True` and surfaced the bare-face entry's name through any disguise — forgotten targets stayed perpetually recognized, with stat changes having no effect.
- New helper `world.identity.invalidate_pierce_cache_for_sleeve(observer, real_sleeve_uid)` walks the observer's recognition memory to identify every `apparent_uid` belonging to the sleeve and drops matching keys from `observer.db.disguise_pierce_cache`.
- Wired into both forget paths: `_forget_visible` (uses entry's `real_sleeve_uid`, falls back to `target.sleeve_uid` for pre-schema entries) and `_forget_remembered` (entry-only since target may be absent).

## Scope rationale
Sleeve-wide, not per-`apparent_uid`. `forget` is a cognitive act about a *person*, so every cached pierce verdict for any of that person's disguised presentations drops together. Per-`apparent_uid` invalidation would leave stale `True`s the moment the target swapped any signature axis, immediately re-creating the bug. Matches how `_remember_target` already correlates entries by `real_sleeve_uid` for auto-linking.

## Pre-schema fallback
Pre-schema memory entries (missing `real_sleeve_uid`) in the absent-target path skip invalidation — there's no anchor to reverse-key by. The pierce candidate filter in `attempt_display_pierce` still guards rendering correctness in that case: it requires a truthy `assigned_name`, which `forget` just cleared. The visible-target path falls back to `target.sleeve_uid` so it still invalidates on pre-schema entries when the target is present.

## Tests
1189 total passing (1180 baseline + 9 new):
- `TestForgetInvalidatesPierceCache` (6) — sleeve-scope drop, other-sleeve preservation, both forget paths, pre-schema fallback, None-cache no-op.
- `TestInvalidatePierceCacheForSleeve` (3) — empty inputs, no-match return value, drop count + survivors.

Closes #210.