### PR TITLE
Merge @longdesc, @shortdesc, and setdesc into a unified describe command

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -546,20 +546,27 @@ class CmdTempPlace(Command):
         return _parse_placement_description(raw_input)
 
 
-class CmdLongdesc(Command):
+class CmdDescribe(Command):
     """
-    Describe your character's body, part by part.
+    Describe how your character looks.
 
-    The easy way: just type |w@longdesc|n with no arguments to open the
-    interactive editor. It lists every body location with its current
-    description; pick a number, type what that part looks like, and you get
-    an instant preview of how others will see it.
+    The easy way: just type |wdescribe|n with no arguments to open the
+    interactive editor. It lists your short description, your keyword, and
+    every body location with its current value; pick a number, type the new
+    text, and you get an instant preview of how others will see it.
+
+    Your appearance has three parts:
+      |cShort Description|n  - the main paragraph shown when others look at you.
+      |cKeyword|n            - the noun strangers see in your sdesc, e.g. the
+                          "|wman|n" in "a lanky man in a Black Trenchcoat".
+      |cBody locations|n     - per-part longdesc text (eyes, hands, ...) woven
+                          into your description when looked at.
 
     |wTokens|n let one description read naturally whether a part is paired or
     a lone survivor. Wrap a number-flexible word in braces and it flexes to
     match: a pair renders plural, a single side renders singular.
 
-        @longdesc eyes "deep brown {eyes} that {accent} {their} skin"
+        describe eyes "deep brown {eyes} that {accent} {their} skin"
 
         both eyes  -> deep brown eyes that accent their skin
         one eye    -> a deep brown eye that accents their skin
@@ -571,16 +578,18 @@ class CmdLongdesc(Command):
     reference.
 
     Usage:
-        @longdesc                               - Open the interactive editor
-        @longdesc <location> "<description>"    - Set one location directly
-        @longdesc <location>                    - View one location
-        @longdesc/list                          - List available body locations
-        @longdesc/clear <location>              - Remove a description
+        describe                                - Open the interactive editor
+        describe short <description>            - Set your short description
+        describe keyword <word>                 - Set your sdesc keyword
+        describe <location> "<description>"     - Set one body location
+        describe <location>                     - View one body location
+        describe/list                           - List available body locations
+        describe/clear <location>               - Remove a body location
 
     Staff Usage:
-        @longdesc <character>                              - View another's
-        @longdesc <character> <location> "<description>"   - Set on another
-        @longdesc/clear <character> <location>             - Clear on another
+        describe <character>                              - View another's
+        describe <character> <location> "<description>"   - Set on another
+        describe/clear <character> <location>             - Clear on another
 
     Symmetric pairs (eyes, ears, arms, hands, thighs, shins, feet) are
     shorthands that set, view, and clear BOTH sides at once. When both sides
@@ -588,10 +597,12 @@ class CmdLongdesc(Command):
     right_eye, ...) if you want them to differ (e.g. heterochromia).
 
     Examples:
-        @longdesc face "weathered features with high cheekbones"
-        @longdesc eyes "piercing blue {eyes} flecked with gold"
-        @longdesc right_hand "a prosthetic metal hand, intricately engraved"
-        @longdesc/clear face
+        describe short "a lanky figure with restless hands"
+        describe keyword droog
+        describe face "weathered features with high cheekbones"
+        describe eyes "piercing blue {eyes} flecked with gold"
+        describe right_hand "a prosthetic metal hand, intricately engraved"
+        describe/clear face
 
     Body locations include: hair, head, face, left_eye, right_eye, left_ear,
     right_ear, neck, chest, back, abdomen, groin, left_arm, right_arm,
@@ -601,13 +612,13 @@ class CmdLongdesc(Command):
     integrated with your base description.
     """
 
-    key = "@longdesc"
+    key = "describe"
     aliases = []
     locks = "cmd:all()"
     help_category = "Character"
 
     def func(self):
-        """Execute the longdesc command."""
+        """Execute the describe command."""
         caller = self.caller
         raw_args = self.args.strip()
         
@@ -632,10 +643,30 @@ class CmdLongdesc(Command):
             self._handle_clear(caller, args)
             return
 
+        # Reserved one-off subcommands operate on the caller only. "keyword"
+        # and "short" are never valid body locations nor plausible character
+        # names, so they are safe to claim before staff target resolution.
+        first, _, rest = args.partition(" ")
+        if first.lower() == "keyword":
+            keyword = rest.strip().lower()
+            if not keyword:
+                caller.msg("Usage: |wdescribe keyword <word>|n")
+                return
+            self._set_keyword(caller, keyword)
+            return
+
+        if first.lower() == "short":
+            text = rest.strip()
+            if not text:
+                caller.msg("Usage: |wdescribe short <description>|n")
+                return
+            self._set_short(caller, text)
+            return
+
         # Parse arguments for main command
         if not args:
-            # Bare @longdesc (self) opens the interactive editor menu.
-            _show_longdesc_menu(caller)
+            # Bare describe (self) opens the interactive editor menu.
+            _show_describe_menu(caller)
             return
 
         # Check if this is staff targeting another character
@@ -682,6 +713,67 @@ class CmdLongdesc(Command):
                 self._view_longdesc(caller, target_char, location)
             else:
                 self._show_all_longdescs(caller, target_char)
+
+    def _set_keyword(self, caller, keyword):
+        """Validate and set an sdesc keyword directly (one-off path)."""
+        from world.identity import (
+            get_all_keywords,
+            is_valid_keyword,
+            log_custom_keyword,
+            validate_custom_keyword,
+        )
+
+        gender = caller.gender
+
+        # Approved-list keyword for this gender — accept immediately.
+        if is_valid_keyword(keyword, gender):
+            self._apply_keyword(caller, keyword)
+            return
+
+        # Gender-restricted approved keyword — reject with clear message.
+        if keyword in get_all_keywords():
+            caller.msg(
+                f"|r'{keyword}' is not available for your character.|n\n"
+                f"Use |wdescribe|n to see the full list."
+            )
+            return
+
+        # Not on any approved list — validate as a custom keyword.
+        valid, reason = validate_custom_keyword(keyword)
+        if not valid:
+            caller.msg(f"|r'{keyword}' is not a valid keyword.|n {reason}")
+            return
+
+        # Accept the custom keyword, log it to the catalog.
+        account = caller.account if caller.account else None
+        log_custom_keyword(keyword, caller.key, account=account)
+        self._apply_keyword(caller, keyword)
+
+    def _apply_keyword(self, caller, keyword):
+        """Set the keyword on the caller and show confirmation."""
+        old_keyword = caller.sdesc_keyword
+        caller.sdesc_keyword = keyword
+
+        sdesc = caller.get_sdesc()
+        if old_keyword:
+            caller.msg(
+                f"Changed keyword from |w{old_keyword}|n to |w{keyword}|n.\n"
+                f"You now appear as: |c{sdesc}|n"
+            )
+        else:
+            caller.msg(
+                f"Set keyword to |w{keyword}|n.\n"
+                f"You now appear as: |c{sdesc}|n"
+            )
+
+    def _set_short(self, caller, text):
+        """Set the caller's main (short) description and show a preview."""
+        caller.db.desc = text
+        caller.msg("Set your short description.")
+        rendered = caller._process_description_variables(
+            text, caller, force_third_person=True
+        )
+        caller.msg(f"|xPreview:|n {rendered}")
 
     def _handle_list_locations(self, caller):
         """Show all available body locations for the character."""
@@ -786,7 +878,7 @@ class CmdLongdesc(Command):
             caller.msg(f"'{location}' is not a valid body location for {target_char.get_display_name(caller)}.")
             available = ", ".join(target_char.get_available_locations()[:10])  # Show first 10
             caller.msg(f"Available locations include: {available}...")
-            caller.msg("Use '@longdesc/list' to see all available locations.")
+            caller.msg("Use 'describe/list' to see all available locations.")
             return
 
         # Validate description length
@@ -1063,8 +1155,8 @@ def _longdesc_slot_value(char, slot):
     return char.get_longdesc(slot), False
 
 
