### PR TITLE
Nose / jaw / tongue destruction at face longdesc (#355)

### DIFF
--- a/world/anatomy/organs.py
+++ b/world/anatomy/organs.py
@@ -133,6 +133,14 @@ ORGAN_DISPLAY = {
             "putrid": "A blackened tongue, swollen and weeping, its papillae lost to a uniform decaying slime.",
         },
     },
+    "nose": {
+        "display_name": "nose",
+        "default_descriptions": {
+            "pristine": "A neatly excised nose, the cartilage springy and the skin still naturally toned.",
+            "damaged": "A discoloured nose, the cartilage stiffening and the nostrils crusted dark.",
+            "putrid": "A blackening nose, the cartilage slumping inward and the tissue beginning to slough.",
+        },
+    },
     "jaw": {
         "display_name": "jaw",
         "default_descriptions": {

--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -168,16 +168,28 @@ SPECIES_DEFINITIONS = {
                 "can_be_harvested": True
             },
             "tongue": {
-                "container": "head", "max_hp": 20, "hit_weight": "rare",
+                "container": "head", "display_location": "face",
+                "max_hp": 20, "hit_weight": "rare",
                 "capacities": ["talking", "eating"], "talking_contribution": "major",
                 "eating_contribution": "major", "disfiguring_if_lost": True,
                 "can_be_harvested": True
             },
             "jaw": {
-                "container": "head", "max_hp": 10, "hit_weight": "rare",
+                "container": "head", "display_location": "face",
+                "max_hp": 10, "hit_weight": "rare",
                 "capacities": ["talking", "eating"], "talking_contribution": "major",
                 "eating_contribution": "moderate", "disfiguring_if_lost": True, "can_scar": False,
                 "can_be_harvested": True
+            },
+            # Nose — issue #355.  Surfaces at the ``face`` longdesc
+            # the same way jaw and tongue do.  Damage doesn't affect a
+            # named capacity (no smell capacity in scope), but it's
+            # disfiguring and harvestable.
+            "nose": {
+                "container": "head", "display_location": "face",
+                "max_hp": 8, "hit_weight": "rare",
+                "disfiguring_if_lost": True,
+                "can_be_harvested": True,
             },
 
             # NECK CONTAINER → DECAPITATION STRUCTURE

--- a/world/medical/wounds/messages/blunt.py
+++ b/world/medical/wounds/messages/blunt.py
@@ -124,6 +124,13 @@ DESTROYED_BY_LOCATION = {
         "|R{Their} right ear is reduced to a swollen lump of bruised tissue|n",
         "|RWhat is left of {their} right ear is a flattened ruin, dark with bruise and blood|n",
     ],
+    # Face — issue #355.
+    "face": [
+        "|R{Their} {organ} is pulped, the flesh swollen black around the ruin|n",
+        "|RA crushing impact has burst {their} {organ}, fluid weeping down the bruised cheek|n",
+        "|R{Their} {organ} is collapsed inward, the bone caved beneath the impact|n",
+        "|RWhat was {their} {organ} is a sunken pulp, the surrounding flesh pressed flat|n",
+    ],
 }
 
 

--- a/world/medical/wounds/messages/bullet.py
+++ b/world/medical/wounds/messages/bullet.py
@@ -124,6 +124,13 @@ DESTROYED_BY_LOCATION = {
         "|R{Their} right ear is shredded down to a stump, the canal weeping blood|n",
         "|RWhat remains of {their} right ear is a powder-burned ruin clinging to bone|n",
     ],
+    # Face — issue #355.
+    "face": [
+        "|R{Their} {organ} is a smoking crater, the flesh blown wide and weeping|n",
+        "|RA bullet has shot {their} {organ} to wet pulp, fragments crusted on {their} cheek|n",
+        "|R{Their} {organ} is gone, a ragged exit wound where it used to be|n",
+        "|RWhere {their} {organ} sat, a powder-blackened crater oozes blood and matter|n",
+    ],
 }
 
 

--- a/world/medical/wounds/messages/cut.py
+++ b/world/medical/wounds/messages/cut.py
@@ -98,6 +98,16 @@ DESTROYED_BY_LOCATION = {
         "|R{Their} right ear is sliced in half, the upper portion lost and the lower bleeding freely|n",
         "|RWhat remains of {their} right ear is a sliced ribbon of skin and cartilage|n",
     ],
+    # Face — issue #355.  Nose / jaw / tongue all surface here.  The
+    # ``{organ}`` token is humanized at render time
+    # (``"left_eye"`` → ``"left eye"``) so each organ's destruction
+    # reads with its own name in the same template.
+    "face": [
+        "|R{Their} {organ} is split open, the flesh cleaved through and weeping|n",
+        "|RA cleaving cut has bisected {their} {organ}, leaving a deep ragged gash|n",
+        "|R{Their} {organ} is sliced through along a single sharp seam, blood welling at the edges|n",
+        "|RWhere {their} {organ} sat, a slashed ruin weeps freely down {their} cheek|n",
+    ],
 }
 
 

