### PR TITLE
Join condition sentence to prose with single space (#225)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -2077,19 +2077,19 @@ into the look output naturally — no custom override required.  A
 freshly harvested heart reads:
 
 ```
-It is a pristine specimen.
-A dense, dark-red heart, its muscle firm and the great vessels
-stumped cleanly above.
+It is a pristine specimen. A dense, dark-red heart, its muscle firm
+and the great vessels stumped cleanly above.
 ```
 
 Issue #221 added the leading condition sentence (`"It is a {pristine
 | damaged | putrid | desiccated} specimen."`) that surfaces the
 freshness state stripped from the item key in issue #212.  Issue
-#223 then simplified the original colour-coded standalone tagline
-(`|gPristine.|n` + blank line) to the current plain-sentence form so
-the prefix blends into the description as a single logical paragraph
-rather than reading as two visual blocks.  The
-`format_condition_tagline` / `prepend_condition_to_desc` helpers
+#223 simplified the original colour-coded standalone tagline
+(`|gPristine.|n` + blank line) to the current plain-sentence form,
+and issue #225 then switched the sentence-to-prose join from a
+newline to a single space so the whole description renders as one
+continuous paragraph rather than breaking across two visible lines.
+The `format_condition_tagline` / `prepend_condition_to_desc` helpers
 live in `world/anatomy/conditions.py` and are shared between
 `configure_from_harvest` (organs) and `configure_from_sever`
 (appendages, including severed heads) so both surfaces render

--- a/world/anatomy/conditions.py
+++ b/world/anatomy/conditions.py
@@ -23,9 +23,9 @@ Design notes
   colour-coded standalone tagline (``|gPristine.|n``) separated from
   the prose by a blank line.  In practice that read as two distinct
   blocks rather than one description.  The replacement is a single
