### PR TITLE
Restyle describe editor menu for readability

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1210,6 +1210,15 @@ def _describe_preview_oneline(text, width=60):
     return flat
 
 
+def _describe_slot_label(slot):
+    """Human-readable label for a slot, display-only.
+
+    ``left_eye`` -> ``Left Eye``, ``eyes`` -> ``Eyes``. The internal slot
+    string is unchanged; this is purely for the menu's appearance.
+    """
+    return " ".join(word.capitalize() for word in slot.split("_"))
+
+
 def _node_describe_list(caller, raw_string, **kwargs):
     """EvMenu node: short description, keyword, and body-location slots."""
     from world.grammar import DEFAULT_SDESC_KEYWORDS
@@ -1219,35 +1228,43 @@ def _node_describe_list(caller, raw_string, **kwargs):
         slots = _build_longdesc_slots(caller)
         caller.ndb._longdesc_slots = slots
 
-    text = "\n|xSelect an item by number to edit it.|n\n"
+    # Build (number, label, value) rows first so the label column can be
+    # aligned and the "::" separators line up for readability.
+    rows = []
 
     # 1) Short description (db.desc).
     desc = caller.db.desc
     if desc:
-        shown = f"\"{_describe_preview_oneline(desc)}\""
+        shown = _describe_preview_oneline(desc)
     else:
-        shown = "|x(empty)|n"
-    text += f"  |w{1:>2}|n |cShort Description:|n {shown}\n"
+        shown = "(empty)"
+    rows.append(("1", "Short Description", shown))
 
     # 2) Sdesc keyword.
     gender = caller.gender
     default_kw = DEFAULT_SDESC_KEYWORDS.get(gender, "person")
     current_kw = caller.sdesc_keyword
     shown_kw = current_kw if current_kw else f"{default_kw} (default)"
-    text += f"  |w{2:>2}|n |cKeyword:|n {shown_kw}\n"
+    rows.append(("2", "Keyword", shown_kw))
 
     # 3..N) Body-location longdesc slots.
     for offset, slot in enumerate(slots):
         idx = offset + 3
         value, diverged = _longdesc_slot_value(caller, slot)
         if diverged:
-            shown = "|y(sides differ \u2014 editing sets both alike)|n"
+            shown = "(sides differ \u2014 editing sets both alike)"
         elif value:
-            shown = f"\"{value}\""
+            shown = value
         else:
-            shown = "|x(empty)|n"
-        text += f"  |w{idx:>2}|n |c{slot}:|n {shown}\n"
-    text += f"  |w{'x':>2}|n |cExit|n"
+            shown = "(empty)"
+        rows.append((str(idx), _describe_slot_label(slot), shown))
+
+    label_width = max(len(label) for _num, label, _val in rows)
+
+    text = "\n|wDescribe \u2014 select a number to edit.|n\n"
+    for num, label, value in rows:
+        text += f"  |w{num:>2}.|n |W{label:<{label_width}} :: {value}|n\n"
+    text += f"  |w{'x':>2}.|n |WExit|n"
 
     options = ({"key": "_default", "goto": _process_describe_choice},)
     return text, options
@@ -1292,21 +1309,21 @@ def _node_longdesc_exit(caller, raw_string, **kwargs):
 def _node_describe_short(caller, raw_string, **kwargs):
     """EvMenu node: prompt for the caller's main (short) description."""
     desc = caller.db.desc
-    text = "\n|cEditing: Short Description|n\n"
+    text = "\n|wEditing: Short Description|n\n"
     if desc:
-        text += f"\n|xCurrent:|n \"{desc}\"\n"
+        text += f"\n|WCurrent:|n |W{desc}|n\n"
         rendered = caller._process_description_variables(
             desc, caller, force_third_person=True
         )
-        text += f"\n|xPreview:|n {rendered}\n"
+        text += f"\n|WPreview:|n |W{rendered}|n\n"
     else:
