### PR TITLE
Add lookplace and tempplace to describe command

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -555,10 +555,12 @@ class CmdDescribe(Command):
     every body location with its current value; pick a number, type the new
     text, and you get an instant preview of how others will see it.
 
-    Your appearance has three parts:
+    Your appearance has five parts:
       |wShort Description|n  - the main paragraph shown when others look at you.
       |wKeyword|n            - the noun strangers see in your sdesc, e.g. the
                           "|wman|n" in "a lanky man in a Black Trenchcoat".
+      |wLook Place|n         - your default room positioning ("standing here.").
+      |wTemp Place|n         - a temporary override cleared on room exit.
       |wBody locations|n     - per-part longdesc text (eyes, hands, ...) woven
                           into your description when looked at.
 
@@ -585,6 +587,10 @@ class CmdDescribe(Command):
         describe                                - Open the interactive editor
         describe short <description>            - Set your short description
         describe keyword <word>                 - Set your sdesc keyword
+        describe lookplace <description>        - Set your look place
+        describe lookplace clear                - Reset look place to default
+        describe tempplace <description>        - Set your temp place
+        describe tempplace clear                - Clear temp place
         describe <location> "<description>"     - Set one body location
         describe <location>                     - View one body location
         describe/list                           - List available body locations
@@ -665,6 +671,14 @@ class CmdDescribe(Command):
                 caller.msg("Usage: |wdescribe short <description>|n")
                 return
             self._set_short(caller, text)
+            return
+
+        if first.lower() in ("lookplace", "look_place"):
+            self._set_lookplace(caller, rest.strip())
+            return
+
+        if first.lower() in ("tempplace", "temp_place"):
+            self._set_tempplace(caller, rest.strip())
             return
 
         # Parse arguments for main command
@@ -778,6 +792,53 @@ class CmdDescribe(Command):
             text, caller, force_third_person=True
         )
         caller.msg(f"|WPreview:|n |W{rendered}|n")
+
+    def _set_lookplace(self, caller, text):
+        """Set or display the caller's look_place."""
+        if not text:
+            current = caller.look_place or "standing here."
+            caller.msg(f"Your current look place: '{current}'")
+            return
+        if text.lower() in ("clear", "none", "remove"):
+            caller.look_place = "standing here."
+            caller.msg("Look place reset to 'standing here.'")
+            return
+        description = _parse_placement_description(text)
+        if not description:
+            caller.msg("Usage: |wdescribe lookplace <description>|n")
+            return
+        if len(description) > 200:
+            caller.msg(f"|rLook place too long ({len(description)} chars). Max 200.|n")
+            return
+        if not description.endswith(('.', '!', '?')):
+            description += '.'
+        caller.look_place = description
+        caller.msg(f"Look place set to: '{description}'")
+
+    def _set_tempplace(self, caller, text):
+        """Set or display the caller's temp_place."""
+        if not text:
+            current = caller.temp_place or ""
+            if current:
+                caller.msg(f"Your current temp place: '{current}'")
+            else:
+                caller.msg("No temp place set.")
+            return
+        if text.lower() in ("clear", "none", "remove"):
+            caller.temp_place = ""
+            caller.msg("Temp place cleared.")
+            return
+        description = _parse_placement_description(text)
+        if not description:
+            caller.msg("Usage: |wdescribe tempplace <description>|n")
+            return
+        if len(description) > 200:
+            caller.msg(f"|rTemp place too long ({len(description)} chars). Max 200.|n")
+            return
+        if not description.endswith(('.', '!', '?')):
+            description += '.'
+        caller.temp_place = description
+        caller.msg(f"Temp place set to: '{description}' (cleared on room exit)")
 
     def _handle_list_locations(self, caller):
         """Show all available body locations for the character."""
@@ -1186,6 +1247,8 @@ def _show_describe_menu(caller):
             "node_describe_list": _node_describe_list,
             "node_describe_short": _node_describe_short,
             "node_describe_keyword": _node_describe_keyword,
