### PR TITLE
Add severance messaging library (closes #329, foundation for #330/#333)

### DIFF
--- a/typeclasses/armor_mixin.py
+++ b/typeclasses/armor_mixin.py
@@ -172,6 +172,7 @@ class ArmorMixin:
         if location == "neck":
             if self._bone_freshly_destroyed("neck"):
                 self.db.decapitation_pending = True
+                self._broadcast_decapitation_message(injury_type)
             return
 
         # Living limb severance: head is excluded (decapitation routes
@@ -183,6 +184,74 @@ class ArmorMixin:
 
         from typeclasses.items import apply_sever_to_character
         apply_sever_to_character(self, location, injury_type=injury_type)
+
+    def _broadcast_decapitation_message(self, injury_type):
+        """Render the moment-of-decapitation narrative beat (issue #329).
+
+        Fires synchronously when the cervical spine is destroyed by an
+        edged hit. Mirrors the limb-severance broadcast in
+        :func:`typeclasses.items.apply_sever_to_character`, but for the
+        head — which can't be detached as an Appendage synchronously
+        (the corpse doesn't exist yet). The actual head item spawns at
+        ``_create_corpse_from_character``; this is the audible/visible
+        beat that tells the room what just happened.
+
+        Wrapped entirely in a try/except so unit-test stubs without
+        ``.ndb`` / ``.msg`` / ``.location`` don't crash combat. The
+        flag-setting (``db.decapitation_pending``) is the load-bearing
+        contract; this broadcast is decoration on top.
+
+        Args:
+            injury_type (str): Severing injury type
+                (``cut`` / ``stab`` / ``laceration``).
+        """
+        try:
+            # Resolve attacker from the most recent damage context. The
+            # combat handler stages this through ``ndb._last_damage_*``
+            # (set by the attack processor just before damage applies).
+            ndb = getattr(self, "ndb", None)
+            attacker = getattr(ndb, "_last_damage_attacker", None) if ndb else None
+            weapon = getattr(ndb, "_last_damage_weapon", None) if ndb else None
+
+            from world.combat.messages.severance import get_severance_message
+            from world.identity_utils import msg_room_identity
+
+            msgs = get_severance_message(
+                location="head",
+                injury_type=injury_type,
+                attacker=attacker,
+                target=self,
+                item=weapon,
+                severity="grievous",
+                hit_location="neck",
+            )
+            if attacker is not None:
+                attacker.msg(msgs["attacker_msg"])
+            self.msg(msgs["victim_msg"])
+            if self.location is not None:
+                exclude = [self]
+                if attacker is not None:
+                    exclude.append(attacker)
+                msg_room_identity(
+                    location=self.location,
+                    template=msgs["observer_template"],
+                    char_refs=msgs["observer_char_refs"],
+                    exclude=exclude,
+                )
+        except Exception:
+            # Don't break combat if the messaging layer hiccups.
+            try:
+                from evennia.comms.models import ChannelDB
+                from world.combat.constants import SPLATTERCAST_CHANNEL
+                splattercast = ChannelDB.objects.get_channel(
+                    SPLATTERCAST_CHANNEL
+                )
+                splattercast.msg(
+                    f"DECAPITATION_MSG_ERROR: {self.key} - failed to "
+                    f"broadcast decapitation message"
+                )
+            except Exception:
+                pass
 
     def _calculate_armor_damage_reduction(self, damage, location, injury_type):
         """

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1790,18 +1790,52 @@ def apply_sever_to_character(character, container, *, injury_type="cut"):
 
     detach_items_to_appendage(character, appendage, container)
 
-    from world.identity_utils import msg_room_identity
+    # Severance narrative — issue #332. Replaces the previous inline
+    # template with a library lookup so each (location, injury_type,
+    # severity) cell gets variant prose. Falls back gracefully to the
+    # old inline pattern if anything goes wrong.
+    attacker = getattr(character.ndb, "_last_damage_attacker", None)
+    weapon = getattr(character.ndb, "_last_damage_weapon", None)
+    try:
+        from world.combat.messages.severance import get_severance_message
+        from world.identity_utils import msg_room_identity
 
-    part_name = appendage.key
-    msg_room_identity(
-        location=room,
-        template=(
-            f"{{actor}}'s {part_name} is severed in a spray of blood "
-            f"and falls to the ground!"
-        ),
-        char_refs={"actor": character},
-        exclude=[],
-    )
+        msgs = get_severance_message(
+            location=container,
+            injury_type=injury_type,
+            attacker=attacker,
+            target=character,
+            item=weapon,
+            severity="grievous",
+            hit_location=container,
+        )
+        if attacker is not None:
+            attacker.msg(msgs["attacker_msg"])
+        character.msg(msgs["victim_msg"])
+        exclude = [character]
+        if attacker is not None:
+            exclude.append(attacker)
+        msg_room_identity(
+            location=room,
+            template=msgs["observer_template"],
+            char_refs=msgs["observer_char_refs"],
+            exclude=exclude,
+        )
+    except Exception:
+        # Library lookup hiccup — fall back to the legacy inline beat
+        # so we never silently swallow a severance moment.
+        from world.identity_utils import msg_room_identity
+
+        part_name = appendage.key
+        msg_room_identity(
+            location=room,
+            template=(
+                f"{{actor}}'s {part_name} is severed in a spray of blood "
+                f"and falls to the ground!"
+            ),
+            char_refs={"actor": character},
+            exclude=[],
+        )
 
     return appendage
 

--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -480,14 +480,27 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
         if weapon and hasattr(weapon, "db") and weapon.db.weapon_type:
             weapon_type = weapon.db.weapon_type
 
-        # Apply damage first to determine if this is a killing blow
-        # take_damage now returns (died, actual_damage_applied)
-        target_died, actual_damage = target.take_damage(
-            damage,
-            location=hit_location,
-            injury_type=injury_type,
-            target_organ=target_organ,
-        )
+        # Stage attacker / weapon on target ndb so downstream severance
+        # messaging (issue #332, fired from _maybe_sever_from_damage) can
+        # attribute the moment-of-decapitation / moment-of-amputation
+        # narrative to the right character + weapon. Cleared after the
+        # damage call so this is strictly request-scoped.
+        target.ndb._last_damage_attacker = attacker
+        target.ndb._last_damage_weapon = weapon
+        try:
+            # Apply damage first to determine if this is a killing blow
+            # take_damage now returns (died, actual_damage_applied)
+            target_died, actual_damage = target.take_damage(
+                damage,
+                location=hit_location,
+                injury_type=injury_type,
+                target_organ=target_organ,
+            )
+        finally:
+            if hasattr(target.ndb, "_last_damage_attacker"):
+                del target.ndb._last_damage_attacker
+            if hasattr(target.ndb, "_last_damage_weapon"):
+                del target.ndb._last_damage_weapon
 
         if target_died:
             _handle_kill(

--- a/world/combat/messages/severance/__init__.py
+++ b/world/combat/messages/severance/__init__.py
@@ -1,0 +1,269 @@
+"""Severance messaging library — narrative for limb / head detachment.
+
+When a bone is destroyed by edged damage (cut / stab / laceration), the
+severance pipeline routes through ``_maybe_sever_from_damage`` (head) or
+``apply_sever_to_character`` (limbs). Both should broadcast a narrative
+beat — distinct from the hit/kill messages — describing the
+detachment.
+
+This loader mirrors :func:`world.combat.messages.get_combat_message` so
+callers get the same render shape (attacker / victim / observer audiences
+plus an identity-aware ``observer_template`` for ``msg_room_identity``).
+
+Templates are stored per-location (``head.py``, ``arms.py``, ``hands.py``,
+``thighs.py``, ``shins.py``, ``feet.py``), keyed by injury type
+(``cut`` / ``stab`` / ``laceration``) and severity (``grievous`` /
+``minor``). Authors extend by appending entries to the appropriate
+``MESSAGES`` cell.
+
+Example::
+
+    from world.combat.messages.severance import get_severance_message
+    from world.identity_utils import msg_room_identity
+
+    msgs = get_severance_message(
+        location="head", injury_type="laceration",
+        attacker=attacker, target=target, item=weapon,
+        severity="grievous", hit_location="neck",
+    )
+    attacker.msg(msgs["attacker_msg"])
+    target.msg(msgs["victim_msg"])
+    msg_room_identity(
+        location=attacker.location,
+        template=msgs["observer_template"],
+        char_refs=msgs["observer_char_refs"],
+        exclude=[attacker, target],
+    )
+
+See ``specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md`` and issue #332
+for the broader design context.
+"""
+
+from __future__ import annotations
+
+import importlib
+import random
+
+from world.combat.utils import get_display_name_safe
+from world.grammar import capitalize_first
+
+# Pair-key shorthands accepted as location aliases for the limb files.
+_LIMB_ALIASES = {
+    "left_arm": "arms",
+    "right_arm": "arms",
+    "left_hand": "hands",
+    "right_hand": "hands",
+    "left_thigh": "thighs",
+    "right_thigh": "thighs",
+    "left_shin": "shins",
+    "right_shin": "shins",
+    "left_foot": "feet",
+    "right_foot": "feet",
+    # The neck container is the routing site for decapitation;
+    # narrative lives in head.py.
+    "neck": "head",
+    "head": "head",
+}
+
+_VALID_SEVERITIES = ("grievous", "minor")
+_VALID_INJURY_TYPES = ("cut", "stab", "laceration")
+
+
+def _resolve_module_name(location: str) -> str:
+    """Map a hit-location key to the severance module that owns it."""
+    if location in _LIMB_ALIASES:
+        return _LIMB_ALIASES[location]
+    # Already a module name (e.g. ``"arms"``) or a singular pair key.
+    if location in ("arms", "hands", "thighs", "shins", "feet"):
+        return location
+    return location  # Caller passed something we don't recognise — fall
+                    # through and the importlib lookup below will fail
+                    # safely.
+
+
+class _PassThrough(dict):
+    """Dict subclass returning ``{key}`` for missing keys (partial format)."""
+
+    def __missing__(self, key: str) -> str:
+        return f"{{{key}}}"
+
+
+def _select_template(
+    location: str, injury_type: str, severity: str
+) -> dict | None:
+    """Load the MESSAGES dict and pick a random variant.
+
+    Returns ``None`` if any lookup step fails — callers fall through to
+    a generic fallback template.
+    """
+    module_name = _resolve_module_name(location)
+    try:
+        module = importlib.import_module(
+            f"world.combat.messages.severance.{module_name}"
+        )
+    except ModuleNotFoundError:
+        return None
+
+    messages = getattr(module, "MESSAGES", {})
+    by_injury = messages.get(injury_type)
+    if not isinstance(by_injury, dict):
+        return None
+
+    variants = by_injury.get(severity)
+    if not isinstance(variants, list) or not variants:
+        # Fall back to the other severity if this one isn't populated yet.
+        other = "minor" if severity == "grievous" else "grievous"
+        variants = by_injury.get(other) or []
+
+    valid = [v for v in variants if isinstance(v, dict)]
+    return random.choice(valid) if valid else None
+
+
+def _fallback_template(location: str) -> dict:
+    """Generic severance template when location-specific content is missing."""
+    return {
+        "attacker_msg": (
+            "Your blow severs {target_name}'s {hit_location} clean from "
+            "their body."
+        ),
+        "victim_msg": (
+            "{attacker_name}'s blow severs your {hit_location} clean from "
+            "your body."
+        ),
+        "observer_msg": (
+            "{attacker_name}'s blow severs {target_name}'s {hit_location} "
+            "clean from their body."
+        ),
+    }
+
+
+def get_severance_message(
+    location: str,
+    injury_type: str = "cut",
+    attacker=None,
+    target=None,
+    item=None,
+    severity: str = "grievous",
+    **kwargs,
+) -> dict:
+    """Render a severance message set for one body location.
+
+    Mirrors :func:`world.combat.messages.get_combat_message`'s return
+    shape so callers can plug into the same render path (per-audience
+    messages plus identity-aware observer template).
+
+    Args:
+        location: Hit-location key (\"head\", \"neck\", \"left_arm\",
+            \"right_hand\", ...) or pair-key shorthand (\"arms\", \"hands\",
+            ...). Aliases map onto the correct module via
+            :data:`_LIMB_ALIASES`.
+        injury_type: One of ``"cut"``, ``"stab"``, ``"laceration"``.
+            Anything else falls through to the generic fallback.
+        attacker: The character making the severing blow.
+        target: The character whose body part is being severed.
+        item: The weapon used (may be ``None`` for unarmed claws etc.).
+        severity: ``"grievous"`` (default, dramatic / brutal) or
+            ``"minor"`` (clean / surgical). Falls back to the other
+            severity if the chosen cell is empty.
+        **kwargs: Extra format substitutions (``hit_location`` is the
+            common one — defaults to the canonical location key with
+            underscores replaced by spaces).
+
+    Returns:
+        Dict with ``attacker_msg``, ``victim_msg``, ``observer_msg``
+        (legacy pre-resolved), ``observer_template`` (identity-aware),
+        and ``observer_char_refs`` (mapping for ``msg_room_identity``).
+    """
+    if injury_type not in _VALID_INJURY_TYPES:
+        injury_type = "cut"
+    if severity not in _VALID_SEVERITIES:
+        severity = "grievous"
+
+    chosen = _select_template(location, injury_type, severity) or _fallback_template(location)
+
+    # Identity-aware names.
+    attacker_sees_target = (
+        get_display_name_safe(target, attacker) if target else "someone"
+    )
+    target_sees_attacker = (
+        capitalize_first(get_display_name_safe(attacker, target))
+        if attacker
+        else "Someone"
+    )
+
+    item_s = item.key if item else "their weapon"
+
+    shared = {
+        "item_name": item_s,
+        "item": item_s,
+        **kwargs,
+    }
+    if "hit_location" not in shared:
+        shared["hit_location"] = location.replace("_", " ")
+    elif isinstance(shared["hit_location"], str):
+        shared["hit_location"] = shared["hit_location"].replace("_", " ")
+
+    attacker_format = {
+        **shared,
+        "attacker_name": "You",
+        "target_name": attacker_sees_target,
+        "attacker": "You",
+        "target": attacker_sees_target,
+    }
+    victim_format = {
+        **shared,
+        "attacker_name": target_sees_attacker,
+        "target_name": "you",
+        "attacker": target_sees_attacker,
+        "target": "you",
+    }
+    attacker_key = attacker.key if attacker else "Someone"
+    target_key = target.key if target else "someone"
+    observer_legacy_format = {
+        **shared,
+        "attacker_name": attacker_key,
+        "target_name": target_key,
+        "attacker": attacker_key,
+        "target": target_key,
+    }
+
+    def _apply_color(msg: str) -> str:
+        """Severance is a dramatic positive-strike beat → bright red."""
+        if msg.startswith("|") and msg.endswith("|n"):
+            return msg
+        return f"|r{msg}|n"
+
+    final: dict = {}
+    fallback = _fallback_template(location)
+    format_maps = {
+        "attacker_msg": attacker_format,
+        "victim_msg": victim_format,
+        "observer_msg": observer_legacy_format,
+    }
+    for key, fmt in format_maps.items():
+        tmpl = chosen.get(key, fallback.get(key, ""))
+        try:
+            final[key] = _apply_color(tmpl.format(**fmt))
+        except KeyError as exc:
+            final[key] = f"(Error: Missing placeholder {exc} in '{key}')"
+        except Exception as exc:
+            final[key] = f"(Error: Formatting issue in '{key}': {exc})"
+
+    # Identity-aware observer template — swap char-name placeholders to
+    # the msg_room_identity tokens, then partial-format the rest.
+    observer_raw = chosen.get("observer_msg", fallback["observer_msg"])
+    observer_template = (
+        observer_raw
+        .replace("{attacker_name}", "{actor}")
+        .replace("{target_name}", "{target_char}")
+        .replace("{attacker}", "{actor}")
+        .replace("{target}", "{target_char}")
+    )
+    try:
+        observer_template = observer_template.format_map(_PassThrough(shared))
+        final["observer_template"] = _apply_color(observer_template)
+    except Exception:
+        final["observer_template"] = final.get("observer_msg", "")
+
+    final["observer_char_refs"] = {"actor": attacker, "target_char": target}
+    return final

--- a/world/combat/messages/severance/arms.py
+++ b/world/combat/messages/severance/arms.py
@@ -1,0 +1,148 @@
+"""Arm severance templates — left or right arm detached at the shoulder.
+
+Fires when an edged hit destroys a left_arm or right_arm humerus. The
+``{hit_location}`` kwarg resolves to ``"left arm"`` or ``"right arm"``.
+
+See ``world/combat/messages/severance/__init__.py`` for the loader.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade cleaves {target_name}'s {hit_location} from the shoulder in a single arc. The limb spins to the floor before they have time to look down.",
+                "victim_msg": "{attacker_name}'s blade cleaves your {hit_location} from your shoulder in a single arc. The limb hits the floor before you have time to look down.",
+                "observer_msg": "{attacker_name}'s blade cleaves {target_name}'s {hit_location} from the shoulder in a single arc. The limb spins to the floor before they have time to look down.",
+            },
+            {
+                "attacker_msg": "Bone parts under the edge with a crunch you feel in your wrist. {target_name}'s {hit_location} detaches and falls, blood arcing from the open socket.",
+                "victim_msg": "Bone parts under {attacker_name}'s edge with a crunch you feel through your whole body. Your {hit_location} detaches and falls.",
+                "observer_msg": "Bone parts under {attacker_name}'s edge with a crunch. {target_name}'s {hit_location} detaches and falls, blood arcing from the open socket.",
+            },
+            {
+                "attacker_msg": "The chop is too hard, too low. {target_name}'s {hit_location} cartwheels away in a spray of red, fingers still twitching for a weapon that isn't there.",
+                "victim_msg": "The chop is too hard, too low. Your {hit_location} cartwheels away in a spray of red, fingers still twitching.",
+                "observer_msg": "{attacker_name}'s chop is too hard, too low. {target_name}'s {hit_location} cartwheels away in a spray of red, fingers still twitching for a weapon that isn't there.",
+            },
+            {
+                "attacker_msg": "You take {target_name}'s {hit_location} off at the joint and the limb goes one way while the body lurches the other, balance lost between heartbeats.",
+                "victim_msg": "{attacker_name} takes your {hit_location} off at the joint and the limb goes one way while your body lurches the other.",
+                "observer_msg": "{attacker_name} takes {target_name}'s {hit_location} off at the joint and the limb goes one way while the body lurches the other, balance lost between heartbeats.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A single clean stroke separates {target_name}'s {hit_location} from the shoulder. The cut is so neat the limb almost looks placed.",
+                "victim_msg": "{attacker_name}'s single clean stroke separates your {hit_location} from your shoulder. The cut is so neat the limb almost looks placed.",
+                "observer_msg": "{attacker_name}'s single clean stroke separates {target_name}'s {hit_location} from the shoulder. The cut is so neat the limb almost looks placed.",
+            },
+            {
+                "attacker_msg": "The edge finds the gap between bones and {target_name}'s {hit_location} falls free as if it were never properly attached.",
+                "victim_msg": "{attacker_name}'s edge finds the gap between bones and your {hit_location} falls free.",
+                "observer_msg": "{attacker_name}'s edge finds the gap between bones and {target_name}'s {hit_location} falls free as if it were never properly attached.",
+            },
+            {
+                "attacker_msg": "Your blade passes through {target_name}'s shoulder with almost no resistance. The {hit_location} settles to the floor with a soft, final thud.",
+                "victim_msg": "{attacker_name}'s blade passes through your shoulder with almost no resistance. Your {hit_location} settles to the floor with a soft, final thud.",
+                "observer_msg": "{attacker_name}'s blade passes through {target_name}'s shoulder with almost no resistance. The {hit_location} settles to the floor with a soft, final thud.",
+            },
+            {
+                "attacker_msg": "One stroke, surgically placed. {target_name}'s {hit_location} comes away with no struggle, no flourish — only the small surprise on their face.",
+                "victim_msg": "One stroke, surgically placed. Your {hit_location} comes away with no struggle.",
+                "observer_msg": "{attacker_name}'s single surgical stroke takes {target_name}'s {hit_location} away with no struggle, no flourish — only the small surprise on their face.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point under {target_name}'s armpit and lever. The {hit_location} tears free at the joint, ligaments snapping like wet rope.",
+                "victim_msg": "{attacker_name} drives the point under your armpit and levers. Your {hit_location} tears free at the joint.",
+                "observer_msg": "{attacker_name} drives the point under {target_name}'s armpit and levers. The {hit_location} tears free at the joint, ligaments snapping like wet rope.",
+            },
+            {
+                "attacker_msg": "The thrust goes deep and pries the joint apart. {target_name}'s {hit_location} comes loose in a mess of strained sinew and bright arterial spray.",
+                "victim_msg": "{attacker_name}'s thrust goes deep and pries your joint apart. Your {hit_location} comes loose in a mess of strained sinew.",
+                "observer_msg": "{attacker_name}'s thrust goes deep and pries the joint apart. {target_name}'s {hit_location} comes loose in a mess of strained sinew and bright arterial spray.",
+            },
+            {
+                "attacker_msg": "Your point catches under the ball of the shoulder and rips. {target_name}'s {hit_location} pulls free, dragging ribbons of tissue behind it.",
+                "victim_msg": "{attacker_name}'s point catches under the ball of your shoulder and rips. Your {hit_location} pulls free.",
+                "observer_msg": "{attacker_name}'s point catches under the ball of {target_name}'s shoulder and rips. The {hit_location} pulls free, dragging ribbons of tissue.",
+            },
+            {
+                "attacker_msg": "You shove the blade in and twist until the shoulder gives. {target_name}'s {hit_location} comes off with a wet crack that echoes off the walls.",
+                "victim_msg": "{attacker_name} shoves the blade in and twists until your shoulder gives. Your {hit_location} comes off with a wet crack.",
+                "observer_msg": "{attacker_name} shoves the blade in and twists until {target_name}'s shoulder gives. The {hit_location} comes off with a wet crack that echoes off the walls.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The point slides between bones at the precise angle and {target_name}'s {hit_location} simply detaches, as if it had been waiting for permission.",
+                "victim_msg": "{attacker_name}'s point slides between your bones at the precise angle and your {hit_location} simply detaches.",
+                "observer_msg": "{attacker_name}'s point slides between bones at the precise angle and {target_name}'s {hit_location} simply detaches, as if it had been waiting for permission.",
+            },
+            {
+                "attacker_msg": "A clean puncture at the joint and {target_name}'s {hit_location} comes free in a single deliberate motion.",
+                "victim_msg": "{attacker_name}'s clean puncture at your joint and your {hit_location} comes free in a single deliberate motion.",
+                "observer_msg": "{attacker_name}'s clean puncture at the joint and {target_name}'s {hit_location} comes free in a single deliberate motion.",
+            },
+            {
+                "attacker_msg": "Your blade finds the joint capsule and parts it without violence. {target_name}'s {hit_location} drops to the floor with no fanfare.",
+                "victim_msg": "{attacker_name}'s blade finds your joint capsule and parts it without violence. Your {hit_location} drops to the floor.",
+                "observer_msg": "{attacker_name}'s blade finds the joint capsule and parts it without violence. {target_name}'s {hit_location} drops to the floor with no fanfare.",
+            },
+            {
+                "attacker_msg": "The thrust is precise and economical. {target_name}'s {hit_location} parts from the body the way pages turn in a book.",
+                "victim_msg": "{attacker_name}'s thrust is precise and economical. Your {hit_location} parts from your body the way pages turn in a book.",
+                "observer_msg": "{attacker_name}'s thrust is precise and economical. {target_name}'s {hit_location} parts from the body the way pages turn in a book.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "The blade grinds through {target_name}'s shoulder in a chorus of breaking bone. The {hit_location} comes free in a single ragged moment, hand still gripping at empty air.",
+                "victim_msg": "{attacker_name}'s blade grinds through your shoulder in a chorus of breaking bone. Your {hit_location} comes free in a single ragged moment.",
+                "observer_msg": "{attacker_name}'s blade grinds through {target_name}'s shoulder in a chorus of breaking bone. The {hit_location} comes free in a single ragged moment, hand still gripping at empty air.",
+            },
+            {
+                "attacker_msg": "You saw, tear, and *finish*. {target_name}'s {hit_location} comes apart in a slurry of red and gristle, the bone end ragged where it tore.",
+                "victim_msg": "{attacker_name} saws, tears, and *finishes*. Your {hit_location} comes apart in a slurry of red and gristle.",
+                "observer_msg": "{attacker_name} saws, tears, and *finishes*. {target_name}'s {hit_location} comes apart in a slurry of red and gristle, the bone end ragged where it tore.",
+            },
+            {
+                "attacker_msg": "Chain teeth chew through {target_name}'s shoulder until the {hit_location} drops away, the wound a mess of pulped muscle and shredded skin.",
+                "victim_msg": "Chain teeth chew through your shoulder until the {hit_location} drops away.",
+                "observer_msg": "Chain teeth chew through {target_name}'s shoulder until the {hit_location} drops away, the wound a mess of pulped muscle and shredded skin.",
+            },
+            {
+                "attacker_msg": "The edge catches and you *pull*. Tendons part with audible snaps, and {target_name}'s {hit_location} tears free, splashing the deck behind it.",
+                "victim_msg": "{attacker_name}'s edge catches and they *pull*. Tendons part with audible snaps, and your {hit_location} tears free.",
+                "observer_msg": "{attacker_name}'s edge catches and they *pull*. Tendons part with audible snaps, and {target_name}'s {hit_location} tears free, splashing the deck behind it.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The cut is rough but the arm is small. {target_name}'s {hit_location} parts from the shoulder in a moment that's more tear than slice.",
+                "victim_msg": "{attacker_name}'s cut is rough but the arm is small. Your {hit_location} parts from your shoulder in a moment that's more tear than slice.",
+                "observer_msg": "{attacker_name}'s cut is rough but the arm is small. {target_name}'s {hit_location} parts from the shoulder in a moment that's more tear than slice.",
+            },
+            {
+                "attacker_msg": "Serrated edge bites once, twice, and {target_name}'s {hit_location} comes loose with a sound like wet canvas tearing.",
+                "victim_msg": "{attacker_name}'s serrated edge bites once, twice, and your {hit_location} comes loose.",
+                "observer_msg": "{attacker_name}'s serrated edge bites once, twice, and {target_name}'s {hit_location} comes loose with a sound like wet canvas tearing.",
+            },
+            {
+                "attacker_msg": "You drag the blade through {target_name}'s shoulder and the {hit_location} parts free, the wound ragged but the result unambiguous.",
+                "victim_msg": "{attacker_name} drags the blade through your shoulder and your {hit_location} parts free.",
+                "observer_msg": "{attacker_name} drags the blade through {target_name}'s shoulder and the {hit_location} parts free, the wound ragged but the result unambiguous.",
+            },
+            {
+                "attacker_msg": "The tear is uneven, but {target_name}'s {hit_location} drops to the floor anyway, blood already pooling.",
+                "victim_msg": "{attacker_name}'s tear is uneven, but your {hit_location} drops to the floor anyway.",
+                "observer_msg": "{attacker_name}'s tear is uneven, but {target_name}'s {hit_location} drops to the floor anyway, blood already pooling.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/feet.py
+++ b/world/combat/messages/severance/feet.py
@@ -1,0 +1,148 @@
+"""Foot severance templates — left or right foot detached at the ankle.
+
+Fires when an edged hit destroys a left_foot or right_foot metatarsals.
+The ``{hit_location}`` kwarg resolves to ``"left foot"`` or ``"right foot"``.
+
+See ``world/combat/messages/severance/__init__.py`` for the loader.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade cleaves through {target_name}'s ankle in a low arc. The {hit_location} stays where it landed, while the leg lurches backward, finding no support.",
+                "victim_msg": "{attacker_name}'s blade cleaves through your ankle in a low arc. Your {hit_location} stays where it was, while your leg lurches backward.",
+                "observer_msg": "{attacker_name}'s blade cleaves through {target_name}'s ankle in a low arc. The {hit_location} stays where it landed, while the leg lurches backward, finding no support.",
+            },
+            {
+                "attacker_msg": "The metatarsals shatter under your edge. {target_name}'s {hit_location} drops away in a spray of red, the stump beneath it shocked white.",
+                "victim_msg": "Your metatarsals shatter under {attacker_name}'s edge. Your {hit_location} drops away in a spray of red.",
+                "observer_msg": "{target_name}'s metatarsals shatter under {attacker_name}'s edge. The {hit_location} drops away in a spray of red, the stump beneath it shocked white.",
+            },
+            {
+                "attacker_msg": "You take {target_name}'s {hit_location} off at the ankle joint and the body lurches forward, balance broken in a way nothing will fix.",
+                "victim_msg": "{attacker_name} takes your {hit_location} off at the ankle joint and you lurch forward, balance broken.",
+                "observer_msg": "{attacker_name} takes {target_name}'s {hit_location} off at the ankle joint and the body lurches forward, balance broken in a way nothing will fix.",
+            },
+            {
+                "attacker_msg": "Your chop catches the heel and continues through. {target_name}'s {hit_location} drops away, the wound spurting in time with their racing pulse.",
+                "victim_msg": "{attacker_name}'s chop catches your heel and continues through. Your {hit_location} drops away.",
+                "observer_msg": "{attacker_name}'s chop catches the heel and continues through. {target_name}'s {hit_location} drops away, the wound spurting in time with their racing pulse.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A surgical cut at the ankle joint and {target_name}'s {hit_location} separates from the leg with minimal fuss.",
+                "victim_msg": "{attacker_name}'s surgical cut at your ankle joint and your {hit_location} separates from your leg.",
+                "observer_msg": "{attacker_name}'s surgical cut at the ankle joint and {target_name}'s {hit_location} separates from the leg with minimal fuss.",
+            },
+            {
+                "attacker_msg": "The edge finds the gap between tibia and metatarsals and parts {target_name}'s {hit_location} away cleanly.",
+                "victim_msg": "{attacker_name}'s edge finds the gap between your tibia and metatarsals and parts your {hit_location} away cleanly.",
+                "observer_msg": "{attacker_name}'s edge finds the gap between tibia and metatarsals and parts {target_name}'s {hit_location} away cleanly.",
+            },
+            {
+                "attacker_msg": "Your blade passes through the ankle joint without resistance. {target_name}'s {hit_location} settles to the floor with strange grace.",
+                "victim_msg": "{attacker_name}'s blade passes through your ankle joint without resistance. Your {hit_location} settles to the floor.",
+                "observer_msg": "{attacker_name}'s blade passes through the ankle joint without resistance. {target_name}'s {hit_location} settles to the floor with strange grace.",
+            },
+            {
+                "attacker_msg": "One stroke, exactly placed. {target_name}'s {hit_location} comes away in a moment that ends as quietly as it began.",
+                "victim_msg": "{attacker_name}'s one stroke, exactly placed. Your {hit_location} comes away.",
+                "observer_msg": "{attacker_name}'s one stroke, exactly placed. {target_name}'s {hit_location} comes away in a moment that ends as quietly as it began.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point into the ankle joint and *lever*. {target_name}'s {hit_location} pries loose with a wet pop and the body crumples forward.",
+                "victim_msg": "{attacker_name} drives the point into your ankle joint and *levers*. Your {hit_location} pries loose with a wet pop.",
+                "observer_msg": "{attacker_name} drives the point into {target_name}'s ankle joint and *levers*. The {hit_location} pries loose with a wet pop and the body crumples forward.",
+            },
+            {
+                "attacker_msg": "Your thrust tears through the joint capsule. {target_name}'s {hit_location} comes loose in a wet, brutal moment, ligaments dangling.",
+                "victim_msg": "{attacker_name}'s thrust tears through your joint capsule. Your {hit_location} comes loose.",
+                "observer_msg": "{attacker_name}'s thrust tears through the joint capsule. {target_name}'s {hit_location} comes loose in a wet, brutal moment, ligaments dangling.",
+            },
+            {
+                "attacker_msg": "The point goes deep and levers outward. {target_name}'s {hit_location} tears free at the ankle, the wound a ragged ruin.",
+                "victim_msg": "{attacker_name}'s point goes deep and levers outward. Your {hit_location} tears free at the ankle.",
+                "observer_msg": "{attacker_name}'s point goes deep and levers outward. {target_name}'s {hit_location} tears free at the ankle, the wound a ragged ruin.",
+            },
+            {
+                "attacker_msg": "You shove the blade into the heel and *grind*. The ankle disintegrates and {target_name}'s {hit_location} drops away in a spray of bone meal.",
+                "victim_msg": "{attacker_name} shoves the blade into your heel and *grinds*. Your ankle disintegrates and your {hit_location} drops away.",
+                "observer_msg": "{attacker_name} shoves the blade into {target_name}'s heel and *grinds*. The ankle disintegrates and the {hit_location} drops away in a spray of bone meal.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The point slips into the ankle joint with surgical precision and {target_name}'s {hit_location} separates from the leg in a single clean motion.",
+                "victim_msg": "{attacker_name}'s point slips into your ankle joint with surgical precision and your {hit_location} separates from your leg.",
+                "observer_msg": "{attacker_name}'s point slips into the ankle joint with surgical precision and {target_name}'s {hit_location} separates from the leg in a single clean motion.",
+            },
+            {
+                "attacker_msg": "A precise thrust at the ankle and {target_name}'s {hit_location} comes loose. The body finds the floor.",
+                "victim_msg": "{attacker_name}'s precise thrust at your ankle and your {hit_location} comes loose.",
+                "observer_msg": "{attacker_name}'s precise thrust at the ankle and {target_name}'s {hit_location} comes loose. The body finds the floor.",
+            },
+            {
+                "attacker_msg": "Your blade finds the joint capsule and parts it without violence. {target_name}'s {hit_location} drops away.",
+                "victim_msg": "{attacker_name}'s blade finds your joint capsule and parts it without violence. Your {hit_location} drops away.",
+                "observer_msg": "{attacker_name}'s blade finds the joint capsule and parts it without violence. {target_name}'s {hit_location} drops away.",
+            },
+            {
+                "attacker_msg": "The thrust is economical and exact. {target_name}'s {hit_location} comes free from the ankle with no fanfare.",
+                "victim_msg": "{attacker_name}'s thrust is economical and exact. Your {hit_location} comes free from your ankle.",
+                "observer_msg": "{attacker_name}'s thrust is economical and exact. {target_name}'s {hit_location} comes free from the ankle with no fanfare.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "Chain teeth chew through {target_name}'s ankle in a wet grinding chorus. The {hit_location} drops away in pieces, leaving the leg ending at a shredded stump.",
+                "victim_msg": "Chain teeth chew through your ankle. Your {hit_location} drops away in pieces.",
+                "observer_msg": "Chain teeth chew through {target_name}'s ankle in a wet grinding chorus. The {hit_location} drops away in pieces, leaving the leg ending at a shredded stump.",
+            },
+            {
+                "attacker_msg": "You saw through {target_name}'s ankle and the metatarsals shatter. The {hit_location} comes apart in a slurry of bone and skin.",
+                "victim_msg": "{attacker_name} saws through your ankle and your metatarsals shatter. Your {hit_location} comes apart.",
+                "observer_msg": "{attacker_name} saws through {target_name}'s ankle and the metatarsals shatter. The {hit_location} comes apart in a slurry of bone and skin.",
+            },
+            {
+                "attacker_msg": "Your blade catches and *grinds*. {target_name}'s {hit_location} tears free in a ragged moment, blood pooling instantly.",
+                "victim_msg": "{attacker_name}'s blade catches and *grinds*. Your {hit_location} tears free.",
+                "observer_msg": "{attacker_name}'s blade catches and *grinds*. {target_name}'s {hit_location} tears free in a ragged moment, blood pooling instantly.",
+            },
+            {
+                "attacker_msg": "The chain rips through {target_name}'s ankle, dragging tendon and bone shards. The {hit_location} comes off ragged but undeniable.",
+                "victim_msg": "{attacker_name}'s chain rips through your ankle. Your {hit_location} comes off ragged but undeniable.",
+                "observer_msg": "{attacker_name}'s chain rips through {target_name}'s ankle, dragging tendon and bone shards. The {hit_location} comes off ragged but undeniable.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The cut is rough but the ankle is small. {target_name}'s {hit_location} parts from the leg in a moment that's more tear than slice.",
+                "victim_msg": "{attacker_name}'s cut is rough but your ankle is small. Your {hit_location} parts from your leg.",
+                "observer_msg": "{attacker_name}'s cut is rough but the ankle is small. {target_name}'s {hit_location} parts from the leg in a moment that's more tear than slice.",
+            },
+            {
+                "attacker_msg": "Serrated edge bites through the ankle and {target_name}'s {hit_location} comes loose with a wet, tearing sound.",
+                "victim_msg": "{attacker_name}'s serrated edge bites through your ankle and your {hit_location} comes loose.",
+                "observer_msg": "{attacker_name}'s serrated edge bites through the ankle and {target_name}'s {hit_location} comes loose with a wet, tearing sound.",
+            },
+            {
+                "attacker_msg": "You drag the blade through {target_name}'s ankle and the {hit_location} parts free, the cut ragged but the result clear.",
+                "victim_msg": "{attacker_name} drags the blade through your ankle and your {hit_location} parts free.",
+                "observer_msg": "{attacker_name} drags the blade through {target_name}'s ankle and the {hit_location} parts free, the cut ragged but the result clear.",
+            },
+            {
+                "attacker_msg": "The tear is uneven but the metatarsals surrender. {target_name}'s {hit_location} drops away in a wash of red.",
+                "victim_msg": "{attacker_name}'s tear is uneven but your metatarsals surrender. Your {hit_location} drops away.",
+                "observer_msg": "{attacker_name}'s tear is uneven but the metatarsals surrender. {target_name}'s {hit_location} drops away in a wash of red.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/hands.py
+++ b/world/combat/messages/severance/hands.py
@@ -1,0 +1,148 @@
+"""Hand severance templates — left or right hand detached at the wrist.
+
+Fires when an edged hit destroys a left_hand or right_hand metacarpals.
+The ``{hit_location}`` kwarg resolves to ``"left hand"`` or ``"right hand"``.
+
+See ``world/combat/messages/severance/__init__.py`` for the loader.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade takes {target_name}'s {hit_location} off at the wrist in a single arc. The hand falls still gripping at something it can no longer hold.",
+                "victim_msg": "{attacker_name}'s blade takes your {hit_location} off at the wrist in a single arc. The hand falls still gripping at something it can no longer hold.",
+                "observer_msg": "{attacker_name}'s blade takes {target_name}'s {hit_location} off at the wrist in a single arc. The hand falls still gripping at something it can no longer hold.",
+            },
+            {
+                "attacker_msg": "A clean horizontal stroke and {target_name}'s {hit_location} is gone — spinning to the floor, fingers curled, the wound spurting red in time with their pulse.",
+                "victim_msg": "{attacker_name}'s clean horizontal stroke and your {hit_location} is gone — spinning to the floor, fingers curled.",
+                "observer_msg": "{attacker_name}'s clean horizontal stroke and {target_name}'s {hit_location} is gone — spinning to the floor, fingers curled, the wound spurting red.",
+            },
+            {
+                "attacker_msg": "Bone parts at the joint and {target_name}'s {hit_location} drops to the deck with a wet slap, the body recoiling from its sudden incompleteness.",
+                "victim_msg": "Bone parts at the joint and your {hit_location} drops to the deck with a wet slap, your body recoiling from its sudden incompleteness.",
+                "observer_msg": "Bone parts at the joint and {target_name}'s {hit_location} drops to the deck with a wet slap, the body recoiling from its sudden incompleteness.",
+            },
+            {
+                "attacker_msg": "Your edge passes through {target_name}'s wrist and the {hit_location} falls in a slow, terrible parabola. Blood traces an arc behind it.",
+                "victim_msg": "{attacker_name}'s edge passes through your wrist and your {hit_location} falls in a slow, terrible parabola.",
+                "observer_msg": "{attacker_name}'s edge passes through {target_name}'s wrist and the {hit_location} falls in a slow, terrible parabola. Blood traces an arc behind it.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A surgical cut at the wrist joint and {target_name}'s {hit_location} comes off as neatly as a glove being removed.",
+                "victim_msg": "{attacker_name}'s surgical cut at your wrist joint and your {hit_location} comes off as neatly as a glove being removed.",
+                "observer_msg": "{attacker_name}'s surgical cut at the wrist joint and {target_name}'s {hit_location} comes off as neatly as a glove being removed.",
+            },
+            {
+                "attacker_msg": "The blade finds the gap between wrist bones and parts {target_name}'s {hit_location} from the body in a single uncomplicated motion.",
+                "victim_msg": "{attacker_name}'s blade finds the gap between your wrist bones and parts your {hit_location} from your body in a single uncomplicated motion.",
+                "observer_msg": "{attacker_name}'s blade finds the gap between {target_name}'s wrist bones and parts the {hit_location} from the body in a single uncomplicated motion.",
+            },
+            {
+                "attacker_msg": "One stroke, no spectacle. {target_name}'s {hit_location} settles to the floor like it had been gently placed there.",
+                "victim_msg": "{attacker_name}'s one stroke, no spectacle. Your {hit_location} settles to the floor like it had been gently placed there.",
+                "observer_msg": "{attacker_name}'s one stroke, no spectacle. {target_name}'s {hit_location} settles to the floor like it had been gently placed there.",
+            },
+            {
+                "attacker_msg": "Your edge finds the bone end and {target_name}'s {hit_location} drops free, the cut so clean it could be admired.",
+                "victim_msg": "{attacker_name}'s edge finds your bone end and your {hit_location} drops free, the cut so clean it could be admired.",
+                "observer_msg": "{attacker_name}'s edge finds the bone end and {target_name}'s {hit_location} drops free, the cut so clean it could be admired.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point through {target_name}'s wrist and *twist*. Carpal bones scatter, tendons part, the {hit_location} drops away in a mess.",
+                "victim_msg": "{attacker_name} drives the point through your wrist and *twists*. Carpal bones scatter, tendons part, your {hit_location} drops away.",
+                "observer_msg": "{attacker_name} drives the point through {target_name}'s wrist and *twists*. Carpal bones scatter, tendons part, the {hit_location} drops away in a mess.",
+            },
+            {
+                "attacker_msg": "The thrust splits the wrist apart from the inside out. {target_name}'s {hit_location} hangs by a flap of skin for half a heartbeat, then falls.",
+                "victim_msg": "{attacker_name}'s thrust splits your wrist apart from the inside out. Your {hit_location} hangs by a flap of skin, then falls.",
+                "observer_msg": "{attacker_name}'s thrust splits the wrist apart from the inside out. {target_name}'s {hit_location} hangs by a flap of skin for half a heartbeat, then falls.",
+            },
+            {
+                "attacker_msg": "Your point goes deep and levers outward. {target_name}'s {hit_location} tears free at the joint, leaving the bone end of the arm exposed and bleeding.",
+                "victim_msg": "{attacker_name}'s point goes deep and levers outward. Your {hit_location} tears free at the joint.",
+                "observer_msg": "{attacker_name}'s point goes deep and levers outward. {target_name}'s {hit_location} tears free at the joint, leaving the bone end of the arm exposed and bleeding.",
+            },
+            {
+                "attacker_msg": "The blade impales the wrist and rips downward. {target_name}'s {hit_location} comes off in a brutal mechanical motion, blood spurting from severed arteries.",
+                "victim_msg": "{attacker_name}'s blade impales your wrist and rips downward. Your {hit_location} comes off in a brutal mechanical motion.",
+                "observer_msg": "{attacker_name}'s blade impales the wrist and rips downward. {target_name}'s {hit_location} comes off in a brutal mechanical motion, blood spurting from severed arteries.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The point slips between carpal bones and {target_name}'s {hit_location} parts from the body in a single small motion.",
+                "victim_msg": "{attacker_name}'s point slips between your carpal bones and your {hit_location} parts from your body in a single small motion.",
+                "observer_msg": "{attacker_name}'s point slips between carpal bones and {target_name}'s {hit_location} parts from the body in a single small motion.",
+            },
+            {
+                "attacker_msg": "A precise thrust at the wrist joint and {target_name}'s {hit_location} simply comes loose, gravity doing the rest.",
+                "victim_msg": "{attacker_name}'s precise thrust at your wrist joint and your {hit_location} simply comes loose.",
+                "observer_msg": "{attacker_name}'s precise thrust at the wrist joint and {target_name}'s {hit_location} simply comes loose, gravity doing the rest.",
+            },
+            {
+                "attacker_msg": "Your blade finds the precise gap and {target_name}'s {hit_location} drops away with no struggle, no flourish.",
+                "victim_msg": "{attacker_name}'s blade finds the precise gap and your {hit_location} drops away with no struggle.",
+                "observer_msg": "{attacker_name}'s blade finds the precise gap and {target_name}'s {hit_location} drops away with no struggle, no flourish.",
+            },
+            {
+                "attacker_msg": "The point enters where it must and {target_name}'s {hit_location} parts from the wrist in a moment of mechanical certainty.",
+                "victim_msg": "{attacker_name}'s point enters where it must and your {hit_location} parts from your wrist in a moment of mechanical certainty.",
+                "observer_msg": "{attacker_name}'s point enters where it must and {target_name}'s {hit_location} parts from the wrist in a moment of mechanical certainty.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "Chain teeth chew through {target_name}'s wrist in a wet grinding chorus. The {hit_location} drops away, fingers still twitching like a question.",
+                "victim_msg": "Chain teeth chew through your wrist in a wet grinding chorus. Your {hit_location} drops away, fingers still twitching.",
+                "observer_msg": "Chain teeth chew through {target_name}'s wrist in a wet grinding chorus. The {hit_location} drops away, fingers still twitching like a question.",
+            },
+            {
+                "attacker_msg": "You saw and *rip*. {target_name}'s {hit_location} comes apart at the wrist in a slurry of carpal fragments and torn skin.",
+                "victim_msg": "{attacker_name} saws and *rips*. Your {hit_location} comes apart at the wrist in a slurry of carpal fragments.",
+                "observer_msg": "{attacker_name} saws and *rips*. {target_name}'s {hit_location} comes apart at the wrist in a slurry of carpal fragments and torn skin.",
+            },
+            {
+                "attacker_msg": "The serrated edge catches and drags. {target_name}'s {hit_location} tears free, the wound a ragged mess where the wrist used to be.",
+                "victim_msg": "{attacker_name}'s serrated edge catches and drags. Your {hit_location} tears free.",
+                "observer_msg": "{attacker_name}'s serrated edge catches and drags. {target_name}'s {hit_location} tears free, the wound a ragged mess where the wrist used to be.",
+            },
+            {
+                "attacker_msg": "Your blade chews through {target_name}'s wrist in a single brutal pass. The {hit_location} comes off in pieces — bones, skin, gristle — but mostly it comes off.",
+                "victim_msg": "{attacker_name}'s blade chews through your wrist in a single brutal pass. Your {hit_location} comes off in pieces.",
+                "observer_msg": "{attacker_name}'s blade chews through {target_name}'s wrist in a single brutal pass. The {hit_location} comes off in pieces — bones, skin, gristle — but mostly it comes off.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The cut is rough but the wrist is narrow. {target_name}'s {hit_location} parts from the body in a tearing moment that ends quickly.",
+                "victim_msg": "{attacker_name}'s cut is rough but your wrist is narrow. Your {hit_location} parts from your body in a tearing moment.",
+                "observer_msg": "{attacker_name}'s cut is rough but the wrist is narrow. {target_name}'s {hit_location} parts from the body in a tearing moment that ends quickly.",
+            },
+            {
+                "attacker_msg": "Serrated edge bites through the wrist and {target_name}'s {hit_location} comes loose, ragged but undeniable.",
+                "victim_msg": "{attacker_name}'s serrated edge bites through your wrist and your {hit_location} comes loose, ragged but undeniable.",
+                "observer_msg": "{attacker_name}'s serrated edge bites through the wrist and {target_name}'s {hit_location} comes loose, ragged but undeniable.",
+            },
+            {
+                "attacker_msg": "You drag the blade across {target_name}'s wrist and the {hit_location} parts free in a small, tearing surrender.",
+                "victim_msg": "{attacker_name} drags the blade across your wrist and your {hit_location} parts free.",
+                "observer_msg": "{attacker_name} drags the blade across {target_name}'s wrist and the {hit_location} parts free in a small, tearing surrender.",
+            },
+            {
+                "attacker_msg": "The tear is uneven but the result is unambiguous. {target_name}'s {hit_location} falls away, blood already pooling on the deck.",
+                "victim_msg": "{attacker_name}'s tear is uneven but the result is unambiguous. Your {hit_location} falls away.",
+                "observer_msg": "{attacker_name}'s tear is uneven but the result is unambiguous. {target_name}'s {hit_location} falls away, blood already pooling on the deck.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/head.py
+++ b/world/combat/messages/severance/head.py
@@ -1,0 +1,150 @@
+"""Head severance templates — decapitation narrative for combat.
+
+Fires when an edged hit (cut / stab / laceration) destroys the cervical
+spine, flagging ``decapitation_pending``. Narrative focuses on the head
+parting from the body, not on the neck wound itself.
+
+See ``world/combat/messages/severance/__init__.py`` for the loader and
+``MESSAGES`` schema.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade carves through {target_name}'s neck in a single brutal arc. Their head spins free, eyes still tracking nothing, and meets the deck with a wet crack.",
+                "victim_msg": "{attacker_name}'s blade carves through your neck in a single brutal arc. Your head spins free, eyes still tracking nothing.",
+                "observer_msg": "{attacker_name}'s blade carves through {target_name}'s neck in a single brutal arc. Their head spins free, eyes still tracking nothing, and meets the deck with a wet crack.",
+            },
+            {
+                "attacker_msg": "The cut is too deep, too fast. {target_name}'s head topples backward before the body knows it has lost its anchor — blood plumes in a wide red column.",
+                "victim_msg": "The cut is too deep, too fast. Your head topples backward before the body knows it has lost its anchor.",
+                "observer_msg": "The cut is too deep, too fast. {target_name}'s head topples backward before the body knows it has lost its anchor — blood plumes in a wide red column.",
+            },
+            {
+                "attacker_msg": "You hew through {target_name}'s neck and feel the resistance vanish mid-stroke. Their head drops to the ground, mouth open in a question that will never close.",
+                "victim_msg": "{attacker_name} hews through your neck and the resistance vanishes mid-stroke. Your head drops, mouth open in a question that will never close.",
+                "observer_msg": "{attacker_name} hews through {target_name}'s neck and the resistance vanishes mid-stroke. The head drops to the ground, mouth open in a question that will never close.",
+            },
+            {
+                "attacker_msg": "Bone parts like wet wood. {target_name}'s head sails free, trailing a slow rope of red, and hits the floor before the body has begun to fall.",
+                "victim_msg": "Bone parts like wet wood. Your head sails free, trailing a slow rope of red.",
+                "observer_msg": "Bone parts like wet wood. {target_name}'s head sails free, trailing a slow rope of red, and hits the floor before the body has begun to fall.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "One stroke. {target_name}'s head leaves the body in something almost ceremonial, and the cut is so clean it might have been mistaken for an act of mercy.",
+                "victim_msg": "One stroke. Your head leaves your body in something almost ceremonial.",
+                "observer_msg": "One stroke. {target_name}'s head leaves the body in something almost ceremonial, and the cut is so clean it might have been mistaken for an act of mercy.",
+            },
+            {
+                "attacker_msg": "The edge passes through {target_name}'s neck without protest. The head settles to the floor with the soft weight of an offering.",
+                "victim_msg": "The edge passes through your neck without protest. Your head settles to the floor with the soft weight of an offering.",
+                "observer_msg": "The edge passes through {target_name}'s neck without protest. The head settles to the floor with the soft weight of an offering.",
+            },
+            {
+                "attacker_msg": "A clean line opens beneath {target_name}'s jaw and the head simply detaches, gravity claiming what's no longer held.",
+                "victim_msg": "A clean line opens beneath your jaw and your head simply detaches, gravity claiming what's no longer held.",
+                "observer_msg": "A clean line opens beneath {target_name}'s jaw and the head simply detaches, gravity claiming what's no longer held.",
+            },
+            {
+                "attacker_msg": "Your blade finds the joint between vertebrae and the head parts from the body without a single ragged fibre — surgical, almost respectful.",
+                "victim_msg": "{attacker_name}'s blade finds the joint between your vertebrae and your head parts from your body without a single ragged fibre.",
+                "observer_msg": "{attacker_name}'s blade finds the joint between {target_name}'s vertebrae and the head parts from the body without a single ragged fibre — surgical, almost respectful.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point through {target_name}'s throat and *twist*. The neck gives up its structure all at once, and the head sags loose, then falls.",
+                "victim_msg": "{attacker_name} drives the point through your throat and *twists*. The neck gives up its structure all at once.",
+                "observer_msg": "{attacker_name} drives the point through {target_name}'s throat and *twists*. The neck gives up its structure all at once, and the head sags loose, then falls.",
+            },
+            {
+                "attacker_msg": "The point goes deep and keeps going, tearing through bone and sinew until {target_name}'s head hangs by a flap of skin. Then that gives too.",
+                "victim_msg": "{attacker_name}'s point goes deep and keeps going, tearing through bone and sinew until your head hangs by a flap of skin. Then that gives too.",
+                "observer_msg": "{attacker_name}'s point goes deep and keeps going, tearing through bone and sinew until {target_name}'s head hangs by a flap of skin. Then that gives too.",
+            },
+            {
+                "attacker_msg": "Impalement becomes amputation. {target_name}'s head jerks once on the blade, then slides free, leaving the body to discover its absence.",
+                "victim_msg": "Impalement becomes amputation. Your head jerks once on the blade, then slides free.",
+                "observer_msg": "Impalement becomes amputation. {target_name}'s head jerks once on the blade, then slides free, leaving the body to discover its absence.",
+            },
+            {
+                "attacker_msg": "You shove the point up under {target_name}'s jaw and *pull*. Vertebrae splinter outward and the head comes loose, dangling on rags of tissue, then dropping.",
+                "victim_msg": "{attacker_name} shoves the point up under your jaw and *pulls*. Vertebrae splinter outward and your head comes loose.",
+                "observer_msg": "{attacker_name} shoves the point up under {target_name}'s jaw and *pulls*. Vertebrae splinter outward and the head comes loose, dangling on rags of tissue, then dropping.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The point slips between vertebrae and the head detaches as cleanly as plucking fruit. {target_name} never had time to register the betrayal.",
+                "victim_msg": "The point slips between your vertebrae and your head detaches as cleanly as plucking fruit.",
+                "observer_msg": "The point slips between {target_name}'s vertebrae and the head detaches as cleanly as plucking fruit. They never had time to register the betrayal.",
+            },
+            {
+                "attacker_msg": "A surgical thrust through the precise gap. {target_name}'s head separates and you ease it down with something approaching tenderness.",
+                "victim_msg": "{attacker_name}'s surgical thrust finds the precise gap. Your head separates and is eased down with something approaching tenderness.",
+                "observer_msg": "{attacker_name}'s surgical thrust finds the precise gap. {target_name}'s head separates and is eased down with something approaching tenderness.",
+            },
+            {
+                "attacker_msg": "The blade enters where it must and exits with the head no longer attached — a single moment of mechanical perfection.",
+                "victim_msg": "{attacker_name}'s blade enters where it must and exits with your head no longer attached — a single moment of mechanical perfection.",
+                "observer_msg": "{attacker_name}'s blade enters where it must and exits with {target_name}'s head no longer attached — a single moment of mechanical perfection.",
+            },
+            {
+                "attacker_msg": "You find the joint without looking, slide through, and {target_name}'s head leaves the body without complaint or spectacle.",
+                "victim_msg": "{attacker_name} finds the joint without looking, slides through, and your head leaves your body without complaint or spectacle.",
+                "observer_msg": "{attacker_name} finds the joint without looking, slides through, and {target_name}'s head leaves the body without complaint or spectacle.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "Teeth and torque take {target_name}'s head off in pieces. Bone fragments and tissue spray outward while the engine's note doesn't change.",
+                "victim_msg": "Teeth and torque take your head off in pieces. Bone and tissue spray outward.",
+                "observer_msg": "Teeth and torque take {target_name}'s head off in pieces. Bone fragments and tissue spray outward while the engine's note doesn't change.",
+            },
+            {
+                "attacker_msg": "The blade catches, drags, and *grinds*. {target_name}'s head comes apart at the neck in a slurry of red, and what's left of it lands separately.",
+                "victim_msg": "{attacker_name}'s blade catches, drags, and *grinds*. Your head comes apart at the neck in a slurry of red.",
+                "observer_msg": "{attacker_name}'s blade catches, drags, and *grinds*. {target_name}'s head comes apart at the neck in a slurry of red, and what's left of it lands separately.",
+            },
+            {
+                "attacker_msg": "You saw, you tear, you *rip*. {target_name}'s head leaves the body in a single ragged motion, ribbons of meat trailing after it like banners.",
+                "victim_msg": "{attacker_name} saws, tears, *rips*. Your head leaves your body in a single ragged motion.",
+                "observer_msg": "{attacker_name} saws, tears, *rips*. {target_name}'s head leaves the body in a single ragged motion, ribbons of meat trailing after it like banners.",
+            },
+            {
+                "attacker_msg": "Chain teeth chew through {target_name}'s neck in a wet, mechanical lullaby. The head spins free, hair clogging the bar, and the body keeps standing for one heartbeat too long.",
+                "victim_msg": "Chain teeth chew through your neck in a wet, mechanical lullaby. The head spins free.",
+                "observer_msg": "Chain teeth chew through {target_name}'s neck in a wet, mechanical lullaby. The head spins free, hair clogging the bar, and the body keeps standing for one heartbeat too long.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The cut is rough but final. {target_name}'s head comes free in a single tearing pull, the wound ragged but undeniable.",
+                "victim_msg": "{attacker_name}'s cut is rough but final. Your head comes free in a single tearing pull.",
+                "observer_msg": "{attacker_name}'s cut is rough but final. {target_name}'s head comes free in a single tearing pull, the wound ragged but undeniable.",
+            },
+            {
+                "attacker_msg": "Serrated edge catches, then breaks through. {target_name}'s head is off in a moment that's neither clean nor uncertain.",
+                "victim_msg": "{attacker_name}'s serrated edge catches, then breaks through. Your head is off in a moment that's neither clean nor uncertain.",
+                "observer_msg": "{attacker_name}'s serrated edge catches, then breaks through. {target_name}'s head is off in a moment that's neither clean nor uncertain.",
+            },
+            {
+                "attacker_msg": "You drag the blade across {target_name}'s neck and feel the connection give in a series of small surrenders, the head loosening, then detaching.",
+                "victim_msg": "{attacker_name} drags the blade across your neck and the connection gives in a series of small surrenders.",
+                "observer_msg": "{attacker_name} drags the blade across {target_name}'s neck and the connection gives in a series of small surrenders, the head loosening, then detaching.",
+            },
+            {
+                "attacker_msg": "The tear is uneven but complete. {target_name}'s head leaves the body in a moment that asks for no witnesses but gets them anyway.",
+                "victim_msg": "The tear is uneven but complete. Your head leaves your body in a moment that asks for no witnesses.",
+                "observer_msg": "The tear is uneven but complete. {target_name}'s head leaves the body in a moment that asks for no witnesses but gets them anyway.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/shins.py
+++ b/world/combat/messages/severance/shins.py
@@ -1,0 +1,148 @@
+"""Shin severance templates — left or right shin detached at the knee.
+
+Fires when an edged hit destroys a left_shin or right_shin tibia. The
+``{hit_location}`` kwarg resolves to ``"left shin"`` or ``"right shin"``.
+
+See ``world/combat/messages/severance/__init__.py`` for the loader.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade cleaves through {target_name}'s knee. The {hit_location} cartwheels away in a spray of red, and the body crashes to the deck without the leg to catch it.",
+                "victim_msg": "{attacker_name}'s blade cleaves through your knee. Your {hit_location} cartwheels away in a spray of red.",
+                "observer_msg": "{attacker_name}'s blade cleaves through {target_name}'s knee. The {hit_location} cartwheels away in a spray of red, and the body crashes to the deck without the leg to catch it.",
+            },
+            {
+                "attacker_msg": "The tibia parts under your edge with a deep, satisfying crack. {target_name}'s {hit_location} drops away and the body topples in a slow, terrible arc.",
+                "victim_msg": "Your tibia parts under {attacker_name}'s edge with a deep crack. Your {hit_location} drops away and you topple.",
+                "observer_msg": "{target_name}'s tibia parts under {attacker_name}'s edge with a deep crack. The {hit_location} drops away and the body topples in a slow, terrible arc.",
+            },
+            {
+                "attacker_msg": "You take {target_name}'s {hit_location} off at the knee in a single hard stroke. The leg falls, the body kneels, and blood floods the deck around the wound.",
+                "victim_msg": "{attacker_name} takes your {hit_location} off at the knee in a single hard stroke. Your leg falls, you kneel.",
+                "observer_msg": "{attacker_name} takes {target_name}'s {hit_location} off at the knee in a single hard stroke. The leg falls, the body kneels, and blood floods the deck.",
+            },
+            {
+                "attacker_msg": "Your chop catches just below the kneecap and continues through. {target_name}'s {hit_location} flies free, blood arcing high behind it.",
+                "victim_msg": "{attacker_name}'s chop catches just below your kneecap and continues through. Your {hit_location} flies free.",
+                "observer_msg": "{attacker_name}'s chop catches just below {target_name}'s kneecap and continues through. The {hit_location} flies free, blood arcing high behind it.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A clean stroke at the knee joint and {target_name}'s {hit_location} separates from the leg in a moment of surgical precision.",
+                "victim_msg": "{attacker_name}'s clean stroke at your knee joint and your {hit_location} separates from your leg.",
+                "observer_msg": "{attacker_name}'s clean stroke at the knee joint and {target_name}'s {hit_location} separates from the leg in a moment of surgical precision.",
+            },
+            {
+                "attacker_msg": "The edge finds the gap between femur and tibia and parts {target_name}'s {hit_location} away cleanly.",
+                "victim_msg": "{attacker_name}'s edge finds the gap between your femur and tibia and parts your {hit_location} away cleanly.",
+                "observer_msg": "{attacker_name}'s edge finds the gap between femur and tibia and parts {target_name}'s {hit_location} away cleanly.",
+            },
+            {
+                "attacker_msg": "Your blade passes through the knee joint without complaint. {target_name}'s {hit_location} falls free, the cut so neat it could be admired.",
+                "victim_msg": "{attacker_name}'s blade passes through your knee joint without complaint. Your {hit_location} falls free.",
+                "observer_msg": "{attacker_name}'s blade passes through the knee joint without complaint. {target_name}'s {hit_location} falls free, the cut so neat it could be admired.",
+            },
+            {
+                "attacker_msg": "One stroke, exactly placed at the joint. {target_name}'s {hit_location} comes away with no struggle and the body kneels with strange grace.",
+                "victim_msg": "{attacker_name}'s one stroke, exactly placed. Your {hit_location} comes away with no struggle.",
+                "observer_msg": "{attacker_name}'s one stroke, exactly placed at the joint. {target_name}'s {hit_location} comes away with no struggle and the body kneels with strange grace.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point into the knee joint and *twist*. The patella shatters, the joint pries apart, and {target_name}'s {hit_location} hangs loose before it falls.",
+                "victim_msg": "{attacker_name} drives the point into your knee joint and *twists*. Your patella shatters, your {hit_location} hangs loose.",
+                "observer_msg": "{attacker_name} drives the point into {target_name}'s knee joint and *twists*. The patella shatters, the joint pries apart, and the {hit_location} hangs loose before it falls.",
+            },
+            {
+                "attacker_msg": "Your thrust tears through the joint capsule. {target_name}'s {hit_location} comes loose in a wet, brutal moment, the leg flopping away from the knee.",
+                "victim_msg": "{attacker_name}'s thrust tears through your joint capsule. Your {hit_location} comes loose in a wet, brutal moment.",
+                "observer_msg": "{attacker_name}'s thrust tears through the joint capsule. {target_name}'s {hit_location} comes loose in a wet, brutal moment, the leg flopping away from the knee.",
+            },
+            {
+                "attacker_msg": "The point goes deep and levers downward. {target_name}'s {hit_location} tears free at the knee, dragging tendons behind it like reins.",
+                "victim_msg": "{attacker_name}'s point goes deep and levers downward. Your {hit_location} tears free at the knee.",
+                "observer_msg": "{attacker_name}'s point goes deep and levers downward. {target_name}'s {hit_location} tears free at the knee, dragging tendons behind it like reins.",
+            },
+            {
+                "attacker_msg": "You shove the blade through the patella and *grind*. The joint disintegrates and {target_name}'s {hit_location} drops away in a spray of bone and meat.",
+                "victim_msg": "{attacker_name} shoves the blade through your patella and *grinds*. Your {hit_location} drops away.",
+                "observer_msg": "{attacker_name} shoves the blade through {target_name}'s patella and *grinds*. The joint disintegrates and the {hit_location} drops away in a spray of bone and meat.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The point slips into the knee joint with surgical precision and {target_name}'s {hit_location} separates from the leg in a single clean motion.",
+                "victim_msg": "{attacker_name}'s point slips into your knee joint with surgical precision and your {hit_location} separates from your leg.",
+                "observer_msg": "{attacker_name}'s point slips into the knee joint with surgical precision and {target_name}'s {hit_location} separates from the leg in a single clean motion.",
+            },
+            {
+                "attacker_msg": "A precise thrust at the joint and {target_name}'s {hit_location} comes loose. The body finds the floor with surprising grace.",
+                "victim_msg": "{attacker_name}'s precise thrust at your joint and your {hit_location} comes loose.",
+                "observer_msg": "{attacker_name}'s precise thrust at the joint and {target_name}'s {hit_location} comes loose. The body finds the floor with surprising grace.",
+            },
+            {
+                "attacker_msg": "Your blade finds the joint capsule and parts it without violence. {target_name}'s {hit_location} drops away.",
+                "victim_msg": "{attacker_name}'s blade finds your joint capsule and parts it without violence. Your {hit_location} drops away.",
+                "observer_msg": "{attacker_name}'s blade finds the joint capsule and parts it without violence. {target_name}'s {hit_location} drops away.",
+            },
+            {
+                "attacker_msg": "The thrust is economical and exact. {target_name}'s {hit_location} comes free from the knee with no fanfare.",
+                "victim_msg": "{attacker_name}'s thrust is economical and exact. Your {hit_location} comes free from your knee with no fanfare.",
+                "observer_msg": "{attacker_name}'s thrust is economical and exact. {target_name}'s {hit_location} comes free from the knee with no fanfare.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "Chain teeth chew through {target_name}'s knee in a wet grinding chorus. The {hit_location} drops away in pieces, leaving the leg ending at a shredded stump.",
+                "victim_msg": "Chain teeth chew through your knee in a wet grinding chorus. Your {hit_location} drops away in pieces.",
+                "observer_msg": "Chain teeth chew through {target_name}'s knee in a wet grinding chorus. The {hit_location} drops away in pieces, leaving the leg ending at a shredded stump.",
+            },
+            {
+                "attacker_msg": "You saw through {target_name}'s knee and the tibia splinters under the chain. The {hit_location} comes apart in a slurry of bone and muscle.",
+                "victim_msg": "{attacker_name} saws through your knee and your tibia splinters. Your {hit_location} comes apart.",
+                "observer_msg": "{attacker_name} saws through {target_name}'s knee and the tibia splinters under the chain. The {hit_location} comes apart in a slurry of bone and muscle.",
+            },
+            {
+                "attacker_msg": "Your blade catches and *grinds*. {target_name}'s {hit_location} tears free in a ragged moment, blood pooling instantly.",
+                "victim_msg": "{attacker_name}'s blade catches and *grinds*. Your {hit_location} tears free.",
+                "observer_msg": "{attacker_name}'s blade catches and *grinds*. {target_name}'s {hit_location} tears free in a ragged moment, blood pooling instantly.",
+            },
+            {
+                "attacker_msg": "The chain rips through {target_name}'s knee, dragging skin and tendon and bone shards. The {hit_location} comes off ragged but undeniable.",
+                "victim_msg": "{attacker_name}'s chain rips through your knee. Your {hit_location} comes off ragged but undeniable.",
+                "observer_msg": "{attacker_name}'s chain rips through {target_name}'s knee, dragging skin and tendon and bone shards. The {hit_location} comes off ragged but undeniable.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The cut is rough but the knee gives way. {target_name}'s {hit_location} parts from the leg in a moment that's more tear than slice.",
+                "victim_msg": "{attacker_name}'s cut is rough but your knee gives way. Your {hit_location} parts from your leg.",
+                "observer_msg": "{attacker_name}'s cut is rough but the knee gives way. {target_name}'s {hit_location} parts from the leg in a moment that's more tear than slice.",
+            },
+            {
+                "attacker_msg": "Serrated edge bites through the knee and {target_name}'s {hit_location} comes loose with a wet, tearing sound.",
+                "victim_msg": "{attacker_name}'s serrated edge bites through your knee and your {hit_location} comes loose.",
+                "observer_msg": "{attacker_name}'s serrated edge bites through the knee and {target_name}'s {hit_location} comes loose with a wet, tearing sound.",
+            },
+            {
+                "attacker_msg": "You drag the blade through {target_name}'s knee and the {hit_location} parts free, the cut ragged but the result clear.",
+                "victim_msg": "{attacker_name} drags the blade through your knee and your {hit_location} parts free.",
+                "observer_msg": "{attacker_name} drags the blade through {target_name}'s knee and the {hit_location} parts free, the cut ragged but the result clear.",
+            },
+            {
+                "attacker_msg": "The tear is uneven but the tibia surrenders. {target_name}'s {hit_location} drops away in a wash of red.",
+                "victim_msg": "{attacker_name}'s tear is uneven but your tibia surrenders. Your {hit_location} drops away.",
+                "observer_msg": "{attacker_name}'s tear is uneven but the tibia surrenders. {target_name}'s {hit_location} drops away in a wash of red.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/thighs.py
+++ b/world/combat/messages/severance/thighs.py
@@ -1,0 +1,148 @@
+"""Thigh severance templates — left or right thigh detached at the hip.
+
+Fires when an edged hit destroys a left_thigh or right_thigh femur. The
+``{hit_location}`` kwarg resolves to ``"left thigh"`` or ``"right thigh"``.
+
+See ``world/combat/messages/severance/__init__.py`` for the loader.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade cleaves {target_name}'s {hit_location} from the hip in a sweeping arc. The leg crashes to the deck and the body topples after it in a slow, terrible cascade.",
+                "victim_msg": "{attacker_name}'s blade cleaves your {hit_location} from your hip in a sweeping arc. Your leg crashes to the deck and you topple after it.",
+                "observer_msg": "{attacker_name}'s blade cleaves {target_name}'s {hit_location} from the hip in a sweeping arc. The leg crashes to the deck and the body topples after it in a slow, terrible cascade.",
+            },
+            {
+                "attacker_msg": "The femur parts under your edge with a deep crack. {target_name}'s {hit_location} comes away in a fountain of arterial red, and they go down before they can scream.",
+                "victim_msg": "Your femur parts under {attacker_name}'s edge with a deep crack. Your {hit_location} comes away in a fountain of arterial red.",
+                "observer_msg": "{target_name}'s femur parts under {attacker_name}'s edge with a deep crack. The {hit_location} comes away in a fountain of arterial red, and they go down before they can scream.",
+            },
+            {
+                "attacker_msg": "Your chop catches at the hip joint and continues through. {target_name}'s {hit_location} cartwheels free, blood arcing high in a final salute.",
+                "victim_msg": "{attacker_name}'s chop catches at your hip joint and continues through. Your {hit_location} cartwheels free.",
+                "observer_msg": "{attacker_name}'s chop catches at {target_name}'s hip joint and continues through. The {hit_location} cartwheels free, blood arcing high in a final salute.",
+            },
+            {
+                "attacker_msg": "You take {target_name}'s {hit_location} off above the knee in a single hard stroke. The leg falls, the body collapses, and the deck is suddenly very red.",
+                "victim_msg": "{attacker_name} takes your {hit_location} off above the knee in a single hard stroke. Your leg falls, your body collapses.",
+                "observer_msg": "{attacker_name} takes {target_name}'s {hit_location} off above the knee in a single hard stroke. The leg falls, the body collapses, and the deck is suddenly very red.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A surgical stroke at the hip joint and {target_name}'s {hit_location} separates from the body with almost no fuss.",
+                "victim_msg": "{attacker_name}'s surgical stroke at your hip joint and your {hit_location} separates from your body with almost no fuss.",
+                "observer_msg": "{attacker_name}'s surgical stroke at the hip joint and {target_name}'s {hit_location} separates from the body with almost no fuss.",
+            },
+            {
+                "attacker_msg": "The edge finds the joint capsule and parts it cleanly. {target_name}'s {hit_location} settles to the deck with the soft weight of an offering.",
+                "victim_msg": "{attacker_name}'s edge finds your joint capsule and parts it cleanly. Your {hit_location} settles to the deck.",
+                "observer_msg": "{attacker_name}'s edge finds the joint capsule and parts it cleanly. {target_name}'s {hit_location} settles to the deck with the soft weight of an offering.",
+            },
+            {
+                "attacker_msg": "Your blade passes through the femoral neck without complaint. {target_name}'s {hit_location} comes free, the cut so neat it could be admired.",
+                "victim_msg": "{attacker_name}'s blade passes through your femoral neck without complaint. Your {hit_location} comes free.",
+                "observer_msg": "{attacker_name}'s blade passes through the femoral neck without complaint. {target_name}'s {hit_location} comes free, the cut so neat it could be admired.",
+            },
+            {
+                "attacker_msg": "One stroke, exactly placed. {target_name}'s {hit_location} falls away and the body kneels rather than collapsing.",
+                "victim_msg": "{attacker_name}'s one stroke, exactly placed. Your {hit_location} falls away.",
+                "observer_msg": "{attacker_name}'s one stroke, exactly placed. {target_name}'s {hit_location} falls away and the body kneels rather than collapsing.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point into the hip joint and *lever*. {target_name}'s {hit_location} pries loose with a wet crack and the body folds sideways.",
+                "victim_msg": "{attacker_name} drives the point into your hip joint and *levers*. Your {hit_location} pries loose with a wet crack.",
+                "observer_msg": "{attacker_name} drives the point into {target_name}'s hip joint and *levers*. The {hit_location} pries loose with a wet crack and the body folds sideways.",
+            },
+            {
+                "attacker_msg": "Your thrust tears through the femoral head. {target_name}'s {hit_location} hangs by tendons for a moment, then falls away in a spray of red.",
+                "victim_msg": "{attacker_name}'s thrust tears through your femoral head. Your {hit_location} hangs by tendons for a moment, then falls.",
+                "observer_msg": "{attacker_name}'s thrust tears through {target_name}'s femoral head. The {hit_location} hangs by tendons for a moment, then falls away in a spray of red.",
+            },
+            {
+                "attacker_msg": "The point goes deep and rips through the joint capsule. {target_name}'s {hit_location} tears free, the wound a brutal ruin where the hip used to be.",
+                "victim_msg": "{attacker_name}'s point goes deep and rips through your joint capsule. Your {hit_location} tears free.",
+                "observer_msg": "{attacker_name}'s point goes deep and rips through the joint capsule. {target_name}'s {hit_location} tears free, the wound a brutal ruin where the hip used to be.",
+            },
+            {
+                "attacker_msg": "You shove the blade in and *grind*. The femur snaps at the neck and {target_name}'s {hit_location} comes away dragging shreds of muscle.",
+                "victim_msg": "{attacker_name} shoves the blade in and *grinds*. Your femur snaps at the neck and your {hit_location} comes away.",
+                "observer_msg": "{attacker_name} shoves the blade in and *grinds*. {target_name}'s femur snaps at the neck and the {hit_location} comes away dragging shreds of muscle.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The point slips into the joint with surgical precision and {target_name}'s {hit_location} separates from the body in a single clean motion.",
+                "victim_msg": "{attacker_name}'s point slips into your joint with surgical precision and your {hit_location} separates from your body.",
+                "observer_msg": "{attacker_name}'s point slips into the joint with surgical precision and {target_name}'s {hit_location} separates from the body in a single clean motion.",
+            },
+            {
+                "attacker_msg": "A precise thrust at the hip and {target_name}'s {hit_location} comes loose, the body finding the floor with surprising grace.",
+                "victim_msg": "{attacker_name}'s precise thrust at your hip and your {hit_location} comes loose.",
+                "observer_msg": "{attacker_name}'s precise thrust at the hip and {target_name}'s {hit_location} comes loose, the body finding the floor with surprising grace.",
+            },
+            {
+                "attacker_msg": "Your blade finds the joint capsule and parts it without struggle. {target_name}'s {hit_location} drops free.",
+                "victim_msg": "{attacker_name}'s blade finds your joint capsule and parts it without struggle. Your {hit_location} drops free.",
+                "observer_msg": "{attacker_name}'s blade finds the joint capsule and parts it without struggle. {target_name}'s {hit_location} drops free.",
+            },
+            {
+                "attacker_msg": "The thrust is economical. {target_name}'s {hit_location} comes away from the hip with no fanfare and no waste.",
+                "victim_msg": "{attacker_name}'s thrust is economical. Your {hit_location} comes away from your hip with no fanfare.",
+                "observer_msg": "{attacker_name}'s thrust is economical. {target_name}'s {hit_location} comes away from the hip with no fanfare and no waste.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "Chain teeth chew through {target_name}'s {hit_location} in a wet mechanical chorus. Bone fragments scatter, the leg falls, and the body topples after it.",
+                "victim_msg": "Chain teeth chew through your {hit_location} in a wet mechanical chorus. Your leg falls, your body topples.",
+                "observer_msg": "Chain teeth chew through {target_name}'s {hit_location} in a wet mechanical chorus. Bone fragments scatter, the leg falls, and the body topples after it.",
+            },
+            {
+                "attacker_msg": "You saw through {target_name}'s thigh and the femur splinters under the chain. The {hit_location} comes apart in a slurry of muscle and bone meal.",
+                "victim_msg": "{attacker_name} saws through your thigh and your femur splinters under the chain. Your {hit_location} comes apart.",
+                "observer_msg": "{attacker_name} saws through {target_name}'s thigh and the femur splinters under the chain. The {hit_location} comes apart in a slurry of muscle and bone meal.",
+            },
+            {
+                "attacker_msg": "Your blade catches and *grinds*. {target_name}'s {hit_location} tears free in a ragged moment, blood flooding the deck around them.",
+                "victim_msg": "{attacker_name}'s blade catches and *grinds*. Your {hit_location} tears free in a ragged moment.",
+                "observer_msg": "{attacker_name}'s blade catches and *grinds*. {target_name}'s {hit_location} tears free in a ragged moment, blood flooding the deck around them.",
+            },
+            {
+                "attacker_msg": "The chain rips through {target_name}'s thigh, dragging cloth and skin and muscle. The {hit_location} comes off in pieces — but it comes off.",
+                "victim_msg": "{attacker_name}'s chain rips through your thigh, dragging cloth and skin and muscle. Your {hit_location} comes off in pieces.",
+                "observer_msg": "{attacker_name}'s chain rips through {target_name}'s thigh, dragging cloth and skin and muscle. The {hit_location} comes off in pieces — but it comes off.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "The cut is rough but the femur is brittle. {target_name}'s {hit_location} parts from the hip in a moment that's more tear than slice.",
+                "victim_msg": "{attacker_name}'s cut is rough but the femur is brittle. Your {hit_location} parts from your hip in a moment that's more tear than slice.",
+                "observer_msg": "{attacker_name}'s cut is rough but the femur is brittle. {target_name}'s {hit_location} parts from the hip in a moment that's more tear than slice.",
+            },
+            {
+                "attacker_msg": "Serrated edge bites through the thigh and {target_name}'s {hit_location} comes loose with a wet, tearing sound.",
+                "victim_msg": "{attacker_name}'s serrated edge bites through your thigh and your {hit_location} comes loose.",
+                "observer_msg": "{attacker_name}'s serrated edge bites through the thigh and {target_name}'s {hit_location} comes loose with a wet, tearing sound.",
+            },
+            {
+                "attacker_msg": "You drag the blade through {target_name}'s thigh and the {hit_location} parts free, the cut ragged but the result undeniable.",
+                "victim_msg": "{attacker_name} drags the blade through your thigh and your {hit_location} parts free.",
+                "observer_msg": "{attacker_name} drags the blade through {target_name}'s thigh and the {hit_location} parts free, the cut ragged but the result undeniable.",
+            },
+            {
+                "attacker_msg": "The tear is uneven but the femur gives. {target_name}'s {hit_location} drops away in a wash of red.",
+                "victim_msg": "{attacker_name}'s tear is uneven but your femur gives. Your {hit_location} drops away in a wash of red.",
+                "observer_msg": "{attacker_name}'s tear is uneven but the femur gives. {target_name}'s {hit_location} drops away in a wash of red.",
+            },
+        ],
+    },
+}

--- a/world/tests/test_severance_messages.py
+++ b/world/tests/test_severance_messages.py
@@ -1,0 +1,255 @@
+"""Tests for the severance messaging library (issue #332).
+
+Covers:
+
+* The loader's location → module routing (pair-key aliases work).
+* Injury-type and severity routing (cut/stab/laceration × grievous/minor).
+* Fallback when an injury type / severity isn't seeded.
+* Each per-location module has the expected MESSAGES shape with content
+  in every cell.
+* Per-audience message rendering (attacker / victim / observer).
+* Identity-aware observer_template wiring.
+* Hit-location underscore handling and color wrapping.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.combat.messages.severance import (
+    _LIMB_ALIASES,
+    _resolve_module_name,
+    get_severance_message,
+)
+
+
+class _FakeChar:
+    """Minimal character stub for loader tests."""
+
+    def __init__(self, key="char"):
+        self.key = key
+
+    def get_display_name(self, looker):
+        return self.key
+
+
+class _FakeItem:
+    def __init__(self, key="blade"):
+        self.key = key
+
+
+# =====================================================================
+# Routing / module resolution
+# =====================================================================
+
+
+class ModuleResolutionTests(TestCase):
+
+    def test_head_alias_routes_to_head_module(self):
+        self.assertEqual(_resolve_module_name("head"), "head")
+
+    def test_neck_alias_routes_to_head_module(self):
+        # Decapitation is a "neck container" hit, but the narrative
+        # template library is the head.
+        self.assertEqual(_resolve_module_name("neck"), "head")
+
+    def test_limb_side_routes_to_pair_module(self):
+        self.assertEqual(_resolve_module_name("left_arm"), "arms")
+        self.assertEqual(_resolve_module_name("right_arm"), "arms")
+        self.assertEqual(_resolve_module_name("left_hand"), "hands")
+        self.assertEqual(_resolve_module_name("right_thigh"), "thighs")
+        self.assertEqual(_resolve_module_name("left_shin"), "shins")
+        self.assertEqual(_resolve_module_name("right_foot"), "feet")
+
+    def test_pair_key_passes_through(self):
+        for pair_key in ("arms", "hands", "thighs", "shins", "feet"):
+            with self.subTest(pair_key=pair_key):
+                self.assertEqual(_resolve_module_name(pair_key), pair_key)
+
+    def test_aliases_table_covers_all_severable_limbs(self):
+        from world.combat.constants import SEVERABLE_CONTAINERS
+
+        for loc in SEVERABLE_CONTAINERS:
+            with self.subTest(location=loc):
+                self.assertIn(loc, _LIMB_ALIASES,
+                              f"Severable {loc} missing from _LIMB_ALIASES")
+
+
+# =====================================================================
+# Per-module content presence
+# =====================================================================
+
+
+class DataLayerTests(TestCase):
+
+    EXPECTED_INJURY_TYPES = ("cut", "stab", "laceration")
+    EXPECTED_SEVERITIES = ("grievous", "minor")
+    LOCATIONS = ("head", "arms", "hands", "thighs", "shins", "feet")
+
+    def test_each_location_has_messages_dict(self):
+        import importlib
+        for loc in self.LOCATIONS:
+            with self.subTest(location=loc):
+                mod = importlib.import_module(
+                    f"world.combat.messages.severance.{loc}"
+                )
+                self.assertTrue(hasattr(mod, "MESSAGES"))
+
+    def test_each_cell_has_variants(self):
+        """Every (location, injury_type, severity) cell has at least 3
+        variants, each with all three audience messages."""
+        import importlib
+        for loc in self.LOCATIONS:
+            mod = importlib.import_module(
+                f"world.combat.messages.severance.{loc}"
+            )
+            for itype in self.EXPECTED_INJURY_TYPES:
+                for sev in self.EXPECTED_SEVERITIES:
+                    cell = mod.MESSAGES.get(itype, {}).get(sev, [])
+                    with self.subTest(loc=loc, injury=itype, severity=sev):
+                        self.assertGreaterEqual(
+                            len(cell), 3,
+                            f"{loc}.{itype}.{sev} has only "
+                            f"{len(cell)} variants",
+                        )
+                        for variant in cell:
+                            for key in ("attacker_msg", "victim_msg",
+                                        "observer_msg"):
+                                self.assertIn(
+                                    key, variant,
+                                    f"{loc}.{itype}.{sev} missing {key}"
+                                )
+
+
+# =====================================================================
+# Loader rendering
+# =====================================================================
+
+
+class LoaderRenderTests(TestCase):
+
+    def test_returns_required_keys(self):
+        attacker = _FakeChar("Vasquez")
+        target = _FakeChar("Maria")
+        item = _FakeItem("katana")
+        msgs = get_severance_message(
+            "head", "cut", attacker, target, item,
+            severity="grievous", hit_location="neck",
+        )
+        for key in ("attacker_msg", "victim_msg", "observer_msg",
+                    "observer_template", "observer_char_refs"):
+            self.assertIn(key, msgs)
+
+    def test_observer_char_refs_populated(self):
+        attacker = _FakeChar("Vasquez")
+        target = _FakeChar("Maria")
+        msgs = get_severance_message(
+            "left_arm", "cut", attacker, target, _FakeItem("sword"),
+        )
+        self.assertEqual(msgs["observer_char_refs"]["actor"], attacker)
+        self.assertEqual(msgs["observer_char_refs"]["target_char"], target)
+
+    def test_hit_location_underscore_replaced(self):
+        attacker = _FakeChar("Vasquez")
+        target = _FakeChar("Maria")
+        msgs = get_severance_message(
+            "left_arm", "cut", attacker, target, _FakeItem("sword"),
+            hit_location="left_arm",
+        )
+        # No template should still contain underscored "left_arm"
+        for key in ("attacker_msg", "victim_msg", "observer_msg",
+                    "observer_template"):
+            self.assertNotIn("left_arm", msgs[key])
+
+    def test_messages_are_color_wrapped_red(self):
+        attacker = _FakeChar("Vasquez")
+        target = _FakeChar("Maria")
+        msgs = get_severance_message(
+            "head", "cut", attacker, target, _FakeItem("katana"),
+        )
+        # Severance is a dramatic positive-strike beat → bright red.
+        self.assertTrue(msgs["attacker_msg"].startswith("|r"))
+        self.assertTrue(msgs["attacker_msg"].endswith("|n"))
+
+    def test_observer_template_has_identity_tokens(self):
+        attacker = _FakeChar("Vasquez")
+        target = _FakeChar("Maria")
+        msgs = get_severance_message(
+            "head", "cut", attacker, target, _FakeItem("katana"),
+        )
+        # The observer_template should carry the identity-aware tokens
+        # (literal {actor}/{target_char}) so msg_room_identity can
+        # resolve them per-observer.
+        template = msgs["observer_template"]
+        self.assertTrue(
+            "{actor}" in template or "{target_char}" in template,
+            f"Observer template has no identity tokens: {template!r}"
+        )
+
+    def test_attacker_msg_uses_you_perspective(self):
+        attacker = _FakeChar("Vasquez")
+        target = _FakeChar("Maria")
+        # Try several templates — at least one should use "Your"/"You".
+        outputs = [
+            get_severance_message(
+                "head", "cut", attacker, target, _FakeItem("katana"),
+            )["attacker_msg"]
+            for _ in range(15)
+        ]
+        joined = " ".join(outputs)
+        # Should not contain the attacker's name in attacker_msg.
+        self.assertNotIn("Vasquez", joined)
+
+    def test_victim_msg_uses_your_perspective(self):
+        attacker = _FakeChar("Vasquez")
+        target = _FakeChar("Maria")
+        outputs = [
+            get_severance_message(
+                "left_hand", "cut", attacker, target, _FakeItem("sword"),
+            )["victim_msg"]
+            for _ in range(15)
+        ]
+        joined = " ".join(outputs)
+        # Should not contain the victim's name in victim_msg.
+        self.assertNotIn("Maria", joined)
+
+
+# =====================================================================
+# Fallback paths
+# =====================================================================
+
+
+class FallbackTests(TestCase):
+
+    def test_unknown_injury_type_falls_back_to_cut(self):
+        attacker = _FakeChar("A")
+        target = _FakeChar("B")
+        # An unknown injury type still produces a valid message dict.
+        msgs = get_severance_message(
+            "head", "bullet", attacker, target,  # bullet isn't severing
+        )
+        self.assertIn("attacker_msg", msgs)
+        self.assertTrue(len(msgs["attacker_msg"]) > 0)
+
+    def test_unknown_severity_falls_back_to_grievous(self):
+        attacker = _FakeChar("A")
+        target = _FakeChar("B")
+        msgs = get_severance_message(
+            "head", "cut", attacker, target, severity="catastrophic",
+        )
+        self.assertIn("attacker_msg", msgs)
+        self.assertTrue(len(msgs["attacker_msg"]) > 0)
+
+    def test_unknown_location_falls_through_to_generic(self):
+        # Location with no module returns the generic fallback template.
+        attacker = _FakeChar("A")
+        target = _FakeChar("B")
+        msgs = get_severance_message(
+            "tentacle", "cut", attacker, target,
+            hit_location="tentacle",
+        )
+        # Generic fallback still produces all keys.
+        self.assertIn("attacker_msg", msgs)
+        self.assertIn("victim_msg", msgs)
+        self.assertIn("observer_msg", msgs)


### PR DESCRIPTION
## Summary

- New \`world/combat/messages/severance/\` package — per-location templates (head/arms/hands/thighs/shins/feet) keyed by injury_type × severity. 144 entries × 3 audience messages seeded.
- \`get_severance_message\` loader mirrors \`get_combat_message\`'s shape: attacker / victim / observer audiences plus identity-aware \`observer_template\` + \`observer_char_refs\`. Bright-red colored.
- \`_LIMB_ALIASES\` routes side-specific locations (\`left_arm\`, \`right_hand\`) onto the correct pair module.
- \`_maybe_sever_from_damage\` now fires the head/decapitation message synchronously when \`cervical_spine\` destruction flags \`decapitation_pending\`. Closes #329.
- \`apply_sever_to_character\` replaces its inline single-template broadcast with a library call.
- \`world.combat.attack\` stages \`ndb._last_damage_attacker\` / \`_last_damage_weapon\` before \`take_damage\` so the severance broadcast knows who hit whom. Request-scoped (cleared in \`finally\`).

## Foundation for follow-ups

- **#330** — once the severance message provides the dramatic beat, the 90s death progression can be skipped for decapitation without losing the narrative.
- **#333** — the kill-template rewrite can relocate severance-themed templates (e.g. chainsaw's \"enters at neck, exits at pelvis\") into this library.

## Test plan
- [x] \`docker exec gelatinous evennia test --settings settings.py world.tests.test_severance_messages\` (17 pass)
- [x] Full suite \`docker exec gelatinous evennia test --settings settings.py world\` (1549 pass)
- [ ] In-game: chainsaw kill on mob's neck — decapitation message fires at the killing blow, not silently later
- [ ] In-game: sword cut on left arm bone — limb severance shows variant prose instead of the legacy single inline template

🤖 Generated with [Claude Code](https://claude.com/claude-code)