### PR TITLE
Interactive @longdesc editor with rendered preview + tokens-first help

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -547,47 +547,57 @@ class CmdTempPlace(Command):
 
 class CmdLongdesc(Command):
     """
-    Set or view detailed descriptions for your character's body parts.
+    Describe your character's body, part by part.
 
-    Usage:
-        @longdesc <location> "<description>"    - Set description for a body part
-        @longdesc <location>                    - View current description for location
-        @longdesc                               - List all your current longdescs
-        @longdesc/list                          - List all available body locations
-        @longdesc/clear <location>              - Remove description for location
+    The easy way: just type |w@longdesc|n with no arguments to open the
+    interactive editor. It lists every body location with its current
+    description; pick a number, type what that part looks like, and you get
+    an instant preview of how others will see it.
 
-    Staff Usage:
-        @longdesc <character> <location> "<description>"  - Set on another character
-        @longdesc/clear <character> <location>             - Clear on another character
-
-    Examples:
-        @longdesc face "weathered features with high cheekbones"
-        @longdesc left_eye "a piercing blue eye with flecks of gold"
-        @longdesc right_hand "a prosthetic metal hand with intricate engravings"
-        @longdesc/clear face
-        @longdesc face
-        @longdesc/list
-
-    Symmetric pairs (eyes, ears, arms, hands, thighs, shins, feet) are
-    shorthands that set, view, and clear BOTH sides at once:
+    |wTokens|n let one description read naturally whether a part is paired or
+    a lone survivor. Wrap a number-flexible word in braces and it flexes to
+    match: a pair renders plural, a single side renders singular.
 
         @longdesc eyes "deep brown {eyes} that {accent} {their} skin"
 
-    When both sides match they collapse into one line; set the sides
-    individually if you want them to differ (e.g. heterochromia).
+        both eyes  -> deep brown eyes that accent their skin
+        one eye    -> a deep brown eye that accents their skin
 
-    Braces mark number-flexible words so a pair reads naturally as plural
-    ("brown eyes that accent") while a lone survivor reads singular ("a brown
-    eye that accents"). Brace the body-part noun ({eye}/{an eye}) and any verb
-    that agrees with it ({accent}, {are}). Braces are optional — plain prose
-    renders verbatim. Pronoun tokens ({their}, {they}, ...) work as before.
+    Brace the body-part noun ({eye} or {an eye} to control the article) and
+    any verb that must agree with it ({accent}, {are}). Pronoun tokens
+    ({their}, {they}, {them}, ...) adapt to your gender and the viewer. Plain,
+    unbraced prose always renders verbatim. See |whelp tokens|n for the full
+    reference.
 
-    Body locations include: head, face, left_eye, right_eye, left_ear, right_ear,
-    neck, chest, back, abdomen, groin, left_arm, right_arm, left_hand, right_hand,
-    left_thigh, right_thigh, left_shin, right_shin, left_foot, right_foot.
+    Usage:
+        @longdesc                               - Open the interactive editor
+        @longdesc <location> "<description>"    - Set one location directly
+        @longdesc <location>                    - View one location
+        @longdesc/list                          - List available body locations
+        @longdesc/clear <location>              - Remove a description
 
-    Extended anatomy (tails, wings, etc.) is supported for modified characters.
-    Descriptions appear when others look at you, integrated with your base description.
+    Staff Usage:
+        @longdesc <character>                              - View another's
+        @longdesc <character> <location> "<description>"   - Set on another
+        @longdesc/clear <character> <location>             - Clear on another
+
+    Symmetric pairs (eyes, ears, arms, hands, thighs, shins, feet) are
+    shorthands that set, view, and clear BOTH sides at once. When both sides
+    match they collapse into one line; set the sides individually (left_eye,
+    right_eye, ...) if you want them to differ (e.g. heterochromia).
+
+    Examples:
+        @longdesc face "weathered features with high cheekbones"
+        @longdesc eyes "piercing blue {eyes} flecked with gold"
+        @longdesc right_hand "a prosthetic metal hand, intricately engraved"
+        @longdesc/clear face
+
+    Body locations include: hair, head, face, left_eye, right_eye, left_ear,
+    right_ear, neck, chest, back, abdomen, groin, left_arm, right_arm,
+    left_hand, right_hand, left_thigh, right_thigh, left_shin, right_shin,
+    left_foot, right_foot. Extended anatomy (tails, wings, etc.) is supported
+    for modified characters. Descriptions appear when others look at you,
+    integrated with your base description.
     """
 
     key = "@longdesc"
