### PR TITLE
Render paired longdesc collapse via verbatim number tokens (#266)

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -11,6 +11,7 @@ from world.combat.constants import (
     SKINTONE_PALETTE, VALID_SKINTONES,
     STAT_DESCRIPTORS, STAT_TIER_RANGES,
     ANATOMICAL_REGIONS, ANATOMICAL_DISPLAY_ORDER,
+    PAIR_MERGE_KEYS,
 )
 from world.medical.utils import get_medical_status_description
 import re
@@ -567,6 +568,20 @@ class CmdLongdesc(Command):
         @longdesc face
         @longdesc/list
 
+    Symmetric pairs (eyes, ears, arms, hands, thighs, shins, feet) are
+    shorthands that set, view, and clear BOTH sides at once:
+
+        @longdesc eyes "deep brown {eyes} that {accent} {their} skin"
+
+    When both sides match they collapse into one line; set the sides
+    individually if you want them to differ (e.g. heterochromia).
+
+    Braces mark number-flexible words so a pair reads naturally as plural
+    ("brown eyes that accent") while a lone survivor reads singular ("a brown
+    eye that accents"). Brace the body-part noun ({eye}/{an eye}) and any verb
+    that agrees with it ({accent}, {are}). Braces are optional — plain prose
+    renders verbatim. Pronoun tokens ({their}, {they}, ...) work as before.
+
     Body locations include: head, face, left_eye, right_eye, left_ear, right_ear,
     neck, chest, back, abdomen, groin, left_arm, right_arm, left_hand, right_hand,
     left_thigh, right_thigh, left_shin, right_shin, left_foot, right_foot.
@@ -730,14 +745,41 @@ class CmdLongdesc(Command):
             # Clear specific location
             self._clear_specific_location(caller, target_char, location)
 
+    def _expand_pair_locations(self, target_char, location):
+        """Resolve a typed location into the concrete locations to act on.
+
+        A symmetric pair shorthand (e.g. ``eyes``) expands to both underlying
+        sides (``left_eye``, ``right_eye``) so a single command fans out to
+        both. A normal location resolves to itself.
+
+        Args:
+            target_char: Character whose anatomy is being checked.
+            location: The location string the player typed.
+
+        Returns:
+            list[str] | None: Concrete locations to act on, or ``None`` if the
+            location is neither a valid single location nor a usable pair
+            shorthand for this character.
+        """
+        if location in PAIR_MERGE_KEYS:
+            left, right = PAIR_MERGE_KEYS[location]
+            if (target_char.has_location(left)
+                    and target_char.has_location(right)):
+                return [left, right]
+            return None
+        if target_char.has_location(location):
+            return [location]
+        return None
+
     def _set_longdesc(self, caller, target_char, location, description):
-        """Set a longdesc for a specific location."""
+        """Set a longdesc for a specific location (or both sides of a pair)."""
         if not location:
             caller.msg("Please specify a body location.")
             return
 
-        # Validate location exists on character
-        if not target_char.has_location(location):
+        # Validate location exists on character (pair shorthand fans out).
+        locations = self._expand_pair_locations(target_char, location)
+        if not locations:
             caller.msg(f"'{location}' is not a valid body location for {target_char.get_display_name(caller)}.")
             available = ", ".join(target_char.get_available_locations()[:10])  # Show first 10
             caller.msg(f"Available locations include: {available}...")
@@ -751,15 +793,19 @@ class CmdLongdesc(Command):
 
         if len(description.strip()) == 0:
             # Empty description means clear
-            target_char.set_longdesc(location, None)
+            for loc in locations:
+                target_char.set_longdesc(loc, None)
             if target_char == caller:
                 caller.msg(f"Cleared description for {location}.")
             else:
                 caller.msg(f"Cleared description for {location} on {target_char.get_display_name(caller)}.")
             return
 
-        # Set the description
-        success = target_char.set_longdesc(location, description.strip())
+        # Set the description (the same string on both sides of a pair).
+        success = all(
+            target_char.set_longdesc(loc, description.strip())
+            for loc in locations
+        )
         if success:
             if target_char == caller:
                 caller.msg(f"Set description for {location}: \"{description.strip()}\"")
@@ -769,22 +815,31 @@ class CmdLongdesc(Command):
             caller.msg("Failed to set description. Please try again.")
 
     def _view_longdesc(self, caller, target_char, location):
-        """View a specific longdesc."""
-        if not target_char.has_location(location):
+        """View a specific longdesc (or both sides of a pair)."""
+        locations = self._expand_pair_locations(target_char, location)
+        if not locations:
             caller.msg(f"'{location}' is not a valid body location.")
             return
 
-        description = target_char.get_longdesc(location)
-        if description:
-            if target_char == caller:
-                caller.msg(f"{location}: \"{description}\"")
+        owner_prefix = (
+            "" if target_char == caller
+            else f"{target_char.get_display_name(caller)}'s "
+        )
+
+        # A pair shorthand whose sides match collapses to one line under the
+        # shorthand; diverging sides (or a normal location) show per side.
+        descriptions = [(loc, target_char.get_longdesc(loc)) for loc in locations]
+        if len(descriptions) == 2 and descriptions[0][1] == descriptions[1][1]:
+            descriptions = [(location, descriptions[0][1])]
+
+        for loc, description in descriptions:
+            if description:
+                caller.msg(f"{owner_prefix}{loc}: \"{description}\"")
             else:
-                caller.msg(f"{target_char.get_display_name(caller)}'s {location}: \"{description}\"")
-        else:
-            if target_char == caller:
-                caller.msg(f"No description set for {location}.")
-            else:
-                caller.msg(f"No description set for {location} on {target_char.get_display_name(caller)}.")
+                if target_char == caller:
+                    caller.msg(f"No description set for {loc}.")
+                else:
+                    caller.msg(f"No description set for {loc} on {target_char.get_display_name(caller)}.")
 
     def _show_all_longdescs(self, caller, target_char=None):
         """Show all current longdescs for a character."""
@@ -819,20 +874,22 @@ class CmdLongdesc(Command):
                 caller.msg(f"  |c{location}:|n \"{description}\"")
 
     def _clear_specific_location(self, caller, target_char, location):
-        """Clear a specific location's longdesc."""
-        if not target_char.has_location(location):
+        """Clear a specific location's longdesc (or both sides of a pair)."""
+        locations = self._expand_pair_locations(target_char, location)
+        if not locations:
             caller.msg(f"'{location}' is not a valid body location.")
             return
 
-        current_desc = target_char.get_longdesc(location)
-        if not current_desc:
+        current = [(loc, target_char.get_longdesc(loc)) for loc in locations]
+        if not any(desc for _loc, desc in current):
             if target_char == caller:
                 caller.msg(f"No description set for {location}.")
             else:
                 caller.msg(f"No description set for {location} on {target_char.get_display_name(caller)}.")
             return
 
-        target_char.set_longdesc(location, None)
+        for loc in locations:
+            target_char.set_longdesc(loc, None)
         if target_char == caller:
             caller.msg(f"Cleared description for {location}.")
         else:

--- a/specs/GRAMMAR_ENGINE_SPEC.md
+++ b/specs/GRAMMAR_ENGINE_SPEC.md
@@ -58,6 +58,69 @@ cases emerge.
 
 ---
 
+## Noun Number
+
+```python
+def pluralize_noun(noun: str) -> str:
+    """Singular → plural ("hand" → "hands", "foot" → "feet")."""
+
+def singularize_noun(noun: str) -> str:
+    """Plural → singular ("eyes" → "eye", "feet" → "foot").
+
+    Returns the input unchanged when it is already singular (``inflect``
+    reports ``False``). First-letter capitalization is preserved.
+    """
+```
+
+Both wrap the `inflect` singleton and preserve leading capitalization. Note
+`inflect.plural_noun` mangles an already-plural input (`"eyes"` → `"eyess"`),
+so number-flexing first normalizes to the singular base.
+
+---
+
+## Number-Flexing Tokens
+
+Consumed by the paired-longdesc collapse (see `LONGDESC_SYSTEM_SPEC.md`).
+Authors write paired body-part prose in the plural and wrap the
+number-flexible words in `{braces}`; the renderer re-renders those braced
+words to a target **number** — `"plural"` for a collapsed both-sides pair,
+`"singular"` for a lone survivor or single side. Tokens are opt-in: untouched
+words render verbatim (the engine never rewrites un-braced prose).
+
+```python
+def flex_noun(body: str, number: str) -> str:
+    """Render a noun token ("eye", "eyes", "an eye") to *number*.
+
+    Input-form-agnostic. On a plural render a leading indefinite article is
+    dropped and the noun pluralised; on a singular render the noun is
+    singularised and the article re-agreed (a/an). Leading case preserved.
+    """
+
+def flex_verb(word: str, number: str) -> str:
+    """Render a verb token ("accents", "accent", "is", "are") to *number*.
+
+    Plural → base/plural form ("accent", "are"); singular → third-person
+    singular ("accents", "is"). Irregulars (be/have/do/was) use a closed
+    bidirectional table; regulars normalise via ``inflect.plural_verb`` then
+    re-conjugate. Leading case preserved.
+    """
+```
+
+**Noun-vs-verb autodetect (deterministic, closed-set rule)** — performed by
+the caller (`AppearanceMixin._substitute_longdesc_tokens`), not by POS
+tagging: a braced word is a **noun** iff its singular is in the closed set of
+pair base nouns (`eye`, `ear`, `arm`, `hand`, `thigh`, `shin`, `foot`,
+derived from `world.combat.constants.PAIR_MERGE_KEYS`), optionally preceded by
+`a`/`an`. Any other braced **single** word is a **verb**. A multi-word token
+that is not an article+pair-noun is left literal and logged.
+
+**Scope** — only brace words whose grammatical number tracks the body part
+(the part noun and verbs whose subject **is** that part). A main-clause verb
+agreeing with the person-pronoun ("They have …") is a gender/pronoun concern,
+not a pair concern, and is left un-braced.
+
+---
+
 ## Article Handling
 
 The engine exposes two article-related helpers:

--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -283,9 +283,9 @@ With your administrative visibility, you see: item1 [#123], item2 [#456], weapon
 - **Constants-driven**: Uses `PARAGRAPH_BREAK_THRESHOLD`, `REGION_BREAK_PRIORITY`, and `ANATOMICAL_REGIONS` for fine-tuning
 
 #### Paired Longdesc Collapse ✅
-Symmetric left/right paired appendages collapse into a single pluralized line
-when their descriptions are interchangeable, avoiding redundant repetition
-(e.g. two identical "a pale blue eye." lines becoming "Pale blue eyes.").
+Symmetric left/right paired appendages collapse into a single line when their
+descriptions are interchangeable, avoiding redundant repetition (e.g. two
+identical "a pale blue eye." lines becoming one "pale blue eyes." line).
 
 **Pairs are derived dynamically** from `left_*` / `right_*` location keys
 (union of `longdesc` keys, `coverage_map`, `ANATOMICAL_DISPLAY_ORDER`, and
@@ -303,16 +303,34 @@ When eligible, the pair renders as one line and the right-side entry is
 skipped. Asymmetric coverage (one side clothed), differing prose, or a single
 amputated limb all **fail** the identity test and render each side separately.
 
-**Pluralization** (`_pluralize_pair_longdesc`):
-- Pluralizes the first whole-word occurrence of the pair's anatomical base
-  noun (`eye`→`eyes`, `foot`→`feet`) via `world.grammar.pluralize_noun`
-  (wrapping `inflect`).
-- Strips one leading article (`a` / `an` / `the`), tolerating leading color
-  codes / `{tokens}`; recapitalizes via `grammar.capitalize_first` if the
-  article was capitalized.
-- **Safe fallback**: if the base noun is absent from the prose (e.g. "a
-  freckled forearm" for base "arm"), returns `None` → the pair renders
-  separately rather than producing malformed text.
+**Verbatim collapse + number tokens** (the system never rewrites player
+prose): the identical string is rendered **once, at plural number**, through
+`_process_description_variables(..., number="plural")`. Words the author
+wrapped in `{braces}` are flexed to plural; everything else renders verbatim.
+A lone survivor or single side renders the same string at `number="singular"`.
+This dissolves the old "can we safely pluralize?" failure mode — there is no
+heuristic noun-substitution and no `None` fallback; any identical pair
+collapses.
+
+Number tokens (see `GRAMMAR_ENGINE_SPEC.md` §Number-Flexing Tokens):
+- **Noun** — a braced word whose singular is a known pair noun (`eye`, `ear`,
+  `arm`, `hand`, `thigh`, `shin`, `foot`; the closed set derived from
+  `PAIR_MERGE_KEYS`). `{eye}`/`{eyes}` flex the noun; `{an eye}` additionally
+  drops the article on plural and re-agrees `a`/`an` on singular.
+- **Verb** — any other braced single word, conjugated to agree with the part:
+  plural `{accent}`/`{are}`, singular `{accents}`/`{is}`. Only brace verbs
+  whose subject **is** the body part; a main-clause verb agreeing with the
+  person-pronoun ("They have …") is left un-braced.
+- **Unrecognised** tokens (multi-word non-noun, typos) are left **literal** and
+  logged — a stray brace no longer drops the whole substitution (the old
+  `str.format` footgun is gone; substitution is now per-token via `re.sub`).
+
+**Authoring convenience — pair shorthand**: `@longdesc <pair> "..."` (where
+`<pair>` is a `PAIR_MERGE_KEYS` key: `eyes`, `ears`, `arms`, `hands`,
+`thighs`, `shins`, `feet`) sets, views, and clears **both** sides at once,
+guaranteeing the byte-for-byte identity collapse requires. The pair keys are
+write-conveniences only — not body locations, not wearable, not render keys.
+Set the sides individually to make them differ (e.g. heterochromia).
 
 **Both-severed stumps** render via `world.medical.wounds`
 `get_paired_severed_description` using the type-agnostic
@@ -326,9 +344,11 @@ wound sentences into "both hands" is a possible future refinement, not
 currently done.)
 
 **Implementation**: `_build_paired_longdesc_collapse`,
-`_merge_paired_location`, `_get_severed_locations`, and
-`_pluralize_pair_longdesc` in `typeclasses/appearance_mixin.py`, consulted by
-both passes of `_get_visible_body_descriptions`.
+`_merge_paired_location`, `_get_severed_locations`,
+`_substitute_longdesc_tokens`, and `_pair_base_nouns` in
+`typeclasses/appearance_mixin.py`, consulted by both passes of
+`_get_visible_body_descriptions`; pair shorthand fan-out in
+`CmdLongdesc._expand_pair_locations` (`commands/CmdCharacter.py`).
 
 ### Visibility Rules ✅
 - **Default**: All body locations are visible unless covered by clothing

--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -251,9 +251,8 @@ class AppearanceMixin:
             if left_loc in coverage_map or right_loc in coverage_map:
                 continue
 
-            base_noun = left_loc[len("left_"):].replace("_", " ")
             merged = self._merge_paired_location(
-                looker, left_loc, right_loc, base_noun, longdescs, severed_locs
+                looker, left_loc, right_loc, longdescs, severed_locs
             )
             if merged is not None:
                 collapse_map[left_loc] = merged
@@ -261,25 +260,25 @@ class AppearanceMixin:
 
         return collapse_map, skip_set
 
-    def _merge_paired_location(self, looker, left_loc, right_loc, base_noun,
+    def _merge_paired_location(self, looker, left_loc, right_loc,
                                longdescs, severed_locs):
         """
         Build the merged description for one collapsible pair, or ``None``.
 
-        Handles the two collapse cases: identical longdescs (pluralized, with
-        each side's wounds appended on its own side) and both-sides-severed
-        (a single plural stump line).
+        Handles the two collapse cases: identical longdescs (rendered once at
+        plural number, with each side's wounds appended on its own side) and
+        both-sides-severed (a single plural stump line). Identical prose is
+        rendered verbatim — number-flexible words the author wrapped in
+        ``{braces}`` are re-rendered to plural; everything else is unchanged.
         """
         left_desc = longdescs.get(left_loc)
         right_desc = longdescs.get(right_loc)
 
         # Case 1: identical, non-empty longdescs on both sides.
         if left_desc and right_desc and left_desc == right_desc:
-            plural = self._pluralize_pair_longdesc(left_desc, base_noun)
-            if plural is None:
-                return None
             processed = self._process_description_variables(
-                plural, looker, force_third_person=True, apply_skintone=True,
+                left_desc, looker, force_third_person=True,
+                apply_skintone=True, number="plural",
             )
             parts = [processed]
             # A wound simply sits on its own side without splitting the pair.
@@ -324,46 +323,6 @@ class AppearanceMixin:
             if all(w.get('stage') == 'severed' for w in location_wounds):
                 severed.add(location)
         return severed
-
-    def _pluralize_pair_longdesc(self, text, base_noun):
-        """
-        Pluralize an identical paired longdesc for a merged rendering.
-
-        Pluralizes the first whole-word occurrence of the anatomical noun
-        (e.g. "hand" -> "hands") and strips a single leading article,
-        preserving the article's capitalization onto the new first word.
-
-        Returns ``None`` when the anatomical noun is absent from the prose,
-        signalling the caller to render the two sides separately rather than
-        risk a grammatically broken merge.
-        """
-        import re
-        from world.grammar import pluralize_noun, capitalize_first
-
-        noun_pattern = re.compile(r'\b' + re.escape(base_noun) + r'\b',
-                                  re.IGNORECASE)
-        if not noun_pattern.search(text):
-            return None
-
-        plural = pluralize_noun(base_noun)
-        merged, _count = noun_pattern.subn(plural, text, count=1)
-
-        # Strip a single leading article, tolerating leading color codes or
-        # template tokens, and re-capitalize if the article was capitalized.
-        article_pattern = re.compile(
-            r'^((?:\|[a-zA-Z0-9]|\{[^}]+\}|\s)*)(a|an|the)\b[ \t]+',
-            re.IGNORECASE,
-        )
-        match = article_pattern.match(merged)
-        if match:
-            lead = match.group(1)
-            article_capitalized = match.group(2)[0].isupper()
-            remainder = merged[match.end():]
-            if article_capitalized:
-                remainder = capitalize_first(remainder)
-            merged = lead + remainder
-
-        return merged
 
     def _format_longdescs_with_paragraphs(self, longdesc_list):
         """
@@ -589,14 +548,86 @@ class AppearanceMixin:
         # Join all parts with appropriate spacing (blank lines between sections)
         return '\n\n'.join(parts)
 
+    @staticmethod
+    def _pair_base_nouns():
+        """Return the closed set of singular pair nouns (eye, ear, hand, ...).
+
+        These are the only words a longdesc number-token treats as the body's
+        part noun; any other braced single word is treated as a verb.
+        """
+        from world.combat.constants import PAIR_MERGE_KEYS
+
+        nouns = set()
+        for left_loc, _right_loc in PAIR_MERGE_KEYS.values():
+            # "left_eye" -> "eye", "left_foot" -> "foot"
+            nouns.add(left_loc.split("_", 1)[1])
+        return nouns
+
+    def _substitute_longdesc_tokens(self, desc, variables, number):
+        """Resolve brace tokens in a longdesc, one token at a time.
+
+        Resolution order per ``{token}``:
+          1. Pronoun / name token present in *variables*.
+          2. Number-flexible body-part token: a noun if its singular is a
+             known pair noun (optionally with a leading ``a``/``an``), else a
+             single-word verb. Both are flexed to *number*.
+          3. Anything else is left literal (the brace is preserved) and logged.
+
+        Args:
+            desc (str): Raw longdesc prose.
+            variables (dict): Pronoun/name token → replacement.
+            number (str): "singular" or "plural" for body-part tokens.
+
+        Returns:
+            str: Prose with recognised tokens substituted.
+        """
+        import re
+        from world.grammar import flex_noun, flex_verb, singularize_noun
+
+        pair_nouns = self._pair_base_nouns()
+        article_re = re.compile(r"^(?:a|an)\s+(.+)$", re.IGNORECASE)
+
+        def _resolve(match):
+            body = match.group(1)
+
+            # 1. Pronoun / name tokens.
+            if body in variables:
+                return str(variables[body])
+
+            # 2. Number-flexible body-part tokens.
+            art_match = article_re.match(body)
+            core = art_match.group(1) if art_match else body
+            if " " not in core:
+                core_base = singularize_noun(core).lower()
+                if core_base in pair_nouns:
+                    return flex_noun(body, number)
+                if art_match is None:
+                    # Single bareword that is not a pair noun → verb.
+                    return flex_verb(body, number)
+
+            # 3. Unrecognised token: leave it literal, but log it so authors
+            #    can spot typos instead of silently shipping a broken token.
+            print(
+                "Longdesc token not recognised, left literal: "
+                f"{{{body}}} (in: {desc[:80]!r})"
+            )
+            return match.group(0)
+
+        return re.sub(r"\{([^{}]+)\}", _resolve, desc)
+
     def _process_description_variables(
-        self, desc, looker, force_third_person=False, apply_skintone=False
+        self, desc, looker, force_third_person=False, apply_skintone=False,
+        number="singular",
     ):
         """
         Process template variables in descriptions for perspective-aware text.
 
-        Uses simple template variables like {their}, {they}, {name} similar
-        to {color}.
+        Uses simple brace tokens like {their}, {they}, {name} (like {color}).
+        In addition to pronoun/name tokens, number-flexible body-part words may
+        be wrapped in braces ({eye}, {an eye}, {accents}); these are rendered
+        to match *number* — "plural" for a collapsed pair, "singular" for a
+        single side or lone survivor. Tokens the resolver does not recognise
+        are left literal (a stray brace no longer drops the whole substitution).
 
         Args:
             desc (str): Description text with potential template variables.
@@ -604,6 +635,8 @@ class AppearanceMixin:
             force_third_person (bool): If True, always use 3rd person pronouns.
             apply_skintone (bool): If True, apply skintone coloring
                 (for longdescs only).
+            number (str): "singular" or "plural"; the grammatical number that
+                braced body-part tokens should render to.
 
         Returns:
             str: Description with variables substituted.
@@ -724,15 +757,13 @@ class AppearanceMixin:
             ),
         }
 
-        # Substitute all variables in the description
-        try:
-            processed_desc = desc.format(**variables)
-        except (KeyError, ValueError) as e:
-            # If there are template errors, use original description and log
-            processed_desc = desc
-            print(f"Template processing error in _process_description_variables: {e}")
-            print(f"Description: {desc[:100]}...")
-            print(f"Variables available: {list(variables.keys())}")
+        # Substitute all brace tokens one at a time. Pronoun/name tokens
+        # resolve from ``variables``; otherwise a token is a number-flexible
+        # body-part word (noun if its singular is a known pair noun, verb
+        # otherwise). Unresolvable tokens are left literal.
+        processed_desc = self._substitute_longdesc_tokens(
+            desc, variables, number
+        )
 
         # Apply skintone coloring only if requested (for longdescs only)
         if apply_skintone:

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -66,6 +66,30 @@ REGION_BREAK_PRIORITY = True     # Prefer breaking between anatomical regions
 # Valid location validation set (expandable)
 VALID_LONGDESC_LOCATIONS = set(DEFAULT_LONGDESC_LOCATIONS.keys())
 
+# Symmetric left/right body-part pairs.
+#
+# Maps a plural shorthand key (the form a player types into ``@longdesc`` and
+# the noun a collapsed pair reads as) to its two underlying ``left_*``/
+# ``right_*`` locations. Serves three roles:
+#   1. Write-convenience: ``@longdesc eyes "..."`` fans the same string out to
+#      both ``left_eye`` and ``right_eye``.
+#   2. Collapse aid: identifies which locations may merge into one line.
+#   3. Closed anatomical-noun set: the singular base nouns (eye, ear, ...) are
+#      the only words a longdesc number-token treats as the part noun rather
+#      than as a verb.
+#
+# These keys are NOT body locations themselves: they are not in the default
+# anatomy, are not wearable, and are not render keys.
+PAIR_MERGE_KEYS = {
+    "eyes": ("left_eye", "right_eye"),
+    "ears": ("left_ear", "right_ear"),
+    "arms": ("left_arm", "right_arm"),
+    "hands": ("left_hand", "right_hand"),
+    "thighs": ("left_thigh", "right_thigh"),
+    "shins": ("left_shin", "right_shin"),
+    "feet": ("left_foot", "right_foot"),
+}
+
 # Anatomical display order (head to toe). The head region mirrors how an
 # observer organically registers a person: hair first, then the eyes, after
 # which the head and face resolve into view, then the ears and neck.

--- a/world/grammar.py
+++ b/world/grammar.py
@@ -14,6 +14,8 @@ See specs/GRAMMAR_ENGINE_SPEC.md for the full specification.
 
 from __future__ import annotations
 
+import re
+
 import inflect
 
 # ---------------------------------------------------------------------------
@@ -117,6 +119,132 @@ def pluralize_noun(noun: str) -> str:
     if noun[0].isupper():
         return plural[0].upper() + plural[1:]
     return plural
+
+
+def singularize_noun(noun: str) -> str:
+    """Return the singular form of a (possibly already-singular) noun.
+
+    Thin wrapper over the ``inflect`` engine. ``inflect.singular_noun``
+    returns ``False`` for a noun that is already singular, so this helper
+    normalises that to "return the input unchanged". Capitalization of the
+    first letter is preserved ("Eyes" → "Eye", "feet" → "foot").
+
+    Args:
+        noun: A noun, singular or plural (a single word, e.g. "eyes").
+
+    Returns:
+        The singular form, capitalized to match ``noun``'s first letter.
+    """
+    if not noun:
+        return noun
+
+    singular = _engine.singular_noun(noun)
+    # ``singular_noun`` returns False when the input is already singular.
+    if not singular:
+        return noun
+
+    if noun[0].isupper():
+        return singular[0].upper() + singular[1:]
+    return singular
+
+
+# ---------------------------------------------------------------------------
+# Number-Flexing Tokens (paired-longdesc collapse)
+# ---------------------------------------------------------------------------
+#
+# Authors write paired body-part prose in the plural and wrap the
+# number-flexible words in ``{braces}``. The engine re-renders those braced
+# words to match a render *number* — ``"plural"`` for a collapsed, both-sides
+# pair; ``"singular"`` for a lone survivor or a single side. Number tokens are
+# OPT-IN: untouched words render verbatim.
+#
+# Only words whose grammatical number tracks the body part itself should be
+# braced (the part noun and any verb whose subject *is* that part). A main
+# clause verb that agrees with the person-pronoun ("They have ...") is left
+# un-braced — its agreement is a gender/pronoun concern, not a pair concern.
+
+#: Closed table of irregular verb forms keyed by *any* recognised form.
+#: Maps to ``(third_person_singular, plural_or_base)``. Lets a braced verb be
+#: authored in either number and re-rendered to the needed one.
+_IRREGULAR_VERB_FORMS: dict[str, tuple[str, str]] = {
+    "is": ("is", "are"), "are": ("is", "are"), "be": ("is", "are"),
+    "was": ("was", "were"), "were": ("was", "were"),
+    "has": ("has", "have"), "have": ("has", "have"),
+    "does": ("does", "do"), "do": ("does", "do"),
+}
+
+#: Matches an indefinite article immediately leading a noun-token body, e.g.
+#: ``"an eye"`` or ``"A eye"``. The article is dropped on a plural render and
+#: re-agreed (a/an) on a singular render.
+_ARTICLE_NOUN_RE = re.compile(r"^(a|an)\s+(.+)$", re.IGNORECASE)
+
+
+def _match_leading_case(word: str, like: str) -> str:
+    """Capitalise *word*'s first letter iff *like*'s first letter is upper."""
+    if like[:1].isupper():
+        return word[:1].upper() + word[1:]
+    return word
+
+
+def flex_noun(body: str, number: str) -> str:
+    """Render a noun token to the requested grammatical *number*.
+
+    Input-form-agnostic: the noun may be authored singular or plural, with
+    or without a leading indefinite article. On a plural render the article
+    (if any) is dropped and the noun pluralised; on a singular render the
+    noun is singularised and the article re-agreed (``a``/``an``).
+
+    Args:
+        body: The token body, e.g. ``"eye"``, ``"eyes"``, ``"an eye"``.
+        number: ``"plural"`` or ``"singular"``.
+
+    Returns:
+        The flexed noun phrase, first-letter case matched to *body*.
+    """
+    match = _ARTICLE_NOUN_RE.match(body)
+    article = match.group(1) if match else None
+    word = match.group(2) if match else body
+
+    singular = singularize_noun(word)
+
+    if number == "plural":
+        # Plural drops the indefinite article entirely.
+        return _match_leading_case(pluralize_noun(singular), body)
+
+    if article:
+        agreed = get_article(singular)
+        agreed = _match_leading_case(agreed, body)
+        return f"{agreed} {singular}"
+    return _match_leading_case(singular, body)
+
+
+def flex_verb(word: str, number: str) -> str:
+    """Render a verb token to agree with the requested *number*.
+
+    Input-form-agnostic: ``{accents}`` and ``{accent}`` both work. A plural
+    render yields the base/plural form ("accent", "are"); a singular render
+    yields the third-person singular form ("accents", "is").
+
+    Args:
+        word: The single-word verb token body, e.g. ``"accents"``, ``"are"``.
+        number: ``"plural"`` or ``"singular"``.
+
+    Returns:
+        The flexed verb, first-letter case matched to *word*.
+    """
+    lower = word.lower()
+
+    if lower in _IRREGULAR_VERB_FORMS:
+        singular_form, plural_form = _IRREGULAR_VERB_FORMS[lower]
+        out = plural_form if number == "plural" else singular_form
+        return _match_leading_case(out, word)
+
+    # Regular verb: normalise to the base/plural form via inflect, then
+    # conjugate back down for the singular render.
+    base = _engine.plural_verb(lower) or lower
+    if number == "plural":
+        return _match_leading_case(base, word)
+    return _match_leading_case(conjugate_third_person(base), word)
 
 
 # ---------------------------------------------------------------------------

--- a/world/tests/test_grammar.py
+++ b/world/tests/test_grammar.py
@@ -16,9 +16,12 @@ from world.grammar import (
     GENDER_MAP,
     capitalize_first,
     conjugate_third_person,
+    flex_noun,
+    flex_verb,
     get_article,
     is_pluralia_tantum,
     possessive,
+    singularize_noun,
     transform_pronoun,
     with_article,
 )
@@ -540,3 +543,95 @@ class TestCapitalizeFirst(TestCase):
             capitalize_first("a compact woman nods."),
             "A compact woman nods.",
         )
+
+
+# -----------------------------------------------------------------------
+# Singularization
+# -----------------------------------------------------------------------
+
+
+class TestSingularizeNoun(TestCase):
+    """Tests for ``singularize_noun``."""
+
+    def test_regular_plural(self) -> None:
+        self.assertEqual(singularize_noun("eyes"), "eye")
+
+    def test_irregular_plural(self) -> None:
+        self.assertEqual(singularize_noun("feet"), "foot")
+
+    def test_already_singular_unchanged(self) -> None:
+        self.assertEqual(singularize_noun("eye"), "eye")
+        self.assertEqual(singularize_noun("foot"), "foot")
+
+    def test_preserves_leading_capital(self) -> None:
+        self.assertEqual(singularize_noun("Eyes"), "Eye")
+        self.assertEqual(singularize_noun("Feet"), "Foot")
+
+    def test_empty_string(self) -> None:
+        self.assertEqual(singularize_noun(""), "")
+
+
+# -----------------------------------------------------------------------
+# Number-Flexing Tokens
+# -----------------------------------------------------------------------
+
+
+class TestFlexNoun(TestCase):
+    """Tests for ``flex_noun`` (input-form-agnostic noun number)."""
+
+    def test_singular_input_to_plural(self) -> None:
+        self.assertEqual(flex_noun("eye", "plural"), "eyes")
+
+    def test_plural_input_to_plural_no_double(self) -> None:
+        self.assertEqual(flex_noun("eyes", "plural"), "eyes")
+
+    def test_plural_input_to_singular(self) -> None:
+        self.assertEqual(flex_noun("eyes", "singular"), "eye")
+
+    def test_irregular_to_plural(self) -> None:
+        self.assertEqual(flex_noun("foot", "plural"), "feet")
+
+    def test_irregular_to_singular(self) -> None:
+        self.assertEqual(flex_noun("feet", "singular"), "foot")
+
+    def test_article_dropped_on_plural(self) -> None:
+        self.assertEqual(flex_noun("an eye", "plural"), "eyes")
+
+    def test_article_agreement_fixed_on_singular(self) -> None:
+        # "a eye" should re-agree to "an eye" in the singular render.
+        self.assertEqual(flex_noun("a eye", "singular"), "an eye")
+
+    def test_article_kept_on_singular(self) -> None:
+        self.assertEqual(flex_noun("an eye", "singular"), "an eye")
+
+    def test_leading_capital_preserved_plural(self) -> None:
+        self.assertEqual(flex_noun("An eye", "plural"), "Eyes")
+
+    def test_leading_capital_preserved_singular(self) -> None:
+        self.assertEqual(flex_noun("Feet", "singular"), "Foot")
+
+
+class TestFlexVerb(TestCase):
+    """Tests for ``flex_verb`` (input-form-agnostic verb agreement)."""
+
+    def test_regular_singular_input_to_plural(self) -> None:
+        self.assertEqual(flex_verb("accents", "plural"), "accent")
+
+    def test_regular_base_input_to_singular(self) -> None:
+        self.assertEqual(flex_verb("accent", "singular"), "accents")
+
+    def test_regular_y_verb(self) -> None:
+        self.assertEqual(flex_verb("carries", "plural"), "carry")
+        self.assertEqual(flex_verb("carry", "singular"), "carries")
+
+    def test_irregular_be(self) -> None:
+        self.assertEqual(flex_verb("is", "plural"), "are")
+        self.assertEqual(flex_verb("are", "singular"), "is")
+
+    def test_irregular_have(self) -> None:
+        self.assertEqual(flex_verb("has", "plural"), "have")
+        self.assertEqual(flex_verb("have", "singular"), "has")
+
+    def test_leading_capital_preserved(self) -> None:
+        self.assertEqual(flex_verb("Accents", "plural"), "Accent")
+        self.assertEqual(flex_verb("Are", "singular"), "Is")

--- a/world/tests/test_paired_longdesc_collapse.py
+++ b/world/tests/test_paired_longdesc_collapse.py
@@ -1,10 +1,11 @@
 """Unit tests for symmetric left/right longdesc collapse.
 
 A matched ``left_*``/``right_*`` pair with identical longdescs renders as one
-pluralized line (e.g. "Calloused hands."); a wound sits on its own side
+line (the prose rendered once at plural number); a wound sits on its own side
 without splitting the pair; a pair severed on both sides collapses to one
 plural stump line; and any divergence (coverage, severance of one side,
-differing prose) falls back to separate rendering.
+differing prose) falls back to separate rendering. Token rendering
+(``{eye}``/``{accents}`` number-flexing) is covered by ``TokenRenderTests``.
 
 Run via::
 
@@ -31,49 +32,31 @@ class _Body(AppearanceMixin):
         self._severed = set(severed or ())
 
     def _process_description_variables(self, desc, looker, **kwargs):
-        # Passthrough so tests can assert on the pluralized text directly.
+        # Passthrough so tests can assert which pairs collapse without
+        # exercising the token renderer (covered separately).
         return desc
 
     def _get_severed_locations(self):
         return set(self._severed)
 
 
-class PluralizePairLongdescTests(TestCase):
+class _Render(AppearanceMixin):
+    """Minimal host for exercising the real token renderer."""
 
-    def setUp(self):
-        self.obj = _Bare()
+    gender = "neutral"
 
-    def test_strips_article_and_pluralizes_with_capital(self):
-        out = self.obj._pluralize_pair_longdesc(
-            "A calloused hand with scarred knuckles.", "hand"
+    class _DB:
+        skintone = None
+
+    db = _DB()
+
+    def get_display_name(self, looker):
+        return "Vasquez"
+
+    def render(self, desc, number):
+        return self._process_description_variables(
+            desc, looker=object(), force_third_person=True, number=number,
         )
-        self.assertEqual(out, "Calloused hands with scarred knuckles.")
-
-    def test_lowercase_fragment_stays_lowercase(self):
-        out = self.obj._pluralize_pair_longdesc("a milky eye", "eye")
-        self.assertEqual(out, "milky eyes")
-
-    def test_irregular_plural_foot_to_feet(self):
-        out = self.obj._pluralize_pair_longdesc("A scarred foot.", "foot")
-        self.assertEqual(out, "Scarred feet.")
-
-    def test_definite_article_handled(self):
-        out = self.obj._pluralize_pair_longdesc("The gnarled hand.", "hand")
-        self.assertEqual(out, "Gnarled hands.")
-
-    def test_missing_noun_returns_none(self):
-        # The anatomical noun isn't present; cannot safely pluralize.
-        out = self.obj._pluralize_pair_longdesc(
-            "a sleek prosthetic appendage", "hand"
-        )
-        self.assertIsNone(out)
-
-    def test_only_first_occurrence_pluralized(self):
-        out = self.obj._pluralize_pair_longdesc(
-            "a hand, a working hand", "hand"
-        )
-        # Leading article stripped; only the first 'hand' becomes plural.
-        self.assertEqual(out, "hands, a working hand")
 
 
 class GetSeveredLocationsTests(TestCase):
@@ -113,7 +96,7 @@ class BuildPairedCollapseTests(TestCase):
             None, longdescs, coverage_map or {}
         )
 
-    def test_identical_pair_collapses_to_plural(self):
+    def test_identical_pair_collapses(self):
         longdescs = {
             "left_hand": "A calloused hand.",
             "right_hand": "A calloused hand.",
@@ -124,7 +107,8 @@ class BuildPairedCollapseTests(TestCase):
             collapse_map, skip = self._build(longdescs)
         self.assertIn("left_hand", collapse_map)
         self.assertIn("right_hand", skip)
-        self.assertEqual(collapse_map["left_hand"], "Calloused hands.")
+        # Rendered once, verbatim (the passthrough stub bypasses token flex).
+        self.assertEqual(collapse_map["left_hand"], "A calloused hand.")
 
     def test_wound_on_one_side_stays_merged(self):
         longdescs = {
@@ -143,7 +127,7 @@ class BuildPairedCollapseTests(TestCase):
             collapse_map, skip = self._build(longdescs)
         self.assertEqual(
             collapse_map["left_hand"],
-            "Calloused hands. A fresh laceration crosses the right hand.",
+            "A calloused hand. A fresh laceration crosses the right hand.",
         )
         self.assertIn("right_hand", skip)
 
@@ -171,7 +155,9 @@ class BuildPairedCollapseTests(TestCase):
             collapse_map, _skip = self._build(longdescs)
         self.assertEqual(collapse_map, {})
 
-    def test_non_pluralizable_pair_falls_back(self):
+    def test_untokenized_identical_pair_collapses_verbatim(self):
+        # Identity, not the presence of an anatomical noun, drives collapse:
+        # untokenized prose renders once, verbatim.
         longdescs = {
             "left_hand": "a sleek prosthetic appendage",
             "right_hand": "a sleek prosthetic appendage",
@@ -179,8 +165,11 @@ class BuildPairedCollapseTests(TestCase):
         with mock.patch(
             f"{WOUNDS}.get_standalone_wound_description", return_value=""
         ):
-            collapse_map, _skip = self._build(longdescs)
-        self.assertEqual(collapse_map, {})
+            collapse_map, skip = self._build(longdescs)
+        self.assertEqual(
+            collapse_map["left_hand"], "a sleek prosthetic appendage"
+        )
+        self.assertIn("right_hand", skip)
 
     def test_both_severed_collapses_to_plural_stump(self):
         self.obj = _Body(severed={"left_hand", "right_hand"})
@@ -213,8 +202,65 @@ class BuildPairedCollapseTests(TestCase):
             f"{WOUNDS}.get_standalone_wound_description", return_value=""
         ):
             collapse_map, skip = self._build(longdescs)
-        self.assertEqual(collapse_map["left_wing"], "Feathered wings.")
+        self.assertEqual(collapse_map["left_wing"], "A feathered wing.")
         self.assertIn("right_wing", skip)
+
+
+class TokenRenderTests(TestCase):
+    """The real token renderer: pronoun tokens plus number-flexing."""
+
+    def setUp(self):
+        self.obj = _Render()
+
+    def test_pronoun_token_unaffected_by_number(self):
+        # Pronoun number tracks gender, not the body-part render number.
+        self.assertEqual(
+            self.obj.render("{Their} gaze.", "plural"), "Their gaze."
+        )
+        self.assertEqual(
+            self.obj.render("{Their} gaze.", "singular"), "Their gaze."
+        )
+
+    def test_pair_renders_plural(self):
+        out = self.obj.render(
+            "deep brown {eyes} that {accent} {their} skin", "plural"
+        )
+        self.assertEqual(out, "deep brown eyes that accent their skin")
+
+    def test_survivor_renders_singular(self):
+        out = self.obj.render(
+            "deep brown {eyes} that {accent} {their} skin", "singular"
+        )
+        self.assertEqual(out, "deep brown eye that accents their skin")
+
+    def test_article_noun_token_plural_drops_article(self):
+        out = self.obj.render("{An eye} {gleams} coldly.", "plural")
+        self.assertEqual(out, "Eyes gleam coldly.")
+
+    def test_article_noun_token_singular_keeps_article(self):
+        out = self.obj.render("{An eye} {gleams} coldly.", "singular")
+        self.assertEqual(out, "An eye gleams coldly.")
+
+    def test_irregular_pair_noun(self):
+        self.assertEqual(
+            self.obj.render("scarred {feet}", "plural"), "scarred feet"
+        )
+        self.assertEqual(
+            self.obj.render("scarred {feet}", "singular"), "scarred foot"
+        )
+
+    def test_noun_vs_verb_autodetect(self):
+        # "arm" is a pair noun; "flex" is not, so it conjugates as a verb.
+        out = self.obj.render("{arms} that {flex}", "singular")
+        self.assertEqual(out, "arm that flexes")
+
+    def test_untokenized_prose_verbatim(self):
+        text = "a milky white orb, unseeing."
+        self.assertEqual(self.obj.render(text, "plural"), text)
+
+    def test_unknown_multiword_token_left_literal(self):
+        out = self.obj.render("a strange {foo bar} thing", "plural")
+        self.assertEqual(out, "a strange {foo bar} thing")
 
 
 class PairedSeveredDescriptionTests(TestCase):


### PR DESCRIPTION
## Summary
- Replaces the heuristic noun-pluralizer (`_pluralize_pair_longdesc`) with a deterministic, **opt-in token** model so the engine **never rewrites player prose**.
- An identical `left_*`/`right_*` pair collapses by rendering the shared string **once at plural number**; a lone survivor or single side renders the same string at **singular number**.
- Untokenized prose renders **verbatim** — there is no more "can we safely pluralize?" failure/`None` fallback; any identical pair collapses.

## Token model
Authors wrap number-flexible **body-part** words in `{braces}`:
- **Noun** — braced word whose singular is a known pair noun (`eye`, `ear`, `arm`, `hand`, `thigh`, `shin`, `foot`, from `PAIR_MERGE_KEYS`). `{eye}`/`{eyes}` flex the noun; `{an eye}` additionally drops the article on plural and re-agrees `a`/`an` on singular.
- **Verb** — any other braced single word, conjugated to agree with the part: plural `{accent}`/`{are}`, singular `{accents}`/`{is}`. Only brace verbs whose subject **is** the part; a main-clause verb agreeing with the person-pronoun ("They have …") is left un-braced.
- **Unrecognised** tokens (multi-word non-noun, typos) are left **literal** and logged. Substitution is now per-token via `re.sub`, killing the old `str.format` footgun where one bad token dropped the entire substitution.

Noun-vs-verb autodetect is a **deterministic closed-set rule** (no POS/probabilistic tagging).

## Authoring convenience
`@longdesc` gains pair shorthands — `eyes`, `ears`, `arms`, `hands`, `thighs`, `shins`, `feet` — that **set/view/clear both sides at once**, guaranteeing the byte-for-byte identity collapse requires. Pair keys are write-conveniences only (not body locations, not wearable, not render keys). Set sides individually to diverge them (heterochromia).

## Changes
- `world/grammar.py`: add `singularize_noun`, `flex_noun`, `flex_verb` (+ irregular verb-form table).
- `world/combat/constants.py`: add `PAIR_MERGE_KEYS`.
- `typeclasses/appearance_mixin.py`: `_substitute_longdesc_tokens` + `_pair_base_nouns`; thread `number` through `_process_description_variables`; verbatim plural collapse in `_merge_paired_location`; delete `_pluralize_pair_longdesc`.
- `commands/CmdCharacter.py`: `CmdLongdesc._expand_pair_locations` fan-out + braced help.
- Specs: `LONGDESC_SYSTEM_SPEC.md`, `GRAMMAR_ENGINE_SPEC.md`.

## Testing
- New: `flex_noun`/`flex_verb`/`singularize_noun` grammar tests; `TokenRenderTests` (pair-plural vs survivor-singular, article token, noun-vs-verb autodetect, untokenized passthrough, unknown-token literal).
- Rewrote `test_paired_longdesc_collapse.py` for verbatim collapse.
- Full `world` suite green: **1412 tests pass** (was 1388).

Closes #266