### PR TITLE
Trigger limb severance and decapitation from edged combat damage

### DIFF
--- a/typeclasses/armor_mixin.py
+++ b/typeclasses/armor_mixin.py
@@ -76,6 +76,14 @@ class ArmorMixin:
         # Save medical state after damage
         self.save_medical_state()
 
+        # Combat-driven severance (Phase C, issue #245 follow-up): an
+        # edged hit that reduces a severable limb's bone to 0 HP shears
+        # the limb clean off; an edged neck hit that destroys the
+        # cervical spine flags a decapitation to be realised in the
+        # death → corpse pipeline.  Must run before the death handler
+        # below so the flag is set before ``at_death`` spawns the corpse.
+        self._maybe_sever_from_damage(location, injury_type)
+
         # Debug broadcast damage application
         try:
             from world.combat.utils import debug_broadcast
@@ -97,6 +105,84 @@ class ArmorMixin:
 
         # Return death status and actual damage applied (after armor) for combat system
         return (died, final_damage)
+
+    def _bone_freshly_destroyed(self, location):
+        """Return True if ``location``'s bone organ was just destroyed.
+
+        A severable limb container holds exactly one representative bone
+        organ.  This reports True when that organ is present, at or below
+        0 HP, and not already marked ``"severed"`` — i.e. this hit (or a
+        prior combat hit) pulped it, but it has not yet been amputated.
+        The ``"severed"`` guard makes the caller idempotent: a second
+        edged hit to an already-detached stump will not re-sever it.
+
+        Args:
+            location (str): Body location / container to inspect.
+
+        Returns:
+            bool: Whether a fresh (un-severed) bone destruction is present.
+        """
+        try:
+            medical_state = self.medical_state
+        except AttributeError:
+            return False
+        if medical_state is None:
+            return False
+
+        organs = [
+            organ for organ in medical_state.organs.values()
+            if getattr(organ, "container", None) == location
+        ]
+        if not organs:
+            return False
+        return all(
+            organ.current_hp <= 0 and organ.wound_stage != "severed"
+            for organ in organs
+        )
+
+    def _maybe_sever_from_damage(self, location, injury_type):
+        """Detach a limb or flag a decapitation when an edged hit pulps bone.
+
+        Only edged / sharp injuries (:data:`SEVERING_INJURY_TYPES`) shear
+        a part off; blunt, bullet, and burn damage destroy the bone in
+        place without a clean detachment.  The body part must have just
+        lost its representative bone (see :meth:`_bone_freshly_destroyed`).
+
+        * **Neck** — a destroyed cervical spine is already lethal via
+          ``neck_integrity`` collapse, so we cannot sever synchronously
+          (the corpse does not yet exist).  Instead we set
+          ``db.decapitation_pending``; the death → corpse pipeline reads
+          it and spawns the :class:`~typeclasses.items.SeveredHead`.
+        * **Any other severable limb** — survivable.  We detach it
+          immediately into an :class:`~typeclasses.items.Appendage` via
+          :func:`~typeclasses.items.apply_sever_to_character`.
+
+        Args:
+            location (str): Body location that was hit.
+            injury_type (str): Injury type applied.
+        """
+        from world.combat.constants import (
+            SEVERABLE_CONTAINERS,
+            SEVERING_INJURY_TYPES,
+        )
+
+        if injury_type not in SEVERING_INJURY_TYPES:
+            return
+
+        if location == "neck":
+            if self._bone_freshly_destroyed("neck"):
+                self.db.decapitation_pending = True
+            return
+
+        # Living limb severance: head is excluded (decapitation routes
+        # through the neck → death path above), neck is handled above.
+        if location not in SEVERABLE_CONTAINERS or location == "head":
+            return
+        if not self._bone_freshly_destroyed(location):
+            return
+
+        from typeclasses.items import apply_sever_to_character
+        apply_sever_to_character(self, location, injury_type=injury_type)
 
     def _calculate_armor_damage_reduction(self, damage, location, injury_type):
         """

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -681,6 +681,27 @@ class DeathProgressionScript(DefaultScript):
         sdesc = corpse.db.sdesc_at_death if corpse.db.sdesc_at_death is not None else character.key
         corpse.db.desc = f"The lifeless body of a {sdesc}. {corpse.db.physical_description}"
         
+        # Combat-driven decapitation (Phase C, issue #245 follow-up): a
+        # lethal edged neck hit set ``db.decapitation_pending`` on the
+        # dying character in ``ArmorMixin.take_damage``.  The death
+        # pipeline is asynchronous, so the actual head-item spawn waits
+        # until here, once the corpse is fully populated with longdesc /
+        # wound / identity snapshots.  ``spawn_severed_head_for_corpse``
+        # mirrors the manual ``CmdSever`` head path.
+        if character.db.decapitation_pending:
+            try:
+                from typeclasses.items import spawn_severed_head_for_corpse
+                spawn_severed_head_for_corpse(corpse)
+            except Exception as e:
+                try:
+                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    splattercast.msg(
+                        f"DEATH_DECAPITATION_ERROR: {character.key} - {e}"
+                    )
+                except Exception:
+                    pass
+            character.db.decapitation_pending = False
+        
         return corpse
 
     def _transition_character_to_death(self, character):

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1477,6 +1477,62 @@ def apply_sever_to_corpse(corpse, location_arg, *, head_locations=None):
         corpse.db.head_severed = True
 
 
+def spawn_severed_head_for_corpse(corpse):
+    """Spawn + configure a :class:`SeveredHead` for a decapitated corpse.
+
+    Combat-driven decapitation (Phase C, issue #245 follow-up) cannot
+    reach the corpse synchronously: a lethal edged neck hit flags the
+    dying character, the asynchronous death pipeline builds the corpse,
+    and this helper is invoked at the tail of
+    :meth:`typeclasses.death_progression.DeathProgressionScript._create_corpse_from_character`
+    once the corpse is fully populated.  It mirrors the manual
+    :class:`commands.forensics.CmdSever` head path: spawn the
+    super-item, copy the corpse's identity / decay / trimmed snapshot
+    onto it via :meth:`SeveredHead.configure_from_sever`, record the
+    sever, and clear the head-cluster prose off the corpse via
+    :func:`apply_sever_to_corpse`.
+
+    Idempotent: if the head has already been severed (``"head"`` in
+    ``corpse.db.severed_locations``) this is a no-op returning ``None``.
+
+    Args:
+        corpse: The freshly built corpse to decapitate.
+
+    Returns:
+        The spawned :class:`SeveredHead`, or ``None`` if the corpse has
+        no location or the head was already severed.
+    """
+    from evennia import create_object
+    from world.combat.constants import ORGAN_CONDITION_BY_DECAY
+
+    room = corpse.location
+    if room is None:
+        return None
+    if "head" in (corpse.db.severed_locations or ()):
+        return None
+
+    get_decay_stage = getattr(corpse, "get_decay_stage", None)
+    decay_stage = get_decay_stage() if callable(get_decay_stage) else "fresh"
+    condition = ORGAN_CONDITION_BY_DECAY.get(decay_stage, "damaged")
+
+    head = create_object(
+        "typeclasses.items.SeveredHead",
+        key=f"{condition} head",
+        location=room,
+    )
+    head.configure_from_sever(
+        location_name="head", condition=condition, corpse=corpse,
+    )
+
+    severed_list = list(corpse.db.severed_locations or ())
+    severed_list.append("head")
+    corpse.db.severed_locations = severed_list
+
+    apply_sever_to_corpse(corpse, "head")
+
+    return head
+
+
 # ---------------------------------------------------------------------
 # Living-character severance (PR Phase B, issue #245)
 # ---------------------------------------------------------------------

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -836,3 +836,11 @@ SEVER_HAND_BY_CONTAINER = {
     "right_arm": "right",
     "right_hand": "right",
 }
+
+# Edged / sharp injury types that can shear a body part clean off.  When
+# an attack of one of these types reduces a severable limb container's
+# representative bone to 0 HP, the limb detaches (Phase C, issue #245
+# follow-up).  Blunt, bullet, and burn damage destroy the bone without
+# producing a clean detachment, so they are deliberately excluded: a
+# limb pulped by a hammer or boiled by fire stays grimly attached.
+SEVERING_INJURY_TYPES = frozenset({"cut", "stab", "laceration"})

--- a/world/tests/test_combat_sever_trigger.py
+++ b/world/tests/test_combat_sever_trigger.py
@@ -1,0 +1,207 @@
+"""Unit tests for the Phase C combat severance trigger (#245 follow-up).
+
+Exercises the damage-driven severance decision logic added to
+:class:`typeclasses.armor_mixin.ArmorMixin` against plain-Python stubs
+(no Evennia typeclass / DB):
+
+* :meth:`ArmorMixin._bone_freshly_destroyed` — reports a limb whose
+  representative bone is at/below 0 HP and not yet cleanly amputated.
+* :meth:`ArmorMixin._maybe_sever_from_damage` — gates on edged injury
+  type, routes the neck to a deferred decapitation flag, and detaches
+  any other severable limb immediately.
+
+The :data:`world.combat.constants.SEVERING_INJURY_TYPES` membership
+contract is also covered.
+
+Run via::
+
+    evennia test world.tests.test_combat_sever_trigger
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+import typeclasses.items as items_module
+from typeclasses.armor_mixin import ArmorMixin
+from world.combat.constants import (
+    SEVERABLE_CONTAINERS,
+    SEVERING_INJURY_TYPES,
+)
+
+
+class _DB:
+    """Bare attribute container — matches Evennia ``obj.db`` surface."""
+
+
+class _FakeOrgan:
+    def __init__(self, container, *, current_hp=10, max_hp=10,
+                 wound_stage=None):
+        self.container = container
+        self.current_hp = current_hp
+        self.max_hp = max_hp
+        self.wound_stage = wound_stage
+
+
+class _FakeMedicalState:
+    def __init__(self, organs):
+        self.organs = organs
+
+
+class _FakeCharacter(ArmorMixin):
+    """Minimal host exposing only what the trigger logic touches."""
+
+    def __init__(self, organs):
+        self.db = _DB()
+        self.db.decapitation_pending = None
+        self.medical_state = _FakeMedicalState(organs)
+
+
+# ---------------------------------------------------------------------
+# SEVERING_INJURY_TYPES
+# ---------------------------------------------------------------------
+
+
+class SeveringInjuryTypesTests(TestCase):
+    def test_edged_types_present(self):
+        self.assertIn("cut", SEVERING_INJURY_TYPES)
+        self.assertIn("stab", SEVERING_INJURY_TYPES)
+        self.assertIn("laceration", SEVERING_INJURY_TYPES)
+
+    def test_non_edged_types_absent(self):
+        for injury in ("blunt", "bullet", "burn", "generic"):
+            self.assertNotIn(injury, SEVERING_INJURY_TYPES)
+
+
+# ---------------------------------------------------------------------
+# _bone_freshly_destroyed
+# ---------------------------------------------------------------------
+
+
+class BoneFreshlyDestroyedTests(TestCase):
+    def test_destroyed_bone_is_fresh(self):
+        char = _FakeCharacter({
+            "left_humerus": _FakeOrgan(
+                "left_arm", current_hp=0, wound_stage="destroyed"
+            ),
+        })
+        self.assertTrue(char._bone_freshly_destroyed("left_arm"))
+
+    def test_intact_bone_is_not_fresh(self):
+        char = _FakeCharacter({
+            "left_humerus": _FakeOrgan("left_arm", current_hp=10),
+        })
+        self.assertFalse(char._bone_freshly_destroyed("left_arm"))
+
+    def test_already_severed_bone_is_not_fresh(self):
+        # Idempotency guard: a re-hit on an amputated stump must not
+        # re-sever it.
+        char = _FakeCharacter({
+            "left_humerus": _FakeOrgan(
+                "left_arm", current_hp=0, wound_stage="severed"
+            ),
+        })
+        self.assertFalse(char._bone_freshly_destroyed("left_arm"))
+
+    def test_no_organ_in_location_is_not_fresh(self):
+        char = _FakeCharacter({
+            "heart": _FakeOrgan("chest", current_hp=0),
+        })
+        self.assertFalse(char._bone_freshly_destroyed("left_arm"))
+
+    def test_all_organs_must_be_destroyed(self):
+        # A container with a still-functional organ is not "lost".
+        char = _FakeCharacter({
+            "a": _FakeOrgan("left_arm", current_hp=0,
+                            wound_stage="destroyed"),
+            "b": _FakeOrgan("left_arm", current_hp=5),
+        })
+        self.assertFalse(char._bone_freshly_destroyed("left_arm"))
+
+
+# ---------------------------------------------------------------------
+# _maybe_sever_from_damage
+# ---------------------------------------------------------------------
+
+
+class MaybeSeverFromDamageTests(TestCase):
+    def setUp(self):
+        # Capture apply_sever_to_character calls without touching the DB.
+        self._orig = items_module.apply_sever_to_character
+        self.calls = []
+
+        def _spy(character, container, *, injury_type="cut"):
+            self.calls.append((character, container, injury_type))
+
+        items_module.apply_sever_to_character = _spy
+
+    def tearDown(self):
+        items_module.apply_sever_to_character = self._orig
+
+    def _destroyed(self, container):
+        return _FakeCharacter({
+            "bone": _FakeOrgan(container, current_hp=0,
+                               wound_stage="destroyed"),
+        })
+
+    def test_edged_limb_hit_severs_immediately(self):
+        char = self._destroyed("left_arm")
+        char._maybe_sever_from_damage("left_arm", "cut")
+        self.assertEqual(self.calls, [(char, "left_arm", "cut")])
+        self.assertIsNone(char.db.decapitation_pending)
+
+    def test_blunt_limb_hit_does_not_sever(self):
+        char = self._destroyed("left_arm")
+        char._maybe_sever_from_damage("left_arm", "blunt")
+        self.assertEqual(self.calls, [])
+
+    def test_edged_neck_hit_flags_decapitation(self):
+        char = self._destroyed("neck")
+        char._maybe_sever_from_damage("neck", "stab")
+        # Neck routes through death → corpse, not a synchronous sever.
+        self.assertEqual(self.calls, [])
+        self.assertTrue(char.db.decapitation_pending)
+
+    def test_blunt_neck_hit_does_not_flag(self):
+        char = self._destroyed("neck")
+        char._maybe_sever_from_damage("neck", "blunt")
+        self.assertIsNone(char.db.decapitation_pending)
+
+    def test_intact_limb_not_severed(self):
+        char = _FakeCharacter({
+            "bone": _FakeOrgan("right_arm", current_hp=8),
+        })
+        char._maybe_sever_from_damage("right_arm", "cut")
+        self.assertEqual(self.calls, [])
+
+    def test_already_severed_limb_not_re_severed(self):
+        char = _FakeCharacter({
+            "bone": _FakeOrgan("right_arm", current_hp=0,
+                               wound_stage="severed"),
+        })
+        char._maybe_sever_from_damage("right_arm", "cut")
+        self.assertEqual(self.calls, [])
+
+    def test_head_location_excluded(self):
+        # Head is severable-on-corpse only; living decapitation routes
+        # through the neck path, so a direct head hit never severs here.
+        char = self._destroyed("head")
+        char._maybe_sever_from_damage("head", "cut")
+        self.assertEqual(self.calls, [])
+        self.assertIsNone(char.db.decapitation_pending)
+
+    def test_non_severable_location_ignored(self):
+        char = self._destroyed("chest")
+        char._maybe_sever_from_damage("chest", "cut")
+        self.assertEqual(self.calls, [])
+
+    def test_every_living_severable_limb_routes(self):
+        living_limbs = SEVERABLE_CONTAINERS - {"head"}
+        for container in living_limbs:
+            with self.subTest(container=container):
+                self.calls.clear()
+                char = self._destroyed(container)
+                char._maybe_sever_from_damage(container, "laceration")
+                self.assertEqual(
+                    self.calls, [(char, container, "laceration")]
+                )


### PR DESCRIPTION
## Summary
- Phase C of combat-driven body-part severance: connects the damage pipeline to the Phase A neck organ (#243/#244) and Phase B living-sever core (#245/#246).
- An **edged** hit (`cut`/`stab`/`laceration`) that reduces a severable part's representative bone to 0 HP now triggers detachment; blunt/bullet/burn destroy bone in place with no clean detachment.
- **Limbs** detach immediately into an `Appendage` (survivable, capacity loss only). **Neck** flags `db.decapitation_pending`; the async death -> corpse pipeline spawns a `SeveredHead` and clears head-cluster prose off the corpse.

## Changes
- `world/combat/constants.py`: `SEVERING_INJURY_TYPES`.
- `typeclasses/armor_mixin.py`: `_bone_freshly_destroyed` + `_maybe_sever_from_damage`, called from `take_damage` before the death handler (so the decapitation flag is set before `at_death` spawns the corpse). Idempotent via the `severed` wound-stage guard.
- `typeclasses/items.py`: `spawn_severed_head_for_corpse` corpse helper (mirrors the manual `CmdSever` head path).
- `typeclasses/death_progression.py`: decapitation hook before `return corpse` in `_create_corpse_from_character`.
- `world/tests/test_combat_sever_trigger.py`: 16 unit tests.

## Testing
- `evennia test --settings settings.py world` -> **1333 passing** (1317 baseline + 16 new), no regressions.

Closes #247.