### PR TITLE
Whiten describe help surface + standardize full-sentence examples

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -556,20 +556,24 @@ class CmdDescribe(Command):
     text, and you get an instant preview of how others will see it.
 
     Your appearance has three parts:
-      |cShort Description|n  - the main paragraph shown when others look at you.
-      |cKeyword|n            - the noun strangers see in your sdesc, e.g. the
+      |wShort Description|n  - the main paragraph shown when others look at you.
+      |wKeyword|n            - the noun strangers see in your sdesc, e.g. the
                           "|wman|n" in "a lanky man in a Black Trenchcoat".
-      |cBody locations|n     - per-part longdesc text (eyes, hands, ...) woven
+      |wBody locations|n     - per-part longdesc text (eyes, hands, ...) woven
                           into your description when looked at.
+
+    Write each body location as a |wcomplete sentence|n - capitalized, ending
+    in a period. Locations in the same region are joined with spaces, so full
+    sentences read as natural prose while bare fragments run together.
 
     |wTokens|n let one description read naturally whether a part is paired or
     a lone survivor. Wrap a number-flexible word in braces and it flexes to
     match: a pair renders plural, a single side renders singular.
 
-        describe eyes "deep brown {eyes} that {accent} {their} skin"
+        describe eyes "{Their} bright brown {eyes} {accent} {their} skin."
 
-        both eyes  -> deep brown eyes that accent their skin
-        one eye    -> a deep brown eye that accents their skin
+        both eyes  -> Their bright brown eyes accent their skin.
+        one eye    -> Their bright brown eye accents their skin.
 
     Brace the body-part noun ({eye} or {an eye} to control the article) and
     any verb that must agree with it ({accent}, {are}). Pronoun tokens
@@ -599,9 +603,9 @@ class CmdDescribe(Command):
     Examples:
         describe short "a lanky figure with restless hands"
         describe keyword droog
-        describe face "weathered features with high cheekbones"
-        describe eyes "piercing blue {eyes} flecked with gold"
-        describe right_hand "a prosthetic metal hand, intricately engraved"
+        describe face "High cheekbones and a day's worth of stubble lend {their} face a rough, unhurried calm."
+        describe eyes "{Their} bright brown {eyes} {accent} {their} sun-worn skin."
+        describe right_hand "A prosthetic forearm of brushed steel ends in five articulated fingers."
         describe/clear face
 
     Body locations include: hair, head, face, left_eye, right_eye, left_ear,

--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -179,14 +179,14 @@ builder `@desc`; that decision is deferred.
 
 **Examples**:
 ```
-describe face "weathered features with high cheekbones"
-describe left_eye "a piercing blue eye with flecks of gold"
-describe right_eye "a cybernetic replacement with a red LED"
-describe left_hand "calloused hand with dirt under the fingernails"
-describe right_hand "a prosthetic metal hand with intricate engravings"
-describe chest "broad shoulders tapering to a narrow waist"
-describe tail "a long, serpentine tail ending in a barbed tip"
-describe left_wing "a massive feathered wing, midnight black"
+describe face "High cheekbones and a defined jawline lend {their} face a rough calm."
+describe left_eye "A piercing blue eye glints with flecks of gold."
+describe right_eye "A cybernetic replacement glows with a steady red LED."
+describe left_hand "A calloused hand carries dirt under the fingernails."
+describe right_hand "A prosthetic metal hand ends in intricately engraved fingers."
+describe chest "Broad shoulders taper to a narrow waist."
+describe tail "A long, serpentine tail ends in a barbed tip."
+describe left_wing "A massive feathered wing spreads in midnight black."
 ```
 
 ### Command Behavior
