### PR TITLE
PR-A: Species-keyed pair table (#350 sub-track A)

### DIFF
--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -586,20 +586,26 @@ class AppearanceMixin:
             return "right"
         return None
 
-    @staticmethod
-    def _flex_noun_vocabulary():
+    def _flex_noun_vocabulary(self):
         """Return the singular nouns a longdesc number-token flexes as a noun.
 
-        Two sources, unioned: the symmetric pair nouns derived from
-        ``PAIR_MERGE_KEYS`` (eye, ear, arm, hand, thigh, shin, foot) plus the
-        curated ``LONGDESC_FLEX_NOUNS`` body-noun vocabulary (leg, shoulder,
-        hip, ...). These are the only words a number-token treats as the body's
-        part noun; any other braced single word is treated as a verb.
+        Two sources, unioned: the symmetric pair nouns derived from the
+        species's pair table (eye, ear, arm, hand, thigh, shin, foot for
+        humans; a cyclops contributes nothing here, a spider contributes
+        its own multi-eye vocabulary) plus the curated ``LONGDESC_FLEX_NOUNS``
+        body-noun vocabulary (leg, shoulder, hip, ...). These are the only
+        words a number-token treats as the body's part noun; any other
+        braced single word is treated as a verb.
+
+        Species-aware via ``self.db.species`` (issue #350 / PR-A); unknown
+        / None species falls through to the human pair table.
         """
-        from world.combat.constants import LONGDESC_FLEX_NOUNS, PAIR_MERGE_KEYS
+        from world.anatomy.species import get_species_pair_keys
+        from world.combat.constants import LONGDESC_FLEX_NOUNS
 
         nouns = set(LONGDESC_FLEX_NOUNS)
-        for left_loc, _right_loc in PAIR_MERGE_KEYS.values():
+        species = getattr(self.db, "species", None) if hasattr(self, "db") else None
+        for left_loc, _right_loc in get_species_pair_keys(species).values():
             # "left_eye" -> "eye", "left_foot" -> "foot"
             nouns.add(left_loc.split("_", 1)[1])
         return nouns
@@ -635,7 +641,7 @@ class AppearanceMixin:
             str: Prose with recognised tokens substituted.
         """
         import re
-        from world.combat.constants import PAIR_MERGE_KEYS
+        from world.anatomy.species import get_species_pair_keys
         from world.grammar import (
             _match_leading_case,
             flex_noun,
@@ -645,12 +651,14 @@ class AppearanceMixin:
         )
 
         flex_nouns = self._flex_noun_vocabulary()
-        # Singulars that come from a PAIR_MERGE_KEYS pair (eye, ear,
-        # arm, hand, thigh, shin, foot). Side prefix applies to these.
-        # Non-pair flex nouns (leg, shoulder, hip, ...) keep bare form.
+        # Singulars that come from the species's pair table (eye, ear,
+        # arm, hand, thigh, shin, foot for humans; anything a non-human
+        # species declares). Side prefix applies to these. Non-pair
+        # flex nouns (leg, shoulder, hip, ...) keep bare form.
+        species = getattr(self.db, "species", None) if hasattr(self, "db") else None
         pair_singulars = {
             left.split("_", 1)[1]  # "left_eye" -> "eye"
-            for left, _right in PAIR_MERGE_KEYS.values()
+            for left, _right in get_species_pair_keys(species).values()
         }
         article_re = re.compile(r"^(?:a|an)\s+(.+)$", re.IGNORECASE)
 

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -263,10 +263,9 @@ class Corpse(IdentityBearerMixin, Item):
 
         # Import anatomical display order
         try:
-            from world.combat.constants import (
-                ANATOMICAL_DISPLAY_ORDER,
-                PAIR_MERGE_KEYS,
-            )
+            from world.anatomy.species import get_species_pair_keys
+            from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
+            pair_keys = get_species_pair_keys(self.db.species)
         except ImportError:
             # Fallback order if constants not available
             ANATOMICAL_DISPLAY_ORDER = [
@@ -275,7 +274,7 @@ class Corpse(IdentityBearerMixin, Item):
                 "left_arm", "right_arm", "left_hand", "right_hand",
                 "left_thigh", "right_thigh", "left_shin", "right_shin", "left_foot", "right_foot"
             ]
-            PAIR_MERGE_KEYS = {}
+            pair_keys = {}
 
         descriptions = []
         longdesc_data = self.db.longdesc_data
@@ -288,7 +287,7 @@ class Corpse(IdentityBearerMixin, Item):
         # their right_* partner under a single plural render.
         collapse_anchor = {}  # left_loc -> plural-rendered description
         collapse_skip = set()  # right_loc partners to skip
-        for _pair_key, (left_loc, right_loc) in PAIR_MERGE_KEYS.items():
+        for _pair_key, (left_loc, right_loc) in pair_keys.items():
             # Asymmetric clothing breaks the visual pairing.
             if left_loc in coverage_map or right_loc in coverage_map:
                 continue
@@ -641,6 +640,7 @@ class Corpse(IdentityBearerMixin, Item):
             name=original_name,
             number=number,
             side=side,
+            species=self.db.species,
         )
         
         # Apply skintone coloring if preserved (only to body descriptions, not clothing items)
@@ -772,6 +772,7 @@ class Corpse(IdentityBearerMixin, Item):
             gender=original_gender,
             name=original_name,
             number=verb_number,
+            species=species,
         )
 
         return get_species_corpse_description(species, stage, base_desc)

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1321,6 +1321,10 @@ class Appendage(Item):
         wounds = self.db.wounds_at_death or []
         gender = self.db.original_gender
         name = self.db.original_character_name or "the corpse"
+        # Issue #350 / PR-A: thread species through so the body-noun
+        # flex pass consults the species pair table.  ``source_species``
+        # was captured at sever time; falls back to "human" when absent.
+        species = self.db.source_species or "human"
 
         try:
             from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
@@ -1364,7 +1368,9 @@ class Appendage(Item):
             text = longdescs.get(loc)
             if text:
                 pieces.append(
-                    substitute_pronoun_tokens(text, gender=gender, name=name)
+                    substitute_pronoun_tokens(
+                        text, gender=gender, name=name, species=species,
+                    )
                 )
             for idx, wound in enumerate(wounds):
                 if idx in handled_wounds or _wound_location(wound) != loc:

--- a/world/anatomy/__init__.py
+++ b/world/anatomy/__init__.py
@@ -46,6 +46,7 @@ from .species import (
     get_species_corpse_name,
     get_species_location_display,
     get_species_organ_name,
+    get_species_pair_keys,
     get_species_part_name,
     get_species_severed_chain_name,
 )
@@ -63,6 +64,7 @@ __all__ = (
     "get_species_corpse_name",
     "get_species_location_display",
     "get_species_organ_name",
+    "get_species_pair_keys",
     "get_species_part_name",
     "get_species_severed_chain_name",
     "prepend_condition_to_desc",

--- a/world/anatomy/longdesc_tokens.py
+++ b/world/anatomy/longdesc_tokens.py
@@ -69,7 +69,8 @@ _PRONOUN_MAP = {
 
 
 def substitute_pronoun_tokens(text, *, gender, name="the corpse",
-                              number="singular", side=None):
+                              number="singular", side=None,
+                              species=None):
     """Replace ``{pronoun}`` / ``{name}`` / body-noun tokens in preserved prose.
 
     Always third-person (the subject is an inanimate corpse or severed
@@ -104,6 +105,12 @@ def substitute_pronoun_tokens(text, *, gender, name="the corpse",
             set with ``number="singular"`` and the token is a pair-
             keyed body noun, the side is prefixed onto the singular
             form (#341).
+        species (str | None): Species identifier used to pick the
+            pair-keyed noun set (issue #350 / PR-A).  Unknown / None
+            falls back to ``"human"`` via the species registry so
+            existing humanoid callers keep working without threading
+            a species argument; non-humans declare their own pair
+            table in :data:`world.anatomy.species.SPECIES_DEFINITIONS`.
 
     Returns:
         str: ``text`` with pronoun, name, and body-noun tokens resolved.
@@ -128,12 +135,12 @@ def substitute_pronoun_tokens(text, *, gender, name="the corpse",
 
     # Body-noun / verb flex pass.  Done after pronouns so an unhandled
     # leftover brace can fall through cleanly.
-    processed = _flex_body_tokens(processed, number, side)
+    processed = _flex_body_tokens(processed, number, side, species=species)
 
     return processed
 
 
-def _flex_body_tokens(text, number, side=None):
+def _flex_body_tokens(text, number, side=None, *, species=None):
     """Flex remaining braced tokens as body nouns or verbs.
 
     Mirrors the resolution order of
@@ -145,10 +152,17 @@ def _flex_body_tokens(text, number, side=None):
 
     Side-aware singular flex (#341) for pair-keyed nouns is applied
     when ``side`` is provided AND number is singular.
+
+    Pair-keyed nouns are species-aware (issue #350 / PR-A): the set is
+    derived from ``world.anatomy.get_species_pair_keys(species)``.
+    Unknown / None species fall back to the human pair table so
+    callers without species context (admin tooling, generic prose)
+    keep current behavior.
     """
     import re
 
-    from world.combat.constants import LONGDESC_FLEX_NOUNS, PAIR_MERGE_KEYS
+    from world.anatomy.species import get_species_pair_keys
+    from world.combat.constants import LONGDESC_FLEX_NOUNS
     from world.grammar import (
         _match_leading_case,
         flex_noun,
@@ -159,7 +173,8 @@ def _flex_body_tokens(text, number, side=None):
 
     flex_nouns = set(LONGDESC_FLEX_NOUNS)
     pair_singulars = set()
-    for left_loc, _right_loc in PAIR_MERGE_KEYS.values():
+    pair_keys = get_species_pair_keys(species)
+    for left_loc, _right_loc in pair_keys.values():
         # "left_eye" -> "eye"
         singular = left_loc.split("_", 1)[1]
         flex_nouns.add(singular)

--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -96,6 +96,28 @@ SPECIES_DEFINITIONS = {
             "right_ear": "right ear",
         },
 
+        # Symmetric body-noun pair table (issue #350 / PR-A).  Each
+        # entry maps a pair shorthand (``"eyes"``, ``"arms"``, ...) to
+        # the ``(left_location, right_location)`` tuple it collapses.
+        # Consumed by the longdesc renderer's pair-collapse pass, the
+        # body-noun flex / side-aware singular routing, and the
+        # ``describe`` command's pair-shorthand expansion.  Previously
+        # this lived as a global ``world.combat.constants.PAIR_MERGE_KEYS``
+        # constant; moving it here lets non-humans declare their own
+        # anatomy (cyclops → ``{}``; insectoid compound eye → ``{}``;
+        # spider → ``{"eyes": ("anterior_eyes", "posterior_eyes"), ...}``;
+        # hydra → multi-head pairs).  The global constant in
+        # ``world.combat.constants`` is now derived from this table.
+        "pair_keys": {
+            "eyes":   ("left_eye",   "right_eye"),
+            "ears":   ("left_ear",   "right_ear"),
+            "arms":   ("left_arm",   "right_arm"),
+            "hands":  ("left_hand",  "right_hand"),
+            "thighs": ("left_thigh", "right_thigh"),
+            "shins":  ("left_shin",  "right_shin"),
+            "feet":   ("left_foot",  "right_foot"),
+        },
+
         # Compound names used when severance carries downstream limb
         # parts off the body as a single Appendage (issue #339).
         # Severing at the thigh takes shin + foot, so the Appendage
@@ -211,6 +233,41 @@ def _resolve_species(species: str | None) -> dict:
     if not species:
         return SPECIES_DEFINITIONS["human"]
     return SPECIES_DEFINITIONS.get(species, SPECIES_DEFINITIONS["human"])
+
+
+def get_species_pair_keys(species: str | None) -> dict:
+    """Return the symmetric pair table for a species.
+
+    Each entry maps a pair shorthand (``"eyes"``, ``"arms"``, ...) to
+    a ``(left_location, right_location)`` tuple.  The longdesc
+    renderer's pair-collapse pass, the body-noun flex / side-aware
+    singular routing, and the ``describe`` command's pair-shorthand
+    expansion all consult this table to decide which surfaces pair
+    on a given body.
+
+    Species variation:
+
+    * Bilateral humanoids (humans, rat-people, dogs) declare the
+      familiar ``left_*``/``right_*`` pairs.
+    * Single-instance organs (cyclops central eye, insectoid compound
+      eye) declare no pair for that surface — destruction at that
+      location is single-line by definition because the pair-collapse
+      pass never reaches it.
+    * Multi-pair anatomies (spider with anterior / posterior eye
+      clusters) can declare any number of pairs keyed by the species's
+      own anatomical vocabulary.
+
+    Args:
+        species: Species identifier (e.g. ``"human"``); ``None`` /
+            unknown species fall back to ``"human"``.
+
+    Returns:
+        Pair-shorthand → ``(left, right)`` mapping.  Empty dict on
+        species that declare no pairs (returns a fresh dict so callers
+        can mutate without aliasing the registry).
+    """
+    spec = _resolve_species(species)
+    return dict(spec.get("pair_keys") or {})
 
 
 def get_species_location_display(species: str | None, location: str) -> str:

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -66,7 +66,7 @@ REGION_BREAK_PRIORITY = True     # Prefer breaking between anatomical regions
 # Valid location validation set (expandable)
 VALID_LONGDESC_LOCATIONS = set(DEFAULT_LONGDESC_LOCATIONS.keys())
 
-# Symmetric left/right body-part pairs.
+# Symmetric left/right body-part pairs (HUMAN default).
 #
 # Maps a plural shorthand key (the form a player types into ``describe`` and
 # the noun a collapsed pair reads as) to its two underlying ``left_*``/
@@ -80,15 +80,18 @@ VALID_LONGDESC_LOCATIONS = set(DEFAULT_LONGDESC_LOCATIONS.keys())
 #
 # These keys are NOT body locations themselves: they are not in the default
 # anatomy, are not wearable, and are not render keys.
-PAIR_MERGE_KEYS = {
-    "eyes": ("left_eye", "right_eye"),
-    "ears": ("left_ear", "right_ear"),
-    "arms": ("left_arm", "right_arm"),
-    "hands": ("left_hand", "right_hand"),
-    "thighs": ("left_thigh", "right_thigh"),
-    "shins": ("left_shin", "right_shin"),
-    "feet": ("left_foot", "right_foot"),
-}
+#
+# As of issue #350 (PR-A) the canonical source of truth lives in the species
+# registry: ``world.anatomy.species.SPECIES_DEFINITIONS["human"]["pair_keys"]``.
+# This constant is derived from that table so existing callers that lack a
+# species context (admin commands, mob-flavor generators) continue to work
+# while species-aware callers (longdesc renderers, corpse, severance) consult
+# ``world.anatomy.get_species_pair_keys(species)`` directly.
+from world.anatomy.species import SPECIES_DEFINITIONS as _SPECIES_DEFINITIONS
+PAIR_MERGE_KEYS = dict(
+    _SPECIES_DEFINITIONS["human"].get("pair_keys") or {}
+)
+del _SPECIES_DEFINITIONS
 
 # Curated vocabulary of singular body nouns the longdesc token resolver should
 # number-flex as NOUNS rather than conjugate as verbs. This is VOCABULARY ONLY:

--- a/world/tests/test_species_pair_keys.py
+++ b/world/tests/test_species_pair_keys.py
@@ -1,0 +1,140 @@
+"""Tests for the species-keyed pair table (issue #350 / PR-A).
+
+Pre-PR, ``PAIR_MERGE_KEYS`` was a flat global constant. PR-A moved the
+canonical source of truth into the species registry so non-humans can
+declare their own pair anatomy (cyclops → no eye pair; insectoid →
+no pair, single compound eye; spider → ``("anterior_eyes",
+"posterior_eyes")``; hydra → multi-pair).
+
+Tests cover:
+
+* The human species declares the historical pair table.
+* ``get_species_pair_keys`` returns the right table per species, falls
+  back to human on unknown, returns a fresh dict (no aliasing).
+* The legacy global ``PAIR_MERGE_KEYS`` is now derived from the human
+  table — same contents, single source of truth.
+* The pure ``substitute_pronoun_tokens`` helper threads species
+  through so a species with no eye pair (e.g., a hypothetical cyclops)
+  doesn't apply the side-aware singular flex.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.anatomy.species import (
+    SPECIES_DEFINITIONS,
+    get_species_pair_keys,
+)
+from world.anatomy import substitute_pronoun_tokens
+from world.combat.constants import PAIR_MERGE_KEYS
+
+
+class HumanPairTableShape(TestCase):
+
+    def test_human_declares_canonical_pair_set(self):
+        pairs = get_species_pair_keys("human")
+        self.assertEqual(
+            set(pairs.keys()),
+            {"eyes", "ears", "arms", "hands", "thighs", "shins", "feet"},
+        )
+
+    def test_each_pair_is_left_right_tuple(self):
+        for pair_key, (left, right) in get_species_pair_keys("human").items():
+            with self.subTest(pair_key=pair_key):
+                self.assertTrue(left.startswith("left_"))
+                self.assertTrue(right.startswith("right_"))
+                # Right stem must mirror left stem (left_eye/right_eye,
+                # left_foot/right_foot).
+                self.assertEqual(
+                    left.split("_", 1)[1],
+                    right.split("_", 1)[1],
+                )
+
+
+class GetSpeciesPairKeysHelper(TestCase):
+
+    def test_unknown_species_falls_back_to_human(self):
+        # Unknown species — registry guarantee per spec: fall back to
+        # human rather than raising.
+        unknown = get_species_pair_keys("alien_xenoform_qrz")
+        human = get_species_pair_keys("human")
+        self.assertEqual(unknown, human)
+
+    def test_none_species_falls_back_to_human(self):
+        self.assertEqual(get_species_pair_keys(None),
+                         get_species_pair_keys("human"))
+
+    def test_returns_fresh_dict_no_aliasing(self):
+        # Callers may mutate the returned dict (defensive callers, or
+        # ones that want to temporarily augment the set) — that must
+        # not corrupt the registry.
+        pairs = get_species_pair_keys("human")
+        pairs["test_pair"] = ("left_test", "right_test")
+        pairs2 = get_species_pair_keys("human")
+        self.assertNotIn("test_pair", pairs2)
+
+
+class LegacyGlobalConstantDerivedFromHuman(TestCase):
+
+    def test_pair_merge_keys_matches_human_table(self):
+        # Single source of truth: the legacy global constant is now
+        # derived from SPECIES_DEFINITIONS["human"]["pair_keys"].
+        self.assertEqual(
+            dict(PAIR_MERGE_KEYS),
+            dict(SPECIES_DEFINITIONS["human"]["pair_keys"]),
+        )
+
+
+class SubstitutePronounTokensThreadsSpecies(TestCase):
+    """The pure token helper accepts an optional species parameter so
+    the body-noun flex pass consults the right pair table."""
+
+    def test_human_singular_eye_with_side_prefixes(self):
+        # Baseline: human, singular eye with side="left" → "left eye"
+        # (side-aware singular flex from #341 still applies).
+        out = substitute_pronoun_tokens(
+            "{Their} {eyes} are bright.",
+            gender="male", number="singular", side="left",
+            species="human",
+        )
+        self.assertEqual(out, "His left eye are bright.")
+
+    def test_default_species_is_human(self):
+        # No species → falls back to human (existing callers don't
+        # need to change).
+        out = substitute_pronoun_tokens(
+            "{Their} {eyes} are bright.",
+            gender="male", number="singular", side="left",
+        )
+        self.assertEqual(out, "His left eye are bright.")
+
+    def test_species_with_no_eye_pair_keeps_bare_noun(self):
+        # Simulate a cyclops-style species by registering one ad-hoc.
+        # The body-noun flex pass shouldn't apply side prefix because
+        # "eye" isn't in this species's pair table.
+        SPECIES_DEFINITIONS["_test_cyclops"] = {
+            "display_name": "test cyclops",
+            "pair_keys": {},  # no pairs
+            "location_display": {},
+            "decay_part_prefixes": {},
+            "decay_organ_prefixes": {},
+            "decay_corpse_names": {},
+            "decay_corpse_descriptions": {},
+        }
+        try:
+            out = substitute_pronoun_tokens(
+                "{Their} {eye} is bright.",
+                gender="male", number="singular", side="left",
+                species="_test_cyclops",
+            )
+            # No side prefix — bare "eye" since the species has no
+            # eye pair. Pronoun still resolves.
+            # NB: "eye" is also in LONGDESC_FLEX_NOUNS so it still
+            # gets noun-flexed (kept singular here), just without
+            # the side prefix.
+            self.assertIn("His", out)
+            self.assertIn("eye", out)
+            self.assertNotIn("left eye", out)
+        finally:
+            del SPECIES_DEFINITIONS["_test_cyclops"]


### PR DESCRIPTION
## Summary

First of three sub-PRs landing the species-aware destroyed-organ rendering architecture from #350.

- Adds ``pair_keys`` field to ``SPECIES_DEFINITIONS[\"human\"]`` declaring the canonical eyes/ears/arms/hands/thighs/shins/feet pairs.
- Adds ``get_species_pair_keys(species)`` helper in ``world/anatomy/species.py``, exported via ``world.anatomy``.
- Migrates the three species-aware renderer paths:
  - ``AppearanceMixin._flex_noun_vocabulary`` and ``_substitute_longdesc_tokens`` consult the species pair table via ``self.db.species``.
  - ``Corpse._get_preserved_longdesc_descriptions`` reads pair-collapse anchors from the species table.
  - ``Appendage.return_appearance`` threads ``source_species`` through the pronoun-substitution helper.
- ``substitute_pronoun_tokens`` accepts an optional ``species`` kwarg; defaults to ``\"human\"`` so callers without species context keep working.
- ``PAIR_MERGE_KEYS`` in ``world/combat/constants.py`` is now derived from the human pair_keys table — single source of truth. Non-species-aware consumers (``CmdCharacter``, ``mob_flavor``) keep importing the constant unchanged.

Non-humans now declare their own pair anatomy in one place. A cyclops adds ``\"pair_keys\": {}`` to its species def; a spider declares ``{\"anterior_eyes\": (\"left_anterior_eye\", \"right_anterior_eye\"), \"posterior_eyes\": (...)}``; a hydra declares multi-head pair sets. No renderer code change needed for any of those.

## Test plan
- [x] ``evennia test --settings settings.py world.tests.test_species_pair_keys`` — 9/9 pass (covers helper fallback, dict-aliasing safety, legacy global derivation, ad-hoc cyclops simulation for the species threading path)
- [x] Full suite: ``evennia test --settings settings.py world`` — 1647/1647 pass

Refs #350. Sub-tracks B (universal longdesc suppression at destroyed surfaces) and C (DESTROYED_BY_PAIR overlay + paired destruction collapse) follow.