### PR TITLE
Rename back 'spine' organ to 'thoracolumbar_spine'

### DIFF
--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -226,7 +226,7 @@ class CmdHarvest(Command):
     * The corpse is skeletal (no soft tissue remains).
     * The corpse predates PR #186 and has no medical snapshot.
     * The named organ is missing, undeclared as harvestable, or
-      flagged ``cannot_be_destroyed`` (spine).
+      flagged ``cannot_be_destroyed`` (thoracolumbar spine).
     * The organ has already been harvested, lives inside a severed
       limb container, or is destroyed.
 

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1625,7 +1625,7 @@ autopsies render the removed organ as `absent`.
   - Skeletal corpse — no soft tissue remains.
   - Pre-PR-#186 corpse — `get_medical_snapshot() is None`.
   - Organ not present in the snapshot.
-  - Organ flagged `cannot_be_destroyed` (spine).
+  - Organ flagged `cannot_be_destroyed` (thoracolumbar spine).
   - Organ not flagged `can_be_harvested` (lungs, brain, eyes, etc.).
   - Organ already in `corpse.db.removed_organs`.
   - Organ's container in `corpse.db.severed_locations` (PR #189
@@ -2159,7 +2159,7 @@ stage harvest gate) renders empty so the term never leaks to players.
 
 #### Bone vs. Soft-Tissue Prose Tiers (issue #213 ✅)
 
