### PR TITLE
Render Roman numeral on every sleeve including the first (#50)

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -243,8 +243,9 @@ class CmdStats(Command):
     are shown using standardized classification descriptors (A-Z tiers) for 
     efficient liability assessment.
     
-    File reference includes subject ID and mortality revision count in Roman 
-    numerals. Authorized personnel may access diagnostic numeric values for 
+    File reference includes subject ID. The subject name carries the
+    sleeve iteration as a Roman numeral suffix (e.g. "Laszlo XLIV").
+    Authorized personnel may access diagnostic numeric values for 
     detailed risk evaluation and resource allocation purposes.
     """
 

--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -127,40 +127,44 @@ def generate_random_template():
 
 def build_name_from_death_count(base_name, death_count):
     """
-    Build character name with Roman numeral based on death_count.
-    
-    The death_count is the source of truth - it's incremented at death (at_death()).
-    - death_count = 1: No Roman numeral (original character)
-    - death_count = 2: Roman numeral II (first death/clone)
-    - death_count = 3: Roman numeral III (second death/clone)
-    - etc.
-    
+    Build character display name with Roman numeral based on death_count.
+
+    The death_count is the source of truth — set to 1 at character
+    creation and incremented at death (at_death()). Every sleeve renders
+    with a Roman numeral so the first sleeve is "<name> I", the second
+    is "<name> II", etc.
+
+    - death_count = 1 → "<name> I"   (original sleeve)
+    - death_count = 2 → "<name> II"  (first clone)
+    - death_count = 3 → "<name> III" (second clone)
+
     Examples:
-        ("Brock", 1) → "Brock"
-        ("Brock", 2) → "Brock II"
-        ("Brock", 3) → "Brock III"
+        ("Brock", 1)  → "Brock I"
+        ("Brock", 2)  → "Brock II"
         ("Marcus", 10) → "Marcus X"
-    
+
     Args:
-        base_name (str): Character base name (may include old Roman numeral to strip)
-        death_count (int): Current death_count value
-        
+        base_name (str): Character base name (may include old Roman
+            numeral, which will be stripped).
+        death_count (int | None): Current death_count value. ``None`` or
+            values < 1 fall back to 1 (defensive — covers legacy
+            characters that pre-date the default flip).
+
     Returns:
-        str: Name with appropriate Roman numeral (or none if death_count=1)
+        str: Name with appropriate Roman numeral suffix.
     """
-    # Strip any existing Roman numeral from base_name
+    # Strip any existing Roman numeral from base_name.
     # Only strip if there's whitespace before the Roman numeral to avoid
-    # stripping letters from names like "Drivel" (ends with "L")
+    # stripping letters from names like "Drivel" (ends with "L").
     pattern = r'^(.+?)\s+([IVXLCDM]+)$'
     match = re.match(pattern, base_name.strip(), re.IGNORECASE)
     if match:
         base_name = match.group(1).strip()
-    
-    # Original character (death_count=1) has no Roman numeral
-    if death_count == 1:
-        return base_name
-    
-    # death_count 2+ gets Roman numeral (2=II, 3=III, etc.)
+
+    # Defensive fallback for None / pre-fix legacy values.
+    if death_count is None or death_count < 1:
+        death_count = 1
+
     roman = int_to_roman(death_count)
     return f"{base_name} {roman}"
 
@@ -273,8 +277,12 @@ def create_character_from_template(account, template, sex="ambiguous"):
     # Get spawn location
     start_location = get_start_location()
     
-    # Create full name
-    full_name = f"{template['first_name']} {template['last_name']}"
+    # Create full name with Roman numeral suffix (first sleeve → "I").
+    # death_count defaults to 1 via AttributeProperty; pass it explicitly
+    # because the attribute isn't readable until after create_character.
+    full_name = build_name_from_death_count(
+        f"{template['first_name']} {template['last_name']}", 1
+    )
     
     # Use Evennia's proper character creation method
     char, errors = account.create_character(
@@ -1402,7 +1410,11 @@ def first_char_finalize(caller, raw_string, **kwargs):
     # Get data
     first_name = caller.ndb.charcreate_data.get('first_name', '')
     last_name = caller.ndb.charcreate_data.get('last_name', '')
-    full_name = f"{first_name} {last_name}"
+    # First sleeve renders with Roman numeral "I"; helper is the single
+    # source of truth for display name composition.
+    full_name = build_name_from_death_count(
+        f"{first_name} {last_name}", 1
+    )
     sex = caller.ndb.charcreate_data.get('sex', 'ambiguous')
     height = caller.ndb.charcreate_data.get('height', 'average')
     build = caller.ndb.charcreate_data.get('build', 'average')

--- a/specs/WEB_RESPAWN_CHARACTER_CREATION_SPEC.md
+++ b/specs/WEB_RESPAWN_CHARACTER_CREATION_SPEC.md
@@ -10,7 +10,9 @@ Implement the respawn character creation flow (templates + flash clone) on the D
 - **First character**: Custom stat allocation (300 points across GRIM)
 - **Respawn**: EvMenu with 3 random templates + flash clone option
 - **Flash clone**: Inherits stats, appearance, sex from archived character
-- **Roman numerals**: Auto-appends based on death_count (Jorge Jackson → Jorge Jackson II)
+- **Roman numerals**: Auto-appends based on death_count. Every sleeve
+  carries a Roman numeral suffix — first sleeve renders as `Jorge
+  Jackson I`, first clone as `Jorge Jackson II`, etc. (issue #50).
 
 ### Web Character Creation (web/website/views/characters.py)
 - **Current**: Single Django form for manual character creation

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -64,8 +64,11 @@ class Character(
     is_holographic = AttributeProperty(False, category="shop", autocreate=True)
     tokens = AttributeProperty(0, category="shop", autocreate=True)
     
-    # Death tracking system
-    death_count = AttributeProperty(0, category='mortality', autocreate=True)
+    # Sleeve iteration counter (cosmetic; drives Roman-numeral suffix in
+    # display name). Starts at 1 so first sleeve renders as "<name> I";
+    # incremented in at_death so each subsequent clone advances the numeral.
+    # Player-facing only — not consumed by any combat/identity mechanic.
+    death_count = AttributeProperty(1, category='mortality', autocreate=True)
     
     # Appearance attributes - stored in db but no auto-creation for optional features
     # skintone is set via @skintone command and stored as db.skintone

--- a/world/tests/test_sleeve_naming.py
+++ b/world/tests/test_sleeve_naming.py
@@ -1,0 +1,105 @@
+"""
+Tests for sleeve display-name composition (issue #50).
+
+Covers ``commands.charcreate.build_name_from_death_count`` — the single
+source of truth for rendering a character's display name with a Roman
+numeral suffix that reflects the sleeve iteration (``death_count``).
+
+These are pure-function tests; no Evennia DB fixtures required.
+"""
+
+import unittest
+
+from commands.charcreate import build_name_from_death_count
+
+
+class TestBuildNameFromDeathCount(unittest.TestCase):
+    """Helper renders the Roman numeral suffix correctly across cases."""
+
+    def test_first_sleeve_appends_i(self):
+        """death_count=1 → bare name gets " I" appended."""
+        self.assertEqual(
+            build_name_from_death_count("Brock", 1),
+            "Brock I",
+        )
+
+    def test_second_sleeve_appends_ii(self):
+        """death_count=2 → " II" suffix (first clone)."""
+        self.assertEqual(
+            build_name_from_death_count("Brock", 2),
+            "Brock II",
+        )
+
+    def test_high_death_count_uses_large_numeral(self):
+        """death_count=44 → XLIV suffix (matches user sample)."""
+        self.assertEqual(
+            build_name_from_death_count("Laszlo", 44),
+            "Laszlo XLIV",
+        )
+
+    def test_strips_existing_roman_numeral_before_appending(self):
+        """Existing suffix is stripped so re-application doesn't compound."""
+        self.assertEqual(
+            build_name_from_death_count("Brock III", 4),
+            "Brock IV",
+        )
+
+    def test_preserves_name_ending_in_roman_letter(self):
+        """Names like 'Drivel' (ends in L) are NOT stripped — needs whitespace."""
+        # No whitespace before the trailing "L", so strip regex must skip it.
+        self.assertEqual(
+            build_name_from_death_count("Drivel", 1),
+            "Drivel I",
+        )
+
+    def test_none_death_count_falls_back_to_one(self):
+        """Defensive: None → treat as first sleeve."""
+        self.assertEqual(
+            build_name_from_death_count("Ghost", None),
+            "Ghost I",
+        )
+
+    def test_zero_death_count_falls_back_to_one(self):
+        """Defensive: pre-fix legacy 0 → treat as first sleeve."""
+        self.assertEqual(
+            build_name_from_death_count("Ghost", 0),
+            "Ghost I",
+        )
+
+    def test_negative_death_count_falls_back_to_one(self):
+        """Defensive: <1 → treat as first sleeve."""
+        self.assertEqual(
+            build_name_from_death_count("Ghost", -3),
+            "Ghost I",
+        )
+
+    def test_two_word_name_only_strips_trailing_numeral(self):
+        """First/last name preserved; only trailing numeral stripped."""
+        self.assertEqual(
+            build_name_from_death_count("Marcus Aurelius II", 3),
+            "Marcus Aurelius III",
+        )
+
+
+class TestCharacterDeathCountDefault(unittest.TestCase):
+    """AttributeProperty default is 1 (issue #50)."""
+
+    def test_default_is_one(self):
+        """death_count AttributeProperty default must be 1, not 0."""
+        from typeclasses.characters import Character
+
+        # Inspect the class-level AttributeProperty descriptor.
+        descriptor = Character.__dict__["death_count"]
+        # AttributeProperty stores its default as the first positional arg;
+        # Evennia exposes it as ``_default`` on the descriptor.
+        default = getattr(descriptor, "_default", None)
+        self.assertEqual(
+            default,
+            1,
+            "death_count AttributeProperty default must be 1 so the "
+            "first sleeve renders as '<name> I' (issue #50).",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Flip `death_count` AttributeProperty default `0` → `1` so the first sleeve has a valid iteration counter.
- Drop the `death_count == 1` short-circuit in `build_name_from_death_count` so every sleeve renders with a Roman numeral suffix (first sleeve = `I`).
- Wire the two first-sleeve creation paths (`create_character_from_template`, `first_char_finalize`) through the helper with explicit `death_count=1` (the AttributeProperty isn't readable until after `account.create_character` returns).
- Add defensive `None` / `<1` fallback in the helper so legacy pre-fix characters don't crash rendering.

## Player-facing only
This is a cosmetic naming change. `death_count` is consumed only by:
- the name helper (this PR),
- the welcome-message flavour text in `create_flash_clone`,
- the `Death Count:` line in clone welcome messaging.

No combat, identity, recognition, or sleeve-uid mechanic reads it. Increment logic in `at_death` is unchanged.

## Behaviour change
| Scenario | Before | After |
|---|---|---|
| First sleeve | `Brock` | `Brock I` |
| First clone | `Brock II` | `Brock II` |
| Tenth clone | `Brock XI` | `Brock XI` |
| `score` Subject line | `Brock` (first) / `Brock XLIV` (later) | `Brock I` / `Brock XLIV` (consistent) |

## Migration
Live characters at `death_count = 0` will skip directly to `II` on their first respawn (one-time ghost iteration). Defensive fallback in the helper protects any pre-fix legacy values from rendering crashes.

## CmdStats docstring
Trimmed the misleading claim that the file reference contains the Roman numeral — the numeral lives in the Subject line, which uses `target.key` directly.

## Tests
- New `world/tests/test_sleeve_naming.py` (10 tests):
  - first/second/large-numeral rendering (`I`, `II`, `XLIV`)
  - existing-numeral stripping (`Brock III` + dc=4 → `Brock IV`)
  - non-Roman-letter-name preservation (`Drivel` stays `Drivel`)
  - `None` / `0` / `-3` defensive fallbacks
  - two-word names with trailing numeral
  - `Character.death_count` AttributeProperty `_default == 1` regression
- Full suite: **1236 passing** (was 1226, +10 new, 0 regressions).

## Spec
- `specs/WEB_RESPAWN_CHARACTER_CREATION_SPEC.md`: updated bullet to reflect every-sleeve-numeral behaviour.

Fixes #50.