### PR TITLE
Tweak describe menu header text and spacing

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1261,7 +1261,7 @@ def _node_describe_list(caller, raw_string, **kwargs):
 
     label_width = max(len(label) for _num, label, _val in rows)
 
-    text = "\n|wDescribe \u2014 select a number to edit.|n\n"
+    text = "\n|wSelect a number to edit|n\n\n"
     for num, label, value in rows:
         text += f"  |w{num:>2}.|n |W{label:<{label_width}} :: {value}|n\n"
     text += f"  |w{'x':>2}.|n |WExit|n"

--- a/world/tests/test_longdesc_menu.py
+++ b/world/tests/test_longdesc_menu.py
@@ -304,4 +304,4 @@ class EntryApplicationTests(TestCase):
         char.ndb._longdesc_slots = _build_longdesc_slots(char)
         # No active slot set: node falls back to rendering the list.
         text, options = _node_longdesc_entry(char, "")
-        self.assertIn("select a number to edit", text)
+        self.assertIn("Select a number to edit", text)


### PR DESCRIPTION
## Summary
- Header now reads "Select a number to edit" (was "Describe — select a number to edit.").
- Added a blank line between the header and the first list row.

Refs #280