-        text += "\n|xCurrent:|n (empty)\n"
+        text += "\n|WCurrent: (empty)|n\n"
 
     text += (
-        "\n|wType your main description \u2014 the first thing others see when"
-        "\nthey look at you. Use |y{their}/{they}|w for pronoun tokens that"
+        "\n|WType your main description \u2014 the first thing others see when"
+        "\nthey look at you. Use {their}/{they} for pronoun tokens that"
         "\nadapt to the viewer; plain prose renders verbatim."
-        "\n\nType |yclear|w to remove it, or |yback|w to return unchanged.|n"
+        "\n\nType clear to remove it, or back to return unchanged.|n"
     )
 
     options = ({"key": "_default", "goto": _process_describe_short},)
@@ -1329,7 +1346,7 @@ def _process_describe_short(caller, raw_string, **kwargs):
     rendered = caller._process_description_variables(
         entry, caller, force_third_person=True
     )
-    caller.msg(f"|xPreview:|n {rendered}")
+    caller.msg(f"|WPreview:|n |W{rendered}|n")
     return "node_describe_list"
 
 
@@ -1349,8 +1366,8 @@ def _node_describe_keyword(caller, raw_string, **kwargs):
     default_kw = DEFAULT_SDESC_KEYWORDS.get(gender, "person")
     display_current = current if current else f"{default_kw} (default)"
 
-    text = "\n|cEditing: Keyword|n\n"
-    text += f"\n|xCurrent:|n |w{display_current}|n\n\n"
+    text = "\n|wEditing: Keyword|n\n"
+    text += f"\n|WCurrent: {display_current}|n\n\n"
 
     # Render in 3 columns.
     col_width = 26
@@ -1363,15 +1380,15 @@ def _node_describe_keyword(caller, raw_string, **kwargs):
             if idx < len(keywords):
                 kw = keywords[idx]
                 num = f"{idx + 1}"
-                marker = "|g*|n" if kw == current else " "
-                entry = f"|w{num:>3}|n{marker}{kw}"
+                marker = "|W*|n" if kw == current else " "
+                entry = f"|w{num:>3}|n{marker}|W{kw}|n"
                 padding = col_width - len(f"{num:>3} {kw}")
                 line += entry + " " * max(padding, 1)
         text += line.rstrip() + "\n"
 
     text += (
-        "\n|wEnter a number or keyword name to select. For a custom word, use"
-        "\n|ydescribe keyword <word>|w. Type |yback|w to return.|n"
+        "\n|WEnter a number or keyword name to select. For a custom word, use"
+        "\ndescribe keyword <word>. Type back to return.|n"
     )
 
     options = ({"key": "_default", "goto": _process_describe_keyword},)
@@ -1440,20 +1457,20 @@ def _node_longdesc_entry(caller, raw_string, **kwargs):
         return _node_describe_list(caller, raw_string, **kwargs)
 
     value, diverged = _longdesc_slot_value(caller, slot)
-    text = f"\n|cEditing: {slot}|n\n"
+    text = f"\n|wEditing: {_describe_slot_label(slot)}|n\n"
     if diverged:
-        text += "\n|ySides currently differ; saving here sets both alike.|n\n"
+        text += "\n|WSides currently differ; saving here sets both alike.|n\n"
     elif value:
-        text += f"\n|xCurrent:|n \"{value}\"\n"
+        text += f"\n|WCurrent: {value}|n\n"
     else:
-        text += "\n|xCurrent:|n (empty)\n"
+        text += "\n|WCurrent: (empty)|n\n"
 
     text += (
-        "\n|wType the new description. Brace number-flexible words so a pair"
+        "\n|WType the new description. Brace number-flexible words so a pair"
         "\nreads plural and a lone side reads singular \u2014 e.g."
-        "\n  |ydeep brown {eyes} that {accent} {their} skin|w"
-        "\nUse |y{their}/{they}|w for pronouns; plain prose renders verbatim."
-        "\n\nType |yclear|w to remove it, or |yback|w to return unchanged.|n"
+        "\n  deep brown {eyes} that {accent} {their} skin"
+        "\nUse {their}/{they} for pronouns; plain prose renders verbatim."
+        "\n\nType clear to remove it, or back to return unchanged.|n"
     )
 
     options = ({"key": "_default", "goto": _process_longdesc_entry},)

