### PR TITLE
Gate corpse sever on a wielded blade with a timed Int+Motorics cut (#190)

### DIFF
--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -24,6 +24,7 @@ Currently ships:
 from __future__ import annotations
 
 from evennia import Command, create_object
+from evennia.utils import utils
 
 from typeclasses.corpse import Corpse
 from typeclasses.items import SeveredHead, apply_sever_to_corpse
@@ -31,12 +32,15 @@ from world.combat.constants import (
     AUTOPSY_DC_BASIC,
     HARVEST_CRIT_FAIL,
     HARVEST_DC_BASIC,
+    NDB_COMBAT_HANDLER,
     ORGAN_CONDITION_BY_DECAY,
-    SEVER_CRIT_FAIL,
-    SEVER_DC_BASIC,
+    SEVER_CRIT_FAIL_SUM,
+    SEVER_DC_INT_MOT,
+    SEVER_TIME_SECONDS,
     SEVERABLE_CONTAINERS,
 )
 from world.combat.dice import roll_stat
+from world.combat.utils import get_wielded_weapon
 from world.forensics import (
     attempt_forensic_recognition,
     extract_subject_from_corpse,
@@ -490,7 +494,12 @@ class CmdSever(Command):
       sever <location> from <corpse>
       sever <corpse>            (lists severable locations)
 
-    Rolls Motorics vs ``SEVER_DC_BASIC``.  On success an
+    Requires a wielded edged weapon flagged ``db.can_sever`` (PR #190).
+    The cut takes :data:`world.combat.constants.SEVER_TIME_SECONDS`
+    real-seconds and resolves on a combined
+    ``intellect + motorics`` roll vs
+    :data:`world.combat.constants.SEVER_DC_INT_MOT` — anatomical
+    know-how *and* a steady hand.  On success an
     :class:`~typeclasses.items.Appendage` item is spawned into the
     severer's inventory and the location is appended to
     ``corpse.db.severed_locations``.  Subsequent ``harvest`` attempts
@@ -499,13 +508,22 @@ class CmdSever(Command):
     spawn separate organ items for the contained anatomy; a future
     butchery pass may unbundle them).
 
-    A natural roll of ``SEVER_CRIT_FAIL`` botches the cut: no item,
-    no bookkeeping mutation, just a "mangled" message.  Unlike
+    A combined sum at or below
+    :data:`world.combat.constants.SEVER_CRIT_FAIL_SUM` botches the cut:
+    no item, no bookkeeping mutation, just a "mangled" message.  Unlike
     organ harvest crit-fail (which destroys the organ), limb
     botches are recoverable — try again.
 
+    The cut is **re-validated on completion** rather than actively
+    interrupted (the codebase has no channeled-action infrastructure).
+    If, when the timer fires, the actor has moved away from the corpse,
+    stopped wielding the blade, entered combat, or the corpse has been
+    moved or destroyed, the cut aborts with no mutation.
+
     Refused outright when:
 
+    * The actor is not wielding a ``can_sever`` weapon.
+    * A sever is already in progress for the actor.
     * The corpse is skeletal (no soft tissue left to cut through).
     * The corpse predates PR #186 and has no medical snapshot.
     * The named location is not in
@@ -603,9 +621,34 @@ class CmdSever(Command):
             )
             return
 
-        # Pre-roll broadcast.
+        # Wielded-blade gate (PR #190): the cut requires an edged
+        # weapon flagged ``can_sever``.  ``db.can_sever is not True``
+        # treats an unset / non-edged weapon as ineligible.
+        weapon = get_wielded_weapon(caller)
+        if weapon is None:
+            caller.msg(
+                "You need a bladed weapon in hand to sever a limb."
+            )
+            return
+        if weapon.db.can_sever is not True:
+            caller.msg(
+                f"{weapon.get_display_name(caller)} is too dull to "
+                f"sever a limb — you need a keener edge."
+            )
+            return
+
+        # One cut at a time.
+        if caller.ndb.sever_task is not None:
+            caller.msg("You are already mid-cut.")
+            return
+
         readable_name = location_arg.replace("_", " ")
-        corpse_display = target.get_display_name(caller)
+
+        # Pre-cut broadcast.
+        caller.msg(
+            f"You set your {weapon.get_display_name(caller)} to the "
+            f"{readable_name} and begin to cut..."
+        )
         msg_room_identity(
             location=caller.location,
             template=(
@@ -616,9 +659,79 @@ class CmdSever(Command):
             exclude=[caller],
         )
 
-        roll = roll_stat(caller, "motorics")
+        # Schedule the resolution.  The cut is re-validated on
+        # completion rather than actively interrupted.
+        caller.ndb.sever_task = utils.delay(
+            SEVER_TIME_SECONDS,
+            self._complete_sever,
+            caller,
+            target,
+            location_arg,
+        )
 
-        if roll == SEVER_CRIT_FAIL:
+    def _complete_sever(self, caller, target, location_arg):
+        """Resolve a scheduled sever after re-validating the situation.
+
+        Called by ``utils.delay`` once ``SEVER_TIME_SECONDS`` elapses.
+        Re-checks every precondition that could have changed during the
+        cut (the actor moving away, unwielding the blade, entering
+        combat, or the corpse being moved / destroyed) before rolling.
+        Any failed check aborts the cut with no mutation.
+        """
+        caller.ndb.sever_task = None
+        readable_name = location_arg.replace("_", " ")
+
+        # Corpse still present and intact?
+        if (
+            target is None
+            or target.pk is None
+            or target.location is None
+            or target.location != caller.location
+        ):
+            caller.msg(
+                f"The remains are gone; your cut for the "
+                f"{readable_name} finds nothing."
+            )
+            return
+        if target.get_decay_stage() == "skeletal":
+            caller.msg(
+                "The remains are too far decomposed — only bone is left."
+            )
+            return
+
+        # Blade still in hand and still keen?
+        weapon = get_wielded_weapon(caller)
+        if weapon is None or weapon.db.can_sever is not True:
+            caller.msg(
+                f"Without a blade in hand the cut for the "
+                f"{readable_name} comes to nothing."
+            )
+            return
+
+        # Not dragged into combat mid-cut.
+        if getattr(caller.ndb, NDB_COMBAT_HANDLER, None) is not None:
+            caller.msg(
+                f"The fighting breaks your concentration; you abandon "
+                f"the cut for the {readable_name}."
+            )
+            return
+
+        # Location still severable and not already taken.
+        if location_arg not in SEVERABLE_CONTAINERS:
+            return
+        if location_arg in (target.db.severed_locations or ()):
+            caller.msg(
+                f"The {readable_name} has already been severed from "
+                f"these remains."
+            )
+            return
+
+        corpse_display = target.get_display_name(caller)
+
+        # Combined Intellect + Motorics roll (PR #190).
+        roll = roll_stat(caller, "intellect") + roll_stat(caller, "motorics")
+
+        if roll <= SEVER_CRIT_FAIL_SUM:
             caller.msg(
                 f"Your cut goes wide — you mangle the {readable_name} "
                 f"but fail to detach it."
@@ -634,7 +747,7 @@ class CmdSever(Command):
             )
             return
 
-        if roll < SEVER_DC_BASIC:
+        if roll < SEVER_DC_INT_MOT:
             caller.msg(
                 f"You hack at {corpse_display} but cannot detach the "
                 f"{readable_name} cleanly. The limb remains attached."

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1714,23 +1714,49 @@ had.
 
 ### Command contract
 
-- **Roll**: Motorics vs `SEVER_DC_BASIC`.  Natural `SEVER_CRIT_FAIL`
-  (= 1) mangles the cut but leaves state intact — no item, no
-  bookkeeping mutation.  Crit-fail is **non-destructive** (unlike
-  harvest, which destroys the organ); limbs are coarser anatomy
-  and the realistic failure-mode is hacking a mess, not destroying
-  the limb beyond recovery.
+- **Wielded-blade gate**: the actor must wield an edged weapon flagged
+  `db.can_sever` (stamped on `SWORD`, `KATANA`, `DAGGER`,
+  `FIGHTING_FAN`/tessen, `CHAINSAW` prototypes).  A missing weapon
+  ("you need a bladed weapon in hand") or a non-`can_sever` weapon
+  ("too dull") is refused before any cut begins.  The check is
+  `weapon.db.can_sever is not True`, so an unset flag reads as
+  ineligible — no base-class default is required.
+- **Cast-time**: the cut takes `SEVER_TIME_SECONDS` real-seconds,
+  scheduled via `utils.delay`.  Only one cut may be in flight per
+  actor (`caller.ndb.sever_task`); a second `sever` is refused with
+  "you are already mid-cut".
+- **Roll**: combined `intellect + motorics` (two independent
+  `roll_stat` calls summed, per the `CmdExplosives` pattern) vs
+  `SEVER_DC_INT_MOT`.  A sum at or below `SEVER_CRIT_FAIL_SUM` mangles
+  the cut but leaves state intact — no item, no bookkeeping mutation.
+  Crit-fail is **non-destructive** (unlike harvest, which destroys the
+  organ); limbs are coarser anatomy and the realistic failure-mode is
+  hacking a mess, not destroying the limb beyond recovery.  `SEVER_DC_INT_MOT`
+  (14), `SEVER_CRIT_FAIL_SUM` (3), and `SEVER_TIME_SECONDS` (3) are
+  coarse placeholders pending a balance pass.
 - **Ambiguous form** (`sever <corpse>`) lists severable locations.
-- **Pre-roll refusals** (no Motorics roll spent):
+- **Pre-cast refusals** (no roll spent, no cut scheduled):
   - Skeletal corpse / pre-PR-#186 corpse.
   - Location not in
     :data:`world.combat.constants.SEVERABLE_CONTAINERS`.
   - Snapshot contains no organs in that container (the corpse
     never had that limb).
   - Location already in `corpse.db.severed_locations`.
-- **Pre-roll broadcast** via `msg_room_identity`.
+  - No `can_sever` weapon wielded; a cut already pending.
+- **Pre-cast broadcast** via `msg_room_identity`.
+- **Completion-time re-validation** (the codebase has no
+  channeled-action infrastructure; all timed actions validate at
+  completion rather than actively interrupting).  When the timer
+  fires, the cut aborts with **no mutation** if any of the following
+  changed during the cut — satisfying the four interruption rules:
+  - The corpse was moved away (`target.location != caller.location`)
+    or destroyed (`target.pk is None`), or has since gone skeletal.
+  - The actor stopped wielding a `can_sever` blade.
+  - The actor entered combat (`caller.ndb.combat_handler is not None`).
+  - The location was severed by someone else in the interim.
 - **On success**: append location to `severed_locations`, spawn
-  `Appendage` item with `configure_from_sever`.
+  `Appendage` (or `SeveredHead` for `head`) with `configure_from_sever`,
+  and `apply_sever_to_corpse` for the wound/longdesc carry-forward.
 
 ### Severable partition
 
@@ -1831,13 +1857,15 @@ limb — a future butchery pass may unbundle.
 ### DC tuning (provisional)
 
 ```python
-SEVER_DC_BASIC = 3
-SEVER_CRIT_FAIL = 1
+SEVER_DC_INT_MOT = 14      # vs intellect_roll + motorics_roll
+SEVER_CRIT_FAIL_SUM = 3    # combined sum at/under this botches
+SEVER_TIME_SECONDS = 3     # cast-time, re-validated on completion
 ```
 
-Matches `HARVEST_DC_BASIC` / `AUTOPSY_DC_BASIC` — all three are
-basic forensic / surgical competency gates.  Flagged for balance
-review alongside the harvest economy work.
+All three are coarse placeholders re-tuned for the combined
+`intellect + motorics` *sum* range (the old single-Motorics
+`SEVER_DC_BASIC = 3` / natural-1 `SEVER_CRIT_FAIL` no longer apply).
+Flagged for balance review alongside the harvest economy work.
 
 ### Out of scope (deferred past PR #190)
 

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -776,15 +776,25 @@ ORGAN_CONDITION_BY_DECAY = {
 }
 
 # Surgical Sever (PR #190) --------------------------------------------
-# Motorics DC for removing a limb (or the head) from a corpse via
-# ``sever <location> from <corpse>``.  A natural ``SEVER_CRIT_FAIL``
-# botches the cut — no item is spawned and no bookkeeping mutates,
-# unlike the harvest crit-fail which destroys the organ.  The
-# asymmetry is deliberate: limbs are coarser anatomy and the
-# failure-mode is "you hacked a mess into the corpse" rather than
-# "you ruptured a delicate organ".
-SEVER_DC_BASIC = 3
-SEVER_CRIT_FAIL = 1
+# ``sever <location> from <corpse>`` is gated on a wielded edged weapon
+# flagged ``db.can_sever`` and resolved on a combined Intellect+Motorics
+# roll (the cut demands anatomical know-how *and* a steady hand), unlike
+# the single-Motorics harvest.  A botch spawns no item and mutates no
+# bookkeeping — unlike the harvest crit-fail which destroys the organ.
+# The asymmetry is deliberate: limbs are coarser anatomy and the
+# failure-mode is "you hacked a mess into the corpse" rather than "you
+# ruptured a delicate organ".  Because the resolution rolls a two-die
+# *sum* rather than a single die, there is no natural-1 crit-fail — a
+# low *sum* botches instead.  All three values are deliberately coarse
+# placeholders; balance is deferred to a tuning pass.
+#
+# DC for ``intellect_roll + motorics_roll`` vs the cut.
+SEVER_DC_INT_MOT = 14
+# Combined-sum at or below this botches the cut (mangled, recoverable).
+SEVER_CRIT_FAIL_SUM = 3
+# Real-seconds the cut takes; re-validated on completion (the actor may
+# have moved, unwielded, entered combat, or the corpse may be gone).
+SEVER_TIME_SECONDS = 3
 
 # Severable body locations: the limb partition from
 # :meth:`world.medical.core.Organ._is_limb_container` plus ``head``

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -191,6 +191,7 @@ SWORD = {
     "damage": 10,
     "weapon_type": "long_sword",  # Using existing message type
     "damage_type": "cut",  # Medical system injury type
+    "can_sever": True,  # Edged: can sever limbs from a corpse (PR #190)
 }
 
 # Baseball bat (enhanced deflection)
@@ -240,6 +241,7 @@ KATANA = {
     "deflection_bonus": 0.25,  # +5 to deflection threshold (excellent for parrying)
     "weapon_type": "katana",  # Using existing katana message type
     "damage_type": "cut",  # Medical system injury type
+    "can_sever": True,  # Edged: can sever limbs from a corpse (PR #190)
 }
 
 # Dagger (poor deflection)
@@ -252,6 +254,7 @@ DAGGER = {
     "deflection_bonus": -0.05,  # -1 to deflection threshold (penalty)
     "weapon_type": "knife",  # Using existing message type
     "damage_type": "stab",  # Medical system injury type
+    "can_sever": True,  # Edged: can sever limbs from a corpse (PR #190)
 }
 
 # Tessen (iron war fan)
@@ -264,6 +267,7 @@ FIGHTING_FAN = {
     "deflection_bonus": 0.15,  # +3 to deflection threshold (good defensive weapon)
     "weapon_type": "tessen",
     "damage_type": "cut",  # Medical system injury type
+    "can_sever": True,  # Edged: can sever limbs from a corpse (PR #190)
 }
 
 # Chainsaw (devastating damage, no deflection)
@@ -276,6 +280,7 @@ CHAINSAW = {
     "deflection_bonus": -0.50,  # -10 to deflection threshold (major penalty - chainsaws are terrible for defense)
     "weapon_type": "chainsaw",  # Using our newly converted message type
     "damage_type": "laceration",  # Medical system injury type
+    "can_sever": True,  # Edged: can sever limbs from a corpse (PR #190)
 }
 
 # =============================================================================

--- a/world/tests/test_cmd_sever.py
+++ b/world/tests/test_cmd_sever.py
@@ -3,22 +3,24 @@
 Mirrors the harvest test strategy: lightweight fakes + Corpse symbol
 swap so ``isinstance(target, Corpse)`` accepts our stand-in.
 
-Coverage matrix:
+PR #190 enhancements covered here:
 
-* Usage / argument parsing.
-* Non-corpse rejection.
-* Skeletal short-circuit.
-* Pre-PR-#186 snapshot-less refusal.
-* Ambiguous form lists severable locations (filters non-severable
-  containers and already-severed).
-* Non-severable container rejection (e.g. ``chest``).
-* Snapshot-missing-location rejection.
-* Already-severed rejection.
-* Mid-range fail vs crit-fail vs success — bookkeeping correctness.
-* Condition tracks decay.
-* Forward-compat: after sever-arm, harvest cannot target organs in
-  that arm (verified at the harvest gate, exercised here by reading
-  the post-sever ``severed_locations`` state).
+* Wielded-blade gate — a ``db.can_sever`` weapon is required; a missing
+  or dull weapon is refused before any cut begins.
+* One-cut-at-a-time guard (``caller.ndb.sever_task``).
+* Cast-time scheduling via ``utils.delay`` (``SEVER_TIME_SECONDS``).
+* Combined ``intellect + motorics`` resolution vs ``SEVER_DC_INT_MOT``;
+  a sum at or below ``SEVER_CRIT_FAIL_SUM`` botches (recoverable).
+* Completion-time re-validation: the cut aborts with no mutation if the
+  corpse moved / was destroyed, the actor stopped wielding the blade,
+  or the actor entered combat during the cut.
+
+Legacy coverage retained:
+
+* Usage / argument parsing, non-corpse rejection, skeletal / snapshot
+  gates, ambiguous listing, per-location refusals, bookkeeping
+  correctness, head routing to ``SeveredHead``, wound + longdesc
+  carry-forward (PR #198), head-sever identity surface (issue #208).
 
 Run via::
 
@@ -27,6 +29,7 @@ Run via::
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -34,8 +37,9 @@ from commands import forensics as cmd_module
 from commands.forensics import CmdSever
 from world.combat.constants import (
     ORGAN_CONDITION_BY_DECAY,
-    SEVER_CRIT_FAIL,
-    SEVER_DC_BASIC,
+    SEVER_CRIT_FAIL_SUM,
+    SEVER_DC_INT_MOT,
+    SEVER_TIME_SECONDS,
 )
 
 
@@ -70,9 +74,13 @@ class _FakeCorpse(_CorpseStandIn):
         wounds_at_death=None,
         longdesc_data=None,
         dbref="#101",
+        location=None,
+        pk=101,
     ):
         self.key = key
         self.dbref = dbref
+        self.pk = pk
+        self.location = location
         self.db = _DB()
         self.db.signature_at_death = (
             "sleeve-1", "tall", "lean", "hooded", ("balaclava",),
@@ -133,7 +141,26 @@ def _make_caller(*, location=None):
     caller.msg = MagicMock()
     caller.search = MagicMock()
     caller.motorics = 10
+    caller.intellect = 10
+    # Pending-cast / combat re-validation state (PR #190).
+    caller.ndb.sever_task = None
+    caller.ndb.combat_handler = None
     return caller
+
+
+def _make_weapon(*, can_sever=True, display="a knife"):
+    weapon = MagicMock()
+    weapon.db.can_sever = can_sever
+    weapon.get_display_name = MagicMock(return_value=display)
+    return weapon
+
+
+def _make_corpse(caller, **kwargs):
+    """Build a corpse co-located with *caller* and wire it to search."""
+    kwargs.setdefault("location", caller.location)
+    corpse = _FakeCorpse(**kwargs)
+    caller.search.return_value = corpse
+    return corpse
 
 
 def _make_cmd(*, caller, args):
@@ -142,6 +169,51 @@ def _make_cmd(*, caller, args):
     cmd.args = args
     cmd.switches = ()
     return cmd
+
+
+def _rolls(intel, motor):
+    """A ``roll_stat`` side-effect returning per-stat fixed values."""
+    def _inner(char, stat, *args, **kwargs):
+        del char, args, kwargs
+        return {"intellect": intel, "motorics": motor}.get(stat, 1)
+    return _inner
+
+
+def _immediate_delay(seconds, callback, *args, **kwargs):
+    """Stand-in for ``utils.delay`` that resolves synchronously."""
+    del seconds
+    callback(*args, **kwargs)
+    return MagicMock()
+
+
+# Per-stat roll values that land the combined sum in each band.
+_SUCCESS = SEVER_DC_INT_MOT  # intel + motor == DC (success boundary)
+_MID_FAIL = SEVER_CRIT_FAIL_SUM + 2  # above crit band, below DC
+_CRIT = 1  # sum == 2 → at/under SEVER_CRIT_FAIL_SUM (assumes >= 2)
+
+
+def _split(total):
+    """Split a target sum into (intellect, motorics) halves."""
+    return total // 2, total - total // 2
+
+
+@contextmanager
+def _sever_env(*, weapon=None, intel=None, motor=None, create_return=None):
+    """Patch the cast-time + roll surface for a full sever resolution."""
+    weapon = weapon if weapon is not None else _make_weapon()
+    if intel is None or motor is None:
+        intel, motor = _split(_SUCCESS)
+    create_mock = MagicMock(return_value=create_return or MagicMock())
+    with patch.object(
+        cmd_module, "get_wielded_weapon", return_value=weapon
+    ), patch.object(
+        cmd_module.utils, "delay", side_effect=_immediate_delay
+    ), patch.object(
+        cmd_module, "roll_stat", side_effect=_rolls(intel, motor)
+    ), patch.object(
+        cmd_module, "create_object", create_mock
+    ):
+        yield create_mock
 
 
 class CmdSeverTests(TestCase):
@@ -171,17 +243,15 @@ class CmdSeverTests(TestCase):
 
     def test_skeletal_short_circuit(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(
-            decay_stage="skeletal", snapshot=_snapshot_with_limbs()
+        _make_corpse(
+            caller, decay_stage="skeletal", snapshot=_snapshot_with_limbs()
         )
-        caller.search.return_value = corpse
         _make_cmd(caller=caller, args="left_arm from corpse").func()
         self.assertIn("decomposed", caller.msg.call_args[0][0])
 
     def test_no_snapshot_refused(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=None)
-        caller.search.return_value = corpse
+        _make_corpse(caller, snapshot=None)
         _make_cmd(caller=caller, args="left_arm from corpse").func()
         self.assertIn("predate", caller.msg.call_args[0][0])
 
@@ -189,8 +259,7 @@ class CmdSeverTests(TestCase):
 
     def test_ambiguous_lists_severable(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
+        _make_corpse(caller, snapshot=_snapshot_with_limbs())
         _make_cmd(caller=caller, args="corpse").func()
         msg = caller.msg.call_args[0][0]
         # Limb partition + head present
@@ -202,14 +271,14 @@ class CmdSeverTests(TestCase):
 
     def test_ambiguous_with_nothing_left(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(
+        _make_corpse(
+            caller,
             snapshot=_snapshot_with_limbs(),
             severed_locations=[
                 "head", "left_arm", "right_arm",
                 "left_thigh", "right_thigh",
             ],
         )
-        caller.search.return_value = corpse
         _make_cmd(caller=caller, args="corpse").func()
         self.assertIn("no limbs left", caller.msg.call_args[0][0])
 
@@ -217,8 +286,7 @@ class CmdSeverTests(TestCase):
 
     def test_non_severable_container_rejected(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
+        _make_corpse(caller, snapshot=_snapshot_with_limbs())
         _make_cmd(caller=caller, args="chest from corpse").func()
         self.assertIn(
             "not a detachable", caller.msg.call_args[0][0]
@@ -234,44 +302,130 @@ class CmdSeverTests(TestCase):
                 },
             },
         }
-        corpse = _FakeCorpse(snapshot=snap)
-        caller.search.return_value = corpse
+        _make_corpse(caller, snapshot=snap)
         _make_cmd(caller=caller, args="left_arm from corpse").func()
         self.assertIn("no left arm", caller.msg.call_args[0][0])
 
     def test_already_severed_rejected(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(
+        _make_corpse(
+            caller,
             snapshot=_snapshot_with_limbs(),
             severed_locations=["left_arm"],
         )
-        caller.search.return_value = corpse
         _make_cmd(caller=caller, args="left_arm from corpse").func()
         self.assertIn(
             "already been severed", caller.msg.call_args[0][0]
         )
 
+    # ----- wielded-blade gate (PR #190) -----
+
+    def test_no_weapon_refused(self):
+        caller = _make_caller()
+        _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with patch.object(
+            cmd_module, "get_wielded_weapon", return_value=None
+        ), patch.object(cmd_module.utils, "delay") as delay:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            delay.assert_not_called()
+        self.assertIn("bladed weapon", caller.msg.call_args[0][0])
+
+    def test_dull_weapon_refused(self):
+        caller = _make_caller()
+        _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        blunt = _make_weapon(can_sever=False, display="a club")
+        with patch.object(
+            cmd_module, "get_wielded_weapon", return_value=blunt
+        ), patch.object(cmd_module.utils, "delay") as delay:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            delay.assert_not_called()
+        self.assertIn("too dull", caller.msg.call_args[0][0])
+
+    def test_already_mid_cut_refused(self):
+        caller = _make_caller()
+        caller.ndb.sever_task = MagicMock()  # a cut already pending
+        _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with patch.object(
+            cmd_module, "get_wielded_weapon", return_value=_make_weapon()
+        ), patch.object(cmd_module.utils, "delay") as delay:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            delay.assert_not_called()
+        self.assertIn("already mid-cut", caller.msg.call_args[0][0])
+
+    # ----- cast-time scheduling -----
+
+    def test_schedules_delayed_cut(self):
+        """A valid request schedules the resolution rather than
+        resolving inline; nothing is spawned until the timer fires."""
+        caller = _make_caller()
+        _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with patch.object(
+            cmd_module, "get_wielded_weapon", return_value=_make_weapon()
+        ), patch.object(cmd_module.utils, "delay") as delay, \
+                patch.object(cmd_module, "create_object") as mk:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            delay.assert_called_once()
+            self.assertEqual(delay.call_args[0][0], SEVER_TIME_SECONDS)
+            mk.assert_not_called()
+
+    # ----- completion-time re-validation (PR #190) -----
+
+    def test_completion_aborts_if_corpse_moved_away(self):
+        caller = _make_caller()
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        corpse.location = _FakeRoom()  # no longer co-located
+        with _sever_env() as mk:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            mk.assert_not_called()
+        self.assertEqual(corpse.db.severed_locations, [])
+
+    def test_completion_aborts_if_corpse_destroyed(self):
+        caller = _make_caller()
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        corpse.pk = None  # deleted mid-cut
+        with _sever_env() as mk:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            mk.assert_not_called()
+        self.assertEqual(corpse.db.severed_locations, [])
+
+    def test_completion_aborts_if_blade_unwielded(self):
+        caller = _make_caller()
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        # Blade present at the gate, gone by completion.
+        weapon = _make_weapon()
+        with patch.object(
+            cmd_module, "get_wielded_weapon", side_effect=[weapon, None]
+        ), patch.object(
+            cmd_module.utils, "delay", side_effect=_immediate_delay
+        ), patch.object(cmd_module, "create_object") as mk:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            mk.assert_not_called()
+        self.assertEqual(corpse.db.severed_locations, [])
+
+    def test_completion_aborts_if_in_combat(self):
+        caller = _make_caller()
+        caller.ndb.combat_handler = MagicMock()  # dragged into a fight
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with _sever_env() as mk:
+            _make_cmd(caller=caller, args="left_arm from corpse").func()
+            mk.assert_not_called()
+        self.assertEqual(corpse.db.severed_locations, [])
+
     # ----- roll outcomes -----
 
     def test_roll_fail_leaves_state_intact(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
-        fail_roll = SEVER_DC_BASIC - 1
-        self.assertGreater(fail_roll, SEVER_CRIT_FAIL)
-        with patch.object(cmd_module, "roll_stat", return_value=fail_roll), \
-                patch.object(cmd_module, "create_object") as mk:
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        intel, motor = _split(_MID_FAIL)
+        with _sever_env(intel=intel, motor=motor) as mk:
             _make_cmd(caller=caller, args="left_arm from corpse").func()
             mk.assert_not_called()
         self.assertEqual(corpse.db.severed_locations, [])
 
     def test_crit_fail_no_mutation_no_item(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_CRIT_FAIL
-        ), patch.object(cmd_module, "create_object") as mk:
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with _sever_env(intel=_CRIT, motor=_CRIT) as mk:
             _make_cmd(caller=caller, args="left_arm from corpse").func()
             mk.assert_not_called()
         # Unlike harvest crit-fail, sever crit-fail does NOT destroy
@@ -285,14 +439,9 @@ class CmdSeverTests(TestCase):
 
     def test_success_spawns_appendage_and_appends(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
         fake_app = MagicMock()
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=fake_app
-        ) as mk:
+        with _sever_env(create_return=fake_app) as mk:
             _make_cmd(caller=caller, args="left_arm from corpse").func()
             mk.assert_called_once()
             kwargs = mk.call_args.kwargs
@@ -307,29 +456,20 @@ class CmdSeverTests(TestCase):
 
     def test_success_condition_tracks_decay(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(
-            snapshot=_snapshot_with_limbs(), decay_stage="advanced"
+        corpse = _make_corpse(
+            caller, snapshot=_snapshot_with_limbs(), decay_stage="advanced"
         )
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC + 5
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ) as mk:
+        with _sever_env() as mk:
             _make_cmd(caller=caller, args="head from corpse").func()
         self.assertIn(
             ORGAN_CONDITION_BY_DECAY["advanced"], mk.call_args.kwargs["key"]
         )
+        self.assertEqual(corpse.db.severed_locations, ["head"])
 
     def test_location_accepts_spaces(self):
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ):
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with _sever_env():
             _make_cmd(caller=caller, args="left arm from corpse").func()
         self.assertEqual(corpse.db.severed_locations, ["left_arm"])
 
@@ -343,13 +483,8 @@ class CmdSeverTests(TestCase):
         state contract those tests depend on.
         """
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ):
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with _sever_env():
             _make_cmd(caller=caller, args="left_arm from corpse").func()
         self.assertIn("left_arm", corpse.db.severed_locations)
 
@@ -360,13 +495,8 @@ class CmdSeverTests(TestCase):
         not the plain ``Appendage`` other locations get.
         """
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ) as mk:
+        _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with _sever_env() as mk:
             _make_cmd(caller=caller, args="head from corpse").func()
         args, kwargs = mk.call_args
         # First positional arg is the typeclass path.
@@ -376,13 +506,8 @@ class CmdSeverTests(TestCase):
     def test_non_head_still_routes_to_appendage(self):
         """Non-head severable locations still spawn plain Appendage."""
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ) as mk:
+        _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with _sever_env() as mk:
             _make_cmd(caller=caller, args="left_arm from corpse").func()
         args, _ = mk.call_args
         self.assertEqual(args[0], "typeclasses.items.Appendage")
@@ -393,19 +518,15 @@ class CmdSeverTests(TestCase):
         """After a limb sever, the corpse's longdesc for that location
         is removed (it moved to the appendage)."""
         caller = _make_caller()
-        corpse = _FakeCorpse(
+        corpse = _make_corpse(
+            caller,
             snapshot=_snapshot_with_limbs(),
             longdesc_data={
                 "left_arm": "a pale freckled arm",
                 "chest": "a broad chest",
             },
         )
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ):
+        with _sever_env():
             _make_cmd(caller=caller, args="left_arm from corpse").func()
         self.assertNotIn("left_arm", corpse.db.longdesc_data)
         self.assertIn("chest", corpse.db.longdesc_data)
@@ -414,13 +535,8 @@ class CmdSeverTests(TestCase):
         """After a limb sever, the corpse gains a synthesized
         ``severed``-type wound at the severed location."""
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ):
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with _sever_env():
             _make_cmd(caller=caller, args="left_arm from corpse").func()
         stump_wounds = [
             w for w in corpse.db.wounds_at_death
@@ -433,7 +549,8 @@ class CmdSeverTests(TestCase):
         """Severing the head clears longdesc for the entire
         SEVERED_HEAD_LOCATIONS cluster, not just ``head``."""
         caller = _make_caller()
-        corpse = _FakeCorpse(
+        corpse = _make_corpse(
+            caller,
             snapshot=_snapshot_with_limbs(),
             longdesc_data={
                 "head": "a shaven scalp",
@@ -443,12 +560,7 @@ class CmdSeverTests(TestCase):
                 "chest": "a broad chest",
             },
         )
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ):
+        with _sever_env():
             _make_cmd(caller=caller, args="head from corpse").func()
         self.assertEqual(set(corpse.db.longdesc_data.keys()), {"chest"})
 
@@ -460,29 +572,18 @@ class CmdSeverTests(TestCase):
         ``Corpse.get_display_name`` reads to suppress unaided
         recognition while preserving autopsy access."""
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
         # Pre-sever invariant: flag absent / falsy.
         self.assertFalse(getattr(corpse.db, "head_severed", False))
-        caller.search.return_value = corpse
-        fake_head = MagicMock()
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=fake_head
-        ):
+        with _sever_env(create_return=MagicMock()):
             _make_cmd(caller=caller, args="head from corpse").func()
         self.assertTrue(corpse.db.head_severed)
 
     def test_limb_sever_does_not_mark_head_severed(self):
         """Severing a non-head limb must NOT set head_severed."""
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ):
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        with _sever_env():
             _make_cmd(caller=caller, args="left_arm from corpse").func()
         self.assertFalse(getattr(corpse.db, "head_severed", False))
 
@@ -491,16 +592,11 @@ class CmdSeverTests(TestCase):
         ``apparent_uid_at_death`` / ``sleeve_uid`` after the head is
         severed — autopsy and recognition-memory lookups still work."""
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
         sig_before = corpse.db.signature_at_death
         uid_before = corpse.db.apparent_uid_at_death
         sleeve_before = corpse.db.signature_at_death[0]
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC
-        ), patch.object(
-            cmd_module, "create_object", return_value=MagicMock()
-        ):
+        with _sever_env():
             _make_cmd(caller=caller, args="head from corpse").func()
         self.assertEqual(corpse.db.signature_at_death, sig_before)
         self.assertEqual(corpse.db.apparent_uid_at_death, uid_before)
@@ -509,29 +605,22 @@ class CmdSeverTests(TestCase):
     def test_failed_head_sever_does_not_mark_head_severed(self):
         """Sub-DC head roll must not set ``head_severed``."""
         caller = _make_caller()
-        corpse = _FakeCorpse(snapshot=_snapshot_with_limbs())
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC - 1
-        ), patch.object(
-            cmd_module, "create_object"
-        ):
+        corpse = _make_corpse(caller, snapshot=_snapshot_with_limbs())
+        intel, motor = _split(_MID_FAIL)
+        with _sever_env(intel=intel, motor=motor):
             _make_cmd(caller=caller, args="head from corpse").func()
         self.assertFalse(getattr(corpse.db, "head_severed", False))
 
     def test_failed_sever_does_not_clear_longdesc(self):
         """Sub-DC rolls must not mutate corpse longdesc."""
         caller = _make_caller()
-        corpse = _FakeCorpse(
+        corpse = _make_corpse(
+            caller,
             snapshot=_snapshot_with_limbs(),
             longdesc_data={"left_arm": "a pale arm"},
         )
-        caller.search.return_value = corpse
-        with patch.object(
-            cmd_module, "roll_stat", return_value=SEVER_DC_BASIC - 1
-        ), patch.object(
-            cmd_module, "create_object"
-        ):
+        intel, motor = _split(_MID_FAIL)
+        with _sever_env(intel=intel, motor=motor):
             _make_cmd(caller=caller, args="left_arm from corpse").func()
         # Longdesc untouched on failure.
         self.assertEqual(


### PR DESCRIPTION
## Summary

Enhances the existing corpse-only `sever <location> from <corpse>` command (issue #190) with three contracts, all surfaced on the existing `CmdSever` — no combat/living-character sever is introduced.

- **Wielded-blade gate** — requires an edged weapon flagged `db.can_sever`, stamped on the `SWORD`, `KATANA`, `DAGGER`, `FIGHTING_FAN` (tessen), and `CHAINSAW` prototypes. A missing weapon or a non-`can_sever` weapon is refused before any cut begins (`weapon.db.can_sever is not True`, so unset reads as ineligible — no base-class default needed).
- **Combined Intellect+Motorics roll** vs `SEVER_DC_INT_MOT`, with a low-sum botch band `SEVER_CRIT_FAIL_SUM` replacing the obsolete single-Motorics natural-1 crit-fail. Botch remains non-destructive (recoverable), unlike harvest.
- **Configurable cast-time** (`SEVER_TIME_SECONDS`) scheduled via `utils.delay`, re-validated on completion rather than actively interrupted (the codebase has no channeled-action infrastructure). The four interruption rules — actor moves away, corpse moved/destroyed, blade unwielded, actor enters combat — are enforced as completion-time abort checks with no mutation. One cut at a time per actor (`caller.ndb.sever_task`).

Retires the now-unused `SEVER_DC_BASIC` / `SEVER_CRIT_FAIL`. The three new constants are coarse placeholders pending a balance pass.

## Testing

- `evennia test world.tests.test_cmd_sever` — 33 tests (was 25), covering the blade gate, pending-cast guard, cast-time scheduling, all four completion-time re-validation aborts, the Int+Motorics roll bands, and the retained PR-194/#198/#208 behaviour.
- Full suite `world commands typeclasses` — **1292 passing** (baseline 1284).

## Docs

- `specs/IDENTITY_RECOGNITION_SPEC.md` Surgical Sever section updated: blade gate, cast-time, completion-time re-validation model, and re-tuned DC constants.