### PR TITLE
Revert paired-longdesc selection model (#267)

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -571,14 +571,6 @@ class CmdLongdesc(Command):
     neck, chest, back, abdomen, groin, left_arm, right_arm, left_hand, right_hand,
     left_thigh, right_thigh, left_shin, right_shin, left_foot, right_foot.
 
-    Symmetric pairs — eyes, ears, arms, hands, thighs, shins, feet:
-        Each pair can be described as one line using its merged key (e.g.
-        @longdesc eyes "..."). When both sides are visible, that single line
-        is shown for the pair. Write only the merged key for one clean line,
-        or write the merged key AND both sides if you want each side to keep
-        its own prose when a limb is covered or lost. If you skip the merged
-        key but give both sides identical text, that line is shown once too.
-
     Extended anatomy (tails, wings, etc.) is supported for modified characters.
     Descriptions appear when others look at you, integrated with your base description.
     """
@@ -667,25 +659,16 @@ class CmdLongdesc(Command):
 
     def _handle_list_locations(self, caller):
         """Show all available body locations for the character."""
-        from world.combat.constants import PAIR_MERGE_KEYS
-
         locations = caller.get_available_locations()
         if not locations:
             caller.msg("No body locations available.")
             return
 
-        merge_keys = set(PAIR_MERGE_KEYS)
-
         # Group locations by type for better display
         grouped_locations = {}
         extended_locations = []
-        merge_locations = []
 
         for location in locations:
-            if location in merge_keys:
-                merge_locations.append(location)
-                continue
-
             found_region = None
             for region_name, region_locations in ANATOMICAL_REGIONS.items():
                 if location in region_locations:
@@ -716,14 +699,6 @@ class CmdLongdesc(Command):
 
         if extended_locations:
             caller.msg(f"  |cExtended Anatomy:|n {', '.join(extended_locations)}")
-
-        if merge_locations:
-            # Show each merge key beside the sides it represents.
-            ordered = [k for k in PAIR_MERGE_KEYS if k in merge_locations]
-            pairs = ", ".join(
-                f"{k} ({'/'.join(PAIR_MERGE_KEYS[k])})" for k in ordered
-            )
-            caller.msg(f"  |cSymmetric Shorthand:|n {pairs}")
 
     def _handle_clear(self, caller, args):
         """Handle clear commands."""

--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -283,50 +283,36 @@ With your administrative visibility, you see: item1 [#123], item2 [#456], weapon
 - **Constants-driven**: Uses `PARAGRAPH_BREAK_THRESHOLD`, `REGION_BREAK_PRIORITY`, and `ANATOMICAL_REGIONS` for fine-tuning
 
 #### Paired Longdesc Collapse ✅
-Symmetric left/right paired appendages collapse into a single line when their
-descriptions are interchangeable, avoiding redundant repetition (e.g. two
-identical "a pale blue eye." lines becoming one line). The system **never
-rewrites authored prose** — it only *selects* which stored string represents
-the pair. There is no pluralization or grammar transformation at render time.
+Symmetric left/right paired appendages collapse into a single pluralized line
+when their descriptions are interchangeable, avoiding redundant repetition
+(e.g. two identical "a pale blue eye." lines becoming "Pale blue eyes.").
 
 **Pairs are derived dynamically** from `left_*` / `right_*` location keys
 (union of `longdesc` keys, `coverage_map`, `ANATOMICAL_DISPLAY_ORDER`, and
 severed locations), so custom species anatomy (`left_wing` / `right_wing`,
 etc.) participates automatically with no hardcoded list.
 
-**Merge keys** — registered symmetric pairs each expose a third addressable
-longdesc location, the *merge key*, defined in
-`world.combat.constants.PAIR_MERGE_KEYS`:
+**Collapse eligibility** — a pair collapses only when **both** sides are
+uncovered AND **one** of:
+- **Identical longdescs**: both sides hold the same non-empty longdesc string
+  (literal equality — WYSIWYG, no normalization), OR
+- **Both cleanly severed**: both sides are fully severed (every organ in the
+  location has `wound_stage == "severed"`); the longdesc key is absent.
 
-```python
-PAIR_MERGE_KEYS = {
-    "eyes": ("left_eye", "right_eye"),   "ears":  ("left_ear", "right_ear"),
-    "arms": ("left_arm", "right_arm"),   "hands": ("left_hand", "right_hand"),
-    "thighs": ("left_thigh", "right_thigh"), "shins": ("left_shin", "right_shin"),
-    "feet": ("left_foot", "right_foot"),
-}
-```
+When eligible, the pair renders as one line and the right-side entry is
+skipped. Asymmetric coverage (one side clothed), differing prose, or a single
+amputated limb all **fail** the identity test and render each side separately.
 
-A player **writes one** (the merge key alone, for a single clean line) **or
-three** (the merge key plus both sides, to retain per-side prose when a limb is
-later covered or severed). Merge keys are in `VALID_LONGDESC_LOCATIONS` but are
-**not** default anatomy, are **not** wearable (`CLOTHING_LOCATIONS` excludes
-them), and **never render on their own line** — only through the pair anchor.
-
-**Selection** (`_merge_paired_location`) — when **both** sides are uncovered:
-- **Both cleanly severed** (every organ `wound_stage == "severed"`, longdesc
-  key absent) → one paired stump line (see below).
-- Else if the **merge key carries a longdesc** → that one authored line.
-- Else if **both sides hold the same** non-empty longdesc (literal equality —
-  WYSIWYG, no normalization) → that line, shown once verbatim.
-- Otherwise (differing prose, only one side described) → render separately.
-
-Asymmetric coverage (one side clothed) or a single amputated limb **never**
-collapse: the merge key is ignored and the visible/surviving side renders on
-its own (its side longdesc if written, else the default). Writing only the
-merge key (write-1) therefore means a lost side falls back to the generic
-default line — an accepted trade-off; write all three to keep flavor through
-coverage and severance.
+**Pluralization** (`_pluralize_pair_longdesc`):
+- Pluralizes the first whole-word occurrence of the pair's anatomical base
+  noun (`eye`→`eyes`, `foot`→`feet`) via `world.grammar.pluralize_noun`
+  (wrapping `inflect`).
+- Strips one leading article (`a` / `an` / `the`), tolerating leading color
+  codes / `{tokens}`; recapitalizes via `grammar.capitalize_first` if the
+  article was capitalized.
+- **Safe fallback**: if the base noun is absent from the prose (e.g. "a
+  freckled forearm" for base "arm"), returns `None` → the pair renders
+  separately rather than producing malformed text.
 
 **Both-severed stumps** render via `world.medical.wounds`
 `get_paired_severed_description` using the type-agnostic
@@ -335,14 +321,14 @@ coverage and severance.
 
 **Wounds do not gate collapse**: a wound on one side does not split the pair —
 the merged line renders once and per-side wound sentences continue to append
-through the normal wound-layering path.
+through the normal wound-layering path. (Collapsing two identical per-side
+wound sentences into "both hands" is a possible future refinement, not
+currently done.)
 
 **Implementation**: `_build_paired_longdesc_collapse`,
-`_merge_paired_location`, and `_get_severed_locations` in
-`typeclasses/appearance_mixin.py`, consulted by both passes of
-`_get_visible_body_descriptions` (which also suppresses merge keys from
-standalone rendering). Merge keys are made addressable for set/view/clear/list
-by `has_location` / `get_available_locations`.
+`_merge_paired_location`, `_get_severed_locations`, and
+`_pluralize_pair_longdesc` in `typeclasses/appearance_mixin.py`, consulted by
+both passes of `_get_visible_body_descriptions`.
 
 ### Visibility Rules ✅
 - **Default**: All body locations are visible unless covered by clothing

--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -77,22 +77,14 @@ class AppearanceMixin:
         Returns:
             list: List of (location, description) tuples in anatomical order.
         """
-        from world.combat.constants import (
-            ANATOMICAL_DISPLAY_ORDER,
-            PAIR_MERGE_KEYS,
-        )
+        from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
 
         descriptions = []
         coverage_map = self._build_clothing_coverage_map()
         longdescs = self.longdesc or {}
 
-        # Merge keys (e.g. "eyes") are authored shorthand for a symmetric pair;
-        # they never render on their own line, only through the pair anchor.
-        merge_keys = set(PAIR_MERGE_KEYS)
-
         # Pre-compute symmetric left/right pairs that collapse into a single
-        # line by selecting an authored string (merged key, or identical sides,
-        # or a paired stump). Prose is never rewritten.
+        # pluralized line (identical longdescs, or both cleanly severed).
         collapse_map, collapse_skip = self._build_paired_longdesc_collapse(
             looker, longdescs, coverage_map
         )
@@ -162,9 +154,6 @@ class AppearanceMixin:
         all_locations = set(longdescs.keys()) | set(coverage_map.keys())
         for location in all_locations:
             if location not in ANATOMICAL_DISPLAY_ORDER:
-                if location in merge_keys:
-                    # Authored pair shorthand; rendered only via the anchor.
-                    continue
                 if location in collapse_skip:
                     continue
                 if location in collapse_map:
@@ -221,12 +210,12 @@ class AppearanceMixin:
         """
         Compute which symmetric left/right pairs collapse into one line.
 
-        A ``left_*``/``right_*`` pair collapses (selecting a single authored
-        string, never rewriting prose) when both sides are uncovered and one
-        of these holds: the pair's merged key (e.g. ``eyes``) carries a
-        longdesc; both sides carry the same non-empty longdesc; or both sides
-        have been cleanly severed. Any asymmetric arrangement (covered side,
-        severed side, differing prose) renders each side on its own.
+        A ``left_*``/``right_*`` pair collapses when both sides are uncovered
+        and either (a) their longdescs are identical and non-empty, or (b)
+        both sides have been cleanly severed. Severance deletes a location's
+        longdesc key, so a single amputated limb naturally fails the identity
+        test and renders on its own — only a matched, intact (or matched,
+        fully amputated) pair merges.
 
         Args:
             looker: Character looking.
@@ -238,18 +227,10 @@ class AppearanceMixin:
                 ``left_*`` anchor location to its merged description string and
                 ``skip_set`` holds the ``right_*`` partners to skip.
         """
-        from world.combat.constants import (
-            ANATOMICAL_DISPLAY_ORDER,
-            PAIR_MERGE_KEYS,
-        )
+        from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
 
         collapse_map = {}
         skip_set = set()
-
-        # Reverse the merge-key table to find a pair's authored merged key.
-        left_to_merge_key = {
-            left: key for key, (left, _right) in PAIR_MERGE_KEYS.items()
-        }
 
         severed_locs = self._get_severed_locations()
         # Consider every left_* location the body could render this pass.
@@ -270,10 +251,9 @@ class AppearanceMixin:
             if left_loc in coverage_map or right_loc in coverage_map:
                 continue
 
-            merged_key = left_to_merge_key.get(left_loc)
+            base_noun = left_loc[len("left_"):].replace("_", " ")
             merged = self._merge_paired_location(
-                looker, left_loc, right_loc, merged_key, longdescs,
-                severed_locs,
+                looker, left_loc, right_loc, base_noun, longdescs, severed_locs
             )
             if merged is not None:
                 collapse_map[left_loc] = merged
@@ -281,73 +261,52 @@ class AppearanceMixin:
 
         return collapse_map, skip_set
 
-    def _merge_paired_location(self, looker, left_loc, right_loc, merged_key,
+    def _merge_paired_location(self, looker, left_loc, right_loc, base_noun,
                                longdescs, severed_locs):
         """
         Build the merged description for one collapsible pair, or ``None``.
 
-        The system never rewrites authored prose; it only *selects* which
-        stored string represents both sides:
-
-        * If both sides are cleanly severed, a single paired stump line.
-        * Otherwise, if the pair's merged key (e.g. ``eyes``) carries a
-          longdesc, that one authored line.
-        * Otherwise, if both sides carry the same non-empty longdesc, that
-          verbatim line shown once.
-
-        Any other arrangement (one side severed, sides differ, only one side
-        described) returns ``None`` so the caller renders each side on its
-        own. Each side's wounds are appended on its own side, never merged.
+        Handles the two collapse cases: identical longdescs (pluralized, with
+        each side's wounds appended on its own side) and both-sides-severed
+        (a single plural stump line).
         """
         left_desc = longdescs.get(left_loc)
         right_desc = longdescs.get(right_loc)
-        pair_intact = (
-            left_loc not in severed_locs and right_loc not in severed_locs
-        )
 
-        # Severance takes precedence: a fully amputated pair gets one stump
-        # line; a single amputation never collapses (survivor renders alone).
-        if not pair_intact:
-            if (left_desc is None and right_desc is None
-                    and left_loc in severed_locs
-                    and right_loc in severed_locs):
-                try:
-                    from world.medical.wounds import (
-                        get_paired_severed_description,
+        # Case 1: identical, non-empty longdescs on both sides.
+        if left_desc and right_desc and left_desc == right_desc:
+            plural = self._pluralize_pair_longdesc(left_desc, base_noun)
+            if plural is None:
+                return None
+            processed = self._process_description_variables(
+                plural, looker, force_third_person=True, apply_skintone=True,
+            )
+            parts = [processed]
+            # A wound simply sits on its own side without splitting the pair.
+            try:
+                from world.medical.wounds import get_standalone_wound_description
+                for side in (left_loc, right_loc):
+                    wound_desc = get_standalone_wound_description(
+                        self, side, looker
                     )
-                    return get_paired_severed_description(
-                        self, left_loc, right_loc, looker
-                    )
-                except ImportError:
-                    return None
-            return None
+                    if wound_desc:
+                        parts.append(wound_desc)
+            except ImportError:
+                pass
+            return " ".join(parts)
 
-        # Both sides present: select the authored string that represents them.
-        merged_desc = longdescs.get(merged_key) if merged_key else None
-        if merged_desc:
-            chosen = merged_desc
-        elif left_desc and right_desc and left_desc == right_desc:
-            chosen = left_desc
-        else:
-            # Sides differ, or only one is described — render separately.
-            return None
-
-        processed = self._process_description_variables(
-            chosen, looker, force_third_person=True, apply_skintone=True,
-        )
-        parts = [processed]
-        # A wound simply sits on its own side without splitting the pair.
-        try:
-            from world.medical.wounds import get_standalone_wound_description
-            for side in (left_loc, right_loc):
-                wound_desc = get_standalone_wound_description(
-                    self, side, looker
+        # Case 2: both sides cleanly severed (neither carries a longdesc).
+        if (not left_desc and not right_desc
+                and left_loc in severed_locs and right_loc in severed_locs):
+            try:
+                from world.medical.wounds import get_paired_severed_description
+                return get_paired_severed_description(
+                    self, left_loc, right_loc, looker
                 )
-                if wound_desc:
-                    parts.append(wound_desc)
-        except ImportError:
-            pass
-        return " ".join(parts)
+            except ImportError:
+                return None
+
+        return None
 
     def _get_severed_locations(self):
         """Return the set of body locations that are cleanly severed."""
@@ -365,6 +324,46 @@ class AppearanceMixin:
             if all(w.get('stage') == 'severed' for w in location_wounds):
                 severed.add(location)
         return severed
+
+    def _pluralize_pair_longdesc(self, text, base_noun):
+        """
+        Pluralize an identical paired longdesc for a merged rendering.
+
+        Pluralizes the first whole-word occurrence of the anatomical noun
+        (e.g. "hand" -> "hands") and strips a single leading article,
+        preserving the article's capitalization onto the new first word.
+
+        Returns ``None`` when the anatomical noun is absent from the prose,
+        signalling the caller to render the two sides separately rather than
+        risk a grammatically broken merge.
+        """
+        import re
+        from world.grammar import pluralize_noun, capitalize_first
+
+        noun_pattern = re.compile(r'\b' + re.escape(base_noun) + r'\b',
+                                  re.IGNORECASE)
+        if not noun_pattern.search(text):
+            return None
+
+        plural = pluralize_noun(base_noun)
+        merged, _count = noun_pattern.subn(plural, text, count=1)
+
+        # Strip a single leading article, tolerating leading color codes or
+        # template tokens, and re-capitalize if the article was capitalized.
+        article_pattern = re.compile(
+            r'^((?:\|[a-zA-Z0-9]|\{[^}]+\}|\s)*)(a|an|the)\b[ \t]+',
+            re.IGNORECASE,
+        )
+        match = article_pattern.match(merged)
+        if match:
+            lead = match.group(1)
+            article_capitalized = match.group(2)[0].isupper()
+            remainder = merged[match.end():]
+            if article_capitalized:
+                remainder = capitalize_first(remainder)
+            merged = lead + remainder
+
+        return merged
 
     def _format_longdescs_with_paragraphs(self, longdesc_list):
         """
@@ -444,9 +443,6 @@ class AppearanceMixin:
         """
         Checks if this character has a specific body location.
 
-        A symmetric merge key (e.g. ``eyes``) is addressable whenever both of
-        its side locations exist, even before it has been written.
-
         Args:
             location: Body location to check.
 
@@ -454,29 +450,17 @@ class AppearanceMixin:
             bool: True if character has this location.
         """
         longdescs = self.longdesc or {}
-        if location in longdescs:
-            return True
-        from world.combat.constants import PAIR_MERGE_KEYS
-        pair = PAIR_MERGE_KEYS.get(location)
-        return bool(pair) and all(side in longdescs for side in pair)
+        return location in longdescs
 
     def get_available_locations(self):
         """
         Gets list of all body locations this character has.
 
-        Includes symmetric merge keys whose both sides exist, so the merged
-        shorthand can be set/viewed/cleared and listed.
-
         Returns:
             list: List of available body location names.
         """
         longdescs = self.longdesc or {}
-        locations = list(longdescs.keys())
-        from world.combat.constants import PAIR_MERGE_KEYS
-        for key, pair in PAIR_MERGE_KEYS.items():
-            if key not in longdescs and all(side in longdescs for side in pair):
-                locations.append(key)
-        return locations
+        return list(longdescs.keys())
 
     def set_longdesc(self, location, description):
         """

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -63,31 +63,8 @@ MAX_DESCRIPTION_LENGTH = 1000  # Generous limit, allows detailed descriptions
 PARAGRAPH_BREAK_THRESHOLD = 400  # Characters before automatic paragraph break
 REGION_BREAK_PRIORITY = True     # Prefer breaking between anatomical regions
 
-# Symmetric pair merge keys. Each maps an authored "merged" longdesc location
-# (the form a player writes once to describe both sides at once) to its
-# ``(left, right)`` side locations. The render path never rewrites prose: when
-# both sides of a pair are visible and the merged key carries a longdesc, that
-# single authored line stands in for the pair. Side keys remain addressable so
-# a player can write all three (merged + both sides) and retain per-side prose
-# when a limb is later covered or severed. The merged keys are valid longdesc
-# locations for set/clear/view, but are NOT default anatomy, are never worn as
-# clothing, and never render on their own — only through the pair anchor.
-PAIR_MERGE_KEYS = {
-    "eyes": ("left_eye", "right_eye"),
-    "ears": ("left_ear", "right_ear"),
-    "arms": ("left_arm", "right_arm"),
-    "hands": ("left_hand", "right_hand"),
-    "thighs": ("left_thigh", "right_thigh"),
-    "shins": ("left_shin", "right_shin"),
-    "feet": ("left_foot", "right_foot"),
-}
-
-# Valid location validation set (expandable). Includes the symmetric merge
-# keys so they can be set/viewed/cleared, even though they are not part of the
-# default anatomy or anatomical display order.
-VALID_LONGDESC_LOCATIONS = set(DEFAULT_LONGDESC_LOCATIONS.keys()) | set(
-    PAIR_MERGE_KEYS.keys()
-)
+# Valid location validation set (expandable)
+VALID_LONGDESC_LOCATIONS = set(DEFAULT_LONGDESC_LOCATIONS.keys())
 
 # Anatomical display order (head to toe). The head region mirrors how an
 # observer organically registers a person: hair first, then the eyes, after
@@ -144,10 +121,8 @@ COVERAGE_INHERITANCE = {
 # CLOTHING SYSTEM CONSTANTS  
 # ===================================================================
 
-# Clothing uses the physical body locations (default anatomy), NOT the
-# symmetric merge keys — merge keys are authored longdesc shorthand, not
-# wearable locations.
-CLOTHING_LOCATIONS = set(DEFAULT_LONGDESC_LOCATIONS.keys())
+# Clothing uses same body locations as longdesc system for consistency
+CLOTHING_LOCATIONS = VALID_LONGDESC_LOCATIONS
 
 # Default clothing layer assignments
 DEFAULT_CLOTHING_LAYER = 2

--- a/world/tests/test_paired_longdesc_collapse.py
+++ b/world/tests/test_paired_longdesc_collapse.py
@@ -1,14 +1,10 @@
-"""Unit tests for symmetric left/right longdesc collapse (selection model).
+"""Unit tests for symmetric left/right longdesc collapse.
 
-The render path never rewrites authored prose; it only *selects* which stored
-string represents a symmetric pair:
-
-* an authored merged key (e.g. ``eyes``) stands in for both sides when both
-  are visible;
-* failing that, two identical side longdescs render once, verbatim;
-* a pair severed on both sides collapses to one paired stump line;
-* any divergence (asymmetric coverage, one side severed, differing prose with
-  no merged key) falls back to separate, per-side rendering.
+A matched ``left_*``/``right_*`` pair with identical longdescs renders as one
+pluralized line (e.g. "Calloused hands."); a wound sits on its own side
+without splitting the pair; a pair severed on both sides collapses to one
+plural stump line; and any divergence (coverage, severance of one side,
+differing prose) falls back to separate rendering.
 
 Run via::
 
@@ -35,32 +31,49 @@ class _Body(AppearanceMixin):
         self._severed = set(severed or ())
 
     def _process_description_variables(self, desc, looker, **kwargs):
-        # Passthrough so tests can assert on the selected text directly.
+        # Passthrough so tests can assert on the pluralized text directly.
         return desc
 
     def _get_severed_locations(self):
         return set(self._severed)
 
 
-class _Render(AppearanceMixin):
-    """Full-render host: stubs clothing, skintone processing and severance."""
+class PluralizePairLongdescTests(TestCase):
 
-    def __init__(self, longdescs, severed=None):
-        self._longdescs = dict(longdescs)
-        self._severed = set(severed or ())
+    def setUp(self):
+        self.obj = _Bare()
 
-    @property
-    def longdesc(self):
-        return self._longdescs
+    def test_strips_article_and_pluralizes_with_capital(self):
+        out = self.obj._pluralize_pair_longdesc(
+            "A calloused hand with scarred knuckles.", "hand"
+        )
+        self.assertEqual(out, "Calloused hands with scarred knuckles.")
 
-    def _build_clothing_coverage_map(self):
-        return {}
+    def test_lowercase_fragment_stays_lowercase(self):
+        out = self.obj._pluralize_pair_longdesc("a milky eye", "eye")
+        self.assertEqual(out, "milky eyes")
 
-    def _process_description_variables(self, desc, looker, **kwargs):
-        return desc
+    def test_irregular_plural_foot_to_feet(self):
+        out = self.obj._pluralize_pair_longdesc("A scarred foot.", "foot")
+        self.assertEqual(out, "Scarred feet.")
 
-    def _get_severed_locations(self):
-        return set(self._severed)
+    def test_definite_article_handled(self):
+        out = self.obj._pluralize_pair_longdesc("The gnarled hand.", "hand")
+        self.assertEqual(out, "Gnarled hands.")
+
+    def test_missing_noun_returns_none(self):
+        # The anatomical noun isn't present; cannot safely pluralize.
+        out = self.obj._pluralize_pair_longdesc(
+            "a sleek prosthetic appendage", "hand"
+        )
+        self.assertIsNone(out)
+
+    def test_only_first_occurrence_pluralized(self):
+        out = self.obj._pluralize_pair_longdesc(
+            "a hand, a working hand", "hand"
+        )
+        # Leading article stripped; only the first 'hand' becomes plural.
+        self.assertEqual(out, "hands, a working hand")
 
 
 class GetSeveredLocationsTests(TestCase):
@@ -100,8 +113,7 @@ class BuildPairedCollapseTests(TestCase):
             None, longdescs, coverage_map or {}
         )
 
-    def test_identical_pair_collapses_verbatim(self):
-        # No pluralization — the authored line is shown exactly as written.
+    def test_identical_pair_collapses_to_plural(self):
         longdescs = {
             "left_hand": "A calloused hand.",
             "right_hand": "A calloused hand.",
@@ -112,37 +124,7 @@ class BuildPairedCollapseTests(TestCase):
             collapse_map, skip = self._build(longdescs)
         self.assertIn("left_hand", collapse_map)
         self.assertIn("right_hand", skip)
-        self.assertEqual(collapse_map["left_hand"], "A calloused hand.")
-
-    def test_merged_key_stands_in_for_both_sides(self):
-        # Write-1: only the merged key is set; both sides default-empty.
-        longdescs = {"eyes": "{Their} eyes gleam an unsettling silver."}
-        with mock.patch(
-            f"{WOUNDS}.get_standalone_wound_description", return_value=""
-        ):
-            collapse_map, skip = self._build(longdescs)
-        self.assertEqual(
-            collapse_map["left_eye"],
-            "{Their} eyes gleam an unsettling silver.",
-        )
-        self.assertIn("right_eye", skip)
-
-    def test_merged_key_wins_over_differing_sides(self):
-        # Write-3: merged key is authoritative while both sides are visible.
-        longdescs = {
-            "eyes": "{Their} eyes gleam an unsettling silver.",
-            "left_eye": "a silver left eye",
-            "right_eye": "a silver right eye",
-        }
-        with mock.patch(
-            f"{WOUNDS}.get_standalone_wound_description", return_value=""
-        ):
-            collapse_map, skip = self._build(longdescs)
-        self.assertEqual(
-            collapse_map["left_eye"],
-            "{Their} eyes gleam an unsettling silver.",
-        )
-        self.assertIn("right_eye", skip)
+        self.assertEqual(collapse_map["left_hand"], "Calloused hands.")
 
     def test_wound_on_one_side_stays_merged(self):
         longdescs = {
@@ -161,7 +143,7 @@ class BuildPairedCollapseTests(TestCase):
             collapse_map, skip = self._build(longdescs)
         self.assertEqual(
             collapse_map["left_hand"],
-            "A calloused hand. A fresh laceration crosses the right hand.",
+            "Calloused hands. A fresh laceration crosses the right hand.",
         )
         self.assertIn("right_hand", skip)
 
@@ -178,23 +160,7 @@ class BuildPairedCollapseTests(TestCase):
         self.assertEqual(collapse_map, {})
         self.assertEqual(skip, set())
 
-    def test_covered_side_ignores_merged_key(self):
-        # One eye covered: the pair does not collapse and the merged key must
-        # not stand in — the visible side renders on its own elsewhere.
-        longdescs = {
-            "eyes": "{Their} eyes gleam an unsettling silver.",
-            "left_eye": "a silver left eye",
-            "right_eye": "a silver right eye",
-        }
-        coverage = {"left_eye": object()}
-        with mock.patch(
-            f"{WOUNDS}.get_standalone_wound_description", return_value=""
-        ):
-            collapse_map, skip = self._build(longdescs, coverage)
-        self.assertEqual(collapse_map, {})
-        self.assertEqual(skip, set())
-
-    def test_differing_prose_without_merged_key_does_not_collapse(self):
+    def test_differing_prose_does_not_collapse(self):
         longdescs = {
             "left_hand": "A calloused hand.",
             "right_hand": "A scarred hand.",
@@ -205,15 +171,18 @@ class BuildPairedCollapseTests(TestCase):
             collapse_map, _skip = self._build(longdescs)
         self.assertEqual(collapse_map, {})
 
-    def test_only_one_side_described_does_not_collapse(self):
-        longdescs = {"left_hand": "A calloused hand."}
+    def test_non_pluralizable_pair_falls_back(self):
+        longdescs = {
+            "left_hand": "a sleek prosthetic appendage",
+            "right_hand": "a sleek prosthetic appendage",
+        }
         with mock.patch(
             f"{WOUNDS}.get_standalone_wound_description", return_value=""
         ):
             collapse_map, _skip = self._build(longdescs)
         self.assertEqual(collapse_map, {})
 
-    def test_both_severed_collapses_to_paired_stump(self):
+    def test_both_severed_collapses_to_plural_stump(self):
         self.obj = _Body(severed={"left_hand", "right_hand"})
         with mock.patch(
             f"{WOUNDS}.get_paired_severed_description",
@@ -235,19 +204,7 @@ class BuildPairedCollapseTests(TestCase):
             collapse_map, _skip = self._build(longdescs)
         self.assertEqual(collapse_map, {})
 
-    def test_one_side_severed_with_merged_key_does_not_collapse(self):
-        # Write-1 + one side lost: the merged key must not stand in; the
-        # survivor falls back to its own (default) rendering elsewhere.
-        self.obj = _Body(severed={"left_eye"})
-        longdescs = {"eyes": "{Their} eyes gleam an unsettling silver."}
-        with mock.patch(
-            f"{WOUNDS}.get_standalone_wound_description", return_value=""
-        ):
-            collapse_map, _skip = self._build(longdescs)
-        self.assertEqual(collapse_map, {})
-
-    def test_custom_longdesc_pair_collapses_verbatim(self):
-        # A non-registered symmetric pair still collapses on identical prose.
+    def test_custom_longdesc_pair_collapses(self):
         longdescs = {
             "left_wing": "A feathered wing.",
             "right_wing": "A feathered wing.",
@@ -256,45 +213,8 @@ class BuildPairedCollapseTests(TestCase):
             f"{WOUNDS}.get_standalone_wound_description", return_value=""
         ):
             collapse_map, skip = self._build(longdescs)
-        self.assertEqual(collapse_map["left_wing"], "A feathered wing.")
+        self.assertEqual(collapse_map["left_wing"], "Feathered wings.")
         self.assertIn("right_wing", skip)
-
-
-class VisibleBodyDescriptionsTests(TestCase):
-    """End-to-end selection through ``_get_visible_body_descriptions``."""
-
-    def _render(self, host):
-        with mock.patch(
-            f"{WOUNDS}.get_standalone_wound_description", return_value=""
-        ), mock.patch(
-            f"{WOUNDS}.append_wounds_to_longdesc",
-            side_effect=lambda desc, *a, **k: desc,
-        ):
-            return host._get_visible_body_descriptions(None)
-
-    def test_merged_key_renders_at_anchor_not_standalone(self):
-        host = _Render({"eyes": "{Their} eyes gleam silver."})
-        result = dict(self._render(host))
-        self.assertEqual(result.get("left_eye"), "{Their} eyes gleam silver.")
-        self.assertNotIn("right_eye", result)
-        # The merged key itself never renders as its own line.
-        self.assertNotIn("eyes", result)
-
-    def test_identical_sides_render_once(self):
-        host = _Render(
-            {"left_hand": "A calloused hand.", "right_hand": "A calloused hand."}
-        )
-        result = dict(self._render(host))
-        self.assertEqual(result.get("left_hand"), "A calloused hand.")
-        self.assertNotIn("right_hand", result)
-
-    def test_differing_sides_render_separately(self):
-        host = _Render(
-            {"left_hand": "A calloused hand.", "right_hand": "A scarred hand."}
-        )
-        result = dict(self._render(host))
-        self.assertEqual(result.get("left_hand"), "A calloused hand.")
-        self.assertEqual(result.get("right_hand"), "A scarred hand.")
 
 
 class PairedSeveredDescriptionTests(TestCase):


### PR DESCRIPTION
## Summary
- Reverts #267. The selection-only merge-key model (write-1-or-3, `PAIR_MERGE_KEYS`) did not improve the experience in practice and felt clunkier than the v1 pluralized collapse.
- Restores the v1 behavior from #265: identical symmetric pairs collapse into a single pluralized line via `_pluralize_pair_longdesc`.

## Notes
- Full `world` suite green at 1388 (v1 baseline).
- Re-opens the design question tracked in #266.