### PR TITLE
Phase 4+5: Ship rat species + authoring guide (#356)

### DIFF
--- a/specs/SPECIES_AUTHORING.md
+++ b/specs/SPECIES_AUTHORING.md
@@ -1,0 +1,133 @@
+# Species Authoring Guide
+
+How to add a new species to Gelatinous so combat, severance, medical, longdesc rendering, decay naming, and corpse / severed-part prose all behave correctly without renderer code changes.
+
+This guide is the species-onboarding playbook produced as Phase 5 of issue #356. Phases 1–4 lifted previously-global humanoid constants into the species registry. The rat (`SPECIES_DEFINITIONS["rat"]`) is the reference non-human implementation.
+
+## Where species data lives
+
+Two files hold the per-species data; everything else in the codebase consumes them via helpers:
+
+- **`world/anatomy/species.py`** — `SPECIES_DEFINITIONS[species]` declares every per-species table (organs, severability, display order, decay templates, pair keys).
+- **`world/anatomy/severed_parts.py`** — `SEVERED_PART_DESCRIPTIONS[species]` holds the prose for severed body parts at the three decay-condition tiers.
+
+Two optional secondary places:
+
+- **`world/medical/wounds/messages/*.py`** — per-injury-type wound prose. The existing tables are species-agnostic (humans share them). If a species needs distinct destruction or severance prose, declare a species-keyed overlay on each injury-type module (currently only human prose is shipped).
+- **`world/anatomy/organs.py`** — `ORGAN_DISPLAY` for organ-name display. Species-agnostic today; new species reuse the existing mammalian organ names where biologically equivalent.
+
+## Required tables in `SPECIES_DEFINITIONS[species]`
+
+Every species declaration MUST include the following keys. Missing entries fall through to the human default and the renderer will produce wrong prose — anatomically distinct species need all of them filled in.
+
+### Display
+
+| Key | Type | Notes |
+|---|---|---|
+| `display_name` | str | Short glance-tag — `"rat"`, `"cyclops"`, etc. |
+| `location_display` | dict | `body_location → "display string"`. Drives every species-routed location name in player-facing prose. |
+| `severed_chain_display` | dict | Compound names for multi-segment severance (`{"left_thigh": "left leg"}`). Used by `get_species_severed_chain_name`. |
+| `anatomical_display_order` | list | Render order (head-to-toe by convention). Drives the per-location loop in living, corpse, and severed-part renderers. |
+| `anatomical_regions` | dict | `region_name → [locations]`. Drives the paragraph-break formatter. |
+| `default_longdesc_locations` | dict | `location → None` seed map for fresh-character longdesc initialization. |
+
+### Decay
+
+| Key | Type | Notes |
+|---|---|---|
+| `decay_part_prefixes` | dict | `decay_stage → template` with `{species}` / `{part}` substitution. Drives severed-part naming. |
+| `decay_organ_prefixes` | dict | Same shape, for harvested organ names. |
+| `decay_corpse_names` | dict | Tier-to-name mapping (`fresh → "rat carcass"`, `skeletal → "skeletal remains"`). |
+| `decay_corpse_descriptions` | dict | Tier-to-prose mapping; the body paragraph rendered on `look`. |
+
+### Pair keys
+
+| Key | Type | Notes |
+|---|---|---|
+| `pair_keys` | dict | `shorthand → (left_location, right_location)`. Drives longdesc pair-collapse, side-aware singular flex (#341), and the `describe` shorthand expansion. Empty `{}` for single-instance organs (cyclops, compound eye). |
+
+### Organs
+
+| Key | Type | Notes |
+|---|---|---|
+| `organs` | dict | `organ_name → spec`. Spec keys: `container`, optional `display_location` (for sensory organs surfacing at a specific longdesc line — see #346), `max_hp`, `hit_weight`, `vital`, `capacity` / `capacities`, contribution wiring, capability flags (`can_be_harvested`, `can_be_destroyed`, `damage_always_scars`, `backup_available`, ...). Mirrors the shape `MedicalState.to_dict()["organs"][name]` produces. |
+
+### Severability
+
+| Key | Type | Notes |
+|---|---|---|
+| `severable_containers` | frozenset | Body locations that can be detached as discrete items. |
+| `severed_head_locations` | frozenset | Cluster bundled with decapitation (head, neck, face/snout, hair/fur, eyes, ears, ...). |
+| `sever_hand_by_container` | dict | `limb_container → hand_side` for wielded-weapon detachment. Empty `{}` for species that can't wield. |
+| `limb_downstream_chain` | dict | `proximal → (chain tuple including proximal)`. Severing a thigh takes the shin and foot, etc. |
+| `limb_parent` | dict | `distal → proximal`. Reverse view used by the cut-point wound filter. |
+
+## Required entries in `SEVERED_PART_DESCRIPTIONS[species]`
+
+Each severable container needs prose at three condition tiers (`pristine`, `damaged`, `putrid`). The container set must match `species["severable_containers"]` — every container the species can lose. Falls through to human entries when missing; for anatomically distinct species the human prose will read wrong (e.g., "severed left arm" prose on a rat foreleg).
+
+Example minimal declaration:
+
+```python
+SEVERED_PART_DESCRIPTIONS["rat"]["tail"] = {
+    "pristine": "A long, ringed rat tail, severed at the base and weeping a thin line of blood.",
+    "damaged":  "A dried-out rat tail, the rings gone leathery.",
+    "putrid":   "A swollen rat tail, the rings discoloured.",
+}
+```
+
+## Adding a species — step by step
+
+1. **Sketch the anatomy** outside code first: which longdesc surfaces (head/snout vs head/face? wings? extra arms? tail?), which pair structure, which severable containers, which organs.
+2. **Add the `SPECIES_DEFINITIONS[species]` entry** in `world/anatomy/species.py` filling every required table above. Copy the human entry as a starting template; rewrite as anatomy demands.
+3. **Add `SEVERED_PART_DESCRIPTIONS[species]` entries** in `world/anatomy/severed_parts.py` for every severable container × condition tier (severable_containers × 3 entries).
+4. **Write a `world/tests/test_<species>_species.py` test module** patterned on `test_rat_species.py`. Cover: registry shape, distinct organ set vs human, distinct severability tables, distinct display order, distinct pair keys, end-to-end `MedicalState` construction producing species-shaped organs.
+5. **Run the full suite** — `evennia test --settings settings.py world` — and confirm no human regressions. The species architecture should mean no humans see any difference.
+6. **Smoke-test in game** — spawn the species, `look` at one, kill it, `look` at the corpse, sever a limb / tail / head, look at the appendage. Every string should read as the species; check for any leaked "human" / "left arm" / "thigh" vocabulary.
+
+## Consumer pattern
+
+When writing code that branches on anatomy, never read the global constants in `world/combat/constants.py` if the call site has a character / corpse / appendage context. Use the species-keyed helpers:
+
+```python
+from world.anatomy import (
+    get_organ_spec,
+    get_species_anatomical_display_order,
+    get_species_anatomical_regions,
+    get_species_default_longdesc_locations,
+    get_species_limb_downstream_chain,
+    get_species_limb_parent,
+    get_species_organs,
+    get_species_pair_keys,
+    get_species_severable_containers,
+    get_species_sever_hand_by_container,
+    get_species_severed_head_locations,
+)
+```
+
+Each helper takes a species identifier and falls back to human on `None` / unknown so test stubs and species-less call sites keep working. The global constants in `world/combat/constants.py` (`PAIR_MERGE_KEYS`, `ORGANS`, `SEVERABLE_CONTAINERS`, etc.) remain importable as **derived aliases of the human entry** — keep using them at call sites that don't have a species context (admin commands, mob-flavor generators, tests that always operate on humans).
+
+## What `Phases 1–4` migrated
+
+For reference, the consumers updated to be species-aware during the rollout:
+
+- `MedicalState._initialize_default_organs`, `MedicalState.get_organ`, `Organ.__init__`
+- `ArmorMixin._maybe_sever_from_damage` (severable set)
+- `apply_sever_to_character`, `Appendage.configure_from_sever`, `Appendage.configure_from_living_sever` (downstream chain)
+- `apply_sever_to_corpse`, `apply_severed_head_overlay`, `apply_severed_head_overlay_from_living`, `spawn_severed_head_for_living`, `SeveredHead.configure_from_sever`, `SeveredHead.configure_from_living_decap` (head cluster)
+- `detach_items_to_appendage` (hand-side map)
+- `get_character_wounds` (limb-parent map, cut-point filter)
+- `AppearanceMixin.get_longdesc_appearance`, `_build_paired_longdesc_collapse`, `_flex_noun_vocabulary`, `_substitute_longdesc_tokens` (display order, pair keys)
+- `Corpse._get_preserved_longdesc_descriptions`, `_process_corpse_description_variables`, `_build_decay_desc_paragraph` (display order, pair keys, decay templates)
+- `Appendage.return_appearance` (display order, pair keys)
+- `Character.at_object_creation` (default longdesc surfaces)
+
+If you add a new consumer that reads a global anatomy constant, ask whether it should be species-aware — and if so, migrate it via the matching helper.
+
+## Open follow-ups (not yet species-keyed)
+
+- `LONGDESC_FLEX_NOUNS` (vocabulary of body-noun singulars that flex as nouns vs verbs). Currently human-anchored; defer until a species has different flex vocabulary.
+- `ORGAN_DISPLAY` (organ display names). Currently shared; a future species with biologically distinct organs would need its own table.
+- `BODY_CAPACITIES` (capacity-to-organ wiring). Species use the same capacities (sight, hearing, breathing, etc.) today; if a species has fundamentally different vital systems, this'll need species-keying.
+
+These can be lifted incrementally as the species roster grows. The pattern is identical: add to `SPECIES_DEFINITIONS[species]`, write a `get_species_*` helper, derive the legacy global from the human entry.

--- a/world/anatomy/severed_parts.py
+++ b/world/anatomy/severed_parts.py
@@ -203,6 +203,151 @@ SEVERED_PART_DESCRIPTIONS = {
 }
 
 
+SEVERED_PART_DESCRIPTIONS.setdefault("rat", {
+    "head": {
+        "pristine": (
+            "A severed rat's head, the snout still twitching as if "
+            "ready to sniff and the cut at the neck weeping fresh "
+            "blood."
+        ),
+        "damaged": (
+            "A discoloured rat's head, the fur matted and the neck "
+            "stump dried into a dark, leathery crust."
+        ),
+        "putrid": (
+            "A bloated rat's head, the features distorted and the "
+            "fur sliding off in soft, fetid patches."
+        ),
+    },
+    "left_foreleg": {
+        "pristine": (
+            "A small severed foreleg, the fur still soft and the "
+            "shoulder-cut weeping thin blood."
+        ),
+        "damaged": (
+            "A withered severed foreleg, the fur sparse and the "
+            "stump dark with dried matter."
+        ),
+        "putrid": (
+            "A bloated severed foreleg, the flesh going soft and the "
+            "fur sloughing in fetid clumps."
+        ),
+    },
+    "right_foreleg": {
+        "pristine": (
+            "A small severed foreleg, the fur still soft and the "
+            "shoulder-cut weeping thin blood."
+        ),
+        "damaged": (
+            "A withered severed foreleg, the fur sparse and the "
+            "stump dark with dried matter."
+        ),
+        "putrid": (
+            "A bloated severed foreleg, the flesh going soft and the "
+            "fur sloughing in fetid clumps."
+        ),
+    },
+    "left_forepaw": {
+        "pristine": (
+            "A tiny severed forepaw, the claws still neatly arranged "
+            "and the cut at the wrist edged with blood."
+        ),
+        "damaged": (
+            "A shrivelled severed forepaw, the claws curled inward "
+            "and the stump dried hard."
+        ),
+        "putrid": (
+            "A swollen severed forepaw, the small pads loose and the "
+            "claws coming free of the rotting flesh."
+        ),
+    },
+    "right_forepaw": {
+        "pristine": (
+            "A tiny severed forepaw, the claws still neatly arranged "
+            "and the cut at the wrist edged with blood."
+        ),
+        "damaged": (
+            "A shrivelled severed forepaw, the claws curled inward "
+            "and the stump dried hard."
+        ),
+        "putrid": (
+            "A swollen severed forepaw, the small pads loose and the "
+            "claws coming free of the rotting flesh."
+        ),
+    },
+    "left_hindleg": {
+        "pristine": (
+            "A small severed hindleg, the long thigh muscle still "
+            "twitching and the hip-cut weeping fresh blood."
+        ),
+        "damaged": (
+            "A withered severed hindleg, the muscle gone slack and "
+            "the cut dried dark."
+        ),
+        "putrid": (
+            "A bloated severed hindleg, the flesh going soft and "
+            "fetid where the cut once was."
+        ),
+    },
+    "right_hindleg": {
+        "pristine": (
+            "A small severed hindleg, the long thigh muscle still "
+            "twitching and the hip-cut weeping fresh blood."
+        ),
+        "damaged": (
+            "A withered severed hindleg, the muscle gone slack and "
+            "the cut dried dark."
+        ),
+        "putrid": (
+            "A bloated severed hindleg, the flesh going soft and "
+            "fetid where the cut once was."
+        ),
+    },
+    "left_hindpaw": {
+        "pristine": (
+            "A tiny severed hindpaw, the long toes still spread and "
+            "the cut at the ankle weeping."
+        ),
+        "damaged": (
+            "A shrivelled severed hindpaw, the toes curled inward "
+            "and the stump dried hard."
+        ),
+        "putrid": (
+            "A swollen severed hindpaw, the small pads loose and the "
+            "claws coming free of the rotting flesh."
+        ),
+    },
+    "right_hindpaw": {
+        "pristine": (
+            "A tiny severed hindpaw, the long toes still spread and "
+            "the cut at the ankle weeping."
+        ),
+        "damaged": (
+            "A shrivelled severed hindpaw, the toes curled inward "
+            "and the stump dried hard."
+        ),
+        "putrid": (
+            "A swollen severed hindpaw, the small pads loose and the "
+            "claws coming free of the rotting flesh."
+        ),
+    },
+    "tail": {
+        "pristine": (
+            "A long, ringed rat tail, severed at the base and "
+            "weeping a thin line of blood from the cut."
+        ),
+        "damaged": (
+            "A dried-out rat tail, the rings gone leathery and the "
+            "base-cut crusted hard."
+        ),
+        "putrid": (
+            "A swollen rat tail, the rings discoloured and the "
+            "flesh sloughing softly off the vertebrae."
+        ),
+    },
+})
+
+
 def get_severed_part_description(species, location, condition):
     """Return condition-keyed prose for a severed body part.
 

--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -502,6 +502,323 @@ SPECIES_DEFINITIONS = {
             ),
         },
     },
+
+    # =================================================================
+    # RAT — first non-human species (issue #356 Phase 4).
+    # =================================================================
+    #
+    # Quadrupedal anatomy: fore/hindlimb pairs instead of arms/legs, a
+    # tail as an extra severable container, and snout/fur in place of
+    # face/hair on the head cluster.  Internal organs collapse to the
+    # same mammalian set as human (brain, heart, lungs, liver) since
+    # the physiology is shared — only the skeletal organs and HP
+    # values diverge.  Cannot wield items (no hand-side map), so
+    # severance never pulls a weapon onto a detached forepaw.
+    "rat": {
+        "display_name": "rat",
+
+        "location_display": {
+            "head": "head",
+            "snout": "snout",
+            "neck": "neck",
+            "fur": "fur",
+            "chest": "chest",
+            "abdomen": "abdomen",
+            "back": "back",
+            "groin": "groin",
+            "left_foreleg":  "left foreleg",
+            "right_foreleg": "right foreleg",
+            "left_forepaw":  "left forepaw",
+            "right_forepaw": "right forepaw",
+            "left_hindleg":  "left hindleg",
+            "right_hindleg": "right hindleg",
+            "left_hindpaw":  "left hindpaw",
+            "right_hindpaw": "right hindpaw",
+            "tail": "tail",
+            "left_eye":  "left eye",
+            "right_eye": "right eye",
+            "left_ear":  "left ear",
+            "right_ear": "right ear",
+        },
+
+        "severed_chain_display": {
+            "left_foreleg":  "left foreleg",
+            "right_foreleg": "right foreleg",
+            "left_forepaw":  "left forepaw",
+            "right_forepaw": "right forepaw",
+            "left_hindleg":  "left hindleg",
+            "right_hindleg": "right hindleg",
+            "left_hindpaw":  "left hindpaw",
+            "right_hindpaw": "right hindpaw",
+            "tail":          "tail",
+        },
+
+        "decay_part_prefixes": {
+            "fresh":    "{species} {part}",
+            "early":    "{species} {part}",
+            "moderate": "rotting {part}",
+            "advanced": "rotting {part}",
+            "skeletal": "skeletal {part}",
+        },
+        "decay_organ_prefixes": {
+            "fresh":    "{species} {organ}",
+            "early":    "{species} {organ}",
+            "moderate": "rotting {organ}",
+            "advanced": "rotting {organ}",
+            "skeletal": "desiccated {organ}",
+        },
+        "decay_corpse_names": {
+            "fresh":    "rat carcass",
+            "early":    "rat carcass",
+            "moderate": "rotting carcass",
+            "advanced": "rotting carcass",
+            "skeletal": "skeletal remains",
+        },
+        "decay_corpse_descriptions": {
+            "fresh": (
+                "A small {species} body, recently dead. {base_desc} "
+                "The fur is still in place and the body shows no signs "
+                "of decomposition yet."
+            ),
+            "early": (
+                "A small {species} carcass. {base_desc} The fur has "
+                "begun to mat and the small body has gone stiff."
+            ),
+            "moderate": (
+                "Decomposing small mammalian remains. The fur is "
+                "matted and falling away in patches, with a sharp odor "
+                "of rot rising from the bloated body."
+            ),
+            "advanced": (
+                "Putrid small mammalian remains. Most of the soft "
+                "tissue has liquefied; the skeleton is visible through "
+                "what is left of the fur."
+            ),
+            "skeletal": (
+                "Skeletal {species} remains. Tiny bones and the long, "
+                "ringed sweep of the tail are all that is left."
+            ),
+        },
+
+        "pair_keys": {
+            "eyes":      ("left_eye",      "right_eye"),
+            "ears":      ("left_ear",      "right_ear"),
+            "forelegs":  ("left_foreleg",  "right_foreleg"),
+            "forepaws":  ("left_forepaw",  "right_forepaw"),
+            "hindlegs":  ("left_hindleg",  "right_hindleg"),
+            "hindpaws":  ("left_hindpaw",  "right_hindpaw"),
+        },
+
+        # Rat organs — shared mammalian internals (brain, heart, etc.)
+        # plus rat-specific skeletal organs at fore/hindlimb / tail
+        # containers.  HP values scaled down for a small body.
+        "organs": {
+            # Head
+            "brain":     {"container": "head", "max_hp": 5, "hit_weight": "very_rare",
+                          "vital": True, "capacity": "consciousness",
+                          "contribution": "total"},
+            "left_eye":  {"container": "head", "display_location": "left_eye",
+                          "max_hp": 4, "hit_weight": "rare",
+                          "capacity": "sight", "contribution": "major",
+                          "disfiguring_if_lost": True},
+            "right_eye": {"container": "head", "display_location": "right_eye",
+                          "max_hp": 4, "hit_weight": "rare",
+                          "capacity": "sight", "contribution": "major",
+                          "disfiguring_if_lost": True},
+            "left_ear":  {"container": "head", "display_location": "left_ear",
+                          "max_hp": 5, "hit_weight": "rare",
+                          "capacity": "hearing", "contribution": "major",
+                          "disfiguring_if_lost": True},
+            "right_ear": {"container": "head", "display_location": "right_ear",
+                          "max_hp": 5, "hit_weight": "rare",
+                          "capacity": "hearing", "contribution": "major",
+                          "disfiguring_if_lost": True},
+            "jaw":       {"container": "head", "max_hp": 5, "hit_weight": "rare",
+                          "capacities": ["eating"],
+                          "eating_contribution": "major"},
+
+            # Neck
+            "cervical_spine": {"container": "neck", "max_hp": 5,
+                               "hit_weight": "rare", "vital": True,
+                               "capacity": "neck_integrity",
+                               "contribution": "total",
+                               "can_be_destroyed": True},
+
+            # Chest / abdomen / back / groin — mammalian universals
+            "heart":         {"container": "chest", "max_hp": 6,
+                              "hit_weight": "uncommon", "vital": True,
+                              "capacity": "blood_pumping", "contribution": "total"},
+            "left_lung":     {"container": "chest", "max_hp": 8,
+                              "hit_weight": "uncommon", "capacity": "breathing",
+                              "contribution": "major", "backup_available": True},
+            "right_lung":    {"container": "chest", "max_hp": 8,
+                              "hit_weight": "uncommon", "capacity": "breathing",
+                              "contribution": "major", "backup_available": True},
+            "liver":         {"container": "abdomen", "max_hp": 8,
+                              "hit_weight": "uncommon", "vital": True,
+                              "capacity": "digestion", "contribution": "total"},
+            "left_kidney":   {"container": "abdomen", "max_hp": 5,
+                              "hit_weight": "uncommon",
+                              "capacity": "blood_filtration",
+                              "contribution": "major",
+                              "backup_available": True},
+            "right_kidney":  {"container": "abdomen", "max_hp": 5,
+                              "hit_weight": "uncommon",
+                              "capacity": "blood_filtration",
+                              "contribution": "major",
+                              "backup_available": True},
+            "stomach":       {"container": "abdomen", "max_hp": 8,
+                              "hit_weight": "uncommon",
+                              "capacity": "digestion",
+                              "contribution": "moderate"},
+            "thoracolumbar_spine": {"container": "back", "max_hp": 10,
+                                    "hit_weight": "uncommon",
+                                    "capacity": "moving", "contribution": "total",
+                                    "cannot_be_destroyed": True,
+                                    "paralysis_if_destroyed": True},
+            "pelvis":        {"container": "groin", "max_hp": 10,
+                              "hit_weight": "uncommon",
+                              "capacity": "moving", "contribution": "total",
+                              "vital": True},
+
+            # Foreleg skeletal organs (analogous to humerus / metacarpals)
+            "left_foreleg_bone":   {"container": "left_foreleg", "max_hp": 10,
+                                    "hit_weight": "common",
+                                    "capacity": "manipulation",
+                                    "contribution": "major",
+                                    "can_be_destroyed": True,
+                                    "fracture_vulnerable": True,
+                                    "bone_type": "long_bone"},
+            "right_foreleg_bone":  {"container": "right_foreleg", "max_hp": 10,
+                                    "hit_weight": "common",
+                                    "capacity": "manipulation",
+                                    "contribution": "major",
+                                    "can_be_destroyed": True,
+                                    "fracture_vulnerable": True,
+                                    "bone_type": "long_bone"},
+            "left_forepaw_bones":  {"container": "left_forepaw", "max_hp": 6,
+                                    "hit_weight": "uncommon",
+                                    "capacity": "manipulation",
+                                    "contribution": "moderate",
+                                    "can_be_destroyed": True,
+                                    "bone_type": "small_bones"},
+            "right_forepaw_bones": {"container": "right_forepaw", "max_hp": 6,
+                                    "hit_weight": "uncommon",
+                                    "capacity": "manipulation",
+                                    "contribution": "moderate",
+                                    "can_be_destroyed": True,
+                                    "bone_type": "small_bones"},
+
+            # Hindleg skeletal organs
+            "left_hindleg_bone":   {"container": "left_hindleg", "max_hp": 12,
+                                    "hit_weight": "common",
+                                    "capacity": "moving",
+                                    "contribution": "major",
+                                    "can_be_destroyed": True,
+                                    "fracture_vulnerable": True,
+                                    "bone_type": "long_bone"},
+            "right_hindleg_bone":  {"container": "right_hindleg", "max_hp": 12,
+                                    "hit_weight": "common",
+                                    "capacity": "moving",
+                                    "contribution": "major",
+                                    "can_be_destroyed": True,
+                                    "fracture_vulnerable": True,
+                                    "bone_type": "long_bone"},
+            "left_hindpaw_bones":  {"container": "left_hindpaw", "max_hp": 8,
+                                    "hit_weight": "uncommon",
+                                    "capacity": "moving",
+                                    "contribution": "minor",
+                                    "can_be_destroyed": True,
+                                    "bone_type": "small_bones"},
+            "right_hindpaw_bones": {"container": "right_hindpaw", "max_hp": 8,
+                                    "hit_weight": "uncommon",
+                                    "capacity": "moving",
+                                    "contribution": "minor",
+                                    "can_be_destroyed": True,
+                                    "bone_type": "small_bones"},
+
+            # Tail — rat-unique
+            "tail_vertebrae": {"container": "tail", "max_hp": 6,
+                               "hit_weight": "uncommon",
+                               "can_be_destroyed": True,
+                               "bone_type": "long_bone"},
+        },
+
+        # Severability — rat can lose any limb or the tail; head
+        # severance handled like human.
+        "severable_containers": frozenset({
+            "head",
+            "left_foreleg", "right_foreleg",
+            "left_forepaw", "right_forepaw",
+            "left_hindleg", "right_hindleg",
+            "left_hindpaw", "right_hindpaw",
+            "tail",
+        }),
+        "severed_head_locations": frozenset({
+            "fur", "head", "snout", "neck",
+            "left_eye", "right_eye",
+            "left_ear", "right_ear",
+        }),
+        # Rats can't wield items.
+        "sever_hand_by_container": {},
+        # Two-segment limbs: foreleg+forepaw, hindleg+hindpaw.  No
+        # three-segment thigh→shin→foot chain.
+        "limb_downstream_chain": {
+            "left_foreleg":  ("left_foreleg",  "left_forepaw"),
+            "right_foreleg": ("right_foreleg", "right_forepaw"),
+            "left_forepaw":  ("left_forepaw",),
+            "right_forepaw": ("right_forepaw",),
+            "left_hindleg":  ("left_hindleg",  "left_hindpaw"),
+            "right_hindleg": ("right_hindleg", "right_hindpaw"),
+            "left_hindpaw":  ("left_hindpaw",),
+            "right_hindpaw": ("right_hindpaw",),
+            "tail":          ("tail",),
+        },
+        "limb_parent": {
+            "left_forepaw":  "left_foreleg",
+            "right_forepaw": "right_foreleg",
+            "left_hindpaw":  "left_hindleg",
+            "right_hindpaw": "right_hindleg",
+        },
+
+        # Render order: head-cluster, torso, forelegs, hindlegs, tail.
+        "anatomical_display_order": [
+            "fur",
+            "left_eye", "right_eye",
+            "head", "snout",
+            "left_ear", "right_ear",
+            "neck",
+            "chest", "back", "abdomen", "groin",
+            "left_foreleg", "right_foreleg",
+            "left_forepaw", "right_forepaw",
+            "left_hindleg", "right_hindleg",
+            "left_hindpaw", "right_hindpaw",
+            "tail",
+        ],
+        "anatomical_regions": {
+            "head_region": ["fur", "left_eye", "right_eye", "head", "snout",
+                            "left_ear", "right_ear", "neck"],
+            "torso_region": ["chest", "back", "abdomen", "groin"],
+            "foreleg_region": ["left_foreleg", "right_foreleg",
+                               "left_forepaw", "right_forepaw"],
+            "hindleg_region": ["left_hindleg", "right_hindleg",
+                               "left_hindpaw", "right_hindpaw"],
+            "tail_region": ["tail"],
+        },
+        "default_longdesc_locations": {
+            "fur": None,
+            "left_eye": None, "right_eye": None,
+            "head": None, "snout": None,
+            "left_ear": None, "right_ear": None,
+            "neck": None,
+            "chest": None, "back": None, "abdomen": None, "groin": None,
+            "left_foreleg": None, "right_foreleg": None,
+            "left_forepaw": None, "right_forepaw": None,
+            "left_hindleg": None, "right_hindleg": None,
+            "left_hindpaw": None, "right_hindpaw": None,
+            "tail": None,
+        },
+    },
 }
 
 

--- a/world/tests/test_rat_species.py
+++ b/world/tests/test_rat_species.py
@@ -1,0 +1,279 @@
+"""Tests for the rat species (issue #356 Phase 4).
+
+End-to-end check that the rat species data is wired correctly across
+every species-aware helper.  Phases 1-3 made the architecture species-
+keyed; this PR ships the actual rat data plus severed-part prose.
+
+Coverage:
+
+* Rat declares every required species table (organs, severability,
+  display, decay, severed-part prose).
+* Each species helper returns rat-specific data, not human-defaults.
+* A MedicalState constructed for a rat character has rat organs and
+  no humanoid organs.
+* Severance helpers route through rat anatomy: severing a foreleg
+  takes the forepaw via the chain; tail is severable and stands
+  alone; head cluster uses snout/fur.
+* Rat severed-part prose is wired across all rat severable locations.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.anatomy import (
+    get_organ_spec,
+    get_severed_part_description,
+    get_species_anatomical_display_order,
+    get_species_anatomical_regions,
+    get_species_corpse_description,
+    get_species_corpse_name,
+    get_species_default_longdesc_locations,
+    get_species_limb_downstream_chain,
+    get_species_limb_parent,
+    get_species_organs,
+    get_species_pair_keys,
+    get_species_part_name,
+    get_species_severable_containers,
+    get_species_sever_hand_by_container,
+    get_species_severed_head_locations,
+)
+from world.anatomy.species import SPECIES_DEFINITIONS
+from world.medical.core import MedicalState
+
+
+class RatSpeciesDeclared(TestCase):
+
+    def test_rat_in_registry(self):
+        self.assertIn("rat", SPECIES_DEFINITIONS)
+
+    def test_rat_has_all_required_tables(self):
+        rat = SPECIES_DEFINITIONS["rat"]
+        for field in (
+            "display_name", "location_display", "severed_chain_display",
+            "decay_part_prefixes", "decay_organ_prefixes",
+            "decay_corpse_names", "decay_corpse_descriptions",
+            "pair_keys", "organs",
+            "severable_containers", "severed_head_locations",
+            "sever_hand_by_container", "limb_downstream_chain",
+            "limb_parent",
+            "anatomical_display_order", "anatomical_regions",
+            "default_longdesc_locations",
+        ):
+            with self.subTest(field=field):
+                self.assertIn(field, rat)
+
+
+class RatOrgansDistinctFromHuman(TestCase):
+
+    def test_rat_organs_includes_tail_vertebrae(self):
+        organs = get_species_organs("rat")
+        self.assertIn("tail_vertebrae", organs)
+        self.assertEqual(organs["tail_vertebrae"]["container"], "tail")
+
+    def test_rat_organs_use_foreleg_hindleg_containers(self):
+        organs = get_species_organs("rat")
+        # Rat-specific skeletal organs.
+        self.assertIn("left_foreleg_bone", organs)
+        self.assertEqual(
+            organs["left_foreleg_bone"]["container"], "left_foreleg",
+        )
+        self.assertIn("left_hindleg_bone", organs)
+
+    def test_rat_does_not_inherit_humanoid_arm_leg_bones(self):
+        organs = get_species_organs("rat")
+        self.assertNotIn("left_humerus", organs)
+        self.assertNotIn("left_femur", organs)
+        self.assertNotIn("left_tibia", organs)
+        self.assertNotIn("left_metatarsals", organs)
+
+    def test_shared_mammalian_organs_present(self):
+        # Brain, heart, lungs, liver, etc. are the same identifier
+        # across species (mammalian universals).
+        organs = get_species_organs("rat")
+        for name in ("brain", "heart", "left_lung", "liver",
+                     "left_kidney", "stomach", "cervical_spine"):
+            with self.subTest(name=name):
+                self.assertIn(name, organs)
+
+    def test_organ_spec_routes_to_species(self):
+        # left_foreleg_bone is a rat-only organ; human lookup
+        # returns empty.
+        self.assertEqual(get_organ_spec("left_foreleg_bone", "human"), {})
+        rat_spec = get_organ_spec("left_foreleg_bone", "rat")
+        self.assertEqual(rat_spec["container"], "left_foreleg")
+
+
+class RatSeverabilityDistinct(TestCase):
+
+    def test_severable_includes_tail(self):
+        self.assertIn("tail", get_species_severable_containers("rat"))
+
+    def test_severable_excludes_human_arm_thigh(self):
+        containers = get_species_severable_containers("rat")
+        for human_only in ("left_arm", "left_hand",
+                           "left_thigh", "left_shin", "left_foot"):
+            with self.subTest(loc=human_only):
+                self.assertNotIn(human_only, containers)
+
+    def test_head_cluster_uses_snout_and_fur(self):
+        cluster = get_species_severed_head_locations("rat")
+        self.assertIn("snout", cluster)
+        self.assertIn("fur", cluster)
+        self.assertNotIn("face", cluster)
+        self.assertNotIn("hair", cluster)
+
+    def test_rats_dont_wield(self):
+        self.assertEqual(get_species_sever_hand_by_container("rat"), {})
+
+    def test_foreleg_chain_takes_forepaw(self):
+        chain = get_species_limb_downstream_chain("rat")
+        self.assertEqual(
+            chain["left_foreleg"], ("left_foreleg", "left_forepaw"),
+        )
+
+    def test_tail_chain_is_single_segment(self):
+        chain = get_species_limb_downstream_chain("rat")
+        self.assertEqual(chain["tail"], ("tail",))
+
+    def test_no_three_segment_chain(self):
+        chain = get_species_limb_downstream_chain("rat")
+        for tup in chain.values():
+            self.assertLessEqual(
+                len(tup), 2,
+                f"rat chain should not exceed two segments: {tup}",
+            )
+
+    def test_limb_parent_maps_paws_to_legs(self):
+        parents = get_species_limb_parent("rat")
+        self.assertEqual(parents["left_forepaw"], "left_foreleg")
+        self.assertEqual(parents["left_hindpaw"], "left_hindleg")
+
+
+class RatDisplayDistinct(TestCase):
+
+    def test_display_order_ends_with_tail(self):
+        order = get_species_anatomical_display_order("rat")
+        self.assertEqual(order[-1], "tail")
+
+    def test_display_order_uses_snout_not_face(self):
+        order = get_species_anatomical_display_order("rat")
+        self.assertIn("snout", order)
+        self.assertNotIn("face", order)
+
+    def test_regions_have_foreleg_hindleg_tail(self):
+        regions = get_species_anatomical_regions("rat")
+        self.assertIn("foreleg_region", regions)
+        self.assertIn("hindleg_region", regions)
+        self.assertIn("tail_region", regions)
+        self.assertNotIn("arm_region", regions)
+
+    def test_default_longdesc_has_tail(self):
+        defaults = get_species_default_longdesc_locations("rat")
+        self.assertIn("tail", defaults)
+        self.assertIn("snout", defaults)
+        self.assertNotIn("left_arm", defaults)
+
+
+class RatPairKeysDistinct(TestCase):
+
+    def test_pair_keys_use_foreleg_hindleg(self):
+        pairs = get_species_pair_keys("rat")
+        self.assertIn("forelegs", pairs)
+        self.assertIn("hindlegs", pairs)
+        self.assertEqual(
+            pairs["forelegs"], ("left_foreleg", "right_foreleg"),
+        )
+
+    def test_pair_keys_exclude_arms_thighs(self):
+        pairs = get_species_pair_keys("rat")
+        self.assertNotIn("arms", pairs)
+        self.assertNotIn("thighs", pairs)
+
+
+class RatDecayNaming(TestCase):
+
+    def test_corpse_name_says_carcass(self):
+        # Rats die into a "carcass", not a "corpse".
+        self.assertEqual(
+            get_species_corpse_name("rat", "fresh"), "rat carcass",
+        )
+
+    def test_corpse_description_mentions_fur(self):
+        out = get_species_corpse_description("rat", "fresh", "A small body.")
+        self.assertIn("fur", out.lower())
+
+    def test_severed_part_name_uses_rat_prefix(self):
+        # Fresh severed rat foreleg reads as "rat left foreleg".
+        out = get_species_part_name("rat", "left_foreleg", "fresh")
+        self.assertEqual(out, "rat left foreleg")
+
+
+class RatSeveredPartProse(TestCase):
+
+    def test_all_rat_severable_locations_have_prose(self):
+        # Every rat severable container should have severed-part
+        # prose at all three condition tiers.  Falls through to human
+        # is wrong here — rat-specific entries should exist.
+        from world.anatomy import get_species_severable_containers
+        rat_severable = get_species_severable_containers("rat")
+        # Sever-into-Appendage targets the cut point; for the head
+        # bundle, that's "head" itself, so the relevant location set
+        # equals the severable containers.
+        for loc in rat_severable:
+            for condition in ("pristine", "damaged", "putrid"):
+                with self.subTest(loc=loc, condition=condition):
+                    out = get_severed_part_description("rat", loc, condition)
+                    self.assertTrue(
+                        out, f"missing rat prose at {loc}/{condition}",
+                    )
+
+    def test_rat_head_prose_mentions_snout(self):
+        out = get_severed_part_description("rat", "head", "pristine")
+        self.assertIn("snout", out.lower())
+
+    def test_rat_tail_prose_mentions_rings(self):
+        out = get_severed_part_description("rat", "tail", "pristine")
+        self.assertIn("ring", out.lower())
+
+
+# ---------------------------------------------------------------------
+# End-to-end: a rat character's medical state
+# ---------------------------------------------------------------------
+
+
+class _RatCharacter:
+    """Minimal rat-character stub for MedicalState init."""
+
+    def __init__(self):
+        self.db = SimpleNamespace(species="rat")
+
+
+class MedicalStateForRat(TestCase):
+
+    def test_rat_medical_state_has_rat_organs(self):
+        rat = _RatCharacter()
+        state = MedicalState(character=rat)
+        for must in ("brain", "heart", "tail_vertebrae",
+                     "left_foreleg_bone", "left_hindleg_bone"):
+            with self.subTest(must=must):
+                self.assertIn(must, state.organs)
+
+    def test_rat_medical_state_has_no_humanoid_organs(self):
+        rat = _RatCharacter()
+        state = MedicalState(character=rat)
+        for must_not in ("left_humerus", "left_femur", "left_tibia",
+                         "left_metacarpals", "left_metatarsals"):
+            with self.subTest(must_not=must_not):
+                self.assertNotIn(must_not, state.organs)
+
+    def test_rat_organs_routes_to_rat_containers(self):
+        rat = _RatCharacter()
+        state = MedicalState(character=rat)
+        self.assertEqual(
+            state.organs["left_foreleg_bone"].container, "left_foreleg",
+        )
+        self.assertEqual(
+            state.organs["tail_vertebrae"].container, "tail",
+        )


### PR DESCRIPTION
## Summary

Closes the #356 stack with the actual rat species data + onboarding documentation.

### Rat species (Phase 4)

Anatomically distinct from humans:

- Quadrupedal — fore/hindlegs + fore/hindpaws instead of arms/hands + thighs/shins/feet
- New severable container: ``tail``
- ``snout`` / ``fur`` on the head cluster in place of ``face`` / ``hair``
- Two-segment limb chains (no three-segment thigh→shin→foot)
- Can't wield items (empty ``sever_hand_by_container``)
- Shared mammalian internal organs with scaled-down HP

Adds rat-flavored severed-part prose at all three condition tiers for every rat severable container, and rat decay naming (``"rat carcass"`` instead of ``"rat corpse"``).

### Authoring guide (Phase 5)

``specs/SPECIES_AUTHORING.md`` covers:

- Where species data lives
- Every required table in ``SPECIES_DEFINITIONS[species]`` with notes on what each drives
- Six-step playbook for adding a species
- Consumer pattern for species-aware code
- List of migrated consumers from Phases 1-3 for reference
- Open follow-ups not yet species-keyed (``LONGDESC_FLEX_NOUNS``, ``ORGAN_DISPLAY``, ``BODY_CAPACITIES``)

## Test plan

- [x] ``evennia test --settings settings.py world.tests.test_rat_species`` — 30/30 pass
- [x] Full suite: 1745/1745 pass

Closes #356.