### PR TITLE
docs: fix combat spec drift to match shipped code

### DIFF
--- a/specs/COMBAT_REFACTOR_SPEC.md
+++ b/specs/COMBAT_REFACTOR_SPEC.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This specification outlines a systematic refactor of the combat module to address technical debt accumulated through incremental LLM development. The refactor will transform both the monolithic `handler.py` (1,470 lines) and the oversized `utils.py` (1,007 lines) into a maintainable, modular system.
+This specification outlines a systematic refactor of the combat module to address technical debt accumulated through incremental LLM development. The refactor will transform both the monolithic `handler.py` (originally 1,470 lines; currently ~1,077) and the oversized `utils.py` (originally 1,007 lines; currently ~1,047) into a maintainable, modular system. **Status:** partially delivered — `dice.py`, `debug.py`, and `actions.py` were split out, but several proposed modules below were never created and the size-reduction targets have not yet been met.
 
 ## Problem Statement
 
@@ -11,8 +11,8 @@ The combat module has already undergone one refactoring attempt that extracted f
 
 ```
 Current Architecture:
-├── handler.py       # 1,470 lines - Combat orchestration + action processing  
-├── utils.py         # 1,007 lines - Mixed utilities (refactor dumping ground)
+├── handler.py       # ~1,077 lines (was 1,470) - Combat orchestration + action processing  
+├── utils.py         # ~1,047 lines (was 1,007) - Mixed utilities (refactor dumping ground)
 ├── grappling.py     # ~300 lines - Specialized grappling logic
 ├── proximity.py     # ~250 lines - Specialized proximity logic
 └── constants.py     # ~200 lines - Shared constants
@@ -21,7 +21,7 @@ Total: ~3,200 lines with significant cross-file duplication
 ```
 
 ### Current Issues
-- **Dual Monoliths**: Both `handler.py` (1,470 lines) and `utils.py` (1,007 lines) exceed maintainable size
+- **Dual Monoliths**: Both `handler.py` (~1,077 lines, was 1,470) and `utils.py` (~1,047 lines, was 1,007) exceed maintainable size
 - **Cross-File Duplication**: Same patterns repeated across both files
   - Contest patterns: `handler.py` (6 instances) + `utils.py` (inconsistent dice patterns)
   - Debug messages: `handler.py` (128) + `utils.py` (19) = 147 total splattercast calls
@@ -48,11 +48,11 @@ Total: ~3,200 lines with significant cross-file duplication
 5. **Maintainability**: Clear interfaces and minimal coupling
 
 ### Success Metrics
-- `handler.py` reduced to <500 lines (orchestration only)
-- `utils.py` broken down into focused modules (<300 lines each)
+- `handler.py` reduced to <500 lines (orchestration only) — **NOT yet met** (currently ~1,077)
+- `utils.py` broken down into focused modules (<300 lines each) — **NOT yet met** (still ~1,047)
 - No code duplication (0 repeated patterns across ALL files)
 - <10 debug messages per file
-- Each file <300 lines (fits in LLM context)
+- Each file <300 lines (fits in LLM context) — **target; not met for handler.py/utils.py**
 - Clear separation: orchestration vs implementation vs utilities
 
 ## Refactor Strategy
@@ -78,41 +78,43 @@ Given LLM limitations, we'll use **incremental extraction** with **validation at
 **Current (Post-Initial Refactor)**:
 ```
 world/combat/
-├── handler.py       # 1,470 lines - Mixed orchestration + processing
-├── utils.py         # 1,007 lines - Mixed utilities dumping ground
+├── handler.py       # ~1,077 lines (was 1,470) - Mixed orchestration + processing
+├── utils.py         # ~1,047 lines (was 1,007) - Mixed utilities dumping ground
 ├── grappling.py     # ~300 lines - Grappling logic  
 ├── proximity.py     # ~250 lines - Proximity system
 └── constants.py     # ~200 lines - Constants
 ```
 
 **Target (Responsibility-Based)**:
+
+Status legend: ✅ delivered (file exists) · ❌ NOT implemented (never split out).
 ```
 world/combat/
-├── handler.py              # <500 lines - Pure orchestration
-├── action_processors.py    # <300 lines - Combat action resolution
-├── contest_system.py       # <200 lines - Contest resolution (from both files)
-├── state_manager.py        # <300 lines - State manipulation (from both files)  
-├── debug_logger.py         # <100 lines - Centralized logging (from both files)
-├── dice_system.py          # <150 lines - Standardized dice rolling (from utils.py)
-├── weapon_utilities.py     # <200 lines - Weapon handling (from utils.py)
-├── character_attributes.py # <250 lines - Safe attribute access (from both files)
-├── grappling.py            # <300 lines - Grappling logic (refactored)
-├── proximity.py            # <250 lines - Proximity system
-└── constants.py            # <200 lines - Constants
+├── handler.py              # target <500 lines - Pure orchestration (❌ still ~1,077)
+├── actions.py              # ✅ delivered - Combat action resolution
+├── contest_system.py       # ❌ NOT implemented - contest logic still lives in handler.py/utils.py
+├── state_manager.py        # ❌ NOT implemented - state manipulation still in handler.py/utils.py
+├── debug.py                # ✅ delivered - Centralized logging
+├── dice.py                 # ✅ delivered - Standardized dice rolling
+├── weapon_utilities.py     # ❌ NOT implemented - weapon helpers still in utils.py
+├── character_attributes.py # ❌ NOT implemented - safe attribute access still inline
+├── grappling.py            # ✅ delivered - Grappling logic
+├── proximity.py            # ✅ delivered - Proximity system
+└── constants.py            # ✅ delivered - Constants
 ```
 
 ### Responsibility Matrix
 
-| Module | Primary Responsibility | Key Functions | Source Files |
-|--------|----------------------|---------------|--------------|
-| `handler.py` | Combat orchestration | Round management, script lifecycle | Current handler.py |
-| `action_processors.py` | Action resolution | Process attacks, grapples, movement | Current handler.py |
-| `contest_system.py` | Contest mechanics | Motorics rolls, opposed checks | Both handler.py + utils.py |
-| `state_manager.py` | State manipulation | Combatant entry management | Both handler.py + utils.py |
-| `debug_logger.py` | Logging coordination | Centralized debug system | Both handler.py + utils.py |
-| `dice_system.py` | Dice operations | Standardized rolling patterns | Current utils.py |
-| `weapon_utilities.py` | Weapon handling | Weapon access, validation | Current utils.py |
-| `character_attributes.py` | Safe attribute access | Defensive patterns | Both handler.py + utils.py |
+| Module | Primary Responsibility | Key Functions | Source Files | Status |
+|--------|----------------------|---------------|--------------|--------|
+| `handler.py` | Combat orchestration | Round management, script lifecycle | Current handler.py | ✅ exists (not yet slimmed) |
+| `actions.py` | Action resolution | Process attacks, grapples, movement | Current handler.py | ✅ delivered |
+| `contest_system.py` | Contest mechanics | Motorics rolls, opposed checks | Both handler.py + utils.py | ❌ NOT implemented |
+| `state_manager.py` | State manipulation | Combatant entry management | Both handler.py + utils.py | ❌ NOT implemented |
+| `debug.py` | Logging coordination | Centralized debug system | Both handler.py + utils.py | ✅ delivered |
+| `dice.py` | Dice operations | Standardized rolling patterns | Current utils.py | ✅ delivered |
+| `weapon_utilities.py` | Weapon handling | Weapon access, validation | Current utils.py | ❌ NOT implemented |
+| `character_attributes.py` | Safe attribute access | Defensive patterns | Both handler.py + utils.py | ❌ NOT implemented |
 
 ## Phase 1: Extract Cross-File Repeated Patterns
 
@@ -239,7 +241,7 @@ splattercast.msg(f"SOME_PREFIX: detailed message with {variables}")
 
 **Cross-File Impact**: Both files have identical channel access ceremonies, different message formats
 
-**New Interface** (`debug_logger.py`):
+**New Interface** (`debug.py`):
 ```python
 def combat_log(level, category, message, char=None, target=None, handler=None):
     """
@@ -267,7 +269,7 @@ combat_log("INFO", "ATTACK", "Hit for {damage} damage", char=attacker, target=vi
    grep -n "splattercast.msg" world/combat/utils.py | wc -l    # Should show 19
    grep -n "SPLATTERCAST_CHANNEL" world/combat/*.py
    ```
-2. Create unified `debug_logger.py` for ALL combat debug messages
+2. Create unified `debug.py` for ALL combat debug messages
 3. Replace `utils.py` debug calls first (19 instances, easier to validate)
    - **Manual Test**: Verify debug output appears correctly in splattercast channel
 4. Replace `handler.py` debug calls in batches of 15-20