@@ -623,8 +633,8 @@ class CmdLongdesc(Command):
 
         # Parse arguments for main command
         if not args:
-            # Show all current longdescs
-            self._show_all_longdescs(caller)
+            # Bare @longdesc (self) opens the interactive editor menu.
+            _show_longdesc_menu(caller)
             return
 
         # Check if this is staff targeting another character
@@ -761,15 +771,7 @@ class CmdLongdesc(Command):
             location is neither a valid single location nor a usable pair
             shorthand for this character.
         """
-        if location in PAIR_MERGE_KEYS:
-            left, right = PAIR_MERGE_KEYS[location]
-            if (target_char.has_location(left)
-                    and target_char.has_location(right)):
-                return [left, right]
-            return None
-        if target_char.has_location(location):
-            return [location]
-        return None
+        return _expand_longdesc_pair(target_char, location)
 
     def _set_longdesc(self, caller, target_char, location, description):
         """Set a longdesc for a specific location (or both sides of a pair)."""
@@ -811,6 +813,10 @@ class CmdLongdesc(Command):
                 caller.msg(f"Set description for {location}: \"{description.strip()}\"")
             else:
                 caller.msg(f"Set description for {location} on {target_char.get_display_name(caller)}: \"{description.strip()}\"")
+            for line in _render_longdesc_preview(
+                caller, target_char, location, locations, description.strip()
+            ):
+                caller.msg(line)
         else:
             caller.msg("Failed to set description. Please try again.")
 
@@ -919,6 +925,273 @@ class CmdLongdesc(Command):
             caller.msg(f"Cleared all {count} longdesc descriptions.")
         else:
             caller.msg(f"Cleared all {count} longdesc descriptions from {target_char.get_display_name(caller)}.")
+
+
+# =============================================================================
+# LONGDESC SHARED HELPERS + INTERACTIVE EDITOR (EvMenu)
+# =============================================================================
+
+def _expand_longdesc_pair(char, location):
+    """Resolve a typed location into the concrete locations to act on.
+
+    A symmetric pair shorthand (e.g. ``eyes``) expands to both underlying
+    sides (``left_eye``, ``right_eye``). A normal location resolves to itself.
+
+    Args:
+        char: Character whose anatomy is being checked.
+        location: The location string the player typed.
+
+    Returns:
+        list[str] | None: Concrete locations to act on, or ``None`` if the
+        location is neither a valid single location nor a usable pair
+        shorthand for this character.
+    """
+    if location in PAIR_MERGE_KEYS:
+        left, right = PAIR_MERGE_KEYS[location]
+        if char.has_location(left) and char.has_location(right):
+            return [left, right]
+        return None
+    if char.has_location(location):
+        return [location]
+    return None
+
+
+def _render_longdesc_preview(viewer, target_char, location, locations, description):
+    """Build preview lines showing how a longdesc renders, flagging stray tokens.
+
+    For a symmetric pair the preview shows both the plural form (both sides
+    intact) and the singular form (a lone survivor). For a single location it
+    shows the singular render. Any brace tokens the resolver did not recognise
+    survive in the rendered output and are surfaced as a warning.
+
+    Args:
+        viewer: Character who will read the preview (the command caller).
+        target_char: Character the longdesc belongs to.
+        location: The slot/location label the player acted on.
+        locations: Concrete locations the description was written to.
+        description: The raw description string.
+
+    Returns:
+        list[str]: Message lines (no trailing newlines).
+    """
+    is_pair = location in PAIR_MERGE_KEYS and len(locations) == 2
+    brace_re = re.compile(r"\{[^{}]+\}")
+    unresolved = set()
+
+    def _render(number):
+        rendered = target_char._process_description_variables(
+            description, viewer, force_third_person=True, number=number,
+        )
+        unresolved.update(brace_re.findall(rendered))
+        return rendered
+
+    lines = ["|wPreview:|n"]
+    if is_pair:
+        lines.append(f"  |cboth sides:|n {_render('plural')}")
+        lines.append(f"  |clone side:|n {_render('singular')}")
+    else:
+        lines.append(f"  {_render('singular')}")
+
+    if unresolved:
+        tokens = ", ".join(sorted(unresolved))
+        lines.append(
+            f"  |yUnrecognized token(s) left literal: {tokens}|n"
+        )
+    return lines
+
+
+def _build_longdesc_slots(char):
+    """Ordered, de-duplicated list of editable longdesc slots.
+
+    Symmetric pairs collapse to their shorthand (``eyes`` rather than
+    ``left_eye``/``right_eye``); an asymmetric pair (only one side present)
+    shows that side individually. Non-pair locations show as themselves.
+    Slots follow anatomical order, with extended anatomy appended.
+
+    Args:
+        char: Character whose anatomy is being listed.
+
+    Returns:
+        list[str]: Slot labels a player can select and type into.
+    """
+    available = set(char.get_available_locations())
+
+    # side location -> (shorthand, partner side)
+    pair_of = {}
+    for shorthand, (left, right) in PAIR_MERGE_KEYS.items():
+        pair_of[left] = (shorthand, right)
+        pair_of[right] = (shorthand, left)
+
+    ordered = [loc for loc in ANATOMICAL_DISPLAY_ORDER if loc in available]
+    ordered += sorted(
+        loc for loc in available if loc not in ANATOMICAL_DISPLAY_ORDER
+    )
+
+    slots = []
+    seen = set()
+    for loc in ordered:
+        if loc in pair_of:
+            shorthand, partner = pair_of[loc]
+            if partner in available:
+                # Symmetric pair: one shorthand slot for both sides.
+                if shorthand not in seen:
+                    slots.append(shorthand)
+                    seen.add(shorthand)
+                continue
+            # Asymmetric: fall through and show this side on its own.
+        if loc not in seen:
+            slots.append(loc)
+            seen.add(loc)
+    return slots
+
+
+def _longdesc_slot_value(char, slot):
+    """Return ``(value, diverged)`` for a slot's current description.
+
+    For a pair shorthand whose sides match, ``value`` is that shared text and
+    ``diverged`` is ``False``. If the sides differ, ``value`` is one side's
+    text and ``diverged`` is ``True``. For a single location, ``diverged`` is
+    always ``False``.
+    """
+    if slot in PAIR_MERGE_KEYS:
+        left, right = PAIR_MERGE_KEYS[slot]
+        lval, rval = char.get_longdesc(left), char.get_longdesc(right)
+        if lval == rval:
+            return lval, False
+        return (lval or rval), True
+    return char.get_longdesc(slot), False
+
+
+def _show_longdesc_menu(caller):
+    """Open the interactive longdesc editor menu for the caller (self only)."""
+    from evennia.utils.evmenu import EvMenu
+
+    caller.ndb._longdesc_slots = _build_longdesc_slots(caller)
+    EvMenu(
+        caller,
+        {
+            "node_longdesc_list": _node_longdesc_list,
+            "node_longdesc_entry": _node_longdesc_entry,
+        },
+        startnode="node_longdesc_list",
+        cmd_on_exit=_longdesc_exit,
+    )
+
+
+def _longdesc_exit(caller, menu):
+    """Clean up ndb data when the longdesc menu closes."""
+    for attr in ("_longdesc_slots", "_longdesc_active_slot"):
+        if hasattr(caller.ndb, attr):
+            delattr(caller.ndb, attr)
+
+
+def _node_longdesc_list(caller, raw_string, **kwargs):
+    """EvMenu node: numbered list of slots with their current values."""
+    slots = getattr(caller.ndb, "_longdesc_slots", None)
+    if slots is None:
+        slots = _build_longdesc_slots(caller)
+        caller.ndb._longdesc_slots = slots
+
+    text = "\n|c=== Longdesc Editor ===|n\n"
+    text += "\n|xSelect a body location by number to set its description.|n\n"
+    for idx, slot in enumerate(slots, 1):
+        value, diverged = _longdesc_slot_value(caller, slot)
+        if diverged:
+            shown = "|y(sides differ \u2014 editing sets both alike)|n"
+        elif value:
+            shown = f"\"{value}\""
+        else:
+            shown = "|x(empty)|n"
+        text += f"  |w{idx:>2}|n |c{slot}:|n {shown}\n"
+    text += "\n|wEnter a number to edit, or |yquit|w to exit.|n"
+
+    options = ({"key": "_default", "goto": _process_longdesc_slot},)
+    return text, options
+
+
+def _process_longdesc_slot(caller, raw_string, **kwargs):
+    """Goto-callable: pick a slot to edit by number."""
+    choice = raw_string.strip()
+    slots = getattr(caller.ndb, "_longdesc_slots", [])
+    if not choice:
+        return None  # Re-display the list.
+
+    try:
+        idx = int(choice) - 1
+    except ValueError:
+        caller.msg(f"|rEnter a number 1-{len(slots)}, or |yquit|r to exit.|n")
+        return None
+
+    if not (0 <= idx < len(slots)):
+        caller.msg(f"|rInvalid number. Enter 1-{len(slots)}.|n")
+        return None
+
+    caller.ndb._longdesc_active_slot = slots[idx]
+    return "node_longdesc_entry"
+
+
+def _node_longdesc_entry(caller, raw_string, **kwargs):
+    """EvMenu node: prompt for the description of the active slot."""
+    slot = getattr(caller.ndb, "_longdesc_active_slot", None)
+    if not slot:
+        # Defensive: reached without a selection — show the list instead.
+        return _node_longdesc_list(caller, raw_string, **kwargs)
+
+    value, diverged = _longdesc_slot_value(caller, slot)
+    text = f"\n|c=== Editing: {slot} ===|n\n"
+    if diverged:
+        text += "\n|ySides currently differ; saving here sets both alike.|n\n"
+    elif value:
+        text += f"\n|xCurrent:|n \"{value}\"\n"
+    else:
+        text += "\n|xCurrent:|n (empty)\n"
+
+    text += (
+        "\n|wType the new description. Brace number-flexible words so a pair"
+        "\nreads plural and a lone side reads singular \u2014 e.g."
+        "\n  |ydeep brown {eyes} that {accent} {their} skin|w"
+        "\nUse |y{their}/{they}|w for pronouns; plain prose renders verbatim."
+        "\n\nType |yclear|w to remove it, or |yback|w to return unchanged.|n"
+    )
+
+    options = ({"key": "_default", "goto": _process_longdesc_entry},)
+    return text, options
+
+
+def _process_longdesc_entry(caller, raw_string, **kwargs):
+    """Goto-callable: apply the typed description (or clear/back)."""
+    slot = getattr(caller.ndb, "_longdesc_active_slot", None)
+    if not slot:
+        return "node_longdesc_list"
+
+    entry = raw_string.strip()
+    if not entry or entry.lower() == "back":
+        return "node_longdesc_list"
+
+    locations = _expand_longdesc_pair(caller, slot)
+    if not locations:
+        caller.msg(f"|r'{slot}' is no longer a valid location.|n")
+        return "node_longdesc_list"
+
+    if entry.lower() == "clear":
+        for loc in locations:
+            caller.set_longdesc(loc, None)
+        caller.msg(f"Cleared description for {slot}.")
+        return "node_longdesc_list"
+
+    if len(entry) > MAX_DESCRIPTION_LENGTH:
+        caller.msg(
+            f"|rDescription is too long ({len(entry)} characters). "
+            f"Maximum is {MAX_DESCRIPTION_LENGTH}.|n"
+        )
+        return None  # Re-display the entry node.
+
+    for loc in locations:
+        caller.set_longdesc(loc, entry)
+    caller.msg(f"Set description for {slot}.")
+    for line in _render_longdesc_preview(caller, caller, slot, locations, entry):
+        caller.msg(line)
+    return "node_longdesc_list"
 
 
 class CmdSkintone(Command):

--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -189,12 +189,49 @@ position. This procedure was used to propagate the `hair` location (added in
 ### Command Variations
 - `@longdesc <location>` - View current description for location
 - `@longdesc/list` - List all available body locations for this character
-- `@longdesc` - List all set longdescs for character (only shows non-None values)
+- `@longdesc` - Open the interactive editor menu (self only)
 - `@longdesc/clear <location>` - Remove description for location (set to None)
 
 #### Staff Commands (Permission Override)
 - `@longdesc <character> <location> "<description>"` - Set longdesc on another character
+- `@longdesc <character>` - View all set longdescs on another character
 - `@longdesc/clear <character> <location>` - Clear specific location on another character
+
+### Interactive Editor (EvMenu)
+
+Bare `@longdesc` (acting on self) opens an EvMenu-driven editor instead of
+printing a static list. The flow:
+
+1. **List node** (`node_longdesc_list`): a one-per-line numbered list of
+   editable **slots** with each slot's current value. Slots are built by
+   `_build_longdesc_slots`:
+   - Symmetric pairs collapse to their shorthand (`eyes`, `hands`, ...) so the
+     dynamic anatomy reads as a clean, compact list.
+   - An asymmetric pair (only one side present) shows that side individually.
+   - Non-pair locations show as themselves; extended anatomy is appended after
+     the anatomical-order entries.
+   - A pair whose two sides currently diverge is flagged (editing it via the
+     shorthand sets both sides alike).
+2. **Entry node** (`node_longdesc_entry`): shows the slot's current value and a
+   token hint, then accepts the new description. `clear` removes it, `back`/blank
+   returns unchanged, over-length input is rejected and re-prompts.
+3. On save the description fans out to both sides of a pair (or the single
+   location) and a **rendered preview** is shown.
+
+The one-off `@longdesc <location> "<description>"` form is retained and shares
+the same preview output.
+
+### Rendered Preview
+
+`_render_longdesc_preview` shows how a freshly-set description will read. For a
+symmetric pair it renders both the **plural** form (both sides intact) and the
+**singular** form (a lone survivor); for a single location it renders the
+singular form. Any brace token the resolver does not recognise survives in the
+rendered output and is surfaced as an explicit warning, so typos like
+`{thier}` are caught at authoring time rather than shipped silently. The
+preview fires after both the interactive editor save and the one-off
+`@longdesc <location> "..."` command.
+
 
 ## Implementation Details
 

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -26,6 +26,86 @@ Each dict is on the form
 
 HELP_ENTRY_DICTS = [
     {
+        "key": "tokens",
+        "aliases": ["token", "braces"],
+        "category": "Character",
+        "text": """
+            |cDescription Tokens|n
+
+            Tokens are words wrapped in |w{braces}|n inside a description. When
+            the description is shown, each token is replaced with the right word
+            for the viewer and the situation. Any text that is |wnot|n in braces
+            is shown exactly as written, so you only need tokens where something
+            must change.
+
+            There are two kinds of tokens: |wpronoun tokens|n and
+            |wnumber-flexible tokens|n.
+
+            # subtopics
+
+            ## pronouns
+
+            Pronoun tokens adapt to your character's gender and to whoever is
+            looking. Use the lowercase form mid-sentence and the capitalized
+            form at the start of a sentence.
+
+                |w{they}|n / |w{They}|n         - subject  (he, she, they, you)
+                |w{them}|n / |w{Them}|n         - object   (him, her, them, you)
+                |w{their}|n / |w{Their}|n       - possessive (his, her, their, your)
+                |w{theirs}|n / |w{Theirs}|n     - possessive absolute
+                |w{themself}|n / |w{themselves}|n - reflexive
+
+            A viewer looking at someone else sees third-person pronouns matching
+            that character's gender; the character themself sees "you/your".
+
+            Example:
+
+                a long scar runs down {their} cheek
+
+                others see -> a long scar runs down her cheek
+                you see    -> a long scar runs down your cheek
+
+            ## number
+
+            Number-flexible tokens let a single description read naturally
+            whether a body part is paired (both present) or a lone survivor
+            (one lost). The token flexes between plural and singular to match.
+
+            Brace the |wbody-part noun|n and any |wverb|n that must agree with
+            it:
+
+                deep brown {eyes} that {accent} {their} skin
+
+                both present -> deep brown eyes that accent their skin
+                one present  -> a deep brown eye that accents their skin
+
+            The recognised part nouns are the symmetric pairs: eye, ear, arm,
+            hand, thigh, shin, foot. A single braced word that is |wnot|n one of
+            these is treated as a verb and conjugated to match.
+
+            |wArticles:|n brace |w{an eye}|n (or |w{a hand}|n) to let the
+            article appear only in the singular form and drop in the plural.
+            The article re-agrees a/an automatically.
+
+            Caveat: if you put an adjective between the article and the noun,
+            omit the article from the brace and write it plainly, so the plural
+            stays clean. Prefer:
+
+                {eyes} of pale jade        not   {an eyes} of pale jade
+
+            ## verbatim
+
+            Braces are entirely optional. A description with no tokens is shown
+            verbatim, exactly as you typed it. Use tokens only where the wording
+            must change for the viewer (pronouns) or for missing body parts
+            (number). Anything the resolver does not recognise is left on screen
+            literally with its braces intact, so a typo like |w{thier}|n is easy
+            to spot in the preview rather than silently vanishing.
+
+            See also: |whelp @longdesc|n.
+        """,
+    },
+    {
         "key": "evennia",
         "aliases": ["ev"],
         "category": "General",

--- a/world/tests/test_longdesc_menu.py
+++ b/world/tests/test_longdesc_menu.py
@@ -1,0 +1,278 @@
+"""Unit tests for the interactive ``@longdesc`` editor and shared helpers.
+
+Covers slot construction (pair collapse, asymmetric sides, extended anatomy,
+anatomical ordering), slot-value reporting (matching vs diverged pairs),
+pair expansion, the rendered preview (plural + singular + stray-token
+warning), and the menu node goto-callables (slot selection and entry
+application, including ``clear``/``back``/length-guard paths).
+
+Run via::
+
+    evennia test world.tests.test_longdesc_menu
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from typeclasses.appearance_mixin import AppearanceMixin
+from commands.CmdCharacter import (
+    _build_longdesc_slots,
+    _expand_longdesc_pair,
+    _longdesc_slot_value,
+    _node_longdesc_entry,
+    _process_longdesc_entry,
+    _process_longdesc_slot,
+    _render_longdesc_preview,
+)
+from world.combat.constants import (
+    DEFAULT_LONGDESC_LOCATIONS,
+    MAX_DESCRIPTION_LENGTH,
+)
+
+
+class _DB:
+    skintone = None
+
+
+class _NDB:
+    pass
+
+
+class FakeChar(AppearanceMixin):
+    """Lightweight host implementing the longdesc surface + real renderer."""
+
+    gender = "neutral"
+
+    def __init__(self, locations):
+        self._longdesc = dict(locations)
+        self.db = _DB()
+        self.ndb = _NDB()
+        self.messages = []
+
+    # --- longdesc storage surface -------------------------------------
+    def get_available_locations(self):
+        return list(self._longdesc.keys())
+
+    def has_location(self, loc):
+        return loc in self._longdesc
+
+    def get_longdesc(self, loc):
+        return self._longdesc.get(loc)
+
+    def set_longdesc(self, loc, desc):
+        if loc not in self._longdesc:
+            return False
+        self._longdesc[loc] = desc
+        return True
+
+    # --- identity surface ---------------------------------------------
+    def get_display_name(self, looker):
+        return "Vasquez"
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def _full_body():
+    return FakeChar(DEFAULT_LONGDESC_LOCATIONS)
+
+
+class BuildSlotsTests(TestCase):
+
+    def test_symmetric_pairs_collapse_to_shorthand(self):
+        slots = _build_longdesc_slots(_full_body())
+        self.assertIn("eyes", slots)
+        self.assertIn("hands", slots)
+        self.assertNotIn("left_eye", slots)
+        self.assertNotIn("right_eye", slots)
+
+    def test_non_pair_locations_present(self):
+        slots = _build_longdesc_slots(_full_body())
+        for loc in ("hair", "head", "face", "neck", "chest", "back", "groin"):
+            self.assertIn(loc, slots)
+
+    def test_anatomical_ordering(self):
+        slots = _build_longdesc_slots(_full_body())
+        # hair leads; eyes shorthand sits where the eyes do; feet trails.
+        self.assertEqual(slots[0], "hair")
+        self.assertLess(slots.index("eyes"), slots.index("chest"))
+        self.assertLess(slots.index("chest"), slots.index("feet"))
+
+    def test_asymmetric_pair_shows_single_side(self):
+        char = FakeChar({"left_eye": None, "head": None})
+        slots = _build_longdesc_slots(char)
+        self.assertIn("left_eye", slots)
+        self.assertNotIn("eyes", slots)
+
+    def test_extended_anatomy_appended(self):
+        char = FakeChar({"head": None, "tail": None, "left_wing": None})
+        slots = _build_longdesc_slots(char)
+        self.assertIn("tail", slots)
+        self.assertIn("left_wing", slots)
+        # Extended anatomy comes after known anatomical-order entries.
+        self.assertLess(slots.index("head"), slots.index("tail"))
+
+
+class SlotValueTests(TestCase):
+
+    def test_matching_pair_collapses(self):
+        char = FakeChar({"left_eye": "brown eye", "right_eye": "brown eye"})
+        value, diverged = _longdesc_slot_value(char, "eyes")
+        self.assertEqual(value, "brown eye")
+        self.assertFalse(diverged)
+
+    def test_diverged_pair_flagged(self):
+        char = FakeChar({"left_eye": "brown eye", "right_eye": "blue eye"})
+        value, diverged = _longdesc_slot_value(char, "eyes")
+        self.assertTrue(diverged)
+        self.assertIn(value, ("brown eye", "blue eye"))
+
+    def test_single_location(self):
+        char = FakeChar({"face": "a scarred face"})
+        value, diverged = _longdesc_slot_value(char, "face")
+        self.assertEqual(value, "a scarred face")
+        self.assertFalse(diverged)
+
+
+class ExpandPairTests(TestCase):
+
+    def test_symmetric_pair_expands(self):
+        char = _full_body()
+        self.assertEqual(
+            _expand_longdesc_pair(char, "eyes"), ["left_eye", "right_eye"]
+        )
+
+    def test_single_location(self):
+        char = _full_body()
+        self.assertEqual(_expand_longdesc_pair(char, "face"), ["face"])
+
+    def test_invalid_location(self):
+        char = _full_body()
+        self.assertIsNone(_expand_longdesc_pair(char, "antenna"))
+
+    def test_asymmetric_pair_rejected(self):
+        char = FakeChar({"left_eye": None})
+        self.assertIsNone(_expand_longdesc_pair(char, "eyes"))
+
+
+class PreviewTests(TestCase):
+
+    def test_pair_shows_plural_and_singular(self):
+        char = _full_body()
+        lines = _render_longdesc_preview(
+            char, char, "eyes", ["left_eye", "right_eye"],
+            "deep brown {eyes} that {accent} {their} skin",
+        )
+        joined = "\n".join(lines)
+        self.assertIn("brown eyes that accent", joined)
+        self.assertIn("brown eye that accents", joined)
+
+    def test_single_location_singular_only(self):
+        char = _full_body()
+        lines = _render_longdesc_preview(
+            char, char, "face", ["face"], "a weathered {face}",
+        )
+        # "face" is not a pair noun -> treated as verb-ish flex, but render
+        # must succeed and show exactly one preview body line.
+        body_lines = [ln for ln in lines if not ln.startswith("|wPreview")]
+        self.assertEqual(len(body_lines), 1)
+
+    def test_unrecognized_token_warned(self):
+        # The token engine verb-flexes unknown *single* words, so only a
+        # genuinely-literal token (multi-word, non-article) survives in braces
+        # and triggers the explicit warning.
+        char = _full_body()
+        lines = _render_longdesc_preview(
+            char, char, "face", ["face"], "a face shaped by {the old days}",
+        )
+        joined = "\n".join(lines)
+        self.assertIn("Unrecognized token", joined)
+        self.assertIn("{the old days}", joined)
+
+    def test_clean_prose_no_warning(self):
+        char = _full_body()
+        lines = _render_longdesc_preview(
+            char, char, "face", ["face"], "a weathered face",
+        )
+        joined = "\n".join(lines)
+        self.assertNotIn("Unrecognized token", joined)
+
+
+class SlotSelectionTests(TestCase):
+
+    def _char_with_slots(self):
+        char = _full_body()
+        char.ndb._longdesc_slots = _build_longdesc_slots(char)
+        return char
+
+    def test_valid_number_targets_slot(self):
+        char = self._char_with_slots()
+        result = _process_longdesc_slot(char, "1")
+        self.assertEqual(result, "node_longdesc_entry")
+        self.assertEqual(char.ndb._longdesc_active_slot, char.ndb._longdesc_slots[0])
+
+    def test_out_of_range_redisplays(self):
+        char = self._char_with_slots()
+        result = _process_longdesc_slot(char, "999")
+        self.assertIsNone(result)
+        self.assertTrue(any("Invalid number" in m for m in char.messages))
+
+    def test_non_numeric_redisplays(self):
+        char = self._char_with_slots()
+        result = _process_longdesc_slot(char, "eyes")
+        self.assertIsNone(result)
+
+
+class EntryApplicationTests(TestCase):
+
+    def _char_editing(self, slot):
+        char = _full_body()
+        char.ndb._longdesc_slots = _build_longdesc_slots(char)
+        char.ndb._longdesc_active_slot = slot
+        return char
+
+    def test_set_fans_out_to_both_sides(self):
+        char = self._char_editing("eyes")
+        result = _process_longdesc_entry(char, "brown {eyes}")
+        self.assertEqual(result, "node_longdesc_list")
+        self.assertEqual(char.get_longdesc("left_eye"), "brown {eyes}")
+        self.assertEqual(char.get_longdesc("right_eye"), "brown {eyes}")
+        self.assertTrue(any("Preview" in m for m in char.messages))
+
+    def test_clear_removes_both_sides(self):
+        char = self._char_editing("eyes")
+        char.set_longdesc("left_eye", "x")
+        char.set_longdesc("right_eye", "x")
+        result = _process_longdesc_entry(char, "clear")
+        self.assertEqual(result, "node_longdesc_list")
+        self.assertIsNone(char.get_longdesc("left_eye"))
+        self.assertIsNone(char.get_longdesc("right_eye"))
+
+    def test_back_returns_unchanged(self):
+        char = self._char_editing("face")
+        char.set_longdesc("face", "original")
+        result = _process_longdesc_entry(char, "back")
+        self.assertEqual(result, "node_longdesc_list")
+        self.assertEqual(char.get_longdesc("face"), "original")
+
+    def test_blank_returns_unchanged(self):
+        char = self._char_editing("face")
+        char.set_longdesc("face", "original")
+        result = _process_longdesc_entry(char, "   ")
+        self.assertEqual(result, "node_longdesc_list")
+        self.assertEqual(char.get_longdesc("face"), "original")
+
+    def test_too_long_redisplays_entry(self):
+        char = self._char_editing("face")
+        result = _process_longdesc_entry(char, "x" * (MAX_DESCRIPTION_LENGTH + 1))
+        self.assertIsNone(result)
+        self.assertTrue(any("too long" in m.lower() for m in char.messages))
+        self.assertIsNone(char.get_longdesc("face"))
+
+    def test_entry_node_returns_to_list_without_slot(self):
+        char = _full_body()
+        char.ndb._longdesc_slots = _build_longdesc_slots(char)
+        # No active slot set: node falls back to rendering the list.
+        text, options = _node_longdesc_entry(char, "")
+        self.assertIn("Longdesc Editor", text)