@@ -360,12 +360,17 @@ With your administrative visibility, you see: item1 [#123], item2 [#456], weapon
 - **Overflow handling**: If single region exceeds threshold, break at most logical location within region
 - **Coverage integration**: Only visible descriptions (body longdescs + clothing longdescs) count toward thresholds
 - **Writer freedom**: No forced connecting words or narrative structure - writers control their own style
+- **Authoring convention**: Locations within a region are joined with single
+  spaces; the renderer adds no capitalization or punctuation. Author each
+  location as a **complete sentence** (capitalized, period-terminated) so the
+  joined output reads as prose — bare fragments run together into a run-on.
 - **Constants-driven**: Uses `PARAGRAPH_BREAK_THRESHOLD`, `REGION_BREAK_PRIORITY`, and `ANATOMICAL_REGIONS` for fine-tuning
 
 #### Paired Longdesc Collapse ✅
 Symmetric left/right paired appendages collapse into a single line when their
-descriptions are interchangeable, avoiding redundant repetition (e.g. two
-identical "a pale blue eye." lines becoming one "pale blue eyes." line).
+descriptions are interchangeable, avoiding redundant repetition (e.g. a single
+`{Their} {eyes} {are} pale blue.` rendering once as "Their eyes are pale blue."
+instead of repeating "Their eye is pale blue." for each side).
 
 **Pairs are derived dynamically** from `left_*` / `right_*` location keys
 (union of `longdesc` keys, `coverage_map`, `ANATOMICAL_DISPLAY_ORDER`, and
@@ -448,20 +453,20 @@ Following the Mr. Hands AttributeProperty pattern:
 ```python
 # Auto-created on character creation (like Mr. Hands)
 character.db.longdesc = {
-    "head": None, "face": "weathered features with high cheekbones", 
-    "left_eye": "a piercing blue eye with flecks of gold", "right_eye": "a cybernetic replacement with a red LED",
+    "head": None, "face": "High cheekbones and a defined jawline lend {their} face a rough calm.", 
+    "left_eye": "A piercing blue eye glints with flecks of gold.", "right_eye": "A cybernetic replacement glows with a steady red LED.",
     "left_ear": None, "right_ear": None, "neck": None,
-    "chest": "broad shoulders tapering to a narrow waist", 
+    "chest": "Broad shoulders taper to a narrow waist.", 
     "back": None, "abdomen": None, "groin": None,
     "left_arm": None, "right_arm": None,
-    "left_hand": "calloused hand with dirt under the fingernails",
-    "right_hand": "a prosthetic metal hand with intricate engravings",
+    "left_hand": "A calloused hand carries dirt under the fingernails.",
+    "right_hand": "A prosthetic metal hand ends in intricately engraved fingers.",
     "left_thigh": None, "right_thigh": None,
     "left_shin": None, "right_shin": None,
     "left_foot": None, "right_foot": None,
     # Extended anatomy (when added)
-    "tail": "a long, serpentine tail ending in a barbed tip",
-    "left_wing": "a massive feathered wing, midnight black"
+    "tail": "A long, serpentine tail ends in a barbed tip.",
+    "left_wing": "A massive feathered wing spreads in midnight black."
 }
 ```
 
@@ -755,9 +760,9 @@ longdesc = AttributeProperty(
 
 ```bash
 # Basic description setting
-@longdesc face "weathered features with high cheekbones"
-@longdesc left_eye "a piercing blue eye with flecks of gold"  
-@longdesc right_hand "a prosthetic metal hand with intricate engravings"
+@longdesc face "High cheekbones and a defined jawline lend {their} face a rough calm."
+@longdesc left_eye "A piercing blue eye glints with flecks of gold."  
+@longdesc right_hand "A prosthetic metal hand ends in intricately engraved fingers."
 
 # Discovery and management
 @longdesc/list           # Show available locations grouped by region

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -30,7 +30,7 @@ HELP_ENTRY_DICTS = [
         "aliases": ["token", "braces"],
         "category": "Character",
         "text": """
-            |cDescription Tokens|n
+            |wDescription Tokens|n
 
             Tokens are words wrapped in |w{braces}|n inside a description. When
             the description is shown, each token is replaced with the right word
@@ -60,10 +60,10 @@ HELP_ENTRY_DICTS = [
 
             Example:
 
-                a long scar runs down {their} cheek
+                A long scar runs down {their} cheek.
 
-                others see -> a long scar runs down her cheek
-                you see    -> a long scar runs down your cheek
+                others see -> A long scar runs down her cheek.
+                you see    -> A long scar runs down your cheek.
 
             ## number
 
@@ -74,10 +74,10 @@ HELP_ENTRY_DICTS = [
             Brace the |wbody-part noun|n and any |wverb|n that must agree with
             it:
 
-                deep brown {eyes} that {accent} {their} skin
+                {Their} bright brown {eyes} {accent} {their} skin.
 
-                both present -> deep brown eyes that accent their skin
-                one present  -> a deep brown eye that accents their skin
+                both present -> Their bright brown eyes accent their skin.
+                one present  -> Their bright brown eye accents their skin.
 
             The recognised part nouns are the symmetric pairs: eye, ear, arm,
             hand, thigh, shin, foot. A single braced word that is |wnot|n one of

--- a/world/tests/test_longdesc_menu.py
+++ b/world/tests/test_longdesc_menu.py
@@ -168,11 +168,11 @@ class PreviewTests(TestCase):
         char = _full_body()
         lines = _render_longdesc_preview(
             char, char, "eyes", ["left_eye", "right_eye"],
-            "deep brown {eyes} that {accent} {their} skin",
+            "{Their} bright brown {eyes} {accent} {their} skin.",
         )
         joined = "\n".join(lines)
-        self.assertIn("brown eyes that accent", joined)
-        self.assertIn("brown eye that accents", joined)
+        self.assertIn("brown eyes accent", joined)
+        self.assertIn("brown eye accents", joined)
 
     def test_single_location_singular_only(self):
         char = _full_body()

--- a/world/tests/test_paired_longdesc_collapse.py
+++ b/world/tests/test_paired_longdesc_collapse.py
@@ -223,15 +223,15 @@ class TokenRenderTests(TestCase):
 
     def test_pair_renders_plural(self):
         out = self.obj.render(
-            "deep brown {eyes} that {accent} {their} skin", "plural"
+            "{Their} bright brown {eyes} {accent} {their} skin.", "plural"
         )
-        self.assertEqual(out, "deep brown eyes that accent their skin")
+        self.assertEqual(out, "Their bright brown eyes accent their skin.")
 
     def test_survivor_renders_singular(self):
         out = self.obj.render(
-            "deep brown {eyes} that {accent} {their} skin", "singular"
+            "{Their} bright brown {eyes} {accent} {their} skin.", "singular"
         )
-        self.assertEqual(out, "deep brown eye that accents their skin")
+        self.assertEqual(out, "Their bright brown eye accents their skin.")
 
     def test_article_noun_token_plural_drops_article(self):
         out = self.obj.render("{An eye} {gleams} coldly.", "plural")


### PR DESCRIPTION
## Summary
- Whitens the documented describe surface to match the all-white interactive menu: cyan section headers in the `CmdDescribe` docstring and the `help tokens` title -> bold white `|w` (inline emphasis kept).
- Standardizes all longdesc examples on the full-sentence house style (capitalized, period-terminated, `{Their}`-led, number-flex tokens on pairs, braced agreeing verbs) across the docstring, `help tokens`, and `LONGDESC_SYSTEM_SPEC.md`.
- Adds an explicit authoring-convention note to the spec: locations are space-joined with no renderer-added punctuation, so complete sentences read as prose while fragments run together.
- Mirrors the new canonical example in the token-render and preview test fixtures.

## Scope
Help text + examples only. Runtime cyan in `describe/list`, `describe <location>` view, and sdesc echoes intentionally left as-is. `GRAMMAR_ENGINE_SPEC.md` number-flex section is API-level (token snippets, no run-on prose) — reviewed, no rewrite needed.

## Testing
- Render-checked every new `{token}` example via `evennia shell` (plural + singular) — all flex correctly and read as clean sentences.
- `evennia test world.tests.test_paired_longdesc_collapse world.tests.test_longdesc_menu world.tests.test_describe_menu` (80 OK)
- Full `evennia test world` suite: 1470 OK

Closes #285