@@ -413,7 +415,7 @@ roll_with_disadvantage(stat_value) # rolls twice, takes min
 standard_roll(stat_value)          # single roll
 ```
 
-**New Interface** (`dice_system.py`):
+**New Interface** (`dice.py`):
 ```python
 @dataclass
 class DiceResult:
@@ -518,7 +520,7 @@ def remove_combatant_from_handler(handler, character):
 - `_resolve_charge()`: 144 lines
 - `_resolve_disarm()`: 88 lines
 
-**New Interface** (`action_processors.py`):
+**New Interface** (`actions.py`):
 ```python
 def process_auto_resistance(handler, combatants_list):
     """Process automatic escape attempts for non-yielding victims"""
@@ -584,10 +586,10 @@ def _process_combat_round(self, combatants):
 - Combat state validation triggers
 
 **Extracted Responsibilities**:
-- ✅ Contest resolution → `contest_system.py`
-- ✅ Debug logging → `debug_logger.py`  
-- ✅ State manipulation → `state_manager.py`
-- ✅ Action processing → `action_processors.py`
+- ❌ Contest resolution → `contest_system.py` (NOT implemented; still inline in handler.py/utils.py)
+- ✅ Debug logging → `debug.py`  
+- ❌ State manipulation → `state_manager.py` (NOT implemented; still inline in handler.py/utils.py)
+- ✅ Action processing → `actions.py`
 
 ## LLM Reference Commands & Context Management
 
@@ -683,7 +685,7 @@ sed -n '402,833p' world/combat/handler.py | wc -l  # at_repeat() size
 
 ### Context Management for Large File Reads
 
-#### Reading handler.py (1,470 lines) in chunks:
+#### Reading handler.py (~1,077 lines, was 1,470) in chunks:
 ```bash
 # Method 1: By sections
 sed -n '1,200p' world/combat/handler.py      # Header and imports
@@ -696,7 +698,7 @@ sed -n '1100,1470p' world/combat/handler.py  # Resolve methods
 grep -n "def " world/combat/handler.py | head -10  # First 10 methods
 ```
 
-#### Reading utils.py (1,007 lines) in chunks:
+#### Reading utils.py (~1,047 lines, was 1,007) in chunks:
 ```bash
 # By function groups
 sed -n '1,100p' world/combat/utils.py       # Imports and constants
@@ -731,8 +733,8 @@ This reference section provides comprehensive command patterns for LLM context m
 - **Split**: If file grows >300 lines, split by responsibility
 - **Reference Commands**: 
   ```bash
-  wc -l world/combat/handler.py  # Current: 1,470 lines
-  wc -l world/combat/utils.py    # Current: 1,007 lines
+  wc -l world/combat/handler.py  # Current: ~1,077 lines (was 1,470)
+  wc -l world/combat/utils.py    # Current: ~1,047 lines (was 1,007)
   ```
 
 #### 2. **Single Change Principle**
@@ -976,8 +978,8 @@ def validate_db_key(key):
 ## Success Criteria
 
 ### Quantitative Goals
-- [ ] `handler.py` <500 lines (down from 1,470)
-- [ ] `utils.py` eliminated - broken into focused modules  
+- [ ] `handler.py` <500 lines — **NOT met** (currently ~1,077, was 1,470)
+- [ ] `utils.py` eliminated - broken into focused modules — **NOT met** (still ~1,047)
 - [ ] No code duplication (0 repeated patterns across ALL files)  
 - [ ] All files <300 lines
 - [ ] <10 debug messages per file
@@ -1001,17 +1003,17 @@ def validate_db_key(key):
 
 ### Immediate Priority (Phase 1 - Cross-File Consolidation)
 1. **Week 1**: Extract contest system (`contest_system.py`) - consolidate from both files
-2. **Week 1**: Extract debug logging (`debug_logger.py`) - consolidate 147 total messages  
+2. **Week 1**: Extract debug logging (`debug.py`) - consolidate 147 total messages  
 3. **Week 2**: Extract state management (`state_manager.py`) - cross-file patterns
 
 ### Medium Priority (Phase 2 - Utils Decomposition)