### PR DESCRIPTION
## Summary
- Bare `@longdesc` (self) now opens an EvMenu-style editor: a numbered, one-per-line list of every available body location with its current value. Symmetric pairs (`eyes`, `ears`, `hands`, ...) collapse to a single shorthand slot; asymmetric pairs show the lone side; extended anatomy is appended in anatomical order. Selecting a slot prompts for the description (`clear`/`back` supported, length-guarded).
- After saving — both in the menu and via the retained one-off `@longdesc <loc> "..."` form — a **rendered preview** shows the plural (both sides) and singular (lone survivor) renders, and flags any literal leftover `{...}` tokens.
- Rewrote the `@longdesc` docstring tokens-first and added a separate `tokens` file-help entry (the future unified home for token docs).

## Implementation
- `commands/CmdCharacter.py`: module-level `_expand_longdesc_pair`, `_render_longdesc_preview`, `_build_longdesc_slots`, `_longdesc_slot_value`, and EvMenu nodes (`_show_longdesc_menu`, `_node_longdesc_list`, `_process_longdesc_slot`, `_node_longdesc_entry`, `_process_longdesc_entry`, `_longdesc_exit`). `CmdLongdesc._expand_pair_locations` delegates to the shared helper; `_set_longdesc` now emits the preview.
- `world/help_entries.py`: new `tokens` entry (pronoun / number / verbatim subtopics).
- `specs/LONGDESC_SYSTEM_SPEC.md`: documents the interactive editor and preview.

## Testing
- New `world/tests/test_longdesc_menu.py` (25 tests): slot construction, slot values, pair expansion, preview (plural+singular + stray-token warning), and node goto-callables.
- Full `world` suite green: 1437 tests (was 1412).

## Notes / tradeoff
The token engine verb-flexes any unknown *single* word, so a pronoun typo like `{thier}` renders as `thiers` (visible in the preview text) rather than triggering the explicit warning; only genuinely-literal multi-word tokens surface the "Unrecognized token" notice.

Closes #270