+            "node_lookplace_entry": _node_lookplace_entry,
+            "node_tempplace_entry": _node_tempplace_entry,
             "node_longdesc_entry": _node_longdesc_entry,
             "node_longdesc_exit": _node_longdesc_exit,
         },
@@ -1251,9 +1314,17 @@ def _node_describe_list(caller, raw_string, **kwargs):
     shown_kw = current_kw if current_kw else f"{default_kw} (default)"
     rows.append(("2", "Keyword", shown_kw))
 
-    # 3..N) Body-location longdesc slots.
+    # 3) Look place.
+    look_place = caller.look_place or "standing here."
+    rows.append(("3", "Look Place", look_place))
+
+    # 4) Temp place.
+    temp_place = caller.temp_place or "(none)"
+    rows.append(("4", "Temp Place", temp_place))
+
+    # 5..N) Body-location longdesc slots.
     for offset, slot in enumerate(slots):
-        idx = offset + 3
+        idx = offset + 5
         value, diverged = _longdesc_slot_value(caller, slot)
         if diverged:
             shown = "(sides differ \u2014 editing sets both alike)"
@@ -1284,7 +1355,7 @@ def _process_describe_choice(caller, raw_string, **kwargs):
     if choice.lower() in ("x", "exit"):
         return "node_longdesc_exit"
 
-    last = len(slots) + 2
+    last = len(slots) + 4
     try:
         idx = int(choice)
     except ValueError:
@@ -1295,8 +1366,12 @@ def _process_describe_choice(caller, raw_string, **kwargs):
         return "node_describe_short"
     if idx == 2:
         return "node_describe_keyword"
+    if idx == 3:
+        return "node_lookplace_entry"
+    if idx == 4:
+        return "node_tempplace_entry"
 
-    slot_idx = idx - 3
+    slot_idx = idx - 5
     if 0 <= slot_idx < len(slots):
         caller.ndb._longdesc_active_slot = slots[slot_idx]
         return "node_longdesc_entry"
@@ -1451,6 +1526,83 @@ def _menu_apply_keyword(caller, keyword):
             f"\nSet keyword to |w{keyword}|n."
             f"\nYou now appear as: |c{sdesc}|n"
         )
+
+
+def _node_lookplace_entry(caller, raw_string, **kwargs):
+    """EvMenu node: prompt for the caller's look place."""
+    current = caller.look_place or "standing here."
+    text = "\n|wEditing: Look Place|n\n"
+    text += f"\n|WCurrent: {current}|n\n"
+    text += (
+        "\n|WType your look place description — how you appear in a room by"
+        "\ndefault (e.g. 'leaning against the wall.'). Type |wclear|n to reset"
+        "\nto 'standing here.', or |wback|n to return unchanged.|n"
+    )
+    options = ({"key": "_default", "goto": _process_lookplace_entry},)
+    return text, options
+
+
+def _process_lookplace_entry(caller, raw_string, **kwargs):
+    """Goto-callable: apply the typed look place (or clear/back)."""
+    entry = raw_string.strip()
+    if not entry or entry.lower() == "back":
+        return "node_describe_list"
+    if entry.lower() in ("clear", "none", "remove"):
+        caller.look_place = "standing here."
+        caller.msg("Look place reset to 'standing here.'")
+        return "node_describe_list"
+    description = _parse_placement_description(entry)
+    if not description:
+        caller.msg("|rPlease enter a description.|n")
+        return None
+    if len(description) > 200:
+        caller.msg(f"|rToo long ({len(description)} chars). Max 200.|n")
+        return None
+    if not description.endswith(('.', '!', '?')):
+        description += '.'
+    caller.look_place = description
+    caller.msg(f"Look place set to: '{description}'")
+    return "node_describe_list"
+
+
+def _node_tempplace_entry(caller, raw_string, **kwargs):
+    """EvMenu node: prompt for the caller's temp place."""
+    current = caller.temp_place or ""
+    text = "\n|wEditing: Temp Place|n\n"
+    if current:
+        text += f"\n|WCurrent: {current}|n\n"
+    else:
+        text += "\n|WCurrent: (none)|n\n"
+    text += (
+        "\n|WType a temporary placement description — overrides your look place"
+        "\nuntil you move rooms (e.g. 'crouched behind the counter.'). Type"
+        "\n|wclear|n to remove it, or |wback|n to return unchanged.|n"
+    )
+    options = ({"key": "_default", "goto": _process_tempplace_entry},)
+    return text, options
+
+
+def _process_tempplace_entry(caller, raw_string, **kwargs):
+    """Goto-callable: apply the typed temp place (or clear/back)."""
+    entry = raw_string.strip()
+    if not entry or entry.lower() == "back":
+        return "node_describe_list"
+    if entry.lower() in ("clear", "none", "remove"):
+        caller.temp_place = ""
+        caller.msg("Temp place cleared.")
+        return "node_describe_list"
+    description = _parse_placement_description(entry)
+    if not description:
+        caller.msg("|rPlease enter a description.|n")
+        return None
+    if len(description) > 200:
+        caller.msg(f"|rToo long ({len(description)} chars). Max 200.|n")
+        return None
+    if not description.endswith(('.', '!', '?')):
+        description += '.'
+    caller.temp_place = description
+    caller.msg(f"Temp place set to: '{description}' (cleared on room exit)")
+    return "node_describe_list"
 
 
 def _node_longdesc_entry(caller, raw_string, **kwargs):

