### PR TITLE
Fix longdesc tokens conjugating non-pair body nouns as verbs

### DIFF
--- a/specs/GRAMMAR_ENGINE_SPEC.md
+++ b/specs/GRAMMAR_ENGINE_SPEC.md
@@ -108,11 +108,13 @@ def flex_verb(word: str, number: str) -> str:
 
 **Noun-vs-verb autodetect (deterministic, closed-set rule)** — performed by
 the caller (`AppearanceMixin._substitute_longdesc_tokens`), not by POS
-tagging: a braced word is a **noun** iff its singular is in the closed set of
-pair base nouns (`eye`, `ear`, `arm`, `hand`, `thigh`, `shin`, `foot`,
-derived from `world.combat.constants.PAIR_MERGE_KEYS`), optionally preceded by
-`a`/`an`. Any other braced **single** word is a **verb**. A multi-word token
-that is not an article+pair-noun is left literal and logged.
+tagging: a braced word is a **noun** iff its singular is in the flex-noun
+vocabulary — the pair base nouns (`eye`, `ear`, `arm`, `hand`, `thigh`,
+`shin`, `foot`, derived from `world.combat.constants.PAIR_MERGE_KEYS`) plus the
+curated `world.combat.constants.LONGDESC_FLEX_NOUNS` body-noun set (`leg`,
+`shoulder`, `hip`, `knee`, …) — optionally preceded by `a`/`an`. Any other
+braced **single** word is a **verb**. A multi-word token that is not an
+article+noun is left literal and logged.
 
 **Scope** — only brace words whose grammatical number tracks the body part
 (the part noun and verbs whose subject **is** that part). A main-clause verb

--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -385,10 +385,14 @@ heuristic noun-substitution and no `None` fallback; any identical pair
 collapses.
 
 Number tokens (see `GRAMMAR_ENGINE_SPEC.md` §Number-Flexing Tokens):
-- **Noun** — a braced word whose singular is a known pair noun (`eye`, `ear`,
-  `arm`, `hand`, `thigh`, `shin`, `foot`; the closed set derived from
-  `PAIR_MERGE_KEYS`). `{eye}`/`{eyes}` flex the noun; `{an eye}` additionally
-  drops the article on plural and re-agrees `a`/`an` on singular.
+- **Noun** — a braced word whose singular is in the flex-noun vocabulary: the
+  pair nouns (`eye`, `ear`, `arm`, `hand`, `thigh`, `shin`, `foot`; derived
+  from `PAIR_MERGE_KEYS`) **plus** the curated `LONGDESC_FLEX_NOUNS` body-noun
+  set (`leg`, `shoulder`, `hip`, `knee`, …). `{eye}`/`{eyes}` flex the noun;
+  `{an eye}` additionally drops the article on plural and re-agrees `a`/`an` on
+  singular. `LONGDESC_FLEX_NOUNS` is **vocabulary only** — its words are not
+  anatomy locations, not pairs, and not `describe` shorthands; extend it freely
+  as players find gaps.
 - **Verb** — any other braced single word, conjugated to agree with the part:
   plural `{accent}`/`{are}`, singular `{accents}`/`{is}`. Only brace verbs
   whose subject **is** the body part; a main-clause verb agreeing with the
@@ -417,7 +421,7 @@ currently done.)
 
 **Implementation**: `_build_paired_longdesc_collapse`,
 `_merge_paired_location`, `_get_severed_locations`,
-`_substitute_longdesc_tokens`, and `_pair_base_nouns` in
+`_substitute_longdesc_tokens`, and `_flex_noun_vocabulary` in
 `typeclasses/appearance_mixin.py`, consulted by both passes of
 `_get_visible_body_descriptions`; pair shorthand fan-out in
 `_expand_longdesc_pair` (`commands/CmdCharacter.py`, used by `CmdDescribe`).

--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -549,15 +549,18 @@ class AppearanceMixin:
         return '\n\n'.join(parts)
 
     @staticmethod
-    def _pair_base_nouns():
-        """Return the closed set of singular pair nouns (eye, ear, hand, ...).
+    def _flex_noun_vocabulary():
+        """Return the singular nouns a longdesc number-token flexes as a noun.
 