-class _LongdescEvMenu(EvMenu):
-    """EvMenu for the longdesc editor: no border separators, no auto options.
+class _DescribeEvMenu(EvMenu):
+    """EvMenu for the describe editor: no border separators, no auto options.
 
     The node text renders its own numbered list and explicit ``x Exit`` row,
     so the default EvMenu decorations (separator rules and the auto-formatted
@@ -1081,37 +1173,72 @@ class _LongdescEvMenu(EvMenu):
         return nodetext
 
 
-def _show_longdesc_menu(caller):
-    """Open the interactive longdesc editor menu for the caller (self only)."""
+def _show_describe_menu(caller):
+    """Open the interactive describe editor menu for the caller (self only)."""
     caller.ndb._longdesc_slots = _build_longdesc_slots(caller)
-    _LongdescEvMenu(
+    _DescribeEvMenu(
         caller,
         {
-            "node_longdesc_list": _node_longdesc_list,
+            "node_describe_list": _node_describe_list,
+            "node_describe_short": _node_describe_short,
+            "node_describe_keyword": _node_describe_keyword,
             "node_longdesc_entry": _node_longdesc_entry,
             "node_longdesc_exit": _node_longdesc_exit,
         },
-        startnode="node_longdesc_list",
-        cmd_on_exit=_longdesc_exit,
+        startnode="node_describe_list",
+        cmd_on_exit=_describe_exit,
     )
 
 
-def _longdesc_exit(caller, menu):
-    """Clean up ndb data when the longdesc menu closes."""
-    for attr in ("_longdesc_slots", "_longdesc_active_slot"):
+def _describe_exit(caller, menu):
+    """Clean up ndb data when the describe menu closes."""
+    for attr in (
+        "_longdesc_slots",
+        "_longdesc_active_slot",
+        "_shortdesc_keywords",
+        "_shortdesc_gender",
+    ):
         if hasattr(caller.ndb, attr):
             delattr(caller.ndb, attr)
 
 
-def _node_longdesc_list(caller, raw_string, **kwargs):
-    """EvMenu node: numbered list of slots with their current values."""
+def _describe_preview_oneline(text, width=60):
+    """Collapse a description to a single, length-capped preview line."""
+    flat = " ".join(text.split())
+    if len(flat) > width:
+        flat = flat[: width - 1] + "\u2026"
+    return flat
+
+
+def _node_describe_list(caller, raw_string, **kwargs):
+    """EvMenu node: short description, keyword, and body-location slots."""
+    from world.grammar import DEFAULT_SDESC_KEYWORDS
+
     slots = getattr(caller.ndb, "_longdesc_slots", None)
     if slots is None:
         slots = _build_longdesc_slots(caller)
         caller.ndb._longdesc_slots = slots
 
-    text = "\n|xSelect a body location by number to set its description.|n\n"
-    for idx, slot in enumerate(slots, 1):
+    text = "\n|xSelect an item by number to edit it.|n\n"
+
+    # 1) Short description (db.desc).
+    desc = caller.db.desc
+    if desc:
+        shown = f"\"{_describe_preview_oneline(desc)}\""
+    else:
+        shown = "|x(empty)|n"
+    text += f"  |w{1:>2}|n |cShort Description:|n {shown}\n"
+
+    # 2) Sdesc keyword.
+    gender = caller.gender
+    default_kw = DEFAULT_SDESC_KEYWORDS.get(gender, "person")
+    current_kw = caller.sdesc_keyword
+    shown_kw = current_kw if current_kw else f"{default_kw} (default)"
+    text += f"  |w{2:>2}|n |cKeyword:|n {shown_kw}\n"
+
+    # 3..N) Body-location longdesc slots.
+    for offset, slot in enumerate(slots):
+        idx = offset + 3
         value, diverged = _longdesc_slot_value(caller, slot)
         if diverged:
             shown = "|y(sides differ \u2014 editing sets both alike)|n"
@@ -1122,12 +1249,12 @@ def _node_longdesc_list(caller, raw_string, **kwargs):
         text += f"  |w{idx:>2}|n |c{slot}:|n {shown}\n"
     text += f"  |w{'x':>2}|n |cExit|n"
 
-    options = ({"key": "_default", "goto": _process_longdesc_slot},)
+    options = ({"key": "_default", "goto": _process_describe_choice},)
     return text, options
 
 
-def _process_longdesc_slot(caller, raw_string, **kwargs):
-    """Goto-callable: pick a slot to edit by number, or exit."""
+def _process_describe_choice(caller, raw_string, **kwargs):
+    """Goto-callable: route the top-level menu selection."""
     choice = raw_string.strip()
     slots = getattr(caller.ndb, "_longdesc_slots", [])
     if not choice:
@@ -1136,18 +1263,25 @@ def _process_longdesc_slot(caller, raw_string, **kwargs):
     if choice.lower() in ("x", "exit"):
         return "node_longdesc_exit"
 
+    last = len(slots) + 2
     try:
-        idx = int(choice) - 1
+        idx = int(choice)
     except ValueError:
-        caller.msg(f"|rEnter a number 1-{len(slots)}, or |yx|r to exit.|n")
+        caller.msg(f"|rEnter a number 1-{last}, or |yx|r to exit.|n")
         return None
 
-    if not (0 <= idx < len(slots)):
-        caller.msg(f"|rInvalid number. Enter 1-{len(slots)}.|n")
-        return None
+    if idx == 1:
+        return "node_describe_short"
+    if idx == 2:
+        return "node_describe_keyword"
 
-    caller.ndb._longdesc_active_slot = slots[idx]
-    return "node_longdesc_entry"
+    slot_idx = idx - 3
+    if 0 <= slot_idx < len(slots):
+        caller.ndb._longdesc_active_slot = slots[slot_idx]
+        return "node_longdesc_entry"
+
+    caller.msg(f"|rInvalid number. Enter 1-{last}.|n")
+    return None
 
 
 def _node_longdesc_exit(caller, raw_string, **kwargs):
@@ -1155,12 +1289,155 @@ def _node_longdesc_exit(caller, raw_string, **kwargs):
     return "", None
 
 
+def _node_describe_short(caller, raw_string, **kwargs):
+    """EvMenu node: prompt for the caller's main (short) description."""
+    desc = caller.db.desc
+    text = "\n|cEditing: Short Description|n\n"
+    if desc:
+        text += f"\n|xCurrent:|n \"{desc}\"\n"
+        rendered = caller._process_description_variables(
+            desc, caller, force_third_person=True
+        )
+        text += f"\n|xPreview:|n {rendered}\n"
+    else:
+        text += "\n|xCurrent:|n (empty)\n"
+
+    text += (
+        "\n|wType your main description \u2014 the first thing others see when"
+        "\nthey look at you. Use |y{their}/{they}|w for pronoun tokens that"
+        "\nadapt to the viewer; plain prose renders verbatim."
+        "\n\nType |yclear|w to remove it, or |yback|w to return unchanged.|n"
+    )
+
+    options = ({"key": "_default", "goto": _process_describe_short},)
+    return text, options
+
+
+def _process_describe_short(caller, raw_string, **kwargs):
+    """Goto-callable: apply the typed short description (or clear/back)."""
+    entry = raw_string.strip()
+    if not entry or entry.lower() == "back":
+        return "node_describe_list"
+
+    if entry.lower() == "clear":
+        caller.db.desc = ""
+        caller.msg("Cleared your short description.")
+        return "node_describe_list"
+
+    caller.db.desc = entry
+    caller.msg("Set your short description.")
+    rendered = caller._process_description_variables(
+        entry, caller, force_third_person=True
+    )
+    caller.msg(f"|xPreview:|n {rendered}")
+    return "node_describe_list"
+
+
+def _node_describe_keyword(caller, raw_string, **kwargs):
+    """EvMenu node: curated keyword list with a current marker."""
+    from world.identity import get_valid_keywords
+    from world.grammar import DEFAULT_SDESC_KEYWORDS
+
+    gender = getattr(caller.ndb, "_shortdesc_gender", caller.gender)
+    keywords = getattr(caller.ndb, "_shortdesc_keywords", None)
+    if keywords is None:
+        keywords = sorted(get_valid_keywords(gender))
+        caller.ndb._shortdesc_keywords = keywords
+        caller.ndb._shortdesc_gender = gender
+
+    current = caller.sdesc_keyword
+    default_kw = DEFAULT_SDESC_KEYWORDS.get(gender, "person")
+    display_current = current if current else f"{default_kw} (default)"
+
+    text = "\n|cEditing: Keyword|n\n"
+    text += f"\n|xCurrent:|n |w{display_current}|n\n\n"
+
+    # Render in 3 columns.
+    col_width = 26
+    cols = 3
+    rows = (len(keywords) + cols - 1) // cols
+    for row in range(rows):
+        line = "  "
+        for col in range(cols):
+            idx = col * rows + row
+            if idx < len(keywords):
+                kw = keywords[idx]
+                num = f"{idx + 1}"
+                marker = "|g*|n" if kw == current else " "
+                entry = f"|w{num:>3}|n{marker}{kw}"
+                padding = col_width - len(f"{num:>3} {kw}")
+                line += entry + " " * max(padding, 1)
+        text += line.rstrip() + "\n"
+
+    text += (
+        "\n|wEnter a number or keyword name to select. For a custom word, use"
+        "\n|ydescribe keyword <word>|w. Type |yback|w to return.|n"
+    )
+
+    options = ({"key": "_default", "goto": _process_describe_keyword},)
+    return text, options
+
+
+def _process_describe_keyword(caller, raw_string, **kwargs):
+    """Goto-callable: apply a numbered/named keyword (or back)."""
+    choice = raw_string.strip()
+    keywords = getattr(caller.ndb, "_shortdesc_keywords", [])
+    if not choice:
+        return None  # Re-display.
+
+    if choice.lower() == "back":
+        return "node_describe_list"
+
+    # Try as a number.
+    try:
+        idx = int(choice) - 1
+        if 0 <= idx < len(keywords):
+            _menu_apply_keyword(caller, keywords[idx])
+            return "node_describe_list"
+        caller.msg(f"|rInvalid number. Enter 1-{len(keywords)}.|n")
+        return None
+    except ValueError:
+        pass
+
+    # Try as a keyword name.
+    if choice.lower() in {kw.lower() for kw in keywords}:
+        keyword = next(kw for kw in keywords if kw.lower() == choice.lower())
+        _menu_apply_keyword(caller, keyword)
+        return "node_describe_list"
+
+    caller.msg(
+        f"|r'{choice}' is not in the list. Use "
+        f"|ydescribe keyword <word>|r for a custom keyword.|n"
+    )
+    return None
+
+
+def _menu_apply_keyword(caller, keyword):
+    """Set the keyword from the menu and show confirmation (stays in menu)."""
+    old = caller.sdesc_keyword
+    caller.sdesc_keyword = keyword
+    sdesc = caller.get_sdesc()
+
+    if old and old != keyword:
+        caller.msg(
+            f"\nChanged keyword from |w{old}|n to |w{keyword}|n."
+            f"\nYou now appear as: |c{sdesc}|n"
+        )
+    elif old == keyword:
+        caller.msg(f"\nKeyword is already |w{keyword}|n.")
+    else:
+        caller.msg(
+            f"\nSet keyword to |w{keyword}|n."
+            f"\nYou now appear as: |c{sdesc}|n"
+        )
+
+
 def _node_longdesc_entry(caller, raw_string, **kwargs):
     """EvMenu node: prompt for the description of the active slot."""
     slot = getattr(caller.ndb, "_longdesc_active_slot", None)
     if not slot:
         # Defensive: reached without a selection — show the list instead.
-        return _node_longdesc_list(caller, raw_string, **kwargs)
+        return _node_describe_list(caller, raw_string, **kwargs)
 
     value, diverged = _longdesc_slot_value(caller, slot)
     text = f"\n|cEditing: {slot}|n\n"
@@ -1187,22 +1464,22 @@ def _process_longdesc_entry(caller, raw_string, **kwargs):
     """Goto-callable: apply the typed description (or clear/back)."""
     slot = getattr(caller.ndb, "_longdesc_active_slot", None)
     if not slot:
-        return "node_longdesc_list"
+        return "node_describe_list"
 
     entry = raw_string.strip()
     if not entry or entry.lower() == "back":
-        return "node_longdesc_list"
+        return "node_describe_list"
 
     locations = _expand_longdesc_pair(caller, slot)
     if not locations:
         caller.msg(f"|r'{slot}' is no longer a valid location.|n")
-        return "node_longdesc_list"
+        return "node_describe_list"
 
     if entry.lower() == "clear":
         for loc in locations:
             caller.set_longdesc(loc, None)
         caller.msg(f"Cleared description for {slot}.")
-        return "node_longdesc_list"
+        return "node_describe_list"
 
     if len(entry) > MAX_DESCRIPTION_LENGTH:
         caller.msg(
@@ -1216,7 +1493,7 @@ def _process_longdesc_entry(caller, raw_string, **kwargs):
     caller.msg(f"Set description for {slot}.")
     for line in _render_longdesc_preview(caller, caller, slot, locations, entry):
         caller.msg(line)
-    return "node_longdesc_list"
+    return "node_describe_list"
 
 
 class CmdSkintone(Command):
@@ -1350,227 +1627,6 @@ class CmdSkintone(Command):
 # ===================================================================
 # IDENTITY SYSTEM COMMANDS
 # ===================================================================
-
-
-class CmdShortdesc(Command):
-    """
-    View or change your short description keyword.
-
-    Usage:
-      @shortdesc               - show current keyword and open selection menu
-      @shortdesc change        - open selection menu
-      @shortdesc <keyword>     - instantly set your keyword
-
-    Your short description (sdesc) is how strangers see you before they
-    learn your name.  It consists of a physical descriptor (derived from
-    your height and build), a keyword (set here), and a distinguishing
-    feature (auto-derived from what you're wielding or wearing).
-
-    Example sdesc: "a lanky man in a Black Trenchcoat"
-                         ^^^
-                      keyword
-
-    Available keywords depend on your character's gender.
-    """
-
-    key = "@shortdesc"
-    aliases = ["shortdesc"]
-    locks = "cmd:all()"
-    help_category = "Character"
-
-    def func(self):
-        caller = self.caller
-        args = self.args.strip().lower()
-
-        if not args or args == "change":
-            self._show_menu(caller)
-            return
-
-        # Instant-set mode
-        self._set_keyword(caller, args)
-
-    def _set_keyword(self, caller, keyword):
-        """Validate and set a keyword directly."""
-        from world.identity import (
-            get_all_keywords,
-            is_valid_keyword,
-            log_custom_keyword,
-            validate_custom_keyword,
-        )
-
-        gender = caller.gender
-
-        # Approved-list keyword for this gender — accept immediately.
-        if is_valid_keyword(keyword, gender):
-            self._apply_keyword(caller, keyword)
-            return
-
-        # Gender-restricted approved keyword — reject with clear message.
-        if keyword in get_all_keywords():
-            caller.msg(
-                f"|r'{keyword}' is not available for your character.|n\n"
-                f"Use |w@shortdesc|n to see the full list."
-            )
-            return
-
-        # Not on any approved list — validate as a custom keyword.
-        valid, reason = validate_custom_keyword(keyword)
-        if not valid:
-            caller.msg(f"|r'{keyword}' is not a valid keyword.|n {reason}")
-            return
-
-        # Accept the custom keyword, log it to the catalog.
-        account = caller.account if caller.account else None
-        log_custom_keyword(keyword, caller.key, account=account)
-        self._apply_keyword(caller, keyword)
-
-    def _apply_keyword(self, caller, keyword):
-        """Set the keyword on the caller and show confirmation."""
-        old_keyword = caller.sdesc_keyword
-        caller.sdesc_keyword = keyword
-
-        sdesc = caller.get_sdesc()
-        if old_keyword:
-            caller.msg(
-                f"Changed keyword from |w{old_keyword}|n to |w{keyword}|n.\n"
-                f"You now appear as: |c{sdesc}|n"
-            )
-        else:
-            caller.msg(
-                f"Set keyword to |w{keyword}|n.\n"
-                f"You now appear as: |c{sdesc}|n"
-            )
-
-    def _show_menu(self, caller):
-        """Open the EvMenu keyword selection interface."""
-        from evennia.utils.evmenu import EvMenu
-        from world.identity import get_valid_keywords
-        from world.grammar import DEFAULT_SDESC_KEYWORDS
-
-        gender = caller.gender
-        valid_keywords = sorted(get_valid_keywords(gender))
-        current = caller.sdesc_keyword
-        sdesc = caller.get_sdesc()
-
-        # Store data for the menu node
-        caller.ndb._shortdesc_keywords = valid_keywords
-        caller.ndb._shortdesc_gender = gender
-
-        EvMenu(
-            caller,
-            {"node_keyword_list": _node_keyword_list},
-            startnode="node_keyword_list",
-            cmd_on_exit=_shortdesc_exit,
-        )
-
-
-def _shortdesc_exit(caller, menu):
-    """Clean up ndb data when the menu closes."""
-    if hasattr(caller.ndb, "_shortdesc_keywords"):
-        del caller.ndb._shortdesc_keywords
-    if hasattr(caller.ndb, "_shortdesc_gender"):
-        del caller.ndb._shortdesc_gender
-
-
-def _node_keyword_list(caller, raw_string, **kwargs):
-    """EvMenu node: display keyword list and accept selection."""
-    from world.identity import get_valid_keywords
-    from world.grammar import DEFAULT_SDESC_KEYWORDS
-
-    gender = getattr(caller.ndb, "_shortdesc_gender", caller.gender)
-    keywords = getattr(caller.ndb, "_shortdesc_keywords", None)
-    if keywords is None:
-        keywords = sorted(get_valid_keywords(gender))
-        caller.ndb._shortdesc_keywords = keywords
-
-    current = caller.sdesc_keyword
-    default_kw = DEFAULT_SDESC_KEYWORDS.get(gender, "person")
-    display_current = current if current else f"{default_kw} (default)"
-    sdesc = caller.get_sdesc()
-
-    # Build numbered list in columns
-    text = f"\n|c=== Short Description Keyword ===|n\n"
-    text += f"\n  Current keyword: |w{display_current}|n"
-    text += f"  |xYou appear as: |c{sdesc}|n|x\n"
-    text += f"\n|yAvailable keywords for your character:|n\n"
-
-    # Render in 3 columns
-    col_width = 26
-    cols = 3
-    rows = (len(keywords) + cols - 1) // cols
-    for row in range(rows):
-        line = "  "
-        for col in range(cols):
-            idx = col * rows + row
-            if idx < len(keywords):
-                kw = keywords[idx]
-                num = f"{idx + 1}"
-                marker = "|g*|n" if kw == current else " "
-                entry = f"|w{num:>3}|n{marker}{kw}"
-                # Pad to column width (accounting for color codes)
-                padding = col_width - len(f"{num:>3} {kw}")
-                line += entry + " " * max(padding, 1)
-        text += line.rstrip() + "\n"
-
-    text += (
-        f"\n|wEnter a number (1-{len(keywords)}) or keyword name to select."
-        f"\nYou can also use |y@shortdesc <word>|w to set a custom keyword."
-        f"\nType |yquit|w to exit.|n"
-    )
-
-    options = ({"key": "_default", "goto": _process_keyword_choice},)
-    return text, options
-
-
-def _process_keyword_choice(caller, raw_string, **kwargs):
-    """Goto-callable: process numbered or text keyword input."""
-    choice = raw_string.strip().lower()
-    keywords = getattr(caller.ndb, "_shortdesc_keywords", [])
-
-    if not choice:
-        return None  # Re-display
-
-    # Try as a number
-    try:
-        idx = int(choice) - 1
-        if 0 <= idx < len(keywords):
-            keyword = keywords[idx]
-            return _apply_keyword(caller, keyword)
-        else:
-            caller.msg(f"|rInvalid number. Enter 1-{len(keywords)}.|n")
-            return None  # Re-display
-    except ValueError:
-        pass
-
-    # Try as a keyword name
-    if choice in {kw.lower() for kw in keywords}:
-        # Find the actual-case keyword
-        keyword = next(kw for kw in keywords if kw.lower() == choice)
-        return _apply_keyword(caller, keyword)
-
-    caller.msg(f"|r'{raw_string.strip()}' is not a valid keyword or number.|n")
-    return None  # Re-display
-
-
-def _apply_keyword(caller, keyword):
-    """Set the keyword and exit the menu."""
-    old = caller.sdesc_keyword
-    caller.sdesc_keyword = keyword
-    sdesc = caller.get_sdesc()
-
-    if old and old != keyword:
-        caller.msg(
-            f"\nChanged keyword from |w{old}|n to |w{keyword}|n."
-            f"\nYou now appear as: |c{sdesc}|n"
-        )
-    elif old == keyword:
-        caller.msg(f"\nKeyword is already |w{keyword}|n.")
-    else:
-        caller.msg(
-            f"\nSet keyword to |w{keyword}|n."
-            f"\nYou now appear as: |c{sdesc}|n"
-        )
-    return None  # Exit menu after setting
 
 
 class CmdRemember(Command):
@@ -2523,7 +2579,7 @@ class CmdAppear(Command):
     sleeve — that's a tell).
 
     A keyword override accepts any keyword from the full catalog
-    (gender restrictions don't apply to disguise).  Use |w@shortdesc|n
+    (gender restrictions don't apply to disguise).  Use |wdescribe keyword|n
     to introduce new keywords to the catalog.
 
     A persona is a previously saved snapshot of all three override axes
@@ -2615,8 +2671,8 @@ class CmdAppear(Command):
         if keyword not in {kw.lower() for kw in get_all_keywords()}:
             caller.msg(
                 f"|r'{raw_keyword}' isn't a recognized keyword or persona.|n  "
-                f"Use |w@shortdesc|n to introduce new keywords to the "
-                f"catalog first."
+                f"Use |wdescribe keyword <word>|n to introduce new keywords "
+                f"to the catalog first."
             )
             return
         self._maybe_break_persona(caller)

--- a/commands/_identity_targeting.py
+++ b/commands/_identity_targeting.py
@@ -212,7 +212,7 @@ def resolve_admin_target(caller, query: str) -> Optional[object]:
 
     Phase 2: global key search via :func:`evennia.search_object`,
     filtered to Character instances.  Provides cross-room reach for
-    staff tooling (``@heal``, ``@longdesc``, ``@testdeath``, etc.).
+    staff tooling (``@heal``, ``describe``, ``@testdeath``, etc.).
 
     Args:
         caller: The staff character issuing the command.

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -16,6 +16,7 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 
 
 from evennia import default_cmds, CmdSet
+from evennia.commands.default.general import CmdSetDesc
 from commands import CmdCharacter
 from commands import CmdInventory
 from commands import CmdAdmin
@@ -35,8 +36,8 @@ from commands.CmdExplosives import (
     CmdClearDetonator,
 )
 from commands.CmdGraffiti import CmdGraffiti, CmdPress
-from commands.CmdCharacter import CmdLongdesc, CmdSkintone
-from commands.CmdCharacter import CmdShortdesc, CmdRemember, CmdForget, CmdRecall, CmdMemory
+from commands.CmdCharacter import CmdDescribe, CmdSkintone
+from commands.CmdCharacter import CmdRemember, CmdForget, CmdRecall, CmdMemory
 from commands.CmdCommunication import CmdSay, CmdWhisper, CmdEmote, CmdDotPose
 from commands.forensics import CmdAutopsy, CmdHarvest, CmdSever
 from world.emote_templates import SOCIAL_COMMANDS
@@ -176,14 +177,17 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdGraffiti())
         self.add(CmdPress())
         
-        # Add longdesc system command
-        self.add(CmdLongdesc())
+        # Add unified describe command (short desc + keyword + longdesc).
+        # Replaces @longdesc, @shortdesc, and Evennia's default setdesc.
+        self.add(CmdDescribe())
+        # Remove Evennia's default setdesc; the Short Description menu option
+        # and `describe short <text>` now own the main description.
+        self.remove(CmdSetDesc())
         
         # Add skintone system command
         self.add(CmdSkintone())
         
         # Add identity system commands
-        self.add(CmdShortdesc())
         self.add(CmdRemember())
         self.add(CmdForget())
         self.add(CmdRecall())

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -32,7 +32,7 @@ What strangers see instead of a name. Composed from observable physical traits:
 ```
 
 - **Physical descriptor** — auto-derived from height × build (immutable without a new sleeve)
-- **Keyword** — player-selected via `@shortdesc`, gender-gated
+- **Keyword** — player-selected via `describe keyword`, gender-gated
 - **Distinguishing feature** — auto-derived from visible state: clothing > hair > nothing
 
 Skintone is deliberately excluded from the sdesc. It appears only in the longdesc when someone `look`s at the character directly.
@@ -119,7 +119,7 @@ Derived from the cross-product of height and build. Players select height and bu
 
 ### Keyword List
 
-Players select their keyword via `@shortdesc`. Keywords are gender-gated: feminine-presenting and gender-neutral keywords are available to female characters, masculine-presenting and gender-neutral to male characters. The `appear` command allows selecting **any keyword from the full catalog** regardless of the character's gender — a male character can disguise as a "woman" and vice versa. This is available to all characters, not restricted by access level.
+Players select their keyword via `describe keyword`. Keywords are gender-gated: feminine-presenting and gender-neutral keywords are available to female characters, masculine-presenting and gender-neutral to male characters. The `appear` command allows selecting **any keyword from the full catalog** regardless of the character's gender — a male character can disguise as a "woman" and vice versa. This is available to all characters, not restricted by access level.
 
 **Feminine-presenting (24):**
 female, girl, lass, woman, matron, grandma, hag, granny, madam, tomboy, chick, gal, chica, vixen, diva, dame, sheila, mona, bimbo, bitch, lady, senorita, chola, devotchka
@@ -179,16 +179,22 @@ Two new attributes selected at character creation:
 
 Combined for display: `"{hair_color} {hair_style} hair"` → `"red dreaded hair"` or shorthand like `"red dreadlocks"`. The exact phrasing can use a small mapping table for natural-sounding combinations (e.g., "dreaded" + color → `"{color} dreadlocks"`).
 
-### `@shortdesc` Command
+### `describe keyword` Command
 
 ```
-@shortdesc <keyword>
+describe keyword <word>
 ```
 
 Changes the player's keyword component only. Validates against the gender-gated keyword list. The physical descriptor and distinguishing feature cannot be set this way — they reflect reality.
 
+The keyword is also editable from the interactive `describe` editor (bare
+`describe` → item `2 Keyword`), which presents the gender-gated catalog as a
+selectable list. The former standalone `@shortdesc` command has been merged
+into `describe` (issue #276); `describe keyword <word>` is its direct
+replacement and the only path for **custom** (off-catalog) keywords.
+
 ```
-> @shortdesc droog
+> describe keyword droog
 You will now appear as "a lanky droog in a leather jacket" to those who don't know you.
 ```
 
@@ -645,7 +651,7 @@ Pronouns must follow the disguise. A character presenting as "a woman" should be
 1. If the character has an active `keyword_override`, look the override up in the runtime keyword catalog (`ServerConfig` entries under keys `identity.feminine_keywords` / `identity.masculine_keywords` / `identity.neutral_keywords`, falling back to the `_DEFAULT_FEMININE_KEYWORDS` / `_DEFAULT_MASCULINE_KEYWORDS` / `_DEFAULT_NEUTRAL_KEYWORDS` frozensets in `world/identity.py` when a key is unset).
    - Match in the feminine list → render as `she/her/hers`.
    - Match in the masculine list → render as `he/him/his`.
-   - Match in the neutral list, **or no match anywhere** (e.g. a custom `@shortdesc` keyword such as `ronin` or `wraith`, which carries no gender metadata in `KeywordEvent`) → render as `they/them/theirs` (singular they).
+   - Match in the neutral list, **or no match anywhere** (e.g. a custom `describe keyword` keyword such as `ronin` or `wraith`, which carries no gender metadata in `KeywordEvent`) → render as `they/them/theirs` (singular they).
 2. If the character has **no** active `keyword_override`, pronouns derive from the character's real `gender` property as today (no behavior change for undisguised characters).
 
 **Implementation surface (engine PR):**
@@ -654,7 +660,7 @@ A single helper, conceptually `get_apparent_gender(char)`, returns one of `"male
 
 **No explicit `gender_override` axis in Phase 3.** Derivation is sufficient: a player who wants to be referred to with a different pronoun set picks a keyword from the desired gender list (the full catalog is available via `appear <keyword>`, gender filter bypassed). An explicit override axis is noted in Future Hooks for the case where a player wants a custom keyword *and* a non-neutral pronoun set.
 
-**Custom-keyword consequence:** Keywords minted via `@shortdesc` (logged as `KeywordEvent` rows) have no gender field on the model. They will always render neutral under this rule. This is acceptable — custom keywords are deliberately ambiguous, and forcing the player to also pick from the gendered catalog if they want gendered pronouns matches the deliberate-tradecraft theme of the system.
+**Custom-keyword consequence:** Keywords minted via `describe keyword` (logged as `KeywordEvent` rows) have no gender field on the model. They will always render neutral under this rule. This is acceptable — custom keywords are deliberately ambiguous, and forcing the player to also pick from the gendered catalog if they want gendered pronouns matches the deliberate-tradecraft theme of the system.
 
 ### Personas — Player-Facing Persona Recall
 
@@ -702,7 +708,7 @@ graph LR
 - `appear` — show current overrides + active persona
 - `appear taller | shorter` — nudge perceived height one step on the `HEIGHTS` scale; refuses at the extremes (an unreachable axis value is itself a tell)
 - `appear thinner | fatter` — same on the `BUILDS` scale
-- `appear <keyword>` — present as the given keyword; validated against the full keyword catalog (gender filter does not apply to disguise). New keywords are introduced via `@shortdesc`, not via `appear`.
+- `appear <keyword>` — present as the given keyword; validated against the full keyword catalog (gender filter does not apply to disguise). New keywords are introduced via `describe keyword`, not via `appear`.
 - `appear <persona name>` — restore a saved persona (clean swap)
 - `stop appearing` — clear all overrides and any adopted-persona pointer; the only canonical clear verb (no aliases)
 - `remember me as <persona name>` — snapshot current overrides as a persona; allowed even with no axes set (intentional — supports saving a baseline)
@@ -1041,7 +1047,7 @@ These are designed into the architecture but not implemented yet:
 - **Voice modulation**: Integration with say/whisper/communication so voice becomes part of the identity signature for observers who can hear but not see (or in addition to visual identification).
 - **Web UI integration**: Personas designed to mirror the planned identity/contact archive system; eventual web UI surface for managing personas, photos, and contact memory in one place.
 - **Salt-acquisition mechanics for true impersonation**: Stolen contact cards, hacked digital identities, and other adversarial means by which an impostor can acquire the original's salt and become auto-recognized as them.
-- **Explicit `gender_override` axis**: Phase 3 derives pronouns from `keyword_override` against the catalog's gender lists, so a player who wants gendered pronouns picks a gendered keyword. A future explicit override axis would let a player pair a custom (`@shortdesc`) keyword with a chosen pronoun set without forcing them through a catalog keyword. Deferred until a real player need surfaces.
+- **Explicit `gender_override` axis**: Phase 3 derives pronouns from `keyword_override` against the catalog's gender lists, so a player who wants gendered pronouns picks a gendered keyword. A future explicit override axis would let a player pair a custom (`describe keyword`) keyword with a chosen pronoun set without forcing them through a catalog keyword. Deferred until a real player need surfaces.
 - **Forensic linking of multiple Apparent UIDs to one real identity**: Investigation gameplay where a sufficiently-resourced investigator can correlate multiple recognition entries (different Apparent UIDs) and infer they refer to the same underlying `sleeve_uid`. Requires evidence-system integration (Phase 5+).
 - **Player-initiated lost-contact pruning**: A `forget --lost` (or similar) command letting players explicitly drop entries the system has marked `lost_contact`. Auto-pruning is deliberately not done; this gives the player the choice.
 
@@ -2420,7 +2426,7 @@ the decay-tier fallback until autopsied.
 | `db.build` | str | Selected at chargen | Chargen | Yes |
 | `db.hair_color` | str or None | Selected at chargen | Chargen / `@hair` | Yes |
 | `db.hair_style` | str or None | Selected at chargen | Chargen / `@hair` | Yes |
-| `db.sdesc_keyword` | str | Selected at chargen | `@shortdesc` | Yes |
+| `db.sdesc_keyword` | str | Selected at chargen | `describe keyword` | Yes |
 
 `sdesc_physical` is not stored — it is computed on access from `height` and `build` via the descriptor table.
 
@@ -2500,7 +2506,8 @@ gender-appropriate default (`DEFAULT_SDESC_KEYWORDS[gender]` —
 `"man"` / `"woman"` / `"person"`) via the lazy fallback in
 `Character.get_sdesc()` (`typeclasses/characters.py`). Players
 customize their keyword at any time post-chargen via the
-`@shortdesc` command, which presents the gender-gated approved list
+`describe keyword` command (or the interactive `describe` editor),
+which presents the gender-gated approved list
 and accepts custom alpha-only keywords (logged as
 `KeywordEvent(event_type="custom_set")`). This keeps the chargen
 flow short and defers a writing decision until the player has
@@ -2519,7 +2526,7 @@ Existing characters need identity attributes backfilled. Use the existing `@fixc
 
 1. Generate `sleeve_uid` for all existing characters (unique per character)
 2. Set default `height` = `"average"`, `build` = `"average"` (or derive from existing descriptive data if possible)
-3. Set default `hair_color` and `hair_style` = `None` (forces players to set via `@shortdesc` or `@hair`)
+3. Set default `hair_color` and `hair_style` = `None` (forces players to set via `describe keyword` or `@hair`)
 4. Set default `sdesc_keyword` based on existing `sex` attribute (`"man"` for male, `"woman"` for female, `"person"` for ambiguous)
 5. Initialize empty `recognition_memory` (Character AttributeProperty; defaults to `{}` automatically)
 6. Staff can run `@fixchar/all` to batch-process
@@ -2553,7 +2560,7 @@ Per-phase detail below.
 - Sdesc composition logic
 - `recognition_memory` AttributeProperty on Character (migration to brain organ deferred — see §Memory Architecture)
 - `Character.get_display_name(looker)` override
-- `@shortdesc` command
+- `describe keyword` command (keyword facet of the unified `describe`)
 - `remember` / `forget` / `recall` / `memory` commands
 - Grammar engine (articles, possessive, objective, self-perception)
 - Chargen updates

--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -122,10 +122,10 @@ propagate to already-existing characters. Their stored dict keeps the key set
 
 Consequences for a body that predates a new default location:
 - The location is absent from `get_available_locations()`, so it never appears
-  in `@longdesc/list`.
-- `has_location()` returns `False` for it, so `@longdesc <new_location> "..."`
+  in `describe/list`.
+- `has_location()` returns `False` for it, so `describe <new_location> "..."`
   is rejected — the player cannot describe a body part they anatomically have.
-- `@longdesc/list` groups by region in **dict-insertion order**, so a key added
+- `describe/list` groups by region in **dict-insertion order**, so a key added
   out of canonical position can also display out of anatomical order.
 
 **Whenever `DEFAULT_LONGDESC_LOCATIONS` gains a location (or its order
@@ -155,26 +155,38 @@ print(f"Updated {updated} characters")
 ```
 
 Because the rebuild also reorders each dict into canonical order, it doubles
-as the fix for `@longdesc/list` showing a backfilled key (e.g. `hair`) out of
+as the fix for `describe/list` showing a backfilled key (e.g. `hair`) out of
 position. This procedure was used to propagate the `hair` location (added in
 #176) to the 155 pre-existing bodies that lacked it.
 
 ## Command Interface
 
-### Primary Command: `@longdesc`
+### Primary Command: `describe`
 
-**Syntax**: `@longdesc <location> "<description>"`
+As of the command-merge work (issue #276), the former `@longdesc`,
+`@shortdesc`, and Evennia's default `setdesc` are unified into a single
+`describe` command (`commands/CmdCharacter.py::CmdDescribe`, `key="describe"`,
+**no aliases**). It owns all three facets of a character's appearance:
+
+- **Short Description** — the main paragraph (`db.desc`), formerly `setdesc`.
+- **Keyword** — the sdesc noun (`sdesc_keyword`), formerly `@shortdesc`.
+- **Body locations** — per-part longdesc text (the subject of this spec).
+
+`describe` is **not** aliased to `desc` to avoid colliding with Evennia's
+builder `@desc`; that decision is deferred.
+
+**Syntax**: `describe <location> "<description>"`
 
 **Examples**:
 ```
-@longdesc face "weathered features with high cheekbones"
-@longdesc left_eye "a piercing blue eye with flecks of gold"
-@longdesc right_eye "a cybernetic replacement with a red LED"
-@longdesc left_hand "calloused hand with dirt under the fingernails"
-@longdesc right_hand "a prosthetic metal hand with intricate engravings"
-@longdesc chest "broad shoulders tapering to a narrow waist"
-@longdesc tail "a long, serpentine tail ending in a barbed tip"
-@longdesc left_wing "a massive feathered wing, midnight black"
+describe face "weathered features with high cheekbones"
+describe left_eye "a piercing blue eye with flecks of gold"
+describe right_eye "a cybernetic replacement with a red LED"
+describe left_hand "calloused hand with dirt under the fingernails"
+describe right_hand "a prosthetic metal hand with intricate engravings"
+describe chest "broad shoulders tapering to a narrow waist"
+describe tail "a long, serpentine tail ending in a barbed tip"
+describe left_wing "a massive feathered wing, midnight black"
 ```
 
 ### Command Behavior
@@ -187,38 +199,61 @@ position. This procedure was used to propagate the `hair` location (added in
 - **Staff override**: Staff with Builder+ permissions can target other characters
 
 ### Command Variations
-- `@longdesc <location>` - View current description for location
-- `@longdesc/list` - List all available body locations for this character
-- `@longdesc` - Open the interactive editor menu (self only)
-- `@longdesc/clear <location>` - Remove description for location (set to None)
+- `describe` - Open the interactive editor menu (self only)
+- `describe short <description>` - Set the short description (`db.desc`)
+- `describe keyword <word>` - Set the sdesc keyword (`sdesc_keyword`)
+- `describe <location> "<description>"` - Set one body location
+- `describe <location>` - View current description for location
+- `describe/list` - List all available body locations for this character
+- `describe/clear <location>` - Remove description for location (set to None)
+
+The `keyword` and `short` sub-words are reserved one-off forms that always
+operate on the caller; they are claimed before staff target resolution because
+they are neither valid body locations nor plausible character names.
 
 #### Staff Commands (Permission Override)
-- `@longdesc <character> <location> "<description>"` - Set longdesc on another character
-- `@longdesc <character>` - View all set longdescs on another character
-- `@longdesc/clear <character> <location>` - Clear specific location on another character
+- `describe <character> <location> "<description>"` - Set longdesc on another character
+- `describe <character>` - View all set longdescs on another character
+- `describe/clear <character> <location>` - Clear specific location on another character
 
 ### Interactive Editor (EvMenu)
 
-Bare `@longdesc` (acting on self) opens an EvMenu-driven editor instead of
-printing a static list. The flow:
+Bare `describe` (acting on self) opens an EvMenu-driven editor instead of
+printing a static list. The list is **flat**: the Short Description and Keyword
+sit above the anatomy slots so a player edits every facet of their appearance
+from one place. The flow:
 
-1. **List node** (`node_longdesc_list`): a one-per-line numbered list of
-   editable **slots** with each slot's current value. Slots are built by
-   `_build_longdesc_slots`:
-   - Symmetric pairs collapse to their shorthand (`eyes`, `hands`, ...) so the
-     dynamic anatomy reads as a clean, compact list.
-   - An asymmetric pair (only one side present) shows that side individually.
-   - Non-pair locations show as themselves; extended anatomy is appended after
-     the anatomical-order entries.
-   - A pair whose two sides currently diverge is flagged (editing it via the
-     shorthand sets both sides alike).
-2. **Entry node** (`node_longdesc_entry`): shows the slot's current value and a
+1. **List node** (`node_describe_list`): a one-per-line numbered list whose
+   first two rows are fixed and the rest are dynamic body slots:
+   - `1 Short Description:` — current `db.desc` (one-line preview, or `(empty)`).
+   - `2 Keyword:` — current `sdesc_keyword`, or the gendered default marked
+     `(default)`.
+   - `3..N` — editable longdesc **slots**, built by `_build_longdesc_slots`:
+     - Symmetric pairs collapse to their shorthand (`eyes`, `hands`, ...) so the
+       dynamic anatomy reads as a clean, compact list.
+     - An asymmetric pair (only one side present) shows that side individually.
+     - Non-pair locations show as themselves; extended anatomy is appended after
+       the anatomical-order entries.
+     - A pair whose two sides currently diverge is flagged (editing it via the
+       shorthand sets both sides alike).
+   - `x Exit` closes the menu cleanly.
+2. **Short Description node** (`node_describe_short`): shows the current value
+   and a live rendered preview (`_process_description_variables` with
+   `force_third_person=True`), then accepts new prose. `clear` empties it,
+   `back`/blank returns unchanged. No length cap is applied to the short
+   description.
+3. **Keyword node** (`node_describe_keyword`): a curated 3-column list of the
+   keywords valid for the character's grammar gender, with the current keyword
+   marked. Selection (by number or name) applies the keyword and **returns to
+   the list** (stays in the menu). Custom keywords are set via the one-off
+   `describe keyword <word>` command.
+4. **Entry node** (`node_longdesc_entry`): shows the slot's current value and a
    token hint, then accepts the new description. `clear` removes it, `back`/blank
    returns unchanged, over-length input is rejected and re-prompts.
-3. On save the description fans out to both sides of a pair (or the single
+5. On save the longdesc fans out to both sides of a pair (or the single
    location) and a **rendered preview** is shown.
 
-The one-off `@longdesc <location> "<description>"` form is retained and shares
+The one-off `describe <location> "<description>"` form is retained and shares
 the same preview output.
 
 ### Rendered Preview
@@ -230,7 +265,7 @@ singular form. Any brace token the resolver does not recognise survives in the
 rendered output and is surfaced as an explicit warning, so typos like
 `{thier}` are caught at authoring time rather than shipped silently. The
 preview fires after both the interactive editor save and the one-off
-`@longdesc <location> "..."` command.
+`describe <location> "..."` command.
 
 
 ## Implementation Details
@@ -362,7 +397,7 @@ Number tokens (see `GRAMMAR_ENGINE_SPEC.md` §Number-Flexing Tokens):
   logged — a stray brace no longer drops the whole substitution (the old
   `str.format` footgun is gone; substitution is now per-token via `re.sub`).
 
-**Authoring convenience — pair shorthand**: `@longdesc <pair> "..."` (where
+**Authoring convenience — pair shorthand**: `describe <pair> "..."` (where
 `<pair>` is a `PAIR_MERGE_KEYS` key: `eyes`, `ears`, `arms`, `hands`,
 `thighs`, `shins`, `feet`) sets, views, and clears **both** sides at once,
 guaranteeing the byte-for-byte identity collapse requires. The pair keys are
@@ -385,7 +420,7 @@ currently done.)
 `_substitute_longdesc_tokens`, and `_pair_base_nouns` in
 `typeclasses/appearance_mixin.py`, consulted by both passes of
 `_get_visible_body_descriptions`; pair shorthand fan-out in
-`CmdLongdesc._expand_pair_locations` (`commands/CmdCharacter.py`).
+`_expand_longdesc_pair` (`commands/CmdCharacter.py`, used by `CmdDescribe`).
 
 ### Visibility Rules ✅
 - **Default**: All body locations are visible unless covered by clothing

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -68,10 +68,10 @@ VALID_LONGDESC_LOCATIONS = set(DEFAULT_LONGDESC_LOCATIONS.keys())
 
 # Symmetric left/right body-part pairs.
 #
-# Maps a plural shorthand key (the form a player types into ``@longdesc`` and
+# Maps a plural shorthand key (the form a player types into ``describe`` and
 # the noun a collapsed pair reads as) to its two underlying ``left_*``/
 # ``right_*`` locations. Serves three roles:
-#   1. Write-convenience: ``@longdesc eyes "..."`` fans the same string out to
+#   1. Write-convenience: ``describe eyes "..."`` fans the same string out to
 #      both ``left_eye`` and ``right_eye``.
 #   2. Collapse aid: identifies which locations may merge into one line.
 #   3. Closed anatomical-noun set: the singular base nouns (eye, ear, ...) are

--- a/world/grammar.py
+++ b/world/grammar.py
@@ -376,7 +376,7 @@ GENDER_MAP: dict[str, str] = {
 
 #: Default sdesc keyword assigned to new characters based on grammar gender.
 #: Used as a fallback when no keyword has been explicitly chosen via
-#: ``@shortdesc``.  Keyed by the grammar gender (output of ``GENDER_MAP``),
+#: ``describe keyword``.  Keyed by the grammar gender (output of ``GENDER_MAP``),
 #: not the raw ``sex`` attribute.
 DEFAULT_SDESC_KEYWORDS: dict[str, str] = {
     "male": "man",

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -102,7 +102,7 @@ HELP_ENTRY_DICTS = [
             literally with its braces intact, so a typo like |w{thier}|n is easy
             to spot in the preview rather than silently vanishing.
 
-            See also: |whelp @longdesc|n.
+            See also: |whelp describe|n.
         """,
     },
     {

--- a/world/identity.py
+++ b/world/identity.py
@@ -1022,7 +1022,7 @@ def get_apparent_gender(char: Any) -> str:
        * Match in the feminine list → ``"female"``
        * Match in the masculine list → ``"male"``
        * Match in the neutral list, **or no match anywhere** (custom
-         ``@shortdesc`` keyword carrying no gender metadata) →
+         ``describe keyword`` keyword carrying no gender metadata) →
          ``"neutral"``.
 
     2. Otherwise, fall through to the character's real grammar gender

--- a/world/models.py
+++ b/world/models.py
@@ -13,7 +13,7 @@ class KeywordEvent(models.Model):
     Tracks three kinds of events:
 
     * **custom_set** — A player set a custom (non-approved) keyword via
-      ``@shortdesc``.
+      ``describe keyword``.
     * **admin_add** — An admin added a keyword to the approved list via
       ``@keywords add``.
     * **admin_remove** — An admin removed a keyword from the approved

--- a/world/tests/test_admin_command_identity.py
+++ b/world/tests/test_admin_command_identity.py
@@ -2,7 +2,7 @@
 Tests for admin command identity targeting (PR δ).
 
 Verifies that staff commands ``@heal``, ``@testdeath``,
-``@testunconscious``, ``@resetmedical``, ``@longdesc`` (set & clear),
+``@testunconscious``, ``@resetmedical``, ``describe`` (set & clear),
 and ``@skintone`` route character-target resolution through
 ``commands._identity_targeting.resolve_admin_target``.
 
@@ -170,32 +170,32 @@ class TestCmdResetMedicalIdentity(TestCase):
 
 
 # ===================================================================
-# CmdLongdesc — set and clear paths both use helper for staff target
+# CmdDescribe — set and clear paths both use helper for staff target
 # ===================================================================
 
 
-class TestCmdLongdescIdentity(TestCase):
-    """``@longdesc`` set + clear use admin helper for staff targeting."""
+class TestCmdDescribeIdentity(TestCase):
+    """``describe`` set + clear use admin helper for staff targeting."""
 
     def _make_set_cmd(self, args='man head "scarred"'):
-        from commands.CmdCharacter import CmdLongdesc
+        from commands.CmdCharacter import CmdDescribe
 
-        cmd = CmdLongdesc()
-        cmd.key = "@longdesc"
+        cmd = CmdDescribe()
+        cmd.key = "describe"
         cmd.args = args
-        cmd.cmdstring = "@longdesc"
+        cmd.cmdstring = "describe"
         cmd.caller = MagicMock()
         cmd.caller.locks.check_lockstring = lambda *a, **kw: True
         cmd.caller.location = MagicMock()
         return cmd
 
     def _make_clear_cmd(self, args="man head"):
-        from commands.CmdCharacter import CmdLongdesc
+        from commands.CmdCharacter import CmdDescribe
 
-        cmd = CmdLongdesc()
-        cmd.key = "@longdesc"
+        cmd = CmdDescribe()
+        cmd.key = "describe"
         cmd.args = args
-        cmd.cmdstring = "@longdesc"
+        cmd.cmdstring = "describe"
         cmd.caller = MagicMock()
         cmd.caller.locks.check_lockstring = lambda *a, **kw: True
         cmd.caller.location = MagicMock()
@@ -233,7 +233,7 @@ class TestCmdLongdescIdentity(TestCase):
         target.longdesc = MagicMock()
         mock_resolve.return_value = target
         cmd = self._make_clear_cmd(args="man head")
-        # Force the clear path: @longdesc with no quotes is clear.
+        # Force the clear path: describe with no quotes is the view/clear path.
         try:
             cmd.func()
         except Exception:

--- a/world/tests/test_describe_menu.py
+++ b/world/tests/test_describe_menu.py
@@ -1,0 +1,305 @@
+"""Unit tests for the unified ``describe`` editor: combined list, short
+description, and keyword nodes.
+
+The ``describe`` command merges the former ``@longdesc``, ``@shortdesc``, and
+Evennia ``setdesc`` surfaces into one flat EvMenu whose top-level list is::
+
+    1  Short Description   (db.desc)
+    2  Keyword             (sdesc_keyword)
+    3..N  body-location longdesc slots
+    x  Exit
+
+These tests cover the combined-list numbering/rendering, the Short
+Description node (set / clear / back / preview and the one-off
+``describe short`` path), the Keyword node (numbered + named selection,
+return-to-list behaviour, invalid input), and verify that Evennia's default
+``setdesc`` is removed from the character cmdset.
+
+Run via::
+
+    evennia test world.tests.test_describe_menu
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from typeclasses.appearance_mixin import AppearanceMixin
+from commands.CmdCharacter import (
+    CmdDescribe,
+    _build_longdesc_slots,
+    _menu_apply_keyword,
+    _node_describe_keyword,
+    _node_describe_list,
+    _node_describe_short,
+    _process_describe_keyword,
+    _process_describe_short,
+)
+from world.combat.constants import DEFAULT_LONGDESC_LOCATIONS
+
+
+class _DB:
+    skintone = None
+    desc = ""
+
+
+class _NDB:
+    pass
+
+
+class FakeChar(AppearanceMixin):
+    """Lightweight host implementing the describe surface + real renderer.
+
+    Provides the longdesc storage surface (as in ``test_longdesc_menu``) plus
+    the short-description (``db.desc``) and keyword (``sdesc_keyword`` /
+    ``get_sdesc``) surfaces the unified editor reads and mutates.
+    """
+
+    gender = "neutral"
+
+    def __init__(self, locations=None, *, desc="", sdesc_keyword=None):
+        self._longdesc = dict(locations or {})
+        self.db = _DB()
+        self.db.desc = desc
+        self.ndb = _NDB()
+        self.sdesc_keyword = sdesc_keyword
+        self.messages = []
+
+    # --- longdesc storage surface -------------------------------------
+    def get_available_locations(self):
+        return list(self._longdesc.keys())
+
+    def has_location(self, loc):
+        return loc in self._longdesc
+
+    def get_longdesc(self, loc):
+        return self._longdesc.get(loc)
+
+    def set_longdesc(self, loc, desc):
+        if loc not in self._longdesc:
+            return False
+        self._longdesc[loc] = desc
+        return True
+
+    # --- identity surface ---------------------------------------------
+    def get_display_name(self, looker):
+        return "Vasquez"
+
+    def get_sdesc(self):
+        return f"a {self.sdesc_keyword or 'person'}"
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def _full_body(**kwargs):
+    return FakeChar(DEFAULT_LONGDESC_LOCATIONS, **kwargs)
+
+
+# =====================================================================
+# Combined top-level list rendering
+# =====================================================================
+
+
+class ListNodeTests(TestCase):
+
+    def test_short_description_is_item_one(self):
+        char = _full_body(desc="a lanky figure")
+        text, _ = _node_describe_list(char, "")
+        self.assertIn("Short Description:", text)
+        self.assertIn("a lanky figure", text)
+        # The "1" marker precedes the Short Description label.
+        self.assertLess(text.index(" 1"), text.index("Short Description:"))
+
+    def test_empty_short_description_shows_placeholder(self):
+        char = _full_body(desc="")
+        text, _ = _node_describe_list(char, "")
+        # Placeholder appears on the Short Description line.
+        sd_line = next(
+            ln for ln in text.splitlines() if "Short Description:" in ln
+        )
+        self.assertIn("(empty)", sd_line)
+
+    def test_keyword_is_item_two_with_default_marker(self):
+        char = _full_body(sdesc_keyword=None)
+        text, _ = _node_describe_list(char, "")
+        kw_line = next(ln for ln in text.splitlines() if "Keyword:" in ln)
+        self.assertIn(" 2", kw_line)
+        self.assertIn("(default)", kw_line)
+
+    def test_keyword_shows_current_value(self):
+        char = _full_body(sdesc_keyword="droog")
+        text, _ = _node_describe_list(char, "")
+        kw_line = next(ln for ln in text.splitlines() if "Keyword:" in ln)
+        self.assertIn("droog", kw_line)
+        self.assertNotIn("(default)", kw_line)
+
+    def test_body_slots_start_at_three(self):
+        char = _full_body()
+        slots = _build_longdesc_slots(char)
+        text, _ = _node_describe_list(char, "")
+        # First body slot is numbered 3 (1=short, 2=keyword).
+        first_slot = slots[0]
+        slot_line = next(
+            ln for ln in text.splitlines() if f"{first_slot}:" in ln
+        )
+        self.assertIn(" 3", slot_line)
+
+    def test_exit_row_present(self):
+        char = _full_body()
+        text, _ = _node_describe_list(char, "")
+        self.assertIn("Exit", text)
+        exit_line = next(ln for ln in text.splitlines() if "Exit" in ln)
+        self.assertIn("x", exit_line)
+
+
+# =====================================================================
+# Short Description node
+# =====================================================================
+
+
+class ShortDescNodeTests(TestCase):
+
+    def test_set_stores_desc_and_returns_to_list(self):
+        char = _full_body(desc="")
+        result = _process_describe_short(char, "a weathered traveller")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.db.desc, "a weathered traveller")
+        self.assertTrue(any("Preview" in m for m in char.messages))
+
+    def test_clear_empties_desc(self):
+        char = _full_body(desc="something")
+        result = _process_describe_short(char, "clear")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.db.desc, "")
+        self.assertTrue(any("Cleared" in m for m in char.messages))
+
+    def test_back_returns_unchanged(self):
+        char = _full_body(desc="original")
+        result = _process_describe_short(char, "back")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.db.desc, "original")
+
+    def test_blank_returns_unchanged(self):
+        char = _full_body(desc="original")
+        result = _process_describe_short(char, "   ")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.db.desc, "original")
+
+    def test_node_shows_current_and_preview(self):
+        char = _full_body(desc="a quiet figure")
+        text, _ = _node_describe_short(char, "")
+        self.assertIn("Short Description", text)
+        self.assertIn("a quiet figure", text)
+        self.assertIn("Preview", text)
+
+    def test_one_off_set_short_stores_and_previews(self):
+        char = _full_body(desc="")
+        cmd = CmdDescribe()
+        cmd.caller = char
+        cmd._set_short(char, "a grizzled merc")
+        self.assertEqual(char.db.desc, "a grizzled merc")
+        self.assertTrue(any("Preview" in m for m in char.messages))
+
+
+# =====================================================================
+# Keyword node
+# =====================================================================
+
+
+class KeywordMenuTests(TestCase):
+
+    def _char_with_keywords(self, keywords=("dude", "person", "punk")):
+        char = _full_body(sdesc_keyword=None)
+        char.ndb._shortdesc_keywords = sorted(keywords)
+        char.ndb._shortdesc_gender = "neutral"
+        return char
+
+    def test_numbered_selection_applies_and_returns(self):
+        char = self._char_with_keywords()
+        # sorted -> ["dude", "person", "punk"]; choice "1" => "dude".
+        result = _process_describe_keyword(char, "1")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.sdesc_keyword, "dude")
+
+    def test_named_selection_applies(self):
+        char = self._char_with_keywords()
+        result = _process_describe_keyword(char, "punk")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.sdesc_keyword, "punk")
+
+    def test_named_selection_is_case_insensitive(self):
+        char = self._char_with_keywords()
+        result = _process_describe_keyword(char, "PUNK")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.sdesc_keyword, "punk")
+
+    def test_back_returns_to_list_unchanged(self):
+        char = self._char_with_keywords()
+        result = _process_describe_keyword(char, "back")
+        self.assertEqual(result, "node_describe_list")
+        self.assertIsNone(char.sdesc_keyword)
+
+    def test_out_of_range_number_redisplays(self):
+        char = self._char_with_keywords()
+        result = _process_describe_keyword(char, "99")
+        self.assertIsNone(result)
+        self.assertIsNone(char.sdesc_keyword)
+        self.assertTrue(any("Invalid number" in m for m in char.messages))
+
+    def test_unknown_name_redisplays_with_custom_hint(self):
+        char = self._char_with_keywords()
+        result = _process_describe_keyword(char, "zzyzx")
+        self.assertIsNone(result)
+        self.assertIsNone(char.sdesc_keyword)
+        self.assertTrue(
+            any("describe keyword" in m for m in char.messages)
+        )
+
+    def test_blank_redisplays(self):
+        char = self._char_with_keywords()
+        result = _process_describe_keyword(char, "")
+        self.assertIsNone(result)
+
+    def test_menu_apply_sets_keyword_and_confirms(self):
+        char = _full_body(sdesc_keyword=None)
+        _menu_apply_keyword(char, "droog")
+        self.assertEqual(char.sdesc_keyword, "droog")
+        self.assertTrue(any("droog" in m for m in char.messages))
+
+    def test_menu_apply_reports_unchanged_when_same(self):
+        char = _full_body(sdesc_keyword="droog")
+        _menu_apply_keyword(char, "droog")
+        self.assertEqual(char.sdesc_keyword, "droog")
+        self.assertTrue(any("already" in m for m in char.messages))
+
+    def test_node_renders_valid_keyword_catalog(self):
+        # Exercises the DB-backed get_valid_keywords path (defaults under the
+        # test runner). Neutral gender => all approved keywords available.
+        char = _full_body(sdesc_keyword=None)
+        text, _ = _node_describe_keyword(char, "")
+        self.assertIn("Keyword", text)
+        self.assertIsNotNone(getattr(char.ndb, "_shortdesc_keywords", None))
+        self.assertTrue(len(char.ndb._shortdesc_keywords) > 0)
+
+
+# =====================================================================
+# Cmdset wiring — Evennia's setdesc is replaced by describe
+# =====================================================================
+
+
+class CmdsetWiringTests(TestCase):
+
+    def test_describe_present_and_setdesc_removed(self):
+        from commands.default_cmdsets import CharacterCmdSet
+
+        cmdset = CharacterCmdSet()
+        cmdset.at_cmdset_creation()
+        keys = {cmd.key for cmd in cmdset.commands}
+        self.assertIn("describe", keys)
+        self.assertNotIn("setdesc", keys)
+
+    def test_describe_has_no_aliases(self):
+        cmd = CmdDescribe()
+        self.assertEqual(cmd.key, "describe")
+        self.assertEqual(list(cmd.aliases), [])

--- a/world/tests/test_identity.py
+++ b/world/tests/test_identity.py
@@ -1404,7 +1404,7 @@ class TestGetApparentGender(TestCase):
         self.assertEqual(get_apparent_gender(char), "neutral")
 
     def test_custom_keyword_override_returns_neutral(self) -> None:
-        """Custom ``@shortdesc`` keywords carry no gender metadata → neutral."""
+        """Custom ``describe keyword`` keywords carry no gender metadata → neutral."""
         from world.identity import get_apparent_gender
 
         char = _SignatureMockCharacter(

--- a/world/tests/test_identity_commands.py
+++ b/world/tests/test_identity_commands.py
@@ -1,5 +1,5 @@
 """
-Tests for Identity Phase 1c commands: ``@shortdesc`` and the memory
+Tests for Identity Phase 1c commands: ``describe keyword`` and the memory
 verb cluster (``remember``, ``forget``, ``recall``, ``memory``).
 
 Tests the command logic and helper functions using mocks.
@@ -100,29 +100,29 @@ def _make_character(
 
 
 # ===================================================================
-# @shortdesc — instant set mode
+# describe keyword — instant set mode
 # ===================================================================
 
 
 class TestShortdescInstantSet(TestCase):
-    """Test the _set_keyword logic from CmdShortdesc."""
+    """Test the _set_keyword logic from CmdDescribe."""
 
     def test_valid_keyword_sets_attribute(self):
         """Valid keyword is stored on the character."""
-        from commands.CmdCharacter import CmdShortdesc
+        from commands.CmdCharacter import CmdDescribe
 
         char = _make_character(sex="male", sdesc_keyword=None)
-        cmd = CmdShortdesc()
+        cmd = CmdDescribe()
         cmd.caller = char
         cmd._set_keyword(char, "dude")
         self.assertEqual(char.sdesc_keyword, "dude")
 
     def test_invalid_keyword_rejected(self):
         """Non-alpha keyword produces error and does not change attribute."""
-        from commands.CmdCharacter import CmdShortdesc
+        from commands.CmdCharacter import CmdDescribe
 
         char = _make_character(sex="male", sdesc_keyword="man")
-        cmd = CmdShortdesc()
+        cmd = CmdDescribe()
         cmd.caller = char
         cmd._set_keyword(char, "cyber2punk")
         # Should still be "man"
@@ -133,7 +133,7 @@ class TestShortdescInstantSet(TestCase):
 
     def test_gender_gated_keyword(self):
         """Male character cannot use a feminine-only keyword."""
-        from commands.CmdCharacter import CmdShortdesc
+        from commands.CmdCharacter import CmdDescribe
         from world.identity import (
             _DEFAULT_FEMININE_KEYWORDS,
             _DEFAULT_NEUTRAL_KEYWORDS,
@@ -144,7 +144,7 @@ class TestShortdescInstantSet(TestCase):
         kw = sorted(feminine_only)[0]
 
         char = _make_character(sex="male", sdesc_keyword="man")
-        cmd = CmdShortdesc()
+        cmd = CmdDescribe()
         cmd.caller = char
         cmd._set_keyword(char, kw)
         # Should still be "man"
@@ -155,11 +155,11 @@ class TestShortdescInstantSet(TestCase):
 
     def test_neutral_keyword_available_to_all(self):
         """Neutral keywords are available to any gender."""
-        from commands.CmdCharacter import CmdShortdesc
+        from commands.CmdCharacter import CmdDescribe
 
         for sex in ("male", "female", "ambiguous"):
             char = _make_character(sex=sex, sdesc_keyword=None)
-            cmd = CmdShortdesc()
+            cmd = CmdDescribe()
             cmd.caller = char
             cmd._set_keyword(char, "person")
             self.assertEqual(char.sdesc_keyword, "person")
@@ -180,7 +180,7 @@ class TestShortdescInstantSet(TestCase):
 
 
 # ===================================================================
-# @shortdesc — EvMenu helpers
+# describe keyword — EvMenu helpers
 # ===================================================================
 
 
@@ -189,36 +189,36 @@ class TestShortdescMenuHelpers(TestCase):
 
     def test_numeric_selection(self):
         """Entering a number selects the keyword at that index."""
-        from commands.CmdCharacter import _process_keyword_choice
+        from commands.CmdCharacter import _process_describe_keyword
 
         char = _make_character(sex="male", sdesc_keyword=None)
         keywords = ["bro", "dude", "guy", "man", "person"]
         char.ndb._shortdesc_keywords = keywords
 
         # Select "2" → "dude" (index 1)
-        result = _process_keyword_choice(char, "2")
+        result = _process_describe_keyword(char, "2")
         self.assertEqual(char.sdesc_keyword, "dude")
 
     def test_name_selection(self):
         """Entering a keyword name selects it."""
-        from commands.CmdCharacter import _process_keyword_choice
+        from commands.CmdCharacter import _process_describe_keyword
 
         char = _make_character(sex="male", sdesc_keyword=None)
         keywords = ["bro", "dude", "guy", "man", "person"]
         char.ndb._shortdesc_keywords = keywords
 
-        result = _process_keyword_choice(char, "guy")
+        result = _process_describe_keyword(char, "guy")
         self.assertEqual(char.sdesc_keyword, "guy")
 
     def test_invalid_number_rejected(self):
         """Out-of-range number shows error and returns None (re-display)."""
-        from commands.CmdCharacter import _process_keyword_choice
+        from commands.CmdCharacter import _process_describe_keyword
 
         char = _make_character(sex="male", sdesc_keyword="man")
         keywords = ["bro", "dude", "guy", "man", "person"]
         char.ndb._shortdesc_keywords = keywords
 
-        result = _process_keyword_choice(char, "99")
+        result = _process_describe_keyword(char, "99")
         self.assertIsNone(result)
         char.msg.assert_called()
         msg_text = char.msg.call_args[0][0]
@@ -226,26 +226,26 @@ class TestShortdescMenuHelpers(TestCase):
 
     def test_invalid_text_rejected(self):
         """Unknown text shows error and returns None (re-display)."""
-        from commands.CmdCharacter import _process_keyword_choice
+        from commands.CmdCharacter import _process_describe_keyword
 
         char = _make_character(sex="male", sdesc_keyword="man")
         keywords = ["bro", "dude", "guy", "man", "person"]
         char.ndb._shortdesc_keywords = keywords
 
-        result = _process_keyword_choice(char, "xyzinvalid")
+        result = _process_describe_keyword(char, "xyzinvalid")
         self.assertIsNone(result)
         char.msg.assert_called()
         msg_text = char.msg.call_args[0][0]
-        self.assertIn("not a valid keyword", msg_text)
+        self.assertIn("not in the list", msg_text)
 
     def test_empty_input_redisplays(self):
         """Empty input returns None (re-display)."""
-        from commands.CmdCharacter import _process_keyword_choice
+        from commands.CmdCharacter import _process_describe_keyword
 
         char = _make_character(sex="male", sdesc_keyword="man")
         char.ndb._shortdesc_keywords = ["man"]
 
-        result = _process_keyword_choice(char, "   ")
+        result = _process_describe_keyword(char, "   ")
         self.assertIsNone(result)
 
 
@@ -1346,7 +1346,7 @@ class TestLostContactRenderAnnotation(TestCase):
 
 
 # ===================================================================
-# @shortdesc — custom keyword acceptance
+# describe keyword — custom keyword acceptance
 # ===================================================================
 
 
@@ -1455,14 +1455,14 @@ class TestAlsoKnownAsRendering(TestCase):
 
 
 
-    """Test that @shortdesc accepts arbitrary valid custom keywords."""
+    """Test that describe keyword accepts arbitrary valid custom keywords."""
 
     def test_custom_keyword_accepted(self):
         """A novel alpha-only word is accepted as a custom keyword."""
-        from commands.CmdCharacter import CmdShortdesc
+        from commands.CmdCharacter import CmdDescribe
 
         char = _make_character(sex="male", sdesc_keyword="man")
-        cmd = CmdShortdesc()
+        cmd = CmdDescribe()
         cmd.caller = char
         with patch("world.identity.log_custom_keyword") as mock_log:
             cmd._set_keyword(char, "ronin")
@@ -1473,10 +1473,10 @@ class TestAlsoKnownAsRendering(TestCase):
 
     def test_custom_keyword_not_logged_for_approved(self):
         """Approved keywords bypass the catalog entirely."""
-        from commands.CmdCharacter import CmdShortdesc
+        from commands.CmdCharacter import CmdDescribe
 
         char = _make_character(sex="male", sdesc_keyword="man")
-        cmd = CmdShortdesc()
+        cmd = CmdDescribe()
         cmd.caller = char
         with patch("world.identity.log_custom_keyword") as mock_log:
             cmd._set_keyword(char, "dude")
@@ -1485,10 +1485,10 @@ class TestAlsoKnownAsRendering(TestCase):
 
     def test_custom_keyword_rejected_with_digits(self):
         """Keywords containing digits are rejected."""
-        from commands.CmdCharacter import CmdShortdesc
+        from commands.CmdCharacter import CmdDescribe
 
         char = _make_character(sex="male", sdesc_keyword="man")
-        cmd = CmdShortdesc()
+        cmd = CmdDescribe()
         cmd.caller = char
         cmd._set_keyword(char, "r0nin")
         self.assertEqual(char.sdesc_keyword, "man")
@@ -1497,17 +1497,17 @@ class TestAlsoKnownAsRendering(TestCase):
 
     def test_custom_keyword_rejected_too_short(self):
         """Single-character keyword is rejected."""
-        from commands.CmdCharacter import CmdShortdesc
+        from commands.CmdCharacter import CmdDescribe
 
         char = _make_character(sex="male", sdesc_keyword="man")
-        cmd = CmdShortdesc()
+        cmd = CmdDescribe()
         cmd.caller = char
         cmd._set_keyword(char, "x")
         self.assertEqual(char.sdesc_keyword, "man")
 
     def test_custom_keyword_shows_sdesc(self):
         """Confirmation message includes updated sdesc."""
-        from commands.CmdCharacter import CmdShortdesc
+        from commands.CmdCharacter import CmdDescribe
 
         char = _make_character(
             sex="male",
@@ -1515,7 +1515,7 @@ class TestAlsoKnownAsRendering(TestCase):
             build="lean",
             sdesc_keyword="man",
         )
-        cmd = CmdShortdesc()
+        cmd = CmdDescribe()
         cmd.caller = char
         with patch("world.identity.log_custom_keyword"):
             cmd._set_keyword(char, "samurai")
@@ -1796,7 +1796,7 @@ class TestCmdAppearKeyword(TestCase):
         self.assertIsNone(caller.db.keyword_override)
         msg = caller.msg.call_args[0][0]
         self.assertIn("isn't a recognized keyword", msg)
-        self.assertIn("@shortdesc", msg)
+        self.assertIn("describe", msg)
 
 
 # ===================================================================

--- a/world/tests/test_longdesc_menu.py
+++ b/world/tests/test_longdesc_menu.py
@@ -1,9 +1,9 @@
-"""Unit tests for the interactive ``@longdesc`` editor and shared helpers.
+"""Unit tests for the ``describe`` longdesc helpers and editor nodes.
 
 Covers slot construction (pair collapse, asymmetric sides, extended anatomy,
 anatomical ordering), slot-value reporting (matching vs diverged pairs),
 pair expansion, the rendered preview (plural + singular + stray-token
-warning), and the menu node goto-callables (slot selection and entry
+warning), and the menu node goto-callables (top-level routing and entry
 application, including ``clear``/``back``/length-guard paths).
 
 Run via::
@@ -22,8 +22,8 @@ from commands.CmdCharacter import (
     _longdesc_slot_value,
     _node_longdesc_entry,
     _node_longdesc_exit,
+    _process_describe_choice,
     _process_longdesc_entry,
-    _process_longdesc_slot,
     _render_longdesc_preview,
 )
 from world.combat.constants import (
@@ -34,6 +34,7 @@ from world.combat.constants import (
 
 class _DB:
     skintone = None
+    desc = ""
 
 
 class _NDB:
@@ -44,6 +45,7 @@ class FakeChar(AppearanceMixin):
     """Lightweight host implementing the longdesc surface + real renderer."""
 
     gender = "neutral"
+    sdesc_keyword = None
 
     def __init__(self, locations):
         self._longdesc = dict(locations)
@@ -70,6 +72,9 @@ class FakeChar(AppearanceMixin):
     # --- identity surface ---------------------------------------------
     def get_display_name(self, looker):
         return "Vasquez"
+
+    def get_sdesc(self):
+        return f"a {self.sdesc_keyword or 'person'}"
 
     def msg(self, text):
         self.messages.append(text)
@@ -207,26 +212,37 @@ class SlotSelectionTests(TestCase):
         char.ndb._longdesc_slots = _build_longdesc_slots(char)
         return char
 
+    def test_short_description_choice_routes_to_short_node(self):
+        char = self._char_with_slots()
+        result = _process_describe_choice(char, "1")
+        self.assertEqual(result, "node_describe_short")
+
+    def test_keyword_choice_routes_to_keyword_node(self):
+        char = self._char_with_slots()
+        result = _process_describe_choice(char, "2")
+        self.assertEqual(result, "node_describe_keyword")
+
     def test_valid_number_targets_slot(self):
         char = self._char_with_slots()
-        result = _process_longdesc_slot(char, "1")
+        # Slots begin at 3 (1=short desc, 2=keyword).
+        result = _process_describe_choice(char, "3")
         self.assertEqual(result, "node_longdesc_entry")
         self.assertEqual(char.ndb._longdesc_active_slot, char.ndb._longdesc_slots[0])
 
     def test_out_of_range_redisplays(self):
         char = self._char_with_slots()
-        result = _process_longdesc_slot(char, "999")
+        result = _process_describe_choice(char, "999")
         self.assertIsNone(result)
         self.assertTrue(any("Invalid number" in m for m in char.messages))
 
     def test_non_numeric_redisplays(self):
         char = self._char_with_slots()
-        result = _process_longdesc_slot(char, "eyes")
+        result = _process_describe_choice(char, "eyes")
         self.assertIsNone(result)
 
     def test_exit_choice_routes_to_end_node(self):
         char = self._char_with_slots()
-        result = _process_longdesc_slot(char, "x")
+        result = _process_describe_choice(char, "x")
         self.assertEqual(result, "node_longdesc_exit")
         self.assertFalse(hasattr(char.ndb, "_longdesc_active_slot"))
 
@@ -248,7 +264,7 @@ class EntryApplicationTests(TestCase):
     def test_set_fans_out_to_both_sides(self):
         char = self._char_editing("eyes")
         result = _process_longdesc_entry(char, "brown {eyes}")
-        self.assertEqual(result, "node_longdesc_list")
+        self.assertEqual(result, "node_describe_list")
         self.assertEqual(char.get_longdesc("left_eye"), "brown {eyes}")
         self.assertEqual(char.get_longdesc("right_eye"), "brown {eyes}")
         self.assertTrue(any("Preview" in m for m in char.messages))
@@ -258,7 +274,7 @@ class EntryApplicationTests(TestCase):
         char.set_longdesc("left_eye", "x")
         char.set_longdesc("right_eye", "x")
         result = _process_longdesc_entry(char, "clear")
-        self.assertEqual(result, "node_longdesc_list")
+        self.assertEqual(result, "node_describe_list")
         self.assertIsNone(char.get_longdesc("left_eye"))
         self.assertIsNone(char.get_longdesc("right_eye"))
 
@@ -266,14 +282,14 @@ class EntryApplicationTests(TestCase):
         char = self._char_editing("face")
         char.set_longdesc("face", "original")
         result = _process_longdesc_entry(char, "back")
-        self.assertEqual(result, "node_longdesc_list")
+        self.assertEqual(result, "node_describe_list")
         self.assertEqual(char.get_longdesc("face"), "original")
 
     def test_blank_returns_unchanged(self):
         char = self._char_editing("face")
         char.set_longdesc("face", "original")
         result = _process_longdesc_entry(char, "   ")
-        self.assertEqual(result, "node_longdesc_list")
+        self.assertEqual(result, "node_describe_list")
         self.assertEqual(char.get_longdesc("face"), "original")
 
     def test_too_long_redisplays_entry(self):
@@ -288,4 +304,4 @@ class EntryApplicationTests(TestCase):
         char.ndb._longdesc_slots = _build_longdesc_slots(char)
         # No active slot set: node falls back to rendering the list.
         text, options = _node_longdesc_entry(char, "")
-        self.assertIn("Select a body location", text)
+        self.assertIn("Select an item", text)


### PR DESCRIPTION
## Summary
- Merge `@longdesc`, `@shortdesc`, and Evennia's default `setdesc` into a single `describe` command (`key="describe"`, no aliases) that owns all three facets of a character's appearance.
- Bare `describe` opens one **flat** EvMenu: `1 Short Description` (`db.desc`), `2 Keyword` (`sdesc_keyword`), and `3..N` anatomy longdesc slots, plus `x Exit`.
- Add one-off subcommands `describe short <text>` and `describe keyword <word>`; remove Evennia's `setdesc` from the character cmdset.
- Update `LONGDESC_SYSTEM_SPEC.md` and `IDENTITY_RECOGNITION_SPEC.md` to document the merged command, new layout, removed `setdesc`, and subcommand grammar.

## Menu layout
- **Short Description node** — current value + live rendered preview (`force_third_person=True`); `clear`/`back`; no length cap.
- **Keyword node** — curated 3-column gender-gated catalog with current marker; numbered/named selection applies and returns to the list. Custom keywords via `describe keyword <word>`.
- **Anatomy slots** — unchanged longdesc behaviour (pair collapse, divergence flag, rendered preview).

## Decisions
- No `desc` alias (avoids colliding with Evennia builder `@desc`; deferred).
- `keyword`/`short` sub-words are reserved one-offs claimed before staff target resolution.

## Tests
- New `world/tests/test_describe_menu.py` (24 tests): combined-list numbering/rendering, short-description set/clear/back/preview + one-off, keyword numbered/named/invalid/back + apply, and cmdset wiring (describe present, setdesc removed).
- Updated `test_longdesc_menu`, `test_identity_commands`, `test_admin_command_identity`, `test_identity` for the renamed command/nodes.
- Full `world` suite green: **1465 tests OK**.

Closes #276