### PR TITLE
Reformat look-condition tagline as plain sentence (#223)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -2077,24 +2077,24 @@ into the look output naturally — no custom override required.  A
 freshly harvested heart reads:
 
 ```
-|gPristine.|n
-
+It is a pristine specimen.
 A dense, dark-red heart, its muscle firm and the great vessels
 stumped cleanly above.
 ```
 
-Issue #221 added the colour-coded `|gPristine.|n` tagline that leads
-the description.  The tagline (pristine = green, damaged = yellow,
-putrid = red, desiccated = bright red) explicitly surfaces the
-freshness state that issue #212 deliberately stripped from the item
-key — keys now carry species + decay-tier information, the tagline
-carries condition.  The `format_condition_tagline` /
-`prepend_condition_to_desc` helpers live in
-`world/anatomy/conditions.py` and are shared between
+Issue #221 added the leading condition sentence (`"It is a {pristine
+| damaged | putrid | desiccated} specimen."`) that surfaces the
+freshness state stripped from the item key in issue #212.  Issue
+#223 then simplified the original colour-coded standalone tagline
+(`|gPristine.|n` + blank line) to the current plain-sentence form so
+the prefix blends into the description as a single logical paragraph
+rather than reading as two visual blocks.  The
+`format_condition_tagline` / `prepend_condition_to_desc` helpers
+live in `world/anatomy/conditions.py` and are shared between
 `configure_from_harvest` (organs) and `configure_from_sever`
 (appendages, including severed heads) so both surfaces render