-Bones (jaw, spine, pelvis, both humeri, both metacarpal clusters,
+Bones (jaw, thoracolumbar spine, pelvis, both humeri, both metacarpal clusters,
 both femora, both tibiae, both metatarsal rows) decay differently
 from soft tissue: they dry, stain, and crack rather than weep,
 slough, or dissolve.  Issue #213 captured this in two ways:
@@ -2265,7 +2265,7 @@ live.
 - **`cervical_spine` organ** registered in `world/medical/constants.py`
   `ORGANS`: `container: "neck"`, `vital: True`,
   `capacity: "neck_integrity"`, `contribution: "total"`, and explicitly
-  `can_be_destroyed` (unlike the thoracic / lumbar `spine` in `back`,
+  `can_be_destroyed` (unlike the `thoracolumbar_spine` in `back`,
   which cannot — the cervical spine *is* the decapitation locus).
 - **`neck_integrity` body capacity** in `BODY_CAPACITIES`:
   `organs: ["cervical_spine"]`, `directly_fatal: True`.

--- a/world/anatomy/organs.py
+++ b/world/anatomy/organs.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 #: registry.
 BONE_ORGANS = frozenset({
     "jaw",
-    "spine",
+    "thoracolumbar_spine",
     "pelvis",
     "left_humerus",
     "right_humerus",
@@ -198,13 +198,13 @@ ORGAN_DISPLAY = {
             "putrid": "A bloated, blackening stomach, its walls ruptured and weeping a foul digestive slurry.",
         },
     },
-    "spine": {
-        "display_name": "spine",
+    "thoracolumbar_spine": {
+        "display_name": "thoracolumbar spine",
         "default_descriptions": {
-            "pristine": "A clean length of spine, its vertebrae articulated and the intervertebral discs firm between glossy ivory bone.",
-            "damaged": "A dulled spine, the discs flattened and hairline cracks tracing the lateral processes of several vertebrae.",
-            "putrid": "A stained spine, the canal fouled with dark mineral residue and the vertebrae beginning to loosen from one another.",
-            "desiccated": "A bone-dry spine, chalk-pale and brittle, the vertebrae held together only by parchment-thin remnants of ligament.",
+            "pristine": "A clean length of thoracolumbar spine, its vertebrae articulated and the intervertebral discs firm between glossy ivory bone.",
+            "damaged": "A dulled thoracolumbar spine, the discs flattened and hairline cracks tracing the lateral processes of several vertebrae.",
+            "putrid": "A stained thoracolumbar spine, the canal fouled with dark mineral residue and the vertebrae beginning to loosen from one another.",
+            "desiccated": "A bone-dry thoracolumbar spine, chalk-pale and brittle, the vertebrae held together only by parchment-thin remnants of ligament.",
         },
     },
     "left_humerus": {

--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -209,9 +209,9 @@ BODY_CAPACITIES = {
         "total_loss_penalty": "deafness"
     },
     "moving": {
-        "organs": ["spine", "pelvis", "left_femur", "right_femur", "left_tibia", "right_tibia", 
+        "organs": ["thoracolumbar_spine", "pelvis", "left_femur", "right_femur", "left_tibia", "right_tibia", 
                   "left_metatarsals", "right_metatarsals"],
-        "spine_contribution": 1.0,    # Spine damage = paralysis
+        "thoracolumbar_spine_contribution": 1.0,    # Spine damage = paralysis
         "pelvis_contribution": 1.0,   # Essential for walking
         "femur_contribution": 0.4,    # Each femur contributes 40%
         "tibia_contribution": 0.4,    # Each tibia contributes 40%
@@ -308,7 +308,7 @@ ORGANS = {
 
     # NECK CONTAINER → DECAPITATION STRUCTURE
     # The cervical spine is the decapitation locus (combat-sever Phase A,
-    # #243). Unlike the thoracic/lumbar "spine" organ in the "back"
+    # #243). Unlike the "thoracolumbar_spine" organ in the "back"
     # container (cannot_be_destroyed), this one CAN be destroyed: bringing
     # it to 0 HP severs the head from the body. It is vital and gates the
     # "neck_integrity" capacity (total contribution), so destruction is
@@ -359,7 +359,10 @@ ORGANS = {
     },
 
     # BACK CONTAINER → STRUCTURAL ORGANS INSIDE
-    "spine": {
+    # The thoracolumbar spine is the thoracic/lumbar vertebral column in the
+    # back. Distinct from cervical_spine (the neck decapitation locus); unlike
+    # that organ, it cannot be destroyed (its loss is paralysis, not death).
+    "thoracolumbar_spine": {
         "container": "back", "max_hp": 25, "hit_weight": "uncommon",
         "capacity": "moving", "contribution": "total", "cannot_be_destroyed": True,
         "causes_pain_when_damaged": True, "paralysis_if_destroyed": True

--- a/world/tests/test_cmd_harvest.py
+++ b/world/tests/test_cmd_harvest.py
@@ -15,7 +15,7 @@ Coverage matrix:
 * Skeletal-corpse short-circuit.
 * Pre-PR-#186 snapshot-less corpse refusal.
 * Ambiguous ``harvest <corpse>`` lists harvestable organs.
-* Snapshot organ missing / spec missing / spine refusal.
+* Snapshot organ missing / spec missing / thoracolumbar-spine refusal.
 * Already-removed / inside-severed-limb / destroyed refusal.
 * Roll-fail (mid-range) leaves snapshot untouched.
 * Critical-fail (natural 1) zeroes ``current_hp`` in snapshot.
@@ -115,7 +115,7 @@ def _snapshot_with(*, heart_hp=15, liver_hp=20, kidney_hp=15):
             "left_kidney": {
                 "current_hp": kidney_hp, "max_hp": 15, "container": "abdomen",
             },
-            "spine": {
+            "thoracolumbar_spine": {
                 "current_hp": 25, "max_hp": 25, "container": "back",
             },
             "left_lung": {
@@ -208,8 +208,8 @@ class CmdHarvestTests(TestCase):
         self.assertIn("heart", msg)
         self.assertIn("liver", msg)
         self.assertIn("left kidney", msg)
-        # spine is cannot_be_destroyed; lung is can_be_harvested=False
-        self.assertNotIn("spine", msg)
+        # thoracolumbar spine is cannot_be_destroyed; lung is can_be_harvested=False
+        self.assertNotIn("thoracolumbar spine", msg)
         self.assertNotIn("lung", msg)
 
     def test_ambiguous_with_nothing_left(self):
@@ -237,7 +237,7 @@ class CmdHarvestTests(TestCase):
         caller = _make_caller()
         corpse = _FakeCorpse(snapshot=_snapshot_with())
         caller.search.return_value = corpse
-        _make_cmd(caller=caller, args="spine from corpse").func()
+        _make_cmd(caller=caller, args="thoracolumbar_spine from corpse").func()
         msg = caller.msg.call_args[0][0]
         self.assertIn("too deeply integrated", msg)
 

--- a/world/tests/test_neck_organ_decapitation.py
+++ b/world/tests/test_neck_organ_decapitation.py
@@ -36,7 +36,7 @@ class TestNeckOrganSchema(TestCase):
         self.assertEqual(organ.get("contribution"), "total")
 
     def test_cervical_spine_is_destroyable(self):
-        # Unlike the thoracic/lumbar ``spine`` in the ``back`` container,
+        # Unlike the thoracolumbar_spine in the ``back`` container,
         # the cervical spine must be destroyable (it is the decapitation
         # locus).
         self.assertTrue(ORGANS["cervical_spine"].get("can_be_destroyed"))


### PR DESCRIPTION
## Summary
- Renames the `back` organ `spine` -> `thoracolumbar_spine` (display name "thoracolumbar spine") to remove ambiguity against `cervical_spine` (the neck decapitation locus). The plain `spine` read as "the whole spine" when it only models the thoracic/lumbar column.
- `world/medical/constants.py`: organ key; `"moving"` capacity `organs` list; `spine_contribution` -> `thoracolumbar_spine_contribution` (**required** — capacity contribution resolves via `f"{organ_name}_contribution"`).
- `world/anatomy/organs.py`: `BONE_ORGANS` entry + display block (key, `display_name`, decay descriptions).
- Tests (`test_cmd_harvest.py` snapshot key + refusal arg + comments; `test_neck_organ_decapitation.py` comment) and docstring/spec references (`forensics.py`, `IDENTITY_RECOGNITION_SPEC.md`).
- Combat-message flavor text mentioning "spine" is narrative and intentionally left untouched.

## Verification
- Full `world` suite: **1338 passing**, no regressions.
- Functional check in shell: destroying `thoracolumbar_spine` drives the `moving` capacity from 1.0 -> 0.737 (contribution 1.0 of 3.8), confirming the renamed contribution key resolves correctly.

## Deploy note
- Requires a **DB migration** to rename the persisted organ key `spine` -> `thoracolumbar_spine` on existing characters (run post-merge via `evennia shell`, then reload). Without it, `get_organ` lazily recreates the organ at full HP and orphans the old key.

Closes #254