### PR TITLE
Add neck organ and decapitation death model (#243)

### DIFF
--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -173,6 +173,19 @@ BODY_CAPACITIES = {
         "stomach_contribution": 0.5,  # Stomach is secondary
         "fatal_threshold": 0.0  # Death if liver lost
     },
+    "neck_integrity": {
+        # Decapitation gate. The cervical spine bundles the airway, the
+        # great vessels, and the spinal cord at the neck; severing it is
+        # immediately fatal. Modeled as its own vital capacity (rather
+        # than folding into "breathing") so destruction reads as a clean
+        # decapitation death without perturbing the lungs' contribution
+        # math. See is_dead() in core.py and combat-sever Phase A (#243).
+        "organs": ["cervical_spine"],
+        "fatal_threshold": 0.0,
+        "directly_fatal": True,
+        "affects": ["consciousness", "breathing", "moving"],
+        "description": "Integrity of the neck - zero equals decapitation/death"
+    },
     
     # Blood Loss System
     "blood_loss": {
@@ -276,6 +289,19 @@ ORGANS = {
         "capacities": ["talking", "eating"], "talking_contribution": "major",
         "eating_contribution": "moderate", "disfiguring_if_lost": True, "can_scar": False,
         "can_be_harvested": True
+    },
+
+    # NECK CONTAINER → DECAPITATION STRUCTURE
+    # The cervical spine is the decapitation locus (combat-sever Phase A,
+    # #243). Unlike the thoracic/lumbar "spine" organ in the "back"
+    # container (cannot_be_destroyed), this one CAN be destroyed: bringing
+    # it to 0 HP severs the head from the body. It is vital and gates the
+    # "neck_integrity" capacity (total contribution), so destruction is
+    # immediately fatal via is_dead().
+    "cervical_spine": {
+        "container": "neck", "max_hp": 12, "hit_weight": "rare",
+        "vital": True, "capacity": "neck_integrity", "contribution": "total",
+        "causes_pain_when_damaged": True, "can_be_destroyed": True
     },
 
     # CHEST CONTAINER → VITAL ORGANS INSIDE  

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -411,6 +411,8 @@ class MedicalState:
             return True
         if self.calculate_body_capacity("digestion") <= 0.0:
             return True  # Liver failure
+        if self.calculate_body_capacity("neck_integrity") <= 0.0:
+            return True  # Decapitation - cervical spine severed (#243)
             
         # Death from blood loss
         if self.blood_level <= (100.0 - BLOOD_LOSS_DEATH_THRESHOLD):

--- a/world/tests/test_neck_organ_decapitation.py
+++ b/world/tests/test_neck_organ_decapitation.py
@@ -1,0 +1,94 @@
+"""Tests for the neck organ + decapitation death model (combat-sever Phase A, #243).
+
+Covers:
+
+* schema presence of the ``cervical_spine`` organ and the
+  ``neck_integrity`` body capacity;
+* hit-location routing — ``neck`` resolves to ``cervical_spine``;
+* the death wiring — destroying ``cervical_spine`` drives
+  ``MedicalState.is_dead()`` True via ``neck_integrity`` at 0.0;
+* the pre-migration safety net — a medical state that lacks the organ
+  lazily reads a healthy neck (not decapitated) thanks to
+  ``get_organ`` lazy creation.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.medical.constants import BODY_CAPACITIES, ORGANS
+from world.medical.core import MedicalState
+from world.medical.utils import (
+    get_organ_by_body_location,
+    select_target_organ,
+)
+
+
+class TestNeckOrganSchema(TestCase):
+    """The neck organ and its capacity must be registered in the schema."""
+
+    def test_cervical_spine_registered(self):
+        self.assertIn("cervical_spine", ORGANS)
+        organ = ORGANS["cervical_spine"]
+        self.assertEqual(organ["container"], "neck")
+        self.assertTrue(organ.get("vital"))
+        self.assertEqual(organ.get("capacity"), "neck_integrity")
+        self.assertEqual(organ.get("contribution"), "total")
+
+    def test_cervical_spine_is_destroyable(self):
+        # Unlike the thoracic/lumbar ``spine`` in the ``back`` container,
+        # the cervical spine must be destroyable (it is the decapitation
+        # locus).
+        self.assertTrue(ORGANS["cervical_spine"].get("can_be_destroyed"))
+        self.assertNotIn("cannot_be_destroyed", ORGANS["cervical_spine"])
+
+    def test_neck_integrity_capacity_registered(self):
+        self.assertIn("neck_integrity", BODY_CAPACITIES)
+        cap = BODY_CAPACITIES["neck_integrity"]
+        self.assertEqual(cap["organs"], ["cervical_spine"])
+        self.assertTrue(cap.get("directly_fatal"))
+
+
+class TestNeckHitRouting(TestCase):
+    """Combat damage aimed at the neck must resolve to the cervical spine."""
+
+    def test_neck_location_contains_cervical_spine(self):
+        organs = get_organ_by_body_location("neck")
+        self.assertIn("cervical_spine", organs)
+
+    def test_select_target_organ_neck(self):
+        # The neck has a single organ, so selection is deterministic.
+        organ = select_target_organ("neck", precision_roll=10, attacker_skill=5)
+        self.assertEqual(organ, "cervical_spine")
+
+
+class TestDecapitationDeath(TestCase):
+    """Destroying the cervical spine is immediately fatal."""
+
+    def test_healthy_neck_is_full_and_alive(self):
+        state = MedicalState()
+        self.assertAlmostEqual(
+            state.calculate_body_capacity("neck_integrity"), 1.0
+        )
+        self.assertFalse(state.is_dead())
+
+    def test_destroyed_cervical_spine_is_fatal(self):
+        state = MedicalState()
+        organ = state.get_organ("cervical_spine")
+        state.take_organ_damage("cervical_spine", organ.max_hp + 5, "cut")
+        self.assertTrue(state.get_organ("cervical_spine").is_destroyed())
+        self.assertEqual(
+            state.calculate_body_capacity("neck_integrity"), 0.0
+        )
+        self.assertTrue(state.is_dead())
+
+    def test_missing_organ_lazily_reads_healthy(self):
+        # Simulates a pre-migration character whose persisted organ set
+        # lacks ``cervical_spine``.  ``get_organ`` lazily creates a full-HP
+        # organ, so the character must NOT read as decapitated.
+        state = MedicalState()
+        state.organs.pop("cervical_spine", None)
+        self.assertAlmostEqual(
+            state.calculate_body_capacity("neck_integrity"), 1.0
+        )
+        self.assertFalse(state.is_dead())


### PR DESCRIPTION
## Summary
- Add a real `cervical_spine` organ (container `neck`, vital, hit_weight `rare`, `max_hp 12`, destroyable) — the decapitation locus the model previously lacked.
- Add a new explicit vital capacity `neck_integrity` (cervical spine contributes `total`) so destruction is fatal without perturbing the lungs' breathing math.
- Wire `MedicalState.is_dead()` to treat `neck_integrity <= 0.0` as death (decapitation).

## Notes
- **No mass-death risk pre-migration:** `get_organ` lazily creates a full-HP organ, so characters whose persisted medical state predates `cervical_spine` read a healthy neck. A DB backfill (persisting the organ into existing states) will run post-merge during deploy, mirroring the #190 `can_sever` backfill.
- `neck` location display + anatomy mappings already existed; no display/ordering changes needed.

## Tests
- New `world/tests/test_neck_organ_decapitation.py` (8 tests): schema presence, neck→cervical_spine hit routing, decapitation→`is_dead`, and the pre-migration lazy-read safety net.
- Full `world` suite: **1300 passing** (1292 baseline + 8), no regressions.

## Scope
Phase A of the combat-driven severance feature. Living-limb detachment + item retention (Phase B), combat trigger + weapon gate (Phase C), and spec/docs (Phase D) follow in separate PRs.

Closes #243