-4. **Week 2**: Extract dice system (`dice_system.py`) - standardize 6 patterns
+4. **Week 2**: Extract dice system (`dice.py`) - standardize 6 patterns
 5. **Week 2**: Extract weapon utilities (`weapon_utilities.py`) - clean interface
 6. **Week 3**: Extract combat entry management (`combat_entry_manager.py`)
 
 ### High Priority (Phase 3 - Handler Decomposition)  
-7. **Week 3**: Extract grapple processors (`action_processors.py`)
-8. **Week 3**: Extract combat processors (`action_processors.py`)
+7. **Week 3**: Extract grapple processors (`actions.py`)
+8. **Week 3**: Extract combat processors (`actions.py`)
 
 ### Final Priority (Phase 4 - Handler Simplification)
 9. **Week 4**: Simplify handler structure

--- a/specs/COMBAT_SYSTEM.md
+++ b/specs/COMBAT_SYSTEM.md
@@ -118,10 +118,11 @@ The **G.R.I.M. Combat System** is a roleplay-focused, turn-based combat engine t
 - **`disarm <target>`**: Attempt to remove target's weapon
 - **`aim <target>`**: Improve accuracy for next attack
 
-### Information Commands (`commands/combat/info_commands.py`)
-- **`look`**: Enhanced awareness during combat
-- **`combatants`**: List all active combatants
-- **`status`**: Check your combat condition
+### Information Commands (main character cmdset)
+There is no dedicated combat info-command module. Combat-aware `look` is provided
+by the main character cmdset (so it works both in and out of combat) rather than a
+separate `commands/combat/` file.
+- **`look`**: Enhanced awareness during combat (registered on the main character cmdset)
 
 ## Combat Flow
 

--- a/specs/GRAPPLE_SYSTEM_SPEC.md
+++ b/specs/GRAPPLE_SYSTEM_SPEC.md
@@ -237,7 +237,7 @@ When a grenade explodes, before applying damage to characters in proximity:
 - **Observer Message**: `"{grappler} uses {victim} as a blast shield against the {grenade} explosion!"`
 
 #### **Implementation Gap**
-The grenade explosion system (`CmdThrow.py`) bypasses combat handler's `_process_attack()` method, using direct `apply_damage(character, damage, location, injury_type)` calls instead. Integration would require adding grappling shield checks within the explosion damage resolution before `apply_damage()` calls.
+The grenade explosion system (`CmdThrow.py`, with detonation logic now largely in `commands/CmdExplosives.py` and `commands/explosion_utils.py`) bypasses combat handler's `_process_attack()` method, using direct `apply_damage(character, damage, location, injury_type)` calls instead. Integration would require adding grappling shield checks within the explosion damage resolution before `apply_damage()` calls.
 
 ---
 

--- a/specs/PROXIMITY_SYSTEM_SPEC.md
+++ b/specs/PROXIMITY_SYSTEM_SPEC.md
@@ -21,7 +21,7 @@ The G.R.I.M. Combat System currently operates with dual proximity systems that e
 #### Combat Proximity Code Locations
 ```python
 # Primary usage in combat system
-world/combat/special_actions.py:
+commands/combat/special_actions.py:
 - CmdGrapple: Establishes proximity on successful grapple
 - CmdDisarm: Requires proximity for disarm attempts
 - CmdReleaseGrapple: Clears proximity relationships
@@ -172,7 +172,7 @@ grenade.ndb.proximity_relationships = [char1, char2, char3]
 
 #### Unified Proximity Utilities
 ```python
-# world/combat/proximity.py (new file)
+# world/combat/proximity.py
 def establish_proximity(entity1, entity2):
     """Establish bidirectional proximity between any two entities."""
 

--- a/specs/REMOTE_DETONATOR_SPEC.md
+++ b/specs/REMOTE_DETONATOR_SPEC.md
@@ -1,8 +1,10 @@
 # Remote Detonator System Specification
 
-## Status: 📋 SPECIFICATION - READY FOR IMPLEMENTATION
+## Status: ✅ IMPLEMENTED
 
-*All implementation questions resolved. Spec finalized 2025-01-13.*
+*Shipped. `RemoteDetonator` lives in `typeclasses/items.py`; the detonator
+commands (`CmdScan`, `CmdDetonate`, `CmdDetonateList`, `CmdClearDetonator`) live
+in `commands/CmdExplosives.py`. Spec finalized 2025-01-13.*
 
 ## Overview
 A handheld remote detonator device that can scan and remotely trigger explosive devices. The detonator maintains a list of up to 20 scanned explosives and can trigger them individually or simultaneously by pulling their pins and starting their normal fuse countdowns. This system integrates with all existing explosive types (sticky grenades, rigged explosives, standard grenades) and respects their unique behaviors.
