### PR TITLE
Document data-driven vital-area derivation in armor spec

### DIFF
--- a/specs/MODULAR_ARMOR_SYSTEM_SPEC.md
+++ b/specs/MODULAR_ARMOR_SYSTEM_SPEC.md
@@ -226,6 +226,14 @@ The system separates **ability to hit** from **target selection wisdom**:
 
 ### Vital Area Targeting Ability
 
+> **Vital area derivation (#251)**: the set of vital body locations is computed
+> dynamically by `_get_vital_locations` from the lethal body capacities
+> (`LETHAL_CAPACITY_NAMES` in `world/medical/constants.py` — the capacities
+> `is_dead()` enforces plus `consciousness`). Each lethal capacity's organs are
+> mapped to their `container`, yielding `{head, chest, neck, abdomen}` for the
+> stock anatomy. It is data-driven, not a hardcoded literal, so anatomy changes
+> propagate automatically.
+
 **Skill Calculation**: `vital_targeting_skill = attacker_grit + attacker_motorics`
 
 **Ability Tiers**:


### PR DESCRIPTION
## Summary
- Adds a note to `specs/MODULAR_ARMOR_SYSTEM_SPEC.md` (Vital Area Targeting Ability) documenting that the vital-location set is derived dynamically from `LETHAL_CAPACITY_NAMES` via `_get_vital_locations`, not a hardcoded literal.

Follow-up doc for #251.