### PR TITLE
Fix flaky harvested-prose test by repairing broken template (#219)

### DIFF
--- a/world/medical/wounds/messages/harvested.py
+++ b/world/medical/wounds/messages/harvested.py
@@ -33,7 +33,7 @@ WOUND_DESCRIPTIONS = {
         "from the {location}, the cavity still wet and red|n",
         "|RThe {location} bears a surgical opening where the {organ} "
         "was excised, the edges of the cut still glistening|n",
-        "|RWhere the {organ} used to sit inside the {location}, only "
+        "|RWhere the {organ} was lifted free from the {location}, only "
         "a hollow, blood-slick pocket remains|n",
         "|RA careful cut along the {location} has exposed the empty "
         "socket where the {organ} was lifted free|n",
@@ -43,7 +43,7 @@ WOUND_DESCRIPTIONS = {
         "the {location}, the cavity sunken and dark|n",
         "|rThe {location} bears a healed-over surgical opening where "
         "the {organ} was removed, the edges crusted brown|n",
-        "|rWhere the {organ} used to sit inside the {location}, only "
+        "|rWhere the {organ} was extracted from the {location}, only "
         "a shrunken, empty pocket remains|n",
         "|rA puckered seam along the {location} marks the long-ago "
         "extraction of the {organ}|n",

--- a/world/tests/test_wound_descriptions_harvested.py
+++ b/world/tests/test_wound_descriptions_harvested.py
@@ -15,35 +15,69 @@ Run via::
 from __future__ import annotations
 
 from unittest import TestCase
+from unittest.mock import patch
 
 from world.medical.wounds import get_wound_description
+from world.medical.wounds.messages.harvested import WOUND_DESCRIPTIONS
+
+# Vocabulary every harvested-stage template must contain to read as
+# extraction prose.  The contract is enforced exhaustively (every
+# template, not random-sample) — see ``test_every_template_uses_extraction_vocab``.
+EXTRACTION_KEYWORDS = (
+    "incision", "extracted", "excised", "removed",
+    "extraction", "lifted", "puckered",
+)
 
 
 class HarvestedWoundRenderingTests(TestCase):
 
-    def test_eye_harvest_old_stage_renders_extraction_prose(self):
-        out = get_wound_description(
-            injury_type="harvested",
-            location="head",
-            severity="Critical",
-            stage="old",
-            organ="left_eye",
-        )
-        lowered = out.lower()
-        # Templates evoke surgical / excision / extraction prose at the
-        # head location with the organ token present.
-        self.assertIn("head", lowered)
-        self.assertIn("left eye", lowered)
-        self.assertTrue(
-            any(
-                token in lowered
-                for token in (
-                    "incision", "extracted", "excised", "removed",
-                    "extraction", "lifted", "puckered",
+    def test_every_template_uses_extraction_vocab(self):
+        """Issue #219: every harvested template must read as extraction prose.
+
+        Earlier coverage random-sampled ``get_wound_description`` and
+        asserted vocabulary on the sampled output, which flaked when
+        the renderer picked the one template lacking an extraction
+        keyword (~25% rate).  This assertion enforces the contract
+        exhaustively across every template and stage so future template
+        additions can't reintroduce the regression.
+        """
+        for stage, templates in WOUND_DESCRIPTIONS.items():
+            for idx, template in enumerate(templates):
+                lowered = template.lower()
+                self.assertTrue(
+                    any(kw in lowered for kw in EXTRACTION_KEYWORDS),
+                    f"Stage {stage!r} template #{idx} lacks extraction "
+                    f"vocabulary: {template!r}",
                 )
-            ),
-            f"Expected extraction prose; got {out!r}",
-        )
+
+    def test_eye_harvest_old_stage_renders_extraction_prose(self):
+        """Deterministic regression guard against the original flake.
+
+        Patches ``random.choice`` to walk every old-stage template in
+        order rather than sampling, so a single broken template
+        introduced by a future PR will fail this test reliably rather
+        than 1-in-N times.
+        """
+        old_templates = WOUND_DESCRIPTIONS["old"]
+        for template in old_templates:
+            with patch(
+                "world.medical.wounds.wound_descriptions.random.choice",
+                return_value=template,
+            ):
+                out = get_wound_description(
+                    injury_type="harvested",
+                    location="head",
+                    severity="Critical",
+                    stage="old",
+                    organ="left_eye",
+                )
+            lowered = out.lower()
+            self.assertIn("head", lowered)
+            self.assertIn("left eye", lowered)
+            self.assertTrue(
+                any(kw in lowered for kw in EXTRACTION_KEYWORDS),
+                f"Expected extraction prose; got {out!r}",
+            )
 
     def test_heart_harvest_chest_location(self):
         out = get_wound_description(


### PR DESCRIPTION
## Summary
Eliminates the ~25% flake rate on \`test_eye_harvest_old_stage_renders_extraction_prose\` by fixing the actually-broken templates and strengthening the test contract.

## Root cause
\`get_wound_description\` uses \`random.choice\` over the 4 \`old\`-stage harvested-wound templates. One template — \"Where the {organ} used to sit inside the {location}, only a shrunken, empty pocket remains\" — contains none of the extraction-vocabulary keywords (\`incision\`, \`extracted\`, \`excised\`, \`removed\`, \`extraction\`, \`lifted\`, \`puckered\`) the test asserts. When the renderer picked it, the test failed legitimately.

The test's contract (\"every harvested-stage template must read as extraction prose\") is correct; the broken template was the bug.

## Changes
- \`world/medical/wounds/messages/harvested.py\`:
  - Old-stage template #3: \`used to sit inside\` → \`was extracted from\`.
  - Fresh-stage template #3: same defensive fix (\`used to sit inside\` → \`was lifted free from\`).
- \`world/tests/test_wound_descriptions_harvested.py\`:
  - Add \`test_every_template_uses_extraction_vocab\` walking \`WOUND_DESCRIPTIONS\` exhaustively (every stage, every template) so future additions can't reintroduce the bug.
  - Rework \`test_eye_harvest_old_stage_renders_extraction_prose\` to patch \`random.choice\` and walk all 4 old-stage templates in turn — turns a probabilistic test into a deterministic regression guard.

## Tests
- Target file: 5/5 consecutive runs passed (was ~75%).
- Full suite: 1204 passing (was 1203; +1 net new contract test).

Closes #219.