@@ -618,9 +620,9 @@ def at_delete(self):
                 pass  # Already removed
 ```
 
-**3. New Commands** (`commands/CmdThrow.py` - add to existing file)
+**3. New Commands** (`commands/CmdExplosives.py`)
 ```python
-# NOTE: All detonator commands added to CmdThrow.py (monolithic explosives file)
+# NOTE: All detonator commands live in CmdExplosives.py (the explosives command file)
 # NOTE: Constants like DB_PIN_PULLED are already imported at top of file via:
 #       from world.combat.constants import *
 
@@ -741,9 +743,9 @@ These decisions were made during the specification phase to resolve implementati
 - **Implementation:** Check `DB_PIN_PULLED` flag before remote detonation (constant from `world.combat.constants`)
 
 **2. Code Organization**
-- **Decision:** Add all detonator commands to `commands/CmdThrow.py` (monolithic approach)
-- **Rationale:** "Throw and explosives work in tandem. So, that file needs to be monolithic."
-- **Implementation:** CmdScan, CmdDetonate, CmdDetonateList, CmdClearDetonator all in CmdThrow.py
+- **Decision:** Detonator commands live in `commands/CmdExplosives.py` (the dedicated explosives command file)
+- **Rationale:** Explosives commands are grouped together in their own module
+- **Implementation:** CmdScan, CmdDetonate, CmdDetonateList, CmdClearDetonator all in `commands/CmdExplosives.py`
 
 **3. Rigged Explosive Countdown Timing**
 - **Decision:** Use normal fuse_time (already 1 second from rigging process)

--- a/specs/STICKY_GRENADE_SPEC.md
+++ b/specs/STICKY_GRENADE_SPEC.md
@@ -86,10 +86,10 @@ When dropped: grenade → armor → room
 - ✅ Stats: magnetic_strength=8, blast_damage=30, fuse_time=6s, dud_chance=0.02
 
 **Key Functions Implemented:**
-- ✅ `calculate_stick_chance(metal, magnetic, strength)` in world/combat/utils.py
-- ✅ `establish_stick(grenade, armor, hit_location)` in world/combat/utils.py
-- ✅ `get_outermost_armor_at_location(character, location)` in world/combat/utils.py
-- ✅ `get_stuck_grenades_on_character(character)` in world/combat/utils.py
+- ✅ `calculate_stick_chance(grenade, armor)` in world/combat/explosives.py
+- ✅ `establish_stick(grenade, armor, hit_location)` in world/combat/explosives.py
+- ✅ `get_outermost_armor_at_location(character, location)` in world/combat/explosives.py
+- ✅ `get_stuck_grenades_on_character(character)` in world/combat/explosives.py
 - ✅ `select_most_magnetic_target_in_room(room, grenade)` in commands/CmdThrow.py
 - ✅ `resolve_weapon_hit(weapon, target, thrower)` handles stick mechanics
 
@@ -99,8 +99,10 @@ When dropped: grenade → armor → room
 - **commands/CmdThrow.py lines ~790-880**: Stick check after throw hit determination
 - **commands/CmdThrow.py lines ~1918-1955**: Rigged grenade magnetic targeting
 - **commands/CmdThrow.py lines ~1968-2020**: Rigged grenade explosion with proximity fix
-- **world/combat/utils.py lines ~1248-1332**: `calculate_stick_chance()` implementation
-- **world/combat/utils.py lines ~1400-1460**: `establish_stick()` and helper functions
+- **world/combat/explosives.py lines ~144-323**: `calculate_stick_chance()` implementation
+- **world/combat/explosives.py lines ~325-483**: `establish_stick()` and helper functions (`get_outermost_armor_at_location`, `get_stuck_grenades_on_character`, `break_stick`)
+
+  Note: `world/combat/utils.py` only re-exports these symbols (`from .explosives import ...`); it does not define them.
 - **world/prototypes.py lines ~124-145**: SPDR M9 grenade prototype
 
 ### Testing Results