--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -224,10 +224,18 @@ sit above the anatomy slots so a player edits every facet of their appearance
 from one place. The flow:
 
 1. **List node** (`node_describe_list`): a one-per-line numbered list whose
-   first two rows are fixed and the rest are dynamic body slots:
-   - `1 Short Description:` — current `db.desc` (one-line preview, or `(empty)`).
-   - `2 Keyword:` — current `sdesc_keyword`, or the gendered default marked
-     `(default)`.
+   first two rows are fixed and the rest are dynamic body slots. Rows render
+   as `N. Label :: value` with the label column aligned so the `::` separators
+   line up. The menu is rendered all-white for readability: in this palette
+   `|w` is bold white and `|W` is unbold white, so **only the row numbers and
+   section headers are bold**; labels, values, and placeholders are unbold
+   white. Values are shown unquoted, and slot labels are capitalized for
+   display (`left_eye` -> `Left Eye`, `eyes` -> `Eyes`) via
+   `_describe_slot_label` — the internal slot strings are unchanged.
+   - `1. Short Description :: …` — current `db.desc` (one-line preview, or
+     `(empty)`).
+   - `2. Keyword :: …` — current `sdesc_keyword`, or the gendered default
+     marked `(default)`.
    - `3..N` — editable longdesc **slots**, built by `_build_longdesc_slots`:
      - Symmetric pairs collapse to their shorthand (`eyes`, `hands`, ...) so the
        dynamic anatomy reads as a clean, compact list.
@@ -236,7 +244,7 @@ from one place. The flow:
        the anatomical-order entries.
      - A pair whose two sides currently diverge is flagged (editing it via the
        shorthand sets both sides alike).
-   - `x Exit` closes the menu cleanly.
+   - `x. Exit` closes the menu cleanly.
 2. **Short Description node** (`node_describe_short`): shows the current value
    and a live rendered preview (`_process_description_variables` with
    `force_third_person=True`), then accepts new prose. `clear` empties it,

--- a/world/tests/test_describe_menu.py
+++ b/world/tests/test_describe_menu.py
@@ -4,10 +4,10 @@ description, and keyword nodes.
 The ``describe`` command merges the former ``@longdesc``, ``@shortdesc``, and
 Evennia ``setdesc`` surfaces into one flat EvMenu whose top-level list is::
 
