### PR TITLE
Surface harvested/severed item condition in look output (#221)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -2077,9 +2077,24 @@ into the look output naturally — no custom override required.  A
 freshly harvested heart reads:
 
 ```
+|gPristine.|n
+
 A dense, dark-red heart, its muscle firm and the great vessels
 stumped cleanly above.
 ```
+
+Issue #221 added the colour-coded `|gPristine.|n` tagline that leads
+the description.  The tagline (pristine = green, damaged = yellow,
+putrid = red, desiccated = bright red) explicitly surfaces the
+freshness state that issue #212 deliberately stripped from the item
+key — keys now carry species + decay-tier information, the tagline
+carries condition.  The `format_condition_tagline` /
+`prepend_condition_to_desc` helpers live in
+`world/anatomy/conditions.py` and are shared between
+`configure_from_harvest` (organs) and `configure_from_sever`
+(appendages, including severed heads) so both surfaces render
+identically.  The `refuse` condition (gameplay-internal skeletal-stage
+harvest gate) renders empty so the term never leaks to players.
 
 > **Historical note (PR-G → PR #204):** the original PR-G shipped
 > with an `Organ.return_appearance` override that prepended prose to

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1032,6 +1032,7 @@ class Organ(Item):
         from world.anatomy import (
             get_organ_default_description,
             get_species_organ_name,
+            prepend_condition_to_desc,
         )
 
         self.db.organ_name = organ_name
@@ -1053,11 +1054,19 @@ class Organ(Item):
         self.key = get_species_organ_name(species, organ_name, decay_stage)
         # PR #204: populate db.desc the Evennia-standard way so the
         # engine renderer handles it (rather than overriding
-        # return_appearance to prepend prose).  Conditional: leave the
-        # engine default in place when no prose is registered.
+        # return_appearance to prepend prose).
+        #
+        # Issue #221: prepend a colour-coded condition tagline so the
+        # look output explicitly surfaces the freshness state the key
+        # intentionally dropped in issue #212.  ``prepend_condition_to_desc``
+        # composes a final desc that blends the tagline above the prose;
+        # when neither tagline nor prose is registered (e.g. ``refuse``
+        # condition with no registered prose) the helper returns ``""``
+        # and we leave the engine default in place.
         prose = get_organ_default_description(organ_name, condition)
-        if prose:
-            self.db.desc = prose
+        composed = prepend_condition_to_desc(condition, prose)
+        if composed:
+            self.db.desc = composed
 
 
 class Appendage(Item):
@@ -1138,12 +1147,17 @@ class Appendage(Item):
         # engine renderer handles it.  ``Appendage.return_appearance``
         # still composes wound + longdesc carry-forward dynamically on
         # top of the engine-rendered base (which now includes our
-        # seeded desc), so both surfaces coexist cleanly.  Conditional:
-        # leave the engine default in place when no prose is registered.
-        from world.anatomy import get_severed_part_description
+        # seeded desc), so both surfaces coexist cleanly.
+        #
+        # Issue #221: prepend a colour-coded condition tagline so the
+        # look output explicitly surfaces the freshness state.  The
+        # tagline travels in ``db.desc`` so the dynamic wound /
+        # longdesc composition below still rides on top cleanly.
+        from world.anatomy import get_severed_part_description, prepend_condition_to_desc
         prose = get_severed_part_description(species, location_name, condition)
-        if prose:
-            self.db.desc = prose
+        composed = prepend_condition_to_desc(condition, prose)
+        if composed:
+            self.db.desc = composed
         # PR #198: pull this location's wound + longdesc prose off the
         # corpse onto ourselves.  The corpse-side mutation
         # (delete-from-source + synthesized stump wound) is handled by

--- a/world/anatomy/__init__.py
+++ b/world/anatomy/__init__.py
@@ -19,8 +19,14 @@ Public surface:
 * :data:`world.anatomy.organs.ORGAN_DISPLAY`
 * :func:`world.anatomy.organs.get_organ_display_name`
 * :func:`world.anatomy.organs.get_organ_default_description`
+* :func:`world.anatomy.conditions.format_condition_tagline`
+* :func:`world.anatomy.conditions.prepend_condition_to_desc`
 """
 
+from .conditions import (
+    format_condition_tagline,
+    prepend_condition_to_desc,
+)
 from .organs import (
     ORGAN_DISPLAY,
     get_organ_default_description,
@@ -42,6 +48,7 @@ __all__ = (
     "ORGAN_DISPLAY",
     "SEVERED_PART_DESCRIPTIONS",
     "SPECIES_DEFINITIONS",
+    "format_condition_tagline",
     "get_organ_default_description",
     "get_organ_display_name",
     "get_severed_part_description",
@@ -49,4 +56,5 @@ __all__ = (
     "get_species_location_display",
     "get_species_organ_name",
     "get_species_part_name",
+    "prepend_condition_to_desc",
 )

--- a/world/anatomy/conditions.py
+++ b/world/anatomy/conditions.py
@@ -1,0 +1,86 @@
+"""Freshness-condition presentation helpers (issue #221).
+
+Centralises the colour-coded tagline that surfaces an item's
+freshness condition (``pristine`` / ``damaged`` / ``putrid`` /
+``desiccated``) at the top of its ``look`` output.
+
+Design notes
+============
+
+* **Single source of truth**: both :class:`typeclasses.items.Organ`
+  and :class:`typeclasses.items.Appendage` consume this helper at
+  ``configure_from_harvest`` / ``configure_from_sever`` time so the
+  tagline travels in ``self.db.desc`` and the engine renderer slots
+  it in naturally (AGENTS.md "populate ``db.desc`` the Evennia-
+  standard way" contract; cf. PR #204).
+
+* **Decoupled from key composition**: the condition word was removed
+  from the item key in issue #212 (keys now carry species + decay
+  tier).  This helper surfaces the condition information that the
+  key intentionally dropped.
+
+* **Defensive empty for unknown / refuse**: callers prepend the
+  helper's output unconditionally; an empty string means "no
+  tagline" and the engine renderer falls through to the prose
+  alone.  ``refuse`` is the gameplay-internal condition for
+  skeletal-stage harvest (refused at the command gate), so leaking
+  the term would be a UX bug.
+"""
+
+from __future__ import annotations
+
+#: Condition → ANSI-colour-coded capitalised tagline.  Used as a
+#: blends-into-description prefix line in ``db.desc``.
+_CONDITION_TAGLINES = {
+    "pristine": "|gPristine.|n",
+    "damaged": "|yDamaged.|n",
+    "putrid": "|rPutrid.|n",
+    "desiccated": "|RDesiccated.|n",
+}
+
+
+def format_condition_tagline(condition: str | None) -> str:
+    """Return a coloured, capitalised tagline for the given condition.
+
+    Args:
+        condition: One of ``pristine`` / ``damaged`` / ``putrid`` /
+            ``desiccated``.  ``None``, empty, ``refuse``, or any
+            unregistered condition returns an empty string so callers
+            can prepend the output unconditionally without leaking
+            internal vocabulary.
+
+    Returns:
+        The coloured tagline (e.g. ``"|gPristine.|n"``) or ``""``.
+    """
+    if not condition:
+        return ""
+    return _CONDITION_TAGLINES.get(condition, "")
+
+
+def prepend_condition_to_desc(condition: str | None, desc: str | None) -> str:
+    """Compose a final ``db.desc`` value with a condition tagline prefix.
+
+    Centralised so both :class:`typeclasses.items.Organ` and
+    :class:`typeclasses.items.Appendage` produce identical formatting
+    (single blank line between tagline and prose, no trailing
+    whitespace).
+
+    Args:
+        condition: Freshness condition identifier.
+        desc: The base prose description, typically from
+            :func:`world.anatomy.organs.get_organ_default_description`
+            or :func:`world.anatomy.severed_parts.get_severed_part_description`.
+            May be empty / ``None`` when no prose is registered.
+
+    Returns:
+        ``"{tagline}\\n\\n{desc}"`` when both are present; ``tagline``
+        alone when prose is empty; ``desc`` alone when the condition
+        has no tagline; ``""`` when both are empty.
+    """
+    tagline = format_condition_tagline(condition)
+    body = desc or ""
+    if tagline and body:
+        return f"{tagline}\n\n{body}"
+    if tagline:
+        return tagline
+    return body

--- a/world/tests/test_condition_tagline.py
+++ b/world/tests/test_condition_tagline.py
@@ -1,0 +1,92 @@
+"""Tests for the condition-tagline helper (issue #221).
+
+Covers :mod:`world.anatomy.conditions` — the small helper module that
+formats the colour-coded freshness tagline shown atop a harvested
+organ or severed appendage's ``look`` output.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.anatomy import (
+    format_condition_tagline,
+    prepend_condition_to_desc,
+)
+
+
+class TestFormatConditionTagline(TestCase):
+    """Tagline rendering for each recognised condition."""
+
+    def test_pristine_renders_green(self):
+        self.assertEqual(format_condition_tagline("pristine"), "|gPristine.|n")
+
+    def test_damaged_renders_yellow(self):
+        self.assertEqual(format_condition_tagline("damaged"), "|yDamaged.|n")
+
+    def test_putrid_renders_red(self):
+        self.assertEqual(format_condition_tagline("putrid"), "|rPutrid.|n")
+
+    def test_desiccated_renders_bright_red(self):
+        self.assertEqual(
+            format_condition_tagline("desiccated"), "|RDesiccated.|n"
+        )
+
+    def test_refuse_renders_empty(self):
+        # ``refuse`` is the gameplay-internal skeletal-stage harvest
+        # condition; leaking the term in look output would be a UX bug.
+        self.assertEqual(format_condition_tagline("refuse"), "")
+
+    def test_none_renders_empty(self):
+        self.assertEqual(format_condition_tagline(None), "")
+
+    def test_empty_string_renders_empty(self):
+        self.assertEqual(format_condition_tagline(""), "")
+
+    def test_unknown_condition_renders_empty(self):
+        self.assertEqual(format_condition_tagline("phlegmatic"), "")
+
+
+class TestPrependConditionToDesc(TestCase):
+    """Composition rules for ``{tagline}\\n\\n{desc}``."""
+
+    def test_tagline_and_desc_compose_with_blank_line(self):
+        result = prepend_condition_to_desc(
+            "pristine", "A fresh human heart, glistening."
+        )
+        self.assertEqual(
+            result, "|gPristine.|n\n\nA fresh human heart, glistening."
+        )
+
+    def test_tagline_only_when_desc_empty(self):
+        self.assertEqual(
+            prepend_condition_to_desc("damaged", ""), "|yDamaged.|n"
+        )
+
+    def test_tagline_only_when_desc_none(self):
+        self.assertEqual(
+            prepend_condition_to_desc("damaged", None), "|yDamaged.|n"
+        )
+
+    def test_desc_only_when_condition_has_no_tagline(self):
+        # ``refuse`` / unknown conditions yield no tagline — caller's
+        # prose passes through unchanged.
+        self.assertEqual(
+            prepend_condition_to_desc("refuse", "A withered remnant."),
+            "A withered remnant.",
+        )
+
+    def test_empty_when_both_inputs_empty(self):
+        self.assertEqual(prepend_condition_to_desc("refuse", ""), "")
+        self.assertEqual(prepend_condition_to_desc(None, None), "")
+        self.assertEqual(prepend_condition_to_desc("", ""), "")
+
+    def test_all_four_conditions_round_trip(self):
+        # Exhaustive contract: every recognised condition produces a
+        # non-empty composed result when paired with prose.
+        for condition in ("pristine", "damaged", "putrid", "desiccated"):
+            with self.subTest(condition=condition):
+                result = prepend_condition_to_desc(condition, "Body part.")
+                self.assertIn("Body part.", result)
+                self.assertTrue(result.startswith("|"))
+                self.assertIn("\n\n", result)

--- a/world/tests/test_organ_display.py
+++ b/world/tests/test_organ_display.py
@@ -152,6 +152,8 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         )
         self.assertTrue(organ.db.desc)
         self.assertIn("heart", organ.db.desc.lower())
+        # Issue #221: condition tagline prepended above the prose.
+        self.assertTrue(organ.db.desc.startswith("|gPristine.|n"))
 
     def test_damaged_condition_uses_damaged_prose(self):
         organ = self._fake_organ()
@@ -162,6 +164,8 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         self.assertTrue(organ.db.desc)
         # Damaged prose typically signals decay-onset vocabulary.
         self.assertIn("liver", organ.db.desc.lower())
+        # Issue #221: yellow ``damaged`` tagline leads the desc.
+        self.assertTrue(organ.db.desc.startswith("|yDamaged.|n"))
 
     def test_putrid_condition_uses_putrid_prose(self):
         organ = self._fake_organ()
@@ -171,6 +175,8 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         )
         self.assertTrue(organ.db.desc)
         self.assertIn("brain", organ.db.desc.lower())
+        # Issue #221: red ``putrid`` tagline leads the desc.
+        self.assertTrue(organ.db.desc.startswith("|rPutrid.|n"))
 
     def test_unknown_organ_leaves_desc_untouched(self):
         organ = self._fake_organ()
@@ -178,9 +184,10 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
             organ_name="flux_capacitor", condition="pristine",
             corpse=self._fake_corpse(),
         )