-        These are the only words a longdesc number-token treats as the body's
+        Two sources, unioned: the symmetric pair nouns derived from
+        ``PAIR_MERGE_KEYS`` (eye, ear, arm, hand, thigh, shin, foot) plus the
+        curated ``LONGDESC_FLEX_NOUNS`` body-noun vocabulary (leg, shoulder,
+        hip, ...). These are the only words a number-token treats as the body's
         part noun; any other braced single word is treated as a verb.
         """
-        from world.combat.constants import PAIR_MERGE_KEYS
+        from world.combat.constants import LONGDESC_FLEX_NOUNS, PAIR_MERGE_KEYS
 
-        nouns = set()
+        nouns = set(LONGDESC_FLEX_NOUNS)
         for left_loc, _right_loc in PAIR_MERGE_KEYS.values():
             # "left_eye" -> "eye", "left_foot" -> "foot"
             nouns.add(left_loc.split("_", 1)[1])
@@ -568,9 +571,9 @@ class AppearanceMixin:
 
         Resolution order per ``{token}``:
           1. Pronoun / name token present in *variables*.
-          2. Number-flexible body-part token: a noun if its singular is a
-             known pair noun (optionally with a leading ``a``/``an``), else a
-             single-word verb. Both are flexed to *number*.
+          2. Number-flexible body-part token: a noun if its singular is in
+             the flex-noun vocabulary (optionally with a leading ``a``/``an``),
+             else a single-word verb. Both are flexed to *number*.
           3. Anything else is left literal (the brace is preserved) and logged.
 
         Args:
@@ -584,7 +587,7 @@ class AppearanceMixin:
         import re
         from world.grammar import flex_noun, flex_verb, singularize_noun
 
-        pair_nouns = self._pair_base_nouns()
+        flex_nouns = self._flex_noun_vocabulary()
         article_re = re.compile(r"^(?:a|an)\s+(.+)$", re.IGNORECASE)
 
         def _resolve(match):
@@ -599,10 +602,10 @@ class AppearanceMixin:
             core = art_match.group(1) if art_match else body
             if " " not in core:
                 core_base = singularize_noun(core).lower()
-                if core_base in pair_nouns:
+                if core_base in flex_nouns:
                     return flex_noun(body, number)
                 if art_match is None:
-                    # Single bareword that is not a pair noun → verb.
+                    # Single bareword that is not a flex noun → verb.
                     return flex_verb(body, number)
 
             # 3. Unrecognised token: leave it literal, but log it so authors

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -90,6 +90,31 @@ PAIR_MERGE_KEYS = {
     "feet": ("left_foot", "right_foot"),
 }
 
+# Curated vocabulary of singular body nouns the longdesc token resolver should
+# number-flex as NOUNS rather than conjugate as verbs. This is VOCABULARY ONLY:
+# these words are NOT anatomy locations, NOT render keys, and NOT `describe`
+# slot shorthands (that role belongs to PAIR_MERGE_KEYS, which must stay
+# anchored to real left_*/right_* slots). The resolver singularizes a token
+# before lookup, so every entry here is the SINGULAR form.
+#
+# Why a curated allow-list rather than "treat every braced word as a noun":
+# many body words are noun/verb homographs ("accent", "frame", "taper") that
+# longdescs legitimately brace as VERBS (e.g. "{eyes} that {accent} {their}
+# skin"). Defaulting unknown words to verbs keeps those working; we only add
+# words that are unambiguously body nouns. Extend freely as players find gaps.
+LONGDESC_FLEX_NOUNS = {
+    # Limbs / joints not covered by a PAIR_MERGE_KEYS pair.
+    "leg", "shoulder", "hip", "knee", "elbow", "wrist", "ankle",
+    "calf", "forearm", "thumb", "finger", "toe",
+    # Face / head detail.
+    "lip", "nostril", "eyebrow", "eyelash", "cheek", "dimple", "jaw", "tooth",
+    # Torso / rear.
+    "rib", "collarbone", "knuckle", "nail",
+    "breast", "tit", "nipple", "ass", "buttock",
+    # Skin features authors commonly pluralize.
+    "scar", "freckle",
+}
+
 # Anatomical display order (head to toe). The head region mirrors how an
 # observer organically registers a person: hair first, then the eyes, after
 # which the head and face resolve into view, then the ears and neck.

--- a/world/tests/test_paired_longdesc_collapse.py
+++ b/world/tests/test_paired_longdesc_collapse.py
@@ -254,6 +254,54 @@ class TokenRenderTests(TestCase):
         out = self.obj.render("{arms} that {flex}", "singular")
         self.assertEqual(out, "arm that flexes")
 
+    def test_curated_body_noun_flexes_as_noun(self):
+        # "leg" is not a PAIR_MERGE_KEYS pair, but is in LONGDESC_FLEX_NOUNS,
+        # so it must flex as a noun (plural->legs, singular->leg) rather than
+        # being conjugated backwards as a verb.
+        self.assertEqual(
+            self.obj.render("long {legs}", "plural"), "long legs"
+        )
+        self.assertEqual(
+            self.obj.render("long {legs}", "singular"), "long leg"
+        )
+
+    def test_curated_body_nouns_assorted(self):
+        for noun_plural, noun_singular in (
+            ("shoulders", "shoulder"),
+            ("hips", "hip"),
+            ("knees", "knee"),
+            ("eyebrows", "eyebrow"),
+        ):
+            self.assertEqual(
+                self.obj.render(f"broad {{{noun_plural}}}", "plural"),
+                f"broad {noun_plural}",
+            )
+            self.assertEqual(
+                self.obj.render(f"broad {{{noun_plural}}}", "singular"),
+                f"broad {noun_singular}",
+            )
+
+    def test_curated_body_noun_with_article(self):
+        # Article form drops the article on plural, keeps it on singular.
+        self.assertEqual(
+            self.obj.render("{a leg} {is} bare", "plural"), "legs are bare"
+        )
+        self.assertEqual(
+            self.obj.render("{a leg} {is} bare", "singular"), "a leg is bare"
+        )
+
+    def test_non_body_word_still_verb(self):
+        # A word that is neither a flex noun nor in variables stays a verb,
+        # preserving the {accent}-style braced-verb behavior.
+        self.assertEqual(
+            self.obj.render("{eyes} that {gleam}", "plural"),
+            "eyes that gleam",
+        )
+        self.assertEqual(
+            self.obj.render("{eyes} that {gleam}", "singular"),
+            "eye that gleams",
+        )
+
     def test_untokenized_prose_verbatim(self):
         text = "a milky white orb, unseeing."
         self.assertEqual(self.obj.render(text, "plural"), text)


### PR DESCRIPTION
## Summary
- Braced longdesc nouns like `{legs}`, `{shoulders}`, `{hips}` were mis-rendered: the resolver only treated a word as a noun if its singular was a `PAIR_MERGE_KEYS` pair noun (eye/ear/arm/hand/thigh/shin/foot), so everything else fell through to `flex_verb` and conjugated backwards.
- `PAIR_MERGE_KEYS` can't simply absorb these words — it does double duty as the `describe` slot-editing shorthand, anchored to real `left_*`/`right_*` anatomy. Adding `left_leg` etc. would create phantom slots.
- Fix decouples the grammar vocabulary from the anatomy-pair map: new curated `LONGDESC_FLEX_NOUNS` body-noun set, unioned into the flex-noun vocabulary (`_pair_base_nouns` -> `_flex_noun_vocabulary`). Verb-as-default is unchanged, so braced verbs like `{accent}`/`{are}` still work.

## Tests
- Added `TokenRenderTests` cases for `{legs}`, `{shoulders}`, `{hips}`, `{knees}`, `{eyebrows}`, `{a leg}` article form, and a regression that non-body words still conjugate as verbs.
- Full `world` suite: 1469 passing.

## Specs
- Updated `LONGDESC_SYSTEM_SPEC.md` and `GRAMMAR_ENGINE_SPEC.md` noun-vocabulary descriptions.

Closes #278