--- a/world/medical/wounds/messages/generic.py
+++ b/world/medical/wounds/messages/generic.py
@@ -156,6 +156,13 @@ DESTROYED_BY_LOCATION = {
         "|R{Their} right ear has been ruined, the canal exposed and weeping|n",
         "|R{Their} right ear is a torn stump of cartilage and skin|n",
     ],
+    # Face — issue #355 generic fallback.
+    "face": [
+        "|R{Their} {organ} is destroyed, leaving a ruined wound|n",
+        "|RWhere {their} {organ} sat, a raw wound weeps blood|n",
+        "|R{Their} {organ} is gone, the surrounding flesh torn|n",
+        "|R{Their} {organ} has been destroyed beyond recognition|n",
+    ],
 }
 
 

--- a/world/medical/wounds/messages/laceration.py
+++ b/world/medical/wounds/messages/laceration.py
@@ -130,6 +130,13 @@ DESTROYED_BY_LOCATION = {
         "|R{Their} right ear hangs in shredded ribbons of skin and cartilage|n",
         "|RWhat is left of {their} right ear is a torn mess of cartilage and skin tags|n",
     ],
+    # Face — issue #355.
+    "face": [
+        "|R{Their} {organ} is a jagged tear across the flesh, ragged flaps hanging loose|n",
+        "|RA brutal rip has shredded {their} {organ}, leaving torn strips of skin and tissue|n",
+        "|R{Their} {organ} is torn open across its width, the underlying structure collapsed beneath ragged tissue|n",
+        "|RWhere {their} {organ} sat, a ripped wound leaks blood down {their} cheek|n",
+    ],
 }
 
 

--- a/world/medical/wounds/messages/stab.py
+++ b/world/medical/wounds/messages/stab.py
@@ -124,6 +124,15 @@ DESTROYED_BY_LOCATION = {
         "|R{Their} right ear hangs limp around a deep stab hole|n",
         "|RWhat is left of {their} right ear surrounds a punched-through wound seeping blood|n",
     ],
+    # Face — issue #355.  Nose / jaw / tongue surface here via the
+    # ``{organ}`` token, which humanizes to the destroyed organ's
+    # name in each rendered line.
+    "face": [
+        "|R{Their} {organ} is a punctured ruin, dark blood welling from the deep hole|n",
+        "|RA driven thrust has skewered {their} {organ}, the wound bleeding around the puncture|n",
+        "|R{Their} {organ} is collapsed inward around a deep puncture wound|n",
+        "|RWhere {their} {organ} sat, a narrow ragged hole weeps dark blood|n",
+    ],
 }
 
 

