### PR TITLE
Add per-injury-type compound wound templates

### DIFF
--- a/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
+++ b/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
@@ -2024,13 +2024,37 @@ def _format_wound_grammar(text):
     # Handles color codes like |r, |g, |n and template vars like {skintone}
     
 # Longdesc integration hooks (world/medical/wounds/longdesc_hooks.py)
-def append_wounds_to_longdesc(character, location, base_longdesc):
-    """Integrate wound descriptions into character longdesc"""
-    wounds = get_wounds_for_location(character, location)
-    if wounds:
-        wound_desc = _create_compound_wound_description_for_location(wounds, location)
-        return f"{base_longdesc} {wound_desc}"
-    return base_longdesc
+#
+# Two render paths share one summarizer so multi-wound output is concise:
+#   - append_wounds_to_longdesc        -> location already has a longdesc
+#   - get_standalone_wound_description -> location has wounds but no longdesc
+# Both delegate to _summarize_location_wounds.
+
+def append_wounds_to_longdesc(original_desc, character, location, looker=None):
+    """Append a wound summary onto an existing longdesc for a location."""
+    summary = _summarize_location_wounds(
+        [w for w in get_character_wounds(character) if w['location'] == location],
+        character,
+    )
+    if not summary:
+        return original_desc
+    # Strip the summary's terminal period (preserving any |n reset) so the
+    # combined sentence flows, then re-terminate.
+    return f"{original_desc} {summary.rstrip('.|n')}."
+
+def get_standalone_wound_description(character, location, looker=None):
+    """Return a standalone wound sentence for a location with no longdesc."""
+    return _summarize_location_wounds(
+        [w for w in get_character_wounds(character) if w['location'] == location],
+        character,
+    )
+
+def _summarize_location_wounds(location_wounds, character=None):
+    """One wound -> type/stage description; two or more -> one compound line."""
+    prioritized = _prioritize_wounds_for_display(location_wounds)
+    if len(prioritized) == 1:
+        return get_wound_description(**prioritized[0], character=character)
+    return _compound_phrase(prioritized[0], len(prioritized) - 1, character)
 ```
 
 #### Treatment Quality & Method System

--- a/world/medical/wounds/longdesc_hooks.py
+++ b/world/medical/wounds/longdesc_hooks.py
@@ -20,7 +20,14 @@ from .wound_descriptions import (
     get_wound_description,
     _format_wound_grammar,
 )
-from .constants import get_location_display_name, INJURY_SEVERITY_MAP
+from .constants import (
+    get_location_display_name,
+    INJURY_SEVERITY_MAP,
+    MEDICAL_COLORS,
+)
+from . import messages
+
+import random
 
 
 def append_wounds_to_longdesc(original_desc, character, location, looker=None):
@@ -121,13 +128,18 @@ def _compound_phrase(worst_wound, others_count, character=None):
     """
     Concise single-line summary for two or more wounds at one location.
 
-    FUTURE (not implemented this pass): per-injury-type compound templates,
-    mirroring the single-wound ``messages.<type>.WOUND_DESCRIPTIONS`` dicts.
-    A later pass can look up ``messages.<worst_type>.COMPOUND_DESCRIPTIONS``,
-    ``random.choice`` a variant, and fall back to ``messages.generic`` then to
-    the generic phrasing below — exactly how ``get_wound_description`` resolves
-    single wounds. The type message modules are intentionally left untouched
-    until that feature lands.
+    Per-injury-type compound templates mirror the single-wound
+    ``messages.<type>.WOUND_DESCRIPTIONS`` dicts: the worst wound's
+    ``injury_type`` selects a ``messages.<type>.COMPOUND_DESCRIPTIONS``
+    set (falling back to ``messages.generic``), keyed by the worst
+    wound's healing ``stage``. A random variant is chosen and formatted
+    with the worst wound's severity, the location name, and an
+    ``{others_phrase}`` count of the remaining wounds — exactly how
+    ``get_wound_description`` resolves a single wound.
+
+    When no template set resolves (e.g. an injury type with no compound
+    dict and a missing generic fallback), the legacy inline phrasing
+    below is used so the summarizer always returns a sentence.
 
     Args:
         worst_wound (dict): Highest-priority wound at this location.
@@ -137,24 +149,74 @@ def _compound_phrase(worst_wound, others_count, character=None):
     Returns:
         str: A formatted, single-sentence compound summary.
     """
-    location_display = get_location_display_name(worst_wound['location'], character)
-    others_phrase = "another wound" if others_count == 1 else "several other wounds"
+    location_display = get_location_display_name(
+        worst_wound['location'], character
+    )
+    others_phrase = (
+        "another wound" if others_count == 1 else "several other wounds"
+    )
+    stage = worst_wound['stage']
+    injury_type = worst_wound['injury_type']
+    severity = INJURY_SEVERITY_MAP.get(
+        worst_wound['severity'], worst_wound['severity'].lower()
+    )
 
+    template = _resolve_compound_template(injury_type, stage)
+    if template:
+        format_vars = {
+            'severity': severity,
+            'location': location_display,
+            'others_phrase': others_phrase,
+            'skintone': _skintone_color(character),
+        }
+        format_vars.update(MEDICAL_COLORS)
+        return _format_wound_grammar(template.format(**format_vars))
+
+    # Ultimate fallback: legacy inline phrasing (no template set available).
     # No fresh/raw wound in the mix: render a calm, skintone-colored summary.
-    if worst_wound['stage'] in ("treated", "healing", "scarred"):
+    if stage in ("treated", "healing", "scarred"):
         skintone_color = _skintone_color(character)
         phrase = (f"{skintone_color}multiple old wounds mark the "
                   f"{location_display}|n")
         return _format_wound_grammar(phrase)
 
-    severity = INJURY_SEVERITY_MAP.get(
-        worst_wound['severity'], worst_wound['severity'].lower()
-    )
-    injury_type = worst_wound['injury_type']
     type_word = "" if injury_type == "generic" else f"{injury_type} "
     phrase = (f"|Ra {severity} {type_word}wound and {others_phrase} "
               f"mark the {location_display}|n")
     return _format_wound_grammar(phrase)
+
+
+def _resolve_compound_template(injury_type, stage):
+    """
+    Resolve a random compound template for an injury type and stage.
+
+    Mirrors ``get_wound_description`` resolution: look up the injury
+    type's ``COMPOUND_DESCRIPTIONS`` module dict, fall back to
+    ``messages.generic`` when the type has none, then key by ``stage``
+    with a ``"fresh"`` default.
+
+    Args:
+        injury_type (str): Worst wound's injury type (bullet, cut, ...).
+        stage (str): Worst wound's healing stage.
+
+    Returns:
+        str | None: A chosen template string, or ``None`` when no
+            template set is available (caller falls back to inline prose).
+    """
+    compound = None
+    module = getattr(messages, injury_type, None)
+    if module is not None:
+        compound = getattr(module, 'COMPOUND_DESCRIPTIONS', None)
+    if not compound:
+        compound = getattr(messages.generic, 'COMPOUND_DESCRIPTIONS', None)
+    if not compound:
+        return None
+
+    variants = compound.get(stage) or compound.get('fresh')
+    if not variants:
+        return None
+    return random.choice(variants)
+
 
 
 def _skintone_color(character):

--- a/world/medical/wounds/messages/blunt.py
+++ b/world/medical/wounds/messages/blunt.py
@@ -65,3 +65,34 @@ WOUND_DESCRIPTIONS = {
         "{skintone}a {severity} healed impact wound scar on the {location}|n"
     ]
 }
+
+
+# Compound descriptions: two or more wounds at one location, worst-first.
+COMPOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|Ra {severity} contusion and {others_phrase} mottle the {location}|n",
+        "|Ra {severity} impact wound joins {others_phrase} across the {location}|n",
+        "|Rthe {location} is battered by a {severity} contusion alongside {others_phrase}|n",
+        "|Ra {severity} contusion and {others_phrase} bruise the {location}|n",
+    ],
+
+    "treated": [
+        "{skintone}a {severity} wrapped contusion and {others_phrase} dress the {location}|n",
+        "{skintone}the {location} carries a {severity} compressed impact wound among {others_phrase}|n",
+    ],
+
+    "healing": [
+        "{skintone}a {severity} fading contusion and {others_phrase} mend across the {location}|n",
+        "{skintone}the {location} shows a {severity} healing impact wound among {others_phrase}|n",
+    ],
+
+    "destroyed": [
+        "|Ra {severity} crushing blow has pulped the {location}, joined by {others_phrase}|n",
+        "|Rthe {location} is a shattered ruin of a {severity} contusion and {others_phrase}|n",
+    ],
+
+    "scarred": [
+        "{skintone}a {severity} impact scar and {others_phrase} discolor the {location}|n",
+        "{skintone}the {location} is mottled by a {severity} contusion scar among {others_phrase}|n",
+    ],
+}

--- a/world/medical/wounds/messages/bullet.py
+++ b/world/medical/wounds/messages/bullet.py
@@ -65,3 +65,34 @@ WOUND_DESCRIPTIONS = {
         "{skintone}a {severity} healed projectile wound scar on the {location}|n"
     ]
 }
+
+
+# Compound descriptions: two or more wounds at one location, worst-first.
+COMPOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|Ra {severity} bullet wound and {others_phrase} riddle the {location}|n",
+        "|Ra {severity} gunshot wound joins {others_phrase} across the {location}|n",
+        "|Rthe {location} is torn by a {severity} bullet wound alongside {others_phrase}|n",
+        "|Ra {severity} bullet wound and {others_phrase} pepper the {location}|n",
+    ],
+
+    "treated": [
+        "{skintone}a {severity} bandaged bullet wound and {others_phrase} dress the {location}|n",
+        "{skintone}the {location} carries a {severity} patched gunshot wound among {others_phrase}|n",
+    ],
+
+    "healing": [
+        "{skintone}a {severity} healing bullet wound and {others_phrase} mend across the {location}|n",
+        "{skintone}the {location} shows a {severity} mending gunshot wound among {others_phrase}|n",
+    ],
+
+    "destroyed": [
+        "|Ra {severity} gunshot has shattered the {location}, joined by {others_phrase}|n",
+        "|Rthe {location} is a pulped ruin of a {severity} bullet wound and {others_phrase}|n",
+    ],
+
+    "scarred": [
+        "{skintone}a {severity} bullet scar and {others_phrase} pock the {location}|n",
+        "{skintone}the {location} is stippled by a {severity} gunshot scar among {others_phrase}|n",
+    ],
+}

--- a/world/medical/wounds/messages/cut.py
+++ b/world/medical/wounds/messages/cut.py
@@ -65,3 +65,34 @@ WOUND_DESCRIPTIONS = {
         "{skintone}a {severity} faded slash scar in the {location}|n"
     ]
 }
+
+
+# Compound descriptions: two or more wounds at one location, worst-first.
+COMPOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|Ra {severity} laceration and {others_phrase} crisscross the {location}|n",
+        "|Ra {severity} gash joins {others_phrase} across the {location}|n",
+        "|Rthe {location} is opened by a {severity} cut alongside {others_phrase}|n",
+        "|Ra {severity} slash and {others_phrase} score the {location}|n",
+    ],
+
+    "treated": [
+        "{skintone}a {severity} sutured laceration and {others_phrase} dress the {location}|n",
+        "{skintone}the {location} carries a {severity} stitched gash among {others_phrase}|n",
+    ],
+
+    "healing": [
+        "{skintone}a {severity} healing laceration and {others_phrase} mend across the {location}|n",
+        "{skintone}the {location} shows a {severity} knitting gash among {others_phrase}|n",
+    ],
+
+    "destroyed": [
+        "|Ra {severity} cut has flayed the {location}, joined by {others_phrase}|n",
+        "|Rthe {location} is a shredded ruin of a {severity} laceration and {others_phrase}|n",
+    ],
+
+    "scarred": [
+        "{skintone}a {severity} slash scar and {others_phrase} line the {location}|n",
+        "{skintone}the {location} is etched by a {severity} cutting scar among {others_phrase}|n",
+    ],
+}

--- a/world/medical/wounds/messages/generic.py
+++ b/world/medical/wounds/messages/generic.py
@@ -65,3 +65,45 @@ WOUND_DESCRIPTIONS = {
         "{skintone}a {severity} scar from old trauma on the {location}|n"
     ]
 }
+
+
+# Compound descriptions collapse two or more wounds at one location into a
+# single concise line. The worst wound drives {severity}; {others_phrase}
+# renders the remaining count ("another wound" / "several other wounds").
+# Generic is the fallback set for any injury type lacking its own.
+COMPOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|Ra {severity} wound and {others_phrase} mark the {location}|n",
+        "|Ra {severity} wound joins {others_phrase} across the {location}|n",
+        "|Rthe {location} bears a {severity} wound alongside {others_phrase}|n",
+        "|Ra {severity} wound and {others_phrase} cover the {location}|n",
+    ],
+
+    "treated": [
+        "{skintone}a {severity} treated wound and {others_phrase} dress the {location}|n",
+        "{skintone}the {location} carries a {severity} bandaged wound among {others_phrase}|n",
+        "{skintone}a {severity} tended wound joins {others_phrase} on the {location}|n",
+    ],
+
+    "healing": [
+        "{skintone}a {severity} healing wound and {others_phrase} mend across the {location}|n",
+        "{skintone}the {location} shows a {severity} healing wound among {others_phrase}|n",
+        "{skintone}a {severity} mending wound joins {others_phrase} on the {location}|n",
+    ],
+
+    "destroyed": [
+        "|Ra {severity} ruinous wound and {others_phrase} have wrecked the {location}|n",
+        "|Rthe {location} is a mangled ruin of a {severity} wound and {others_phrase}|n",
+    ],
+
+    "severed": [
+        "|Ra {severity} wound and {others_phrase} surround the ruined {location}|n",
+        "|Rthe ruined {location} is ringed by a {severity} wound and {others_phrase}|n",
+    ],
+
+    "scarred": [
+        "{skintone}a {severity} scar and {others_phrase} crisscross the {location}|n",
+        "{skintone}the {location} is marked by a {severity} scar among {others_phrase}|n",
+        "{skintone}a {severity} old scar joins {others_phrase} on the {location}|n",
+    ],
+}

--- a/world/medical/wounds/messages/stab.py
+++ b/world/medical/wounds/messages/stab.py
@@ -65,3 +65,34 @@ WOUND_DESCRIPTIONS = {
         "{skintone}a {severity} faded stab scar in the {location}|n"
     ]
 }
+
+
+# Compound descriptions: two or more wounds at one location, worst-first.
+COMPOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|Ra {severity} stab wound and {others_phrase} punch the {location}|n",
+        "|Ra {severity} puncture joins {others_phrase} across the {location}|n",
+        "|Rthe {location} is pierced by a {severity} stab wound alongside {others_phrase}|n",
+        "|Ra {severity} stab wound and {others_phrase} riddle the {location}|n",
+    ],
+
+    "treated": [
+        "{skintone}a {severity} packed stab wound and {others_phrase} dress the {location}|n",
+        "{skintone}the {location} carries a {severity} bandaged puncture among {others_phrase}|n",
+    ],
+
+    "healing": [
+        "{skintone}a {severity} healing stab wound and {others_phrase} mend across the {location}|n",
+        "{skintone}the {location} shows a {severity} closing puncture among {others_phrase}|n",
+    ],
+
+    "destroyed": [
+        "|Ra {severity} stab wound has mangled the {location}, joined by {others_phrase}|n",
+        "|Rthe {location} is a shredded ruin of a {severity} puncture and {others_phrase}|n",
+    ],
+
+    "scarred": [
+        "{skintone}a {severity} stab scar and {others_phrase} pock the {location}|n",
+        "{skintone}the {location} is stippled by a {severity} puncture scar among {others_phrase}|n",
+    ],
+}

--- a/world/tests/test_standalone_wounds.py
+++ b/world/tests/test_standalone_wounds.py
@@ -15,14 +15,22 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest import TestCase, mock
 
+from world.medical.wounds import messages
+from world.medical.wounds.constants import MEDICAL_COLORS
 from world.medical.wounds.longdesc_hooks import (
     _summarize_location_wounds,
     _compound_phrase,
+    _resolve_compound_template,
     get_standalone_wound_description,
     append_wounds_to_longdesc,
 )
 
 HOOKS = "world.medical.wounds.longdesc_hooks.get_character_wounds"
+
+# Injury-type modules that ship their own compound template sets.
+COMPOUND_MODULES = ("bullet", "cut", "stab", "blunt", "generic")
+# Stage keys every compound module must define.
+REQUIRED_STAGES = ("fresh", "treated", "healing", "destroyed", "scarred")
 
 
 def _fake_character(species="human", skintone=None):
@@ -65,8 +73,9 @@ class SummarizeLocationWoundsTests(TestCase):
         self.assertIn("left arm", lowered)
         # Worst wound (Critical) drives the lead severity word.
         self.assertIn("grievous", lowered)
-        # Concise: one summary clause, not two concatenated descriptions.
-        self.assertEqual(lowered.count("mark the"), 1)
+        # Concise: a single compound clause names the remainder exactly once,
+        # rather than concatenating one description per wound.
+        self.assertEqual(lowered.count("another wound"), 1)
         self.assertLessEqual(out.count("|R"), 1)
 
     def test_three_plus_wounds_use_several_other(self):
@@ -88,13 +97,16 @@ class SummarizeLocationWoundsTests(TestCase):
 
 class CompoundPhraseTests(TestCase):
 
-    def test_healed_mix_renders_calm_old_wounds(self):
+    def test_healed_mix_renders_without_fresh_red(self):
+        # A scarred worst wound resolves a calm, skintone-keyed compound
+        # template — never the bright-red fresh-wound coloring.
         worst = _wound(severity="Moderate", stage="scarred")
-        out = _compound_phrase(worst, others_count=2).lower()
-        self.assertIn("multiple old wounds", out)
-        self.assertIn("left arm", out)
-        # Healed summaries are not flagged with fresh-wound red.
-        self.assertNotIn("|r", _compound_phrase(worst, 2))
+        raw = _compound_phrase(worst, others_count=2)
+        self.assertIn("left arm", raw.lower())
+        self.assertNotIn("|R", raw)
+        self.assertNotIn("|r", raw)
+        # Still a single concise clause naming the remainder once.
+        self.assertEqual(raw.lower().count("several other wounds"), 1)
 
     def test_generic_type_omits_redundant_type_word(self):
         worst = _wound(injury_type="generic", severity="Critical", stage="fresh")
@@ -102,10 +114,78 @@ class CompoundPhraseTests(TestCase):
         self.assertIn("grievous wound", out)
         self.assertNotIn("generic", out)
 
-    def test_typed_wound_includes_type_word(self):
+    def test_typed_wound_lead_severity_and_location(self):
         worst = _wound(injury_type="stab", severity="Severe", stage="fresh")
         out = _compound_phrase(worst, others_count=1).lower()
-        self.assertIn("stab wound", out)
+        # Severe -> "serious"; the location is always named.
+        self.assertIn("serious", out)
+        self.assertIn("left arm", out)
+        self.assertIn("another wound", out)
+
+    def test_inline_fallback_when_no_template_resolves(self):
+        # With no compound template set available anywhere, the summarizer
+        # still returns a terminated sentence via legacy inline prose.
+        worst = _wound(injury_type="cut", severity="Critical", stage="fresh")
+        with mock.patch(
+            "world.medical.wounds.longdesc_hooks._resolve_compound_template",
+            return_value=None,
+        ):
+            out = _compound_phrase(worst, others_count=1)
+        self.assertIn("left arm", out.lower())
+        self.assertTrue(out.rstrip().endswith(("|n", ".")))
+
+
+class ResolveCompoundTemplateTests(TestCase):
+
+    def test_typed_lookup_uses_own_module(self):
+        for _ in range(20):
+            tmpl = _resolve_compound_template("bullet", "fresh")
+            self.assertIn(tmpl, messages.bullet.COMPOUND_DESCRIPTIONS["fresh"])
+
+    def test_unknown_type_falls_back_to_generic(self):
+        # ``severed`` is a real injury type with no compound dict of its own.
+        for _ in range(20):
+            tmpl = _resolve_compound_template("severed", "fresh")
+            self.assertIn(tmpl, messages.generic.COMPOUND_DESCRIPTIONS["fresh"])
+
+    def test_unknown_stage_defaults_to_fresh(self):
+        for _ in range(20):
+            tmpl = _resolve_compound_template("cut", "nonexistent_stage")
+            self.assertIn(tmpl, messages.cut.COMPOUND_DESCRIPTIONS["fresh"])
+
+    def test_all_modules_define_required_stages(self):
+        for name in COMPOUND_MODULES:
+            module = getattr(messages, name)
+            compound = module.COMPOUND_DESCRIPTIONS
+            for stage in REQUIRED_STAGES:
+                self.assertIn(
+                    stage, compound,
+                    f"{name}.COMPOUND_DESCRIPTIONS missing stage '{stage}'",
+                )
+                self.assertTrue(
+                    compound[stage],
+                    f"{name}.COMPOUND_DESCRIPTIONS['{stage}'] is empty",
+                )
+
+    def test_every_template_formats_without_keyerror(self):
+        format_vars = {
+            "severity": "grievous",
+            "location": "left arm",
+            "others_phrase": "another wound",
+            "skintone": "",
+            **MEDICAL_COLORS,
+        }
+        for name in COMPOUND_MODULES:
+            compound = getattr(messages, name).COMPOUND_DESCRIPTIONS
+            for stage, variants in compound.items():
+                for template in variants:
+                    try:
+                        template.format(**format_vars)
+                    except KeyError as exc:  # pragma: no cover - failure path
+                        self.fail(
+                            f"{name}.{stage} template references unknown "
+                            f"variable {exc}: {template!r}"
+                        )
 
 
 class StandaloneWoundDescriptionTests(TestCase):


### PR DESCRIPTION
## Summary
- Route the multi-wound location summarizer (`_compound_phrase`) through per-injury-type `COMPOUND_DESCRIPTIONS` template sets that mirror the single-wound `WOUND_DESCRIPTIONS` dicts, so a bullet-riddled location now reads distinctly from a slashed or bludgeoned one.
- Add a `_resolve_compound_template(injury_type, stage)` seam mirroring `get_wound_description` resolution: type module → `messages.generic` fallback → stage key with a `fresh` default. Legacy inline phrasing remains as the ultimate fallback when no template set resolves.
- Add `COMPOUND_DESCRIPTIONS` (fresh/treated/healing/destroyed/scarred; generic also severed) to `messages/{generic,bullet,cut,stab,blunt}.py`; `severed`/`harvested` fall back to generic by design.
- Fix a stale function-signature block in `specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md`.

## Testing
- `evennia test --settings settings.py world.tests.test_standalone_wounds` — 20 passed (relaxed over-specific assertions to structural invariants; added `_resolve_compound_template` coverage for typed lookup, generic fallback, stage defaulting, required-stage presence, and KeyError-free formatting).
- `evennia test --settings settings.py world` — 1369 passed.

Closes #262