### PR TITLE
Spawn severed head at decapitation moment (#343)

### DIFF
--- a/typeclasses/armor_mixin.py
+++ b/typeclasses/armor_mixin.py
@@ -148,11 +148,16 @@ class ArmorMixin:
         place without a clean detachment.  The body part must have just
         lost its representative bone (see :meth:`_bone_freshly_destroyed`).
 
-        * **Neck** — a destroyed cervical spine is already lethal via
-          ``neck_integrity`` collapse, so we cannot sever synchronously
-          (the corpse does not yet exist).  Instead we set
-          ``db.decapitation_pending``; the death → corpse pipeline reads
-          it and spawns the :class:`~typeclasses.items.SeveredHead`.
+        * **Neck** — a destroyed cervical spine is lethal via
+          ``neck_integrity`` collapse, but the :class:`~typeclasses.items.SeveredHead`
+          spawns synchronously off the *living* body via
+          :func:`~typeclasses.items.spawn_severed_head_for_living`
+          (issue #343) so the head appears in the room at the killing
+          blow rather than ~90s later when the corpse is built. We also
+          set ``db.decapitation_pending`` so the death → corpse pipeline
+          knows to propagate the severed-head bookkeeping onto the
+          corpse; that path's corpse-side spawn becomes an idempotent
+          no-op.
         * **Any other severable limb** — survivable.  We detach it
           immediately into an :class:`~typeclasses.items.Appendage` via
           :func:`~typeclasses.items.apply_sever_to_character`.
@@ -173,6 +178,30 @@ class ArmorMixin:
             if self._bone_freshly_destroyed("neck"):
                 self.db.decapitation_pending = True
                 self._broadcast_decapitation_message(injury_type)
+                try:
+                    from typeclasses.items import spawn_severed_head_for_living
+                    spawn_severed_head_for_living(
+                        self, injury_type=injury_type,
+                    )
+                except Exception:
+                    # Living-side spawn is the preferred path, but if it
+                    # raises (test stub without Evennia, transient DB
+                    # hiccup, etc.) the corpse-side spawn in
+                    # death_progression still fires as a fallback because
+                    # ``head_severed_at_decap`` was never set.
+                    try:
+                        from evennia.comms.models import ChannelDB
+                        from world.combat.constants import SPLATTERCAST_CHANNEL
+                        splattercast = ChannelDB.objects.get_channel(
+                            SPLATTERCAST_CHANNEL
+                        )
+                        splattercast.msg(
+                            f"DECAPITATION_LIVING_SPAWN_ERROR: "
+                            f"{getattr(self, 'key', '?')} - falling back "
+                            f"to corpse-side head spawn"
+                        )
+                    except Exception:
+                        pass
             return
 
         # Living limb severance: head is excluded (decapitation routes

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -683,15 +683,40 @@ class DeathProgressionScript(DefaultScript):
         
         # Combat-driven decapitation (Phase C, issue #245 follow-up): a
         # lethal edged neck hit set ``db.decapitation_pending`` on the
-        # dying character in ``ArmorMixin.take_damage``.  The death
-        # pipeline is asynchronous, so the actual head-item spawn waits
-        # until here, once the corpse is fully populated with longdesc /
-        # wound / identity snapshots.  ``spawn_severed_head_for_corpse``
-        # mirrors the manual ``CmdSever`` head path.
+        # dying character in ``ArmorMixin.take_damage``.
+        #
+        # Issue #343 split the spawn between two paths:
+        #
+        # * Preferred — the head spawns *immediately* at the killing
+        #   blow off the living character via
+        #   ``spawn_severed_head_for_living``, which sets
+        #   ``character.db.head_severed_at_decap``.  When that path took,
+        #   we only need to propagate the corpse-side bookkeeping
+        #   (``head_severed`` flag, ``severed_locations``, head-cluster
+        #   prose / wound cleanup) so the corpse renders headless and
+        #   the legacy spawn is a no-op.
+        # * Fallback — if the living-side spawn raised (test stub, DB
+        #   hiccup), the legacy ``spawn_severed_head_for_corpse`` builds
+        #   the head off the corpse exactly as it always did.
         if character.db.decapitation_pending:
             try:
-                from typeclasses.items import spawn_severed_head_for_corpse
-                spawn_severed_head_for_corpse(corpse)
+                from typeclasses.items import (
+                    apply_sever_to_corpse,
+                    spawn_severed_head_for_corpse,
+                )
+                if character.db.head_severed_at_decap:
+                    # Head item already exists in the world. Mirror the
+                    # corpse-side bookkeeping that ``spawn_severed_head_for_corpse``
+                    # would have laid down so the corpse renders as a
+                    # decapitated body (head_severed flag, severed_locations,
+                    # head-cluster prose / wound cleanup, synthesized stump).
+                    severed_list = list(corpse.db.severed_locations or ())
+                    if "head" not in severed_list:
+                        severed_list.append("head")
+                        corpse.db.severed_locations = severed_list
+                    apply_sever_to_corpse(corpse, "head")
+                else:
+                    spawn_severed_head_for_corpse(corpse)
             except Exception as e:
                 try:
                     splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1586,6 +1586,83 @@ def spawn_severed_head_for_corpse(corpse):
     return head
 
 
+def spawn_severed_head_for_living(character, *, injury_type="cut"):
+    """Spawn + configure a :class:`SeveredHead` at the moment of decapitation.
+
+    Living counterpart to :func:`spawn_severed_head_for_corpse`: the
+    head item appears in the room synchronously with the killing blow
+    (issue #343), rather than ~90s later when death progression builds
+    the corpse.  The character then continues through the normal death
+    pipeline, but now visibly headless — the corpse-side spawn becomes
+    a no-op via the existing idempotency check on
+    ``corpse.db.severed_locations``.
+
+    Steps:
+
+    1. Spawn a :class:`SeveredHead` in the character's room.
+    2. Populate identity / decay / prose / trimmed snapshot via
+       :meth:`SeveredHead.configure_from_living_decap` (which reads
+       prose + wounds BEFORE the body is mutated).
+    3. Strip the head-cluster prose + organ wound stages from the
+       character via :func:`sever_character_body`, persist medical
+       state, and recompute vital signs so the headless body is
+       reflected immediately.
+    4. Set ``character.db.head_severed_at_decap = True`` so the
+       death-progression hook in
+       :meth:`death_progression.DeathProgressionScript._create_corpse_from_character`
+       knows to propagate the severed-head bookkeeping onto the corpse
+       (and skip the redundant corpse-side spawn).
+
+    Idempotent: if the character is already flagged as
+    ``head_severed_at_decap`` the call returns ``None`` without
+    re-spawning.
+
+    Args:
+        character: The character whose cervical spine just collapsed.
+        injury_type: Edged injury that caused the cut (default ``"cut"``).
+            Preserved for future use; the item itself is condition-tagged
+            ``"pristine"`` regardless.
+
+    Returns:
+        The spawned :class:`SeveredHead`, or ``None`` if the character
+        has no location to drop it into or the head has already been
+        severed.
+    """
+    from evennia import create_object
+    from world.combat.constants import SEVERED_HEAD_LOCATIONS
+
+    room = character.location
+    if room is None:
+        return None
+    if character.db.head_severed_at_decap:
+        return None
+
+    head = create_object(
+        "typeclasses.items.SeveredHead",
+        key="severed head",
+        location=room,
+    )
+    head.configure_from_living_decap(
+        character=character, injury_type=injury_type,
+    )
+
+    # Strip the head-cluster from the living body. ``sever_character_body``
+    # drops the longdesc entries and sets head-container organs to
+    # ``wound_stage="severed"`` / ``current_hp=0`` — matching the limb
+    # pathway. Vital-sign recomputation lets capacity loss take effect
+    # so blood / consciousness reflect the headless state.
+    sever_character_body(character, SEVERED_HEAD_LOCATIONS)
+    medical_state = character.medical_state
+    update_vital_signs = getattr(medical_state, "update_vital_signs", None)
+    if callable(update_vital_signs):
+        update_vital_signs()
+    character.save_medical_state()
+
+    character.db.head_severed_at_decap = True
+
+    return head
+
+
 # ---------------------------------------------------------------------
 # Living-character severance (PR Phase B, issue #245)
 # ---------------------------------------------------------------------
@@ -2027,6 +2104,84 @@ def apply_severed_head_overlay(head, corpse):
     # autopsy.  See issue #208.
 
 
+def apply_severed_head_overlay_from_living(head, character):
+    """Copy identity / decay / trimmed snapshot from a *living* character.
+
+    Living counterpart to :func:`apply_severed_head_overlay` (which reads
+    from a corpse).  Used by :func:`spawn_severed_head_for_living` so the
+    head item spawned the moment the cervical spine is destroyed carries
+    the same identity / recognition / trimmed-snapshot surface a
+    corpse-spawned head would (issue #343).
+
+    The head's decay clock starts *now* — there is no shared corpse clock
+    yet because the death-progression window has not begun.  When the
+    corpse is built ~90s later, both the corpse and the head will age on
+    their own clocks; in practice the head is slightly fresher than the
+    corpse by the length of the progression window, which is the right
+    storytelling: the head was detached first.
+
+    Contract — after this call ``head.db`` has:
+
+    * ``signature_at_death`` / ``apparent_uid_at_death`` derived from the
+      live character via :mod:`world.identity` (mirrors the corpse
+      snapshot in :meth:`death_progression.DeathProgressionScript._create_corpse_from_character`).
+    * ``sleeve_uid`` copied from ``character.sleeve_uid`` (the
+      ``AttributeProperty`` on :class:`typeclasses.characters.Character`).
+    * ``creation_time`` / ``death_time`` = ``time.time()``;
+      ``death_cause`` derived from ``character.get_death_cause()`` when
+      available, else ``"decapitation"``.
+    * ``medical_state_at_death`` = trimmed snapshot of head-container
+      organs from ``character.medical_state.to_dict()``; body-wide
+      fields blanked.
+    * ``removed_organs`` filtered to the head-container subset (no
+      living-character removed-organ list exists; defaults to empty).
+    """
+    import time
+
+    # Identity snapshot — same axes the corpse captures at death.
+    try:
+        from world.identity import get_apparent_uid, get_identity_signature
+        head.db.signature_at_death = get_identity_signature(character)
+        head.db.apparent_uid_at_death = get_apparent_uid(character)
+    except (AttributeError, TypeError, ValueError):
+        head.db.signature_at_death = None
+        head.db.apparent_uid_at_death = None
+
+    # ``sleeve_uid`` lives on a category="identity" AttributeProperty;
+    # reading the property (not ``db.sleeve_uid``) is required.
+    head.db.sleeve_uid = getattr(character, "sleeve_uid", None)
+
+    now = time.time()
+    head.db.creation_time = now
+    head.db.death_time = now
+    try:
+        cause = character.get_death_cause()
+    except (AttributeError, TypeError):
+        cause = None
+    head.db.death_cause = cause or "decapitation"
+
+    # Trimmed head-container medical snapshot — same shape the corpse
+    # path produces, so harvest / autopsy code consumes it identically.
+    head_organs = {}
+    try:
+        snapshot = character.medical_state.to_dict() or {}
+    except (AttributeError, TypeError):
+        snapshot = {}
+    organs = snapshot.get("organs") or {}
+    for name, data in organs.items():
+        if (data.get("container") or "") == "head":
+            head_organs[name] = dict(data)
+
+    head.db.medical_state_at_death = {
+        "organs": head_organs,
+        "conditions": [],
+        "blood_level": None,
+        "pain_level": None,
+        "consciousness": None,
+    }
+    head.db.removed_organs = []
+
+
 class SeveredHead(IdentityBearerMixin, Appendage):
     """A severed head — super-item spawned by ``sever head from <corpse>``.
 
@@ -2210,4 +2365,85 @@ class SeveredHead(IdentityBearerMixin, Appendage):
         apply_wound_and_longdesc_overlay(
             self, corpse, SEVERED_HEAD_LOCATIONS,
         )
+
+    def configure_from_living_decap(self, *, character, injury_type="cut"):
+        """Populate head fields from a *living* decapitated character.
+
+        Living counterpart to :meth:`configure_from_sever` — invoked by
+        :func:`spawn_severed_head_for_living` the instant the cervical
+        spine is destroyed.  Sets provenance, condition, prose, identity,
+        decay, and the trimmed head-container snapshot directly off the
+        live character, without going through the death-progression
+        corpse pipeline (issue #343).
+
+        Bookkeeping mirrors :meth:`Appendage.configure_from_living_sever`:
+
+        * ``location_name`` is always ``"head"``.
+        * ``condition`` is always ``"pristine"`` (a fresh living sever
+          has no decay; the head ages from this moment forward).
+        * ``key`` is the species-aware fresh-tier head name.
+        * ``desc`` is the species-aware severed-part description.
+        * Longdesc + visible wounds for the head cluster are overlaid
+          via :func:`apply_living_sever_overlay`.
+        * Identity / decay / snapshot are overlaid via
+          :func:`apply_severed_head_overlay_from_living`.
+        """
+        from world.anatomy import (
+            get_severed_part_description,
+            get_species_part_name,
+            prepend_condition_to_desc,
+        )
+        from world.combat.constants import SEVERED_HEAD_LOCATIONS
+
+        condition = "pristine"
+        self.db.location_name = "head"
+        self.db.condition = condition
+        self.db.source_corpse_dbref = None
+
+        # Snapshot gender + name so carried longdesc pronoun / name tokens
+        # resolve at render time (parity with the limb living-sever path).
+        self.db.original_gender = character.gender
+        self.db.original_character_name = character.key
+
+        species = character.db.species or "human"
+        self.db.source_species = species
+        self.key = get_species_part_name(species, "head", "fresh")
+
+        prose = get_severed_part_description(species, "head", condition)
+        composed = prepend_condition_to_desc(condition, prose)
+        if composed:
+            self.db.desc = composed
+
+        # Forensic-chain provenance — also stamped by
+        # ``apply_severed_head_overlay_from_living`` as
+        # ``signature_at_death`` / ``apparent_uid_at_death``; the
+        # Appendage-layer ``source_*`` fields are kept in lockstep so
+        # the manual ``CmdSever`` and combat paths read the same.
+        try:
+            from world.identity import get_apparent_uid, get_identity_signature
+            self.db.source_signature = get_identity_signature(character)
+            self.db.source_apparent_uid = get_apparent_uid(character)
+        except (AttributeError, TypeError, ValueError):
+            self.db.source_signature = None
+            self.db.source_apparent_uid = None
+
+        # Carry the full head-cluster prose + wounds onto the head.
+        # Read BEFORE the caller mutates the body via
+        # ``sever_character_body`` so the source data is still intact.
+        from world.medical.wounds import get_character_wounds
+
+        longdescs = dict(character.longdesc or {})
+        try:
+            wounds = get_character_wounds(character) or []
+        except (AttributeError, TypeError, ValueError):
+            wounds = []
+        apply_living_sever_overlay(
+            self,
+            longdescs=longdescs,
+            wounds=wounds,
+            locations=SEVERED_HEAD_LOCATIONS,
+        )
+
+        # Identity / decay / trimmed head-container snapshot.
+        apply_severed_head_overlay_from_living(self, character)
 

--- a/world/tests/test_head_spawn_at_decap.py
+++ b/world/tests/test_head_spawn_at_decap.py
@@ -1,0 +1,411 @@
+"""Unit tests for the at-decap head spawn (issue #343).
+
+Previously the :class:`~typeclasses.items.SeveredHead` item only
+materialised when the corpse was built at the *tail* of the death-
+progression window (~90s after the killing blow), driven from
+:meth:`~typeclasses.death_progression.DeathProgressionScript._create_corpse_from_character`.
+Issue #343 shifts the spawn synchronously onto the cervical-spine-
+destroyed *living* character so the head appears in the room at the
+moment of the hit.
+
+These tests exercise the three new pure / orchestrator helpers in
+:mod:`typeclasses.items`:
+
+* :func:`apply_severed_head_overlay_from_living` — copies identity /
+  decay clock / trimmed head-container snapshot from a live character
+  onto a head stub. Living counterpart to
+  :func:`apply_severed_head_overlay`.
+* :meth:`SeveredHead.configure_from_living_decap` — high-level
+  configure: prose, key, condition, plus the overlay above and the
+  head-cluster prose / wound overlay.
+* :func:`spawn_severed_head_for_living` — orchestrator: spawns the
+  head item, configures it from the living character, mutates the
+  body (head-cluster longdesc + organ stages), and sets the
+  ``head_severed_at_decap`` flag.
+
+The orchestrator's ``create_object`` call is monkeypatched to a plain
+stub so we don't need an Evennia DB. The pure overlay helper and the
+configure method are exercised against plain-Python stubs directly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+import typeclasses.items as items_module
+from typeclasses.items import (
+    apply_severed_head_overlay_from_living,
+    spawn_severed_head_for_living,
+)
+from world.combat.constants import SEVERED_HEAD_LOCATIONS
+
+
+class _DB:
+    """Bare attribute container — matches Evennia ``obj.db`` surface."""
+
+    def __init__(self):
+        self.head_severed_at_decap = None
+
+
+class _FakeHead:
+    """SeveredHead-shaped stub for the pure overlay tests."""
+
+    def __init__(self):
+        self.db = _DB()
+
+
+class _FakeOrgan:
+    def __init__(self, name, container, *, current_hp=10, max_hp=10,
+                 wound_stage=None, injury_type=None):
+        self.name = name
+        self.container = container
+        self.current_hp = current_hp
+        self.max_hp = max_hp
+        self.wound_stage = wound_stage
+        self.injury_type = injury_type
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "current_hp": self.current_hp,
+            "max_hp": self.max_hp,
+            "container": self.container,
+            "wound_stage": self.wound_stage,
+            "injury_type": self.injury_type,
+            "conditions": [],
+            "wound_timestamp": None,
+        }
+
+
+class _FakeMedicalState:
+    def __init__(self, organs):
+        self.organs = organs
+        self.vital_signs_updated = False
+
+    def update_vital_signs(self):
+        self.vital_signs_updated = True
+
+    def to_dict(self):
+        return {
+            "organs": {
+                name: organ.to_dict() for name, organ in self.organs.items()
+            },
+            "conditions": [],
+            "blood_level": 100,
+            "pain_level": 0,
+            "consciousness": 100,
+        }
+
+
+class _FakeCharacter:
+    """Minimal living-character stub for the at-decap head spawn path."""
+
+    def __init__(self, *, location=SimpleNamespace(key="alley"),
+                 organs=None, longdesc=None, gender="male",
+                 species="human", key="Anthony",
+                 sleeve_uid="slv-anthony",
+                 death_cause="decapitation"):
+        self.location = location
+        self.gender = gender
+        self.key = key
+        self.sleeve_uid = sleeve_uid
+        self.longdesc = dict(longdesc or {})
+        self.medical_state = _FakeMedicalState(organs or {})
+        self._death_cause = death_cause
+        self._saved = False
+        self.db = _DB()
+        self.db.species = species
+
+    def get_death_cause(self):
+        return self._death_cause
+
+    def save_medical_state(self):
+        self._saved = True
+
+
+def _head_organs():
+    return {
+        "brain": _FakeOrgan("brain", "head", current_hp=0,
+                            wound_stage="destroyed"),
+        "left_eye": _FakeOrgan("left_eye", "head"),
+        "right_eye": _FakeOrgan("right_eye", "head"),
+    }
+
+
+# ---------------------------------------------------------------------
+# apply_severed_head_overlay_from_living
+# ---------------------------------------------------------------------
+
+
+class ApplyLivingOverlayTests(TestCase):
+    """Pure copy of identity / decay / trimmed snapshot from the live body."""
+
+    def test_sleeve_uid_copied_from_character(self):
+        char = _FakeCharacter(sleeve_uid="slv-XYZ")
+        head = _FakeHead()
+        apply_severed_head_overlay_from_living(head, char)
+        self.assertEqual(head.db.sleeve_uid, "slv-XYZ")
+
+    def test_creation_and_death_time_now(self):
+        import time
+        char = _FakeCharacter()
+        head = _FakeHead()
+        before = time.time()
+        apply_severed_head_overlay_from_living(head, char)
+        after = time.time()
+        self.assertGreaterEqual(head.db.creation_time, before)
+        self.assertLessEqual(head.db.creation_time, after)
+        # Head and death-time share the same now-anchor.
+        self.assertEqual(head.db.creation_time, head.db.death_time)
+
+    def test_death_cause_from_character(self):
+        char = _FakeCharacter(death_cause="chainsaw to the neck")
+        head = _FakeHead()
+        apply_severed_head_overlay_from_living(head, char)
+        self.assertEqual(head.db.death_cause, "chainsaw to the neck")
+
+    def test_death_cause_defaults_to_decapitation(self):
+        char = _FakeCharacter(death_cause=None)
+        head = _FakeHead()
+        apply_severed_head_overlay_from_living(head, char)
+        self.assertEqual(head.db.death_cause, "decapitation")
+
+    def test_medical_snapshot_only_head_container(self):
+        organs = {
+            "brain": _FakeOrgan("brain", "head", current_hp=0,
+                                wound_stage="destroyed"),
+            "heart": _FakeOrgan("heart", "chest", current_hp=10),
+            "left_eye": _FakeOrgan("left_eye", "head"),
+        }
+        char = _FakeCharacter(organs=organs)
+        head = _FakeHead()
+        apply_severed_head_overlay_from_living(head, char)
+
+        snap = head.db.medical_state_at_death
+        organ_names = set(snap["organs"].keys())
+        self.assertEqual(organ_names, {"brain", "left_eye"})
+        # Body-wide fields are blanked — they describe the whole body
+        # and would lie if reported off a disembodied head.
+        self.assertEqual(snap["conditions"], [])
+        self.assertIsNone(snap["blood_level"])
+        self.assertIsNone(snap["pain_level"])
+        self.assertIsNone(snap["consciousness"])
+
+    def test_organ_dicts_deep_copied(self):
+        # Mutating the head snapshot must not bleed back into the live
+        # character's medical state.
+        char = _FakeCharacter(organs=_head_organs())
+        head = _FakeHead()
+        apply_severed_head_overlay_from_living(head, char)
+        head.db.medical_state_at_death["organs"]["brain"]["current_hp"] = 99
+        self.assertEqual(
+            char.medical_state.organs["brain"].current_hp, 0
+        )
+
+    def test_removed_organs_defaults_empty(self):
+        char = _FakeCharacter()
+        head = _FakeHead()
+        apply_severed_head_overlay_from_living(head, char)
+        self.assertEqual(head.db.removed_organs, [])
+
+
+# ---------------------------------------------------------------------
+# spawn_severed_head_for_living orchestrator
+# ---------------------------------------------------------------------
+
+
+class _SpawnedHeadStub:
+    """Stand-in for the SeveredHead spawn target.
+
+    We don't actually want to exercise the full
+    :meth:`SeveredHead.configure_from_living_decap` over a typeclass
+    instance here (its species / longdesc imports route through Evennia-
+    aware modules); these tests stub configure_from_living_decap so we
+    can isolate the orchestrator's responsibility: spawn + mutate body +
+    flag.
+    """
+
+    def __init__(self, key, location):
+        self.key = key
+        self.location = location
+        self.db = _DB()
+        self.configure_calls = []
+
+    def configure_from_living_decap(self, *, character, injury_type):
+        self.configure_calls.append((character, injury_type))
+
+
+class SpawnSeveredHeadForLivingTests(TestCase):
+    def setUp(self):
+        # Capture create_object so no DB call happens.
+        self.spawned = []
+
+        def _fake_create(typeclass, key, location):
+            stub = _SpawnedHeadStub(key=key, location=location)
+            self.spawned.append((typeclass, stub))
+            return stub
+
+        # spawn_severed_head_for_living does an inline
+        # ``from evennia import create_object`` — monkeypatch via the
+        # ``evennia`` module.
+        import evennia
+        self._orig_create = evennia.create_object
+        evennia.create_object = _fake_create
+
+    def tearDown(self):
+        import evennia
+        evennia.create_object = self._orig_create
+
+    def test_no_location_no_spawn(self):
+        char = _FakeCharacter(location=None)
+        result = spawn_severed_head_for_living(char, injury_type="cut")
+        self.assertIsNone(result)
+        self.assertEqual(self.spawned, [])
+        # The flag must NOT be set if the spawn aborted — otherwise
+        # death progression would skip the corpse-side fallback.
+        self.assertIsNone(char.db.head_severed_at_decap)
+
+    def test_idempotent_when_already_severed(self):
+        char = _FakeCharacter()
+        char.db.head_severed_at_decap = True
+        result = spawn_severed_head_for_living(char)
+        self.assertIsNone(result)
+        self.assertEqual(self.spawned, [])
+
+    def test_spawns_into_room(self):
+        room = SimpleNamespace(key="alley")
+        char = _FakeCharacter(
+            location=room,
+            organs=_head_organs(),
+            longdesc={
+                "face": "{Their} face is angular.",
+                "chest": "{Their} chest is broad.",
+            },
+        )
+        result = spawn_severed_head_for_living(char, injury_type="cut")
+        self.assertIsNotNone(result)
+        self.assertEqual(len(self.spawned), 1)
+        typeclass, head = self.spawned[0]
+        self.assertEqual(typeclass, "typeclasses.items.SeveredHead")
+        self.assertIs(head.location, room)
+        # Orchestrator delegated identity / prose to configure_from_living_decap.
+        self.assertEqual(head.configure_calls, [(char, "cut")])
+
+    def test_body_stripped_after_spawn(self):
+        char = _FakeCharacter(
+            organs=_head_organs(),
+            longdesc={
+                "face": "{Their} face is angular.",
+                "neck": "{Their} neck is corded.",
+                "chest": "{Their} chest is broad.",
+            },
+        )
+        spawn_severed_head_for_living(char)
+        # Head-cluster longdesc gone, body locations preserved.
+        self.assertNotIn("face", char.longdesc)
+        self.assertNotIn("neck", char.longdesc)
+        self.assertIn("chest", char.longdesc)
+        # Head organs marked severed / hp=0; body organs untouched.
+        for organ in char.medical_state.organs.values():
+            if organ.container == "head":
+                self.assertEqual(organ.wound_stage, "severed")
+                self.assertEqual(organ.current_hp, 0)
+
+    def test_at_decap_flag_set(self):
+        char = _FakeCharacter(organs=_head_organs())
+        spawn_severed_head_for_living(char)
+        self.assertTrue(char.db.head_severed_at_decap)
+
+    def test_vital_signs_recomputed(self):
+        char = _FakeCharacter(organs=_head_organs())
+        spawn_severed_head_for_living(char)
+        self.assertTrue(char.medical_state.vital_signs_updated)
+
+    def test_medical_state_persisted(self):
+        char = _FakeCharacter(organs=_head_organs())
+        spawn_severed_head_for_living(char)
+        self.assertTrue(char._saved)
+
+    def test_clears_full_head_cluster_not_just_head_location(self):
+        # Issue #343 contract: the WHOLE head-cluster
+        # (face / neck / eyes / ears / hair) leaves with the head, not
+        # just the bare "head" container.
+        longdesc = {
+            loc: f"{{Their}} {loc} prose" for loc in SEVERED_HEAD_LOCATIONS
+        }
+        longdesc["chest"] = "{Their} chest prose"
+        char = _FakeCharacter(organs=_head_organs(), longdesc=longdesc)
+        spawn_severed_head_for_living(char)
+        for loc in SEVERED_HEAD_LOCATIONS:
+            self.assertNotIn(loc, char.longdesc,
+                             f"{loc} should have left with the head")
+        self.assertIn("chest", char.longdesc)
+
+
+# ---------------------------------------------------------------------
+# Armor-mixin neck-hit integration
+# ---------------------------------------------------------------------
+
+
+class NeckHitDispatchTests(TestCase):
+    """The combat severance trigger must call the at-decap spawn."""
+
+    def setUp(self):
+        from typeclasses.armor_mixin import ArmorMixin
+
+        self.calls = []
+        self._orig = items_module.spawn_severed_head_for_living
+
+        def _spy(character, *, injury_type="cut"):
+            self.calls.append((character, injury_type))
+            # Mirror the live function's flag-set so tests can verify
+            # the orchestrator was invoked AND the path completes.
+            character.db.head_severed_at_decap = True
+
+        items_module.spawn_severed_head_for_living = _spy
+
+        class _NeckHit(ArmorMixin):
+            def __init__(self, organs):
+                self.db = SimpleNamespace(
+                    decapitation_pending=None,
+                    head_severed_at_decap=None,
+                )
+                self.medical_state = SimpleNamespace(organs=organs)
+
+        self._NeckHit = _NeckHit
+
+    def tearDown(self):
+        items_module.spawn_severed_head_for_living = self._orig
+
+    def _destroyed_neck(self):
+        return self._NeckHit({
+            "cervical_spine": _FakeOrgan(
+                "cervical_spine", "neck", current_hp=0,
+                wound_stage="destroyed",
+            ),
+        })
+
+    def test_edged_neck_hit_spawns_head_at_decap(self):
+        char = self._destroyed_neck()
+        char._maybe_sever_from_damage("neck", "cut")
+        self.assertEqual(self.calls, [(char, "cut")])
+        # Decapitation flag still set — death progression reads it.
+        self.assertTrue(char.db.decapitation_pending)
+        # And the new flag — death progression reads this too.
+        self.assertTrue(char.db.head_severed_at_decap)
+
+    def test_blunt_neck_hit_does_not_spawn(self):
+        char = self._destroyed_neck()
+        char._maybe_sever_from_damage("neck", "blunt")
+        self.assertEqual(self.calls, [])
+        self.assertIsNone(char.db.head_severed_at_decap)
+
+    def test_intact_neck_does_not_spawn(self):
+        char = self._NeckHit({
+            "cervical_spine": _FakeOrgan(
+                "cervical_spine", "neck", current_hp=10,
+            ),
+        })
+        char._maybe_sever_from_damage("neck", "cut")
+        self.assertEqual(self.calls, [])


### PR DESCRIPTION
## Summary
- Adds `spawn_severed_head_for_living(character)` — a living-source orchestrator that mirrors `apply_sever_to_character` and creates the `SeveredHead` item synchronously when the cervical spine is destroyed.
- Adds the supporting pure helpers: `apply_severed_head_overlay_from_living` (identity / decay / trimmed snapshot from the live body) and `SeveredHead.configure_from_living_decap` (prose + key + cluster overlay).
- Wires `ArmorMixin._maybe_sever_from_damage` to call the new spawn on the neck path right after the decapitation broadcast.
- Updates `DeathProgressionScript._create_corpse_from_character` to detect `character.db.head_severed_at_decap` and apply the corpse-side bookkeeping (severed_locations, head_severed flag, head-cluster cleanup, stump wound) instead of re-spawning. Corpse-side spawn still runs as a fallback if the living-side spawn raised.
- Adds 18 unit tests in `world/tests/test_head_spawn_at_decap.py` covering the overlay, the orchestrator, idempotency, and the armor-mixin dispatch.

Pre-fix: chainsaw decapitation in combat ended with the headless body lying in the room for ~90s with no head item visible until the corpse was built. Post-fix: the head appears in the room at the killing blow.

## Test plan
- [x] `evennia test --settings settings.py world.tests.test_head_spawn_at_decap` — 18/18 pass
- [x] `evennia test --settings settings.py world.tests.test_combat_sever_trigger world.tests.test_living_sever world.tests.test_severed_head world.tests.test_neck_organ_decapitation world.tests.test_sever_overlay world.tests.test_severed_head_recognition` — 90/90 pass
- [x] `evennia test --settings settings.py world.tests.test_corpse_token_render world.tests.test_cmd_autopsy_severed_head world.tests.test_cmd_harvest_severed_head world.tests.test_cmd_sever world.tests.test_severance_messages` — 76/76 pass
- [x] Full suite: `evennia test --settings settings.py world` — 1613/1613 pass

Closes #343