-  uniform sentence (``"It is a pristine specimen."``) on the line
-  immediately above the prose — one logical paragraph, no colour
-  codes, no blank-line break.
+  uniform sentence (``"It is a pristine specimen."``) joined to the
+  prose with a single space (issue #225) so the whole description
+  flows as one paragraph rather than two visible lines.
 
 * **Defensive empty for unknown / refuse**: callers prepend the
   helper's output unconditionally; an empty string means "no
@@ -70,9 +70,11 @@ def prepend_condition_to_desc(condition: str | None, desc: str | None) -> str:
     """Compose a final ``db.desc`` value with a condition sentence prefix.
 
     Centralised so both :class:`typeclasses.items.Organ` and
-    :class:`typeclasses.items.Appendage` produce identical formatting
-    (sentence on its own line directly above the prose, no blank-line
-    separation, no trailing whitespace).
+    :class:`typeclasses.items.Appendage` produce identical formatting:
+    sentence joined to the prose with a single space so the whole
+    description renders as one continuous paragraph on a single line
+    (issue #225 — the prior ``"\\n"`` join broke onto two visible
+    lines, which read as two separate blocks).
 
     Args:
         condition: Freshness condition identifier.
@@ -82,14 +84,14 @@ def prepend_condition_to_desc(condition: str | None, desc: str | None) -> str:
             May be empty / ``None`` when no prose is registered.
 
     Returns:
-        ``"{sentence}\\n{desc}"`` when both are present; ``sentence``
+        ``"{sentence} {desc}"`` when both are present; ``sentence``
         alone when prose is empty; ``desc`` alone when the condition
         has no sentence; ``""`` when both are empty.
     """
     sentence = format_condition_tagline(condition)
     body = desc or ""
     if sentence and body:
-        return f"{sentence}\n{body}"
+        return f"{sentence} {body}"
     if sentence:
         return sentence
     return body

--- a/world/tests/test_condition_tagline.py
+++ b/world/tests/test_condition_tagline.py
@@ -67,22 +67,30 @@ class TestFormatConditionTagline(TestCase):
 
 
 class TestPrependConditionToDesc(TestCase):
-    """Composition rules for ``{sentence}\\n{desc}`` (no blank-line gap)."""
+    """Composition rules for ``{sentence} {desc}`` (single-space join)."""
 
-    def test_sentence_and_desc_compose_with_single_newline(self):
+    def test_sentence_and_desc_compose_with_single_space(self):
         result = prepend_condition_to_desc(
             "pristine", "A fresh human heart, glistening."
         )
         self.assertEqual(
             result,
-            "It is a pristine specimen.\nA fresh human heart, glistening.",
+            "It is a pristine specimen. A fresh human heart, glistening.",
         )
 
-    def test_no_blank_line_between_sentence_and_prose(self):
-        # Issue #223 regression guard: the original #221 cut used
-        # ``\n\n`` which rendered as a visual paragraph break.
+    def test_no_newline_between_sentence_and_prose(self):
+        # Issue #225 regression guard: the prior cut joined with ``\n``,
+        # producing two visible lines under the item name.  The composed
+        # output must be a single continuous paragraph.
         result = prepend_condition_to_desc("damaged", "Some prose.")
-        self.assertNotIn("\n\n", result)
+        self.assertNotIn("\n", result)
+
+    def test_no_double_space_between_sentence_and_prose(self):
+        # Defensive: the period belongs to the sentence; the prose
+        # starts with a capital and no leading whitespace.  We must
+        # join with exactly one space.
+        result = prepend_condition_to_desc("putrid", "Some prose.")
+        self.assertNotIn("  ", result)
 
     def test_sentence_only_when_desc_empty(self):
         self.assertEqual(
@@ -111,11 +119,12 @@ class TestPrependConditionToDesc(TestCase):
 
     def test_all_four_conditions_round_trip(self):
         # Exhaustive contract: every recognised condition produces a
-        # non-empty composed result when paired with prose, with the
-        # sentence leading and the prose following on the next line.
+        # non-empty composed result when paired with prose, joined by a
+        # single space into one continuous paragraph.
         for condition in ("pristine", "damaged", "putrid", "desiccated"):
             with self.subTest(condition=condition):
                 result = prepend_condition_to_desc(condition, "Body part.")
                 self.assertIn("Body part.", result)
                 self.assertTrue(result.startswith("It is a "))
-                self.assertIn(" specimen.\n", result)
+                self.assertIn(" specimen. ", result)
+                self.assertNotIn("\n", result)

--- a/world/tests/test_organ_display.py
+++ b/world/tests/test_organ_display.py
@@ -152,10 +152,10 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         )
         self.assertTrue(organ.db.desc)
         self.assertIn("heart", organ.db.desc.lower())
-        # Issue #221 / #223: plain condition sentence prepended above
-        # the prose, single newline (no blank-line gap).
+        # Issue #221 / #223 / #225: plain condition sentence joined to
+        # the prose with a single space (one continuous paragraph).
         self.assertTrue(
-            organ.db.desc.startswith("It is a pristine specimen.\n")
+            organ.db.desc.startswith("It is a pristine specimen. ")
         )
 
     def test_damaged_condition_uses_damaged_prose(self):
@@ -168,7 +168,7 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         # Damaged prose typically signals decay-onset vocabulary.
         self.assertIn("liver", organ.db.desc.lower())
         self.assertTrue(
-            organ.db.desc.startswith("It is a damaged specimen.\n")
+            organ.db.desc.startswith("It is a damaged specimen. ")
         )
 
     def test_putrid_condition_uses_putrid_prose(self):
@@ -180,7 +180,7 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         self.assertTrue(organ.db.desc)
         self.assertIn("brain", organ.db.desc.lower())
         self.assertTrue(
-            organ.db.desc.startswith("It is a putrid specimen.\n")
+            organ.db.desc.startswith("It is a putrid specimen. ")
         )
 
     def test_unknown_organ_leaves_desc_untouched(self):

--- a/world/tests/test_severed_part_descriptions.py
+++ b/world/tests/test_severed_part_descriptions.py
@@ -149,9 +149,10 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("left arm", app.db.desc.lower())
-        # Issue #221 / #223: plain condition sentence leads the desc.
+        # Issue #221 / #223 / #225: plain sentence joined to prose with
+        # a single space (one continuous paragraph).
         self.assertTrue(
-            app.db.desc.startswith("It is a pristine specimen.\n")
+            app.db.desc.startswith("It is a pristine specimen. ")
         )
 
     def test_damaged_right_thigh_populates_desc(self):
@@ -163,7 +164,7 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         self.assertTrue(app.db.desc)
         self.assertIn("right thigh", app.db.desc.lower())
         self.assertTrue(
-            app.db.desc.startswith("It is a damaged specimen.\n")
+            app.db.desc.startswith("It is a damaged specimen. ")
         )
 
     def test_putrid_head_populates_desc(self):
@@ -175,7 +176,7 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         self.assertTrue(app.db.desc)
         self.assertIn("head", app.db.desc.lower())
         self.assertTrue(
-            app.db.desc.startswith("It is a putrid specimen.\n")
+            app.db.desc.startswith("It is a putrid specimen. ")
         )
 
     def test_unknown_location_leaves_desc_untouched(self):


### PR DESCRIPTION
## Summary
- PR #224 joined the freshness sentence to the prose with ``\n``, producing two visible lines under the item name.
- The intended render is one continuous paragraph — sentence and prose concatenated with a single space.
- Updated tests, added regression guards (no newline in composed output, no double-space).
- Spec example block flipped to the single-line form.

## Render
Before:
\`\`\`
human brain(#2185)
It is a pristine specimen.
A glistening pinkish-grey mass, folded into intricate gyri and slick with cerebrospinal fluid.
\`\`\`

After:
\`\`\`
human brain(#2185)
It is a pristine specimen. A glistening pinkish-grey mass, folded into intricate gyri and slick with cerebrospinal fluid.
\`\`\`

## Tests
- 1221 passing (+1 over PR #224 — double-space defensive guard).

Closes #225