### PR TITLE
Destroyed-stage prose overlay keyed by location + injury type (#347)

### DIFF
--- a/world/medical/wounds/messages/blunt.py
+++ b/world/medical/wounds/messages/blunt.py
@@ -96,3 +96,32 @@ COMPOUND_DESCRIPTIONS = {
         "{skintone}the {location} is mottled by a {severity} contusion scar among {others_phrase}|n",
     ],
 }
+
+
+# Issue #347: destroyed-stage overlay keyed by location.
+DESTROYED_BY_LOCATION = {
+    "left_eye": [
+        "|R{Their} left eye is pulped in its socket, the lid swollen black around the ruin|n",
+        "|RA crushing impact has burst {their} left eye, fluid weeping over the bruised cheek|n",
+        "|R{Their} left eye is collapsed inward, the socket caved and weeping|n",
+        "|RWhat was {their} left eye is a sunken pulp, the orbital bone pressed flat around it|n",
+    ],
+    "right_eye": [
+        "|R{Their} right eye is pulped in its socket, the lid swollen black around the ruin|n",
+        "|RA crushing impact has burst {their} right eye, fluid weeping over the bruised cheek|n",
+        "|R{Their} right eye is collapsed inward, the socket caved and weeping|n",
+        "|RWhat was {their} right eye is a sunken pulp, the orbital bone pressed flat around it|n",
+    ],
+    "left_ear": [
+        "|R{Their} left ear is mashed flat against the skull, the cartilage crushed and weeping|n",
+        "|RA heavy blow has pulped {their} left ear into the side of {their} head|n",
+        "|R{Their} left ear is reduced to a swollen lump of bruised tissue|n",
+        "|RWhat is left of {their} left ear is a flattened ruin, dark with bruise and blood|n",
+    ],
+    "right_ear": [
+        "|R{Their} right ear is mashed flat against the skull, the cartilage crushed and weeping|n",
+        "|RA heavy blow has pulped {their} right ear into the side of {their} head|n",
+        "|R{Their} right ear is reduced to a swollen lump of bruised tissue|n",
+        "|RWhat is left of {their} right ear is a flattened ruin, dark with bruise and blood|n",
+    ],
+}

--- a/world/medical/wounds/messages/bullet.py
+++ b/world/medical/wounds/messages/bullet.py
@@ -96,3 +96,32 @@ COMPOUND_DESCRIPTIONS = {
         "{skintone}the {location} is stippled by a {severity} gunshot scar among {others_phrase}|n",
     ],
 }
+
+
+# Issue #347: destroyed-stage overlay keyed by location.
+DESTROYED_BY_LOCATION = {
+    "left_eye": [
+        "|R{Their} left eye is a smoking crater, the socket blown wide and weeping|n",
+        "|RA bullet has shot {their} left eye to wet pulp, fragments crusted on {their} cheek|n",
+        "|R{Their} left eye is gone, a ragged exit wound where the socket used to be|n",
+        "|RWhere {their} left eye sat, a powder-blackened crater oozes blood and matter|n",
+    ],
+    "right_eye": [
+        "|R{Their} right eye is a smoking crater, the socket blown wide and weeping|n",
+        "|RA bullet has shot {their} right eye to wet pulp, fragments crusted on {their} cheek|n",
+        "|R{Their} right eye is gone, a ragged exit wound where the socket used to be|n",
+        "|RWhere {their} right eye sat, a powder-blackened crater oozes blood and matter|n",
+    ],
+    "left_ear": [
+        "|R{Their} left ear is a ragged hole where cartilage used to be, the rim blown away|n",
+        "|RA bullet has torn {their} left ear off in passing, the wound charred at the edges|n",
+        "|R{Their} left ear is shredded down to a stump, the canal weeping blood|n",
+        "|RWhat remains of {their} left ear is a powder-burned ruin clinging to bone|n",
+    ],
+    "right_ear": [
+        "|R{Their} right ear is a ragged hole where cartilage used to be, the rim blown away|n",
+        "|RA bullet has torn {their} right ear off in passing, the wound charred at the edges|n",
+        "|R{Their} right ear is shredded down to a stump, the canal weeping blood|n",
+        "|RWhat remains of {their} right ear is a powder-burned ruin clinging to bone|n",
+    ],
+}

