### PR TITLE
Fix emote targeting to honor assigned recognition names

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1297,6 +1297,28 @@ If multiple characters match the same target string:
 - If no ordinal and multiple matches, prompt the player: `"Which one? There are two tall men here."`
 - Assigned names should be unique within a player's recognition memory (reassignment overwrites)
 
+### Emote / Dot-Pose Targeting Parity
+
+The emote/dot-pose engine (`world/emote.py`) does **not** route character
+references through `Character.search` — it builds its own candidate list in
+`build_char_candidates()` and matches with whole-string, word-boundary
+regexes. To keep targeting consistent with the `look`/`attack` path
+(`world.search._match_assigned_name`, which matches assigned names by
+case-insensitive **substring**), `build_char_candidates()` additionally
+emits each whitespace-delimited **word** of an occupant's assigned
+recognition name as its own candidate. So an actor who remembers someone as
+`"Whimsical Wendy"` can target them with `.flick a nod at Wendy` (or
+`Whimsical`, or the full name). Only player-**assigned** names are
+tokenized — sdescs are not, so generic descriptors (`"lanky"`, `"man"`)
+never over-match free-form emote prose. The longest-match-first sort keeps
+the full assigned name winning when it is typed in full.
+
+`world.identity.get_assigned_name(observer, target)` is the single source
+of truth for "what name has the observer assigned to this target's current
+Apparent UID." It is consumed by `Character.get_display_name`,
+`world.search._match_assigned_name`, and `world.emote.build_char_candidates`
+so all three resolution paths agree.
+
 ---
 
 ## Staff Vision

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1031,17 +1031,13 @@ class Character(
             return self.key
 
         # Check if looker has a recognized name for this Apparent UID.
-        from world.identity import get_apparent_uid
+        from world.identity import get_apparent_uid, get_assigned_name
+
+        assigned = get_assigned_name(looker, self)
+        if assigned:
+            return assigned
 
         apparent_uid = get_apparent_uid(self)
-        if apparent_uid is not None and hasattr(looker, "recognition_memory"):
-            memory = looker.recognition_memory
-            if memory and apparent_uid in memory:
-                entry = memory[apparent_uid]
-                assigned = entry.get("assigned_name")
-                if assigned:
-                    return assigned
-
         # Disguise piercing: looker doesn't know this presentation, but
         # may have previously remembered the underlying sleeve under a
         # different presentation.  Opposed Intellect-vs-Resonance roll

--- a/world/emote.py
+++ b/world/emote.py
@@ -275,7 +275,11 @@ def build_char_candidates(
         sorted longest first.
     """
     from world.grammar import DEFAULT_SDESC_KEYWORDS, get_article
-    from world.identity import compose_sdesc, get_physical_descriptor
+    from world.identity import (
+        compose_sdesc,
+        get_assigned_name,
+        get_physical_descriptor,
+    )
     from world.search import strip_leading_article
 
     candidates: list[tuple[str, "Character", bool]] = []
@@ -294,6 +298,23 @@ def build_char_candidates(
             stripped = strip_leading_article(display_name)
             if stripped != display_name:
                 names.append((stripped, False))
+
+        # 2b. Individual words of an assigned recognition name.
+        # When the actor has remembered this character under a name like
+        # "Whimsical Wendy", allow targeting by any single word of it
+        # (e.g. "Wendy") — parity with the substring matching used by the
+        # ``look`` path (world.search._match_assigned_name).  Only the
+        # player-assigned name is tokenized; sdescs are NOT, so generic
+        # descriptors ("lanky", "man") never over-match emote prose.  The
+        # length-descending sort below keeps the full name winning when
+        # the actor types it in full.
+        assigned = get_assigned_name(actor, char)
+        if assigned:
+            existing = [n for n, _rc in names]
+            for token in assigned.split():
+                if token and token not in existing:
+                    names.append((token, False))
+                    existing.append(token)
 
         # 3. Raw sdesc (no article)
         sdesc = char.get_sdesc()

--- a/world/identity.py
+++ b/world/identity.py
@@ -911,6 +911,44 @@ def get_apparent_uid(char: Any) -> str | None:
     ).hexdigest()
 
 
+def get_assigned_name(observer: Any, target: Any) -> str | None:
+    """Return *observer*'s assigned recognition name for *target*.
+
+    Single source of truth for "what name has the observer chosen to
+    remember this character by."  Resolves *target*'s current Apparent
+    UID and looks up the matching ``recognition_memory`` entry on
+    *observer*, returning its non-empty ``assigned_name``.
+
+    Used by the display-name pipeline (:meth:`Character.get_display_name`),
+    identity-aware search (:func:`world.search._match_assigned_name`),
+    and the emote/dot-pose target resolver
+    (:func:`world.emote.build_char_candidates`) so all three agree on the
+    exact name the observer has assigned.
+
+    Note: this returns the assigned name only.  It does NOT attempt
+    disguise piercing — callers that need the full display resolution
+    (assigned name → pierce → sdesc fallback) should use
+    :meth:`Character.get_display_name`.
+
+    Args:
+        observer: The character whose recognition memory is consulted.
+        target: The character being named.
+
+    Returns:
+        The non-empty assigned name string, or ``None`` when the
+        observer has no name assigned for *target*'s current
+        presentation (including when *target* has no Apparent UID).
+    """
+    apparent_uid = get_apparent_uid(target)
+    if apparent_uid is None:
+        return None
+    memory = getattr(observer, "recognition_memory", None)
+    if not memory or apparent_uid not in memory:
+        return None
+    assigned = memory[apparent_uid].get("assigned_name") or ""
+    return assigned or None
+
+
 # Decay stages at which a corpse's body-identity axis (``sleeve_uid``) is
 # no longer recoverable by an unaided observer.  Stages strictly listed
 # here cause :func:`get_apparent_uid_for_decay` to blank the sleeve_uid

--- a/world/search.py
+++ b/world/search.py
@@ -167,17 +167,9 @@ def _match_assigned_name(
         ``True`` if the searcher's assigned name for *target*'s current
         Apparent UID matches *query*.
     """
-    from world.identity import get_apparent_uid
+    from world.identity import get_assigned_name
 
-    apparent_uid = get_apparent_uid(target)
-    if apparent_uid is None:
-        return False
-
-    memory = getattr(searcher, "recognition_memory", None)
-    if not memory or apparent_uid not in memory:
-        return False
-
-    assigned = memory[apparent_uid].get("assigned_name", "")
+    assigned = get_assigned_name(searcher, target)
     if not assigned:
         return False
 

--- a/world/tests/test_emote.py
+++ b/world/tests/test_emote.py
@@ -847,6 +847,108 @@ class TestCharacterReferences(TestCase):
 
 
 # ===================================================================
+# Tests: Assigned-name word-token targeting (Issue #260)
+# ===================================================================
+
+
+class TestAssignedNameTokenTargeting(TestCase):
+    """Targeting by a single word of a multi-word assigned name.
+
+    Parity with the ``look`` path (world.search._match_assigned_name),
+    which matches assigned names by case-insensitive substring.  The
+    emote engine resolves single words of the assigned name to the
+    remembered character.
+    """
+
+    def setUp(self):
+        self.actor = _make_character(
+            key="Jorge Jackson",
+            sex="male",
+            height="tall",
+            build="lean",
+            sdesc_keyword="man",
+            sleeve_uid="uid-jorge",
+        )
+        self.wendy = _make_character(
+            key="Gertrude Vance",
+            sex="female",
+            height="short",
+            build="athletic",
+            sdesc_keyword="woman",
+            sleeve_uid="uid-wendy",
+        )
+        # Actor remembers Gertrude under a two-word assigned name.
+        self.actor.recognition_memory = {
+            apparent_uid_for(self.wendy): {
+                "assigned_name": "Whimsical Wendy"
+            },
+        }
+
+    def _resolve(self, body):
+        tokens = tokenize_dot_pose(
+            body, self.actor, [self.actor, self.wendy]
+        )
+        return [t for t in tokens if isinstance(t, CharRefToken)]
+
+    def test_full_assigned_name_resolves(self) -> None:
+        """The complete assigned name still resolves."""
+        refs = self._resolve("flick a nod at Whimsical Wendy.")
+        self.assertTrue(refs)
+        self.assertIs(refs[0].character, self.wendy)
+
+    def test_last_word_resolves(self) -> None:
+        """A bare last word of the assigned name resolves (Wendy)."""
+        refs = self._resolve("flick a nod at Wendy.")
+        self.assertTrue(refs)
+        self.assertIs(refs[0].character, self.wendy)
+
+    def test_first_word_resolves(self) -> None:
+        """A bare first word of the assigned name resolves (Whimsical)."""
+        refs = self._resolve("flick a nod at Whimsical.")
+        self.assertTrue(refs)
+        self.assertIs(refs[0].character, self.wendy)
+
+    def test_full_name_wins_over_token(self) -> None:
+        """When the full name is typed, one ref spanning it is produced."""
+        refs = self._resolve("flick a nod at Whimsical Wendy.")
+        self.assertEqual(len(refs), 1)
+        self.assertEqual(refs[0].original_text, "Whimsical Wendy")
+
+    def test_candidate_tokens_present(self) -> None:
+        """build_char_candidates emits each assigned-name word."""
+        candidates = build_char_candidates(
+            self.actor, [self.actor, self.wendy]
+        )
+        names = [name for name, _char, _rc in candidates]
+        self.assertIn("Whimsical Wendy", names)
+        self.assertIn("Whimsical", names)
+        self.assertIn("Wendy", names)
+
+    def test_single_word_name_no_duplicate(self) -> None:
+        """A single-word assigned name is not added twice."""
+        self.actor.recognition_memory = {
+            apparent_uid_for(self.wendy): {"assigned_name": "Wendy"},
+        }
+        candidates = build_char_candidates(
+            self.actor, [self.actor, self.wendy]
+        )
+        names = [name for name, _char, _rc in candidates]
+        self.assertEqual(names.count("Wendy"), 1)
+
+    def test_sdesc_word_does_not_overmatch(self) -> None:
+        """Assigned-name tokenizing must not affect sdesc word matching.
+
+        An observer/actor who has NOT assigned a name still only matches
+        the target through deliberate sdesc/keyword candidates — a stray
+        sdesc adjective in lowercase prose must not resolve.
+        """
+        self.actor.recognition_memory = {}
+        refs = self._resolve("muse about something whimsical.")
+        self.assertEqual(refs, [])
+
+
+
+# ===================================================================
 # Tests: Full Spec Examples
 # ===================================================================
 

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -1327,6 +1327,48 @@ class TestGetApparentUid(TestCase):
         )
 
 
+class TestGetAssignedName(TestCase):
+    """Observer's assigned recognition name for a target."""
+
+    def test_returns_assigned_name_when_remembered(self) -> None:
+        from world.identity import get_apparent_uid, get_assigned_name
+
+        target = _SignatureMockCharacter(sleeve_uid="uid-wendy")
+        observer = _SignatureMockCharacter(sleeve_uid="uid-bob")
+        observer.recognition_memory = {
+            get_apparent_uid(target): {"assigned_name": "Whimsical Wendy"},
+        }
+        self.assertEqual(
+            get_assigned_name(observer, target), "Whimsical Wendy"
+        )
+
+    def test_none_when_no_memory_entry(self) -> None:
+        from world.identity import get_assigned_name
+
+        target = _SignatureMockCharacter(sleeve_uid="uid-wendy")
+        observer = _SignatureMockCharacter(sleeve_uid="uid-bob")
+        self.assertIsNone(get_assigned_name(observer, target))
+
+    def test_none_when_blank_assigned_name(self) -> None:
+        """An entry with an empty assigned_name returns ``None``."""
+        from world.identity import get_apparent_uid, get_assigned_name
+
+        target = _SignatureMockCharacter(sleeve_uid="uid-wendy")
+        observer = _SignatureMockCharacter(sleeve_uid="uid-bob")
+        observer.recognition_memory = {
+            get_apparent_uid(target): {"assigned_name": ""},
+        }
+        self.assertIsNone(get_assigned_name(observer, target))
+
+    def test_none_when_target_has_no_uid(self) -> None:
+        """A target with no Apparent UID can never be named."""
+        from world.identity import get_assigned_name
+
+        target = _SignatureMockCharacter(sleeve_uid=None)
+        observer = _SignatureMockCharacter(sleeve_uid="uid-bob")
+        self.assertIsNone(get_assigned_name(observer, target))
+
+
 class TestGetApparentGender(TestCase):
     """Gender derivation follows keyword override → real grammar gender."""
 


### PR DESCRIPTION
## Summary
- Targeting a character in an emote/dot-pose by a single word of an assigned recognition name now resolves (e.g. `.flick a nod at Wendy` when you remember someone as "Whimsical Wendy"), matching the existing `look`/`attack` behavior.
- `build_char_candidates()` in `world/emote.py` now emits each whitespace-delimited word of an occupant's **assigned** name as its own match candidate. Only player-assigned names are tokenized — sdescs are not — so generic descriptors ("lanky", "man") never over-match free-form emote prose. Longest-match-first sort keeps the full name winning when typed in full.
- Adds `world.identity.get_assigned_name(observer, target)` as the single source of truth and deduplicates the previously-inlined lookups in `Character.get_display_name` and `world.search._match_assigned_name` onto it.

## Root cause
The emote engine builds its own candidate list and matches with whole-string word-boundary regexes (`\bWhimsical Wendy\b`), so a bare token like `Wendy` never matched. The `look` path differs: `world/search.py:_match_assigned_name` substring-matches assigned names.

## Tests
- New `TestAssignedNameTokenTargeting` (full name, first word, last word, full-name-wins, candidate tokens, single-word no-dup, sdesc no-overmatch) in `world/tests/test_emote.py`.
- New `TestGetAssignedName` (remembered / no-entry / blank / no-uid) in `world/tests/test_identity.py`.
- Full `world` suite green: **1363** tests (was 1352, +11).

## Spec
- `specs/IDENTITY_RECOGNITION_SPEC.md` §Target Resolution gains an "Emote / Dot-Pose Targeting Parity" subsection documenting the tokenization rule and the shared `get_assigned_name` helper.

Closes #260