### PR TITLE
Severed-part destroyed-organ longdesc suppression (#350 follow-up)

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1326,6 +1326,24 @@ class Appendage(Item):
         # was captured at sever time; falls back to "human" when absent.
         species = self.db.source_species or "human"
 
+        # Issue #350 follow-up: suppress the authored longdesc at any
+        # display location whose organ was destroyed at sever time.
+        # The carried wound list (``wounds_at_death``) is rewritten to
+        # ``stage="old"`` at sever overlay so a wound-list check would
+        # miss destroyed-stage entries; we read the preserved organ
+        # snapshot directly instead.  Without this, a head decapitated
+        # after an eye was pulped renders "His left eye is brown"
+        # alongside the carried eye wound (issue #350 PR-B parity).
+        try:
+            from world.medical.wounds import (
+                get_destroyed_locations_from_snapshot,
+            )
+            destroyed_locs = get_destroyed_locations_from_snapshot(
+                self.db.medical_state_at_death
+            )
+        except ImportError:
+            destroyed_locs = set()
+
         try:
             from world.combat.constants import ANATOMICAL_DISPLAY_ORDER
         except ImportError:
@@ -1366,7 +1384,11 @@ class Appendage(Item):
         def _build_location_chunk(loc):
             pieces = []
             text = longdescs.get(loc)
-            if text:
+            if text and loc not in destroyed_locs:
+                # Suppression rule mirrors the living-character /
+                # corpse paths (PR-B): a destroyed organ surfaces its
+                # destruction through the wound layer, so the authored
+                # body-part prose is dropped to avoid contradicting it.
                 pieces.append(
                     substitute_pronoun_tokens(
                         text, gender=gender, name=name, species=species,

--- a/world/medical/wounds/__init__.py
+++ b/world/medical/wounds/__init__.py
@@ -33,6 +33,7 @@ from .wound_descriptions import (
 from .longdesc_hooks import (
     append_wounds_to_longdesc,
     get_destroyed_display_locations,
+    get_destroyed_locations_from_snapshot,
     get_paired_destroyed_description,
     get_paired_severed_description,
     get_standalone_wound_description,
@@ -55,6 +56,7 @@ __all__ = [
     # Longdesc integration hooks
     'append_wounds_to_longdesc',
     'get_destroyed_display_locations',
+    'get_destroyed_locations_from_snapshot',
     'get_paired_destroyed_description',
     'get_paired_severed_description',
     'get_standalone_wound_description',

--- a/world/medical/wounds/longdesc_hooks.py
+++ b/world/medical/wounds/longdesc_hooks.py
@@ -30,6 +30,57 @@ from . import messages
 import random
 
 
+def get_destroyed_locations_from_snapshot(snapshot):
+    """Return the set of display locations with destroyed-stage organs
+    in a preserved medical-state snapshot.
+
+    Used by severed-part renderers (``Appendage.return_appearance``,
+    including ``SeveredHead``) to drive the destroyed-organ longdesc
+    suppression (issue #350 follow-up).  These items can't use
+    :func:`get_destroyed_display_locations` because their carried
+    wound list (``db.wounds_at_death``) is rewritten to
+    ``stage="old"`` at sever time — the destroyed-stage signal lives
+    only in the preserved organ snapshot.
+
+    Snapshot shape (the dict produced by
+    :meth:`world.medical.core.MedicalState.to_dict`):
+
+    .. code-block:: python
+
+        {
+            "organs": {
+                "left_eye": {
+                    "container": "head",
+                    "display_location": "left_eye",
+                    "wound_stage": "destroyed",
+                    ...
+                },
+                ...
+            },
+            ...
+        }
+
+    Falls back to ``container`` when a snapshot entry omits
+    ``display_location`` (legacy snapshots pre-#346).
+
+    Args:
+        snapshot: ``dict`` produced by ``MedicalState.to_dict``, or
+            ``None``.
+
+    Returns:
+        ``set[str]`` of display-location names.
+    """
+    organs = (snapshot or {}).get("organs") or {}
+    locs = set()
+    for data in organs.values():
+        if data.get("wound_stage") != "destroyed":
+            continue
+        loc = data.get("display_location") or data.get("container")
+        if loc:
+            locs.add(loc)
+    return locs
+
+
 def get_destroyed_display_locations(wounds):
     """Return the set of display locations with destroyed-stage wounds.
 

--- a/world/tests/test_severed_part_destroyed_suppression.py
+++ b/world/tests/test_severed_part_destroyed_suppression.py
@@ -1,0 +1,129 @@
+"""Tests for severed-part destroyed-organ longdesc suppression.
+
+Issue #350 follow-up.  PR-B suppressed authored longdescs at destroyed
+display surfaces on living characters and corpses; severed parts
+(``Appendage``, ``SeveredHead``) were deferred because their carried
+wound list (``wounds_at_death``) is rewritten to ``stage=\"old\"`` at
+sever-overlay time — the wound-list-based check used by PR-B never
+matches.
+
+The fix consults the preserved organ snapshot
+(``db.medical_state_at_death``), where the destroyed wound stage is
+preserved verbatim.  A head decapitated after an eye was destroyed
+in life now drops the authored eye longdesc instead of rendering
+\"His left eye is brown\" alongside the carried wound.
+
+Tests cover the pure helper and the integration shape on a stub
+Appendage; the live ``return_appearance`` integration is exercised
+implicitly via the full suite running the existing severed-head
+renderer tests.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.medical.wounds import get_destroyed_locations_from_snapshot
+
+
+class HelperReturnsDestroyedDisplayLocations(TestCase):
+
+    def test_empty_snapshot_returns_empty_set(self):
+        self.assertEqual(get_destroyed_locations_from_snapshot(None), set())
+        self.assertEqual(get_destroyed_locations_from_snapshot({}), set())
+
+    def test_no_organs_returns_empty_set(self):
+        self.assertEqual(
+            get_destroyed_locations_from_snapshot({"organs": {}}),
+            set(),
+        )
+
+    def test_destroyed_organ_extracted_via_display_location(self):
+        snapshot = {
+            "organs": {
+                "left_eye": {
+                    "container": "head",
+                    "display_location": "left_eye",
+                    "wound_stage": "destroyed",
+                },
+            },
+        }
+        self.assertEqual(
+            get_destroyed_locations_from_snapshot(snapshot),
+            {"left_eye"},
+        )
+
+    def test_destroyed_organ_falls_back_to_container_when_no_display(self):
+        # Legacy snapshot pre-#346 didn't carry display_location.
+        snapshot = {
+            "organs": {
+                "heart": {
+                    "container": "chest",
+                    "wound_stage": "destroyed",
+                },
+            },
+        }
+        self.assertEqual(
+            get_destroyed_locations_from_snapshot(snapshot),
+            {"chest"},
+        )
+
+    def test_non_destroyed_stages_ignored(self):
+        snapshot = {
+            "organs": {
+                "left_eye": {
+                    "container": "head",
+                    "display_location": "left_eye",
+                    "wound_stage": "severed",
+                },
+                "brain": {
+                    "container": "head",
+                    "wound_stage": "fresh",
+                },
+                "left_humerus": {
+                    "container": "left_arm",
+                    "wound_stage": None,
+                },
+            },
+        }
+        self.assertEqual(
+            get_destroyed_locations_from_snapshot(snapshot),
+            set(),
+        )
+
+    def test_mixed_organs(self):
+        snapshot = {
+            "organs": {
+                "left_eye": {
+                    "container": "head",
+                    "display_location": "left_eye",
+                    "wound_stage": "destroyed",
+                },
+                "right_eye": {
+                    "container": "head",
+                    "display_location": "right_eye",
+                    "wound_stage": "destroyed",
+                },
+                "brain": {
+                    "container": "head",
+                    "wound_stage": "fresh",
+                },
+            },
+        }
+        self.assertEqual(
+            get_destroyed_locations_from_snapshot(snapshot),
+            {"left_eye", "right_eye"},
+        )
+
+    def test_missing_location_data_skipped(self):
+        # Defensive: organ entries lacking both container and
+        # display_location produce no location to add.
+        snapshot = {
+            "organs": {
+                "weird_orphan": {"wound_stage": "destroyed"},
+            },
+        }
+        self.assertEqual(
+            get_destroyed_locations_from_snapshot(snapshot),
+            set(),
+        )


### PR DESCRIPTION
## Summary

PR-B in the #350 stack suppressed destroyed-organ longdescs on living characters and corpses via the visible wound list. Severed parts (``Appendage`` / ``SeveredHead``) were deferred because ``apply_living_sever_overlay`` rewrites the carried wound list to ``stage=\"old\"`` at sever time — the wound-list-based check never matches destroyed-stage entries on a severed item.

This consults the preserved organ snapshot (``db.medical_state_at_death``) directly, where the destroyed wound_stage is preserved verbatim:

- Adds ``get_destroyed_locations_from_snapshot(snapshot)`` in ``world/medical/wounds/longdesc_hooks.py`` — pure helper extracting display locations with ``wound_stage == \"destroyed\"`` organs from the ``MedicalState.to_dict`` shape. Falls back to ``container`` when an entry omits ``display_location`` (legacy pre-#346 snapshots).
- ``Appendage.return_appearance`` consults the helper once and drops the authored longdesc at any destroyed surface. The wound layer continues to render the carried wound at ``stage=\"old\"`` as today.

## End-to-end behavior

Pre-fix: a head decapitated after an eye was pulped:
> His left eye is brown. (carried longdesc) An old wound on the left eye. (carried wound)

Post-fix:
> An old wound on the left eye.

Brain destruction (no display_location surface) is unaffected — there's no longdesc at the head's brain to suppress. Pair-collapse on severed parts is intentionally not added: ``stage=\"old\"`` reads less dramatic per-side than the destroyed-stage prose did on living/corpse paths, and the edge case (both eyes destroyed before decap) is rare enough to defer.

## Test plan

- [x] ``evennia test --settings settings.py world.tests.test_severed_part_destroyed_suppression`` — 7/7 pass (helper edge cases: empty snapshot, missing organs, display_location vs container fallback, non-destroyed stage filtering, mixed organs, defensive missing-data)
- [x] Full suite: ``evennia test --settings settings.py world`` — 1675/1675 pass

Refs #350.