### PR TITLE
Side-aware singular flex for paired body nouns

### DIFF
--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -116,12 +116,18 @@ class AppearanceMixin:
                         added_clothing_items.add(clothing_item)
             else:
                 # Location not covered - use character's longdesc if set with
-                # template variable processing
+                # template variable processing.
+                # Per-location render path: this branch fires when the
+                # location renders independently (not as part of a paired
+                # collapse), which is the single-side case. Pass the
+                # side so paired body-noun tokens flex to the side-aware
+                # singular form (#341): "right arm" instead of "arm".
                 if location in longdescs and longdescs[location]:
                     # Longdesc should have skintone applied
                     processed_desc = self._process_description_variables(
                         longdescs[location], looker,
                         force_third_person=True, apply_skintone=True,
+                        side=self._side_from_location(location),
                     )
 
                     # Add wounds to this location if any exist
@@ -171,10 +177,13 @@ class AppearanceMixin:
                             added_clothing_items.add(clothing_item)
                 elif location in longdescs and longdescs[location]:
                     # Extended location with longdesc - apply template variable
-                    # processing and skintone
+                    # processing and skintone. Same side-aware singular
+                    # flex treatment as the standard-anatomy branch
+                    # above (#341).
                     processed_desc = self._process_description_variables(
                         longdescs[location], looker,
                         force_third_person=True, apply_skintone=True,
+                        side=self._side_from_location(location),
                     )
 
                     # Add wounds to this extended location if any exist
@@ -561,6 +570,23 @@ class AppearanceMixin:
         return '\n\n'.join(parts)
 
     @staticmethod
+    def _side_from_location(location):
+        """Return ``"left"``/``"right"``/``None`` for a body location.
+
+        Pure helper used by the per-location render path to drive
+        side-aware singular flex (issue #341). Extended anatomy keys
+        without a left/right prefix return ``None`` and skip the side
+        prefix entirely.
+        """
+        if not location:
+            return None
+        if location.startswith("left_"):
+            return "left"
+        if location.startswith("right_"):
+            return "right"
+        return None
+
+    @staticmethod
     def _flex_noun_vocabulary():
         """Return the singular nouns a longdesc number-token flexes as a noun.
 
@@ -578,7 +604,7 @@ class AppearanceMixin:
             nouns.add(left_loc.split("_", 1)[1])
         return nouns
 
-    def _substitute_longdesc_tokens(self, desc, variables, number):
+    def _substitute_longdesc_tokens(self, desc, variables, number, side=None):
         """Resolve brace tokens in a longdesc, one token at a time.
 
         Resolution order per ``{token}``:
@@ -588,18 +614,44 @@ class AppearanceMixin:
              else a single-word verb. Both are flexed to *number*.
           3. Anything else is left literal (the brace is preserved) and logged.
 
