### PR TITLE
Drop species token for unknown-species organs (#215)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1636,6 +1636,15 @@ because soft tissue dries out rather than skeletonizing.  The
 freshness `condition` (`pristine` / `damaged` / `putrid`) is
 conveyed via `db.desc` and surfaces at `look` time, not in the key.
 
+**Unknown-species fallback (issue #215):** unregistered species drop
+the species token entirely at fresh / early stages — an organ from
+an alien species renders as bare `"heart"`, not `"human heart"`.
+This is a deliberate feature: builders who create something truly
+alien get inscrutable organ names for free, and the system never
+misclaims provenance.  Late-decay tiers already drop species via
+their templates, so this fallback only affects fresh / early surface
+output.
+
 ### DC tuning (provisional)
 
 ```python

--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -248,10 +248,17 @@ def get_species_organ_name(
     wanting more precision must ``look`` (which shows condition-keyed
     prose) or use forensic commands.
 
+    **Unknown-species fallback (issue #215):** unknown species drop the
+    species token entirely — an organ from an unregistered species
+    renders as bare ``"heart"`` rather than misclaiming it as human.
+    This is a feature: builders creating something truly alien get
+    inscrutable organ names for free.  Late-decay tiers already drop
+    species via their templates, so this only changes the
+    fresh / early surface for unregistered species.
+
     Args:
-        species: Species identifier; unknown / None → human (the
-            defensive fallback contract documented in
-            ``specs/IDENTITY_RECOGNITION_SPEC.md``).
+        species: Species identifier; ``None`` or unregistered species
+            drop the species token from the fresh / early template.
         organ_name: Canonical organ identifier from
             :data:`world.medical.constants.ORGANS`.  Unregistered
             organs fall back to their underscore-stripped key.
@@ -264,7 +271,13 @@ def get_species_organ_name(
     """
     from .organs import get_organ_display_name
 
-    spec = _resolve_species(species)
+    # Issue #215: detect unknown species before falling through to the
+    # ``_resolve_species`` human-default behaviour.  Unknown species
+    # use the human template shape (so decay tiers still work) but
+    # render with an empty species token, producing bare organ names
+    # at fresh / early stages.
+    is_known = bool(species) and species in SPECIES_DEFINITIONS
+    spec = SPECIES_DEFINITIONS[species] if is_known else SPECIES_DEFINITIONS["human"]
     prefixes = spec.get("decay_organ_prefixes") or {}
     template = (
         prefixes.get(decay_stage)
@@ -272,5 +285,8 @@ def get_species_organ_name(
         or "{organ}"
     )
     organ_display = get_organ_display_name(organ_name)
-    species_display = spec.get("display_name", "")
-    return template.format(species=species_display, organ=organ_display)
+    species_display = spec.get("display_name", "") if is_known else ""
+    rendered = template.format(species=species_display, organ=organ_display)
+    # Collapse any leading whitespace left behind when species_display
+    # is empty (template was ``"{species} {organ}"``).
+    return " ".join(rendered.split())

--- a/world/tests/test_organ_display.py
+++ b/world/tests/test_organ_display.py
@@ -228,15 +228,15 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         self.assertEqual(organ.key, "desiccated heart")
 
     def test_key_falls_back_for_unknown_species(self):
-        # Issue #212: unknown species fall through to human via
-        # ``_resolve_species`` — keeps the system robust as new
-        # species register incrementally.
+        # Issue #215: unknown species drop the species token entirely
+        # at fresh decay — accidentally-alien organs render as bare
+        # ``liver`` rather than misclaiming as human.
         organ = self._fake_organ()
         corpse = self._fake_corpse(species="unobtanium_alien")
         organ.configure_from_harvest(
             organ_name="liver", condition="pristine", corpse=corpse,
         )
-        self.assertEqual(organ.key, "human liver")
+        self.assertEqual(organ.key, "liver")
 
 
 class TestOrganHasNoReturnAppearanceOverride(TestCase):

--- a/world/tests/test_species_anatomy.py
+++ b/world/tests/test_species_anatomy.py
@@ -197,10 +197,33 @@ class TestOrganName(TestCase):
             "human brain",
         )
 
-    def test_unknown_species_falls_back_to_human(self):
+    def test_unknown_species_drops_species_token(self):
+        # Issue #215: unknown species drop the species prefix entirely
+        # at fresh / early decay, rendering bare organ names.  Feature,
+        # not bug — accidentally-alien organs read as inscrutable.
         self.assertEqual(
             get_species_organ_name("unobtanium_alien", "heart", "fresh"),
-            "human heart",
+            "heart",
+        )
+
+    def test_none_species_drops_species_token(self):
+        # Issue #215: ``None`` species behaves identically to unknown.
+        self.assertEqual(
+            get_species_organ_name(None, "liver", "fresh"),
+            "liver",
+        )
+
+    def test_unknown_species_late_decay_unaffected(self):
+        # Late-decay templates already drop the species token, so
+        # unknown-species rendering at moderate / skeletal stages
+        # matches the known-species output.
+        self.assertEqual(
+            get_species_organ_name("unobtanium_alien", "heart", "moderate"),
+            "rotting heart",
+        )
+        self.assertEqual(
+            get_species_organ_name("unobtanium_alien", "heart", "skeletal"),
+            "desiccated heart",
         )
 
     def test_unknown_organ_falls_back_to_underscore_stripped(self):


### PR DESCRIPTION
## Summary
- Unknown / unregistered species now drop the species token entirely at fresh / early decay — an alien-species heart renders as bare \`heart\`, not \`human heart\`.
- Late-decay tiers unaffected (they already drop species via their templates).
- Known species (human) behaviour unchanged.

## Rationale
Per #215: the previous \`_resolve_species\` fallback silently misclaimed unregistered species as human. Treating unknowns as inscrutable is more correct narratively and becomes an accidental feature for builders creating truly alien anatomy.

## Tests
- 1203 passing in Docker (+2 net).
- Updated \`test_unknown_species_falls_back_to_human\` → \`test_unknown_species_drops_species_token\` (and a \`None\` species sibling).
- Added \`test_unknown_species_late_decay_unaffected\` covering moderate / skeletal output.
- Updated \`test_organ_display.test_key_falls_back_for_unknown_species\` expectation to bare \`liver\`.

## Spec
- Documented the unknown-species fallback in \`specs/IDENTITY_RECOGNITION_SPEC.md\` alongside the #212 contract.

Closes #215.