### PR TITLE
Make corpse decay prose species-aware (#232)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1374,6 +1374,7 @@ Corpses already preserve forensic data (original name, dbref, physical descripti
 - Worn-item changes on the corpse re-derive the apparent presentation — **shipped** via `at_object_leave` invalidation, so stripping a body changes its signature exactly like stripping a live character.
 - Corpse decay interacts with recognition via the **decay-aware recognition** policy below — **shipped** (PR B).
 - **Pure `look`** (issue #230) — **shipped**. ``Corpse.return_appearance`` is a pure read; it does not write ``db.desc``, ``key``, or aliases. All decay-stage aliases (``corpse``, ``remains``, ``body``, ``human corpse``, ``rotting corpse``, ``skeletal remains``) are pre-seeded at creation by ``_seed_decay_aliases_and_key`` so search/targeting works from t=0 regardless of which stage is current. The corpse's ``key`` is refreshed on stage transitions by ``_refresh_decay_key_if_changed``, invoked from ``Room._check_corpse_decay`` on character entry (a lifecycle event). The staged decay paragraph is computed on the fly by ``_build_decay_desc_paragraph`` and inlined into the look output without persisting. The death-time ``db.desc`` snapshot set in ``death_progression.py`` survives untouched.
+- **Species-aware decay prose** (issue #232) — **shipped**. ``_build_decay_desc_paragraph`` delegates to ``world.anatomy.species.get_species_corpse_description(species, decay_stage, base_desc)`` rather than hardcoding "human", so a non-human corpse's body prose reads correctly at every stage (e.g. "Decomposing synth remains."). The death-time physical description is embedded into the fresh / early tiers; moderate onward describe the decay state generically as the original features deteriorate. Following the unknown-species token-drop convention (issue #215), an unregistered / ``None`` species drops the species word entirely ("A recently deceased body.") rather than misclaiming itself as human. The helper is pure, preserving the #230 pure-look contract.
 
 #### Decay-Aware Recognition
 
@@ -2003,19 +2004,23 @@ new species can be added by registering a single dict.
 | `location_display`     | Canonical body-location → readable string mapping.   |
 | `decay_part_prefixes`  | Decay-stage → severed-part template (`{species} {part}`). |
 | `decay_corpse_names`   | Decay-stage → whole-corpse name string.              |
+| `decay_corpse_descriptions` | Decay-stage → whole-corpse body-prose template (`{species}` / `{base_desc}`). |
 
-**Three pure-function helpers** (state-free, callable per
-`get_display_name` invocation):
+**Pure-function helpers** (state-free, callable per
+`get_display_name` / `return_appearance` invocation):
 
 ```python
 get_species_location_display(species, location) -> str
 get_species_part_name(species, location, decay_stage) -> str
 get_species_corpse_name(species, decay_stage) -> str
+get_species_corpse_description(species, decay_stage, base_desc) -> str
+get_species_organ_name(species, organ_name, decay_stage) -> str
 ```
 
-Unknown species fall back to the `"human"` definition; unknown
-locations fall back to underscore-stripped passthrough; unknown decay
-stages fall back to the `"fresh"` template.
+Unknown species fall back to the `"human"` definition (or, for the
+description / organ helpers, drop the species token per issue #215);
+unknown locations fall back to underscore-stripped passthrough; unknown
+decay stages fall back to the `"fresh"` template.
 
 **Provenance propagation**:
 

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -708,38 +708,23 @@ class Corpse(IdentityBearerMixin, Item):
         composed string; ``return_appearance`` slots it into the look
         output without persisting anything.
 
+        Issue #232: the staged prose is now species-aware, delegating to
+        :func:`world.anatomy.species.get_species_corpse_description` so a
+        non-human corpse no longer reads as "human".  Unknown / ``None``
+        species drop the species token entirely (the #215 convention).
+        The death-time physical description is embedded into the fresh /
+        early tiers by the helper.
+
         The death-time ``db.desc`` snapshot
         (``typeclasses/death_progression.py:682``) is preserved untouched
         for debug / admin / forensic tooling (Option α from the #230
         design discussion).
         """
+        from world.anatomy import get_species_corpse_description
+
+        species = self.db.species or "human"
         base_desc = self.db.physical_description or "A lifeless body."
-        decay_descriptions = {
-            "fresh": (
-                f"A recently deceased human body. {base_desc} "
-                "The body appears fresh, with no signs of decomposition yet visible."
-            ),
-            "early": (
-                f"A pale human corpse. {base_desc} "
-                "The skin has begun to pale and cool, with early signs of "
-                "lividity visible."
-            ),
-            "moderate": (
-                "Decomposing human remains. Bloating and discoloration have "
-                "begun, with a distinct odor of decay. The original features "
-                "are still recognizable but deteriorating."
-            ),
-            "advanced": (
-                "Putrid human remains. Advanced decomposition has set in with "
-                "severe bloating, fluid leakage, and strong putrid odors. "
-                "Identification is becoming difficult."
-            ),
-            "skeletal": (
-                "Skeletal human remains. Only bones, dried tissue, and "
-                "clothing remain. The decomposition process is nearly complete."
-            ),
-        }
-        return decay_descriptions.get(stage, base_desc)
+        return get_species_corpse_description(species, stage, base_desc)
 
     def _refresh_decay_key_if_changed(self):
         """Update ``self.key`` if the current decay stage no longer matches.

--- a/world/anatomy/__init__.py
+++ b/world/anatomy/__init__.py
@@ -12,6 +12,7 @@ Public surface:
 * :data:`world.anatomy.species.SPECIES_DEFINITIONS`
 * :func:`world.anatomy.species.get_species_part_name`
 * :func:`world.anatomy.species.get_species_corpse_name`
+* :func:`world.anatomy.species.get_species_corpse_description`
 * :func:`world.anatomy.species.get_species_location_display`
 * :func:`world.anatomy.species.get_species_organ_name`
 * :data:`world.anatomy.severed_parts.SEVERED_PART_DESCRIPTIONS`
@@ -39,6 +40,7 @@ from .severed_parts import (
 )
 from .species import (
     SPECIES_DEFINITIONS,
+    get_species_corpse_description,
     get_species_corpse_name,
     get_species_location_display,
     get_species_organ_name,
@@ -54,6 +56,7 @@ __all__ = (
     "get_organ_default_description",
     "get_organ_display_name",
     "get_severed_part_description",
+    "get_species_corpse_description",
     "get_species_corpse_name",
     "get_species_location_display",
     "get_species_organ_name",

--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -132,6 +132,51 @@ SPECIES_DEFINITIONS = {
             "advanced": "rotting corpse",
             "skeletal": "skeletal remains",
         },
+
+        # Decay-tier corpse *description* templates — the body paragraph
+        # rendered on ``look`` (distinct from the glance-level name in
+        # ``decay_corpse_names``).  Rendered by
+        # :func:`get_species_corpse_description` with ``{species}`` and
+        # ``{base_desc}`` substitution.  ``{base_desc}`` is the
+        # death-time physical description; it is embedded only in the
+        # fresh / early templates — by moderate the original features
+        # have deteriorated enough that the snapshot no longer applies,
+        # so those tiers describe the decay state generically.
+        #
+        # Unlike the *name* templates (which hard-drop the species token
+        # at moderate+), every description tier keeps ``{species}`` so a
+        # known species reads naturally at all stages ("Decomposing
+        # human remains").  The token-drop convention (module docstring,
+        # issue #215) is applied for *unknown* species instead: the
+        # helper substitutes an empty token and collapses whitespace,
+        # yielding "Decomposing remains." rather than misclaiming human.
+        "decay_corpse_descriptions": {
+            "fresh": (
+                "A recently deceased {species} body. {base_desc} "
+                "The body appears fresh, with no signs of decomposition "
+                "yet visible."
+            ),
+            "early": (
+                "A pale {species} corpse. {base_desc} The skin has begun "
+                "to pale and cool, with early signs of lividity visible."
+            ),
+            "moderate": (
+                "Decomposing {species} remains. Bloating and "
+                "discoloration have begun, with a distinct odor of "
+                "decay. The original features are still recognizable but "
+                "deteriorating."
+            ),
+            "advanced": (
+                "Putrid {species} remains. Advanced decomposition has set "
+                "in with severe bloating, fluid leakage, and strong "
+                "putrid odors. Identification is becoming difficult."
+            ),
+            "skeletal": (
+                "Skeletal {species} remains. Only bones, dried tissue, "
+                "and clothing remain. The decomposition process is nearly "
+                "complete."
+            ),
+        },
     },
 }
 
@@ -227,6 +272,60 @@ def get_species_corpse_name(
     if decay_stage in names:
         return names[decay_stage]
     return names.get("fresh", "corpse")
+
+
+def get_species_corpse_description(
+    species: str | None,
+    decay_stage: str | None,
+    base_desc: str = "A lifeless body.",
+) -> str:
+    """Return the decay-modulated *body paragraph* for a whole corpse.
+
+    Used by :class:`typeclasses.corpse.Corpse._build_decay_desc_paragraph`
+    to render the description paragraph shown on ``look`` — the prose
+    counterpart to the glance-level name from
+    :func:`get_species_corpse_name`.  The result drifts with the corpse's
+    decay stage: fresh / early embed the death-time physical description
+    (``base_desc``); moderate onward describe the decay state generically
+    as the original features deteriorate.
+
+    **Unknown-species fallback (issue #215):** unknown / ``None`` species
+    drop the species token entirely — an alien corpse reads "A recently
+    deceased body." rather than misclaiming itself as human.  Known
+    species surface their token at every tier (e.g. "Decomposing human
+    remains").  This mirrors the token-drop contract of
+    :func:`get_species_organ_name`.
+
+    This helper is pure: it composes and returns a string with no I/O or
+    state mutation, preserving the corpse pure-look contract (issue
+    #230).
+
+    Args:
+        species: Species identifier; ``None`` or unregistered species
+            drop the species token from every template.
+        decay_stage: One of ``fresh`` / ``early`` / ``moderate`` /
+            ``advanced`` / ``skeletal``.  ``None`` or unknown stages fall
+            back to the ``fresh`` template.
+        base_desc: The death-time physical description, embedded in the
+            fresh / early templates.  Defaults to a neutral placeholder.
+
+    Returns:
+        Description paragraph ready to slot into ``return_appearance``.
+    """
+    # Issue #215: detect unknown species before the human-default
+    # fallback so an unregistered species renders with an empty species
+    # token rather than claiming "human".
+    is_known = bool(species) and species in SPECIES_DEFINITIONS
+    spec = SPECIES_DEFINITIONS[species] if is_known else SPECIES_DEFINITIONS["human"]
+    descriptions = spec.get("decay_corpse_descriptions") or {}
+    template = descriptions.get(decay_stage) or descriptions.get("fresh")
+    if not template:
+        return base_desc
+    species_display = spec.get("display_name", "") if is_known else ""
+    rendered = template.format(species=species_display, base_desc=base_desc)
+    # Collapse any double spaces / leading whitespace left behind when
+    # the species token is empty (template was "... {species} ...").
+    return " ".join(rendered.split())
 
 
 def get_species_organ_name(

--- a/world/tests/test_species_anatomy.py
+++ b/world/tests/test_species_anatomy.py
@@ -14,6 +14,7 @@ from unittest import TestCase
 
 from world.anatomy import (
     SPECIES_DEFINITIONS,
+    get_species_corpse_description,
     get_species_corpse_name,
     get_species_location_display,
     get_species_organ_name,
@@ -34,6 +35,7 @@ class TestSpeciesRegistry(TestCase):
             "location_display",
             "decay_part_prefixes",
             "decay_corpse_names",
+            "decay_corpse_descriptions",
         ):
             self.assertIn(key, human, f"human species missing '{key}'")
 
@@ -43,6 +45,11 @@ class TestSpeciesRegistry(TestCase):
         stages = {"fresh", "early", "moderate", "advanced", "skeletal"}
         self.assertEqual(set(human["decay_part_prefixes"].keys()), stages)
         self.assertEqual(set(human["decay_corpse_names"].keys()), stages)
+        # Issue #232: corpse-description prose templates mirror the same
+        # five-stage shape as names / part / organ prefixes.
+        self.assertEqual(
+            set(human["decay_corpse_descriptions"].keys()), stages
+        )
         # Issue #212: organ-specific decay prefixes mirror part prefixes
         # in shape but substitute ``desiccated`` for ``skeletal``.
         self.assertEqual(set(human["decay_organ_prefixes"].keys()), stages)
@@ -231,3 +238,75 @@ class TestOrganName(TestCase):
             get_species_organ_name("human", "flux_capacitor", "fresh"),
             "human flux capacitor",
         )
+
+
+class TestCorpseDescription(TestCase):
+    """Issue #232: species + decay-tier aware corpse body prose."""
+
+    BASE = "He has tousled brown hair and a jagged scar."
+
+    def test_fresh_includes_species_and_base_desc(self):
+        out = get_species_corpse_description("human", "fresh", self.BASE)
+        self.assertTrue(out.startswith("A recently deceased human body."))
+        self.assertIn(self.BASE, out)
+        self.assertIn("no signs of decomposition yet visible", out)
+
+    def test_early_includes_species_and_base_desc(self):
+        out = get_species_corpse_description("human", "early", self.BASE)
+        self.assertTrue(out.startswith("A pale human corpse."))
+        self.assertIn(self.BASE, out)
+
+    def test_moderate_includes_species_drops_base_desc(self):
+        out = get_species_corpse_description("human", "moderate", self.BASE)
+        self.assertTrue(out.startswith("Decomposing human remains."))
+        # By moderate decay the death-time snapshot no longer applies.
+        self.assertNotIn(self.BASE, out)
+
+    def test_advanced_includes_species_drops_base_desc(self):
+        out = get_species_corpse_description("human", "advanced", self.BASE)
+        self.assertTrue(out.startswith("Putrid human remains."))
+        self.assertNotIn(self.BASE, out)
+
+    def test_skeletal_includes_species_drops_base_desc(self):
+        out = get_species_corpse_description("human", "skeletal", self.BASE)
+        self.assertTrue(out.startswith("Skeletal human remains."))
+        self.assertNotIn(self.BASE, out)
+
+    def test_unknown_stage_falls_back_to_fresh(self):
+        out = get_species_corpse_description("human", "wibbly", self.BASE)
+        self.assertTrue(out.startswith("A recently deceased human body."))
+
+    def test_unknown_species_drops_species_token(self):
+        # Issue #215 convention: an unregistered species drops the
+        # species word entirely rather than misclaiming "human", and
+        # leaves no double space behind.
+        out = get_species_corpse_description(
+            "unobtanium_alien", "fresh", self.BASE
+        )
+        self.assertTrue(out.startswith("A recently deceased body."))
+        self.assertNotIn("human", out)
+        self.assertNotIn("  ", out)
+
+    def test_none_species_drops_species_token(self):
+        out = get_species_corpse_description(None, "moderate", self.BASE)
+        self.assertTrue(out.startswith("Decomposing remains."))
+        self.assertNotIn("human", out)
+        self.assertNotIn("  ", out)
+
+    def test_unknown_species_late_decay_no_double_space(self):
+        # Every tier templates {species}; the empty token must collapse
+        # cleanly at all stages, not just the fresh / early ones.
+        for stage in ("fresh", "early", "moderate", "advanced", "skeletal"):
+            out = get_species_corpse_description("xeno", stage, self.BASE)
+            self.assertNotIn("  ", out, f"double space at stage {stage!r}")
+            self.assertNotIn("human", out, f"'human' leaked at {stage!r}")
+
+    def test_default_base_desc_used_when_omitted(self):
+        out = get_species_corpse_description("human", "fresh")
+        self.assertIn("A lifeless body.", out)
+
+    def test_empty_base_desc_no_double_space(self):
+        # An empty base_desc in the fresh template must not leave a
+        # double space where {base_desc} was.
+        out = get_species_corpse_description("human", "fresh", "")
+        self.assertNotIn("  ", out)

--- a/world/tests/test_species_corpse_description.py
+++ b/world/tests/test_species_corpse_description.py
@@ -1,0 +1,123 @@
+"""Integration tests for issue #232: species-aware corpse decay prose.
+
+The unit-level behaviour of
+:func:`world.anatomy.species.get_species_corpse_description` is covered
+in :mod:`world.tests.test_species_anatomy`.  This module exercises the
+typeclass integration path:
+:meth:`typeclasses.corpse.Corpse._build_decay_desc_paragraph` delegates
+to that helper, so a non-human corpse's ``look`` body prose surfaces the
+correct species (or drops the token for unknown species) — and the
+delegation preserves the issue #230 pure-look contract (no state
+mutation on render).
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_species_corpse_description
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from evennia.utils.test_resources import EvenniaTest
+
+from typeclasses.characters import Character
+from typeclasses.death_progression import DeathProgressionScript
+
+
+class TestSpeciesAwareCorpseProse(EvenniaTest):
+    """Corpse body prose reflects ``db.species`` via the #232 helper."""
+
+    character_typeclass = Character
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.victim = self.char1
+        self.victim.sleeve_uid = "sleeve-species-desc-001"
+        _ = self.victim.medical_state  # trigger lazy init
+        self.script = DeathProgressionScript()
+
+    def _make_corpse(self):
+        return self.script._create_corpse_from_character(self.victim)
+
+    # ------------------------------------------------------------------
+    # Species surfaces in the body prose
+    # ------------------------------------------------------------------
+
+    def test_human_corpse_prose_mentions_human(self) -> None:
+        corpse = self._make_corpse()
+        try:
+            corpse.db.species = "human"
+            paragraph = corpse._build_decay_desc_paragraph("fresh")
+            self.assertIn("human", paragraph)
+        finally:
+            corpse.delete()
+
+    def test_unknown_species_corpse_drops_token(self) -> None:
+        """A non-registered species must not be misclaimed as human."""
+        corpse = self._make_corpse()
+        try:
+            corpse.db.species = "unobtanium_alien"
+            paragraph = corpse._build_decay_desc_paragraph("fresh")
+            self.assertTrue(
+                paragraph.startswith("A recently deceased body.")
+            )
+            self.assertNotIn("human", paragraph)
+            self.assertNotIn("  ", paragraph)
+        finally:
+            corpse.delete()
+
+    def test_none_species_defaults_to_human(self) -> None:
+        """``db.species is None`` → corpse-side 'human' default applies."""
+        corpse = self._make_corpse()
+        try:
+            corpse.db.species = None
+            paragraph = corpse._build_decay_desc_paragraph("moderate")
+            self.assertTrue(paragraph.startswith("Decomposing human remains."))
+        finally:
+            corpse.delete()
+
+    def test_base_desc_embedded_in_fresh_stage(self) -> None:
+        corpse = self._make_corpse()
+        try:
+            corpse.db.species = "human"
+            corpse.db.physical_description = "A jagged scar crosses one cheek."
+            paragraph = corpse._build_decay_desc_paragraph("fresh")
+            self.assertIn("A jagged scar crosses one cheek.", paragraph)
+        finally:
+            corpse.delete()
+
+    def test_return_appearance_shows_species_prose(self) -> None:
+        corpse = self._make_corpse()
+        try:
+            corpse.db.species = "human"
+            with patch.object(
+                corpse, "get_decay_stage", return_value="advanced"
+            ):
+                output = corpse.return_appearance(self.char2)
+            self.assertIsNotNone(output)
+            self.assertIn("Putrid human remains.", output)
+        finally:
+            corpse.delete()
+
+    # ------------------------------------------------------------------
+    # Pure-look contract preserved (issue #230 regression guard)
+    # ------------------------------------------------------------------
+
+    def test_species_aware_look_does_not_mutate_state(self) -> None:
+        """Delegation to the species helper must remain a pure read."""
+        corpse = self._make_corpse()
+        try:
+            corpse.db.species = "unobtanium_alien"
+            desc_before = corpse.db.desc
+            key_before = corpse.key
+            aliases_before = set(corpse.aliases.all())
+
+            for _ in range(3):
+                corpse.return_appearance(self.char2)
+
+            self.assertEqual(corpse.db.desc, desc_before)
+            self.assertEqual(corpse.key, key_before)
+            self.assertEqual(set(corpse.aliases.all()), aliases_before)
+        finally:
+            corpse.delete()


### PR DESCRIPTION
## Summary
- Closes #232. Corpse `look`-body prose was hardcoded to "human" in `Corpse._build_decay_desc_paragraph`, even though the corpse *name* already routed through `get_species_corpse_name` — so a non-human corpse showed a species-correct name but human-specific body text.
- Adds `decay_corpse_descriptions` templates to the `human` species def and a pure `get_species_corpse_description(species, decay_stage, base_desc)` helper to `world/anatomy/species.py`; exports it from `world/anatomy/__init__.py`.
- `_build_decay_desc_paragraph` now delegates to the helper. Known species surface their token at every decay tier ("Decomposing human remains."); unknown / `None` species drop the species token entirely per the issue #215 convention ("A recently deceased body.") rather than misclaiming human.

## Design notes
- The helper is **pure** — composes and returns a string with no I/O or mutation — preserving the issue #230 pure-look contract. The death-time `db.desc` snapshot (Option α) remains untouched.
- `{base_desc}` (death-time physical description) is embedded only in the fresh / early tiers; moderate onward describe the decay state generically as the original features deteriorate.
- The preserved-longdesc / worn-clothing rendering path in `return_appearance` is unchanged — corpses still inherit their longdesc.

## Tests
- `world/tests/test_species_anatomy.py`: new `TestCorpseDescription` (species presence/absence per tier, base_desc embedding, unknown/None token-drop + no double-space at every stage, default/empty base_desc handling) + registry-shape assertions for the new key.
- `world/tests/test_species_corpse_description.py` (new): typeclass integration — non-human prose, unknown-species token-drop, None→human default, base_desc embedding, `return_appearance` output, and a #230 no-mutation regression guard.
- Full suite green in Docker: **1264 passing**.

## Spec
- `specs/IDENTITY_RECOGNITION_SPEC.md`: corpse section documents the species-aware prose + unknown-species token-drop; helper-list and species-registry table updated.