### PR TITLE
docs: fix identity/desc spec drift, retire superseded pronoun spec

### DIFF
--- a/specs/GRAMMAR_ENGINE_SPEC.md
+++ b/specs/GRAMMAR_ENGINE_SPEC.md
@@ -334,7 +334,7 @@ DEFAULT_SDESC_KEYWORDS = {
 ```
 
 Fallback keyword assigned to new characters based on grammar gender,
-when no explicit keyword has been chosen via `@shortdesc`. Keyed by the
+when no explicit keyword has been chosen via `describe keyword`. Keyed by the
 output of `GENDER_MAP`, not the raw `sex` attribute.
 
 ---

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -524,7 +524,7 @@ Disguise has three independent layers, each controllable on its own and combinin
 |-------|--------------|-----------------|
 | **Presentation overrides** | `appear` command | Per-axis: height, build, keyword, (future) voice |
 | **Disguise items** | Equipping/removing tagged clothing | Distinguishing feature + identity signature (when essential) |
-| **Body modification** (future) | Pharmaceuticals / cybernetics | `@longdesc` + identity signature |
+| **Body modification** (future) | Pharmaceuticals / cybernetics | `describe` + identity signature |
 
 The **sdesc** is always composed the same way regardless of disguise state:
 
@@ -638,7 +638,7 @@ The composed sdesc descriptor (`gaunt`, `burly`, etc.) is recomputed from the ov
 
 **What `appear` does NOT change:**
 - Distinguishing feature (auto-derived from worn items + hair)
-- `@longdesc` (looking directly reveals real physical detail until body-mod layers exist)
+- `describe` (looking directly reveals real physical detail until body-mod layers exist)
 - Voice (deferred to future communication-system integration)
 - The character's real `sleeve_uid` (the underlying body identity)
 
@@ -774,7 +774,7 @@ A disguise's effectiveness scales with the player's investment:
 | Add one essential item (e.g., balaclava) | Signature changes; "unmasking" possible if removed |
 | Full ensemble (all axes + multiple essentials) | Distinct identity; harder for observers to connect to real you |
 | All of the above + change non-essential clothing | Visual distinguishing feature also changes |
-| All of the above + body mod (future) | `@longdesc` no longer reveals the truth on close inspection |
+| All of the above + body mod (future) | `describe` no longer reveals the truth on close inspection |
 
 **Vector math — how completeness translates into pierce penalty.**
 
@@ -1042,7 +1042,7 @@ These are designed into the architecture but not implemented yet:
 - **Perception checks (shipped)**: See [Disguise Piercing](#disguise-piercing). Opposed Intellect-vs-Resonance with familiarity bonus and per-vector penalty.
 - **Active impersonation detection (Phase 5)**: Resonance-based hints when a *fresh* signature (different `sleeve_uid`) closely matches a known identity (e.g., *"this person reminds you of someone..."*).
 - **Forcible item removal via grapple**: Requires grapple-system integration for stripping equipment from a grappled character.
-- **Pharmaceutical / biomod items**: Consumable or implanted modifications that override `@longdesc` and contribute to the identity signature (extending the signature function with body-mod inputs). Closes the last gap: with body mods, even direct `look` reveals a different person. Pharmaceuticals would be temporary (wears off over time), potentially expensive/rare, and could carry side effects (stat penalties, addiction).
+- **Pharmaceutical / biomod items**: Consumable or implanted modifications that override `describe` and contribute to the identity signature (extending the signature function with body-mod inputs). Closes the last gap: with body mods, even direct `look` reveals a different person. Pharmaceuticals would be temporary (wears off over time), potentially expensive/rare, and could carry side effects (stat penalties, addiction).
 - **Photos / identity artifacts**: Captured signature snapshots usable as recipes (own personas) or investigation tools (others'). Salt-acquisition mechanics enable true impersonation gameplay. Ties into Phase 4 (cybernetics) where digital identity data becomes hackable and forgeable.
 - **Voice modulation**: Integration with say/whisper/communication so voice becomes part of the identity signature for observers who can hear but not see (or in addition to visual identification).
 - **Web UI integration**: Personas designed to mirror the planned identity/contact archive system; eventual web UI surface for managing personas, photos, and contact memory in one place.
@@ -1284,7 +1284,7 @@ if is_identity_match(caller, victim, name):
 
 #### Admin commands
 
-Staff commands that need cross-room reach (`@longdesc`, `@heal`, `@testdeath`, etc.) follow a **dual-path** convention: try `identity_match_characters` against the caller's room first (so disguised neighbors resolve via identity, not real key), then fall back to `evennia.search_object(query)` filtered to characters for global key matching. `commands._identity_targeting.resolve_admin_target(caller, query)` provides this pattern.
+Staff commands that need cross-room reach (`describe`, `@heal`, `@testdeath`, etc.) follow a **dual-path** convention: try `identity_match_characters` against the caller's room first (so disguised neighbors resolve via identity, not real key), then fall back to `evennia.search_object(query)` filtered to characters for global key matching. `commands._identity_targeting.resolve_admin_target(caller, query)` provides this pattern.
 
 Item targets (inventory, weapons, room objects) are out of scope for this rule — items do not participate in the identity system, so `caller.search(name, candidates=inventory)` and `caller.search(name, location=caller)` remain correct for item lookups.
 
@@ -1294,7 +1294,7 @@ Item targets (inventory, weapons, room objects) are out of scope for this rule �
 - **Same-room inventory exchange**: `commands/CmdInventory.py` (`CmdGive`)
 - **Same-room medical**: `commands/CmdConsumption.py` (`CmdInject`)
 - **Cross-room combat target**: `commands/combat/movement.py` (`CmdAdvance`, `CmdCharge`)
-- **Admin dual-path**: `commands/CmdCharacter.py` (`@longdesc`)
+- **Admin dual-path**: `commands/CmdCharacter.py` (`describe`)
 
 ### Ambiguity Resolution
 
@@ -2661,7 +2661,7 @@ Sites that broadcast **only** non-character text (item names, constant prose) ar
 - Distinguishing-feature interaction with disguise items (which items suppress which features) — **shipped** (#176): hair fallback suppression is driven by the unified clothing-coverage system (item lists `"hair"` in `coverage` → fallback skipped). The legacy `covers_hair` boolean has been removed. `"hair"` is now a first-class body location in `DEFAULT_LONGDESC_LOCATIONS` and leads the `ANATOMICAL_DISPLAY_ORDER` head region, which is ordered by organic recognition — hair, then eyes, then the head and face, followed by ears and neck (#238). Broader suppression conventions (e.g. mask-suppresses-face) follow naturally from coverage lists; no parallel flags required.
 - Item-driven sdesc fragment contributions (cohesion with `sdesc_short` from Phase 2) — **shipped** (#180): all 13 disguise prototypes' `worn_sdesc_short` values verified to produce grammatical `format_clothing_feature` clauses. Fixed `mirrorshades` slipping through `_PLURALIA_TANTUM_NOUNS` (would render as `"in a mirrorshades"`); added renderer-cohesion regression test that walks every prototype.
 - Sub-visible disguise items (`disguise_silent_feature`) — **shipped** (issue #174). Items flagged `disguise_silent_feature=True` are excluded from the distinguishing-feature partition in `get_distinguishing_feature` (`typeclasses/characters.py:908–925`) while remaining fully participant in the disguise / Apparent UID system (signature, recognition memory, swap detection). Sole current user: `COLORED_CONTACTS` — contacts sit on the eye, so observers register eye colour rather than "person in colored contacts." Extension point for future sub-visible items (dental prosthetics, scent maskers, etc.). Orthogonal to the Class A / Class B `disguise_adjective` axis (sdesc adjective injection) and to the `"hair"` coverage-list entry (hair feature suppression, #176).
-- Pharmaceutical / biomod items for `@longdesc` override — **deferred** (depends on body-mod system; tracked under Future Hooks).
+- Pharmaceutical / biomod items for `describe` override — **deferred** (depends on body-mod system; tracked under Future Hooks).
 - Photos / identity artifacts — **deferred** (tracked under Future Hooks).
 
 #### Taxonomy decisions (`disguise_type_id`)

--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -493,7 +493,7 @@ longdesc = AttributeProperty(
 ### Current Layer: Base Longdescs
 - Player-set descriptions stored in database
 - Direct display when location is visible
-- Manual setting via @longdesc command
+- Manual setting via `describe` command
 
 ### Future Layer Integration Points
 
@@ -623,7 +623,7 @@ longdesc = AttributeProperty(
 
 ### Initial Implementation ✅ COMPLETED
 1. ✅ **Body location constants definition** - Added to `world/combat/constants.py`
-2. ✅ **@longdesc command implementation** - Complete command in `commands/CmdLongdesc.py`
+2. ✅ **`describe` command implementation** - Complete command (`CmdDescribe`) in `commands/CmdCharacter.py`
 3. ✅ **Character appearance integration** - Enhanced `typeclasses/characters.py`
 4. ✅ **Comprehensive testing and validation** - Full in-game testing completed
 
@@ -648,7 +648,7 @@ longdesc = AttributeProperty(
 ## Success Criteria
 
 ### Functional Requirements ✅ COMPLETED
-- ✅ **Players can set/view/modify longdescs** - Complete @longdesc command suite tested
+- ✅ **Players can set/view/modify longdescs** - Complete `describe` command suite tested
 - ✅ **Descriptions appear in character appearance** - `return_appearance()` integration working
 - ✅ **System integrates with existing look command** - Seamless Evennia integration confirmed
 - ✅ **Validation prevents invalid inputs** - Comprehensive error handling tested
@@ -700,22 +700,22 @@ longdesc = AttributeProperty(
 - `get_longdesc()` - Description retrieval with error handling
 - `return_appearance()` - Integration with Evennia's look system
 
-#### 3. Command System (`commands/CmdLongdesc.py`)
+#### 3. Command System (`commands/CmdCharacter.py`)
 **Status**: ✅ **IMPLEMENTED**  
-**Complete Command Suite**:
-- `@longdesc <location> "<description>"` - Set descriptions with validation
-- `@longdesc <location>` - View specific location descriptions
-- `@longdesc` - List all current character descriptions
-- `@longdesc/list` - Show available body locations grouped by anatomical regions
-- `@longdesc/clear <location>` - Clear specific location descriptions
-- `@longdesc/clear` - Clear all descriptions with confirmation
+**Complete Command Suite** (`describe`):
+- `describe` - Open the interactive editor (lists short desc, keyword, and every body location; pick a slot, type new text, see an instant preview)
+- `describe <location> "<description>"` - Set one body location with validation
+- `describe <location>` - View a specific location's description
+- `describe/list` - Show available body locations grouped by anatomical regions
+- `describe/clear <location>` - Clear a specific location's description
+- `describe/clear` - Clear all descriptions with confirmation
 - **Admin Commands**: Staff can target other characters with proper permission checking
 - **Comprehensive Validation**: Location existence, description length, anatomy verification
 - **User-Friendly Error Messages**: Clear feedback for all error conditions
 
 #### 4. Command Registration (`commands/default_cmdsets.py`)
 **Status**: ✅ **IMPLEMENTED**  
-- Added import and registration of `CmdLongdesc` in `CharacterCmdSet`
+- Added import and registration of `CmdDescribe` in `CharacterCmdSet`
 - Integrated with existing command structure
 
 ### Technical Architecture ✅ IMPLEMENTED
@@ -752,7 +752,7 @@ longdesc = AttributeProperty(
 
 #### Ready for Live Testing 🧪 PENDING
 - 🧪 **Character creation and longdesc initialization** - Auto-creation on character creation
-- 🧪 **@longdesc command functionality** - All command variations and switches
+- 🧪 **`describe` command functionality** - All command variations and switches
 - 🧪 **Character appearance integration** - Look command integration via `return_appearance()`
 - 🧪 **Error handling and edge cases** - Invalid locations, permission checks, validation
 
@@ -760,21 +760,23 @@ longdesc = AttributeProperty(
 
 ```bash
 # Basic description setting
-@longdesc face "High cheekbones and a defined jawline lend {their} face a rough calm."
-@longdesc left_eye "A piercing blue eye glints with flecks of gold."  
-@longdesc right_hand "A prosthetic metal hand ends in intricately engraved fingers."
+describe face "High cheekbones and a defined jawline lend {their} face a rough calm."
+describe left_eye "A piercing blue eye glints with flecks of gold."  
+describe right_hand "A prosthetic metal hand ends in intricately engraved fingers."
+
+# Interactive editor (lists short desc, keyword, and every body location for editing)
+describe
 
 # Discovery and management
-@longdesc/list           # Show available locations grouped by region
-@longdesc face           # View current face description
-@longdesc                # List all set descriptions in anatomical order
-@longdesc/clear face     # Clear specific location
-@longdesc/clear          # Clear all descriptions with confirmation
+describe/list           # Show available locations grouped by region
+describe face           # View current face description
+describe/clear face     # Clear specific location
+describe/clear          # Clear all descriptions with confirmation
 
 # Staff moderation commands  
-@longdesc PlayerName face "staff-modified description"
-@longdesc/clear PlayerName face
-@longdesc/clear PlayerName
+describe PlayerName face "staff-modified description"
+describe/clear PlayerName face
+describe/clear PlayerName
 ```
 
 ### Integration with Look System ✅ IMPLEMENTED
@@ -799,7 +801,7 @@ Broad shoulders taper to a narrow waist, clearly showing years of physical train
 
 1. **Start Evennia server** with implemented changes
 2. **Test character creation** - verify longdesc auto-initialization  
-3. **Test @longdesc commands** - all variations, switches, and edge cases
+3. **Test `describe` commands** - all variations, switches, and edge cases
 4. **Test look integration** - verify appearance assembly and formatting
 5. **Test admin commands** - staff permissions and character targeting
 6. **Validate error handling** - invalid inputs, permission failures

--- a/specs/PRONOUN_DEEP_DIVE_IMPLEMENTATION_SPEC.md
+++ b/specs/PRONOUN_DEEP_DIVE_IMPLEMENTATION_SPEC.md
@@ -1,5 +1,7 @@
 # Pronoun System Deep Dive: Clothing & Longdesc Integration
 
+> **STATUS: SUPERSEDED / HISTORICAL.** The `$pron()`/FuncParser design proposed here was not implemented. Perspective-aware pronouns shipped via the grammar engine and `{their}`/`{they}` brace tokens instead. See `GRAMMAR_ENGINE_SPEC.md` and `LONGDESC_SYSTEM_SPEC.md` for the actual implementation. Retained for historical design context.
+
 ## Overview
 
 This specification focuses on integrating Evennia's `$pron()` system specifically with clothing and longdesc systems to create perspective-aware character descriptions. The goal is to make `look <character>` commands show different text based on who is looking - using "your" when examining yourself vs "his/her/their" when examining others.


### PR DESCRIPTION
## Summary
- `IDENTITY_RECOGNITION_SPEC.md` / `LONGDESC_SYSTEM_SPEC.md` / `GRAMMAR_ENGINE_SPEC.md`: replace leftover `@longdesc`/`@shortdesc` tokens with the unified `describe` command; fix dead `commands/CmdLongdesc.py` path → `commands/CmdCharacter.py::CmdDescribe`; align examples with real `describe` syntax.
- `PRONOUN_DEEP_DIVE_IMPLEMENTATION_SPEC.md`: prepend SUPERSEDED/HISTORICAL banner — the proposed `$pron()`/FuncParser design was never built; perspective-aware pronouns shipped via the grammar engine and `{their}`/`{they}` brace tokens. Body retained for design history.

Docs-only. Closes #293