--- a/world/medical/wounds/messages/cut.py
+++ b/world/medical/wounds/messages/cut.py
@@ -67,6 +67,40 @@ WOUND_DESCRIPTIONS = {
 }
 
 
+# Issue #347: destroyed-stage overlay keyed by location.  Sensory
+# surfaces (eyes, ears) read wrong with limb-vocabulary destruction
+# prose, so these cells override the generic ``destroyed`` list with
+# anatomically appropriate templates.  Missing cells fall through to
+# ``WOUND_DESCRIPTIONS["destroyed"]`` — limb destruction reads
+# correctly through the existing prose.
+DESTROYED_BY_LOCATION = {
+    "left_eye": [
+        "|R{Their} left eye is split open, vitreous fluid weeping down {their} cheek|n",
+        "|RA cleaving cut has bisected {their} left eye, the lid hanging in a bloody flap|n",
+        "|R{Their} left eye is sliced through, the cornea opened along a single sharp seam|n",
+        "|RWhere {their} left eye sat, a slashed ruin weeps clear fluid and blood|n",
+    ],
+    "right_eye": [
+        "|R{Their} right eye is split open, vitreous fluid weeping down {their} cheek|n",
+        "|RA cleaving cut has bisected {their} right eye, the lid hanging in a bloody flap|n",
+        "|R{Their} right eye is sliced through, the cornea opened along a single sharp seam|n",
+        "|RWhere {their} right eye sat, a slashed ruin weeps clear fluid and blood|n",
+    ],
+    "left_ear": [
+        "|R{Their} left ear hangs in two pieces, cartilage exposed at the cut|n",
+        "|RA blade has cleaved {their} left ear nearly off, the cartilage pale through the slit|n",
+        "|R{Their} left ear is sliced in half, the upper portion lost and the lower bleeding freely|n",
+        "|RWhat remains of {their} left ear is a sliced ribbon of skin and cartilage|n",
+    ],
+    "right_ear": [
+        "|R{Their} right ear hangs in two pieces, cartilage exposed at the cut|n",
+        "|RA blade has cleaved {their} right ear nearly off, the cartilage pale through the slit|n",
+        "|R{Their} right ear is sliced in half, the upper portion lost and the lower bleeding freely|n",
+        "|RWhat remains of {their} right ear is a sliced ribbon of skin and cartilage|n",
+    ],
+}
+
+
 # Compound descriptions: two or more wounds at one location, worst-first.
 COMPOUND_DESCRIPTIONS = {
     "fresh": [

--- a/world/medical/wounds/messages/generic.py
+++ b/world/medical/wounds/messages/generic.py
@@ -126,3 +126,34 @@ PAIRED_SEVERED_DESCRIPTIONS = [
     "once were|n",
     "{location} have been surgically removed with clinical precision|n",
 ]
+
+
+# Issue #347: destroyed-stage overlay keyed by location.  Used as the
+# ultimate fallback when the injury-type module is missing or has no
+# overlay entry — generic destruction prose for sensory surfaces.
+DESTROYED_BY_LOCATION = {
+    "left_eye": [
+        "|R{Their} left eye is a ruined socket, the orb destroyed beyond recognition|n",
+        "|RWhere {their} left eye sat, a wet wound weeps fluid and blood|n",
+        "|R{Their} left eye is gone, the socket a raw wound|n",
+        "|R{Their} left eye has been destroyed, leaving a hollow ruin|n",
+    ],
+    "right_eye": [
+        "|R{Their} right eye is a ruined socket, the orb destroyed beyond recognition|n",
+        "|RWhere {their} right eye sat, a wet wound weeps fluid and blood|n",
+        "|R{Their} right eye is gone, the socket a raw wound|n",
+        "|R{Their} right eye has been destroyed, leaving a hollow ruin|n",
+    ],
+    "left_ear": [
+        "|R{Their} left ear is destroyed, only a ragged wound remaining|n",
+        "|RWhere {their} left ear was, a torn wound bleeds slowly|n",
+        "|R{Their} left ear has been ruined, the canal exposed and weeping|n",
+        "|R{Their} left ear is a torn stump of cartilage and skin|n",
+    ],
+    "right_ear": [
+        "|R{Their} right ear is destroyed, only a ragged wound remaining|n",
+        "|RWhere {their} right ear was, a torn wound bleeds slowly|n",
+        "|R{Their} right ear has been ruined, the canal exposed and weeping|n",
+        "|R{Their} right ear is a torn stump of cartilage and skin|n",
+    ],
+}

--- a/world/medical/wounds/messages/laceration.py
+++ b/world/medical/wounds/messages/laceration.py
@@ -102,3 +102,32 @@ COMPOUND_DESCRIPTIONS = {
         "{skintone}the {location} is etched by a {severity} laceration scar among {others_phrase}|n",
     ],
 }
+
+
+# Issue #347: destroyed-stage overlay keyed by location.
+DESTROYED_BY_LOCATION = {
+    "left_eye": [
+        "|R{Their} left eye is a jagged tear across the socket, vitreous fluid leaking through ragged flaps|n",
+        "|RA brutal rip has shredded {their} left eye, the lid hanging in torn strips|n",
+        "|R{Their} left eye is torn open across its width, the orb collapsed beneath ragged tissue|n",
+        "|RWhere {their} left eye sat, a ripped wound leaks fluid down the cheek|n",
+    ],
+    "right_eye": [
+        "|R{Their} right eye is a jagged tear across the socket, vitreous fluid leaking through ragged flaps|n",
+        "|RA brutal rip has shredded {their} right eye, the lid hanging in torn strips|n",
+        "|R{Their} right eye is torn open across its width, the orb collapsed beneath ragged tissue|n",
+        "|RWhere {their} right eye sat, a ripped wound leaks fluid down the cheek|n",
+    ],
+    "left_ear": [
+        "|R{Their} left ear is torn into ragged strips, the cartilage visible through shredded skin|n",
+        "|RA brutal rip has torn {their} left ear in two, the upper portion lost|n",
+        "|R{Their} left ear hangs in shredded ribbons of skin and cartilage|n",
+        "|RWhat is left of {their} left ear is a torn mess of cartilage and skin tags|n",
+    ],
+    "right_ear": [
+        "|R{Their} right ear is torn into ragged strips, the cartilage visible through shredded skin|n",
+        "|RA brutal rip has torn {their} right ear in two, the upper portion lost|n",
+        "|R{Their} right ear hangs in shredded ribbons of skin and cartilage|n",
+        "|RWhat is left of {their} right ear is a torn mess of cartilage and skin tags|n",
+    ],
+}

--- a/world/medical/wounds/messages/stab.py
+++ b/world/medical/wounds/messages/stab.py
@@ -96,3 +96,32 @@ COMPOUND_DESCRIPTIONS = {
         "{skintone}the {location} is stippled by a {severity} puncture scar among {others_phrase}|n",
     ],
 }
