### PR TITLE
PR-C: Paired destruction collapse + DESTROYED_BY_PAIR overlay (#350 sub-track C)

### DIFF
--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -100,6 +100,16 @@ class AppearanceMixin:
             looker, longdescs, coverage_map, destroyed_locs
         )
 
+        # Issue #350 / PR-C: wound-side pair collapse for both-sides-
+        # destroyed-same-mechanism.  Pre-renders one pair line at the
+        # left location and skips the right; takes precedence over
+        # per-side wound rendering in the loop below.
+        destroyed_pair_anchor, destroyed_pair_skip = (
+            self._build_destroyed_pair_collapse(
+                looker, coverage_map, destroyed_locs,
+            )
+        )
+
         # Track which clothing items we've already added to avoid duplicates
         added_clothing_items = set()
 
@@ -107,6 +117,17 @@ class AppearanceMixin:
         for location in ANATOMICAL_DISPLAY_ORDER:
             if location in collapse_skip:
                 # Partner of a collapsed pair; rendered at the anchor location.
+                continue
+            if location in destroyed_pair_skip:
+                # Issue #350 / PR-C: right side of a destruction pair
+                # collapse; rendered at the left anchor.
+                continue
+            if location in destroyed_pair_anchor:
+                # Issue #350 / PR-C: both sides destroyed by same
+                # mechanism — single pluralized destruction line.
+                descriptions.append(
+                    (location, destroyed_pair_anchor[location])
+                )
                 continue
             if location in collapse_map:
                 descriptions.append((location, collapse_map[location]))
@@ -178,6 +199,13 @@ class AppearanceMixin:
         for location in all_locations:
             if location not in ANATOMICAL_DISPLAY_ORDER:
                 if location in collapse_skip:
+                    continue
+                if location in destroyed_pair_skip:
+                    continue
+                if location in destroyed_pair_anchor:
+                    descriptions.append(
+                        (location, destroyed_pair_anchor[location])
+                    )
                     continue
                 if location in collapse_map:
                     descriptions.append((location, collapse_map[location]))
@@ -370,6 +398,60 @@ class AppearanceMixin:
             if all(w.get('stage') == 'severed' for w in location_wounds):
                 severed.add(location)
         return severed
