### PR TITLE
Collapse symmetric paired longdescs into a single pluralized line

### DIFF
--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -282,6 +282,54 @@ With your administrative visibility, you see: item1 [#123], item2 [#456], weapon
 - **Writer freedom**: No forced connecting words or narrative structure - writers control their own style
 - **Constants-driven**: Uses `PARAGRAPH_BREAK_THRESHOLD`, `REGION_BREAK_PRIORITY`, and `ANATOMICAL_REGIONS` for fine-tuning
 
+#### Paired Longdesc Collapse ✅
+Symmetric left/right paired appendages collapse into a single pluralized line
+when their descriptions are interchangeable, avoiding redundant repetition
+(e.g. two identical "a pale blue eye." lines becoming "Pale blue eyes.").
+
+**Pairs are derived dynamically** from `left_*` / `right_*` location keys
+(union of `longdesc` keys, `coverage_map`, `ANATOMICAL_DISPLAY_ORDER`, and
+severed locations), so custom species anatomy (`left_wing` / `right_wing`,
+etc.) participates automatically with no hardcoded list.
+
+**Collapse eligibility** — a pair collapses only when **both** sides are
+uncovered AND **one** of:
+- **Identical longdescs**: both sides hold the same non-empty longdesc string
+  (literal equality — WYSIWYG, no normalization), OR
+- **Both cleanly severed**: both sides are fully severed (every organ in the
+  location has `wound_stage == "severed"`); the longdesc key is absent.
+
+When eligible, the pair renders as one line and the right-side entry is
+skipped. Asymmetric coverage (one side clothed), differing prose, or a single
+amputated limb all **fail** the identity test and render each side separately.
+
+**Pluralization** (`_pluralize_pair_longdesc`):
+- Pluralizes the first whole-word occurrence of the pair's anatomical base
+  noun (`eye`→`eyes`, `foot`→`feet`) via `world.grammar.pluralize_noun`
+  (wrapping `inflect`).
+- Strips one leading article (`a` / `an` / `the`), tolerating leading color
+  codes / `{tokens}`; recapitalizes via `grammar.capitalize_first` if the
+  article was capitalized.
+- **Safe fallback**: if the base noun is absent from the prose (e.g. "a
+  freckled forearm" for base "arm"), returns `None` → the pair renders
+  separately rather than producing malformed text.
+
+**Both-severed stumps** render via `world.medical.wounds`
+`get_paired_severed_description` using the type-agnostic
+`PAIRED_SEVERED_DESCRIPTIONS` templates, with `{location}` filled as
+`both <plural>` (e.g. "both hands").
+
+**Wounds do not gate collapse**: a wound on one side does not split the pair —
+the merged line renders once and per-side wound sentences continue to append
+through the normal wound-layering path. (Collapsing two identical per-side
+wound sentences into "both hands" is a possible future refinement, not
+currently done.)
+
+**Implementation**: `_build_paired_longdesc_collapse`,
+`_merge_paired_location`, `_get_severed_locations`, and
+`_pluralize_pair_longdesc` in `typeclasses/appearance_mixin.py`, consulted by
+both passes of `_get_visible_body_descriptions`.
+
 ### Visibility Rules ✅
 - **Default**: All body locations are visible unless covered by clothing
 - **Clothing Coverage**: Worn items hide covered locations and display their own descriptions instead

--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -83,11 +83,23 @@ class AppearanceMixin:
         coverage_map = self._build_clothing_coverage_map()
         longdescs = self.longdesc or {}
 
+        # Pre-compute symmetric left/right pairs that collapse into a single
+        # pluralized line (identical longdescs, or both cleanly severed).
+        collapse_map, collapse_skip = self._build_paired_longdesc_collapse(
+            looker, longdescs, coverage_map
+        )
+
         # Track which clothing items we've already added to avoid duplicates
         added_clothing_items = set()
 
         # Process in anatomical order
         for location in ANATOMICAL_DISPLAY_ORDER:
+            if location in collapse_skip:
+                # Partner of a collapsed pair; rendered at the anchor location.
+                continue
+            if location in collapse_map:
+                descriptions.append((location, collapse_map[location]))
+                continue
             if location in coverage_map:
                 # Location covered by clothing - use outermost item's current worn_desc
                 clothing_item = coverage_map[location]
@@ -142,6 +154,11 @@ class AppearanceMixin:
         all_locations = set(longdescs.keys()) | set(coverage_map.keys())
         for location in all_locations:
             if location not in ANATOMICAL_DISPLAY_ORDER:
+                if location in collapse_skip:
+                    continue
+                if location in collapse_map:
+                    descriptions.append((location, collapse_map[location]))
+                    continue
                 if location in coverage_map:
                     # Extended location with clothing
                     clothing_item = coverage_map[location]
@@ -188,6 +205,165 @@ class AppearanceMixin:
                         pass
 
         return descriptions
+
+    def _build_paired_longdesc_collapse(self, looker, longdescs, coverage_map):
+        """
+        Compute which symmetric left/right pairs collapse into one line.
+
+        A ``left_*``/``right_*`` pair collapses when both sides are uncovered
+        and either (a) their longdescs are identical and non-empty, or (b)
+        both sides have been cleanly severed. Severance deletes a location's
+        longdesc key, so a single amputated limb naturally fails the identity
+        test and renders on its own — only a matched, intact (or matched,
+        fully amputated) pair merges.
+
+        Args:
+            looker: Character looking.
+            longdescs (dict): The character's ``location -> desc`` mapping.
+            coverage_map (dict): ``location -> clothing item`` coverage.
+
+        Returns:
+            tuple: ``(collapse_map, skip_set)`` where ``collapse_map`` maps a
+                ``left_*`` anchor location to its merged description string and
+                ``skip_set`` holds the ``right_*`` partners to skip.
+        """
+        from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
+
+        collapse_map = {}
+        skip_set = set()
+
+        severed_locs = self._get_severed_locations()
+        # Consider every left_* location the body could render this pass.
+        sources = (
+            set(longdescs)
+            | set(coverage_map)
+            | set(ANATOMICAL_DISPLAY_ORDER)
+            | severed_locs
+        )
+
+        for left_loc in sources:
+            if not left_loc.startswith("left_"):
+                continue
+            right_loc = "right_" + left_loc[len("left_"):]
+            if right_loc in skip_set:
+                continue
+            # Asymmetric clothing breaks the visual pairing.
+            if left_loc in coverage_map or right_loc in coverage_map:
+                continue
+
+            base_noun = left_loc[len("left_"):].replace("_", " ")
+            merged = self._merge_paired_location(
+                looker, left_loc, right_loc, base_noun, longdescs, severed_locs
+            )
+            if merged is not None:
+                collapse_map[left_loc] = merged
+                skip_set.add(right_loc)
+
+        return collapse_map, skip_set
+
+    def _merge_paired_location(self, looker, left_loc, right_loc, base_noun,
+                               longdescs, severed_locs):
+        """
+        Build the merged description for one collapsible pair, or ``None``.
+
+        Handles the two collapse cases: identical longdescs (pluralized, with
+        each side's wounds appended on its own side) and both-sides-severed
+        (a single plural stump line).
+        """
+        left_desc = longdescs.get(left_loc)
+        right_desc = longdescs.get(right_loc)
+
+        # Case 1: identical, non-empty longdescs on both sides.
+        if left_desc and right_desc and left_desc == right_desc:
+            plural = self._pluralize_pair_longdesc(left_desc, base_noun)
+            if plural is None:
+                return None
+            processed = self._process_description_variables(
+                plural, looker, force_third_person=True, apply_skintone=True,
+            )
+            parts = [processed]
+            # A wound simply sits on its own side without splitting the pair.
+            try:
+                from world.medical.wounds import get_standalone_wound_description
+                for side in (left_loc, right_loc):
+                    wound_desc = get_standalone_wound_description(
+                        self, side, looker
+                    )
+                    if wound_desc:
+                        parts.append(wound_desc)
+            except ImportError:
+                pass
+            return " ".join(parts)
+
+        # Case 2: both sides cleanly severed (neither carries a longdesc).
+        if (not left_desc and not right_desc
+                and left_loc in severed_locs and right_loc in severed_locs):
+            try:
+                from world.medical.wounds import get_paired_severed_description
+                return get_paired_severed_description(
+                    self, left_loc, right_loc, looker
+                )
+            except ImportError:
+                return None
+
+        return None
+
+    def _get_severed_locations(self):
+        """Return the set of body locations that are cleanly severed."""
+        try:
+            from world.medical.wounds import get_character_wounds
+        except ImportError:
+            return set()
+
+        wounds_by_location = {}
+        for wound in get_character_wounds(self):
+            wounds_by_location.setdefault(wound['location'], []).append(wound)
+
+        severed = set()
+        for location, location_wounds in wounds_by_location.items():
+            if all(w.get('stage') == 'severed' for w in location_wounds):
+                severed.add(location)
+        return severed
+
+    def _pluralize_pair_longdesc(self, text, base_noun):
+        """
+        Pluralize an identical paired longdesc for a merged rendering.
+
+        Pluralizes the first whole-word occurrence of the anatomical noun
+        (e.g. "hand" -> "hands") and strips a single leading article,
+        preserving the article's capitalization onto the new first word.
+
+        Returns ``None`` when the anatomical noun is absent from the prose,
+        signalling the caller to render the two sides separately rather than
+        risk a grammatically broken merge.
+        """
+        import re
+        from world.grammar import pluralize_noun, capitalize_first
+
+        noun_pattern = re.compile(r'\b' + re.escape(base_noun) + r'\b',
+                                  re.IGNORECASE)
+        if not noun_pattern.search(text):
+            return None
+
+        plural = pluralize_noun(base_noun)
+        merged, _count = noun_pattern.subn(plural, text, count=1)
+
+        # Strip a single leading article, tolerating leading color codes or
+        # template tokens, and re-capitalize if the article was capitalized.
+        article_pattern = re.compile(
+            r'^((?:\|[a-zA-Z0-9]|\{[^}]+\}|\s)*)(a|an|the)\b[ \t]+',
+            re.IGNORECASE,
+        )
+        match = article_pattern.match(merged)
+        if match:
+            lead = match.group(1)
+            article_capitalized = match.group(2)[0].isupper()
+            remainder = merged[match.end():]
+            if article_capitalized:
+                remainder = capitalize_first(remainder)
+            merged = lead + remainder
+
+        return merged
 
     def _format_longdescs_with_paragraphs(self, longdesc_list):
         """

--- a/world/grammar.py
+++ b/world/grammar.py
@@ -88,6 +88,38 @@ def conjugate_third_person(verb: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Noun Pluralization
+# ---------------------------------------------------------------------------
+
+
+def pluralize_noun(noun: str) -> str:
+    """Return the plural form of a singular noun.
+
+    Thin wrapper over the ``inflect`` engine so callers do not reach into
+    the singleton directly. Handles regular and irregular plurals
+    ("hand" → "hands", "foot" → "feet", "eye" → "eyes") and preserves the
+    leading capitalization of the input.
+
+    Args:
+        noun: A singular noun (a single word, e.g. "hand").
+
+    Returns:
+        The plural form, capitalized to match ``noun``'s first letter.
+    """
+    if not noun:
+        return noun
+
+    plural = _engine.plural_noun(noun)
+    # ``plural_noun`` can return False on unexpected input; fall back safely.
+    if not plural:
+        return noun
+
+    if noun[0].isupper():
+        return plural[0].upper() + plural[1:]
+    return plural
+
+
+# ---------------------------------------------------------------------------
 # Article Handling
 # ---------------------------------------------------------------------------
 

--- a/world/medical/wounds/__init__.py
+++ b/world/medical/wounds/__init__.py
@@ -33,6 +33,7 @@ from .wound_descriptions import (
 from .longdesc_hooks import (
     append_wounds_to_longdesc,
     get_standalone_wound_description,
+    get_paired_severed_description,
 )
 
 from .constants import (
@@ -52,6 +53,7 @@ __all__ = [
     # Longdesc integration hooks
     'append_wounds_to_longdesc',
     'get_standalone_wound_description',
+    'get_paired_severed_description',
 
     # Constants
     'WOUND_STAGES',

--- a/world/medical/wounds/longdesc_hooks.py
+++ b/world/medical/wounds/longdesc_hooks.py
@@ -186,6 +186,63 @@ def _compound_phrase(worst_wound, others_count, character=None):
     return _format_wound_grammar(phrase)
 
 
+def get_paired_severed_description(character, left_location, right_location,
+                                  looker=None):
+    """
+    Render one plural stump line for a symmetric pair severed on both sides.
+
+    When both members of a ``left_*``/``right_*`` pair have been cleanly
+    amputated, their individual stump descriptions are collapsed into a
+    single plural sentence (e.g. "Both hands have been cleanly amputated...")
+    so the body description reads naturally instead of repeating two nearly
+    identical amputation lines.
+
+    Args:
+        character: Character object (reserved for future species naming).
+        left_location (str): The ``left_*`` member of the pair.
+        right_location (str): The ``right_*`` member of the pair.
+        looker: Character looking (reserved for future permission checks).
+
+    Returns:
+        str | None: A formatted plural stump sentence when both sides are
+            severed, else ``None``.
+    """
+    if not (_location_is_severed(character, left_location)
+            and _location_is_severed(character, right_location)):
+        return None
+
+    from world.grammar import pluralize_noun
+
+    base_noun = _pair_base_noun(left_location)
+    plural = pluralize_noun(base_noun)
+    location_display = f"both {plural}"
+
+    templates = getattr(messages.generic, 'PAIRED_SEVERED_DESCRIPTIONS', None)
+    if not templates:
+        return None
+    template = random.choice(templates)
+    return _format_wound_grammar(template.format(location=location_display))
+
+
+def _location_is_severed(character, location):
+    """Return True if every wound at ``location`` is a clean severance."""
+    location_wounds = [
+        w for w in get_character_wounds(character)
+        if w['location'] == location
+    ]
+    if not location_wounds:
+        return False
+    return all(w.get('stage') == 'severed' for w in location_wounds)
+
+
+def _pair_base_noun(location):
+    """Strip a ``left_``/``right_`` prefix to the bare body-part noun."""
+    for prefix in ("left_", "right_"):
+        if location.startswith(prefix):
+            return location[len(prefix):].replace("_", " ")
+    return location.replace("_", " ")
+
+
 def _resolve_compound_template(injury_type, stage):
     """
     Resolve a random compound template for an injury type and stage.

--- a/world/medical/wounds/messages/generic.py
+++ b/world/medical/wounds/messages/generic.py
@@ -107,3 +107,22 @@ COMPOUND_DESCRIPTIONS = {
         "{skintone}a {severity} old scar joins {others_phrase} on the {location}|n",
     ],
 }
+
+
+# Paired-severance descriptions collapse a symmetric left/right pair that has
+# been *cleanly amputated on both sides* into one plural stump line. The
+# ``{location}`` slot receives a plural body-part phrase (e.g. "both hands").
+# Severance prose is type-agnostic, so this single generic set serves every
+# injury type. Rendered through ``_format_wound_grammar`` (capitalized and
+# terminated), so templates need no leading capital or trailing period.
+PAIRED_SEVERED_DESCRIPTIONS = [
+    "a pair of clean surgical amputations where {location} once were, "
+    "properly treated|n",
+    "{location} have been medically severed with sterile bandaging|n",
+    "a professionally treated pair of amputation sites where {location} "
+    "were removed|n",
+    "{location} have been cleanly amputated with proper medical closure|n",
+    "a sterile pair of severances with surgical care where {location} "
+    "once were|n",
+    "{location} have been surgically removed with clinical precision|n",
+]

--- a/world/tests/test_paired_longdesc_collapse.py
+++ b/world/tests/test_paired_longdesc_collapse.py
@@ -1,0 +1,250 @@
+"""Unit tests for symmetric left/right longdesc collapse.
+
+A matched ``left_*``/``right_*`` pair with identical longdescs renders as one
+pluralized line (e.g. "Calloused hands."); a wound sits on its own side
+without splitting the pair; a pair severed on both sides collapses to one
+plural stump line; and any divergence (coverage, severance of one side,
+differing prose) falls back to separate rendering.
+
+Run via::
+
+    evennia test world.tests.test_paired_longdesc_collapse
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase, mock
+
+from typeclasses.appearance_mixin import AppearanceMixin
+
+WOUNDS = "world.medical.wounds"
+
+
+class _Bare(AppearanceMixin):
+    """Mixin host with no overrides, for testing the real helper methods."""
+
+
+class _Body(AppearanceMixin):
+    """Mixin host that stubs the cross-cutting deps the collapse logic uses."""
+
+    def __init__(self, severed=None):
+        self._severed = set(severed or ())
+
+    def _process_description_variables(self, desc, looker, **kwargs):
+        # Passthrough so tests can assert on the pluralized text directly.
+        return desc
+
+    def _get_severed_locations(self):
+        return set(self._severed)
+
+
+class PluralizePairLongdescTests(TestCase):
+
+    def setUp(self):
+        self.obj = _Bare()
+
+    def test_strips_article_and_pluralizes_with_capital(self):
+        out = self.obj._pluralize_pair_longdesc(
+            "A calloused hand with scarred knuckles.", "hand"
+        )
+        self.assertEqual(out, "Calloused hands with scarred knuckles.")
+
+    def test_lowercase_fragment_stays_lowercase(self):
+        out = self.obj._pluralize_pair_longdesc("a milky eye", "eye")
+        self.assertEqual(out, "milky eyes")
+
+    def test_irregular_plural_foot_to_feet(self):
+        out = self.obj._pluralize_pair_longdesc("A scarred foot.", "foot")
+        self.assertEqual(out, "Scarred feet.")
+
+    def test_definite_article_handled(self):
+        out = self.obj._pluralize_pair_longdesc("The gnarled hand.", "hand")
+        self.assertEqual(out, "Gnarled hands.")
+
+    def test_missing_noun_returns_none(self):
+        # The anatomical noun isn't present; cannot safely pluralize.
+        out = self.obj._pluralize_pair_longdesc(
+            "a sleek prosthetic appendage", "hand"
+        )
+        self.assertIsNone(out)
+
+    def test_only_first_occurrence_pluralized(self):
+        out = self.obj._pluralize_pair_longdesc(
+            "a hand, a working hand", "hand"
+        )
+        # Leading article stripped; only the first 'hand' becomes plural.
+        self.assertEqual(out, "hands, a working hand")
+
+
+class GetSeveredLocationsTests(TestCase):
+
+    def setUp(self):
+        self.obj = _Bare()
+
+    def test_location_with_all_severed_wounds_is_severed(self):
+        wounds = [
+            {"location": "left_hand", "stage": "severed"},
+            {"location": "left_hand", "stage": "severed"},
+            {"location": "chest", "stage": "fresh"},
+        ]
+        with mock.patch(f"{WOUNDS}.get_character_wounds", return_value=wounds):
+            self.assertEqual(self.obj._get_severed_locations(), {"left_hand"})
+
+    def test_mixed_stage_location_is_not_severed(self):
+        wounds = [
+            {"location": "left_hand", "stage": "severed"},
+            {"location": "left_hand", "stage": "fresh"},
+        ]
+        with mock.patch(f"{WOUNDS}.get_character_wounds", return_value=wounds):
+            self.assertEqual(self.obj._get_severed_locations(), set())
+
+    def test_no_wounds_no_severed(self):
+        with mock.patch(f"{WOUNDS}.get_character_wounds", return_value=[]):
+            self.assertEqual(self.obj._get_severed_locations(), set())
+
+
+class BuildPairedCollapseTests(TestCase):
+
+    def setUp(self):
+        self.obj = _Body()
+
+    def _build(self, longdescs, coverage_map=None):
+        return self.obj._build_paired_longdesc_collapse(
+            None, longdescs, coverage_map or {}
+        )
+
+    def test_identical_pair_collapses_to_plural(self):
+        longdescs = {
+            "left_hand": "A calloused hand.",
+            "right_hand": "A calloused hand.",
+        }
+        with mock.patch(
+            f"{WOUNDS}.get_standalone_wound_description", return_value=""
+        ):
+            collapse_map, skip = self._build(longdescs)
+        self.assertIn("left_hand", collapse_map)
+        self.assertIn("right_hand", skip)
+        self.assertEqual(collapse_map["left_hand"], "Calloused hands.")
+
+    def test_wound_on_one_side_stays_merged(self):
+        longdescs = {
+            "left_hand": "A calloused hand.",
+            "right_hand": "A calloused hand.",
+        }
+
+        def _wound(_self, location, _looker):
+            if location == "right_hand":
+                return "A fresh laceration crosses the right hand."
+            return ""
+
+        with mock.patch(
+            f"{WOUNDS}.get_standalone_wound_description", side_effect=_wound
+        ):
+            collapse_map, skip = self._build(longdescs)
+        self.assertEqual(
+            collapse_map["left_hand"],
+            "Calloused hands. A fresh laceration crosses the right hand.",
+        )
+        self.assertIn("right_hand", skip)
+
+    def test_asymmetric_coverage_does_not_collapse(self):
+        longdescs = {
+            "left_hand": "A calloused hand.",
+            "right_hand": "A calloused hand.",
+        }
+        coverage = {"left_hand": object()}
+        with mock.patch(
+            f"{WOUNDS}.get_standalone_wound_description", return_value=""
+        ):
+            collapse_map, skip = self._build(longdescs, coverage)
+        self.assertEqual(collapse_map, {})
+        self.assertEqual(skip, set())
+
+    def test_differing_prose_does_not_collapse(self):
+        longdescs = {
+            "left_hand": "A calloused hand.",
+            "right_hand": "A scarred hand.",
+        }
+        with mock.patch(
+            f"{WOUNDS}.get_standalone_wound_description", return_value=""
+        ):
+            collapse_map, _skip = self._build(longdescs)
+        self.assertEqual(collapse_map, {})
+
+    def test_non_pluralizable_pair_falls_back(self):
+        longdescs = {
+            "left_hand": "a sleek prosthetic appendage",
+            "right_hand": "a sleek prosthetic appendage",
+        }
+        with mock.patch(
+            f"{WOUNDS}.get_standalone_wound_description", return_value=""
+        ):
+            collapse_map, _skip = self._build(longdescs)
+        self.assertEqual(collapse_map, {})
+
+    def test_both_severed_collapses_to_plural_stump(self):
+        self.obj = _Body(severed={"left_hand", "right_hand"})
+        with mock.patch(
+            f"{WOUNDS}.get_paired_severed_description",
+            return_value="Both hands have been cleanly amputated.",
+        ):
+            collapse_map, skip = self._build({})
+        self.assertEqual(
+            collapse_map["left_hand"],
+            "Both hands have been cleanly amputated.",
+        )
+        self.assertIn("right_hand", skip)
+
+    def test_one_side_severed_does_not_collapse(self):
+        self.obj = _Body(severed={"left_hand"})
+        longdescs = {"right_hand": "A calloused hand."}
+        with mock.patch(
+            f"{WOUNDS}.get_standalone_wound_description", return_value=""
+        ):
+            collapse_map, _skip = self._build(longdescs)
+        self.assertEqual(collapse_map, {})
+
+    def test_custom_longdesc_pair_collapses(self):
+        longdescs = {
+            "left_wing": "A feathered wing.",
+            "right_wing": "A feathered wing.",
+        }
+        with mock.patch(
+            f"{WOUNDS}.get_standalone_wound_description", return_value=""
+        ):
+            collapse_map, skip = self._build(longdescs)
+        self.assertEqual(collapse_map["left_wing"], "Feathered wings.")
+        self.assertIn("right_wing", skip)
+
+
+class PairedSeveredDescriptionTests(TestCase):
+    """The wound-module helper that renders the merged stump line."""
+
+    def test_both_severed_returns_plural_stump(self):
+        from world.medical.wounds import get_paired_severed_description
+
+        wounds = [
+            {"location": "left_hand", "stage": "severed"},
+            {"location": "right_hand", "stage": "severed"},
+        ]
+        with mock.patch(
+            "world.medical.wounds.longdesc_hooks.get_character_wounds",
+            return_value=wounds,
+        ):
+            out = get_paired_severed_description(None, "left_hand", "right_hand")
+        self.assertIsInstance(out, str)
+        self.assertIn("hands", out.lower())
+        # Capitalized and terminated by the grammar formatter.
+        self.assertTrue(out[0].isupper())
+        self.assertTrue(out.rstrip().endswith((".", ".|n")))
+
+    def test_not_both_severed_returns_none(self):
+        from world.medical.wounds import get_paired_severed_description
+
+        wounds = [{"location": "left_hand", "stage": "severed"}]
+        with mock.patch(
+            "world.medical.wounds.longdesc_hooks.get_character_wounds",
+            return_value=wounds,
+        ):
+            out = get_paired_severed_description(None, "left_hand", "right_hand")
+        self.assertIsNone(out)


### PR DESCRIPTION
## Summary
- Identical left/right paired-appendage longdescs now render as one pluralized line (e.g. two "a pale blue eye." entries become "Pale blue eyes.") instead of two redundant lines.
- A pair collapses only when both sides are uncovered AND either hold identical non-empty longdescs or are both cleanly severed; both-severed pairs collapse to a single plural stump ("both hands").
- Pluralization strips a leading article and pluralizes the pair's anatomical base noun (`eye`→`eyes`, `foot`→`feet`) via `inflect`, with safe fallback to separate rendering when the noun is absent from the prose.
- Wounds do not gate collapse — a wound on one side keeps the merged line and per-side wound sentences still append through the normal wound-layering path.
- Pairs derived dynamically from `left_*`/`right_*` keys so custom species anatomy participates automatically.

## Implementation
- `world/grammar.py`: new `pluralize_noun()` wrapping `inflect` (preserves leading capitalization).
- `typeclasses/appearance_mixin.py`: `_build_paired_longdesc_collapse`, `_merge_paired_location`, `_get_severed_locations`, `_pluralize_pair_longdesc`; both passes of `_get_visible_body_descriptions` consult the collapse map.
- `world/medical/wounds/`: `get_paired_severed_description` + `PAIRED_SEVERED_DESCRIPTIONS` for both-severed stump rendering.
- Rendering-layer only — no storage or migration change; `@longdesc` authoring unchanged.

## Testing
- New `world/tests/test_paired_longdesc_collapse.py` (19 tests) covering pluralization, severed-location detection, and all collapse/no-collapse cases.
- Full `world` suite green: **1388 tests** (1369 prior + 19 new).
- Verified `inflect` pluralization in Docker: `foot`→`feet`, capitalization preserved.

Closes #264