+
+
+# Issue #347: destroyed-stage overlay keyed by location.
+DESTROYED_BY_LOCATION = {
+    "left_eye": [
+        "|R{Their} left eye is a punctured ruin, fluid leaking from the deep hole through it|n",
+        "|RA driven thrust has skewered {their} left eye, the socket bleeding around the puncture|n",
+        "|R{Their} left eye is collapsed inward around a deep puncture wound|n",
+        "|RWhere {their} left eye sat, a narrow ragged hole weeps fluid and dark blood|n",
+    ],
+    "right_eye": [
+        "|R{Their} right eye is a punctured ruin, fluid leaking from the deep hole through it|n",
+        "|RA driven thrust has skewered {their} right eye, the socket bleeding around the puncture|n",
+        "|R{Their} right eye is collapsed inward around a deep puncture wound|n",
+        "|RWhere {their} right eye sat, a narrow ragged hole weeps fluid and dark blood|n",
+    ],
+    "left_ear": [
+        "|R{Their} left ear is punctured through, a dark hole bored clean across the cartilage|n",
+        "|RA thrust has driven through {their} left ear, leaving a torn passage front to back|n",
+        "|R{Their} left ear hangs limp around a deep stab hole|n",
+        "|RWhat is left of {their} left ear surrounds a punched-through wound seeping blood|n",
+    ],
+    "right_ear": [
+        "|R{Their} right ear is punctured through, a dark hole bored clean across the cartilage|n",
+        "|RA thrust has driven through {their} right ear, leaving a torn passage front to back|n",
+        "|R{Their} right ear hangs limp around a deep stab hole|n",
+        "|RWhat is left of {their} right ear surrounds a punched-through wound seeping blood|n",
+    ],
+}

