### PR TITLE
Route wounds at organ display surface, not container (#346)

### DIFF
--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -272,24 +272,28 @@ ORGANS = {
         "can_be_harvested": True
     },
     "left_eye": {
-        "container": "head", "max_hp": 10, "hit_weight": "rare",
+        "container": "head", "display_location": "left_eye",
+        "max_hp": 10, "hit_weight": "rare",
         "capacity": "sight", "contribution": "major", "disfiguring_if_lost": True,
         "damage_always_scars": True, "vulnerable_to_blunt": False,
         "can_be_harvested": True
     },
     "right_eye": {
-        "container": "head", "max_hp": 10, "hit_weight": "rare",
+        "container": "head", "display_location": "right_eye",
+        "max_hp": 10, "hit_weight": "rare",
         "capacity": "sight", "contribution": "major", "disfiguring_if_lost": True,
         "damage_always_scars": True, "vulnerable_to_blunt": False,
         "can_be_harvested": True
     },
     "left_ear": {
-        "container": "head", "max_hp": 12, "hit_weight": "rare",
+        "container": "head", "display_location": "left_ear",
+        "max_hp": 12, "hit_weight": "rare",
         "capacity": "hearing", "contribution": "major", "disfiguring_if_lost": True,
         "can_be_harvested": True
     },
     "right_ear": {
-        "container": "head", "max_hp": 12, "hit_weight": "rare",
+        "container": "head", "display_location": "right_ear",
+        "max_hp": 12, "hit_weight": "rare",
         "capacity": "hearing", "contribution": "major", "disfiguring_if_lost": True,
         "can_be_harvested": True
     },

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -36,6 +36,13 @@ class Organ:
         self.max_hp = self.data.get("max_hp", 10)
         self.current_hp = self.max_hp  # Start at full health
         self.container = self.data.get("container", "unknown")
+        # Display surface for wound rendering (issue #346).  Most organs
+        # render their wounds at the bulk container ("heart" wounds → the
+        # chest line) but sensory organs surface at a more specific
+        # location ("left_eye" wounds → the left_eye line) so the
+        # longdesc renderer can show destruction at the right anatomical
+        # surface.  Falls back to ``container`` when the spec omits it.
+        self.display_location = self.data.get("display_location") or self.container
         self.hit_weight = self.data.get("hit_weight", "common")
         
         # Functional properties
@@ -239,6 +246,7 @@ class Organ:
             "max_hp": self.max_hp,
             "conditions": self.conditions.copy(),
             "container": self.container,
+            "display_location": self.display_location,
             "wound_stage": self.wound_stage,
             "injury_type": self.injury_type,
             "wound_timestamp": self.wound_timestamp
@@ -262,6 +270,14 @@ class Organ:
         organ.wound_stage = data.get("wound_stage")
         organ.injury_type = data.get("injury_type")
         organ.wound_timestamp = data.get("wound_timestamp")
+        # Issue #346: persisted organs may predate ``display_location`` —
+        # the ``cls(data["name"])`` constructor already seeded it from
+        # the ORGANS spec, so only override when the snapshot carries
+        # a non-None value (preserves bespoke per-character routing if
+        # we ever add it; covers the legacy-snapshot case automatically).
+        snapshot_display = data.get("display_location")
+        if snapshot_display:
+            organ.display_location = snapshot_display
         return organ
 
 

--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -186,10 +186,17 @@ def get_character_wounds(character):
     # Check all organs in the character's medical state for damage
     for organ_name, organ in medical_state.organs.items():
         if organ.current_hp < organ.max_hp:  # Organ is damaged
-            location = organ.container
+            # Issue #346: file the wound at the organ's display surface,
+            # not its bulk container. Most organs (heart, lungs, liver)
+            # have ``display_location == container``; sensory organs
+            # (left_eye, right_eye, left_ear, right_ear) route to a more
+            # specific longdesc surface so the destruction reads at the
+            # right anatomical line. Visibility / coverage checks still
+            # consult the container — clothing covers the bulk region.
+            location = getattr(organ, "display_location", None) or organ.container
 
             # Only include if wound location is visible (not concealed by clothing)
-            if _is_wound_visible(character, location):
+            if _is_wound_visible(character, organ.container):
                 # Determine injury type and stage based on organ condition
                 injury_type = _determine_injury_type_from_organ(organ)
                 stage = _determine_wound_stage_from_organ(organ)

--- a/world/tests/test_organ_display_location.py
+++ b/world/tests/test_organ_display_location.py
@@ -1,0 +1,223 @@
+"""Tests for the organ ``display_location`` routing (issue #346).
+
+Pre-fix, ``get_character_wounds`` filed every wound at ``organ.container``.
+Sensory organs (``left_eye``, ``right_eye``, ``left_ear``, ``right_ear``)
+have ``container = "head"``, which has no authored longdesc surface in
+the human anatomy registry — so destruction at those organs went
+visually nowhere. The fix routes wounds through ``organ.display_location``
+(defaulting to ``container`` when absent), so eye / ear destruction
+surfaces at the right anatomical line while limb / torso wounds keep
+filing under their bulk container.
+
+Coverage gates (visibility) still consult the bulk container — clothing
+covers the head bulk, so eye wounds hide behind a hood the same way.
+
+Run via::
+
+    evennia test world.tests.test_organ_display_location
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.core import Organ
+from world.medical.constants import ORGANS
+from world.medical.wounds import get_character_wounds
+
+
+class OrganDisplayLocationFieldTests(TestCase):
+    """The Organ class exposes display_location read from the spec."""
+
+    def test_sensory_organs_declare_display_location(self):
+        for name in ("left_eye", "right_eye", "left_ear", "right_ear"):
+            with self.subTest(name=name):
+                organ = Organ(name)
+                self.assertEqual(organ.display_location, name)
+                # Sensory organs still belong to the head container —
+                # the display_location is a routing override, not a
+                # relocation.
+                self.assertEqual(organ.container, "head")
+
+    def test_internal_organs_fall_back_to_container(self):
+        # Heart, lungs, liver, brain etc. have no display_location
+        # override; they should default to their container.
+        for name in ("heart", "left_lung", "liver", "brain"):
+            with self.subTest(name=name):
+                organ = Organ(name)
+                self.assertEqual(organ.display_location, organ.container)
+
+    def test_round_trip_through_dict(self):
+        # to_dict / from_dict preserves the display_location field.
+        organ = Organ("left_eye")
+        organ.current_hp = 0
+        organ.wound_stage = "destroyed"
+        organ.injury_type = "cut"
+        snap = organ.to_dict()
+        self.assertEqual(snap["display_location"], "left_eye")
+
+        restored = Organ.from_dict(snap)
+        self.assertEqual(restored.display_location, "left_eye")
+
+    def test_legacy_snapshot_without_display_location_uses_spec(self):
+        # Snapshots written before this PR don't carry display_location;
+        # the from_dict path must fall back to the spec default rather
+        # than leaving the field as the container.
+        snap = {
+            "name": "left_eye",
+            "current_hp": 0,
+            "max_hp": 10,
+            "conditions": [],
+            "wound_stage": "destroyed",
+            "injury_type": "cut",
+            "wound_timestamp": None,
+            # display_location intentionally absent
+        }
+        restored = Organ.from_dict(snap)
+        self.assertEqual(restored.display_location, "left_eye")
+
+
+class OrgansRegistryShape(TestCase):
+    """The ORGANS constants table declares display_location for sensory
+    organs but leaves it absent for internal / limb organs."""
+
+    def test_sensory_organs_have_display_location(self):
+        for name in ("left_eye", "right_eye", "left_ear", "right_ear"):
+            with self.subTest(name=name):
+                self.assertIn("display_location", ORGANS[name])
+                self.assertEqual(
+                    ORGANS[name]["display_location"], name,
+                    f"{name} should route to its own longdesc surface",
+                )
+
+    def test_non_sensory_organs_absent_or_match_container(self):
+        # Heart / liver / brain / etc. either have no display_location
+        # override or it matches the container — both produce the
+        # correct fallback behavior.
+        for name in ("brain", "heart", "liver", "left_humerus"):
+            with self.subTest(name=name):
+                spec = ORGANS[name]
+                override = spec.get("display_location")
+                if override is not None:
+                    self.assertEqual(override, spec["container"])
+
+
+# ---------------------------------------------------------------------
+# get_character_wounds routing
+# ---------------------------------------------------------------------
+
+
+class _FakeMedicalState:
+    def __init__(self, organs):
+        self.organs = organs
+
+
+class _FakeCharacter:
+    """Minimal stand-in for the wound-rendering pipeline."""
+
+    def __init__(self, organs, *, covered_locations=None):
+        self.medical_state = _FakeMedicalState(organs)
+        self._covered = set(covered_locations or ())
+        self.db = SimpleNamespace(species="human", skintone=None)
+
+    def is_location_covered(self, location):
+        return location in self._covered
+
+
+def _damaged(name, *, current_hp=0, wound_stage="destroyed",
+             injury_type="cut"):
+    organ = Organ(name)
+    organ.current_hp = current_hp
+    organ.wound_stage = wound_stage
+    organ.injury_type = injury_type
+    return organ
+
+
+class GetCharacterWoundsRoutingTests(TestCase):
+    """Wounds file at organ.display_location, not container."""
+
+    def test_destroyed_eye_files_at_eye_not_head(self):
+        organs = {"left_eye": _damaged("left_eye")}
+        char = _FakeCharacter(organs)
+        wounds = get_character_wounds(char)
+        self.assertEqual(len(wounds), 1)
+        self.assertEqual(wounds[0]["location"], "left_eye")
+        self.assertEqual(wounds[0]["organ"], "left_eye")
+
+    def test_destroyed_ear_files_at_ear_not_head(self):
+        organs = {"right_ear": _damaged("right_ear")}
+        char = _FakeCharacter(organs)
+        wounds = get_character_wounds(char)
+        self.assertEqual(wounds[0]["location"], "right_ear")
+
+    def test_destroyed_heart_still_files_at_chest(self):
+        # Negative control: organs WITHOUT a display_location override
+        # continue to file at their container exactly as before.
+        organs = {"heart": _damaged("heart")}
+        char = _FakeCharacter(organs)
+        wounds = get_character_wounds(char)
+        self.assertEqual(wounds[0]["location"], "chest")
+
+    def test_destroyed_brain_still_files_at_head(self):
+        # Brain has no specific longdesc surface — destruction stays
+        # filed under "head" (and the longdesc renderer's head
+        # surfaces show nothing, which is correct: a destroyed brain
+        # has no external longdesc signature).
+        organs = {"brain": _damaged("brain")}
+        char = _FakeCharacter(organs)
+        wounds = get_character_wounds(char)
+        self.assertEqual(wounds[0]["location"], "head")
+
+    def test_destroyed_limb_files_at_limb(self):
+        # Limb organ (humerus) — container IS the longdesc surface, so
+        # no routing change; the wound files at "left_arm" as before.
+        organs = {"left_humerus": _damaged("left_humerus")}
+        char = _FakeCharacter(organs)
+        wounds = get_character_wounds(char)
+        self.assertEqual(wounds[0]["location"], "left_arm")
+
+    def test_multiple_destroyed_organs_one_container_split_by_surface(self):
+        # Both eyes + brain destroyed: brain stays at "head", eyes split
+        # to their respective surfaces. Three wounds, three distinct
+        # locations.
+        organs = {
+            "brain": _damaged("brain"),
+            "left_eye": _damaged("left_eye"),
+            "right_eye": _damaged("right_eye"),
+        }
+        char = _FakeCharacter(organs)
+        wounds = get_character_wounds(char)
+        locations = sorted(w["location"] for w in wounds)
+        self.assertEqual(locations, ["head", "left_eye", "right_eye"])
+
+
+class CoverageGateUsesContainer(TestCase):
+    """Visibility check consults the bulk container, not the display
+    surface — clothing covers the head bulk, so an eye wound is hidden
+    by a hood the same way a brain wound would be (issue #346
+    explicitly preserves this routing)."""
+
+    def test_eye_wound_hidden_when_head_covered(self):
+        organs = {"left_eye": _damaged("left_eye")}
+
+        bare = _FakeCharacter(organs)
+        self.assertEqual(len(get_character_wounds(bare)), 1)
+
+        # Coverage at the bulk container ("head") hides the eye wound
+        # even though its display surface is "left_eye". This is the
+        # invariant: visibility consults container, location consults
+        # display surface.
+        covered = _FakeCharacter(organs, covered_locations=("head",))
+        self.assertEqual(len(get_character_wounds(covered)), 0)
+
+    def test_eye_wound_shows_when_only_eye_surface_covered(self):
+        # Inverse: covering "left_eye" alone (e.g., an eyepatch
+        # registered as covering only that display surface) does NOT
+        # hide the wound, because visibility checks the container.
+        # This is intentional — the existing clothing system covers
+        # by container, and #346 preserves that semantics.
+        organs = {"left_eye": _damaged("left_eye")}
+        covered = _FakeCharacter(organs, covered_locations=("left_eye",))
+        # Container "head" is not in the covered set → wound visible.
+        self.assertEqual(len(get_character_wounds(covered)), 1)


### PR DESCRIPTION
## Summary
- Adds optional ``display_location`` field to the ``ORGANS`` registry for sensory organs (left_eye, right_eye, left_ear, right_ear), routing each to its own longdesc surface.
- Threads ``display_location`` through ``Organ.__init__`` / ``to_dict`` / ``from_dict`` so the field survives persistence and legacy snapshots fall back to the spec default.
- ``get_character_wounds`` now files wounds at ``organ.display_location`` (defaults to ``organ.container``). Combat hit_location, damage distribution, severance trigger, and clothing-coverage visibility checks all continue to consult the container.
- 14 unit tests covering the registry shape, persistence round-trip, routing for sensory / internal / limb organs, and the container-keyed coverage gate invariant.

Pre-fix: a destroyed eye produced no visible longdesc change because the wound was filed under ``head`` (which has no authored longdesc surface). Post-fix: the wound files at ``left_eye`` and renders at the right anatomical line. Note: the existing destroyed-stage wound prose is limb-vocabulary ("His left eye has been mangled into ribbons of flesh"); the authoring expansion lands in #347.

## Test plan
- [x] ``evennia test --settings settings.py world.tests.test_organ_display_location`` — 14/14 pass
- [x] Full suite: ``evennia test --settings settings.py world`` — 1627/1627 pass

Closes #346