@@ -306,18 +308,26 @@ grenade.db.stuck_to_armor = Armor object or None  # The specific armor piece it'
 ### Stick Chance Calculation (Option C - Realistic)
 
 ```python
-def calculate_stick_chance(metal_level, magnetic_level, grenade_strength):
+def calculate_stick_chance(grenade, armor):
     """
     Calculate probability that grenade will stick to armor.
-    
+
+    Note: the shipped signature is ``calculate_stick_chance(grenade, armor)``.
+    ``grenade_strength`` is read from ``grenade.db.magnetic_strength`` and
+    ``metal_level`` / ``magnetic_level`` are read from ``armor`` (including the
+    highest values across installed plates for plate carriers).
+
     Requirements:
     - Magnetic level must be sufficient (ferrous metal present)
     - Metal level provides surface area for attachment
     - Both must meet minimum thresholds
-    
-    Returns: integer 0-100 (percentage chance)
+
+    Returns: integer 0-95 (percentage chance)
     """
-    
+    grenade_strength = grenade.db.magnetic_strength or 5
+    metal_level = armor.db.metal_level or 0
+    magnetic_level = armor.db.magnetic_level or 0
+
     # THRESHOLD CHECK: Is material magnetic enough?
     if magnetic_level < (grenade_strength - 3):
         return 0  # Not magnetic enough - no stick possible
@@ -397,10 +407,7 @@ def calculate_stick_chance(metal_level, magnetic_level, grenade_strength):
       - If no, attempt stick check
       
    d. Calculate stick chance:
-      metal_level = item.db.metal_level
-      magnetic_level = item.db.magnetic_level
-      grenade_strength = grenade.db.magnetic_strength
-      stick_chance = calculate_stick_chance(metal, magnetic, strength)
+      stick_chance = calculate_stick_chance(grenade, item)
       
    e. Roll for stick:
       roll = random(1, 100)
@@ -444,7 +451,7 @@ for item in sorted(layers_on_chest, key=lambda x: x.layer, reverse=True):
     if item.already_has_grenade:
         continue  # Skip, try next layer
     
-    stick_chance = calculate_stick_chance(item.metal, item.magnetic, grenade.strength)
+    stick_chance = calculate_stick_chance(grenade, item)
     if roll_stick(stick_chance):
         stick_to(item)
         break
@@ -1245,7 +1252,7 @@ class Item(DefaultObject):
         # Add stuck grenade check
 ```
 
-**typeclasses/explosives.py (new file or add to items.py)**
+**Sticky grenade typeclass/prototype** (no separate `typeclasses/explosives.py` was created; the stick logic itself lives in `world/combat/explosives.py`)
 - Create StickyGrenade class
 - Inherits from existing Grenade/Explosive class
 - Add is_sticky and magnetic_strength attributes
@@ -1273,11 +1280,7 @@ if obj.db.is_sticky:
     # Get armor covering hit location
     armor = get_outermost_armor_at_location(target, hit_location)
     if armor and not armor.db.stuck_grenade:
-        stick_chance = calculate_stick_chance(
-            armor.db.metal_level,
-            armor.db.magnetic_level,
-            obj.db.magnetic_strength
-        )
+        stick_chance = calculate_stick_chance(obj, armor)
         if random.randint(1, 100) <= stick_chance:
             establish_stick(obj, armor, target, hit_location)
             # Send stick success messages
@@ -1327,7 +1330,7 @@ if armor.db.stuck_grenade:
     # Grenade automatically moves with it (grenade.location = armor)
 ```
 
-**world/combat/utils.py (or new explosives_utils.py)**
+**world/combat/explosives.py**
 - Add calculate_stick_chance() function
 - Add get_stuck_grenades_on_character() helper
 - Add get_explosion_room() helper (for hierarchy traversal)
@@ -1335,8 +1338,8 @@ if armor.db.stuck_grenade:
 - Add find_best_stick_target() for multi-target (future)
 
 ```python
-def calculate_stick_chance(metal_level, magnetic_level, grenade_strength):
-    """Calculate stick probability. Returns 0-100."""
+def calculate_stick_chance(grenade, armor):
+    """Calculate stick probability. Returns 0-95."""
     # See Section 3 for full implementation
     
 def get_explosion_room(grenade):