+
+    def _build_destroyed_pair_collapse(self, looker, coverage_map,
+                                       destroyed_locs):
+        """Pre-compute wound-side pair collapse for both-sides-destroyed
+        symmetric pairs (issue #350 / PR-C).
+
+        For each pair-key in the species pair table whose left+right
+        sides are both in ``destroyed_locs`` AND share an injury type,
+        we render one ``DESTROYED_BY_PAIR``-overlay pair line at the
+        left anchor and skip the right side in the main render loop.
+        Pairs with asymmetric coverage are excluded — clothing breaks
+        the visual pairing the same way it does for the longdesc
+        collapse pass.
+
+        Mismatched mechanisms (left eye cut, right eye shot) fail the
+        common-injury-type check inside
+        :func:`world.medical.wounds.get_paired_destroyed_description`
+        and the per-side rendering takes over.
+
+        Args:
+            looker: Reserved for permission checks.
+            coverage_map: ``location -> clothing_item`` mapping.
+            destroyed_locs: Set of locations with destroyed wounds
+                (pre-computed by :meth:`_get_destroyed_locations`).
+
+        Returns:
+            ``(anchor_map, skip_set)`` — left anchors to pair-line
+            strings and right partners to skip.
+        """
+        anchor = {}
+        skip = set()
+        try:
+            from world.anatomy.species import get_species_pair_keys
+            from world.medical.wounds import get_paired_destroyed_description
+        except ImportError:
+            return anchor, skip
+
+        species = getattr(self.db, "species", None)
+        for pair_key, (left_loc, right_loc) in get_species_pair_keys(species).items():
+            if left_loc not in destroyed_locs:
+                continue
+            if right_loc not in destroyed_locs:
+                continue
+            # Asymmetric clothing breaks the visual pairing — same rule
+            # as the longdesc-collapse pass.
+            if left_loc in coverage_map or right_loc in coverage_map:
+                continue
+            rendered = get_paired_destroyed_description(
+                self, pair_key, left_loc, right_loc, looker=looker,
+            )
+            if rendered:
+                anchor[left_loc] = rendered
+                skip.add(right_loc)
+        return anchor, skip
 
     def _get_destroyed_locations(self):
         """Return the set of display locations with destroyed-stage wounds.

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -295,6 +295,30 @@ class Corpse(IdentityBearerMixin, Item):
         except ImportError:
             destroyed_locs = set()
 
+        # Issue #350 / PR-C: wound-side pair collapse for both-sides-
+        # destroyed-same-mechanism.  Uses the preserved wound snapshot
+        # (no live medical state on a corpse) by threading wounds=
+        # through ``get_paired_destroyed_description``.
+        destroyed_pair_anchor = {}
+        destroyed_pair_skip = set()
+        try:
+            from world.medical.wounds import get_paired_destroyed_description
+            snapshot_wounds = self.db.wounds_at_death or []
+            for pair_key, (l_loc, r_loc) in pair_keys.items():
+                if l_loc not in destroyed_locs or r_loc not in destroyed_locs:
+                    continue
+                if l_loc in coverage_map or r_loc in coverage_map:
+                    continue
+                rendered = get_paired_destroyed_description(
+                    self, pair_key, l_loc, r_loc,
+                    wounds=snapshot_wounds,
+                )
+                if rendered:
+                    destroyed_pair_anchor[l_loc] = rendered
+                    destroyed_pair_skip.add(r_loc)
+        except ImportError:
+            pass
+
         # Pre-compute symmetric pair collapse: which left_* anchors absorb
         # their right_* partner under a single plural render.
         collapse_anchor = {}  # left_loc -> plural-rendered description
@@ -330,6 +354,15 @@ class Corpse(IdentityBearerMixin, Item):
             if location in collapse_skip:
                 # Right side of a collapsed pair — already rendered at the
                 # left anchor; do not render again.
+                continue
+            if location in destroyed_pair_skip:
+                # Issue #350 / PR-C: right side of a destruction pair
+                # collapse; rendered at the left anchor below.
+                continue
+            if location in destroyed_pair_anchor:
+                descriptions.append(
+                    (location, destroyed_pair_anchor[location])
+                )
                 continue
             if location in coverage_map:
                 # Location covered by clothing - use clothing description instead

--- a/world/medical/wounds/__init__.py
+++ b/world/medical/wounds/__init__.py
@@ -33,6 +33,7 @@ from .wound_descriptions import (
 from .longdesc_hooks import (
     append_wounds_to_longdesc,
     get_destroyed_display_locations,
+    get_paired_destroyed_description,
     get_paired_severed_description,
     get_standalone_wound_description,
 )
@@ -54,6 +55,7 @@ __all__ = [
     # Longdesc integration hooks
     'append_wounds_to_longdesc',
     'get_destroyed_display_locations',
+    'get_paired_destroyed_description',
     'get_paired_severed_description',
     'get_standalone_wound_description',
 

--- a/world/medical/wounds/longdesc_hooks.py
+++ b/world/medical/wounds/longdesc_hooks.py
@@ -260,6 +260,150 @@ def get_paired_severed_description(character, left_location, right_location,
     return _format_wound_grammar(template.format(location=location_display))
 
 
+def get_paired_destroyed_description(character, pair_key,
+                                     left_location, right_location,
+                                     looker=None, wounds=None):
+    """Render one plural destruction line for both sides destroyed by
+    the same injury type (issue #350 / PR-C).
+
+    When both members of a ``left_*``/``right_*`` pair carry destroyed
+    wounds AND those wounds share an injury type, the per-side
+    destruction lines are collapsed into a single pair line keyed by
+    the pair shorthand (``"eyes"``, ``"ears"``, ...) on the injury-
+    type module's ``DESTROYED_BY_PAIR`` overlay.  Falls through to
+    ``messages.generic.DESTROYED_BY_PAIR`` when the per-injury-type
+    overlay has no entry; returns ``None`` when the generic also
+    lacks a template (caller then renders each side independently).
+
+    Mismatched mechanisms (e.g., left eye cut, right eye shot) do NOT
+    collapse — the per-side render reads more honestly than a
+    paper-thin \"both eyes destroyed\" generalization that hides which
+    mechanism took which.
+
+    Args:
+        character: Character / corpse object.  Used for gender /
+            species lookup (falls back across ``.gender`` and
+            ``.db.original_gender`` so both live characters and
+            corpses work) and for skintone if a template needs it.
+        pair_key (str): Pair shorthand from the species pair table
+            (``"eyes"``, ``"ears"``, ``"arms"``, ...).
+        left_location (str): The ``left_*`` member.
+        right_location (str): The ``right_*`` member.
+        looker: Reserved for future permission checks.
+        wounds: Optional wound-list override.  When ``None`` (the
+            living-character default) we call ``get_character_wounds``
+            which filters by clothing visibility.  Corpses pass
+            ``self.db.wounds_at_death`` so the preserved snapshot
+            drives the collapse decision without a live medical-state
+            lookup.
+
+    Returns:
+        str | None: A formatted pair-destruction sentence when both
+            sides are destroyed by a common injury type and an
+            overlay template exists, else ``None``.
+    """
+    if wounds is None:
+        wounds = get_character_wounds(character)
+    left_destroyed = [
+        w for w in wounds
+        if w["location"] == left_location and w.get("stage") == "destroyed"
+    ]
+    right_destroyed = [
+        w for w in wounds
+        if w["location"] == right_location and w.get("stage") == "destroyed"
+    ]
+    if not left_destroyed or not right_destroyed:
+        return None
+
+    # Common injury type: both sides destroyed by the same mechanism.
+    # Mismatched mechanisms fall through to per-side rendering — that
+    # reads more honestly than collapsing two different causes into
+    # one pair line.
+    left_types = {w["injury_type"] for w in left_destroyed}
+    right_types = {w["injury_type"] for w in right_destroyed}
+    common = left_types & right_types
+    if not common:
+        return None
+    # When more than one injury type matches both sides (e.g., both
+    # eyes carried cut AND blunt wounds, both destroyed), pick the
+    # alphabetical first for determinism — the variation between
+    # cells is mostly cosmetic and the per-side fallback is fine if
+    # this isn't a great match.
+    injury_type = sorted(common)[0]
+
+    # Overlay lookup: per-injury-type → generic fallback → None.
+    try:
+        message_module = getattr(messages, injury_type)
+    except AttributeError:
+        message_module = messages.generic
+    overlay = getattr(message_module, "DESTROYED_BY_PAIR", None) or {}
+    variants = overlay.get(pair_key)
+    if not variants:
+        generic_overlay = getattr(messages.generic, "DESTROYED_BY_PAIR", None) or {}
+        variants = generic_overlay.get(pair_key)
+    if not variants:
+        return None
+
+    template = random.choice(variants)
+
+    # Severity drive from the worst left+right wound (Critical wins).
+    severity_order = ("Light", "Moderate", "Severe", "Critical")
+    worst = max(
+        left_destroyed + right_destroyed,
+        key=lambda w: severity_order.index(w.get("severity", "Moderate"))
+        if w.get("severity") in severity_order else 1,
+    )
+
+    location_display = ""  # Pair templates address the body directly via
+    # pronouns / explicit pair noun; the {location} token is available if
+    # an author wants the species-routed pair noun.
+    try:
+        from world.grammar import pluralize_noun
+        # Pair shorthand IS already plural ("eyes", "ears"), but some
+        # authors may have built it from a singular stem. Be defensive.
+        location_display = pluralize_noun(
+            pair_key[:-1] if pair_key.endswith("s") else pair_key
+        )
+    except ImportError:
+        location_display = pair_key
+
+    format_vars = {
+        "severity": INJURY_SEVERITY_MAP.get(
+            worst.get("severity", "Moderate"),
+            worst.get("severity", "Moderate").lower(),
+        ),
+        "location": location_display,
+        "injury_type": injury_type,
+        "skintone": "",
+    }
+    format_vars.update(MEDICAL_COLORS)
+
+    class _PreserveMissing(dict):
+        def __missing__(self, key):
+            return "{" + key + "}"
+
+    rendered = template.format_map(_PreserveMissing(format_vars))
+
+    # Pronoun pass — pair-collapsed prose typically uses ``{Their}``,
+    # ``{their}``, ``{them}`` to read naturally.  Plural number so
+    # body-noun flex stays at the pair-shorthand level (``"eyes"``
+    # not ``"eye"``).
+    try:
+        from world.anatomy import substitute_pronoun_tokens
+        gender = (
+            getattr(character, "gender", None)
+            or character.db.original_gender
+        )
+        species = getattr(character.db, "species", None) or "human"
+        rendered = substitute_pronoun_tokens(
+            rendered, gender=gender, number="plural", species=species,
+        )
+    except (AttributeError, ImportError):
+        pass
+
+    return _format_wound_grammar(rendered)
+
+
 def _location_is_severed(character, location):
     """Return True if every wound at ``location`` is a clean severance."""
     location_wounds = [

--- a/world/medical/wounds/messages/blunt.py
+++ b/world/medical/wounds/messages/blunt.py
@@ -125,3 +125,20 @@ DESTROYED_BY_LOCATION = {
         "|RWhat is left of {their} right ear is a flattened ruin, dark with bruise and blood|n",
     ],
 }
+
+
+# Issue #350 / PR-C: paired destruction overlay (blunt).
+DESTROYED_BY_PAIR = {
+    "eyes": [
+        "|RBoth of {their} eyes are pulped in their sockets, the lids swollen black around the twin ruins|n",
+        "|RCrushing impacts have burst both of {their} eyes, fluid weeping over the bruised cheeks|n",
+        "|R{Their} eyes are collapsed inward on both sides, the sockets caved and weeping|n",
+        "|RWhat was {their} eyes are sunken pulps, the orbital bones pressed flat around them|n",
+    ],
+    "ears": [
+        "|RBoth of {their} ears are mashed flat against the skull, the cartilage crushed and weeping|n",
+        "|RHeavy blows have pulped both of {their} ears into the sides of {their} head|n",
+        "|R{Their} ears are reduced to swollen lumps of bruised tissue on both sides|n",
+        "|RWhat is left of {their} ears are flattened ruins, dark with bruise and blood|n",
+    ],
+}

--- a/world/medical/wounds/messages/bullet.py
+++ b/world/medical/wounds/messages/bullet.py
@@ -125,3 +125,20 @@ DESTROYED_BY_LOCATION = {
         "|RWhat remains of {their} right ear is a powder-burned ruin clinging to bone|n",
     ],
 }
+
+
+# Issue #350 / PR-C: paired destruction overlay (bullet).
+DESTROYED_BY_PAIR = {
+    "eyes": [
+        "|RBoth of {their} eyes are smoking craters, the sockets blown wide and weeping|n",
+        "|RBullets have shot both of {their} eyes to wet pulp, fragments crusted on {their} cheeks|n",
+        "|R{Their} eyes are gone, ragged exit wounds where the sockets used to be|n",
+        "|RWhere {their} eyes sat, powder-blackened craters ooze blood and matter|n",
+    ],
+    "ears": [
+        "|RBoth of {their} ears are ragged holes where cartilage used to be, the rims blown away|n",
+        "|RBullets have torn both of {their} ears off in passing, the wounds charred at the edges|n",
+        "|R{Their} ears are shredded down to stumps on both sides, the canals weeping blood|n",
+        "|RWhat remains of {their} ears are powder-burned ruins clinging to bone|n",
+    ],
+}

--- a/world/medical/wounds/messages/cut.py
+++ b/world/medical/wounds/messages/cut.py
@@ -130,3 +130,23 @@ COMPOUND_DESCRIPTIONS = {
         "{skintone}the {location} is etched by a {severity} cutting scar among {others_phrase}|n",
     ],
 }
+
+
+# Issue #350 / PR-C: paired destruction overlay keyed by pair shorthand.
+# Used when both sides of a symmetric pair have been destroyed by a
+# CUT-class wound; collapses two per-side lines into one plural line
+# that reads anatomically natural.
+DESTROYED_BY_PAIR = {
+    "eyes": [
+        "|RBoth of {their} eyes have been split open, vitreous fluid weeping down {their} cheeks|n",
+        "|R{Their} eyes are sliced through, the lids hanging in bloody flaps on both sides|n",
+        "|RA cleaving stroke has bisected both of {their} eyes, the sockets weeping in tandem|n",
+        "|RWhere {their} eyes sat, twin slashed ruins drip fluid and blood|n",
+    ],
+    "ears": [
+        "|RBoth of {their} ears hang in pieces, cartilage exposed where blades crossed|n",
+        "|R{Their} ears have been cleaved nearly off on both sides, pale cartilage gleaming through the slits|n",
+        "|RA blade has sliced both of {their} ears, the upper portions lost and the lower ones bleeding freely|n",
+        "|RWhat remains of {their} ears are sliced ribbons of skin and cartilage on both sides|n",
+    ],
+}

--- a/world/medical/wounds/messages/generic.py
+++ b/world/medical/wounds/messages/generic.py
@@ -157,3 +157,22 @@ DESTROYED_BY_LOCATION = {
         "|R{Their} right ear is a torn stump of cartilage and skin|n",
     ],
 }
+
+
+# Issue #350 / PR-C: paired destruction overlay (generic fallback).
+# Used when the per-injury-type module has no entry for this pair,
+# or as the ultimate fallback when no per-side mechanism matches.
+DESTROYED_BY_PAIR = {
+    "eyes": [
+        "|RBoth of {their} eyes are ruined sockets, the orbs destroyed beyond recognition|n",
+        "|RWhere {their} eyes sat, twin wet wounds weep fluid and blood|n",
+        "|R{Their} eyes are gone, the sockets raw on both sides|n",
+        "|RBoth of {their} eyes have been destroyed, leaving hollow ruins|n",
+    ],
+    "ears": [
+        "|RBoth of {their} ears are destroyed, only ragged wounds remaining|n",
+        "|RWhere {their} ears were, torn wounds bleed slowly on both sides|n",
+        "|R{Their} ears have been ruined, the canals exposed and weeping|n",
+        "|RBoth of {their} ears are torn stumps of cartilage and skin|n",
+    ],
+}

--- a/world/medical/wounds/messages/laceration.py
+++ b/world/medical/wounds/messages/laceration.py
@@ -131,3 +131,20 @@ DESTROYED_BY_LOCATION = {
         "|RWhat is left of {their} right ear is a torn mess of cartilage and skin tags|n",
     ],
 }
+
+
+# Issue #350 / PR-C: paired destruction overlay (laceration).
+DESTROYED_BY_PAIR = {
+    "eyes": [
+        "|RBoth of {their} eyes are jagged tears across the sockets, vitreous fluid leaking through ragged flaps|n",
+        "|RBrutal rips have shredded both of {their} eyes, the lids hanging in torn strips|n",
+        "|R{Their} eyes are torn open across their width, the orbs collapsed beneath ragged tissue|n",
+        "|RWhere {their} eyes sat, ripped wounds leak fluid down both cheeks|n",
+    ],
+    "ears": [
+        "|RBoth of {their} ears are torn into ragged strips, the cartilage visible through shredded skin|n",
+        "|RBrutal rips have torn both of {their} ears in two, the upper portions lost|n",
+        "|R{Their} ears hang in shredded ribbons of skin and cartilage on both sides|n",
+        "|RWhat is left of {their} ears are torn messes of cartilage and skin tags|n",
+    ],
+}

--- a/world/medical/wounds/messages/stab.py
+++ b/world/medical/wounds/messages/stab.py
@@ -125,3 +125,20 @@ DESTROYED_BY_LOCATION = {
         "|RWhat is left of {their} right ear surrounds a punched-through wound seeping blood|n",
     ],
 }
+
+
+# Issue #350 / PR-C: paired destruction overlay (stab).
+DESTROYED_BY_PAIR = {
+    "eyes": [
+        "|RBoth of {their} eyes are punctured ruins, fluid leaking from twin deep wounds|n",
+        "|RDriven thrusts have skewered both of {their} eyes, the sockets bleeding around the punctures|n",
+        "|R{Their} eyes are collapsed inward around deep puncture wounds on both sides|n",
+        "|RWhere {their} eyes sat, two narrow ragged holes weep fluid and dark blood|n",
+    ],
+    "ears": [
+        "|RBoth of {their} ears are punctured through, dark holes bored clean across the cartilage|n",
+        "|RThrusts have driven through both of {their} ears, leaving torn passages front to back|n",
+        "|R{Their} ears hang limp around deep stab holes on both sides|n",
+        "|RWhat is left of {their} ears surrounds punched-through wounds seeping blood|n",
+    ],
+}

--- a/world/tests/test_paired_destroyed_collapse.py
+++ b/world/tests/test_paired_destroyed_collapse.py
@@ -1,0 +1,255 @@
+"""Tests for the paired destruction collapse (issue #350 / PR-C).
+
+When both sides of a symmetric pair (eyes, ears, ...) carry destroyed
+wounds AND share an injury type, the renderer collapses the two
+per-side destruction lines into a single pluralized line keyed by the
+``DESTROYED_BY_PAIR`` overlay on the injury-type message module.
+
+Tests cover:
+
+* Each shipped injury-type module declares the overlay for eyes and
+  ears with at least 3 variants per cell.
+* ``get_paired_destroyed_description`` returns a pair line when both
+  sides destroyed by same mechanism.
+* Returns ``None`` when sides diverge (different injury types) —
+  per-side rendering takes over rather than lying about a unified
+  cause.
+* Returns ``None`` when only one side is destroyed.
+* Pronoun tokens resolve against the character's gender.
+* Generic fallback fires when the per-injury-type module has no
+  overlay for the pair key.
+* Corpse path: helper threads the preserved wound snapshot through
+  the ``wounds`` override and renders the same way.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.wounds import (
+    get_paired_destroyed_description,
+)
+from world.medical.wounds import messages
+
+
+PAIR_KEYS_WITH_OVERLAY = ("eyes", "ears")
+INJURY_TYPES_WITH_OVERLAY = (
+    "cut", "stab", "bullet", "blunt", "laceration", "generic",
+)
+
+
+def _char(gender="male", species="human"):
+    return SimpleNamespace(
+        gender=gender,
+        db=SimpleNamespace(
+            original_gender=gender,
+            species=species,
+            skintone=None,
+        ),
+    )
+
+
+def _wound(location, injury_type="cut", severity="Critical",
+           stage="destroyed", organ=None):
+    return {
+        "injury_type": injury_type,
+        "location": location,
+        "severity": severity,
+        "stage": stage,
+        "organ": organ or location,
+    }
+
+
+class OverlayDeclaredOnEveryModule(TestCase):
+
+    def test_every_module_declares_pair_overlay(self):
+        for itype in INJURY_TYPES_WITH_OVERLAY:
+            with self.subTest(itype=itype):
+                module = getattr(messages, itype)
+                overlay = getattr(module, "DESTROYED_BY_PAIR", None)
+                self.assertIsNotNone(
+                    overlay,
+                    f"{itype}.py must declare DESTROYED_BY_PAIR",
+                )
+
+    def test_every_module_covers_eyes_and_ears(self):
+        for itype in INJURY_TYPES_WITH_OVERLAY:
+            module = getattr(messages, itype)
+            overlay = module.DESTROYED_BY_PAIR
+            for pair_key in PAIR_KEYS_WITH_OVERLAY:
+                with self.subTest(itype=itype, pair_key=pair_key):
+                    self.assertIn(pair_key, overlay)
+                    self.assertGreaterEqual(
+                        len(overlay[pair_key]), 3,
+                        f"{itype}.{pair_key} needs ≥3 variants",
+                    )
+
+
+class CollapseFiresWhenBothSidesSameMechanism(TestCase):
+
+    def test_both_eyes_cut_yields_pair_line(self):
+        char = _char()
+        wounds = [
+            _wound("left_eye", injury_type="cut"),
+            _wound("right_eye", injury_type="cut"),
+        ]
+        out = get_paired_destroyed_description(
+            char, "eyes", "left_eye", "right_eye", wounds=wounds,
+        )
+        self.assertIsNotNone(out)
+        # Pair-collapsed prose uses "both" or "their eyes" — assert the
+        # line reads at plural register, not at per-side singular.
+        self.assertNotIn("left eye", out.lower())
+        self.assertNotIn("right eye", out.lower())
+        # Pronoun was resolved.
+        self.assertNotIn("{Their}", out)
+
+    def test_both_ears_blunt_yields_pair_line(self):
+        char = _char(gender="female")
+        wounds = [
+            _wound("left_ear", injury_type="blunt"),
+            _wound("right_ear", injury_type="blunt"),
+        ]
+        out = get_paired_destroyed_description(
+            char, "ears", "left_ear", "right_ear", wounds=wounds,
+        )
+        self.assertIsNotNone(out)
+        self.assertNotIn("left ear", out.lower())
+        self.assertNotIn("right ear", out.lower())
+
+
+class CollapseRejectsMismatchedMechanism(TestCase):
+
+    def test_eyes_split_mechanisms_returns_none(self):
+        # Left eye cut, right eye shot — per-side rendering wins.
+        char = _char()
+        wounds = [
+            _wound("left_eye", injury_type="cut"),
+            _wound("right_eye", injury_type="bullet"),
+        ]
+        out = get_paired_destroyed_description(
+            char, "eyes", "left_eye", "right_eye", wounds=wounds,
+        )
+        self.assertIsNone(out)
+
+    def test_one_eye_only_returns_none(self):
+        # Only left eye destroyed; right intact.
+        char = _char()
+        wounds = [_wound("left_eye", injury_type="cut")]
+        out = get_paired_destroyed_description(
+            char, "eyes", "left_eye", "right_eye", wounds=wounds,
+        )
+        self.assertIsNone(out)
+
+    def test_no_destroyed_wounds_returns_none(self):
+        char = _char()
+        wounds = [
+            _wound("left_eye", injury_type="cut", stage="fresh"),
+            _wound("right_eye", injury_type="cut", stage="fresh"),
+        ]
+        out = get_paired_destroyed_description(
+            char, "eyes", "left_eye", "right_eye", wounds=wounds,
+        )
+        self.assertIsNone(out)
+
+
+class PronounSubstitution(TestCase):
+
+    def test_male_renders_his(self):
+        char = _char(gender="male")
+        wounds = [
+            _wound("left_eye", injury_type="cut"),
+            _wound("right_eye", injury_type="cut"),
+        ]
+        out = get_paired_destroyed_description(
+            char, "eyes", "left_eye", "right_eye", wounds=wounds,
+        )
+        # "Their" → "His" (male possessive). _format_wound_grammar may
+        # capitalise at the start, so check both forms.
+        self.assertTrue("His" in out or "his" in out)
+
+    def test_female_renders_her(self):
+        char = _char(gender="female")
+        wounds = [
+            _wound("left_eye", injury_type="cut"),
+            _wound("right_eye", injury_type="cut"),
+        ]
+        out = get_paired_destroyed_description(
+            char, "eyes", "left_eye", "right_eye", wounds=wounds,
+        )
+        self.assertTrue("Her" in out or "her" in out)
+
+
+class GenericFallback(TestCase):
+    """When the per-injury-type module lacks a pair overlay for a given
+    pair key, the renderer falls through to the generic overlay."""
+
+    def test_unknown_injury_type_falls_through_to_generic(self):
+        # "harvested" module exists but has no DESTROYED_BY_PAIR.
+        # Result: collapse fires using generic prose.
+        char = _char()
+        wounds = [
+            _wound("left_eye", injury_type="harvested"),
+            _wound("right_eye", injury_type="harvested"),
+        ]
+        out = get_paired_destroyed_description(
+            char, "eyes", "left_eye", "right_eye", wounds=wounds,
+        )
+        self.assertIsNotNone(out)
+
+
+class CorpsePathUsesWoundOverride(TestCase):
+    """A corpse calls the helper with ``wounds=db.wounds_at_death`` so
+    the preserved snapshot drives the collapse without a live medical
+    state lookup."""
+
+    def test_corpse_with_preserved_destroyed_wounds(self):
+        # Simulate a corpse: same shape as a character but the wounds
+        # arrive via the explicit ``wounds`` parameter rather than
+        # ``get_character_wounds``.
+        corpse = _char(species="human")
+        snapshot = [
+            _wound("left_ear", injury_type="cut"),
+            _wound("right_ear", injury_type="cut"),
+        ]
+        out = get_paired_destroyed_description(
+            corpse, "ears", "left_ear", "right_ear", wounds=snapshot,
+        )
+        self.assertIsNotNone(out)
+        self.assertNotIn("{", out, "leaked brace in corpse pair line")
+
+
+class VariantRendering(TestCase):
+    """Every variant in every overlay cell must render without leaking
+    braces or raising."""
+
+    def test_every_variant_renders_clean(self):
+        import random
+        char = _char()
+        wounds = [
+            _wound("left_eye", injury_type="cut"),
+            _wound("right_eye", injury_type="cut"),
+        ]
+        for itype in INJURY_TYPES_WITH_OVERLAY:
+            module = getattr(messages, itype)
+            for pair_key, variants in module.DESTROYED_BY_PAIR.items():
+                left = f"left_{pair_key[:-1] if pair_key.endswith('s') else pair_key}"
+                right = f"right_{pair_key[:-1] if pair_key.endswith('s') else pair_key}"
+                for variant in variants:
+                    with self.subTest(itype=itype, pair_key=pair_key):
+                        original = random.choice
+                        random.choice = lambda seq, _v=variant: _v
+                        try:
+                            out = get_paired_destroyed_description(
+                                char, pair_key, left, right,
+                                wounds=[
+                                    _wound(left, injury_type=itype),
+                                    _wound(right, injury_type=itype),
+                                ],
+                            )
+                        finally:
+                            random.choice = original
+                        self.assertTrue(out)
+                        self.assertNotIn("{", out, f"leaked brace in {out!r}")
+                        self.assertNotIn("}", out)


### PR DESCRIPTION
## Summary

Third and final sub-PR closing #350.

### Prose overlays

Adds ``DESTROYED_BY_PAIR`` overlays to each shipped injury-type module (``cut`` / ``stab`` / ``bullet`` / ``blunt`` / ``laceration`` / ``generic``) keyed by the pair shorthand from the species pair table (``\"eyes\"``, ``\"ears\"``). 4 variants per cell, mechanism-appropriate vocabulary (chainsaw-cut eyes splitting open vs bullets cratering vs blunt impacts pulping, etc.).

### Renderer

- ``get_paired_destroyed_description(character, pair_key, left_loc, right_loc, ..., wounds=None)``:
  - Pure collapse decision: both sides destroyed AND share an injury type → render one pair line; otherwise return ``None``.
  - Mismatched mechanisms (left eye cut, right eye shot) intentionally do not collapse — per-side rendering reads more honestly.
  - ``wounds`` override lets the corpse path inject ``db.wounds_at_death`` directly, since corpses have no live medical state for ``get_character_wounds`` to read.
- ``AppearanceMixin._build_destroyed_pair_collapse`` pre-computes wound-side anchors/skips alongside the longdesc-collapse pass. The per-location render loop checks pair anchors before falling through to clothing / longdesc.
- ``Corpse._get_preserved_longdesc_descriptions`` mirrors the same pattern using the preserved wound snapshot.

### Species awareness

The pair-collapse pre-compute iterates ``get_species_pair_keys(species)`` (PR-A), so non-humans behave correctly with no renderer code change:

- Cyclops (no eye pair declared) → never enters this path; central eye destruction renders single-line.
- Insectoid compound eye → likewise single-line by definition.
- Spider with anterior/posterior eye pairs → each declared pair can collapse independently if both members destroyed by same mechanism.
- Hydra multi-head → multiple eye/ear pairs each collapse on their own when symmetric.

## End-to-end result

Pre-fix (after PR-A + PR-B):
> His left eye is split open, vitreous fluid weeping down his cheek. His right eye is a smoking crater, the socket blown wide and weeping.

Post-fix (after PR-C, both eyes cut):
> Both his eyes have been split open, vitreous fluid weeping down his cheeks.

## Test plan

- [x] ``evennia test --settings settings.py world.tests.test_paired_destroyed_collapse`` — 12/12 pass (overlay shape, collapse-fires / collapse-rejects / pronoun substitution / generic fallback / corpse override / every-variant smoke)
- [x] Full suite: ``evennia test --settings settings.py world`` — 1668/1668 pass

Closes #350.