-identically.  The `refuse` condition (gameplay-internal skeletal-stage
-harvest gate) renders empty so the term never leaks to players.
+identically.  The `refuse` condition (gameplay-internal skeletal-
+stage harvest gate) renders empty so the term never leaks to players.
 
 > **Historical note (PR-G → PR #204):** the original PR-G shipped
 > with an `Organ.return_appearance` override that prepended prose to

--- a/world/anatomy/conditions.py
+++ b/world/anatomy/conditions.py
@@ -1,8 +1,8 @@
-"""Freshness-condition presentation helpers (issue #221).
+"""Freshness-condition presentation helpers (issue #221, #223).
 
-Centralises the colour-coded tagline that surfaces an item's
-freshness condition (``pristine`` / ``damaged`` / ``putrid`` /
-``desiccated``) at the top of its ``look`` output.
+Centralises the condition sentence prepended to an item's
+``db.desc`` so the ``look`` output explicitly conveys the freshness
+state (``pristine`` / ``damaged`` / ``putrid`` / ``desiccated``).
 
 Design notes
 ============
@@ -10,7 +10,7 @@ Design notes
 * **Single source of truth**: both :class:`typeclasses.items.Organ`
   and :class:`typeclasses.items.Appendage` consume this helper at
   ``configure_from_harvest`` / ``configure_from_sever`` time so the
-  tagline travels in ``self.db.desc`` and the engine renderer slots
+  sentence travels in ``self.db.desc`` and the engine renderer slots
   it in naturally (AGENTS.md "populate ``db.desc`` the Evennia-
   standard way" contract; cf. PR #204).
 
@@ -19,9 +19,17 @@ Design notes
   tier).  This helper surfaces the condition information that the
   key intentionally dropped.
 
+* **Plain sentence form** (issue #223): the original #221 cut used a
+  colour-coded standalone tagline (``|gPristine.|n``) separated from
+  the prose by a blank line.  In practice that read as two distinct
+  blocks rather than one description.  The replacement is a single
+  uniform sentence (``"It is a pristine specimen."``) on the line
+  immediately above the prose — one logical paragraph, no colour
+  codes, no blank-line break.
+
 * **Defensive empty for unknown / refuse**: callers prepend the
   helper's output unconditionally; an empty string means "no
-  tagline" and the engine renderer falls through to the prose
+  sentence" and the engine renderer falls through to the prose
   alone.  ``refuse`` is the gameplay-internal condition for
   skeletal-stage harvest (refused at the command gate), so leaking
   the term would be a UX bug.
@@ -29,18 +37,19 @@ Design notes
 
 from __future__ import annotations
 
-#: Condition → ANSI-colour-coded capitalised tagline.  Used as a
-#: blends-into-description prefix line in ``db.desc``.
-_CONDITION_TAGLINES = {
-    "pristine": "|gPristine.|n",
-    "damaged": "|yDamaged.|n",
-    "putrid": "|rPutrid.|n",
-    "desiccated": "|RDesiccated.|n",
-}
+#: Set of condition identifiers the helper recognises.  Any other
+#: value (``None``, ``""``, ``"refuse"``, ``"phlegmatic"``, ...)
+#: yields an empty sentence.  Kept as a frozenset rather than an
+#: explicit per-condition mapping because the rendered sentence is
+#: now purely formulaic — ``"It is a {condition} specimen."`` — so a
+#: dict would just duplicate the keys.
+_RECOGNISED_CONDITIONS = frozenset(
+    {"pristine", "damaged", "putrid", "desiccated"}
+)
 
 
 def format_condition_tagline(condition: str | None) -> str:
-    """Return a coloured, capitalised tagline for the given condition.
+    """Return a plain condition sentence for the given freshness state.
 
     Args:
         condition: One of ``pristine`` / ``damaged`` / ``putrid`` /
@@ -50,20 +59,20 @@ def format_condition_tagline(condition: str | None) -> str:
             internal vocabulary.
 
     Returns:
-        The coloured tagline (e.g. ``"|gPristine.|n"``) or ``""``.
+        The sentence (e.g. ``"It is a pristine specimen."``) or ``""``.
     """
-    if not condition:
+    if not condition or condition not in _RECOGNISED_CONDITIONS:
         return ""
-    return _CONDITION_TAGLINES.get(condition, "")
+    return f"It is a {condition} specimen."
 
 
 def prepend_condition_to_desc(condition: str | None, desc: str | None) -> str:
-    """Compose a final ``db.desc`` value with a condition tagline prefix.
+    """Compose a final ``db.desc`` value with a condition sentence prefix.
 
     Centralised so both :class:`typeclasses.items.Organ` and
     :class:`typeclasses.items.Appendage` produce identical formatting
-    (single blank line between tagline and prose, no trailing
-    whitespace).
+    (sentence on its own line directly above the prose, no blank-line
+    separation, no trailing whitespace).
 
     Args:
         condition: Freshness condition identifier.
@@ -73,14 +82,14 @@ def prepend_condition_to_desc(condition: str | None, desc: str | None) -> str:
             May be empty / ``None`` when no prose is registered.
 
     Returns:
-        ``"{tagline}\\n\\n{desc}"`` when both are present; ``tagline``
+        ``"{sentence}\\n{desc}"`` when both are present; ``sentence``
         alone when prose is empty; ``desc`` alone when the condition
-        has no tagline; ``""`` when both are empty.
+        has no sentence; ``""`` when both are empty.
     """
-    tagline = format_condition_tagline(condition)
+    sentence = format_condition_tagline(condition)
     body = desc or ""
-    if tagline and body:
-        return f"{tagline}\n\n{body}"
-    if tagline:
-        return tagline
+    if sentence and body:
+        return f"{sentence}\n{body}"
+    if sentence:
+        return sentence
     return body

--- a/world/tests/test_condition_tagline.py
+++ b/world/tests/test_condition_tagline.py
@@ -1,8 +1,8 @@
-"""Tests for the condition-tagline helper (issue #221).
+"""Tests for the condition-sentence helper (issue #221 / #223).
 
 Covers :mod:`world.anatomy.conditions` — the small helper module that
-formats the colour-coded freshness tagline shown atop a harvested
-organ or severed appendage's ``look`` output.
+formats the plain freshness sentence prepended to a harvested organ
+or severed appendage's ``look`` output.
 """
 
 from __future__ import annotations
@@ -16,20 +16,30 @@ from world.anatomy import (
 
 
 class TestFormatConditionTagline(TestCase):
-    """Tagline rendering for each recognised condition."""
+    """Sentence rendering for each recognised condition."""
 
-    def test_pristine_renders_green(self):
-        self.assertEqual(format_condition_tagline("pristine"), "|gPristine.|n")
-
-    def test_damaged_renders_yellow(self):
-        self.assertEqual(format_condition_tagline("damaged"), "|yDamaged.|n")
-
-    def test_putrid_renders_red(self):
-        self.assertEqual(format_condition_tagline("putrid"), "|rPutrid.|n")
-
-    def test_desiccated_renders_bright_red(self):
+    def test_pristine_sentence(self):
         self.assertEqual(
-            format_condition_tagline("desiccated"), "|RDesiccated.|n"
+            format_condition_tagline("pristine"),
+            "It is a pristine specimen.",
+        )
+
+    def test_damaged_sentence(self):
+        self.assertEqual(
+            format_condition_tagline("damaged"),
+            "It is a damaged specimen.",
+        )
+
+    def test_putrid_sentence(self):
+        self.assertEqual(
+            format_condition_tagline("putrid"),
+            "It is a putrid specimen.",
+        )
+
+    def test_desiccated_sentence(self):
+        self.assertEqual(
+            format_condition_tagline("desiccated"),
+            "It is a desiccated specimen.",
         )
 
     def test_refuse_renders_empty(self):
@@ -46,30 +56,48 @@ class TestFormatConditionTagline(TestCase):
     def test_unknown_condition_renders_empty(self):
         self.assertEqual(format_condition_tagline("phlegmatic"), "")
 
+    def test_no_ansi_colour_codes(self):
+        # Issue #223 regression guard: the original #221 cut wrapped
+        # the tagline in |g / |y / |r / |R colour codes which read as
+        # a separate UI block.  The plain-sentence form must stay
+        # free of ANSI escapes so it blends into the description.
+        for condition in ("pristine", "damaged", "putrid", "desiccated"):
+            with self.subTest(condition=condition):
+                self.assertNotIn("|", format_condition_tagline(condition))
+
 
 class TestPrependConditionToDesc(TestCase):
-    """Composition rules for ``{tagline}\\n\\n{desc}``."""
+    """Composition rules for ``{sentence}\\n{desc}`` (no blank-line gap)."""
 
-    def test_tagline_and_desc_compose_with_blank_line(self):
+    def test_sentence_and_desc_compose_with_single_newline(self):
         result = prepend_condition_to_desc(
             "pristine", "A fresh human heart, glistening."
         )
         self.assertEqual(
-            result, "|gPristine.|n\n\nA fresh human heart, glistening."
+            result,
+            "It is a pristine specimen.\nA fresh human heart, glistening.",
         )
 
-    def test_tagline_only_when_desc_empty(self):
+    def test_no_blank_line_between_sentence_and_prose(self):
+        # Issue #223 regression guard: the original #221 cut used
+        # ``\n\n`` which rendered as a visual paragraph break.
+        result = prepend_condition_to_desc("damaged", "Some prose.")
+        self.assertNotIn("\n\n", result)
+
+    def test_sentence_only_when_desc_empty(self):
         self.assertEqual(
-            prepend_condition_to_desc("damaged", ""), "|yDamaged.|n"
+            prepend_condition_to_desc("damaged", ""),
+            "It is a damaged specimen.",
         )
 
-    def test_tagline_only_when_desc_none(self):
+    def test_sentence_only_when_desc_none(self):
         self.assertEqual(
-            prepend_condition_to_desc("damaged", None), "|yDamaged.|n"
+            prepend_condition_to_desc("damaged", None),
+            "It is a damaged specimen.",
         )
 
-    def test_desc_only_when_condition_has_no_tagline(self):
-        # ``refuse`` / unknown conditions yield no tagline — caller's
+    def test_desc_only_when_condition_has_no_sentence(self):
+        # ``refuse`` / unknown conditions yield no sentence — caller's
         # prose passes through unchanged.
         self.assertEqual(
             prepend_condition_to_desc("refuse", "A withered remnant."),
@@ -83,10 +111,11 @@ class TestPrependConditionToDesc(TestCase):
 
     def test_all_four_conditions_round_trip(self):
         # Exhaustive contract: every recognised condition produces a
-        # non-empty composed result when paired with prose.
+        # non-empty composed result when paired with prose, with the
+        # sentence leading and the prose following on the next line.
         for condition in ("pristine", "damaged", "putrid", "desiccated"):
             with self.subTest(condition=condition):
                 result = prepend_condition_to_desc(condition, "Body part.")
                 self.assertIn("Body part.", result)
-                self.assertTrue(result.startswith("|"))
-                self.assertIn("\n\n", result)
+                self.assertTrue(result.startswith("It is a "))
+                self.assertIn(" specimen.\n", result)

--- a/world/tests/test_organ_display.py
+++ b/world/tests/test_organ_display.py
@@ -152,8 +152,11 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         )
         self.assertTrue(organ.db.desc)
         self.assertIn("heart", organ.db.desc.lower())
-        # Issue #221: condition tagline prepended above the prose.
-        self.assertTrue(organ.db.desc.startswith("|gPristine.|n"))
+        # Issue #221 / #223: plain condition sentence prepended above
+        # the prose, single newline (no blank-line gap).
+        self.assertTrue(
+            organ.db.desc.startswith("It is a pristine specimen.\n")
+        )
 
     def test_damaged_condition_uses_damaged_prose(self):
         organ = self._fake_organ()
@@ -164,8 +167,9 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         self.assertTrue(organ.db.desc)
         # Damaged prose typically signals decay-onset vocabulary.
         self.assertIn("liver", organ.db.desc.lower())
-        # Issue #221: yellow ``damaged`` tagline leads the desc.
-        self.assertTrue(organ.db.desc.startswith("|yDamaged.|n"))
+        self.assertTrue(
+            organ.db.desc.startswith("It is a damaged specimen.\n")
+        )
 
     def test_putrid_condition_uses_putrid_prose(self):
         organ = self._fake_organ()
@@ -175,8 +179,9 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         )
         self.assertTrue(organ.db.desc)
         self.assertIn("brain", organ.db.desc.lower())
-        # Issue #221: red ``putrid`` tagline leads the desc.
-        self.assertTrue(organ.db.desc.startswith("|rPutrid.|n"))
+        self.assertTrue(
+            organ.db.desc.startswith("It is a putrid specimen.\n")
+        )
 
     def test_unknown_organ_leaves_desc_untouched(self):
         organ = self._fake_organ()
@@ -185,9 +190,9 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
             corpse=self._fake_corpse(),
         )
         # Issue #221: even when no prose is registered, the condition
-        # tagline still surfaces so the player gets *some* freshness
-        # signal in the look output (the tagline alone is meaningful).
-        self.assertEqual(organ.db.desc, "|gPristine.|n")
+        # sentence alone surfaces so the player gets *some* freshness
+        # signal in the look output.
+        self.assertEqual(organ.db.desc, "It is a pristine specimen.")
 
     def test_refuse_condition_leaves_desc_untouched(self):
         organ = self._fake_organ()
@@ -195,7 +200,7 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
             organ_name="heart", condition="refuse",
             corpse=self._fake_corpse(),
         )
-        # ``refuse`` has no registered prose AND no tagline (issue #221:
+        # ``refuse`` has no registered prose AND no sentence (issue #221:
         # defensive empty for gameplay-internal conditions); preserve
         # engine default.
         self.assertIsNone(organ.db.desc)

--- a/world/tests/test_severed_part_descriptions.py
+++ b/world/tests/test_severed_part_descriptions.py
@@ -149,8 +149,10 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("left arm", app.db.desc.lower())
-        # Issue #221: condition tagline leads the desc.
-        self.assertTrue(app.db.desc.startswith("|gPristine.|n"))
+        # Issue #221 / #223: plain condition sentence leads the desc.
+        self.assertTrue(
+            app.db.desc.startswith("It is a pristine specimen.\n")
+        )
 
     def test_damaged_right_thigh_populates_desc(self):
         app = self._fake_appendage()
@@ -160,7 +162,9 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("right thigh", app.db.desc.lower())
-        self.assertTrue(app.db.desc.startswith("|yDamaged.|n"))
+        self.assertTrue(
+            app.db.desc.startswith("It is a damaged specimen.\n")
+        )
 
     def test_putrid_head_populates_desc(self):
         app = self._fake_appendage()
@@ -170,7 +174,9 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("head", app.db.desc.lower())
-        self.assertTrue(app.db.desc.startswith("|rPutrid.|n"))
+        self.assertTrue(
+            app.db.desc.startswith("It is a putrid specimen.\n")
+        )
 
     def test_unknown_location_leaves_desc_untouched(self):
         app = self._fake_appendage()
@@ -179,8 +185,8 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
             corpse=self._fake_corpse(),
         )
         # Issue #221: even without registered prose, the condition
-        # tagline alone surfaces — a meaningful freshness signal.
-        self.assertEqual(app.db.desc, "|gPristine.|n")
+        # sentence alone surfaces — a meaningful freshness signal.
+        self.assertEqual(app.db.desc, "It is a pristine specimen.")
 
     def test_key_still_assigned_alongside_desc(self):
         # Regression guard for the species-aware key path.


### PR DESCRIPTION
## Summary
- Drop ANSI colour codes and blank-line separation from the freshness tagline shipped in PR #222.
- Replace with a single plain sentence on the line directly above the prose: ``It is a {pristine|damaged|putrid|desiccated} specimen.``
- Single-newline join keeps the prefix in the same visual paragraph as the prose.
- ``refuse`` / unknown conditions still render empty (defensive — gameplay-internal term never leaks).

## Render
Before (PR #222):
\`\`\`
human brain(#2185)
|gPristine.|n

A glistening pinkish-grey mass, folded into intricate gyri and slick with cerebrospinal fluid.
\`\`\`

After (this PR):
\`\`\`
human brain(#2185)
It is a pristine specimen.
A glistening pinkish-grey mass, folded into intricate gyri and slick with cerebrospinal fluid.
\`\`\`

## Tests
- Helper-test file rewritten: 12 cases covering each condition + empty / refuse / unknown.
- Two explicit regression guards: no ANSI ``|`` codes in the sentence, no ``\\n\\n`` blank-line gap in composed output.
- ``test_organ_display.py`` / ``test_severed_part_descriptions.py`` integration assertions updated.
- Full suite: **1220 passing** (no regressions).

Closes #223