### PR TITLE
Whiten remaining describe preview output

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -773,7 +773,7 @@ class CmdDescribe(Command):
         rendered = caller._process_description_variables(
             text, caller, force_third_person=True
         )
-        caller.msg(f"|xPreview:|n {rendered}")
+        caller.msg(f"|WPreview:|n |W{rendered}|n")
 
     def _handle_list_locations(self, caller):
         """Show all available body locations for the character."""
@@ -1078,17 +1078,17 @@ def _render_longdesc_preview(viewer, target_char, location, locations, descripti
         unresolved.update(brace_re.findall(rendered))
         return rendered
 
-    lines = ["|wPreview:|n"]
+    lines = ["|WPreview:|n"]
     if is_pair:
-        lines.append(f"  |cboth sides:|n {_render('plural')}")
-        lines.append(f"  |clone side:|n {_render('singular')}")
+        lines.append(f"  |Wboth sides:|n |W{_render('plural')}|n")
+        lines.append(f"  |Wlone side:|n |W{_render('singular')}|n")
     else:
-        lines.append(f"  {_render('singular')}")
+        lines.append(f"  |W{_render('singular')}|n")
 
     if unresolved:
         tokens = ", ".join(sorted(unresolved))
         lines.append(
-            f"  |yUnrecognized token(s) left literal: {tokens}|n"
+            f"  |WUnrecognized token(s) left literal: {tokens}|n"
         )
     return lines
 

--- a/world/tests/test_longdesc_menu.py
+++ b/world/tests/test_longdesc_menu.py
@@ -181,7 +181,7 @@ class PreviewTests(TestCase):
         )
         # "face" is not a pair noun -> treated as verb-ish flex, but render
         # must succeed and show exactly one preview body line.
-        body_lines = [ln for ln in lines if not ln.startswith("|wPreview")]
+        body_lines = [ln for ln in lines if not ln.startswith("|WPreview")]
         self.assertEqual(len(body_lines), 1)
 
     def test_unrecognized_token_warned(self):


### PR DESCRIPTION
## Summary
- Whitens the two preview code paths the #280 menu restyle missed.
- `_set_short` preview: `|xPreview:|n` (grey) -> bold/unbold white.
- `_render_longdesc_preview`: `|wPreview:|n` header kept white; `|cboth sides:|n`/`|clone side:|n` (cyan) and `|yUnrecognized token(s)` (yellow) -> unbold white `|W`.
- Updates the format-coupled body-line assertion in `test_longdesc_menu.py`.

## Testing
- `evennia test world.tests.test_describe_menu world.tests.test_longdesc_menu` (54 OK)
- Full `evennia test world` suite: 1470 OK
- Render-checked preview output via `evennia shell` — all lines now emit only `|W`/`|n`.

Closes #283