### PR TITLE
Fix _get_vital_locations to derive vital locations from lethal capacities

### DIFF
--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -243,6 +243,21 @@ BODY_CAPACITIES = {
     }
 }
 
+# Capacities whose total loss kills or incapacitates the character. This is the
+# single source of truth for "what makes a body location vital": the union of
+# the capacities is_dead() enforces (blood_pumping, breathing, digestion,
+# neck_integrity) plus consciousness (brain). _get_vital_locations() maps each
+# of these capacities' organs to their containers to build the vital-location
+# set used by the combat hit-location bias. Keep in sync with is_dead() in
+# world/medical/core.py.
+LETHAL_CAPACITY_NAMES = (
+    "blood_pumping",
+    "breathing",
+    "digestion",
+    "neck_integrity",
+    "consciousness",
+)
+
 # ===================================================================
 # ORGAN DEFINITIONS
 # ===================================================================

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -51,32 +51,40 @@ def calculate_hit_weights_for_location(location):
 def _get_vital_locations(character):
     """
     Dynamically determine vital body locations based on organ criticality.
-    
-    A location is vital if it contains critical organs (organs whose failure causes death).
-    This allows for dynamic anatomy - characters with different body structures will have
-    different vital areas.
-    
+
+    A location is vital if it houses an organ belonging to a lethal capacity -
+    a capacity whose total loss kills or incapacitates the character (see
+    LETHAL_CAPACITY_NAMES and is_dead() in world/medical/core.py). Each lethal
+    capacity's organs are mapped to their containing body location via the
+    organ schema's ``container`` field. This keeps the vital set data-driven so
+    that anatomy changes (new organs, new lethal capacities) are reflected
+    automatically.
+
     Args:
         character: Character object with medical state
-        
+
     Returns:
         set: Set of vital body location names
     """
-    from .constants import ORGANS
-    
+    from .constants import BODY_CAPACITIES, LETHAL_CAPACITY_NAMES, ORGANS
+
     vital_locations = set()
-    
-    # Check each organ - if it's critical (failure causes death), its location is vital
-    for organ_name, organ_data in ORGANS.items():
-        if organ_data.get('critical', False):  # Critical organs
-            location = organ_data.get('location')
-            if location:
-                vital_locations.add(location)
-    
-    # Fallback to common vital areas if no critical organs found
+
+    for capacity_name in LETHAL_CAPACITY_NAMES:
+        capacity_data = BODY_CAPACITIES.get(capacity_name, {})
+        for organ_name in capacity_data.get("organs", []):
+            organ_data = ORGANS.get(organ_name)
+            if not organ_data:
+                continue
+            container = organ_data.get("container")
+            if container:
+                vital_locations.add(container)
+
+    # Fallback to common vital areas if nothing could be derived (defensive;
+    # should not happen with the stock anatomy).
     if not vital_locations:
         vital_locations = {"head", "chest", "neck", "abdomen"}
-    
+
     return vital_locations
 
 

--- a/world/tests/test_vital_locations.py
+++ b/world/tests/test_vital_locations.py
@@ -1,0 +1,72 @@
+"""Tests for ``_get_vital_locations`` (vital body-location derivation, #251).
+
+``_get_vital_locations`` previously iterated ``ORGANS`` looking for keys that
+do not exist in the schema (``critical`` / ``location``), so it always fell
+through to a hardcoded fallback. It now derives the vital set from the
+capacities that actually kill or incapacitate the character
+(``LETHAL_CAPACITY_NAMES``) by mapping each capacity's organs to their
+``container``.
+
+Covers:
+
+* the stock anatomy resolves to ``{head, chest, neck, abdomen}``;
+* ``neck`` is present *by data* (cervical spine -> neck), not by the fallback;
+* the result is genuinely data-driven (a new lethal-capacity organ's container
+  shows up), and never returns the empty set.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.medical.constants import (
+    BODY_CAPACITIES,
+    LETHAL_CAPACITY_NAMES,
+    ORGANS,
+)
+from world.medical.utils import _get_vital_locations
+
+
+class TestVitalLocations(TestCase):
+    def test_stock_anatomy_vital_set(self):
+        self.assertEqual(
+            _get_vital_locations(None),
+            {"head", "chest", "neck", "abdomen"},
+        )
+
+    def test_neck_is_vital_by_data(self):
+        # cervical_spine lives in the neck and belongs to neck_integrity, a
+        # lethal capacity -> neck must be vital regardless of the fallback.
+        self.assertIn("neck", _get_vital_locations(None))
+
+    def test_lethal_capacity_organs_map_to_their_containers(self):
+        # Every lethal capacity's organs should contribute their container.
+        expected = set()
+        for capacity_name in LETHAL_CAPACITY_NAMES:
+            for organ_name in BODY_CAPACITIES.get(capacity_name, {}).get(
+                "organs", []
+            ):
+                container = ORGANS.get(organ_name, {}).get("container")
+                if container:
+                    expected.add(container)
+        self.assertEqual(_get_vital_locations(None), expected)
+
+    def test_is_data_driven_not_hardcoded(self):
+        # Patching a lethal capacity to reference an organ in a novel container
+        # must surface that container in the result, proving the derivation is
+        # dynamic rather than a constant literal.
+        patched_organs = dict(ORGANS)
+        patched_organs["test_vital_organ"] = {"container": "tail"}
+        patched_caps = {
+            name: dict(data) for name, data in BODY_CAPACITIES.items()
+        }
+        patched_caps["blood_pumping"] = {"organs": ["test_vital_organ"]}
+        with patch("world.medical.constants.ORGANS", patched_organs), patch(
+            "world.medical.constants.BODY_CAPACITIES", patched_caps
+        ):
+            result = _get_vital_locations(None)
+        self.assertIn("tail", result)
+
+    def test_never_empty(self):
+        self.assertTrue(_get_vital_locations(None))


### PR DESCRIPTION
## Summary
- `_get_vital_locations` checked `organ_data.get('critical')` / `organ_data.get('location')` — keys that do not exist in the organ schema (organs use `container`; no organ defines `critical`). The dynamic branch never matched, so it **always** returned the hardcoded fallback `{head, chest, neck, abdomen}`.
- Now derives the vital set from `LETHAL_CAPACITY_NAMES` (the capacities `is_dead()` enforces plus `consciousness`) by mapping each capacity's organs to their `container`. New `LETHAL_CAPACITY_NAMES` constant in `world/medical/constants.py` is the single source of truth.
- Result is unchanged for stock anatomy (`{head, chest, neck, abdomen}`) but is now data-driven, so `neck` is vital by data rather than by the fallback literal.

## Tests
- New `world/tests/test_vital_locations.py` (5 tests): stock set, neck-by-data, container mapping, data-driven (patched novel capacity/organ), never-empty.
- Full `world` suite: **1338 passing** (1333 baseline + 5 new), no regressions.

Closes #251