-    1  Short Description   (db.desc)
-    2  Keyword             (sdesc_keyword)
-    3..N  body-location longdesc slots
-    x  Exit
+     1. Short Description :: (db.desc)
+     2. Keyword           :: (sdesc_keyword)
+     3..N. body-location longdesc slots (capitalized labels)
+     x. Exit
 
 These tests cover the combined-list numbering/rendering, the Short
 Description node (set / clear / back / preview and the one-off
@@ -28,6 +28,7 @@ from typeclasses.appearance_mixin import AppearanceMixin
 from commands.CmdCharacter import (
     CmdDescribe,
     _build_longdesc_slots,
+    _describe_slot_label,
     _menu_apply_keyword,
     _node_describe_keyword,
     _node_describe_list,
@@ -106,31 +107,31 @@ class ListNodeTests(TestCase):
     def test_short_description_is_item_one(self):
         char = _full_body(desc="a lanky figure")
         text, _ = _node_describe_list(char, "")
-        self.assertIn("Short Description:", text)
+        self.assertIn("Short Description", text)
         self.assertIn("a lanky figure", text)
         # The "1" marker precedes the Short Description label.
-        self.assertLess(text.index(" 1"), text.index("Short Description:"))
+        self.assertLess(text.index(" 1"), text.index("Short Description"))
 
     def test_empty_short_description_shows_placeholder(self):
         char = _full_body(desc="")
         text, _ = _node_describe_list(char, "")
         # Placeholder appears on the Short Description line.
         sd_line = next(
-            ln for ln in text.splitlines() if "Short Description:" in ln
+            ln for ln in text.splitlines() if "Short Description" in ln
         )
         self.assertIn("(empty)", sd_line)
 
     def test_keyword_is_item_two_with_default_marker(self):
         char = _full_body(sdesc_keyword=None)
         text, _ = _node_describe_list(char, "")
-        kw_line = next(ln for ln in text.splitlines() if "Keyword:" in ln)
+        kw_line = next(ln for ln in text.splitlines() if "Keyword" in ln)
         self.assertIn(" 2", kw_line)
         self.assertIn("(default)", kw_line)
 
     def test_keyword_shows_current_value(self):
         char = _full_body(sdesc_keyword="droog")
         text, _ = _node_describe_list(char, "")
-        kw_line = next(ln for ln in text.splitlines() if "Keyword:" in ln)
+        kw_line = next(ln for ln in text.splitlines() if "Keyword" in ln)
         self.assertIn("droog", kw_line)
         self.assertNotIn("(default)", kw_line)
 
@@ -138,12 +139,23 @@ class ListNodeTests(TestCase):
         char = _full_body()
         slots = _build_longdesc_slots(char)
         text, _ = _node_describe_list(char, "")
-        # First body slot is numbered 3 (1=short, 2=keyword).
-        first_slot = slots[0]
+        # First body slot is numbered 3 (1=short, 2=keyword) and shown with
+        # its capitalized display label.
+        first_label = _describe_slot_label(slots[0])
         slot_line = next(
-            ln for ln in text.splitlines() if f"{first_slot}:" in ln
+            ln for ln in text.splitlines() if first_label in ln
         )
         self.assertIn(" 3", slot_line)
+
+    def test_rows_use_double_colon_separator(self):
+        char = _full_body(desc="a lanky figure")
+        text, _ = _node_describe_list(char, "")
+        sd_line = next(
+            ln for ln in text.splitlines() if "Short Description" in ln
+        )
+        self.assertIn("::", sd_line)
+        # Values are no longer wrapped in quotes.
+        self.assertNotIn('"a lanky figure"', text)
 
     def test_exit_row_present(self):
         char = _full_body()

--- a/world/tests/test_longdesc_menu.py
+++ b/world/tests/test_longdesc_menu.py
@@ -304,4 +304,4 @@ class EntryApplicationTests(TestCase):
         char.ndb._longdesc_slots = _build_longdesc_slots(char)
         # No active slot set: node falls back to rendering the list.
         text, options = _node_longdesc_entry(char, "")
-        self.assertIn("Select an item", text)
+        self.assertIn("select a number to edit", text)


### PR DESCRIPTION
## Summary
- The interactive `describe` editor menu is now all-white for readability. In this palette `|w` is bold white and `|W` is unbold white, so only the row numbers and section headers are bold; labels, values, and placeholders are unbold white.
- New row format `N. Label :: value` with the label column aligned (the `::` separators line up) and values no longer wrapped in quotes.
- Slot labels capitalized for display (`left_eye` -> `Left Eye`, `eyes` -> `Eyes`) via a new display-only `_describe_slot_label`; internal slot strings are unchanged.
- Sub-nodes (short description, keyword grid, longdesc entry) restyled to match.

## Tests
- Updated format-coupled assertions in `test_describe_menu.py` and one in `test_longdesc_menu.py`; added a `::`/unquoted-value check.
- Full `world` suite: 1470 passing.

## Notes
Pure presentation change; no behavior/logic touched. `LONGDESC_SYSTEM_SPEC.md` sample rows updated.

Closes #280