### PR TITLE
Resolve longdesc pronoun tokens on severed parts (#234)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1925,6 +1925,23 @@ clock, not its own), then any inherited wounds via
 description on it readable as "a severed left hand — tattoo prose —
 old slash wound" regardless of where the hand ends up.
 
+**Pronoun-token substitution (#234)**: carried longdesc prose may
+contain author-written `{their}` / `{they}` / `{name}` brace tokens.
+Because the living-character renderer is no longer in play, both the
+corpse and the severed-part paths resolve these against *preserved*
+character data via the shared pure helper
+`world.anatomy.longdesc_tokens.substitute_pronoun_tokens(text, *,
+gender, name)` — always third person. `Corpse` keeps its own
+`{color}` / skintone handling and calls the helper for the pronoun /
+name pass; `Appendage.configure_from_sever` snapshots
+`original_gender` / `original_character_name` off the corpse so
+`return_appearance` can run each longdesc through the same helper.
+Parts spawned before the snapshot existed degrade to plural pronouns
+("their" / "they"), never leaking braces. (Note: `%`-style tokens such
+as `%p` are **not** supported anywhere — the only token vocabulary is
+the brace form.)
+
+
 **Helpers** (`typeclasses/items.py`):
 - `apply_wound_and_longdesc_overlay(item, corpse, locations)` —
   moves the listed locations' wounds and longdesc from corpse → item.

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -554,53 +554,18 @@ class Corpse(IdentityBearerMixin, Item):
             # No item context, just remove color tags
             processed_desc = processed_desc.replace("{color}", "")
         
-        # Process gender pronouns (always third person for corpses)
-        gender_mapping = {
-            'male': 'male',
-            'female': 'female', 
-            'neutral': 'plural',
-            'nonbinary': 'plural',
-            'other': 'plural'
-        }
-        
-        character_gender = gender_mapping.get(original_gender, 'plural')
-        
-        # Pronoun processing - comprehensive mapping
-        pronoun_map = {
-            'male': {
-                'They': 'He', 'they': 'he', 
-                'Their': 'His', 'their': 'his',
-                'Them': 'Him', 'them': 'him',
-                'Theirs': 'His', 'theirs': 'his',
-                'Themselves': 'Himself', 'themselves': 'himself',
-                'Themself': 'Himself', 'themself': 'himself'
-            },
-            'female': {
-                'They': 'She', 'they': 'she',
-                'Their': 'Her', 'their': 'her', 
-                'Them': 'Her', 'them': 'her',
-                'Theirs': 'Hers', 'theirs': 'hers',
-                'Themselves': 'Herself', 'themselves': 'herself',
-                'Themself': 'Herself', 'themself': 'herself'
-            },
-            'plural': {
-                'They': 'They', 'they': 'they',
-                'Their': 'Their', 'their': 'their',
-                'Them': 'Them', 'them': 'them', 
-                'Theirs': 'Theirs', 'theirs': 'theirs',
-                'Themselves': 'Themselves', 'themselves': 'themselves',
-                'Themself': 'Themselves', 'themself': 'themselves'
-            }
-        }
-        
-        pronouns = pronoun_map.get(character_gender, pronoun_map['plural'])
-        for template, replacement in pronouns.items():
-            if f"{{{template}}}" in processed_desc:
-                processed_desc = processed_desc.replace(f"{{{template}}}", replacement)
-        
-        # Process name variables
-        processed_desc = processed_desc.replace("{name}", original_name)
-        processed_desc = processed_desc.replace("{name's}", f"{original_name}'s")
+        # Process gender pronouns and name tokens (always third person
+        # for corpses).  Delegated to the shared pure helper so the
+        # severed-part renderer (Appendage.return_appearance) and this
+        # path stay byte-for-byte consistent.  ``{color}`` / skintone
+        # handling stays corpse-side because it depends on item context.
+        from world.anatomy import substitute_pronoun_tokens
+
+        processed_desc = substitute_pronoun_tokens(
+            processed_desc,
+            gender=original_gender,
+            name=original_name,
+        )
         
         # Apply skintone coloring if preserved (only to body descriptions, not clothing items)
         if original_skintone and not hasattr(self, '_current_item_context'):

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1130,6 +1130,13 @@ class Appendage(Item):
         self.db.source_signature = corpse.db.signature_at_death
         self.db.source_apparent_uid = corpse.db.apparent_uid_at_death
         self.db.source_corpse_dbref = corpse.dbref
+        # Issue #234: snapshot the preserved gender + name so carried
+        # longdesc prose can have its {their}/{they}/{name} tokens
+        # resolved at render time (the living-character renderer is no
+        # longer in play).  Parts spawned before this field existed fall
+        # back to plural pronouns in return_appearance.
+        self.db.original_gender = corpse.db.original_gender
+        self.db.original_character_name = corpse.db.original_character_name
         # PR-G: inherit species from corpse so the appendage's
         # decay-modulated key matches its origin anatomy.
         species = corpse.db.species or "human"
@@ -1185,6 +1192,15 @@ class Appendage(Item):
 
         longdescs = self.db.longdesc_data or {}
         if longdescs:
+            from world.anatomy import substitute_pronoun_tokens
+
+            # Issue #234: resolve {their}/{they}/{name} tokens against
+            # the snapshotted character data before display.  Always
+            # third person — the source character is gone.  A missing
+            # snapshot (older parts) yields plural pronouns, not leaked
+            # braces.
+            gender = self.db.original_gender
+            name = self.db.original_character_name or "the corpse"
             try:
                 from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
             except ImportError:
@@ -1193,13 +1209,21 @@ class Appendage(Item):
             for loc in ANATOMICAL_DISPLAY_ORDER:
                 text = longdescs.get(loc)
                 if text and loc not in seen:
-                    parts.append(text)
+                    parts.append(
+                        substitute_pronoun_tokens(
+                            text, gender=gender, name=name
+                        )
+                    )
                     seen.add(loc)
             # Any longdesc locations not in the canonical order
             # (defensive — preserves prose for nonstandard anatomy).
             for loc, text in longdescs.items():
                 if text and loc not in seen:
-                    parts.append(text)
+                    parts.append(
+                        substitute_pronoun_tokens(
+                            text, gender=gender, name=name
+                        )
+                    )
                     seen.add(loc)
 
         wounds = self.db.wounds_at_death or []

--- a/world/anatomy/__init__.py
+++ b/world/anatomy/__init__.py
@@ -22,12 +22,14 @@ Public surface:
 * :func:`world.anatomy.organs.get_organ_default_description`
 * :func:`world.anatomy.conditions.format_condition_tagline`
 * :func:`world.anatomy.conditions.prepend_condition_to_desc`
+* :func:`world.anatomy.longdesc_tokens.substitute_pronoun_tokens`
 """
 
 from .conditions import (
     format_condition_tagline,
     prepend_condition_to_desc,
 )
+from .longdesc_tokens import substitute_pronoun_tokens
 from .organs import (
     BONE_ORGANS,
     ORGAN_DISPLAY,
@@ -62,4 +64,5 @@ __all__ = (
     "get_species_organ_name",
     "get_species_part_name",
     "prepend_condition_to_desc",
+    "substitute_pronoun_tokens",
 )

--- a/world/anatomy/longdesc_tokens.py
+++ b/world/anatomy/longdesc_tokens.py
@@ -1,0 +1,106 @@
+"""Pronoun / name token substitution for preserved longdesc prose.
+
+Players author body-part longdesc descriptions with brace-style tokens
+(``{their}``, ``{they}``, ``{name}`` ...) that are rendered against the
+*owner's* gender while they are alive.  When the body becomes a corpse
+or a severed limb, the living-character renderer is no longer in play,
+so the carried-forward prose must be substituted against *preserved*
+character data instead.
+
+This module is the single, pure source of that pronoun + name
+substitution.  It is deliberately object-free (no Evennia imports) so
+it is trivially unit-testable, and is consumed by both
+:class:`typeclasses.corpse.Corpse` and
+:class:`typeclasses.items.Appendage`.
+
+Both consumers are inanimate (a corpse, a severed part), so substitution
+is always third-person.  The corpse layer keeps its own ``{color}`` /
+skintone handling and calls :func:`substitute_pronoun_tokens` for the
+pronoun + name pass only.
+
+Scope note: the *living*-character renderer
+(:meth:`typeclasses.appearance_mixin.AppearanceMixin._process_description_variables`)
+has its own pronoun logic that also handles the first-person ("you")
+case.  Consolidating that path onto this helper is out of scope here.
+"""
+
+from __future__ import annotations
+
+# Map a stored character gender onto a pronoun bucket.  Unknown / None
+# genders collapse to ``plural`` ("they"/"their"), matching the corpse
+# layer's historical fallback.
+_GENDER_TO_BUCKET = {
+    "male": "male",
+    "female": "female",
+    "neutral": "plural",
+    "nonbinary": "plural",
+    "other": "plural",
+}
+
+# Brace-token -> replacement, keyed by pronoun bucket.  Keys are the
+# template names as authored inside braces (case-sensitive so authors
+# control capitalisation: ``{Their}`` vs ``{their}``).
+_PRONOUN_MAP = {
+    "male": {
+        "They": "He", "they": "he",
+        "Their": "His", "their": "his",
+        "Them": "Him", "them": "him",
+        "Theirs": "His", "theirs": "his",
+        "Themselves": "Himself", "themselves": "himself",
+        "Themself": "Himself", "themself": "himself",
+    },
+    "female": {
+        "They": "She", "they": "she",
+        "Their": "Her", "their": "her",
+        "Them": "Her", "them": "her",
+        "Theirs": "Hers", "theirs": "hers",
+        "Themselves": "Herself", "themselves": "herself",
+        "Themself": "Herself", "themself": "herself",
+    },
+    "plural": {
+        "They": "They", "they": "they",
+        "Their": "Their", "their": "their",
+        "Them": "Them", "them": "them",
+        "Theirs": "Theirs", "theirs": "theirs",
+        "Themselves": "Themselves", "themselves": "themselves",
+        "Themself": "Themselves", "themself": "themselves",
+    },
+}
+
+
+def substitute_pronoun_tokens(text, *, gender, name="the corpse"):
+    """Replace ``{pronoun}`` / ``{name}`` tokens in preserved prose.
+
+    Always third-person (the subject is an inanimate corpse or severed
+    part).  Unknown or ``None`` gender falls back to plural pronouns.
+
+    Args:
+        text (str): Longdesc prose, possibly containing brace tokens.
+        gender (str | None): Preserved character gender (e.g. ``"male"``,
+            ``"female"``, ``"neutral"``, ``"nonbinary"``, ``"other"``).
+        name (str): Display name substituted for ``{name}`` /
+            ``{name's}``.  Defaults to ``"the corpse"``.
+
+    Returns:
+        str: ``text`` with pronoun and name tokens resolved.  Tokens
+        this helper does not recognise (e.g. ``{color}``) are left
+        untouched for an upstream layer to handle.
+    """
+    if not text:
+        return text
+
+    bucket = _GENDER_TO_BUCKET.get(gender, "plural")
+    pronouns = _PRONOUN_MAP[bucket]
+
+    processed = text
+    for template, replacement in pronouns.items():
+        token = f"{{{template}}}"
+        if token in processed:
+            processed = processed.replace(token, replacement)
+
+    # Name tokens.  ``{name's}`` first so the bare ``{name}`` replace
+    # below cannot strip the possessive token's leading "{name".
+    processed = processed.replace("{name's}", f"{name}'s")
+    processed = processed.replace("{name}", name)
+
+    return processed

--- a/world/tests/test_longdesc_tokens.py
+++ b/world/tests/test_longdesc_tokens.py
@@ -1,0 +1,109 @@
+"""Tests for the pronoun / name token helper (issue #234).
+
+Covers :func:`world.anatomy.longdesc_tokens.substitute_pronoun_tokens`,
+the single source of brace-token substitution shared by
+:class:`typeclasses.corpse.Corpse` and
+:class:`typeclasses.items.Appendage`.
+
+Run via::
+
+    evennia test world.tests.test_longdesc_tokens
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.anatomy import substitute_pronoun_tokens
+
+
+class TestSubstitutePronounTokens(TestCase):
+    def test_male_pronoun_set_exact(self):
+        out = substitute_pronoun_tokens(
+            "{They}/{they} {Their}/{their} {Them}/{them} "
+            "{Theirs}/{theirs} {Themselves}/{themselves} "
+            "{Themself}/{themself}",
+            gender="male",
+        )
+        self.assertEqual(
+            out,
+            "He/he His/his Him/him His/his Himself/himself Himself/himself",
+        )
+
+    def test_female_pronoun_set_exact(self):
+        out = substitute_pronoun_tokens(
+            "{They}/{they} {Their}/{their} {Them}/{them} "
+            "{Theirs}/{theirs} {Themselves}/{themselves} "
+            "{Themself}/{themself}",
+            gender="female",
+        )
+        self.assertEqual(
+            out,
+            "She/she Her/her Her/her Hers/hers Herself/herself "
+            "Herself/herself",
+        )
+
+    def test_plural_pronoun_set_exact(self):
+        out = substitute_pronoun_tokens(
+            "{They}/{they} {Their}/{their} {Them}/{them} "
+            "{Theirs}/{theirs} {Themselves}/{themselves} "
+            "{Themself}/{themself}",
+            gender="neutral",
+        )
+        self.assertEqual(
+            out,
+            "They/they Their/their Them/them Theirs/theirs "
+            "Themselves/themselves Themselves/themselves",
+        )
+
+    def test_unknown_gender_falls_back_to_plural(self):
+        out = substitute_pronoun_tokens("{Their} eyes.", gender="cylon")
+        self.assertEqual(out, "Their eyes.")
+
+    def test_none_gender_falls_back_to_plural(self):
+        out = substitute_pronoun_tokens("{Their} eyes.", gender=None)
+        self.assertEqual(out, "Their eyes.")
+
+    def test_name_token(self):
+        out = substitute_pronoun_tokens(
+            "{name} stares.", gender="male", name="Vasquez"
+        )
+        self.assertEqual(out, "Vasquez stares.")
+
+    def test_name_possessive_token(self):
+        out = substitute_pronoun_tokens(
+            "{name's} cold stare.", gender="male", name="Vasquez"
+        )
+        self.assertEqual(out, "Vasquez's cold stare.")
+
+    def test_name_and_possessive_together(self):
+        out = substitute_pronoun_tokens(
+            "{name} flexes {name's} fingers.",
+            gender="female",
+            name="Ripley",
+        )
+        self.assertEqual(out, "Ripley flexes Ripley's fingers.")
+
+    def test_default_name_is_the_corpse(self):
+        out = substitute_pronoun_tokens("{name} lies still.", gender=None)
+        self.assertEqual(out, "the corpse lies still.")
+
+    def test_no_tokens_passthrough(self):
+        text = "A weathered scar runs along the jaw."
+        self.assertEqual(
+            substitute_pronoun_tokens(text, gender="male"), text
+        )
+
+    def test_unrecognised_tokens_left_untouched(self):
+        # {color} is handled by an upstream corpse/clothing layer, not
+        # here — the helper must leave it intact.
+        out = substitute_pronoun_tokens(
+            "{color}A {their} coat.", gender="female"
+        )
+        self.assertEqual(out, "{color}A her coat.")
+
+    def test_empty_string_passthrough(self):
+        self.assertEqual(substitute_pronoun_tokens("", gender="male"), "")
+
+    def test_none_text_passthrough(self):
+        self.assertIsNone(substitute_pronoun_tokens(None, gender="male"))

--- a/world/tests/test_severed_part_descriptions.py
+++ b/world/tests/test_severed_part_descriptions.py
@@ -110,6 +110,9 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         corpse.db.wounds = []
         corpse.db.wounds_at_death = []
         corpse.db.severed_locations = []
+        # Issue #234: preserved gender / name snapshot.
+        corpse.db.original_gender = "male"
+        corpse.db.original_character_name = "Jdoe"
         corpse._stage = stage
 
         def get_decay_stage():
@@ -135,6 +138,8 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         app.db.wounds_at_death = []
         app.db.longdesc_data = {}
         app.db.desc = None
+        app.db.original_gender = None
+        app.db.original_character_name = None
         app.key = ""
         app.configure_from_sever = (
             Appendage.configure_from_sever.__get__(app)
@@ -198,3 +203,14 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         # Fresh corpse → "human left arm" via species helper.
         self.assertEqual(app.key, "human left arm")
+
+    def test_gender_and_name_snapshotted_from_corpse(self):
+        # Issue #234: configure_from_sever must carry the preserved
+        # gender + name so return_appearance can resolve pronoun tokens.
+        app = self._fake_appendage()
+        app.configure_from_sever(
+            location_name="left_arm", condition="pristine",
+            corpse=self._fake_corpse(),
+        )
+        self.assertEqual(app.db.original_gender, "male")
+        self.assertEqual(app.db.original_character_name, "Jdoe")

--- a/world/tests/test_severed_part_token_substitution.py
+++ b/world/tests/test_severed_part_token_substitution.py
@@ -1,0 +1,67 @@
+"""Integration test: severed parts resolve longdesc pronoun tokens.
+
+Issue #234: :meth:`typeclasses.items.Appendage.return_appearance` must
+run carried-forward longdesc prose through the shared pronoun/name
+helper so brace tokens (``{their}``, ``{they}``, ``{name}`` ...) are
+resolved instead of leaking literally into the look output.
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_severed_part_token_substitution
+"""
+
+from __future__ import annotations
+
+from evennia import create_object
+from evennia.utils.test_resources import EvenniaTest
+
+from typeclasses.characters import Character
+from typeclasses.items import Appendage
+
+
+class TestSeveredPartTokenSubstitution(EvenniaTest):
+    character_typeclass = Character
+
+    def _make_part(self, *, gender, name, longdesc_data):
+        part = create_object(Appendage, key="severed head", location=self.room1)
+        part.db.original_gender = gender
+        part.db.original_character_name = name
+        part.db.longdesc_data = longdesc_data
+        part.db.wounds_at_death = []
+        return part
+
+    def test_male_tokens_resolved_in_look(self):
+        part = self._make_part(
+            gender="male",
+            name="Vasquez",
+            longdesc_data={
+                "head": "{Their} cheeks are gaunt and {their} eyes hollow.",
+            },
+        )
+        out = part.return_appearance(self.char1)
+        self.assertIn("His cheeks are gaunt and his eyes hollow.", out)
+        self.assertNotIn("{Their}", out)
+        self.assertNotIn("{their}", out)
+
+    def test_female_name_token_resolved(self):
+        part = self._make_part(
+            gender="female",
+            name="Ripley",
+            longdesc_data={"head": "{name's} jaw is set. {They} stare blankly."},
+        )
+        out = part.return_appearance(self.char1)
+        self.assertIn("Ripley's jaw is set.", out)
+        self.assertIn("She stare blankly.", out)
+        self.assertNotIn("{", out.split("\n")[-1])
+
+    def test_missing_gender_snapshot_falls_back_to_plural(self):
+        # Older parts spawned before issue #234 lack the snapshot; they
+        # must degrade to plural pronouns, never leak braces.
+        part = self._make_part(
+            gender=None,
+            name=None,
+            longdesc_data={"head": "{Their} eyes stare."},
+        )
+        out = part.return_appearance(self.char1)
+        self.assertIn("Their eyes stare.", out)
+        self.assertNotIn("{Their}", out)


### PR DESCRIPTION
## Summary
- Fixes #234: severed body parts (`look head`) leaked `{their}`/`{they}`/`{name}` brace tokens because `Appendage.return_appearance` appended carried-forward longdesc prose verbatim, while only the corpse path substituted them.
- Extracts the pronoun/name substitution into a pure, testable helper `world/anatomy/longdesc_tokens.substitute_pronoun_tokens(text, *, gender, name)` (object-free, always third person, unknown/None gender → plural).
- Refactors `Corpse._process_corpse_description_variables` to delegate the pronoun/name pass to the helper, keeping `{color}`/skintone handling corpse-side (byte-for-byte behaviour preserved).
- `Appendage.configure_from_sever` snapshots `original_gender` / `original_character_name` off the corpse; `Appendage.return_appearance` runs each longdesc through the helper. Parts spawned before the snapshot degrade to plural pronouns — no leaked braces.

## Out of scope
- The `%p` leak seen on corpses is **not** a code defect: `%p` is not a supported token anywhere; the only token vocabulary is the brace form. Classified as player content, no change (per maintainer decision).

## Tests
- New `world/tests/test_longdesc_tokens.py` — pure-helper coverage (full pronoun sets per gender, name/possessive, unknown/None fallback, unrecognised-token passthrough).
- New `world/tests/test_severed_part_token_substitution.py` — EvenniaTest integration: `look`ing a severed part resolves tokens, missing-snapshot fallback.
- Extended `world/tests/test_severed_part_descriptions.py` — asserts gender/name snapshot on sever.
- Full suite: **1281 passing** (was 1264).

## Spec
- `specs/IDENTITY_RECOGNITION_SPEC.md` Severed-item rendering section documents the shared helper, the snapshot, the plural fallback, and the `%`-token non-support note.