### PR TITLE
Drop per-location decay modifier spam from corpse rendering

### DIFF
--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -299,10 +299,12 @@ class Corpse(IdentityBearerMixin, Item):
             if left_desc != right_desc:
                 continue
             # Both sides match — render once at plural number.
+            # Overall decay state is conveyed by the corpse header
+            # paragraph (_build_decay_desc_paragraph); per-location
+            # echoes were dropped in issue #323.
             processed = self._process_corpse_description_variables(
                 left_desc, number="plural",
             )
-            processed = self._apply_decay_to_description(processed)
             collapse_anchor[left_loc] = processed
             collapse_skip.add(right_loc)
 
@@ -330,10 +332,10 @@ class Corpse(IdentityBearerMixin, Item):
                     final_desc = collapse_anchor[location]
                 elif location in longdesc_data and longdesc_data[location]:
                     description = longdesc_data[location]
-                    # Process template variables like living characters do
-                    processed_desc = self._process_corpse_description_variables(description)
-                    # Apply decay modifications to the description
-                    final_desc = self._apply_decay_to_description(processed_desc)
+                    # Process template variables like living characters do.
+                    # Overall decay is conveyed by the corpse header
+                    # paragraph; per-location echoes were dropped (#323).
+                    final_desc = self._process_corpse_description_variables(description)
 
                 # Add preserved wound descriptions for this location
                 wound_descriptions = self.get_preserved_wound_descriptions(location)
@@ -448,25 +450,26 @@ class Corpse(IdentityBearerMixin, Item):
             # Clear item context
             if hasattr(self, '_current_item_context'):
                 delattr(self, '_current_item_context')
-            
-            # Apply decay modifications
-            return self._apply_decay_to_description(corpse_desc)
-        
+
+            # Overall decay is conveyed by the corpse header paragraph;
+            # per-location echoes were dropped (#323).
+            return corpse_desc
+
         # Fallback to item description
         item_desc = clothing_item.db.desc
         if item_desc:
             # Process template variables
             processed_desc = self._process_corpse_description_variables(item_desc)
-            
+
             # Create a simple worn description
             item_name = clothing_item.get_display_name(None)
             corpse_desc = f"The corpse is wearing {item_name}."
-            
+
             # Clear item context
             if hasattr(self, '_current_item_context'):
                 delattr(self, '_current_item_context')
-                
-            return self._apply_decay_to_description(corpse_desc)
+
+            return corpse_desc
         
         # Clear item context
         if hasattr(self, '_current_item_context'):
@@ -629,21 +632,6 @@ class Corpse(IdentityBearerMixin, Item):
                 pass
         
         return processed_desc
-    
-    def _apply_decay_to_description(self, description):
-        """Modify a description based on current decay stage."""
-        stage = self.get_decay_stage()
-        
-        decay_modifiers = {
-            "fresh": "",  # No modification for fresh corpses
-            "early": " The area shows early signs of pallor and cooling.",
-            "moderate": " Visible discoloration and early decomposition changes are apparent.",
-            "advanced": " Severe decomposition changes have altered the appearance significantly.", 
-            "skeletal": " Only skeletal remains and dried tissue are visible."
-        }
-        
-        modifier = decay_modifiers.get(stage, "")
-        return f"{description}{modifier}"
     
     def return_appearance(self, looker, **kwargs):
         """Render the corpse without mutating any persistent state.

--- a/world/tests/test_corpse_token_render.py
+++ b/world/tests/test_corpse_token_render.py
@@ -42,7 +42,6 @@ class _CorpseStub:
     _build_corpse_clothing_coverage_map = (
         Corpse._build_corpse_clothing_coverage_map
     )
-    _apply_decay_to_description = Corpse._apply_decay_to_description
     _build_decay_desc_paragraph = Corpse._build_decay_desc_paragraph
     get_preserved_wound_descriptions = Corpse.get_preserved_wound_descriptions
     get_decay_stage = Corpse.get_decay_stage
@@ -215,6 +214,36 @@ class PairCollapseTests(TestCase):
         # The braced {eyes} flexes to singular "eye"; surrounding plain
         # prose (the bare verb "hold") stays as authored.
         self.assertIn("His eye hold steady", eye_entries[0][1])
+
+    def test_no_per_location_decay_echo(self):
+        """Issue #323: the per-location decay modifier was being appended
+        to every longdesc line, producing the same sentence 20+ times.
+        Overall decay is conveyed by the corpse header paragraph
+        (_build_decay_desc_paragraph) — per-location longdescs must not
+        carry an echo.
+        """
+        c = _CorpseStub(
+            gender="male",
+            longdesc_data={
+                "hair": "It is cropped close.",
+                "face": "His face is unremarkable.",
+                "chest": "His chest is broad.",
+            },
+        )
+        descriptions = c._get_preserved_longdesc_descriptions()
+        # No location's rendered prose should contain the decay tagline.
+        decay_phrases = (
+            "early signs of pallor",
+            "Visible discoloration",
+            "Severe decomposition",
+            "skeletal remains",
+        )
+        for loc, text in descriptions:
+            for phrase in decay_phrases:
+                self.assertNotIn(
+                    phrase, text,
+                    f"Decay echo leaked into {loc} longdesc: {text!r}",
+                )
 
     def test_no_leaked_braces_anywhere(self):
         # End-to-end: load all the pair-key templates and confirm output


### PR DESCRIPTION
## Summary

- Removes the per-location \`_apply_decay_to_description\` calls from \`Corpse._get_preserved_longdesc_descriptions\` (pair-collapse + single-location paths) and \`_get_clothing_desc_for_corpse\` (both worn-desc and fallback paths).
- Removes the now-unused \`_apply_decay_to_description\` helper itself, plus the stub binding in the test file.
- Adds a regression test that walks the rendered longdesc list and asserts no decay tagline phrase leaks into any per-location text.

The corpse header paragraph (\`_build_decay_desc_paragraph\` via \`get_species_corpse_description\`) already conveys overall decay state once. The per-location echo was rendering the same sentence 20+ times per look — pure spam.

\`Appendage\` / \`SeveredHead\` are unaffected; they surface decay via the independent condition-keyed prose helper (\`pristine\` / \`damaged\` / \`putrid\` / \`refuse\`).

## Test plan
- [x] \`docker exec gelatinous evennia test --settings settings.py world\` (1525 pass)
- [ ] Look at a fresh corpse: decay sentence appears once in the header, no per-location echoes
- [ ] Look at a moderate-stage corpse: same shape, with the moderate decay sentence in the header
- [ ] Look at a severed appendage: unchanged condition-keyed prose

🤖 Generated with [Claude Code](https://claude.com/claude-code)