### PR TITLE
Make corpse `look` a pure read (#230)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1373,6 +1373,7 @@ Corpses already preserve forensic data (original name, dbref, physical descripti
 - Looking at a corpse: investigator sees recognized name or sdesc based on their memory — **shipped**. The corpse's `get_display_name` routes through the observer's recognition memory keyed on the corpse's apparent UID (derived from `sleeve_uid` plus whatever the corpse is still wearing).
 - Worn-item changes on the corpse re-derive the apparent presentation — **shipped** via `at_object_leave` invalidation, so stripping a body changes its signature exactly like stripping a live character.
 - Corpse decay interacts with recognition via the **decay-aware recognition** policy below — **shipped** (PR B).
+- **Pure `look`** (issue #230) — **shipped**. ``Corpse.return_appearance`` is a pure read; it does not write ``db.desc``, ``key``, or aliases. All decay-stage aliases (``corpse``, ``remains``, ``body``, ``human corpse``, ``rotting corpse``, ``skeletal remains``) are pre-seeded at creation by ``_seed_decay_aliases_and_key`` so search/targeting works from t=0 regardless of which stage is current. The corpse's ``key`` is refreshed on stage transitions by ``_refresh_decay_key_if_changed``, invoked from ``Room._check_corpse_decay`` on character entry (a lifecycle event). The staged decay paragraph is computed on the fly by ``_build_decay_desc_paragraph`` and inlined into the look output without persisting. The death-time ``db.desc`` snapshot set in ``death_progression.py`` survives untouched.
 
 #### Decay-Aware Recognition
 

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -79,6 +79,46 @@ class Corpse(IdentityBearerMixin, Item):
             "advanced": 604800, # < 1 week
             "skeletal": float('inf')  # > 1 week
         }
+
+        # Issue #230: pre-populate all decay-stage aliases at creation so
+        # ``target corpse`` / ``harvest organ from rotting corpse`` work
+        # from t=0 regardless of which stage we're currently in.  Aliases
+        # are append-only and stage progression is monotonic, so pre-
+        # adding every stage's name covers the corpse's whole lifetime
+        # without ever needing alias mutation on look.
+        self._seed_decay_aliases_and_key()
+
+    def _seed_decay_aliases_and_key(self):
+        """Set the initial ``key`` and pre-add every decay-stage alias.
+
+        Called once from :meth:`at_object_creation`.  Idempotent — safe
+        to call again from migration tooling if needed.  Combines the
+        stage-independent aliases (``corpse``, ``remains``, ``body``)
+        with the per-stage display names from the species registry so
+        search / targeting works at any stage without on-look mutation.
+        """
+        from world.anatomy import get_species_corpse_name
+
+        species = self.db.species or "human"
+        stage_names = {
+            get_species_corpse_name(species, stage)
+            for stage in ("fresh", "early", "moderate", "advanced", "skeletal")
+        }
+        # Stage-independent aliases — always valid regardless of decay.
+        base_aliases = {"corpse", "remains", "body"}
+        desired = stage_names | base_aliases
+
+        current = set(self.aliases.all())
+        for alias in desired:
+            if alias not in current:
+                self.aliases.add(alias)
+
+        # Initial key: the fresh-stage name.  The room decay check
+        # (see ``_refresh_decay_key_if_changed``) advances this lazily
+        # on character entry as stages transition.
+        fresh_name = get_species_corpse_name(species, "fresh")
+        if self.key != fresh_name:
+            self.key = fresh_name
     
     def get_decay_stage(self):
         """Calculate current decay stage based on time elapsed."""
@@ -592,30 +632,43 @@ class Corpse(IdentityBearerMixin, Item):
         return f"{description}{modifier}"
     
     def return_appearance(self, looker, **kwargs):
-        """Update appearance based on current decay stage when looked at."""
-        # Check for complete decay first
+        """Render the corpse without mutating any persistent state.
+
+        Issue #230: previously this method called
+        ``_update_decay_descriptions`` which wrote ``self.key``,
+        ``self.aliases``, and ``self.db.desc`` on every look — a pure
+        read with persistent side effects.  Aliases and the initial
+        ``key`` are now seeded at creation
+        (:meth:`_seed_decay_aliases_and_key`); ``key`` refresh on stage
+        transition runs from the room's character-entry hook
+        (:meth:`_refresh_decay_key_if_changed`); and the staged decay
+        paragraph is computed on the fly here.  Result: ``look`` is a
+        pure read.
+        """
+        # Lifecycle event (deletes the corpse) — acceptable mutation;
+        # not a "render" side effect.
         if self._handle_complete_decay():
-            return None  # Corpse was destroyed
-            
-        # Update decay-based descriptions just-in-time
-        self._update_decay_descriptions()
-        
-        # Build appearance similar to character with preserved longdesc data
+            return None
+
+        stage = self.get_decay_stage()
+
+        # Build appearance similar to character with preserved longdesc data.
         parts = []
-        
-        # 1. Corpse name and main description (current decay state)
+
+        # 1. Corpse name and main description (computed per current stage).
         name_and_desc = [self.get_display_name(looker)]
-        if self.db.desc:
-            name_and_desc.append(self.db.desc)
+        decay_paragraph = self._build_decay_desc_paragraph(stage)
+        if decay_paragraph:
+            name_and_desc.append(decay_paragraph)
         parts.append('\n'.join(name_and_desc))
-        
-        # 2. Display preserved longdesc data with clothing integration
+
+        # 2. Display preserved longdesc data with clothing integration.
         if self.db.longdesc_data:
             longdesc_descriptions = self._get_preserved_longdesc_descriptions()
             if longdesc_descriptions:
                 formatted_longdesc = self._format_corpse_longdescs(longdesc_descriptions)
                 parts.append(formatted_longdesc)
-        
+
         return '\n\n'.join(parts)
     
     def at_object_receive(self, moved_obj, source_location, **kwargs):
@@ -647,91 +700,67 @@ class Corpse(IdentityBearerMixin, Item):
             if self.db.apparent_uid_at_death is not None:
                 self.db.apparent_uid_at_death = None
     
-    def _update_decay_descriptions(self):
-        """Update descriptions based on current decay stage."""
+    def _build_decay_desc_paragraph(self, stage):
+        """Return the staged decay paragraph for ``stage``.  Pure.
+
+        Issue #230: replaces the old ``_update_decay_descriptions``
+        which wrote ``self.db.desc``.  This helper just *returns* the
+        composed string; ``return_appearance`` slots it into the look
+        output without persisting anything.
+
+        The death-time ``db.desc`` snapshot
+        (``typeclasses/death_progression.py:682``) is preserved untouched
+        for debug / admin / forensic tooling (Option α from the #230
+        design discussion).
+        """
+        base_desc = self.db.physical_description or "A lifeless body."
+        decay_descriptions = {
+            "fresh": (
+                f"A recently deceased human body. {base_desc} "
+                "The body appears fresh, with no signs of decomposition yet visible."
+            ),
+            "early": (
+                f"A pale human corpse. {base_desc} "
+                "The skin has begun to pale and cool, with early signs of "
+                "lividity visible."
+            ),
+            "moderate": (
+                "Decomposing human remains. Bloating and discoloration have "
+                "begun, with a distinct odor of decay. The original features "
+                "are still recognizable but deteriorating."
+            ),
+            "advanced": (
+                "Putrid human remains. Advanced decomposition has set in with "
+                "severe bloating, fluid leakage, and strong putrid odors. "
+                "Identification is becoming difficult."
+            ),
+            "skeletal": (
+                "Skeletal human remains. Only bones, dried tissue, and "
+                "clothing remain. The decomposition process is nearly complete."
+            ),
+        }
+        return decay_descriptions.get(stage, base_desc)
+
+    def _refresh_decay_key_if_changed(self):
+        """Update ``self.key`` if the current decay stage no longer matches.
+
+        Issue #230: called from :meth:`typeclasses.rooms.Room._check_corpse_decay`
+        on character entry — a lifecycle event, NOT from ``look``.  This
+        keeps ``look`` pure while still letting ``@find`` and direct
+        ``self.key`` consumers see the current stage name.
+
+        Aliases are not touched here: every decay-stage alias is
+        pre-seeded at creation by :meth:`_seed_decay_aliases_and_key`,
+        so search/targeting works at any stage regardless of which
+        stage's name is currently in ``key``.
+        """
         from world.anatomy import get_species_corpse_name
 
-        stage = self.get_decay_stage()
-        decay_factor = self.get_decay_factor()
-        
-        # Base physical description
-        base_desc = self.db.physical_description or "A lifeless body."
-
-        # PR-G: derive the player-facing corpse name from the species
-        # registry rather than hardcoded per-stage strings.  This keeps
-        # non-human corpses (when they exist) consistent and lets the
-        # registry own the decay vocabulary in one place.
         species = self.db.species or "human"
+        stage = self.get_decay_stage()
         stage_name = get_species_corpse_name(species, stage)
-
-        # Update the corpse's primary key so glance-level rendering
-        # (room contents, inventory listings) reflects the current
-        # decay tier.  Recognition memory (handled by
-        # IdentityBearerMixin.get_display_name) overrides this when an
-        # observer has assigned a name to the corpse.
         if self.key != stage_name:
             self.key = stage_name
-
-        # Update aliases to include the current decay stage name
-        # Don't use clear() as it wipes out Evennia's multi-match tracking
-        # Instead, get current aliases and add our decay-related ones
-        current_aliases = set(self.aliases.all())
-
-        # Define the aliases we want for this decay stage
-        desired_aliases = {stage_name, "corpse", "remains", "body"}
-
-        # Add any missing aliases
-        for alias in desired_aliases:
-            if alias not in current_aliases:
-                self.aliases.add(alias)
-        
-        # Stage-specific description modifications
-        decay_descriptions = {
-            "fresh": f"A recently deceased human body. {base_desc} "
-                    f"The body appears fresh, with no signs of decomposition yet visible.",
-            
-            "early": f"A pale human corpse. {base_desc} "
-                    f"The skin has begun to pale and cool, with early signs of lividity visible.",
-            
-            "moderate": f"Decomposing human remains. "
-                       f"Bloating and discoloration have begun, with a distinct odor of decay. "
-                       f"The original features are still recognizable but deteriorating.",
-            
-            "advanced": f"Putrid human remains. "
-                       f"Advanced decomposition has set in with severe bloating, fluid leakage, "
-                       f"and strong putrid odors. Identification is becoming difficult.",
-            
-            "skeletal": f"Skeletal human remains. "
-                       f"Only bones, dried tissue, and clothing remain. The decomposition process "
-                       f"is nearly complete."
-        }
-        
-        # Update main description
-        self.db.desc = decay_descriptions.get(stage, base_desc)
-        
-        # Update longdesc if it exists
-        if hasattr(self, 'longdesc') and self.longdesc:
-            self._update_longdesc_for_decay(stage, decay_factor)
-    
-    def _update_longdesc_for_decay(self, stage, decay_factor):
-        """Update longdesc details based on decay stage."""
-        # This would modify specific longdesc body parts based on decay
-        # For now, we'll just add a general decay note
-        if hasattr(self, 'longdesc') and self.longdesc:
-            # Add decay information to longdesc
-            decay_notes = {
-                "fresh": "appears fresh and recently deceased",
-                "early": "shows early signs of decomposition with pale skin",
-                "moderate": "displays moderate decomposition with bloating and discoloration", 
-                "advanced": "exhibits advanced putrefaction with severe decay",
-                "skeletal": "has decomposed to mostly skeletal remains"
-            }
-            
-            decay_note = decay_notes.get(stage, "shows signs of decay")
-            
-            # You could modify specific body parts here based on your longdesc system
-            # For example: modify skin color, add bloating to torso, etc.
-    
     def get_forensic_data(self):
         """Return forensic data for investigation purposes."""
         stage = self.get_decay_stage()

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -82,6 +82,14 @@ class Room(ObjectParent, DefaultRoom):
         
         for corpse in corpses:
             try:
+                # Issue #230: refresh corpse key to current decay stage.
+                # ``look`` is now a pure read; key advancement on stage
+                # transitions runs here, triggered by character entry.
+                try:
+                    corpse._refresh_decay_key_if_changed()
+                except Exception:
+                    pass  # Don't let key refresh block decay cleanup.
+
                 if corpse.check_complete_decay():
                     # Drop items to room
                     for item in list(corpse.contents):

--- a/world/tests/test_corpse_pure_look.py
+++ b/world/tests/test_corpse_pure_look.py
@@ -1,0 +1,222 @@
+"""
+Tests for issue #230: corpse ``look`` must be a pure read.
+
+Pre-#230 behaviour: :meth:`typeclasses.corpse.Corpse.return_appearance`
+called ``_update_decay_descriptions`` which wrote ``self.key``,
+``self.aliases``, and ``self.db.desc`` on every look — a pure read
+with persistent side effects.
+
+Post-#230:
+
+* All decay-stage aliases are pre-seeded at creation by
+  :meth:`Corpse._seed_decay_aliases_and_key` so search/targeting works
+  at t=0 regardless of which stage is current.
+* ``self.key`` advances on stage transitions via
+  :meth:`Corpse._refresh_decay_key_if_changed`, which is invoked from
+  :meth:`typeclasses.rooms.Room._check_corpse_decay` on character entry
+  — a lifecycle event, NOT from ``look``.
+* The staged decay paragraph is computed on the fly by
+  :meth:`Corpse._build_decay_desc_paragraph` and inlined into the
+  ``return_appearance`` output without persisting.
+* The death-time ``db.desc`` snapshot
+  (``death_progression.py:682``) survives untouched (Option α).
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_corpse_pure_look
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from evennia import create_object
+from evennia.utils.test_resources import EvenniaTest
+
+from typeclasses.characters import Character
+from typeclasses.corpse import Corpse
+from typeclasses.death_progression import DeathProgressionScript
+
+
+class TestCorpseLookIsPure(EvenniaTest):
+    """``look`` must not mutate ``db.desc``, ``key``, or aliases."""
+
+    character_typeclass = Character
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.victim = self.char1
+        self.victim.sleeve_uid = "sleeve-pure-look-001"
+        _ = self.victim.medical_state  # trigger lazy init
+        self.script = DeathProgressionScript()
+
+    def _make_corpse(self):
+        return self.script._create_corpse_from_character(self.victim)
+
+    # ------------------------------------------------------------------
+    # Pre-seeded aliases / key (creation-time)
+    # ------------------------------------------------------------------
+
+    def test_all_decay_aliases_present_at_creation(self) -> None:
+        """Every stage's display name + universal aliases exist at t=0."""
+        corpse = self._make_corpse()
+        try:
+            aliases = set(corpse.aliases.all())
+            for required in (
+                "corpse", "remains", "body",
+                "human corpse", "rotting corpse", "skeletal remains",
+            ):
+                self.assertIn(
+                    required,
+                    aliases,
+                    f"alias {required!r} missing at corpse creation",
+                )
+        finally:
+            corpse.delete()
+
+    def test_initial_key_is_fresh_stage(self) -> None:
+        """Newly created corpse's key is the fresh-stage display name."""
+        corpse = self._make_corpse()
+        try:
+            self.assertEqual(corpse.key, "human corpse")
+        finally:
+            corpse.delete()
+
+    # ------------------------------------------------------------------
+    # Look is pure
+    # ------------------------------------------------------------------
+
+    def test_look_does_not_mutate_db_desc(self) -> None:
+        """``return_appearance`` must not write ``db.desc``."""
+        corpse = self._make_corpse()
+        try:
+            before = corpse.db.desc
+            corpse.return_appearance(self.char2)
+            after = corpse.db.desc
+            self.assertEqual(before, after)
+        finally:
+            corpse.delete()
+
+    def test_look_does_not_mutate_key(self) -> None:
+        """``return_appearance`` must not write ``self.key``."""
+        corpse = self._make_corpse()
+        try:
+            before = corpse.key
+            corpse.return_appearance(self.char2)
+            after = corpse.key
+            self.assertEqual(before, after)
+        finally:
+            corpse.delete()
+
+    def test_look_does_not_mutate_aliases(self) -> None:
+        """``return_appearance`` must not add/remove aliases."""
+        corpse = self._make_corpse()
+        try:
+            before = set(corpse.aliases.all())
+            corpse.return_appearance(self.char2)
+            after = set(corpse.aliases.all())
+            self.assertEqual(before, after)
+        finally:
+            corpse.delete()
+
+    def test_death_time_desc_survives_look(self) -> None:
+        """A custom death-time ``db.desc`` must survive multiple looks (Option α)."""
+        corpse = self._make_corpse()
+        try:
+            custom = "The lifeless body of a tall human. They wore scars like armor."
+            corpse.db.desc = custom
+            for _ in range(3):
+                corpse.return_appearance(self.char2)
+            self.assertEqual(corpse.db.desc, custom)
+        finally:
+            corpse.delete()
+
+    # ------------------------------------------------------------------
+    # Staged paragraph rendering (pure compute)
+    # ------------------------------------------------------------------
+
+    def test_staged_paragraph_contains_stage_keyword(self) -> None:
+        """The computed paragraph must mention each stage's signature word."""
+        corpse = self._make_corpse()
+        try:
+            expectations = {
+                "fresh": "fresh",
+                "early": "pale",
+                "moderate": "Decomposing",
+                "advanced": "Putrid",
+                "skeletal": "Skeletal",
+            }
+            for stage, keyword in expectations.items():
+                paragraph = corpse._build_decay_desc_paragraph(stage)
+                self.assertIn(
+                    keyword,
+                    paragraph,
+                    f"stage {stage!r} paragraph missing keyword {keyword!r}",
+                )
+        finally:
+            corpse.delete()
+
+    def test_return_appearance_includes_stage_paragraph(self) -> None:
+        """``return_appearance`` output includes the staged paragraph for current stage."""
+        corpse = self._make_corpse()
+        try:
+            with patch.object(corpse, "get_decay_stage", return_value="moderate"):
+                output = corpse.return_appearance(self.char2)
+            self.assertIsNotNone(output)
+            self.assertIn("Decomposing", output)
+        finally:
+            corpse.delete()
+
+    # ------------------------------------------------------------------
+    # Key refresh on stage transition
+    # ------------------------------------------------------------------
+
+    def test_refresh_key_updates_on_stage_change(self) -> None:
+        """``_refresh_decay_key_if_changed`` advances key when stage changed."""
+        corpse = self._make_corpse()
+        try:
+            self.assertEqual(corpse.key, "human corpse")
+            with patch.object(corpse, "get_decay_stage", return_value="moderate"):
+                corpse._refresh_decay_key_if_changed()
+            self.assertEqual(corpse.key, "rotting corpse")
+            with patch.object(corpse, "get_decay_stage", return_value="skeletal"):
+                corpse._refresh_decay_key_if_changed()
+            self.assertEqual(corpse.key, "skeletal remains")
+        finally:
+            corpse.delete()
+
+    def test_refresh_key_noop_when_stage_unchanged(self) -> None:
+        """Repeated refresh at the same stage leaves the key untouched."""
+        corpse = self._make_corpse()
+        try:
+            initial = corpse.key
+            for _ in range(3):
+                corpse._refresh_decay_key_if_changed()
+            self.assertEqual(corpse.key, initial)
+        finally:
+            corpse.delete()
+
+    def test_room_entry_triggers_key_refresh(self) -> None:
+        """Character entering a room with a decayed corpse refreshes its key."""
+        corpse = self._make_corpse()
+        try:
+            # Force corpse into an advanced-decay stage without touching
+            # creation_time directly (the room hook calls into
+            # _check_corpse_decay → _refresh_decay_key_if_changed).
+            with patch.object(
+                Corpse, "get_decay_stage", return_value="advanced"
+            ):
+                # Move char2 into char1's room to trigger
+                # ``Room.at_object_receive`` → ``_check_corpse_decay``.
+                # Both chars start in self.room1 in EvenniaTest, so move
+                # char2 out and back to trigger the receive hook.
+                self.char2.move_to(self.room2, quiet=True)
+                self.char2.move_to(self.room1, quiet=True)
+            self.assertEqual(corpse.key, "rotting corpse")
+        finally:
+            corpse.delete()
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()


### PR DESCRIPTION
## Summary
- `Corpse.return_appearance` no longer mutates persistent state.
- All decay-stage aliases + fresh-stage `key` are seeded at corpse creation.
- Key refresh on stage transitions runs from `Room._check_corpse_decay` (character-entry hook), not from `look`.
- Staged decay paragraph is computed on the fly by `_build_decay_desc_paragraph`.
- Death-time `db.desc` snapshot survives untouched (Option α).

## Fixes
1. **Aliases work from t=0.** `harvest organ from corpse` no longer silently fails on a fresh-unobserved corpse.
2. **Custom death-time `db.desc` survives.** No longer clobbered on first observer's look.
3. **`self.key` no longer stale post-stage-transition** — refreshed on character entry.
4. **`look` is now a pure read.** No write-amplification.

## Scope
Tight per design discussion. Hardcoded "human" decay strings stay inline. Species-aware decay prose (item F) is a separate follow-up.

## Migration
None. Live corpses keep whatever `key`/aliases prior looks wrote; new lookups go through the pure code path.

## Tests
- `world/tests/test_corpse_pure_look.py` — 11 new tests covering pure-look invariants, creation-time alias availability, staged-paragraph rendering per stage, key refresh on stage change + room-entry trigger, and death-time desc survival across multiple looks.
- Full suite: **1247 passing** (was 1236, +11 new, 0 regressions).

## Spec
- `specs/IDENTITY_RECOGNITION_SPEC.md` — pure-look contract documented under the corpse section.

Fixes #230.