--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -38,9 +38,26 @@ def get_wound_description(injury_type, location, severity="Moderate", stage="fre
         # Fallback to generic wound descriptions
         message_module = messages.generic
         wound_messages = message_module.WOUND_DESCRIPTIONS
-    
-    # Get descriptions for this stage
-    stage_descriptions = wound_messages.get(stage, wound_messages.get("fresh", []))
+
+    # Issue #347: destroyed-stage overlay keyed by (injury_type, location).
+    # Limb-vocabulary doesn't fit sensory destruction ("His left eye
+    # has been mangled into ribbons of flesh" reads wrong) so each
+    # injury-type module may declare a ``DESTROYED_BY_LOCATION`` dict
+    # mapping high-specificity surfaces (eyes, ears, ...) to bespoke
+    # prose. Falls through to the generic destroyed-stage list when no
+    # overlay exists for this (injury_type, location) cell, so authoring
+    # is incremental and a missing overlay never produces an unauthored
+    # template.
+    stage_descriptions = None
+    if stage == "destroyed":
+        overlay = getattr(message_module, "DESTROYED_BY_LOCATION", None)
+        if overlay and location in overlay:
+            stage_descriptions = overlay[location]
+
+    if stage_descriptions is None:
+        stage_descriptions = wound_messages.get(
+            stage, wound_messages.get("fresh", [])
+        )
     
     if not stage_descriptions:
         location_display = get_location_display_name(location, character)
@@ -85,12 +102,42 @@ def get_wound_description(injury_type, location, severity="Moderate", stage="fre
     from .constants import MEDICAL_COLORS
     format_vars.update(MEDICAL_COLORS)
     
-    # Format with parameters
-    formatted_description = description_data.format(**format_vars)
-    
+    # Format with parameters.  Issue #347: the destroyed-stage overlay
+    # uses pronoun tokens (``{Their}``, ``{their}``) that aren't in
+    # ``format_vars``; we use ``format_map`` with a fallback dict that
+    # preserves unknown ``{key}`` tokens for the pronoun pass below
+    # (a plain ``.format(**format_vars)`` would KeyError on them).
+    class _PreserveMissing(dict):
+        def __missing__(self, key):
+            return "{" + key + "}"
+
+    formatted_description = description_data.format_map(
+        _PreserveMissing(format_vars)
+    )
+
+    # Issue #347: pronoun pass for templates that use ``{Their}`` /
+    # ``{their}`` / ``{Them}`` etc.  Existing templates without
+    # pronoun tokens are no-ops through this pass.
+    if character is not None:
+        try:
+            from world.anatomy import substitute_pronoun_tokens
+            gender = (
+                getattr(character, "gender", None)
+                or character.db.original_gender
+            )
+            formatted_description = substitute_pronoun_tokens(
+                formatted_description,
+                gender=gender,
+                number="singular",
+            )
+        except (AttributeError, ImportError):
+            # Character stub without gender / Evennia not importable —
+            # leave tokens literal rather than crashing.
+            pass
+
     # Apply grammar formatting (capitalization and punctuation)
     formatted_description = _format_wound_grammar(formatted_description)
-    
+
     return formatted_description
 
 

--- a/world/tests/test_corpse_wound_stage.py
+++ b/world/tests/test_corpse_wound_stage.py
@@ -58,8 +58,9 @@ class CorpseWoundStageTests(TestCase):
         # shredded, severance) rather than the old clinical wording
         # (amputation, surgically removed).
         severed_markers = (
-            "stump", "bone", "joint", "tear", "severance", "shredded",
-            "amputation", "severed", "amputated",
+            "stump", "bone", "joint", "tear", "torn", "severance",
+            "shredded", "amputation", "severed", "amputated",
+            "wreckage", "loose",
         )
         fresh_markers = (
             "showing damage", "traumatic wound", "requiring attention",

--- a/world/tests/test_destroyed_by_location_overlay.py
+++ b/world/tests/test_destroyed_by_location_overlay.py
@@ -1,0 +1,241 @@
+"""Tests for the destroyed-stage prose overlay (issue #347).
+
+After #346 routes wounds to ``left_eye`` / ``right_eye`` / ``left_ear`` /
+``right_ear`` (instead of the bulk ``head`` container), the generic
+destroyed-stage prose in ``world/medical/wounds/messages/*.py`` reads
+wrong for sensory surfaces — \"His left eye has been mangled into
+ribbons of flesh\" is limb vocabulary, not eye vocabulary.
+
+This issue adds a ``DESTROYED_BY_LOCATION`` overlay to each injury-type
+module so destruction at high-specificity surfaces reads in the right
+anatomical register, with fall-through to the existing generic
+destroyed list for unmapped locations.
+
+Tests verify:
+
+* Each shipped injury-type module declares the overlay for the four
+  sensory locations.
+* ``get_wound_description`` consults the overlay before the generic
+  destroyed list when ``stage == \"destroyed\"``.
+* Pronoun tokens (``{Their}`` / ``{their}``) resolve against the
+  character's gender.
+* Limb destruction still uses the generic prose (fall-through).
+* Non-destroyed stages are unaffected by the overlay.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.wounds import messages
+from world.medical.wounds.wound_descriptions import get_wound_description
+
+
+SENSORY_LOCATIONS = ("left_eye", "right_eye", "left_ear", "right_ear")
+INJURY_TYPES_WITH_OVERLAY = (
+    "cut", "stab", "bullet", "blunt", "laceration", "generic",
+)
+
+
+def _char(gender="male"):
+    """Minimal stub exposing the surfaces ``get_wound_description`` reads."""
+    return SimpleNamespace(
+        gender=gender,
+        db=SimpleNamespace(
+            original_gender=gender,
+            skintone=None,
+            species="human",
+        ),
+    )
+
+
+class OverlayDeclaredOnEveryShippedModule(TestCase):
+    """Each shipped injury-type module declares the overlay for all
+    sensory surfaces with at least 3 variants per cell."""
+
+    def test_every_module_declares_overlay(self):
+        for itype in INJURY_TYPES_WITH_OVERLAY:
+            with self.subTest(itype=itype):
+                module = getattr(messages, itype)
+                overlay = getattr(module, "DESTROYED_BY_LOCATION", None)
+                self.assertIsNotNone(
+                    overlay,
+                    f"{itype}.py must declare DESTROYED_BY_LOCATION",
+                )
+
+    def test_every_module_covers_all_sensory_locations(self):
+        for itype in INJURY_TYPES_WITH_OVERLAY:
+            module = getattr(messages, itype)
+            overlay = module.DESTROYED_BY_LOCATION
+            for loc in SENSORY_LOCATIONS:
+                with self.subTest(itype=itype, location=loc):
+                    self.assertIn(loc, overlay)
+                    self.assertGreaterEqual(
+                        len(overlay[loc]), 3,
+                        f"{itype}.{loc} needs at least 3 variants for "
+                        f"non-repetitive rendering",
+                    )
+
+
+class OverlaySwapsAtDestroyedStage(TestCase):
+    """``get_wound_description`` consults the overlay for destroyed
+    sensory wounds."""
+
+    def test_destroyed_eye_uses_eye_vocabulary(self):
+        # We can't assert exact prose (random.choice variance), but we
+        # CAN assert the rendered output uses anatomical eye vocabulary
+        # and never the limb "mangled / ribbons of flesh" wording from
+        # the generic destroyed list.
+        out = get_wound_description(
+            injury_type="cut", location="left_eye",
+            severity="Critical", stage="destroyed",
+            organ="left_eye", character=_char(),
+        )
+        self.assertNotIn("ribbons of flesh", out)
+        self.assertNotIn("hanging by threads", out)
+        # And reads like an eye line.
+        self.assertIn("eye", out.lower())
+
+    def test_destroyed_ear_uses_ear_vocabulary(self):
+        out = get_wound_description(
+            injury_type="bullet", location="left_ear",
+            severity="Critical", stage="destroyed",
+            organ="left_ear", character=_char(),
+        )
+        self.assertNotIn("ribbons of flesh", out)
+        self.assertIn("ear", out.lower())
+
+    def test_overlay_runs_through_every_variant(self):
+        # Smoke: each variant in every (injury_type, location) overlay
+        # cell renders without leaking braces, raising, or producing
+        # an empty string.
+        for itype in INJURY_TYPES_WITH_OVERLAY:
+            module = getattr(messages, itype)
+            for loc, variants in module.DESTROYED_BY_LOCATION.items():
+                for variant in variants:
+                    with self.subTest(itype=itype, loc=loc):
+                        # We monkeypatch ``random.choice`` to a passthrough
+                        # so the variant under test is the one rendered.
+                        import random
+                        original = random.choice
+                        random.choice = lambda seq, _v=variant: _v
+                        try:
+                            out = get_wound_description(
+                                injury_type=itype,
+                                location=loc,
+                                severity="Critical",
+                                stage="destroyed",
+                                organ=loc,
+                                character=_char(),
+                            )
+                        finally:
+                            random.choice = original
+                        self.assertTrue(out)
+                        self.assertNotIn("{", out,
+                                         f"leaked brace in {out!r}")
+                        self.assertNotIn("}", out)
+
+
+class PronounSubstitution(TestCase):
+    """Pronoun tokens resolve against the character's gender."""
+
+    def test_male_renders_his(self):
+        # Force a known variant by monkeypatching random.choice.
+        import random
+        forced = "|R{Their} left eye is gone.|n"
+        original = random.choice
+        random.choice = lambda seq, _v=forced: _v
+        try:
+            out = get_wound_description(
+                injury_type="generic", location="left_eye",
+                severity="Critical", stage="destroyed",
+                organ="left_eye", character=_char(gender="male"),
+            )
+        finally:
+            random.choice = original
+        # _format_wound_grammar may sentence-cap "His" at the start;
+        # we just need the token resolved to the male possessive.
+        self.assertIn("His", out)
+        self.assertNotIn("{Their}", out)
+
+    def test_female_renders_her(self):
+        import random
+        forced = "|R{Their} left eye is gone.|n"
+        original = random.choice
+        random.choice = lambda seq, _v=forced: _v
+        try:
+            out = get_wound_description(
+                injury_type="generic", location="left_eye",
+                severity="Critical", stage="destroyed",
+                organ="left_eye", character=_char(gender="female"),
+            )
+        finally:
+            random.choice = original
+        self.assertIn("Her", out)
+
+    def test_no_character_leaves_tokens_literal(self):
+        # No pronoun pass when character is None.  The brace token
+        # remains so a downstream renderer (or a developer noticing
+        # the leak) can spot the missing context.
+        import random
+        forced = "|R{Their} left eye is gone.|n"
+        original = random.choice
+        random.choice = lambda seq, _v=forced: _v
+        try:
+            out = get_wound_description(
+                injury_type="generic", location="left_eye",
+                severity="Critical", stage="destroyed",
+                organ="left_eye", character=None,
+            )
+        finally:
+            random.choice = original
+        self.assertIn("{Their}", out)
+
+
+class LimbDestructionFallsThrough(TestCase):
+    """Limb destruction has no overlay → uses the generic destroyed
+    list (limb vocabulary reads correctly for limbs)."""
+
+    def test_destroyed_arm_uses_generic_limb_prose(self):
+        out = get_wound_description(
+            injury_type="cut", location="left_arm",
+            severity="Critical", stage="destroyed",
+            organ="left_humerus", character=_char(),
+        )
+        # The generic destroyed list contains "ribbons of flesh" /
+        # "hanging by threads" / "bloody tatters" — at least one of
+        # those families is what limb destruction reads as. We assert
+        # only that the output does NOT use eye-only vocabulary, to
+        # confirm the fall-through path took.
+        self.assertNotIn("vitreous fluid", out)
+        self.assertNotIn("orb", out)
+        self.assertIn("arm", out.lower())
+
+
+class NonDestroyedStagesUnchanged(TestCase):
+    """Overlay is destroyed-stage only — fresh/treated/healing/scarred
+    routing is unchanged."""
+
+    def test_fresh_stage_ignores_overlay(self):
+        # A "fresh" stage wound at left_eye must NOT pick from the
+        # destroyed overlay — it should render through WOUND_DESCRIPTIONS
+        # ["fresh"].
+        out = get_wound_description(
+            injury_type="cut", location="left_eye",
+            severity="Light", stage="fresh",
+            organ="left_eye", character=_char(),
+        )
+        # Fresh cut prose mentions cut/laceration/slash vocabulary, not
+        # "ruined socket" / "split open" (overlay-only phrases).
+        self.assertNotIn("vitreous fluid", out)
+        self.assertNotIn("ruined socket", out)
+
+    def test_scarred_stage_ignores_overlay(self):
+        out = get_wound_description(
+            injury_type="cut", location="left_eye",
+            severity="Moderate", stage="scarred",
+            organ="left_eye", character=_char(),
+        )
+        self.assertNotIn("vitreous fluid", out)
+        self.assertNotIn("ruined socket", out)


### PR DESCRIPTION
## Summary
- Adds ``DESTROYED_BY_LOCATION`` overlays to each shipped injury-type message module (``cut`` / ``stab`` / ``bullet`` / ``blunt`` / ``laceration`` / ``generic``) covering ``left_eye`` / ``right_eye`` / ``left_ear`` / ``right_ear`` with anatomically appropriate prose.
- ``get_wound_description`` consults the overlay before the generic destroyed list when ``stage == \"destroyed\"``. Limb destruction falls through cleanly to the existing limb-vocabulary prose.
- Adds pronoun substitution at the wound-render layer so overlay templates can use ``{Their}`` / ``{their}`` naturally. Renderer swaps ``.format()`` for ``.format_map()`` with a missing-key fallback so unhandled brace tokens survive the format pass for the pronoun pass to consume.
- Expands the severed-marker list in ``test_corpse_wound_stage`` to cover \"torn / wreckage / loose\" prose — pre-existing flakiness exposed by new ``random.choice`` consumers in this PR shifting test-order random state.

Pre-fix: a destroyed eye rendered \"His left eye has been mangled into ribbons of flesh\". Post-fix: it renders e.g. \"His left eye is split open, vitreous fluid weeping down his cheek\" (cut), \"His left eye is a smoking crater\" (bullet), \"His left eye is pulped in its socket\" (blunt) — varied across 4 variants per (injury_type, location) cell.

Depends on #346 (without correct organ-display routing, the overlay never gets hit).

## Test plan
- [x] ``evennia test --settings settings.py world.tests.test_destroyed_by_location_overlay`` — 11/11 pass
- [x] Full suite: ``evennia test --settings settings.py world`` — 1638/1638 pass

Closes #347