--- a/world/tests/test_describe_menu.py
+++ b/world/tests/test_describe_menu.py
@@ -1,19 +1,23 @@
 """Unit tests for the unified ``describe`` editor: combined list, short
-description, and keyword nodes.
+description, keyword, lookplace, tempplace, and body-location nodes.
 
-The ``describe`` command merges the former ``@longdesc``, ``@shortdesc``, and
-Evennia ``setdesc`` surfaces into one flat EvMenu whose top-level list is::
+The ``describe`` command merges the former ``@longdesc``, ``@shortdesc``,
+``@look_place``, ``@temp_place``, and Evennia ``setdesc`` surfaces into one
+flat EvMenu whose top-level list is::
 
      1. Short Description :: (db.desc)
      2. Keyword           :: (sdesc_keyword)
-     3..N. body-location longdesc slots (capitalized labels)
+     3. Look Place        :: (look_place)
+     4. Temp Place        :: (temp_place)
+     5..N. body-location longdesc slots (capitalized labels)
      x. Exit
 
 These tests cover the combined-list numbering/rendering, the Short
 Description node (set / clear / back / preview and the one-off
 ``describe short`` path), the Keyword node (numbered + named selection,
-return-to-list behaviour, invalid input), and verify that Evennia's default
-``setdesc`` is removed from the character cmdset.
+return-to-list behaviour, invalid input), the Look/Temp Place nodes (set /
+clear / back), and verify that Evennia's default ``setdesc`` is removed from
+the character cmdset.
 
 Run via::
 
@@ -33,8 +37,12 @@ from commands.CmdCharacter import (
     _node_describe_keyword,
     _node_describe_list,
     _node_describe_short,
+    _node_lookplace_entry,
+    _node_tempplace_entry,
     _process_describe_keyword,
     _process_describe_short,
+    _process_lookplace_entry,
+    _process_tempplace_entry,
 )
 from world.combat.constants import DEFAULT_LONGDESC_LOCATIONS
 
@@ -58,12 +66,15 @@ class FakeChar(AppearanceMixin):
 
     gender = "neutral"
 
-    def __init__(self, locations=None, *, desc="", sdesc_keyword=None):
+    def __init__(self, locations=None, *, desc="", sdesc_keyword=None,
+                 look_place="standing here.", temp_place=""):
         self._longdesc = dict(locations or {})
         self.db = _DB()
         self.db.desc = desc
         self.ndb = _NDB()
         self.sdesc_keyword = sdesc_keyword
+        self.look_place = look_place
+        self.temp_place = temp_place
         self.messages = []
 
     # --- longdesc storage surface -------------------------------------
@@ -135,17 +146,37 @@ class ListNodeTests(TestCase):
         self.assertIn("droog", kw_line)
         self.assertNotIn("(default)", kw_line)
 
-    def test_body_slots_start_at_three(self):
+    def test_lookplace_is_item_three(self):
+        char = _full_body(look_place="leaning on the wall.")
+        text, _ = _node_describe_list(char, "")
+        lp_line = next(ln for ln in text.splitlines() if "Look Place" in ln)
+        self.assertIn(" 3", lp_line)
+        self.assertIn("leaning on the wall.", lp_line)
+
+    def test_tempplace_is_item_four(self):
+        char = _full_body(temp_place="crouched behind the counter.")
+        text, _ = _node_describe_list(char, "")
+        tp_line = next(ln for ln in text.splitlines() if "Temp Place" in ln)
+        self.assertIn(" 4", tp_line)
+        self.assertIn("crouched behind the counter.", tp_line)
+
+    def test_tempplace_shows_none_when_empty(self):
+        char = _full_body(temp_place="")
+        text, _ = _node_describe_list(char, "")
+        tp_line = next(ln for ln in text.splitlines() if "Temp Place" in ln)
+        self.assertIn("(none)", tp_line)
+
+    def test_body_slots_start_at_five(self):
         char = _full_body()
         slots = _build_longdesc_slots(char)
         text, _ = _node_describe_list(char, "")
-        # First body slot is numbered 3 (1=short, 2=keyword) and shown with
-        # its capitalized display label.
+        # First body slot is numbered 5 (1=short, 2=keyword, 3=lookplace,
+        # 4=tempplace) and shown with its capitalized display label.
         first_label = _describe_slot_label(slots[0])
         slot_line = next(
             ln for ln in text.splitlines() if first_label in ln
         )
-        self.assertIn(" 3", slot_line)
+        self.assertIn(" 5", slot_line)
 
     def test_rows_use_double_colon_separator(self):
         char = _full_body(desc="a lanky figure")
@@ -293,6 +324,111 @@ class KeywordMenuTests(TestCase):
         self.assertIn("Keyword", text)
         self.assertIsNotNone(getattr(char.ndb, "_shortdesc_keywords", None))
         self.assertTrue(len(char.ndb._shortdesc_keywords) > 0)
+
+
+# =====================================================================
+# Look Place node
+# =====================================================================
+
+
+class LookPlaceNodeTests(TestCase):
+
+    def test_set_stores_and_returns_to_list(self):
+        char = _full_body()
+        result = _process_lookplace_entry(char, "sitting at the bar.")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.look_place, "sitting at the bar.")
+
+    def test_auto_appends_period(self):
+        char = _full_body()
+        _process_lookplace_entry(char, "leaning against the wall")
+        self.assertEqual(char.look_place, "leaning against the wall.")
+
+    def test_clear_resets_to_default(self):
+        char = _full_body(look_place="sitting.")
+        result = _process_lookplace_entry(char, "clear")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.look_place, "standing here.")
+        self.assertTrue(any("reset" in m for m in char.messages))
+
+    def test_back_returns_unchanged(self):
+        char = _full_body(look_place="original.")
+        result = _process_lookplace_entry(char, "back")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.look_place, "original.")
+
+    def test_blank_returns_unchanged(self):
+        char = _full_body(look_place="original.")
+        result = _process_lookplace_entry(char, "   ")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.look_place, "original.")
+
+    def test_too_long_redisplays(self):
+        char = _full_body()
+        result = _process_lookplace_entry(char, "x" * 201)
+        self.assertIsNone(result)
+        self.assertTrue(any("long" in m for m in char.messages))
+
+    def test_node_shows_current(self):
+        char = _full_body(look_place="standing in the corner.")
+        text, _ = _node_lookplace_entry(char, "")
+        self.assertIn("Look Place", text)
+        self.assertIn("standing in the corner.", text)
+
+
+# =====================================================================
+# Temp Place node
+# =====================================================================
+
+
+class TempPlaceNodeTests(TestCase):
+
+    def test_set_stores_and_returns_to_list(self):
+        char = _full_body()
+        result = _process_tempplace_entry(char, "crouched behind the crate.")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.temp_place, "crouched behind the crate.")
+
+    def test_auto_appends_period(self):
+        char = _full_body()
+        _process_tempplace_entry(char, "hiding in the shadows")
+        self.assertEqual(char.temp_place, "hiding in the shadows.")
+
+    def test_clear_empties(self):
+        char = _full_body(temp_place="something.")
+        result = _process_tempplace_entry(char, "clear")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.temp_place, "")
+        self.assertTrue(any("cleared" in m for m in char.messages))
+
+    def test_back_returns_unchanged(self):
+        char = _full_body(temp_place="original.")
+        result = _process_tempplace_entry(char, "back")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.temp_place, "original.")
+
+    def test_blank_returns_unchanged(self):
+        char = _full_body(temp_place="original.")
+        result = _process_tempplace_entry(char, "   ")
+        self.assertEqual(result, "node_describe_list")
+        self.assertEqual(char.temp_place, "original.")
+
+    def test_too_long_redisplays(self):
+        char = _full_body()
+        result = _process_tempplace_entry(char, "x" * 201)
+        self.assertIsNone(result)
+        self.assertTrue(any("long" in m for m in char.messages))
+
+    def test_node_shows_none_when_empty(self):
+        char = _full_body(temp_place="")
+        text, _ = _node_tempplace_entry(char, "")
+        self.assertIn("Temp Place", text)
+        self.assertIn("(none)", text)
+
+    def test_node_shows_current_when_set(self):
+        char = _full_body(temp_place="hiding behind a pillar.")
+        text, _ = _node_tempplace_entry(char, "")
+        self.assertIn("hiding behind a pillar.", text)
 
 
 # =====================================================================

--- a/world/tests/test_longdesc_menu.py
+++ b/world/tests/test_longdesc_menu.py
@@ -46,6 +46,8 @@ class FakeChar(AppearanceMixin):
 
     gender = "neutral"
     sdesc_keyword = None
+    look_place = "standing here."
+    temp_place = ""
 
     def __init__(self, locations):
         self._longdesc = dict(locations)
@@ -224,8 +226,8 @@ class SlotSelectionTests(TestCase):
 
     def test_valid_number_targets_slot(self):
         char = self._char_with_slots()
-        # Slots begin at 3 (1=short desc, 2=keyword).
-        result = _process_describe_choice(char, "3")
+        # Slots begin at 5 (1=short desc, 2=keyword, 3=lookplace, 4=tempplace).
+        result = _process_describe_choice(char, "5")
         self.assertEqual(result, "node_longdesc_entry")
         self.assertEqual(char.ndb._longdesc_active_slot, char.ndb._longdesc_slots[0])
 


### PR DESCRIPTION
## Summary

- `describe lookplace <text>` / `describe lookplace clear` — set or reset look_place
- `describe tempplace <text>` / `describe tempplace clear` — set or clear temp_place
- Both appear as rows 3 and 4 in the interactive `describe` EvMenu editor; body locations shift to start at row 5
- `@look_place` / `@temp_place` commands kept intact for backwards compatibility

## Test plan
- [ ] `describe lookplace sitting at the bar.` sets look_place
- [ ] `describe lookplace clear` resets to "standing here."
- [ ] `describe tempplace hiding behind a crate.` sets temp_place; clears on room exit
- [ ] `describe tempplace clear` clears immediately
- [ ] Bare `describe` opens editor; rows 3/4 are Look Place/Temp Place; body slots begin at 5
- [ ] `docker exec gelatinous evennia test --settings settings.py world.tests.test_describe_menu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)