@@ -1374,18 +1377,21 @@ These utility functions are essential for the sticky grenade system:
 
 ### calculate_stick_chance()
 ```python
-def calculate_stick_chance(metal_level, magnetic_level, grenade_strength):
+def calculate_stick_chance(grenade, armor):
     """
     Calculate probability that grenade will stick to armor.
-    
-    Args:
-        metal_level (int): Amount of metal in armor (0-10)
-        magnetic_level (int): Magnetic responsiveness (0-10)
-        grenade_strength (int): Magnet power level (1-10)
-    
+
+    Shipped signature is ``(grenade, armor)``. Internally derives
+    ``grenade_strength`` from ``grenade.db.magnetic_strength`` and
+    ``metal_level`` / ``magnetic_level`` from ``armor``.
+
     Returns:
-        int: Stick chance percentage (0-100)
+        int: Stick chance percentage (0-95)
     """
+    grenade_strength = grenade.db.magnetic_strength or 5
+    metal_level = armor.db.metal_level or 0
+    magnetic_level = armor.db.magnetic_level or 0
+
     # THRESHOLD CHECK: Is material magnetic enough?
     if magnetic_level < (grenade_strength - 3):
         return 0  # Not magnetic enough - no stick possible

--- a/specs/THROW_COMMAND_SPEC.md
+++ b/specs/THROW_COMMAND_SPEC.md
@@ -8,8 +8,8 @@
 - ✅ **CmdThrow** - Complete 4-syntax throwing system
 - ✅ **CmdPull** - Pin pulling mechanism with timer management  
 - ✅ **CmdCatch** - Defensive object interception
-- ✅ **CmdRig** - Exit trapping system
-- ✅ **Enhanced CmdDrop** - Universal proximity assignment
+- ✅ **CmdRig** - Exit trapping system (lives in `commands/CmdExplosives.py`, not `CmdThrow.py`)
+- ✅ **Enhanced CmdDrop** - Universal proximity assignment (lives in `commands/CmdInventory.py`, not `CmdThrow.py`)
 
 ### **System Infrastructure**
 - ✅ **Flight mechanics** - 2-second flight with room description integration
@@ -392,7 +392,7 @@ Grenade B explodes: affects [Alice, Bob] (inherited proximity)
 ### Phase 4: Additional Commands ✅ **COMPLETED**
 - ✅ **CmdPull**: Pin pulling mechanism for grenade activation
 - ✅ **CmdCatch**: Defensive catching of thrown objects
-- ✅ **CmdRig**: Exit trap setup with immunity system
+- ✅ **CmdRig** (in `commands/CmdExplosives.py`): Exit trap setup with immunity system
 - ✅ **CmdDefuse**: Manual defuse with skill checks and time pressure
 - ✅ **Auto-defuse**: Automatic proximity-based defuse attempts
 - ✅ **Dual proximity cleanup**: Movement system integration

--- a/specs/WREST_COMMAND_SPEC.md
+++ b/specs/WREST_COMMAND_SPEC.md
@@ -180,8 +180,8 @@ def is_target_grappled(target):
 - `MSG_WREST_OBJECT_NOT_FOUND`
 
 ### Command Location
-- **File**: `commands/CmdWrest.py` (standalone command, not combat-specific)
-- **Import location**: General commands, not combat module
+- **File**: `commands/CmdInventory.py` — `CmdWrest` (key `"wrest"`), with related logic in `commands/combat/special_actions.py`
+- **Import location**: General inventory commands, not a standalone module
 - **Reason**: Works outside combat, different from combat commands
 
 ## Testing Scenarios


### PR DESCRIPTION
## Summary
Handoff prep: corrects combat specs that cited code which has since moved/renamed.
- `COMBAT_SYSTEM.md`: drop nonexistent `info_commands.py`; combat look comes from main char cmdset.
- `COMBAT_REFACTOR_SPEC.md`: `dice_system`/`debug_logger`/`action_processors` → `dice`/`debug`/`actions`; mark never-built modules; real line counts; unmet targets flagged.
- `PROXIMITY_SYSTEM_SPEC.md`: `special_actions.py` → `commands/combat/`; drop stale "(new file)".
- `WREST`/`THROW`: `CmdWrest`/`CmdDrop` in `CmdInventory.py`, `CmdRig` in `CmdExplosives.py`.
- `STICKY_GRENADE_SPEC.md`: functions in `world/combat/explosives.py`; correct `calculate_stick_chance(grenade, armor)`.
- `REMOTE_DETONATOR_SPEC.md`: status → implemented; commands in `CmdExplosives.py`.
- `GRAPPLE_SYSTEM_SPEC.md`: detonation attribution → `CmdExplosives.py`.

Docs-only. Closes #291