--- a/world/tests/test_face_destruction_routing.py
+++ b/world/tests/test_face_destruction_routing.py
@@ -1,0 +1,153 @@
+"""Tests for nose / jaw / tongue destruction → face longdesc surface
+(issue #355).
+
+After #346 routed wounds at the organ's ``display_location``, and
+after #347 added per-injury-type destroyed-stage overlays, this
+issue closes the authoring gap for face-surface organs: nose, jaw,
+and tongue all surface their destruction at the ``face`` longdesc
+line via the ``{organ}`` token in shared face templates.
+
+Tests verify:
+
+* Human declares nose / jaw / tongue with ``display_location: \"face\"``.
+* Each shipped injury-type module declares a ``face`` entry in
+  ``DESTROYED_BY_LOCATION`` with at least 3 variants.
+* Templates use ``{organ}`` so each organ's destruction renders with
+  its own name.
+* A destroyed-jaw wound at the face surface picks the face overlay,
+  not the generic destroyed limb prose.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.anatomy import get_organ_spec
+from world.medical.wounds import messages
+from world.medical.wounds.wound_descriptions import get_wound_description
+
+
+FACE_ORGANS = ("nose", "jaw", "tongue")
+INJURY_TYPES_WITH_OVERLAY = (
+    "cut", "stab", "bullet", "blunt", "laceration", "generic",
+)
+
+
+def _char(gender="male"):
+    return SimpleNamespace(
+        gender=gender,
+        db=SimpleNamespace(
+            original_gender=gender,
+            species="human",
+            skintone=None,
+        ),
+    )
+
+
+class FaceOrgansRouteToFaceSurface(TestCase):
+
+    def test_nose_display_location_is_face(self):
+        spec = get_organ_spec("nose", "human")
+        self.assertEqual(spec.get("display_location"), "face")
+        self.assertEqual(spec.get("container"), "head")
+
+    def test_jaw_display_location_is_face(self):
+        spec = get_organ_spec("jaw", "human")
+        self.assertEqual(spec.get("display_location"), "face")
+
+    def test_tongue_display_location_is_face(self):
+        spec = get_organ_spec("tongue", "human")
+        self.assertEqual(spec.get("display_location"), "face")
+
+
+class FaceOverlayDeclaredOnEveryModule(TestCase):
+
+    def test_every_module_declares_face_overlay(self):
+        for itype in INJURY_TYPES_WITH_OVERLAY:
+            with self.subTest(itype=itype):
+                module = getattr(messages, itype)
+                overlay = getattr(module, "DESTROYED_BY_LOCATION", {})
+                self.assertIn("face", overlay,
+                              f"{itype}.py needs a face entry")
+                self.assertGreaterEqual(
+                    len(overlay["face"]), 3,
+                    f"{itype}.face needs at least 3 variants",
+                )
+
+    def test_face_templates_use_organ_token(self):
+        # Each face template should use {organ} so the rendered prose
+        # names which specific face-surface organ was destroyed.
+        for itype in INJURY_TYPES_WITH_OVERLAY:
+            module = getattr(messages, itype)
+            overlay = module.DESTROYED_BY_LOCATION
+            for variant in overlay["face"]:
+                with self.subTest(itype=itype):
+                    self.assertIn(
+                        "{organ}", variant,
+                        f"{itype}.face variant missing {{organ}}: {variant!r}",
+                    )
+
+
+class DestructionRenderingByOrgan(TestCase):
+    """A destroyed-jaw wound at the face location should render with
+    'jaw' in the prose; a destroyed-nose wound at face should render
+    with 'nose'.  Same template, different organ token."""
+
+    def test_destroyed_jaw_renders_jaw_at_face(self):
+        out = get_wound_description(
+            injury_type="cut", location="face",
+            severity="Critical", stage="destroyed",
+            organ="jaw", character=_char(),
+        )
+        self.assertIn("jaw", out.lower())
+        # And uses the face template family, not the limb one.
+        self.assertNotIn("ribbons of flesh", out)
+        self.assertNotIn("hanging by threads", out)
+
+    def test_destroyed_nose_renders_nose_at_face(self):
+        out = get_wound_description(
+            injury_type="bullet", location="face",
+            severity="Critical", stage="destroyed",
+            organ="nose", character=_char(),
+        )
+        self.assertIn("nose", out.lower())
+        self.assertNotIn("ribbons of flesh", out)
+
+    def test_destroyed_tongue_renders_tongue_at_face(self):
+        out = get_wound_description(
+            injury_type="laceration", location="face",
+            severity="Critical", stage="destroyed",
+            organ="tongue", character=_char(),
+        )
+        self.assertIn("tongue", out.lower())
+
+
+class FaceVariantsRenderWithoutLeakedBraces(TestCase):
+
+    def test_every_face_variant_renders_clean(self):
+        import random
+        char = _char()
+        for itype in INJURY_TYPES_WITH_OVERLAY:
+            module = getattr(messages, itype)
+            for variant in module.DESTROYED_BY_LOCATION["face"]:
+                for organ in FACE_ORGANS:
+                    with self.subTest(itype=itype, organ=organ):
+                        original = random.choice
+                        random.choice = lambda seq, _v=variant: _v
+                        try:
+                            out = get_wound_description(
+                                injury_type=itype,
+                                location="face",
+                                severity="Critical",
+                                stage="destroyed",
+                                organ=organ,
+                                character=char,
+                            )
+                        finally:
+                            random.choice = original
+                        self.assertTrue(out)
+                        self.assertNotIn("{", out,
+                                         f"leaked brace in {out!r}")
+                        self.assertNotIn("}", out)
+                        self.assertIn(organ, out.lower())


### PR DESCRIPTION
## Summary

Adds the face-surface destruction overlay authoring per #355. nose / jaw / tongue all route through the existing ``face`` longdesc via ``display_location: \"face\"`` and a shared ``{organ}``-substituted template.

- ``nose`` added to ORGANS (was missing); jaw + tongue updated with ``display_location: \"face\"``.
- ``nose`` ORGAN_DISPLAY entry for autopsy / harvest prose.
- ``face`` entries on cut / stab / bullet / blunt / laceration / generic ``DESTROYED_BY_LOCATION`` with 4 variants each, using ``{organ}`` substitution.

Multi-organ destruction at face renders honestly as per-organ lines; PR-B's authored-longdesc suppression handles dropping the original face prose once any face-surface organ is destroyed.

## Test plan

- [x] ``evennia test --settings settings.py world.tests.test_face_destruction_routing`` — 9/9 pass
- [x] Full suite: 1766/1766 pass

Closes #355.