### PR TITLE
Render organs with species-qualified, decay-modulated keys (#212)

### DIFF
--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -418,9 +418,14 @@ class CmdHarvest(Command):
 
         organ_item = create_object(
             "typeclasses.items.Organ",
-            key=f"{condition} {readable_name}",
+            key=organ_arg,
             location=caller,
         )
+        # Issue #212: ``configure_from_harvest`` is the sole authority
+        # for the final key (species + decay-tier aware via
+        # :func:`world.anatomy.species.get_species_organ_name`).  The
+        # ``key=organ_arg`` above is a transient placeholder for the
+        # window between spawn and configuration.
         organ_item.configure_from_harvest(
             organ_name=organ_arg, condition=condition, corpse=target,
         )

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1625,9 +1625,16 @@ autopsies render the removed organ as `absent`.
 | `db.source_apparent_uid` | Copy of `corpse.db.apparent_uid_at_death` |
 | `db.source_corpse_dbref` | Audit pointer; not resolution-guaranteed |
 
-The display key is rendered `"<condition> <organ name>"`
-(underscores → spaces) at spawn time via
-`configure_from_harvest`.
+The display key is rendered via `get_species_organ_name(species,
+organ_name, decay_stage)` at spawn time by `configure_from_harvest`
+(issue #212).  Fresh / early decay produces `"{species} {organ}"`
+(e.g. `human heart`); moderate / advanced drops to `"rotting
+{organ}"`; the skeletal tier reads `"desiccated {organ}"` —
+mirroring the appendage decay-tier contract from
+`get_species_part_name` but substituting `desiccated` for `skeletal`
+because soft tissue dries out rather than skeletonizing.  The
+freshness `condition` (`pristine` / `damaged` / `putrid`) is
+conveyed via `db.desc` and surfaces at `look` time, not in the key.
 
 ### DC tuning (provisional)
 

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -982,9 +982,14 @@ class Organ(Item):
             audit / debugging — not guaranteed resolvable (the corpse
             may have decayed and been deleted).
 
-    The display name is rendered ``"<condition> <organ_name>"``
-    (e.g. ``"pristine heart"``) at ``at_object_creation`` time; callers
-    that need the raw organ identifier should read ``db.organ_name``.
+    The display name renders as ``"<species> <organ>"`` for fresh /
+    early corpses (e.g. ``"human heart"``), drops to ``"rotting
+    <organ>"`` at moderate / advanced decay, and to ``"desiccated
+    <organ>"`` at the skeletal tier — mirroring the
+    :class:`Appendage` decay-tier contract.  Condition (pristine /
+    damaged / putrid) is conveyed via ``self.db.desc`` and surfaces
+    at ``look`` time; callers that need the raw organ identifier
+    should read ``db.organ_name``.
     """
 
     def at_object_creation(self):
@@ -1010,10 +1015,11 @@ class Organ(Item):
             condition (str): Freshness descriptor.
             corpse: The source :class:`typeclasses.corpse.Corpse`.
 
-        Sets the display key to ``"<condition> <display_name>"`` using
-        the player-facing organ display name from
-        :data:`world.anatomy.organs.ORGAN_DISPLAY` (falling back to
-        the underscore-stripped canonical key).
+        Sets the display key via
+        :func:`world.anatomy.species.get_species_organ_name`, which
+        renders decay-modulated species-aware names (``"human heart"``
+        → ``"rotting heart"`` → ``"desiccated heart"``) matching the
+        appendage naming contract.  Issue #212.
 
         PR #204: also seeds ``self.db.desc`` from the condition-keyed
         default description so the Evennia-standard ``return_appearance``
@@ -1025,7 +1031,7 @@ class Organ(Item):
         """
         from world.anatomy import (
             get_organ_default_description,
-            get_organ_display_name,
+            get_species_organ_name,
         )
 
         self.db.organ_name = organ_name
@@ -1034,9 +1040,17 @@ class Organ(Item):
         self.db.source_apparent_uid = corpse.db.apparent_uid_at_death
         self.db.source_corpse_dbref = corpse.dbref
         # PR-G: species inheritance for condition-aware prose.
-        self.db.source_species = corpse.db.species or "human"
-        readable = get_organ_display_name(organ_name)
-        self.key = f"{condition} {readable}"
+        species = corpse.db.species or "human"
+        self.db.source_species = species
+        # Issue #212: read decay stage off the corpse for species-aware
+        # key composition.  Mirrors the Appendage pattern below.  Fake
+        # corpses in unit tests may lack ``get_decay_stage`` — fall back
+        # to ``fresh`` (the species-revealing tier) for those paths.
+        if hasattr(corpse, "get_decay_stage"):
+            decay_stage = corpse.get_decay_stage()
+        else:
+            decay_stage = "fresh"
+        self.key = get_species_organ_name(species, organ_name, decay_stage)
         # PR #204: populate db.desc the Evennia-standard way so the
         # engine renderer handles it (rather than overriding
         # return_appearance to prepend prose).  Conditional: leave the

--- a/world/anatomy/__init__.py
+++ b/world/anatomy/__init__.py
@@ -13,6 +13,7 @@ Public surface:
 * :func:`world.anatomy.species.get_species_part_name`
 * :func:`world.anatomy.species.get_species_corpse_name`
 * :func:`world.anatomy.species.get_species_location_display`
+* :func:`world.anatomy.species.get_species_organ_name`
 * :data:`world.anatomy.severed_parts.SEVERED_PART_DESCRIPTIONS`
 * :func:`world.anatomy.severed_parts.get_severed_part_description`
 * :data:`world.anatomy.organs.ORGAN_DISPLAY`
@@ -33,6 +34,7 @@ from .species import (
     SPECIES_DEFINITIONS,
     get_species_corpse_name,
     get_species_location_display,
+    get_species_organ_name,
     get_species_part_name,
 )
 
@@ -45,5 +47,6 @@ __all__ = (
     "get_severed_part_description",
     "get_species_corpse_name",
     "get_species_location_display",
+    "get_species_organ_name",
     "get_species_part_name",
 )

--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -30,6 +30,11 @@ Design notes
   description (which still carries decay prose) or ``autopsy`` (which
   rolls Intellect for forensic recovery).
 
+  Harvested **organs** follow the same shape via
+  :data:`decay_organ_prefixes`, but the skeletal-tier tag is
+  ``desiccated`` rather than ``skeletal`` — a heart or kidney doesn't
+  skeletonize, it dries out.  See :func:`get_species_organ_name`.
+
 * **No species in skeletal/rotting stages**: deliberate gameplay
   signal — late decay obscures species at a glance.  Once a body has
   rotted past recognition or reduced to bone, the casual observer
@@ -101,6 +106,18 @@ SPECIES_DEFINITIONS = {
             "moderate": "rotting {part}",
             "advanced": "rotting {part}",
             "skeletal": "skeletal {part}",
+        },
+
+        # Decay-tier prefix templates for harvested organs.  Same shape
+        # as ``decay_part_prefixes`` but the skeletal tier uses
+        # ``desiccated`` — soft tissue dries out rather than
+        # skeletonizing.  Rendered by :func:`get_species_organ_name`.
+        "decay_organ_prefixes": {
+            "fresh":    "{species} {organ}",
+            "early":    "{species} {organ}",
+            "moderate": "rotting {organ}",
+            "advanced": "rotting {organ}",
+            "skeletal": "desiccated {organ}",
         },
 
         # Decay-tier corpse-name templates.  Rendered by
@@ -210,3 +227,50 @@ def get_species_corpse_name(
     if decay_stage in names:
         return names[decay_stage]
     return names.get("fresh", "corpse")
+
+
+def get_species_organ_name(
+    species: str | None,
+    organ_name: str,
+    decay_stage: str | None = None,
+) -> str:
+    """Return the decay-modulated display name for a harvested organ.
+
+    Used by :class:`typeclasses.items.Organ` to render decay-aware
+    glance names like ``"human heart"`` (fresh) → ``"rotting heart"``
+    (moderate) → ``"desiccated heart"`` (skeletal).  The skeletal tier
+    deliberately reads ``desiccated`` rather than ``skeletal`` — soft
+    tissue dries out rather than skeletonizing.
+
+    Mirrors the contract of :func:`get_species_part_name`: fresh/early
+    surface species cleanly, moderate/advanced obscure it ("rotting"
+    only), and the skeletal tier abandons species entirely.  Players
+    wanting more precision must ``look`` (which shows condition-keyed
+    prose) or use forensic commands.
+
+    Args:
+        species: Species identifier; unknown / None → human (the
+            defensive fallback contract documented in
+            ``specs/IDENTITY_RECOGNITION_SPEC.md``).
+        organ_name: Canonical organ identifier from
+            :data:`world.medical.constants.ORGANS`.  Unregistered
+            organs fall back to their underscore-stripped key.
+        decay_stage: One of ``fresh`` / ``early`` / ``moderate`` /
+            ``advanced`` / ``skeletal``.  ``None`` or unknown stages
+            fall back to the ``fresh`` template.
+
+    Returns:
+        Display string ready for use as ``self.key`` or in look output.
+    """
+    from .organs import get_organ_display_name
+
+    spec = _resolve_species(species)
+    prefixes = spec.get("decay_organ_prefixes") or {}
+    template = (
+        prefixes.get(decay_stage)
+        or prefixes.get("fresh")
+        or "{organ}"
+    )
+    organ_display = get_organ_display_name(organ_name)
+    species_display = spec.get("display_name", "")
+    return template.format(species=species_display, organ=organ_display)

--- a/world/tests/test_cmd_harvest.py
+++ b/world/tests/test_cmd_harvest.py
@@ -334,17 +334,24 @@ class CmdHarvestTests(TestCase):
         self.assertEqual(corpse.db.removed_organs, ["heart"])
 
     def test_success_condition_tracks_decay(self):
+        # Issue #212: condition no longer appears in the placeholder
+        # key passed to ``create_object`` — it's carried via the
+        # ``configure_from_harvest`` call, which is the sole authority
+        # for the final species + decay-aware key.
         caller = _make_caller()
         corpse = _FakeCorpse(snapshot=_snapshot_with(), decay_stage="advanced")
         caller.search.return_value = corpse
+        fake_organ = MagicMock()
         with patch.object(
             cmd_module, "roll_stat", return_value=HARVEST_DC_BASIC + 5
         ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ) as mk:
+            cmd_module, "create_object", return_value=fake_organ
+        ):
             _make_cmd(caller=caller, args="liver from corpse").func()
-        self.assertIn(
-            ORGAN_CONDITION_BY_DECAY["advanced"], mk.call_args.kwargs["key"]
+        fake_organ.configure_from_harvest.assert_called_once_with(
+            organ_name="liver",
+            condition=ORGAN_CONDITION_BY_DECAY["advanced"],
+            corpse=corpse,
         )
 
     def test_organ_name_accepts_spaces(self):

--- a/world/tests/test_organ_display.py
+++ b/world/tests/test_organ_display.py
@@ -194,12 +194,49 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
     def test_key_still_assigned_alongside_desc(self):
         # Regression guard: the desc plumbing must not skip the
         # display-key assignment that the rest of the system reads.
+        # Issue #212: key is now species-qualified, decay-modulated
+        # via ``get_species_organ_name`` — fake corpse lacks
+        # ``get_decay_stage`` so the configure helper falls back to
+        # the ``fresh`` template (``{species} {organ}``).
         organ = self._fake_organ()
         organ.configure_from_harvest(
             organ_name="heart", condition="pristine",
             corpse=self._fake_corpse(),
         )
-        self.assertEqual(organ.key, "pristine heart")
+        self.assertEqual(organ.key, "human heart")
+
+    def test_key_omits_species_at_moderate_decay(self):
+        # Issue #212: moderate/advanced decay drops the species token
+        # ("rotting heart").  Stub a corpse with ``get_decay_stage``.
+        organ = self._fake_organ()
+        corpse = self._fake_corpse()
+        corpse.get_decay_stage = lambda: "moderate"
+        organ.configure_from_harvest(
+            organ_name="heart", condition="damaged", corpse=corpse,
+        )
+        self.assertEqual(organ.key, "rotting heart")
+
+    def test_key_uses_desiccated_at_skeletal_decay(self):
+        # Issue #212: organs use ``desiccated`` (not ``skeletal``) at
+        # the skeletal decay tier — soft tissue dries out.
+        organ = self._fake_organ()
+        corpse = self._fake_corpse()
+        corpse.get_decay_stage = lambda: "skeletal"
+        organ.configure_from_harvest(
+            organ_name="heart", condition="refuse", corpse=corpse,
+        )
+        self.assertEqual(organ.key, "desiccated heart")
+
+    def test_key_falls_back_for_unknown_species(self):
+        # Issue #212: unknown species fall through to human via
+        # ``_resolve_species`` — keeps the system robust as new
+        # species register incrementally.
+        organ = self._fake_organ()
+        corpse = self._fake_corpse(species="unobtanium_alien")
+        organ.configure_from_harvest(
+            organ_name="liver", condition="pristine", corpse=corpse,
+        )
+        self.assertEqual(organ.key, "human liver")
 
 
 class TestOrganHasNoReturnAppearanceOverride(TestCase):

--- a/world/tests/test_species_anatomy.py
+++ b/world/tests/test_species_anatomy.py
@@ -16,6 +16,7 @@ from world.anatomy import (
     SPECIES_DEFINITIONS,
     get_species_corpse_name,
     get_species_location_display,
+    get_species_organ_name,
     get_species_part_name,
 )
 
@@ -42,6 +43,9 @@ class TestSpeciesRegistry(TestCase):
         stages = {"fresh", "early", "moderate", "advanced", "skeletal"}
         self.assertEqual(set(human["decay_part_prefixes"].keys()), stages)
         self.assertEqual(set(human["decay_corpse_names"].keys()), stages)
+        # Issue #212: organ-specific decay prefixes mirror part prefixes
+        # in shape but substitute ``desiccated`` for ``skeletal``.
+        self.assertEqual(set(human["decay_organ_prefixes"].keys()), stages)
 
 
 class TestLocationDisplay(TestCase):
@@ -143,4 +147,64 @@ class TestCorpseName(TestCase):
     def test_unknown_species_falls_back_to_human(self):
         self.assertEqual(
             get_species_corpse_name("synth", "fresh"), "human corpse"
+        )
+
+
+class TestOrganName(TestCase):
+    """Issue #212: species + decay-tier aware organ naming."""
+
+    def test_fresh_includes_species(self):
+        self.assertEqual(
+            get_species_organ_name("human", "heart", "fresh"),
+            "human heart",
+        )
+
+    def test_early_includes_species(self):
+        self.assertEqual(
+            get_species_organ_name("human", "left_kidney", "early"),
+            "human left kidney",
+        )
+
+    def test_moderate_drops_species(self):
+        self.assertEqual(
+            get_species_organ_name("human", "heart", "moderate"),
+            "rotting heart",
+        )
+
+    def test_advanced_drops_species(self):
+        self.assertEqual(
+            get_species_organ_name("human", "liver", "advanced"),
+            "rotting liver",
+        )
+
+    def test_skeletal_uses_desiccated_for_soft_tissue(self):
+        # Organs don't skeletonize — they desiccate.  This is the
+        # critical divergence from ``get_species_part_name``.
+        self.assertEqual(
+            get_species_organ_name("human", "heart", "skeletal"),
+            "desiccated heart",
+        )
+
+    def test_none_stage_falls_back_to_fresh(self):
+        self.assertEqual(
+            get_species_organ_name("human", "brain", None),
+            "human brain",
+        )
+
+    def test_unknown_stage_falls_back_to_fresh(self):
+        self.assertEqual(
+            get_species_organ_name("human", "brain", "wibbly"),
+            "human brain",
+        )
+
+    def test_unknown_species_falls_back_to_human(self):
+        self.assertEqual(
+            get_species_organ_name("unobtanium_alien", "heart", "fresh"),
+            "human heart",
+        )
+
+    def test_unknown_organ_falls_back_to_underscore_stripped(self):
+        self.assertEqual(
+            get_species_organ_name("human", "flux_capacitor", "fresh"),
+            "human flux capacitor",
         )


### PR DESCRIPTION
## Summary
- Organs now follow the same decay-tier vocabulary as severed appendages: fresh/early surface species (`human heart`), moderate/advanced drop to `rotting heart`, skeletal becomes `desiccated heart` (soft tissue dries rather than skeletonizing).
- Freshness condition (`pristine`/`damaged`/`putrid`) moves out of the key and lives in `db.desc`, surfacing at `look` time.
- `Organ.configure_from_harvest` is the sole authority for the final key; `CmdHarvest` passes a transient `organ_arg` placeholder to `create_object`.

## Implementation
- New helper `world.anatomy.species.get_species_organ_name(species, organ_name, decay_stage)` parallel to `get_species_part_name`, with defensive fallbacks (unknown species → human; unknown organ → underscore-stripped key; unknown / None stage → fresh).
- New `decay_organ_prefixes` table in `SPECIES_DEFINITIONS[\"human\"]` (skeletal tier reads `desiccated {organ}`).
- `Organ.configure_from_harvest` now reads `corpse.get_decay_stage()` and composes the key via the new helper.
- `CmdHarvest` drops the condition-prefixed pre-set key.

## Tests
- 1201 passing in Docker (baseline 1189; +12 new).
- `test_species_anatomy.TestOrganName`: 9 cases covering the species × decay × fallback matrix.
- `test_organ_display`: key regression updated (`human heart` not `pristine heart`); new coverage for moderate-decay, skeletal-decay, and unknown-species paths.
- `test_cmd_harvest.test_success_condition_tracks_decay`: reworked to assert the condition reaches `configure_from_harvest` rather than the placeholder `create_object` key.

## Spec
- Updated `specs/IDENTITY_RECOGNITION_SPEC.md` organ section to document the new key contract.

## Follow-up
- #213 — bones need condition-based descriptions (organs and bones currently share the same prose table; bones should desiccate/stain rather than weep).

Closes #212.