+        Side-aware singular flex (issue #341): when a paired body noun
+        (``arm``, ``hand``, ``eye``, ``ear``, ``thigh``, ``shin``, ``foot``)
+        flexes to singular AND ``side`` is provided, the side is prefixed
+        — ``{arms}`` becomes ``"right arm"`` instead of bare ``"arm"`` when
+        rendered from the ``right_arm`` location. Plural flex is unaffected
+        (both sides present → just ``"arms"``). Articles are re-agreed:
+        ``{an arm}`` with ``side="right"`` becomes ``"a right arm"``.
+
         Args:
             desc (str): Raw longdesc prose.
             variables (dict): Pronoun/name token → replacement.
             number (str): "singular" or "plural" for body-part tokens.
+            side (str | None): ``"left"`` / ``"right"`` / ``None``.
+                When set with ``number="singular"`` and the token is a
+                pair-keyed body noun, the side is prefixed onto the
+                singular form.
 
         Returns:
             str: Prose with recognised tokens substituted.
         """
         import re
-        from world.grammar import flex_noun, flex_verb, singularize_noun
+        from world.combat.constants import PAIR_MERGE_KEYS
+        from world.grammar import (
+            _match_leading_case,
+            flex_noun,
+            flex_verb,
+            get_article,
+            singularize_noun,
+        )
 
         flex_nouns = self._flex_noun_vocabulary()
+        # Singulars that come from a PAIR_MERGE_KEYS pair (eye, ear,
+        # arm, hand, thigh, shin, foot). Side prefix applies to these.
+        # Non-pair flex nouns (leg, shoulder, hip, ...) keep bare form.
+        pair_singulars = {
+            left.split("_", 1)[1]  # "left_eye" -> "eye"
+            for left, _right in PAIR_MERGE_KEYS.values()
+        }
         article_re = re.compile(r"^(?:a|an)\s+(.+)$", re.IGNORECASE)
 
         def _resolve(match):
@@ -615,6 +667,17 @@ class AppearanceMixin:
             if " " not in core:
                 core_base = singularize_noun(core).lower()
                 if core_base in flex_nouns:
+                    # Side-aware singular flex (#341): prefix the side
+                    # for pair-keyed nouns when rendering a single side.
+                    if (number == "singular" and side
+                            and core_base in pair_singulars):
+                        side_phrase = f"{side} {core_base}"
+                        if art_match:
+                            article = get_article(side_phrase)
+                            rendered = f"{article} {side_phrase}"
+                        else:
+                            rendered = side_phrase
+                        return _match_leading_case(rendered, body)
                     return flex_noun(body, number)
                 if art_match is None:
                     # Single bareword that is not a flex noun → verb.
@@ -632,7 +695,7 @@ class AppearanceMixin:
 
     def _process_description_variables(
         self, desc, looker, force_third_person=False, apply_skintone=False,
-        number="singular",
+        number="singular", side=None,
     ):
         """
         Process template variables in descriptions for perspective-aware text.
@@ -652,6 +715,12 @@ class AppearanceMixin:
                 (for longdescs only).
             number (str): "singular" or "plural"; the grammatical number that
                 braced body-part tokens should render to.
+            side (str | None): ``"left"`` / ``"right"`` / ``None``. When
+                ``number="singular"`` and the location is a paired body
+                location (left/right side of a PAIR_MERGE_KEYS pair) and
+                only this side remains, ``side`` carries the side info
+                so paired body nouns render as ``"right arm"`` instead
+                of bare ``"arm"`` (issue #341).
 
         Returns:
             str: Description with variables substituted.
@@ -777,7 +846,7 @@ class AppearanceMixin:
         # body-part word (noun if its singular is a known pair noun, verb
         # otherwise). Unresolvable tokens are left literal.
         processed_desc = self._substitute_longdesc_tokens(
-            desc, variables, number
+            desc, variables, number, side=side
         )
 
         # Apply skintone coloring only if requested (for longdescs only)

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -335,7 +335,18 @@ class Corpse(IdentityBearerMixin, Item):
                     # Process template variables like living characters do.
                     # Overall decay is conveyed by the corpse header
                     # paragraph; per-location echoes were dropped (#323).
-                    final_desc = self._process_corpse_description_variables(description)
+                    # Side-aware singular flex for paired body nouns
+                    # (#341): when only one side of a pair remains on
+                    # the corpse, render as "right arm" instead of
+                    # bare "arm".
+                    side = None
+                    if location.startswith("left_"):
+                        side = "left"
+                    elif location.startswith("right_"):
+                        side = "right"
+                    final_desc = self._process_corpse_description_variables(
+                        description, side=side,
+                    )
 
                 # Add preserved wound descriptions for this location
                 wound_descriptions = self.get_preserved_wound_descriptions(location)
@@ -563,7 +574,8 @@ class Corpse(IdentityBearerMixin, Item):
             # Fallback if constants not available
             return "extended"
     
-    def _process_corpse_description_variables(self, description, number="singular"):
+    def _process_corpse_description_variables(self, description, number="singular",
+                                              side=None):
         """Process template variables in corpse descriptions using preserved character data.
 
         Args:
@@ -572,6 +584,10 @@ class Corpse(IdentityBearerMixin, Item):
                 body-noun and verb flexing in ``substitute_pronoun_tokens``.
                 Pass ``"plural"`` for a collapsed symmetric pair so
                 ``{eyes}`` / ``{ears}`` / ``{hands}`` render in plural form.
+            side (str | None): ``"left"`` / ``"right"`` / ``None`` (#341).
+                When set with ``number="singular"``, pair-keyed body
+                nouns flex to side-aware singular form (``"right arm"``
+                instead of ``"arm"``).
         """
         if not description:
             return description
@@ -624,6 +640,7 @@ class Corpse(IdentityBearerMixin, Item):
             gender=original_gender,
             name=original_name,
             number=number,
+            side=side,
         )
         
         # Apply skintone coloring if preserved (only to body descriptions, not clothing items)

--- a/world/anatomy/longdesc_tokens.py
+++ b/world/anatomy/longdesc_tokens.py
@@ -69,7 +69,7 @@ _PRONOUN_MAP = {
 
 
 def substitute_pronoun_tokens(text, *, gender, name="the corpse",
-                              number="singular"):
+                              number="singular", side=None):
     """Replace ``{pronoun}`` / ``{name}`` / body-noun tokens in preserved prose.
 
     Always third-person (the subject is an inanimate corpse or severed
@@ -85,6 +85,11 @@ def substitute_pronoun_tokens(text, *, gender, name="the corpse",
     so an upstream layer (corpse skintone / ``{color}``) can still claim
     them.
 
+    Side-aware singular flex (issue #341): when ``side`` is provided
+    and a paired body-noun token flexes to singular, the side is
+    prefixed — ``{arms}`` becomes ``"right arm"`` instead of bare
+    ``"arm"``.
+
     Args:
         text (str): Longdesc prose, possibly containing brace tokens.
         gender (str | None): Preserved character gender (e.g. ``"male"``,
@@ -95,6 +100,10 @@ def substitute_pronoun_tokens(text, *, gender, name="the corpse",
             body-noun and verb flexing — ``"plural"`` for a collapsed
             symmetric pair (eyes/ears/...), ``"singular"`` for a lone
             side or a singular location (face/neck/...).
+        side (str | None): ``"left"`` / ``"right"`` / ``None``. When
+            set with ``number="singular"`` and the token is a pair-
+            keyed body noun, the side is prefixed onto the singular
+            form (#341).
 
     Returns:
         str: ``text`` with pronoun, name, and body-noun tokens resolved.
@@ -119,12 +128,12 @@ def substitute_pronoun_tokens(text, *, gender, name="the corpse",
 
     # Body-noun / verb flex pass.  Done after pronouns so an unhandled
     # leftover brace can fall through cleanly.
-    processed = _flex_body_tokens(processed, number)
+    processed = _flex_body_tokens(processed, number, side)
 
     return processed
 
 
-def _flex_body_tokens(text, number):
+def _flex_body_tokens(text, number, side=None):
     """Flex remaining braced tokens as body nouns or verbs.
 
     Mirrors the resolution order of
@@ -133,16 +142,28 @@ def _flex_body_tokens(text, number):
     flex-noun vocabulary renders as a noun; any other single-word brace
     renders as a verb.  Multi-word braces are left literal — that's the
     "unknown token" case authors use for emphasis or future substitutions.
+
+    Side-aware singular flex (#341) for pair-keyed nouns is applied
+    when ``side`` is provided AND number is singular.
     """
     import re
 
     from world.combat.constants import LONGDESC_FLEX_NOUNS, PAIR_MERGE_KEYS
-    from world.grammar import flex_noun, flex_verb, singularize_noun
+    from world.grammar import (
+        _match_leading_case,
+        flex_noun,
+        flex_verb,
+        get_article,
+        singularize_noun,
+    )
 
     flex_nouns = set(LONGDESC_FLEX_NOUNS)
+    pair_singulars = set()
     for left_loc, _right_loc in PAIR_MERGE_KEYS.values():
         # "left_eye" -> "eye"
-        flex_nouns.add(left_loc.split("_", 1)[1])
+        singular = left_loc.split("_", 1)[1]
+        flex_nouns.add(singular)
+        pair_singulars.add(singular)
 
     article_re = re.compile(r"^(?:a|an)\s+(.+)$", re.IGNORECASE)
 
@@ -154,6 +175,16 @@ def _flex_body_tokens(text, number):
             return match.group(0)
         core_base = singularize_noun(core).lower()
         if core_base in flex_nouns:
+            # Side-aware singular for pair nouns (#341).
+            if (number == "singular" and side
+                    and core_base in pair_singulars):
+                side_phrase = f"{side} {core_base}"
+                if art_match:
+                    article = get_article(side_phrase)
+                    rendered = f"{article} {side_phrase}"
+                else:
+                    rendered = side_phrase
+                return _match_leading_case(rendered, body)
             return flex_noun(body, number)
         if art_match is None:
             return flex_verb(body, number)

--- a/world/tests/test_corpse_token_render.py
+++ b/world/tests/test_corpse_token_render.py
@@ -211,9 +211,11 @@ class PairCollapseTests(TestCase):
                        if loc in ("left_eye", "right_eye")]
         self.assertEqual(len(eye_entries), 1)
         self.assertEqual(eye_entries[0][0], "left_eye")
-        # The braced {eyes} flexes to singular "eye"; surrounding plain
-        # prose (the bare verb "hold") stays as authored.
-        self.assertIn("His eye hold steady", eye_entries[0][1])
+        # The braced {eyes} flexes to singular, and side-aware singular
+        # flex (#341) prefixes the side: "left eye" instead of bare
+        # "eye". Surrounding plain prose ("hold") stays as authored
+        # (verb-bracing is the deferred #331).
+        self.assertIn("His left eye hold steady", eye_entries[0][1])
 
     def test_no_per_location_decay_echo(self):
         """Issue #323: the per-location decay modifier was being appended

--- a/world/tests/test_side_aware_singular_flex.py
+++ b/world/tests/test_side_aware_singular_flex.py
@@ -1,0 +1,170 @@
+"""Side-aware singular flex for paired body nouns (issue #341).
+
+When a paired body-noun token (``{arms}``, ``{eyes}``, ``{ears}``,
+``{hands}``, ``{thighs}``, ``{shins}``, ``{feet}``) flexes to singular
+because only one side remains, the side is prefixed onto the noun.
+
+Pre-fix: ``Her arm is wiry`` (lost the side info).
+Post-fix: ``Her right arm is wiry`` (side preserved).
+
+Tests cover:
+
+* The ``substitute_pronoun_tokens`` helper (used by corpse + Appendage).
+* All 7 pair-keyed nouns × both sides.
+* Plural flex (no side info needed) is unchanged.
+* Locations without left/right prefix produce no side prefix.
+* Articles re-agree (``{an arm}`` + ``side="right"`` → ``"a right arm"``).
+* Case-matching preserves leading-letter case from the body token.
+* Non-pair flex nouns (``{leg}``, ``{shoulder}``) are unaffected.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.anatomy import substitute_pronoun_tokens
+
+
+class PairNounSideFlex(TestCase):
+
+    def test_arm_singular_with_side_right(self):
+        out = substitute_pronoun_tokens(
+            "{Their} {arms} are wiry.",
+            gender="female", number="singular", side="right",
+        )
+        self.assertEqual(out, "Her right arm are wiry.")
+        # Verb agreement is #331, not in scope here — `are` stays bare.
+
+    def test_arm_singular_with_side_left(self):
+        out = substitute_pronoun_tokens(
+            "{Their} {arms} are wiry.",
+            gender="male", number="singular", side="left",
+        )
+        self.assertEqual(out, "His left arm are wiry.")
+
+    def test_no_side_falls_back_to_bare_singular(self):
+        out = substitute_pronoun_tokens(
+            "{Their} {arms} are wiry.",
+            gender="female", number="singular", side=None,
+        )
+        self.assertEqual(out, "Her arm are wiry.")
+
+    def test_plural_ignores_side(self):
+        # Side info is irrelevant when both sides are present.
+        out = substitute_pronoun_tokens(
+            "{Their} {arms} are wiry.",
+            gender="female", number="plural", side="right",
+        )
+        self.assertEqual(out, "Her arms are wiry.")
+
+    def test_all_pair_nouns_with_side(self):
+        # Spot-check every PAIR_MERGE_KEYS noun + both sides.
+        cases = [
+            ("eyes", "right", "right eye"),
+            ("eyes", "left", "left eye"),
+            ("ears", "right", "right ear"),
+            ("ears", "left", "left ear"),
+            ("hands", "right", "right hand"),
+            ("hands", "left", "left hand"),
+            ("thighs", "right", "right thigh"),
+            ("thighs", "left", "left thigh"),
+            ("shins", "right", "right shin"),
+            ("shins", "left", "left shin"),
+            ("feet", "right", "right foot"),
+            ("feet", "left", "left foot"),
+        ]
+        for token, side, expected in cases:
+            with self.subTest(token=token, side=side):
+                out = substitute_pronoun_tokens(
+                    f"the {{{token}}}.",
+                    gender="male", number="singular", side=side,
+                )
+                self.assertEqual(out, f"the {expected}.")
+
+
+class CapitalisationPreserved(TestCase):
+
+    def test_capitalised_token_capitalises_side(self):
+        # {Arms} starts with uppercase → output starts with uppercase.
+        out = substitute_pronoun_tokens(
+            "{Arms} extend.",
+            gender="male", number="singular", side="right",
+        )
+        self.assertEqual(out, "Right arm extend.")
+
+    def test_lowercase_token_lowercase_side(self):
+        out = substitute_pronoun_tokens(
+            "her {arms}.",
+            gender="female", number="singular", side="left",
+        )
+        self.assertEqual(out, "her left arm.")
+
+
+class ArticleReAgreement(TestCase):
+
+    def test_an_arm_becomes_a_right_arm(self):
+        # "an arm" → "a right arm" (article re-agrees with the consonant
+        # start of "right").
+        out = substitute_pronoun_tokens(
+            "It is {an arm}.",
+            gender=None, number="singular", side="right",
+        )
+        self.assertEqual(out, "It is a right arm.")
+
+    def test_an_eye_becomes_a_right_eye(self):
+        # "an eye" → "a right eye".
+        out = substitute_pronoun_tokens(
+            "It is {an eye}.",
+            gender=None, number="singular", side="right",
+        )
+        self.assertEqual(out, "It is a right eye.")
+
+    def test_an_eye_left_is_a_left_eye(self):
+        # "left" also starts with a consonant.
+        out = substitute_pronoun_tokens(
+            "It is {an eye}.",
+            gender=None, number="singular", side="left",
+        )
+        self.assertEqual(out, "It is a left eye.")
+
+
+class NonPairTokensUnaffected(TestCase):
+    """Side prefix applies ONLY to pair-keyed nouns."""
+
+    def test_leg_unaffected(self):
+        # "leg" is in LONGDESC_FLEX_NOUNS but not in PAIR_MERGE_KEYS
+        # singulars — should NOT get a side prefix.
+        out = substitute_pronoun_tokens(
+            "the {leg}.",
+            gender=None, number="singular", side="right",
+        )
+        self.assertEqual(out, "the leg.")
+
+    def test_shoulder_unaffected(self):
+        out = substitute_pronoun_tokens(
+            "the {shoulder}.",
+            gender=None, number="singular", side="left",
+        )
+        self.assertEqual(out, "the shoulder.")
+
+
+class LivingCharacterRenderer(TestCase):
+    """The AppearanceMixin renderer also threads side through."""
+
+    def test_side_helper_recognises_prefixes(self):
+        from typeclasses.appearance_mixin import AppearanceMixin
+        self.assertEqual(
+            AppearanceMixin._side_from_location("left_arm"), "left"
+        )
+        self.assertEqual(
+            AppearanceMixin._side_from_location("right_foot"), "right"
+        )
+        self.assertIsNone(
+            AppearanceMixin._side_from_location("face")
+        )
+        self.assertIsNone(
+            AppearanceMixin._side_from_location("hair")
+        )
+        self.assertIsNone(
+            AppearanceMixin._side_from_location(None)
+        )


### PR DESCRIPTION
## Summary

When a paired body-noun token flexes to singular because only one side remains, prefix the side onto the singular noun. Severing one arm now renders the other as \"right arm\" / \"left arm\" instead of bare \"arm\".

- New \`side\` parameter on the resolver (\`_substitute_longdesc_tokens\` for living characters, \`substitute_pronoun_tokens\` for corpse / Appendage) defaults to \`None\` for backwards compat.
- Per-location renderers derive \`side\` from the location — \`right_arm\` → \"right\", \`face\` → None (no side prefix on non-paired locations).
- Article re-agreement: \`{an arm}\` + \`side=\"right\"\` → \"a right arm\" via \`get_article\`.
- Leading-case preservation: \`{Arms}\` → \"Right arm\" (matches body token's first-letter case).
- Plural flex (both sides present) is unaffected.

## Test plan
- [x] \`docker exec gelatinous evennia test --settings settings.py world.tests.test_side_aware_singular_flex\` (13 pass)
- [x] Full suite (1595 pass)
- [ ] In-game: chainsaw a left arm → look at the character; right arm longdesc reads \"Her right arm is wiry...\" instead of \"Her arm is wiry...\"

## Out of scope

Extended anatomy with 3+ arms (\"other arms\" treatment) — separate concern requiring non-binary anatomy modeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)