### PR TITLE
Move pelvis organ from abdomen to groin container

### DIFF
--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -427,8 +427,13 @@ ORGANS = {
     },
 
     # STRUCTURAL ORGANS FOR MOVEMENT
+    # Pelvis is housed in the ``groin`` container (issue #325). Before this
+    # change it lived in ``abdomen`` — anatomically wrong, and it left the
+    # groin container with zero organs, making groin combat hits a free
+    # no-op (apply_anatomical_damage's distribution returned ``{}`` and no
+    # organ HP / wound / bleeding ever resulted).
     "pelvis": {
-        "container": "abdomen", "max_hp": 25, "hit_weight": "uncommon",
+        "container": "groin", "max_hp": 25, "hit_weight": "uncommon",
         "capacity": "moving", "contribution": "total", "vital": True
     }
 }

--- a/world/tests/test_groin_pelvis.py
+++ b/world/tests/test_groin_pelvis.py
@@ -1,0 +1,89 @@
+"""Tests for the pelvis-in-groin container fix (issue #325).
+
+Pre-fix the pelvis organ was housed in the ``abdomen`` container, leaving
+``groin`` with zero organs. Combat hits that the engine routed to the
+groin fell through ``distribute_damage_to_organs("groin", ...)``'s
+empty-list path, ``apply_anatomical_damage`` never called
+``take_organ_damage``, and the character took zero medical damage despite
+the hit message firing.
+
+Tests cover:
+
+* The pelvis is registered in the groin container.
+* ``get_organ_by_body_location("groin")`` includes the pelvis (the
+  symptomatic empty-list case is gone).
+* ``distribute_damage_to_organs("groin", ...)`` resolves to the pelvis
+  on a stock anatomy character — actual organ damage is applied.
+* ``_get_vital_locations`` is unchanged — pelvis belongs to ``moving``
+  (not a lethal capacity), so groin does not become a vital location.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.medical.constants import LETHAL_CAPACITY_NAMES, ORGANS
+from world.medical.utils import (
+    _get_vital_locations,
+    get_organ_by_body_location,
+)
+
+
+class TestPelvisContainer(TestCase):
+    def test_pelvis_lives_in_groin(self):
+        self.assertEqual(ORGANS["pelvis"]["container"], "groin")
+
+    def test_groin_container_has_pelvis(self):
+        organs = get_organ_by_body_location("groin")
+        self.assertIn("pelvis", organs)
+
+    def test_abdomen_container_no_longer_has_pelvis(self):
+        organs = get_organ_by_body_location("abdomen")
+        self.assertNotIn("pelvis", organs)
+
+
+class TestGroinDamageFlow(TestCase):
+    """``distribute_damage_to_organs("groin", ...)`` must now route to the
+    pelvis instead of returning the symptomatic empty dict."""
+
+    def _stock_medical_state(self):
+        from world.medical.core import MedicalState
+        return MedicalState(character=None)
+
+    def test_distribute_damage_routes_to_pelvis(self):
+        from world.medical.utils import distribute_damage_to_organs
+
+        ms = self._stock_medical_state()
+        distribution = distribute_damage_to_organs(
+            "groin", 10, ms, injury_type="blunt",
+        )
+        self.assertIn("pelvis", distribution)
+        self.assertGreater(distribution["pelvis"], 0)
+
+    def test_distribute_damage_with_target_organ_pelvis(self):
+        from world.medical.utils import distribute_damage_to_organs
+
+        ms = self._stock_medical_state()
+        distribution = distribute_damage_to_organs(
+            "groin", 12, ms, injury_type="blunt",
+            target_organ="pelvis",
+        )
+        self.assertEqual(distribution, {"pelvis": 12})
+
+
+class TestVitalLocationsUnchanged(TestCase):
+    """Moving the pelvis to the groin must not affect the vital set —
+    pelvis is in ``moving``, not a lethal capacity."""
+
+    def test_groin_not_in_vital_set(self):
+        # Defensive: groin must not show up as a vital location just
+        # because it now has an organ. Pelvis isn't in
+        # LETHAL_CAPACITY_NAMES, so the container shouldn't either.
+        vital = _get_vital_locations(None)
+        self.assertNotIn("groin", vital)
+
+    def test_pelvis_capacity_is_not_lethal(self):
+        # Guard the assumption that justifies the container move — if
+        # someone reclassifies "moving" as lethal in the future, the
+        # vital-set behaviour will need re-review.
+        self.assertNotIn("moving", LETHAL_CAPACITY_NAMES)


### PR DESCRIPTION
## Summary

- Pelvis is already fully defined as an organ (max_hp 25, hit_weight uncommon, vital, capacity \"moving\") with decay-stage prose, but its container was set to \`\"abdomen\"\` — anatomically wrong and leaving groin with zero organs.
- Combat hits that landed on the groin therefore did nothing: \`distribute_damage_to_organs(\"groin\", ...)\` returned \`{}\`, the organ-damage loop never executed, and \`take_damage\` returned \`(False, final_damage)\` — hit message fired but the body took zero medical damage.
- One-character fix: \`pelvis.container = \"groin\"\`. Now groin hits damage the pelvis, which already contributes 1.0 to the \"moving\" capacity, so a pulped pelvis impairs walking proportionally.
- \`_get_vital_locations\` unchanged — pelvis is in \"moving\", not \`LETHAL_CAPACITY_NAMES\`, so groin does NOT become a vital location.

## Test plan
- [x] \`docker exec gelatinous evennia test --settings settings.py world.tests.test_groin_pelvis world.tests.test_vital_locations\` (12 pass)
- [x] Full suite \`docker exec gelatinous evennia test --settings settings.py world\` (1532 pass)
- [ ] In-game: attack a mob's groin and verify organ damage / wound / mobility impairment

🤖 Generated with [Claude Code](https://claude.com/claude-code)