-        # Falls through to engine default — we do NOT set an empty
-        # string, so the original ``None`` survives.
-        self.assertIsNone(organ.db.desc)
+        # Issue #221: even when no prose is registered, the condition
+        # tagline still surfaces so the player gets *some* freshness
+        # signal in the look output (the tagline alone is meaningful).
+        self.assertEqual(organ.db.desc, "|gPristine.|n")
 
     def test_refuse_condition_leaves_desc_untouched(self):
         organ = self._fake_organ()
@@ -188,7 +195,9 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
             organ_name="heart", condition="refuse",
             corpse=self._fake_corpse(),
         )
-        # ``refuse`` has no registered prose; preserve engine default.
+        # ``refuse`` has no registered prose AND no tagline (issue #221:
+        # defensive empty for gameplay-internal conditions); preserve
+        # engine default.
         self.assertIsNone(organ.db.desc)
 
     def test_key_still_assigned_alongside_desc(self):

--- a/world/tests/test_severed_part_descriptions.py
+++ b/world/tests/test_severed_part_descriptions.py
@@ -149,6 +149,8 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("left arm", app.db.desc.lower())
+        # Issue #221: condition tagline leads the desc.
+        self.assertTrue(app.db.desc.startswith("|gPristine.|n"))
 
     def test_damaged_right_thigh_populates_desc(self):
         app = self._fake_appendage()
