### PR TITLE
Add Medical & Combat Audit and Remediation Spec

### DIFF
--- a/specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md
+++ b/specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md
@@ -1,0 +1,629 @@
+# Medical & Combat Audit and Remediation Spec
+
+## Overview
+
+End-to-end audit of the medical and combat systems, the death-progression
+pipeline, and the tertiary systems they depend on (wounds, conditions, armor,
+corpse, hit selection). This spec catalogues every drift, dead metadata flag,
+and documented-but-unimplemented feature found in that audit, and lays out a
+prioritised remediation plan with discrete phases.
+
+Status: **proposal**. Author: audit pass after the pelvis-in-groin fix
+(issue #325) surfaced broader questions about death model and dead metadata.
+
+---
+
+## Core Insight — Schema Without Consumers
+
+The repeated pattern surfaced by this audit isn't "dead code from sloppy
+work" — it's **a top-down anatomical schema whose bottom-up consumers were
+never built**. The medical system has three intended layers:
+
+1. **Schema** (`ORGANS`, `BODY_CAPACITIES`, threshold constants). Authored
+   anatomically — heart, lungs, kidneys, spine, brain, with realistic
+   contributions and thresholds.
+2. **Capacity calculation** (`MedicalState.calculate_body_capacity`,
+   `update_vital_signs`). Implemented and load-bearing.
+3. **Consumer systems** that *react to* capacity loss — perception/senses,
+   movement policing, equipment-handling rules, chronic medical
+   conditions. **Largely unbuilt.**
+
+Capacity loss therefore has nowhere to go. A character with 0 `sight`
+capacity can still see; with 0 `hearing` they hear; with 12% `moving`
+they walk normally; with the spine destroyed they stand. The schema
+predicts these outcomes; nothing in the runtime enforces them.
+
+This means the dead flags are *not* a cleanup target. They are a
+**substrate-readiness signal**: each flag advertises a consumer system
+that hasn't been written yet. Deleting them would be deleting design
+documentation. The right work is **building the substrates**, then wiring
+the flags into them.
+
+The plan in this spec is sequenced around that insight: foundational
+consumer systems first (where their absence is the gate), then wiring,
+then a final flag-audit pass that deletes only what no consumer ever
+plans to use.
+
+---
+
+## Background
+
+The medical system is structured as three layers:
+
+1. **Static schema** in `world/medical/constants.py` — `ORGANS`, `BODY_CAPACITIES`,
+   `LETHAL_CAPACITY_NAMES`, thresholds.
+2. **Runtime state** in `world/medical/core.py` — `Organ`, `MedicalState`,
+   `is_dead`, `is_unconscious`, `calculate_body_capacity`, `update_vital_signs`.
+3. **Tickers and effects** in `world/medical/conditions.py` and
+   `world/medical/script.py` — bleeding / pain / infection / consciousness
+   suppression, with a 12-second per-character `MedicalScript` driving them.
+
+Combat reaches into the medical layer through `ArmorMixin.take_damage`
+(`typeclasses/armor_mixin.py`), which applies armor reduction, calls
+`apply_anatomical_damage`, then checks `is_dead()` / `is_unconscious()`
+and dispatches to `at_death()` / `_handle_unconsciousness()`. The combat
+handler itself (`world/combat/handler.py`) orchestrates turns; the per-attack
+logic lives in `world/combat/attack.py`.
+
+Death after the synchronous attack is *not* immediate — `at_death()` shows
+the death curtain and launches a 360-second `DeathProgressionScript`
+(`typeclasses/death_progression.py`) with an 11-message narrative and a
+medical-revival window.
+
+The system has evolved through ~14 medical-related PRs (#243 decapitation,
+#251/#252 vital-locations refactor, #254 spinal rename, #325 pelvis-in-groin)
+plus many incremental fixes. The aggregate result is **correct in the paths
+that get exercised, but carries substantial unimplemented design intent in
+the form of declarative metadata**.
+
+---
+
+## Findings
+
+### Category A — Death Model: Aligned, Documented, But Comment-Drifted
+
+| Item | Current Code | Spec Intent | Verdict |
+|---|---|---|---|
+| `is_dead()` checks `blood_pumping`, `breathing`, `digestion`, `neck_integrity`, blood loss | Yes | Yes (`HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` L731–746) | **Correct** |
+| Brain destruction → unconsciousness, not death | Yes | Yes (L732 "consciousness is unconsciousness, not death") | **Intentional** |
+| Brain destruction eventually kills via secondary bleeding | Yes (head wound → `BleedingCondition` → blood loss → `is_dead`) | Implicit | **Works** |
+| Kidney loss is fatal | **No** (`is_dead` never reads `blood_filtration`) | Schema says `total_loss_fatal: True` | **DRIFT** |
+| Comment above `LETHAL_CAPACITY_NAMES` "Keep in sync with is_dead()" | Misleading — it's actually a superset (adds `consciousness` for vital-location bias) | Spec clarifies | **Wording bug** |
+
+**Action**: Rewrite the `LETHAL_CAPACITY_NAMES` comment to explicitly say
+"this is the union of `is_dead()` lethal capacities PLUS `consciousness`,
+which makes the head a vital target but is unconsciousness rather than
+death". This stops future devs from incorrectly "syncing" `consciousness`
+into `is_dead`. **Resolve kidney case** as a separate design call (below).
+
+### Category B — Declarative Metadata Awaiting Substrate
+
+I audited every flag in `ORGANS` and `BODY_CAPACITIES` for read-counts
+outside of the constants file and tests. The "Disposition" column
+reflects the Core Insight above: most of these are *not* dead code, they
+are waiting on a consumer system that hasn't been built.
+
+| Flag | Reads | Intended Consumer | Disposition |
+|---|---|---|---|
+| `vital` (on `Organ`) | 0 | None — superseded by data-driven `_get_vital_locations` | **Vestigial**: delete. |
+| `fatal_threshold` (on capacity) | 0 | Could replace the `<= 0.0` literal in `is_dead` if `is_dead` were refactored to be data-driven | Keep until Phase 7 audit (delete or wire). |
+| `directly_fatal` (on capacity) | 0 (1 test assertion) | Same as `fatal_threshold` — data-driven `is_dead` | Keep until Phase 7 audit. |
+| `total_loss_fatal: True` on `blood_filtration` | 0 | **Chronic Conditions framework** — total kidney loss should spawn a fatal `RenalFailure` condition that takes time to kill (not instant death) | **Substrate gap**: chronic conditions. |
+| `incapacitation_threshold: 0.15` on `moving` | 0 | **Movement Policing system** — when capacity is below this, character cannot move | **Substrate gap**: movement policing. |
+| `unconscious_threshold` (in `consciousness` capacity dict) | 0 | None — duplicated as top-level `CONSCIOUSNESS_UNCONSCIOUS_THRESHOLD` (the one that's actually read) | **Vestigial**: delete. |
+| `modifiers: ["pain", "blood_pumping", ...]` on `consciousness` | 0 | The cascade is already implemented imperatively in `update_vital_signs`; this list is documentation only | **Vestigial**: delete or convert to spec comment. |
+| `affects: ["consciousness", "moving"]` on capacities | 0 | Could drive a generic capacity-effect graph; currently a manual `update_vital_signs` formula does the work | **Vestigial unless** a generic effect-graph is built. |
+| `total_loss_penalty: "blindness"` / `"deafness"` | 0 | **Senses System** — total loss should spawn `BlindCondition` / `DeafCondition` and gate perception | **Substrate gap**: senses. |
+| `total_loss_effects: ["cannot_negotiate", ...]` on `talking` | 0 | **Social interaction rules** — can't speak → can't negotiate, persuade, etc. | **Substrate gap**: social system policing. |
+| `cannot_be_destroyed: True` on `thoracolumbar_spine` | 0 | Should clamp `Organ.take_damage` to floor at 1 HP for this organ | **Direct wire** — small fix, no substrate dependency. |
+| `paralysis_if_destroyed: True` on `thoracolumbar_spine` | 0 | **Movement Policing system** — produces a permanent `ParalysisCondition` that zeroes `moving` capacity | **Substrate gap**: movement policing. |
+| `can_be_destroyed` (most organs) | 0 (1 test) | Inverse of `cannot_be_destroyed`; redundant if the negative form is the canonical one | **Vestigial**: delete after `cannot_be_destroyed` is wired. |
+| `fracture_vulnerable` | 4 | Used by bone-fracture condition spawn path | Live, keep. |
+| `bone_type` | 5 | Used by bone-fracture and severance routing | Live, keep. |
+
+**13 of 15 audited flags are unconsumed by code today.** Reclassified by
+the rubric above:
+
+* **Vestigial (delete)**: `vital` (organ), `unconscious_threshold` (dict
+  copy), `modifiers`, `affects`, `can_be_destroyed`.
+* **Direct wire (no substrate)**: `cannot_be_destroyed` on spine.
+* **Substrate-gap (build substrate first, then wire)**: `total_loss_fatal`
+  (chronic conditions), `incapacitation_threshold` (movement),
+  `total_loss_penalty` blindness/deafness (senses), `total_loss_effects`
+  (social), `paralysis_if_destroyed` (movement).
+* **Audit-later**: `fatal_threshold`, `directly_fatal` — keep until
+  `is_dead` refactor lands.
+
+**This reclassification is the central reason the original Phase 4 and
+Phase 5 cannot ship as I originally scoped them**: their work is gated on
+substrate that doesn't exist yet.
+
+### Category C — Documented "Next" Features
+
+These features are explicitly described in `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC`
+as future work or "could be added".
+
+| Feature | Spec ref | Current state |
+|---|---|---|
+| **Brain death blocks revival** in death progression | L273–296 — has `# NEXT:` pseudo-code | Not implemented. `_check_medical_revival_conditions` only checks `is_dead()`. A brain-destroyed character whose bleeding stops could currently revive into a vegetative shell. |
+| **Movement incapacitation at <15% moving capacity** | L219 (`incapacitation_threshold: 0.15`) | Not enforced. Walk commands don't check capacity. |
+| **Blindness on `sight = 0`** | `total_loss_penalty: "blindness"` | Not enforced. Combat targeting / look unaffected. |
+| **Deafness on `hearing = 0`** | `total_loss_penalty: "deafness"` | Not enforced. |
+| **Paralysis on thoracolumbar spine destruction** | `paralysis_if_destroyed: True` | Not enforced. Spine can be destroyed but produces no paralysis condition. |
+| **Manipulation loss → drop weapons / can't wield** | `affects: ["work_speed", "melee_accuracy"]` | Not enforced beyond hit accuracy implicitly. |
+| **Pain-driven unconsciousness path** | `PAIN_UNCONSCIOUS_THRESHOLD: 80` | **Partially**: pain reduces `self.consciousness` float, which then trips the consciousness threshold. Not a direct check, but functionally equivalent. |
+
+### Category D — Combat-Side Drift
+
+| Item | State |
+|---|---|
+| `select_hit_location` falls back to `chest` when character has no longdesc | Defensive but masks bad data — a logged warning would surface broken anatomy. |
+| `damage_distribution = {}` falls through to `total_damage: damage_amount` with no organs damaged | This was the **groin pre-#325 bug**. Now fixed for groin, but the *failure mode* still exists: any future location with no organs silently absorbs damage with no medical effect. Should raise / log. |
+| `select_target_organ` returns `None` for organ-less locations, but `take_damage` accepts `target_organ=None` and routes via location-wide distribution | Coherent but only works *if* the location has any organs. |
+| `take_damage` claim/reality split | `take_damage` returns `(died, final_damage)` to the combat system, but if the medical layer applied no actual damage (organ-less location, all destroyed), the `final_damage` value is misleading — combat sees "hit for X" but body has no record. |
+| Combat-driven severance trigger checks `SEVERING_INJURY_TYPES` (`cut`/`stab`/`laceration`) | Documented in spec, works. |
+| `unconscious_pending` flag on combat hit defers UI message until after the hit narrative | Works. |
+| `_calculate_armor_damage_reduction` runs before `apply_anatomical_damage` | Correct ordering. |
+
+### Category E — Tertiary System Touchpoints
+
+| System | Touch point | State |
+|---|---|---|
+| **Wounds** (`world/medical/wounds/`) | `take_organ_damage` calls `_create_conditions_from_damage` which spawns `BleedingCondition`/`PainCondition`/`InfectionCondition`. Wound *prose* renders via `append_wounds_to_longdesc` and the per-injury-type message dicts. | Solid. |
+| **Armor** (`typeclasses/armor_mixin.py`) | `_calculate_armor_damage_reduction(amount, location, injury_type)` via the effectiveness matrix in `world/combat/constants.py` | Works. Tied to clothing coverage. |
+| **Conditions / `MedicalScript`** | 12-second per-character ticker, drives bleeding-out, pain decay, infection progression | Works. Calls `is_dead()` after each tick → triggers `at_death()` if conditions push body past threshold. This is the path that makes brain destruction *eventually* lethal. |
+| **Death Progression** (`typeclasses/death_progression.py`) | 360s revival window with 11 narrative messages; `_check_medical_revival_conditions` calls `is_dead()` to detect treatment success | Works, but doesn't check brain HP for revival blocking (per Category C). |
+| **Corpse** (`typeclasses/corpse.py`) | Death-time snapshot of `physical_description`, `longdesc_data`, `wounds_at_death`, `apparent_uid_at_death`, `signature_at_death`, medical snapshot | Works. Recently de-bugged (#319, #320, #323, #324). |
+| **Forensics** (`world/forensics.py`) | Reads corpse signature for autopsy; blood-pool extractor exists but has no command | Engine ready, blood-pool surface command outstanding (separate spec). |
+| **Hit Selection** (`select_hit_location`) | Data-driven from organ schema; vital-location bias from `_get_vital_locations` (which derives from `LETHAL_CAPACITY_NAMES`) | Works. |
+
+### Category F — Architectural Tensions
+
+1. **Two consciousness names mean different things.**
+   - `self.consciousness` (float on `MedicalState`) is the *runtime value*
+     including pain/blood penalties.
+   - `calculate_body_capacity("consciousness")` is the *organ-only floor*
+     (brain HP fraction).
+   - `is_unconscious()` checks `self.consciousness < threshold`.
+   - `is_dead()` doesn't check either.
+   - **No bug, but confusing**. A docstring on each helper clarifying which
+     value it reads would prevent future drift.
+
+2. **The "no organs in container" failure mode is silent.**
+   - Pre-#325 groin demonstrated this: a damage call to a location with
+     zero registered organs returns success-shaped data but applies no
+     medical effect.
+   - Now that the bug is fixed for groin, the failure mode itself remains —
+     any future anatomy slot missing organ coverage will repeat it without
+     a single log line.
+
+3. **`LETHAL_CAPACITY_NAMES` overloads two concepts.**
+   - It's both the "what kills you" set AND the "what makes a location a
+     vital target" set, with `consciousness` artificially added for the
+     latter purpose.
+   - Splitting into `LETHAL_CAPACITY_NAMES` (true lethal) and
+     `VITAL_TARGETING_CAPACITY_NAMES` (lethal ∪ incapacitating) would
+     remove the comment confusion that triggered this audit.
+
+4. **`_get_vital_locations` is called per-attack.**
+   - Iterates `LETHAL_CAPACITY_NAMES` → `BODY_CAPACITIES` → `ORGANS` →
+     containers on every hit selection. Acceptable but cacheable; not
+     urgent.
+
+---
+
+## Drift Quick Reference (Headline Items)
+
+* `LETHAL_CAPACITY_NAMES` comment overstates synchrony with `is_dead`.
+* `blood_filtration.total_loss_fatal` is data-true but code-false (kidney loss is "fatal" in spec, ignored in runtime).
+* `incapacitation_threshold` on `moving` is documented but never enforced.
+* `total_loss_penalty` on `sight`/`hearing` describes blindness/deafness; neither is produced as a condition.
+* `cannot_be_destroyed` and `paralysis_if_destroyed` on `thoracolumbar_spine` are noted in the spec; neither is honored.
+* Brain-blocks-revival is `# NEXT:` in spec and not in code.
+* `Organ.vital` is set on init from schema; never read.
+
+---
+
+## Remediation Plan
+
+The plan is sequenced around the Core Insight: **build substrate before
+wiring schema to it**. Phases are grouped into three tracks:
+
+* **Track 1 — Standalone Now** (no substrate dependency).
+* **Track 2 — Foundational Substrates** (build the missing consumer systems).
+* **Track 3 — Wiring & Cleanup** (only meaningful after Track 2 lands).
+
+Each phase ships as a single PR (sub-issues if review-sized).
+
+---
+
+### Track 1 — Standalone Now
+
+These phases have no substrate dependency. They ship in any order and
+deliver visible value immediately.
+
+#### Phase 1 — Documentation & Architectural Clarification (no behavior change)
+
+**Goal**: Lock in the intentional design boundaries so future audits stop
+re-discovering the same drift.
+
+Tasks:
+
+1. Rewrite the `LETHAL_CAPACITY_NAMES` comment in `world/medical/constants.py`
+   to explicitly state the dual role (lethal ∪ targeting-vital), and that
+   consciousness is in it for *targeting* not for *death*.
+2. Add per-method docstrings to `MedicalState.is_dead`, `is_unconscious`,
+   `calculate_body_capacity` clarifying:
+   - `is_dead` enforces four lethal capacities + blood-loss floor.
+   - `is_unconscious` reads the runtime `self.consciousness` (which
+     includes pain / blood / suppression penalties).
+   - `calculate_body_capacity` returns the organ-only floor for that
+     capacity.
+3. Reframe `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md`'s `# NEXT:` brain-death
+   pseudo-code: point it at Phase 2 of this spec.
+4. Add a `specs/MEDICAL_SUBSTRATE_READINESS.md` index that documents
+   each declarative flag, its intended consumer system, and the phase
+   that will wire it.
+
+**Effort**: half-day.
+**Risk**: zero.
+**Dependencies**: none.
+
+#### Phase 2 — Brain Death Blocks Revival
+
+**Goal**: Ship the spec's `# NEXT:` feature. A brain-destroyed character
+cannot revive from the death-progression window, even if other lethal
+capacities are repaired.
+
+Tasks:
+
+1. Add `_brain_is_destroyed()` helper on `MedicalState`.
+2. Update `DeathProgressionScript._check_medical_revival_conditions` to
+   return `False` when brain is destroyed regardless of other state.
+3. Add a revival-failure message for the dying character (RP cue).
+4. Tests: revival succeeds when bleeding stops; revival fails when brain
+   destroyed.
+
+**Effort**: small.
+**Risk**: low.
+**Dependencies**: none.
+
+#### Phase 3 — Failure-Mode Surfacing
+
+**Goal**: The "location has no organs" failure mode (pre-#325 groin)
+shipped silently for a long time. Make the next one loud.
+
+Tasks:
+
+1. `apply_anatomical_damage`: when `damage_distribution` is empty AND
+   `get_organ_by_body_location(location)` is empty, log a Splattercast
+   warning (`ANATOMY_GAP: damage to {location} on {character} had no
+   organ to receive it`).
+2. `select_hit_location`: log when all available locations have a total
+   weight of 0 (would-be-floor masks broken anatomy).
+3. Optional: startup self-check that walks the anatomy table and reports
+   unbacked containers.
+
+**Effort**: small.
+**Risk**: zero — log-only.
+**Dependencies**: none.
+
+#### Phase 4 — Vestigial-Flag Deletion (no-substrate cases)
+
+**Goal**: Delete the flags that the audit clearly classified as
+vestigial, separate from the substrate-gated ones.
+
+Tasks:
+
+1. Remove `Organ.vital` field and the per-organ `vital` flags.
+2. Remove `unconscious_threshold` from the `consciousness` capacity dict
+   (the top-level constant is the only source actually read).
+3. Remove `can_be_destroyed` flags (redundant with negative form once
+   spine clamp lands in Phase 7).
+4. Update any tests that assert these values.
+
+Excluded from this phase: `modifiers`, `affects` lists, and the
+`total_loss_*` strings — those wait on substrate-resolution decisions.
+
+**Effort**: small.
+**Risk**: low.
+**Dependencies**: none for items 1–2. Item 3 should wait on Phase 7
+to avoid touching the same file twice.
+
+#### Phase 5 — `LETHAL_CAPACITY_NAMES` Split
+
+**Goal**: Remove the dual-role ambiguity that triggered this audit.
+
+```python
+LETHAL_CAPACITY_NAMES = (
+    "blood_pumping", "breathing", "digestion", "neck_integrity",
+)                                              # what kills you
+VITAL_TARGETING_CAPACITIES = LETHAL_CAPACITY_NAMES + ("consciousness",)
+```
+
+Update `_get_vital_locations` to read `VITAL_TARGETING_CAPACITIES`; leave
+`is_dead` reading `LETHAL_CAPACITY_NAMES` (or its inline literals). The
+comment becomes self-evident.
+
+**Effort**: small.
+**Risk**: low — pure rename / split.
+**Dependencies**: none (but ships nicer alongside Phase 1 docs).
+
+---
+
+### Track 2 — Foundational Substrates
+
+These phases build the consumer systems whose absence makes most of the
+medical flags appear dead. Each is a real piece of architecture and
+deserves its own design pass (and probably its own spec doc, linked
+back here).
+
+#### Phase 6 — Chronic Medical Conditions Framework
+
+**Goal**: A pattern for slow-kill conditions that accumulate organ failure
+over time. Today's `Bleeding` / `Pain` / `Infection` / `ConsciousnessSuppression`
+are all *acute* conditions with severity-based blood loss or pain or
+suppression. A `RenalFailure` / `LiverFailure` / `RespiratoryFailure`
+condition needs a different shape — a long-running degradation that
+escalates to a death trigger.
+
+Tasks:
+
+1. Design pass: what does a chronic condition look like? A new base class
+   `ChronicCondition` extending `MedicalCondition` with:
+   - A `progression_rate` (how fast it worsens).
+   - A `fatal_at_severity` threshold.
+   - An `apply_tick_effect` that escalates severity over time even when
+     untreated.
+   - Integration with `is_dead`: when any chronic condition reaches its
+     fatal threshold, `is_dead` returns True.
+2. Refactor `is_dead` to consult chronic conditions in addition to its
+   capacity checks.
+3. Document patterns and edge cases in a new
+   `specs/CHRONIC_MEDICAL_CONDITIONS_SPEC.md`.
+
+**Effort**: medium.
+**Risk**: medium — touches the death determination path.
+**Dependencies**: Phase 1 (docs/clarification).
+**Unlocks**: Kidney death (Phase 9), other organ-failure cascades.
+
+#### Phase 7 — Movement Policing Substrate
+
+**Goal**: A rule layer that commands consult before allowing a character
+to move. Today nothing checks `moving` capacity before letting a
+character walk. Needs to.
+
+Tasks:
+
+1. Design pass: where does movement get gated? Candidate hooks:
+   - In `Character.move_to` / `at_pre_move` — generic check.
+   - In `CmdFlee`, `CmdAdvance`, `CmdRetreat`, `CmdCharge` — combat
+     movement.
+   - In compass movement commands (north, south, etc.).
+2. Add a `can_move()` method on `Character` (or `MedicalState`) that
+   returns `(allowed, reason)` based on:
+   - `moving` capacity above `incapacitation_threshold` (0.15).
+   - No `ParalysisCondition` present (added in Phase 11).
+   - No "downed/prone" state (future state machine).
+3. Wire `at_pre_move` and combat-movement commands to call it.
+4. Implement the `cannot_be_destroyed` clamp on `thoracolumbar_spine`
+   in `Organ.take_damage` (spine HP can't drop below 1 from normal
+   damage — combat-severance still routes through the edged-weapon
+   path).
+5. Document in a new `specs/MOVEMENT_POLICING_SPEC.md`.
+
+**Effort**: medium.
+**Risk**: medium — touches a lot of command surface.
+**Dependencies**: Phase 1.
+**Unlocks**: Paralysis (Phase 11), movement incapacitation (Phase 10).
+
+#### Phase 8 — Senses System
+
+**Goal**: Perception (sight, hearing) becomes a gated capability rather
+than a free always-available power. When a character has zero sight,
+`look` shows blank/dark output; combat targeting is much harder; movement
+through unknown rooms fails.
+
+Tasks:
+
+1. Design pass: the senses system is its own architecture. At minimum:
+   - `BlindCondition` and `DeafCondition` produced when respective
+     capacities reach 0.
+   - `look` hooks check the looker's `sight` capacity and modify output:
+     full at 1.0, blurred at 0.5, no detail at 0.1, nothing at 0.
+   - Combat: blind attacker takes a per-hit penalty.
+   - Communication: deaf character receives no `say` / `whisper` content
+     in their session output.
+2. Implement `BlindCondition` and `DeafCondition` (subclass `MedicalCondition`).
+3. Wire them to spawn when `sight = 0` / `hearing = 0` via a hook in
+   `update_vital_signs` or a periodic check in `MedicalScript`.
+4. Hook the appropriate command and render points.
+5. Document in `specs/SENSES_SYSTEM_SPEC.md`.
+
+**Effort**: large — this is real architecture.
+**Risk**: medium-high — touches perception across the codebase.
+**Dependencies**: Phase 1.
+**Unlocks**: Sight/hearing penalty wiring.
+
+**Note from user**: this phase is acknowledged as significant. The
+likely path is ship the *infrastructure* (conditions + hook points) in
+Phase 8, but defer the *consequences* (combat penalties, blanked look,
+muted comm) to incremental follow-ups so the substrate can land without
+gating on every consumer being perfect.
+
+#### Phase 9 — Equipment-Handling Substrate (manipulation)
+
+**Goal**: Manipulation capacity actually gates wielding, wearing, and
+fine-motor combat actions.
+
+Tasks:
+
+1. Design pass: threshold tiers for manipulation:
+   - Above ~0.7: full function.
+   - 0.3–0.7: clumsy (combat accuracy penalty, slower equip).
+   - Below 0.3: can hold what's already wielded but cannot equip/disequip;
+     reduced attack accuracy.
+   - At 0.0: drops everything currently held.
+2. Add `can_wield()` / `can_equip()` checks at the relevant command
+   sites (`wield`, `wear`, `wrest`, `disarm`, `give`, `get`).
+3. Wire a drop-on-zero hook in `update_vital_signs`.
+4. Document in `specs/EQUIPMENT_HANDLING_SPEC.md`.
+
+**Effort**: medium.
+**Risk**: medium — equipment commands span several files.
+**Dependencies**: Phase 1.
+**Unlocks**: Manipulation incapacitation (Phase 10).
+
+---
+
+### Track 3 — Wiring & Cleanup
+
+Each phase here depends on a substrate from Track 2 being live. They
+are the "wire the schema into the consumer" pass.
+
+#### Phase 10 — Functional Capacity Incapacitation Wiring
+
+**Goal**: Now that substrates exist, wire each capacity's
+`incapacitation_threshold` and `total_loss_penalty` into the consumer.
+
+Tasks:
+
+1. **Movement**: `moving < incapacitation_threshold (0.15)` → character
+   is "downed", cannot move. Uses Phase 7 substrate.
+2. **Manipulation**: tiered penalties from Phase 9 substrate.
+3. **Sight**: `sight = 0` → spawn `BlindCondition` (Phase 8 substrate).
+4. **Hearing**: `hearing = 0` → spawn `DeafCondition` (Phase 8 substrate).
+5. **Talking**: `talking = 0` → spawn `MuteCondition` (small extension
+   of senses substrate).
+
+**Effort**: medium — one PR per capacity.
+**Risk**: medium — first time mechanical penalties land on players.
+**Dependencies**: Phases 7 (movement), 8 (senses), 9 (manipulation).
+
+#### Phase 11 — Paralysis
+
+**Goal**: Ship the `paralysis_if_destroyed` intent on `thoracolumbar_spine`.
+
+Tasks:
+
+1. Add `ParalysisCondition` (extends `MedicalCondition`, location =
+   `back`, severity 1, permanent).
+2. Spawn it when spine HP drops below a threshold (default ~50% — final
+   value during balancing). Spine itself doesn't go to 0 thanks to
+   the Phase 7 clamp.
+3. `ParalysisCondition` zeroes `moving` capacity via Phase 7's
+   `can_move()` check returning False with reason "paralyzed".
+4. Combat-driven severance from edged hits (per #243) still applies —
+   that's *decapitation* via the neck container, which already kills.
+
+**Effort**: medium.
+**Risk**: medium — interactions with sever-from-living path need test
+coverage.
+**Dependencies**: Phase 7 (movement policing, spine clamp).
+
+#### Phase 12 — Kidney Death via Chronic Condition
+
+**Goal**: Total kidney loss becomes fatal — but as a chronic condition
+(realistic acute-on-chronic renal failure), not as an instant `is_dead`
+check.
+
+Tasks:
+
+1. Add `RenalFailureCondition` extending `ChronicCondition` from Phase 6.
+2. Spawn it when `blood_filtration <= 0` (both kidneys destroyed).
+3. Progression: severity escalates over time; fatal at severity threshold
+   (timeline TBD during balancing — likely real-time hours, in-game
+   days once the time system lands).
+4. Treatment paths: dialysis substitute? Cybernetic kidney replacement?
+   Deferred to future medical-tools work.
+5. Tests: kidney destruction spawns the condition; condition escalates
+   over time; reaching fatal severity triggers death.
+
+**Effort**: small (the substrate from Phase 6 does the heavy lifting).
+**Risk**: low.
+**Dependencies**: Phase 6 (chronic conditions framework).
+
+#### Phase 13 — Final Dead-Flag Audit & Cleanup
+
+**Goal**: After substrates are live, the remaining substrate-gated flags
+have either been wired (keep) or remain unused (delete).
+
+Tasks:
+
+1. Re-audit `modifiers` / `affects` lists: if Phase 10's wiring uses
+   them as data, keep; otherwise delete and document the cascade
+   imperatively.
+2. `fatal_threshold` / `directly_fatal`: either refactor `is_dead` to
+   be data-driven over these (single source of truth) or delete.
+3. `total_loss_effects` on `talking`: if Phase 10 wires a `MuteCondition`
+   that consumes them, keep; else delete the strings (they're
+   declarative-only documentation).
+4. Confirm `total_loss_penalty` strings are referenced by Phase 10's
+   wiring; otherwise delete.
+
+**Effort**: small once Track 2 lands.
+**Risk**: low — non-load-bearing.
+**Dependencies**: Phases 6, 7, 8, 9, 10.
+
+---
+
+## Implementation Sequence
+
+Recommended ordering, with reasoning:
+
+**Sprint 1 — fast wins, no substrate dependency**:
+
+1. Phase 1 (docs)
+2. Phase 5 (`LETHAL_CAPACITY_NAMES` split)
+3. Phase 2 (brain blocks revival)
+4. Phase 3 (failure-mode logging)
+5. Phase 4 (vestigial-flag deletion, partial)
+
+All five can ship in a short session — half-day to full day each.
+
+**Sprint 2 — substrate buildout**:
+
+6. Phase 6 (chronic conditions framework)
+7. Phase 7 (movement policing) — and the spine clamp it includes
+8. Phase 9 (equipment handling) — smaller than senses, lower risk
+9. Phase 8 (senses system) — biggest single piece of new architecture
+
+This sprint is the main effort. Each phase is a real spec + PR cycle.
+
+**Sprint 3 — wiring**:
+
+10. Phase 11 (paralysis)
+11. Phase 12 (kidney chronic condition)
+12. Phase 10 (functional incapacitation wiring, one capacity per PR)
+13. Phase 13 (final dead-flag audit)
+
+By the end, every audited flag is either consumed by working code or
+deleted. The medical schema reads as truthful runtime documentation.
+
+---
+
+## Out of Scope
+
+Explicitly **not** addressed here, for clarity:
+
+* **Blood pool forensic command** (PR-ready, separate spec).
+* **Phase 5 identity mechanics** (memory decay, auto-recognition via Resonance).
+* **Treatment / healing balance pass** (existing `apply_treatment` paths
+  are functional but un-balanced; that's a separate playtest exercise).
+* **Time system integration** (wound timestamps, decay — blocked on
+  issue #301).
+* **Per-region decay rendering** on corpses (was decided as a future
+  feature when removing the per-location decay spam in #323).
+* **GMCP / web client / shop / world-state** (open issues #302–#308,
+  not medical/combat work).
+* **`_get_vital_locations` caching** — low-priority perf nit.
+
+---
+
+## Acceptance for This Spec
+
+* User reviews and either approves the plan or marks specific phases as
+  no-go.
+* Approved phases are converted to GitHub issues, each with the relevant
+  test plan and acceptance criteria already drafted in this spec.
+* `specs/README.md` index entry added for this spec.

--- a/specs/README.md
+++ b/specs/README.md
@@ -12,6 +12,7 @@ Design specifications for game systems and features. 37 spec files covering comb
 | `PROXIMITY_SYSTEM_SPEC.md` | Tactical positioning mechanics |
 | `GRAPPLE_SYSTEM_SPEC.md` | Grappling and restraint mechanics |
 | `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` | Medical/trauma system design; canonical source of truth for anatomy (spinal organs, neck integrity) and death/decapitation conditions |
+| `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md` | **Planning artifact** — end-to-end audit of medical/combat/death systems and a phased remediation plan. Content gets absorbed into canonical specs as each phase lands, then this document retires. |
 | `CLOTHING_SYSTEM_SPEC.md` | Clothing and layering system |
 | `MODULAR_ARMOR_SYSTEM_SPEC.md` | Armor coverage and damage reduction |
 | `SHOP_SYSTEM_SPEC.md` | Shop pricing and inventory |


### PR DESCRIPTION
## Summary

End-to-end audit of medical, combat, death-progression, and tertiary systems with a phased remediation plan. Ships as a living planning artifact in \`specs/\`; content absorbs into the canonical system specs as each phase lands, then this document retires.

Core insight: the dead declarative metadata on \`ORGANS\` / \`BODY_CAPACITIES\` isn't sloppy code — it's a top-down schema whose bottom-up consumer systems (senses, movement policing, equipment handling, chronic medical conditions) were never built. The flags are substrate-readiness signals.

## Plan structure

* **Track 1 (Standalone Now)** — Phases 1–5: docs, brain-blocks-revival, failure-mode logging, vestigial-flag deletion, \`LETHAL_CAPACITY_NAMES\` split. No substrate dependency.
* **Track 2 (Foundational Substrates)** — Phases 6–9: chronic conditions framework, movement policing, senses system, equipment handling.
* **Track 3 (Wiring & Cleanup)** — Phases 10–13: paralysis, kidney chronic condition, functional incapacitation wiring, final dead-flag audit.

## Test plan
- [x] Spec file added.
- [x] \`specs/README.md\` index updated.
- [x] No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)