### PR TITLE
Fix @longdesc editor re-rendering the list on exit

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1089,6 +1089,7 @@ def _show_longdesc_menu(caller):
         {
             "node_longdesc_list": _node_longdesc_list,
             "node_longdesc_entry": _node_longdesc_entry,
+            "node_longdesc_exit": _node_longdesc_exit,
         },
         startnode="node_longdesc_list",
         cmd_on_exit=_longdesc_exit,
@@ -1133,9 +1134,7 @@ def _process_longdesc_slot(caller, raw_string, **kwargs):
         return None  # Re-display the list.
 
     if choice.lower() in ("x", "exit"):
-        if hasattr(caller.ndb, "_evmenu"):
-            caller.ndb._evmenu.close_menu()
-        return None
+        return "node_longdesc_exit"
 
     try:
         idx = int(choice) - 1
@@ -1149,6 +1148,11 @@ def _process_longdesc_slot(caller, raw_string, **kwargs):
 
     caller.ndb._longdesc_active_slot = slots[idx]
     return "node_longdesc_entry"
+
+
+def _node_longdesc_exit(caller, raw_string, **kwargs):
+    """EvMenu end node: returning no options makes EvMenu close cleanly."""
+    return "", None
 
 
 def _node_longdesc_entry(caller, raw_string, **kwargs):

--- a/world/tests/test_longdesc_menu.py
+++ b/world/tests/test_longdesc_menu.py
@@ -21,6 +21,7 @@ from commands.CmdCharacter import (
     _expand_longdesc_pair,
     _longdesc_slot_value,
     _node_longdesc_entry,
+    _node_longdesc_exit,
     _process_longdesc_entry,
     _process_longdesc_slot,
     _render_longdesc_preview,
@@ -223,13 +224,17 @@ class SlotSelectionTests(TestCase):
         result = _process_longdesc_slot(char, "eyes")
         self.assertIsNone(result)
 
-    def test_exit_choice_closes_without_selecting(self):
+    def test_exit_choice_routes_to_end_node(self):
         char = self._char_with_slots()
-        # No _evmenu attached in the unit harness; must not raise and must
-        # not set an active slot.
         result = _process_longdesc_slot(char, "x")
-        self.assertIsNone(result)
+        self.assertEqual(result, "node_longdesc_exit")
         self.assertFalse(hasattr(char.ndb, "_longdesc_active_slot"))
+
+    def test_exit_node_has_no_options(self):
+        # A node returning None options makes EvMenu close without re-display.
+        char = self._char_with_slots()
+        text, options = _node_longdesc_exit(char, "")
+        self.assertIsNone(options)
 
 
 class EntryApplicationTests(TestCase):


### PR DESCRIPTION
## Summary
Selecting `x` re-printed the whole list before closing because `close_menu()` was called from within the slot goto callable, and EvMenu still re-renders the current node once after a goto returns `None`.

`x`/`exit` now routes to a dedicated `node_longdesc_exit` end-node that returns `None` options, so EvMenu closes cleanly (running `cmd_on_exit` cleanup) without a second render.

## Testing
- `world.tests.test_longdesc_menu`: 27 tests green (exit now asserts routing to the end-node + end-node returns no options).

Closes #274