@@ -158,6 +160,7 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("right thigh", app.db.desc.lower())
+        self.assertTrue(app.db.desc.startswith("|yDamaged.|n"))
 
     def test_putrid_head_populates_desc(self):
         app = self._fake_appendage()
@@ -167,6 +170,7 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("head", app.db.desc.lower())
+        self.assertTrue(app.db.desc.startswith("|rPutrid.|n"))
 
     def test_unknown_location_leaves_desc_untouched(self):
         app = self._fake_appendage()
@@ -174,8 +178,9 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
             location_name="tentacle", condition="pristine",
             corpse=self._fake_corpse(),
         )
-        # No registered prose → engine default preserved.
-        self.assertIsNone(app.db.desc)
+        # Issue #221: even without registered prose, the condition
+        # tagline alone surfaces — a meaningful freshness signal.
+        self.assertEqual(app.db.desc, "|gPristine.|n")
 
     def test_key_still_assigned_alongside_desc(self):
         # Regression guard for the species-aware key path.


### PR DESCRIPTION
## Summary
- Prepend a colour-coded condition tagline to ``db.desc`` at ``configure_from_harvest`` / ``configure_from_sever`` time so the look output explicitly conveys the freshness state that issue #212 deliberately stripped from item keys.
- New shared helper ``world/anatomy/conditions.py`` keeps ``Organ`` and ``Appendage`` rendering identical.
- ``refuse`` condition (gameplay-internal harvest gate) renders empty — never leaks to players.

## Render
| Condition | Tagline |
|---|---|
| pristine | ``|gPristine.|n`` |
| damaged  | ``|yDamaged.|n`` |
| putrid   | ``|rPutrid.|n`` |
| desiccated | ``|RDesiccated.|n`` |
| refuse / unknown | (empty) |

A pristine heart now reads:

```
|gPristine.|n

A dense, dark-red heart, its muscle firm and the great vessels
stumped cleanly above.
```

## Tests
- New ``test_condition_tagline.py``: helper unit tests (14 cases).
- Updated ``test_organ_display.py`` / ``test_severed_part_descriptions.py``: ``configure_from_*`` integration tests now assert tagline prefix.
- Full suite: **1218 passing** (+14, no regressions).

Closes #221