### PR TITLE
Rewrite severed-stage wound prose for combat + add laceration.py

### DIFF
--- a/world/medical/wounds/messages/__init__.py
+++ b/world/medical/wounds/messages/__init__.py
@@ -5,7 +5,8 @@ Imports all wound message types for easy access.
 """
 
 from . import bullet
-from . import cut  
+from . import cut
+from . import laceration
 from . import stab
 from . import blunt
 from . import generic

--- a/world/medical/wounds/messages/blunt.py
+++ b/world/medical/wounds/messages/blunt.py
@@ -46,13 +46,13 @@ WOUND_DESCRIPTIONS = {
     ],
     
     "severed": [
-        "A clean surgical amputation where the {location} once was, properly bandaged|n",
-        "The {location} has been medically severed with sterile wound dressing|n",
-        "A professionally treated amputation site where the {location} was removed|n",
-        "The {location} has been cleanly amputated with surgical closure|n",
-        "A sterile severance with medical sutures where the {location} once was|n",
-        "The {location} has been surgically removed with proper medical care|n",
-        "A medically treated amputation where the {location} was cleanly severed|n"
+        "|RThe {location} has been pulped off the body, the stump shattered and ragged|n",
+        "|RWhere the {location} once attached, only a mangled mess of crushed tissue and splintered bone remains|n",
+        "|RBlunt force took the {location} away, the wound a ruin of crushed bone and pulped meat|n",
+        "|RThe {location} is gone — pounded loose from the joint, the stump torn and ragged|n",
+        "|RA crushing severance marks where the {location} once was, the bone end pulverized|n",
+        "|RThe {location} has been beaten off the body, the wound a brutal pulp|n",
+        "|RHeavy impact tore the {location} away, leaving a wreck of crushed bone and torn skin|n"
     ],
     
     "scarred": [

--- a/world/medical/wounds/messages/bullet.py
+++ b/world/medical/wounds/messages/bullet.py
@@ -46,13 +46,13 @@ WOUND_DESCRIPTIONS = {
     ],
     
     "severed": [
-        "A clean surgical amputation where the {location} once was, properly bandaged|n",
-        "The {location} has been medically severed with neat surgical dressing|n",
-        "A professionally treated amputation site where the {location} was removed|n",
-        "The {location} has been cleanly amputated with proper medical closure|n",
-        "A sterile amputation site with surgical sutures where the {location} once was|n",
-        "The {location} has been surgically removed with clinical precision|n",
-        "A medically treated severance where the {location} was cleanly amputated|n"
+        "|RThe {location} has been blown clean off, the stump shredded and ragged|n",
+        "|RWhere the {location} once attached, only torn flesh and shattered bone remain|n",
+        "|RHigh-velocity impact took the {location} away, the wound a ruin of meat and fragments|n",
+        "|RThe {location} is gone — torn off in a spray of red, the stump a shredded mess|n",
+        "|RA round took the {location} clean off, the bone end pulverized and the flesh torn|n",
+        "|RThe {location} has been ballistic-amputated, the wound a ragged crater|n",
+        "|RHeavy gunfire tore the {location} away, leaving a wound of mangled tissue and bone shards|n"
     ],
     
     "scarred": [

--- a/world/medical/wounds/messages/cut.py
+++ b/world/medical/wounds/messages/cut.py
@@ -46,13 +46,13 @@ WOUND_DESCRIPTIONS = {
     ],
     
     "severed": [
-        "A clean surgical amputation where the {location} once was, properly closed|n",
-        "The {location} has been medically severed with neat surgical stitching|n",
-        "A professionally treated amputation site where the {location} was removed|n",
-        "The {location} has been cleanly amputated with sterile dressing|n",
-        "A surgical severance with proper closure where the {location} once was|n",
-        "The {location} has been surgically removed with clinical care|n",
-        "A medically treated amputation where the {location} was cleanly severed|n"
+        "|RThe {location} has been struck clean off, the cut edge still weeping|n",
+        "|RWhere the {location} once attached, only a clean wound and bare bone remain|n",
+        "|RA single edge took the {location} away, leaving the wound sharp and bright with blood|n",
+        "|RThe {location} is gone — cleaved at the joint, the wound surprisingly neat|n",
+        "|RA clean amputation marks where the {location} once was, the stump glistening with fresh blood|n",
+        "|RThe {location} has been severed by a blade, the wound clean but raw|n",
+        "|RA precise cut took the {location} off at the joint, the wound edges still seeping|n"
     ],
     
     "scarred": [

--- a/world/medical/wounds/messages/generic.py
+++ b/world/medical/wounds/messages/generic.py
@@ -46,13 +46,13 @@ WOUND_DESCRIPTIONS = {
     ],
     
     "severed": [
-        "A clean surgical amputation where the {location} once was, properly treated|n",
-        "The {location} has been medically severed with sterile bandaging|n",
-        "A professionally treated amputation site where the {location} was removed|n",
-        "The {location} has been cleanly amputated with proper medical closure|n",
-        "A sterile severance with surgical care where the {location} once was|n",
-        "The {location} has been surgically removed with clinical precision|n",
-        "A medically treated amputation where the {location} was cleanly severed|n"
+        "|RThe {location} has been severed at the joint, leaving a ragged stump|n",
+        "|RWhere the {location} once attached, only a raw wound and bare bone remain|n",
+        "|RA single brutal moment took the {location} away, the wound still weeping|n",
+        "|RThe {location} is gone — severed cleanly, the stump bright with fresh blood|n",
+        "|RA visceral amputation marks where the {location} once was, the wound raw|n",
+        "|RThe {location} has been taken off the body, leaving a ragged, weeping wound|n",
+        "|RBlood pools beneath the stump where the {location} used to be|n"
     ],
     
     "scarred": [

--- a/world/medical/wounds/messages/laceration.py
+++ b/world/medical/wounds/messages/laceration.py
@@ -1,0 +1,104 @@
+"""
+Laceration wound descriptions following weapon message pattern.
+
+Used by weapons with ``damage_type: "laceration"`` — chainsaw, blowtorch,
+and other tearing / chewing damage sources. Distinct from clean ``cut``
+(blade slice) and impact ``stab`` (puncture): lacerations are ragged,
+chewed, sawn wounds with torn edges and irregular shapes.
+
+Multiple description variants for each healing stage. Compound
+descriptions handle multiple wounds at the same location.
+"""
+
+WOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|Ra {severity} jagged laceration across the {location} with torn edges|n",
+        "|Ra {severity} ragged tear on the {location} weeping freely|n",
+        "|Ra {severity} chewed wound in the {location} with shredded edges|n",
+        "|Ra {severity} sawn gash on the {location} where the teeth bit deep|n",
+        "|Ra {severity} ripped opening in the {location} exposing torn tissue|n",
+        "|Ra {severity} mangled laceration on the {location} with bone visible|n",
+        "|Ra {severity} torn wound on the {location} bleeding heavily|n"
+    ],
+
+    "treated": [
+        "{skintone}a {severity} sutured laceration on the {location} with {suture_color}heavy stitches|n",
+        "{skintone}a {severity} bandaged tear in the {location} with extensive dressing|n",
+        "{skintone}a {severity} packed wound on the {location} held closed under {bandage_color}gauze|n",
+        "{skintone}a {severity} treated rip in the {location} closed with effort|n",
+        "{skintone}a {severity} dressed tear on the {location} under thick padding|n",
+        "{skintone}a {severity} stapled laceration in the {location} with {medical_staple_color}industrial closure|n",
+        "{skintone}a {severity} repaired tear on the {location} with visible stitching|n"
+    ],
+
+    "healing": [
+        "{skintone}a {severity} healing laceration on the {location} with thick scabbing|n",
+        "{skintone}a {severity} mending tear in the {location} drawing slowly closed|n",
+        "{skintone}a {severity} knitting rip on the {location} with raised edges|n",
+        "{skintone}a {severity} recovering tear in the {location}|n",
+        "{skintone}a {severity} closing laceration on the {location} forming new skin|n",
+        "{skintone}a {severity} improving rip wound in the {location}|n",
+        "{skintone}a {severity} mending shredded wound on the {location}|n"
+    ],
+
+    "destroyed": [
+        "|Ra {severity} devastating laceration has chewed the {location} into pulped ruin|n",
+        "|Ra {severity} massive tearing has rent the {location} apart in ragged sheets|n",
+        "|Ra {severity} brutal shredding has left the {location} unrecognizable|n",
+        "|Ra {severity} savage chewing has reduced the {location} to ribbons and meat|n",
+        "|Ra {severity} catastrophic tearing has obliterated the {location} in a spray of red|n",
+        "|Ra {severity} horrific laceration has flayed the {location} to the bone|n",
+        "|Ra {severity} brutal sawing has destroyed the {location} in pieces|n"
+    ],
+
+    "severed": [
+        "|RThe {location} has been chewed off at the joint, the wound a savage ruin|n",
+        "|RWhere the {location} once attached, only shredded tissue and splintered bone remain|n",
+        "|RTearing teeth took the {location} away, leaving a wound torn and weeping|n",
+        "|RThe {location} is gone — sawn off at the joint, the stump ragged and brutal|n",
+        "|RA mauling severance marks where the {location} once was, the wound a shredded mess|n",
+        "|RThe {location} has been torn loose from the body, leaving wreckage|n",
+        "|RChain teeth tore the {location} away, leaving a stump of pulped meat and bone|n"
+    ],
+
+    "scarred": [
+        "{skintone}a {severity} jagged laceration scar across the {location}|n",
+        "{skintone}a {severity} ragged tear scar on the {location} permanently marked|n",
+        "{skintone}a {severity} chewed wound scar in the {location} thick and raised|n",
+        "{skintone}a {severity} old tearing scar on the {location} with bumpy texture|n",
+        "{skintone}a {severity} healed shredded wound mark on the {location}|n",
+        "{skintone}a {severity} faded tear scar in the {location} with rough edges|n",
+        "{skintone}a {severity} permanent rip mark on the {location}|n"
+    ]
+}
+
+
+# Compound descriptions: two or more wounds at one location, worst-first.
+COMPOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|Ra {severity} laceration and {others_phrase} chew across the {location}|n",
+        "|Ra {severity} tear joins {others_phrase} ripping into the {location}|n",
+        "|Rthe {location} is shredded by a {severity} laceration alongside {others_phrase}|n",
+        "|Ra {severity} ragged wound and {others_phrase} score the {location}|n",
+    ],
+
+    "treated": [
+        "{skintone}a {severity} sutured laceration and {others_phrase} dress the {location}|n",
+        "{skintone}the {location} carries a {severity} stapled tear among {others_phrase}|n",
+    ],
+
+    "healing": [
+        "{skintone}a {severity} healing laceration and {others_phrase} mend across the {location}|n",
+        "{skintone}the {location} shows a {severity} knitting tear among {others_phrase}|n",
+    ],
+
+    "destroyed": [
+        "|Ra {severity} laceration has flayed the {location}, joined by {others_phrase}|n",
+        "|Rthe {location} is a shredded ruin of a {severity} tear and {others_phrase}|n",
+    ],
+
+    "scarred": [
+        "{skintone}a {severity} tear scar and {others_phrase} line the {location}|n",
+        "{skintone}the {location} is etched by a {severity} laceration scar among {others_phrase}|n",
+    ],
+}

--- a/world/medical/wounds/messages/stab.py
+++ b/world/medical/wounds/messages/stab.py
@@ -46,13 +46,13 @@ WOUND_DESCRIPTIONS = {
     ],
     
     "severed": [
-        "A clean surgical amputation where the {location} once was, properly sutured|n",
-        "The {location} has been medically severed with sterile bandaging|n",
-        "A professionally treated amputation site where the {location} was removed|n",
-        "The {location} has been cleanly amputated with surgical closure|n",
-        "A sterile severance with medical sutures where the {location} once was|n",
-        "The {location} has been surgically removed with proper wound care|n",
-        "A medically treated amputation site where the {location} was cleanly severed|n"
+        "|RThe {location} has been pried away at the joint, the wound torn and weeping|n",
+        "|RWhere the {location} once attached, only torn ligaments and exposed bone remain|n",
+        "|RA driven point levered the {location} off, the wound ragged but undeniable|n",
+        "|RThe {location} is gone — wrenched free at the joint, the stump a mess of torn sinew|n",
+        "|RA precise thrust pried the {location} away, leaving a wound that shouldn't be possible|n",
+        "|RThe {location} has been impaled and torn loose, the wound ragged at the edges|n",
+        "|RHard leverage took the {location} away, leaving a wound of torn ligaments and bared bone|n"
     ],
     
     "scarred": [

--- a/world/tests/test_corpse_wound_stage.py
+++ b/world/tests/test_corpse_wound_stage.py
@@ -51,11 +51,15 @@ class CorpseWoundStageTests(TestCase):
         descriptions = corpse.get_preserved_wound_descriptions()
         self.assertEqual(len(descriptions), 1)
         text = descriptions[0]
-        # The severed-stage templates describe stumps / amputations.
-        # Fresh-stage templates describe active injuries.
-        # The substantive marker words live in each.
+        # The severed-stage templates describe stumps and joint
+        # severance. Fresh-stage templates describe active injuries.
+        # Markers updated for #337's combat-flavored prose rewrite —
+        # the new templates use visceral vocabulary (stump, joint,
+        # shredded, severance) rather than the old clinical wording
+        # (amputation, surgically removed).
         severed_markers = (
-            "amputation", "severed", "amputated", "removed",
+            "stump", "bone", "joint", "tear", "severance", "shredded",
+            "amputation", "severed", "amputated",
         )
         fresh_markers = (
             "showing damage", "traumatic wound", "requiring attention",

--- a/world/tests/test_severed_prose.py
+++ b/world/tests/test_severed_prose.py
@@ -1,0 +1,136 @@
+"""Regression guard for severed-stage wound prose tone (issue #337).
+
+Pre-#337 every injury-type wound file had clinical / medical severed-stage
+prose ("clean surgical amputation", "sterile bandaging", "clinical
+precision") — appropriate for ``CmdSever`` post-death scalpel work, but
+jarringly wrong for combat-driven severance via chainsaw, sword, or axe.
+
+These tests pin the rewrite: no injury-type ``severed``-stage template
+contains the clinical vocabulary that was the symptom. Also verifies the
+new ``laceration.py`` exists with full stage coverage so chainsaw /
+blowtorch wounds get tearing-flavor prose instead of falling back to
+``generic.py``.
+
+The ``severed.py`` file (used by ``injury_type='severed'`` for
+``CmdSever``) is intentionally NOT covered by these guards — its
+clinical / stump-prose mix is appropriate for the post-death scalpel
+flow it represents.
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest import TestCase
+
+
+class SeveredStageProseTests(TestCase):
+    """Severed-stage templates across injury types must not read clinical."""
+
+    # Templates with these substrings indicate the old medicalised prose
+    # that was the symptom in #337. The wording was chosen to avoid
+    # false positives — "severance", "amputation", "amputated" are still
+    # acceptable so long as they aren't paired with the clinical
+    # modifiers below.
+    CLINICAL_MARKERS = (
+        "surgical",
+        "medically",
+        "medical",
+        "sterile",
+        "professionally",
+        "clinical",
+        "clinically",
+    )
+
+    INJURY_TYPES = ("blunt", "bullet", "cut", "generic", "stab",
+                    "laceration")
+
+    def _load_severed_templates(self, injury_type):
+        module = importlib.import_module(
+            f"world.medical.wounds.messages.{injury_type}"
+        )
+        return module.WOUND_DESCRIPTIONS.get("severed", [])
+
+    def test_severed_stage_has_at_least_seven_variants(self):
+        for itype in self.INJURY_TYPES:
+            with self.subTest(injury_type=itype):
+                templates = self._load_severed_templates(itype)
+                self.assertGreaterEqual(
+                    len(templates), 7,
+                    f"{itype}.py has only {len(templates)} severed-stage "
+                    f"variants (expected >= 7)",
+                )
+
+    def test_no_clinical_vocabulary_in_severed_templates(self):
+        for itype in self.INJURY_TYPES:
+            for template in self._load_severed_templates(itype):
+                for marker in self.CLINICAL_MARKERS:
+                    with self.subTest(injury=itype, marker=marker):
+                        self.assertNotIn(
+                            marker, template.lower(),
+                            f"{itype}.py severed template still contains "
+                            f"clinical marker {marker!r}: {template!r}"
+                        )
+
+
+class LacerationFileTests(TestCase):
+    """The laceration injury type now has its own wound-message file."""
+
+    EXPECTED_STAGES = ("fresh", "treated", "healing", "destroyed",
+                       "severed", "scarred")
+
+    def setUp(self):
+        # Re-import to pick up newly-added module on first run.
+        import world.medical.wounds.messages as messages
+        importlib.reload(messages)
+        from world.medical.wounds.messages import laceration
+        self.lac = laceration
+
+    def test_laceration_module_loads(self):
+        self.assertTrue(hasattr(self.lac, "WOUND_DESCRIPTIONS"))
+
+    def test_all_stages_populated(self):
+        for stage in self.EXPECTED_STAGES:
+            with self.subTest(stage=stage):
+                cell = self.lac.WOUND_DESCRIPTIONS.get(stage, [])
+                self.assertGreaterEqual(
+                    len(cell), 7,
+                    f"laceration.{stage} has only {len(cell)} variants",
+                )
+
+    def test_compound_descriptions_present(self):
+        self.assertTrue(hasattr(self.lac, "COMPOUND_DESCRIPTIONS"))
+        compound = self.lac.COMPOUND_DESCRIPTIONS
+        # At least the four "always present" compound stages.
+        for stage in ("fresh", "treated", "healing", "destroyed"):
+            with self.subTest(stage=stage):
+                self.assertIn(stage, compound)
+                self.assertGreaterEqual(len(compound[stage]), 1)
+
+    def test_get_wound_description_routes_to_laceration(self):
+        # End-to-end smoke test — `get_wound_description` with
+        # injury_type='laceration' returns laceration-flavor prose, not
+        # generic fallback.
+        from world.medical.wounds import get_wound_description
+
+        # Sample a fresh wound multiple times to cover variant selection.
+        outputs = [
+            get_wound_description(
+                injury_type="laceration",
+                location="left_arm",
+                severity="Critical",
+                stage="fresh",
+            )
+            for _ in range(20)
+        ]
+        joined = " ".join(outputs).lower()
+        # At least one of these laceration-flavor markers should appear
+        # across 20 samples — confirms the routing worked.
+        lac_markers = (
+            "jagged", "ragged", "chewed", "sawn", "ripped", "tearing",
+            "mangled", "torn", "shredded",
+        )
+        self.assertTrue(
+            any(marker in joined for marker in lac_markers),
+            f"laceration routing produced no laceration-flavor markers "
+            f"across 20 samples: {outputs[:3]!r}..."
+        )


### PR DESCRIPTION
## Summary

Two related changes addressing the playtest in #337:

1. **Combat-flavored severed-stage rewrites** across \`blunt\`, \`bullet\`, \`cut\`, \`generic\`, \`stab\`. 35 new templates total (7 × 5). Each injury type gets prose appropriate to its mechanical flavor — pulped/shattered for blunt, blown-off for bullet, clean-edge for cut, torn-loose for stab, neutral combat stump for generic.
2. **New \`laceration.py\` wound-message file** with full stage coverage (fresh / treated / healing / destroyed / severed / scarred + compound descriptions). \`damage_type: \"laceration\"\` is in active use on chainsaw, blowtorch, and other tearing weapons but previously fell through to \`generic.py\` for all stages. 49 templates total. Tone: chewed, sawn, torn, mauled, shredded.

\`severed.py\` (used by \`CmdSever\` via \`injury_type='severed'\`) is **intentionally untouched** — its clinical / medical prose is appropriate for the post-death scalpel work it represents.

## Test plan
- [x] \`docker exec gelatinous evennia test --settings settings.py world.tests.test_severed_prose\` (6 pass)
- [x] Full suite (1560 pass)
- [ ] In-game: chainsaw kill that severs a limb during combat — corpse afterward shows tearing/chewing stump prose, not clinical amputation prose

## Tests added

- \`test_severed_prose.py\` — regression guard against re-introduction of clinical vocabulary in any injury-type severed stage; verifies \`laceration.py\` exists with all expected stages; smoke-tests \`get_wound_description\` routing for the new injury type.
- \`test_corpse_wound_stage.py\` marker list widened to accept the new visceral vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)