### PR TITLE
Species-key CmdArmor + cleanup dead anatomy imports

### DIFF
--- a/commands/CmdArmor.py
+++ b/commands/CmdArmor.py
@@ -11,7 +11,6 @@ from world.combat.constants import (
     COLOR_SUCCESS,
     COLOR_NORMAL,
     COVERAGE_INHERITANCE,
-    ANATOMICAL_DISPLAY_ORDER,
     ARMOR_EFFECTIVENESS_MATRIX,
 )
 from world.identity_utils import msg_room_identity
@@ -268,15 +267,20 @@ class CmdArmor(Command):
         # Build coverage map - stores list of armor pieces per location
         coverage_map = {}
 
-        # Get all possible body locations from character
+        # Get all possible body locations from character — species-
+        # aware per #356 follow-up so non-human anatomies (rats with
+        # forelegs/hindlegs/tail, etc.) iterate their own location set
+        # instead of the humanoid default.
+        from world.anatomy import get_species_anatomical_display_order
+        species_order = get_species_anatomical_display_order(
+            getattr(caller.db, "species", None)
+        )
         if caller.longdesc:
             all_locations = [
-                loc
-                for loc in ANATOMICAL_DISPLAY_ORDER
-                if loc in caller.longdesc
+                loc for loc in species_order if loc in caller.longdesc
             ]
         else:
-            all_locations = ANATOMICAL_DISPLAY_ORDER
+            all_locations = species_order
 
         for armor in worn_armor:
             coverage = armor.get_current_coverage()
@@ -523,16 +527,19 @@ class CmdArmor(Command):
         if caller.worn_items:
             worn_by_location = dict(caller.worn_items)
 
-        # Get character's valid locations from longdesc
+        # Get character's valid locations from longdesc — species-
+        # aware per #356 follow-up.
+        from world.anatomy import get_species_anatomical_display_order
+        species_order = get_species_anatomical_display_order(
+            getattr(caller.db, "species", None)
+        )
         if caller.longdesc:
             # longdesc is a dict of {location: description}, check the keys
             valid_locations = [
-                loc
-                for loc in ANATOMICAL_DISPLAY_ORDER
-                if loc in caller.longdesc
+                loc for loc in species_order if loc in caller.longdesc
             ]
         else:
-            valid_locations = ANATOMICAL_DISPLAY_ORDER
+            valid_locations = species_order
 
         # Fixed widths for consistent box sizes
         LOCATION_BOX_WIDTH = 15

--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -657,9 +657,15 @@ class AppearanceMixin:
 
         # 2. Longdesc + clothing integration (uses automatic paragraph parsing)
         if self.longdesc is None:
+            # Issue #356 follow-up: species-aware default longdesc set.
+            # Character.at_object_creation normally seeds this already;
+            # this branch is a defensive fallback for objects somehow
+            # missing the initial seed.
             try:
-                from world.combat.constants import DEFAULT_LONGDESC_LOCATIONS
-                self.longdesc = DEFAULT_LONGDESC_LOCATIONS.copy()
+                from world.anatomy import get_species_default_longdesc_locations
+                self.longdesc = get_species_default_longdesc_locations(
+                    getattr(self.db, "species", None)
+                )
             except ImportError:
                 pass
 

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -7,7 +7,7 @@ persistence. These form the foundation of the medical system.
 
 from evennia.comms.models import ChannelDB
 from .constants import (
-    ORGANS, BODY_CAPACITIES, CONTRIBUTION_VALUES, 
+    CONTRIBUTION_VALUES,
     CONSCIOUSNESS_UNCONSCIOUS_THRESHOLD, BLOOD_LOSS_DEATH_THRESHOLD,
     PAIN_CONSCIOUSNESS_MODIFIER, PAIN_UNCONSCIOUS_THRESHOLD
 )


### PR DESCRIPTION
## Summary

Closes the last three known follow-ups in the post-#356 audit:

- ``CmdArmor`` — two sites listing valid body locations migrated to ``get_species_anatomical_display_order(caller.db.species)``. Rats can't wear armor today but the migration is free and means armor's ready for the next non-human species.
- ``world/medical/core.py`` — removes the now-dead ``ORGANS`` and ``BODY_CAPACITIES`` imports left over after #361.
- ``AppearanceMixin.get_longdesc_appearance`` defensive fallback — consults the species default longdesc set rather than the humanoid global.

``COVERAGE_INHERITANCE`` in CmdArmor is intentionally not migrated; it bakes humanoid coverage hierarchy and would need species-keying once a non-human species actually wears armor.

## Test plan

- [x] Full suite: 1757/1757 pass

Refs #356.