### PR TITLE
Carry hair onto severed heads; flow severed-part prose (#236)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1902,9 +1902,10 @@ severed item. The corpse keeps only the synthesized stump wound at
 the sever location. This prevents double-reporting in autopsy.
 
 **Head cluster**: severing the head moves wounds and longdesc for
-the entire head cluster — `{head, face, neck, left_eye, right_eye,
-left_ear, right_ear}` (see `SEVERED_HEAD_LOCATIONS` in
-`world/combat/constants.py`). Limbs use a single-location move.
+the entire head cluster — `{hair, head, face, neck, left_eye,
+right_eye, left_ear, right_ear}` (see `SEVERED_HEAD_LOCATIONS` in
+`world/combat/constants.py`). Hair (#236) frames the head and visually
+leaves with it. Limbs use a single-location move.
 
 **Stump wound contract**: synthesized as
 `{injury_type: "severed", location: <sever_loc>, severity: "Critical",
@@ -1917,13 +1918,19 @@ treated / healing / scarred / destroyed stages all defined, with `old`
 being the canonical autopsy form).
 
 **Severed-item rendering**: `Appendage.return_appearance` (and the
-`SeveredHead` override) renders the base condition prose, then any
-carried longdesc verbatim per location (no decay modulation — once
-written into death prose, it ages with the host item's overall decay
-clock, not its own), then any inherited wounds via
-`get_wound_description`. This keeps a severed hand with a tattoo
-description on it readable as "a severed left hand — tattoo prose —
-old slash wound" regardless of where the hand ends up.
+`SeveredHead` override) renders the base condition prose, then the
+carried longdesc + inherited wounds as a **single flowing paragraph**
+appended after the item name (#236 — the name stays on its own header
+line). Composition is per-location, in anatomical order: each
+location's longdesc is immediately followed by that location's wound
+description(s), so a wound stays connected to the body part it belongs
+to (mirroring the corpse). Wounds whose location has no carried
+longdesc still render (appended last) so no forensic detail is
+silently dropped. Longdescs carry no decay modulation — once written
+into death prose, they age with the host item's overall decay clock,
+not their own. This keeps a severed left hand readable as "a severed
+left hand. <tattoo prose> <old slash wound>" regardless of where the
+hand ends up.
 
 **Pronoun-token substitution (#234)**: carried longdesc prose may
 contain author-written `{their}` / `{they}` / `{name}` brace tokens.

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1176,81 +1176,117 @@ class Appendage(Item):
         """Compose appearance from base desc + carried longdesc + wounds.
 
         PR #198: severed limbs and heads carry forward the source
-        corpse's per-location longdesc prose and wound records.  We
-        render them after the base ``return_appearance`` output so the
-        condition-keyed line (e.g. ``"fresh left arm"``) still leads.
+        corpse's per-location longdesc prose and wound records.
 
-        Longdesc text is shown verbatim — the ``condition`` prefix in
-        the key already conveys decay state, so we deliberately skip
-        the decay-modulation pass that
-        :class:`typeclasses.corpse.Corpse` applies to its preserved
-        longdescs.  Wound descriptions render at ``stage="old"`` to
-        match the corpse's own preserved-wound contract.
+        Issue #236: the carried prose renders as a single flowing
+        paragraph appended to the base ``return_appearance`` output (the
+        name stays on its own header line via ``base``).  Composition is
+        **per location**, in anatomical order: each location's longdesc
+        is immediately followed by that location's wound description(s),
+        so a wound stays connected to the body part it belongs to —
+        mirroring :meth:`typeclasses.corpse.Corpse` rendering.
+
+        Longdesc text is shown verbatim (decay-modulated only by the
+        condition prefix already baked into the key).  Pronoun / name
+        brace tokens are resolved against the snapshotted character data
+        (issue #234); a missing snapshot degrades to plural pronouns.
+        Wound descriptions render at ``stage="old"`` to match the
+        corpse's preserved-wound contract.
         """
         base = super().return_appearance(looker, **kwargs)
-        parts = [base] if base else []
+
+        from world.anatomy import substitute_pronoun_tokens
 
         longdescs = self.db.longdesc_data or {}
-        if longdescs:
-            from world.anatomy import substitute_pronoun_tokens
-
-            # Issue #234: resolve {their}/{they}/{name} tokens against
-            # the snapshotted character data before display.  Always
-            # third person — the source character is gone.  A missing
-            # snapshot (older parts) yields plural pronouns, not leaked
-            # braces.
-            gender = self.db.original_gender
-            name = self.db.original_character_name or "the corpse"
-            try:
-                from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
-            except ImportError:
-                ANATOMICAL_DISPLAY_ORDER = list(longdescs.keys())
-            seen = set()
-            for loc in ANATOMICAL_DISPLAY_ORDER:
-                text = longdescs.get(loc)
-                if text and loc not in seen:
-                    parts.append(
-                        substitute_pronoun_tokens(
-                            text, gender=gender, name=name
-                        )
-                    )
-                    seen.add(loc)
-            # Any longdesc locations not in the canonical order
-            # (defensive — preserves prose for nonstandard anatomy).
-            for loc, text in longdescs.items():
-                if text and loc not in seen:
-                    parts.append(
-                        substitute_pronoun_tokens(
-                            text, gender=gender, name=name
-                        )
-                    )
-                    seen.add(loc)
-
         wounds = self.db.wounds_at_death or []
-        if wounds:
-            try:
-                from world.medical.wounds import get_wound_description
-            except ImportError:
-                get_wound_description = None
-            if get_wound_description is not None:
-                for wound in wounds:
-                    try:
-                        rendered = get_wound_description(
-                            injury_type=wound.get("injury_type", "generic"),
-                            location=wound.get(
-                                "location", self.db.location_name or ""
-                            ),
-                            severity=wound.get("severity", "Moderate"),
-                            stage="old",
-                            organ=wound.get("organ"),
-                            character=self,
-                        )
-                    except (KeyError, ValueError, AttributeError):
-                        continue
-                    if rendered:
-                        parts.append(rendered)
+        gender = self.db.original_gender
+        name = self.db.original_character_name or "the corpse"
 
-        return "\n".join(p for p in parts if p)
+        try:
+            from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
+        except ImportError:
+            ANATOMICAL_DISPLAY_ORDER = list(longdescs.keys())
+
+        try:
+            from world.medical.wounds import get_wound_description
+        except ImportError:
+            get_wound_description = None
+
+        def _render_wound(wound):
+            """Render one preserved wound; None on failure / no renderer."""
+            if get_wound_description is None:
+                return None
+            try:
+                return get_wound_description(
+                    injury_type=wound.get("injury_type", "generic"),
+                    location=wound.get("location")
+                    or self.db.location_name
+                    or "",
+                    severity=wound.get("severity", "Moderate"),
+                    stage="old",
+                    organ=wound.get("organ"),
+                    character=self,
+                )
+            except (KeyError, ValueError, AttributeError):
+                return None
+
+        def _wound_location(wound):
+            return wound.get("location") or self.db.location_name or ""
+
+        # Compose one chunk per location: longdesc first, then any
+        # wounds at that location, so they stay connected.
+        chunks = []
+        seen_locs = set()
+        handled_wounds = set()
+
+        def _build_location_chunk(loc):
+            pieces = []
+            text = longdescs.get(loc)
+            if text:
+                pieces.append(
+                    substitute_pronoun_tokens(text, gender=gender, name=name)
+                )
+            for idx, wound in enumerate(wounds):
+                if idx in handled_wounds or _wound_location(wound) != loc:
+                    continue
+                rendered = _render_wound(wound)
+                handled_wounds.add(idx)
+                if rendered:
+                    pieces.append(rendered)
+            return " ".join(pieces)
+
+        for loc in ANATOMICAL_DISPLAY_ORDER:
+            if loc in seen_locs:
+                continue
+            seen_locs.add(loc)
+            chunk = _build_location_chunk(loc)
+            if chunk:
+                chunks.append(chunk)
+
+        # Longdesc locations outside the canonical order (defensive —
+        # preserves prose + connected wounds for nonstandard anatomy).
+        for loc in longdescs:
+            if loc in seen_locs:
+                continue
+            seen_locs.add(loc)
+            chunk = _build_location_chunk(loc)
+            if chunk:
+                chunks.append(chunk)
+
+        # Any wounds whose location had no longdesc chunk above — render
+        # them so forensic detail is never silently dropped.
+        for idx, wound in enumerate(wounds):
+            if idx in handled_wounds:
+                continue
+            handled_wounds.add(idx)
+            rendered = _render_wound(wound)
+            if rendered:
+                chunks.append(rendered)
+
+        body = " ".join(chunks)
+        if not body:
+            return base
+        return f"{base} {body}" if base else body
 
 
 def apply_wound_and_longdesc_overlay(appendage, corpse, locations):

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -802,9 +802,10 @@ SEVERABLE_CONTAINERS = frozenset({
 # all of these locations move from the corpse onto the SeveredHead,
 # since they are visually and anatomically part of the head cluster.
 # The corpse loses prose for every location in this set and gains a
-# single synthesized ``severed`` wound at ``head``.
+# single synthesized ``severed`` wound at ``head``.  "hair" is part of
+# the cluster (#236): it frames the head and visually leaves with it.
 SEVERED_HEAD_LOCATIONS = frozenset({
-    "head", "face", "neck",
+    "hair", "head", "face", "neck",
     "left_eye", "right_eye",
     "left_ear", "right_ear",
 })

--- a/world/tests/test_sever_overlay.py
+++ b/world/tests/test_sever_overlay.py
@@ -122,6 +122,28 @@ class ApplyWoundAndLongdescOverlayTests(TestCase):
             {"head", "face", "neck", "left_eye"},
         )
 
+    def test_hair_rides_head_cluster(self):
+        # Issue #236: hair frames the head and must follow it on sever.
+        corpse = _FakeCorpse(
+            wounds=[_wound("hair", injury_type="cut")],
+            longdescs={
+                "hair": "long silver braids bound with copper wire",
+                "chest": "a broad chest",  # should NOT carry
+            },
+        )
+        appendage = _FakeAppendage()
+        apply_wound_and_longdesc_overlay(
+            appendage, corpse, SEVERED_HEAD_LOCATIONS,
+        )
+        self.assertIn("hair", appendage.db.longdesc_data)
+        self.assertEqual(
+            appendage.db.longdesc_data["hair"],
+            "long silver braids bound with copper wire",
+        )
+        self.assertEqual(
+            {w["location"] for w in appendage.db.wounds_at_death}, {"hair"}
+        )
+
     def test_empty_corpse_state_yields_empty_appendage_state(self):
         corpse = _FakeCorpse()
         appendage = _FakeAppendage()
@@ -195,6 +217,7 @@ class ApplySeverToCorpseTests(TestCase):
 
     def test_head_sever_clears_full_cluster_longdescs(self):
         corpse = _FakeCorpse(longdescs={
+            "hair": "long silver braids",
             "head": "a shaven scalp",
             "face": "sharp features",
             "neck": "a thick neck",

--- a/world/tests/test_severed_part_token_substitution.py
+++ b/world/tests/test_severed_part_token_substitution.py
@@ -5,6 +5,10 @@ run carried-forward longdesc prose through the shared pronoun/name
 helper so brace tokens (``{their}``, ``{they}``, ``{name}`` ...) are
 resolved instead of leaking literally into the look output.
 
+Issue #236: the carried prose renders as a single flowing paragraph
+(name on its own header line), composed per-location so each wound
+stays connected to its longdesc location.
+
 Run via::
 
     evennia test --settings settings.py world.tests.test_severed_part_token_substitution
@@ -22,12 +26,12 @@ from typeclasses.items import Appendage
 class TestSeveredPartTokenSubstitution(EvenniaTest):
     character_typeclass = Character
 
-    def _make_part(self, *, gender, name, longdesc_data):
+    def _make_part(self, *, gender, name, longdesc_data, wounds_at_death=None):
         part = create_object(Appendage, key="severed head", location=self.room1)
         part.db.original_gender = gender
         part.db.original_character_name = name
         part.db.longdesc_data = longdesc_data
-        part.db.wounds_at_death = []
+        part.db.wounds_at_death = wounds_at_death or []
         return part
 
     def test_male_tokens_resolved_in_look(self):
@@ -52,7 +56,7 @@ class TestSeveredPartTokenSubstitution(EvenniaTest):
         out = part.return_appearance(self.char1)
         self.assertIn("Ripley's jaw is set.", out)
         self.assertIn("She stare blankly.", out)
-        self.assertNotIn("{", out.split("\n")[-1])
+        self.assertNotIn("{", out)
 
     def test_missing_gender_snapshot_falls_back_to_plural(self):
         # Older parts spawned before issue #234 lack the snapshot; they
@@ -65,3 +69,59 @@ class TestSeveredPartTokenSubstitution(EvenniaTest):
         out = part.return_appearance(self.char1)
         self.assertIn("Their eyes stare.", out)
         self.assertNotIn("{Their}", out)
+
+    def test_longdescs_flow_into_single_paragraph(self):
+        # Issue #236: multiple longdesc locations must read as one
+        # flowing paragraph (space-joined), not a newline per location.
+        part = self._make_part(
+            gender="male",
+            name="Vasquez",
+            longdesc_data={
+                "hair": "Close-cropped silver hair.",
+                "face": "A weathered face.",
+                "left_eye": "A pale blue left eye.",
+            },
+        )
+        out = part.return_appearance(self.char1)
+        # The three locations appear as one continuous, space-joined run
+        # (anatomical order: hair, face, left_eye) — no newline between.
+        self.assertIn(
+            "Close-cropped silver hair. A weathered face. "
+            "A pale blue left eye.",
+            out,
+        )
+
+    def test_wound_stays_connected_to_its_longdesc_location(self):
+        # Issue #236: a wound renders immediately after the longdesc for
+        # the SAME location, not dumped at the end detached from it.
+        part = self._make_part(
+            gender="male",
+            name="Vasquez",
+            longdesc_data={
+                "face": "A weathered face.",
+                "left_eye": "A pale blue left eye.",
+            },
+            wounds_at_death=[
+                {
+                    "injury_type": "bullet",
+                    "location": "face",
+                    "severity": "Severe",
+                    "stage": "old",
+                    "organ": None,
+                },
+            ],
+        )
+        out = part.return_appearance(self.char1)
+        face_idx = out.index("A weathered face.")
+        eye_idx = out.index("A pale blue left eye.")
+        # Face longdesc precedes the eye longdesc (anatomical order)...
+        self.assertLess(face_idx, eye_idx)
+        # ...and the face wound text renders in the gap between them,
+        # keeping the wound connected to the face location.
+        between = out[face_idx + len("A weathered face."):eye_idx]
+        self.assertTrue(
+            between.strip(),
+            "Expected the face wound description to render between the "
+            "face longdesc and the eye longdesc.",
+        )
+


### PR DESCRIPTION
## Summary
Fixes #236 — two severed-part rendering defects:

- **Hair follows the head**: `"hair"` added to `SEVERED_HEAD_LOCATIONS`. Hair frames the head and visually leaves with it; previously the hair longdesc stayed stranded on the corpse. Both `apply_wound_and_longdesc_overlay` (head side) and `apply_sever_to_corpse` (corpse side) read this constant, so the move is symmetric.
- **Flowing, connected prose**: `Appendage.return_appearance` now renders the carried longdesc + wounds as a **single flowing paragraph** (name on its own header line) instead of one line per location. Composition is **per-location** in anatomical order — each location's longdesc is immediately followed by that location's wound description(s), keeping wounds connected to the body part they belong to (matching the corpse). Wounds whose location has no carried longdesc still render (appended last) so no forensic detail is dropped.

## Tests
- `test_sever_overlay.py`: hair rides the head cluster onto the part and is removed from the corpse.
- `test_severed_part_token_substitution.py`: longdescs flow as one space-joined paragraph; a wound renders between its location's longdesc and the next location (connection guard).
- Full suite: **1284 passing** (was 1281).

## Spec
`specs/IDENTITY_RECOGNITION_SPEC.md` head-cluster + severed-item rendering sections updated (hair in cluster; single flowing paragraph; per-location wound connection).

## Out of scope
`%`-style tokens (e.g. `%p`) remain unsupported — brace tokens only.