### PR TITLE
Parameterize weapon kill templates with {hit_location} (#333)

### DIFF
--- a/world/combat/messages/anti-material_rifle.py
+++ b/world/combat/messages/anti-material_rifle.py
@@ -61,7 +61,7 @@ MESSAGES = {
             "observer_msg": "The air itself seems to grow heavy as {attacker_name} prepares to fire the anti-material rifle, anticipating the bone-jarring *BOOM* and the shockwave."
         },
         {
-            "attacker_msg": "Your face is a grim mask of focus, finger slowly approaching the heavy trigger of your anti-material rifle.",
+            "attacker_msg": "Your {hit_location} is a grim mask of focus, finger slowly approaching the heavy trigger of your anti-material rifle.",
             "victim_msg": "{attacker_name}’s face is a grim mask of focus, finger slowly approaching the heavy trigger of their anti-material rifle, aimed at you.",
             "observer_msg": "{attacker_name}’s face is a grim mask of focus, finger slowly approaching the heavy trigger of the anti-material rifle."
         },
@@ -278,9 +278,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name}’s anti-material rifle bullet makes impact, leaving another catastrophic, instantly fatal puncture, if 'puncture' can describe the massive crater in {target_name}. A single, enormous spent casing hits the ground as the bolt is worked."
         },
         {
-            "attacker_msg": "A painful, echoing, ground-shaking crack as the bullet from your anti-material rifle strikes {target_name}'s {hit_location}, which, along with most of their {hit_location} cavity, are instantly atomized. You cycle the bolt, chambering another heavy, destructive round.",
-            "victim_msg": "A painful, echoing, ground-shaking crack as the bullet from {attacker_name}'s anti-material rifle strikes your {hit_location}, which, along with most of your {hit_location} cavity, are instantly atomized! {attacker_name} cycles the bolt, chambering another heavy, destructive round.",
-            "observer_msg": "A painful, echoing, ground-shaking crack as the bullet from {attacker_name}'s anti-material rifle strikes {target_name}'s {hit_location}, which, along with most of their {hit_location} cavity, are instantly atomized. {attacker_name} cycles the bolt, chambering another heavy, destructive round."
+            "attacker_msg": "A painful, echoing, ground-shaking crack as the bullet from your anti-material rifle strikes {target_name}'s {hit_location}, which, along with most of their chest cavity, are instantly atomized. You cycle the bolt, chambering another heavy, destructive round.",
+            "victim_msg": "A painful, echoing, ground-shaking crack as the bullet from {attacker_name}'s anti-material rifle strikes your {hit_location}, which, along with most of your chest cavity, are instantly atomized! {attacker_name} cycles the bolt, chambering another heavy, destructive round.",
+            "observer_msg": "A painful, echoing, ground-shaking crack as the bullet from {attacker_name}'s anti-material rifle strikes {target_name}'s {hit_location}, which, along with most of their chest cavity, are instantly atomized. {attacker_name} cycles the bolt, chambering another heavy, destructive round."
         },
         {
             "attacker_msg": "The projectile from your anti-material rifle hits {target_name}’s collarbone; their entire upper {hit_location} explodes outward in a cloud of red. The bolt is worked, ejecting the casing with a flick of your {hit_location}.",
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            "attacker_msg": "Your anti-material rifle fires with a deafening, earth-shattering *KRA-THOOM*, the massive bullet thundering past {target_name}'s head and blasting a car-sized crater out of a distant concrete wall, showering the area with debris. You are violently shoved back by the recoil, working the heavy bolt, *CLUNK-CLANK*, ejecting a smoking, oversized casing.",
-            "victim_msg": "{attacker_name}'s anti-material rifle fires with a deafening, earth-shattering *KRA-THOOM*, the massive bullet thundering past your head and blasting a car-sized crater out of a distant concrete wall, showering the area with debris! {attacker_name} is violently shoved back by the recoil, working the heavy bolt, *CLUNK-CLANK*, ejecting a smoking, oversized casing.",
-            "observer_msg": "{attacker_name}'s anti-material rifle fires with a deafening, earth-shattering *KRA-THOOM*, the massive bullet thundering past {target_name}'s head and blasting a car-sized crater out of a distant concrete wall, showering the area with debris. {attacker_name} is violently shoved back by the recoil, working the heavy bolt, *CLUNK-CLANK*, ejecting a smoking, oversized casing."
+            "attacker_msg": "Your anti-material rifle fires with a deafening, earth-shattering *KRA-THOOM*, the massive bullet thundering past {target_name}'s {hit_location} and blasting a car-sized crater out of a distant concrete wall, showering the area with debris. You are violently shoved back by the recoil, working the heavy bolt, *CLUNK-CLANK*, ejecting a smoking, oversized casing.",
+            "victim_msg": "{attacker_name}'s anti-material rifle fires with a deafening, earth-shattering *KRA-THOOM*, the massive bullet thundering past your {hit_location} and blasting a car-sized crater out of a distant concrete wall, showering the area with debris! {attacker_name} is violently shoved back by the recoil, working the heavy bolt, *CLUNK-CLANK*, ejecting a smoking, oversized casing.",
+            "observer_msg": "{attacker_name}'s anti-material rifle fires with a deafening, earth-shattering *KRA-THOOM*, the massive bullet thundering past {target_name}'s {hit_location} and blasting a car-sized crater out of a distant concrete wall, showering the area with debris. {attacker_name} is violently shoved back by the recoil, working the heavy bolt, *CLUNK-CLANK*, ejecting a smoking, oversized casing."
         },
         {
             "attacker_msg": "You fire, but {target_name} flinches violently, ears ringing, as your anti-material rifle roars like a vengeful god, the .50 caliber or larger bullet gouging a deep, smoking trench in the ground where they just stood, kicking up a ten-foot plume of earth. You fight the muzzle climb, cycling the action for another earth-shattering shot.",
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "{target_name} ducks, terrified, just as your anti-material rifle fires, the bullet searing the air where their head had been with palpable force and a deafening sonic crack. You cycle the bolt methodically, the ground still vibrating.",
-            "victim_msg": "You duck, terrified, just as {attacker_name}'s anti-material rifle fires, the bullet searing the air where your head had been with palpable force and a deafening sonic crack! {attacker_name} cycles the bolt methodically, the ground still vibrating.",
+            "victim_msg": "You duck, terrified, just as {attacker_name}'s anti-material rifle fires, the bullet searing the air where your {hit_location} had been with palpable force and a deafening sonic crack! {attacker_name} cycles the bolt methodically, the ground still vibrating.",
             "observer_msg": "{target_name} ducks, terrified, just as {attacker_name}'s anti-material rifle fires, the bullet searing the air where their head had been with palpable force and a deafening sonic crack. {attacker_name} cycles the bolt methodically, the ground still vibrating."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             "observer_msg": "A quick sidestep from {target_name} leaves {attacker_name}'s anti-material rifle to punch a massive, gaping hole clean through an empty armored personnel carrier. {attacker_name} cycles the bolt, unflinching at the display of raw power."
         },
         {
-            "attacker_msg": "Your anti-material rifle bucks ferociously in your shoulder as you miss {target_name}, the recoil throwing your aim completely off for a moment and kicking up a cloud of dust around you. You work the bolt, chambering a fresh, devastating round.",
+            "attacker_msg": "Your anti-material rifle bucks ferociously in your {hit_location} as you miss {target_name}, the recoil throwing your aim completely off for a moment and kicking up a cloud of dust around you. You work the bolt, chambering a fresh, devastating round.",
             "victim_msg": "{attacker_name}'s anti-material rifle bucks ferociously in their shoulder as they miss you, the recoil throwing their aim completely off for a moment and kicking up a cloud of dust around them! {attacker_name} works the bolt, chambering a fresh, devastating round.",
             "observer_msg": "{attacker_name}'s anti-material rifle bucks ferociously in their shoulder as they miss {target_name}, the recoil throwing their aim completely off for a moment and kicking up a cloud of dust around them. {attacker_name} works the bolt, chambering a fresh, devastating round."
         },
@@ -415,7 +415,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name}’s aim is hurried, the bullet from the anti-material rifle veering wildly off target and impacting with a distant, explosive crash. {attacker_name} cycles the bolt, chambering another heavy, destructive round."
         },
         {
-            "attacker_msg": "A desperate dive from {target_name} means your anti-material rifle shot only tears a large, smoking hole in their discarded, heavy flak jacket, which offers no protection. The bolt is worked, ejecting the casing with a flick of your wrist.",
+            "attacker_msg": "A desperate dive from {target_name} means your anti-material rifle shot only tears a large, smoking hole in their discarded, heavy flak jacket, which offers no protection. The bolt is worked, ejecting the casing with a flick of your {hit_location}.",
             "victim_msg": "Your desperate dive means {attacker_name}'s anti-material rifle shot only tears a large, smoking hole in your discarded, heavy flak jacket, which offers no protection! The bolt is worked, ejecting the casing with a flick of their wrist.",
             "observer_msg": "A desperate dive from {target_name} means {attacker_name}'s anti-material rifle shot only tears a large, smoking hole in their discarded, heavy flak jacket, which offers no protection. The bolt is worked, ejecting the casing with a flick of {attacker_name}'s wrist."
         },
@@ -458,28 +458,28 @@ MESSAGES = {
     "kill": [
         {
             "attacker_msg": "Your anti-material rifle bullet strikes {target_name} square in the forehead; their head, and indeed most of their upper body, simply explodes into a cloud of red mist and bone shrapnel, instantly obliterating them. You calmly work the heavy bolt, *CLUNK-CLANK*, ejecting a smoking, oversized casing, the job done.",
-            "victim_msg": "{attacker_name}'s anti-material rifle bullet strikes you square in the forehead; your head, and indeed most of your upper body, simply explodes into a cloud of red mist and bone shrapnel, instantly obliterating you. Darkness claims you.",
+            "victim_msg": "{attacker_name}'s anti-material rifle bullet strikes you square in the forehead; your {hit_location}, and indeed most of your upper body, simply explodes into a cloud of red mist and bone shrapnel, instantly obliterating you. Darkness claims you.",
             "observer_msg": "{attacker_name}'s anti-material rifle bullet strikes {target_name} square in the forehead; their head, and indeed most of their upper body, simply explodes into a cloud of red mist and bone shrapnel, instantly obliterating them. {attacker_name} calmly works the heavy bolt, *CLUNK-CLANK*, ejecting a smoking, oversized casing, the job done."
         },
         {
             "attacker_msg": "Your anti-material rifle roars like an artillery piece, and {target_name} clutches their chest as a massive, gaping hole appears, their entire torso erupting outwards before they collapse, utterly destroyed. You smoothly cycle the action, the rifle ready again, though nothing remains to shoot.",
-            "victim_msg": "{attacker_name}'s anti-material rifle roars like an artillery piece! You clutch your chest as a massive, gaping hole appears, your entire torso erupting outwards before you collapse, utterly destroyed. It's over.",
+            "victim_msg": "{attacker_name}'s anti-material rifle roars like an artillery piece! You clutch your {hit_location} as a massive, gaping hole appears, your entire torso erupting outwards before you collapse, utterly destroyed. It's over.",
             "observer_msg": "{attacker_name}'s anti-material rifle roars like an artillery piece, and {target_name} clutches their chest as a massive, gaping hole appears, their entire torso erupting outwards before they collapse, utterly destroyed. {attacker_name} smoothly cycles the action, the rifle ready again, though nothing remains to shoot."
         },
         {
-            "attacker_msg": "With a final, precise shot, your anti-material rifle sends a heavy, armor-piercing bullet through {target_name}'s heart; their body is torn apart by the hydrostatic shock, ending their struggles catastrophically and instantly. A huge brass casing flips through the air as you work the bolt with effort.",
-            "victim_msg": "With a final, precise shot, {attacker_name}'s anti-material rifle sends a heavy, armor-piercing bullet through your heart; your body is torn apart by the hydrostatic shock, ending your struggles catastrophically and instantly. You are slain.",
-            "observer_msg": "With a final, precise shot, {attacker_name}'s anti-material rifle sends a heavy, armor-piercing bullet through {target_name}'s heart; their body is torn apart by the hydrostatic shock, ending their struggles catastrophically and instantly. A huge brass casing flips through the air as the bolt is worked with effort."
+            "attacker_msg": "With a final, precise shot, your anti-material rifle sends a heavy, armor-piercing bullet through {target_name}'s {hit_location}; their body is torn apart by the hydrostatic shock, ending their struggles catastrophically and instantly. A huge brass casing flips through the air as you work the bolt with effort.",
+            "victim_msg": "With a final, precise shot, {attacker_name}'s anti-material rifle sends a heavy, armor-piercing bullet through your {hit_location}; your body is torn apart by the hydrostatic shock, ending your struggles catastrophically and instantly. You are slain.",
+            "observer_msg": "With a final, precise shot, {attacker_name}'s anti-material rifle sends a heavy, armor-piercing bullet through {target_name}'s {hit_location}; their body is torn apart by the hydrostatic shock, ending their struggles catastrophically and instantly. A huge brass casing flips through the air as the bolt is worked with effort."
         },
         {
-            "attacker_msg": "The massive bullet fired point-blank into {target_name}'s throat from your anti-material rifle nearly severs their head and continues on to obliterate whatever was behind them; they die in a horrific, explosive spray of gore. You chamber another round with a decisive, heavy *SHLOCK-THUNK*.",
-            "victim_msg": "The massive bullet fired point-blank into your throat from {attacker_name}'s anti-material rifle nearly severs your head and continues on to obliterate whatever was behind you; you die in a horrific, explosive spray of gore. Your life fades...",
-            "observer_msg": "The massive bullet fired point-blank into {target_name}'s throat from {attacker_name}'s anti-material rifle nearly severs their head and continues on to obliterate whatever was behind them; they die in a horrific, explosive spray of gore. {attacker_name} chambers another round with a decisive, heavy *SHLOCK-THUNK*."
+            "attacker_msg": "The massive bullet fired point-blank into {target_name}'s {hit_location} from your anti-material rifle nearly severs their head and continues on to obliterate whatever was behind them; they die in a horrific, explosive spray of gore. You chamber another round with a decisive, heavy *SHLOCK-THUNK*.",
+            "victim_msg": "The massive bullet fired point-blank into your {hit_location} from {attacker_name}'s anti-material rifle nearly severs your {hit_location} and continues on to obliterate whatever was behind you; you die in a horrific, explosive spray of gore. Your life fades...",
+            "observer_msg": "The massive bullet fired point-blank into {target_name}'s {hit_location} from {attacker_name}'s anti-material rifle nearly severs their head and continues on to obliterate whatever was behind them; they die in a horrific, explosive spray of gore. {attacker_name} chambers another round with a decisive, heavy *SHLOCK-THUNK*."
         },
         {
-            "attacker_msg": "Your carefully placed shot with the anti-material rifle tears through {target_name}'s spine and out the other side, taking most of their internal organs with it; they slump, a lifeless, eviscerated puppet. The bolt is cycled, another house-wrecking round sliding home.",
-            "victim_msg": "{attacker_name}’s carefully placed shot with their anti-material rifle tears through your spine and out the other side, taking most of your internal organs with it; you slump, a lifeless, eviscerated puppet. You have been defeated.",
-            "observer_msg": "{attacker_name}’s carefully placed shot with the anti-material rifle tears through {target_name}'s spine and out the other side, taking most of their internal organs with it; they slump, a lifeless, eviscerated puppet. The bolt is cycled, another house-wrecking round sliding home."
+            "attacker_msg": "Your carefully placed shot with the anti-material rifle tears through {target_name}'s {hit_location} and out the other side, taking most of their internal organs with it; they slump, a lifeless, eviscerated puppet. The bolt is cycled, another house-wrecking round sliding home.",
+            "victim_msg": "{attacker_name}’s carefully placed shot with their anti-material rifle tears through your {hit_location} and out the other side, taking most of your internal organs with it; you slump, a lifeless, eviscerated puppet. You have been defeated.",
+            "observer_msg": "{attacker_name}’s carefully placed shot with the anti-material rifle tears through {target_name}'s {hit_location} and out the other side, taking most of their internal organs with it; they slump, a lifeless, eviscerated puppet. The bolt is cycled, another house-wrecking round sliding home."
         },
         {
             "attacker_msg": "Your anti-material rifle, an instrument of precise, overwhelming death, delivers a killing blow as {target_name} is overcome by the catastrophic, explosive bullet wound, their form ceasing to resemble anything human. You work the bolt, preparing for any other threats, though unlikely.",
@@ -488,13 +488,13 @@ MESSAGES = {
         },
         {
             "attacker_msg": "A precise shot to the base of the skull from your anti-material rifle vaporizes the target area and a significant portion of the surrounding anatomy, ending {target_name}'s life with absolute, gory finality. The bolt handle is lifted and drawn back with effort, then slammed forward.",
-            "victim_msg": "A precise shot to the base of your skull from {attacker_name}'s anti-material rifle vaporizes the target area and a significant portion of the surrounding anatomy, ending your life with absolute, gory finality. You are dead.",
+            "victim_msg": "A precise shot to the base of your {hit_location} from {attacker_name}'s anti-material rifle vaporizes the target area and a significant portion of the surrounding anatomy, ending your life with absolute, gory finality. You are dead.",
             "observer_msg": "A precise shot to the base of the skull from {attacker_name}'s anti-material rifle vaporizes the target area and a significant portion of the surrounding anatomy, ending {target_name}'s life with absolute, gory finality. The bolt handle is lifted and drawn back with effort, then slammed forward."
         },
         {
-            "attacker_msg": "Your single shot from the anti-material rifle pierces {target_name}'s lung; the resulting cavitation blows their chest cavity apart, and they collapse, dying swiftly and messily. You cycle the bolt methodically, the ground still vibrating.",
-            "victim_msg": "{attacker_name}'s single shot from their anti-material rifle pierces your lung; the resulting cavitation blows your chest cavity apart, and you collapse, dying swiftly and messily. Darkness envelops you.",
-            "observer_msg": "{attacker_name}'s single shot from the anti-material rifle pierces {target_name}'s lung; the resulting cavitation blows their chest cavity apart, and they collapse, dying swiftly and messily. {attacker_name} cycles the bolt methodically, the ground still vibrating."
+            "attacker_msg": "Your single shot from the anti-material rifle pierces {target_name}'s {hit_location}; the resulting cavitation blows their chest cavity apart, and they collapse, dying swiftly and messily. You cycle the bolt methodically, the ground still vibrating.",
+            "victim_msg": "{attacker_name}'s single shot from their anti-material rifle pierces your {hit_location}; the resulting cavitation blows your chest cavity apart, and you collapse, dying swiftly and messily. Darkness envelops you.",
+            "observer_msg": "{attacker_name}'s single shot from the anti-material rifle pierces {target_name}'s {hit_location}; the resulting cavitation blows their chest cavity apart, and they collapse, dying swiftly and messily. {attacker_name} cycles the bolt methodically, the ground still vibrating."
         },
         {
             "attacker_msg": "The unyielding, armor-piercing slug from your anti-material rifle pierces a vital organ in {target_name}, which ruptures with explosive force, tearing them apart from the inside; they fall, dead before they hit the ground, or what's left of them does. A hot, oversized casing is ejected as you prepare another shot.",
@@ -503,7 +503,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "With a final, thunderous, concussive crack, you finish {target_name} with a heavy bullet through the eye from your anti-material rifle; the back of their skull, and much of the wall behind them, erupts outwards. The bolt is worked with smooth, powerful efficiency.",
-            "victim_msg": "With a final, thunderous, concussive crack, {attacker_name} finishes you with a heavy bullet through the eye from their anti-material rifle; the back of your skull, and much of the wall behind you, erupts outwards. You have perished.",
+            "victim_msg": "With a final, thunderous, concussive crack, {attacker_name} finishes you with a heavy bullet through the eye from their anti-material rifle; the back of your {hit_location}, and much of the wall behind you, erupts outwards. You have perished.",
             "observer_msg": "With a final, thunderous, concussive crack, {attacker_name} finishes {target_name} with a heavy bullet through the eye from the anti-material rifle; the back of their skull, and much of the wall behind them, erupts outwards. The bolt is worked with smooth, powerful efficiency."
         },
         {
@@ -572,7 +572,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s anti-material rifle, an instrument of deadly, precise, and overwhelming efficiency, claims another victim in {target_name} with shocking, gory, and absolute finality, leaving no doubt. The bolt is cycled, chambering another heavy, destructive round."
         },
         {
-            "attacker_msg": "{target_name}’s eyes widen in disbelief and pure, abject terror as your anti-material rifle delivers the final, life-ending, body-obliterating bullet. The bolt is worked, ejecting the casing with a flick of your wrist, the deed done.",
+            "attacker_msg": "{target_name}’s eyes widen in disbelief and pure, abject terror as your anti-material rifle delivers the final, life-ending, body-obliterating bullet. The bolt is worked, ejecting the casing with a flick of your {hit_location}, the deed done.",
             "victim_msg": "Your eyes widen in disbelief and pure, abject terror as {attacker_name}'s anti-material rifle delivers the final, life-ending, body-obliterating bullet. Darkness takes you...",
             "observer_msg": "{target_name}’s eyes widen in disbelief and pure, abject terror as {attacker_name}'s anti-material rifle delivers the final, life-ending, body-obliterating bullet. The bolt is worked, ejecting the casing with a flick of {attacker_name}'s wrist, the deed done."
         },

--- a/world/combat/messages/assault_rifle.py
+++ b/world/combat/messages/assault_rifle.py
@@ -1,7 +1,7 @@
 MESSAGES = {
     "initiate": [
         {
-            "attacker_msg": "You snap your assault rifle to your shoulder, its modern, utilitarian lines exuding efficiency as you aim at {target_name}.",
+            "attacker_msg": "You snap your assault rifle to your {hit_location}, its modern, utilitarian lines exuding efficiency as you aim at {target_name}.",
             "victim_msg": "{attacker_name} snaps an assault rifle to their shoulder, aiming at you; its modern, utilitarian lines exude efficiency.",
             "observer_msg": "{attacker_name} snaps an assault rifle to their shoulder, the weapon's modern, utilitarian lines exuding efficiency as they aim at {target_name}."
         },
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "{target_name} drops prone just as your assault rifle fires a burst, bullets cracking the air inches above their head. Your rifle cycles, ready for {target_name} to reappear.",
-            "victim_msg": "You drop prone just as {attacker_name}'s assault rifle fires a burst, bullets cracking the air inches above your head! Their rifle cycles, ready for you to reappear.",
+            "victim_msg": "You drop prone just as {attacker_name}'s assault rifle fires a burst, bullets cracking the air inches above your {hit_location}! Their rifle cycles, ready for you to reappear.",
             "observer_msg": "{target_name} drops prone just as {attacker_name}'s assault rifle fires a burst, bullets cracking the air inches above their head. The rifle cycles, ready for {target_name} to reappear."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             "observer_msg": "A quick sidestep from {target_name} leaves {attacker_name}'s assault rifle to punch a pattern of holes in a nearby wall. The rifle cycles, {attacker_name} maintaining their aim, ready to fire again."
         },
         {
-            "attacker_msg": "Your assault rifle bucks in your shoulder as you send a burst wide of {target_name}. Your rifle cycles, chambering fresh rounds, as you quickly compensate for muzzle climb.",
+            "attacker_msg": "Your assault rifle bucks in your {hit_location} as you send a burst wide of {target_name}. Your rifle cycles, chambering fresh rounds, as you quickly compensate for muzzle climb.",
             "victim_msg": "{attacker_name}'s assault rifle bucks in their shoulder as they send a burst wide of you! Their rifle cycles, chambering fresh rounds, as they quickly compensate for muzzle climb.",
             "observer_msg": "The assault rifle bucks in {attacker_name}'s shoulder as they send a burst wide of {target_name}. The rifle cycles, chambering fresh rounds, {attacker_name} quickly compensating for muzzle climb."
         },
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "Your assault rifle erupts in a controlled burst, stitching a fatal line of impacts across {target_name}'s chest; they collapse in a heap, riddled. The action cycles with a final *CHING*, ejecting a casing, the threat decisively neutralized.",
-            "victim_msg": "{attacker_name}'s assault rifle erupts in a controlled burst, stitching a fatal line of impacts across your chest; you collapse in a heap, riddled! The action cycles with a final *CHING*, ejecting a casing.",
-            "observer_msg": "{attacker_name}'s assault rifle erupts in a controlled burst, stitching a fatal line of impacts across {target_name}'s chest; they collapse in a heap, riddled. The action cycles with a final *CHING*, ejecting a casing, the threat decisively neutralized."
+            "attacker_msg": "Your assault rifle erupts in a controlled burst, stitching a fatal line of impacts across {target_name}'s {hit_location}; they collapse in a heap, riddled. The action cycles with a final *CHING*, ejecting a casing, the threat decisively neutralized.",
+            "victim_msg": "{attacker_name}'s assault rifle erupts in a controlled burst, stitching a fatal line of impacts across your {hit_location}; you collapse in a heap, riddled! The action cycles with a final *CHING*, ejecting a casing.",
+            "observer_msg": "{attacker_name}'s assault rifle erupts in a controlled burst, stitching a fatal line of impacts across {target_name}'s {hit_location}; they collapse in a heap, riddled. The action cycles with a final *CHING*, ejecting a casing, the threat decisively neutralized."
         },
         {
             "attacker_msg": "Your assault rifle barks a deadly staccato, and {target_name} crumples as multiple high-velocity slugs tear through vital areas, ending their fight instantly. Your rifle ejects hot casings, bolt locking back on an empty magazine or ready for the next foe.",
@@ -468,7 +468,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "With a quick, aimed burst to the head, your assault rifle drops {target_name} like a stone, their life extinguished in a hail of lead. Brass casings spin away as the action cycles, the job done with brutal efficiency.",
-            "victim_msg": "With a quick, aimed burst to your head, {attacker_name}'s assault rifle drops you like a stone, your life extinguished in a hail of lead! Brass casings spin away as the action cycles.",
+            "victim_msg": "With a quick, aimed burst to your {hit_location}, {attacker_name}'s assault rifle drops you like a stone, your life extinguished in a hail of lead! Brass casings spin away as the action cycles.",
             "observer_msg": "With a quick, aimed burst to the head, {attacker_name}'s assault rifle drops {target_name} like a stone, their life extinguished in a hail of lead. Brass casings spin away as the action cycles, the job done with brutal efficiency."
         },
         {
@@ -488,7 +488,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "A precise burst to the throat from your assault rifle silences {target_name} permanently, their body collapsing. Your rifle ejects casings, as you already assess the battlefield.",
-            "victim_msg": "A precise burst to your throat from {attacker_name}'s assault rifle silences you permanently, your body collapsing! Their rifle ejects casings.",
+            "victim_msg": "A precise burst to your {hit_location} from {attacker_name}'s assault rifle silences you permanently, your body collapsing! Their rifle ejects casings.",
             "observer_msg": "A precise burst to the throat from {attacker_name}'s assault rifle silences {target_name} permanently, their body collapsing. The rifle ejects casings, {attacker_name} already assessing the battlefield."
         },
         {

--- a/world/combat/messages/baseball_bat.py
+++ b/world/combat/messages/baseball_bat.py
@@ -6,9 +6,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} hefts the baseball bat, its familiar weight promising solid impact as they eye {target_name}."
         },
         {
-            "attacker_msg": "With a determined look, you grip your baseball bat, ready to swing for the fences... or {target_name}'s head.",
-            "victim_msg": "With a determined look, {attacker_name} grips a baseball bat, ready to swing for the fences... or your head.",
-            "observer_msg": "With a determined look, {attacker_name} grips the baseball bat, ready to swing for the fences... or {target_name}'s head."
+            "attacker_msg": "With a determined look, you grip your baseball bat, ready to swing for the fences... or {target_name}'s {hit_location}.",
+            "victim_msg": "With a determined look, {attacker_name} grips a baseball bat, ready to swing for the fences... or your {hit_location}.",
+            "observer_msg": "With a determined look, {attacker_name} grips the baseball bat, ready to swing for the fences... or {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You tap the end of your baseball bat on the ground, a dull thud echoing as you prepare to engage {target_name}.",
@@ -81,7 +81,7 @@ MESSAGES = {
             "observer_msg": "The grain of the wood (or the gleam of aluminum) on the baseball bat is visible, a testament to its simple effectiveness against {target_name}."
         },
         {
-            "attacker_msg": "You hold your baseball bat cocked over your shoulder, ready to bring its full weight down upon {target_name}.",
+            "attacker_msg": "You hold your baseball bat cocked over your {hit_location}, ready to bring its full weight down upon {target_name}.",
             "victim_msg": "{attacker_name} holds a baseball bat cocked over their shoulder, ready to bring its full weight down upon you.",
             "observer_msg": "{attacker_name} holds the baseball bat cocked over their shoulder, ready to bring its full weight down upon {target_name}."
         },
@@ -228,19 +228,19 @@ MESSAGES = {
             "observer_msg": "{attacker_name}’s follow-through swing with the baseball bat catches {target_name} off-balance and in considerable pain."
         },
         {
-            "attacker_msg": "A flick of your wrist sends the end of your baseball bat into {target_name}'s {hit_location} with a sharp crack.",
+            "attacker_msg": "A flick of your {hit_location} sends the end of your baseball bat into {target_name}'s {hit_location} with a sharp crack.",
             "victim_msg": "A flick of {attacker_name}'s wrist sends the end of their baseball bat into your {hit_location} with a sharp crack!",
             "observer_msg": "A flick of {attacker_name}'s wrist sends the end of the baseball bat into {target_name}'s {hit_location} with a sharp crack."
         },
         {
             "attacker_msg": "Your baseball bat thuds heavily as it connects with {target_name}, driving the air from their lungs.",
-            "victim_msg": "{attacker_name}'s baseball bat thuds heavily as it connects with you, driving the air from your lungs!",
+            "victim_msg": "{attacker_name}'s baseball bat thuds heavily as it connects with you, driving the air from your {hit_location}!",
             "observer_msg": "The baseball bat thuds heavily as it connects with {target_name}, driving the air from their lungs."
         },
         {
-            "attacker_msg": "Your bat finds purchase, delivering a crushing blow to {target_name}'s thigh, dropping them to a knee.",
-            "victim_msg": "{attacker_name}’s bat finds purchase, delivering a crushing blow to your thigh, dropping you to a knee!",
-            "observer_msg": "{attacker_name}’s bat finds purchase, delivering a crushing blow to {target_name}'s thigh, dropping them to a knee."
+            "attacker_msg": "Your bat finds purchase, delivering a crushing blow to {target_name}'s {hit_location}, dropping them to a knee.",
+            "victim_msg": "{attacker_name}’s bat finds purchase, delivering a crushing blow to your {hit_location}, dropping you to a knee!",
+            "observer_msg": "{attacker_name}’s bat finds purchase, delivering a crushing blow to {target_name}'s {hit_location}, dropping them to a knee."
         },
         {
             "attacker_msg": "A glancing blow from your baseball bat still manages to leave {target_name} reeling and bruised.",
@@ -284,7 +284,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The end of your baseball bat connects like a hammer, striking {target_name}’s forearm.",
-            "victim_msg": "The end of {attacker_name}'s baseball bat connects like a hammer, striking your forearm!",
+            "victim_msg": "The end of {attacker_name}'s baseball bat connects like a hammer, striking your {hit_location}!",
             "observer_msg": "The end of {attacker_name}'s baseball bat connects like a hammer, striking {target_name}’s forearm."
         },
         {
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            "attacker_msg": "Your baseball bat whistles through the air with considerable force, inches from {target_name}'s head.",
-            "victim_msg": "{attacker_name}'s baseball bat whistles through the air with considerable force, inches from your head!",
-            "observer_msg": "{attacker_name}'s baseball bat whistles through the air with considerable force, inches from {target_name}'s head."
+            "attacker_msg": "Your baseball bat whistles through the air with considerable force, inches from {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name}'s baseball bat whistles through the air with considerable force, inches from your {hit_location}!",
+            "observer_msg": "{attacker_name}'s baseball bat whistles through the air with considerable force, inches from {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "{target_name} narrowly avoids the heavy arc of your baseball bat with a desperate duck.",
@@ -457,14 +457,14 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "Your baseball bat connects with {target_name}'s temple with a sickening crack; {target_name} drops, instantly still.",
-            "victim_msg": "{attacker_name}'s baseball bat connects with your temple with a sickening crack; you drop, instantly still.",
-            "observer_msg": "{attacker_name}'s baseball bat connects with {target_name}'s temple with a sickening crack; {target_name} drops, instantly still."
+            "attacker_msg": "Your baseball bat connects with {target_name}'s {hit_location} with a sickening crack; {target_name} drops, instantly still.",
+            "victim_msg": "{attacker_name}'s baseball bat connects with your {hit_location} with a sickening crack; you drop, instantly still.",
+            "observer_msg": "{attacker_name}'s baseball bat connects with {target_name}'s {hit_location} with a sickening crack; {target_name} drops, instantly still."
         },
         {
-            "attacker_msg": "Your devastating home-run swing with the baseball bat crushes {target_name}'s skull, ending the fight brutally.",
-            "victim_msg": "A devastating home-run swing from {attacker_name}'s baseball bat crushes your skull, ending your fight brutally.",
-            "observer_msg": "A devastating home-run swing from {attacker_name}'s baseball bat crushes {target_name}'s skull, ending the fight brutally."
+            "attacker_msg": "Your devastating home-run swing with the baseball bat crushes {target_name}'s {hit_location}, ending the fight brutally.",
+            "victim_msg": "A devastating home-run swing from {attacker_name}'s baseball bat crushes your {hit_location}, ending your fight brutally.",
+            "observer_msg": "A devastating home-run swing from {attacker_name}'s baseball bat crushes {target_name}'s {hit_location}, ending the fight brutally."
         },
         {
             "attacker_msg": "With a final, focused strike, your baseball bat shatters {target_name}'s collarbone and drives them to the ground, unmoving.",
@@ -472,14 +472,14 @@ MESSAGES = {
             "observer_msg": "With a final, focused strike, {attacker_name}'s baseball bat shatters {target_name}'s collarbone and drives them to the ground, unmoving."
         },
         {
-            "attacker_msg": "The heavy wood/metal of your baseball bat strikes {target_name}'s throat, a swift and brutal end.",
-            "victim_msg": "The heavy wood/metal of {attacker_name}'s baseball bat strikes your throat, a swift and brutal end for you.",
-            "observer_msg": "The heavy wood/metal of {attacker_name}'s baseball bat strikes {target_name}'s throat, a swift and brutal end."
+            "attacker_msg": "The heavy wood/metal of your baseball bat strikes {target_name}'s {hit_location}, a swift and brutal end.",
+            "victim_msg": "The heavy wood/metal of {attacker_name}'s baseball bat strikes your {hit_location}, a swift and brutal end for you.",
+            "observer_msg": "The heavy wood/metal of {attacker_name}'s baseball bat strikes {target_name}'s {hit_location}, a swift and brutal end."
         },
         {
-            "attacker_msg": "Your powerful swing with the baseball bat caves in {target_name}'s chest; they collapse, gasping their last.",
-            "victim_msg": "{attacker_name}’s powerful swing with their baseball bat caves in your chest; you collapse, gasping your last.",
-            "observer_msg": "{attacker_name}’s powerful swing with the baseball bat caves in {target_name}'s chest; they collapse, gasping their last."
+            "attacker_msg": "Your powerful swing with the baseball bat caves in {target_name}'s {hit_location}; they collapse, gasping their last.",
+            "victim_msg": "{attacker_name}’s powerful swing with their baseball bat caves in your {hit_location}; you collapse, gasping your last.",
+            "observer_msg": "{attacker_name}’s powerful swing with the baseball bat caves in {target_name}'s {hit_location}; they collapse, gasping their last."
         },
         {
             "attacker_msg": "Your baseball bat, a simple tool of deadly force, delivers a killing blow, and {target_name}’s struggles cease.",
@@ -488,7 +488,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "A precise strike to the base of the skull with your baseball bat ends {target_name}'s life in an instant.",
-            "victim_msg": "A precise strike to the base of your skull with {attacker_name}'s baseball bat ends your life in an instant.",
+            "victim_msg": "A precise strike to the base of your {hit_location} with {attacker_name}'s baseball bat ends your life in an instant.",
             "observer_msg": "A precise strike to the base of the skull with {attacker_name}'s baseball bat ends {target_name}'s life in an instant."
         },
         {
@@ -497,9 +497,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} drives the end of the baseball bat into {target_name}'s eye socket, the outcome grimly certain."
         },
         {
-            "attacker_msg": "Your unyielding baseball bat breaks {target_name}'s neck with a sharp snap; they fall, lifeless.",
-            "victim_msg": "{attacker_name}'s unyielding baseball bat breaks your neck with a sharp snap; you fall, lifeless.",
-            "observer_msg": "The unyielding baseball bat in {attacker_name}'s hands breaks {target_name}'s neck with a sharp snap; they fall, lifeless."
+            "attacker_msg": "Your unyielding baseball bat breaks {target_name}'s {hit_location} with a sharp snap; they fall, lifeless.",
+            "victim_msg": "{attacker_name}'s unyielding baseball bat breaks your {hit_location} with a sharp snap; you fall, lifeless.",
+            "observer_msg": "The unyielding baseball bat in {attacker_name}'s hands breaks {target_name}'s {hit_location} with a sharp snap; they fall, lifeless."
         },
         {
             "attacker_msg": "With a final, savage grunt, you finish {target_name} with a decisive, crushing strike from your baseball bat.",

--- a/world/combat/messages/baton.py
+++ b/world/combat/messages/baton.py
@@ -1,7 +1,7 @@
 MESSAGES = {
     "initiate": [
         {
-            "attacker_msg": "A flick of your wrist brings your baton to full length. It doesn’t make a sound — but the tension it draws does.",
+            "attacker_msg": "A flick of your {hit_location} brings your baton to full length. It doesn’t make a sound — but the tension it draws does.",
             "victim_msg": "A flick of {attacker_name}'s wrist brings their baton to full length. It doesn’t make a sound — but the tension it draws does.",
             "observer_msg": "A flick of {attacker_name}'s wrist brings their baton to full length. It doesn’t make a sound — but the tension it draws does."
         },
@@ -11,7 +11,7 @@ MESSAGES = {
             "observer_msg": "A slow grip, a fast pull — and the baton extends with purpose. {attacker_name} doesn't grin. But the corners of their eyes tighten."
         },
         {
-            "attacker_msg": "A small smile creeps across your face as you draw the baton. There’s no fear in that gesture — only confidence.",
+            "attacker_msg": "A small smile creeps across your {hit_location} as you draw the baton. There’s no fear in that gesture — only confidence.",
             "victim_msg": "A small smile creeps across {attacker_name}'s face as they draw the baton. There’s no fear in that gesture — only confidence.",
             "observer_msg": "A small smile creeps across {attacker_name}'s face as they draw the baton. There’s no fear in that gesture — only confidence."
         },
@@ -91,7 +91,7 @@ MESSAGES = {
             "observer_msg": "With a half-step forward, {attacker_name} clicks the baton open and lowers their center of gravity. The dance is starting."
         },
         {
-            "attacker_msg": "With a practiced gesture, you twirl the baton once and bring it to rest across your shoulder. The intent is clear — this won’t be subtle.",
+            "attacker_msg": "With a practiced gesture, you twirl the baton once and bring it to rest across your {hit_location}. The intent is clear — this won’t be subtle.",
             "victim_msg": "With a practiced gesture, {attacker_name} twirls the baton once and brings it to rest across their shoulder. The intent is clear — this won’t be subtle.",
             "observer_msg": "With a practiced gesture, {attacker_name} twirls the baton once and brings it to rest across their shoulder. The intent is clear — this won’t be subtle."
         },
@@ -111,22 +111,22 @@ MESSAGES = {
             "observer_msg": "{attacker_name} draws the baton with a slow, deliberate motion. It unfolds with a metallic click, and suddenly the conversation has changed."
         },
         {
-            "attacker_msg": "You draw the baton with a swift flick of your wrist. It extends with a satisfying snap, like punctuation at the end of a threat.",
+            "attacker_msg": "You draw the baton with a swift flick of your {hit_location}. It extends with a satisfying snap, like punctuation at the end of a threat.",
             "victim_msg": "{attacker_name} draws the baton with a swift flick of their wrist. It extends with a satisfying snap, like punctuation at the end of a threat.",
             "observer_msg": "{attacker_name} draws the baton with a swift flick of their wrist. It extends with a satisfying snap, like punctuation at the end of a threat."
         },
         {
-            "attacker_msg": "You flex your wrist. The baton answers with a stiff metallic growl. It’s awake now.",
+            "attacker_msg": "You flex your {hit_location}. The baton answers with a stiff metallic growl. It’s awake now.",
             "victim_msg": "{attacker_name} flexes their wrist. The baton answers with a stiff metallic growl. It’s awake now.",
             "observer_msg": "{attacker_name} flexes their wrist. The baton answers with a stiff metallic growl. It’s awake now."
         },
         {
-            "attacker_msg": "You flick your wrist and the baton springs open, sleek and dark. It hums with stored violence.",
+            "attacker_msg": "You flick your {hit_location} and the baton springs open, sleek and dark. It hums with stored violence.",
             "victim_msg": "{attacker_name} flicks their wrist and the baton springs open, sleek and dark. It hums with stored violence.",
             "observer_msg": "{attacker_name} flicks their wrist and the baton springs open, sleek and dark. It hums with stored violence."
         },
         {
-            "attacker_msg": "You give the baton a lazy twirl before resting it against your shoulder. Your expression doesn’t change — the weapon speaks for you.",
+            "attacker_msg": "You give the baton a lazy twirl before resting it against your {hit_location}. Your expression doesn’t change — the weapon speaks for you.",
             "victim_msg": "{attacker_name} gives the baton a lazy twirl before resting it against their shoulder. Their expression doesn’t change — the weapon speaks for them.",
             "observer_msg": "{attacker_name} gives the baton a lazy twirl before resting it against their shoulder. Their expression doesn’t change — the weapon speaks for them."
         },
@@ -136,7 +136,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} pulls the baton from a loop at their side, extends it with a flick, and tests its balance like they’ve done this before. Many times."
         },
         {
-            "attacker_msg": "You roll your wrist, testing the baton’s weight. It's not for show — it’s to remember how it feels before blood touches it.",
+            "attacker_msg": "You roll your {hit_location}, testing the baton’s weight. It's not for show — it’s to remember how it feels before blood touches it.",
             "victim_msg": "{attacker_name} rolls their wrist, testing the baton’s weight. It's not for show — it’s to remember how it feels before blood touches it.",
             "observer_msg": "{attacker_name} rolls their wrist, testing the baton’s weight. It's not for show — it’s to remember how it feels before blood touches it."
         },
@@ -279,7 +279,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You drive the tip of your baton into {target_name}'s solar plexus. The air leaves their lungs in a ragged gasp. They fold without grace.",
-            "victim_msg": "{attacker_name} drives the tip of their baton into your solar plexus. The air leaves your lungs in a ragged gasp. You fold without grace.",
+            "victim_msg": "{attacker_name} drives the tip of their baton into your solar plexus. The air leaves your {hit_location} in a ragged gasp. You fold without grace.",
             "observer_msg": "{attacker_name} drives the tip of their baton into {target_name}'s solar plexus. The air leaves their lungs in a ragged gasp. They fold without grace."
         },
         {
@@ -390,9 +390,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s baton slices through a halo of dust where {target_name} just stood. Close — too close."
         },
         {
-            "attacker_msg": "Your baton slices through the space where {target_name}'s ribs should’ve been. They duck, adrenaline peaking.",
-            "victim_msg": "{attacker_name}'s baton slices through the space where your ribs should’ve been. You duck, adrenaline peaking.",
-            "observer_msg": "{attacker_name}'s baton slices through the space where {target_name}'s ribs should’ve been. They duck, adrenaline peaking."
+            "attacker_msg": "Your baton slices through the space where {target_name}'s {hit_location} should’ve been. They duck, adrenaline peaking.",
+            "victim_msg": "{attacker_name}'s baton slices through the space where your {hit_location} should’ve been. You duck, adrenaline peaking.",
+            "observer_msg": "{attacker_name}'s baton slices through the space where {target_name}'s {hit_location} should’ve been. They duck, adrenaline peaking."
         },
         {
             "attacker_msg": "Your blow was too high, too hasty. Your boots shift, resetting your posture like the next strike is already loading.",
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "Your brutal downward slam caves in {target_name}'s ribs. Internal bleeding does the rest. They never get up.",
-            "victim_msg": "{attacker_name}'s brutal downward slam caves in your ribs. Internal bleeding does the rest. You never get up.",
-            "observer_msg": "{attacker_name}'s brutal downward slam caves in {target_name}'s ribs. Internal bleeding does the rest. They never get up."
+            "attacker_msg": "Your brutal downward slam caves in {target_name}'s {hit_location}. Internal bleeding does the rest. They never get up.",
+            "victim_msg": "{attacker_name}'s brutal downward slam caves in your {hit_location}. Internal bleeding does the rest. You never get up.",
+            "observer_msg": "{attacker_name}'s brutal downward slam caves in {target_name}'s {hit_location}. Internal bleeding does the rest. They never get up."
         },
         {
             "attacker_msg": "Your jab to {target_name}'s eye socket ends everything. They don’t scream. There’s no time.",
@@ -467,9 +467,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s jab to {target_name}'s eye socket ends everything. They don’t scream. There’s no time."
         },
         {
-            "attacker_msg": "Your jab to {target_name}'s sternum collapses their chest cavity. They drop like a switch was flipped, lungs folding in silence.",
-            "victim_msg": "{attacker_name}'s jab to your sternum collapses your chest cavity. You drop like a switch was flipped, lungs folding in silence.",
-            "observer_msg": "{attacker_name}'s jab to {target_name}'s sternum collapses their chest cavity. They drop like a switch was flipped, lungs folding in silence."
+            "attacker_msg": "Your jab to {target_name}'s {hit_location} collapses their chest cavity. They drop like a switch was flipped, lungs folding in silence.",
+            "victim_msg": "{attacker_name}'s jab to your {hit_location} collapses your chest cavity. You drop like a switch was flipped, lungs folding in silence.",
+            "observer_msg": "{attacker_name}'s jab to {target_name}'s {hit_location} collapses their chest cavity. They drop like a switch was flipped, lungs folding in silence."
         },
         {
             "attacker_msg": "A quick series of hits from your baton — jaw, sternum, temple. {target_name} falls, limp and glassy-eyed, like the world stopped turning.",
@@ -477,13 +477,13 @@ MESSAGES = {
             "observer_msg": "A quick series of hits from {attacker_name}'s baton — jaw, sternum, temple. {target_name} falls, limp and glassy-eyed, like the world stopped turning."
         },
         {
-            "attacker_msg": "A sharp twist of your motion delivers the baton straight to {target_name}'s jaw. Their neck snaps. Their body collapses. The scene ends.",
-            "victim_msg": "A sharp twist of {attacker_name}'s motion delivers the baton straight to your jaw. Your neck snaps. Your body collapses. The scene ends.",
-            "observer_msg": "A sharp twist of {attacker_name}'s motion delivers the baton straight to {target_name}'s jaw. Their neck snaps. Their body collapses. The scene ends."
+            "attacker_msg": "A sharp twist of your motion delivers the baton straight to {target_name}'s {hit_location}. Their neck snaps. Their body collapses. The scene ends.",
+            "victim_msg": "A sharp twist of {attacker_name}'s motion delivers the baton straight to your {hit_location}. Your {hit_location} snaps. Your body collapses. The scene ends.",
+            "observer_msg": "A sharp twist of {attacker_name}'s motion delivers the baton straight to {target_name}'s {hit_location}. Their neck snaps. Their body collapses. The scene ends."
         },
         {
             "attacker_msg": "Your single upward jab under {target_name}'s chin collapses their airway and snaps their spine. Their legs give out without resistance.",
-            "victim_msg": "{attacker_name}'s single upward jab under your chin collapses your airway and snaps your spine. Your legs give out without resistance.",
+            "victim_msg": "{attacker_name}'s single upward jab under your chin collapses your airway and snaps your {hit_location}. Your legs give out without resistance.",
             "observer_msg": "{attacker_name}'s single upward jab under {target_name}'s chin collapses their airway and snaps their spine. Their legs give out without resistance."
         },
         {
@@ -492,19 +492,19 @@ MESSAGES = {
             "observer_msg": "It’s not the first hit from {attacker_name}'s baton that kills {target_name} — it’s the third. Repeated trauma until stillness is the only sound left."
         },
         {
-            "attacker_msg": "No poetry. No pageantry. Just your steel to {target_name}'s skull and a silence that feels earned. They aren’t getting back up.",
-            "victim_msg": "No poetry. No pageantry. Just {attacker_name}'s steel to your skull and a silence that feels earned. You aren’t getting back up.",
-            "observer_msg": "No poetry. No pageantry. Just {attacker_name}'s steel to {target_name}'s skull and a silence that feels earned. They aren’t getting back up."
+            "attacker_msg": "No poetry. No pageantry. Just your steel to {target_name}'s {hit_location} and a silence that feels earned. They aren’t getting back up.",
+            "victim_msg": "No poetry. No pageantry. Just {attacker_name}'s steel to your {hit_location} and a silence that feels earned. You aren’t getting back up.",
+            "observer_msg": "No poetry. No pageantry. Just {attacker_name}'s steel to {target_name}'s {hit_location} and a silence that feels earned. They aren’t getting back up."
         },
         {
-            "attacker_msg": "One strike from your baton to {target_name}'s throat silences them mid-breath. They collapse, twitching, and do not rise again.",
-            "victim_msg": "One strike from {attacker_name}'s baton to your throat silences you mid-breath. You collapse, twitching, and do not rise again.",
-            "observer_msg": "One strike from {attacker_name}'s baton to {target_name}'s throat silences them mid-breath. They collapse, twitching, and do not rise again."
+            "attacker_msg": "One strike from your baton to {target_name}'s {hit_location} silences them mid-breath. They collapse, twitching, and do not rise again.",
+            "victim_msg": "One strike from {attacker_name}'s baton to your {hit_location} silences you mid-breath. You collapse, twitching, and do not rise again.",
+            "observer_msg": "One strike from {attacker_name}'s baton to {target_name}'s {hit_location} silences them mid-breath. They collapse, twitching, and do not rise again."
         },
         {
-            "attacker_msg": "One strike from your baton, top of {target_name}'s head. They stiffen, then slump. Their brain gave up before their legs did.",
-            "victim_msg": "One strike from {attacker_name}'s baton, top of your head. You stiffen, then slump. Your brain gave up before your legs did.",
-            "observer_msg": "One strike from {attacker_name}'s baton, top of {target_name}'s head. They stiffen, then slump. Their brain gave up before their legs did."
+            "attacker_msg": "One strike from your baton, top of {target_name}'s {hit_location}. They stiffen, then slump. Their brain gave up before their legs did.",
+            "victim_msg": "One strike from {attacker_name}'s baton, top of your {hit_location}. You stiffen, then slump. Your {hit_location} gave up before your legs did.",
+            "observer_msg": "One strike from {attacker_name}'s baton, top of {target_name}'s {hit_location}. They stiffen, then slump. Their brain gave up before their legs did."
         },
         {
             "attacker_msg": "Your baton catches {target_name} mid-shout. There’s no follow-up. Their words die with them.",
@@ -517,19 +517,19 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s baton comes down like a gavel. {target_name} folds inward, blood leaking from ears, mouth, somewhere deeper."
         },
         {
-            "attacker_msg": "Your baton cracks down on {target_name}'s skull with a noise like a dropped bowling ball. They drop without drama. Or breath.",
-            "victim_msg": "{attacker_name}'s baton cracks down on your skull with a noise like a dropped bowling ball. You drop without drama. Or breath.",
-            "observer_msg": "{attacker_name}'s baton cracks down on {target_name}'s skull with a noise like a dropped bowling ball. They drop without drama. Or breath."
+            "attacker_msg": "Your baton cracks down on {target_name}'s {hit_location} with a noise like a dropped bowling ball. They drop without drama. Or breath.",
+            "victim_msg": "{attacker_name}'s baton cracks down on your {hit_location} with a noise like a dropped bowling ball. You drop without drama. Or breath.",
+            "observer_msg": "{attacker_name}'s baton cracks down on {target_name}'s {hit_location} with a noise like a dropped bowling ball. They drop without drama. Or breath."
         },
         {
-            "attacker_msg": "Your baton crashes into {target_name}'s skull with a sound like a dropped coconut. Their legs buckle. Their body slumps. The light inside goes out.",
-            "victim_msg": "{attacker_name}'s baton crashes into your skull with a sound like a dropped coconut. Your legs buckle. Your body slumps. The light inside goes out.",
-            "observer_msg": "{attacker_name}'s baton crashes into {target_name}'s skull with a sound like a dropped coconut. Their legs buckle. Their body slumps. The light inside goes out."
+            "attacker_msg": "Your baton crashes into {target_name}'s {hit_location} with a sound like a dropped coconut. Their legs buckle. Their body slumps. The light inside goes out.",
+            "victim_msg": "{attacker_name}'s baton crashes into your {hit_location} with a sound like a dropped coconut. Your legs buckle. Your body slumps. The light inside goes out.",
+            "observer_msg": "{attacker_name}'s baton crashes into {target_name}'s {hit_location} with a sound like a dropped coconut. Their legs buckle. Their body slumps. The light inside goes out."
         },
         {
-            "attacker_msg": "Your baton drives into the side of {target_name}'s head with a loud pop. Their eyes go wide. Then dim.",
-            "victim_msg": "{attacker_name}'s baton drives into the side of your head with a loud pop. Your eyes go wide. Then dim.",
-            "observer_msg": "{attacker_name}'s baton drives into the side of {target_name}'s head with a loud pop. Their eyes go wide. Then dim."
+            "attacker_msg": "Your baton drives into the side of {target_name}'s {hit_location} with a loud pop. Their eyes go wide. Then dim.",
+            "victim_msg": "{attacker_name}'s baton drives into the side of your {hit_location} with a loud pop. Your eyes go wide. Then dim.",
+            "observer_msg": "{attacker_name}'s baton drives into the side of {target_name}'s {hit_location} with a loud pop. Their eyes go wide. Then dim."
         },
         {
             "attacker_msg": "Your baton lands one final time, center mass on {target_name}. They gasp, choke, and collapse like a puppet released.",
@@ -537,14 +537,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s baton lands one final time, center mass on {target_name}. They gasp, choke, and collapse like a puppet released."
         },
         {
-            "attacker_msg": "Your baton lands with such force that {target_name}'s skull caves inward. No blood spray, just collapse — instant and terminal.",
-            "victim_msg": "{attacker_name}'s baton lands with such force that your skull caves inward. No blood spray, just collapse — instant and terminal.",
-            "observer_msg": "{attacker_name}'s baton lands with such force that {target_name}'s skull caves inward. No blood spray, just collapse — instant and terminal."
+            "attacker_msg": "Your baton lands with such force that {target_name}'s {hit_location} caves inward. No blood spray, just collapse — instant and terminal.",
+            "victim_msg": "{attacker_name}'s baton lands with such force that your {hit_location} caves inward. No blood spray, just collapse — instant and terminal.",
+            "observer_msg": "{attacker_name}'s baton lands with such force that {target_name}'s {hit_location} caves inward. No blood spray, just collapse — instant and terminal."
         },
         {
-            "attacker_msg": "Your baton lands with such force that {target_name}'s spine audibly separates. Their last sound is breath exiting permanently.",
-            "victim_msg": "{attacker_name}'s baton lands with such force that your spine audibly separates. Your last sound is breath exiting permanently.",
-            "observer_msg": "{attacker_name}'s baton lands with such force that {target_name}'s spine audibly separates. Their last sound is breath exiting permanently."
+            "attacker_msg": "Your baton lands with such force that {target_name}'s {hit_location} audibly separates. Their last sound is breath exiting permanently.",
+            "victim_msg": "{attacker_name}'s baton lands with such force that your {hit_location} audibly separates. Your last sound is breath exiting permanently.",
+            "observer_msg": "{attacker_name}'s baton lands with such force that {target_name}'s {hit_location} audibly separates. Their last sound is breath exiting permanently."
         },
         {
             "attacker_msg": "Your baton strikes between {target_name}'s eyes. Their body convulses once, then ceases to be part of the fight.",
@@ -557,49 +557,49 @@ MESSAGES = {
             "observer_msg": "The end comes not with drama, but with a single, sickening thud from {attacker_name}'s baton. {attacker_name} doesn't gloat. They just breathe, as {target_name} falls."
         },
         {
-            "attacker_msg": "The killing blow from your baton is quiet, surgical. A twist of your wrist, a final jab to the base of {target_name}'s skull. They never see it coming.",
-            "victim_msg": "The killing blow from {attacker_name}'s baton is quiet, surgical. A twist of their wrist, a final jab to the base of your skull. You never see it coming.",
-            "observer_msg": "The killing blow from {attacker_name}'s baton is quiet, surgical. A twist of their wrist, a final jab to the base of {target_name}'s skull. They never see it coming."
+            "attacker_msg": "The killing blow from your baton is quiet, surgical. A twist of your {hit_location}, a final jab to the base of {target_name}'s {hit_location}. They never see it coming.",
+            "victim_msg": "The killing blow from {attacker_name}'s baton is quiet, surgical. A twist of their wrist, a final jab to the base of your {hit_location}. You never see it coming.",
+            "observer_msg": "The killing blow from {attacker_name}'s baton is quiet, surgical. A twist of their wrist, a final jab to the base of {target_name}'s {hit_location}. They never see it coming."
         },
         {
             "attacker_msg": "The killing blow isn’t pretty — it’s personal. You pin {target_name} down and slam your baton into their face until nothing moves.",
-            "victim_msg": "The killing blow isn’t pretty — it’s personal. {attacker_name} pins you down and slams their baton into your face until nothing moves.",
+            "victim_msg": "The killing blow isn’t pretty — it’s personal. {attacker_name} pins you down and slams their baton into your {hit_location} until nothing moves.",
             "observer_msg": "The killing blow isn’t pretty — it’s personal. {attacker_name} pins {target_name} down and slams their baton into their face until nothing moves."
         },
         {
-            "attacker_msg": "The killing blow from your baton lands at the base of {target_name}'s skull. A snap, a twitch, then stillness. You don’t even slow down.",
-            "victim_msg": "The killing blow from {attacker_name}'s baton lands at the base of your skull. A snap, a twitch, then stillness. They don’t even slow down.",
-            "observer_msg": "The killing blow from {attacker_name}'s baton lands at the base of {target_name}'s skull. A snap, a twitch, then stillness. {attacker_name} doesn’t even slow down."
+            "attacker_msg": "The killing blow from your baton lands at the base of {target_name}'s {hit_location}. A snap, a twitch, then stillness. You don’t even slow down.",
+            "victim_msg": "The killing blow from {attacker_name}'s baton lands at the base of your {hit_location}. A snap, a twitch, then stillness. They don’t even slow down.",
+            "observer_msg": "The killing blow from {attacker_name}'s baton lands at the base of {target_name}'s {hit_location}. A snap, a twitch, then stillness. {attacker_name} doesn’t even slow down."
         },
         {
             "attacker_msg": "You circle {target_name} once, then bring your baton down on their temple. The body goes limp before the echo fades.",
-            "victim_msg": "{attacker_name} circles you once, then brings their baton down on your temple. Your body goes limp before the echo fades.",
+            "victim_msg": "{attacker_name} circles you once, then brings their baton down on your {hit_location}. Your body goes limp before the echo fades.",
             "observer_msg": "{attacker_name} circles {target_name} once, then brings their baton down on their temple. The body goes limp before the echo fades."
         },
         {
-            "attacker_msg": "You jam your baton into {target_name}'s neck — once, hard. Their airway crushes. Their body twitches. Silence follows.",
-            "victim_msg": "{attacker_name} jams their baton into your neck — once, hard. Your airway crushes. Your body twitches. Silence follows.",
-            "observer_msg": "{attacker_name} jams their baton into {target_name}'s neck — once, hard. Their airway crushes. Their body twitches. Silence follows."
+            "attacker_msg": "You jam your baton into {target_name}'s {hit_location} — once, hard. Their airway crushes. Their body twitches. Silence follows.",
+            "victim_msg": "{attacker_name} jams their baton into your {hit_location} — once, hard. Your airway crushes. Your body twitches. Silence follows.",
+            "observer_msg": "{attacker_name} jams their baton into {target_name}'s {hit_location} — once, hard. Their airway crushes. Their body twitches. Silence follows."
         },
         {
             "attacker_msg": "You press {target_name} against the wall and deliver a series of rapid strikes with your baton to their neck and ribs. Their body slides down in silence.",
-            "victim_msg": "{attacker_name} presses you against the wall and delivers a series of rapid strikes with their baton to your neck and ribs. Your body slides down in silence.",
+            "victim_msg": "{attacker_name} presses you against the wall and delivers a series of rapid strikes with their baton to your {hit_location} and ribs. Your body slides down in silence.",
             "observer_msg": "{attacker_name} presses {target_name} against the wall and delivers a series of rapid strikes with their baton to their neck and ribs. Their body slides down in silence."
         },
         {
             "attacker_msg": "You raise your baton high and slam it down on {target_name}. Their chest caves, lungs crushed. The death is quiet, final.",
-            "victim_msg": "{attacker_name} raises their baton high and slams it down on you. Your chest caves, lungs crushed. The death is quiet, final.",
+            "victim_msg": "{attacker_name} raises their baton high and slams it down on you. Your {hit_location} caves, lungs crushed. The death is quiet, final.",
             "observer_msg": "{attacker_name} raises their baton high and slams it down on {target_name}. Their chest caves, lungs crushed. The death is quiet, final."
         },
         {
-            "attacker_msg": "You shatter {target_name}'s knee first with your baton, then their skull. It’s not mercy — it’s message.",
-            "victim_msg": "{attacker_name} shatters your knee first with their baton, then your skull. It’s not mercy — it’s message.",
-            "observer_msg": "{attacker_name} shatters {target_name}'s knee first with their baton, then their skull. It’s not mercy — it’s message."
+            "attacker_msg": "You shatter {target_name}'s {hit_location} first with your baton, then their skull. It’s not mercy — it’s message.",
+            "victim_msg": "{attacker_name} shatters your {hit_location} first with their baton, then your {hit_location}. It’s not mercy — it’s message.",
+            "observer_msg": "{attacker_name} shatters {target_name}'s {hit_location} first with their baton, then their skull. It’s not mercy — it’s message."
         },
         {
-            "attacker_msg": "You step forward, calm and focused, and drive your baton into {target_name}'s throat. The gurgle fades fast.",
-            "victim_msg": "{attacker_name} steps forward, calm and focused, and drives their baton into your throat. The gurgle fades fast.",
-            "observer_msg": "{attacker_name} steps forward, calm and focused, and drives their baton into {target_name}'s throat. The gurgle fades fast."
+            "attacker_msg": "You step forward, calm and focused, and drive your baton into {target_name}'s {hit_location}. The gurgle fades fast.",
+            "victim_msg": "{attacker_name} steps forward, calm and focused, and drives their baton into your {hit_location}. The gurgle fades fast.",
+            "observer_msg": "{attacker_name} steps forward, calm and focused, and drives their baton into {target_name}'s {hit_location}. The gurgle fades fast."
         },
         {
             "attacker_msg": "You strike {target_name} again and again with your baton, until they are a heap of broken limbs and wet silence. The baton drips.",

--- a/world/combat/messages/battle_axe.py
+++ b/world/combat/messages/battle_axe.py
@@ -126,12 +126,12 @@ MESSAGES = {
             "observer_msg": "{attacker_name} lifts their axe with effort and purpose. No swing will be wasted."
         },
         {
-            "attacker_msg": "You pull your battle axe from your back with a grunt. It's less a weapon, more a reckoning.",
+            "attacker_msg": "You pull your battle axe from your {hit_location} with a grunt. It's less a weapon, more a reckoning.",
             "victim_msg": "{attacker_name} pulls their battle axe from their back with a grunt. It's less a weapon, more a reckoning.",
             "observer_msg": "{attacker_name} pulls their battle axe from their back with a grunt. It's less a weapon, more a reckoning."
         },
         {
-            "attacker_msg": "You rest your axe against your shoulder. It’s not rest. It’s warning.",
+            "attacker_msg": "You rest your axe against your {hit_location}. It’s not rest. It’s warning.",
             "victim_msg": "{attacker_name} rests their axe against their shoulder. It’s not rest. It’s warning.",
             "observer_msg": "{attacker_name} rests their axe against their shoulder. It’s not rest. It’s warning."
         },
@@ -188,9 +188,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s {hit_location}ways strike caves {target_name}'s {hit_location}. The scream is long — and last."
         },
         {
-            "attacker_msg": "Your one heavy blow cracks {target_name}'s skull. They twitch and fall without dignity.",
-            "victim_msg": "{attacker_name}'s one heavy blow cracks your skull. You twitch and fall without dignity.",
-            "observer_msg": "{attacker_name}'s one heavy blow cracks {target_name}'s skull. They twitch and fall without dignity."
+            "attacker_msg": "Your one heavy blow cracks {target_name}'s {hit_location}. They twitch and fall without dignity.",
+            "victim_msg": "{attacker_name}'s one heavy blow cracks your {hit_location}. You twitch and fall without dignity.",
+            "observer_msg": "{attacker_name}'s one heavy blow cracks {target_name}'s {hit_location}. They twitch and fall without dignity."
         },
         {
             "attacker_msg": "Your one swing connects at {target_name}'s {hit_location}. The impact folds them like cardboard.",
@@ -258,9 +258,9 @@ MESSAGES = {
             "observer_msg": "The blade of {attacker_name}'s axe tears across {target_name}'s upper {hit_location}. They cry out, half-conscious and half-bleeding."
         },
         {
-            "attacker_msg": "The edge of your axe clips {target_name}'s skull. They sway as red pours like thoughts unwritten.",
-            "victim_msg": "The edge of {attacker_name}'s axe clips your skull. You sway as red pours like thoughts unwritten.",
-            "observer_msg": "The edge of {attacker_name}'s axe clips {target_name}'s skull. They sway as red pours like thoughts unwritten."
+            "attacker_msg": "The edge of your axe clips {target_name}'s {hit_location}. They sway as red pours like thoughts unwritten.",
+            "victim_msg": "The edge of {attacker_name}'s axe clips your {hit_location}. You sway as red pours like thoughts unwritten.",
+            "observer_msg": "The edge of {attacker_name}'s axe clips {target_name}'s {hit_location}. They sway as red pours like thoughts unwritten."
         },
         {
             "attacker_msg": "The flat of your axe smashes {target_name}'s mouth. Teeth scatter. So does confidence.",
@@ -467,24 +467,24 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s backswing decapitates {target_name} clean. The silence is immediate and justified."
         },
         {
-            "attacker_msg": "Your backswing tears across {target_name}'s face. Their body hesitates — then collapses.",
-            "victim_msg": "{attacker_name}'s backswing tears across your face. Your body hesitates — then collapses.",
-            "observer_msg": "{attacker_name}'s backswing tears across {target_name}'s face. Their body hesitates — then collapses."
+            "attacker_msg": "Your backswing tears across {target_name}'s {hit_location}. Their body hesitates — then collapses.",
+            "victim_msg": "{attacker_name}'s backswing tears across your {hit_location}. Your body hesitates — then collapses.",
+            "observer_msg": "{attacker_name}'s backswing tears across {target_name}'s {hit_location}. Their body hesitates — then collapses."
         },
         {
-            "attacker_msg": "Your downward strike caves in {target_name}'s chest. Breathing isn’t an option anymore.",
-            "victim_msg": "{attacker_name}'s downward strike caves in your chest. Breathing isn’t an option anymore.",
-            "observer_msg": "{attacker_name}'s downward strike caves in {target_name}'s chest. Breathing isn’t an option anymore."
+            "attacker_msg": "Your downward strike caves in {target_name}'s {hit_location}. Breathing isn’t an option anymore.",
+            "victim_msg": "{attacker_name}'s downward strike caves in your {hit_location}. Breathing isn’t an option anymore.",
+            "observer_msg": "{attacker_name}'s downward strike caves in {target_name}'s {hit_location}. Breathing isn’t an option anymore."
         },
         {
-            "attacker_msg": "Your horizontal slash takes off {target_name}'s jaw. What’s left chokes to death.",
-            "victim_msg": "{attacker_name}'s horizontal slash takes off your jaw. What’s left chokes to death.",
-            "observer_msg": "{attacker_name}'s horizontal slash takes off {target_name}'s jaw. What’s left chokes to death."
+            "attacker_msg": "Your horizontal slash takes off {target_name}'s {hit_location}. What’s left chokes to death.",
+            "victim_msg": "{attacker_name}'s horizontal slash takes off your {hit_location}. What’s left chokes to death.",
+            "observer_msg": "{attacker_name}'s horizontal slash takes off {target_name}'s {hit_location}. What’s left chokes to death."
         },
         {
-            "attacker_msg": "Your spinning arc cuts deep into {target_name}'s chest. They drop, still mid-motion.",
-            "victim_msg": "{attacker_name}'s spinning arc cuts deep into your chest. You drop, still mid-motion.",
-            "observer_msg": "{attacker_name}'s spinning arc cuts deep into {target_name}'s chest. They drop, still mid-motion."
+            "attacker_msg": "Your spinning arc cuts deep into {target_name}'s {hit_location}. They drop, still mid-motion.",
+            "victim_msg": "{attacker_name}'s spinning arc cuts deep into your {hit_location}. You drop, still mid-motion.",
+            "observer_msg": "{attacker_name}'s spinning arc cuts deep into {target_name}'s {hit_location}. They drop, still mid-motion."
         },
         {
             "attacker_msg": "One clean swing of your axe — chest to hip. {target_name} falls in pieces, not pain.",
@@ -492,24 +492,24 @@ MESSAGES = {
             "observer_msg": "One clean swing of {attacker_name}'s axe — chest to hip. {target_name} falls in pieces, not pain."
         },
         {
-            "attacker_msg": "One crushing overhand from your axe splits {target_name}'s head. The scream never forms.",
-            "victim_msg": "One crushing overhand from {attacker_name}'s axe splits your head. Your scream never forms.",
-            "observer_msg": "One crushing overhand from {attacker_name}'s axe splits {target_name}'s head. The scream never forms."
+            "attacker_msg": "One crushing overhand from your axe splits {target_name}'s {hit_location}. The scream never forms.",
+            "victim_msg": "One crushing overhand from {attacker_name}'s axe splits your {hit_location}. Your scream never forms.",
+            "observer_msg": "One crushing overhand from {attacker_name}'s axe splits {target_name}'s {hit_location}. The scream never forms."
         },
         {
-            "attacker_msg": "One mighty swing of your axe crushes {target_name}'s skull sideways. What’s left isn’t much.",
-            "victim_msg": "One mighty swing of {attacker_name}'s axe crushes your skull sideways. What’s left isn’t much.",
-            "observer_msg": "One mighty swing of {attacker_name}'s axe crushes {target_name}'s skull sideways. What’s left isn’t much."
+            "attacker_msg": "One mighty swing of your axe crushes {target_name}'s {hit_location} sideways. What’s left isn’t much.",
+            "victim_msg": "One mighty swing of {attacker_name}'s axe crushes your {hit_location} sideways. What’s left isn’t much.",
+            "observer_msg": "One mighty swing of {attacker_name}'s axe crushes {target_name}'s {hit_location} sideways. What’s left isn’t much."
         },
         {
-            "attacker_msg": "One swing of your axe slices through {target_name}'s ribs like paper. The collapse is immediate and sincere.",
-            "victim_msg": "One swing of {attacker_name}'s axe slices through your ribs like paper. Your collapse is immediate and sincere.",
-            "observer_msg": "One swing of {attacker_name}'s axe slices through {target_name}'s ribs like paper. The collapse is immediate and sincere."
+            "attacker_msg": "One swing of your axe slices through {target_name}'s {hit_location} like paper. The collapse is immediate and sincere.",
+            "victim_msg": "One swing of {attacker_name}'s axe slices through your {hit_location} like paper. Your collapse is immediate and sincere.",
+            "observer_msg": "One swing of {attacker_name}'s axe slices through {target_name}'s {hit_location} like paper. The collapse is immediate and sincere."
         },
         {
-            "attacker_msg": "Your steel axe buries in {target_name}'s stomach. You twist. What’s left isn’t anyone.",
-            "victim_msg": "{attacker_name}'s steel axe buries in your stomach. {attacker_name} twists. What’s left isn’t anyone.",
-            "observer_msg": "{attacker_name}'s steel axe buries in {target_name}'s stomach. {attacker_name} twists. What’s left isn’t anyone."
+            "attacker_msg": "Your steel axe buries in {target_name}'s {hit_location}. You twist. What’s left isn’t anyone.",
+            "victim_msg": "{attacker_name}'s steel axe buries in your {hit_location}. {attacker_name} twists. What’s left isn’t anyone.",
+            "observer_msg": "{attacker_name}'s steel axe buries in {target_name}'s {hit_location}. {attacker_name} twists. What’s left isn’t anyone."
         },
         {
             "attacker_msg": "Your steel axe embeds in {target_name}'s gut. A twist, a jerk — {target_name} ends mid-grimace.",
@@ -517,9 +517,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s steel axe embeds in {target_name}'s gut. A twist, a jerk — {target_name} ends mid-grimace."
         },
         {
-            "attacker_msg": "Your axe bites deep into {target_name}'s neck. They crumple as red geysers upward.",
-            "victim_msg": "{attacker_name}'s axe bites deep into your neck. You crumple as red geysers upward.",
-            "observer_msg": "{attacker_name}'s axe bites deep into {target_name}'s neck. They crumple as red geysers upward."
+            "attacker_msg": "Your axe bites deep into {target_name}'s {hit_location}. They crumple as red geysers upward.",
+            "victim_msg": "{attacker_name}'s axe bites deep into your {hit_location}. You crumple as red geysers upward.",
+            "observer_msg": "{attacker_name}'s axe bites deep into {target_name}'s {hit_location}. They crumple as red geysers upward."
         },
         {
             "attacker_msg": "Your axe connects mid-sentence. {target_name} never finishes the thought or the breath.",
@@ -527,9 +527,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s axe connects mid-sentence. {target_name} never finishes the thought or the breath."
         },
         {
-            "attacker_msg": "Your axe hits {target_name}'s neck and doesn’t stop. They topple, wet and wordless.",
-            "victim_msg": "{attacker_name}'s axe hits your neck and doesn’t stop. You topple, wet and wordless.",
-            "observer_msg": "{attacker_name}'s axe hits {target_name}'s neck and doesn’t stop. They topple, wet and wordless."
+            "attacker_msg": "Your axe hits {target_name}'s {hit_location} and doesn’t stop. They topple, wet and wordless.",
+            "victim_msg": "{attacker_name}'s axe hits your {hit_location} and doesn’t stop. You topple, wet and wordless.",
+            "observer_msg": "{attacker_name}'s axe hits {target_name}'s {hit_location} and doesn’t stop. They topple, wet and wordless."
         },
         {
             "attacker_msg": "Your axe lands square in {target_name}'s clavicle. They don’t scream. There’s no time.",
@@ -542,24 +542,24 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s axe lands with a crunch that silences everything. {target_name}'s blood finishes the sentence."
         },
         {
-            "attacker_msg": "Your axe splits {target_name}'s face. There is no more {target_name} left to speak of.",
-            "victim_msg": "{attacker_name}'s axe splits your face. There is no more of you left to speak of.",
-            "observer_msg": "{attacker_name}'s axe splits {target_name}'s face. There is no more {target_name} left to speak of."
+            "attacker_msg": "Your axe splits {target_name}'s {hit_location}. There is no more {target_name} left to speak of.",
+            "victim_msg": "{attacker_name}'s axe splits your {hit_location}. There is no more of you left to speak of.",
+            "observer_msg": "{attacker_name}'s axe splits {target_name}'s {hit_location}. There is no more {target_name} left to speak of."
         },
         {
-            "attacker_msg": "The blade of your axe drops from above and cleaves {target_name}'s shoulder to lung. They fold inward.",
-            "victim_msg": "The blade of {attacker_name}'s axe drops from above and cleaves your shoulder to lung. You fold inward.",
-            "observer_msg": "The blade of {attacker_name}'s axe drops from above and cleaves {target_name}'s shoulder to lung. They fold inward."
+            "attacker_msg": "The blade of your axe drops from above and cleaves {target_name}'s {hit_location} to lung. They fold inward.",
+            "victim_msg": "The blade of {attacker_name}'s axe drops from above and cleaves your {hit_location} to lung. You fold inward.",
+            "observer_msg": "The blade of {attacker_name}'s axe drops from above and cleaves {target_name}'s {hit_location} to lung. They fold inward."
         },
         {
-            "attacker_msg": "The blade of your axe severs {target_name}'s spine at the neck. They jerk once — then fall wrong.",
-            "victim_msg": "The blade of {attacker_name}'s axe severs your spine at the neck. You jerk once — then fall wrong.",
-            "observer_msg": "The blade of {attacker_name}'s axe severs {target_name}'s spine at the neck. They jerk once — then fall wrong."
+            "attacker_msg": "The blade of your axe severs {target_name}'s {hit_location} at the neck. They jerk once — then fall wrong.",
+            "victim_msg": "The blade of {attacker_name}'s axe severs your {hit_location} at the neck. You jerk once — then fall wrong.",
+            "observer_msg": "The blade of {attacker_name}'s axe severs {target_name}'s {hit_location} at the neck. They jerk once — then fall wrong."
         },
         {
-            "attacker_msg": "The blade of your axe slams into {target_name}'s spine. The result is twitchless collapse.",
-            "victim_msg": "The blade of {attacker_name}'s axe slams into your spine. The result is twitchless collapse.",
-            "observer_msg": "The blade of {attacker_name}'s axe slams into {target_name}'s spine. The result is twitchless collapse."
+            "attacker_msg": "The blade of your axe slams into {target_name}'s {hit_location}. The result is twitchless collapse.",
+            "victim_msg": "The blade of {attacker_name}'s axe slams into your {hit_location}. The result is twitchless collapse.",
+            "observer_msg": "The blade of {attacker_name}'s axe slams into {target_name}'s {hit_location}. The result is twitchless collapse."
         },
         {
             "attacker_msg": "The final blow from your axe lands like a hammer from hell. {target_name} never had a chance.",
@@ -567,9 +567,9 @@ MESSAGES = {
             "observer_msg": "The final blow from {attacker_name}'s axe lands like a hammer from hell. {target_name} never had a chance."
         },
         {
-            "attacker_msg": "The haft of your axe punches {target_name}'s throat. The blade follows. The result is stillness.",
-            "victim_msg": "The haft of {attacker_name}'s axe punches your throat. The blade follows. The result is stillness.",
-            "observer_msg": "The haft of {attacker_name}'s axe punches {target_name}'s throat. The blade follows. The result is stillness."
+            "attacker_msg": "The haft of your axe punches {target_name}'s {hit_location}. The blade follows. The result is stillness.",
+            "victim_msg": "The haft of {attacker_name}'s axe punches your {hit_location}. The blade follows. The result is stillness.",
+            "observer_msg": "The haft of {attacker_name}'s axe punches {target_name}'s {hit_location}. The blade follows. The result is stillness."
         },
         {
             "attacker_msg": "Your swing lands with finality. {target_name} breaks in half emotionally and physically.",
@@ -582,29 +582,29 @@ MESSAGES = {
             "observer_msg": "{attacker_name} buries their axe in {target_name}'s gut, then rips it free. They drop, trailing what mattered."
         },
         {
-            "attacker_msg": "You cleave down into {target_name}'s shoulder with your axe. Their body caves beneath the blade.",
-            "victim_msg": "{attacker_name} cleaves down into your shoulder with their axe. Your body caves beneath the blade.",
-            "observer_msg": "{attacker_name} cleaves down into {target_name}'s shoulder with their axe. Their body caves beneath the blade."
+            "attacker_msg": "You cleave down into {target_name}'s {hit_location} with your axe. Their body caves beneath the blade.",
+            "victim_msg": "{attacker_name} cleaves down into your {hit_location} with their axe. Your body caves beneath the blade.",
+            "observer_msg": "{attacker_name} cleaves down into {target_name}'s {hit_location} with their axe. Their body caves beneath the blade."
         },
         {
-            "attacker_msg": "You drive the blade of your axe into {target_name}'s chest. The axe doesn't stop — neither does gravity.",
-            "victim_msg": "{attacker_name} drives the blade of their axe into your chest. The axe doesn't stop — neither does gravity.",
-            "observer_msg": "{attacker_name} drives the blade of their axe into {target_name}'s chest. The axe doesn't stop — neither does gravity."
+            "attacker_msg": "You drive the blade of your axe into {target_name}'s {hit_location}. The axe doesn't stop — neither does gravity.",
+            "victim_msg": "{attacker_name} drives the blade of their axe into your {hit_location}. The axe doesn't stop — neither does gravity.",
+            "observer_msg": "{attacker_name} drives the blade of their axe into {target_name}'s {hit_location}. The axe doesn't stop — neither does gravity."
         },
         {
-            "attacker_msg": "You slash your axe across {target_name}'s face. Half of it lands first. The rest follows.",
-            "victim_msg": "{attacker_name} slashes their axe across your face. Half of it lands first. The rest follows.",
-            "observer_msg": "{attacker_name} slashes their axe across {target_name}'s face. Half of it lands first. The rest follows."
+            "attacker_msg": "You slash your axe across {target_name}'s {hit_location}. Half of it lands first. The rest follows.",
+            "victim_msg": "{attacker_name} slashes their axe across your {hit_location}. Half of it lands first. The rest follows.",
+            "observer_msg": "{attacker_name} slashes their axe across {target_name}'s {hit_location}. Half of it lands first. The rest follows."
         },
         {
-            "attacker_msg": "You split {target_name}'s skull from crown to thought with your axe. They twitch and fold.",
-            "victim_msg": "{attacker_name} splits your skull from crown to thought with their axe. You twitch and fold.",
-            "observer_msg": "{attacker_name} splits {target_name}'s skull from crown to thought with their axe. They twitch and fold."
+            "attacker_msg": "You split {target_name}'s {hit_location} from crown to thought with your axe. They twitch and fold.",
+            "victim_msg": "{attacker_name} splits your {hit_location} from crown to thought with their axe. You twitch and fold.",
+            "observer_msg": "{attacker_name} splits {target_name}'s {hit_location} from crown to thought with their axe. They twitch and fold."
         },
         {
-            "attacker_msg": "You split {target_name}'s spine with one cut of your axe. There’s no protest. Just aftermath.",
-            "victim_msg": "{attacker_name} splits your spine with one cut of their axe. There’s no protest. Just aftermath.",
-            "observer_msg": "{attacker_name} splits {target_name}'s spine with one cut of their axe. There’s no protest. Just aftermath."
+            "attacker_msg": "You split {target_name}'s {hit_location} with one cut of your axe. There’s no protest. Just aftermath.",
+            "victim_msg": "{attacker_name} splits your {hit_location} with one cut of their axe. There’s no protest. Just aftermath.",
+            "observer_msg": "{attacker_name} splits {target_name}'s {hit_location} with one cut of their axe. There’s no protest. Just aftermath."
         }
     ]
 }

--- a/world/combat/messages/blowtorch.py
+++ b/world/combat/messages/blowtorch.py
@@ -66,7 +66,7 @@ MESSAGES = {
             "observer_msg": "The torch clicks, flares, and steadies into a whispering cone of heat. {attacker_name} steps forward without a word."
         },
         {
-            "attacker_msg": "The torch ignites with a bark of flame. Your hand is steady, your expression unreadable.",
+            "attacker_msg": "The torch ignites with a bark of flame. Your {hit_location} is steady, your expression unreadable.",
             "victim_msg": "The torch ignites with a bark of flame. {attacker_name}'s hand is steady, their expression unreadable.",
             "observer_msg": "The torch ignites with a bark of flame. {attacker_name}'s hand is steady, their expression unreadable."
         },
@@ -320,9 +320,9 @@ MESSAGES = {
             "observer_msg": "A flare of fire blasts past {target_name}'s side, close enough to melt the edge of their coat."
         },
         {
-            "attacker_msg": "A gout of fire roars just past {target_name}'s chest. They stumble — not from heat, but from the nearness of it.",
-            "victim_msg": "A gout of fire roars just past your chest. You stumble — not from heat, but from the nearness of it.",
-            "observer_msg": "A gout of fire roars just past {target_name}'s chest. They stumble — not from heat, but from the nearness of it."
+            "attacker_msg": "A gout of fire roars just past {target_name}'s {hit_location}. They stumble — not from heat, but from the nearness of it.",
+            "victim_msg": "A gout of fire roars just past your {hit_location}. You stumble — not from heat, but from the nearness of it.",
+            "observer_msg": "A gout of fire roars just past {target_name}'s {hit_location}. They stumble — not from heat, but from the nearness of it."
         },
         {
             "attacker_msg": "A hiss, a flash, a miss. The room fills with smoke and tension.",
@@ -346,13 +346,13 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The blowtorch hisses and misses. {target_name} flinches as heat brushes by their face.",
-            "victim_msg": "The blowtorch hisses and misses. You flinch as heat brushes by your face.",
+            "victim_msg": "The blowtorch hisses and misses. You flinch as heat brushes by your {hit_location}.",
             "observer_msg": "The blowtorch hisses and misses. {target_name} flinches as heat brushes by their face."
         },
         {
-            "attacker_msg": "The blowtorch spits a jet of fire that passes just over {target_name}'s shoulder. Close enough to smell burnt hair.",
-            "victim_msg": "The blowtorch spits a jet of fire that passes just over your shoulder. Close enough to smell burnt hair.",
-            "observer_msg": "The blowtorch spits a jet of fire that passes just over {target_name}'s shoulder. Close enough to smell burnt hair."
+            "attacker_msg": "The blowtorch spits a jet of fire that passes just over {target_name}'s {hit_location}. Close enough to smell burnt hair.",
+            "victim_msg": "The blowtorch spits a jet of fire that passes just over your {hit_location}. Close enough to smell burnt hair.",
+            "observer_msg": "The blowtorch spits a jet of fire that passes just over {target_name}'s {hit_location}. Close enough to smell burnt hair."
         },
         {
             "attacker_msg": "The fire flares, loud and angry, but finds only smoke and silence. {target_name} moves fast — for now.",
@@ -365,9 +365,9 @@ MESSAGES = {
             "observer_msg": "The fire scorches a pipe beside {target_name}. It hisses back, mocking the miss."
         },
         {
-            "attacker_msg": "The fire shoots past {target_name}'s hip. They stumble backward, heart pounding louder than the hiss of gas.",
-            "victim_msg": "The fire shoots past your hip. You stumble backward, heart pounding louder than the hiss of gas.",
-            "observer_msg": "The fire shoots past {target_name}'s hip. They stumble backward, heart pounding louder than the hiss of gas."
+            "attacker_msg": "The fire shoots past {target_name}'s {hit_location}. They stumble backward, heart pounding louder than the hiss of gas.",
+            "victim_msg": "The fire shoots past your {hit_location}. You stumble backward, heart pounding louder than the hiss of gas.",
+            "observer_msg": "The fire shoots past {target_name}'s {hit_location}. They stumble backward, heart pounding louder than the hiss of gas."
         },
         {
             "attacker_msg": "The flame grazes empty space. {target_name} blinks away sweat. That was too close.",
@@ -390,9 +390,9 @@ MESSAGES = {
             "observer_msg": "The flame streaks across the floor, chasing shadows. {target_name} dances away in time."
         },
         {
-            "attacker_msg": "The heat washes over {target_name}'s arm, but not close enough to catch. They stumble anyway.",
-            "victim_msg": "The heat washes over your arm, but not close enough to catch. You stumble anyway.",
-            "observer_msg": "The heat washes over {target_name}'s arm, but not close enough to catch. They stumble anyway."
+            "attacker_msg": "The heat washes over {target_name}'s {hit_location}, but not close enough to catch. They stumble anyway.",
+            "victim_msg": "The heat washes over your {hit_location}, but not close enough to catch. You stumble anyway.",
+            "observer_msg": "The heat washes over {target_name}'s {hit_location}, but not close enough to catch. They stumble anyway."
         },
         {
             "attacker_msg": "The torch cuts a line through the space between you and {target_name}. Your patience burns brighter than the flame.",
@@ -463,28 +463,28 @@ MESSAGES = {
         },
         {
             "attacker_msg": "A full blast to the face ends everything. Eyes boil. The voicebox scorches shut. {target_name} collapses as smoke pours skyward.",
-            "victim_msg": "A full blast to your face ends everything. Eyes boil. Your voicebox scorches shut. You collapse as smoke pours skyward.",
-            "observer_msg": "A full blast to {target_name}'s face ends everything. Eyes boil. The voicebox scorches shut. {target_name} collapses as smoke pours skyward."
+            "victim_msg": "A full blast to your {hit_location} ends everything. Eyes boil. Your voicebox scorches shut. You collapse as smoke pours skyward.",
+            "observer_msg": "A full blast to {target_name}'s {hit_location} ends everything. Eyes boil. The voicebox scorches shut. {target_name} collapses as smoke pours skyward."
         },
         {
             "attacker_msg": "A single blast to the stomach. {target_name} falls. The flame follows, and the smell of seared organs rises.",
-            "victim_msg": "A single blast to your stomach. You fall. The flame follows, and the smell of seared organs rises.",
-            "observer_msg": "A single blast to {target_name}'s stomach. They fall. The flame follows, and the smell of seared organs rises."
+            "victim_msg": "A single blast to your {hit_location}. You fall. The flame follows, and the smell of seared organs rises.",
+            "observer_msg": "A single blast to {target_name}'s {hit_location}. They fall. The flame follows, and the smell of seared organs rises."
         },
         {
             "attacker_msg": "A torrent of fire to the torso ends things quickly. {target_name} spasms, drops, and doesn’t rise.",
-            "victim_msg": "A torrent of fire to your torso ends things quickly. You spasm, drop, and don’t rise.",
-            "observer_msg": "A torrent of fire to {target_name}'s torso ends things quickly. They spasm, drop, and don’t rise."
+            "victim_msg": "A torrent of fire to your {hit_location} ends things quickly. You spasm, drop, and don’t rise.",
+            "observer_msg": "A torrent of fire to {target_name}'s {hit_location} ends things quickly. They spasm, drop, and don’t rise."
         },
         {
-            "attacker_msg": "Fire consumes the side of {target_name}'s head. The twitching doesn’t last. The flame keeps roaring.",
-            "victim_msg": "Fire consumes the side of your head. The twitching doesn’t last. The flame keeps roaring.",
-            "observer_msg": "Fire consumes the side of {target_name}'s head. The twitching doesn’t last. The flame keeps roaring."
+            "attacker_msg": "Fire consumes the side of {target_name}'s {hit_location}. The twitching doesn’t last. The flame keeps roaring.",
+            "victim_msg": "Fire consumes the side of your {hit_location}. The twitching doesn’t last. The flame keeps roaring.",
+            "observer_msg": "Fire consumes the side of {target_name}'s {hit_location}. The twitching doesn’t last. The flame keeps roaring."
         },
         {
-            "attacker_msg": "Fire finds {target_name}'s throat. The scream is instant — and then silenced. {target_name} hits the ground smoking.",
-            "victim_msg": "Fire finds your throat. Your scream is instant — and then silenced. You hit the ground smoking.",
-            "observer_msg": "Fire finds {target_name}'s throat. The scream is instant — and then silenced. {target_name} hits the ground smoking."
+            "attacker_msg": "Fire finds {target_name}'s {hit_location}. The scream is instant — and then silenced. {target_name} hits the ground smoking.",
+            "victim_msg": "Fire finds your {hit_location}. Your scream is instant — and then silenced. You hit the ground smoking.",
+            "observer_msg": "Fire finds {target_name}'s {hit_location}. The scream is instant — and then silenced. {target_name} hits the ground smoking."
         },
         {
             "attacker_msg": "Fire roars into {target_name}'s armpit, hitting organs underneath. Their body bucks once, then stops entirely.",
@@ -492,9 +492,9 @@ MESSAGES = {
             "observer_msg": "Fire roars into {target_name}'s armpit, hitting organs underneath. Their body bucks once, then stops entirely."
         },
         {
-            "attacker_msg": "Flame wraps around {target_name}'s head. They spin, slap at their own face, then fall — twitching, steaming.",
-            "victim_msg": "Flame wraps around your head. You spin, slap at your own face, then fall — twitching, steaming.",
-            "observer_msg": "Flame wraps around {target_name}'s head. They spin, slap at their own face, then fall — twitching, steaming."
+            "attacker_msg": "Flame wraps around {target_name}'s {hit_location}. They spin, slap at their own face, then fall — twitching, steaming.",
+            "victim_msg": "Flame wraps around your {hit_location}. You spin, slap at your own face, then fall — twitching, steaming.",
+            "observer_msg": "Flame wraps around {target_name}'s {hit_location}. They spin, slap at their own face, then fall — twitching, steaming."
         },
         {
             "attacker_msg": "One long blast — enough to ignite the clothes, the skin, the everything. {target_name} goes down aflame.",
@@ -507,34 +507,34 @@ MESSAGES = {
             "observer_msg": "One prolonged stream of flame catches {target_name} in the neck. The soft pop of bursting flesh ends it."
         },
         {
-            "attacker_msg": "One steady stream of flame to the side of {target_name}'s head. The skull blackens and splits. It’s over.",
-            "victim_msg": "One steady stream of flame to the side of your head. Your skull blackens and splits. It’s over.",
-            "observer_msg": "One steady stream of flame to the side of {target_name}'s head. Their skull blackens and splits. It’s over."
+            "attacker_msg": "One steady stream of flame to the side of {target_name}'s {hit_location}. The skull blackens and splits. It’s over.",
+            "victim_msg": "One steady stream of flame to the side of your {hit_location}. Your {hit_location} blackens and splits. It’s over.",
+            "observer_msg": "One steady stream of flame to the side of {target_name}'s {hit_location}. Their skull blackens and splits. It’s over."
         },
         {
-            "attacker_msg": "The blowtorch burns through {target_name}'s abdomen. They convulse, collapse, and cook where they lie.",
-            "victim_msg": "The blowtorch burns through your abdomen. You convulse, collapse, and cook where you lie.",
-            "observer_msg": "The blowtorch burns through {target_name}'s abdomen. They convulse, collapse, and cook where they lie."
+            "attacker_msg": "The blowtorch burns through {target_name}'s {hit_location}. They convulse, collapse, and cook where they lie.",
+            "victim_msg": "The blowtorch burns through your {hit_location}. You convulse, collapse, and cook where you lie.",
+            "observer_msg": "The blowtorch burns through {target_name}'s {hit_location}. They convulse, collapse, and cook where they lie."
         },
         {
-            "attacker_msg": "The blowtorch hits square in {target_name}'s chest. Clothing ignites. Their scream becomes smoke before it finishes.",
-            "victim_msg": "The blowtorch hits square in your chest. Clothing ignites. Your scream becomes smoke before it finishes.",
-            "observer_msg": "The blowtorch hits square in {target_name}'s chest. Clothing ignites. Their scream becomes smoke before it finishes."
+            "attacker_msg": "The blowtorch hits square in {target_name}'s {hit_location}. Clothing ignites. Their scream becomes smoke before it finishes.",
+            "victim_msg": "The blowtorch hits square in your {hit_location}. Clothing ignites. Your scream becomes smoke before it finishes.",
+            "observer_msg": "The blowtorch hits square in {target_name}'s {hit_location}. Clothing ignites. Their scream becomes smoke before it finishes."
         },
         {
-            "attacker_msg": "The blowtorch ignites {target_name}'s head. The scream is animal. The smell is unforgettable.",
-            "victim_msg": "The blowtorch ignites your head. Your scream is animal. The smell is unforgettable.",
-            "observer_msg": "The blowtorch ignites {target_name}'s head. The scream is animal. The smell is unforgettable."
+            "attacker_msg": "The blowtorch ignites {target_name}'s {hit_location}. The scream is animal. The smell is unforgettable.",
+            "victim_msg": "The blowtorch ignites your {hit_location}. Your scream is animal. The smell is unforgettable.",
+            "observer_msg": "The blowtorch ignites {target_name}'s {hit_location}. The scream is animal. The smell is unforgettable."
         },
         {
-            "attacker_msg": "The blowtorch turns {target_name}'s arm into ash and agony. They don’t recover — they just fall, twitching.",
-            "victim_msg": "The blowtorch turns your arm into ash and agony. You don’t recover — you just fall, twitching.",
-            "observer_msg": "The blowtorch turns {target_name}'s arm into ash and agony. They don’t recover — they just fall, twitching."
+            "attacker_msg": "The blowtorch turns {target_name}'s {hit_location} into ash and agony. They don’t recover — they just fall, twitching.",
+            "victim_msg": "The blowtorch turns your {hit_location} into ash and agony. You don’t recover — you just fall, twitching.",
+            "observer_msg": "The blowtorch turns {target_name}'s {hit_location} into ash and agony. They don’t recover — they just fall, twitching."
         },
         {
-            "attacker_msg": "The blue flame drills into {target_name}'s temple. They scream once, then fold, half their face still cooking.",
-            "victim_msg": "The blue flame drills into your temple. You scream once, then fold, half your face still cooking.",
-            "observer_msg": "The blue flame drills into {target_name}'s temple. They scream once, then fold, half their face still cooking."
+            "attacker_msg": "The blue flame drills into {target_name}'s {hit_location}. They scream once, then fold, half their face still cooking.",
+            "victim_msg": "The blue flame drills into your {hit_location}. You scream once, then fold, half your {hit_location} still cooking.",
+            "observer_msg": "The blue flame drills into {target_name}'s {hit_location}. They scream once, then fold, half their face still cooking."
         },
         {
             "attacker_msg": "The flame finds {target_name}'s open mouth. The scream is cut short, replaced by gurgling heat.",
@@ -552,9 +552,9 @@ MESSAGES = {
             "observer_msg": "The kill is surgical. The flame hits a nerve cluster. {target_name}'s reaction is fast. The death, faster."
         },
         {
-            "attacker_msg": "The torch eats into {target_name}'s skull from below the chin. They convulse, then slump, smoke rising from a ruined mouth.",
-            "victim_msg": "The torch eats into your skull from below the chin. You convulse, then slump, smoke rising from a ruined mouth.",
-            "observer_msg": "The torch eats into {target_name}'s skull from below the chin. They convulse, then slump, smoke rising from a ruined mouth."
+            "attacker_msg": "The torch eats into {target_name}'s {hit_location} from below the chin. They convulse, then slump, smoke rising from a ruined mouth.",
+            "victim_msg": "The torch eats into your {hit_location} from below the chin. You convulse, then slump, smoke rising from a ruined mouth.",
+            "observer_msg": "The torch eats into {target_name}'s {hit_location} from below the chin. They convulse, then slump, smoke rising from a ruined mouth."
         },
         {
             "attacker_msg": "The torch ignites hair, then skull, then silence. {target_name} collapses into themselves like a dying star.",
@@ -562,29 +562,29 @@ MESSAGES = {
             "observer_msg": "The torch ignites {target_name}'s hair, then skull, then silence. {target_name} collapses into themselves like a dying star."
         },
         {
-            "attacker_msg": "The torch is pressed against {target_name}'s heart. The scream doesn't last. The fire does.",
-            "victim_msg": "The torch is pressed against your heart. Your scream doesn't last. The fire does.",
-            "observer_msg": "The torch is pressed against {target_name}'s heart. The scream doesn't last. The fire does."
+            "attacker_msg": "The torch is pressed against {target_name}'s {hit_location}. The scream doesn't last. The fire does.",
+            "victim_msg": "The torch is pressed against your {hit_location}. Your scream doesn't last. The fire does.",
+            "observer_msg": "The torch is pressed against {target_name}'s {hit_location}. The scream doesn't last. The fire does."
         },
         {
-            "attacker_msg": "The torch sinks into {target_name}'s neck and lingers. They thrash, but only briefly.",
-            "victim_msg": "The torch sinks into your neck and lingers. You thrash, but only briefly.",
-            "observer_msg": "The torch sinks into {target_name}'s neck and lingers. They thrash, but only briefly."
+            "attacker_msg": "The torch sinks into {target_name}'s {hit_location} and lingers. They thrash, but only briefly.",
+            "victim_msg": "The torch sinks into your {hit_location} and lingers. You thrash, but only briefly.",
+            "observer_msg": "The torch sinks into {target_name}'s {hit_location} and lingers. They thrash, but only briefly."
         },
         {
-            "attacker_msg": "You force the torch into {target_name}'s chest and hold it. The flame doesn’t just kill — it consumes.",
-            "victim_msg": "{attacker_name} forces the torch into your chest and holds it. The flame doesn’t just kill — it consumes.",
-            "observer_msg": "{attacker_name} forces the torch into {target_name}'s chest and holds it. The flame doesn’t just kill — it consumes."
+            "attacker_msg": "You force the torch into {target_name}'s {hit_location} and hold it. The flame doesn’t just kill — it consumes.",
+            "victim_msg": "{attacker_name} forces the torch into your {hit_location} and holds it. The flame doesn’t just kill — it consumes.",
+            "observer_msg": "{attacker_name} forces the torch into {target_name}'s {hit_location} and holds it. The flame doesn’t just kill — it consumes."
         },
         {
-            "attacker_msg": "You hold the torch to {target_name}'s back until they stop moving. The smell alone confirms the job is done.",
-            "victim_msg": "{attacker_name} holds the torch to your back until you stop moving. The smell alone confirms the job is done.",
-            "observer_msg": "{attacker_name} holds the torch to {target_name}'s back until they stop moving. The smell alone confirms the job is done."
+            "attacker_msg": "You hold the torch to {target_name}'s {hit_location} until they stop moving. The smell alone confirms the job is done.",
+            "victim_msg": "{attacker_name} holds the torch to your {hit_location} until you stop moving. The smell alone confirms the job is done.",
+            "observer_msg": "{attacker_name} holds the torch to {target_name}'s {hit_location} until they stop moving. The smell alone confirms the job is done."
         },
         {
-            "attacker_msg": "You jam the flame into {target_name}'s face. Skin melts, bone sizzles, and the smell is unforgettable.",
-            "victim_msg": "{attacker_name} jams the flame into your face. Skin melts, bone sizzles, and the smell is unforgettable.",
-            "observer_msg": "{attacker_name} jams the flame into {target_name}'s face. Skin melts, bone sizzles, and the smell is unforgettable."
+            "attacker_msg": "You jam the flame into {target_name}'s {hit_location}. Skin melts, bone sizzles, and the smell is unforgettable.",
+            "victim_msg": "{attacker_name} jams the flame into your {hit_location}. Skin melts, bone sizzles, and the smell is unforgettable.",
+            "observer_msg": "{attacker_name} jams the flame into {target_name}'s {hit_location}. Skin melts, bone sizzles, and the smell is unforgettable."
         },
         {
             "attacker_msg": "You pin {target_name} down and bring the torch close. The writhing stops long before the fire does.",
@@ -597,14 +597,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name} pins {target_name} down and shoves the flame beneath their chin. Smoke pours from {target_name}'s mouth. Nothing more follows."
         },
         {
-            "attacker_msg": "You push the flame into {target_name}'s chest until breath and motion both stop. The body glows before it drops.",
-            "victim_msg": "{attacker_name} pushes the flame into your chest until breath and motion both stop. Your body glows before it drops.",
-            "observer_msg": "{attacker_name} pushes the flame into {target_name}'s chest until breath and motion both stop. The body glows before it drops."
+            "attacker_msg": "You push the flame into {target_name}'s {hit_location} until breath and motion both stop. The body glows before it drops.",
+            "victim_msg": "{attacker_name} pushes the flame into your {hit_location} until breath and motion both stop. Your body glows before it drops.",
+            "observer_msg": "{attacker_name} pushes the flame into {target_name}'s {hit_location} until breath and motion both stop. The body glows before it drops."
         },
         {
-            "attacker_msg": "You scorch {target_name}'s spine. They jerk, twitch, and stop. The fire lingers on bone.",
-            "victim_msg": "{attacker_name} scorches your spine. You jerk, twitch, and stop. The fire lingers on bone.",
-            "observer_msg": "{attacker_name} scorches {target_name}'s spine. They jerk, twitch, and stop. The fire lingers on bone."
+            "attacker_msg": "You scorch {target_name}'s {hit_location}. They jerk, twitch, and stop. The fire lingers on bone.",
+            "victim_msg": "{attacker_name} scorches your {hit_location}. You jerk, twitch, and stop. The fire lingers on bone.",
+            "observer_msg": "{attacker_name} scorches {target_name}'s {hit_location}. They jerk, twitch, and stop. The fire lingers on bone."
         }
     ]
 }

--- a/world/combat/messages/bokken.py
+++ b/world/combat/messages/bokken.py
@@ -234,7 +234,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The bokken thuds heavily as it connects with {target_name}, driving the air from their lungs.",
-            "victim_msg": "The bokken thuds heavily as it connects with you, driving the air from your lungs.",
+            "victim_msg": "The bokken thuds heavily as it connects with you, driving the air from your {hit_location}.",
             "observer_msg": "The bokken thuds heavily as it connects with {target_name}, driving the air from their lungs."
         },
         {
@@ -458,12 +458,12 @@ MESSAGES = {
     "kill": [
         {
             "attacker_msg": "Your bokken connects with {target_name}’s temple with a sickening crack; {target_name} drops, instantly still.",
-            "victim_msg": "{attacker_name}’s bokken connects with your temple with a sickening crack; you drop, instantly still.",
+            "victim_msg": "{attacker_name}’s bokken connects with your {hit_location} with a sickening crack; you drop, instantly still.",
             "observer_msg": "{attacker_name}’s bokken connects with {target_name}’s temple with a sickening crack; {target_name} drops, instantly still."
         },
         {
             "attacker_msg": "A devastating two-handed blow from the bokken crushes {target_name}’s skull, ending the fight brutally.",
-            "victim_msg": "A devastating two-handed blow from the bokken crushes your skull, ending the fight brutally.",
+            "victim_msg": "A devastating two-handed blow from the bokken crushes your {hit_location}, ending the fight brutally.",
             "observer_msg": "A devastating two-handed blow from the bokken crushes {target_name}’s skull, ending the fight brutally."
         },
         {
@@ -473,12 +473,12 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The heavy wood of the bokken strikes {target_name}’s throat, a swift and brutal end.",
-            "victim_msg": "The heavy wood of the bokken strikes your throat, a swift and brutal end.",
+            "victim_msg": "The heavy wood of the bokken strikes your {hit_location}, a swift and brutal end.",
             "observer_msg": "The heavy wood of the bokken strikes {target_name}’s throat, a swift and brutal end."
         },
         {
             "attacker_msg": "Your powerful swing with the bokken caves in {target_name}’s chest; they collapse, gasping their last.",
-            "victim_msg": "{attacker_name}’s powerful swing with the bokken caves in your chest; you collapse, gasping your last.",
+            "victim_msg": "{attacker_name}’s powerful swing with the bokken caves in your {hit_location}; you collapse, gasping your last.",
             "observer_msg": "{attacker_name}’s powerful swing with the bokken caves in {target_name}’s chest; they collapse, gasping their last."
         },
         {
@@ -498,7 +498,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The unyielding wood of the bokken breaks {target_name}’s neck with a sharp snap; they fall, lifeless.",
-            "victim_msg": "The unyielding wood of the bokken breaks your neck with a sharp snap; you fall, lifeless.",
+            "victim_msg": "The unyielding wood of the bokken breaks your {hit_location} with a sharp snap; you fall, lifeless.",
             "observer_msg": "The unyielding wood of the bokken breaks {target_name}’s neck with a sharp snap; they fall, lifeless."
         },
         {

--- a/world/combat/messages/bolt-action_rifle.py
+++ b/world/combat/messages/bolt-action_rifle.py
@@ -61,7 +61,7 @@ MESSAGES = {
             "observer_msg": "The air seems to still as {attacker_name} prepares to fire the bolt-action rifle, anticipating the sharp, heavy *CRACK* of the shot."
         },
         {
-            "attacker_msg": "Your face is a mask of concentration, finger slowly taking up the trigger slack on the bolt-action rifle.",
+            "attacker_msg": "Your {hit_location} is a mask of concentration, finger slowly taking up the trigger slack on the bolt-action rifle.",
             "victim_msg": "{attacker_name}’s face is a mask of concentration, finger slowly taking up the trigger slack on the bolt-action rifle.",
             "observer_msg": "{attacker_name}’s face is a mask of concentration, finger slowly taking up the trigger slack on the bolt-action rifle."
         },
@@ -184,7 +184,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "A direct hit! The bolt-action rifle's bullet smashes into {target_name}'s {hit_location} with the force of a sledgehammer, driving the air from their lungs. You work the bolt, preparing for a follow-up if needed.",
-            "victim_msg": "A direct hit! The bolt-action rifle's bullet smashes into your {hit_location} with the force of a sledgehammer, driving the air from your lungs. {attacker_name} works the bolt, preparing for a follow-up if needed.",
+            "victim_msg": "A direct hit! The bolt-action rifle's bullet smashes into your {hit_location} with the force of a sledgehammer, driving the air from your {hit_location}. {attacker_name} works the bolt, preparing for a follow-up if needed.",
             "observer_msg": "A direct hit! The bolt-action rifle's bullet smashes into {target_name}'s {hit_location} with the force of a sledgehammer, driving the air from their lungs. {attacker_name} works the bolt, preparing for a follow-up if needed."
         },
         {
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            "attacker_msg": "Your bolt-action rifle fires with a deafening *CRACK*, the heavy bullet thundering past {target_name}'s head and blasting a chunk out of a distant wall. You work the bolt, *clack-clack*, ejecting a spent casing.",
-            "victim_msg": "{attacker_name}'s bolt-action rifle fires with a deafening *CRACK*, the heavy bullet thundering past your head and blasting a chunk out of a distant wall. {attacker_name} works the bolt, *clack-clack*, ejecting a spent casing.",
-            "observer_msg": "{attacker_name}'s bolt-action rifle fires with a deafening *CRACK*, the heavy bullet thundering past {target_name}'s head and blasting a chunk out of a distant wall. {attacker_name} works the bolt, *clack-clack*, ejecting a spent casing."
+            "attacker_msg": "Your bolt-action rifle fires with a deafening *CRACK*, the heavy bullet thundering past {target_name}'s {hit_location} and blasting a chunk out of a distant wall. You work the bolt, *clack-clack*, ejecting a spent casing.",
+            "victim_msg": "{attacker_name}'s bolt-action rifle fires with a deafening *CRACK*, the heavy bullet thundering past your {hit_location} and blasting a chunk out of a distant wall. {attacker_name} works the bolt, *clack-clack*, ejecting a spent casing.",
+            "observer_msg": "{attacker_name}'s bolt-action rifle fires with a deafening *CRACK*, the heavy bullet thundering past {target_name}'s {hit_location} and blasting a chunk out of a distant wall. {attacker_name} works the bolt, *clack-clack*, ejecting a spent casing."
         },
         {
             "attacker_msg": "{target_name} flinches as the bolt-action rifle roars, the bullet gouging a deep furrow in the ground where they just stood. You smoothly cycle the action, searching for a new firing solution.",
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "{target_name} ducks just as your bolt-action rifle fires, the bullet searing the air where their head had been with palpable force. You cycle the bolt methodically.",
-            "victim_msg": "You duck just as {attacker_name}'s bolt-action rifle fires, the bullet searing the air where your head had been with palpable force. {attacker_name} cycles the bolt methodically.",
+            "victim_msg": "You duck just as {attacker_name}'s bolt-action rifle fires, the bullet searing the air where your {hit_location} had been with palpable force. {attacker_name} cycles the bolt methodically.",
             "observer_msg": "{target_name} ducks just as {attacker_name}'s bolt-action rifle fires, the bullet searing the air where their head had been with palpable force. {attacker_name} cycles the bolt methodically."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             "observer_msg": "A quick sidestep from {target_name} leaves {attacker_name}'s bolt-action rifle to punch a massive hole in an empty oil drum. {attacker_name} cycles the bolt, unflinching."
         },
         {
-            "attacker_msg": "The bolt-action rifle bucks powerfully in your shoulder as you miss, the recoil throwing your aim off for a moment. You work the bolt, chambering a fresh round.",
+            "attacker_msg": "The bolt-action rifle bucks powerfully in your {hit_location} as you miss, the recoil throwing your aim off for a moment. You work the bolt, chambering a fresh round.",
             "victim_msg": "The bolt-action rifle bucks powerfully in {attacker_name}'s shoulder as they miss, the recoil throwing their aim off for a moment. {attacker_name} works the bolt, chambering a fresh round.",
             "observer_msg": "The bolt-action rifle bucks powerfully in {attacker_name}'s shoulder as they miss, the recoil throwing their aim off for a moment. {attacker_name} works the bolt, chambering a fresh round."
         },
@@ -458,28 +458,28 @@ MESSAGES = {
     "kill": [
         {
             "attacker_msg": "Your bolt-action rifle bullet strikes {target_name} square in the forehead; their head explodes, and they drop, instantly obliterated. You calmly work the bolt, *clack-clack*, ejecting a spent casing.",
-            "victim_msg": "{attacker_name}'s bolt-action rifle bullet strikes you square in the forehead; your head explodes, and you drop, instantly obliterated. {attacker_name} calmly works the bolt, *clack-clack*, ejecting a spent casing.",
+            "victim_msg": "{attacker_name}'s bolt-action rifle bullet strikes you square in the forehead; your {hit_location} explodes, and you drop, instantly obliterated. {attacker_name} calmly works the bolt, *clack-clack*, ejecting a spent casing.",
             "observer_msg": "{attacker_name}'s bolt-action rifle bullet strikes {target_name} square in the forehead; their head explodes, and they drop, instantly obliterated. {attacker_name} calmly works the bolt, *clack-clack*, ejecting a spent casing."
         },
         {
             "attacker_msg": "The bolt-action rifle roars, and {target_name} clutches their chest as a massive hole appears, blood fountaining before they collapse, dead. You smoothly cycle the action, the rifle ready again.",
-            "victim_msg": "The bolt-action rifle roars, and you clutch your chest as a massive hole appears, blood fountaining before you collapse, dead. {attacker_name} smoothly cycles the action, the rifle ready again.",
+            "victim_msg": "The bolt-action rifle roars, and you clutch your {hit_location} as a massive hole appears, blood fountaining before you collapse, dead. {attacker_name} smoothly cycles the action, the rifle ready again.",
             "observer_msg": "The bolt-action rifle roars, and {target_name} clutches their chest as a massive hole appears, blood fountaining before they collapse, dead. {attacker_name} smoothly cycles the action, the rifle ready again."
         },
         {
-            "attacker_msg": "With a final, precise shot, your bolt-action rifle sends a heavy bullet through {target_name}'s heart, ending their struggles catastrophically. A brass casing flips through the air as the bolt is worked.",
-            "victim_msg": "With a final, precise shot, {attacker_name}'s bolt-action rifle sends a heavy bullet through your heart, ending your struggles catastrophically. A brass casing flips through the air as the bolt is worked.",
-            "observer_msg": "With a final, precise shot, {attacker_name}'s bolt-action rifle sends a heavy bullet through {target_name}'s heart, ending their struggles catastrophically. A brass casing flips through the air as the bolt is worked."
+            "attacker_msg": "With a final, precise shot, your bolt-action rifle sends a heavy bullet through {target_name}'s {hit_location}, ending their struggles catastrophically. A brass casing flips through the air as the bolt is worked.",
+            "victim_msg": "With a final, precise shot, {attacker_name}'s bolt-action rifle sends a heavy bullet through your {hit_location}, ending your struggles catastrophically. A brass casing flips through the air as the bolt is worked.",
+            "observer_msg": "With a final, precise shot, {attacker_name}'s bolt-action rifle sends a heavy bullet through {target_name}'s {hit_location}, ending their struggles catastrophically. A brass casing flips through the air as the bolt is worked."
         },
         {
-            "attacker_msg": "The heavy bullet fired point-blank into {target_name}'s throat from the bolt-action rifle nearly severs their head; they die in a horrific spray. You chamber another round with a decisive *shk-THUNK*.",
-            "victim_msg": "The heavy bullet fired point-blank into your throat from the bolt-action rifle nearly severs your head; you die in a horrific spray. {attacker_name} chambers another round with a decisive *shk-THUNK*.",
-            "observer_msg": "The heavy bullet fired point-blank into {target_name}'s throat from the bolt-action rifle nearly severs their head; they die in a horrific spray. {attacker_name} chambers another round with a decisive *shk-THUNK*."
+            "attacker_msg": "The heavy bullet fired point-blank into {target_name}'s {hit_location} from the bolt-action rifle nearly severs their head; they die in a horrific spray. You chamber another round with a decisive *shk-THUNK*.",
+            "victim_msg": "The heavy bullet fired point-blank into your {hit_location} from the bolt-action rifle nearly severs your {hit_location}; you die in a horrific spray. {attacker_name} chambers another round with a decisive *shk-THUNK*.",
+            "observer_msg": "The heavy bullet fired point-blank into {target_name}'s {hit_location} from the bolt-action rifle nearly severs their head; they die in a horrific spray. {attacker_name} chambers another round with a decisive *shk-THUNK*."
         },
         {
-            "attacker_msg": "Your carefully placed shot with the bolt-action rifle tears through {target_name}'s spine; they slump, a lifeless puppet. The bolt is cycled, another round sliding home.",
-            "victim_msg": "{attacker_name}’s carefully placed shot with the bolt-action rifle tears through your spine; you slump, a lifeless puppet. The bolt is cycled, another round sliding home.",
-            "observer_msg": "{attacker_name}’s carefully placed shot with the bolt-action rifle tears through {target_name}'s spine; they slump, a lifeless puppet. The bolt is cycled, another round sliding home."
+            "attacker_msg": "Your carefully placed shot with the bolt-action rifle tears through {target_name}'s {hit_location}; they slump, a lifeless puppet. The bolt is cycled, another round sliding home.",
+            "victim_msg": "{attacker_name}’s carefully placed shot with the bolt-action rifle tears through your {hit_location}; you slump, a lifeless puppet. The bolt is cycled, another round sliding home.",
+            "observer_msg": "{attacker_name}’s carefully placed shot with the bolt-action rifle tears through {target_name}'s {hit_location}; they slump, a lifeless puppet. The bolt is cycled, another round sliding home."
         },
         {
             "attacker_msg": "The bolt-action rifle, an instrument of precise death, delivers a killing blow as {target_name} is overcome by the catastrophic bullet wound. You work the bolt, preparing for any other threats.",
@@ -492,9 +492,9 @@ MESSAGES = {
             "observer_msg": "A precise shot to the base of the skull from {attacker_name}'s bolt-action rifle vaporizes the target area, ending {target_name}'s life with absolute finality. The bolt handle is lifted and drawn back, then slammed forward."
         },
         {
-            "attacker_msg": "Your single shot from the bolt-action rifle pierces {target_name}'s lung; they cough blood and collapse, dying swiftly. You cycle the bolt methodically.",
-            "victim_msg": "{attacker_name}'s single shot from the bolt-action rifle pierces your lung; you cough blood and collapse, dying swiftly. {attacker_name} cycles the bolt methodically.",
-            "observer_msg": "{attacker_name}'s single shot from the bolt-action rifle pierces {target_name}'s lung; they cough blood and collapse, dying swiftly. {attacker_name} cycles the bolt methodically."
+            "attacker_msg": "Your single shot from the bolt-action rifle pierces {target_name}'s {hit_location}; they cough blood and collapse, dying swiftly. You cycle the bolt methodically.",
+            "victim_msg": "{attacker_name}'s single shot from the bolt-action rifle pierces your {hit_location}; you cough blood and collapse, dying swiftly. {attacker_name} cycles the bolt methodically.",
+            "observer_msg": "{attacker_name}'s single shot from the bolt-action rifle pierces {target_name}'s {hit_location}; they cough blood and collapse, dying swiftly. {attacker_name} cycles the bolt methodically."
         },
         {
             "attacker_msg": "The unyielding heavy slug from your bolt-action rifle pierces a vital organ in {target_name}, which ruptures; they fall, dead before they hit the ground. A hot casing is ejected as you prepare another shot.",
@@ -503,7 +503,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "With a final, thunderous crack, you finish {target_name} with a heavy bullet through the eye from the bolt-action rifle, the back of their skull erupting. The bolt is worked with smooth efficiency.",
-            "victim_msg": "With a final, thunderous crack, {attacker_name} finishes you with a heavy bullet through the eye from the bolt-action rifle, the back of your skull erupting. The bolt is worked with smooth efficiency.",
+            "victim_msg": "With a final, thunderous crack, {attacker_name} finishes you with a heavy bullet through the eye from the bolt-action rifle, the back of your {hit_location} erupting. The bolt is worked with smooth efficiency.",
             "observer_msg": "With a final, thunderous crack, {attacker_name} finishes {target_name} with a heavy bullet through the eye from the bolt-action rifle, the back of their skull erupting. The bolt is worked with smooth efficiency."
         },
         {

--- a/world/combat/messages/bowel_disruptor.py
+++ b/world/combat/messages/bowel_disruptor.py
@@ -8,22 +8,22 @@ MESSAGES = {
     "initiate": [
         {
             "attacker_msg": "You grin, a wide, shark-like rictus, aiming the humming, gurgling obscenity of the {item_name} at {target_name}'s tender bits. A silent promise of imminent, unspeakable violation hangs in the air.",
-            "victim_msg": "{attacker_name} levels a truly unholy device – a {item_name} – at your midsection! A faint, wet gurgling sound emanates from it, a sound that promises nothing but regret and laundry bills. Your stomach clenches in preemptive horror.",
+            "victim_msg": "{attacker_name} levels a truly unholy device – a {item_name} – at your midsection! A faint, wet gurgling sound emanates from it, a sound that promises nothing but regret and laundry bills. Your {hit_location} clenches in preemptive horror.",
             "observer_msg": "{attacker_name} takes aim with a strange, gurgling contraption – a {item_name} – pointed directly at {target_name}. An almost palpable wave of impending disaster, and a faint, foul odor, emanates from the weapon.",
         },
         {
             "attacker_msg": "With a wet, throaty chuckle that seems to bubble up from a place of profound misanthropy, you bring the {item_name} to bear on {target_name}. Your eyes, wide and bloodshot, fix on their midsection with predatory intensity.",
-            "victim_msg": "A wet chuckle escapes {attacker_name} as they aim a horrifying device, the {item_name}, squarely at you. Your stomach performs a preemptive Olympic dive. A cold dread, centered in your lower abdomen, begins to spread.",
+            "victim_msg": "A wet chuckle escapes {attacker_name} as they aim a horrifying device, the {item_name}, squarely at you. Your {hit_location} performs a preemptive Olympic dive. A cold dread, centered in your lower abdomen, begins to spread.",
             "observer_msg": "{attacker_name} chuckles wetly, aiming their {item_name} at {target_name}. A palpable sense of dread fills the air, thick and cloying, as {target_name}'s fate seems sealed in a truly disgusting fashion.",
         },
         {
-            "attacker_msg": "You heft the {item_name}, its ominous, squelching hum a prelude to {target_name}'s imminent digestive Armageddon. A look of grim satisfaction settles on your face.",
+            "attacker_msg": "You heft the {item_name}, its ominous, squelching hum a prelude to {target_name}'s imminent digestive Armageddon. A look of grim satisfaction settles on your {hit_location}.",
             "victim_msg": "{attacker_name} hefts the humming, gurgling {item_name}. You feel a preemptive clench deep within your core, a primal terror usually reserved for tax audits or existential crises, but somehow much, much worse.",
             "observer_msg": "The ominous hum of a {item_name} fills the air as {attacker_name} targets {target_name}. The weapon itself seems to pulse with a malevolent, brown energy.",
         },
         {
             "attacker_msg": "You sight down the barrel of the {item_name} at {target_name}, a manic glint in your eyes. The madness is definitely setting in, and it feels disturbingly good.",
-            "victim_msg": "{attacker_name} sights down the barrel of a {item_name}, aimed directly at you. You have a sinking feeling – literally. Your sphincter sends a desperate SOS to your brain, which is currently offline due to panic.",
+            "victim_msg": "{attacker_name} sights down the barrel of a {item_name}, aimed directly at you. You have a sinking feeling – literally. Your sphincter sends a desperate SOS to your {hit_location}, which is currently offline due to panic.",
             "observer_msg": "{attacker_name} aims a {item_name} at {target_name}, a look of unhinged glee on their face. The air crackles with a terrible, brown energy, promising a truly unforgettable spectacle.",
         },
         {
@@ -32,13 +32,13 @@ MESSAGES = {
             "observer_msg": "A look of grim, almost ecstatic satisfaction crosses {attacker_name}'s face as they prepare to fire their {item_name} at {target_name}. This is clearly their art form, a symphony of suffering about to begin.",
         },
         {
-            "attacker_msg": "The {item_name} whirs to life, its targeting laser painting a sickly, pulsating green dot on {target_name}'s abdomen. A silent jeer plays on your lips.",
-            "victim_msg": "A sickly green targeting laser from {attacker_name}'s {item_name} dances over your abdomen like a harbinger of doom. You feel a sudden, overwhelming urge to be anywhere else but here, preferably on a different planet.",
+            "attacker_msg": "The {item_name} whirs to life, its targeting laser painting a sickly, pulsating green dot on {target_name}'s {hit_location}. A silent jeer plays on your lips.",
+            "victim_msg": "A sickly green targeting laser from {attacker_name}'s {item_name} dances over your {hit_location} like a harbinger of doom. You feel a sudden, overwhelming urge to be anywhere else but here, preferably on a different planet.",
             "observer_msg": "{attacker_name}'s {item_name} whirs, a green laser dot appearing on {target_name}. The scene is set for a messy, clinically catastrophic event.",
         },
         {
             "attacker_msg": "You adjust the settings on your {item_name}, cranking it up to a level that promises maximum splatter, and take aim at {target_name}. A vision of abstract expressionist horror fills your mind.",
-            "victim_msg": "{attacker_name} fiddles with their {item_name}, a look of intense concentration on their face, before aiming it at you. Your bowels send urgent, panicked signals to your brain.",
+            "victim_msg": "{attacker_name} fiddles with their {item_name}, a look of intense concentration on their face, before aiming it at you. Your bowels send urgent, panicked signals to your {hit_location}.",
             "observer_msg": "{attacker_name} adjusts their {item_name}, a look of intense, almost surgical concentration on their face as they target {target_name}. They're not just aiming; they're composing a masterpiece of misery.",
         },
         {
@@ -47,8 +47,8 @@ MESSAGES = {
             "observer_msg": "A low thrum from {attacker_name}'s {item_name} signals imminent, unpleasant consequences for {target_name}. A precautionary step back, or perhaps several, seems prudent.",
         },
         {
-            "attacker_msg": "Your finger tightens on the trigger of the {item_name}. {target_name} is about to experience a revelation, a full-body confession. A silent, manic scream builds in your chest.",
-            "victim_msg": "The world narrows to the grotesque nozzle of {attacker_name}'s {item_name}. Your life isn't flashing before your eyes, but your last meal certainly is making a reappearance bid. Your stomach churns with a dread that is both existential and very, very physical.",
+            "attacker_msg": "Your finger tightens on the trigger of the {item_name}. {target_name} is about to experience a revelation, a full-body confession. A silent, manic scream builds in your {hit_location}.",
+            "victim_msg": "The world narrows to the grotesque nozzle of {attacker_name}'s {item_name}. Your life isn't flashing before your eyes, but your last meal certainly is making a reappearance bid. Your {hit_location} churns with a dread that is both existential and very, very physical.",
             "observer_msg": "{attacker_name} looks like a prophet of some forgotten, filthy god, preparing to deliver a sermon of pure, unadulterated gastrointestinal chaos upon {target_name}. The air is thick with anticipation and a faint, sewage-like aroma.",
         },
         {
@@ -62,8 +62,8 @@ MESSAGES = {
             "observer_msg": "{attacker_name} cradles the {item_name} like a diseased infant, its obscene pulsing a clear omen of {target_name}'s impending, very personal, apocalypse. The weapon seems to almost breathe with anticipation.",
         },
         {
-            "attacker_msg": "You calibrate the Disruptor to a setting that promises pure, unadulterated colonic chaos. {target_name} is about to question every life choice that led them to this messy, messy moment. A flicker of cruel amusement crosses your face.",
-            "victim_msg": "{attacker_name} is making adjustments to that... *thing*. Their expression is one of focused malice. Your bowels feel a sudden, sympathetic dread, a cold knot forming in your stomach.",
+            "attacker_msg": "You calibrate the Disruptor to a setting that promises pure, unadulterated colonic chaos. {target_name} is about to question every life choice that led them to this messy, messy moment. A flicker of cruel amusement crosses your {hit_location}.",
+            "victim_msg": "{attacker_name} is making adjustments to that... *thing*. Their expression is one of focused malice. Your bowels feel a sudden, sympathetic dread, a cold knot forming in your {hit_location}.",
             "observer_msg": "{attacker_name} seems to be fine-tuning the {item_name}, a look of profound, almost philosophical inquiry on their face. {target_name} just looks like they're about to have a very bad trip, one that ends in a puddle of regret.",
         },
         {
@@ -88,12 +88,12 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You switch the {item_name} to a setting that promises an abstract masterpiece of questionable taste and even more questionable substances. {target_name}'s insides are the canvas.",
-            "victim_msg": "{attacker_name} adjusts a dial on that... *device*. Their eyes gleam with a disturbing artistic fervor. Your stomach is doing backflips of pure terror. You need an adult. And a priest. And a new pair of pants.",
+            "victim_msg": "{attacker_name} adjusts a dial on that... *device*. Their eyes gleam with a disturbing artistic fervor. Your {hit_location} is doing backflips of pure terror. You need an adult. And a priest. And a new pair of pants.",
             "observer_msg": "{attacker_name} selects a new setting on the {item_name}, a wild, artistic gleam in their eye. {target_name} is about to become the canvas for a truly visceral, and utterly disgusting, piece.",
         },
         {
             "attacker_msg": "The {item_name} whines, a high-pitched, nauseating sound that promises a symphony of suffering for {target_name}. A silent overture to a brown opera.",
-            "victim_msg": "A high-pitched whine emanates from {attacker_name}'s {item_name}, a sound that drills into your skull and makes your intestines quiver. You feel a terrible premonition of... gurgling. And worse.",
+            "victim_msg": "A high-pitched whine emanates from {attacker_name}'s {item_name}, a sound that drills into your {hit_location} and makes your intestines quiver. You feel a terrible premonition of... gurgling. And worse.",
             "observer_msg": "The {item_name} emits a sound that could curdle milk at fifty paces as {attacker_name} targets {target_name}. This is going to be an auditory experience as much as a visual one, unfortunately for everyone nearby.",
         },
         {
@@ -118,7 +118,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The {item_name} practically vibrates out of your hands with pent-up energy, aimed squarely at {target_name}. A silent roar of anticipation builds within you.",
-            "victim_msg": "{attacker_name} is struggling to control the device in their hands, which looks like it could cause a flood of... well, you don't want to think about it. Your stomach just hit the panic button, hard.",
+            "victim_msg": "{attacker_name} is struggling to control the device in their hands, which looks like it could cause a flood of... well, you don't want to think about it. Your {hit_location} just hit the panic button, hard.",
             "observer_msg": "{attacker_name} brandishes the {item_name} at {target_name}, the weapon thrumming with barely contained power. This is escalating into a truly epic display of poor taste and imminent disaster.",
         },
         {
@@ -128,7 +128,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You sight down the barrel, the world a brown-tinged haze of anticipation. {target_name} is a canvas, and you are about to paint your masterpiece of misery. A tremor of excitement runs through you.",
-            "victim_msg": "{attacker_name} has a thousand-yard stare, and it's fixed on your abdomen. The {item_name} hums a dirge for your dignity. You're starting to feel faint, and a little bit nauseous.",
+            "victim_msg": "{attacker_name} has a thousand-yard stare, and it's fixed on your {hit_location}. The {item_name} hums a dirge for your dignity. You're starting to feel faint, and a little bit nauseous.",
             "observer_msg": "There's a terrifying focus in {attacker_name}'s eyes as they aim the {item_name}. {target_name} is about to be the subject of some truly horrific, and deeply personal, art.",
         },
         {
@@ -157,13 +157,13 @@ MESSAGES = {
             "observer_msg": "{attacker_name} struggles to aim the wildly vibrating {item_name} at {target_name}. This is going to be a wild ride, in the worst possible way, for everyone in the blast radius.",
         },
         {
-            "attacker_msg": "A low, ominous whine builds from the {item_name}, resonating deep in your chest and, you hope, in {target_name}'s soon-to-be-ravaged guts. Your eyes narrow.",
-            "victim_msg": "The whine from {attacker_name}'s weapon is escalating, vibrating through your bones, making your teeth ache and your stomach churn. A wave of nausea washes over you.",
+            "attacker_msg": "A low, ominous whine builds from the {item_name}, resonating deep in your {hit_location} and, you hope, in {target_name}'s soon-to-be-ravaged guts. Your eyes narrow.",
+            "victim_msg": "The whine from {attacker_name}'s weapon is escalating, vibrating through your bones, making your teeth ache and your {hit_location} churn. A wave of nausea washes over you.",
             "observer_msg": "The {item_name} emits an increasingly high-pitched and nauseating whine as {attacker_name} prepares to fire on {target_name}. The sound itself is an assault.",
         },
         {
             "attacker_msg": "The weapon feels cold and wet in your hands, an instrument of pure, unadulterated biological warfare. {target_name} is the unfortunate test subject.",
-            "victim_msg": "{attacker_name} hefts the {item_name}, its surface glistening with some unidentifiable, foul slime. The sight alone is enough to make your stomach revolt.",
+            "victim_msg": "{attacker_name} hefts the {item_name}, its surface glistening with some unidentifiable, foul slime. The sight alone is enough to make your {hit_location} revolt.",
             "observer_msg": "The {item_name}, slick and pulsating in {attacker_name}'s grip, is aimed at {target_name}. The sheer wrongness of the device is palpable.",
         },
         {
@@ -178,7 +178,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "A faint, oily sheen coats the nozzle of the {item_name} as it powers up, aimed at {target_name}. The promise of a truly greasy demise hangs in the air.",
-            "victim_msg": "You see a disgusting, oily substance weeping from the nozzle of {attacker_name}'s weapon. Your stomach lurches, and a cold sweat breaks out on your skin.",
+            "victim_msg": "You see a disgusting, oily substance weeping from the nozzle of {attacker_name}'s weapon. Your {hit_location} lurches, and a cold sweat breaks out on your skin.",
             "observer_msg": "The {item_name} glistens with a foul, oily discharge as {attacker_name} prepares to fire at {target_name}. The impending mess promises to be uniquely difficult to clean.",
         },
         {
@@ -188,7 +188,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You feel a perverse sense of calm as you aim. This is your art. {target_name} is your canvas. And the {item_name} is your brush, ready to paint a masterpiece of misery.",
-            "victim_msg": "{attacker_name} has an unnervingly serene expression as they aim that... *thing*. It's the look of a true artist. A very sick, very twisted artist. Your stomach churns with a dread that is both existential and very, very physical.",
+            "victim_msg": "{attacker_name} has an unnervingly serene expression as they aim that... *thing*. It's the look of a true artist. A very sick, very twisted artist. Your {hit_location} churns with a dread that is both existential and very, very physical.",
             "observer_msg": "{attacker_name} approaches the act of firing the {item_name} with a chilling, artistic focus. {target_name} is about to be immortalized in a truly unforgettable, and deeply unpleasant, way.",
         },
         {
@@ -472,7 +472,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The {item_name} sings its swan song, and {target_name} collapses in a heap of existential regret and bodily fluids. Bravo! A standing ovation from an audience of one: you.",
-            "victim_msg": "The song... it's a brown note... a symphony of suffering... and then... blessed, if slightly stained, silence. You are free. And very, very messy. Your heart flutters, then stops.",
+            "victim_msg": "The song... it's a brown note... a symphony of suffering... and then... blessed, if slightly stained, silence. You are free. And very, very messy. Your {hit_location} flutters, then stops.",
             "observer_msg": "{target_name} has expired in a truly spectacular, if horrifyingly undignified, manner. The {item_name} is a weapon of terrible, terrible beauty. And appalling stench.",
         },
         {
@@ -599,7 +599,7 @@ MESSAGES = {
     "miss": [
         {
             "attacker_msg": "Damn and blast! Your shot from the {item_name} goes wide, merely causing a nearby potted fern to explosively, tragically void its soil all over a priceless antique rug. A costly miss.",
-            "victim_msg": "You narrowly avoid a disgusting-looking pulse of pure, weaponized indigestion from {attacker_name}'s {item_name}! You feel a faint, unpleasant rumble pass by, and the air smells faintly of regret and compost. Your heart pounds.",
+            "victim_msg": "You narrowly avoid a disgusting-looking pulse of pure, weaponized indigestion from {attacker_name}'s {item_name}! You feel a faint, unpleasant rumble pass by, and the air smells faintly of regret and compost. Your {hit_location} pounds.",
             "observer_msg": "A sickly beam from {attacker_name}'s {item_name} misses {target_name}, instead hitting a brick wall with a wet, resounding splat and a lingering, questionable odor that will outlast civilizations. The wall weeps brown tears.",
         },
         {
@@ -634,7 +634,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your aim was off! The Disruptor's beam harmlessly (to {target_name}, anyway) excavates a new, suspiciously steaming trench in the floor. The landlord is not going to be happy. And the smell is already terrible.",
-            "victim_msg": "The ground beside you erupts in a geyser of filth and displaced earth! You leap back, your heart hammering. That could have been your everything! Your everything could have been... that.",
+            "victim_msg": "The ground beside you erupts in a geyser of filth and displaced earth! You leap back, your {hit_location} hammering. That could have been your everything! Your everything could have been... that.",
             "observer_msg": "A near miss! {attacker_name}'s {item_name} carves a smoking, stinking furrow in the ground next to {target_name}. The structural integrity of this place is now questionable, as is the air quality.",
         },
         {
@@ -703,7 +703,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} misses {target_name} and ruptures a fire hydrant, which, due to some quirk of municipal plumbing, unleashes a tidal wave of raw sewage. The entire block is now a biohazard. And smells like one.",
         },
         {
-            "attacker_msg": "{target_name} was standing in front of a mirror! You almost gave yourself a colonic. That was too close. You need to be more careful with this thing. Your heart pounds in your chest.",
+            "attacker_msg": "{target_name} was standing in front of a mirror! You almost gave yourself a colonic. That was too close. You need to be more careful with this thing. Your {hit_location} pounds in your {hit_location}.",
             "victim_msg": "You leap aside, and the beam hits a mirror behind you! {attacker_name} looks horrified for a split second. You almost feel a flicker of sympathy. Then you remember they're trying to liquefy your insides. The sympathy vanishes.",
             "observer_msg": "{attacker_name}'s shot misses {target_name} and nearly hits their own reflection. The look of terror on {attacker_name}'s face was priceless. And a little bit understandable. Friendly fire isn't friendly when it's a {item_name}.",
         },
@@ -783,7 +783,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} misses {target_name} and instead creates a new, terrifying form of cheese. It's probably sentient. And very, very angry. And smells like the devil's gym socks after a marathon in Hell.",
         },
         {
-            "attacker_msg": "So close! The beam vaporizes a swarm of flies that were buzzing around {target_name}'s head. Pest control, {item_name} style! Still, a miss is a miss. And the smell of burnt flies is... unique.",
+            "attacker_msg": "So close! The beam vaporizes a swarm of flies that were buzzing around {target_name}'s {hit_location}. Pest control, {item_name} style! Still, a miss is a miss. And the smell of burnt flies is... unique.",
             "victim_msg": "You feel a wave of heat as the beam passes close, and a cloud of... something... vaporizes above you. The smell of burnt insects and... other things... fills the air. You cough, and try not to inhale too deeply.",
             "observer_msg": "{attacker_name}'s missed shot inadvertently performs a very localized, very messy form of pest control. The flies are gone. So is the pleasant aroma of... anything else. The air is now thick with the stench of incinerated insects and pure evil.",
         },

--- a/world/combat/messages/box_cutter.py
+++ b/world/combat/messages/box_cutter.py
@@ -76,7 +76,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} tests the edge on their thumb, drawing a bead of blood and a smile."
         },
         {
-            "attacker_msg": "You let the blade rest on your tongue for a heartbeat before spitting it into your hand.",
+            "attacker_msg": "You let the blade rest on your tongue for a heartbeat before spitting it into your {hit_location}.",
             "victim_msg": "{attacker_name} lets the blade rest on their tongue for a heartbeat before spitting it into their hand.",
             "observer_msg": "{attacker_name} lets the blade rest on their tongue for a heartbeat before spitting it into their hand."
         },
@@ -126,7 +126,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} lets the box cutter dangle from their fingers, blade swinging like a pendulum."
         },
         {
-            "attacker_msg": "You trace the blade along your forearm, leaving a thin red line.",
+            "attacker_msg": "You trace the blade along your {hit_location}, leaving a thin red line.",
             "victim_msg": "{attacker_name} traces the blade along their forearm, leaving a thin red line.",
             "observer_msg": "{attacker_name} traces the blade along their forearm, leaving a thin red line."
         },
@@ -340,7 +340,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} stabs at {target_name}, but the blade glances off armor."
         },
         {
-            "attacker_msg": "A flick of your wrist misses, the blade slicing only air.",
+            "attacker_msg": "A flick of your {hit_location} misses, the blade slicing only air.",
             "victim_msg": "A flick of {attacker_name}'s wrist misses, the blade slicing only air.",
             "observer_msg": "A flick of {attacker_name}'s wrist misses, the blade slicing only air."
         },
@@ -445,7 +445,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s blade glances off a boot, doing nothing."
         },
         {
-            "attacker_msg": "A flick of your wrist misses, the blade humming in the air.",
+            "attacker_msg": "A flick of your {hit_location} misses, the blade humming in the air.",
             "victim_msg": "A flick of {attacker_name}'s wrist misses, the blade humming in the air.",
             "observer_msg": "A flick of {attacker_name}'s wrist misses, the blade humming in the air."
         },
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "You drive the box cutter into {target_name}'s throat. Blood spurts in a fine, surgical arc.",
-            "victim_msg": "{attacker_name} drives the box cutter into your throat. Blood spurts in a fine, surgical arc.",
-            "observer_msg": "{attacker_name} drives the box cutter into {target_name}'s throat. Blood spurts in a fine, surgical arc."
+            "attacker_msg": "You drive the box cutter into {target_name}'s {hit_location}. Blood spurts in a fine, surgical arc.",
+            "victim_msg": "{attacker_name} drives the box cutter into your {hit_location}. Blood spurts in a fine, surgical arc.",
+            "observer_msg": "{attacker_name} drives the box cutter into {target_name}'s {hit_location}. Blood spurts in a fine, surgical arc."
         },
         {
             "attacker_msg": "A quick slash from your box cutter opens {target_name}'s carotid. They drop, clutching at a wound that won’t close.",
@@ -467,19 +467,19 @@ MESSAGES = {
             "observer_msg": "A quick slash from {attacker_name}'s box cutter opens {target_name}'s carotid. They drop, clutching at a wound that won’t close."
         },
         {
-            "attacker_msg": "Your blade slips between {target_name}'s ribs and into their heart. They collapse, twitching.",
-            "victim_msg": "{attacker_name}'s blade slips between your ribs and into your heart. You collapse, twitching.",
-            "observer_msg": "{attacker_name}'s blade slips between {target_name}'s ribs and into their heart. They collapse, twitching."
+            "attacker_msg": "Your blade slips between {target_name}'s {hit_location} and into their heart. They collapse, twitching.",
+            "victim_msg": "{attacker_name}'s blade slips between your {hit_location} and into your {hit_location}. You collapse, twitching.",
+            "observer_msg": "{attacker_name}'s blade slips between {target_name}'s {hit_location} and into their heart. They collapse, twitching."
         },
         {
-            "attacker_msg": "You carve a line across {target_name}'s neck. The blood is bright and fast.",
-            "victim_msg": "{attacker_name} carves a line across your neck. The blood is bright and fast.",
-            "observer_msg": "{attacker_name} carves a line across {target_name}'s neck. The blood is bright and fast."
+            "attacker_msg": "You carve a line across {target_name}'s {hit_location}. The blood is bright and fast.",
+            "victim_msg": "{attacker_name} carves a line across your {hit_location}. The blood is bright and fast.",
+            "observer_msg": "{attacker_name} carves a line across {target_name}'s {hit_location}. The blood is bright and fast."
         },
         {
-            "attacker_msg": "A jab from you under the jaw sends the blade into {target_name}'s brain. They go limp instantly.",
-            "victim_msg": "A jab from {attacker_name} under the jaw sends the blade into your brain. You go limp instantly.",
-            "observer_msg": "A jab from {attacker_name} under the jaw sends the blade into {target_name}'s brain. They go limp instantly."
+            "attacker_msg": "A jab from you under the jaw sends the blade into {target_name}'s {hit_location}. They go limp instantly.",
+            "victim_msg": "A jab from {attacker_name} under the jaw sends the blade into your {hit_location}. You go limp instantly.",
+            "observer_msg": "A jab from {attacker_name} under the jaw sends the blade into {target_name}'s {hit_location}. They go limp instantly."
         },
         {
             "attacker_msg": "Your box cutter punctures {target_name}'s eye. They scream, then fall silent.",
@@ -492,24 +492,24 @@ MESSAGES = {
             "observer_msg": "{attacker_name} slices {target_name}'s femoral artery. Blood pools fast. They don’t last."
         },
         {
-            "attacker_msg": "A quick stab from your box cutter to {target_name}'s temple ends everything in a blink.",
-            "victim_msg": "A quick stab from {attacker_name}'s box cutter to your temple ends everything in a blink.",
-            "observer_msg": "A quick stab from {attacker_name}'s box cutter to {target_name}'s temple ends everything in a blink."
+            "attacker_msg": "A quick stab from your box cutter to {target_name}'s {hit_location} ends everything in a blink.",
+            "victim_msg": "A quick stab from {attacker_name}'s box cutter to your {hit_location} ends everything in a blink.",
+            "observer_msg": "A quick stab from {attacker_name}'s box cutter to {target_name}'s {hit_location} ends everything in a blink."
         },
         {
-            "attacker_msg": "Your blade slips under {target_name}'s sternum. They gasp, then nothing.",
-            "victim_msg": "{attacker_name}'s blade slips under your sternum. You gasp, then nothing.",
-            "observer_msg": "{attacker_name}'s blade slips under {target_name}'s sternum. They gasp, then nothing."
+            "attacker_msg": "Your blade slips under {target_name}'s {hit_location}. They gasp, then nothing.",
+            "victim_msg": "{attacker_name}'s blade slips under your {hit_location}. You gasp, then nothing.",
+            "observer_msg": "{attacker_name}'s blade slips under {target_name}'s {hit_location}. They gasp, then nothing."
         },
         {
-            "attacker_msg": "You draw the blade across {target_name}'s throat. The spray is arterial, the silence final.",
-            "victim_msg": "{attacker_name} draws the blade across your throat. The spray is arterial, the silence final.",
-            "observer_msg": "{attacker_name} draws the blade across {target_name}'s throat. The spray is arterial, the silence final."
+            "attacker_msg": "You draw the blade across {target_name}'s {hit_location}. The spray is arterial, the silence final.",
+            "victim_msg": "{attacker_name} draws the blade across your {hit_location}. The spray is arterial, the silence final.",
+            "observer_msg": "{attacker_name} draws the blade across {target_name}'s {hit_location}. The spray is arterial, the silence final."
         },
         {
-            "attacker_msg": "A downward stab from your box cutter buries the blade in {target_name}'s chest. They shudder, then still.",
-            "victim_msg": "A downward stab from {attacker_name}'s box cutter buries the blade in your chest. You shudder, then still.",
-            "observer_msg": "A downward stab from {attacker_name}'s box cutter buries the blade in {target_name}'s chest. They shudder, then still."
+            "attacker_msg": "A downward stab from your box cutter buries the blade in {target_name}'s {hit_location}. They shudder, then still.",
+            "victim_msg": "A downward stab from {attacker_name}'s box cutter buries the blade in your {hit_location}. You shudder, then still.",
+            "observer_msg": "A downward stab from {attacker_name}'s box cutter buries the blade in {target_name}'s {hit_location}. They shudder, then still."
         },
         {
             "attacker_msg": "Your blade slips between {target_name}'s vertebrae. They drop, boneless.",
@@ -517,24 +517,24 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s blade slips between {target_name}'s vertebrae. They drop, boneless."
         },
         {
-            "attacker_msg": "You carve a smile across {target_name}'s face. The grin is permanent.",
-            "victim_msg": "{attacker_name} carves a smile across your face. The grin is permanent.",
-            "observer_msg": "{attacker_name} carves a smile across {target_name}'s face. The grin is permanent."
+            "attacker_msg": "You carve a smile across {target_name}'s {hit_location}. The grin is permanent.",
+            "victim_msg": "{attacker_name} carves a smile across your {hit_location}. The grin is permanent.",
+            "observer_msg": "{attacker_name} carves a smile across {target_name}'s {hit_location}. The grin is permanent."
         },
         {
-            "attacker_msg": "A jab from your box cutter to {target_name}'s heart. They collapse, eyes wide and empty.",
-            "victim_msg": "A jab from {attacker_name}'s box cutter to your heart. You collapse, eyes wide and empty.",
-            "observer_msg": "A jab from {attacker_name}'s box cutter to {target_name}'s heart. They collapse, eyes wide and empty."
+            "attacker_msg": "A jab from your box cutter to {target_name}'s {hit_location}. They collapse, eyes wide and empty.",
+            "victim_msg": "A jab from {attacker_name}'s box cutter to your {hit_location}. You collapse, eyes wide and empty.",
+            "observer_msg": "A jab from {attacker_name}'s box cutter to {target_name}'s {hit_location}. They collapse, eyes wide and empty."
         },
         {
-            "attacker_msg": "Your blade punctures {target_name}'s lung. They drown on dry land.",
-            "victim_msg": "{attacker_name}'s blade punctures your lung. You drown on dry land.",
-            "observer_msg": "{attacker_name}'s blade punctures {target_name}'s lung. They drown on dry land."
+            "attacker_msg": "Your blade punctures {target_name}'s {hit_location}. They drown on dry land.",
+            "victim_msg": "{attacker_name}'s blade punctures your {hit_location}. You drown on dry land.",
+            "observer_msg": "{attacker_name}'s blade punctures {target_name}'s {hit_location}. They drown on dry land."
         },
         {
-            "attacker_msg": "You slice {target_name}'s wrist, blood spraying in pulses.",
-            "victim_msg": "{attacker_name} slices your wrist, blood spraying in pulses.",
-            "observer_msg": "{attacker_name} slices {target_name}'s wrist, blood spraying in pulses."
+            "attacker_msg": "You slice {target_name}'s {hit_location}, blood spraying in pulses.",
+            "victim_msg": "{attacker_name} slices your {hit_location}, blood spraying in pulses.",
+            "observer_msg": "{attacker_name} slices {target_name}'s {hit_location}, blood spraying in pulses."
         },
         {
             "attacker_msg": "A quick flick of your box cutter opens {target_name}'s jugular. They drop in seconds.",
@@ -547,14 +547,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s blade slips behind {target_name}'s ear. They never see it coming."
         },
         {
-            "attacker_msg": "A stab from your box cutter to the base of {target_name}'s skull ends it instantly.",
-            "victim_msg": "A stab from {attacker_name}'s box cutter to the base of your skull ends it instantly.",
-            "observer_msg": "A stab from {attacker_name}'s box cutter to the base of {target_name}'s skull ends it instantly."
+            "attacker_msg": "A stab from your box cutter to the base of {target_name}'s {hit_location} ends it instantly.",
+            "victim_msg": "A stab from {attacker_name}'s box cutter to the base of your {hit_location} ends it instantly.",
+            "observer_msg": "A stab from {attacker_name}'s box cutter to the base of {target_name}'s {hit_location} ends it instantly."
         },
         {
-            "attacker_msg": "You carve a spiral down {target_name}'s chest. The pattern is red and final.",
-            "victim_msg": "{attacker_name} carves a spiral down your chest. The pattern is red and final.",
-            "observer_msg": "{attacker_name} carves a spiral down {target_name}'s chest. The pattern is red and final."
+            "attacker_msg": "You carve a spiral down {target_name}'s {hit_location}. The pattern is red and final.",
+            "victim_msg": "{attacker_name} carves a spiral down your {hit_location}. The pattern is red and final.",
+            "observer_msg": "{attacker_name} carves a spiral down {target_name}'s {hit_location}. The pattern is red and final."
         },
         {
             "attacker_msg": "Your blade slips into {target_name}'s mouth, blood pouring out.",
@@ -562,14 +562,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s blade slips into {target_name}'s mouth, blood pouring out."
         },
         {
-            "attacker_msg": "A quick slash from your box cutter opens {target_name}'s abdomen. They fold, spilling.",
-            "victim_msg": "A quick slash from {attacker_name}'s box cutter opens your abdomen. You fold, spilling.",
-            "observer_msg": "A quick slash from {attacker_name}'s box cutter opens {target_name}'s abdomen. They fold, spilling."
+            "attacker_msg": "A quick slash from your box cutter opens {target_name}'s {hit_location}. They fold, spilling.",
+            "victim_msg": "A quick slash from {attacker_name}'s box cutter opens your {hit_location}. You fold, spilling.",
+            "observer_msg": "A quick slash from {attacker_name}'s box cutter opens {target_name}'s {hit_location}. They fold, spilling."
         },
         {
-            "attacker_msg": "Your blade punctures {target_name}'s heart. They gasp, then nothing.",
-            "victim_msg": "{attacker_name}'s blade punctures your heart. You gasp, then nothing.",
-            "observer_msg": "{attacker_name}'s blade punctures {target_name}'s heart. They gasp, then nothing."
+            "attacker_msg": "Your blade punctures {target_name}'s {hit_location}. They gasp, then nothing.",
+            "victim_msg": "{attacker_name}'s blade punctures your {hit_location}. You gasp, then nothing.",
+            "observer_msg": "{attacker_name}'s blade punctures {target_name}'s {hit_location}. They gasp, then nothing."
         },
         {
             "attacker_msg": "You draw the blade across {target_name}'s eyes. The world goes dark for them.",
@@ -592,19 +592,19 @@ MESSAGES = {
             "observer_msg": "A quick flick of {attacker_name}'s box cutter opens {target_name}'s femoral. Blood sprays, life drains."
         },
         {
-            "attacker_msg": "Your blade slips into {target_name}'s chest, twisting. They are gone before they hit the ground.",
-            "victim_msg": "{attacker_name}'s blade slips into your chest, twisting. You are gone before you hit the ground.",
-            "observer_msg": "{attacker_name}'s blade slips into {target_name}'s chest, twisting. They are gone before they hit the ground."
+            "attacker_msg": "Your blade slips into {target_name}'s {hit_location}, twisting. They are gone before they hit the ground.",
+            "victim_msg": "{attacker_name}'s blade slips into your {hit_location}, twisting. You are gone before you hit the ground.",
+            "observer_msg": "{attacker_name}'s blade slips into {target_name}'s {hit_location}, twisting. They are gone before they hit the ground."
         },
         {
-            "attacker_msg": "You carve a line across {target_name}'s throat. The spray is bright, the end abrupt.",
-            "victim_msg": "{attacker_name} carves a line across your throat. The spray is bright, the end abrupt.",
-            "observer_msg": "{attacker_name} carves a line across {target_name}'s throat. The spray is bright, the end abrupt."
+            "attacker_msg": "You carve a line across {target_name}'s {hit_location}. The spray is bright, the end abrupt.",
+            "victim_msg": "{attacker_name} carves a line across your {hit_location}. The spray is bright, the end abrupt.",
+            "observer_msg": "{attacker_name} carves a line across {target_name}'s {hit_location}. The spray is bright, the end abrupt."
         },
         {
-            "attacker_msg": "A final stab from your box cutter to {target_name}'s heart. They sag, then fall.",
-            "victim_msg": "A final stab from {attacker_name}'s box cutter to your heart. You sag, then fall.",
-            "observer_msg": "A final stab from {attacker_name}'s box cutter to {target_name}'s heart. They sag, then fall."
+            "attacker_msg": "A final stab from your box cutter to {target_name}'s {hit_location}. They sag, then fall.",
+            "victim_msg": "A final stab from {attacker_name}'s box cutter to your {hit_location}. You sag, then fall.",
+            "observer_msg": "A final stab from {attacker_name}'s box cutter to {target_name}'s {hit_location}. They sag, then fall."
         }
     ]
 }

--- a/world/combat/messages/brass_knuckles.py
+++ b/world/combat/messages/brass_knuckles.py
@@ -6,7 +6,7 @@ MESSAGES = {
             "observer_msg": "A low grunt. A breath. Then {attacker_name} steps forward, the sound of their knuckles clinking together the only herald needed."
         },
         {
-            "attacker_msg": "You tilt your head, take a subtle inhale. Your brass is ready to meet bone. The dance is already starting.",
+            "attacker_msg": "You tilt your {hit_location}, take a subtle inhale. Your brass is ready to meet bone. The dance is already starting.",
             "victim_msg": "A tilt of {attacker_name}'s head. A subtle inhale. Then brass meets bone — not yours, not yet, but soon. The dance is already starting.",
             "observer_msg": "A tilt of {attacker_name}'s head. A subtle inhale. Then brass meets bone — not {target_name}'s, not yet, but soon. The dance is already starting."
         },
@@ -41,7 +41,7 @@ MESSAGES = {
             "observer_msg": "Nothing theatrical. Just {attacker_name} standing there, hands clenched, the brass dull and worn, like it's been through a hundred exits."
         },
         {
-            "attacker_msg": "One ring at a time, you slide your knuckles into place. The sound is soft metal, but it thuds in your chest like a threat.",
+            "attacker_msg": "One ring at a time, you slide your knuckles into place. The sound is soft metal, but it thuds in your {hit_location} like a threat.",
             "victim_msg": "One ring at a time, the knuckles slide into place. The sound is soft metal, but it thuds in the chest like a threat as {attacker_name} readies them.",
             "observer_msg": "One ring at a time, the knuckles slide into place. The sound is soft metal, but it thuds in the chest like a threat as {attacker_name} readies them."
         },
@@ -51,7 +51,7 @@ MESSAGES = {
             "observer_msg": "The air seems to change as {attacker_name} raises their hands. No blade. No flash. Just fists wrapped in the cold shine of brass and an aura that says they’ve ended things with less."
         },
         {
-            "attacker_msg": "Your brass clinks as you rotate your wrist. Not flashy. Not elegant. Just deliberate — like punctuation at the end of a sentence.",
+            "attacker_msg": "Your brass clinks as you rotate your {hit_location}. Not flashy. Not elegant. Just deliberate — like punctuation at the end of a sentence.",
             "victim_msg": "The brass clinks as {attacker_name} rotates their wrist. Not flashy. Not elegant. Just deliberate — like punctuation at the end of a sentence.",
             "observer_msg": "The brass clinks as {attacker_name} rotates their wrist. Not flashy. Not elegant. Just deliberate — like punctuation at the end of a sentence."
         },
@@ -116,7 +116,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} cracks their knuckles — flesh against metal, a promise made audible. There's no flash of steel, just the dull gleam of pain made personal."
         },
         {
-            "attacker_msg": "You crack your neck and slide your brass knuckles on with a solemn kind of ritual. Not flashy — just final.",
+            "attacker_msg": "You crack your {hit_location} and slide your brass knuckles on with a solemn kind of ritual. Not flashy — just final.",
             "victim_msg": "{attacker_name} cracks their neck and slides the brass knuckles on with a solemn kind of ritual. Not flashy — just final.",
             "observer_msg": "{attacker_name} cracks their neck and slides the brass knuckles on with a solemn kind of ritual. Not flashy — just final."
         },
@@ -156,12 +156,12 @@ MESSAGES = {
             "observer_msg": "{attacker_name} rolls their fingers into a ball, testing the weight. The brass hums with muscle memory and old grudges."
         },
         {
-            "attacker_msg": "You roll your neck with a soft pop and slide your brass into place like a relic returned. You can feel the weight of memory in the way you tighten your fist — this isn’t the first time you’ve buried your past in someone else's face.",
-            "victim_msg": "{attacker_name} rolls their neck with a soft pop and slides the brass into place like a relic returned. You can feel the weight of memory in the way they tighten their fist — this isn’t the first time they’ve buried their past in your face.",
-            "observer_msg": "{attacker_name} rolls their neck with a soft pop and slides the brass into place like a relic returned. You can feel the weight of memory in the way they tighten their fist — this isn’t the first time they’ve buried their past in {target_name}'s face."
+            "attacker_msg": "You roll your {hit_location} with a soft pop and slide your brass into place like a relic returned. You can feel the weight of memory in the way you tighten your fist — this isn’t the first time you’ve buried your past in someone else's face.",
+            "victim_msg": "{attacker_name} rolls their neck with a soft pop and slides the brass into place like a relic returned. You can feel the weight of memory in the way they tighten their fist — this isn’t the first time they’ve buried their past in your {hit_location}.",
+            "observer_msg": "{attacker_name} rolls their neck with a soft pop and slides the brass into place like a relic returned. You can feel the weight of memory in the way they tighten their fist — this isn’t the first time they’ve buried their past in {target_name}'s {hit_location}."
         },
         {
-            "attacker_msg": "You rotate your wrist, your brass gleaming like old teeth. The sound echoes louder than it should.",
+            "attacker_msg": "You rotate your {hit_location}, your brass gleaming like old teeth. The sound echoes louder than it should.",
             "victim_msg": "{attacker_name} rotates their wrist, the brass gleaming like old teeth. The sound echoes louder than it should.",
             "observer_msg": "{attacker_name} rotates their wrist, the brass gleaming like old teeth. The sound echoes louder than it should."
         },
@@ -228,9 +228,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s knuckles meet {target_name}'s {hit_location} and the result is immediate — their {hit_location} whips sideways, a fine mist of spit and red trailing behind like punctuation. There’s a beat, a stagger, and the dull thud of knees losing faith."
         },
         {
-            "attacker_msg": "No wasted motion from you — just the brutal truth of metal meeting {target_name}'s skull. They blink, then sway, then drop to a {hit_location}.",
-            "victim_msg": "No wasted motion from {attacker_name} — just the brutal truth of metal meeting your skull. You blink, then sway, then drop to a {hit_location}.",
-            "observer_msg": "No wasted motion from {attacker_name} — just the brutal truth of metal meeting {target_name}'s skull. They blink, then sway, then drop to a {hit_location}."
+            "attacker_msg": "No wasted motion from you — just the brutal truth of metal meeting {target_name}'s {hit_location}. They blink, then sway, then drop to a {hit_location}.",
+            "victim_msg": "No wasted motion from {attacker_name} — just the brutal truth of metal meeting your {hit_location}. You blink, then sway, then drop to a {hit_location}.",
+            "observer_msg": "No wasted motion from {attacker_name} — just the brutal truth of metal meeting {target_name}'s {hit_location}. They blink, then sway, then drop to a {hit_location}."
         },
         {
             "attacker_msg": "Your blow crunches into {target_name}'s {hit_location}. For a moment, everything pauses. Then the blood starts.",
@@ -380,9 +380,9 @@ MESSAGES = {
             "observer_msg": "A miss from {attacker_name}, but not a mistake. They recalibrate instantly, brass knuckles still shining like unfinished business."
         },
         {
-            "attacker_msg": "Your mistimed jab flies past {target_name}'s head. The punch doesn't land, but the message still does.",
-            "victim_msg": "A mistimed jab from {attacker_name} flies past your head. The punch doesn't land, but the message still does.",
-            "observer_msg": "A mistimed jab from {attacker_name} flies past {target_name}'s head. The punch doesn't land, but the message still does."
+            "attacker_msg": "Your mistimed jab flies past {target_name}'s {hit_location}. The punch doesn't land, but the message still does.",
+            "victim_msg": "A mistimed jab from {attacker_name} flies past your {hit_location}. The punch doesn't land, but the message still does.",
+            "observer_msg": "A mistimed jab from {attacker_name} flies past {target_name}'s {hit_location}. The punch doesn't land, but the message still does."
         },
         {
             "attacker_msg": "You swing and hit nothing more. You don't flinch. You've missed before. You'll correct.",
@@ -431,7 +431,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The ground vibrates faintly where your punch should’ve landed on {target_name}. They sidestep, but their face is pale — they felt the future.",
-            "victim_msg": "The ground vibrates faintly where {attacker_name}'s punch should’ve landed on you. You sidestep, but your face is pale — you felt the future.",
+            "victim_msg": "The ground vibrates faintly where {attacker_name}'s punch should’ve landed on you. You sidestep, but your {hit_location} is pale — you felt the future.",
             "observer_msg": "The ground vibrates faintly where {attacker_name}'s punch should’ve landed on {target_name}. They sidestep, but their face is pale — they felt the future."
         },
         {
@@ -471,7 +471,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your swing is sharp, practiced, but still wrong. {target_name} shifts low, and your knuckles pass inches from their face. You can almost hear the sigh of relief that never quite reaches their lungs.",
-            "victim_msg": "{attacker_name}'s swing is sharp, practiced, but still wrong. You shift low, and the knuckles pass inches from your face. You can almost hear your sigh of relief that never quite reaches your lungs.",
+            "victim_msg": "{attacker_name}'s swing is sharp, practiced, but still wrong. You shift low, and the knuckles pass inches from your {hit_location}. You can almost hear your sigh of relief that never quite reaches your {hit_location}.",
             "observer_msg": "{attacker_name}'s swing is sharp, practiced, but still wrong. {target_name} shifts low, and the knuckles pass inches from their face. You can almost hear the sigh of relief that never quite reaches their lungs."
         },
         {
@@ -496,7 +496,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You lunge with force, your momentum dragging the blow too far. {target_name} slides past, breath catching in their throat, mind already recalculating how many more of those they can afford to dodge.",
-            "victim_msg": "{attacker_name} lunges with force, momentum dragging the blow too far. You slide past, breath catching in your throat, mind already recalculating how many more of those you can afford to dodge.",
+            "victim_msg": "{attacker_name} lunges with force, momentum dragging the blow too far. You slide past, breath catching in your {hit_location}, mind already recalculating how many more of those you can afford to dodge.",
             "observer_msg": "{attacker_name} lunges with force, momentum dragging the blow too far. {target_name} slides past, breath catching in their throat, mind already recalculating how many more of those they can afford to dodge."
         },
         {
@@ -530,9 +530,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} swings wide, the brass catching nothing but air and frustration. {target_name} breathes a little harder, a little faster."
         },
         {
-            "attacker_msg": "You swing with raw intention, your brass whistling through the space where {target_name}'s head was a second ago. The silence that follows is laced with anticipation and regret.",
-            "victim_msg": "{attacker_name} swings with raw intention, the brass whistling through the space where your head was a second ago. The silence that follows is laced with anticipation and regret.",
-            "observer_msg": "{attacker_name} swings with raw intention, the brass whistling through the space where {target_name}'s head was a second ago. The silence that follows is laced with anticipation and regret."
+            "attacker_msg": "You swing with raw intention, your brass whistling through the space where {target_name}'s {hit_location} was a second ago. The silence that follows is laced with anticipation and regret.",
+            "victim_msg": "{attacker_name} swings with raw intention, the brass whistling through the space where your {hit_location} was a second ago. The silence that follows is laced with anticipation and regret.",
+            "observer_msg": "{attacker_name} swings with raw intention, the brass whistling through the space where {target_name}'s {hit_location} was a second ago. The silence that follows is laced with anticipation and regret."
         },
         {
             "attacker_msg": "You throw a haymaker that finds only wind and your bad intentions. {target_name} stares, heart pounding.",
@@ -571,7 +571,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "{target_name} ducks just in time as you swing, the metal brushing past their temple like a whisper with bad intentions.",
-            "victim_msg": "You duck just in time as {attacker_name} swings, the metal brushing past your temple like a whisper with bad intentions.",
+            "victim_msg": "You duck just in time as {attacker_name} swings, the metal brushing past your {hit_location} like a whisper with bad intentions.",
             "observer_msg": "{target_name} ducks just in time as {attacker_name} swings, the metal brushing past their temple like a whisper with bad intentions."
         },
         {
@@ -581,7 +581,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "{target_name} pivots just enough to let your punch pass beside them, the force of it tugging air like a promise unfulfilled. Their heart pounds — they were a breath away from blackout.",
-            "victim_msg": "You pivot just enough to let {attacker_name}'s punch pass beside you, the force of it tugging air like a promise unfulfilled. Your heart pounds — you were a breath away from blackout.",
+            "victim_msg": "You pivot just enough to let {attacker_name}'s punch pass beside you, the force of it tugging air like a promise unfulfilled. Your {hit_location} pounds — you were a breath away from blackout.",
             "observer_msg": "{target_name} pivots just enough to let {attacker_name}'s punch pass beside them, the force of it tugging air like a promise unfulfilled. Their heart pounds — they were a breath away from blackout."
         },
         {
@@ -592,29 +592,29 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "Your hook to the side of {target_name}'s head ends the debate. They collapse into themselves like a question answered too late.",
-            "victim_msg": "A hook to the side of your head from {attacker_name} ends the debate. You collapse into yourself like a question answered too late.",
-            "observer_msg": "A hook to the side of {target_name}'s head from {attacker_name} ends the debate. They collapse into themselves like a question answered too late."
+            "attacker_msg": "Your hook to the side of {target_name}'s {hit_location} ends the debate. They collapse into themselves like a question answered too late.",
+            "victim_msg": "A hook to the side of your {hit_location} from {attacker_name} ends the debate. You collapse into yourself like a question answered too late.",
+            "observer_msg": "A hook to the side of {target_name}'s {hit_location} from {attacker_name} ends the debate. They collapse into themselves like a question answered too late."
         },
         {
-            "attacker_msg": "Your last uppercut snaps {target_name}'s head back. It stays there for a moment, as if trying to detach. Then it all comes down.",
-            "victim_msg": "A last uppercut from {attacker_name} snaps your head back. It stays there for a moment, as if trying to detach. Then it all comes down.",
-            "observer_msg": "A last uppercut from {attacker_name} snaps {target_name}'s head back. It stays there for a moment, as if trying to detach. Then it all comes down."
+            "attacker_msg": "Your last uppercut snaps {target_name}'s {hit_location} back. It stays there for a moment, as if trying to detach. Then it all comes down.",
+            "victim_msg": "A last uppercut from {attacker_name} snaps your {hit_location} back. It stays there for a moment, as if trying to detach. Then it all comes down.",
+            "observer_msg": "A last uppercut from {attacker_name} snaps {target_name}'s {hit_location} back. It stays there for a moment, as if trying to detach. Then it all comes down."
         },
         {
-            "attacker_msg": "A straight shot from you to {target_name}'s temple. Lights out. No encore.",
-            "victim_msg": "A straight shot from {attacker_name} to your temple. Lights out. No encore.",
-            "observer_msg": "A straight shot from {attacker_name} to {target_name}'s temple. Lights out. No encore."
+            "attacker_msg": "A straight shot from you to {target_name}'s {hit_location}. Lights out. No encore.",
+            "victim_msg": "A straight shot from {attacker_name} to your {hit_location}. Lights out. No encore.",
+            "observer_msg": "A straight shot from {attacker_name} to {target_name}'s {hit_location}. Lights out. No encore."
         },
         {
-            "attacker_msg": "Your brass crashes into {target_name}'s temple. Their legs give out, arms limp. They fold like a blueprint someone stopped believing in.",
-            "victim_msg": "{attacker_name}'s brass crashes into your temple. Your legs give out, arms limp. You fold like a blueprint someone stopped believing in.",
-            "observer_msg": "{attacker_name}'s brass crashes into {target_name}'s temple. Their legs give out, arms limp. They fold like a blueprint someone stopped believing in."
+            "attacker_msg": "Your brass crashes into {target_name}'s {hit_location}. Their legs give out, arms limp. They fold like a blueprint someone stopped believing in.",
+            "victim_msg": "{attacker_name}'s brass crashes into your {hit_location}. Your legs give out, arms limp. You fold like a blueprint someone stopped believing in.",
+            "observer_msg": "{attacker_name}'s brass crashes into {target_name}'s {hit_location}. Their legs give out, arms limp. They fold like a blueprint someone stopped believing in."
         },
         {
-            "attacker_msg": "Your brass slams into {target_name}'s spine. Their body folds inward like a bad plan under pressure.",
-            "victim_msg": "{attacker_name}'s brass slams into your spine. Your body folds inward like a bad plan under pressure.",
-            "observer_msg": "{attacker_name}'s brass slams into {target_name}'s spine. Their body folds inward like a bad plan under pressure."
+            "attacker_msg": "Your brass slams into {target_name}'s {hit_location}. Their body folds inward like a bad plan under pressure.",
+            "victim_msg": "{attacker_name}'s brass slams into your {hit_location}. Your body folds inward like a bad plan under pressure.",
+            "observer_msg": "{attacker_name}'s brass slams into {target_name}'s {hit_location}. Their body folds inward like a bad plan under pressure."
         },
         {
             "attacker_msg": "It’s not rage — it’s ritual. Your punch is slow, final, full of silence. {target_name} offers no resistance to the dark.",
@@ -623,7 +623,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "It’s not your punch that kills {target_name} — it’s the fall, the angle, the way their skull meets the curb afterward. Your brass just lit the fuse.",
-            "victim_msg": "It’s not the punch from {attacker_name} that kills you — it’s the fall, the angle, the way your skull meets the curb afterward. Brass just lit the fuse.",
+            "victim_msg": "It’s not the punch from {attacker_name} that kills you — it’s the fall, the angle, the way your {hit_location} meets the curb afterward. Brass just lit the fuse.",
             "observer_msg": "It’s not the punch from {attacker_name} that kills {target_name} — it’s the fall, the angle, the way their skull meets the curb afterward. Brass just lit the fuse."
         },
         {
@@ -632,9 +632,9 @@ MESSAGES = {
             "observer_msg": "No scream. No flailing. Just a twitch, a slump, and a red smear across the floor that won’t ask for explanation after {attacker_name}'s blow to {target_name}."
         },
         {
-            "attacker_msg": "No scream. No theatrics. Just a hard, efficient end from you — brass into {target_name}'s throat, collapse into stillness. You don’t gloat. You just exhale, letting the silence finish the sentence you started.",
-            "victim_msg": "No scream. No theatrics. Just a hard, efficient end — {attacker_name}'s brass into your throat, collapse into stillness. {attacker_name} doesn’t gloat. They just exhale, letting the silence finish the sentence they started.",
-            "observer_msg": "No scream. No theatrics. Just a hard, efficient end — {attacker_name}'s brass into {target_name}'s throat, collapse into stillness. {attacker_name} doesn’t gloat. They just exhale, letting the silence finish the sentence they started."
+            "attacker_msg": "No scream. No theatrics. Just a hard, efficient end from you — brass into {target_name}'s {hit_location}, collapse into stillness. You don’t gloat. You just exhale, letting the silence finish the sentence you started.",
+            "victim_msg": "No scream. No theatrics. Just a hard, efficient end — {attacker_name}'s brass into your {hit_location}, collapse into stillness. {attacker_name} doesn’t gloat. They just exhale, letting the silence finish the sentence they started.",
+            "observer_msg": "No scream. No theatrics. Just a hard, efficient end — {attacker_name}'s brass into {target_name}'s {hit_location}, collapse into stillness. {attacker_name} doesn’t gloat. They just exhale, letting the silence finish the sentence they started."
         },
         {
             "attacker_msg": "No theatrics. No wind-up from you. Just brass, velocity, and inevitability. {target_name} won’t be getting back up.",
@@ -647,9 +647,9 @@ MESSAGES = {
             "observer_msg": "One last blow from {attacker_name} — brutal and merciful in equal measure. {target_name} hits the ground before the echo fades."
         },
         {
-            "attacker_msg": "One last hit from you to {target_name}'s ribs. They wheeze, cough, and drop. The pool that spreads is the punctuation.",
-            "victim_msg": "One last hit from {attacker_name} to your ribs. You wheeze, cough, and drop. The pool that spreads is the punctuation.",
-            "observer_msg": "One last hit from {attacker_name} to {target_name}'s ribs. They wheeze, cough, and drop. The pool that spreads is the punctuation."
+            "attacker_msg": "One last hit from you to {target_name}'s {hit_location}. They wheeze, cough, and drop. The pool that spreads is the punctuation.",
+            "victim_msg": "One last hit from {attacker_name} to your {hit_location}. You wheeze, cough, and drop. The pool that spreads is the punctuation.",
+            "observer_msg": "One last hit from {attacker_name} to {target_name}'s {hit_location}. They wheeze, cough, and drop. The pool that spreads is the punctuation."
         },
         {
             "attacker_msg": "One last punch from you, low and upward, catches {target_name} under the jaw. The sound is sick, wet, intimate. Their eyes roll back, and they crumple like a paper model doused in regret.",
@@ -672,9 +672,9 @@ MESSAGES = {
             "observer_msg": "The crunch of {target_name}'s bone from {attacker_name}'s blow, the spray of their blood, and then stillness. The scene exhales."
         },
         {
-            "attacker_msg": "Your final blow is delivered with no fanfare — just your brass meeting {target_name}'s temple in a clean, echoing note of collapse. Their body goes rigid, then slack, as though the string suspending them from life has finally snapped.",
-            "victim_msg": "The final blow from {attacker_name} is delivered with no fanfare — just brass meeting your temple in a clean, echoing note of collapse. Your body goes rigid, then slack, as though the string suspending you from life has finally snapped.",
-            "observer_msg": "The final blow from {attacker_name} is delivered with no fanfare — just brass meeting {target_name}'s temple in a clean, echoing note of collapse. Their body goes rigid, then slack, as though the string suspending them from life has finally snapped."
+            "attacker_msg": "Your final blow is delivered with no fanfare — just your brass meeting {target_name}'s {hit_location} in a clean, echoing note of collapse. Their body goes rigid, then slack, as though the string suspending them from life has finally snapped.",
+            "victim_msg": "The final blow from {attacker_name} is delivered with no fanfare — just brass meeting your {hit_location} in a clean, echoing note of collapse. Your body goes rigid, then slack, as though the string suspending you from life has finally snapped.",
+            "observer_msg": "The final blow from {attacker_name} is delivered with no fanfare — just brass meeting {target_name}'s {hit_location} in a clean, echoing note of collapse. Their body goes rigid, then slack, as though the string suspending them from life has finally snapped."
         },
         {
             "attacker_msg": "Your final blow is short, ugly, and complete. {target_name}’s breath stops trying. Their body agrees.",
@@ -682,9 +682,9 @@ MESSAGES = {
             "observer_msg": "The final blow from {attacker_name} is short, ugly, and complete. {target_name}’s breath stops trying. Their body agrees."
         },
         {
-            "attacker_msg": "Your final punch lands square on {target_name}'s jaw. There’s a sharp sound, then nothing. They fall in silence, eyes open, soul gone.",
-            "victim_msg": "{attacker_name}'s final punch lands square on your jaw. There’s a sharp sound, then nothing. You fall in silence, eyes open, soul gone.",
-            "observer_msg": "{attacker_name}'s final punch lands square on {target_name}'s jaw. There’s a sharp sound, then nothing. They fall in silence, eyes open, soul gone."
+            "attacker_msg": "Your final punch lands square on {target_name}'s {hit_location}. There’s a sharp sound, then nothing. They fall in silence, eyes open, soul gone.",
+            "victim_msg": "{attacker_name}'s final punch lands square on your {hit_location}. There’s a sharp sound, then nothing. You fall in silence, eyes open, soul gone.",
+            "observer_msg": "{attacker_name}'s final punch lands square on {target_name}'s {hit_location}. There’s a sharp sound, then nothing. They fall in silence, eyes open, soul gone."
         },
         {
             "attacker_msg": "Your final punch lands with a sound that makes the air recoil. {target_name} crumples like scaffolding losing faith in architecture.",
@@ -693,12 +693,12 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your final punch leaves {target_name} sagging. Not dead yet, but beyond return. Their eyes say what their lungs can’t.",
-            "victim_msg": "{attacker_name}'s final punch leaves you sagging. Not dead yet, but beyond return. Your eyes say what your lungs can’t.",
+            "victim_msg": "{attacker_name}'s final punch leaves you sagging. Not dead yet, but beyond return. Your eyes say what your {hit_location} can’t.",
             "observer_msg": "{attacker_name}'s final punch leaves {target_name} sagging. Not dead yet, but beyond return. Their eyes say what their lungs can’t."
         },
         {
             "attacker_msg": "Your hit doesn't kill {target_name} immediately. It's the fall — the way their skull hits the concrete like a gavel.",
-            "victim_msg": "{attacker_name}'s hit doesn't kill you immediately. It's the fall — the way your skull hits the concrete like a gavel.",
+            "victim_msg": "{attacker_name}'s hit doesn't kill you immediately. It's the fall — the way your {hit_location} hits the concrete like a gavel.",
             "observer_msg": "{attacker_name}'s hit doesn't kill {target_name} immediately. It's the fall — the way their skull hits the concrete like a gavel."
         },
         {
@@ -727,14 +727,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s strike is clean, final, and horrible. {target_name} drops with a slack-jawed expression that reads like an unfinished sentence."
         },
         {
-            "attacker_msg": "You bury your fist in {target_name}'s throat. The gasp is wet and short. The silence after is clinical.",
-            "victim_msg": "{attacker_name} buries their fist in your throat. The gasp is wet and short. The silence after is clinical.",
-            "observer_msg": "{attacker_name} buries their fist in {target_name}'s throat. The gasp is wet and short. The silence after is clinical."
+            "attacker_msg": "You bury your fist in {target_name}'s {hit_location}. The gasp is wet and short. The silence after is clinical.",
+            "victim_msg": "{attacker_name} buries their fist in your {hit_location}. The gasp is wet and short. The silence after is clinical.",
+            "observer_msg": "{attacker_name} buries their fist in {target_name}'s {hit_location}. The gasp is wet and short. The silence after is clinical."
         },
         {
-            "attacker_msg": "You don’t even breathe hard. You just withdraw your fist from the ruin of {target_name}'s face and let gravity do the rest.",
-            "victim_msg": "{attacker_name} doesn’t even breathe hard. They just withdraw their fist from the ruin of your face and let gravity do the rest.",
-            "observer_msg": "{attacker_name} doesn’t even breathe hard. They just withdraw their fist from the ruin of {target_name}'s face and let gravity do the rest."
+            "attacker_msg": "You don’t even breathe hard. You just withdraw your fist from the ruin of {target_name}'s {hit_location} and let gravity do the rest.",
+            "victim_msg": "{attacker_name} doesn’t even breathe hard. They just withdraw their fist from the ruin of your {hit_location} and let gravity do the rest.",
+            "observer_msg": "{attacker_name} doesn’t even breathe hard. They just withdraw their fist from the ruin of {target_name}'s {hit_location} and let gravity do the rest."
         },
         {
             "attacker_msg": "You hit {target_name} hard enough to silence a thought mid-formation. They don’t even finish falling before the lights go out.",
@@ -747,9 +747,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} steps back as {target_name} falls, letting gravity and brass write the ending together."
         },
         {
-            "attacker_msg": "Your fist buries deep into {target_name}'s temple. There's no scream, just a twitch, then silence. Heavy. Permanent.",
-            "victim_msg": "{attacker_name}'s fist buries deep into your temple. There's no scream, just a twitch, then silence. Heavy. Permanent.",
-            "observer_msg": "{attacker_name}'s fist buries deep into {target_name}'s temple. There's no scream, just a twitch, then silence. Heavy. Permanent."
+            "attacker_msg": "Your fist buries deep into {target_name}'s {hit_location}. There's no scream, just a twitch, then silence. Heavy. Permanent.",
+            "victim_msg": "{attacker_name}'s fist buries deep into your {hit_location}. There's no scream, just a twitch, then silence. Heavy. Permanent.",
+            "observer_msg": "{attacker_name}'s fist buries deep into {target_name}'s {hit_location}. There's no scream, just a twitch, then silence. Heavy. Permanent."
         },
         {
             "attacker_msg": "Your fist connects with surgical malice. Your brass comes back red. {target_name} doesn’t come back at all.",
@@ -757,14 +757,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s fist connects with surgical malice. The brass comes back red. {target_name} doesn’t come back at all."
         },
         {
-            "attacker_msg": "Your fist connects with {target_name}'s throat. The sound they make isn’t human. Then there’s no sound at all.",
-            "victim_msg": "{attacker_name}'s fist connects with your throat. The sound you make isn’t human. Then there’s no sound at all.",
-            "observer_msg": "{attacker_name}'s fist connects with {target_name}'s throat. The sound they make isn’t human. Then there’s no sound at all."
+            "attacker_msg": "Your fist connects with {target_name}'s {hit_location}. The sound they make isn’t human. Then there’s no sound at all.",
+            "victim_msg": "{attacker_name}'s fist connects with your {hit_location}. The sound you make isn’t human. Then there’s no sound at all.",
+            "observer_msg": "{attacker_name}'s fist connects with {target_name}'s {hit_location}. The sound they make isn’t human. Then there’s no sound at all."
         },
         {
-            "attacker_msg": "Your knuckles dig into the side of {target_name}'s skull, and something inside gives way. The light leaves their eyes not as a flicker, but as a retreat — swift, permanent, and uncaring.",
-            "victim_msg": "{attacker_name}'s knuckles dig into the side of your skull, and something inside gives way. The light leaves your eyes not as a flicker, but as a retreat — swift, permanent, and uncaring.",
-            "observer_msg": "{attacker_name}'s knuckles dig into the side of {target_name}'s skull, and something inside gives way. The light leaves their eyes not as a flicker, but as a retreat — swift, permanent, and uncaring."
+            "attacker_msg": "Your knuckles dig into the side of {target_name}'s {hit_location}, and something inside gives way. The light leaves their eyes not as a flicker, but as a retreat — swift, permanent, and uncaring.",
+            "victim_msg": "{attacker_name}'s knuckles dig into the side of your {hit_location}, and something inside gives way. The light leaves your eyes not as a flicker, but as a retreat — swift, permanent, and uncaring.",
+            "observer_msg": "{attacker_name}'s knuckles dig into the side of {target_name}'s {hit_location}, and something inside gives way. The light leaves their eyes not as a flicker, but as a retreat — swift, permanent, and uncaring."
         }
     ]
 }

--- a/world/combat/messages/break-action_shotgun.py
+++ b/world/combat/messages/break-action_shotgun.py
@@ -61,7 +61,7 @@ MESSAGES = {
             "observer_msg": "The air is tense as {attacker_name} prepares to fire the break-action shotgun, anticipating the deafening *BOOM* and the immediate need to reload."
         },
         {
-            "attacker_msg": "Your face is set, finger ready on the trigger of your break-action shotgun, poised to send a cloud of buckshot.",
+            "attacker_msg": "Your {hit_location} is set, finger ready on the trigger of your break-action shotgun, poised to send a cloud of buckshot.",
             "victim_msg": "{attacker_name}’s face is set, finger ready on the trigger of the break-action shotgun, poised to send a cloud of buckshot.",
             "observer_msg": "{attacker_name}’s face is set, finger ready on the trigger of the break-action shotgun, poised to send a cloud of buckshot."
         },
@@ -311,7 +311,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "{target_name} ducks as your break-action shotgun roars, the pellets shredding the air where their head just was. You crack open the shotgun, reload, and snap it shut, ready for another try.",
-            "victim_msg": "You duck as {attacker_name}'s break-action shotgun roars, the pellets shredding the air where your head just was. {attacker_name} cracks open the shotgun, reloads, and snaps it shut, ready for another try.",
+            "victim_msg": "You duck as {attacker_name}'s break-action shotgun roars, the pellets shredding the air where your {hit_location} just was. {attacker_name} cracks open the shotgun, reloads, and snaps it shut, ready for another try.",
             "observer_msg": "{target_name} ducks as {attacker_name}'s break-action shotgun roars, the pellets shredding the air where their head just was. {attacker_name} cracks open the shotgun, reloads, and snaps it shut, ready for another try."
         },
         {
@@ -335,9 +335,9 @@ MESSAGES = {
             "observer_msg": "A sudden movement from {target_name} causes {attacker_name}'s break-action shotgun blast to go wide, the pellets thudding harmlessly into a stack of crates. The action is broken, reloaded, and closed with a solid *clack* by {attacker_name}."
         },
         {
-            "attacker_msg": "Your break-action shotgun fires with a thunderous report, but your aim is off, the shot sailing harmlessly over {target_name}'s head. You break the shotgun open, reload, and snap it shut with practiced speed.",
-            "victim_msg": "{attacker_name}'s break-action shotgun fires with a thunderous report, but their aim is off, the shot sailing harmlessly over your head. The shotgun is broken open, reloaded, and snapped shut with practiced speed by {attacker_name}.",
-            "observer_msg": "{attacker_name}'s break-action shotgun fires with a thunderous report, but their aim is off, the shot sailing harmlessly over {target_name}'s head. The shotgun is broken open, reloaded, and snapped shut with practiced speed by {attacker_name}."
+            "attacker_msg": "Your break-action shotgun fires with a thunderous report, but your aim is off, the shot sailing harmlessly over {target_name}'s {hit_location}. You break the shotgun open, reload, and snap it shut with practiced speed.",
+            "victim_msg": "{attacker_name}'s break-action shotgun fires with a thunderous report, but their aim is off, the shot sailing harmlessly over your {hit_location}. The shotgun is broken open, reloaded, and snapped shut with practiced speed by {attacker_name}.",
+            "observer_msg": "{attacker_name}'s break-action shotgun fires with a thunderous report, but their aim is off, the shot sailing harmlessly over {target_name}'s {hit_location}. The shotgun is broken open, reloaded, and snapped shut with practiced speed by {attacker_name}."
         },
         {
             "attacker_msg": "Your shot is deflected by a piece of cover, the buckshot spraying harmlessly. You flick out spent shells as you reload, seeking a clearer shot.",
@@ -365,7 +365,7 @@ MESSAGES = {
             "observer_msg": "A quick sidestep from {target_name} leaves {attacker_name}'s break-action shotgun to punch a wide pattern of holes in an empty doorway. {attacker_name} reloads, unflinching."
         },
         {
-            "attacker_msg": "Your break-action shotgun jumps in your shoulder as you miss, the recoil spoiling the follow-through. You break the action, chambering fresh, potent shells.",
+            "attacker_msg": "Your break-action shotgun jumps in your {hit_location} as you miss, the recoil spoiling the follow-through. You break the action, chambering fresh, potent shells.",
             "victim_msg": "{attacker_name}'s break-action shotgun jumps in their shoulder as they miss, the recoil spoiling the follow-through. {attacker_name} breaks the action, chambering fresh, potent shells.",
             "observer_msg": "{attacker_name}'s break-action shotgun jumps in their shoulder as they miss, the recoil spoiling the follow-through. {attacker_name} breaks the action, chambering fresh, potent shells."
         },
@@ -462,9 +462,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name}'s break-action shotgun erupts with a deafening *BOOM*, the concentrated blast of buckshot tearing {target_name} apart at close range; they collapse in a bloody heap. {attacker_name} breaks open the action, spent shells smoking as they're ejected, and calmly reloads."
         },
         {
-            "attacker_msg": "Your break-action shotgun roars, and a heavy slug slams into {target_name}'s chest with catastrophic force, ending their fight instantly. You crack open the shotgun, reload, and snap it shut, the job done.",
-            "victim_msg": "{attacker_name}'s break-action shotgun roars, and a heavy slug slams into your chest with catastrophic force, ending your fight instantly. {attacker_name} cracks open the shotgun, reloads, and snaps it shut, the job done.",
-            "observer_msg": "{attacker_name}'s break-action shotgun roars, and a heavy slug slams into {target_name}'s chest with catastrophic force, ending their fight instantly. {attacker_name} cracks open the shotgun, reloads, and snaps it shut, the job done."
+            "attacker_msg": "Your break-action shotgun roars, and a heavy slug slams into {target_name}'s {hit_location} with catastrophic force, ending their fight instantly. You crack open the shotgun, reload, and snap it shut, the job done.",
+            "victim_msg": "{attacker_name}'s break-action shotgun roars, and a heavy slug slams into your {hit_location} with catastrophic force, ending your fight instantly. {attacker_name} cracks open the shotgun, reloads, and snaps it shut, the job done.",
+            "observer_msg": "{attacker_name}'s break-action shotgun roars, and a heavy slug slams into {target_name}'s {hit_location} with catastrophic force, ending their fight instantly. {attacker_name} cracks open the shotgun, reloads, and snaps it shut, the job done."
         },
         {
             "attacker_msg": "With a final, brutal blast to the head, your break-action shotgun obliterates {target_name}, leaving a gruesome scene. Smoke curls from the muzzles as you reload with grim satisfaction.",
@@ -477,9 +477,9 @@ MESSAGES = {
             "observer_msg": "A devastating point-blank discharge from {attacker_name}'s break-action shotgun engulfs {target_name}, who is torn apart by the sheer force of the pellets. {attacker_name} breaks the action, inserts fresh shells, and stands ready."
         },
         {
-            "attacker_msg": "Your break-action shotgun's blast strikes {target_name}'s torso, the massive trauma instantly fatal. You quickly eject the smoking shells and reload, the air thick with the smell of cordite.",
-            "victim_msg": "{attacker_name}'s break-action shotgun's blast strikes your torso, the massive trauma instantly fatal. {attacker_name} quickly ejects the smoking shells and reloads, the air thick with the smell of cordite.",
-            "observer_msg": "{attacker_name}'s break-action shotgun's blast strikes {target_name}'s torso, the massive trauma instantly fatal. {attacker_name} quickly ejects the smoking shells and reloads, the air thick with the smell of cordite."
+            "attacker_msg": "Your break-action shotgun's blast strikes {target_name}'s {hit_location}, the massive trauma instantly fatal. You quickly eject the smoking shells and reload, the air thick with the smell of cordite.",
+            "victim_msg": "{attacker_name}'s break-action shotgun's blast strikes your {hit_location}, the massive trauma instantly fatal. {attacker_name} quickly ejects the smoking shells and reloads, the air thick with the smell of cordite.",
+            "observer_msg": "{attacker_name}'s break-action shotgun's blast strikes {target_name}'s {hit_location}, the massive trauma instantly fatal. {attacker_name} quickly ejects the smoking shells and reloads, the air thick with the smell of cordite."
         },
         {
             "attacker_msg": "Your break-action shotgun, an instrument of brutal close-quarters finality, delivers a killing blow as {target_name} is shredded by the wide, powerful blast. You break the action, reload, and close it with a solid *clack*.",
@@ -537,9 +537,9 @@ MESSAGES = {
             "observer_msg": "A devastating blast from {attacker_name}'s break-action shotgun to {target_name}'s center mass ends the conflict abruptly. {attacker_name} reloads, unflinching at the carnage."
         },
         {
-            "attacker_msg": "Your break-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s torso. You break the action, chambering fresh, potent shells, the area now quiet.",
-            "victim_msg": "{attacker_name}'s break-action shotgun's payload makes solid, brutal, and fatal contact with your torso. {attacker_name} breaks the action, chambering fresh, potent shells, the area now quiet.",
-            "observer_msg": "{attacker_name}'s break-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s torso. {attacker_name} breaks the action, chambering fresh, potent shells, the area now quiet."
+            "attacker_msg": "Your break-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s {hit_location}. You break the action, chambering fresh, potent shells, the area now quiet.",
+            "victim_msg": "{attacker_name}'s break-action shotgun's payload makes solid, brutal, and fatal contact with your {hit_location}. {attacker_name} breaks the action, chambering fresh, potent shells, the area now quiet.",
+            "observer_msg": "{attacker_name}'s break-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s {hit_location}. {attacker_name} breaks the action, chambering fresh, potent shells, the area now quiet."
         },
         {
             "attacker_msg": "Your break-action shotgun projectile cloud finds its mark with lethal precision, delivering a fatal pattern of wounds to {target_name}. Spent shells arc away as you reload.",
@@ -593,7 +593,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your break-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}’s torso. You reload the shotgun, the grim task complete.",
-            "victim_msg": "{attacker_name}’s break-action shotgun delivers a wide, penetrating, and fatal impact to your torso. The shotgun is reloaded by {attacker_name}, the grim task complete.",
+            "victim_msg": "{attacker_name}’s break-action shotgun delivers a wide, penetrating, and fatal impact to your {hit_location}. The shotgun is reloaded by {attacker_name}, the grim task complete.",
             "observer_msg": "{attacker_name}’s break-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}’s torso. The shotgun is reloaded by {attacker_name}, the grim task complete."
         },
         {

--- a/world/combat/messages/brick.py
+++ b/world/combat/messages/brick.py
@@ -86,7 +86,7 @@ MESSAGES = {
             "observer_msg": "They don’t yell. They don’t threaten. {attacker_name} just lifts the brick with the casual cruelty of someone who's done this before."
         },
         {
-            "attacker_msg": "With a grunt, You pull the brick from a jacket pocket. It lands in your hand with a sound like punctuation.",
+            "attacker_msg": "With a grunt, You pull the brick from a jacket pocket. It lands in your {hit_location} with a sound like punctuation.",
             "victim_msg": "With a grunt, {attacker_name} pulls the brick from a jacket pocket. It lands in their hand with a sound like punctuation.",
             "observer_msg": "With a grunt, {attacker_name} pulls the brick from a jacket pocket. It lands in their hand with a sound like punctuation."
         },
@@ -121,7 +121,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} pulls the brick from a coat pocket. It’s chipped, dirty, and exactly what this moment calls for."
         },
         {
-            "attacker_msg": "You raise the brick and let it rest against your shoulder. It’s not a threat — it’s a promise.",
+            "attacker_msg": "You raise the brick and let it rest against your {hit_location}. It’s not a threat — it’s a promise.",
             "victim_msg": "{attacker_name} raises the brick and lets it rest against their shoulder. It’s not a threat — it’s a promise.",
             "observer_msg": "{attacker_name} raises the brick and lets it rest against their shoulder. It’s not a threat — it’s a promise."
         },
@@ -131,17 +131,17 @@ MESSAGES = {
             "observer_msg": "{attacker_name} rolls the brick across their knuckles like brass. It isn’t for show. It’s for momentum."
         },
         {
-            "attacker_msg": "You roll the brick in your hand like weighing dice. This game ends in fractures.",
+            "attacker_msg": "You roll the brick in your {hit_location} like weighing dice. This game ends in fractures.",
             "victim_msg": "{attacker_name} rolls the brick in their hand like weighing dice. This game ends in fractures.",
             "observer_msg": "{attacker_name} rolls the brick in their hand like weighing dice. This game ends in fractures."
         },
         {
-            "attacker_msg": "You roll your wrist, flexing fingers around the brick. The message is clear. This won’t take long.",
+            "attacker_msg": "You roll your {hit_location}, flexing fingers around the brick. The message is clear. This won’t take long.",
             "victim_msg": "{attacker_name} rolls their wrist, flexing fingers around the brick. The message is clear. This won’t take long.",
             "observer_msg": "{attacker_name} rolls their wrist, flexing fingers around the brick. The message is clear. This won’t take long."
         },
         {
-            "attacker_msg": "You rotate the brick in your hand, aligning the chipped corner forward like a blade. It’s blunt precision.",
+            "attacker_msg": "You rotate the brick in your {hit_location}, aligning the chipped corner forward like a blade. It’s blunt precision.",
             "victim_msg": "{attacker_name} rotates the brick in their hand, aligning the chipped corner forward like a blade. It’s blunt precision.",
             "observer_msg": "{attacker_name} rotates the brick in their hand, aligning the chipped corner forward like a blade. It’s blunt precision."
         },
@@ -305,7 +305,7 @@ MESSAGES = {
     ],
     'miss': [
         {
-            "attacker_msg": "A missed lunge twists Your torso off center. The recovery is fast. Too fast.",
+            "attacker_msg": "A missed lunge twists Your {hit_location} off center. The recovery is fast. Too fast.",
             "victim_msg": "A missed lunge twists {attacker_name}'s torso off center. The recovery is fast. Too fast.",
             "observer_msg": "A missed lunge twists {attacker_name}'s torso off center. The recovery is fast. Too fast."
         },
@@ -380,9 +380,9 @@ MESSAGES = {
             "observer_msg": "The brick thuds into the wall beside {target_name}. Dust and mortar explode from the impact."
         },
         {
-            "attacker_msg": "The brick whooshes just past {target_name}'s shoulder, close enough to rattle their sense of safety.",
-            "victim_msg": "The brick whooshes just past your shoulder, close enough to rattle your sense of safety.",
-            "observer_msg": "The brick whooshes just past {target_name}'s shoulder, close enough to rattle their sense of safety."
+            "attacker_msg": "The brick whooshes just past {target_name}'s {hit_location}, close enough to rattle their sense of safety.",
+            "victim_msg": "The brick whooshes just past your {hit_location}, close enough to rattle your sense of safety.",
+            "observer_msg": "The brick whooshes just past {target_name}'s {hit_location}, close enough to rattle their sense of safety."
         },
         {
             "attacker_msg": "The lunge misses. The message doesn’t. {target_name} backs away fast.",
@@ -435,9 +435,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} stumbles mid-swing. The brick hits nothing but the floor — loudly."
         },
         {
-            "attacker_msg": "You swing hard, but the brick catches only air. It whistles past {target_name}'s head like a warning.",
-            "victim_msg": "{attacker_name} swings hard, but the brick catches only air. It whistles past your head like a warning.",
-            "observer_msg": "{attacker_name} swings hard, but the brick catches only air. It whistles past {target_name}'s head like a warning."
+            "attacker_msg": "You swing hard, but the brick catches only air. It whistles past {target_name}'s {hit_location} like a warning.",
+            "victim_msg": "{attacker_name} swings hard, but the brick catches only air. It whistles past your {hit_location} like a warning.",
+            "observer_msg": "{attacker_name} swings hard, but the brick catches only air. It whistles past {target_name}'s {hit_location} like a warning."
         },
         {
             "attacker_msg": "You swing wild and low. The brick carves the floor instead of flesh.",
@@ -445,7 +445,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} swings wild and low. The brick carves the floor instead of flesh."
         },
         {
-            "attacker_msg": "Your strike veers wide. The force behind it leaves your shoulder aching.",
+            "attacker_msg": "Your strike veers wide. The force behind it leaves your {hit_location} aching.",
             "victim_msg": "{attacker_name}'s strike veers wide. The force behind it leaves their shoulder aching.",
             "observer_msg": "{attacker_name}'s strike veers wide. The force behind it leaves their shoulder aching."
         },
@@ -472,9 +472,9 @@ MESSAGES = {
             "observer_msg": "A final hit to the temple flattens part of the skull. {attacker_name} watches until the body stops moving."
         },
         {
-            "attacker_msg": "A side swing twists {target_name}'s head too far. Something snaps. Everything ends.",
-            "victim_msg": "A side swing twists your head too far. Something snaps. Everything ends.",
-            "observer_msg": "A side swing twists {target_name}'s head too far. Something snaps. Everything ends."
+            "attacker_msg": "A side swing twists {target_name}'s {hit_location} too far. Something snaps. Everything ends.",
+            "victim_msg": "A side swing twists your {hit_location} too far. Something snaps. Everything ends.",
+            "observer_msg": "A side swing twists {target_name}'s {hit_location} too far. Something snaps. Everything ends."
         },
         {
             "attacker_msg": "A single blow to the back of the head ends it. {target_name} drops like a puppet cut from strings.",
@@ -502,9 +502,9 @@ MESSAGES = {
             "observer_msg": "One strike to the side of the neck. {target_name} collapses mid-step, brain shutting down before breath."
         },
         {
-            "attacker_msg": "The brick caves in {target_name}'s skull with a single, horrible crunch. They fall before they scream.",
-            "victim_msg": "The brick caves in your skull with a single, horrible crunch. You fall before they scream.",
-            "observer_msg": "The brick caves in {target_name}'s skull with a single, horrible crunch. They fall before they scream."
+            "attacker_msg": "The brick caves in {target_name}'s {hit_location} with a single, horrible crunch. They fall before they scream.",
+            "victim_msg": "The brick caves in your {hit_location} with a single, horrible crunch. You fall before they scream.",
+            "observer_msg": "The brick caves in {target_name}'s {hit_location} with a single, horrible crunch. They fall before they scream."
         },
         {
             "attacker_msg": "The brick caves the chest inward. {target_name} stares for a second, then topples like a tree in a storm.",
@@ -527,9 +527,9 @@ MESSAGES = {
             "observer_msg": "The brick lands across the nose and eyes. Everything caves inward. {target_name} never stands again."
         },
         {
-            "attacker_msg": "The brick lands flat against {target_name}'s jaw. Teeth fly. Then the lights go out.",
-            "victim_msg": "The brick lands flat against your jaw. Teeth fly. Then the lights go out.",
-            "observer_msg": "The brick lands flat against {target_name}'s jaw. Teeth fly. Then the lights go out."
+            "attacker_msg": "The brick lands flat against {target_name}'s {hit_location}. Teeth fly. Then the lights go out.",
+            "victim_msg": "The brick lands flat against your {hit_location}. Teeth fly. Then the lights go out.",
+            "observer_msg": "The brick lands flat against {target_name}'s {hit_location}. Teeth fly. Then the lights go out."
         },
         {
             "attacker_msg": "The brick lands on the bridge of the nose. Eyes explode. So does life.",
@@ -547,9 +547,9 @@ MESSAGES = {
             "observer_msg": "The brick strikes like punctuation at the end of a scream. {target_name} slumps. There’s nothing left to say."
         },
         {
-            "attacker_msg": "The final blow hits the side of {target_name}'s head. They don’t even twitch after.",
-            "victim_msg": "The final blow hits the side of your head. You don’t even twitch after.",
-            "observer_msg": "The final blow hits the side of {target_name}'s head. They don’t even twitch after."
+            "attacker_msg": "The final blow hits the side of {target_name}'s {hit_location}. They don’t even twitch after.",
+            "victim_msg": "The final blow hits the side of your {hit_location}. You don’t even twitch after.",
+            "observer_msg": "The final blow hits the side of {target_name}'s {hit_location}. They don’t even twitch after."
         },
         {
             "attacker_msg": "The kill is fast. The brick drops like a judge’s gavel, and {target_name} drops like a sentence.",
@@ -572,9 +572,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} brings the brick down from overhead. It lands with a sickening finality. {target_name} doesn’t twitch."
         },
         {
-            "attacker_msg": "You drive the brick into {target_name}'s throat. The gurgle is brief. The collapse is final.",
-            "victim_msg": "{attacker_name} drives the brick into your throat. The gurgle is brief. The collapse is final.",
-            "observer_msg": "{attacker_name} drives the brick into {target_name}'s throat. The gurgle is brief. The collapse is final."
+            "attacker_msg": "You drive the brick into {target_name}'s {hit_location}. The gurgle is brief. The collapse is final.",
+            "victim_msg": "{attacker_name} drives the brick into your {hit_location}. The gurgle is brief. The collapse is final.",
+            "observer_msg": "{attacker_name} drives the brick into {target_name}'s {hit_location}. The gurgle is brief. The collapse is final."
         },
         {
             "attacker_msg": "You grip the brick in both hands and slam it home. The sound is pulp and nothing else.",
@@ -582,29 +582,29 @@ MESSAGES = {
             "observer_msg": "{attacker_name} grips the brick in both hands and slams it home. The sound is pulp and nothing else."
         },
         {
-            "attacker_msg": "You grip the brick in both hands and swing until {target_name}'s neck bends wrong. Then more.",
-            "victim_msg": "{attacker_name} grips the brick in both hands and swings until your neck bends wrong. Then more.",
-            "observer_msg": "{attacker_name} grips the brick in both hands and swings until {target_name}'s neck bends wrong. Then more."
+            "attacker_msg": "You grip the brick in both hands and swing until {target_name}'s {hit_location} bends wrong. Then more.",
+            "victim_msg": "{attacker_name} grips the brick in both hands and swings until your {hit_location} bends wrong. Then more.",
+            "observer_msg": "{attacker_name} grips the brick in both hands and swings until {target_name}'s {hit_location} bends wrong. Then more."
         },
         {
-            "attacker_msg": "You pound the brick into {target_name}'s head again and again until it’s over. Then once more, just to be sure.",
-            "victim_msg": "{attacker_name} pounds the brick into your head again and again until it’s over. Then once more, just to be sure.",
-            "observer_msg": "{attacker_name} pounds the brick into {target_name}'s head again and again until it’s over. Then once more, just to be sure."
+            "attacker_msg": "You pound the brick into {target_name}'s {hit_location} again and again until it’s over. Then once more, just to be sure.",
+            "victim_msg": "{attacker_name} pounds the brick into your {hit_location} again and again until it’s over. Then once more, just to be sure.",
+            "observer_msg": "{attacker_name} pounds the brick into {target_name}'s {hit_location} again and again until it’s over. Then once more, just to be sure."
         },
         {
-            "attacker_msg": "You smash the brick into {target_name}'s chest until the body stops jerking. It takes three hits. Maybe four.",
-            "victim_msg": "{attacker_name} smashes the brick into your chest until the body stops jerking. It takes three hits. Maybe four.",
-            "observer_msg": "{attacker_name} smashes the brick into {target_name}'s chest until the body stops jerking. It takes three hits. Maybe four."
+            "attacker_msg": "You smash the brick into {target_name}'s {hit_location} until the body stops jerking. It takes three hits. Maybe four.",
+            "victim_msg": "{attacker_name} smashes the brick into your {hit_location} until the body stops jerking. It takes three hits. Maybe four.",
+            "observer_msg": "{attacker_name} smashes the brick into {target_name}'s {hit_location} until the body stops jerking. It takes three hits. Maybe four."
         },
         {
-            "attacker_msg": "You smash the brick into {target_name}'s face until it’s no longer recognizable. It’s not a fight — it’s a finale.",
-            "victim_msg": "{attacker_name} smashes the brick into your face until it’s no longer recognizable. It’s not a fight — it’s a finale.",
-            "observer_msg": "{attacker_name} smashes the brick into {target_name}'s face until it’s no longer recognizable. It’s not a fight — it’s a finale."
+            "attacker_msg": "You smash the brick into {target_name}'s {hit_location} until it’s no longer recognizable. It’s not a fight — it’s a finale.",
+            "victim_msg": "{attacker_name} smashes the brick into your {hit_location} until it’s no longer recognizable. It’s not a fight — it’s a finale.",
+            "observer_msg": "{attacker_name} smashes the brick into {target_name}'s {hit_location} until it’s no longer recognizable. It’s not a fight — it’s a finale."
         },
         {
-            "attacker_msg": "You step in and drive the brick into the base of {target_name}'s neck. The legs fold. The spine agrees.",
-            "victim_msg": "{attacker_name} steps in and drives the brick into the base of your neck. The legs fold. The spine agrees.",
-            "observer_msg": "{attacker_name} steps in and drives the brick into the base of {target_name}'s neck. The legs fold. The spine agrees."
+            "attacker_msg": "You step in and drive the brick into the base of {target_name}'s {hit_location}. The legs fold. The spine agrees.",
+            "victim_msg": "{attacker_name} steps in and drives the brick into the base of your {hit_location}. The legs fold. The spine agrees.",
+            "observer_msg": "{attacker_name} steps in and drives the brick into the base of {target_name}'s {hit_location}. The legs fold. The spine agrees."
         }
     ]
 }

--- a/world/combat/messages/broken_bottle.py
+++ b/world/combat/messages/broken_bottle.py
@@ -11,7 +11,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} produces a bottle, smashes it against the floor, and brandishes the jagged remains like a primal knife."
         },
         {
-            "attacker_msg": "You don’t bother with theatrics. You just slam the bottle on concrete until the shards glitter in your hand.",
+            "attacker_msg": "You don’t bother with theatrics. You just slam the bottle on concrete until the shards glitter in your {hit_location}.",
             "victim_msg": "{attacker_name} doesn’t bother with theatrics. They just slam the bottle on concrete until the shards glitter in their hand.",
             "observer_msg": "{attacker_name} doesn’t bother with theatrics. They just slam the bottle on concrete until the shards glitter in their hand."
         },
@@ -26,17 +26,17 @@ MESSAGES = {
             "observer_msg": "{attacker_name} yanks the bottle from a trash pile and snaps it clean on a steel edge—ready, improvised, lethal."
         },
         {
-            "attacker_msg": "You break the neck of the bottle on your knee and hold it like a sacred relic of violence.",
+            "attacker_msg": "You break the neck of the bottle on your {hit_location} and hold it like a sacred relic of violence.",
             "victim_msg": "{attacker_name} breaks the neck of the bottle on their knee and holds it like a sacred relic of violence.",
             "observer_msg": "{attacker_name} breaks the neck of the bottle on their knee and holds it like a sacred relic of violence."
         },
         {
-            "attacker_msg": "You tighten your hand around the busted glass, knuckles white, eyes locked on {target_name}.",
+            "attacker_msg": "You tighten your {hit_location} around the busted glass, knuckles white, eyes locked on {target_name}.",
             "victim_msg": "{attacker_name} tightens their hand around the busted glass, knuckles white, eyes locked on you.",
             "observer_msg": "{attacker_name} tightens their hand around the busted glass, knuckles white, eyes locked on {target_name}."
         },
         {
-            "attacker_msg": "You flip the bottle in your hand, catch it mid-air, and crush the base against a rusted beam.",
+            "attacker_msg": "You flip the bottle in your {hit_location}, catch it mid-air, and crush the base against a rusted beam.",
             "victim_msg": "{attacker_name} flips the bottle in their hand, catches it mid-air, and crushes the base against a rusted beam.",
             "observer_msg": "{attacker_name} flips the bottle in their hand, catches it mid-air, and crushes the base against a rusted beam."
         },
@@ -435,7 +435,7 @@ MESSAGES = {
             "observer_msg": "A clumsy slash hits a doorframe. {target_name} slips past."
         },
         {
-            "attacker_msg": "Your hand jerks. The aim is wrong. The glass is sharp. The target is safe.",
+            "attacker_msg": "Your {hit_location} jerks. The aim is wrong. The glass is sharp. The target is safe.",
             "victim_msg": "{attacker_name}'s hand jerks. The aim is wrong. The glass is sharp. You are safe.",
             "observer_msg": "{attacker_name}'s hand jerks. The aim is wrong. The glass is sharp. {target_name} is safe."
         },
@@ -452,19 +452,19 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "You drive the broken bottle deep into {target_name}'s throat. Blood floods out faster than breath.",
-            "victim_msg": "{attacker_name} drives the broken bottle deep into your throat. Blood floods out faster than breath.",
-            "observer_msg": "{attacker_name} drives the broken bottle deep into {target_name}'s throat. Blood floods out faster than breath."
+            "attacker_msg": "You drive the broken bottle deep into {target_name}'s {hit_location}. Blood floods out faster than breath.",
+            "victim_msg": "{attacker_name} drives the broken bottle deep into your {hit_location}. Blood floods out faster than breath.",
+            "observer_msg": "{attacker_name} drives the broken bottle deep into {target_name}'s {hit_location}. Blood floods out faster than breath."
         },
         {
-            "attacker_msg": "One final slash opens {target_name}'s neck. They drop before the scream finishes. You watch them fall.",
-            "victim_msg": "One final slash opens your neck. You drop before the scream finishes. {attacker_name} watches you fall.",
-            "observer_msg": "One final slash opens {target_name}'s neck. They drop before the scream finishes. {attacker_name} watches them fall."
+            "attacker_msg": "One final slash opens {target_name}'s {hit_location}. They drop before the scream finishes. You watch them fall.",
+            "victim_msg": "One final slash opens your {hit_location}. You drop before the scream finishes. {attacker_name} watches you fall.",
+            "observer_msg": "One final slash opens {target_name}'s {hit_location}. They drop before the scream finishes. {attacker_name} watches them fall."
         },
         {
-            "attacker_msg": "The glass plunges into {target_name}'s chest. Their body convulses, then collapses. You step back.",
-            "victim_msg": "The glass plunges into your chest. Your body convulses, then collapses. {attacker_name} steps back.",
-            "observer_msg": "The glass plunges into {target_name}'s chest. Their body convulses, then collapses. {attacker_name} steps back."
+            "attacker_msg": "The glass plunges into {target_name}'s {hit_location}. Their body convulses, then collapses. You step back.",
+            "victim_msg": "The glass plunges into your {hit_location}. Your body convulses, then collapses. {attacker_name} steps back.",
+            "observer_msg": "The glass plunges into {target_name}'s {hit_location}. Their body convulses, then collapses. {attacker_name} steps back."
         },
         {
             "attacker_msg": "A jagged arc across the face blinds {target_name} just before they fall, twitching. You ensure they're down.",
@@ -483,8 +483,8 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The bottle enters below the ribs. You twist. {target_name} folds.",
-            "victim_msg": "The bottle enters below your ribs. {attacker_name} twists. You fold.",
-            "observer_msg": "The bottle enters below {target_name}'s ribs. {attacker_name} twists. {target_name} folds."
+            "victim_msg": "The bottle enters below your {hit_location}. {attacker_name} twists. You fold.",
+            "observer_msg": "The bottle enters below {target_name}'s {hit_location}. {attacker_name} twists. {target_name} folds."
         },
         {
             "attacker_msg": "Glass punches through temple. {target_name} falls like a bag of wet bricks. You don't look away.",
@@ -503,13 +503,13 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You carve across the throat. {target_name} spasms, then stills.",
-            "victim_msg": "{attacker_name} carves across your throat. You spasm, then still.",
-            "observer_msg": "{attacker_name} carves across {target_name}'s throat. They spasm, then still."
+            "victim_msg": "{attacker_name} carves across your {hit_location}. You spasm, then still.",
+            "observer_msg": "{attacker_name} carves across {target_name}'s {hit_location}. They spasm, then still."
         },
         {
-            "attacker_msg": "The final blow lands in the stomach. Blood rushes out. Life drains with it. You wipe your hand.",
-            "victim_msg": "The final blow lands in your stomach. Blood rushes out. Life drains with it. {attacker_name} wipes their hand.",
-            "observer_msg": "The final blow lands in {target_name}'s stomach. Blood rushes out. Life drains with it. {attacker_name} wipes their hand."
+            "attacker_msg": "The final blow lands in the stomach. Blood rushes out. Life drains with it. You wipe your {hit_location}.",
+            "victim_msg": "The final blow lands in your {hit_location}. Blood rushes out. Life drains with it. {attacker_name} wipes their hand.",
+            "observer_msg": "The final blow lands in {target_name}'s {hit_location}. Blood rushes out. Life drains with it. {attacker_name} wipes their hand."
         },
         {
             "attacker_msg": "A stab to the heart ends everything mid-sentence for {target_name}. You hear the silence.",
@@ -518,7 +518,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You pin {target_name} down and drive the bottle into the chest, deep and deliberate.",
-            "victim_msg": "{attacker_name} pins you down and drives the bottle into your chest, deep and deliberate.",
+            "victim_msg": "{attacker_name} pins you down and drives the bottle into your {hit_location}, deep and deliberate.",
             "observer_msg": "{attacker_name} pins {target_name} down and drives the bottle into the chest, deep and deliberate."
         },
         {
@@ -537,9 +537,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} uses both hands to drive the glass home. It doesn’t take long for {target_name} to stop moving."
         },
         {
-            "attacker_msg": "The final slash removes most of {target_name}'s throat. The rest collapses. You step away from the mess.",
-            "victim_msg": "The final slash removes most of your throat. The rest collapses. {attacker_name} steps away from the mess.",
-            "observer_msg": "The final slash removes most of {target_name}'s throat. The rest collapses. {attacker_name} steps away from the mess."
+            "attacker_msg": "The final slash removes most of {target_name}'s {hit_location}. The rest collapses. You step away from the mess.",
+            "victim_msg": "The final slash removes most of your {hit_location}. The rest collapses. {attacker_name} steps away from the mess.",
+            "observer_msg": "The final slash removes most of {target_name}'s {hit_location}. The rest collapses. {attacker_name} steps away from the mess."
         },
         {
             "attacker_msg": "Glass tears into a lung. {target_name} drowns without water. You listen to the gurgle.",
@@ -548,8 +548,8 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The bottle crunches into the skull with a finality only steel should have. {target_name} is gone.",
-            "victim_msg": "The bottle crunches into your skull with a finality only steel should have. You are gone.",
-            "observer_msg": "The bottle crunches into {target_name}'s skull with a finality only steel should have. They are gone."
+            "victim_msg": "The bottle crunches into your {hit_location} with a finality only steel should have. You are gone.",
+            "observer_msg": "The bottle crunches into {target_name}'s {hit_location} with a finality only steel should have. They are gone."
         },
         {
             "attacker_msg": "Blood arcs like fireworks as You make the last cut on {target_name}.",

--- a/world/combat/messages/catchpole.py
+++ b/world/combat/messages/catchpole.py
@@ -36,9 +36,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} feints left, the catchpole's hook slicing through the air before doubling back to ensnare {target_name}."
         },
         {
-            "attacker_msg": "You drive the catchpole upward, the metal coil winding tight before launching toward {target_name}'s ribs.",
-            "victim_msg": "{attacker_name} drives the catchpole upward, the metal coil winding tight before launching toward your ribs.",
-            "observer_msg": "{attacker_name} drives the catchpole upward, the metal coil winding tight before launching toward {target_name}'s ribs."
+            "attacker_msg": "You drive the catchpole upward, the metal coil winding tight before launching toward {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} drives the catchpole upward, the metal coil winding tight before launching toward your {hit_location}.",
+            "observer_msg": "{attacker_name} drives the catchpole upward, the metal coil winding tight before launching toward {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You whip the catchpole in a brutal arc, the hook trailing sparks of fury as it aims to pin {target_name} in place.",
@@ -66,9 +66,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} bends low, sending the catchpole flying in a snapping motion toward {target_name}'s knees."
         },
         {
-            "attacker_msg": "You hurl the catchpole in a tight spiral, the hook spinning like a buzzsaw toward {target_name}'s throat.",
-            "victim_msg": "{attacker_name} hurls the catchpole in a tight spiral, the hook spinning like a buzzsaw toward your throat.",
-            "observer_msg": "{attacker_name} hurls the catchpole in a tight spiral, the hook spinning like a buzzsaw toward {target_name}'s throat."
+            "attacker_msg": "You hurl the catchpole in a tight spiral, the hook spinning like a buzzsaw toward {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} hurls the catchpole in a tight spiral, the hook spinning like a buzzsaw toward your {hit_location}.",
+            "observer_msg": "{attacker_name} hurls the catchpole in a tight spiral, the hook spinning like a buzzsaw toward {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You bluff a thrust and then slam the catchpole's hook sideways, surprising {target_name} with its wicked reach.",
@@ -116,14 +116,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name} half-steps in and whips the catchpole's hook at {target_name}'s side, the movement swift and unforgiving."
         },
         {
-            "attacker_msg": "You draw the catchpole back, the hook sparkling with menace as it arcs toward {target_name}'s throat.",
-            "victim_msg": "{attacker_name} draws the catchpole back, the hook sparkling with menace as it arcs toward your throat.",
-            "observer_msg": "{attacker_name} draws the catchpole back, the hook sparkling with menace as it arcs toward {target_name}'s throat."
+            "attacker_msg": "You draw the catchpole back, the hook sparkling with menace as it arcs toward {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} draws the catchpole back, the hook sparkling with menace as it arcs toward your {hit_location}.",
+            "observer_msg": "{attacker_name} draws the catchpole back, the hook sparkling with menace as it arcs toward {target_name}'s {hit_location}."
         },
         {
-            "attacker_msg": "You feint a jab before yanking the catchpole's hook downward at {target_name}'s knee.",
-            "victim_msg": "{attacker_name} feints a jab before yanking the catchpole's hook downward at your knee.",
-            "observer_msg": "{attacker_name} feints a jab before yanking the catchpole's hook downward at {target_name}'s knee."
+            "attacker_msg": "You feint a jab before yanking the catchpole's hook downward at {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} feints a jab before yanking the catchpole's hook downward at your {hit_location}.",
+            "observer_msg": "{attacker_name} feints a jab before yanking the catchpole's hook downward at {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You spin the catchpole in a blur before thrusting it forward like a poisoned fang at {target_name}.",
@@ -141,14 +141,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name} steps aside and snaps the catchpole's hook at {target_name}, the steel grazing bone with a cruel whisper."
         },
         {
-            "attacker_msg": "You swing the catchpole in a wide circle, the hook catching stray rubble before aiming at {target_name}'s hip.",
-            "victim_msg": "{attacker_name} swings the catchpole in a wide circle, the hook catching stray rubble before aiming at your hip.",
-            "observer_msg": "{attacker_name} swings the catchpole in a wide circle, the hook catching stray rubble before aiming at {target_name}'s hip."
+            "attacker_msg": "You swing the catchpole in a wide circle, the hook catching stray rubble before aiming at {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} swings the catchpole in a wide circle, the hook catching stray rubble before aiming at your {hit_location}.",
+            "observer_msg": "{attacker_name} swings the catchpole in a wide circle, the hook catching stray rubble before aiming at {target_name}'s {hit_location}."
         },
         {
-            "attacker_msg": "You tense, then flick the catchpole's hook upward toward {target_name}'s jaw, the motion fluid and lethal.",
-            "victim_msg": "{attacker_name} tenses, then flicks the catchpole's hook upward toward your jaw, the motion fluid and lethal.",
-            "observer_msg": "{attacker_name} tenses, then flicks the catchpole's hook upward toward {target_name}'s jaw, the motion fluid and lethal."
+            "attacker_msg": "You tense, then flick the catchpole's hook upward toward {target_name}'s {hit_location}, the motion fluid and lethal.",
+            "victim_msg": "{attacker_name} tenses, then flicks the catchpole's hook upward toward your {hit_location}, the motion fluid and lethal.",
+            "observer_msg": "{attacker_name} tenses, then flicks the catchpole's hook upward toward {target_name}'s {hit_location}, the motion fluid and lethal."
         }
     ],
     "hit": [
@@ -253,14 +253,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name} pulls {hit_location} hard and the catchpole's hook tears through {target_name}'s {hit_location} in a jagged, explosive arc."
         },
         {
-            "attacker_msg": "You hook {target_name} under the chin and jerk upward, the impact rattling {target_name}'s skull.",
-            "victim_msg": "{attacker_name} hooks you under the chin and jerks upward, the impact rattling your skull.",
-            "observer_msg": "{attacker_name} hooks {target_name} under the chin and jerks upward, the impact rattling {target_name}'s skull."
+            "attacker_msg": "You hook {target_name} under the chin and jerk upward, the impact rattling {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} hooks you under the chin and jerks upward, the impact rattling your {hit_location}.",
+            "observer_msg": "{attacker_name} hooks {target_name} under the chin and jerks upward, the impact rattling {target_name}'s {hit_location}."
         },
         {
-            "attacker_msg": "You jab the catchpole near {target_name}'s heart, the hook sinking deep before being ripped free.",
-            "victim_msg": "{attacker_name} jabs the catchpole near your heart, the hook sinking deep before being ripped free.",
-            "observer_msg": "{attacker_name} jabs the catchpole near {target_name}'s heart, the hook sinking deep before being ripped free."
+            "attacker_msg": "You jab the catchpole near {target_name}'s {hit_location}, the hook sinking deep before being ripped free.",
+            "victim_msg": "{attacker_name} jabs the catchpole near your {hit_location}, the hook sinking deep before being ripped free.",
+            "observer_msg": "{attacker_name} jabs the catchpole near {target_name}'s {hit_location}, the hook sinking deep before being ripped free."
         },
         {
             "attacker_msg": "You slam the catchpole into {target_name}'s {hit_location}, the joint collapsing under the crushing blow.",
@@ -370,9 +370,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} feints overhead, then strikes low, but the hook clips nothing but dust as {target_name} sidesteps."
         },
         {
-            "attacker_msg": "You tug the catchpole back too soon, the hook whipping harmlessly above {target_name}'s head.",
-            "victim_msg": "{attacker_name} tugs the catchpole back too soon, the hook whipping harmlessly above your head.",
-            "observer_msg": "{attacker_name} tugs the catchpole back too soon, the hook whipping harmlessly above {target_name}'s head."
+            "attacker_msg": "You tug the catchpole back too soon, the hook whipping harmlessly above {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} tugs the catchpole back too soon, the hook whipping harmlessly above your {hit_location}.",
+            "observer_msg": "{attacker_name} tugs the catchpole back too soon, the hook whipping harmlessly above {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You thrust with lethal intent, but the hook glances off {target_name}'s armor and skitters away.",
@@ -447,14 +447,14 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "You drive the catchpole's hook into {target_name}'s throat, tearing open windpipe and will in one brutal motion.",
-            "victim_msg": "{attacker_name} drives the catchpole's hook into your throat, tearing open windpipe and will in one brutal motion.",
-            "observer_msg": "{attacker_name} drives the catchpole's hook into {target_name}'s throat, tearing open windpipe and will in one brutal motion."
+            "attacker_msg": "You drive the catchpole's hook into {target_name}'s {hit_location}, tearing open windpipe and will in one brutal motion.",
+            "victim_msg": "{attacker_name} drives the catchpole's hook into your {hit_location}, tearing open windpipe and will in one brutal motion.",
+            "observer_msg": "{attacker_name} drives the catchpole's hook into {target_name}'s {hit_location}, tearing open windpipe and will in one brutal motion."
         },
         {
-            "attacker_msg": "You jerk the hook free from {target_name}'s chest, the gush of crimson painting the ground beneath them.",
-            "victim_msg": "{attacker_name} jerks the hook free from your chest, the gush of crimson painting the ground beneath you.",
-            "observer_msg": "{attacker_name} jerks the hook free from {target_name}'s chest, the gush of crimson painting the ground beneath them."
+            "attacker_msg": "You jerk the hook free from {target_name}'s {hit_location}, the gush of crimson painting the ground beneath them.",
+            "victim_msg": "{attacker_name} jerks the hook free from your {hit_location}, the gush of crimson painting the ground beneath you.",
+            "observer_msg": "{attacker_name} jerks the hook free from {target_name}'s {hit_location}, the gush of crimson painting the ground beneath them."
         },
         {
             "attacker_msg": "You hook {target_name} under the jaw and lift, the steel snapping vertebrae like twigs.",
@@ -462,9 +462,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} hooks {target_name} under the jaw and lifts, the steel snapping vertebrae like twigs."
         },
         {
-            "attacker_msg": "You wrench the catchpole downward, the barbs shredding {target_name}'s spine in a spray of gore.",
-            "victim_msg": "{attacker_name} wrenches the catchpole downward, the barbs shredding your spine in a spray of gore.",
-            "observer_msg": "{attacker_name} wrenches the catchpole downward, the barbs shredding {target_name}'s spine in a spray of gore."
+            "attacker_msg": "You wrench the catchpole downward, the barbs shredding {target_name}'s {hit_location} in a spray of gore.",
+            "victim_msg": "{attacker_name} wrenches the catchpole downward, the barbs shredding your {hit_location} in a spray of gore.",
+            "observer_msg": "{attacker_name} wrenches the catchpole downward, the barbs shredding {target_name}'s {hit_location} in a spray of gore."
         },
         {
             "attacker_msg": "You rip {target_name} off their feet with the catchpole and slam them into the wall, lifeless.",
@@ -472,9 +472,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} rips {target_name} off their feet with the catchpole and slams them into the wall, lifeless."
         },
         {
-            "attacker_msg": "You twist the hook inside {target_name}'s heart, the bone-crunching thud marking their end.",
-            "victim_msg": "{attacker_name} twists the hook inside your heart, the bone-crunching thud marking your end.",
-            "observer_msg": "{attacker_name} twists the hook inside {target_name}'s heart, the bone-crunching thud marking their end."
+            "attacker_msg": "You twist the hook inside {target_name}'s {hit_location}, the bone-crunching thud marking their end.",
+            "victim_msg": "{attacker_name} twists the hook inside your {hit_location}, the bone-crunching thud marking your end.",
+            "observer_msg": "{attacker_name} twists the hook inside {target_name}'s {hit_location}, the bone-crunching thud marking their end."
         },
         {
             "attacker_msg": "You sling the catchpole upward, impaling {target_name} through both legs before spinning them lifeless.",
@@ -482,9 +482,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} slings the catchpole upward, impaling {target_name} through both legs before spinning them lifeless."
         },
         {
-            "attacker_msg": "You yank the hook from {target_name}'s skull, brain matter collapsing onto cracked masonry.",
-            "victim_msg": "{attacker_name} yanks the hook from your skull, brain matter collapsing onto cracked masonry.",
-            "observer_msg": "{attacker_name} yanks the hook from {target_name}'s skull, brain matter collapsing onto cracked masonry."
+            "attacker_msg": "You yank the hook from {target_name}'s {hit_location}, brain matter collapsing onto cracked masonry.",
+            "victim_msg": "{attacker_name} yanks the hook from your {hit_location}, brain matter collapsing onto cracked masonry.",
+            "observer_msg": "{attacker_name} yanks the hook from {target_name}'s {hit_location}, brain matter collapsing onto cracked masonry."
         },
         {
             "attacker_msg": "You drag {target_name} by the hook across the floor until only a ragged echo of life remains.",
@@ -503,13 +503,13 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You impale {target_name} through the sternum, the catchpole emerging from their back in a twisted monument.",
-            "victim_msg": "{attacker_name} impales you through the sternum, the catchpole emerging from your back in a twisted monument.",
+            "victim_msg": "{attacker_name} impales you through the sternum, the catchpole emerging from your {hit_location} in a twisted monument.",
             "observer_msg": "{attacker_name} impales {target_name} through the sternum, the catchpole emerging from their back in a twisted monument."
         },
         {
-            "attacker_msg": "You rip {target_name}'s throat open and toss the body aside like refuse.",
-            "victim_msg": "{attacker_name} rips your throat open and tosses the body aside like refuse.",
-            "observer_msg": "{attacker_name} rips {target_name}'s throat open and tosses the body aside like refuse."
+            "attacker_msg": "You rip {target_name}'s {hit_location} open and toss the body aside like refuse.",
+            "victim_msg": "{attacker_name} rips your {hit_location} open and tosses the body aside like refuse.",
+            "observer_msg": "{attacker_name} rips {target_name}'s {hit_location} open and tosses the body aside like refuse."
         },
         {
             "attacker_msg": "You yank the catchpole sideways, decapitating {target_name} in a single merciless stroke.",
@@ -517,34 +517,34 @@ MESSAGES = {
             "observer_msg": "{attacker_name} yanks the catchpole sideways, decapitating {target_name} in a single merciless stroke."
         },
         {
-            "attacker_msg": "You drag the hook across {target_name}'s neck, head rolling before coming to rest.",
-            "victim_msg": "{attacker_name} drags the hook across your neck, head rolling before coming to rest.",
-            "observer_msg": "{attacker_name} drags the hook across {target_name}'s neck, head rolling before coming to rest."
+            "attacker_msg": "You drag the hook across {target_name}'s {hit_location}, head rolling before coming to rest.",
+            "victim_msg": "{attacker_name} drags the hook across your {hit_location}, head rolling before coming to rest.",
+            "observer_msg": "{attacker_name} drags the hook across {target_name}'s {hit_location}, head rolling before coming to rest."
         },
         {
-            "attacker_msg": "You embed the hook in {target_name}'s temple, snapping their skull before the world blurs to black.",
-            "victim_msg": "{attacker_name} embeds the hook in your temple, snapping your skull before the world blurs to black.",
-            "observer_msg": "{attacker_name} embeds the hook in {target_name}'s temple, snapping their skull before the world blurs to black."
+            "attacker_msg": "You embed the hook in {target_name}'s {hit_location}, snapping their skull before the world blurs to black.",
+            "victim_msg": "{attacker_name} embeds the hook in your {hit_location}, snapping your {hit_location} before the world blurs to black.",
+            "observer_msg": "{attacker_name} embeds the hook in {target_name}'s {hit_location}, snapping their skull before the world blurs to black."
         },
         {
             "attacker_msg": "You sweep the catchpole in a low arc, severing {target_name}'s legs before their torso collapses.",
-            "victim_msg": "{attacker_name} sweeps the catchpole in a low arc, severing your legs before your torso collapses.",
+            "victim_msg": "{attacker_name} sweeps the catchpole in a low arc, severing your legs before your {hit_location} collapses.",
             "observer_msg": "{attacker_name} sweeps the catchpole in a low arc, severing {target_name}'s legs before their torso collapses."
         },
         {
-            "attacker_msg": "You spin the catchpole upward through {target_name}'s abdomen, lifting them midair before letting go.",
-            "victim_msg": "{attacker_name} spins the catchpole upward through your abdomen, lifting you midair before letting go.",
-            "observer_msg": "{attacker_name} spins the catchpole upward through {target_name}'s abdomen, lifting them midair before letting go."
+            "attacker_msg": "You spin the catchpole upward through {target_name}'s {hit_location}, lifting them midair before letting go.",
+            "victim_msg": "{attacker_name} spins the catchpole upward through your {hit_location}, lifting you midair before letting go.",
+            "observer_msg": "{attacker_name} spins the catchpole upward through {target_name}'s {hit_location}, lifting them midair before letting go."
         },
         {
-            "attacker_msg": "You thrust deep into {target_name}'s groin, the catchpole emerging with a visceral finality.",
-            "victim_msg": "{attacker_name} thrusts deep into your groin, the catchpole emerging with a visceral finality.",
-            "observer_msg": "{attacker_name} thrusts deep into {target_name}'s groin, the catchpole emerging with a visceral finality."
+            "attacker_msg": "You thrust deep into {target_name}'s {hit_location}, the catchpole emerging with a visceral finality.",
+            "victim_msg": "{attacker_name} thrusts deep into your {hit_location}, the catchpole emerging with a visceral finality.",
+            "observer_msg": "{attacker_name} thrusts deep into {target_name}'s {hit_location}, the catchpole emerging with a visceral finality."
         },
         {
-            "attacker_msg": "You rip out {target_name}'s heart with the hook and hold it up like a grotesque trophy.",
-            "victim_msg": "{attacker_name} rips out your heart with the hook and holds it up like a grotesque trophy.",
-            "observer_msg": "{attacker_name} rips out {target_name}'s heart with the hook and holds it up like a grotesque trophy."
+            "attacker_msg": "You rip out {target_name}'s {hit_location} with the hook and hold it up like a grotesque trophy.",
+            "victim_msg": "{attacker_name} rips out your {hit_location} with the hook and holds it up like a grotesque trophy.",
+            "observer_msg": "{attacker_name} rips out {target_name}'s {hit_location} with the hook and holds it up like a grotesque trophy."
         },
         {
             "attacker_msg": "You slam the hook into {target_name}'s lower jaw and pull back, skull cracking under steel.",
@@ -557,14 +557,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name} drives the catchpole into {target_name}'s eye socket, splintering bone with macabre precision."
         },
         {
-            "attacker_msg": "You hook both arms behind {target_name}'s back and yank, their spine folding in on itself.",
-            "victim_msg": "{attacker_name} hooks both arms behind your back and yanks, your spine folding in on itself.",
-            "observer_msg": "{attacker_name} hooks both arms behind {target_name}'s back and yanks, their spine folding in on itself."
+            "attacker_msg": "You hook both arms behind {target_name}'s {hit_location} and yank, their spine folding in on itself.",
+            "victim_msg": "{attacker_name} hooks both arms behind your {hit_location} and yanks, your {hit_location} folding in on itself.",
+            "observer_msg": "{attacker_name} hooks both arms behind {target_name}'s {hit_location} and yanks, their spine folding in on itself."
         },
         {
-            "attacker_msg": "You embed the hook in {target_name}'s chest and spin them until their organs unravel within.",
-            "victim_msg": "{attacker_name} embeds the hook in your chest and spins you until your organs unravel within.",
-            "observer_msg": "{attacker_name} embeds the hook in {target_name}'s chest and spins them until their organs unravel within."
+            "attacker_msg": "You embed the hook in {target_name}'s {hit_location} and spin them until their organs unravel within.",
+            "victim_msg": "{attacker_name} embeds the hook in your {hit_location} and spins you until your organs unravel within.",
+            "observer_msg": "{attacker_name} embeds the hook in {target_name}'s {hit_location} and spins them until their organs unravel within."
         },
         {
             "attacker_msg": "You pull {target_name} flush against the wall with the catchpole, lifeless eyes staring into nothing.",
@@ -572,14 +572,14 @@ MESSAGES = {
             "observer_msg": "{attacker_name} pulls {target_name} flush against the wall with the catchpole, lifeless eyes staring into nothing."
         },
         {
-            "attacker_msg": "You rip off {target_name}'s face with the hook, flesh hanging in ragged strips.",
-            "victim_msg": "{attacker_name} rips off your face with the hook, flesh hanging in ragged strips.",
-            "observer_msg": "{attacker_name} rips off {target_name}'s face with the hook, flesh hanging in ragged strips."
+            "attacker_msg": "You rip off {target_name}'s {hit_location} with the hook, flesh hanging in ragged strips.",
+            "victim_msg": "{attacker_name} rips off your {hit_location} with the hook, flesh hanging in ragged strips.",
+            "observer_msg": "{attacker_name} rips off {target_name}'s {hit_location} with the hook, flesh hanging in ragged strips."
         },
         {
-            "attacker_msg": "You hammer the catchpole through {target_name}'s skull, dropping them in a final, echoing thunk.",
-            "victim_msg": "{attacker_name} hammers the catchpole through your skull, dropping you in a final, echoing thunk.",
-            "observer_msg": "{attacker_name} hammers the catchpole through {target_name}'s skull, dropping them in a final, echoing thunk."
+            "attacker_msg": "You hammer the catchpole through {target_name}'s {hit_location}, dropping them in a final, echoing thunk.",
+            "victim_msg": "{attacker_name} hammers the catchpole through your {hit_location}, dropping you in a final, echoing thunk.",
+            "observer_msg": "{attacker_name} hammers the catchpole through {target_name}'s {hit_location}, dropping them in a final, echoing thunk."
         },
         {
             "attacker_msg": "You yank the hook through {target_name}'s midsection, leaving a gruesome gash in the stone floor.",

--- a/world/combat/messages/cellphone.py
+++ b/world/combat/messages/cellphone.py
@@ -11,12 +11,12 @@ MESSAGES = {
             "observer_msg": "With a grim look, {attacker_name} brandishes the bulky cellphone, its long, rigid antenna jutting out menacingly."
         },
         {
-            "attacker_msg": "Your hand closes around the solid, weighty plastic of the cellphone, a true 'brick' by any standard.",
+            "attacker_msg": "Your {hit_location} closes around the solid, weighty plastic of the cellphone, a true 'brick' by any standard.",
             "victim_msg": "{attacker_name}'s hand closes around the solid, weighty plastic of the cellphone, a true 'brick' by any standard.",
             "observer_msg": "{attacker_name}'s hand closes around the solid, weighty plastic of the cellphone, a true 'brick' by any standard."
         },
         {
-            "attacker_msg": "A cellphone, more akin to a small club than just a communication device, becomes a weapon in your hand.",
+            "attacker_msg": "A cellphone, more akin to a small club than just a communication device, becomes a weapon in your {hit_location}.",
             "victim_msg": "A cellphone, more akin to a small club than just a communication device, becomes a weapon in {attacker_name}'s hand.",
             "observer_msg": "A cellphone, more akin to a small club than just a communication device, becomes a weapon in {attacker_name}'s hand."
         },
@@ -61,12 +61,12 @@ MESSAGES = {
             "observer_msg": "The air around the cellphone seems to thrum with the threat of sudden, jarring impacts from its hard, unyielding casing."
         },
         {
-            "attacker_msg": "Your eyes are narrowed, sighting along the blocky length of the cellphone towards {target_name}'s head.",
-            "victim_msg": "{attacker_name}'s eyes are narrowed, sighting along the blocky length of the cellphone towards your head.",
-            "observer_msg": "{attacker_name}'s eyes are narrowed, sighting along the blocky length of the cellphone towards {target_name}'s head."
+            "attacker_msg": "Your eyes are narrowed, sighting along the blocky length of the cellphone towards {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name}'s eyes are narrowed, sighting along the blocky length of the cellphone towards your {hit_location}.",
+            "observer_msg": "{attacker_name}'s eyes are narrowed, sighting along the blocky length of the cellphone towards {target_name}'s {hit_location}."
         },
         {
-            "attacker_msg": "The cellphone feels unexpectedly weapon-like in your hand, a tool of pure, blunt force.",
+            "attacker_msg": "The cellphone feels unexpectedly weapon-like in your {hit_location}, a tool of pure, blunt force.",
             "victim_msg": "The cellphone feels unexpectedly weapon-like in {attacker_name}'s hand, a tool of pure, blunt force.",
             "observer_msg": "The cellphone feels unexpectedly weapon-like in {attacker_name}'s hand, a tool of pure, blunt force."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            "attacker_msg": "Your cellphone whooshes through the air, its heavy, blocky mass and antenna narrowly missing {target_name}'s head with a faint *zip*.",
-            "victim_msg": "{attacker_name}'s cellphone whooshes through the air, its heavy, blocky mass and antenna narrowly missing your head with a faint *zip*.",
-            "observer_msg": "{attacker_name}'s cellphone whooshes through the air, its heavy, blocky mass and antenna narrowly missing {target_name}'s head with a faint *zip*."
+            "attacker_msg": "Your cellphone whooshes through the air, its heavy, blocky mass and antenna narrowly missing {target_name}'s {hit_location} with a faint *zip*.",
+            "victim_msg": "{attacker_name}'s cellphone whooshes through the air, its heavy, blocky mass and antenna narrowly missing your {hit_location} with a faint *zip*.",
+            "observer_msg": "{attacker_name}'s cellphone whooshes through the air, its heavy, blocky mass and antenna narrowly missing {target_name}'s {hit_location} with a faint *zip*."
         },
         {
             "attacker_msg": "{target_name} stumbles back, avoiding the desperate swing of your cellphone by a hair's breadth, its antenna whistling past their ear.",
@@ -365,7 +365,7 @@ MESSAGES = {
             "observer_msg": "A quick retreat from {target_name} leaves {attacker_name}'s cellphone to impact nothing but air with a solid *SWOOSH*."
         },
         {
-            "attacker_msg": "The cellphone feels dangerously unwieldy in your hand as the intended crushing blow fails to connect, nearly wrenching your wrist.",
+            "attacker_msg": "The cellphone feels dangerously unwieldy in your {hit_location} as the intended crushing blow fails to connect, nearly wrenching your {hit_location}.",
             "victim_msg": "The cellphone feels dangerously unwieldy in {attacker_name}'s hand as the intended crushing blow fails to connect, nearly wrenching their wrist.",
             "observer_msg": "The cellphone feels dangerously unwieldy in {attacker_name}'s hand as the intended crushing blow fails to connect, nearly wrenching their wrist."
         },
@@ -395,9 +395,9 @@ MESSAGES = {
             "observer_msg": "A growl of frustration from {attacker_name} as their cellphone attack is evaded by a nimble {target_name}, who stares at the unusual weapon."
         },
         {
-            "attacker_msg": "The cellphone kicks up dirt beside {target_name}'s foot, its antenna digging a small furrow, but draws no blood.",
-            "victim_msg": "The cellphone kicks up dirt beside your foot, its antenna digging a small furrow, but draws no blood.",
-            "observer_msg": "The cellphone kicks up dirt beside {target_name}'s foot, its antenna digging a small furrow, but draws no blood."
+            "attacker_msg": "The cellphone kicks up dirt beside {target_name}'s {hit_location}, its antenna digging a small furrow, but draws no blood.",
+            "victim_msg": "The cellphone kicks up dirt beside your {hit_location}, its antenna digging a small furrow, but draws no blood.",
+            "observer_msg": "The cellphone kicks up dirt beside {target_name}'s {hit_location}, its antenna digging a small furrow, but draws no blood."
         },
         {
             "attacker_msg": "Your straightforward attack with the cellphone is anticipated and dodged by {target_name}, who looks almost surprised by the weapon's solidity.",
@@ -457,24 +457,24 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "You repeatedly smash the heavy cellphone into {target_name}'s temple; they collapse, skull audibly cracking under the relentless, hard plastic blows, succumbing to massive trauma from the heavy bludgeon.",
-            "victim_msg": "{attacker_name} repeatedly smashes the heavy cellphone into your temple; you collapse, skull audibly cracking under the relentless, hard plastic blows, succumbing to massive trauma from the heavy bludgeon.",
-            "observer_msg": "{attacker_name} repeatedly smashes the heavy cellphone into {target_name}'s temple; they collapse, skull audibly cracking under the relentless, hard plastic blows, succumbing to massive trauma from the heavy bludgeon."
+            "attacker_msg": "You repeatedly smash the heavy cellphone into {target_name}'s {hit_location}; they collapse, skull audibly cracking under the relentless, hard plastic blows, succumbing to massive trauma from the heavy bludgeon.",
+            "victim_msg": "{attacker_name} repeatedly smashes the heavy cellphone into your {hit_location}; you collapse, skull audibly cracking under the relentless, hard plastic blows, succumbing to massive trauma from the heavy bludgeon.",
+            "observer_msg": "{attacker_name} repeatedly smashes the heavy cellphone into {target_name}'s {hit_location}; they collapse, skull audibly cracking under the relentless, hard plastic blows, succumbing to massive trauma from the heavy bludgeon."
         },
         {
-            "attacker_msg": "The cellphone, driven again and again into {target_name}'s chest with surprising force, crushes ribs and pulps organs, and they fall silent, life extinguished by the heavy 'brick'.",
-            "victim_msg": "The cellphone, driven again and again into your chest with surprising force, crushes ribs and pulps organs, and you fall silent, life extinguished by the heavy 'brick'.",
-            "observer_msg": "The cellphone, driven again and again into {target_name}'s chest with surprising force, crushes ribs and pulps organs, and they fall silent, life extinguished by the heavy 'brick'."
+            "attacker_msg": "The cellphone, driven again and again into {target_name}'s {hit_location} with surprising force, crushes ribs and pulps organs, and they fall silent, life extinguished by the heavy 'brick'.",
+            "victim_msg": "The cellphone, driven again and again into your {hit_location} with surprising force, crushes ribs and pulps organs, and you fall silent, life extinguished by the heavy 'brick'.",
+            "observer_msg": "The cellphone, driven again and again into {target_name}'s {hit_location} with surprising force, crushes ribs and pulps organs, and they fall silent, life extinguished by the heavy 'brick'."
         },
         {
-            "attacker_msg": "With a final, brutal swing, you bring the cellphone down on {target_name}'s head with a sickening crunch of plastic and bone, the antenna snapping off as they drop, twitching, then still.",
-            "victim_msg": "With a final, brutal swing, {attacker_name} brings the cellphone down on your head with a sickening crunch of plastic and bone, the antenna snapping off as you drop, twitching, then still.",
-            "observer_msg": "With a final, brutal swing, {attacker_name} brings the cellphone down on {target_name}'s head with a sickening crunch of plastic and bone, the antenna snapping off as they drop, twitching, then still."
+            "attacker_msg": "With a final, brutal swing, you bring the cellphone down on {target_name}'s {hit_location} with a sickening crunch of plastic and bone, the antenna snapping off as they drop, twitching, then still.",
+            "victim_msg": "With a final, brutal swing, {attacker_name} brings the cellphone down on your {hit_location} with a sickening crunch of plastic and bone, the antenna snapping off as you drop, twitching, then still.",
+            "observer_msg": "With a final, brutal swing, {attacker_name} brings the cellphone down on {target_name}'s {hit_location} with a sickening crunch of plastic and bone, the antenna snapping off as they drop, twitching, then still."
         },
         {
-            "attacker_msg": "The heavy impact of the cellphone, antenna first, against {target_name}'s throat crushes their windpipe, causing them to asphyxiate in moments under the relentless, blocky assault.",
-            "victim_msg": "The heavy impact of the cellphone, antenna first, against your throat crushes your windpipe, causing you to asphyxiate in moments under the relentless, blocky assault.",
-            "observer_msg": "The heavy impact of the cellphone, antenna first, against {target_name}'s throat crushes their windpipe, causing them to asphyxiate in moments under the relentless, blocky assault."
+            "attacker_msg": "The heavy impact of the cellphone, antenna first, against {target_name}'s {hit_location} crushes their windpipe, causing them to asphyxiate in moments under the relentless, blocky assault.",
+            "victim_msg": "The heavy impact of the cellphone, antenna first, against your {hit_location} crushes your windpipe, causing you to asphyxiate in moments under the relentless, blocky assault.",
+            "observer_msg": "The heavy impact of the cellphone, antenna first, against {target_name}'s {hit_location} crushes their windpipe, causing them to asphyxiate in moments under the relentless, blocky assault."
         },
         {
             "attacker_msg": "You relentlessly bludgeon {target_name} with the cellphone until they slump, lifeless, in a bruised and broken heap, a victim of the solid device.",
@@ -487,14 +487,14 @@ MESSAGES = {
             "observer_msg": "The cellphone, a desperate tool of death, delivers a killing blow as {target_name} is overcome by catastrophic, internal injuries from the repeated, solid bludgeoning of its dense casing."
         },
         {
-            "attacker_msg": "A precise, savage blow with the edge of the cellphone to {target_name}'s spine ends their life with a sickening, dull crack of hard plastic against bone, the device itself groaning.",
-            "victim_msg": "A precise, savage blow with the edge of the cellphone to your spine ends your life with a sickening, dull crack of hard plastic against bone, the device itself groaning.",
-            "observer_msg": "A precise, savage blow with the edge of the cellphone to {target_name}'s spine ends their life with a sickening, dull crack of hard plastic against bone, the device itself groaning."
+            "attacker_msg": "A precise, savage blow with the edge of the cellphone to {target_name}'s {hit_location} ends their life with a sickening, dull crack of hard plastic against bone, the device itself groaning.",
+            "victim_msg": "A precise, savage blow with the edge of the cellphone to your {hit_location} ends your life with a sickening, dull crack of hard plastic against bone, the device itself groaning.",
+            "observer_msg": "A precise, savage blow with the edge of the cellphone to {target_name}'s {hit_location} ends their life with a sickening, dull crack of hard plastic against bone, the device itself groaning."
         },
         {
-            "attacker_msg": "You bring the cellphone down on {target_name}'s face until they stop moving, the features a bruised ruin, the keypad imprinted on their skin, life extinguished by the mundane but heavy weapon.",
-            "victim_msg": "{attacker_name} brings the cellphone down on your face until you stop moving, the features a bruised ruin, the keypad imprinted on your skin, life extinguished by the mundane but heavy weapon.",
-            "observer_msg": "{attacker_name} brings the cellphone down on {target_name}'s face until they stop moving, the features a bruised ruin, the keypad imprinted on their skin, life extinguished by the mundane but heavy weapon."
+            "attacker_msg": "You bring the cellphone down on {target_name}'s {hit_location} until they stop moving, the features a bruised ruin, the keypad imprinted on their skin, life extinguished by the mundane but heavy weapon.",
+            "victim_msg": "{attacker_name} brings the cellphone down on your {hit_location} until you stop moving, the features a bruised ruin, the keypad imprinted on your skin, life extinguished by the mundane but heavy weapon.",
+            "observer_msg": "{attacker_name} brings the cellphone down on {target_name}'s {hit_location} until they stop moving, the features a bruised ruin, the keypad imprinted on their skin, life extinguished by the mundane but heavy weapon."
         },
         {
             "attacker_msg": "The unyielding weight of the cellphone, slammed repeatedly, shatters something vital in {target_name}, who crumples, unmoving, a grim casualty of this brutal encounter.",
@@ -502,9 +502,9 @@ MESSAGES = {
             "observer_msg": "The unyielding weight of the cellphone, slammed repeatedly, shatters something vital in {target_name}, who crumples, unmoving, a grim casualty of this brutal encounter."
         },
         {
-            "attacker_msg": "With a final, desperate act, you use the cellphone to inflict a fatal, crushing wound to {target_name}'s skull, its casing finally cracking under the strain.",
-            "victim_msg": "With a final, desperate act, {attacker_name} uses the cellphone to inflict a fatal, crushing wound to your skull, its casing finally cracking under the strain.",
-            "observer_msg": "With a final, desperate act, {attacker_name} uses the cellphone to inflict a fatal, crushing wound to {target_name}'s skull, its casing finally cracking under the strain."
+            "attacker_msg": "With a final, desperate act, you use the cellphone to inflict a fatal, crushing wound to {target_name}'s {hit_location}, its casing finally cracking under the strain.",
+            "victim_msg": "With a final, desperate act, {attacker_name} uses the cellphone to inflict a fatal, crushing wound to your {hit_location}, its casing finally cracking under the strain.",
+            "observer_msg": "With a final, desperate act, {attacker_name} uses the cellphone to inflict a fatal, crushing wound to {target_name}'s {hit_location}, its casing finally cracking under the strain."
         },
         {
             "attacker_msg": "The cellphone, wielded with grim intent, turns {target_name} into a broken mess, their struggles quickly ceasing under the heavy, dull impacts of its hard casing and sharp corners.",
@@ -522,13 +522,13 @@ MESSAGES = {
             "observer_msg": "A merciless, heavy blow with the cellphone to the back of the head, and {target_name} is no more, overcome by the vicious, blunt trauma from the heavy weapon, its antenna bent into their flesh."
         },
         {
-            "attacker_msg": "The cellphone, now battered, its antenna broken, and perhaps its casing cracked, drops from your hand as {target_name} lies lifeless and broken.",
+            "attacker_msg": "The cellphone, now battered, its antenna broken, and perhaps its casing cracked, drops from your {hit_location} as {target_name} lies lifeless and broken.",
             "victim_msg": "The cellphone, now battered, its antenna broken, and perhaps its casing cracked, drops from {attacker_name}'s hand as you lie lifeless and broken.",
             "observer_msg": "The cellphone, now battered, its antenna broken, and perhaps its casing cracked, drops from {attacker_name}'s hand as {target_name} lies lifeless and broken."
         },
         {
             "attacker_msg": "You ensure {target_name} will not rise by repeatedly smashing their head with the cellphone until its plastic casing shatters, scattering electronic components.",
-            "victim_msg": "{attacker_name} ensures you will not rise by repeatedly smashing your head with the cellphone until its plastic casing shatters, scattering electronic components.",
+            "victim_msg": "{attacker_name} ensures you will not rise by repeatedly smashing your {hit_location} with the cellphone until its plastic casing shatters, scattering electronic components.",
             "observer_msg": "{attacker_name} ensures {target_name} will not rise by repeatedly smashing their head with the cellphone until its plastic casing shatters, scattering electronic components."
         },
         {
@@ -573,13 +573,13 @@ MESSAGES = {
         },
         {
             "attacker_msg": "{target_name}'s eyes widen in terror as your cellphone delivers the final, agonizing, crushing blow to their head, the antenna scraping their scalp.",
-            "victim_msg": "Your eyes widen in terror as {attacker_name}'s cellphone delivers the final, agonizing, crushing blow to your head, the antenna scraping your scalp.",
+            "victim_msg": "Your eyes widen in terror as {attacker_name}'s cellphone delivers the final, agonizing, crushing blow to your {hit_location}, the antenna scraping your scalp.",
             "observer_msg": "{target_name}'s eyes widen in terror as {attacker_name}'s cellphone delivers the final, agonizing, crushing blow to their head, the antenna scraping their scalp."
         },
         {
-            "attacker_msg": "A sickening crunch echoes as your cellphone fatally smashes {target_name}'s skull, ending their life with a thud of hard plastic and a spray of blood.",
-            "victim_msg": "A sickening crunch echoes as {attacker_name}'s cellphone fatally smashes your skull, ending your life with a thud of hard plastic and a spray of blood.",
-            "observer_msg": "A sickening crunch echoes as {attacker_name}'s cellphone fatally smashes {target_name}'s skull, ending their life with a thud of hard plastic and a spray of blood."
+            "attacker_msg": "A sickening crunch echoes as your cellphone fatally smashes {target_name}'s {hit_location}, ending their life with a thud of hard plastic and a spray of blood.",
+            "victim_msg": "A sickening crunch echoes as {attacker_name}'s cellphone fatally smashes your {hit_location}, ending your life with a thud of hard plastic and a spray of blood.",
+            "observer_msg": "A sickening crunch echoes as {attacker_name}'s cellphone fatally smashes {target_name}'s {hit_location}, ending their life with a thud of hard plastic and a spray of blood."
         },
         {
             "attacker_msg": "You discard the battered, broken cellphone beside {target_name}'s corpse, a grim testament to its makeshift lethality and surprising durability.",

--- a/world/combat/messages/chain.py
+++ b/world/combat/messages/chain.py
@@ -1,12 +1,12 @@
 MESSAGES = {
     "initiate": [
         {
-            "attacker_msg": "A flick of your elbow sends the chain unfurling into space. The metal stretches and sighs.",
+            "attacker_msg": "A flick of your {hit_location} sends the chain unfurling into space. The metal stretches and sighs.",
             "victim_msg": "A flick of {attacker_name}'s elbow sends the chain unfurling into space toward you. The metal stretches and sighs.",
             "observer_msg": "A flick of {attacker_name}'s elbow sends the chain unfurling into space. The metal stretches and sighs."
         },
         {
-            "attacker_msg": "A flick of your wrist sends the chain dancing through the air. Each link sings its own song of punishment.",
+            "attacker_msg": "A flick of your {hit_location} sends the chain dancing through the air. Each link sings its own song of punishment.",
             "victim_msg": "A flick of {attacker_name}'s wrist sends the chain dancing through the air toward you. Each link sings its own song of punishment.",
             "observer_msg": "A flick of {attacker_name}'s wrist sends the chain dancing through the air. Each link sings its own song of punishment."
         },
@@ -41,7 +41,7 @@ MESSAGES = {
             "observer_msg": "The chain hangs heavy from {attacker_name}'s grip. They swing it once, testing weight, momentum, intent."
         },
         {
-            "attacker_msg": "The chain is long, weathered, and unforgiving. You drag it through your hand like you're checking for flaws.",
+            "attacker_msg": "The chain is long, weathered, and unforgiving. You drag it through your {hit_location} like you're checking for flaws.",
             "victim_msg": "The chain is long, weathered, and unforgiving. {attacker_name} drags it through their hand like they're checking for flaws.",
             "observer_msg": "The chain is long, weathered, and unforgiving. {attacker_name} drags it through their hand like they're checking for flaws."
         },
@@ -86,7 +86,7 @@ MESSAGES = {
             "observer_msg": "The sound of the chain dragging behind {attacker_name} precedes them — a whisper of violence waiting to land."
         },
         {
-            "attacker_msg": "The way you coil it around your forearm says more than words ever could.",
+            "attacker_msg": "The way you coil it around your {hit_location} says more than words ever could.",
             "victim_msg": "The way {attacker_name} coils it around their forearm says more than words ever could.",
             "observer_msg": "The way {attacker_name} coils it around their forearm says more than words ever could."
         },
@@ -146,7 +146,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} wraps the chain around one hand, then unwraps it. They're not nervous. They're *measuring.*"
         },
         {
-            "attacker_msg": "You wrap the chain once around your wrist, letting it hang like a serpent ready to strike.",
+            "attacker_msg": "You wrap the chain once around your {hit_location}, letting it hang like a serpent ready to strike.",
             "victim_msg": "{attacker_name} wraps the chain once around their wrist, letting it hang like a serpent ready to strike.",
             "observer_msg": "{attacker_name} wraps the chain once around their wrist, letting it hang like a serpent ready to strike."
         }
@@ -163,9 +163,9 @@ MESSAGES = {
             "observer_msg": "A diagonal strike catches {target_name}'s {hit_location}. The chain bounces, but not before digging deep."
         },
         {
-            "attacker_msg": "A harsh crack across the {hit_location} steals air from {target_name}'s lungs. The chain wraps around briefly before sliding free.",
-            "victim_msg": "A harsh crack across your {hit_location} steals air from your lungs. The chain wraps around briefly before sliding free.",
-            "observer_msg": "A harsh crack across the {hit_location} steals air from {target_name}'s lungs. The chain wraps around briefly before sliding free."
+            "attacker_msg": "A harsh crack across the {hit_location} steals air from {target_name}'s {hit_location}. The chain wraps around briefly before sliding free.",
+            "victim_msg": "A harsh crack across your {hit_location} steals air from your {hit_location}. The chain wraps around briefly before sliding free.",
+            "observer_msg": "A harsh crack across the {hit_location} steals air from {target_name}'s {hit_location}. The chain wraps around briefly before sliding free."
         },
         {
             "attacker_msg": "A hook of the chain slams into {target_name}'s {hit_location}. They fold, breath gone and eyes wide.",
@@ -310,9 +310,9 @@ MESSAGES = {
             "observer_msg": "A low sweep misses {target_name}'s ankles by a whisper. Still enough to make them jump."
         },
         {
-            "attacker_msg": "A miscalculation sends the chain skimming the air above {target_name}'s head. Not this time.",
-            "victim_msg": "A miscalculation sends the chain skimming the air above your head. Not this time.",
-            "observer_msg": "A miscalculation sends the chain skimming the air above {target_name}'s head. Not this time."
+            "attacker_msg": "A miscalculation sends the chain skimming the air above {target_name}'s {hit_location}. Not this time.",
+            "victim_msg": "A miscalculation sends the chain skimming the air above your {hit_location}. Not this time.",
+            "observer_msg": "A miscalculation sends the chain skimming the air above {target_name}'s {hit_location}. Not this time."
         },
         {
             "attacker_msg": "A mistimed swing causes the chain to bounce uselessly across the floor. {target_name} doesn't laugh — not yet.",
@@ -330,9 +330,9 @@ MESSAGES = {
             "observer_msg": "A sideways arc misses completely. The links scatter briefly like a thousand tiny knives that forgot how to cut."
         },
         {
-            "attacker_msg": "A snap of your wrist sends the chain just over {target_name}'s shoulder. Close enough to feel it pass.",
-            "victim_msg": "A snap of {attacker_name}'s wrist sends the chain just over your shoulder. Close enough to feel it pass.",
-            "observer_msg": "A snap of {attacker_name}'s wrist sends the chain just over {target_name}'s shoulder. Close enough to feel it pass."
+            "attacker_msg": "A snap of your {hit_location} sends the chain just over {target_name}'s {hit_location}. Close enough to feel it pass.",
+            "victim_msg": "A snap of {attacker_name}'s wrist sends the chain just over your {hit_location}. Close enough to feel it pass.",
+            "observer_msg": "A snap of {attacker_name}'s wrist sends the chain just over {target_name}'s {hit_location}. Close enough to feel it pass."
         },
         {
             "attacker_msg": "A wild swing misses entirely, but the sound it makes echoes like a threat delayed.",
@@ -458,12 +458,12 @@ MESSAGES = {
     "kill": [
         {
             "attacker_msg": "A blow to the side of the head caves in the temple. The links leave a perfect, terrible pattern.",
-            "victim_msg": "A blow to the side of your head caves in the temple. The links leave a perfect, terrible pattern.",
+            "victim_msg": "A blow to the side of your {hit_location} caves in the temple. The links leave a perfect, terrible pattern.",
             "observer_msg": "A blow to the side of the head caves in the temple. The links leave a perfect, terrible pattern."
         },
         {
             "attacker_msg": "A crushing strike to the temple ends it immediately. The chain leaves a story across the skin.",
-            "victim_msg": "A crushing strike to your temple ends it immediately. The chain leaves a story across your skin.",
+            "victim_msg": "A crushing strike to your {hit_location} ends it immediately. The chain leaves a story across your skin.",
             "observer_msg": "A crushing strike to the temple ends it immediately. The chain leaves a story across the skin."
         },
         {
@@ -472,23 +472,23 @@ MESSAGES = {
             "observer_msg": "A downward strike wraps the chain around {target_name}'s shoulders. It doesn't kill them — the follow-up pull does."
         },
         {
-            "attacker_msg": "A full-body arc ends with the chain around {target_name}'s neck. The floor meets them like an old friend.",
-            "victim_msg": "A full-body arc ends with the chain around your neck. The floor meets you like an old friend.",
-            "observer_msg": "A full-body arc ends with the chain around {target_name}'s neck. The floor meets them like an old friend."
+            "attacker_msg": "A full-body arc ends with the chain around {target_name}'s {hit_location}. The floor meets them like an old friend.",
+            "victim_msg": "A full-body arc ends with the chain around your {hit_location}. The floor meets you like an old friend.",
+            "observer_msg": "A full-body arc ends with the chain around {target_name}'s {hit_location}. The floor meets them like an old friend."
         },
         {
             "attacker_msg": "A hard strike to the throat crushes cartilage and cuts the scream short. {target_name} gurgles and folds.",
-            "victim_msg": "A hard strike to your throat crushes cartilage and cuts the scream short. You gurgle and fold.",
+            "victim_msg": "A hard strike to your {hit_location} crushes cartilage and cuts the scream short. You gurgle and fold.",
             "observer_msg": "A hard strike to the throat crushes cartilage and cuts the scream short. {target_name} gurgles and folds."
         },
         {
-            "attacker_msg": "A heavy swing caves in the side of {target_name}'s head. The chain sticks for a moment before falling free.",
-            "victim_msg": "A heavy swing caves in the side of your head. The chain sticks for a moment before falling free.",
-            "observer_msg": "A heavy swing caves in the side of {target_name}'s head. The chain sticks for a moment before falling free."
+            "attacker_msg": "A heavy swing caves in the side of {target_name}'s {hit_location}. The chain sticks for a moment before falling free.",
+            "victim_msg": "A heavy swing caves in the side of your {hit_location}. The chain sticks for a moment before falling free.",
+            "observer_msg": "A heavy swing caves in the side of {target_name}'s {hit_location}. The chain sticks for a moment before falling free."
         },
         {
             "attacker_msg": "A single overhand strike breaks the clavicle, then the neck. {target_name} doesn't even get a final word.",
-            "victim_msg": "A single overhand strike breaks your clavicle, then your neck. You don't even get a final word.",
+            "victim_msg": "A single overhand strike breaks your clavicle, then your {hit_location}. You don't even get a final word.",
             "observer_msg": "A single overhand strike breaks the clavicle, then the neck. {target_name} doesn't even get a final word."
         },
         {
@@ -497,13 +497,13 @@ MESSAGES = {
             "observer_msg": "It's not the chain that kills — it's the pull. And the impact. And the quiet afterward."
         },
         {
-            "attacker_msg": "Metal links hammer {target_name}'s chest until bone gives way. The sound stops before you do.",
-            "victim_msg": "Metal links hammer your chest until bone gives way. The sound stops before {attacker_name} does.",
-            "observer_msg": "Metal links hammer {target_name}'s chest until bone gives way. The sound stops before {attacker_name} does."
+            "attacker_msg": "Metal links hammer {target_name}'s {hit_location} until bone gives way. The sound stops before you do.",
+            "victim_msg": "Metal links hammer your {hit_location} until bone gives way. The sound stops before {attacker_name} does.",
+            "observer_msg": "Metal links hammer {target_name}'s {hit_location} until bone gives way. The sound stops before {attacker_name} does."
         },
         {
             "attacker_msg": "One lash, one pull, and the spine gives way. {target_name} drops with the grace of rubble.",
-            "victim_msg": "One lash, one pull, and your spine gives way. You drop with the grace of rubble.",
+            "victim_msg": "One lash, one pull, and your {hit_location} gives way. You drop with the grace of rubble.",
             "observer_msg": "One lash, one pull, and the spine gives way. {target_name} drops with the grace of rubble."
         },
         {
@@ -517,49 +517,49 @@ MESSAGES = {
             "observer_msg": "One spin, one step, one pull — the chain tightens, and {target_name} collapses mid-breath."
         },
         {
-            "attacker_msg": "One wild spin and the chain wraps around {target_name}'s face. When it's pulled back, blood follows.",
-            "victim_msg": "One wild spin and the chain wraps around your face. When it's pulled back, blood follows.",
-            "observer_msg": "One wild spin and the chain wraps around {target_name}'s face. When it's pulled back, blood follows."
+            "attacker_msg": "One wild spin and the chain wraps around {target_name}'s {hit_location}. When it's pulled back, blood follows.",
+            "victim_msg": "One wild spin and the chain wraps around your {hit_location}. When it's pulled back, blood follows.",
+            "observer_msg": "One wild spin and the chain wraps around {target_name}'s {hit_location}. When it's pulled back, blood follows."
         },
         {
             "attacker_msg": "The chain coils like a snake, tight around the throat. The end is slow. Certain.",
-            "victim_msg": "The chain coils like a snake, tight around your throat. The end is slow. Certain.",
+            "victim_msg": "The chain coils like a snake, tight around your {hit_location}. The end is slow. Certain.",
             "observer_msg": "The chain coils like a snake, tight around the throat. The end is slow. Certain."
         },
         {
-            "attacker_msg": "The chain lands hard across {target_name}'s temple. The lights go out like someone flipped a switch.",
-            "victim_msg": "The chain lands hard across your temple. The lights go out like someone flipped a switch.",
-            "observer_msg": "The chain lands hard across {target_name}'s temple. The lights go out like someone flipped a switch."
+            "attacker_msg": "The chain lands hard across {target_name}'s {hit_location}. The lights go out like someone flipped a switch.",
+            "victim_msg": "The chain lands hard across your {hit_location}. The lights go out like someone flipped a switch.",
+            "observer_msg": "The chain lands hard across {target_name}'s {hit_location}. The lights go out like someone flipped a switch."
         },
         {
             "attacker_msg": "The chain lands low, breaking the spine at the base. {target_name} drops, still twitching.",
-            "victim_msg": "The chain lands low, breaking your spine at the base. You drop, still twitching.",
+            "victim_msg": "The chain lands low, breaking your {hit_location} at the base. You drop, still twitching.",
             "observer_msg": "The chain lands low, breaking the spine at the base. {target_name} drops, still twitching."
         },
         {
             "attacker_msg": "The chain lashes across the face. The skull breaks beneath the flurry of steel links.",
-            "victim_msg": "The chain lashes across your face. Your skull breaks beneath the flurry of steel links.",
+            "victim_msg": "The chain lashes across your {hit_location}. Your {hit_location} breaks beneath the flurry of steel links.",
             "observer_msg": "The chain lashes across the face. The skull breaks beneath the flurry of steel links."
         },
         {
             "attacker_msg": "The chain loops and yanks. The fall breaks the back. The scream doesn't finish.",
-            "victim_msg": "The chain loops and yanks. The fall breaks your back. Your scream doesn't finish.",
+            "victim_msg": "The chain loops and yanks. The fall breaks your {hit_location}. Your scream doesn't finish.",
             "observer_msg": "The chain loops and yanks. The fall breaks the back. The scream doesn't finish."
         },
         {
-            "attacker_msg": "The chain wraps around {target_name}'s throat and pulls tight. Their heels lift. The chain holds. They do not.",
-            "victim_msg": "The chain wraps around your throat and pulls tight. Your heels lift. The chain holds. You do not.",
-            "observer_msg": "The chain wraps around {target_name}'s throat and pulls tight. Their heels lift. The chain holds. They do not."
+            "attacker_msg": "The chain wraps around {target_name}'s {hit_location} and pulls tight. Their heels lift. The chain holds. They do not.",
+            "victim_msg": "The chain wraps around your {hit_location} and pulls tight. Your heels lift. The chain holds. You do not.",
+            "observer_msg": "The chain wraps around {target_name}'s {hit_location} and pulls tight. Their heels lift. The chain holds. They do not."
         },
         {
-            "attacker_msg": "The chain wraps around {target_name}'s throat and pulls. You don't stop until feet stop twitching.",
-            "victim_msg": "The chain wraps around your throat and pulls. {attacker_name} doesn't stop until your feet stop twitching.",
-            "observer_msg": "The chain wraps around {target_name}'s throat and pulls. {attacker_name} doesn't stop until feet stop twitching."
+            "attacker_msg": "The chain wraps around {target_name}'s {hit_location} and pulls. You don't stop until feet stop twitching.",
+            "victim_msg": "The chain wraps around your {hit_location} and pulls. {attacker_name} doesn't stop until your feet stop twitching.",
+            "observer_msg": "The chain wraps around {target_name}'s {hit_location} and pulls. {attacker_name} doesn't stop until feet stop twitching."
         },
         {
-            "attacker_msg": "The chain wraps twice around {target_name}'s arm — then yanks them off their feet and into a final, fatal blow.",
-            "victim_msg": "The chain wraps twice around your arm — then yanks you off your feet and into a final, fatal blow.",
-            "observer_msg": "The chain wraps twice around {target_name}'s arm — then yanks them off their feet and into a final, fatal blow."
+            "attacker_msg": "The chain wraps twice around {target_name}'s {hit_location} — then yanks them off their feet and into a final, fatal blow.",
+            "victim_msg": "The chain wraps twice around your {hit_location} — then yanks you off your feet and into a final, fatal blow.",
+            "observer_msg": "The chain wraps twice around {target_name}'s {hit_location} — then yanks them off their feet and into a final, fatal blow."
         },
         {
             "attacker_msg": "The final blow is a whirlwind of metal. When it ends, {target_name} is still — and red.",
@@ -573,13 +573,13 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The final swing tightens around the neck, then jerks hard. A snap. A drop. Silence.",
-            "victim_msg": "The final swing tightens around your neck, then jerks hard. A snap. A drop. Silence.",
+            "victim_msg": "The final swing tightens around your {hit_location}, then jerks hard. A snap. A drop. Silence.",
             "observer_msg": "The final swing tightens around the neck, then jerks hard. A snap. A drop. Silence."
         },
         {
-            "attacker_msg": "With a flick of your wrist, you bring the chain across {target_name}'s jaw. The body slumps. The fight ends.",
-            "victim_msg": "With a flick of {attacker_name}'s wrist, they bring the chain across your jaw. Your body slumps. The fight ends.",
-            "observer_msg": "With a flick of {attacker_name}'s wrist, they bring the chain across {target_name}'s jaw. The body slumps. The fight ends."
+            "attacker_msg": "With a flick of your {hit_location}, you bring the chain across {target_name}'s {hit_location}. The body slumps. The fight ends.",
+            "victim_msg": "With a flick of {attacker_name}'s wrist, they bring the chain across your {hit_location}. Your body slumps. The fight ends.",
+            "observer_msg": "With a flick of {attacker_name}'s wrist, they bring the chain across {target_name}'s {hit_location}. The body slumps. The fight ends."
         },
         {
             "attacker_msg": "You choke the life out of {target_name} slowly. The chain doesn't creak. It hums.",
@@ -593,18 +593,18 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You tighten the chain around the back of the skull and yank. The body folds forward like a closing door.",
-            "victim_msg": "{attacker_name} tightens the chain around the back of your skull and yanks. Your body folds forward like a closing door.",
+            "victim_msg": "{attacker_name} tightens the chain around the back of your {hit_location} and yanks. Your body folds forward like a closing door.",
             "observer_msg": "{attacker_name} tightens the chain around the back of the skull and yanks. The body folds forward like a closing door."
         },
         {
-            "attacker_msg": "You whip the chain around {target_name}'s neck and pull. The snap is clean. The silence, cleaner.",
-            "victim_msg": "{attacker_name} whips the chain around your neck and pulls. The snap is clean. The silence, cleaner.",
-            "observer_msg": "{attacker_name} whips the chain around {target_name}'s neck and pulls. The snap is clean. The silence, cleaner."
+            "attacker_msg": "You whip the chain around {target_name}'s {hit_location} and pull. The snap is clean. The silence, cleaner.",
+            "victim_msg": "{attacker_name} whips the chain around your {hit_location} and pulls. The snap is clean. The silence, cleaner.",
+            "observer_msg": "{attacker_name} whips the chain around {target_name}'s {hit_location} and pulls. The snap is clean. The silence, cleaner."
         },
         {
-            "attacker_msg": "You wrap the chain across {target_name}'s chest and pull them close — into the killing blow.",
-            "victim_msg": "{attacker_name} wraps the chain across your chest and pulls you close — into the killing blow.",
-            "observer_msg": "{attacker_name} wraps the chain across {target_name}'s chest and pulls them close — into the killing blow."
+            "attacker_msg": "You wrap the chain across {target_name}'s {hit_location} and pull them close — into the killing blow.",
+            "victim_msg": "{attacker_name} wraps the chain across your {hit_location} and pulls you close — into the killing blow.",
+            "observer_msg": "{attacker_name} wraps the chain across {target_name}'s {hit_location} and pulls them close — into the killing blow."
         }
     ]
 }

--- a/world/combat/messages/chainsaw.py
+++ b/world/combat/messages/chainsaw.py
@@ -6,7 +6,7 @@ MESSAGES = {
             'observer_msg': "A guttural sound fills the room as {attacker_name} turns over their saw. It doesn't want to start — it *needs* to."
         },
         {
-            'attacker_msg': "A single rev makes the air vibrate. You tilt your head, like you're listening for the exact moment fear begins.",
+            'attacker_msg': "A single rev makes the air vibrate. You tilt your {hit_location}, like you're listening for the exact moment fear begins.",
             'victim_msg': "A single rev makes the air vibrate. {attacker_name} tilts their head, like they're listening for the exact moment fear begins.",
             'observer_msg': "A single rev makes the air vibrate. {attacker_name} tilts their head, like they're listening for the exact moment fear begins."
         },
@@ -436,7 +436,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "No contact — just momentum and noise. {target_name} doesn't flinch, but their heart races.",
-            'victim_msg': "No contact — just momentum and noise. You don't flinch, but your heart races.",
+            'victim_msg': "No contact — just momentum and noise. You don't flinch, but your {hit_location} races.",
             'observer_msg': "No contact — just momentum and noise. {target_name} doesn't flinch, but their heart races."
         },
         {
@@ -505,9 +505,9 @@ MESSAGES = {
             'observer_msg': "The saw bites into drywall instead, throwing up dust and sparks. {target_name} stumbles away, coughing relief."
         },
         {
-            'attacker_msg': "The teeth flash past {target_name}'s shoulder, close enough to slice their coat. The noise still rings in their ears.",
-            'victim_msg': "The teeth flash past your shoulder, close enough to slice your coat. The noise still rings in your ears.",
-            'observer_msg': "The teeth flash past {target_name}'s shoulder, close enough to slice their coat. The noise still rings in their ears."
+            'attacker_msg': "The teeth flash past {target_name}'s {hit_location}, close enough to slice their coat. The noise still rings in their ears.",
+            'victim_msg': "The teeth flash past your {hit_location}, close enough to slice your coat. The noise still rings in your ears.",
+            'observer_msg': "The teeth flash past {target_name}'s {hit_location}, close enough to slice their coat. The noise still rings in their ears."
         },
         {
             'attacker_msg': "There's a screech, a scrape — and then stillness. Your eyes burn brighter than the motor.",
@@ -607,9 +607,9 @@ MESSAGES = {
             'observer_msg': "The blade enters between shoulder and throat. By the time it exits, {target_name} is already a memory."
         },
         {
-            'attacker_msg': "Your chain chews its way through {target_name}'s torso, pulling organs into daylight. Their feet leave the floor.",
-            'victim_msg': "The chain chews its way through your torso, pulling organs into daylight. Your feet leave the floor.",
-            'observer_msg': "The chain chews its way through {target_name}'s torso, pulling organs into daylight. Their feet leave the floor."
+            'attacker_msg': "Your chain chews its way through {target_name}'s {hit_location}, pulling organs into daylight. Their feet leave the floor.",
+            'victim_msg': "The chain chews its way through your {hit_location}, pulling organs into daylight. Your feet leave the floor.",
+            'observer_msg': "The chain chews its way through {target_name}'s {hit_location}, pulling organs into daylight. Their feet leave the floor."
         },
         {
             'attacker_msg': "The chain hits vertebrae and keeps going. {target_name}'s body drops in segments, no longer part of a single story.",
@@ -617,9 +617,9 @@ MESSAGES = {
             'observer_msg': "The chain hits vertebrae and keeps going. {target_name}'s body drops in segments, no longer part of a single story."
         },
         {
-            'attacker_msg': "Your chainsaw embeds into {target_name}'s skull with a sickening crunch. When it's over, there's nothing left to identify.",
-            'victim_msg': "The chainsaw embeds into your skull with a sickening crunch. When it's over, there's nothing left to identify.",
-            'observer_msg': "The chainsaw embeds into {target_name}'s skull with a sickening crunch. When it's over, there's nothing left to identify."
+            'attacker_msg': "Your chainsaw embeds into {target_name}'s {hit_location} with a sickening crunch. When it's over, there's nothing left to identify.",
+            'victim_msg': "The chainsaw embeds into your {hit_location} with a sickening crunch. When it's over, there's nothing left to identify.",
+            'observer_msg': "The chainsaw embeds into {target_name}'s {hit_location} with a sickening crunch. When it's over, there's nothing left to identify."
         },
         {
             'attacker_msg': "Your chainsaw enters at the neck and exits at the pelvis. What's left is meat and echo.",
@@ -627,14 +627,14 @@ MESSAGES = {
             'observer_msg': "The chainsaw enters at the neck and exits at the pelvis. What's left is meat and echo."
         },
         {
-            'attacker_msg': "Your chainsaw plunges through {target_name}'s torso with a sickening crunch. They don't fall — they *disintegrate*.",
-            'victim_msg': "The chainsaw plunges through your torso with a sickening crunch. You don't fall — you *disintegrate*.",
-            'observer_msg': "The chainsaw plunges through {target_name}'s torso with a sickening crunch. They don't fall — they *disintegrate*."
+            'attacker_msg': "Your chainsaw plunges through {target_name}'s {hit_location} with a sickening crunch. They don't fall — they *disintegrate*.",
+            'victim_msg': "The chainsaw plunges through your {hit_location} with a sickening crunch. You don't fall — you *disintegrate*.",
+            'observer_msg': "The chainsaw plunges through {target_name}'s {hit_location} with a sickening crunch. They don't fall — they *disintegrate*."
         },
         {
-            'attacker_msg': "Your chainsaw tears through {target_name}'s chest, blood arcing high in a final salute. Their collapse is less a fall than a surrender.",
-            'victim_msg': "The chainsaw tears through your chest, blood arcing high in a final salute. Your collapse is less a fall than a surrender.",
-            'observer_msg': "The chainsaw tears through {target_name}'s chest, blood arcing high in a final salute. Their collapse is less a fall than a surrender."
+            'attacker_msg': "Your chainsaw tears through {target_name}'s {hit_location}, blood arcing high in a final salute. Their collapse is less a fall than a surrender.",
+            'victim_msg': "The chainsaw tears through your {hit_location}, blood arcing high in a final salute. Your collapse is less a fall than a surrender.",
+            'observer_msg': "The chainsaw tears through {target_name}'s {hit_location}, blood arcing high in a final salute. Their collapse is less a fall than a surrender."
         },
         {
             'attacker_msg': "The cut is diagonal, disrespectful. {target_name} falls in two directions, their blood trying to hold them together.",
@@ -652,9 +652,9 @@ MESSAGES = {
             'observer_msg': "The kill isn't clean. It's cruel. {target_name} twitches, then stops, the saw still humming beside them."
         },
         {
-            'attacker_msg': "Your saw finds {target_name}'s neck and keeps going. What's left isn't a wound — it's a border between life and never again.",
-            'victim_msg': "The saw finds your neck and keeps going. What's left isn't a wound — it's a border between life and never again.",
-            'observer_msg': "The saw finds {target_name}'s neck and keeps going. What's left isn't a wound — it's a border between life and never again."
+            'attacker_msg': "Your saw finds {target_name}'s {hit_location} and keeps going. What's left isn't a wound — it's a border between life and never again.",
+            'victim_msg': "The saw finds your {hit_location} and keeps going. What's left isn't a wound — it's a border between life and never again.",
+            'observer_msg': "The saw finds {target_name}'s {hit_location} and keeps going. What's left isn't a wound — it's a border between life and never again."
         },
         {
             'attacker_msg': "There's a sound like snapping wood. {target_name}'s body folds in half, steam rising from the ruin.",
@@ -677,19 +677,19 @@ MESSAGES = {
             'observer_msg': "With a full-body shove, {attacker_name} drives the blade in deep. {target_name} seizes, then vanishes beneath the noise."
         },
         {
-            'attacker_msg': "With one final rev, you bury the blade in {target_name}'s sternum. Their scream ends before the motor does.",
-            'victim_msg': "With one final rev, {attacker_name} buries the blade in your sternum. Your scream ends before the motor does.",
-            'observer_msg': "With one final rev, {attacker_name} buries the blade in {target_name}'s sternum. Their scream ends before the motor does."
+            'attacker_msg': "With one final rev, you bury the blade in {target_name}'s {hit_location}. Their scream ends before the motor does.",
+            'victim_msg': "With one final rev, {attacker_name} buries the blade in your {hit_location}. Your scream ends before the motor does.",
+            'observer_msg': "With one final rev, {attacker_name} buries the blade in {target_name}'s {hit_location}. Their scream ends before the motor does."
         },
         {
-            'attacker_msg': "You drag the saw across {target_name}'s chest and don't stop. There's no final scream — just static.",
-            'victim_msg': "{attacker_name} drags the saw across your chest and doesn't stop. There's no final scream — just static.",
-            'observer_msg': "{attacker_name} drags the saw across {target_name}'s chest and doesn't stop. There's no final scream — just static."
+            'attacker_msg': "You drag the saw across {target_name}'s {hit_location} and don't stop. There's no final scream — just static.",
+            'victim_msg': "{attacker_name} drags the saw across your {hit_location} and doesn't stop. There's no final scream — just static.",
+            'observer_msg': "{attacker_name} drags the saw across {target_name}'s {hit_location} and doesn't stop. There's no final scream — just static."
         },
         {
-            'attacker_msg': "You drive your chainsaw into {target_name}'s chest, leaning in like you're pushing through a heavy door. Blood erupts, spraying across everything with no mercy.",
-            'victim_msg': "{attacker_name} drives the chainsaw into your chest, leaning in like they're pushing through a heavy door. Blood erupts, spraying across everything with no mercy.",
-            'observer_msg': "{attacker_name} drives the chainsaw into {target_name}'s chest, leaning in like they're pushing through a heavy door. Blood erupts, spraying across everything with no mercy."
+            'attacker_msg': "You drive your chainsaw into {target_name}'s {hit_location}, leaning in like you're pushing through a heavy door. Blood erupts, spraying across everything with no mercy.",
+            'victim_msg': "{attacker_name} drives the chainsaw into your {hit_location}, leaning in like they're pushing through a heavy door. Blood erupts, spraying across everything with no mercy.",
+            'observer_msg': "{attacker_name} drives the chainsaw into {target_name}'s {hit_location}, leaning in like they're pushing through a heavy door. Blood erupts, spraying across everything with no mercy."
         },
         {
             'attacker_msg': "You plant the blade and lift. What's left of {target_name} slaps against the floor with a sound that won't be forgotten.",

--- a/world/combat/messages/claymore.py
+++ b/world/combat/messages/claymore.py
@@ -477,9 +477,9 @@ MESSAGES = {
             "observer_msg": "The massive blade of the claymore decapitates {target_name} with a single, brutal chop."
         },
         {
-            "attacker_msg": "Your powerful overhead smash with the claymore caves in {target_name}'s skull and chest cavity.",
-            "victim_msg": "{attacker_name}'s powerful overhead smash with the claymore caves in your skull and chest cavity.",
-            "observer_msg": "{attacker_name}'s powerful overhead smash with the claymore caves in {target_name}'s skull and chest cavity."
+            "attacker_msg": "Your powerful overhead smash with the claymore caves in {target_name}'s {hit_location} and chest cavity.",
+            "victim_msg": "{attacker_name}'s powerful overhead smash with the claymore caves in your {hit_location} and chest cavity.",
+            "observer_msg": "{attacker_name}'s powerful overhead smash with the claymore caves in {target_name}'s {hit_location} and chest cavity."
         },
         {
             "attacker_msg": "The claymore, an avalanche of steel, delivers a killing blow, and {target_name}'s struggles cease in a torrent of gore.",
@@ -492,9 +492,9 @@ MESSAGES = {
             "observer_msg": "A vicious upward swing from {attacker_name}'s claymore nearly tears {target_name} asunder, ending their life instantly."
         },
         {
-            "attacker_msg": "You drive the claymore through {target_name}'s torso, impaling them like a grotesque trophy.",
-            "victim_msg": "{attacker_name} drives the claymore through your torso, impaling you like a grotesque trophy.",
-            "observer_msg": "{attacker_name} drives the claymore through {target_name}'s torso, impaling them like a grotesque trophy."
+            "attacker_msg": "You drive the claymore through {target_name}'s {hit_location}, impaling them like a grotesque trophy.",
+            "victim_msg": "{attacker_name} drives the claymore through your {hit_location}, impaling you like a grotesque trophy.",
+            "observer_msg": "{attacker_name} drives the claymore through {target_name}'s {hit_location}, impaling them like a grotesque trophy."
         },
         {
             "attacker_msg": "The keen edge of the claymore opens a fatal, body-length wound, and {target_name} collapses, unmoving.",
@@ -537,9 +537,9 @@ MESSAGES = {
             "observer_msg": "Blood sprays in a torrent as {attacker_name}'s claymore severs multiple limbs, and {target_name} quickly expires."
         },
         {
-            "attacker_msg": "The point of the claymore, driven by your full weight, punches through armor and out {target_name}'s back.",
-            "victim_msg": "The point of the claymore, driven by {attacker_name}'s full weight, punches through armor and out your back.",
-            "observer_msg": "The point of the claymore, driven by {attacker_name}'s full weight, punches through armor and out {target_name}'s back."
+            "attacker_msg": "The point of the claymore, driven by your full weight, punches through armor and out {target_name}'s {hit_location}.",
+            "victim_msg": "The point of the claymore, driven by {attacker_name}'s full weight, punches through armor and out your {hit_location}.",
+            "observer_msg": "The point of the claymore, driven by {attacker_name}'s full weight, punches through armor and out {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You stand panting over {target_name}, claymore dripping, the victor of a terrifyingly brutal contest.",

--- a/world/combat/messages/combat_knife.py
+++ b/world/combat/messages/combat_knife.py
@@ -126,12 +126,12 @@ MESSAGES = {
             "observer_msg": "{attacker_name} holds the knife in both hands for a moment. Then just one. That's all it takes."
         },
         {
-            "attacker_msg": "You pull the combat knife from a sheath strapped to your leg. It moves like part of you.",
+            "attacker_msg": "You pull the combat knife from a sheath strapped to your {hit_location}. It moves like part of you.",
             "victim_msg": "{attacker_name} pulls the combat knife from a sheath strapped to their leg. It moves like part of them.",
             "observer_msg": "{attacker_name} pulls the combat knife from a sheath strapped to their leg. It moves like part of them."
         },
         {
-            "attacker_msg": "You roll your wrist once, knife gliding effortlessly between fingers. A warm-up for blood.",
+            "attacker_msg": "You roll your {hit_location} once, knife gliding effortlessly between fingers. A warm-up for blood.",
             "victim_msg": "{attacker_name} rolls their wrist once, knife gliding effortlessly between fingers. A warm-up for blood.",
             "observer_msg": "{attacker_name} rolls their wrist once, knife gliding effortlessly between fingers. A warm-up for blood."
         },
@@ -229,7 +229,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The edge sinks into the {hit_location}. {target_name} howls as their arm falls slack.",
-            "victim_msg": "The edge sinks into the {hit_location}. You howl as your arm falls slack.",
+            "victim_msg": "The edge sinks into the {hit_location}. You howl as your {hit_location} falls slack.",
             "observer_msg": "The edge sinks into the {hit_location}. {target_name} howls as their arm falls slack."
         },
         {
@@ -335,9 +335,9 @@ MESSAGES = {
             "observer_msg": "A slash across space, missing by inches but carrying all the threat."
         },
         {
-            "attacker_msg": "A slash whistles past {target_name}'s face, close enough to blur their vision.",
-            "victim_msg": "A slash whistles past your face, close enough to blur your vision.",
-            "observer_msg": "A slash whistles past {target_name}'s face, close enough to blur their vision."
+            "attacker_msg": "A slash whistles past {target_name}'s {hit_location}, close enough to blur their vision.",
+            "victim_msg": "A slash whistles past your {hit_location}, close enough to blur your vision.",
+            "observer_msg": "A slash whistles past {target_name}'s {hit_location}, close enough to blur their vision."
         },
         {
             "attacker_msg": "One overextended jab gives {target_name} the second they needed to retreat.",
@@ -425,9 +425,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} goes low — too low. The knife hits tile and glances away."
         },
         {
-            "attacker_msg": "You lunge and miss, the knife whistling past {target_name}'s ribs.",
-            "victim_msg": "{attacker_name} lunges and misses, the knife whistling past your ribs.",
-            "observer_msg": "{attacker_name} lunges and misses, the knife whistling past {target_name}'s ribs."
+            "attacker_msg": "You lunge and miss, the knife whistling past {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} lunges and misses, the knife whistling past your {hit_location}.",
+            "observer_msg": "{attacker_name} lunges and misses, the knife whistling past {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You stab too early. The knife grazes nothing. {target_name} grins and steps back.",
@@ -527,9 +527,9 @@ MESSAGES = {
             "observer_msg": "Steel slides into the base of the skull. {target_name}'s body freezes, then falls."
         },
         {
-            "attacker_msg": "The blade drives deep into {target_name}'s heart. The collapse is quiet — definitive.",
-            "victim_msg": "The blade drives deep into your heart. The collapse is quiet — definitive.",
-            "observer_msg": "The blade drives deep into {target_name}'s heart. The collapse is quiet — definitive."
+            "attacker_msg": "The blade drives deep into {target_name}'s {hit_location}. The collapse is quiet — definitive.",
+            "victim_msg": "The blade drives deep into your {hit_location}. The collapse is quiet — definitive.",
+            "observer_msg": "The blade drives deep into {target_name}'s {hit_location}. The collapse is quiet — definitive."
         },
         {
             "attacker_msg": "The blade lands in the base of the skull. You don't pull it out until you're sure.",
@@ -547,9 +547,9 @@ MESSAGES = {
             "observer_msg": "The combat knife punches upward under the chin. {target_name} stiffens, then topples backwards."
         },
         {
-            "attacker_msg": "The knife drives into {target_name}'s heart. No theatrics. Just collapse.",
-            "victim_msg": "The knife drives into your heart. No theatrics. Just collapse.",
-            "observer_msg": "The knife drives into {target_name}'s heart. No theatrics. Just collapse."
+            "attacker_msg": "The knife drives into {target_name}'s {hit_location}. No theatrics. Just collapse.",
+            "victim_msg": "The knife drives into your {hit_location}. No theatrics. Just collapse.",
+            "observer_msg": "The knife drives into {target_name}'s {hit_location}. No theatrics. Just collapse."
         },
         {
             "attacker_msg": "The knife enters under the jaw and exits through the tongue. Words die with it.",

--- a/world/combat/messages/cricket_bat.py
+++ b/world/combat/messages/cricket_bat.py
@@ -81,7 +81,7 @@ MESSAGES = {
             "observer_msg": "The distinctive shape of the cricket bat – broad and flat – is clearly visible, a testament to its unique design."
         },
         {
-            "attacker_msg": "You hold the cricket bat angled over your shoulder, ready to bring its full width down upon {target_name}.",
+            "attacker_msg": "You hold the cricket bat angled over your {hit_location}, ready to bring its full width down upon {target_name}.",
             "victim_msg": "{attacker_name} holds the cricket bat angled over their shoulder, ready to bring its full width down upon you.",
             "observer_msg": "{attacker_name} holds the cricket bat angled over their shoulder, ready to bring its full width down upon {target_name}."
         },
@@ -234,7 +234,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "The cricket bat thuds heavily as it connects with {target_name}'s {hit_location}, driving the air from their lungs.",
-            "victim_msg": "The cricket bat thuds heavily as it connects with your {hit_location}, driving the air from your lungs.",
+            "victim_msg": "The cricket bat thuds heavily as it connects with your {hit_location}, driving the air from your {hit_location}.",
             "observer_msg": "The cricket bat thuds heavily as it connects with {target_name}'s {hit_location}, driving the air from their lungs."
         },
         {
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            "attacker_msg": "Your cricket bat whistles through the air with considerable force, the broad face missing {target_name}'s head by inches.",
-            "victim_msg": "{attacker_name}'s cricket bat whistles through the air with considerable force, the broad face missing your head by inches.",
-            "observer_msg": "{attacker_name}'s cricket bat whistles through the air with considerable force, the broad face missing {target_name}'s head by inches."
+            "attacker_msg": "Your cricket bat whistles through the air with considerable force, the broad face missing {target_name}'s {hit_location} by inches.",
+            "victim_msg": "{attacker_name}'s cricket bat whistles through the air with considerable force, the broad face missing your {hit_location} by inches.",
+            "observer_msg": "{attacker_name}'s cricket bat whistles through the air with considerable force, the broad face missing {target_name}'s {hit_location} by inches."
         },
         {
             "attacker_msg": "{target_name} narrowly avoids the heavy, flat arc of your cricket bat with a desperate lurch.",
@@ -457,29 +457,29 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "Your cricket bat connects with {target_name}'s temple with a sickening, flat crack; {target_name} drops, instantly lifeless.",
-            "victim_msg": "{attacker_name}'s cricket bat connects with your temple with a sickening, flat crack; you drop, instantly lifeless.",
-            "observer_msg": "{attacker_name}'s cricket bat connects with {target_name}'s temple with a sickening, flat crack; {target_name} drops, instantly lifeless."
+            "attacker_msg": "Your cricket bat connects with {target_name}'s {hit_location} with a sickening, flat crack; {target_name} drops, instantly lifeless.",
+            "victim_msg": "{attacker_name}'s cricket bat connects with your {hit_location} with a sickening, flat crack; you drop, instantly lifeless.",
+            "observer_msg": "{attacker_name}'s cricket bat connects with {target_name}'s {hit_location} with a sickening, flat crack; {target_name} drops, instantly lifeless."
         },
         {
-            "attacker_msg": "A devastating swing from the cricket bat crushes {target_name}'s skull, ending the fight with brutal finality.",
-            "victim_msg": "A devastating swing from the cricket bat crushes your skull, ending the fight with brutal finality.",
-            "observer_msg": "A devastating swing from the cricket bat crushes {target_name}'s skull, ending the fight with brutal finality."
+            "attacker_msg": "A devastating swing from the cricket bat crushes {target_name}'s {hit_location}, ending the fight with brutal finality.",
+            "victim_msg": "A devastating swing from the cricket bat crushes your {hit_location}, ending the fight with brutal finality.",
+            "observer_msg": "A devastating swing from the cricket bat crushes {target_name}'s {hit_location}, ending the fight with brutal finality."
         },
         {
-            "attacker_msg": "With a final, focused stroke, your cricket bat shatters {target_name}'s sternum, and they collapse, unmoving.",
-            "victim_msg": "With a final, focused stroke, {attacker_name}'s cricket bat shatters your sternum, and you collapse, unmoving.",
-            "observer_msg": "With a final, focused stroke, {attacker_name}'s cricket bat shatters {target_name}'s sternum, and they collapse, unmoving."
+            "attacker_msg": "With a final, focused stroke, your cricket bat shatters {target_name}'s {hit_location}, and they collapse, unmoving.",
+            "victim_msg": "With a final, focused stroke, {attacker_name}'s cricket bat shatters your {hit_location}, and you collapse, unmoving.",
+            "observer_msg": "With a final, focused stroke, {attacker_name}'s cricket bat shatters {target_name}'s {hit_location}, and they collapse, unmoving."
         },
         {
-            "attacker_msg": "The heavy willow of the cricket bat strikes {target_name}'s throat with a sickening thud, a swift and brutal end.",
-            "victim_msg": "The heavy willow of the cricket bat strikes your throat with a sickening thud, a swift and brutal end.",
-            "observer_msg": "The heavy willow of the cricket bat strikes {target_name}'s throat with a sickening thud, a swift and brutal end."
+            "attacker_msg": "The heavy willow of the cricket bat strikes {target_name}'s {hit_location} with a sickening thud, a swift and brutal end.",
+            "victim_msg": "The heavy willow of the cricket bat strikes your {hit_location} with a sickening thud, a swift and brutal end.",
+            "observer_msg": "The heavy willow of the cricket bat strikes {target_name}'s {hit_location} with a sickening thud, a swift and brutal end."
         },
         {
-            "attacker_msg": "Your powerful swing with the cricket bat caves in {target_name}'s chest; they fall, breath rattling to a stop.",
-            "victim_msg": "{attacker_name}'s powerful swing with the cricket bat caves in your chest; you fall, breath rattling to a stop.",
-            "observer_msg": "{attacker_name}'s powerful swing with the cricket bat caves in {target_name}'s chest; they fall, breath rattling to a stop."
+            "attacker_msg": "Your powerful swing with the cricket bat caves in {target_name}'s {hit_location}; they fall, breath rattling to a stop.",
+            "victim_msg": "{attacker_name}'s powerful swing with the cricket bat caves in your {hit_location}; you fall, breath rattling to a stop.",
+            "observer_msg": "{attacker_name}'s powerful swing with the cricket bat caves in {target_name}'s {hit_location}; they fall, breath rattling to a stop."
         },
         {
             "attacker_msg": "The cricket bat, a simple sporting tool turned deadly, delivers a killing blow, and {target_name}'s struggles cease.",
@@ -497,9 +497,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} drives the toe of the cricket bat into {target_name}'s eye socket with brutal force, the outcome grimly certain."
         },
         {
-            "attacker_msg": "The unyielding cricket bat breaks {target_name}'s neck with a sharp, horrifying snap; they fall, a broken puppet.",
-            "victim_msg": "The unyielding cricket bat breaks your neck with a sharp, horrifying snap; you fall, a broken puppet.",
-            "observer_msg": "The unyielding cricket bat breaks {target_name}'s neck with a sharp, horrifying snap; they fall, a broken puppet."
+            "attacker_msg": "The unyielding cricket bat breaks {target_name}'s {hit_location} with a sharp, horrifying snap; they fall, a broken puppet.",
+            "victim_msg": "The unyielding cricket bat breaks your {hit_location} with a sharp, horrifying snap; you fall, a broken puppet.",
+            "observer_msg": "The unyielding cricket bat breaks {target_name}'s {hit_location} with a sharp, horrifying snap; they fall, a broken puppet."
         },
         {
             "attacker_msg": "With a final, savage grunt, you finish {target_name} with a decisive, crushing strike from the cricket bat.",

--- a/world/combat/messages/crowbar.py
+++ b/world/combat/messages/crowbar.py
@@ -26,7 +26,7 @@ MESSAGES = {
             "observer_msg": "Rust flakes from the hook as {attacker_name} rotates it slowly. The weapon remembers pain."
         },
         {
-            "attacker_msg": "The bar rests across your forearm as you survey the field. Casual violence in posture alone.",
+            "attacker_msg": "The bar rests across your {hit_location} as you survey the field. Casual violence in posture alone.",
             "victim_msg": "The bar rests across {attacker_name}'s forearm as they survey the field. Casual violence in posture alone.",
             "observer_msg": "The bar rests across {attacker_name}'s forearm as they survey the field. Casual violence in posture alone."
         },
@@ -36,7 +36,7 @@ MESSAGES = {
             "observer_msg": "The bar swings lightly at {attacker_name}'s side, every step marking the countdown toward violence."
         },
         {
-            "attacker_msg": "The crowbar rests against your shoulder like an old friend — mean, ugly, loyal.",
+            "attacker_msg": "The crowbar rests against your {hit_location} like an old friend — mean, ugly, loyal.",
             "victim_msg": "The crowbar rests against {attacker_name}'s shoulder like an old friend — mean, ugly, loyal.",
             "observer_msg": "The crowbar rests against {attacker_name}'s shoulder like an old friend — mean, ugly, loyal."
         },
@@ -121,7 +121,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} draws the crowbar from their belt, letting the sound announce what's next."
         },
         {
-            "attacker_msg": "You flex the crowbar in your hand like it's a living thing. It rattles once, eager.",
+            "attacker_msg": "You flex the crowbar in your {hit_location} like it's a living thing. It rattles once, eager.",
             "victim_msg": "{attacker_name} flexes the crowbar in their hand like it's a living thing. It rattles once, eager.",
             "observer_msg": "{attacker_name} flexes the crowbar in their hand like it's a living thing. It rattles once, eager."
         },
@@ -131,7 +131,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} hefts the crowbar with one hand and taps it against their palm. It's not subtle. It's not meant to be."
         },
         {
-            "attacker_msg": "You lean the bar across your shoulders, flexing your neck like you're just warming up.",
+            "attacker_msg": "You lean the bar across your shoulders, flexing your {hit_location} like you're just warming up.",
             "victim_msg": "{attacker_name} leans the bar across their shoulders, flexing their neck like they're just warming up.",
             "observer_msg": "{attacker_name} leans the bar across their shoulders, flexing their neck like they're just warming up."
         },
@@ -325,9 +325,9 @@ MESSAGES = {
             "observer_msg": "A quick step back saves {target_name} from a crushed knee. Barely."
         },
         {
-            "attacker_msg": "A tight swing whistles through space where {target_name}'s head was half a second ago.",
-            "victim_msg": "A tight swing whistles through space where your head was half a second ago.",
-            "observer_msg": "A tight swing whistles through space where {target_name}'s head was half a second ago."
+            "attacker_msg": "A tight swing whistles through space where {target_name}'s {hit_location} was half a second ago.",
+            "victim_msg": "A tight swing whistles through space where your {hit_location} was half a second ago.",
+            "observer_msg": "A tight swing whistles through space where {target_name}'s {hit_location} was half a second ago."
         },
         {
             "attacker_msg": "A wide sweep whistles through nothing, but the speed rattles {target_name}'s nerves.",
@@ -405,9 +405,9 @@ MESSAGES = {
             "observer_msg": "The hook gets caught briefly on a railing. {attacker_name} jerks it free with a snarl."
         },
         {
-            "attacker_msg": "The metal sings through the space beside {target_name}'s head. Close. Too close.",
-            "victim_msg": "The metal sings through the space beside your head. Close. Too close.",
-            "observer_msg": "The metal sings through the space beside {target_name}'s head. Close. Too close."
+            "attacker_msg": "The metal sings through the space beside {target_name}'s {hit_location}. Close. Too close.",
+            "victim_msg": "The metal sings through the space beside your {hit_location}. Close. Too close.",
+            "observer_msg": "The metal sings through the space beside {target_name}'s {hit_location}. Close. Too close."
         },
         {
             "attacker_msg": "The steel rings against concrete. The echo haunts the space.",
@@ -532,9 +532,9 @@ MESSAGES = {
             "observer_msg": "The crowbar lands across the throat. The crunch that follows is not survivable."
         },
         {
-            "attacker_msg": "The crowbar lands flat across {target_name}'s temple. They drop mid-motion, the floor catching what's left.",
-            "victim_msg": "The crowbar lands flat across your temple. You drop mid-motion, the floor catching what's left.",
-            "observer_msg": "The crowbar lands flat across {target_name}'s temple. They drop mid-motion, the floor catching what's left."
+            "attacker_msg": "The crowbar lands flat across {target_name}'s {hit_location}. They drop mid-motion, the floor catching what's left.",
+            "victim_msg": "The crowbar lands flat across your {hit_location}. You drop mid-motion, the floor catching what's left.",
+            "observer_msg": "The crowbar lands flat across {target_name}'s {hit_location}. They drop mid-motion, the floor catching what's left."
         },
         {
             "attacker_msg": "The curved end catches the spine. The legs drop. Then everything else.",
@@ -542,9 +542,9 @@ MESSAGES = {
             "observer_msg": "The curved end catches the spine. The legs drop. Then everything else."
         },
         {
-            "attacker_msg": "The curved end digs into {target_name}'s throat. When it comes out, silence follows.",
-            "victim_msg": "The curved end digs into your throat. When it comes out, silence follows.",
-            "observer_msg": "The curved end digs into {target_name}'s throat. When it comes out, silence follows."
+            "attacker_msg": "The curved end digs into {target_name}'s {hit_location}. When it comes out, silence follows.",
+            "victim_msg": "The curved end digs into your {hit_location}. When it comes out, silence follows.",
+            "observer_msg": "The curved end digs into {target_name}'s {hit_location}. When it comes out, silence follows."
         },
         {
             "attacker_msg": "The curved end enters at the jaw. It exits somewhere worse. {target_name} falls in pieces.",
@@ -592,9 +592,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} ends it with a hook to the temple. It sticks a second longer than it should."
         },
         {
-            "attacker_msg": "You hook the crowbar behind {target_name}'s head and yank. The body drops. The soul doesn't linger.",
-            "victim_msg": "{attacker_name} hooks the crowbar behind your head and yanks. The body drops. The soul doesn't linger.",
-            "observer_msg": "{attacker_name} hooks the crowbar behind {target_name}'s head and yanks. The body drops. The soul doesn't linger."
+            "attacker_msg": "You hook the crowbar behind {target_name}'s {hit_location} and yank. The body drops. The soul doesn't linger.",
+            "victim_msg": "{attacker_name} hooks the crowbar behind your {hit_location} and yanks. The body drops. The soul doesn't linger.",
+            "observer_msg": "{attacker_name} hooks the crowbar behind {target_name}'s {hit_location} and yanks. The body drops. The soul doesn't linger."
         },
         {
             "attacker_msg": "You hook the neck and yank. {target_name} hits the ground and stays there.",

--- a/world/combat/messages/cutlass.py
+++ b/world/combat/messages/cutlass.py
@@ -6,7 +6,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} whips out the cutlass, its broad, slightly curved blade glinting wickedly."
         },
         {
-            "attacker_msg": "With a flourish and a grin, you bring the cutlass to a ready guard, its basket hilt protecting your hand.",
+            "attacker_msg": "With a flourish and a grin, you bring the cutlass to a ready guard, its basket hilt protecting your {hit_location}.",
             "victim_msg": "With a flourish and a grin, {attacker_name} brings the cutlass to a ready guard, its basket hilt protecting their hand.",
             "observer_msg": "With a flourish and a grin, {attacker_name} brings the cutlass to a ready guard, its basket hilt protecting their hand."
         },
@@ -16,7 +16,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} tests the weight of the cutlass, the sturdy blade feeling eager in their grip."
         },
         {
-            "attacker_msg": "The cutlass flashes in your hand, a short, brutal promise of a close and bloody fight.",
+            "attacker_msg": "The cutlass flashes in your {hit_location}, a short, brutal promise of a close and bloody fight.",
             "victim_msg": "The cutlass flashes in {attacker_name}'s hand, a short, brutal promise of a close and bloody fight.",
             "observer_msg": "The cutlass flashes in {attacker_name}'s hand, a short, brutal promise of a close and bloody fight."
         },
@@ -86,7 +86,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} holds the cutlass in a forward-canted guard, ready to punch through defenses or hook a limb."
         },
         {
-            "attacker_msg": "The heavy, protective basket hilt of the cutlass is a solid counterweight in your hand.",
+            "attacker_msg": "The heavy, protective basket hilt of the cutlass is a solid counterweight in your {hit_location}.",
             "victim_msg": "The heavy, protective basket hilt of the cutlass is a solid counterweight in {attacker_name}'s hand.",
             "observer_msg": "The heavy, protective basket hilt of the cutlass is a solid counterweight in {attacker_name}'s hand."
         },
@@ -106,7 +106,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} yanks the cutlass free, the sound a harsh rasp of steel on leather, eager for action."
         },
         {
-            "attacker_msg": "The cutlass is a sailor's weapon in your hand, built for effectiveness in chaotic fights, not dueling finesse.",
+            "attacker_msg": "The cutlass is a sailor's weapon in your {hit_location}, built for effectiveness in chaotic fights, not dueling finesse.",
             "victim_msg": "The cutlass is a sailor's weapon in {attacker_name}'s hand, built for effectiveness in chaotic fights, not dueling finesse.",
             "observer_msg": "The cutlass is a sailor's weapon in {attacker_name}'s hand, built for effectiveness in chaotic fights, not dueling finesse."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            "attacker_msg": "Your cutlass chops the air violently, just missing {target_name}'s head by a hair.",
-            "victim_msg": "{attacker_name}'s cutlass chops the air violently, just missing your head by a hair.",
-            "observer_msg": "{attacker_name}'s cutlass chops the air violently, just missing {target_name}'s head by a hair."
+            "attacker_msg": "Your cutlass chops the air violently, just missing {target_name}'s {hit_location} by a hair.",
+            "victim_msg": "{attacker_name}'s cutlass chops the air violently, just missing your {hit_location} by a hair.",
+            "observer_msg": "{attacker_name}'s cutlass chops the air violently, just missing {target_name}'s {hit_location} by a hair."
         },
         {
             "attacker_msg": "{target_name} barely stumbles back, avoiding the brutal slash of your cutlass.",
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "Your cutlass punches through {target_name}'s chest, a fatal, brutal end to the brawl.",
-            "victim_msg": "{attacker_name}'s cutlass punches through your chest, a fatal, brutal end to the brawl.",
-            "observer_msg": "{attacker_name}'s cutlass punches through {target_name}'s chest, a fatal, brutal end to the brawl."
+            "attacker_msg": "Your cutlass punches through {target_name}'s {hit_location}, a fatal, brutal end to the brawl.",
+            "victim_msg": "{attacker_name}'s cutlass punches through your {hit_location}, a fatal, brutal end to the brawl.",
+            "observer_msg": "{attacker_name}'s cutlass punches through {target_name}'s {hit_location}, a fatal, brutal end to the brawl."
         },
         {
             "attacker_msg": "A savage chop from the cutlass, and {target_name} falls, lifeblood gushing onto the deck.",
@@ -467,14 +467,14 @@ MESSAGES = {
             "observer_msg": "A savage chop from the cutlass, and {target_name} falls, lifeblood gushing onto the deck."
         },
         {
-            "attacker_msg": "With a final, merciless slash, your cutlass silences {target_name} permanently, a wicked grin on your face.",
+            "attacker_msg": "With a final, merciless slash, your cutlass silences {target_name} permanently, a wicked grin on your {hit_location}.",
             "victim_msg": "With a final, merciless slash, {attacker_name}'s cutlass silences you permanently, a wicked grin on their face.",
             "observer_msg": "With a final, merciless slash, {attacker_name}'s cutlass silences {target_name} permanently, a wicked grin on their face."
         },
         {
-            "attacker_msg": "The broad blade of the cutlass severs {target_name}'s throat, a swift and bloody conclusion to the fight.",
-            "victim_msg": "The broad blade of the cutlass severs your throat, a swift and bloody conclusion to the fight.",
-            "observer_msg": "The broad blade of the cutlass severs {target_name}'s throat, a swift and bloody conclusion to the fight."
+            "attacker_msg": "The broad blade of the cutlass severs {target_name}'s {hit_location}, a swift and bloody conclusion to the fight.",
+            "victim_msg": "The broad blade of the cutlass severs your {hit_location}, a swift and bloody conclusion to the fight.",
+            "observer_msg": "The broad blade of the cutlass severs {target_name}'s {hit_location}, a swift and bloody conclusion to the fight."
         },
         {
             "attacker_msg": "Your powerful blow with the cutlass leaves {target_name} mortally wounded, collapsing in a heap.",
@@ -492,9 +492,9 @@ MESSAGES = {
             "observer_msg": "A vicious upward slash from {attacker_name}'s cutlass disembowels {target_name} with horrific efficiency."
         },
         {
-            "attacker_msg": "You drive the cutlass deep into {target_name}'s abdomen, the outcome grimly inevitable as they gasp.",
-            "victim_msg": "{attacker_name} drives the cutlass deep into your abdomen, the outcome grimly inevitable as you gasp.",
-            "observer_msg": "{attacker_name} drives the cutlass deep into {target_name}'s abdomen, the outcome grimly inevitable as they gasp."
+            "attacker_msg": "You drive the cutlass deep into {target_name}'s {hit_location}, the outcome grimly inevitable as they gasp.",
+            "victim_msg": "{attacker_name} drives the cutlass deep into your {hit_location}, the outcome grimly inevitable as you gasp.",
+            "observer_msg": "{attacker_name} drives the cutlass deep into {target_name}'s {hit_location}, the outcome grimly inevitable as they gasp."
         },
         {
             "attacker_msg": "The keen edge of the cutlass opens a fatal wound, and {target_name} crumples, unmoving, eyes wide.",

--- a/world/combat/messages/falchion.py
+++ b/world/combat/messages/falchion.py
@@ -66,7 +66,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s eyes are hard and practical, sighting along the brutal edge of the falchion."
         },
         {
-            'attacker_msg': "The falchion feels like a butcher's tool in your hand, perfectly designed for its grim task.",
+            'attacker_msg': "The falchion feels like a butcher's tool in your {hit_location}, perfectly designed for its grim task.",
             'victim_msg': "The falchion feels like a butcher's tool in {attacker_name}'s hand, perfectly designed for its grim task.",
             'observer_msg': "The falchion feels like a butcher's tool in {attacker_name}'s hand, perfectly designed for its grim task."
         },
@@ -106,7 +106,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} yanks the falchion free, the sound a coarse scrape of steel on leather."
         },
         {
-            'attacker_msg': "The falchion is a common soldier's weapon in your hand, built for brutal effectiveness.",
+            'attacker_msg': "The falchion is a common soldier's weapon in your {hit_location}, built for brutal effectiveness.",
             'victim_msg': "The falchion is a common soldier's weapon in {attacker_name}'s hand, built for brutal effectiveness.",
             'observer_msg': "The falchion is a common soldier's weapon in {attacker_name}'s hand, built for brutal effectiveness."
         },
@@ -136,7 +136,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} seems to lean into the weight of the falchion, ready to unleash its full force."
         },
         {
-            'attacker_msg': "The silence is broken by the thud of you stamping your foot, falchion held ready.",
+            'attacker_msg': "The silence is broken by the thud of you stamping your {hit_location}, falchion held ready.",
             'victim_msg': "The silence is broken by the thud of {attacker_name} stamping their foot, falchion held ready.",
             'observer_msg': "The silence is broken by the thud of {attacker_name} stamping their foot, falchion held ready."
         },
@@ -395,9 +395,9 @@ MESSAGES = {
             'observer_msg': "A growl of frustration from {attacker_name} as their falchion attack is evaded by a nimble {target_name}."
         },
         {
-            'attacker_msg': "The falchion carves a deep score in a wooden barricade beside {target_name}'s head, but draws no blood.",
-            'victim_msg': "The falchion carves a deep score in a wooden barricade beside your head, but draws no blood.",
-            'observer_msg': "The falchion carves a deep score in a wooden barricade beside {target_name}'s head, but draws no blood."
+            'attacker_msg': "The falchion carves a deep score in a wooden barricade beside {target_name}'s {hit_location}, but draws no blood.",
+            'victim_msg': "The falchion carves a deep score in a wooden barricade beside your {hit_location}, but draws no blood.",
+            'observer_msg': "The falchion carves a deep score in a wooden barricade beside {target_name}'s {hit_location}, but draws no blood."
         },
         {
             'attacker_msg': "Your straightforward attack with the falchion is anticipated and dodged by {target_name}.",
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "Your falchion descends in a brutal arc, cleaving {target_name}'s skull with a sickening crunch.",
-            'victim_msg': "{attacker_name}'s falchion descends in a brutal arc, cleaving your skull with a sickening crunch.",
-            'observer_msg': "{attacker_name}'s falchion descends in a brutal arc, cleaving {target_name}'s skull with a sickening crunch."
+            'attacker_msg': "Your falchion descends in a brutal arc, cleaving {target_name}'s {hit_location} with a sickening crunch.",
+            'victim_msg': "{attacker_name}'s falchion descends in a brutal arc, cleaving your {hit_location} with a sickening crunch.",
+            'observer_msg': "{attacker_name}'s falchion descends in a brutal arc, cleaving {target_name}'s {hit_location} with a sickening crunch."
         },
         {
             'attacker_msg': "A savage chop from the falchion, and {target_name} falls, a limb nearly severed, lifeblood gushing onto the ground.",
@@ -472,9 +472,9 @@ MESSAGES = {
             'observer_msg': "With a final, merciless hack, {attacker_name}'s falchion silences {target_name} permanently, the broad blade buried deep."
         },
         {
-            'attacker_msg': "The heavy blade of the falchion severs {target_name}'s throat in a single, brutal swipe, a swift and bloody conclusion.",
-            'victim_msg': "The heavy blade of the falchion severs your throat in a single, brutal swipe, a swift and bloody conclusion.",
-            'observer_msg': "The heavy blade of the falchion severs {target_name}'s throat in a single, brutal swipe, a swift and bloody conclusion."
+            'attacker_msg': "The heavy blade of the falchion severs {target_name}'s {hit_location} in a single, brutal swipe, a swift and bloody conclusion.",
+            'victim_msg': "The heavy blade of the falchion severs your {hit_location} in a single, brutal swipe, a swift and bloody conclusion.",
+            'observer_msg': "The heavy blade of the falchion severs {target_name}'s {hit_location} in a single, brutal swipe, a swift and bloody conclusion."
         },
         {
             'attacker_msg': "Your powerful blow with the falchion leaves {target_name} mortally wounded, collapsing in a heap of broken bones.",
@@ -492,14 +492,14 @@ MESSAGES = {
             'observer_msg': "A vicious downward chop from {attacker_name}'s falchion splits {target_name}'s shield and the arm behind it, ending their life."
         },
         {
-            'attacker_msg': "You drive the falchion deep into {target_name}'s abdomen with a powerful thrusting chop, the outcome grimly inevitable.",
-            'victim_msg': "{attacker_name} drives the falchion deep into your abdomen with a powerful thrusting chop, the outcome grimly inevitable.",
-            'observer_msg': "{attacker_name} drives the falchion deep into {target_name}'s abdomen with a powerful thrusting chop, the outcome grimly inevitable."
+            'attacker_msg': "You drive the falchion deep into {target_name}'s {hit_location} with a powerful thrusting chop, the outcome grimly inevitable.",
+            'victim_msg': "{attacker_name} drives the falchion deep into your {hit_location} with a powerful thrusting chop, the outcome grimly inevitable.",
+            'observer_msg': "{attacker_name} drives the falchion deep into {target_name}'s {hit_location} with a powerful thrusting chop, the outcome grimly inevitable."
         },
         {
-            'attacker_msg': "The keen edge of the falchion opens a fatal, gaping wound across {target_name}'s chest, and they crumple, unmoving.",
-            'victim_msg': "The keen edge of the falchion opens a fatal, gaping wound across your chest, and you crumple, unmoving.",
-            'observer_msg': "The keen edge of the falchion opens a fatal, gaping wound across {target_name}'s chest, and they crumple, unmoving."
+            'attacker_msg': "The keen edge of the falchion opens a fatal, gaping wound across {target_name}'s {hit_location}, and they crumple, unmoving.",
+            'victim_msg': "The keen edge of the falchion opens a fatal, gaping wound across your {hit_location}, and you crumple, unmoving.",
+            'observer_msg': "The keen edge of the falchion opens a fatal, gaping wound across {target_name}'s {hit_location}, and they crumple, unmoving."
         },
         {
             'attacker_msg': "With a battle cry, you finish {target_name} with a decisive, brutal strike from the falchion, shattering bone.",

--- a/world/combat/messages/fire_axe.py
+++ b/world/combat/messages/fire_axe.py
@@ -36,7 +36,7 @@ MESSAGES = {
             'observer_msg': "The blade is chipped and stained, notched by time. {attacker_name} lifts it like a relic handed down from ruin."
         },
         {
-            'attacker_msg': "The blade isn't sharp — it's *willing*. You hoist it onto your shoulder like it's part of your soul and burden both.",
+            'attacker_msg': "The blade isn't sharp — it's *willing*. You hoist it onto your {hit_location} like it's part of your soul and burden both.",
             'victim_msg': "The blade isn't sharp — it's *willing*. {attacker_name} hoists it onto their shoulder like it's part of their soul and burden both.",
             'observer_msg': "The blade isn't sharp — it's *willing*. {attacker_name} hoists it onto their shoulder like it's part of their soul and burden both."
         },
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The fire axe isn't elegant, and neither is {attacker_name}. They don't try to intimidate. They just *prepare*."
         },
         {
-            'attacker_msg': "The fire axe rests on your shoulder. The silence stretches thin. Everyone knows what comes next.",
+            'attacker_msg': "The fire axe rests on your {hit_location}. The silence stretches thin. Everyone knows what comes next.",
             'victim_msg': "The fire axe rests on {attacker_name}'s shoulder. The silence stretches thin. Everyone knows what comes next.",
             'observer_msg': "The fire axe rests on {attacker_name}'s shoulder. The silence stretches thin. Everyone knows what comes next."
         },
@@ -131,12 +131,12 @@ MESSAGES = {
             'observer_msg': "{attacker_name} rests the blade against their collarbone, eyes locked on {target_name}. The message is clear. The warning, over."
         },
         {
-            'attacker_msg': "You roll your neck, loosening joints with casual cruelty. The fire axe dangles from one hand, heavy and inevitable.",
+            'attacker_msg': "You roll your {hit_location}, loosening joints with casual cruelty. The fire axe dangles from one hand, heavy and inevitable.",
             'victim_msg': "{attacker_name} rolls their neck, loosening joints with casual cruelty. The fire axe dangles from one hand, heavy and inevitable.",
             'observer_msg': "{attacker_name} rolls their neck, loosening joints with casual cruelty. The fire axe dangles from one hand, heavy and inevitable."
         },
         {
-            'attacker_msg': "You roll your shoulder once, twice. The axe swings low, then high. It's not practice. It's prelude.",
+            'attacker_msg': "You roll your {hit_location} once, twice. The axe swings low, then high. It's not practice. It's prelude.",
             'victim_msg': "{attacker_name} rolls their shoulder once, twice. The axe swings low, then high. It's not practice. It's prelude.",
             'observer_msg': "{attacker_name} rolls their shoulder once, twice. The axe swings low, then high. It's not practice. It's prelude."
         },
@@ -336,7 +336,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "It misses, but not by much. {target_name}'s breath catches in their throat. Your grin doesn't waver.",
-            'victim_msg': "It misses, but not by much. Your breath catches in your throat. {attacker_name}'s grin doesn't waver.",
+            'victim_msg': "It misses, but not by much. Your breath catches in your {hit_location}. {attacker_name}'s grin doesn't waver.",
             'observer_msg': "It misses, but not by much. {target_name}'s breath catches in their throat. {attacker_name}'s grin doesn't waver."
         },
         {
@@ -355,9 +355,9 @@ MESSAGES = {
             'observer_msg': "The axe crashes into a steel girder instead, sparking in protest. {attacker_name}'s snarl says this wasn't over — it was practice."
         },
         {
-            'attacker_msg': "The axe kisses the floor where {target_name}'s foot stood a moment ago. The ground doesn't bleed — this time.",
-            'victim_msg': "The axe kisses the floor where your foot stood a moment ago. The ground doesn't bleed — this time.",
-            'observer_msg': "The axe kisses the floor where {target_name}'s foot stood a moment ago. The ground doesn't bleed — this time."
+            'attacker_msg': "The axe kisses the floor where {target_name}'s {hit_location} stood a moment ago. The ground doesn't bleed — this time.",
+            'victim_msg': "The axe kisses the floor where your {hit_location} stood a moment ago. The ground doesn't bleed — this time.",
+            'observer_msg': "The axe kisses the floor where {target_name}'s {hit_location} stood a moment ago. The ground doesn't bleed — this time."
         },
         {
             'attacker_msg': "The axe shears through furniture instead. Wood explodes. You barely notice.",
@@ -375,9 +375,9 @@ MESSAGES = {
             'observer_msg': "The blade comes down like judgment, but {target_name} scrambles out of reach. The impact leaves a crater where a body should be."
         },
         {
-            'attacker_msg': "The blade whistles past {target_name}'s head, carving the air but not the flesh.",
-            'victim_msg': "The blade whistles past your head, carving the air but not the flesh.",
-            'observer_msg': "The blade whistles past {target_name}'s head, carving the air but not the flesh."
+            'attacker_msg': "The blade whistles past {target_name}'s {hit_location}, carving the air but not the flesh.",
+            'victim_msg': "The blade whistles past your {hit_location}, carving the air but not the flesh.",
+            'observer_msg': "The blade whistles past {target_name}'s {hit_location}, carving the air but not the flesh."
         },
         {
             'attacker_msg': "The fire axe cuts nothing but space. But the space feels different now. Tense. Ready to bleed.",
@@ -458,13 +458,13 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "A clean slice through the throat ends {target_name}'s involvement. Their body lurches. Their head doesn't.",
-            'victim_msg': "A clean slice through the throat ends your involvement. Your body lurches. Your head doesn't.",
+            'victim_msg': "A clean slice through the throat ends your involvement. Your body lurches. Your {hit_location} doesn't.",
             'observer_msg': "A clean slice through the throat ends {target_name}'s involvement. Their body lurches. Their head doesn't."
         },
         {
-            'attacker_msg': "A final swing from you splits {target_name}'s torso in two jagged halves. The scream starts, then chokes on its own blood.",
-            'victim_msg': "A final swing from {attacker_name} splits your torso in two jagged halves. The scream starts, then chokes on its own blood.",
-            'observer_msg': "A final swing from {attacker_name} splits {target_name}'s torso in two jagged halves. The scream starts, then chokes on its own blood."
+            'attacker_msg': "A final swing from you splits {target_name}'s {hit_location} in two jagged halves. The scream starts, then chokes on its own blood.",
+            'victim_msg': "A final swing from {attacker_name} splits your {hit_location} in two jagged halves. The scream starts, then chokes on its own blood.",
+            'observer_msg': "A final swing from {attacker_name} splits {target_name}'s {hit_location} in two jagged halves. The scream starts, then chokes on its own blood."
         },
         {
             'attacker_msg': "A full-bodied swing ends in contact. {target_name} folds like wet cardboard, their insides made public.",
@@ -477,9 +477,9 @@ MESSAGES = {
             'observer_msg': "It lands like punctuation. The axe enters below the jaw, exits behind the ear. {target_name} simply ends."
         },
         {
-            'attacker_msg': "One blow. That's all. The axe lands in the side of {target_name}'s neck and doesn't come out clean. Nothing about this is clean.",
-            'victim_msg': "One blow. That's all. The axe lands in the side of your neck and doesn't come out clean. Nothing about this is clean.",
-            'observer_msg': "One blow. That's all. The axe lands in the side of {target_name}'s neck and doesn't come out clean. Nothing about this is clean."
+            'attacker_msg': "One blow. That's all. The axe lands in the side of {target_name}'s {hit_location} and doesn't come out clean. Nothing about this is clean.",
+            'victim_msg': "One blow. That's all. The axe lands in the side of your {hit_location} and doesn't come out clean. Nothing about this is clean.",
+            'observer_msg': "One blow. That's all. The axe lands in the side of {target_name}'s {hit_location} and doesn't come out clean. Nothing about this is clean."
         },
         {
             'attacker_msg': "One final swing connects and sends {target_name} spinning like a marionette in a fire. They don't get back up.",
@@ -487,9 +487,9 @@ MESSAGES = {
             'observer_msg': "One final swing connects and sends {target_name} spinning like a marionette in a fire. They don't get back up."
         },
         {
-            'attacker_msg': "One hard blow from overhead. {target_name}'s spine snaps like rotted wood. Their collapse is permanent.",
-            'victim_msg': "One hard blow from overhead. Your spine snaps like rotted wood. Your collapse is permanent.",
-            'observer_msg': "One hard blow from overhead. {target_name}'s spine snaps like rotted wood. Their collapse is permanent."
+            'attacker_msg': "One hard blow from overhead. {target_name}'s {hit_location} snaps like rotted wood. Their collapse is permanent.",
+            'victim_msg': "One hard blow from overhead. Your {hit_location} snaps like rotted wood. Your collapse is permanent.",
+            'observer_msg': "One hard blow from overhead. {target_name}'s {hit_location} snaps like rotted wood. Their collapse is permanent."
         },
         {
             'attacker_msg': "One last swing opens {target_name} from hip to shoulder. They stumble, then collapse like a puppet set on fire.",
@@ -497,14 +497,14 @@ MESSAGES = {
             'observer_msg': "One last swing opens {target_name} from hip to shoulder. They stumble, then collapse like a puppet set on fire."
         },
         {
-            'attacker_msg': "The axe crashes down, lodging into {target_name}'s spine. They freeze, then crumple, limbs failing all at once.",
-            'victim_msg': "The axe crashes down, lodging into your spine. You freeze, then crumple, limbs failing all at once.",
-            'observer_msg': "The axe crashes down, lodging into {target_name}'s spine. They freeze, then crumple, limbs failing all at once."
+            'attacker_msg': "The axe crashes down, lodging into {target_name}'s {hit_location}. They freeze, then crumple, limbs failing all at once.",
+            'victim_msg': "The axe crashes down, lodging into your {hit_location}. You freeze, then crumple, limbs failing all at once.",
+            'observer_msg': "The axe crashes down, lodging into {target_name}'s {hit_location}. They freeze, then crumple, limbs failing all at once."
         },
         {
-            'attacker_msg': "The axe embeds in {target_name}'s skull and stays. The body drops like a discarded idea, blood painting the floor in spirals.",
-            'victim_msg': "The axe embeds in your skull and stays. The body drops like a discarded idea, blood painting the floor in spirals.",
-            'observer_msg': "The axe embeds in {target_name}'s skull and stays. The body drops like a discarded idea, blood painting the floor in spirals."
+            'attacker_msg': "The axe embeds in {target_name}'s {hit_location} and stays. The body drops like a discarded idea, blood painting the floor in spirals.",
+            'victim_msg': "The axe embeds in your {hit_location} and stays. The body drops like a discarded idea, blood painting the floor in spirals.",
+            'observer_msg': "The axe embeds in {target_name}'s {hit_location} and stays. The body drops like a discarded idea, blood painting the floor in spirals."
         },
         {
             'attacker_msg': "The axe enters with resistance, then slides through like a confession. {target_name} drops, blood blooming beneath them.",
@@ -512,14 +512,14 @@ MESSAGES = {
             'observer_msg': "The axe enters with resistance, then slides through like a confession. {target_name} drops, blood blooming beneath them."
         },
         {
-            'attacker_msg': "The axe lands in a downward slam, splitting {target_name}'s skull like fruit. Red and bone scatter in a cruel bouquet.",
-            'victim_msg': "The axe lands in a downward slam, splitting your skull like fruit. Red and bone scatter in a cruel bouquet.",
-            'observer_msg': "The axe lands in a downward slam, splitting {target_name}'s skull like fruit. Red and bone scatter in a cruel bouquet."
+            'attacker_msg': "The axe lands in a downward slam, splitting {target_name}'s {hit_location} like fruit. Red and bone scatter in a cruel bouquet.",
+            'victim_msg': "The axe lands in a downward slam, splitting your {hit_location} like fruit. Red and bone scatter in a cruel bouquet.",
+            'observer_msg': "The axe lands in a downward slam, splitting {target_name}'s {hit_location} like fruit. Red and bone scatter in a cruel bouquet."
         },
         {
-            'attacker_msg': "The axe lands with a sickening finality, splitting {target_name}'s skull clean down the center. They fall in silence, their scream stolen mid-birth.",
-            'victim_msg': "The axe lands with a sickening finality, splitting your skull clean down the center. You fall in silence, your scream stolen mid-birth.",
-            'observer_msg': "The axe lands with a sickening finality, splitting {target_name}'s skull clean down the center. They fall in silence, their scream stolen mid-birth."
+            'attacker_msg': "The axe lands with a sickening finality, splitting {target_name}'s {hit_location} clean down the center. They fall in silence, their scream stolen mid-birth.",
+            'victim_msg': "The axe lands with a sickening finality, splitting your {hit_location} clean down the center. You fall in silence, your scream stolen mid-birth.",
+            'observer_msg': "The axe lands with a sickening finality, splitting {target_name}'s {hit_location} clean down the center. They fall in silence, their scream stolen mid-birth."
         },
         {
             'attacker_msg': "The blade embeds in the spine. {target_name} jerks once, then hangs there like punctuation.",
@@ -547,9 +547,9 @@ MESSAGES = {
             'observer_msg': "The cut isn't deep — it's decisive. {target_name} hits the ground hard, their eyes already empty."
         },
         {
-            'attacker_msg': "The edge drives through {target_name}'s throat, cleaving halfway down. They don't even hit the ground cleanly.",
-            'victim_msg': "The edge drives through your throat, cleaving halfway down. You don't even hit the ground cleanly.",
-            'observer_msg': "The edge drives through {target_name}'s throat, cleaving halfway down. They don't even hit the ground cleanly."
+            'attacker_msg': "The edge drives through {target_name}'s {hit_location}, cleaving halfway down. They don't even hit the ground cleanly.",
+            'victim_msg': "The edge drives through your {hit_location}, cleaving halfway down. You don't even hit the ground cleanly.",
+            'observer_msg': "The edge drives through {target_name}'s {hit_location}, cleaving halfway down. They don't even hit the ground cleanly."
         },
         {
             'attacker_msg': "The final blow catches {target_name} in the face, erasing features and expression alike. It's not a death — it's a red exclamation mark.",
@@ -562,9 +562,9 @@ MESSAGES = {
             'observer_msg': "The sound is wet and final. {attacker_name} yanks the blade free from {target_name}'s ribcage with a grunt and no ceremony."
         },
         {
-            'attacker_msg': "The strike caves in {target_name}'s chest with a sound that flattens the room. What's left gurgles and collapses.",
-            'victim_msg': "The strike caves in your chest with a sound that flattens the room. What's left gurgles and collapses.",
-            'observer_msg': "The strike caves in {target_name}'s chest with a sound that flattens the room. What's left gurgles and collapses."
+            'attacker_msg': "The strike caves in {target_name}'s {hit_location} with a sound that flattens the room. What's left gurgles and collapses.",
+            'victim_msg': "The strike caves in your {hit_location} with a sound that flattens the room. What's left gurgles and collapses.",
+            'observer_msg': "The strike caves in {target_name}'s {hit_location} with a sound that flattens the room. What's left gurgles and collapses."
         },
         {
             'attacker_msg': "There's no elegance — just a vertical cleave that splits {target_name} like bad wood. They never even get a last word.",
@@ -572,9 +572,9 @@ MESSAGES = {
             'observer_msg': "There's no elegance — just a vertical cleave that splits {target_name} like bad wood. They never even get a last word."
         },
         {
-            'attacker_msg': "With a roar, you bury the blade deep into {target_name}'s chest. The engine of their breath halts instantly.",
-            'victim_msg': "With a roar, {attacker_name} buries the blade deep into your chest. The engine of your breath halts instantly.",
-            'observer_msg': "With a roar, {attacker_name} buries the blade deep into {target_name}'s chest. The engine of their breath halts instantly."
+            'attacker_msg': "With a roar, you bury the blade deep into {target_name}'s {hit_location}. The engine of their breath halts instantly.",
+            'victim_msg': "With a roar, {attacker_name} buries the blade deep into your {hit_location}. The engine of your breath halts instantly.",
+            'observer_msg': "With a roar, {attacker_name} buries the blade deep into {target_name}'s {hit_location}. The engine of their breath halts instantly."
         },
         {
             'attacker_msg': "You bring the axe down in a diagonal arc that splits {target_name} from shoulder to lung. They crumple mid-turn, the breath still in their mouth.",
@@ -592,9 +592,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} doesn't even look angry. Just focused. The blow lands with exact brutality, and {target_name} ends mid-motion."
         },
         {
-            'attacker_msg': "You heave the axe into {target_name}'s sternum. It doesn't just wound — it opens. What was inside, no longer is.",
-            'victim_msg': "{attacker_name} heaves the axe into your sternum. It doesn't just wound — it opens. What was inside, no longer is.",
-            'observer_msg': "{attacker_name} heaves the axe into {target_name}'s sternum. It doesn't just wound — it opens. What was inside, no longer is."
+            'attacker_msg': "You heave the axe into {target_name}'s {hit_location}. It doesn't just wound — it opens. What was inside, no longer is.",
+            'victim_msg': "{attacker_name} heaves the axe into your {hit_location}. It doesn't just wound — it opens. What was inside, no longer is.",
+            'observer_msg': "{attacker_name} heaves the axe into {target_name}'s {hit_location}. It doesn't just wound — it opens. What was inside, no longer is."
         },
         {
             'attacker_msg': "You swing low and wide, severing {target_name}'s legs at the knees. They drop like meat, already gone.",
@@ -602,9 +602,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} swings low and wide, severing {target_name}'s legs at the knees. They drop like meat, already gone."
         },
         {
-            'attacker_msg': "Your swing cleaves into the side of {target_name}'s head. The skull folds like rotten fruit. There's no time for last words.",
-            'victim_msg': "{attacker_name}'s swing cleaves into the side of your head. The skull folds like rotten fruit. There's no time for last words.",
-            'observer_msg': "{attacker_name}'s swing cleaves into the side of {target_name}'s head. The skull folds like rotten fruit. There's no time for last words."
+            'attacker_msg': "Your swing cleaves into the side of {target_name}'s {hit_location}. The skull folds like rotten fruit. There's no time for last words.",
+            'victim_msg': "{attacker_name}'s swing cleaves into the side of your {hit_location}. The skull folds like rotten fruit. There's no time for last words.",
+            'observer_msg': "{attacker_name}'s swing cleaves into the side of {target_name}'s {hit_location}. The skull folds like rotten fruit. There's no time for last words."
         }
     ]
 }

--- a/world/combat/messages/flamethrower.py
+++ b/world/combat/messages/flamethrower.py
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air grows palpably hotter as {attacker_name} prepares to fire the flamethrower, anticipating the deafening *ROAR* of ignited fuel."
         },
         {
-            'attacker_msg': "Your face is grim, finger tightening on the flamethrower's trigger, ready to unleash a hellish torrent.",
+            'attacker_msg': "Your {hit_location} is grim, finger tightening on the flamethrower's trigger, ready to unleash a hellish torrent.",
             'victim_msg': "{attacker_name}'s face is grim, finger tightening on the flamethrower's trigger, ready to unleash a hellish torrent.",
             'observer_msg': "{attacker_name}'s face is grim, finger tightening on the flamethrower's trigger, ready to unleash a hellish torrent."
         },
@@ -189,7 +189,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The flamethrower's fiery payload sticks to {target_name}, turning them into a human torch. Their screams are cut short as the flames sear their lungs. The heat haze distorts the horrific scene.",
-            'victim_msg': "The flamethrower's fiery payload sticks to you, turning you into a human torch. Your screams are cut short as the flames sear your lungs. The heat haze distorts the horrific scene.",
+            'victim_msg': "The flamethrower's fiery payload sticks to you, turning you into a human torch. Your screams are cut short as the flames sear your {hit_location}. The heat haze distorts the horrific scene.",
             'observer_msg': "The flamethrower's fiery payload sticks to {target_name}, turning them into a human torch. Their screams are cut short as the flames sear their lungs. The heat haze distorts the horrific scene."
         },
         {
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} drops prone just as your flamethrower fires, the jet of burning fuel passing inches above their head with a terrifying roar and a wave of searing heat. The ground above them is scorched black.",
-            'victim_msg': "You drop prone just as {attacker_name}'s flamethrower fires, the jet of burning fuel passing inches above your head with a terrifying roar and a wave of searing heat. The ground above you is scorched black.",
+            'victim_msg': "You drop prone just as {attacker_name}'s flamethrower fires, the jet of burning fuel passing inches above your {hit_location} with a terrifying roar and a wave of searing heat. The ground above you is scorched black.",
             'observer_msg': "{target_name} drops prone just as {attacker_name}'s flamethrower fires, the jet of burning fuel passing inches above their head with a terrifying roar and a wave of searing heat. The ground above them is scorched black."
         },
         {
@@ -487,9 +487,9 @@ MESSAGES = {
             'observer_msg': "The flamethrower, an instrument of pure terror, delivers a killing blow as {target_name} is caught in the searing jet. Their flesh is instantly incinerated, and they fall, a grotesque monument to the fire's fury."
         },
         {
-            'attacker_msg': "A precise gout of liquid fire to the head from your flamethrower, and {target_name}'s skull is instantly blackened and cooked, their life extinguished in a horrific, fiery flash. The smell is nauseating.",
-            'victim_msg': "A precise gout of liquid fire to the head from {attacker_name}'s flamethrower, and your skull is instantly blackened and cooked, your life extinguished in a horrific, fiery flash. The smell is nauseating.",
-            'observer_msg': "A precise gout of liquid fire to the head from {attacker_name}'s flamethrower, and {target_name}'s skull is instantly blackened and cooked, their life extinguished in a horrific, fiery flash. The smell is nauseating."
+            'attacker_msg': "A precise gout of liquid fire to the head from your flamethrower, and {target_name}'s {hit_location} is instantly blackened and cooked, their life extinguished in a horrific, fiery flash. The smell is nauseating.",
+            'victim_msg': "A precise gout of liquid fire to the head from {attacker_name}'s flamethrower, and your {hit_location} is instantly blackened and cooked, your life extinguished in a horrific, fiery flash. The smell is nauseating.",
+            'observer_msg': "A precise gout of liquid fire to the head from {attacker_name}'s flamethrower, and {target_name}'s {hit_location} is instantly blackened and cooked, their life extinguished in a horrific, fiery flash. The smell is nauseating."
         },
         {
             'attacker_msg': "Your blast from the flamethrower is brutally fatal; {target_name} is engulfed, their desperate attempts to escape futile as the fire consumes them from the outside in, leaving only a smoking, charred corpse.",

--- a/world/combat/messages/flare.py
+++ b/world/combat/messages/flare.py
@@ -16,7 +16,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} fumbles for a moment, then produces a bright red flare, its purpose now grimly offensive."
         },
         {
-            'attacker_msg': "A sharp scrape, and the flare in your hand erupts with a dazzling, intense light and a hiss of smoke.",
+            'attacker_msg': "A sharp scrape, and the flare in your {hit_location} erupts with a dazzling, intense light and a hiss of smoke.",
             'victim_msg': "A sharp scrape, and the flare in {attacker_name}'s hand erupts with a dazzling, intense light and a hiss of smoke.",
             'observer_msg': "A sharp scrape, and the flare in {attacker_name}'s hand erupts with a dazzling, intense light and a hiss of smoke."
         },
@@ -41,7 +41,7 @@ MESSAGES = {
             'observer_msg': "Light erupts from the flare, painfully bright, as {attacker_name} prepares to use it as a weapon."
         },
         {
-            'attacker_msg': "You offer no warning, just the sudden, blinding ignition of the flare in your hand.",
+            'attacker_msg': "You offer no warning, just the sudden, blinding ignition of the flare in your {hit_location}.",
             'victim_msg': "{attacker_name} offers no warning, just the sudden, blinding ignition of the flare in their hand.",
             'observer_msg': "{attacker_name} offers no warning, just the sudden, blinding ignition of the flare in their hand."
         },
@@ -61,12 +61,12 @@ MESSAGES = {
             'observer_msg': "The air around the flare shimmers with heat as {attacker_name} aims its incandescent tip."
         },
         {
-            'attacker_msg': "Your face is illuminated by the harsh, flickering light of the flare, your expression fierce.",
+            'attacker_msg': "Your {hit_location} is illuminated by the harsh, flickering light of the flare, your expression fierce.",
             'victim_msg': "{attacker_name}'s face is illuminated by the harsh, flickering light of the flare, their expression fierce.",
             'observer_msg': "{attacker_name}'s face is illuminated by the harsh, flickering light of the flare, their expression fierce."
         },
         {
-            'attacker_msg': "The flare feels dangerously hot in your hand, a tool of desperate, fiery attack.",
+            'attacker_msg': "The flare feels dangerously hot in your {hit_location}, a tool of desperate, fiery attack.",
             'victim_msg': "The flare feels dangerously hot in {attacker_name}'s hand, a tool of desperate, fiery attack.",
             'observer_msg': "The flare feels dangerously hot in {attacker_name}'s hand, a tool of desperate, fiery attack."
         },
@@ -136,7 +136,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} seems to draw courage from the flare's defiant light, their eyes fixed on {target_name}."
         },
         {
-            'attacker_msg': "Silence is broken by the fierce hiss of the flare igniting in your hand.",
+            'attacker_msg': "Silence is broken by the fierce hiss of the flare igniting in your {hit_location}.",
             'victim_msg': "Silence is broken by the fierce hiss of the flare igniting in {attacker_name}'s hand.",
             'observer_msg': "Silence is broken by the fierce hiss of the flare igniting in {attacker_name}'s hand."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your flare sizzles through the air, its intense light narrowly missing {target_name}'s face.",
-            'victim_msg': "{attacker_name}'s flare sizzles through the air, its intense light narrowly missing your face.",
-            'observer_msg': "{attacker_name}'s flare sizzles through the air, its intense light narrowly missing {target_name}'s face."
+            'attacker_msg': "Your flare sizzles through the air, its intense light narrowly missing {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s flare sizzles through the air, its intense light narrowly missing your {hit_location}.",
+            'observer_msg': "{attacker_name}'s flare sizzles through the air, its intense light narrowly missing {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "{target_name} stumbles back, avoiding the thrust of your burning flare by a hair's breadth.",
@@ -395,9 +395,9 @@ MESSAGES = {
             'observer_msg': "A growl of frustration from {attacker_name} as their flare attack is evaded by a nimble {target_name}."
         },
         {
-            'attacker_msg': "The flare scorches a patch of ground beside {target_name}'s foot, but draws no blood, only smoke.",
-            'victim_msg': "The flare scorches a patch of ground beside your foot, but draws no blood, only smoke.",
-            'observer_msg': "The flare scorches a patch of ground beside {target_name}'s foot, but draws no blood, only smoke."
+            'attacker_msg': "The flare scorches a patch of ground beside {target_name}'s {hit_location}, but draws no blood, only smoke.",
+            'victim_msg': "The flare scorches a patch of ground beside your {hit_location}, but draws no blood, only smoke.",
+            'observer_msg': "The flare scorches a patch of ground beside {target_name}'s {hit_location}, but draws no blood, only smoke."
         },
         {
             'attacker_msg': "Your straightforward attack with the flare is anticipated and dodged by {target_name}, who coughs on the smoke.",
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You shove the fiercely burning flare into {target_name}'s face; they collapse, screaming, succumbing to horrific burns and smoke inhalation.",
-            'victim_msg': "{attacker_name} shoves the fiercely burning flare into your face; you collapse, screaming, succumbing to horrific burns and smoke inhalation.",
-            'observer_msg': "{attacker_name} shoves the fiercely burning flare into {target_name}'s face; they collapse, screaming, succumbing to horrific burns and smoke inhalation."
+            'attacker_msg': "You shove the fiercely burning flare into {target_name}'s {hit_location}; they collapse, screaming, succumbing to horrific burns and smoke inhalation.",
+            'victim_msg': "{attacker_name} shoves the fiercely burning flare into your {hit_location}; you collapse, screaming, succumbing to horrific burns and smoke inhalation.",
+            'observer_msg': "{attacker_name} shoves the fiercely burning flare into {target_name}'s {hit_location}; they collapse, screaming, succumbing to horrific burns and smoke inhalation."
         },
         {
             'attacker_msg': "The flare ignites {target_name}'s clothing, and they go up in flames, their agonizing cries quickly silenced by the inferno.",

--- a/world/combat/messages/flare_gun.py
+++ b/world/combat/messages/flare_gun.py
@@ -26,7 +26,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} cocks the hammer or action of the flare gun, its simple mechanism ready to launch a burning projectile."
         },
         {
-            'attacker_msg': "The flare gun, often plastic or rugged metal, feels chunky and purposeful in your hand.",
+            'attacker_msg': "The flare gun, often plastic or rugged metal, feels chunky and purposeful in your {hit_location}.",
             'victim_msg': "The flare gun, often plastic or rugged metal, feels chunky and purposeful in {attacker_name}'s hand.",
             'observer_msg': "The flare gun, often plastic or rugged metal, feels chunky and purposeful in {attacker_name}'s hand."
         },
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air seems to still as {attacker_name} prepares to fire the flare gun, anticipating the sudden eruption of light and sound."
         },
         {
-            'attacker_msg': "Your face is set in concentration, finger tightening on the flare gun's trigger.",
+            'attacker_msg': "Your {hit_location} is set in concentration, finger tightening on the flare gun's trigger.",
             'victim_msg': "{attacker_name}'s face is set in concentration, finger tightening on the flare gun's trigger.",
             'observer_msg': "{attacker_name}'s face is set in concentration, finger tightening on the flare gun's trigger."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your flare gun fires with a loud *THUMP*, the fiery projectile streaking past {target_name}'s head and exploding against a far wall.",
-            'victim_msg': "{attacker_name}'s flare gun fires with a loud *THUMP*, the fiery projectile streaking past your head and exploding against a far wall.",
-            'observer_msg': "{attacker_name}'s flare gun fires with a loud *THUMP*, the fiery projectile streaking past {target_name}'s head and exploding against a far wall."
+            'attacker_msg': "Your flare gun fires with a loud *THUMP*, the fiery projectile streaking past {target_name}'s {hit_location} and exploding against a far wall.",
+            'victim_msg': "{attacker_name}'s flare gun fires with a loud *THUMP*, the fiery projectile streaking past your {hit_location} and exploding against a far wall.",
+            'observer_msg': "{attacker_name}'s flare gun fires with a loud *THUMP*, the fiery projectile streaking past {target_name}'s {hit_location} and exploding against a far wall."
         },
         {
             'attacker_msg': "{target_name} dives aside as the flare arcs through the air, impacting the ground nearby and burning fiercely.",
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick sidestep from {target_name} leaves {attacker_name}'s flare gun to launch its payload into an empty doorway."
         },
         {
-            'attacker_msg': "The flare gun bucks in your hand as you miss, the recoil throwing off your aim for a follow-up (if you had one).",
+            'attacker_msg': "The flare gun bucks in your {hit_location} as you miss, the recoil throwing off your aim for a follow-up (if you had one).",
             'victim_msg': "The flare gun bucks in {attacker_name}'s hand as they miss, the recoil throwing off their aim for a follow-up (if they had one).",
             'observer_msg': "The flare gun bucks in {attacker_name}'s hand as they miss, the recoil throwing off their aim for a follow-up (if they had one)."
         },
@@ -492,9 +492,9 @@ MESSAGES = {
             'observer_msg': "A precise, savage shot from the flare gun to {target_name}'s exposed throat ends their life in a cloud of smoke and searing, melting agony."
         },
         {
-            'attacker_msg': "You fire the flare into {target_name}'s torso, where it burns uncontrollably until they stop moving, flesh blackened and smoking.",
-            'victim_msg': "{attacker_name} fires the flare into your torso, where it burns uncontrollably until you stop moving, flesh blackened and smoking.",
-            'observer_msg': "{attacker_name} fires the flare into {target_name}'s torso, where it burns uncontrollably until they stop moving, flesh blackened and smoking."
+            'attacker_msg': "You fire the flare into {target_name}'s {hit_location}, where it burns uncontrollably until they stop moving, flesh blackened and smoking.",
+            'victim_msg': "{attacker_name} fires the flare into your {hit_location}, where it burns uncontrollably until you stop moving, flesh blackened and smoking.",
+            'observer_msg': "{attacker_name} fires the flare into {target_name}'s {hit_location}, where it burns uncontrollably until they stop moving, flesh blackened and smoking."
         },
         {
             'attacker_msg': "The unyielding chemical fire from the flare projectile consumes {target_name}, who crumples, unmoving, amidst the spreading flames.",

--- a/world/combat/messages/garden_shears.py
+++ b/world/combat/messages/garden_shears.py
@@ -41,7 +41,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} briefly struggles with the weight of the oversized shears before settling into a firm two-handed stance."
         },
         {
-            'attacker_msg': "You rest the heavy, long-handled shears on your shoulder, the formidable blades pointing skyward.",
+            'attacker_msg': "You rest the heavy, long-handled shears on your {hit_location}, the formidable blades pointing skyward.",
             'victim_msg': "{attacker_name} rests the heavy, long-handled shears on their shoulder, the formidable blades pointing skyward.",
             'observer_msg': "{attacker_name} rests the heavy, long-handled shears on their shoulder, the formidable blades pointing skyward."
         },
@@ -116,7 +116,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} works the long handles, clicking the heavy shears open and shut, the rhythm a steady, menacing beat of impending action."
         },
         {
-            'attacker_msg': "You carefully trace one of the long, wickedly sharp edges of the shears along your forearm, a silent vow.",
+            'attacker_msg': "You carefully trace one of the long, wickedly sharp edges of the shears along your {hit_location}, a silent vow.",
             'victim_msg': "{attacker_name} carefully traces one of the long, wickedly sharp edges of the shears along their forearm, a silent vow.",
             'observer_msg': "{attacker_name} carefully traces one of the long, wickedly sharp edges of the shears along their forearm, a silent vow."
         },
@@ -131,7 +131,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} leans on the long-handled shears, the heavy blades resting on the ground, a picture of grim readiness."
         },
         {
-            'attacker_msg': "You touch one of the cold, long blades of the heavy shears to your tongue, a savage grin spreading across your face.",
+            'attacker_msg': "You touch one of the cold, long blades of the heavy shears to your tongue, a savage grin spreading across your {hit_location}.",
             'victim_msg': "{attacker_name} touches one of the cold, long blades of the heavy shears to their tongue, a savage grin spreading across their face.",
             'observer_msg': "{attacker_name} touches one of the cold, long blades of the heavy shears to their tongue, a savage grin spreading across their face."
         },
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You drive the heavy, two-handed shears into {target_name}'s throat with a final, brutal thrust. The fight ends abruptly.",
-            'victim_msg': "{attacker_name} drives the heavy, two-handed shears into your throat with a final, brutal thrust. The fight ends abruptly.",
-            'observer_msg': "{attacker_name} drives the heavy, two-handed shears into {target_name}'s throat with a final, brutal thrust. The fight ends abruptly."
+            'attacker_msg': "You drive the heavy, two-handed shears into {target_name}'s {hit_location} with a final, brutal thrust. The fight ends abruptly.",
+            'victim_msg': "{attacker_name} drives the heavy, two-handed shears into your {hit_location} with a final, brutal thrust. The fight ends abruptly.",
+            'observer_msg': "{attacker_name} drives the heavy, two-handed shears into {target_name}'s {hit_location} with a final, brutal thrust. The fight ends abruptly."
         },
         {
             'attacker_msg': "A quick, powerful snip from the oversized shears to {target_name}'s carotid artery, and they drop, the struggle ceasing.",
@@ -467,14 +467,14 @@ MESSAGES = {
             'observer_msg': "A quick, powerful snip from the oversized shears to {target_name}'s carotid artery, and they drop, the struggle ceasing."
         },
         {
-            'attacker_msg': "The long blades of the heavy shears slip between {target_name}'s ribs and into the heart. {target_name} collapses, the light leaving their eyes.",
-            'victim_msg': "The long blades of the heavy shears slip between your ribs and into the heart. You collapse, the light leaving your eyes.",
-            'observer_msg': "The long blades of the heavy shears slip between {target_name}'s ribs and into the heart. {target_name} collapses, the light leaving their eyes."
+            'attacker_msg': "The long blades of the heavy shears slip between {target_name}'s {hit_location} and into the heart. {target_name} collapses, the light leaving their eyes.",
+            'victim_msg': "The long blades of the heavy shears slip between your {hit_location} and into the heart. You collapse, the light leaving your eyes.",
+            'observer_msg': "The long blades of the heavy shears slip between {target_name}'s {hit_location} and into the heart. {target_name} collapses, the light leaving their eyes."
         },
         {
-            'attacker_msg': "You carve a deep line across {target_name}'s neck with one of the long shear blades. The end is swift and silent.",
-            'victim_msg': "{attacker_name} carves a deep line across your neck with one of the long shear blades. The end is swift and silent.",
-            'observer_msg': "{attacker_name} carves a deep line across {target_name}'s neck with one of the long shear blades. The end is swift and silent."
+            'attacker_msg': "You carve a deep line across {target_name}'s {hit_location} with one of the long shear blades. The end is swift and silent.",
+            'victim_msg': "{attacker_name} carves a deep line across your {hit_location} with one of the long shear blades. The end is swift and silent.",
+            'observer_msg': "{attacker_name} carves a deep line across {target_name}'s {hit_location} with one of the long shear blades. The end is swift and silent."
         },
         {
             'attacker_msg': "A devastating jab under the jaw with the closed points of the heavy shears sends {target_name} crumpling to the ground, motionless.",
@@ -492,24 +492,24 @@ MESSAGES = {
             'observer_msg': "{attacker_name} slices deep into {target_name}'s femoral artery with a long shear blade. {target_name} doesn't last long."
         },
         {
-            'attacker_msg': "A quick, brutal snip from the heavy shears to {target_name}'s temple ends everything in an instant.",
-            'victim_msg': "A quick, brutal snip from the heavy shears to your temple ends everything in an instant.",
-            'observer_msg': "A quick, brutal snip from the heavy shears to {target_name}'s temple ends everything in an instant."
+            'attacker_msg': "A quick, brutal snip from the heavy shears to {target_name}'s {hit_location} ends everything in an instant.",
+            'victim_msg': "A quick, brutal snip from the heavy shears to your {hit_location} ends everything in an instant.",
+            'observer_msg': "A quick, brutal snip from the heavy shears to {target_name}'s {hit_location} ends everything in an instant."
         },
         {
-            'attacker_msg': "The long blades of the heavy shears slip under {target_name}'s sternum with a sickening crunch. {target_name} gasps, then nothing.",
-            'victim_msg': "The long blades of the heavy shears slip under your sternum with a sickening crunch. You gasp, then nothing.",
-            'observer_msg': "The long blades of the heavy shears slip under {target_name}'s sternum with a sickening crunch. {target_name} gasps, then nothing."
+            'attacker_msg': "The long blades of the heavy shears slip under {target_name}'s {hit_location} with a sickening crunch. {target_name} gasps, then nothing.",
+            'victim_msg': "The long blades of the heavy shears slip under your {hit_location} with a sickening crunch. You gasp, then nothing.",
+            'observer_msg': "The long blades of the heavy shears slip under {target_name}'s {hit_location} with a sickening crunch. {target_name} gasps, then nothing."
         },
         {
-            'attacker_msg': "You draw one long, sharp blade of the heavy shears across {target_name}'s throat. The silence that follows is absolute.",
-            'victim_msg': "{attacker_name} draws one long, sharp blade of the heavy shears across your throat. The silence that follows is absolute.",
-            'observer_msg': "{attacker_name} draws one long, sharp blade of the heavy shears across {target_name}'s throat. The silence that follows is absolute."
+            'attacker_msg': "You draw one long, sharp blade of the heavy shears across {target_name}'s {hit_location}. The silence that follows is absolute.",
+            'victim_msg': "{attacker_name} draws one long, sharp blade of the heavy shears across your {hit_location}. The silence that follows is absolute.",
+            'observer_msg': "{attacker_name} draws one long, sharp blade of the heavy shears across {target_name}'s {hit_location}. The silence that follows is absolute."
         },
         {
-            'attacker_msg': "A downward, two-handed snip buries the heavy blades of the shears deep in {target_name}'s chest. {target_name} shudders, then stills.",
-            'victim_msg': "A downward, two-handed snip buries the heavy blades of the shears deep in your chest. You shudder, then still.",
-            'observer_msg': "A downward, two-handed snip buries the heavy blades of the shears deep in {target_name}'s chest. {target_name} shudders, then stills."
+            'attacker_msg': "A downward, two-handed snip buries the heavy blades of the shears deep in {target_name}'s {hit_location}. {target_name} shudders, then stills.",
+            'victim_msg': "A downward, two-handed snip buries the heavy blades of the shears deep in your {hit_location}. You shudder, then still.",
+            'observer_msg': "A downward, two-handed snip buries the heavy blades of the shears deep in {target_name}'s {hit_location}. {target_name} shudders, then stills."
         },
         {
             'attacker_msg': "The long, pointed blades of the heavy shears slip between {target_name}'s vertebrae. {target_name} drops, a puppet with cut strings.",
@@ -532,9 +532,9 @@ MESSAGES = {
             'observer_msg': "The long blades of the heavy shears puncture a lung. {target_name}'s fight is over."
         },
         {
-            'attacker_msg': "You slice through {target_name}'s wrist with the powerful, two-handed shears. The outcome is grimly inevitable.",
-            'victim_msg': "{attacker_name} slices through your wrist with the powerful, two-handed shears. The outcome is grimly inevitable.",
-            'observer_msg': "{attacker_name} slices through {target_name}'s wrist with the powerful, two-handed shears. The outcome is grimly inevitable."
+            'attacker_msg': "You slice through {target_name}'s {hit_location} with the powerful, two-handed shears. The outcome is grimly inevitable.",
+            'victim_msg': "{attacker_name} slices through your {hit_location} with the powerful, two-handed shears. The outcome is grimly inevitable.",
+            'observer_msg': "{attacker_name} slices through {target_name}'s {hit_location} with the powerful, two-handed shears. The outcome is grimly inevitable."
         },
         {
             'attacker_msg': "A quick, brutal flick of the heavy shears opens {target_name}'s jugular. {target_name} drops in seconds, the fight finished.",
@@ -547,9 +547,9 @@ MESSAGES = {
             'observer_msg': "The long, pointed blades of the heavy shears slip behind {target_name}'s ear with deadly precision. {target_name} never sees it coming."
         },
         {
-            'attacker_msg': "A crushing snip to the base of {target_name}'s skull with the oversized shears ends the conflict instantly and decisively.",
-            'victim_msg': "A crushing snip to the base of your skull with the oversized shears ends the conflict instantly and decisively.",
-            'observer_msg': "A crushing snip to the base of {target_name}'s skull with the oversized shears ends the conflict instantly and decisively."
+            'attacker_msg': "A crushing snip to the base of {target_name}'s {hit_location} with the oversized shears ends the conflict instantly and decisively.",
+            'victim_msg': "A crushing snip to the base of your {hit_location} with the oversized shears ends the conflict instantly and decisively.",
+            'observer_msg': "A crushing snip to the base of {target_name}'s {hit_location} with the oversized shears ends the conflict instantly and decisively."
         },
         {
             'attacker_msg': "You, with a final, sweeping motion of the two-handed shears, ensure {target_name} will not rise again.",
@@ -562,14 +562,14 @@ MESSAGES = {
             'observer_msg': "The long blades of the heavy shears slip into {target_name}'s mouth with brutal force, silencing them forever."
         },
         {
-            'attacker_msg': "A quick, powerful snip from the oversized shears opens {target_name}'s abdomen. {target_name} folds, the fight draining out of them.",
-            'victim_msg': "A quick, powerful snip from the oversized shears opens your abdomen. You fold, the fight draining out of you.",
-            'observer_msg': "A quick, powerful snip from the oversized shears opens {target_name}'s abdomen. {target_name} folds, the fight draining out of them."
+            'attacker_msg': "A quick, powerful snip from the oversized shears opens {target_name}'s {hit_location}. {target_name} folds, the fight draining out of them.",
+            'victim_msg': "A quick, powerful snip from the oversized shears opens your {hit_location}. You fold, the fight draining out of you.",
+            'observer_msg': "A quick, powerful snip from the oversized shears opens {target_name}'s {hit_location}. {target_name} folds, the fight draining out of them."
         },
         {
-            'attacker_msg': "The heavy, pointed blades of the shears puncture {target_name}'s heart. {target_name} gasps a final breath, then nothing.",
-            'victim_msg': "The heavy, pointed blades of the shears puncture your heart. You gasp a final breath, then nothing.",
-            'observer_msg': "The heavy, pointed blades of the shears puncture {target_name}'s heart. {target_name} gasps a final breath, then nothing."
+            'attacker_msg': "The heavy, pointed blades of the shears puncture {target_name}'s {hit_location}. {target_name} gasps a final breath, then nothing.",
+            'victim_msg': "The heavy, pointed blades of the shears puncture your {hit_location}. You gasp a final breath, then nothing.",
+            'observer_msg': "The heavy, pointed blades of the shears puncture {target_name}'s {hit_location}. {target_name} gasps a final breath, then nothing."
         },
         {
             'attacker_msg': "You draw the long, sharp blades of the heavy shears across {target_name}'s eyes. Their world goes dark permanently.",
@@ -592,14 +592,14 @@ MESSAGES = {
             'observer_msg': "A quick, vicious flick of the oversized shears opens {target_name}'s femoral artery. Life drains away swiftly."
         },
         {
-            'attacker_msg': "The long blades of the heavy shears slip into {target_name}'s chest, you twisting the long handles with finality. {target_name} is gone.",
-            'victim_msg': "The long blades of the heavy shears slip into your chest, {attacker_name} twisting the long handles with finality. You are gone.",
-            'observer_msg': "The long blades of the heavy shears slip into {target_name}'s chest, {attacker_name} twisting the long handles with finality. {target_name} is gone."
+            'attacker_msg': "The long blades of the heavy shears slip into {target_name}'s {hit_location}, you twisting the long handles with finality. {target_name} is gone.",
+            'victim_msg': "The long blades of the heavy shears slip into your {hit_location}, {attacker_name} twisting the long handles with finality. You are gone.",
+            'observer_msg': "The long blades of the heavy shears slip into {target_name}'s {hit_location}, {attacker_name} twisting the long handles with finality. {target_name} is gone."
         },
         {
-            'attacker_msg': "You carve a deep, fatal line across {target_name}'s throat with one of the long shear blades. The end is abrupt and certain.",
-            'victim_msg': "{attacker_name} carves a deep, fatal line across your throat with one of the long shear blades. The end is abrupt and certain.",
-            'observer_msg': "{attacker_name} carves a deep, fatal line across {target_name}'s throat with one of the long shear blades. The end is abrupt and certain."
+            'attacker_msg': "You carve a deep, fatal line across {target_name}'s {hit_location} with one of the long shear blades. The end is abrupt and certain.",
+            'victim_msg': "{attacker_name} carves a deep, fatal line across your {hit_location} with one of the long shear blades. The end is abrupt and certain.",
+            'observer_msg': "{attacker_name} carves a deep, fatal line across {target_name}'s {hit_location} with one of the long shear blades. The end is abrupt and certain."
         },
         {
             'attacker_msg': "A final, crushing snip to the heart with the heavy, two-handed shears. {target_name} sags, then falls, motionless.",

--- a/world/combat/messages/gladius.py
+++ b/world/combat/messages/gladius.py
@@ -86,7 +86,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} holds the gladius in a forward-canted guard, ready to punch through defenses."
         },
         {
-            'attacker_msg': "The heavy, spherical pommel of the gladius is a solid counterweight in your hand.",
+            'attacker_msg': "The heavy, spherical pommel of the gladius is a solid counterweight in your {hit_location}.",
             'victim_msg': "The heavy, spherical pommel of the gladius is a solid counterweight in {attacker_name}'s hand.",
             'observer_msg': "The heavy, spherical pommel of the gladius is a solid counterweight in {attacker_name}'s hand."
         },
@@ -106,7 +106,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} yanks the gladius free, the sound a harsh rasp of steel on leather."
         },
         {
-            'attacker_msg': "The gladius is a soldier's weapon in your hand, built for effectiveness, not show.",
+            'attacker_msg': "The gladius is a soldier's weapon in your {hit_location}, built for effectiveness, not show.",
             'victim_msg': "The gladius is a soldier's weapon in {attacker_name}'s hand, built for effectiveness, not show.",
             'observer_msg': "The gladius is a soldier's weapon in {attacker_name}'s hand, built for effectiveness, not show."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your gladius chops the air violently, just missing {target_name}'s head.",
-            'victim_msg': "{attacker_name}'s gladius chops the air violently, just missing your head.",
-            'observer_msg': "{attacker_name}'s gladius chops the air violently, just missing {target_name}'s head."
+            'attacker_msg': "Your gladius chops the air violently, just missing {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s gladius chops the air violently, just missing your {hit_location}.",
+            'observer_msg': "{attacker_name}'s gladius chops the air violently, just missing {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "{target_name} barely stumbles back, avoiding the brutal thrust of your gladius.",
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "Your gladius punches through {target_name}'s chest, a fatal, brutal end.",
-            'victim_msg': "{attacker_name}'s gladius punches through your chest, a fatal, brutal end.",
-            'observer_msg': "{attacker_name}'s gladius punches through {target_name}'s chest, a fatal, brutal end."
+            'attacker_msg': "Your gladius punches through {target_name}'s {hit_location}, a fatal, brutal end.",
+            'victim_msg': "{attacker_name}'s gladius punches through your {hit_location}, a fatal, brutal end.",
+            'observer_msg': "{attacker_name}'s gladius punches through {target_name}'s {hit_location}, a fatal, brutal end."
         },
         {
             'attacker_msg': "A savage chop from the gladius, and {target_name} falls, lifeblood gushing onto the ground.",
@@ -472,9 +472,9 @@ MESSAGES = {
             'observer_msg': "With a final, merciless thrust, {attacker_name}'s gladius silences {target_name} permanently."
         },
         {
-            'attacker_msg': "The broad blade of the gladius severs {target_name}'s throat, a swift and bloody conclusion.",
-            'victim_msg': "The broad blade of the gladius severs your throat, a swift and bloody conclusion.",
-            'observer_msg': "The broad blade of the gladius severs {target_name}'s throat, a swift and bloody conclusion."
+            'attacker_msg': "The broad blade of the gladius severs {target_name}'s {hit_location}, a swift and bloody conclusion.",
+            'victim_msg': "The broad blade of the gladius severs your {hit_location}, a swift and bloody conclusion.",
+            'observer_msg': "The broad blade of the gladius severs {target_name}'s {hit_location}, a swift and bloody conclusion."
         },
         {
             'attacker_msg': "Your powerful blow with the gladius leaves {target_name} mortally wounded, collapsing in a heap.",
@@ -492,9 +492,9 @@ MESSAGES = {
             'observer_msg': "A vicious upward thrust from {attacker_name}'s gladius ends {target_name}'s life with horrific efficiency."
         },
         {
-            'attacker_msg': "You drive the gladius deep into {target_name}'s abdomen, the outcome grimly inevitable.",
-            'victim_msg': "{attacker_name} drives the gladius deep into your abdomen, the outcome grimly inevitable.",
-            'observer_msg': "{attacker_name} drives the gladius deep into {target_name}'s abdomen, the outcome grimly inevitable."
+            'attacker_msg': "You drive the gladius deep into {target_name}'s {hit_location}, the outcome grimly inevitable.",
+            'victim_msg': "{attacker_name} drives the gladius deep into your {hit_location}, the outcome grimly inevitable.",
+            'observer_msg': "{attacker_name} drives the gladius deep into {target_name}'s {hit_location}, the outcome grimly inevitable."
         },
         {
             'attacker_msg': "The keen edge of the gladius opens a fatal wound, and {target_name} crumples, unmoving.",

--- a/world/combat/messages/glass_shard.py
+++ b/world/combat/messages/glass_shard.py
@@ -11,7 +11,7 @@ MESSAGES = {
             'observer_msg': "With a desperate look, {attacker_name} brandishes a sharp piece of broken glass, ready to slash and stab."
         },
         {
-            'attacker_msg': "Your hand is wrapped precariously around a shard of glass, its razor edge reflecting a grim light.",
+            'attacker_msg': "Your {hit_location} is wrapped precariously around a shard of glass, its razor edge reflecting a grim light.",
             'victim_msg': "{attacker_name}'s hand is wrapped precariously around a shard of glass, its razor edge reflecting a grim light.",
             'observer_msg': "{attacker_name}'s hand is wrapped precariously around a shard of glass, its razor edge reflecting a grim light."
         },
@@ -36,7 +36,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} points the jagged end of the glass shard towards {target_name}, a clear, vicious threat."
         },
         {
-            'attacker_msg': "Light catches the irregular, razor-sharp edges of the glass shard in your hand.",
+            'attacker_msg': "Light catches the irregular, razor-sharp edges of the glass shard in your {hit_location}.",
             'victim_msg': "Light catches the irregular, razor-sharp edges of the glass shard in {attacker_name}'s hand.",
             'observer_msg': "Light catches the irregular, razor-sharp edges of the glass shard in {attacker_name}'s hand."
         },
@@ -66,7 +66,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s eyes are narrowed, sighting along the sharpest edge of the glass towards {target_name}."
         },
         {
-            'attacker_msg': "The shard of glass feels dangerously sharp and fragile in your hand, a tool of pure desperation.",
+            'attacker_msg': "The shard of glass feels dangerously sharp and fragile in your {hit_location}, a tool of pure desperation.",
             'victim_msg': "The shard of glass feels dangerously sharp and fragile in {attacker_name}'s hand, a tool of pure desperation.",
             'observer_msg': "The shard of glass feels dangerously sharp and fragile in {attacker_name}'s hand, a tool of pure desperation."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your shard of glass whistles through the air, its jagged edge narrowly missing {target_name}'s face.",
-            'victim_msg': "{attacker_name}'s shard of glass whistles through the air, its jagged edge narrowly missing your face.",
-            'observer_msg': "{attacker_name}'s shard of glass whistles through the air, its jagged edge narrowly missing {target_name}'s face."
+            'attacker_msg': "Your shard of glass whistles through the air, its jagged edge narrowly missing {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s shard of glass whistles through the air, its jagged edge narrowly missing your {hit_location}.",
+            'observer_msg': "{attacker_name}'s shard of glass whistles through the air, its jagged edge narrowly missing {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "{target_name} stumbles back, avoiding the desperate slash of your shard of glass by a hair's breadth.",
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick retreat from {target_name} leaves {attacker_name}'s shard of glass to cut nothing but air."
         },
         {
-            'attacker_msg': "The shard of glass feels dangerously slippery in your hand as the intended cutting blow fails to connect.",
+            'attacker_msg': "The shard of glass feels dangerously slippery in your {hit_location} as the intended cutting blow fails to connect.",
             'victim_msg': "The shard of glass feels dangerously slippery in {attacker_name}'s hand as the intended cutting blow fails to connect.",
             'observer_msg': "The shard of glass feels dangerously slippery in {attacker_name}'s hand as the intended cutting blow fails to connect."
         },
@@ -395,9 +395,9 @@ MESSAGES = {
             'observer_msg': "A growl of frustration from {attacker_name} as their shard of glass attack is evaded by a nimble {target_name}."
         },
         {
-            'attacker_msg': "The shard of glass scratches a line on the ground beside {target_name}'s foot, but draws no blood.",
-            'victim_msg': "The shard of glass scratches a line on the ground beside your foot, but draws no blood.",
-            'observer_msg': "The shard of glass scratches a line on the ground beside {target_name}'s foot, but draws no blood."
+            'attacker_msg': "The shard of glass scratches a line on the ground beside {target_name}'s {hit_location}, but draws no blood.",
+            'victim_msg': "The shard of glass scratches a line on the ground beside your {hit_location}, but draws no blood.",
+            'observer_msg': "The shard of glass scratches a line on the ground beside {target_name}'s {hit_location}, but draws no blood."
         },
         {
             'attacker_msg': "Your straightforward attack with the shard of glass is anticipated and dodged by {target_name}, who looks terrified.",
@@ -457,14 +457,14 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You shove the jagged shard of glass into {target_name}'s throat; they collapse, gurgling, succumbing to massive blood loss.",
-            'victim_msg': "{attacker_name} shoves the jagged shard of glass into your throat; you collapse, gurgling, succumbing to massive blood loss.",
-            'observer_msg': "{attacker_name} shoves the jagged shard of glass into {target_name}'s throat; they collapse, gurgling, succumbing to massive blood loss."
+            'attacker_msg': "You shove the jagged shard of glass into {target_name}'s {hit_location}; they collapse, gurgling, succumbing to massive blood loss.",
+            'victim_msg': "{attacker_name} shoves the jagged shard of glass into your {hit_location}; you collapse, gurgling, succumbing to massive blood loss.",
+            'observer_msg': "{attacker_name} shoves the jagged shard of glass into {target_name}'s {hit_location}; they collapse, gurgling, succumbing to massive blood loss."
         },
         {
-            'attacker_msg': "The shard of glass, driven deep into {target_name}'s chest, pierces their heart, and they fall silent, life extinguished.",
-            'victim_msg': "The shard of glass, driven deep into your chest, pierces your heart, and you fall silent, life extinguished.",
-            'observer_msg': "The shard of glass, driven deep into {target_name}'s chest, pierces their heart, and they fall silent, life extinguished."
+            'attacker_msg': "The shard of glass, driven deep into {target_name}'s {hit_location}, pierces their heart, and they fall silent, life extinguished.",
+            'victim_msg': "The shard of glass, driven deep into your {hit_location}, pierces your {hit_location}, and you fall silent, life extinguished.",
+            'observer_msg': "The shard of glass, driven deep into {target_name}'s {hit_location}, pierces their heart, and they fall silent, life extinguished."
         },
         {
             'attacker_msg': "With a final, brutal thrust, you embed the shard of glass in {target_name}'s eye, and they drop, twitching, then still.",
@@ -487,14 +487,14 @@ MESSAGES = {
             'observer_msg': "The shard of glass, a desperate tool of death, delivers a killing blow as {target_name} is overcome by catastrophic, bleeding wounds."
         },
         {
-            'attacker_msg': "A precise, savage thrust with the shard of glass to {target_name}'s temple ends their life in a spray of blood.",
-            'victim_msg': "A precise, savage thrust with the shard of glass to your temple ends your life in a spray of blood.",
-            'observer_msg': "A precise, savage thrust with the shard of glass to {target_name}'s temple ends their life in a spray of blood."
+            'attacker_msg': "A precise, savage thrust with the shard of glass to {target_name}'s {hit_location} ends their life in a spray of blood.",
+            'victim_msg': "A precise, savage thrust with the shard of glass to your {hit_location} ends your life in a spray of blood.",
+            'observer_msg': "A precise, savage thrust with the shard of glass to {target_name}'s {hit_location} ends their life in a spray of blood."
         },
         {
-            'attacker_msg': "You press the shard of glass against {target_name}'s neck until they stop moving, the flesh torn and bloodied, life extinguished.",
-            'victim_msg': "{attacker_name} presses the shard of glass against your neck until you stop moving, the flesh torn and bloodied, life extinguished.",
-            'observer_msg': "{attacker_name} presses the shard of glass against {target_name}'s neck until they stop moving, the flesh torn and bloodied, life extinguished."
+            'attacker_msg': "You press the shard of glass against {target_name}'s {hit_location} until they stop moving, the flesh torn and bloodied, life extinguished.",
+            'victim_msg': "{attacker_name} presses the shard of glass against your {hit_location} until you stop moving, the flesh torn and bloodied, life extinguished.",
+            'observer_msg': "{attacker_name} presses the shard of glass against {target_name}'s {hit_location} until they stop moving, the flesh torn and bloodied, life extinguished."
         },
         {
             'attacker_msg': "The unyielding sharpness of the glass shard severs something vital in {target_name}, who crumples, unmoving, amidst the spreading bloodstain.",
@@ -522,7 +522,7 @@ MESSAGES = {
             'observer_msg': "A merciless, deep stab with the shard of glass, and {target_name} is no more, overcome by the vicious, tearing wound."
         },
         {
-            'attacker_msg': "The shard of glass, now slick with gore, drops from your hand as {target_name} lies lifeless.",
+            'attacker_msg': "The shard of glass, now slick with gore, drops from your {hit_location} as {target_name} lies lifeless.",
             'victim_msg': "The shard of glass, now slick with gore, drops from {attacker_name}'s hand as you lie lifeless.",
             'observer_msg': "The shard of glass, now slick with gore, drops from {attacker_name}'s hand as {target_name} lies lifeless."
         },

--- a/world/combat/messages/grapple.py
+++ b/world/combat/messages/grapple.py
@@ -213,19 +213,19 @@ MESSAGES = {
     # --- Messages for ATTACKS/DAMAGE while ALREADY grappling ---
     "grapple_damage_hit": [  # Action: Successfully damaging a grappled opponent
         {
-            "attacker_msg": "You squeeze the air from {target_name}'s lungs in the grapple.",
-            "victim_msg": "{attacker_name} squeezes the air from your lungs in the grapple!",
-            "observer_msg": "{attacker_name} squeezes the air from {target_name}'s lungs in the grapple."
+            "attacker_msg": "You squeeze the air from {target_name}'s {hit_location} in the grapple.",
+            "victim_msg": "{attacker_name} squeezes the air from your {hit_location} in the grapple!",
+            "observer_msg": "{attacker_name} squeezes the air from {target_name}'s {hit_location} in the grapple."
         },
         {
-            "attacker_msg": "Locked tight, you drive a knee into {target_name}'s ribs.",
-            "victim_msg": "Locked tight, {attacker_name} drives a knee into your ribs!",
-            "observer_msg": "Locked tight, {attacker_name} drives a knee into {target_name}'s ribs."
+            "attacker_msg": "Locked tight, you drive a knee into {target_name}'s {hit_location}.",
+            "victim_msg": "Locked tight, {attacker_name} drives a knee into your {hit_location}!",
+            "observer_msg": "Locked tight, {attacker_name} drives a knee into {target_name}'s {hit_location}."
         },
         {
-            "attacker_msg": "You grind your forearm across {target_name}'s throat.",
-            "victim_msg": "{attacker_name} grinds their forearm across your throat!",
-            "observer_msg": "{attacker_name} grinds their forearm across {target_name}'s throat."
+            "attacker_msg": "You grind your {hit_location} across {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} grinds their forearm across your {hit_location}!",
+            "observer_msg": "{attacker_name} grinds their forearm across {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "While grappling, you land a series of short, brutal punches to {target_name}'s side.",
@@ -248,9 +248,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} chokes {target_name}, who claws desperately at their arms."
         },
         {
-            "attacker_msg": "In the clinch, you slam an elbow into {target_name}'s temple.",
-            "victim_msg": "In the clinch, {attacker_name} slams an elbow into your temple!",
-            "observer_msg": "In the clinch, {attacker_name} slams an elbow into {target_name}'s temple."
+            "attacker_msg": "In the clinch, you slam an elbow into {target_name}'s {hit_location}.",
+            "victim_msg": "In the clinch, {attacker_name} slams an elbow into your {hit_location}!",
+            "observer_msg": "In the clinch, {attacker_name} slams an elbow into {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You use your leverage to crush {target_name} against the ground.",
@@ -268,9 +268,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} bites down hard on {target_name} amidst the struggle."
         },
         {
-            "attacker_msg": "You smash {target_name}'s face into the pavement while maintaining the hold.",
-            "victim_msg": "{attacker_name} smashes your face into the pavement while maintaining the hold!",
-            "observer_msg": "{attacker_name} smashes {target_name}'s face into the pavement while maintaining the hold."
+            "attacker_msg": "You smash {target_name}'s {hit_location} into the pavement while maintaining the hold.",
+            "victim_msg": "{attacker_name} smashes your {hit_location} into the pavement while maintaining the hold!",
+            "observer_msg": "{attacker_name} smashes {target_name}'s {hit_location} into the pavement while maintaining the hold."
         },
         {
             "attacker_msg": "Trapped in the grapple, {target_name} takes a nasty shot to the kidney from you.",
@@ -278,9 +278,9 @@ MESSAGES = {
             "observer_msg": "Trapped in the grapple, {target_name} takes a nasty shot to the kidney from {attacker_name}."
         },
         {
-            "attacker_msg": "You wrench {target_name}'s neck, drawing a choked cry.",
-            "victim_msg": "{attacker_name} wrenches your neck, drawing a choked cry from you!",
-            "observer_msg": "{attacker_name} wrenches {target_name}'s neck, drawing a choked cry."
+            "attacker_msg": "You wrench {target_name}'s {hit_location}, drawing a choked cry.",
+            "victim_msg": "{attacker_name} wrenches your {hit_location}, drawing a choked cry from you!",
+            "observer_msg": "{attacker_name} wrenches {target_name}'s {hit_location}, drawing a choked cry."
         },
         {
             "attacker_msg": "With {target_name} immobilized, you land a precise, painful strike.",
@@ -293,9 +293,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} digs their knuckles into a pressure point on {target_name}."
         },
         {
-            "attacker_msg": "A short, sharp elbow from you cracks against {target_name}'s jaw.",
-            "victim_msg": "A short, sharp elbow from {attacker_name} cracks against your jaw!",
-            "observer_msg": "A short, sharp elbow from {attacker_name} cracks against {target_name}'s jaw."
+            "attacker_msg": "A short, sharp elbow from you cracks against {target_name}'s {hit_location}.",
+            "victim_msg": "A short, sharp elbow from {attacker_name} cracks against your {hit_location}!",
+            "observer_msg": "A short, sharp elbow from {attacker_name} cracks against {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You use the grapple to slam {target_name} into a nearby object.",
@@ -308,9 +308,9 @@ MESSAGES = {
             "observer_msg": "{target_name} groans as {attacker_name} applies a painful submission hold."
         },
         {
-            "attacker_msg": "You drive your shoulder repeatedly into {target_name}'s chest.",
-            "victim_msg": "{attacker_name} drives their shoulder repeatedly into your chest!",
-            "observer_msg": "{attacker_name} drives their shoulder repeatedly into {target_name}'s chest."
+            "attacker_msg": "You drive your {hit_location} repeatedly into {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name} drives their shoulder repeatedly into your {hit_location}!",
+            "observer_msg": "{attacker_name} drives their shoulder repeatedly into {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "In the tight confines of the grapple, you gouge at {target_name}'s eyes.",
@@ -319,7 +319,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You pull {target_name}'s hair, yanking their head into a knee strike.",
-            "victim_msg": "{attacker_name} pulls your hair, yanking your head into a knee strike!",
+            "victim_msg": "{attacker_name} pulls your hair, yanking your {hit_location} into a knee strike!",
             "observer_msg": "{attacker_name} pulls {target_name}'s hair, yanking their head into a knee strike."
         },
         {

--- a/world/combat/messages/hammer.py
+++ b/world/combat/messages/hammer.py
@@ -66,7 +66,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} wipes the cue on their sleeve, as if it matters."
         },
         {
-            'attacker_msg': "You let the cue rest on your shoulder, casual as a hustler at closing time.",
+            'attacker_msg': "You let the cue rest on your {hit_location}, casual as a hustler at closing time.",
             'victim_msg': "{attacker_name} lets the cue rest on their shoulder, casual as a hustler at closing time.",
             'observer_msg': "{attacker_name} lets the cue rest on their shoulder, casual as a hustler at closing time."
         },
@@ -131,7 +131,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} holds the cue like a brush, ready to paint in red."
         },
         {
-            'attacker_msg': "You let the cue rest on your shoulder, eyes never leaving {target_name}.",
+            'attacker_msg': "You let the cue rest on your {hit_location}, eyes never leaving {target_name}.",
             'victim_msg': "{attacker_name} lets the cue rest on their shoulder, eyes never leaving you.",
             'observer_msg': "{attacker_name} lets the cue rest on their shoulder, eyes never leaving {target_name}."
         },
@@ -457,24 +457,24 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You bring the pool cue down on {target_name}'s skull. The wood splinters, blood and bone mixing.",
-            'victim_msg': "{attacker_name} brings the pool cue down on your skull. The wood splinters, blood and bone mixing.",
-            'observer_msg': "{attacker_name} brings the pool cue down on {target_name}'s skull. The wood splinters, blood and bone mixing."
+            'attacker_msg': "You bring the pool cue down on {target_name}'s {hit_location}. The wood splinters, blood and bone mixing.",
+            'victim_msg': "{attacker_name} brings the pool cue down on your {hit_location}. The wood splinters, blood and bone mixing.",
+            'observer_msg': "{attacker_name} brings the pool cue down on {target_name}'s {hit_location}. The wood splinters, blood and bone mixing."
         },
         {
-            'attacker_msg': "A heavy swing cracks {target_name}'s temple. They drop, twitching.",
-            'victim_msg': "A heavy swing cracks your temple. You drop, twitching.",
-            'observer_msg': "A heavy swing cracks {target_name}'s temple. They drop, twitching."
+            'attacker_msg': "A heavy swing cracks {target_name}'s {hit_location}. They drop, twitching.",
+            'victim_msg': "A heavy swing cracks your {hit_location}. You drop, twitching.",
+            'observer_msg': "A heavy swing cracks {target_name}'s {hit_location}. They drop, twitching."
         },
         {
-            'attacker_msg': "The tip jabs into {target_name}'s throat. They collapse, gasping for air that won't come.",
-            'victim_msg': "The tip jabs into your throat. You collapse, gasping for air that won't come.",
-            'observer_msg': "The tip jabs into {target_name}'s throat. They collapse, gasping for air that won't come."
+            'attacker_msg': "The tip jabs into {target_name}'s {hit_location}. They collapse, gasping for air that won't come.",
+            'victim_msg': "The tip jabs into your {hit_location}. You collapse, gasping for air that won't come.",
+            'observer_msg': "The tip jabs into {target_name}'s {hit_location}. They collapse, gasping for air that won't come."
         },
         {
-            'attacker_msg': "You carve a line across {target_name}'s neck. The blood is bright and fast.",
-            'victim_msg': "{attacker_name} carves a line across your neck. The blood is bright and fast.",
-            'observer_msg': "{attacker_name} carves a line across {target_name}'s neck. The blood is bright and fast."
+            'attacker_msg': "You carve a line across {target_name}'s {hit_location}. The blood is bright and fast.",
+            'victim_msg': "{attacker_name} carves a line across your {hit_location}. The blood is bright and fast.",
+            'observer_msg': "{attacker_name} carves a line across {target_name}'s {hit_location}. The blood is bright and fast."
         },
         {
             'attacker_msg': "A jab under the jaw sends the cue splintering into the brain. {target_name} goes limp instantly.",
@@ -517,9 +517,9 @@ MESSAGES = {
             'observer_msg': "The shaft slips between vertebrae. {target_name} drops, boneless."
         },
         {
-            'attacker_msg': "You carve a smile across {target_name}'s face. The grin is permanent.",
-            'victim_msg': "{attacker_name} carves a smile across your face. The grin is permanent.",
-            'observer_msg': "{attacker_name} carves a smile across {target_name}'s face. The grin is permanent."
+            'attacker_msg': "You carve a smile across {target_name}'s {hit_location}. The grin is permanent.",
+            'victim_msg': "{attacker_name} carves a smile across your {hit_location}. The grin is permanent.",
+            'observer_msg': "{attacker_name} carves a smile across {target_name}'s {hit_location}. The grin is permanent."
         },
         {
             'attacker_msg': "A jab to the heart. {target_name} collapses, eyes wide and empty.",

--- a/world/combat/messages/hatchet.py
+++ b/world/combat/messages/hatchet.py
@@ -16,7 +16,7 @@ MESSAGES = {
             'observer_msg': "A whisper of rust and wood fills the air as {attacker_name} lifts the hatchet from their belt."
         },
         {
-            'attacker_msg': "It's not much, but in your hand, the hatchet looks holy. In a terrible way.",
+            'attacker_msg': "It's not much, but in your {hit_location}, the hatchet looks holy. In a terrible way.",
             'victim_msg': "It's not much, but in {attacker_name}'s hand, the hatchet looks holy. In a terrible way.",
             'observer_msg': "It's not much, but in {attacker_name}'s hand, the hatchet looks holy. In a terrible way."
         },
@@ -61,12 +61,12 @@ MESSAGES = {
             'observer_msg': "The hatchet hangs low in {attacker_name}'s grip, heavy with history and blood yet to be shed."
         },
         {
-            'attacker_msg': "The hatchet rests on your shoulder like a burden you've carried before — and loved.",
+            'attacker_msg': "The hatchet rests on your {hit_location} like a burden you've carried before — and loved.",
             'victim_msg': "The hatchet rests on {attacker_name}'s shoulder like a burden they've carried before — and loved.",
             'observer_msg': "The hatchet rests on {attacker_name}'s shoulder like a burden they've carried before — and loved."
         },
         {
-            'attacker_msg': "The hatchet spins once, then lands blade-down in your hand. The movement is fluid. Familiar.",
+            'attacker_msg': "The hatchet spins once, then lands blade-down in your {hit_location}. The movement is fluid. Familiar.",
             'victim_msg': "The hatchet spins once, then lands blade-down in {attacker_name}'s hand. The movement is fluid. Familiar.",
             'observer_msg': "The hatchet spins once, then lands blade-down in {attacker_name}'s hand. The movement is fluid. Familiar."
         },
@@ -116,7 +116,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} flips the hatchet lazily, catching it by the handle with practiced ease. The edge never stops gleaming."
         },
         {
-            'attacker_msg': "You flip the hatchet once in your hand, testing the edge with a glance that cuts deeper than the blade.",
+            'attacker_msg': "You flip the hatchet once in your {hit_location}, testing the edge with a glance that cuts deeper than the blade.",
             'victim_msg': "{attacker_name} flips the hatchet once in their hand, testing the edge with a glance that cuts deeper than the blade.",
             'observer_msg': "{attacker_name} flips the hatchet once in their hand, testing the edge with a glance that cuts deeper than the blade."
         },
@@ -527,9 +527,9 @@ MESSAGES = {
             'observer_msg': "The blade cleaves the collarbone, opening {target_name} to the heart. The end is immediate."
         },
         {
-            'attacker_msg': "The final blow caves in ribs. {target_name}'s chest becomes a hollow place.",
-            'victim_msg': "The final blow caves in ribs. Your chest becomes a hollow place.",
-            'observer_msg': "The final blow caves in ribs. {target_name}'s chest becomes a hollow place."
+            'attacker_msg': "The final blow caves in ribs. {target_name}'s {hit_location} becomes a hollow place.",
+            'victim_msg': "The final blow caves in ribs. Your {hit_location} becomes a hollow place.",
+            'observer_msg': "The final blow caves in ribs. {target_name}'s {hit_location} becomes a hollow place."
         },
         {
             'attacker_msg': "The hatchet bites deep into the chest. {target_name} breathes their last in bubbles of blood.",
@@ -557,14 +557,14 @@ MESSAGES = {
             'observer_msg': "The last strike severs the head completely. It hits the ground and rolls."
         },
         {
-            'attacker_msg': "The weapon carves through ribs like they're kindling. {target_name}'s heart stops mid-beat.",
-            'victim_msg': "The weapon carves through ribs like they're kindling. Your heart stops mid-beat.",
-            'observer_msg': "The weapon carves through ribs like they're kindling. {target_name}'s heart stops mid-beat."
+            'attacker_msg': "The weapon carves through ribs like they're kindling. {target_name}'s {hit_location} stops mid-beat.",
+            'victim_msg': "The weapon carves through ribs like they're kindling. Your {hit_location} stops mid-beat.",
+            'observer_msg': "The weapon carves through ribs like they're kindling. {target_name}'s {hit_location} stops mid-beat."
         },
         {
-            'attacker_msg': "You bury the hatchet in {target_name}'s skull. They drop instantly, twitching once before stillness.",
-            'victim_msg': "{attacker_name} buries the hatchet in your skull. You drop instantly, twitching once before stillness.",
-            'observer_msg': "{attacker_name} buries the hatchet in {target_name}'s skull. They drop instantly, twitching once before stillness."
+            'attacker_msg': "You bury the hatchet in {target_name}'s {hit_location}. They drop instantly, twitching once before stillness.",
+            'victim_msg': "{attacker_name} buries the hatchet in your {hit_location}. You drop instantly, twitching once before stillness.",
+            'observer_msg': "{attacker_name} buries the hatchet in {target_name}'s {hit_location}. They drop instantly, twitching once before stillness."
         },
         {
             'attacker_msg': "You chop downward into the crown of the head. {target_name} collapses like a demolished building.",
@@ -572,19 +572,19 @@ MESSAGES = {
             'observer_msg': "{attacker_name} chops downward into the crown of the head. {target_name} collapses like a demolished building."
         },
         {
-            'attacker_msg': "You drive the blade deep into {target_name}'s chest. Their eyes widen, then close forever.",
-            'victim_msg': "{attacker_name} drives the blade deep into your chest. Your eyes widen, then close forever.",
-            'observer_msg': "{attacker_name} drives the blade deep into {target_name}'s chest. Their eyes widen, then close forever."
+            'attacker_msg': "You drive the blade deep into {target_name}'s {hit_location}. Their eyes widen, then close forever.",
+            'victim_msg': "{attacker_name} drives the blade deep into your {hit_location}. Your eyes widen, then close forever.",
+            'observer_msg': "{attacker_name} drives the blade deep into {target_name}'s {hit_location}. Their eyes widen, then close forever."
         },
         {
-            'attacker_msg': "You hack straight through the neck. {target_name}'s head separates cleanly. The body follows a moment later.",
-            'victim_msg': "{attacker_name} hacks straight through the neck. Your head separates cleanly. The body follows a moment later.",
-            'observer_msg': "{attacker_name} hacks straight through the neck. {target_name}'s head separates cleanly. The body follows a moment later."
+            'attacker_msg': "You hack straight through the neck. {target_name}'s {hit_location} separates cleanly. The body follows a moment later.",
+            'victim_msg': "{attacker_name} hacks straight through the neck. Your {hit_location} separates cleanly. The body follows a moment later.",
+            'observer_msg': "{attacker_name} hacks straight through the neck. {target_name}'s {hit_location} separates cleanly. The body follows a moment later."
         },
         {
-            'attacker_msg': "You sink the hatchet deep into {target_name}'s torso. They fold around it, then slide off.",
-            'victim_msg': "{attacker_name} sinks the hatchet deep into your torso. You fold around it, then slide off.",
-            'observer_msg': "{attacker_name} sinks the hatchet deep into {target_name}'s torso. They fold around it, then slide off."
+            'attacker_msg': "You sink the hatchet deep into {target_name}'s {hit_location}. They fold around it, then slide off.",
+            'victim_msg': "{attacker_name} sinks the hatchet deep into your {hit_location}. You fold around it, then slide off.",
+            'observer_msg': "{attacker_name} sinks the hatchet deep into {target_name}'s {hit_location}. They fold around it, then slide off."
         },
         {
             'attacker_msg': "You split {target_name} cleanly from shoulder to opposite hip. They fall in precise halves.",
@@ -592,14 +592,14 @@ MESSAGES = {
             'observer_msg': "{attacker_name} splits {target_name} cleanly from shoulder to opposite hip. They fall in precise halves."
         },
         {
-            'attacker_msg': "You split {target_name}'s skull with a wet crack. Blood fountains. They topple backward.",
-            'victim_msg': "{attacker_name} splits your skull with a wet crack. Blood fountains. You topple backward.",
-            'observer_msg': "{attacker_name} splits {target_name}'s skull with a wet crack. Blood fountains. They topple backward."
+            'attacker_msg': "You split {target_name}'s {hit_location} with a wet crack. Blood fountains. They topple backward.",
+            'victim_msg': "{attacker_name} splits your {hit_location} with a wet crack. Blood fountains. You topple backward.",
+            'observer_msg': "{attacker_name} splits {target_name}'s {hit_location} with a wet crack. Blood fountains. They topple backward."
         },
         {
-            'attacker_msg': "You swing the hatchet in a wide arc that opens {target_name}'s throat completely. They gurgle once, then silence.",
-            'victim_msg': "{attacker_name} swings the hatchet in a wide arc that opens your throat completely. You gurgle once, then silence.",
-            'observer_msg': "{attacker_name} swings the hatchet in a wide arc that opens {target_name}'s throat completely. They gurgle once, then silence."
+            'attacker_msg': "You swing the hatchet in a wide arc that opens {target_name}'s {hit_location} completely. They gurgle once, then silence.",
+            'victim_msg': "{attacker_name} swings the hatchet in a wide arc that opens your {hit_location} completely. You gurgle once, then silence.",
+            'observer_msg': "{attacker_name} swings the hatchet in a wide arc that opens {target_name}'s {hit_location} completely. They gurgle once, then silence."
         },
         {
             'attacker_msg': "Your final blow cleaves {target_name} from crown to groin. They become two things that were once one.",
@@ -607,9 +607,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s final blow cleaves {target_name} from crown to groin. They become two things that were once one."
         },
         {
-            'attacker_msg': "Your final strike opens {target_name}'s chest like a door. Inside, everything has stopped working.",
-            'victim_msg': "{attacker_name}'s final strike opens your chest like a door. Inside, everything has stopped working.",
-            'observer_msg': "{attacker_name}'s final strike opens {target_name}'s chest like a door. Inside, everything has stopped working."
+            'attacker_msg': "Your final strike opens {target_name}'s {hit_location} like a door. Inside, everything has stopped working.",
+            'victim_msg': "{attacker_name}'s final strike opens your {hit_location} like a door. Inside, everything has stopped working.",
+            'observer_msg': "{attacker_name}'s final strike opens {target_name}'s {hit_location} like a door. Inside, everything has stopped working."
         }
     ]
 }

--- a/world/combat/messages/heavy_machine_gun.py
+++ b/world/combat/messages/heavy_machine_gun.py
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air itself seems to grow heavy as {attacker_name} prepares to fire the heavy machine gun, anticipating the bone-jarring *THUD-THUD-THUD* and the shockwaves."
         },
         {
-            'attacker_msg': "Your face is a grim mask of focus, thumbs or finger hovering over the butterfly trigger or heavy trigger of the HMG.",
+            'attacker_msg': "Your {hit_location} is a grim mask of focus, thumbs or finger hovering over the butterfly trigger or heavy trigger of the HMG.",
             'victim_msg': "{attacker_name}'s face is a grim mask of focus, thumbs or finger hovering over the butterfly trigger or heavy trigger of the HMG.",
             'observer_msg': "{attacker_name}'s face is a grim mask of focus, thumbs or finger hovering over the butterfly trigger or heavy trigger of the HMG."
         },
@@ -278,9 +278,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s heavy machine gun bullets make impact, leaving another catastrophic, instantly fatal series of punctures, if 'puncture' can describe the massive craters. A continuous stream of enormous spent casings hits the ground as the bolt cycles."
         },
         {
-            'attacker_msg': "A painful, echoing, ground-shaking series of cracks as bullets from your heavy machine gun strike {target_name}'s {hit_location}, which, along with most of their {hit_location} cavity, are instantly atomized by the multiple hits. You continue the burst, chambering more heavy, destructive rounds.",
-            'victim_msg': "A painful, echoing, ground-shaking series of cracks as bullets from {attacker_name}'s heavy machine gun strike your {hit_location}, which, along with most of your {hit_location} cavity, are instantly atomized by the multiple hits. {attacker_name} continues the burst, chambering more heavy, destructive rounds.",
-            'observer_msg': "A painful, echoing, ground-shaking series of cracks as bullets from {attacker_name}'s heavy machine gun strike {target_name}'s {hit_location}, which, along with most of their {hit_location} cavity, are instantly atomized by the multiple hits. {attacker_name} continues the burst, chambering more heavy, destructive rounds."
+            'attacker_msg': "A painful, echoing, ground-shaking series of cracks as bullets from your heavy machine gun strike {target_name}'s {hit_location}, which, along with most of their chest cavity, are instantly atomized by the multiple hits. You continue the burst, chambering more heavy, destructive rounds.",
+            'victim_msg': "A painful, echoing, ground-shaking series of cracks as bullets from {attacker_name}'s heavy machine gun strike your {hit_location}, which, along with most of your chest cavity, are instantly atomized by the multiple hits. {attacker_name} continues the burst, chambering more heavy, destructive rounds.",
+            'observer_msg': "A painful, echoing, ground-shaking series of cracks as bullets from {attacker_name}'s heavy machine gun strike {target_name}'s {hit_location}, which, along with most of their chest cavity, are instantly atomized by the multiple hits. {attacker_name} continues the burst, chambering more heavy, destructive rounds."
         },
         {
             'attacker_msg': "The projectiles from your heavy machine gun hit {target_name}'s {hit_location}; their entire upper {hit_location} explodes outward in a cloud of red under the sustained fire. The bolt cycles, ejecting casings with violent flicks.",
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     'miss': [
         {
-            'attacker_msg': "Your heavy machine gun fires with a deafening, earth-shattering *THOOM-THOOM-THOOM*, the massive bullets thundering past {target_name}'s head and blasting car-sized craters out of a distant concrete wall, showering the area with debris. You traverse slightly, empty links and smoking casings spewing from the ejection port.",
-            'victim_msg': "{attacker_name}'s heavy machine gun fires with a deafening, earth-shattering *THOOM-THOOM-THOOM*, the massive bullets thundering past your head and blasting car-sized craters out of a distant concrete wall, showering the area with debris. {attacker_name} traverses slightly, empty links and smoking casings spewing from the ejection port.",
-            'observer_msg': "{attacker_name}'s heavy machine gun fires with a deafening, earth-shattering *THOOM-THOOM-THOOM*, the massive bullets thundering past {target_name}'s head and blasting car-sized craters out of a distant concrete wall, showering the area with debris. {attacker_name} traverses slightly, empty links and smoking casings spewing from the ejection port."
+            'attacker_msg': "Your heavy machine gun fires with a deafening, earth-shattering *THOOM-THOOM-THOOM*, the massive bullets thundering past {target_name}'s {hit_location} and blasting car-sized craters out of a distant concrete wall, showering the area with debris. You traverse slightly, empty links and smoking casings spewing from the ejection port.",
+            'victim_msg': "{attacker_name}'s heavy machine gun fires with a deafening, earth-shattering *THOOM-THOOM-THOOM*, the massive bullets thundering past your {hit_location} and blasting car-sized craters out of a distant concrete wall, showering the area with debris. {attacker_name} traverses slightly, empty links and smoking casings spewing from the ejection port.",
+            'observer_msg': "{attacker_name}'s heavy machine gun fires with a deafening, earth-shattering *THOOM-THOOM-THOOM*, the massive bullets thundering past {target_name}'s {hit_location} and blasting car-sized craters out of a distant concrete wall, showering the area with debris. {attacker_name} traverses slightly, empty links and smoking casings spewing from the ejection port."
         },
         {
             'attacker_msg': "{target_name} flinches violently, ears ringing, as the heavy machine gun roars like a vengeful god, the stream of .50 caliber or larger bullets gouging deep, smoking trenches in the ground where they just stood, kicking up ten-foot plumes of earth. You fight the muzzle climb, adjusting the stream of fire.",
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} ducks, terrified, just as your heavy machine gun fires, the stream of bullets searing the air where their head had been with palpable force and a deafening sonic crack. You walk the fire across the target area, the ground still vibrating.",
-            'victim_msg': "You duck, terrified, just as {attacker_name}'s heavy machine gun fires, the stream of bullets searing the air where your head had been with palpable force and a deafening sonic crack. {attacker_name} walks the fire across the target area, the ground still vibrating.",
+            'victim_msg': "You duck, terrified, just as {attacker_name}'s heavy machine gun fires, the stream of bullets searing the air where your {hit_location} had been with palpable force and a deafening sonic crack. {attacker_name} walks the fire across the target area, the ground still vibrating.",
             'observer_msg': "{target_name} ducks, terrified, just as {attacker_name}'s heavy machine gun fires, the stream of bullets searing the air where their head had been with palpable force and a deafening sonic crack. {attacker_name} walks the fire across the target area, the ground still vibrating."
         },
         {
@@ -458,28 +458,28 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "Your heavy machine gun bullets strike {target_name} square in the forehead; their head, and indeed most of their upper body, simply explodes into a cloud of red mist and bone shrapnel under the sustained, brutal impacts, instantly obliterating them. You calmly cease fire, the barrel smoking, the job done.",
-            'victim_msg': "{attacker_name}'s heavy machine gun bullets strike you square in the forehead; your head, and indeed most of your upper body, simply explodes into a cloud of red mist and bone shrapnel under the sustained, brutal impacts, instantly obliterating you. {attacker_name} calmly ceases fire, the barrel smoking, the job done.",
+            'victim_msg': "{attacker_name}'s heavy machine gun bullets strike you square in the forehead; your {hit_location}, and indeed most of your upper body, simply explodes into a cloud of red mist and bone shrapnel under the sustained, brutal impacts, instantly obliterating you. {attacker_name} calmly ceases fire, the barrel smoking, the job done.",
             'observer_msg': "{attacker_name}'s heavy machine gun bullets strike {target_name} square in the forehead; their head, and indeed most of their upper body, simply explodes into a cloud of red mist and bone shrapnel under the sustained, brutal impacts, instantly obliterating them. {attacker_name} calmly ceases fire, the barrel smoking, the job done."
         },
         {
             'attacker_msg': "The heavy machine gun roars like an artillery piece, and {target_name} clutches their chest as a massive, gaping hole appears from multiple impacts, their entire torso erupting outwards before they collapse, utterly destroyed. You smoothly traverse to the next target, the HMG ready again.",
-            'victim_msg': "The heavy machine gun roars like an artillery piece, and you clutch your chest as a massive, gaping hole appears from multiple impacts, your entire torso erupting outwards before you collapse, utterly destroyed. {attacker_name} smoothly traverses to the next target, the HMG ready again.",
+            'victim_msg': "The heavy machine gun roars like an artillery piece, and you clutch your {hit_location} as a massive, gaping hole appears from multiple impacts, your entire torso erupting outwards before you collapse, utterly destroyed. {attacker_name} smoothly traverses to the next target, the HMG ready again.",
             'observer_msg': "The heavy machine gun roars like an artillery piece, and {target_name} clutches their chest as a massive, gaping hole appears from multiple impacts, their entire torso erupting outwards before they collapse, utterly destroyed. {attacker_name} smoothly traverses to the next target, the HMG ready again."
         },
         {
-            'attacker_msg': "With a final, precise burst, your heavy machine gun sends a stream of heavy, armor-piercing bullets through {target_name}'s heart; their body is torn apart by the hydrostatic shock of multiple impacts, ending their struggles catastrophically and instantly. A stream of huge brass casings clatters out.",
-            'victim_msg': "With a final, precise burst, {attacker_name}'s heavy machine gun sends a stream of heavy, armor-piercing bullets through your heart; your body is torn apart by the hydrostatic shock of multiple impacts, ending your struggles catastrophically and instantly. A stream of huge brass casings clatters out.",
-            'observer_msg': "With a final, precise burst, {attacker_name}'s heavy machine gun sends a stream of heavy, armor-piercing bullets through {target_name}'s heart; their body is torn apart by the hydrostatic shock of multiple impacts, ending their struggles catastrophically and instantly. A stream of huge brass casings clatters out."
+            'attacker_msg': "With a final, precise burst, your heavy machine gun sends a stream of heavy, armor-piercing bullets through {target_name}'s {hit_location}; their body is torn apart by the hydrostatic shock of multiple impacts, ending their struggles catastrophically and instantly. A stream of huge brass casings clatters out.",
+            'victim_msg': "With a final, precise burst, {attacker_name}'s heavy machine gun sends a stream of heavy, armor-piercing bullets through your {hit_location}; your body is torn apart by the hydrostatic shock of multiple impacts, ending your struggles catastrophically and instantly. A stream of huge brass casings clatters out.",
+            'observer_msg': "With a final, precise burst, {attacker_name}'s heavy machine gun sends a stream of heavy, armor-piercing bullets through {target_name}'s {hit_location}; their body is torn apart by the hydrostatic shock of multiple impacts, ending their struggles catastrophically and instantly. A stream of huge brass casings clatters out."
         },
         {
-            'attacker_msg': "The stream of massive bullets fired point-blank into {target_name}'s throat from the heavy machine gun nearly severs their head and continues on to obliterate whatever was behind them; they die in a horrific, explosive spray of gore. You release the trigger, the belt feeding smoothly to a stop.",
-            'victim_msg': "The stream of massive bullets fired point-blank into your throat from the heavy machine gun nearly severs your head and continues on to obliterate whatever was behind you; you die in a horrific, explosive spray of gore. {attacker_name} releases the trigger, the belt feeding smoothly to a stop.",
-            'observer_msg': "The stream of massive bullets fired point-blank into {target_name}'s throat from the heavy machine gun nearly severs their head and continues on to obliterate whatever was behind them; they die in a horrific, explosive spray of gore. {attacker_name} releases the trigger, the belt feeding smoothly to a stop."
+            'attacker_msg': "The stream of massive bullets fired point-blank into {target_name}'s {hit_location} from the heavy machine gun nearly severs their head and continues on to obliterate whatever was behind them; they die in a horrific, explosive spray of gore. You release the trigger, the belt feeding smoothly to a stop.",
+            'victim_msg': "The stream of massive bullets fired point-blank into your {hit_location} from the heavy machine gun nearly severs your {hit_location} and continues on to obliterate whatever was behind you; you die in a horrific, explosive spray of gore. {attacker_name} releases the trigger, the belt feeding smoothly to a stop.",
+            'observer_msg': "The stream of massive bullets fired point-blank into {target_name}'s {hit_location} from the heavy machine gun nearly severs their head and continues on to obliterate whatever was behind them; they die in a horrific, explosive spray of gore. {attacker_name} releases the trigger, the belt feeding smoothly to a stop."
         },
         {
-            'attacker_msg': "Your carefully placed burst with the heavy machine gun tears through {target_name}'s spine and out the other side with multiple impacts, taking most of their internal organs with it; they slump, a lifeless, eviscerated puppet. The bolt cycles with relentless, heavy thuds, then silence.",
-            'victim_msg': "{attacker_name}'s carefully placed burst with the heavy machine gun tears through your spine and out the other side with multiple impacts, taking most of your internal organs with it; you slump, a lifeless, eviscerated puppet. The bolt cycles with relentless, heavy thuds, then silence.",
-            'observer_msg': "{attacker_name}'s carefully placed burst with the heavy machine gun tears through {target_name}'s spine and out the other side with multiple impacts, taking most of their internal organs with it; they slump, a lifeless, eviscerated puppet. The bolt cycles with relentless, heavy thuds, then silence."
+            'attacker_msg': "Your carefully placed burst with the heavy machine gun tears through {target_name}'s {hit_location} and out the other side with multiple impacts, taking most of their internal organs with it; they slump, a lifeless, eviscerated puppet. The bolt cycles with relentless, heavy thuds, then silence.",
+            'victim_msg': "{attacker_name}'s carefully placed burst with the heavy machine gun tears through your {hit_location} and out the other side with multiple impacts, taking most of your internal organs with it; you slump, a lifeless, eviscerated puppet. The bolt cycles with relentless, heavy thuds, then silence.",
+            'observer_msg': "{attacker_name}'s carefully placed burst with the heavy machine gun tears through {target_name}'s {hit_location} and out the other side with multiple impacts, taking most of their internal organs with it; they slump, a lifeless, eviscerated puppet. The bolt cycles with relentless, heavy thuds, then silence."
         },
         {
             'attacker_msg': "The heavy machine gun, an instrument of precise, overwhelming death, delivers a killing blow as {target_name} is overcome by the catastrophic, explosive bullet wounds from the sustained fire, their form ceasing to resemble anything human. You scan for other threats, the HMG still hot.",
@@ -492,9 +492,9 @@ MESSAGES = {
             'observer_msg': "A precise burst to the base of the skull from {attacker_name}'s heavy machine gun vaporizes the target area and a significant portion of the surrounding anatomy with multiple impacts, ending {target_name}'s life with absolute, gory finality. {attacker_name} continues firing for a second, ensuring total destruction."
         },
         {
-            'attacker_msg': "Your sustained burst from the heavy machine gun pierces {target_name}'s lung; the resulting cavitation from multiple large-caliber rounds blows their chest cavity apart, and they collapse, dying swiftly and messily. A river of massive spent casings is ejected as you maintain fire until {target_name} is still.",
-            'victim_msg': "{attacker_name}'s sustained burst from the heavy machine gun pierces your lung; the resulting cavitation from multiple large-caliber rounds blows your chest cavity apart, and you collapse, dying swiftly and messily. A river of massive spent casings is ejected as {attacker_name} maintains fire until you are still.",
-            'observer_msg': "{attacker_name}'s sustained burst from the heavy machine gun pierces {target_name}'s lung; the resulting cavitation from multiple large-caliber rounds blows their chest cavity apart, and they collapse, dying swiftly and messily. A river of massive spent casings is ejected as {attacker_name} maintains fire until {target_name} is still."
+            'attacker_msg': "Your sustained burst from the heavy machine gun pierces {target_name}'s {hit_location}; the resulting cavitation from multiple large-caliber rounds blows their chest cavity apart, and they collapse, dying swiftly and messily. A river of massive spent casings is ejected as you maintain fire until {target_name} is still.",
+            'victim_msg': "{attacker_name}'s sustained burst from the heavy machine gun pierces your {hit_location}; the resulting cavitation from multiple large-caliber rounds blows your chest cavity apart, and you collapse, dying swiftly and messily. A river of massive spent casings is ejected as {attacker_name} maintains fire until you are still.",
+            'observer_msg': "{attacker_name}'s sustained burst from the heavy machine gun pierces {target_name}'s {hit_location}; the resulting cavitation from multiple large-caliber rounds blows their chest cavity apart, and they collapse, dying swiftly and messily. A river of massive spent casings is ejected as {attacker_name} maintains fire until {target_name} is still."
         },
         {
             'attacker_msg': "The unyielding, armor-piercing slugs from your heavy machine gun pierce a vital organ in {target_name}, which ruptures with explosive force from the multiple impacts, tearing them apart from the inside; they fall, dead before they hit the ground, or what's left of them does. Hot, oversized casings are ejected in a continuous stream.",
@@ -503,7 +503,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "With a final, thunderous, concussive roar, you finish {target_name} with a stream of heavy bullets through the eye from the heavy machine gun; the back of their skull, and much of the wall behind them, erupts outwards. The bolt cycles with smooth, powerful, and terrifying efficiency, then stops.",
-            'victim_msg': "With a final, thunderous, concussive roar, {attacker_name} finishes you with a stream of heavy bullets through the eye from the heavy machine gun; the back of your skull, and much of the wall behind you, erupts outwards. The bolt cycles with smooth, powerful, and terrifying efficiency, then stops.",
+            'victim_msg': "With a final, thunderous, concussive roar, {attacker_name} finishes you with a stream of heavy bullets through the eye from the heavy machine gun; the back of your {hit_location}, and much of the wall behind you, erupts outwards. The bolt cycles with smooth, powerful, and terrifying efficiency, then stops.",
             'observer_msg': "With a final, thunderous, concussive roar, {attacker_name} finishes {target_name} with a stream of heavy bullets through the eye from the heavy machine gun; the back of their skull, and much of the wall behind them, erupts outwards. The bolt cycles with smooth, powerful, and terrifying efficiency, then stops."
         },
         {

--- a/world/combat/messages/heavy_pistol.py
+++ b/world/combat/messages/heavy_pistol.py
@@ -11,12 +11,12 @@ MESSAGES = {
             "observer_msg": "With a deliberate, forceful motion, {attacker_name} slams a magazine of large-caliber rounds into the pistol, the weapon's weight evident."
         },
         {
-            "attacker_msg": "Your hand struggles slightly to encompass the wide grip of your pistol, thumbing off the stiff safety with a loud *CLICK*.",
+            "attacker_msg": "Your {hit_location} struggles slightly to encompass the wide grip of your pistol, thumbing off the stiff safety with a loud *CLICK*.",
             "victim_msg": "{attacker_name}'s hand struggles slightly to encompass the wide grip of their pistol, thumbing off the stiff safety with a loud *CLICK*.",
             "observer_msg": "{attacker_name}'s hand struggles slightly to encompass the wide grip of the pistol, thumbing off the stiff safety with a loud *CLICK*."
         },
         {
-            "attacker_msg": "The pistol that appears in your hand is a beast, its large-bore muzzle a dark, terrifying void.",
+            "attacker_msg": "The pistol that appears in your {hit_location} is a beast, its large-bore muzzle a dark, terrifying void.",
             "victim_msg": "The pistol that appears in {attacker_name}'s hand is a beast, its large-bore muzzle a dark, terrifying void, and it seems to be pointed at you.",
             "observer_msg": "The pistol that appears in {attacker_name}'s hand is a beast, its large-bore muzzle a dark, terrifying void."
         },
@@ -61,7 +61,7 @@ MESSAGES = {
             "observer_msg": "The air seems to thicken with tension as {attacker_name} prepares to fire the pistol, anticipating the deafening *BOOM* and violent kick."
         },
         {
-            "attacker_msg": "Your face is a mask of grim concentration, finger deliberately taking up your pistol's long, heavy trigger pull.",
+            "attacker_msg": "Your {hit_location} is a mask of grim concentration, finger deliberately taking up your pistol's long, heavy trigger pull.",
             "victim_msg": "{attacker_name}’s face is a mask of grim concentration, finger deliberately taking up the pistol's long, heavy trigger pull, aimed at you.",
             "observer_msg": "{attacker_name}’s face is a mask of grim concentration, finger deliberately taking up the pistol's long, heavy trigger pull."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            "attacker_msg": "Your pistol erupts with a deafening *KABLAM*, the heavy bullet thundering past {target_name}'s head and blasting a car-sized chunk out of a concrete wall, a large casing ejecting with force.",
-            "victim_msg": "{attacker_name}'s pistol erupts with a deafening *KABLAM*, the heavy bullet thundering past your head and blasting a car-sized chunk out of a concrete wall! A large casing ejects with force.",
-            "observer_msg": "{attacker_name}'s pistol erupts with a deafening *KABLAM*, the heavy bullet thundering past {target_name}'s head and blasting a car-sized chunk out of a concrete wall, a large casing ejecting with force."
+            "attacker_msg": "Your pistol erupts with a deafening *KABLAM*, the heavy bullet thundering past {target_name}'s {hit_location} and blasting a car-sized chunk out of a concrete wall, a large casing ejecting with force.",
+            "victim_msg": "{attacker_name}'s pistol erupts with a deafening *KABLAM*, the heavy bullet thundering past your {hit_location} and blasting a car-sized chunk out of a concrete wall! A large casing ejects with force.",
+            "observer_msg": "{attacker_name}'s pistol erupts with a deafening *KABLAM*, the heavy bullet thundering past {target_name}'s {hit_location} and blasting a car-sized chunk out of a concrete wall, a large casing ejecting with force."
         },
         {
             "attacker_msg": "You fire, but {target_name} throws themselves aside with a yell as your pistol roars like artillery, the bullet gouging a deep, smoking furrow in the ground where they just stood, the slide cycling violently.",
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "{target_name} ducks just as your pistol fires, the bullet searing the air where their head had been with palpable, burning force, the action cycling with a heavy *thump*.",
-            "victim_msg": "You duck just as {attacker_name}'s pistol fires, the bullet searing the air where your head had been with palpable, burning force, the action cycling with a heavy *thump*.",
+            "victim_msg": "You duck just as {attacker_name}'s pistol fires, the bullet searing the air where your {hit_location} had been with palpable, burning force, the action cycling with a heavy *thump*.",
             "observer_msg": "{target_name} ducks just as {attacker_name}'s pistol fires, the bullet searing the air where their head had been with palpable, burning force, the action cycling with a heavy *thump*."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             "observer_msg": "A quick sidestep from {target_name} leaves {attacker_name}'s pistol to punch a massive, ragged hole in an empty oil drum, which visibly deforms from the impact, brass ejecting."
         },
         {
-            "attacker_msg": "Your pistol bucks violently and almost uncontrollably in your hand as you miss {target_name}, the powerful recoil throwing your arm sharply upwards, nearly hitting you in the face.",
+            "attacker_msg": "Your pistol bucks violently and almost uncontrollably in your {hit_location} as you miss {target_name}, the powerful recoil throwing your {hit_location} sharply upwards, nearly hitting you in the face.",
             "victim_msg": "{attacker_name}'s pistol bucks violently and almost uncontrollably in their hand as they miss you, the powerful recoil throwing their arm sharply upwards, nearly hitting them in the face.",
             "observer_msg": "{attacker_name}'s pistol bucks violently and almost uncontrollably in their hand as they miss {target_name}, the powerful recoil throwing their arm sharply upwards, nearly hitting them in the face."
         },
@@ -458,23 +458,23 @@ MESSAGES = {
     "kill": [
         {
             "attacker_msg": "Your pistol bullet strikes {target_name} square in the forehead; their head explodes in a catastrophic shower of gore, bone, and brain matter, and they drop, instantly obliterated. A final large casing ejects with a heavy *ping*.",
-            "victim_msg": "{attacker_name}'s pistol bullet strikes you square in the forehead; your head explodes in a catastrophic shower of gore, bone, and brain matter. You drop, instantly obliterated... Darkness claims you.",
+            "victim_msg": "{attacker_name}'s pistol bullet strikes you square in the forehead; your {hit_location} explodes in a catastrophic shower of gore, bone, and brain matter. You drop, instantly obliterated... Darkness claims you.",
             "observer_msg": "{attacker_name}'s pistol bullet strikes {target_name} square in the forehead; their head explodes in a catastrophic shower of gore, bone, and brain matter, and they drop, instantly obliterated, a final large casing ejecting with a heavy *ping*."
         },
         {
             "attacker_msg": "Your pistol roars like a vengeful god, and {target_name} clutches their chest as a massive, smoking hole appears, blood fountaining before they collapse, utterly destroyed. The slide locks back with a heavy, final *CLUNK*.",
-            "victim_msg": "{attacker_name}'s pistol roars like a vengeful god! You clutch your chest as a massive, smoking hole appears, blood fountaining before you collapse, utterly destroyed... It's over.",
+            "victim_msg": "{attacker_name}'s pistol roars like a vengeful god! You clutch your {hit_location} as a massive, smoking hole appears, blood fountaining before you collapse, utterly destroyed... It's over.",
             "observer_msg": "{attacker_name}'s pistol roars like a vengeful god, and {target_name} clutches their chest as a massive, smoking hole appears, blood fountaining before they collapse, utterly destroyed, the slide locking back with a heavy, final *CLUNK*."
         },
         {
-            "attacker_msg": "With a final, precise shot, your pistol sends a large bullet into {target_name}'s heart, which bursts like an overripe fruit, ending their struggles catastrophically and instantly, a heavy casing tinkling on the floor.",
-            "victim_msg": "With a final, precise shot, {attacker_name}'s pistol sends a large bullet into your heart, which bursts like an overripe fruit, ending your struggles catastrophically and instantly. You are slain.",
-            "observer_msg": "With a final, precise shot, {attacker_name}'s pistol sends a large bullet into {target_name}'s heart, which bursts like an overripe fruit, ending their struggles catastrophically and instantly, a heavy casing tinkling on the floor."
+            "attacker_msg": "With a final, precise shot, your pistol sends a large bullet into {target_name}'s {hit_location}, which bursts like an overripe fruit, ending their struggles catastrophically and instantly, a heavy casing tinkling on the floor.",
+            "victim_msg": "With a final, precise shot, {attacker_name}'s pistol sends a large bullet into your {hit_location}, which bursts like an overripe fruit, ending your struggles catastrophically and instantly. You are slain.",
+            "observer_msg": "With a final, precise shot, {attacker_name}'s pistol sends a large bullet into {target_name}'s {hit_location}, which bursts like an overripe fruit, ending their struggles catastrophically and instantly, a heavy casing tinkling on the floor."
         },
         {
-            "attacker_msg": "The heavy bullet fired point-blank into {target_name}'s throat from your pistol nearly decapitates them; they die in a horrific, gushing spray of blood, the slide cycling violently and ejecting a smoking shell.",
-            "victim_msg": "The heavy bullet fired point-blank into your throat from {attacker_name}'s pistol nearly decapitates you; you die in a horrific, gushing spray of blood. Your life fades...",
-            "observer_msg": "The heavy bullet fired point-blank into {target_name}'s throat from {attacker_name}'s pistol nearly decapitates them; they die in a horrific, gushing spray of blood, the slide cycling violently and ejecting a smoking shell."
+            "attacker_msg": "The heavy bullet fired point-blank into {target_name}'s {hit_location} from your pistol nearly decapitates them; they die in a horrific, gushing spray of blood, the slide cycling violently and ejecting a smoking shell.",
+            "victim_msg": "The heavy bullet fired point-blank into your {hit_location} from {attacker_name}'s pistol nearly decapitates you; you die in a horrific, gushing spray of blood. Your life fades...",
+            "observer_msg": "The heavy bullet fired point-blank into {target_name}'s {hit_location} from {attacker_name}'s pistol nearly decapitates them; they die in a horrific, gushing spray of blood, the slide cycling violently and ejecting a smoking shell."
         },
         {
             "attacker_msg": "Your sustained fire with the pistol tears {target_name} apart piece by piece; they slump, a mangled, unrecognizable, lifeless ruin, spent large brass scattered around like fallen monuments.",
@@ -488,13 +488,13 @@ MESSAGES = {
         },
         {
             "attacker_msg": "A precise shot to the base of the skull from your pistol vaporizes the target area, sending a shockwave through their body, ending {target_name}'s life with absolute, brutal finality, the slide moving with grim force.",
-            "victim_msg": "A precise shot to the base of your skull from {attacker_name}'s pistol vaporizes the target area, sending a shockwave through your body, ending your life with absolute, brutal finality. You are dead.",
+            "victim_msg": "A precise shot to the base of your {hit_location} from {attacker_name}'s pistol vaporizes the target area, sending a shockwave through your body, ending your life with absolute, brutal finality. You are dead.",
             "observer_msg": "A precise shot to the base of the skull from {attacker_name}'s pistol vaporizes the target area, sending a shockwave through their body, ending {target_name}'s life with absolute, brutal finality, the slide moving with grim force."
         },
         {
-            "attacker_msg": "You empty your pistol's magazine into {target_name}'s torso, the multiple massive, concussive impacts ensuring a swift, brutal, and messy obliteration, the slide locking open with a resounding *CLACK*.",
-            "victim_msg": "{attacker_name} empties their pistol's magazine into your torso, the multiple massive, concussive impacts ensuring your swift, brutal, and messy obliteration. Darkness envelops you.",
-            "observer_msg": "{attacker_name} empties the pistol's magazine into {target_name}'s torso, the multiple massive, concussive impacts ensuring a swift, brutal, and messy obliteration, the slide locking open with a resounding *CLACK*."
+            "attacker_msg": "You empty your pistol's magazine into {target_name}'s {hit_location}, the multiple massive, concussive impacts ensuring a swift, brutal, and messy obliteration, the slide locking open with a resounding *CLACK*.",
+            "victim_msg": "{attacker_name} empties their pistol's magazine into your {hit_location}, the multiple massive, concussive impacts ensuring your swift, brutal, and messy obliteration. Darkness envelops you.",
+            "observer_msg": "{attacker_name} empties the pistol's magazine into {target_name}'s {hit_location}, the multiple massive, concussive impacts ensuring a swift, brutal, and messy obliteration, the slide locking open with a resounding *CLACK*."
         },
         {
             "attacker_msg": "The unyielding, massive slug from your pistol pierces a vital organ in {target_name}, which ruptures explosively; they fall, dead before they hit the ground, a heavy casing spinning and clattering.",
@@ -503,7 +503,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "With a final, thunderous crack that echoes through the area, you finish {target_name} with a heavy bullet through the eye from your pistol, the back of their skull erupting in a spray of red mist, the slide cycling one last, brutal time.",
-            "victim_msg": "With a final, thunderous crack that echoes through the area, {attacker_name} finishes you with a heavy bullet through the eye from their pistol, the back of your skull erupting in a spray of red mist. You have perished.",
+            "victim_msg": "With a final, thunderous crack that echoes through the area, {attacker_name} finishes you with a heavy bullet through the eye from their pistol, the back of your {hit_location} erupting in a spray of red mist. You have perished.",
             "observer_msg": "With a final, thunderous crack that echoes through the area, {attacker_name} finishes {target_name} with a heavy bullet through the eye from the pistol, the back of their skull erupting in a spray of red mist, the slide cycling one last, brutal time."
         },
         {

--- a/world/combat/messages/heavy_revolver.py
+++ b/world/combat/messages/heavy_revolver.py
@@ -11,12 +11,12 @@ MESSAGES = {
             'observer_msg': "With a deliberate motion, {attacker_name} spins the massive cylinder of the revolver, its chambers holding potent rounds."
         },
         {
-            'attacker_msg': "Your hand grips the substantial frame of the revolver, thumbing back the heavy hammer with a loud, authoritative *CLICK*.",
+            'attacker_msg': "Your {hit_location} grips the substantial frame of the revolver, thumbing back the heavy hammer with a loud, authoritative *CLICK*.",
             'victim_msg': "{attacker_name}'s hand grips the substantial frame of the revolver, thumbing back the heavy hammer with a loud, authoritative *CLICK*.",
             'observer_msg': "{attacker_name}'s hand grips the substantial frame of the revolver, thumbing back the heavy hammer with a loud, authoritative *CLICK*."
         },
         {
-            'attacker_msg': "The formidable revolver appears in your hand, its oversized muzzle a dark promise of destruction.",
+            'attacker_msg': "The formidable revolver appears in your {hit_location}, its oversized muzzle a dark promise of destruction.",
             'victim_msg': "The formidable revolver appears in {attacker_name}'s hand, its oversized muzzle a dark promise of destruction.",
             'observer_msg': "The formidable revolver appears in {attacker_name}'s hand, its oversized muzzle a dark promise of destruction."
         },
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air seems to crackle with tension as {attacker_name} prepares to fire the revolver, anticipating the deafening roar."
         },
         {
-            'attacker_msg': "Your face is set in grim concentration, finger deliberately taking up the slack on the revolver's trigger.",
+            'attacker_msg': "Your {hit_location} is set in grim concentration, finger deliberately taking up the slack on the revolver's trigger.",
             'victim_msg': "{attacker_name}'s face is set in grim concentration, finger deliberately taking up the slack on the revolver's trigger.",
             'observer_msg': "{attacker_name}'s face is set in grim concentration, finger deliberately taking up the slack on the revolver's trigger."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     'miss': [
         {
-            'attacker_msg': "Your revolver erupts with a deafening *BOOM*, the heavy bullet thundering past {target_name}'s head and blasting a chunk out of a concrete wall.",
-            'victim_msg': "{attacker_name}'s revolver erupts with a deafening *BOOM*, the heavy bullet thundering past your head and blasting a chunk out of a concrete wall.",
-            'observer_msg': "{attacker_name}'s revolver erupts with a deafening *BOOM*, the heavy bullet thundering past {target_name}'s head and blasting a chunk out of a concrete wall."
+            'attacker_msg': "Your revolver erupts with a deafening *BOOM*, the heavy bullet thundering past {target_name}'s {hit_location} and blasting a chunk out of a concrete wall.",
+            'victim_msg': "{attacker_name}'s revolver erupts with a deafening *BOOM*, the heavy bullet thundering past your {hit_location} and blasting a chunk out of a concrete wall.",
+            'observer_msg': "{attacker_name}'s revolver erupts with a deafening *BOOM*, the heavy bullet thundering past {target_name}'s {hit_location} and blasting a chunk out of a concrete wall."
         },
         {
             'attacker_msg': "{target_name} throws themselves aside as the revolver roars, the bullet gouging a deep furrow in the ground where they just stood.",
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} ducks just as your revolver fires, the bullet searing the air where their head had been with palpable force.",
-            'victim_msg': "You duck just as {attacker_name}'s revolver fires, the bullet searing the air where your head had been with palpable force.",
+            'victim_msg': "You duck just as {attacker_name}'s revolver fires, the bullet searing the air where your {hit_location} had been with palpable force.",
             'observer_msg': "{target_name} ducks just as {attacker_name}'s revolver fires, the bullet searing the air where their head had been with palpable force."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick sidestep from {target_name} leaves {attacker_name}'s revolver to punch a massive hole in an empty oil drum."
         },
         {
-            'attacker_msg': "The heavy revolver bucks violently in your hand as you miss, the powerful recoil throwing your arm upwards.",
+            'attacker_msg': "The heavy revolver bucks violently in your {hit_location} as you miss, the powerful recoil throwing your {hit_location} upwards.",
             'victim_msg': "The heavy revolver bucks violently in {attacker_name}'s hand as they miss, the powerful recoil throwing their arm upwards.",
             'observer_msg': "The heavy revolver bucks violently in {attacker_name}'s hand as they miss, the powerful recoil throwing their arm upwards."
         },
@@ -458,23 +458,23 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "Your revolver bullet strikes {target_name} square in the forehead; their head explodes in a shower of gore, and they drop, instantly obliterated.",
-            'victim_msg': "{attacker_name}'s revolver bullet strikes you square in the forehead; your head explodes in a shower of gore, and you drop, instantly obliterated.",
+            'victim_msg': "{attacker_name}'s revolver bullet strikes you square in the forehead; your {hit_location} explodes in a shower of gore, and you drop, instantly obliterated.",
             'observer_msg': "{attacker_name}'s revolver bullet strikes {target_name} square in the forehead; their head explodes in a shower of gore, and they drop, instantly obliterated."
         },
         {
             'attacker_msg': "The revolver roars, and {target_name} clutches their chest as a massive hole appears, blood fountaining before they collapse, dead.",
-            'victim_msg': "The revolver roars, and you clutch your chest as a massive hole appears, blood fountaining before you collapse, dead.",
+            'victim_msg': "The revolver roars, and you clutch your {hit_location} as a massive hole appears, blood fountaining before you collapse, dead.",
             'observer_msg': "The revolver roars, and {target_name} clutches their chest as a massive hole appears, blood fountaining before they collapse, dead."
         },
         {
-            'attacker_msg': "With a final, precise shot, your revolver sends a heavy bullet into {target_name}'s heart, which bursts, ending their struggles catastrophically.",
-            'victim_msg': "With a final, precise shot, {attacker_name}'s revolver sends a heavy bullet into your heart, which bursts, ending your struggles catastrophically.",
-            'observer_msg': "With a final, precise shot, {attacker_name}'s revolver sends a heavy bullet into {target_name}'s heart, which bursts, ending their struggles catastrophically."
+            'attacker_msg': "With a final, precise shot, your revolver sends a heavy bullet into {target_name}'s {hit_location}, which bursts, ending their struggles catastrophically.",
+            'victim_msg': "With a final, precise shot, {attacker_name}'s revolver sends a heavy bullet into your {hit_location}, which bursts, ending your struggles catastrophically.",
+            'observer_msg': "With a final, precise shot, {attacker_name}'s revolver sends a heavy bullet into {target_name}'s {hit_location}, which bursts, ending their struggles catastrophically."
         },
         {
-            'attacker_msg': "The heavy bullet fired point-blank into {target_name}'s throat from the revolver nearly decapitates them; they die in a horrific spray of blood.",
-            'victim_msg': "The heavy bullet fired point-blank into your throat from the revolver nearly decapitates you; you die in a horrific spray of blood.",
-            'observer_msg': "The heavy bullet fired point-blank into {target_name}'s throat from the revolver nearly decapitates them; they die in a horrific spray of blood."
+            'attacker_msg': "The heavy bullet fired point-blank into {target_name}'s {hit_location} from the revolver nearly decapitates them; they die in a horrific spray of blood.",
+            'victim_msg': "The heavy bullet fired point-blank into your {hit_location} from the revolver nearly decapitates you; you die in a horrific spray of blood.",
+            'observer_msg': "The heavy bullet fired point-blank into {target_name}'s {hit_location} from the revolver nearly decapitates them; they die in a horrific spray of blood."
         },
         {
             'attacker_msg': "Your sustained fire with the heavy revolver tears {target_name} apart; they slump, a mangled, lifeless ruin.",
@@ -492,9 +492,9 @@ MESSAGES = {
             'observer_msg': "A precise shot to the base of the skull from {attacker_name}'s heavy revolver vaporizes the target area, ending {target_name}'s life with absolute finality."
         },
         {
-            'attacker_msg': "You empty the revolver's cylinder into {target_name}'s torso, the multiple massive impacts ensuring a swift, brutal, and messy death.",
-            'victim_msg': "{attacker_name} empties the revolver's cylinder into your torso, the multiple massive impacts ensuring a swift, brutal, and messy death.",
-            'observer_msg': "{attacker_name} empties the revolver's cylinder into {target_name}'s torso, the multiple massive impacts ensuring a swift, brutal, and messy death."
+            'attacker_msg': "You empty the revolver's cylinder into {target_name}'s {hit_location}, the multiple massive impacts ensuring a swift, brutal, and messy death.",
+            'victim_msg': "{attacker_name} empties the revolver's cylinder into your {hit_location}, the multiple massive impacts ensuring a swift, brutal, and messy death.",
+            'observer_msg': "{attacker_name} empties the revolver's cylinder into {target_name}'s {hit_location}, the multiple massive impacts ensuring a swift, brutal, and messy death."
         },
         {
             'attacker_msg': "The unyielding heavy slug from your revolver pierces a vital organ in {target_name}, which ruptures; they fall, dead before they hit the ground.",
@@ -503,7 +503,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "With a final, thunderous crack, you finish {target_name} with a heavy bullet through the eye from the revolver, the back of their skull erupting.",
-            'victim_msg': "With a final, thunderous crack, {attacker_name} finishes you with a heavy bullet through the eye from the revolver, the back of your skull erupting.",
+            'victim_msg': "With a final, thunderous crack, {attacker_name} finishes you with a heavy bullet through the eye from the revolver, the back of your {hit_location} erupting.",
             'observer_msg': "With a final, thunderous crack, {attacker_name} finishes {target_name} with a heavy bullet through the eye from the revolver, the back of their skull erupting."
         },
         {

--- a/world/combat/messages/ice_pick.py
+++ b/world/combat/messages/ice_pick.py
@@ -36,7 +36,7 @@ MESSAGES = {
             'observer_msg': "A soft glint and the ice pick appears in {attacker_name}'s grip, cold and deliberate."
         },
         {
-            'attacker_msg': "You roll your wrist lazily, the pick spinning into position like it remembers the last kill.",
+            'attacker_msg': "You roll your {hit_location} lazily, the pick spinning into position like it remembers the last kill.",
             'victim_msg': "{attacker_name} rolls their wrist lazily, the pick spinning into position like it remembers the last kill.",
             'observer_msg': "{attacker_name} rolls their wrist lazily, the pick spinning into position like it remembers the last kill."
         },
@@ -91,7 +91,7 @@ MESSAGES = {
             'observer_msg': "The weapon isn't flashy. Just deadly. {attacker_name} lifts it like it's nothing—and everything."
         },
         {
-            'attacker_msg': "The pick twitches in your hand, an extension of your thoughts—sharp ones.",
+            'attacker_msg': "The pick twitches in your {hit_location}, an extension of your thoughts—sharp ones.",
             'victim_msg': "The pick twitches in {attacker_name}'s hand, an extension of their thoughts—sharp ones.",
             'observer_msg': "The pick twitches in {attacker_name}'s hand, an extension of their thoughts—sharp ones."
         },
@@ -141,7 +141,7 @@ MESSAGES = {
             'observer_msg': "There's no noise except the slight 'ting' as the pick hits a belt buckle on its way out."
         },
         {
-            'attacker_msg': "Your face softens—like an artist before a masterpiece. The pick is your brush.",
+            'attacker_msg': "Your {hit_location} softens—like an artist before a masterpiece. The pick is your brush.",
             'victim_msg': "{attacker_name}'s face softens—like an artist before a masterpiece. The pick is their brush.",
             'observer_msg': "{attacker_name}'s face softens—like an artist before a masterpiece. The pick is their brush."
         },
@@ -325,12 +325,12 @@ MESSAGES = {
             'observer_msg': "The pick snaps through open space. {target_name} spins away like smoke."
         },
         {
-            'attacker_msg': "A tight jab skims past {target_name}'s ribs—no purchase, just a whisper of death denied.",
-            'victim_msg': "A tight jab skims past your ribs—no purchase, just a whisper of death denied.",
-            'observer_msg': "A tight jab skims past {target_name}'s ribs—no purchase, just a whisper of death denied."
+            'attacker_msg': "A tight jab skims past {target_name}'s {hit_location}—no purchase, just a whisper of death denied.",
+            'victim_msg': "A tight jab skims past your {hit_location}—no purchase, just a whisper of death denied.",
+            'observer_msg': "A tight jab skims past {target_name}'s {hit_location}—no purchase, just a whisper of death denied."
         },
         {
-            'attacker_msg': "Your wrist flicks, but {target_name} has already ducked beneath the strike.",
+            'attacker_msg': "Your {hit_location} flicks, but {target_name} has already ducked beneath the strike.",
             'victim_msg': "{attacker_name}'s wrist flicks, but you have already ducked beneath the strike.",
             'observer_msg': "{attacker_name}'s wrist flicks, but {target_name} has already ducked beneath the strike."
         },
@@ -355,9 +355,9 @@ MESSAGES = {
             'observer_msg': "The jab goes wide, {target_name} stepping back with a grin."
         },
         {
-            'attacker_msg': "You overextend and the pick whistles past {target_name}'s shoulder.",
-            'victim_msg': "{attacker_name} overextends and the pick whistles past your shoulder.",
-            'observer_msg': "{attacker_name} overextends and the pick whistles past {target_name}'s shoulder."
+            'attacker_msg': "You overextend and the pick whistles past {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name} overextends and the pick whistles past your {hit_location}.",
+            'observer_msg': "{attacker_name} overextends and the pick whistles past {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "A twisting jab ends in nothing but the wind.",
@@ -405,7 +405,7 @@ MESSAGES = {
             'observer_msg': "The weapon slices through fog. {target_name} fades back."
         },
         {
-            'attacker_msg': "A flick of your wrist sends the pick skyward. You regain control—barely.",
+            'attacker_msg': "A flick of your {hit_location} sends the pick skyward. You regain control—barely.",
             'victim_msg': "A flick of {attacker_name}'s wrist sends the pick skyward. They regain control—barely.",
             'observer_msg': "A flick of {attacker_name}'s wrist sends the pick skyward. They regain control—barely."
         },
@@ -435,7 +435,7 @@ MESSAGES = {
             'observer_msg': "A quick dodge saves {target_name}'s spleen from becoming street art."
         },
         {
-            'attacker_msg': "Your foot slips. The strike veers harmlessly off target.",
+            'attacker_msg': "Your {hit_location} slips. The strike veers harmlessly off target.",
             'victim_msg': "{attacker_name}'s foot slips. The strike veers harmlessly off target.",
             'observer_msg': "{attacker_name}'s foot slips. The strike veers harmlessly off target."
         },
@@ -467,9 +467,9 @@ MESSAGES = {
             'observer_msg': "A final jab splits {target_name}'s eye socket. They collapse like a puppet with its strings cut."
         },
         {
-            'attacker_msg': "The pick drives into the side of {target_name}'s neck. Blood pulses, then stills.",
-            'victim_msg': "The pick drives into the side of your neck. Blood pulses, then stills.",
-            'observer_msg': "The pick drives into the side of {target_name}'s neck. Blood pulses, then stills."
+            'attacker_msg': "The pick drives into the side of {target_name}'s {hit_location}. Blood pulses, then stills.",
+            'victim_msg': "The pick drives into the side of your {hit_location}. Blood pulses, then stills.",
+            'observer_msg': "The pick drives into the side of {target_name}'s {hit_location}. Blood pulses, then stills."
         },
         {
             'attacker_msg': "You find the soft gap between ribs. One stab. One scream. Then silence.",
@@ -477,14 +477,14 @@ MESSAGES = {
             'observer_msg': "{attacker_name} finds the soft gap between ribs. One stab. One scream. Then silence."
         },
         {
-            'attacker_msg': "The pick vanishes into {target_name}'s temple. They slump forward like their strings were cut.",
-            'victim_msg': "The pick vanishes into your temple. You slump forward like your strings were cut.",
-            'observer_msg': "The pick vanishes into {target_name}'s temple. They slump forward like their strings were cut."
+            'attacker_msg': "The pick vanishes into {target_name}'s {hit_location}. They slump forward like their strings were cut.",
+            'victim_msg': "The pick vanishes into your {hit_location}. You slump forward like your strings were cut.",
+            'observer_msg': "The pick vanishes into {target_name}'s {hit_location}. They slump forward like their strings were cut."
         },
         {
-            'attacker_msg': "A savage uppercut with the pick leaves {target_name}'s throat gurgling red.",
-            'victim_msg': "A savage uppercut with the pick leaves your throat gurgling red.",
-            'observer_msg': "A savage uppercut with the pick leaves {target_name}'s throat gurgling red."
+            'attacker_msg': "A savage uppercut with the pick leaves {target_name}'s {hit_location} gurgling red.",
+            'victim_msg': "A savage uppercut with the pick leaves your {hit_location} gurgling red.",
+            'observer_msg': "A savage uppercut with the pick leaves {target_name}'s {hit_location} gurgling red."
         },
         {
             'attacker_msg': "The strike lands beneath {target_name}'s ear. They convulse—then die.",
@@ -492,9 +492,9 @@ MESSAGES = {
             'observer_msg': "The strike lands beneath {target_name}'s ear. They convulse—then die."
         },
         {
-            'attacker_msg': "You stab through {target_name}'s heart with surgical indifference.",
-            'victim_msg': "{attacker_name} stabs through your heart with surgical indifference.",
-            'observer_msg': "{attacker_name} stabs through {target_name}'s heart with surgical indifference."
+            'attacker_msg': "You stab through {target_name}'s {hit_location} with surgical indifference.",
+            'victim_msg': "{attacker_name} stabs through your {hit_location} with surgical indifference.",
+            'observer_msg': "{attacker_name} stabs through {target_name}'s {hit_location} with surgical indifference."
         },
         {
             'attacker_msg': "The pick disappears into {target_name}'s eye. There's a wet pop, then nothing.",
@@ -508,17 +508,17 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A deep plunge into the skull ends {target_name}'s thoughts permanently.",
-            'victim_msg': "A deep plunge into your skull ends your thoughts permanently.",
+            'victim_msg': "A deep plunge into your {hit_location} ends your thoughts permanently.",
             'observer_msg': "A deep plunge into the skull ends {target_name}'s thoughts permanently."
         },
         {
-            'attacker_msg': "You bury the pick into the nape of {target_name}'s neck. They crumple wordlessly.",
-            'victim_msg': "{attacker_name} buries the pick into the nape of your neck. You crumple wordlessly.",
-            'observer_msg': "{attacker_name} buries the pick into the nape of {target_name}'s neck. They crumple wordlessly."
+            'attacker_msg': "You bury the pick into the nape of {target_name}'s {hit_location}. They crumple wordlessly.",
+            'victim_msg': "{attacker_name} buries the pick into the nape of your {hit_location}. You crumple wordlessly.",
+            'observer_msg': "{attacker_name} buries the pick into the nape of {target_name}'s {hit_location}. They crumple wordlessly."
         },
         {
             'attacker_msg': "The blow severs the spine. {target_name} spasms, then lies still.",
-            'victim_msg': "The blow severs your spine. You spasm, then lie still.",
+            'victim_msg': "The blow severs your {hit_location}. You spasm, then lie still.",
             'observer_msg': "The blow severs the spine. {target_name} spasms, then lies still."
         },
         {
@@ -552,9 +552,9 @@ MESSAGES = {
             'observer_msg': "A gasp, a tremble, a fall. The pick did its job."
         },
         {
-            'attacker_msg': "You slide the pick out of {target_name}'s chest with a squelch and walk on.",
-            'victim_msg': "{attacker_name} slides the pick out of your chest with a squelch and walks on.",
-            'observer_msg': "{attacker_name} slides the pick out of {target_name}'s chest with a squelch and walks on."
+            'attacker_msg': "You slide the pick out of {target_name}'s {hit_location} with a squelch and walk on.",
+            'victim_msg': "{attacker_name} slides the pick out of your {hit_location} with a squelch and walks on.",
+            'observer_msg': "{attacker_name} slides the pick out of {target_name}'s {hit_location} with a squelch and walks on."
         },
         {
             'attacker_msg': "Steel punctures the windpipe. {target_name} drops gasping and doesn't rise.",
@@ -568,7 +568,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A clean jab to the base of the skull. {target_name}'s body crumples like laundry.",
-            'victim_msg': "A clean jab to the base of your skull. Your body crumples like laundry.",
+            'victim_msg': "A clean jab to the base of your {hit_location}. Your body crumples like laundry.",
             'observer_msg': "A clean jab to the base of the skull. {target_name}'s body crumples like laundry."
         },
         {
@@ -593,7 +593,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The pick punctures the lung. The gurgle stops with a sigh.",
-            'victim_msg': "The pick punctures your lung. The gurgle stops with a sigh.",
+            'victim_msg': "The pick punctures your {hit_location}. The gurgle stops with a sigh.",
             'observer_msg': "The pick punctures the lung. The gurgle stops with a sigh."
         },
         {

--- a/world/combat/messages/improvised_shield.py
+++ b/world/combat/messages/improvised_shield.py
@@ -6,7 +6,7 @@ MESSAGES = {
             'observer_msg': "A dented plate of steel, held together by spite. {attacker_name} wields it like a banner of ruin."
         },
         {
-            'attacker_msg': "A flick of your wrist and the weight settles. You lean into it like home.",
+            'attacker_msg': "A flick of your {hit_location} and the weight settles. You lean into it like home.",
             'victim_msg': "A flick of {attacker_name}'s wrist and the weight settles. They lean into it like home.",
             'observer_msg': "A flick of {attacker_name}'s wrist and the weight settles. They lean into it like home."
         },
@@ -56,7 +56,7 @@ MESSAGES = {
             'observer_msg': "The object barely qualifies as armor. In {attacker_name}'s hands, it's wrath repurposed."
         },
         {
-            'attacker_msg': "The scrap shakes once in your hand, then stills. That's all it takes.",
+            'attacker_msg': "The scrap shakes once in your {hit_location}, then stills. That's all it takes.",
             'victim_msg': "The scrap shakes once in {attacker_name}'s hand, then stills. That's all it takes.",
             'observer_msg': "The scrap shakes once in {attacker_name}'s hand, then stills. That's all it takes."
         },
@@ -463,32 +463,32 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A savage body-check breaks the spine. {target_name} jerks, then slumps, twitchless.",
-            'victim_msg': "A savage body-check breaks your spine. You jerk, then slump, twitchless.",
+            'victim_msg': "A savage body-check breaks your {hit_location}. You jerk, then slump, twitchless.",
             'observer_msg': "A savage body-check breaks the spine. {target_name} jerks, then slumps, twitchless."
         },
         {
             'attacker_msg': "A slam to the side of the head sends {target_name} into the wall, then the floor, then stillness.",
-            'victim_msg': "A slam to the side of your head sends you into the wall, then the floor, then stillness.",
+            'victim_msg': "A slam to the side of your {hit_location} sends you into the wall, then the floor, then stillness.",
             'observer_msg': "A slam to the side of the head sends {target_name} into the wall, then the floor, then stillness."
         },
         {
             'attacker_msg': "A slam to the throat ends everything. {target_name} collapses mid-step.",
-            'victim_msg': "A slam to your throat ends everything. You collapse mid-step.",
+            'victim_msg': "A slam to your {hit_location} ends everything. You collapse mid-step.",
             'observer_msg': "A slam to the throat ends everything. {target_name} collapses mid-step."
         },
         {
             'attacker_msg': "A thrust pins the head between wall and weapon. When it's pulled back, nothing protests.",
-            'victim_msg': "A thrust pins your head between wall and weapon. When it's pulled back, nothing protests.",
+            'victim_msg': "A thrust pins your {hit_location} between wall and weapon. When it's pulled back, nothing protests.",
             'observer_msg': "A thrust pins the head between wall and weapon. When it's pulled back, nothing protests."
         },
         {
             'attacker_msg': "A vicious swing cracks the jaw, then the skull. The rest is stillness.",
-            'victim_msg': "A vicious swing cracks your jaw, then your skull. The rest is stillness.",
+            'victim_msg': "A vicious swing cracks your {hit_location}, then your {hit_location}. The rest is stillness.",
             'observer_msg': "A vicious swing cracks the jaw, then the skull. The rest is stillness."
         },
         {
             'attacker_msg': "One crushing blow to the back of the head. The silence is immediate, absolute.",
-            'victim_msg': "One crushing blow to the back of your head. The silence is immediate, absolute.",
+            'victim_msg': "One crushing blow to the back of your {hit_location}. The silence is immediate, absolute.",
             'observer_msg': "One crushing blow to the back of the head. The silence is immediate, absolute."
         },
         {
@@ -498,7 +498,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The blow hits the back of the skull. The thud is deep, final, and echoed by silence.",
-            'victim_msg': "The blow hits the back of your skull. The thud is deep, final, and echoed by silence.",
+            'victim_msg': "The blow hits the back of your {hit_location}. The thud is deep, final, and echoed by silence.",
             'observer_msg': "The blow hits the back of the skull. The thud is deep, final, and echoed by silence."
         },
         {
@@ -508,7 +508,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The full weight of the slab crashes into the spine. {target_name} folds like paper.",
-            'victim_msg': "The full weight of the slab crashes into your spine. You fold like paper.",
+            'victim_msg': "The full weight of the slab crashes into your {hit_location}. You fold like paper.",
             'observer_msg': "The full weight of the slab crashes into the spine. {target_name} folds like paper."
         },
         {
@@ -518,7 +518,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The shield caves in the chest. Ribs snap, blood spills, life exits.",
-            'victim_msg': "The shield caves in your chest. Ribs snap, blood spills, life exits.",
+            'victim_msg': "The shield caves in your {hit_location}. Ribs snap, blood spills, life exits.",
             'observer_msg': "The shield caves in the chest. Ribs snap, blood spills, life exits."
         },
         {
@@ -527,9 +527,9 @@ MESSAGES = {
             'observer_msg': "The shield comes down like a guillotine. {target_name} doesn't scream — they don't have time."
         },
         {
-            'attacker_msg': "The shield drives into {target_name}'s chest. Ribs shatter like glass under steel boots.",
-            'victim_msg': "The shield drives into your chest. Ribs shatter like glass under steel boots.",
-            'observer_msg': "The shield drives into {target_name}'s chest. Ribs shatter like glass under steel boots."
+            'attacker_msg': "The shield drives into {target_name}'s {hit_location}. Ribs shatter like glass under steel boots.",
+            'victim_msg': "The shield drives into your {hit_location}. Ribs shatter like glass under steel boots.",
+            'observer_msg': "The shield drives into {target_name}'s {hit_location}. Ribs shatter like glass under steel boots."
         },
         {
             'attacker_msg': "The shield ends it with a sideways strike. {target_name} folds without ceremony.",
@@ -538,12 +538,12 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The shield flips sideways and crashes into the throat. {target_name} gasps once. That's it.",
-            'victim_msg': "The shield flips sideways and crashes into your throat. You gasp once. That's it.",
+            'victim_msg': "The shield flips sideways and crashes into your {hit_location}. You gasp once. That's it.",
             'observer_msg': "The shield flips sideways and crashes into the throat. {target_name} gasps once. That's it."
         },
         {
             'attacker_msg': "The shield hits the temple. {target_name} drops like a puppet with the strings cut.",
-            'victim_msg': "The shield hits your temple. You drop like a puppet with the strings cut.",
+            'victim_msg': "The shield hits your {hit_location}. You drop like a puppet with the strings cut.",
             'observer_msg': "The shield hits the temple. {target_name} drops like a puppet with the strings cut."
         },
         {
@@ -552,18 +552,18 @@ MESSAGES = {
             'observer_msg': "The shield pins {target_name} against the wall, again and again, until silence."
         },
         {
-            'attacker_msg': "The shield slams into {target_name}'s skull with a crunch. The lights go out, and stay out.",
-            'victim_msg': "The shield slams into your skull with a crunch. The lights go out, and stay out.",
-            'observer_msg': "The shield slams into {target_name}'s skull with a crunch. The lights go out, and stay out."
+            'attacker_msg': "The shield slams into {target_name}'s {hit_location} with a crunch. The lights go out, and stay out.",
+            'victim_msg': "The shield slams into your {hit_location} with a crunch. The lights go out, and stay out.",
+            'observer_msg': "The shield slams into {target_name}'s {hit_location} with a crunch. The lights go out, and stay out."
         },
         {
             'attacker_msg': "The slab breaks the face open in two strikes. The third is mercy.",
-            'victim_msg': "The slab breaks your face open in two strikes. The third is mercy.",
+            'victim_msg': "The slab breaks your {hit_location} open in two strikes. The third is mercy.",
             'observer_msg': "The slab breaks the face open in two strikes. The third is mercy."
         },
         {
             'attacker_msg': "The weight smashes the temple like a gavel. Judgment delivered.",
-            'victim_msg': "The weight smashes your temple like a gavel. Judgment delivered.",
+            'victim_msg': "The weight smashes your {hit_location} like a gavel. Judgment delivered.",
             'observer_msg': "The weight smashes the temple like a gavel. Judgment delivered."
         },
         {
@@ -573,7 +573,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You bring the edge down hard on the neck. {target_name} doesn't get up.",
-            'victim_msg': "{attacker_name} brings the edge down hard on your neck. You don't get up.",
+            'victim_msg': "{attacker_name} brings the edge down hard on your {hit_location}. You don't get up.",
             'observer_msg': "{attacker_name} brings the edge down hard on the neck. {target_name} doesn't get up."
         },
         {
@@ -582,9 +582,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} charges, rams, then stamps them with the rim. No one gets up from that."
         },
         {
-            'attacker_msg': "You crush {target_name}'s skull between slab and ground. One hit. No sequel.",
-            'victim_msg': "{attacker_name} crushes your skull between slab and ground. One hit. No sequel.",
-            'observer_msg': "{attacker_name} crushes {target_name}'s skull between slab and ground. One hit. No sequel."
+            'attacker_msg': "You crush {target_name}'s {hit_location} between slab and ground. One hit. No sequel.",
+            'victim_msg': "{attacker_name} crushes your {hit_location} between slab and ground. One hit. No sequel.",
+            'observer_msg': "{attacker_name} crushes {target_name}'s {hit_location} between slab and ground. One hit. No sequel."
         },
         {
             'attacker_msg': "You drive the edge under the chin. The teeth rattle loose. Then the body.",
@@ -597,13 +597,13 @@ MESSAGES = {
             'observer_msg': "{attacker_name} rams them backward into the beam until something gives. It's not the beam."
         },
         {
-            'attacker_msg': "You slam the corner into {target_name}'s temple. They go limp mid-turn.",
-            'victim_msg': "{attacker_name} slams the corner into your temple. You go limp mid-turn.",
-            'observer_msg': "{attacker_name} slams the corner into {target_name}'s temple. They go limp mid-turn."
+            'attacker_msg': "You slam the corner into {target_name}'s {hit_location}. They go limp mid-turn.",
+            'victim_msg': "{attacker_name} slams the corner into your {hit_location}. You go limp mid-turn.",
+            'observer_msg': "{attacker_name} slams the corner into {target_name}'s {hit_location}. They go limp mid-turn."
         },
         {
             'attacker_msg': "You smash downward. The neck crumples. The body follows.",
-            'victim_msg': "{attacker_name} smashes downward. Your neck crumples. Your body follows.",
+            'victim_msg': "{attacker_name} smashes downward. Your {hit_location} crumples. Your body follows.",
             'observer_msg': "{attacker_name} smashes downward. The neck crumples. The body follows."
         }
     ]

--- a/world/combat/messages/katana.py
+++ b/world/combat/messages/katana.py
@@ -6,7 +6,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} unsheathes their katana with a whispering hiss, the blade singing a promise of blood as they step into a fluid stance."
         },
         {
-            'attacker_msg': "With a flick of your wrist and a dead stare, you bring the katana to bear, the edge glinting like a curse in motion.",
+            'attacker_msg': "With a flick of your {hit_location} and a dead stare, you bring the katana to bear, the edge glinting like a curse in motion.",
             'victim_msg': "With a flick of the wrist and a dead stare, {attacker_name} brings the katana to bear, the edge glinting like a curse in motion.",
             'observer_msg': "With a flick of the wrist and a dead stare, {attacker_name} brings the katana to bear, the edge glinting like a curse in motion."
         },
@@ -26,7 +26,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s eyes narrow. The katana glides free of its scabbard, whispering through the air like it remembers old deaths."
         },
         {
-            'attacker_msg': "As if summoned from a dream, the katana materializes in your hand, cutting a line between now and what comes next.",
+            'attacker_msg': "As if summoned from a dream, the katana materializes in your {hit_location}, cutting a line between now and what comes next.",
             'victim_msg': "As if summoned from a dream, the katana materializes in {attacker_name}'s hand, cutting a line between now and what comes next.",
             'observer_msg': "As if summoned from a dream, the katana materializes in {attacker_name}'s hand, cutting a line between now and what comes next."
         },
@@ -116,7 +116,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s shadow lengthens as the katana carves the air—something old and beautiful and wrong waking up."
         },
         {
-            'attacker_msg': "No emotion crosses your face. Only the katana moves, beckoning death like an old friend.",
+            'attacker_msg': "No emotion crosses your {hit_location}. Only the katana moves, beckoning death like an old friend.",
             'victim_msg': "No emotion crosses {attacker_name}'s face. Only the katana moves, beckoning death like an old friend.",
             'observer_msg': "No emotion crosses {attacker_name}'s face. Only the katana moves, beckoning death like an old friend."
         },
@@ -294,7 +294,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The katana catches light—and {target_name}'s {hit_location}—as you draw a long, ragged line down their face.",
-            'victim_msg': "The katana catches light—and your {hit_location}—as {attacker_name} draws a long, ragged line down your face.",
+            'victim_msg': "The katana catches light—and your {hit_location}—as {attacker_name} draws a long, ragged line down your {hit_location}.",
             'observer_msg': "The katana catches light—and {target_name}'s {hit_location}—as {attacker_name} draws a long, ragged line down their face."
         },
         {
@@ -310,9 +310,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s blade cuts air alone, a perfect stroke wasted on empty space."
         },
         {
-            'attacker_msg': "The katana whistles by {target_name}'s head as they duck, a near-death that smells like ozone.",
-            'victim_msg': "The katana whistles by your head as you duck, a near-death that smells like ozone.",
-            'observer_msg': "The katana whistles by {target_name}'s head as they duck, a near-death that smells like ozone."
+            'attacker_msg': "The katana whistles by {target_name}'s {hit_location} as they duck, a near-death that smells like ozone.",
+            'victim_msg': "The katana whistles by your {hit_location} as you duck, a near-death that smells like ozone.",
+            'observer_msg': "The katana whistles by {target_name}'s {hit_location} as they duck, a near-death that smells like ozone."
         },
         {
             'attacker_msg': "You swing wide, graceful but off the mark—{target_name} sidesteps just in time.",
@@ -371,7 +371,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} tumbles to the side, the katana slicing the air where their chest had just been.",
-            'victim_msg': "You tumble to the side, the katana slicing the air where your chest had just been.",
+            'victim_msg': "You tumble to the side, the katana slicing the air where your {hit_location} had just been.",
             'observer_msg': "{target_name} tumbles to the side, the katana slicing the air where their chest had just been."
         },
         {
@@ -380,9 +380,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s blade arcs through the space beside {target_name}, trailing disappointment."
         },
         {
-            'attacker_msg': "Steel hums past {target_name}'s ribs—close enough to chill, but not cut.",
-            'victim_msg': "Steel hums past your ribs—close enough to chill, but not cut.",
-            'observer_msg': "Steel hums past {target_name}'s ribs—close enough to chill, but not cut."
+            'attacker_msg': "Steel hums past {target_name}'s {hit_location}—close enough to chill, but not cut.",
+            'victim_msg': "Steel hums past your {hit_location}—close enough to chill, but not cut.",
+            'observer_msg': "Steel hums past {target_name}'s {hit_location}—close enough to chill, but not cut."
         },
         {
             'attacker_msg': "A low step ruins your trajectory—{target_name} avoids the strike by pure instinct.",
@@ -421,7 +421,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name}'s dodge is messy but effective. The blade swings just over their shoulder.",
-            'victim_msg': "Your dodge is messy but effective. The blade swings just over your shoulder.",
+            'victim_msg': "Your dodge is messy but effective. The blade swings just over your {hit_location}.",
             'observer_msg': "{target_name}'s dodge is messy but effective. The blade swings just over their shoulder."
         },
         {
@@ -477,9 +477,9 @@ MESSAGES = {
             'observer_msg': "A gurgle, a flash of red, and {target_name} crumples. The katana barely slows."
         },
         {
-            'attacker_msg': "The blade glides through {target_name}'s neck with brutal grace, severing life like a whisper.",
-            'victim_msg': "The blade glides through your neck with brutal grace, severing life like a whisper.",
-            'observer_msg': "The blade glides through {target_name}'s neck with brutal grace, severing life like a whisper."
+            'attacker_msg': "The blade glides through {target_name}'s {hit_location} with brutal grace, severing life like a whisper.",
+            'victim_msg': "The blade glides through your {hit_location} with brutal grace, severing life like a whisper.",
+            'observer_msg': "The blade glides through {target_name}'s {hit_location} with brutal grace, severing life like a whisper."
         },
         {
             'attacker_msg': "You end it with one stroke—clean, cruel, final. {target_name}'s body doesn't resist the ground.",
@@ -503,7 +503,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name}'s last breath is a red mist as the katana exits their throat.",
-            'victim_msg': "Your last breath is a red mist as the katana exits your throat.",
+            'victim_msg': "Your last breath is a red mist as the katana exits your {hit_location}.",
             'observer_msg': "{target_name}'s last breath is a red mist as the katana exits their throat."
         },
         {
@@ -527,14 +527,14 @@ MESSAGES = {
             'observer_msg': "{attacker_name} doesn't look back. {target_name} hits the floor in several pieces."
         },
         {
-            'attacker_msg': "The katana carves a line through {target_name}'s chest—one heartbeat later, it splits open like fruit.",
-            'victim_msg': "The katana carves a line through your chest—one heartbeat later, it splits open like fruit.",
-            'observer_msg': "The katana carves a line through {target_name}'s chest—one heartbeat later, it splits open like fruit."
+            'attacker_msg': "The katana carves a line through {target_name}'s {hit_location}—one heartbeat later, it splits open like fruit.",
+            'victim_msg': "The katana carves a line through your {hit_location}—one heartbeat later, it splits open like fruit.",
+            'observer_msg': "The katana carves a line through {target_name}'s {hit_location}—one heartbeat later, it splits open like fruit."
         },
         {
-            'attacker_msg': "The blade bisects {target_name}'s skull in a clean vertical, their expression still caught mid-surprise.",
-            'victim_msg': "The blade bisects your skull in a clean vertical, your expression still caught mid-surprise.",
-            'observer_msg': "The blade bisects {target_name}'s skull in a clean vertical, their expression still caught mid-surprise."
+            'attacker_msg': "The blade bisects {target_name}'s {hit_location} in a clean vertical, their expression still caught mid-surprise.",
+            'victim_msg': "The blade bisects your {hit_location} in a clean vertical, your expression still caught mid-surprise.",
+            'observer_msg': "The blade bisects {target_name}'s {hit_location} in a clean vertical, their expression still caught mid-surprise."
         },
         {
             'attacker_msg': "The scream is brief. The silence after your final cut is eternal.",
@@ -557,9 +557,9 @@ MESSAGES = {
             'observer_msg': "A rising strike cleaves {target_name} open. They stagger, eyes wide, then tip over like a felled tree."
         },
         {
-            'attacker_msg': "You whisper something the katana obeys. {target_name}'s chest bursts open seconds later.",
-            'victim_msg': "{attacker_name} whispers something the katana obeys. Your chest bursts open seconds later.",
-            'observer_msg': "{attacker_name} whispers something the katana obeys. {target_name}'s chest bursts open seconds later."
+            'attacker_msg': "You whisper something the katana obeys. {target_name}'s {hit_location} bursts open seconds later.",
+            'victim_msg': "{attacker_name} whispers something the katana obeys. Your {hit_location} bursts open seconds later.",
+            'observer_msg': "{attacker_name} whispers something the katana obeys. {target_name}'s {hit_location} bursts open seconds later."
         },
         {
             'attacker_msg': "The blade exits spine and breath in one go. {target_name} falls twitching, face frozen in disbelief.",
@@ -582,9 +582,9 @@ MESSAGES = {
             'observer_msg': "{target_name}'s body collapses in stages, each part giving up in time with the dripping steel."
         },
         {
-            'attacker_msg': "A surgical decapitation—you leave {target_name}'s head still blinking at your feet.",
-            'victim_msg': "A surgical decapitation—{attacker_name} leaves your head still blinking at their feet.",
-            'observer_msg': "A surgical decapitation—{attacker_name} leaves {target_name}'s head still blinking at their feet."
+            'attacker_msg': "A surgical decapitation—you leave {target_name}'s {hit_location} still blinking at your feet.",
+            'victim_msg': "A surgical decapitation—{attacker_name} leaves your {hit_location} still blinking at their feet.",
+            'observer_msg': "A surgical decapitation—{attacker_name} leaves {target_name}'s {hit_location} still blinking at their feet."
         },
         {
             'attacker_msg': "{target_name}'s guts hit the floor first. Then the rest follows.",

--- a/world/combat/messages/knife.py
+++ b/world/combat/messages/knife.py
@@ -6,7 +6,7 @@ MESSAGES = {
             "observer_msg": "A flash of steel. That's all {attacker_name} offers before stepping forward, knife low and ready."
         },
         {
-            "attacker_msg": "A flick of your wrist brings the blade into view. You step closer with intent stitched into your stride.",
+            "attacker_msg": "A flick of your {hit_location} brings the blade into view. You step closer with intent stitched into your stride.",
             "victim_msg": "A flick of the wrist, and the blade appears. {attacker_name} steps closer with intent stitched into their stride.",
             "observer_msg": "A flick of the wrist, and the blade appears. {attacker_name} steps closer with intent stitched into their stride."
         },
@@ -31,7 +31,7 @@ MESSAGES = {
             "observer_msg": "A small weapon for a personal job. {attacker_name} grips it like they're writing a final sentence."
         },
         {
-            "attacker_msg": "It's not big. It's not loud. But in your hand, the knife becomes a conclusion.",
+            "attacker_msg": "It's not big. It's not loud. But in your {hit_location}, the knife becomes a conclusion.",
             "victim_msg": "It's not big. It's not loud. But in {attacker_name}'s hand, the knife becomes a conclusion.",
             "observer_msg": "It's not big. It's not loud. But in {attacker_name}'s hand, the knife becomes a conclusion."
         },
@@ -41,7 +41,7 @@ MESSAGES = {
             "observer_msg": "No speech. Just steel. {attacker_name} draws the knife with the calm of someone already decided."
         },
         {
-            "attacker_msg": "Steel meets your hand. The connection is instinctive. You already know how this ends.",
+            "attacker_msg": "Steel meets your {hit_location}. The connection is instinctive. You already know how this ends.",
             "victim_msg": "Steel meets hand. The connection is instinctive. {attacker_name} already knows how this ends.",
             "observer_msg": "Steel meets hand. The connection is instinctive. {attacker_name} already knows how this ends."
         },
@@ -116,7 +116,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} draws the knife from their boot with a smooth, silent motion. It's not showy — it's certain."
         },
         {
-            "attacker_msg": "You draw the knife so smoothly it's like it was always in your hand, just waiting to be noticed.",
+            "attacker_msg": "You draw the knife so smoothly it's like it was always in your {hit_location}, just waiting to be noticed.",
             "victim_msg": "{attacker_name} draws the knife so smoothly it's like it was always in hand, just waiting to be noticed.",
             "observer_msg": "{attacker_name} draws the knife so smoothly it's like it was always in hand, just waiting to be noticed."
         },
@@ -250,8 +250,8 @@ MESSAGES = {
             "observer_msg": "A fast jab misses. The wind it leaves behind still rattles nerves."
         },
         {
-            "attacker_msg": "A flick of your wrist sends the knife off-course. It whistles past their neck like a warning.",
-            "victim_msg": "A flick of the wrist sends the knife off-course. It whistles past your neck like a warning.",
+            "attacker_msg": "A flick of your {hit_location} sends the knife off-course. It whistles past their neck like a warning.",
+            "victim_msg": "A flick of the wrist sends the knife off-course. It whistles past your {hit_location} like a warning.",
             "observer_msg": "A flick of the wrist sends the knife off-course. It whistles past the neck like a warning."
         },
         {
@@ -276,7 +276,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "A quick twist brings your blade past their throat. It leaves a whisper, not a wound.",
-            "victim_msg": "A quick twist brings the blade past your throat. It leaves a whisper, not a wound.",
+            "victim_msg": "A quick twist brings the blade past your {hit_location}. It leaves a whisper, not a wound.",
             "observer_msg": "A quick twist brings the blade past the throat. It leaves a whisper, not a wound."
         },
         {
@@ -286,7 +286,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your slash aimed for their neck misses by inches. The breath that follows is all fear.",
-            "victim_msg": "A slash aimed for your neck misses by inches. The breath that follows is all fear.",
+            "victim_msg": "A slash aimed for your {hit_location} misses by inches. The breath that follows is all fear.",
             "observer_msg": "A slash aimed for the neck misses by inches. The breath that follows is all fear."
         },
         {
@@ -311,7 +311,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your blade hisses by their thigh. Close enough to feel wind. Too close to relax.",
-            "victim_msg": "The blade hisses by your thigh. Close enough to feel wind. Too close to relax.",
+            "victim_msg": "The blade hisses by your {hit_location}. Close enough to feel wind. Too close to relax.",
             "observer_msg": "The blade hisses by the thigh. Close enough to feel wind. Too close to relax."
         },
         {
@@ -331,7 +331,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your knife skates over their shoulder. No blood — this time.",
-            "victim_msg": "The knife skates over your shoulder. No blood — this time.",
+            "victim_msg": "The knife skates over your {hit_location}. No blood — this time.",
             "observer_msg": "The knife skates over a shoulder. No blood — this time."
         },
         {
@@ -388,11 +388,11 @@ MESSAGES = {
     'kill': [
         {
             "attacker_msg": "A deep stab to their heart. It's not theatrical. Just final.",
-            "victim_msg": "A deep stab to your heart. It's not theatrical. Just final. Darkness takes you.",
+            "victim_msg": "A deep stab to your {hit_location}. It's not theatrical. Just final. Darkness takes you.",
             "observer_msg": "A deep stab to the heart. It's not theatrical. Just final."
         },
         {
-            "attacker_msg": "A flash of steel. A jerk of your wrist. {target_name} drops before they know what happened.",
+            "attacker_msg": "A flash of steel. A jerk of your {hit_location}. {target_name} drops before they know what happened.",
             "victim_msg": "A flash of steel. A jerk of the wrist. You drop before you know what happened.",
             "observer_msg": "A flash of steel. A jerk of the wrist. {target_name} drops before they know what happened."
         },
@@ -408,17 +408,17 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your stab to their temple drops {target_name} like a switch was flipped. Darkness comes fast.",
-            "victim_msg": "A stab to your temple drops you like a switch was flipped. Darkness comes fast.",
+            "victim_msg": "A stab to your {hit_location} drops you like a switch was flipped. Darkness comes fast.",
             "observer_msg": "A stab to the temple drops {target_name} like a switch was flipped. Darkness comes fast."
         },
         {
             "attacker_msg": "Your strike to their neck opens a red smile. The grin doesn't last long.",
-            "victim_msg": "A strike to your neck opens a red smile. The grin doesn't last long. You fade away.",
+            "victim_msg": "A strike to your {hit_location} opens a red smile. The grin doesn't last long. You fade away.",
             "observer_msg": "A strike to the neck opens a red smile. The grin doesn't last long."
         },
         {
             "attacker_msg": "Your swift, brutal puncture to their lungs. {target_name} tries to breathe. Then doesn't.",
-            "victim_msg": "A swift, brutal puncture to your lungs. You try to breathe. Then don't.",
+            "victim_msg": "A swift, brutal puncture to your {hit_location}. You try to breathe. Then don't.",
             "observer_msg": "A swift, brutal puncture to the lungs. {target_name} tries to breathe. Then doesn't."
         },
         {
@@ -428,17 +428,17 @@ MESSAGES = {
         },
         {
             "attacker_msg": "One clean jab to their heart. Blood leaks slow, but the lights go fast.",
-            "victim_msg": "One clean jab to your heart. Blood leaks slow, but the lights go fast.",
+            "victim_msg": "One clean jab to your {hit_location}. Blood leaks slow, but the lights go fast.",
             "observer_msg": "One clean jab to the heart. Blood leaks slow, but the lights go fast."
         },
         {
             "attacker_msg": "One deep thrust into their throat ends it. No scream. Just silence.",
-            "victim_msg": "One deep thrust into your throat ends it. No scream. Just silence.",
+            "victim_msg": "One deep thrust into your {hit_location} ends it. No scream. Just silence.",
             "observer_msg": "One deep thrust into the throat ends it. No scream. Just silence."
         },
         {
             "attacker_msg": "One jab under their ribs. {target_name} drops, gasping their last into the floor.",
-            "victim_msg": "One jab under your ribs. You drop, gasping your last into the floor.",
+            "victim_msg": "One jab under your {hit_location}. You drop, gasping your last into the floor.",
             "observer_msg": "One jab under the ribs. {target_name} drops, gasping their last into the floor."
         },
         {
@@ -448,12 +448,12 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your blade finds the base of their spine. {target_name} seizes — then slumps like an unplugged puppet.",
-            "victim_msg": "The blade finds the base of your spine. You seize — then slump like an unplugged puppet.",
+            "victim_msg": "The blade finds the base of your {hit_location}. You seize — then slump like an unplugged puppet.",
             "observer_msg": "The blade finds the base of the spine. {target_name} seizes — then slumps like an unplugged puppet."
         },
         {
             "attacker_msg": "Your blade slashes across their neck. Blood erupts like a fountain of silence.",
-            "victim_msg": "The blade slashes across your neck. Blood erupts like a fountain as silence takes you.",
+            "victim_msg": "The blade slashes across your {hit_location}. Blood erupts like a fountain as silence takes you.",
             "observer_msg": "The blade slashes across the neck. Blood erupts like a fountain of silence."
         },
         {
@@ -468,7 +468,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your knife carves up into their jaw, slipping through bone. {target_name} twitches, then topples.",
-            "victim_msg": "The knife carves up into your jaw, slipping through bone. You twitch, then topple into darkness.",
+            "victim_msg": "The knife carves up into your {hit_location}, slipping through bone. You twitch, then topple into darkness.",
             "observer_msg": "The knife carves up into the jaw, slipping through bone. {target_name} twitches, then topples."
         },
         {
@@ -478,12 +478,12 @@ MESSAGES = {
         },
         {
             "attacker_msg": "Your knife drives into their throat. {target_name} chokes, stumbles, and falls — eyes wide, mouth red.",
-            "victim_msg": "The knife drives into your throat. You choke, stumble, and fall — eyes wide, mouth red.",
+            "victim_msg": "The knife drives into your {hit_location}. You choke, stumble, and fall — eyes wide, mouth red.",
             "observer_msg": "The knife drives into the throat. {target_name} chokes, stumbles, and falls — eyes wide, mouth red."
         },
         {
             "attacker_msg": "Your knife slices up into their spine. {target_name} drops with a strange gasp and no control.",
-            "victim_msg": "The knife slices up into your spine. You drop with a strange gasp and no control.",
+            "victim_msg": "The knife slices up into your {hit_location}. You drop with a strange gasp and no control.",
             "observer_msg": "The knife slices up into the spine. {target_name} drops with a strange gasp and no control."
         },
         {
@@ -498,17 +498,17 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You bury the blade in their chest and leave it there. {target_name} folds around it.",
-            "victim_msg": "{attacker_name} buries the blade in your chest and leaves it there. You fold around it as life fades.",
+            "victim_msg": "{attacker_name} buries the blade in your {hit_location} and leaves it there. You fold around it as life fades.",
             "observer_msg": "{attacker_name} buries the blade in the chest and leaves it there. {target_name} folds around it."
         },
         {
             "attacker_msg": "You drive the knife up beneath their ribs and twist. {target_name} exhales once, then nothing.",
-            "victim_msg": "{attacker_name} drives the knife up beneath your ribs and twists. You exhale once, then nothing.",
+            "victim_msg": "{attacker_name} drives the knife up beneath your {hit_location} and twists. You exhale once, then nothing.",
             "observer_msg": "{attacker_name} drives the knife up beneath the ribs and twists. {target_name} exhales once, then nothing."
         },
         {
             "attacker_msg": "You grab, pull close, and finish it with one jab to their liver. {target_name} collapses instantly.",
-            "victim_msg": "{attacker_name} grabs, pulls close, and finishes it with one jab to your liver. You collapse instantly into darkness.",
+            "victim_msg": "{attacker_name} grabs, pulls close, and finishes it with one jab to your {hit_location}. You collapse instantly into darkness.",
             "observer_msg": "{attacker_name} grabs, pulls close, and finishes it with one jab to the liver. {target_name} collapses instantly."
         },
         {
@@ -528,7 +528,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You slip the knife under their ribs and into the heart. Their body twitches once. Then stills.",
-            "victim_msg": "{attacker_name} slips the knife under your ribs and into the heart. Your body twitches once. Then stills.",
+            "victim_msg": "{attacker_name} slips the knife under your {hit_location} and into the heart. Your body twitches once. Then stills.",
             "observer_msg": "{attacker_name} slips the knife under the ribs and into the heart. The body twitches once. Then stills."
         },
         {

--- a/world/combat/messages/kukri.py
+++ b/world/combat/messages/kukri.py
@@ -66,7 +66,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s eyes are sharp and unwavering, sighting down the curved length of the kukri towards {target_name}."
         },
         {
-            'attacker_msg': "The kukri feels like an extension of your arm, a tool of devastating efficiency and storied lethality.",
+            'attacker_msg': "The kukri feels like an extension of your {hit_location}, a tool of devastating efficiency and storied lethality.",
             'victim_msg': "The kukri feels like an extension of {attacker_name}'s arm, a tool of devastating efficiency and storied lethality.",
             'observer_msg': "The kukri feels like an extension of {attacker_name}'s arm, a tool of devastating efficiency and storied lethality."
         },
@@ -86,7 +86,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} holds the kukri in a traditional Gurkha grip, ready to bring its full, devastating force to bear."
         },
         {
-            'attacker_msg': "The smooth, often horn or hardwood hilt of the kukri fits your hand perfectly, a familiar, dangerous weight.",
+            'attacker_msg': "The smooth, often horn or hardwood hilt of the kukri fits your {hit_location} perfectly, a familiar, dangerous weight.",
             'victim_msg': "The smooth, often horn or hardwood hilt of the kukri fits {attacker_name}'s hand perfectly, a familiar, dangerous weight.",
             'observer_msg': "The smooth, often horn or hardwood hilt of the kukri fits {attacker_name}'s hand perfectly, a familiar, dangerous weight."
         },
@@ -234,7 +234,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The kukri thuds heavily as it connects with {target_name}, driving the air from their lungs and leaving a horrific injury.",
-            'victim_msg': "The kukri thuds heavily as it connects with you, driving the air from your lungs and leaving a horrific injury.",
+            'victim_msg': "The kukri thuds heavily as it connects with you, driving the air from your {hit_location} and leaving a horrific injury.",
             'observer_msg': "The kukri thuds heavily as it connects with {target_name}, driving the air from their lungs and leaving a horrific injury."
         },
         {
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     'miss': [
         {
-            'attacker_msg': "Your kukri whistles through the air with considerable force, inches from {target_name}'s throat.",
-            'victim_msg': "{attacker_name}'s kukri whistles through the air with considerable force, inches from your throat.",
-            'observer_msg': "{attacker_name}'s kukri whistles through the air with considerable force, inches from {target_name}'s throat."
+            'attacker_msg': "Your kukri whistles through the air with considerable force, inches from {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s kukri whistles through the air with considerable force, inches from your {hit_location}.",
+            'observer_msg': "{attacker_name}'s kukri whistles through the air with considerable force, inches from {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "{target_name} narrowly avoids the heavy, chopping arc of your kukri with a desperate dive.",
@@ -457,29 +457,29 @@ MESSAGES = {
     ],
     'kill': [
         {
-            'attacker_msg': "Your kukri connects with {target_name}'s neck with a sickening chop; they drop, instantly still, nearly decapitated.",
-            'victim_msg': "{attacker_name}'s kukri connects with your neck with a sickening chop; you drop, instantly still, nearly decapitated.",
-            'observer_msg': "{attacker_name}'s kukri connects with {target_name}'s neck with a sickening chop; they drop, instantly still, nearly decapitated."
+            'attacker_msg': "Your kukri connects with {target_name}'s {hit_location} with a sickening chop; they drop, instantly still, nearly decapitated.",
+            'victim_msg': "{attacker_name}'s kukri connects with your {hit_location} with a sickening chop; you drop, instantly still, nearly decapitated.",
+            'observer_msg': "{attacker_name}'s kukri connects with {target_name}'s {hit_location} with a sickening chop; they drop, instantly still, nearly decapitated."
         },
         {
-            'attacker_msg': "A devastating two-handed blow from the kukri crushes {target_name}'s skull, ending the fight brutally and decisively.",
-            'victim_msg': "A devastating two-handed blow from the kukri crushes your skull, ending the fight brutally and decisively.",
-            'observer_msg': "A devastating two-handed blow from the kukri crushes {target_name}'s skull, ending the fight brutally and decisively."
+            'attacker_msg': "A devastating two-handed blow from the kukri crushes {target_name}'s {hit_location}, ending the fight brutally and decisively.",
+            'victim_msg': "A devastating two-handed blow from the kukri crushes your {hit_location}, ending the fight brutally and decisively.",
+            'observer_msg': "A devastating two-handed blow from the kukri crushes {target_name}'s {hit_location}, ending the fight brutally and decisively."
         },
         {
             'attacker_msg': "With a final, focused strike, your kukri shatters {target_name}'s collarbone and drives deep into their chest, felling them.",
-            'victim_msg': "With a final, focused strike, {attacker_name}'s kukri shatters your collarbone and drives deep into your chest, felling you.",
+            'victim_msg': "With a final, focused strike, {attacker_name}'s kukri shatters your collarbone and drives deep into your {hit_location}, felling you.",
             'observer_msg': "With a final, focused strike, {attacker_name}'s kukri shatters {target_name}'s collarbone and drives deep into their chest, felling them."
         },
         {
-            'attacker_msg': "The heavy, curved blade of the kukri strikes {target_name}'s throat, a swift and brutal end, blood fountaining.",
-            'victim_msg': "The heavy, curved blade of the kukri strikes your throat, a swift and brutal end, blood fountaining.",
-            'observer_msg': "The heavy, curved blade of the kukri strikes {target_name}'s throat, a swift and brutal end, blood fountaining."
+            'attacker_msg': "The heavy, curved blade of the kukri strikes {target_name}'s {hit_location}, a swift and brutal end, blood fountaining.",
+            'victim_msg': "The heavy, curved blade of the kukri strikes your {hit_location}, a swift and brutal end, blood fountaining.",
+            'observer_msg': "The heavy, curved blade of the kukri strikes {target_name}'s {hit_location}, a swift and brutal end, blood fountaining."
         },
         {
-            'attacker_msg': "Your powerful swing with the kukri caves in {target_name}'s chest; they collapse, gasping their last breath.",
-            'victim_msg': "{attacker_name}'s powerful swing with the kukri caves in your chest; you collapse, gasping your last breath.",
-            'observer_msg': "{attacker_name}'s powerful swing with the kukri caves in {target_name}'s chest; they collapse, gasping their last breath."
+            'attacker_msg': "Your powerful swing with the kukri caves in {target_name}'s {hit_location}; they collapse, gasping their last breath.",
+            'victim_msg': "{attacker_name}'s powerful swing with the kukri caves in your {hit_location}; you collapse, gasping your last breath.",
+            'observer_msg': "{attacker_name}'s powerful swing with the kukri caves in {target_name}'s {hit_location}; they collapse, gasping their last breath."
         },
         {
             'attacker_msg': "The kukri, a tool of deadly force, delivers a killing blow, and {target_name}'s struggles cease in a pool of their own blood.",
@@ -488,7 +488,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A precise, savage chop to the base of the skull with your kukri ends {target_name}'s life in an instant.",
-            'victim_msg': "A precise, savage chop to the base of your skull with {attacker_name}'s kukri ends your life in an instant.",
+            'victim_msg': "A precise, savage chop to the base of your {hit_location} with {attacker_name}'s kukri ends your life in an instant.",
             'observer_msg': "A precise, savage chop to the base of the skull with {attacker_name}'s kukri ends {target_name}'s life in an instant."
         },
         {
@@ -497,9 +497,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} drives the kukri's point into {target_name}'s eye socket with a brutal thrust, the outcome grimly certain."
         },
         {
-            'attacker_msg': "The unyielding steel of the kukri breaks {target_name}'s neck with a sharp snap; they fall, lifeless.",
-            'victim_msg': "The unyielding steel of the kukri breaks your neck with a sharp snap; you fall, lifeless.",
-            'observer_msg': "The unyielding steel of the kukri breaks {target_name}'s neck with a sharp snap; they fall, lifeless."
+            'attacker_msg': "The unyielding steel of the kukri breaks {target_name}'s {hit_location} with a sharp snap; they fall, lifeless.",
+            'victim_msg': "The unyielding steel of the kukri breaks your {hit_location} with a sharp snap; you fall, lifeless.",
+            'observer_msg': "The unyielding steel of the kukri breaks {target_name}'s {hit_location} with a sharp snap; they fall, lifeless."
         },
         {
             'attacker_msg': "With a final, fierce kiai, you finish {target_name} with a decisive, crushing strike from the kukri.",

--- a/world/combat/messages/large_axe.py
+++ b/world/combat/messages/large_axe.py
@@ -463,18 +463,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A brutal backswing removes the jaw. The body drops before the blood hits floor.",
-            'victim_msg': "A brutal backswing removes your jaw. The body drops before the blood hits floor.",
-            'observer_msg': "A brutal backswing removes {target_name}'s jaw. The body drops before the blood hits floor."
+            'victim_msg': "A brutal backswing removes your {hit_location}. The body drops before the blood hits floor.",
+            'observer_msg': "A brutal backswing removes {target_name}'s {hit_location}. The body drops before the blood hits floor."
         },
         {
             'attacker_msg': "A chop through the hip spins {target_name} before gravity takes over.",
-            'victim_msg': "A chop through your hip spins you before gravity takes over.",
-            'observer_msg': "A chop through {target_name}'s hip spins {target_name} before gravity takes over."
+            'victim_msg': "A chop through your {hit_location} spins you before gravity takes over.",
+            'observer_msg': "A chop through {target_name}'s {hit_location} spins {target_name} before gravity takes over."
         },
         {
             'attacker_msg': "A crushing overhead swing cracks the skull in two. Silence reigns.",
-            'victim_msg': "A crushing overhead swing cracks your skull in two. Silence reigns.",
-            'observer_msg': "A crushing overhead swing cracks {target_name}'s skull in two. Silence reigns."
+            'victim_msg': "A crushing overhead swing cracks your {hit_location} in two. Silence reigns.",
+            'observer_msg': "A crushing overhead swing cracks {target_name}'s {hit_location} in two. Silence reigns."
         },
         {
             'attacker_msg': "A downward chop ends mid-breath. The last word never arrives.",
@@ -483,28 +483,28 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A full-bodied arc cleaves the torso. {target_name} is no longer one piece.",
-            'victim_msg': "A full-bodied arc cleaves your torso. You are no longer one piece.",
-            'observer_msg': "A full-bodied arc cleaves {target_name}'s torso. {target_name} is no longer one piece."
+            'victim_msg': "A full-bodied arc cleaves your {hit_location}. You are no longer one piece.",
+            'observer_msg': "A full-bodied arc cleaves {target_name}'s {hit_location}. {target_name} is no longer one piece."
         },
         {
             'attacker_msg': "A savage strike splits skull from jaw. {target_name} slumps in two stages.",
-            'victim_msg': "A savage strike splits your skull from jaw. You slump in two stages.",
-            'observer_msg': "A savage strike splits {target_name}'s skull from jaw. {target_name} slumps in two stages."
+            'victim_msg': "A savage strike splits your {hit_location} from jaw. You slump in two stages.",
+            'observer_msg': "A savage strike splits {target_name}'s {hit_location} from jaw. {target_name} slumps in two stages."
         },
         {
             'attacker_msg': "A spin and chop lands square in the spine. {target_name} stiffens, then falls like scaffolding.",
-            'victim_msg': "A spin and chop lands square in your spine. You stiffen, then fall like scaffolding.",
-            'observer_msg': "A spin and chop lands square in {target_name}'s spine. {target_name} stiffens, then falls like scaffolding."
+            'victim_msg': "A spin and chop lands square in your {hit_location}. You stiffen, then fall like scaffolding.",
+            'observer_msg': "A spin and chop lands square in {target_name}'s {hit_location}. {target_name} stiffens, then falls like scaffolding."
         },
         {
-            'attacker_msg': "One horizontal swing takes {target_name}'s head clean. The silence is shocked and total.",
-            'victim_msg': "One horizontal swing takes your head clean. The silence is shocked and total.",
-            'observer_msg': "One horizontal swing takes {target_name}'s head clean. The silence is shocked and total."
+            'attacker_msg': "One horizontal swing takes {target_name}'s {hit_location} clean. The silence is shocked and total.",
+            'victim_msg': "One horizontal swing takes your {hit_location} clean. The silence is shocked and total.",
+            'observer_msg': "One horizontal swing takes {target_name}'s {hit_location} clean. The silence is shocked and total."
         },
         {
             'attacker_msg': "One wide arc severs the arm — and the will to live.",
-            'victim_msg': "One wide arc severs your arm — and the will to live.",
-            'observer_msg': "One wide arc severs {target_name}'s arm — and the will to live."
+            'victim_msg': "One wide arc severs your {hit_location} — and the will to live.",
+            'observer_msg': "One wide arc severs {target_name}'s {hit_location} — and the will to live."
         },
         {
             'attacker_msg': "Ribs split under the force. Organs follow. You barely notice.",
@@ -513,8 +513,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Steel bites through heart and keeps going. So does the scream, until it doesn't.",
-            'victim_msg': "Steel bites through your heart and keeps going. So does the scream, until it doesn't.",
-            'observer_msg': "Steel bites through {target_name}'s heart and keeps going. So does the scream, until it doesn't."
+            'victim_msg': "Steel bites through your {hit_location} and keeps going. So does the scream, until it doesn't.",
+            'observer_msg': "Steel bites through {target_name}'s {hit_location} and keeps going. So does the scream, until it doesn't."
         },
         {
             'attacker_msg': "Steel drives into the gut. The twist afterward makes death linger longer.",
@@ -523,38 +523,38 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Steel meets spine with a crack like lightning. {target_name} folds, lifeless.",
-            'victim_msg': "Steel meets your spine with a crack like lightning. You fold, lifeless.",
-            'observer_msg': "Steel meets {target_name}'s spine with a crack like lightning. {target_name} folds, lifeless."
+            'victim_msg': "Steel meets your {hit_location} with a crack like lightning. You fold, lifeless.",
+            'observer_msg': "Steel meets {target_name}'s {hit_location} with a crack like lightning. {target_name} folds, lifeless."
         },
         {
             'attacker_msg': "The axe bites into the temple. Lights out. Permanently.",
-            'victim_msg': "The axe bites into your temple. Lights out. Permanently.",
-            'observer_msg': "The axe bites into {target_name}'s temple. Lights out. Permanently."
+            'victim_msg': "The axe bites into your {hit_location}. Lights out. Permanently.",
+            'observer_msg': "The axe bites into {target_name}'s {hit_location}. Lights out. Permanently."
         },
         {
             'attacker_msg': "The axe crashes through the neck. {target_name} collapses headless and irrelevant.",
-            'victim_msg': "The axe crashes through your neck. You collapse headless and irrelevant.",
-            'observer_msg': "The axe crashes through {target_name}'s neck. {target_name} collapses headless and irrelevant."
+            'victim_msg': "The axe crashes through your {hit_location}. You collapse headless and irrelevant.",
+            'observer_msg': "The axe crashes through {target_name}'s {hit_location}. {target_name} collapses headless and irrelevant."
         },
         {
             'attacker_msg': "The axe crushes the face. There's nothing left to recognize.",
-            'victim_msg': "The axe crushes your face. There's nothing left to recognize.",
-            'observer_msg': "The axe crushes {target_name}'s face. There's nothing left to recognize."
+            'victim_msg': "The axe crushes your {hit_location}. There's nothing left to recognize.",
+            'observer_msg': "The axe crushes {target_name}'s {hit_location}. There's nothing left to recognize."
         },
         {
             'attacker_msg': "The axe lands in the neck. It doesn't leave. {target_name} does.",
-            'victim_msg': "The axe lands in your neck. It doesn't leave. You do.",
-            'observer_msg': "The axe lands in {target_name}'s neck. It doesn't leave. {target_name} does."
+            'victim_msg': "The axe lands in your {hit_location}. It doesn't leave. You do.",
+            'observer_msg': "The axe lands in {target_name}'s {hit_location}. It doesn't leave. {target_name} does."
         },
         {
             'attacker_msg': "The axe splits the chest. Everything inside spills and stills.",
-            'victim_msg': "The axe splits your chest. Everything inside spills and stills.",
-            'observer_msg': "The axe splits {target_name}'s chest. Everything inside spills and stills."
+            'victim_msg': "The axe splits your {hit_location}. Everything inside spills and stills.",
+            'observer_msg': "The axe splits {target_name}'s {hit_location}. Everything inside spills and stills."
         },
         {
             'attacker_msg': "The blade lands in the hip, then slides deeper. {target_name} twitches, then stops.",
-            'victim_msg': "The blade lands in your hip, then slides deeper. You twitch, then stop.",
-            'observer_msg': "The blade lands in {target_name}'s hip, then slides deeper. {target_name} twitches, then stops."
+            'victim_msg': "The blade lands in your {hit_location}, then slides deeper. You twitch, then stop.",
+            'observer_msg': "The blade lands in {target_name}'s {hit_location}, then slides deeper. {target_name} twitches, then stops."
         },
         {
             'attacker_msg': "The blade lands with such force it lifts {target_name} before letting them drop.",
@@ -563,8 +563,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The blade tears through the chest. {target_name} falls in halves — emotionally and physically.",
-            'victim_msg': "The blade tears through your chest. You fall in halves — emotionally and physically.",
-            'observer_msg': "The blade tears through {target_name}'s chest. {target_name} falls in halves — emotionally and physically."
+            'victim_msg': "The blade tears through your {hit_location}. You fall in halves — emotionally and physically.",
+            'observer_msg': "The blade tears through {target_name}'s {hit_location}. {target_name} falls in halves — emotionally and physically."
         },
         {
             'attacker_msg': "The final strike breaks everything. {target_name} doesn't move again.",
@@ -578,13 +578,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The spine severs with one crack. {target_name} hits the ground like a switch flipped off.",
-            'victim_msg': "Your spine severs with one crack. You hit the ground like a switch flipped off.",
-            'observer_msg': "{target_name}'s spine severs with one crack. {target_name} hits the ground like a switch flipped off."
+            'victim_msg': "Your {hit_location} severs with one crack. You hit the ground like a switch flipped off.",
+            'observer_msg': "{target_name}'s {hit_location} severs with one crack. {target_name} hits the ground like a switch flipped off."
         },
         {
             'attacker_msg': "The weapon carves through ribs like butter. {target_name} barely gets to react.",
-            'victim_msg': "The weapon carves through your ribs like butter. You barely get to react.",
-            'observer_msg': "The weapon carves through {target_name}'s ribs like butter. {target_name} barely gets to react."
+            'victim_msg': "The weapon carves through your {hit_location} like butter. You barely get to react.",
+            'observer_msg': "The weapon carves through {target_name}'s {hit_location} like butter. {target_name} barely gets to react."
         },
         {
             'attacker_msg': "You bring it down one last time. The silence after is thick with respect.",
@@ -598,13 +598,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You hack deep into the neck. {target_name} drops mid-gurgle.",
-            'victim_msg': "{attacker_name} hacks deep into your neck. You drop mid-gurgle.",
-            'observer_msg': "{attacker_name} hacks deep into {target_name}'s neck. {target_name} drops mid-gurgle."
+            'victim_msg': "{attacker_name} hacks deep into your {hit_location}. You drop mid-gurgle.",
+            'observer_msg': "{attacker_name} hacks deep into {target_name}'s {hit_location}. {target_name} drops mid-gurgle."
         },
         {
             'attacker_msg': "You swing down hard. The chest caves in like a kicked door.",
-            'victim_msg': "{attacker_name} swings down hard. Your chest caves in like a kicked door.",
-            'observer_msg': "{attacker_name} swings down hard. {target_name}'s chest caves in like a kicked door."
+            'victim_msg': "{attacker_name} swings down hard. Your {hit_location} caves in like a kicked door.",
+            'observer_msg': "{attacker_name} swings down hard. {target_name}'s {hit_location} caves in like a kicked door."
         },
     ],
 }

--- a/world/combat/messages/large_shield.py
+++ b/world/combat/messages/large_shield.py
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     'kill': [
         {
-            'attacker_msg': "A brutal downward blow flattens {target_name}'s head into an unrecognizable red smear.",
-            'victim_msg': "A brutal downward blow flattens your head into an unrecognizable red smear.",
-            'observer_msg': "A brutal downward blow flattens {target_name}'s head into an unrecognizable red smear."
+            'attacker_msg': "A brutal downward blow flattens {target_name}'s {hit_location} into an unrecognizable red smear.",
+            'victim_msg': "A brutal downward blow flattens your {hit_location} into an unrecognizable red smear.",
+            'observer_msg': "A brutal downward blow flattens {target_name}'s {hit_location} into an unrecognizable red smear."
         },
         {
             'attacker_msg': "A crushing downward blow breaks neck, spine, and noise alike.",
@@ -473,18 +473,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A full-bodied slam to the chest compresses {target_name} until breathing isn't an option.",
-            'victim_msg': "A full-bodied slam to your chest compresses you until breathing isn't an option.",
-            'observer_msg': "A full-bodied slam to {target_name}'s chest compresses {target_name} until breathing isn't an option."
+            'victim_msg': "A full-bodied slam to your {hit_location} compresses you until breathing isn't an option.",
+            'observer_msg': "A full-bodied slam to {target_name}'s {hit_location} compresses {target_name} until breathing isn't an option."
         },
         {
             'attacker_msg': "A lunging bash snaps the spine mid-charge. {target_name} drops mid-step, lifeless.",
-            'victim_msg': "A lunging bash snaps your spine mid-charge. You drop mid-step, lifeless.",
-            'observer_msg': "A lunging bash snaps {target_name}'s spine mid-charge. {target_name} drops mid-step, lifeless."
+            'victim_msg': "A lunging bash snaps your {hit_location} mid-charge. You drop mid-step, lifeless.",
+            'observer_msg': "A lunging bash snaps {target_name}'s {hit_location} mid-charge. {target_name} drops mid-step, lifeless."
         },
         {
             'attacker_msg': "A relentless press against the ribs. They snap like dry reeds. {target_name} makes no sound at the end.",
-            'victim_msg': "A relentless press against your ribs. They snap like dry reeds. You make no sound at the end.",
-            'observer_msg': "A relentless press against {target_name}'s ribs. They snap like dry reeds. {target_name} makes no sound at the end."
+            'victim_msg': "A relentless press against your {hit_location}. They snap like dry reeds. You make no sound at the end.",
+            'observer_msg': "A relentless press against {target_name}'s {hit_location}. They snap like dry reeds. {target_name} makes no sound at the end."
         },
         {
             'attacker_msg': "A rising blow flips {target_name} backwards. Their body lands wrong. Their spirit doesn't return.",
@@ -498,8 +498,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A savage bash to the temple wipes out everything behind the eyes.",
-            'victim_msg': "A savage bash to your temple wipes out everything behind the eyes.",
-            'observer_msg': "A savage bash to {target_name}'s temple wipes out everything behind the eyes."
+            'victim_msg': "A savage bash to your {hit_location} wipes out everything behind the eyes.",
+            'observer_msg': "A savage bash to {target_name}'s {hit_location} wipes out everything behind the eyes."
         },
         {
             'attacker_msg': "One final swing topples {target_name} like scaffolding in a quake. The dust settles faster than they do.",
@@ -508,8 +508,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "One long shove across the chest caves it in. {target_name} exhales everything they ever were.",
-            'victim_msg': "One long shove across your chest caves it in. You exhale everything you ever were.",
-            'observer_msg': "One long shove across {target_name}'s chest caves it in. {target_name} exhales everything they ever were."
+            'victim_msg': "One long shove across your {hit_location} caves it in. You exhale everything you ever were.",
+            'observer_msg': "One long shove across {target_name}'s {hit_location} caves it in. {target_name} exhales everything they ever were."
         },
         {
             'attacker_msg': "One shove — full force — sends {target_name} into a wall so hard it leaves a dent in both.",
@@ -523,13 +523,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The entire edge crashes into the base of the skull. {target_name} falls like a dropped sack.",
-            'victim_msg': "The entire edge crashes into the base of your skull. You fall like a dropped sack.",
-            'observer_msg': "The entire edge crashes into the base of {target_name}'s skull. {target_name} falls like a dropped sack."
+            'victim_msg': "The entire edge crashes into the base of your {hit_location}. You fall like a dropped sack.",
+            'observer_msg': "The entire edge crashes into the base of {target_name}'s {hit_location}. {target_name} falls like a dropped sack."
         },
         {
-            'attacker_msg': "The entire front edge is brought down on {target_name}'s head. There's no second strike.",
-            'victim_msg': "The entire front edge is brought down on your head. There's no second strike.",
-            'observer_msg': "The entire front edge is brought down on {target_name}'s head. There's no second strike."
+            'attacker_msg': "The entire front edge is brought down on {target_name}'s {hit_location}. There's no second strike.",
+            'victim_msg': "The entire front edge is brought down on your {hit_location}. There's no second strike.",
+            'observer_msg': "The entire front edge is brought down on {target_name}'s {hit_location}. There's no second strike."
         },
         {
             'attacker_msg': "The massive shield comes down like judgment. {target_name} folds beneath it, every sound final.",
@@ -538,13 +538,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The rim crashes into the skull. There's a snap. Then a collapse. Then stillness.",
-            'victim_msg': "The rim crashes into your skull. There's a snap. Then a collapse. Then stillness.",
-            'observer_msg': "The rim crashes into {target_name}'s skull. There's a snap. Then a collapse. Then stillness."
+            'victim_msg': "The rim crashes into your {hit_location}. There's a snap. Then a collapse. Then stillness.",
+            'observer_msg': "The rim crashes into {target_name}'s {hit_location}. There's a snap. Then a collapse. Then stillness."
         },
         {
             'attacker_msg': "The rim punches the throat. The collapse is instant. The breathing isn't.",
-            'victim_msg': "The rim punches your throat. The collapse is instant. The breathing isn't.",
-            'observer_msg': "The rim punches {target_name}'s throat. The collapse is instant. The breathing isn't."
+            'victim_msg': "The rim punches your {hit_location}. The collapse is instant. The breathing isn't.",
+            'observer_msg': "The rim punches {target_name}'s {hit_location}. The collapse is instant. The breathing isn't."
         },
         {
             'attacker_msg': "The shield comes down like judgment. {target_name} is pinned, pulped, and forgotten.",
@@ -553,13 +553,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The shield hits the skull at full tilt. The twitch afterward is purely reflex.",
-            'victim_msg': "The shield hits your skull at full tilt. The twitch afterward is purely reflex.",
-            'observer_msg': "The shield hits {target_name}'s skull at full tilt. The twitch afterward is purely reflex."
+            'victim_msg': "The shield hits your {hit_location} at full tilt. The twitch afterward is purely reflex.",
+            'observer_msg': "The shield hits {target_name}'s {hit_location} at full tilt. The twitch afterward is purely reflex."
         },
         {
             'attacker_msg': "The shield slams into the neck. {target_name} staggers, gurgles, then hits the floor like meat.",
-            'victim_msg': "The shield slams into your neck. You stagger, gurgle, then hit the floor like meat.",
-            'observer_msg': "The shield slams into {target_name}'s neck. {target_name} staggers, gurgles, then hits the floor like meat."
+            'victim_msg': "The shield slams into your {hit_location}. You stagger, gurgle, then hit the floor like meat.",
+            'observer_msg': "The shield slams into {target_name}'s {hit_location}. {target_name} staggers, gurgles, then hits the floor like meat."
         },
         {
             'attacker_msg': "The slab folds {target_name} backward over a crate. When they fall, they stay folded.",
@@ -578,7 +578,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You pin them down and drive the shield into the chest until breathing is academic.",
-            'victim_msg': "{attacker_name} pins you down and drives the shield into your chest until breathing is academic.",
+            'victim_msg': "{attacker_name} pins you down and drives the shield into your {hit_location} until breathing is academic.",
             'observer_msg': "{attacker_name} pins {target_name} down and drives the shield into the chest until breathing is academic."
         },
         {
@@ -602,9 +602,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} rams until resistance fades. They only stop when nothing pushes back."
         },
         {
-            'attacker_msg': "You swing upward. The edge of the shield caves in {target_name}'s jaw and leaves silence behind.",
-            'victim_msg': "{attacker_name} swings upward. The edge of the shield caves in your jaw and leaves silence behind.",
-            'observer_msg': "{attacker_name} swings upward. The edge of the shield caves in {target_name}'s jaw and leaves silence behind."
+            'attacker_msg': "You swing upward. The edge of the shield caves in {target_name}'s {hit_location} and leaves silence behind.",
+            'victim_msg': "{attacker_name} swings upward. The edge of the shield caves in your {hit_location} and leaves silence behind.",
+            'observer_msg': "{attacker_name} swings upward. The edge of the shield caves in {target_name}'s {hit_location} and leaves silence behind."
         },
     ],
 }

--- a/world/combat/messages/lever-action_rifle.py
+++ b/world/combat/messages/lever-action_rifle.py
@@ -1,7 +1,7 @@
 MESSAGES = {
     "initiate": [
         {
-            'attacker_msg': "You bring a classic lever-action rifle to your shoulder, the polished wood stock and blued steel gleaming with deadly promise.",
+            'attacker_msg': "You bring a classic lever-action rifle to your {hit_location}, the polished wood stock and blued steel gleaming with deadly promise.",
             'victim_msg': "{attacker_name} brings a classic lever-action rifle to their shoulder, the polished wood stock and blued steel gleaming with deadly promise.",
             'observer_msg': "{attacker_name} brings a classic lever-action rifle to their shoulder, the polished wood stock and blued steel gleaming with deadly promise."
         },
@@ -61,12 +61,12 @@ MESSAGES = {
             'observer_msg': "The air is tense as {attacker_name} prepares to fire the lever-action rifle, anticipating the solid *CRACK* of the shot and the immediate, fluid cycle of the lever."
         },
         {
-            'attacker_msg': "Your face is set in concentration, finger ready on the trigger of the lever-action rifle, poised to send lead and then quickly reload.",
+            'attacker_msg': "Your {hit_location} is set in concentration, finger ready on the trigger of the lever-action rifle, poised to send lead and then quickly reload.",
             'victim_msg': "{attacker_name}'s face is set in concentration, finger ready on the trigger of the lever-action rifle, poised to send lead and then quickly reload.",
             'observer_msg': "{attacker_name}'s face is set in concentration, finger ready on the trigger of the lever-action rifle, poised to send lead and then quickly reload."
         },
         {
-            'attacker_msg': "The lever-action rifle feels like a trusty, dependable extension of your arm, a tool of the trade honed by generations.",
+            'attacker_msg': "The lever-action rifle feels like a trusty, dependable extension of your {hit_location}, a tool of the trade honed by generations.",
             'victim_msg': "The lever-action rifle feels like a trusty, dependable extension of {attacker_name}'s arm, a tool of the trade honed by generations.",
             'observer_msg': "The lever-action rifle feels like a trusty, dependable extension of {attacker_name}'s arm, a tool of the trade honed by generations."
         },
@@ -311,7 +311,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} ducks just in time as the lever-action rifle barks, the bullet splintering wood where their head had been a split second before. You smoothly cycle the action, already searching for another shot opportunity.",
-            'victim_msg': "You duck just in time as the lever-action rifle barks, the bullet splintering wood where your head had been a split second before. {attacker_name} smoothly cycles the action, already searching for another shot opportunity.",
+            'victim_msg': "You duck just in time as the lever-action rifle barks, the bullet splintering wood where your {hit_location} had been a split second before. {attacker_name} smoothly cycles the action, already searching for another shot opportunity.",
             'observer_msg': "{target_name} ducks just in time as the lever-action rifle barks, the bullet splintering wood where their head had been a split second before. {attacker_name} smoothly cycles the action, already searching for another shot opportunity."
         },
         {
@@ -325,7 +325,7 @@ MESSAGES = {
             'observer_msg': "The heavy bullet streaks wide of {target_name}, a wasted but quickly rectified shot from the lever-action rifle. {attacker_name} chambers another round with a decisive, rapid *clack-clack* of the lever, already re-sighting."
         },
         {
-            'attacker_msg': "You jerk the trigger of the lever-action rifle in haste, the bullet blasting a hole in the ground well short of {target_name}, kicking up dirt. You quickly work the lever, ejecting the hot brass, a flicker of annoyance on your face.",
+            'attacker_msg': "You jerk the trigger of the lever-action rifle in haste, the bullet blasting a hole in the ground well short of {target_name}, kicking up dirt. You quickly work the lever, ejecting the hot brass, a flicker of annoyance on your {hit_location}.",
             'victim_msg': "{attacker_name} jerks the trigger of the lever-action rifle in haste, the bullet blasting a hole in the ground well short of you, kicking up dirt. {attacker_name} quickly works the lever, ejecting the hot brass, a flicker of annoyance on their face.",
             'observer_msg': "{attacker_name} jerks the trigger of the lever-action rifle in haste, the bullet blasting a hole in the ground well short of {target_name}, kicking up dirt. {attacker_name} quickly works the lever, ejecting the hot brass, a flicker of annoyance on their face."
         },
@@ -335,9 +335,9 @@ MESSAGES = {
             'observer_msg': "A sudden, unexpected movement from {target_name} causes {attacker_name}'s lever-action rifle shot to go wide, the bullet thudding harmlessly into the earth. The lever is cycled with a smooth, practiced motion, another round sliding home as if by magic."
         },
         {
-            'attacker_msg': "The lever-action rifle fires with a loud report, but your aim is slightly off, the bullet sailing harmlessly over {target_name}'s head by inches. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, unbroken movement.",
-            'victim_msg': "The lever-action rifle fires with a loud report, but {attacker_name}'s aim is slightly off, the bullet sailing harmlessly over your head by inches. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, unbroken movement.",
-            'observer_msg': "The lever-action rifle fires with a loud report, but {attacker_name}'s aim is slightly off, the bullet sailing harmlessly over {target_name}'s head by inches. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, unbroken movement."
+            'attacker_msg': "The lever-action rifle fires with a loud report, but your aim is slightly off, the bullet sailing harmlessly over {target_name}'s {hit_location} by inches. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, unbroken movement.",
+            'victim_msg': "The lever-action rifle fires with a loud report, but {attacker_name}'s aim is slightly off, the bullet sailing harmlessly over your {hit_location} by inches. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, unbroken movement.",
+            'observer_msg': "The lever-action rifle fires with a loud report, but {attacker_name}'s aim is slightly off, the bullet sailing harmlessly over {target_name}'s {hit_location} by inches. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, unbroken movement."
         },
         {
             'attacker_msg': "Your shot is deflected by an unseen branch, the heavy slug careening off into the undergrowth with a whine, far from {target_name}. A single spent casing is ejected cleanly as you work the lever, already compensating.",
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick sidestep from {target_name} leaves {attacker_name}'s lever-action rifle to punch a neat, round hole in an empty wooden crate. {attacker_name} cycles the lever, unflinching, another round ready almost before the echo fades."
         },
         {
-            'attacker_msg': "The lever-action rifle jumps in your shoulder a bit more than expected as you miss, the recoil spoiling the follow-through for a precious second. You work the lever, chambering a fresh round, re-focusing.",
+            'attacker_msg': "The lever-action rifle jumps in your {hit_location} a bit more than expected as you miss, the recoil spoiling the follow-through for a precious second. You work the lever, chambering a fresh round, re-focusing.",
             'victim_msg': "The lever-action rifle jumps in {attacker_name}'s shoulder a bit more than expected as they miss, the recoil spoiling the follow-through for a precious second. {attacker_name} works the lever, chambering a fresh round, re-focusing.",
             'observer_msg': "The lever-action rifle jumps in {attacker_name}'s shoulder a bit more than expected as they miss, the recoil spoiling the follow-through for a precious second. {attacker_name} works the lever, chambering a fresh round, re-focusing."
         },
@@ -467,19 +467,19 @@ MESSAGES = {
             'observer_msg': "The lever-action rifle roars with authority, and {target_name} collapses in a heap as a heavy slug tears through a vital organ, dead before they even hit the ground. {attacker_name} smoothly cycles the action, the rifle ready again, though likely unneeded."
         },
         {
-            'attacker_msg': "With a final, well-aimed shot, your lever-action rifle sends a bullet clean through {target_name}'s head, ending their struggles instantly and decisively. A gleaming brass casing flips out and away as the lever is worked with fluid, final speed.",
-            'victim_msg': "With a final, well-aimed shot, {attacker_name}'s lever-action rifle sends a bullet clean through your head, ending your struggles instantly and decisively. A gleaming brass casing flips out and away as the lever is worked with fluid, final speed.",
-            'observer_msg': "With a final, well-aimed shot, {attacker_name}'s lever-action rifle sends a bullet clean through {target_name}'s head, ending their struggles instantly and decisively. A gleaming brass casing flips out and away as the lever is worked with fluid, final speed."
+            'attacker_msg': "With a final, well-aimed shot, your lever-action rifle sends a bullet clean through {target_name}'s {hit_location}, ending their struggles instantly and decisively. A gleaming brass casing flips out and away as the lever is worked with fluid, final speed.",
+            'victim_msg': "With a final, well-aimed shot, {attacker_name}'s lever-action rifle sends a bullet clean through your {hit_location}, ending your struggles instantly and decisively. A gleaming brass casing flips out and away as the lever is worked with fluid, final speed.",
+            'observer_msg': "With a final, well-aimed shot, {attacker_name}'s lever-action rifle sends a bullet clean through {target_name}'s {hit_location}, ending their struggles instantly and decisively. A gleaming brass casing flips out and away as the lever is worked with fluid, final speed."
         },
         {
-            'attacker_msg': "The heavy, .30-30 or .45-70 bullet fired from the lever-action rifle smashes into {target_name}'s spine with devastating force; they drop like a puppet with its strings cut, motionless. You chamber another round with a decisive, rapid *clack-clack* of the lever, just in case.",
-            'victim_msg': "The heavy, .30-30 or .45-70 bullet fired from the lever-action rifle smashes into your spine with devastating force; you drop like a puppet with its strings cut, motionless. {attacker_name} chambers another round with a decisive, rapid *clack-clack* of the lever, just in case.",
-            'observer_msg': "The heavy, .30-30 or .45-70 bullet fired from the lever-action rifle smashes into {target_name}'s spine with devastating force; they drop like a puppet with its strings cut, motionless. {attacker_name} chambers another round with a decisive, rapid *clack-clack* of the lever, just in case."
+            'attacker_msg': "The heavy, .30-30 or .45-70 bullet fired from the lever-action rifle smashes into {target_name}'s {hit_location} with devastating force; they drop like a puppet with its strings cut, motionless. You chamber another round with a decisive, rapid *clack-clack* of the lever, just in case.",
+            'victim_msg': "The heavy, .30-30 or .45-70 bullet fired from the lever-action rifle smashes into your {hit_location} with devastating force; you drop like a puppet with its strings cut, motionless. {attacker_name} chambers another round with a decisive, rapid *clack-clack* of the lever, just in case.",
+            'observer_msg': "The heavy, .30-30 or .45-70 bullet fired from the lever-action rifle smashes into {target_name}'s {hit_location} with devastating force; they drop like a puppet with its strings cut, motionless. {attacker_name} chambers another round with a decisive, rapid *clack-clack* of the lever, just in case."
         },
         {
-            'attacker_msg': "Your carefully placed shot with the lever-action rifle pierces {target_name}'s heart; they gasp, clutch their chest, and fall silent, eyes wide. The lever is cycled with a smooth, almost casual motion, another round sliding home, a grim epitaph.",
-            'victim_msg': "{attacker_name}'s carefully placed shot with the lever-action rifle pierces your heart; you gasp, clutch your chest, and fall silent, eyes wide. The lever is cycled with a smooth, almost casual motion, another round sliding home, a grim epitaph.",
-            'observer_msg': "{attacker_name}'s carefully placed shot with the lever-action rifle pierces {target_name}'s heart; they gasp, clutch their chest, and fall silent, eyes wide. The lever is cycled with a smooth, almost casual motion, another round sliding home, a grim epitaph."
+            'attacker_msg': "Your carefully placed shot with the lever-action rifle pierces {target_name}'s {hit_location}; they gasp, clutch their chest, and fall silent, eyes wide. The lever is cycled with a smooth, almost casual motion, another round sliding home, a grim epitaph.",
+            'victim_msg': "{attacker_name}'s carefully placed shot with the lever-action rifle pierces your {hit_location}; you gasp, clutch your {hit_location}, and fall silent, eyes wide. The lever is cycled with a smooth, almost casual motion, another round sliding home, a grim epitaph.",
+            'observer_msg': "{attacker_name}'s carefully placed shot with the lever-action rifle pierces {target_name}'s {hit_location}; they gasp, clutch their chest, and fall silent, eyes wide. The lever is cycled with a smooth, almost casual motion, another round sliding home, a grim epitaph."
         },
         {
             'attacker_msg': "The lever-action rifle, an instrument of classic, rugged lethality, delivers a killing blow as {target_name} is overcome by the devastating, traditional bullet wound. You work the lever with a familiar rhythm, scanning for other threats.",
@@ -488,18 +488,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A precise shot to the neck from your lever-action rifle drops {target_name} in a gurgling heap, blood pooling quickly. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, final movement.",
-            'victim_msg': "A precise shot to your neck from {attacker_name}'s lever-action rifle drops you in a gurgling heap, blood pooling quickly. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, final movement.",
-            'observer_msg': "A precise shot to {target_name}'s neck from {attacker_name}'s lever-action rifle drops {target_name} in a gurgling heap, blood pooling quickly. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, final movement."
+            'victim_msg': "A precise shot to your {hit_location} from {attacker_name}'s lever-action rifle drops you in a gurgling heap, blood pooling quickly. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, final movement.",
+            'observer_msg': "A precise shot to {target_name}'s {hit_location} from {attacker_name}'s lever-action rifle drops {target_name} in a gurgling heap, blood pooling quickly. The lever is worked with a practiced, efficient flick of the wrist, ejecting and loading in one smooth, final movement."
         },
         {
-            'attacker_msg': "Your single, powerful shot from the lever-action rifle punches clean through {target_name}'s lung; they cough once, a spray of crimson, and are still. You cycle the lever methodically, eyes already moving on.",
-            'victim_msg': "{attacker_name}'s single, powerful shot from the lever-action rifle punches clean through your lung; you cough once, a spray of crimson, and are still. {attacker_name} cycles the lever methodically, eyes already moving on.",
-            'observer_msg': "{attacker_name}'s single, powerful shot from the lever-action rifle punches clean through {target_name}'s lung; they cough once, a spray of crimson, and are still. {attacker_name} cycles the lever methodically, eyes already moving on."
+            'attacker_msg': "Your single, powerful shot from the lever-action rifle punches clean through {target_name}'s {hit_location}; they cough once, a spray of crimson, and are still. You cycle the lever methodically, eyes already moving on.",
+            'victim_msg': "{attacker_name}'s single, powerful shot from the lever-action rifle punches clean through your {hit_location}; you cough once, a spray of crimson, and are still. {attacker_name} cycles the lever methodically, eyes already moving on.",
+            'observer_msg': "{attacker_name}'s single, powerful shot from the lever-action rifle punches clean through {target_name}'s {hit_location}; they cough once, a spray of crimson, and are still. {attacker_name} cycles the lever methodically, eyes already moving on."
         },
         {
-            'attacker_msg': "The unyielding, heavy slug from your lever-action rifle pierces {target_name}'s skull with a sickening crunch; they fall without a sound, instantly gone. A hot brass casing is ejected as you prepare another shot with a swift throw of the lever, though the need has passed.",
-            'victim_msg': "The unyielding, heavy slug from {attacker_name}'s lever-action rifle pierces your skull with a sickening crunch; you fall without a sound, instantly gone. A hot brass casing is ejected as {attacker_name} prepares another shot with a swift throw of the lever, though the need has passed.",
-            'observer_msg': "The unyielding, heavy slug from {attacker_name}'s lever-action rifle pierces {target_name}'s skull with a sickening crunch; they fall without a sound, instantly gone. A hot brass casing is ejected as {attacker_name} prepares another shot with a swift throw of the lever, though the need has passed."
+            'attacker_msg': "The unyielding, heavy slug from your lever-action rifle pierces {target_name}'s {hit_location} with a sickening crunch; they fall without a sound, instantly gone. A hot brass casing is ejected as you prepare another shot with a swift throw of the lever, though the need has passed.",
+            'victim_msg': "The unyielding, heavy slug from {attacker_name}'s lever-action rifle pierces your {hit_location} with a sickening crunch; you fall without a sound, instantly gone. A hot brass casing is ejected as {attacker_name} prepares another shot with a swift throw of the lever, though the need has passed.",
+            'observer_msg': "The unyielding, heavy slug from {attacker_name}'s lever-action rifle pierces {target_name}'s {hit_location} with a sickening crunch; they fall without a sound, instantly gone. A hot brass casing is ejected as {attacker_name} prepares another shot with a swift throw of the lever, though the need has passed."
         },
         {
             'attacker_msg': "With a final, sharp, echoing crack, you finish {target_name} with a bullet through the torso from the lever-action rifle, leaving a gaping exit wound. The lever is worked with smooth, almost indifferent efficiency.",

--- a/world/combat/messages/lever-action_shotgun.py
+++ b/world/combat/messages/lever-action_shotgun.py
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air is tense as {attacker_name} prepares to fire the lever-action shotgun, anticipating the powerful *BOOM* and the immediate, fluid cycle of the lever."
         },
         {
-            'attacker_msg': "Your face is set, finger ready on the trigger of the lever-action shotgun, poised to send a cloud of buckshot or a heavy slug.",
+            'attacker_msg': "Your {hit_location} is set, finger ready on the trigger of the lever-action shotgun, poised to send a cloud of buckshot or a heavy slug.",
             'victim_msg': "{attacker_name}'s face is set, finger ready on the trigger of the lever-action shotgun, poised to send a cloud of buckshot or a heavy slug.",
             'observer_msg': "{attacker_name}'s face is set, finger ready on the trigger of the lever-action shotgun, poised to send a cloud of buckshot or a heavy slug."
         },
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} drops low just as your lever-action shotgun fires, pellets whistling over their head. You cycle the lever methodically, scanning.",
-            'victim_msg': "You drop low just as {attacker_name}'s lever-action shotgun fires, pellets whistling over your head. {attacker_name} cycles the lever methodically, scanning.",
+            'victim_msg': "You drop low just as {attacker_name}'s lever-action shotgun fires, pellets whistling over your {hit_location}. {attacker_name} cycles the lever methodically, scanning.",
             'observer_msg': "{target_name} drops low just as {attacker_name}'s lever-action shotgun fires, pellets whistling over their head. {attacker_name} cycles the lever methodically, scanning."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick sidestep from {target_name} leaves {attacker_name}'s lever-action shotgun to blast a pattern into a wall. {attacker_name} cycles the lever, unflinching, ready to fire again."
         },
         {
-            'attacker_msg': "The lever-action shotgun jumps in your shoulder as you miss. You cycle the lever, chambering a fresh, potent shell, correcting your stance.",
+            'attacker_msg': "The lever-action shotgun jumps in your {hit_location} as you miss. You cycle the lever, chambering a fresh, potent shell, correcting your stance.",
             'victim_msg': "The lever-action shotgun jumps in {attacker_name}'s shoulder as they miss. {attacker_name} cycles the lever, chambering a fresh, potent shell, correcting their stance.",
             'observer_msg': "The lever-action shotgun jumps in {attacker_name}'s shoulder as they miss. {attacker_name} cycles the lever, chambering a fresh, potent shell, correcting their stance."
         },
@@ -462,9 +462,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s lever-action shotgun erupts with a deafening *BOOM*, the concentrated blast tearing {target_name} apart; they collapse, lifeless. With a swift *SHINK-KLAK*, {attacker_name} cycles the lever, ejecting a smoking shell, the threat eliminated."
         },
         {
-            'attacker_msg': "The lever-action shotgun roars, and a heavy slug slams into {target_name}'s chest with fatal force, ending their fight instantly. You work the lever with a satisfying *CHAK-CHUNK*, the job done.",
-            'victim_msg': "The lever-action shotgun roars, and a heavy slug slams into your chest with fatal force, ending your fight instantly. {attacker_name} works the lever with a satisfying *CHAK-CHUNK*, the job done.",
-            'observer_msg': "The lever-action shotgun roars, and a heavy slug slams into {target_name}'s chest with fatal force, ending their fight instantly. {attacker_name} works the lever with a satisfying *CHAK-CHUNK*, the job done."
+            'attacker_msg': "The lever-action shotgun roars, and a heavy slug slams into {target_name}'s {hit_location} with fatal force, ending their fight instantly. You work the lever with a satisfying *CHAK-CHUNK*, the job done.",
+            'victim_msg': "The lever-action shotgun roars, and a heavy slug slams into your {hit_location} with fatal force, ending your fight instantly. {attacker_name} works the lever with a satisfying *CHAK-CHUNK*, the job done.",
+            'observer_msg': "The lever-action shotgun roars, and a heavy slug slams into {target_name}'s {hit_location} with fatal force, ending their fight instantly. {attacker_name} works the lever with a satisfying *CHAK-CHUNK*, the job done."
         },
         {
             'attacker_msg': "With a final, brutal blast to the head, your lever-action shotgun obliterates {target_name}. Smoke curls from the muzzle as you cycle the action with a forceful, final lever throw.",
@@ -477,9 +477,9 @@ MESSAGES = {
             'observer_msg': "A devastating point-blank discharge from {attacker_name}'s lever-action shotgun engulfs {target_name}, who is torn apart by the pellets. {attacker_name} works the lever, ejecting a spent shell, standing over the fallen."
         },
         {
-            'attacker_msg': "The lever-action shotgun's blast strikes {target_name}'s torso, the massive trauma instantly fatal. You quickly cycle the lever, another shell ready, though unneeded.",
-            'victim_msg': "The lever-action shotgun's blast strikes your torso, the massive trauma instantly fatal. {attacker_name} quickly cycles the lever, another shell ready, though unneeded.",
-            'observer_msg': "The lever-action shotgun's blast strikes {target_name}'s torso, the massive trauma instantly fatal. {attacker_name} quickly cycles the lever, another shell ready, though unneeded."
+            'attacker_msg': "The lever-action shotgun's blast strikes {target_name}'s {hit_location}, the massive trauma instantly fatal. You quickly cycle the lever, another shell ready, though unneeded.",
+            'victim_msg': "The lever-action shotgun's blast strikes your {hit_location}, the massive trauma instantly fatal. {attacker_name} quickly cycles the lever, another shell ready, though unneeded.",
+            'observer_msg': "The lever-action shotgun's blast strikes {target_name}'s {hit_location}, the massive trauma instantly fatal. {attacker_name} quickly cycles the lever, another shell ready, though unneeded."
         },
         {
             'attacker_msg': "The lever-action shotgun, an instrument of classic, brutal finality, delivers a killing blow as {target_name} is shredded. The action is cycled with a smooth, powerful *SHINK-THUNK*, silence falling.",
@@ -537,9 +537,9 @@ MESSAGES = {
             'observer_msg': "A devastating blast from the lever-action shotgun to {target_name}'s center mass ends the conflict. {attacker_name} cycles the lever, unflinching at the carnage."
         },
         {
-            'attacker_msg': "The lever-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s torso. You cycle the lever, chambering a fresh shell, the area now quiet.",
-            'victim_msg': "The lever-action shotgun's payload makes solid, brutal, and fatal contact with your torso. {attacker_name} cycles the lever, chambering a fresh shell, the area now quiet.",
-            'observer_msg': "The lever-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s torso. {attacker_name} cycles the lever, chambering a fresh shell, the area now quiet."
+            'attacker_msg': "The lever-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s {hit_location}. You cycle the lever, chambering a fresh shell, the area now quiet.",
+            'victim_msg': "The lever-action shotgun's payload makes solid, brutal, and fatal contact with your {hit_location}. {attacker_name} cycles the lever, chambering a fresh shell, the area now quiet.",
+            'observer_msg': "The lever-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s {hit_location}. {attacker_name} cycles the lever, chambering a fresh shell, the area now quiet."
         },
         {
             'attacker_msg': "Your lever-action shotgun projectile cloud finds its mark with lethal precision. A spent shell arcs away as you cycle the lever over {target_name}'s still form.",
@@ -592,9 +592,9 @@ MESSAGES = {
             'observer_msg': "The projectile cloud from {attacker_name}'s lever-action shotgun hits {target_name} with overwhelming force, dropping them. The action is cycled, ejecting the shell smartly."
         },
         {
-            'attacker_msg': "Your lever-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}'s torso. The shotgun is cycled, the grim task complete.",
-            'victim_msg': "{attacker_name}'s lever-action shotgun delivers a wide, penetrating, and fatal impact to your torso. The shotgun is cycled, the grim task complete.",
-            'observer_msg': "{attacker_name}'s lever-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}'s torso. The shotgun is cycled, the grim task complete."
+            'attacker_msg': "Your lever-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}'s {hit_location}. The shotgun is cycled, the grim task complete.",
+            'victim_msg': "{attacker_name}'s lever-action shotgun delivers a wide, penetrating, and fatal impact to your {hit_location}. The shotgun is cycled, the grim task complete.",
+            'observer_msg': "{attacker_name}'s lever-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}'s {hit_location}. The shotgun is cycled, the grim task complete."
         },
         {
             'attacker_msg': "A well-placed, devastating blast from the lever-action shotgun leaves {target_name} lifeless. You cycle the lever, the weapon's classic efficiency clear.",

--- a/world/combat/messages/light_pistol.py
+++ b/world/combat/messages/light_pistol.py
@@ -11,12 +11,12 @@ MESSAGES = {
             'observer_msg': "With a practiced motion, {attacker_name} checks the magazine of the pistol, then snaps it firmly into place."
         },
         {
-            'attacker_msg': "Your hand closes around the polymer or steel grip of the pistol, finger indexing along the slide.",
+            'attacker_msg': "Your {hit_location} closes around the polymer or steel grip of the pistol, finger indexing along the slide.",
             'victim_msg': "{attacker_name}'s hand closes around the polymer or steel grip of the pistol, finger indexing along the slide.",
             'observer_msg': "{attacker_name}'s hand closes around the polymer or steel grip of the pistol, finger indexing along the slide."
         },
         {
-            'attacker_msg': "The pistol appears in your hand, its muzzle a dark, efficient-looking circle.",
+            'attacker_msg': "The pistol appears in your {hit_location}, its muzzle a dark, efficient-looking circle.",
             'victim_msg': "The pistol appears in {attacker_name}'s hand, its muzzle a dark, efficient-looking circle.",
             'observer_msg': "The pistol appears in {attacker_name}'s hand, its muzzle a dark, efficient-looking circle."
         },
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air seems to still as {attacker_name} prepares to fire the pistol, anticipating the sharp *crack* of the shot."
         },
         {
-            'attacker_msg': "Your face is set in concentration, finger hovering near the pistol's trigger.",
+            'attacker_msg': "Your {hit_location} is set in concentration, finger hovering near the pistol's trigger.",
             'victim_msg': "{attacker_name}'s face is set in concentration, finger hovering near the pistol's trigger.",
             'observer_msg': "{attacker_name}'s face is set in concentration, finger hovering near the pistol's trigger."
         },
@@ -184,7 +184,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A direct hit! The pistol's bullet smashes into {target_name}'s {hit_location}, driving the air from their lungs with a sharp *crack*.",
-            'victim_msg': "A direct hit! The pistol's bullet smashes into your {hit_location}, driving the air from your lungs with a sharp *crack*.",
+            'victim_msg': "A direct hit! The pistol's bullet smashes into your {hit_location}, driving the air from your {hit_location} with a sharp *crack*.",
             'observer_msg': "A direct hit! The pistol's bullet smashes into {target_name}'s {hit_location}, driving the air from their lungs with a sharp *crack*."
         },
         {
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your pistol fires with a sharp *CRACK*, the bullet whining past {target_name}'s head and smacking into a wall, a casing ejecting.",
-            'victim_msg': "{attacker_name}'s pistol fires with a sharp *CRACK*, the bullet whining past your head and smacking into a wall, a casing ejecting.",
-            'observer_msg': "{attacker_name}'s pistol fires with a sharp *CRACK*, the bullet whining past {target_name}'s head and smacking into a wall, a casing ejecting."
+            'attacker_msg': "Your pistol fires with a sharp *CRACK*, the bullet whining past {target_name}'s {hit_location} and smacking into a wall, a casing ejecting.",
+            'victim_msg': "{attacker_name}'s pistol fires with a sharp *CRACK*, the bullet whining past your {hit_location} and smacking into a wall, a casing ejecting.",
+            'observer_msg': "{attacker_name}'s pistol fires with a sharp *CRACK*, the bullet whining past {target_name}'s {hit_location} and smacking into a wall, a casing ejecting."
         },
         {
             'attacker_msg': "{target_name} dives aside as the pistol barks, the bullet kicking up chips of concrete where they just stood, the slide cycling.",
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} ducks just as your pistol fires, the bullet searing the air where their head had been, the action cycling.",
-            'victim_msg': "You duck just as {attacker_name}'s pistol fires, the bullet searing the air where your head had been, the action cycling.",
+            'victim_msg': "You duck just as {attacker_name}'s pistol fires, the bullet searing the air where your {hit_location} had been, the action cycling.",
             'observer_msg': "{target_name} ducks just as {attacker_name}'s pistol fires, the bullet searing the air where their head had been, the action cycling."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick sidestep from {target_name} leaves {attacker_name}'s pistol to punch a hole in an empty barrel, brass ejecting."
         },
         {
-            'attacker_msg': "The pistol bucks in your hand as you miss, the recoil spoiling your aim for a moment.",
+            'attacker_msg': "The pistol bucks in your {hit_location} as you miss, the recoil spoiling your aim for a moment.",
             'victim_msg': "The pistol bucks in {attacker_name}'s hand as they miss, the recoil spoiling their aim for a moment.",
             'observer_msg': "The pistol bucks in {attacker_name}'s hand as they miss, the recoil spoiling their aim for a moment."
         },
@@ -463,18 +463,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The pistol barks, and {target_name} clutches their chest, a dark stain spreading rapidly before they fall, dead, the slide locking back.",
-            'victim_msg': "The pistol barks, and you clutch your chest, a dark stain spreading rapidly before you fall, dead, the slide locking back.",
+            'victim_msg': "The pistol barks, and you clutch your {hit_location}, a dark stain spreading rapidly before you fall, dead, the slide locking back.",
             'observer_msg': "The pistol barks, and {target_name} clutches their chest, a dark stain spreading rapidly before they fall, dead, the slide locking back."
         },
         {
-            'attacker_msg': "With a final, precise shot, your pistol sends a bullet into {target_name}'s heart, ending their struggles immediately, a casing tinkling on the floor.",
-            'victim_msg': "With a final, precise shot, {attacker_name}'s pistol sends a bullet into your heart, ending your struggles immediately, a casing tinkling on the floor.",
-            'observer_msg': "With a final, precise shot, {attacker_name}'s pistol sends a bullet into {target_name}'s heart, ending their struggles immediately, a casing tinkling on the floor."
+            'attacker_msg': "With a final, precise shot, your pistol sends a bullet into {target_name}'s {hit_location}, ending their struggles immediately, a casing tinkling on the floor.",
+            'victim_msg': "With a final, precise shot, {attacker_name}'s pistol sends a bullet into your {hit_location}, ending your struggles immediately, a casing tinkling on the floor.",
+            'observer_msg': "With a final, precise shot, {attacker_name}'s pistol sends a bullet into {target_name}'s {hit_location}, ending their struggles immediately, a casing tinkling on the floor."
         },
         {
-            'attacker_msg': "The bullet fired point-blank into {target_name}'s throat from the pistol causes them to gurgle and die in a pool of their own blood, the slide cycling.",
-            'victim_msg': "The bullet fired point-blank into your throat from the pistol causes you to gurgle and die in a pool of your own blood, the slide cycling.",
-            'observer_msg': "The bullet fired point-blank into {target_name}'s throat from the pistol causes them to gurgle and die in a pool of their own blood, the slide cycling."
+            'attacker_msg': "The bullet fired point-blank into {target_name}'s {hit_location} from the pistol causes them to gurgle and die in a pool of their own blood, the slide cycling.",
+            'victim_msg': "The bullet fired point-blank into your {hit_location} from the pistol causes you to gurgle and die in a pool of your own blood, the slide cycling.",
+            'observer_msg': "The bullet fired point-blank into {target_name}'s {hit_location} from the pistol causes them to gurgle and die in a pool of their own blood, the slide cycling."
         },
         {
             'attacker_msg': "Your rapid fire with the pistol riddles {target_name}; they slump, a lifeless puppet cut from its strings, spent brass scattered around.",
@@ -492,9 +492,9 @@ MESSAGES = {
             'observer_msg': "A precise shot to the base of the skull from {attacker_name}'s pistol ends {target_name}'s life with clinical finality, the slide moving smoothly."
         },
         {
-            'attacker_msg': "You empty the pistol's magazine into {target_name}'s torso, the multiple impacts ensuring a swift, brutal death, the slide locking open.",
-            'victim_msg': "{attacker_name} empties the pistol's magazine into your torso, the multiple impacts ensuring a swift, brutal death, the slide locking open.",
-            'observer_msg': "{attacker_name} empties the pistol's magazine into {target_name}'s torso, the multiple impacts ensuring a swift, brutal death, the slide locking open."
+            'attacker_msg': "You empty the pistol's magazine into {target_name}'s {hit_location}, the multiple impacts ensuring a swift, brutal death, the slide locking open.",
+            'victim_msg': "{attacker_name} empties the pistol's magazine into your {hit_location}, the multiple impacts ensuring a swift, brutal death, the slide locking open.",
+            'observer_msg': "{attacker_name} empties the pistol's magazine into {target_name}'s {hit_location}, the multiple impacts ensuring a swift, brutal death, the slide locking open."
         },
         {
             'attacker_msg': "The unyielding lead from your pistol pierces a vital organ in {target_name}; they fall, dead before they hit the ground, a casing spinning.",

--- a/world/combat/messages/light_revolver.py
+++ b/world/combat/messages/light_revolver.py
@@ -11,12 +11,12 @@ MESSAGES = {
             'observer_msg': "With a practiced motion, {attacker_name} checks the cylinder of the revolver, ensuring it's loaded."
         },
         {
-            'attacker_msg': "Your hand closes around the checkered grip of the revolver, thumbing back the hammer with a distinct *click*.",
+            'attacker_msg': "Your {hit_location} closes around the checkered grip of the revolver, thumbing back the hammer with a distinct *click*.",
             'victim_msg': "{attacker_name}'s hand closes around the checkered grip of the revolver, thumbing back the hammer with a distinct *click*.",
             'observer_msg': "{attacker_name}'s hand closes around the checkered grip of the revolver, thumbing back the hammer with a distinct *click*."
         },
         {
-            'attacker_msg': "The revolver appears in your hand, its muzzle a dark, ominous circle.",
+            'attacker_msg': "The revolver appears in your {hit_location}, its muzzle a dark, ominous circle.",
             'victim_msg': "The revolver appears in {attacker_name}'s hand, its muzzle a dark, ominous circle.",
             'observer_msg': "The revolver appears in {attacker_name}'s hand, its muzzle a dark, ominous circle."
         },
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air seems to still as {attacker_name} prepares to fire the revolver, anticipating the sharp crack of the shot."
         },
         {
-            'attacker_msg': "Your face is set in concentration, finger hovering near the revolver's trigger.",
+            'attacker_msg': "Your {hit_location} is set in concentration, finger hovering near the revolver's trigger.",
             'victim_msg': "{attacker_name}'s face is set in concentration, finger hovering near the revolver's trigger.",
             'observer_msg': "{attacker_name}'s face is set in concentration, finger hovering near the revolver's trigger."
         },
@@ -184,7 +184,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A direct hit! The revolver's bullet smashes into {target_name}'s {hit_location}, driving the air from their lungs.",
-            'victim_msg': "A direct hit! The revolver's bullet smashes into your {hit_location}, driving the air from your lungs.",
+            'victim_msg': "A direct hit! The revolver's bullet smashes into your {hit_location}, driving the air from your {hit_location}.",
             'observer_msg': "A direct hit! The revolver's bullet smashes into {target_name}'s {hit_location}, driving the air from their lungs."
         },
         {
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your revolver fires with a sharp *CRACK*, the bullet whining past {target_name}'s head and smacking into a wall.",
-            'victim_msg': "{attacker_name}'s revolver fires with a sharp *CRACK*, the bullet whining past your head and smacking into a wall.",
-            'observer_msg': "{attacker_name}'s revolver fires with a sharp *CRACK*, the bullet whining past {target_name}'s head and smacking into a wall."
+            'attacker_msg': "Your revolver fires with a sharp *CRACK*, the bullet whining past {target_name}'s {hit_location} and smacking into a wall.",
+            'victim_msg': "{attacker_name}'s revolver fires with a sharp *CRACK*, the bullet whining past your {hit_location} and smacking into a wall.",
+            'observer_msg': "{attacker_name}'s revolver fires with a sharp *CRACK*, the bullet whining past {target_name}'s {hit_location} and smacking into a wall."
         },
         {
             'attacker_msg': "{target_name} dives aside as the revolver barks, the bullet kicking up dirt where they just stood.",
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} ducks just as your revolver fires, the bullet searing the air where their head had been.",
-            'victim_msg': "You duck just as {attacker_name}'s revolver fires, the bullet searing the air where your head had been.",
+            'victim_msg': "You duck just as {attacker_name}'s revolver fires, the bullet searing the air where your {hit_location} had been.",
             'observer_msg': "{target_name} ducks just as {attacker_name}'s revolver fires, the bullet searing the air where their head had been."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick sidestep from {target_name} leaves {attacker_name}'s revolver to punch a hole in an empty barrel."
         },
         {
-            'attacker_msg': "The revolver bucks in your hand as you miss, the recoil perhaps spoiling your aim.",
+            'attacker_msg': "The revolver bucks in your {hit_location} as you miss, the recoil perhaps spoiling your aim.",
             'victim_msg': "The revolver bucks in {attacker_name}'s hand as they miss, the recoil perhaps spoiling their aim.",
             'observer_msg': "The revolver bucks in {attacker_name}'s hand as they miss, the recoil perhaps spoiling their aim."
         },
@@ -463,18 +463,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The revolver barks, and {target_name} clutches their chest, a dark stain spreading rapidly before they fall, dead.",
-            'victim_msg': "The revolver barks, and you clutch your chest, a dark stain spreading rapidly before you fall, dead.",
+            'victim_msg': "The revolver barks, and you clutch your {hit_location}, a dark stain spreading rapidly before you fall, dead.",
             'observer_msg': "The revolver barks, and {target_name} clutches their chest, a dark stain spreading rapidly before they fall, dead."
         },
         {
-            'attacker_msg': "With a final, precise shot, your revolver sends a bullet into {target_name}'s heart, ending their struggles immediately.",
-            'victim_msg': "With a final, precise shot, {attacker_name}'s revolver sends a bullet into your heart, ending your struggles immediately.",
-            'observer_msg': "With a final, precise shot, {attacker_name}'s revolver sends a bullet into {target_name}'s heart, ending their struggles immediately."
+            'attacker_msg': "With a final, precise shot, your revolver sends a bullet into {target_name}'s {hit_location}, ending their struggles immediately.",
+            'victim_msg': "With a final, precise shot, {attacker_name}'s revolver sends a bullet into your {hit_location}, ending your struggles immediately.",
+            'observer_msg': "With a final, precise shot, {attacker_name}'s revolver sends a bullet into {target_name}'s {hit_location}, ending their struggles immediately."
         },
         {
-            'attacker_msg': "The bullet fired point-blank into {target_name}'s throat from the revolver causes them to gurgle and die in a pool of their own blood.",
-            'victim_msg': "The bullet fired point-blank into your throat from the revolver causes you to gurgle and die in a pool of your own blood.",
-            'observer_msg': "The bullet fired point-blank into {target_name}'s throat from the revolver causes them to gurgle and die in a pool of their own blood."
+            'attacker_msg': "The bullet fired point-blank into {target_name}'s {hit_location} from the revolver causes them to gurgle and die in a pool of their own blood.",
+            'victim_msg': "The bullet fired point-blank into your {hit_location} from the revolver causes you to gurgle and die in a pool of your own blood.",
+            'observer_msg': "The bullet fired point-blank into {target_name}'s {hit_location} from the revolver causes them to gurgle and die in a pool of their own blood."
         },
         {
             'attacker_msg': "Your sustained fire with the revolver riddles {target_name}; they slump, a lifeless puppet cut from its strings.",
@@ -492,9 +492,9 @@ MESSAGES = {
             'observer_msg': "A precise shot to the base of the skull from {attacker_name}'s revolver ends {target_name}'s life with clinical finality."
         },
         {
-            'attacker_msg': "You empty the revolver's cylinder into {target_name}'s torso, the multiple impacts ensuring a swift, brutal death.",
-            'victim_msg': "{attacker_name} empties the revolver's cylinder into your torso, the multiple impacts ensuring a swift, brutal death.",
-            'observer_msg': "{attacker_name} empties the revolver's cylinder into {target_name}'s torso, the multiple impacts ensuring a swift, brutal death."
+            'attacker_msg': "You empty the revolver's cylinder into {target_name}'s {hit_location}, the multiple impacts ensuring a swift, brutal death.",
+            'victim_msg': "{attacker_name} empties the revolver's cylinder into your {hit_location}, the multiple impacts ensuring a swift, brutal death.",
+            'observer_msg': "{attacker_name} empties the revolver's cylinder into {target_name}'s {hit_location}, the multiple impacts ensuring a swift, brutal death."
         },
         {
             'attacker_msg': "The unyielding lead from your revolver pierces a vital organ in {target_name}; they fall, dead before they hit the ground.",

--- a/world/combat/messages/long_sword.py
+++ b/world/combat/messages/long_sword.py
@@ -11,7 +11,7 @@ MESSAGES = {
             'observer_msg': "With a fluid motion, {attacker_name} brings the long sword to a ready stance, its point unwavering."
         },
         {
-            'attacker_msg': "You test the balance of the long sword, the blade a silver extension of your arm.",
+            'attacker_msg': "You test the balance of the long sword, the blade a silver extension of your {hit_location}.",
             'victim_msg': "{attacker_name} tests the balance of the long sword, the blade a silver extension of their arm.",
             'observer_msg': "{attacker_name} tests the balance of the long sword, the blade a silver extension of their arm."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your long sword whistles through the air, inches from {target_name}'s head.",
-            'victim_msg': "{attacker_name}'s long sword whistles through the air, inches from your head.",
-            'observer_msg': "{attacker_name}'s long sword whistles through the air, inches from {target_name}'s head."
+            'attacker_msg': "Your long sword whistles through the air, inches from {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s long sword whistles through the air, inches from your {hit_location}.",
+            'observer_msg': "{attacker_name}'s long sword whistles through the air, inches from {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "{target_name} narrowly avoids the flashing arc of your long sword.",
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "Your long sword finds {target_name}'s heart with a fatal thrust, ending the fight instantly.",
-            'victim_msg': "{attacker_name}'s long sword finds your heart with a fatal thrust, ending the fight instantly.",
-            'observer_msg': "{attacker_name}'s long sword finds {target_name}'s heart with a fatal thrust, ending the fight instantly."
+            'attacker_msg': "Your long sword finds {target_name}'s {hit_location} with a fatal thrust, ending the fight instantly.",
+            'victim_msg': "{attacker_name}'s long sword finds your {hit_location} with a fatal thrust, ending the fight instantly.",
+            'observer_msg': "{attacker_name}'s long sword finds {target_name}'s {hit_location} with a fatal thrust, ending the fight instantly."
         },
         {
             'attacker_msg': "A devastating cut from the long sword, and {target_name} crumples, lifeblood staining the ground.",
@@ -472,9 +472,9 @@ MESSAGES = {
             'observer_msg': "With a final, precise strike, {attacker_name}'s long sword silences {target_name} forever."
         },
         {
-            'attacker_msg': "The gleaming blade of the long sword pierces {target_name}'s throat, a swift and brutal end.",
-            'victim_msg': "The gleaming blade of the long sword pierces your throat, a swift and brutal end.",
-            'observer_msg': "The gleaming blade of the long sword pierces {target_name}'s throat, a swift and brutal end."
+            'attacker_msg': "The gleaming blade of the long sword pierces {target_name}'s {hit_location}, a swift and brutal end.",
+            'victim_msg': "The gleaming blade of the long sword pierces your {hit_location}, a swift and brutal end.",
+            'observer_msg': "The gleaming blade of the long sword pierces {target_name}'s {hit_location}, a swift and brutal end."
         },
         {
             'attacker_msg': "Your powerful blow with the long sword leaves {target_name} mortally wounded, falling heavily.",
@@ -492,9 +492,9 @@ MESSAGES = {
             'observer_msg': "A clean decapitating strike from {attacker_name}'s long sword ends {target_name}'s life in a heartbeat."
         },
         {
-            'attacker_msg': "You drive the long sword deep into {target_name}'s chest, the outcome grimly certain.",
-            'victim_msg': "{attacker_name} drives the long sword deep into your chest, the outcome grimly certain.",
-            'observer_msg': "{attacker_name} drives the long sword deep into {target_name}'s chest, the outcome grimly certain."
+            'attacker_msg': "You drive the long sword deep into {target_name}'s {hit_location}, the outcome grimly certain.",
+            'victim_msg': "{attacker_name} drives the long sword deep into your {hit_location}, the outcome grimly certain.",
+            'observer_msg': "{attacker_name} drives the long sword deep into {target_name}'s {hit_location}, the outcome grimly certain."
         },
         {
             'attacker_msg': "The keen edge of the long sword opens a fatal wound, and {target_name} collapses, unmoving.",

--- a/world/combat/messages/machete.py
+++ b/world/combat/messages/machete.py
@@ -86,7 +86,7 @@ MESSAGES = {
             'observer_msg': "This isn't a combat knife — it's a tool turned legend. {attacker_name} grips the machete with both hands."
         },
         {
-            'attacker_msg': "With a flick, you free the machete from your back. It's heavy, brutal, perfect.",
+            'attacker_msg': "With a flick, you free the machete from your {hit_location}. It's heavy, brutal, perfect.",
             'victim_msg': "With a flick, {attacker_name} frees the machete from their back. It's heavy, brutal, perfect.",
             'observer_msg': "With a flick, {attacker_name} frees the machete from their back. It's heavy, brutal, perfect."
         },
@@ -116,7 +116,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} grips the machete in both hands. The weight settles like a sentence passed."
         },
         {
-            'attacker_msg': "You pull the machete from behind your back like a secret you've been waiting to tell.",
+            'attacker_msg': "You pull the machete from behind your {hit_location} like a secret you've been waiting to tell.",
             'victim_msg': "{attacker_name} pulls the machete from behind their back like a secret they've been waiting to tell.",
             'observer_msg': "{attacker_name} pulls the machete from behind their back like a secret they've been waiting to tell."
         },
@@ -126,7 +126,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} pulls the machete from its sheath with a long metallic rasp. Everyone hears it."
         },
         {
-            'attacker_msg': "You rest the flat of the machete against your shoulder. The edge points forward, already deciding the outcome.",
+            'attacker_msg': "You rest the flat of the machete against your {hit_location}. The edge points forward, already deciding the outcome.",
             'victim_msg': "{attacker_name} rests the flat of the machete against their shoulder. The edge points forward, already deciding the outcome.",
             'observer_msg': "{attacker_name} rests the flat of the machete against their shoulder. The edge points forward, already deciding the outcome."
         },
@@ -279,7 +279,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You chop into the {hit_location} joint. The arm dangles like a marionette's mistake.",
-            'victim_msg': "{attacker_name} chops into your {hit_location} joint. Your arm dangles like a marionette's mistake.",
+            'victim_msg': "{attacker_name} chops into your {hit_location} joint. Your {hit_location} dangles like a marionette's mistake.",
             'observer_msg': "{attacker_name} chops into {target_name}'s {hit_location} joint. The arm dangles like a marionette's mistake."
         },
         {
@@ -326,8 +326,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A low chop misses the ankle. It finds dirt instead — and leaves a scar in the ground.",
-            'victim_msg': "A low chop misses your ankle. It finds dirt instead — and leaves a scar in the ground.",
-            'observer_msg': "A low chop misses {target_name}'s ankle. It finds dirt instead — and leaves a scar in the ground."
+            'victim_msg': "A low chop misses your {hit_location}. It finds dirt instead — and leaves a scar in the ground.",
+            'observer_msg': "A low chop misses {target_name}'s {hit_location}. It finds dirt instead — and leaves a scar in the ground."
         },
         {
             'attacker_msg': "A missed strike cleaves a chair in two. {target_name} doesn't wait to see the next one.",
@@ -450,9 +450,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} overcommits. The machete buries in the floor instead of flesh."
         },
         {
-            'attacker_msg': "You swing wide. The blade whistles past {target_name}'s face.",
-            'victim_msg': "{attacker_name} swings wide. The blade whistles past your face.",
-            'observer_msg': "{attacker_name} swings wide. The blade whistles past {target_name}'s face."
+            'attacker_msg': "You swing wide. The blade whistles past {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name} swings wide. The blade whistles past your {hit_location}.",
+            'observer_msg': "{attacker_name} swings wide. The blade whistles past {target_name}'s {hit_location}."
         }
     ],
     'kill': [
@@ -463,8 +463,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A clean sweep across the throat. {target_name} drops mid-stride, voice lost in red.",
-            'victim_msg': "A clean sweep across your throat. You drop mid-stride, voice lost in red.",
-            'observer_msg': "A clean sweep across {target_name}'s throat. {target_name} drops mid-stride, voice lost in red."
+            'victim_msg': "A clean sweep across your {hit_location}. You drop mid-stride, voice lost in red.",
+            'observer_msg': "A clean sweep across {target_name}'s {hit_location}. {target_name} drops mid-stride, voice lost in red."
         },
         {
             'attacker_msg': "A cleaving strike separates shoulder from soul. {target_name} doesn't argue with gravity.",
@@ -473,23 +473,23 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A diagonal chop splits the chest. {target_name} collapses mid-scream.",
-            'victim_msg': "A diagonal chop splits your chest. You collapse mid-scream.",
-            'observer_msg': "A diagonal chop splits {target_name}'s chest. {target_name} collapses mid-scream."
+            'victim_msg': "A diagonal chop splits your {hit_location}. You collapse mid-scream.",
+            'observer_msg': "A diagonal chop splits {target_name}'s {hit_location}. {target_name} collapses mid-scream."
         },
         {
             'attacker_msg': "A final chop splits the sternum. {target_name}'s heartbeat stops mid-beat.",
-            'victim_msg': "A final chop splits your sternum. Your heartbeat stops mid-beat.",
-            'observer_msg': "A final chop splits {target_name}'s sternum. {target_name}'s heartbeat stops mid-beat."
+            'victim_msg': "A final chop splits your {hit_location}. Your heartbeat stops mid-beat.",
+            'observer_msg': "A final chop splits {target_name}'s {hit_location}. {target_name}'s heartbeat stops mid-beat."
         },
         {
-            'attacker_msg': "A full-force strike caves in ribs. {target_name}'s heart stops before the second swing.",
-            'victim_msg': "A full-force strike caves in your ribs. Your heart stops before the second swing.",
-            'observer_msg': "A full-force strike caves in {target_name}'s ribs. {target_name}'s heart stops before the second swing."
+            'attacker_msg': "A full-force strike caves in ribs. {target_name}'s {hit_location} stops before the second swing.",
+            'victim_msg': "A full-force strike caves in your {hit_location}. Your {hit_location} stops before the second swing.",
+            'observer_msg': "A full-force strike caves in {target_name}'s {hit_location}. {target_name}'s {hit_location} stops before the second swing."
         },
         {
             'attacker_msg': "A low swing removes a leg. The shock does the rest. {target_name} never makes a sound.",
-            'victim_msg': "A low swing removes your leg. The shock does the rest. You never make a sound.",
-            'observer_msg': "A low swing removes {target_name}'s leg. The shock does the rest. {target_name} never makes a sound."
+            'victim_msg': "A low swing removes your {hit_location}. The shock does the rest. You never make a sound.",
+            'observer_msg': "A low swing removes {target_name}'s {hit_location}. The shock does the rest. {target_name} never makes a sound."
         },
         {
             'attacker_msg': "A rising slash opens {target_name} from hip to ribs. There's nothing left to say.",
@@ -498,23 +498,23 @@ MESSAGES = {
         },
         {
             'attacker_msg': "One clean blow to the heart. {target_name} stiffens — then folds.",
-            'victim_msg': "One clean blow to your heart. You stiffen — then fold.",
-            'observer_msg': "One clean blow to {target_name}'s heart. {target_name} stiffens — then folds."
+            'victim_msg': "One clean blow to your {hit_location}. You stiffen — then fold.",
+            'observer_msg': "One clean blow to {target_name}'s {hit_location}. {target_name} stiffens — then folds."
         },
         {
             'attacker_msg': "One rising slash opens the neck. Blood fountains. {target_name} collapses backward, twitching.",
-            'victim_msg': "One rising slash opens your neck. Blood fountains. You collapse backward, twitching.",
-            'observer_msg': "One rising slash opens {target_name}'s neck. Blood fountains. {target_name} collapses backward, twitching."
+            'victim_msg': "One rising slash opens your {hit_location}. Blood fountains. You collapse backward, twitching.",
+            'observer_msg': "One rising slash opens {target_name}'s {hit_location}. Blood fountains. {target_name} collapses backward, twitching."
         },
         {
             'attacker_msg': "One vertical chop splits the chest. {target_name} falls backward, bleeding in beats.",
-            'victim_msg': "One vertical chop splits your chest. You fall backward, bleeding in beats.",
-            'observer_msg': "One vertical chop splits {target_name}'s chest. {target_name} falls backward, bleeding in beats."
+            'victim_msg': "One vertical chop splits your {hit_location}. You fall backward, bleeding in beats.",
+            'observer_msg': "One vertical chop splits {target_name}'s {hit_location}. {target_name} falls backward, bleeding in beats."
         },
         {
             'attacker_msg': "Steel cracks the skull. The sound is hollow. The result is not.",
-            'victim_msg': "Steel cracks your skull. The sound is hollow. The result is not.",
-            'observer_msg': "Steel cracks {target_name}'s skull. The sound is hollow. The result is not."
+            'victim_msg': "Steel cracks your {hit_location}. The sound is hollow. The result is not.",
+            'observer_msg': "Steel cracks {target_name}'s {hit_location}. The sound is hollow. The result is not."
         },
         {
             'attacker_msg': "Steel drives through collarbone and lung. The scream ends halfway out.",
@@ -523,8 +523,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Steel meets spine. The body falls in halves. You just watch.",
-            'victim_msg': "Steel meets your spine. Your body falls in halves. {attacker_name} just watches.",
-            'observer_msg': "Steel meets {target_name}'s spine. The body falls in halves. {attacker_name} just watches."
+            'victim_msg': "Steel meets your {hit_location}. Your body falls in halves. {attacker_name} just watches.",
+            'observer_msg': "Steel meets {target_name}'s {hit_location}. The body falls in halves. {attacker_name} just watches."
         },
         {
             'attacker_msg': "The blade sinks into the gut and stays. {target_name} quivers, then goes still.",
@@ -538,38 +538,38 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The last cut is slow and purposeful — across the neck. Red follows, then quiet.",
-            'victim_msg': "The last cut is slow and purposeful — across your neck. Red follows, then quiet.",
-            'observer_msg': "The last cut is slow and purposeful — across {target_name}'s neck. Red follows, then quiet."
+            'victim_msg': "The last cut is slow and purposeful — across your {hit_location}. Red follows, then quiet.",
+            'observer_msg': "The last cut is slow and purposeful — across {target_name}'s {hit_location}. Red follows, then quiet."
         },
         {
             'attacker_msg': "The machete hacks down into the shoulder, cleaving into the chest. {target_name} crumples like collapsed scaffolding.",
-            'victim_msg': "The machete hacks down into your shoulder, cleaving into your chest. You crumple like collapsed scaffolding.",
-            'observer_msg': "The machete hacks down into {target_name}'s shoulder, cleaving into the chest. {target_name} crumples like collapsed scaffolding."
+            'victim_msg': "The machete hacks down into your {hit_location}, cleaving into your {hit_location}. You crumple like collapsed scaffolding.",
+            'observer_msg': "The machete hacks down into {target_name}'s {hit_location}, cleaving into the chest. {target_name} crumples like collapsed scaffolding."
         },
         {
             'attacker_msg': "The machete lands in the back of the skull. You let go. The body drops first.",
-            'victim_msg': "The machete lands in the back of your skull. {attacker_name} lets go. Your body drops first.",
-            'observer_msg': "The machete lands in the back of {target_name}'s skull. {attacker_name} lets go. The body drops first."
+            'victim_msg': "The machete lands in the back of your {hit_location}. {attacker_name} lets go. Your body drops first.",
+            'observer_msg': "The machete lands in the back of {target_name}'s {hit_location}. {attacker_name} lets go. The body drops first."
         },
         {
             'attacker_msg': "The machete lands on the side of the head. The skull folds. {target_name} drops like a marionette cut mid-scene.",
-            'victim_msg': "The machete lands on the side of your head. Your skull folds. You drop like a marionette cut mid-scene.",
-            'observer_msg': "The machete lands on the side of {target_name}'s head. The skull folds. {target_name} drops like a marionette cut mid-scene."
+            'victim_msg': "The machete lands on the side of your {hit_location}. Your {hit_location} folds. You drop like a marionette cut mid-scene.",
+            'observer_msg': "The machete lands on the side of {target_name}'s {hit_location}. The skull folds. {target_name} drops like a marionette cut mid-scene."
         },
         {
             'attacker_msg': "The machete lands on the spine with surgical force. {target_name} goes limp before they hit the floor.",
-            'victim_msg': "The machete lands on your spine with surgical force. You go limp before you hit the floor.",
-            'observer_msg': "The machete lands on {target_name}'s spine with surgical force. {target_name} goes limp before they hit the floor."
+            'victim_msg': "The machete lands on your {hit_location} with surgical force. You go limp before you hit the floor.",
+            'observer_msg': "The machete lands on {target_name}'s {hit_location} with surgical force. {target_name} goes limp before they hit the floor."
         },
         {
-            'attacker_msg': "The machete slams into {target_name}'s neck. One strike. One spray. One fall.",
-            'victim_msg': "The machete slams into your neck. One strike. One spray. One fall.",
-            'observer_msg': "The machete slams into {target_name}'s neck. One strike. One spray. One fall."
+            'attacker_msg': "The machete slams into {target_name}'s {hit_location}. One strike. One spray. One fall.",
+            'victim_msg': "The machete slams into your {hit_location}. One strike. One spray. One fall.",
+            'observer_msg': "The machete slams into {target_name}'s {hit_location}. One strike. One spray. One fall."
         },
         {
             'attacker_msg': "The machete slices across the face. When it stops, {target_name} is gone.",
-            'victim_msg': "The machete slices across your face. When it stops, you are gone.",
-            'observer_msg': "The machete slices across {target_name}'s face. When it stops, {target_name} is gone."
+            'victim_msg': "The machete slices across your {hit_location}. When it stops, you are gone.",
+            'observer_msg': "The machete slices across {target_name}'s {hit_location}. When it stops, {target_name} is gone."
         },
         {
             'attacker_msg': "The weapon cleaves through collar and bone. {target_name} drops like meat on a butcher's table.",
@@ -578,13 +578,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You bury the blade in the skull. It takes effort to pull it free.",
-            'victim_msg': "{attacker_name} buries the blade in your skull. It takes effort to pull it free.",
-            'observer_msg': "{attacker_name} buries the blade in {target_name}'s skull. It takes effort to pull it free."
+            'victim_msg': "{attacker_name} buries the blade in your {hit_location}. It takes effort to pull it free.",
+            'observer_msg': "{attacker_name} buries the blade in {target_name}'s {hit_location}. It takes effort to pull it free."
         },
         {
             'attacker_msg': "You bury the blade in the stomach and drag upward. {target_name} splits like overripe fruit.",
-            'victim_msg': "{attacker_name} buries the blade in your stomach and drags upward. You split like overripe fruit.",
-            'observer_msg': "{attacker_name} buries the blade in {target_name}'s stomach and drags upward. {target_name} splits like overripe fruit."
+            'victim_msg': "{attacker_name} buries the blade in your {hit_location} and drags upward. You split like overripe fruit.",
+            'observer_msg': "{attacker_name} buries the blade in {target_name}'s {hit_location} and drags upward. {target_name} splits like overripe fruit."
         },
         {
             'attacker_msg': "You hack through the chest cavity. The body falls open like a book no one should read.",
@@ -598,8 +598,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You step in close and drive the blade into the sternum. The noise it makes is wet and final.",
-            'victim_msg': "{attacker_name} steps in close and drives the blade into your sternum. The noise it makes is wet and final.",
-            'observer_msg': "{attacker_name} steps in close and drives the blade into {target_name}'s sternum. The noise it makes is wet and final."
+            'victim_msg': "{attacker_name} steps in close and drives the blade into your {hit_location}. The noise it makes is wet and final.",
+            'observer_msg': "{attacker_name} steps in close and drives the blade into {target_name}'s {hit_location}. The noise it makes is wet and final."
         },
         {
             'attacker_msg': "You swing low, take out both knees, then bring the blade down. {target_name} doesn't rise.",

--- a/world/combat/messages/machine_pistol.py
+++ b/world/combat/messages/machine_pistol.py
@@ -11,12 +11,12 @@ MESSAGES = {
             'observer_msg': "With a jerky motion, {attacker_name} slams a long, thin stick magazine into the machine pistol, the simple weapon looking almost like a toy, but promising a terrifying rate of fire."
         },
         {
-            'attacker_msg': "Your hand barely contains the machine pistol's narrow grip, the other hand instinctively moving to brace the wildly jumping muzzle.",
+            'attacker_msg': "Your {hit_location} barely contains the machine pistol's narrow grip, the other hand instinctively moving to brace the wildly jumping muzzle.",
             'victim_msg': "{attacker_name}'s hand barely contains the machine pistol's narrow grip, the other hand instinctively moving to brace the wildly jumping muzzle.",
             'observer_msg': "{attacker_name}'s hand barely contains the machine pistol's narrow grip, the other hand instinctively moving to brace the wildly jumping muzzle."
         },
         {
-            'attacker_msg': "The machine pistol appears in your hand as if from nowhere, a crude assembly of stamped metal and plastic, built for one purpose: spewing lead.",
+            'attacker_msg': "The machine pistol appears in your {hit_location} as if from nowhere, a crude assembly of stamped metal and plastic, built for one purpose: spewing lead.",
             'victim_msg': "The machine pistol appears in {attacker_name}'s hand as if from nowhere, a crude assembly of stamped metal and plastic, built for one purpose: spewing lead.",
             'observer_msg': "The machine pistol appears in {attacker_name}'s hand as if from nowhere, a crude assembly of stamped metal and plastic, built for one purpose: spewing lead."
         },
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air feels charged with manic energy as {attacker_name} prepares to unleash the machine pistol's insane, almost unbelievable rate of fire, a blizzard of tiny bullets imminent."
         },
         {
-            'attacker_msg': "Your face is a grimace of pure, unadulterated 'here goes nothing,' ready to fight the machine pistol's vicious, unpredictable muzzle climb.",
+            'attacker_msg': "Your {hit_location} is a grimace of pure, unadulterated 'here goes nothing,' ready to fight the machine pistol's vicious, unpredictable muzzle climb.",
             'victim_msg': "{attacker_name}'s face is a grimace of pure, unadulterated 'here goes nothing,' ready to fight the machine pistol's vicious, unpredictable muzzle climb.",
             'observer_msg': "{attacker_name}'s face is a grimace of pure, unadulterated 'here goes nothing,' ready to fight the machine pistol's vicious, unpredictable muzzle climb."
         },
@@ -184,7 +184,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A direct hit! The machine pistol's sustained, point-blank burst smashes into {target_name}'s {hit_location}, driving the air from their lungs with a series of incredibly rapid, brutal *thuds* that merge into one long, wet, tearing sound.",
-            'victim_msg': "A direct hit! The machine pistol's sustained, point-blank burst smashes into your {hit_location}, driving the air from your lungs with a series of incredibly rapid, brutal *thuds* that merge into one long, wet, tearing sound.",
+            'victim_msg': "A direct hit! The machine pistol's sustained, point-blank burst smashes into your {hit_location}, driving the air from your {hit_location} with a series of incredibly rapid, brutal *thuds* that merge into one long, wet, tearing sound.",
             'observer_msg': "A direct hit! The machine pistol's sustained, point-blank burst smashes into {target_name}'s {hit_location}, driving the air from their lungs with a series of incredibly rapid, brutal *thuds* that merge into one long, wet, tearing sound."
         },
         {
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your machine pistol erupts with a screaming, deafening *BRRRRRRRRRRRRRRRAP*, the bullets whining wildly past {target_name}'s head and chewing up everything in a thirty-foot arc around them, a torrent of hot casings ejecting like metallic vomit.",
-            'victim_msg': "{attacker_name}'s machine pistol erupts with a screaming, deafening *BRRRRRRRRRRRRRRRAP*, the bullets whining wildly past your head and chewing up everything in a thirty-foot arc around you, a torrent of hot casings ejecting like metallic vomit.",
-            'observer_msg': "{attacker_name}'s machine pistol erupts with a screaming, deafening *BRRRRRRRRRRRRRRRAP*, the bullets whining wildly past {target_name}'s head and chewing up everything in a thirty-foot arc around them, a torrent of hot casings ejecting like metallic vomit."
+            'attacker_msg': "Your machine pistol erupts with a screaming, deafening *BRRRRRRRRRRRRRRRAP*, the bullets whining wildly past {target_name}'s {hit_location} and chewing up everything in a thirty-foot arc around them, a torrent of hot casings ejecting like metallic vomit.",
+            'victim_msg': "{attacker_name}'s machine pistol erupts with a screaming, deafening *BRRRRRRRRRRRRRRRAP*, the bullets whining wildly past your {hit_location} and chewing up everything in a thirty-foot arc around you, a torrent of hot casings ejecting like metallic vomit.",
+            'observer_msg': "{attacker_name}'s machine pistol erupts with a screaming, deafening *BRRRRRRRRRRRRRRRAP*, the bullets whining wildly past {target_name}'s {hit_location} and chewing up everything in a thirty-foot arc around them, a torrent of hot casings ejecting like metallic vomit."
         },
         {
             'attacker_msg': "{target_name} dives desperately aside as the machine pistol shrieks like a tortured soul, a wide, indiscriminate spray of bullets kicking up chips of concrete, wood, and metal everywhere *but* where they stood a nanosecond ago, the bolt cycling at an insane, blurring rate.",
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} ducks, trips, and falls just as your machine pistol fires, a horizontal, waist-high hail of bullets searing the air where their torso had been, the action cycling with a high-pitched, continuous, terrifying scream.",
-            'victim_msg': "You duck, trip, and fall just as {attacker_name}'s machine pistol fires, a horizontal, waist-high hail of bullets searing the air where your torso had been, the action cycling with a high-pitched, continuous, terrifying scream.",
+            'victim_msg': "You duck, trip, and fall just as {attacker_name}'s machine pistol fires, a horizontal, waist-high hail of bullets searing the air where your {hit_location} had been, the action cycling with a high-pitched, continuous, terrifying scream.",
             'observer_msg': "{target_name} ducks, trips, and falls just as {attacker_name}'s machine pistol fires, a horizontal, waist-high hail of bullets searing the air where their torso had been, the action cycling with a high-pitched, continuous, terrifying scream."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick, panicked sidestep from {target_name} leaves {attacker_name}'s machine pistol to punch a ragged, dense line of hundreds upon hundreds of holes in an empty, parked bus, brass ejecting in a solid, unbroken arc of gold."
         },
         {
-            'attacker_msg': "The machine pistol bucks, writhes, and jumps in your hand like a landed fish on amphetamines as you miss, the recoil sending bullets everywhere except towards the intended {target_name}, who watches in horrified awe.",
+            'attacker_msg': "The machine pistol bucks, writhes, and jumps in your {hit_location} like a landed fish on amphetamines as you miss, the recoil sending bullets everywhere except towards the intended {target_name}, who watches in horrified awe.",
             'victim_msg': "The machine pistol bucks, writhes, and jumps in {attacker_name}'s hand like a landed fish on amphetamines as they miss, the recoil sending bullets everywhere except towards you, who watch in horrified awe.",
             'observer_msg': "The machine pistol bucks, writhes, and jumps in {attacker_name}'s hand like a landed fish on amphetamines as they miss, the recoil sending bullets everywhere except towards {target_name}, who watches in horrified awe."
         },

--- a/world/combat/messages/meat_cleaver.py
+++ b/world/combat/messages/meat_cleaver.py
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} holds the cleaver like a judge's gavel—sentence about to be passed."
         },
         {
-            'attacker_msg': "You let the cleaver rest on your shoulder, casual as a butcher at closing time.",
+            'attacker_msg': "You let the cleaver rest on your {hit_location}, casual as a butcher at closing time.",
             'victim_msg': "{attacker_name} lets the cleaver rest on their shoulder, casual as a butcher at closing time.",
             'observer_msg': "{attacker_name} lets the cleaver rest on their shoulder, casual as a butcher at closing time."
         },
@@ -136,7 +136,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} holds the cleaver like a brush, ready to paint in red."
         },
         {
-            'attacker_msg': "You let the cleaver rest on your shoulder, eyes never leaving {target_name}.",
+            'attacker_msg': "You let the cleaver rest on your {hit_location}, eyes never leaving {target_name}.",
             'victim_msg': "{attacker_name} lets the cleaver rest on their shoulder, eyes never leaving you.",
             'observer_msg': "{attacker_name} lets the cleaver rest on their shoulder, eyes never leaving {target_name}."
         },
@@ -340,7 +340,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} hacks at {target_name}, but the blade glances off armor."
         },
         {
-            'attacker_msg': "A flick of your wrist misses, the blade slicing only air.",
+            'attacker_msg': "A flick of your {hit_location} misses, the blade slicing only air.",
             'victim_msg': "A flick of {attacker_name}'s wrist misses, the blade slicing only air.",
             'observer_msg': "A flick of the wrist misses, the blade slicing only air."
         },
@@ -445,7 +445,7 @@ MESSAGES = {
             'observer_msg': "The blade glances off a boot, doing nothing."
         },
         {
-            'attacker_msg': "A flick of your wrist misses, the blade humming in the air.",
+            'attacker_msg': "A flick of your {hit_location} misses, the blade humming in the air.",
             'victim_msg': "A flick of {attacker_name}'s wrist misses, the blade humming in the air.",
             'observer_msg': "A flick of the wrist misses, the blade humming in the air."
         },
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You bring the cleaver down on {target_name}'s neck. Blood spurts in a thick, brutal arc.",
-            'victim_msg': "{attacker_name} brings the cleaver down on your neck. Blood spurts in a thick, brutal arc.",
-            'observer_msg': "{attacker_name} brings the cleaver down on {target_name}'s neck. Blood spurts in a thick, brutal arc."
+            'attacker_msg': "You bring the cleaver down on {target_name}'s {hit_location}. Blood spurts in a thick, brutal arc.",
+            'victim_msg': "{attacker_name} brings the cleaver down on your {hit_location}. Blood spurts in a thick, brutal arc.",
+            'observer_msg': "{attacker_name} brings the cleaver down on {target_name}'s {hit_location}. Blood spurts in a thick, brutal arc."
         },
         {
             'attacker_msg': "A heavy chop opens {target_name}'s carotid. They drop, clutching at a wound that won't close.",
@@ -472,9 +472,9 @@ MESSAGES = {
             'observer_msg': "The blade slips between ribs and into the heart. {target_name} collapses, twitching."
         },
         {
-            'attacker_msg': "You carve a line across {target_name}'s throat. The blood is bright and fast.",
-            'victim_msg': "{attacker_name} carves a line across your throat. The blood is bright and fast.",
-            'observer_msg': "{attacker_name} carves a line across {target_name}'s throat. The blood is bright and fast."
+            'attacker_msg': "You carve a line across {target_name}'s {hit_location}. The blood is bright and fast.",
+            'victim_msg': "{attacker_name} carves a line across your {hit_location}. The blood is bright and fast.",
+            'observer_msg': "{attacker_name} carves a line across {target_name}'s {hit_location}. The blood is bright and fast."
         },
         {
             'attacker_msg': "A chop under the jaw sends the cleaver into the brain. {target_name} goes limp instantly.",
@@ -517,9 +517,9 @@ MESSAGES = {
             'observer_msg': "The blade slips between vertebrae. {target_name} drops, boneless."
         },
         {
-            'attacker_msg': "You carve a smile across {target_name}'s face. The grin is permanent.",
-            'victim_msg': "{attacker_name} carves a smile across your face. The grin is permanent.",
-            'observer_msg': "{attacker_name} carves a smile across {target_name}'s face. The grin is permanent."
+            'attacker_msg': "You carve a smile across {target_name}'s {hit_location}. The grin is permanent.",
+            'victim_msg': "{attacker_name} carves a smile across your {hit_location}. The grin is permanent.",
+            'observer_msg': "{attacker_name} carves a smile across {target_name}'s {hit_location}. The grin is permanent."
         },
         {
             'attacker_msg': "A chop to the heart. {target_name} collapses, eyes wide and empty.",

--- a/world/combat/messages/meat_hook.py
+++ b/world/combat/messages/meat_hook.py
@@ -21,7 +21,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} dangles the hook from a chain-wrapped wrist, letting gravity speak first."
         },
         {
-            'attacker_msg': "The meat hook glints in flickering light as you roll your neck and step forward.",
+            'attacker_msg': "The meat hook glints in flickering light as you roll your {hit_location} and step forward.",
             'victim_msg': "The meat hook glints in flickering light as {attacker_name} rolls their neck and steps forward.",
             'observer_msg': "The meat hook glints in flickering light as {attacker_name} rolls their neck and steps forward."
         },
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "A grunt, a glare, and then the hook rises—{attacker_name} speaks fluent brutality."
         },
         {
-            'attacker_msg': "You test the weight of the hook in your hand, as if remembering how much damage it used to do.",
+            'attacker_msg': "You test the weight of the hook in your {hit_location}, as if remembering how much damage it used to do.",
             'victim_msg': "{attacker_name} tests the weight of the hook in their hand, as if remembering how much damage it used to do.",
             'observer_msg': "{attacker_name} tests the weight of the hook in their hand, as if remembering how much damage it used to do."
         },
@@ -229,7 +229,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A nasty gash opens along {target_name}'s {hit_location} as the hook rakes across their face.",
-            'victim_msg': "A nasty gash opens along your {hit_location} as the hook rakes across your face.",
+            'victim_msg': "A nasty gash opens along your {hit_location} as the hook rakes across your {hit_location}.",
             'observer_msg': "A nasty gash opens along {target_name}'s {hit_location} as the hook rakes across their face."
         },
         {
@@ -248,9 +248,9 @@ MESSAGES = {
             'observer_msg': "The hook arcs in and rips a flap of skin from {target_name}'s {hit_location}. The wound steams in cold air."
         },
         {
-            'attacker_msg': "One clean shot to the {hit_location} makes {target_name}'s arm useless and trembling.",
-            'victim_msg': "One clean shot to the {hit_location} makes your arm useless and trembling.",
-            'observer_msg': "One clean shot to the {hit_location} makes {target_name}'s arm useless and trembling."
+            'attacker_msg': "One clean shot to the {hit_location} makes {target_name}'s {hit_location} useless and trembling.",
+            'victim_msg': "One clean shot to the {hit_location} makes your {hit_location} useless and trembling.",
+            'observer_msg': "One clean shot to the {hit_location} makes {target_name}'s {hit_location} useless and trembling."
         },
         {
             'attacker_msg': "A whipping blow lands in the {hit_location}. The hook catches and pulls something that shouldn't come loose.",
@@ -298,7 +298,7 @@ MESSAGES = {
             'observer_msg': "{target_name} tries to block. The hook still gets in."
         },
         {
-            'attacker_msg': "A twist of your wrist and the hook digs deeper than anyone expected. {target_name}'s eyes say the rest.",
+            'attacker_msg': "A twist of your {hit_location} and the hook digs deeper than anyone expected. {target_name}'s eyes say the rest.",
             'victim_msg': "A twist of {attacker_name}'s wrist and the hook digs deeper than anyone expected. Your eyes say the rest.",
             'observer_msg': "A twist of the wrist and the hook digs deeper than anyone expected. {target_name}'s eyes say the rest."
         }
@@ -310,9 +310,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} swings wide. The hook slams into a wall, sending flakes of rust flying."
         },
         {
-            'attacker_msg': "The hook hisses past {target_name}'s head—close enough to taste metal in the air.",
-            'victim_msg': "The hook hisses past your head—close enough to taste metal in the air.",
-            'observer_msg': "The hook hisses past {target_name}'s head—close enough to taste metal in the air."
+            'attacker_msg': "The hook hisses past {target_name}'s {hit_location}—close enough to taste metal in the air.",
+            'victim_msg': "The hook hisses past your {hit_location}—close enough to taste metal in the air.",
+            'observer_msg': "The hook hisses past {target_name}'s {hit_location}—close enough to taste metal in the air."
         },
         {
             'attacker_msg': "A wide arc misses completely. The chain sings, but {target_name} is untouched.",
@@ -335,9 +335,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} whips the hook forward, but {target_name} stumbles out of reach at the last second."
         },
         {
-            'attacker_msg': "The hook sails harmlessly past {target_name}'s ribs, dragging only air behind it.",
-            'victim_msg': "The hook sails harmlessly past your ribs, dragging only air behind it.",
-            'observer_msg': "The hook sails harmlessly past {target_name}'s ribs, dragging only air behind it."
+            'attacker_msg': "The hook sails harmlessly past {target_name}'s {hit_location}, dragging only air behind it.",
+            'victim_msg': "The hook sails harmlessly past your {hit_location}, dragging only air behind it.",
+            'observer_msg': "The hook sails harmlessly past {target_name}'s {hit_location}, dragging only air behind it."
         },
         {
             'attacker_msg': "A grunt and a miss—your footwork is off. The strike fails.",
@@ -430,7 +430,7 @@ MESSAGES = {
             'observer_msg': "The hook bounces off a metal railing as {target_name} sidesteps."
         },
         {
-            'attacker_msg': "A flick of your wrist gone wrong—steel meets pavement.",
+            'attacker_msg': "A flick of your {hit_location} gone wrong—steel meets pavement.",
             'victim_msg': "A flick of {attacker_name}'s wrist gone wrong—steel meets pavement.",
             'observer_msg': "A flick of the wrist gone wrong—steel meets pavement."
         },
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You plunge the hook into {target_name}'s chest and lift. Something vital tears loose as they scream.",
-            'victim_msg': "{attacker_name} plunges the hook into your chest and lifts. Something vital tears loose as you scream.",
-            'observer_msg': "{attacker_name} plunges the hook into {target_name}'s chest and lifts. Something vital tears loose as they scream."
+            'attacker_msg': "You plunge the hook into {target_name}'s {hit_location} and lift. Something vital tears loose as they scream.",
+            'victim_msg': "{attacker_name} plunges the hook into your {hit_location} and lifts. Something vital tears loose as you scream.",
+            'observer_msg': "{attacker_name} plunges the hook into {target_name}'s {hit_location} and lifts. Something vital tears loose as they scream."
         },
         {
             'attacker_msg': "The point sinks under {target_name}'s chin. You hoist them off their feet like a trophy.",
@@ -467,9 +467,9 @@ MESSAGES = {
             'observer_msg': "The point sinks under {target_name}'s chin. {attacker_name} hoists them off their feet like a trophy."
         },
         {
-            'attacker_msg': "The hook buries deep in {target_name}'s ribs. One twist. One final breath.",
-            'victim_msg': "The hook buries deep in your ribs. One twist. One final breath.",
-            'observer_msg': "The hook buries deep in {target_name}'s ribs. One twist. One final breath."
+            'attacker_msg': "The hook buries deep in {target_name}'s {hit_location}. One twist. One final breath.",
+            'victim_msg': "The hook buries deep in your {hit_location}. One twist. One final breath.",
+            'observer_msg': "The hook buries deep in {target_name}'s {hit_location}. One twist. One final breath."
         },
         {
             'attacker_msg': "You jerk the hook back, dragging viscera with it. {target_name} slumps like wet cloth.",
@@ -477,9 +477,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} jerks the hook back, dragging viscera with it. {target_name} slumps like wet cloth."
         },
         {
-            'attacker_msg': "A full swing caves in {target_name}'s skull. The hook stays buried as their body collapses.",
-            'victim_msg': "A full swing caves in your skull. The hook stays buried as your body collapses.",
-            'observer_msg': "A full swing caves in {target_name}'s skull. The hook stays buried as their body collapses."
+            'attacker_msg': "A full swing caves in {target_name}'s {hit_location}. The hook stays buried as their body collapses.",
+            'victim_msg': "A full swing caves in your {hit_location}. The hook stays buried as your body collapses.",
+            'observer_msg': "A full swing caves in {target_name}'s {hit_location}. The hook stays buried as their body collapses."
         },
         {
             'attacker_msg': "The hook pierces the heart. {target_name} freezes, then drops like a puppet unstrung.",
@@ -487,9 +487,9 @@ MESSAGES = {
             'observer_msg': "The hook pierces the heart. {target_name} freezes, then drops like a puppet unstrung."
         },
         {
-            'attacker_msg': "You slash across {target_name}'s throat. Blood spurts. The silence after is deafening.",
-            'victim_msg': "{attacker_name} slashes across your throat. Blood spurts. The silence after is deafening.",
-            'observer_msg': "{attacker_name} slashes across {target_name}'s throat. Blood spurts. The silence after is deafening."
+            'attacker_msg': "You slash across {target_name}'s {hit_location}. Blood spurts. The silence after is deafening.",
+            'victim_msg': "{attacker_name} slashes across your {hit_location}. Blood spurts. The silence after is deafening.",
+            'observer_msg': "{attacker_name} slashes across {target_name}'s {hit_location}. Blood spurts. The silence after is deafening."
         },
         {
             'attacker_msg': "The meat hook stabs through {target_name}'s gut and out the back. They fold over the chain and die shaking.",
@@ -507,14 +507,14 @@ MESSAGES = {
             'observer_msg': "One upward rip opens {target_name} from stomach to sternum. The floor catches everything else."
         },
         {
-            'attacker_msg': "A sickening crack as the hook breaks through {target_name}'s spine. They don't even fall right.",
-            'victim_msg': "A sickening crack as the hook breaks through your spine. You don't even fall right.",
-            'observer_msg': "A sickening crack as the hook breaks through {target_name}'s spine. They don't even fall right."
+            'attacker_msg': "A sickening crack as the hook breaks through {target_name}'s {hit_location}. They don't even fall right.",
+            'victim_msg': "A sickening crack as the hook breaks through your {hit_location}. You don't even fall right.",
+            'observer_msg': "A sickening crack as the hook breaks through {target_name}'s {hit_location}. They don't even fall right."
         },
         {
-            'attacker_msg': "You swing in a wide arc, catching {target_name}'s neck. The body spins, then crumples.",
-            'victim_msg': "{attacker_name} swings in a wide arc, catching your neck. The body spins, then crumples.",
-            'observer_msg': "{attacker_name} swings in a wide arc, catching {target_name}'s neck. The body spins, then crumples."
+            'attacker_msg': "You swing in a wide arc, catching {target_name}'s {hit_location}. The body spins, then crumples.",
+            'victim_msg': "{attacker_name} swings in a wide arc, catching your {hit_location}. The body spins, then crumples.",
+            'observer_msg': "{attacker_name} swings in a wide arc, catching {target_name}'s {hit_location}. The body spins, then crumples."
         },
         {
             'attacker_msg': "The hook goes in beneath the ribs. You pull up. {target_name} doesn't scream—they gurgle.",
@@ -537,9 +537,9 @@ MESSAGES = {
             'observer_msg': "The chain coils tight as {attacker_name} reels in the kill. {target_name} arrives in pieces."
         },
         {
-            'attacker_msg': "A brutal hook to the temple caves half of {target_name}'s face inward. Death follows fast.",
-            'victim_msg': "A brutal hook to the temple caves half of your face inward. Death follows fast.",
-            'observer_msg': "A brutal hook to the temple caves half of {target_name}'s face inward. Death follows fast."
+            'attacker_msg': "A brutal hook to the temple caves half of {target_name}'s {hit_location} inward. Death follows fast.",
+            'victim_msg': "A brutal hook to the temple caves half of your {hit_location} inward. Death follows fast.",
+            'observer_msg': "A brutal hook to the temple caves half of {target_name}'s {hit_location} inward. Death follows fast."
         },
         {
             'attacker_msg': "The hook enters low and exits high. {target_name}'s scream becomes static.",
@@ -582,9 +582,9 @@ MESSAGES = {
             'observer_msg': "A quick stab to the base of the skull ends {target_name} instantly."
         },
         {
-            'attacker_msg': "You whirl the chain overhead and bring it down. {target_name}'s head folds sideways.",
-            'victim_msg': "{attacker_name} whirls the chain overhead and brings it down. Your head folds sideways.",
-            'observer_msg': "{attacker_name} whirls the chain overhead and brings it down. {target_name}'s head folds sideways."
+            'attacker_msg': "You whirl the chain overhead and bring it down. {target_name}'s {hit_location} folds sideways.",
+            'victim_msg': "{attacker_name} whirls the chain overhead and brings it down. Your {hit_location} folds sideways.",
+            'observer_msg': "{attacker_name} whirls the chain overhead and brings it down. {target_name}'s {hit_location} folds sideways."
         },
         {
             'attacker_msg': "The hook lands, and you let it go. It stays with the body.",

--- a/world/combat/messages/melee.py
+++ b/world/combat/messages/melee.py
@@ -116,7 +116,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} shifts their weight, then explodes into motion, {item} aimed at {target_name}."
         },
         {
-            'attacker_msg': "A grim expression settles on your face as you engage {target_name} with {item}.",
+            'attacker_msg': "A grim expression settles on your {hit_location} as you engage {target_name} with {item}.",
             'victim_msg': "A grim expression settles on {attacker_name}'s face as they engage you with {item}.",
             'observer_msg': "A grim expression settles on {attacker_name}'s face as they engage {target_name} with {item}."
         },

--- a/world/combat/messages/metal_club.py
+++ b/world/combat/messages/metal_club.py
@@ -51,7 +51,7 @@ MESSAGES = {
             'observer_msg': "The club rotates once before locking into a ready grip. {attacker_name} doesn't pose — they prepare."
         },
         {
-            'attacker_msg': "The club's handle fits like a memory in your hand. Bad ones. Repeatable ones.",
+            'attacker_msg': "The club's handle fits like a memory in your {hit_location}. Bad ones. Repeatable ones.",
             'victim_msg': "The club's handle fits like a memory in {attacker_name}'s hand. Bad ones. Repeatable ones.",
             'observer_msg': "The club's handle fits like a memory in {attacker_name}'s hand. Bad ones. Repeatable ones."
         },
@@ -116,7 +116,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} hoists the club like it's not the first time. The dents say it's not the last either."
         },
         {
-            'attacker_msg': "You pull the club free from your back. Gravity does the rest.",
+            'attacker_msg': "You pull the club free from your {hit_location}. Gravity does the rest.",
             'victim_msg': "{attacker_name} pulls the club free from their back. Gravity does the rest.",
             'observer_msg': "{attacker_name} pulls the club free from their back. Gravity does the rest."
         },
@@ -131,7 +131,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} raises the club with deliberate ease. They've been waiting for this moment."
         },
         {
-            'attacker_msg': "You roll the club in your hand like it's a coin flip that only ends one way.",
+            'attacker_msg': "You roll the club in your {hit_location} like it's a coin flip that only ends one way.",
             'victim_msg': "{attacker_name} rolls the club in their hand like it's a coin flip that only ends one way.",
             'observer_msg': "{attacker_name} rolls the club in their hand like it's a coin flip that only ends one way."
         },
@@ -370,9 +370,9 @@ MESSAGES = {
             'observer_msg': "The club bounces off a crate, sending splinters flying. {attacker_name} snarls and resets."
         },
         {
-            'attacker_msg': "The club hisses past {target_name}'s shoulder, brushing air but not skin.",
-            'victim_msg': "The club hisses past your shoulder, brushing air but not skin.",
-            'observer_msg': "The club hisses past {target_name}'s shoulder, brushing air but not skin."
+            'attacker_msg': "The club hisses past {target_name}'s {hit_location}, brushing air but not skin.",
+            'victim_msg': "The club hisses past your {hit_location}, brushing air but not skin.",
+            'observer_msg': "The club hisses past {target_name}'s {hit_location}, brushing air but not skin."
         },
         {
             'attacker_msg': "The club smashes a crate instead. The splinters spray like warning shrapnel.",
@@ -532,14 +532,14 @@ MESSAGES = {
             'observer_msg': "The club slams into the temple. The skull cracks. The eyes glaze. The body falls."
         },
         {
-            'attacker_msg': "The club slams into {target_name}'s skull. The crack echoes. The body drops before the blood does.",
-            'victim_msg': "The club slams into your skull. The crack echoes. The body drops before the blood does.",
-            'observer_msg': "The club slams into {target_name}'s skull. The crack echoes. The body drops before the blood does."
+            'attacker_msg': "The club slams into {target_name}'s {hit_location}. The crack echoes. The body drops before the blood does.",
+            'victim_msg': "The club slams into your {hit_location}. The crack echoes. The body drops before the blood does.",
+            'observer_msg': "The club slams into {target_name}'s {hit_location}. The crack echoes. The body drops before the blood does."
         },
         {
-            'attacker_msg': "The club smashes into {target_name}'s head. The skull cracks, then caves. No second hit needed.",
-            'victim_msg': "The club smashes into your head. The skull cracks, then caves. No second hit needed.",
-            'observer_msg': "The club smashes into {target_name}'s head. The skull cracks, then caves. No second hit needed."
+            'attacker_msg': "The club smashes into {target_name}'s {hit_location}. The skull cracks, then caves. No second hit needed.",
+            'victim_msg': "The club smashes into your {hit_location}. The skull cracks, then caves. No second hit needed.",
+            'observer_msg': "The club smashes into {target_name}'s {hit_location}. The skull cracks, then caves. No second hit needed."
         },
         {
             'attacker_msg': "The club sweeps sideways across the neck. Bone cracks. Blood sprays. {target_name} is finished.",

--- a/world/combat/messages/mirror_shard.py
+++ b/world/combat/messages/mirror_shard.py
@@ -11,7 +11,7 @@ MESSAGES = {
             'observer_msg': "With a desperate look, {attacker_name} brandishes a sharp piece of broken mirror, ready to slash and stab, {target_name}'s own twisted face reflected within."
         },
         {
-            'attacker_msg': "Your hand is wrapped precariously around a mirror shard, its razor edge reflecting a grim, fragmented light.",
+            'attacker_msg': "Your {hit_location} is wrapped precariously around a mirror shard, its razor edge reflecting a grim, fragmented light.",
             'victim_msg': "{attacker_name}'s hand is wrapped precariously around a mirror shard, its razor edge reflecting a grim, fragmented light.",
             'observer_msg': "{attacker_name}'s hand is wrapped precariously around a mirror shard, its razor edge reflecting a grim, fragmented light."
         },
@@ -36,7 +36,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} points the jagged end of the mirror shard towards {target_name}, a clear, vicious threat, a sliver of {target_name}'s own fear staring back."
         },
         {
-            'attacker_msg': "Light catches the irregular, razor-sharp edges of the mirror shard in your hand, throwing distorted slivers of light.",
+            'attacker_msg': "Light catches the irregular, razor-sharp edges of the mirror shard in your {hit_location}, throwing distorted slivers of light.",
             'victim_msg': "Light catches the irregular, razor-sharp edges of the mirror shard in {attacker_name}'s hand, throwing distorted slivers of light.",
             'observer_msg': "Light catches the irregular, razor-sharp edges of the mirror shard in {attacker_name}'s hand, throwing distorted slivers of light."
         },
@@ -66,7 +66,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s eyes are narrowed, sighting along the sharpest edge of the mirror towards {target_name}, their own reflection a grim mask."
         },
         {
-            'attacker_msg': "The mirror shard feels dangerously sharp and fragile in your hand, a tool of pure desperation, reflecting a broken world.",
+            'attacker_msg': "The mirror shard feels dangerously sharp and fragile in your {hit_location}, a tool of pure desperation, reflecting a broken world.",
             'victim_msg': "The mirror shard feels dangerously sharp and fragile in {attacker_name}'s hand, a tool of pure desperation, reflecting a broken world.",
             'observer_msg': "The mirror shard feels dangerously sharp and fragile in {attacker_name}'s hand, a tool of pure desperation, reflecting a broken world."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your mirror shard whistles through the air, its jagged edge narrowly missing {target_name}'s face, reflecting a streak of light.",
-            'victim_msg': "{attacker_name}'s mirror shard whistles through the air, its jagged edge narrowly missing your face, reflecting a streak of light.",
-            'observer_msg': "{attacker_name}'s mirror shard whistles through the air, its jagged edge narrowly missing {target_name}'s face, reflecting a streak of light."
+            'attacker_msg': "Your mirror shard whistles through the air, its jagged edge narrowly missing {target_name}'s {hit_location}, reflecting a streak of light.",
+            'victim_msg': "{attacker_name}'s mirror shard whistles through the air, its jagged edge narrowly missing your {hit_location}, reflecting a streak of light.",
+            'observer_msg': "{attacker_name}'s mirror shard whistles through the air, its jagged edge narrowly missing {target_name}'s {hit_location}, reflecting a streak of light."
         },
         {
             'attacker_msg': "{target_name} stumbles back, avoiding the desperate slash of your mirror shard, seeing their own wide eyes in its passing glint.",
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick retreat from {target_name} leaves {attacker_name}'s mirror shard to cut nothing but air, reflecting {attacker_name}'s own angry face."
         },
         {
-            'attacker_msg': "The mirror shard feels dangerously slippery in your hand as the intended cutting blow fails, reflecting your own fumbling.",
+            'attacker_msg': "The mirror shard feels dangerously slippery in your {hit_location} as the intended cutting blow fails, reflecting your own fumbling.",
             'victim_msg': "The mirror shard feels dangerously slippery in {attacker_name}'s hand as the intended cutting blow fails, reflecting their own fumbling.",
             'observer_msg': "The mirror shard feels dangerously slippery in {attacker_name}'s hand as the intended cutting blow fails, reflecting their own fumbling."
         },
@@ -395,9 +395,9 @@ MESSAGES = {
             'observer_msg': "A growl of frustration from {attacker_name} as their mirror shard attack is evaded, their angry face caught in the glass."
         },
         {
-            'attacker_msg': "The mirror shard scratches a line on the ground beside {target_name}'s foot, reflecting a sliver of their boot.",
-            'victim_msg': "The mirror shard scratches a line on the ground beside your foot, reflecting a sliver of your boot.",
-            'observer_msg': "The mirror shard scratches a line on the ground beside {target_name}'s foot, reflecting a sliver of their boot."
+            'attacker_msg': "The mirror shard scratches a line on the ground beside {target_name}'s {hit_location}, reflecting a sliver of their boot.",
+            'victim_msg': "The mirror shard scratches a line on the ground beside your {hit_location}, reflecting a sliver of your boot.",
+            'observer_msg': "The mirror shard scratches a line on the ground beside {target_name}'s {hit_location}, reflecting a sliver of their boot."
         },
         {
             'attacker_msg': "Your straightforward attack with the mirror shard is anticipated and dodged by {target_name}, who sees their own relief in its passing.",
@@ -457,14 +457,14 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You shove the jagged mirror shard into {target_name}'s throat; they collapse, gurgling, their dying eyes reflected in the bloody glass.",
-            'victim_msg': "{attacker_name} shoves the jagged mirror shard into your throat; you collapse, gurgling, your dying eyes reflected in the bloody glass.",
-            'observer_msg': "{attacker_name} shoves the jagged mirror shard into {target_name}'s throat; they collapse, gurgling, their dying eyes reflected in the bloody glass."
+            'attacker_msg': "You shove the jagged mirror shard into {target_name}'s {hit_location}; they collapse, gurgling, their dying eyes reflected in the bloody glass.",
+            'victim_msg': "{attacker_name} shoves the jagged mirror shard into your {hit_location}; you collapse, gurgling, your dying eyes reflected in the bloody glass.",
+            'observer_msg': "{attacker_name} shoves the jagged mirror shard into {target_name}'s {hit_location}; they collapse, gurgling, their dying eyes reflected in the bloody glass."
         },
         {
-            'attacker_msg': "The mirror shard, driven deep into {target_name}'s chest, pierces their heart, and they fall silent, their last reflection a rictus of pain.",
-            'victim_msg': "The mirror shard, driven deep into your chest, pierces your heart, and you fall silent, your last reflection a rictus of pain.",
-            'observer_msg': "The mirror shard, driven deep into {target_name}'s chest, pierces their heart, and they fall silent, their last reflection a rictus of pain."
+            'attacker_msg': "The mirror shard, driven deep into {target_name}'s {hit_location}, pierces their heart, and they fall silent, their last reflection a rictus of pain.",
+            'victim_msg': "The mirror shard, driven deep into your {hit_location}, pierces your {hit_location}, and you fall silent, your last reflection a rictus of pain.",
+            'observer_msg': "The mirror shard, driven deep into {target_name}'s {hit_location}, pierces their heart, and they fall silent, their last reflection a rictus of pain."
         },
         {
             'attacker_msg': "With a final, brutal thrust, you embed the mirror shard in {target_name}'s eye, and they drop, their vacant stare mirrored in the shard.",
@@ -487,14 +487,14 @@ MESSAGES = {
             'observer_msg': "The mirror shard, a desperate tool of death, delivers a killing blow, {target_name} overcome by wounds, their last sight their own demise in the glass."
         },
         {
-            'attacker_msg': "A precise, savage thrust with the mirror shard to {target_name}'s temple ends their life, a final, bloody image captured in its surface.",
-            'victim_msg': "A precise, savage thrust with the mirror shard to your temple ends your life, a final, bloody image captured in its surface.",
-            'observer_msg': "A precise, savage thrust with the mirror shard to {target_name}'s temple ends their life, a final, bloody image captured in its surface."
+            'attacker_msg': "A precise, savage thrust with the mirror shard to {target_name}'s {hit_location} ends their life, a final, bloody image captured in its surface.",
+            'victim_msg': "A precise, savage thrust with the mirror shard to your {hit_location} ends your life, a final, bloody image captured in its surface.",
+            'observer_msg': "A precise, savage thrust with the mirror shard to {target_name}'s {hit_location} ends their life, a final, bloody image captured in its surface."
         },
         {
-            'attacker_msg': "You press the mirror shard against {target_name}'s neck until they stop moving, the glass dark with blood, reflecting nothing but the end.",
-            'victim_msg': "{attacker_name} presses the mirror shard against your neck until you stop moving, the glass dark with blood, reflecting nothing but the end.",
-            'observer_msg': "{attacker_name} presses the mirror shard against {target_name}'s neck until they stop moving, the glass dark with blood, reflecting nothing but the end."
+            'attacker_msg': "You press the mirror shard against {target_name}'s {hit_location} until they stop moving, the glass dark with blood, reflecting nothing but the end.",
+            'victim_msg': "{attacker_name} presses the mirror shard against your {hit_location} until you stop moving, the glass dark with blood, reflecting nothing but the end.",
+            'observer_msg': "{attacker_name} presses the mirror shard against {target_name}'s {hit_location} until they stop moving, the glass dark with blood, reflecting nothing but the end."
         },
         {
             'attacker_msg': "The unyielding sharpness of the mirror shard severs something vital in {target_name}, who crumples, their still face a pale reflection.",
@@ -522,7 +522,7 @@ MESSAGES = {
             'observer_msg': "A merciless, deep stab with the mirror shard, and {target_name} is no more, their vacant eyes reflected in the bloody surface."
         },
         {
-            'attacker_msg': "The mirror shard, now slick and dark, drops from your hand as {target_name} lies lifeless, reflecting only the aftermath.",
+            'attacker_msg': "The mirror shard, now slick and dark, drops from your {hit_location} as {target_name} lies lifeless, reflecting only the aftermath.",
             'victim_msg': "The mirror shard, now slick and dark, drops from {attacker_name}'s hand as you lie lifeless, reflecting only the aftermath.",
             'observer_msg': "The mirror shard, now slick and dark, drops from {attacker_name}'s hand as {target_name} lies lifeless, reflecting only the aftermath."
         },

--- a/world/combat/messages/nail_bat.py
+++ b/world/combat/messages/nail_bat.py
@@ -26,7 +26,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} slams the bat against the ground once, spikes digging into the floor with a hungry sound."
         },
         {
-            'attacker_msg': "You tilt your head and smirk, bat held low like an afterthought. The nails are not.",
+            'attacker_msg': "You tilt your {hit_location} and smirk, bat held low like an afterthought. The nails are not.",
             'victim_msg': "{attacker_name} tilts their head and smirks, bat held low like an afterthought. The nails are not.",
             'observer_msg': "{attacker_name} tilts their head and smirks, bat held low like an afterthought. The nails are not."
         },
@@ -36,12 +36,12 @@ MESSAGES = {
             'observer_msg': "A grunt escapes {attacker_name} as they lift the bat high and take a low stance, ready to bring the pain."
         },
         {
-            'attacker_msg': "You crack your neck to one side, then the other, before raising the nail-studded bat to chest level.",
+            'attacker_msg': "You crack your {hit_location} to one side, then the other, before raising the nail-studded bat to chest level.",
             'victim_msg': "{attacker_name} cracks their neck to one side, then the other, before raising the nail-studded bat to chest level.",
             'observer_msg': "{attacker_name} cracks their neck to one side, then the other, before raising the nail-studded bat to chest level."
         },
         {
-            'attacker_msg': "You rest the nail bat against your shoulder, tapping the head in a slow, rhythmic beat of what's to come.",
+            'attacker_msg': "You rest the nail bat against your {hit_location}, tapping the head in a slow, rhythmic beat of what's to come.",
             'victim_msg': "{attacker_name} rests the nail bat against their shoulder, tapping the head in a slow, rhythmic beat of what's to come.",
             'observer_msg': "{attacker_name} rests the nail bat against their shoulder, tapping the head in a slow, rhythmic beat of what's to come."
         },
@@ -71,7 +71,7 @@ MESSAGES = {
             'observer_msg': "Nails clink against stone as {attacker_name} drags the bat forward like a butcher with a trophy."
         },
         {
-            'attacker_msg': "You lift the bat over your head, letting the nails catch the light like tiny fangs.",
+            'attacker_msg': "You lift the bat over your {hit_location}, letting the nails catch the light like tiny fangs.",
             'victim_msg': "{attacker_name} lifts the bat over their head, letting the nails catch the light like tiny fangs.",
             'observer_msg': "{attacker_name} lifts the bat over their head, letting the nails catch the light like tiny fangs."
         },
@@ -86,7 +86,7 @@ MESSAGES = {
             'observer_msg': "With a casual swing, {attacker_name} warms up the bat on the air, testing its thirst."
         },
         {
-            'attacker_msg': "You step in, dragging the bat across your shoulder like a war drum stick.",
+            'attacker_msg': "You step in, dragging the bat across your {hit_location} like a war drum stick.",
             'victim_msg': "{attacker_name} steps in, dragging the bat across their shoulder like a war drum stick.",
             'observer_msg': "{attacker_name} steps in, dragging the bat across their shoulder like a war drum stick."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "You swing hard but find only air, the bat whistling past {target_name}'s head.",
-            'victim_msg': "{attacker_name} swings hard but finds only air, the bat whistling past your head.",
-            'observer_msg': "{attacker_name} swings hard but finds only air, the bat whistling past {target_name}'s head."
+            'attacker_msg': "You swing hard but find only air, the bat whistling past {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name} swings hard but finds only air, the bat whistling past your {hit_location}.",
+            'observer_msg': "{attacker_name} swings hard but finds only air, the bat whistling past {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "Nails scrape the wall behind {target_name}, a shower of sparks chasing their dodge.",
@@ -457,24 +457,24 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "The bat lands square in {target_name}'s temple. They crumple like wet paper, skull caved inward.",
-            'victim_msg': "The bat lands square in your temple. You crumple like wet paper, skull caved inward.",
-            'observer_msg': "The bat lands square in {target_name}'s temple. They crumple like wet paper, skull caved inward."
+            'attacker_msg': "The bat lands square in {target_name}'s {hit_location}. They crumple like wet paper, skull caved inward.",
+            'victim_msg': "The bat lands square in your {hit_location}. You crumple like wet paper, skull caved inward.",
+            'observer_msg': "The bat lands square in {target_name}'s {hit_location}. They crumple like wet paper, skull caved inward."
         },
         {
-            'attacker_msg': "A jagged arc crushes {target_name}'s chest. Ribs splinter. Breathing stops.",
-            'victim_msg': "A jagged arc crushes your chest. Ribs splinter. Breathing stops.",
-            'observer_msg': "A jagged arc crushes {target_name}'s chest. Ribs splinter. Breathing stops."
+            'attacker_msg': "A jagged arc crushes {target_name}'s {hit_location}. Ribs splinter. Breathing stops.",
+            'victim_msg': "A jagged arc crushes your {hit_location}. Ribs splinter. Breathing stops.",
+            'observer_msg': "A jagged arc crushes {target_name}'s {hit_location}. Ribs splinter. Breathing stops."
         },
         {
-            'attacker_msg': "The nails punch into {target_name}'s face and stay there. They fall, still twitching.",
-            'victim_msg': "The nails punch into your face and stay there. You fall, still twitching.",
-            'observer_msg': "The nails punch into {target_name}'s face and stay there. They fall, still twitching."
+            'attacker_msg': "The nails punch into {target_name}'s {hit_location} and stay there. They fall, still twitching.",
+            'victim_msg': "The nails punch into your {hit_location} and stay there. You fall, still twitching.",
+            'observer_msg': "The nails punch into {target_name}'s {hit_location} and stay there. They fall, still twitching."
         },
         {
-            'attacker_msg': "A low swing caves in {target_name}'s knee—then a second shatters their spine. Done.",
-            'victim_msg': "A low swing caves in your knee—then a second shatters your spine. Done.",
-            'observer_msg': "A low swing caves in {target_name}'s knee—then a second shatters their spine. Done."
+            'attacker_msg': "A low swing caves in {target_name}'s {hit_location}—then a second shatters their spine. Done.",
+            'victim_msg': "A low swing caves in your {hit_location}—then a second shatters your {hit_location}. Done.",
+            'observer_msg': "A low swing caves in {target_name}'s {hit_location}—then a second shatters their spine. Done."
         },
         {
             'attacker_msg': "You plant the bat into {target_name}'s gut and lift. Guts trail after.",
@@ -492,14 +492,14 @@ MESSAGES = {
             'observer_msg': "The bat lands with a final, echoing thud. {target_name} stops moving. The blood doesn't."
         },
         {
-            'attacker_msg': "A sideways smash unhinges {target_name}'s jaw. Then the lights go out.",
-            'victim_msg': "A sideways smash unhinges your jaw. Then the lights go out.",
-            'observer_msg': "A sideways smash unhinges {target_name}'s jaw. Then the lights go out."
+            'attacker_msg': "A sideways smash unhinges {target_name}'s {hit_location}. Then the lights go out.",
+            'victim_msg': "A sideways smash unhinges your {hit_location}. Then the lights go out.",
+            'observer_msg': "A sideways smash unhinges {target_name}'s {hit_location}. Then the lights go out."
         },
         {
-            'attacker_msg': "Nails embed deep into {target_name}'s chest. You twist. The scream dies fast.",
-            'victim_msg': "Nails embed deep into your chest. {attacker_name} twists. The scream dies fast.",
-            'observer_msg': "Nails embed deep into {target_name}'s chest. {attacker_name} twists. The scream dies fast."
+            'attacker_msg': "Nails embed deep into {target_name}'s {hit_location}. You twist. The scream dies fast.",
+            'victim_msg': "Nails embed deep into your {hit_location}. {attacker_name} twists. The scream dies fast.",
+            'observer_msg': "Nails embed deep into {target_name}'s {hit_location}. {attacker_name} twists. The scream dies fast."
         },
         {
             'attacker_msg': "The blow knocks {target_name}'s feet out from under them—along with their last breath.",
@@ -507,9 +507,9 @@ MESSAGES = {
             'observer_msg': "The blow knocks {target_name}'s feet out from under them—along with their last breath."
         },
         {
-            'attacker_msg': "With a grunt, you drive the bat into {target_name}'s throat. They gargle, then collapse.",
-            'victim_msg': "With a grunt, {attacker_name} drives the bat into your throat. You gargle, then collapse.",
-            'observer_msg': "With a grunt, {attacker_name} drives the bat into {target_name}'s throat. They gargle, then collapse."
+            'attacker_msg': "With a grunt, you drive the bat into {target_name}'s {hit_location}. They gargle, then collapse.",
+            'victim_msg': "With a grunt, {attacker_name} drives the bat into your {hit_location}. You gargle, then collapse.",
+            'observer_msg': "With a grunt, {attacker_name} drives the bat into {target_name}'s {hit_location}. They gargle, then collapse."
         },
         {
             'attacker_msg': "The bat descends. {target_name} doesn't rise.",
@@ -517,9 +517,9 @@ MESSAGES = {
             'observer_msg': "The bat descends. {target_name} doesn't rise."
         },
         {
-            'attacker_msg': "One clean arc takes the top half of {target_name}'s skull off like a lid.",
-            'victim_msg': "One clean arc takes the top half of your skull off like a lid.",
-            'observer_msg': "One clean arc takes the top half of {target_name}'s skull off like a lid."
+            'attacker_msg': "One clean arc takes the top half of {target_name}'s {hit_location} off like a lid.",
+            'victim_msg': "One clean arc takes the top half of your {hit_location} off like a lid.",
+            'observer_msg': "One clean arc takes the top half of {target_name}'s {hit_location} off like a lid."
         },
         {
             'attacker_msg': "You swing three times. The last connects. {target_name} drops in pieces.",
@@ -542,9 +542,9 @@ MESSAGES = {
             'observer_msg': "The impact is so severe {target_name} bounces off the wall—dead midair."
         },
         {
-            'attacker_msg': "A single vertical blow collapses {target_name}'s spine like kindling.",
-            'victim_msg': "A single vertical blow collapses your spine like kindling.",
-            'observer_msg': "A single vertical blow collapses {target_name}'s spine like kindling."
+            'attacker_msg': "A single vertical blow collapses {target_name}'s {hit_location} like kindling.",
+            'victim_msg': "A single vertical blow collapses your {hit_location} like kindling.",
+            'observer_msg': "A single vertical blow collapses {target_name}'s {hit_location} like kindling."
         },
         {
             'attacker_msg': "The floor catches {target_name} gently. The bat was not so kind.",
@@ -557,9 +557,9 @@ MESSAGES = {
             'observer_msg': "A splatter, a twitch, and stillness. {attacker_name} doesn't even look down."
         },
         {
-            'attacker_msg': "The nails find {target_name}'s heart. There's a moment. Then just silence.",
-            'victim_msg': "The nails find your heart. There's a moment. Then just silence.",
-            'observer_msg': "The nails find {target_name}'s heart. There's a moment. Then just silence."
+            'attacker_msg': "The nails find {target_name}'s {hit_location}. There's a moment. Then just silence.",
+            'victim_msg': "The nails find your {hit_location}. There's a moment. Then just silence.",
+            'observer_msg': "The nails find {target_name}'s {hit_location}. There's a moment. Then just silence."
         },
         {
             'attacker_msg': "You step away. {target_name} stays down. Permanently.",
@@ -573,13 +573,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A whirling swing removes {target_name}'s ear—and most of their brain.",
-            'victim_msg': "A whirling swing removes your ear—and most of your brain.",
+            'victim_msg': "A whirling swing removes your ear—and most of your {hit_location}.",
             'observer_msg': "A whirling swing removes {target_name}'s ear—and most of their brain."
         },
         {
-            'attacker_msg': "The bat splits {target_name}'s head like a melon, then some.",
-            'victim_msg': "The bat splits your head like a melon, then some.",
-            'observer_msg': "The bat splits {target_name}'s head like a melon, then some."
+            'attacker_msg': "The bat splits {target_name}'s {hit_location} like a melon, then some.",
+            'victim_msg': "The bat splits your {hit_location} like a melon, then some.",
+            'observer_msg': "The bat splits {target_name}'s {hit_location} like a melon, then some."
         },
         {
             'attacker_msg': "The final hit echoes for a long time. {target_name} doesn't hear it.",

--- a/world/combat/messages/nail_gun.py
+++ b/world/combat/messages/nail_gun.py
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your nail gun fires with a sharp *thwack-hiss*, the nail embedding itself in the wall beside {target_name}'s head.",
-            'victim_msg': "{attacker_name}'s nail gun fires with a sharp *thwack-hiss*, the nail embedding itself in the wall beside your head.",
-            'observer_msg': "{attacker_name}'s nail gun fires with a sharp *thwack-hiss*, the nail embedding itself in the wall beside {target_name}'s head."
+            'attacker_msg': "Your nail gun fires with a sharp *thwack-hiss*, the nail embedding itself in the wall beside {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s nail gun fires with a sharp *thwack-hiss*, the nail embedding itself in the wall beside your {hit_location}.",
+            'observer_msg': "{attacker_name}'s nail gun fires with a sharp *thwack-hiss*, the nail embedding itself in the wall beside {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "{target_name} narrowly avoids a nail from your nail gun, which punches into a nearby crate.",
@@ -462,19 +462,19 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s nail gun drives a nail straight into {target_name}'s eye; they collapse, twitching, life extinguished."
         },
         {
-            'attacker_msg': "A rapid burst from the nail gun riddles {target_name}'s chest, each nail a fatal puncture, and they fall silent.",
-            'victim_msg': "A rapid burst from the nail gun riddles your chest, each nail a fatal puncture, and you fall silent.",
-            'observer_msg': "A rapid burst from the nail gun riddles {target_name}'s chest, each nail a fatal puncture, and they fall silent."
+            'attacker_msg': "A rapid burst from the nail gun riddles {target_name}'s {hit_location}, each nail a fatal puncture, and they fall silent.",
+            'victim_msg': "A rapid burst from the nail gun riddles your {hit_location}, each nail a fatal puncture, and you fall silent.",
+            'observer_msg': "A rapid burst from the nail gun riddles {target_name}'s {hit_location}, each nail a fatal puncture, and they fall silent."
         },
         {
-            'attacker_msg': "With a final, grim shot, your nail gun sends a nail into {target_name}'s temple, ending their struggles instantly.",
-            'victim_msg': "With a final, grim shot, {attacker_name}'s nail gun sends a nail into your temple, ending your struggles instantly.",
-            'observer_msg': "With a final, grim shot, {attacker_name}'s nail gun sends a nail into {target_name}'s temple, ending their struggles instantly."
+            'attacker_msg': "With a final, grim shot, your nail gun sends a nail into {target_name}'s {hit_location}, ending their struggles instantly.",
+            'victim_msg': "With a final, grim shot, {attacker_name}'s nail gun sends a nail into your {hit_location}, ending your struggles instantly.",
+            'observer_msg': "With a final, grim shot, {attacker_name}'s nail gun sends a nail into {target_name}'s {hit_location}, ending their struggles instantly."
         },
         {
-            'attacker_msg': "The nail gun fires point-blank into {target_name}'s throat, a wet gurgle their only response as they die.",
-            'victim_msg': "The nail gun fires point-blank into your throat, a wet gurgle your only response as you die.",
-            'observer_msg': "The nail gun fires point-blank into {target_name}'s throat, a wet gurgle their only response as they die."
+            'attacker_msg': "The nail gun fires point-blank into {target_name}'s {hit_location}, a wet gurgle their only response as they die.",
+            'victim_msg': "The nail gun fires point-blank into your {hit_location}, a wet gurgle your only response as you die.",
+            'observer_msg': "The nail gun fires point-blank into {target_name}'s {hit_location}, a wet gurgle their only response as they die."
         },
         {
             'attacker_msg': "Your sustained fire with the nail gun turns {target_name} into a macabre pincushion; they slump, lifeless.",
@@ -492,14 +492,14 @@ MESSAGES = {
             'observer_msg': "A precise shot to the base of the skull with {attacker_name}'s nail gun ends {target_name}'s life with a sickening thud."
         },
         {
-            'attacker_msg': "You empty the nail gun into {target_name}'s torso, the multiple impacts ensuring a swift, brutal death.",
-            'victim_msg': "{attacker_name} empties the nail gun into your torso, the multiple impacts ensuring a swift, brutal death.",
-            'observer_msg': "{attacker_name} empties the nail gun into {target_name}'s torso, the multiple impacts ensuring a swift, brutal death."
+            'attacker_msg': "You empty the nail gun into {target_name}'s {hit_location}, the multiple impacts ensuring a swift, brutal death.",
+            'victim_msg': "{attacker_name} empties the nail gun into your {hit_location}, the multiple impacts ensuring a swift, brutal death.",
+            'observer_msg': "{attacker_name} empties the nail gun into {target_name}'s {hit_location}, the multiple impacts ensuring a swift, brutal death."
         },
         {
-            'attacker_msg': "The unyielding steel nails from your nail gun pierce {target_name}'s heart; they fall, dead before they hit the ground.",
-            'victim_msg': "The unyielding steel nails from {attacker_name}'s nail gun pierce your heart; you fall, dead before you hit the ground.",
-            'observer_msg': "The unyielding steel nails from {attacker_name}'s nail gun pierce {target_name}'s heart; they fall, dead before they hit the ground."
+            'attacker_msg': "The unyielding steel nails from your nail gun pierce {target_name}'s {hit_location}; they fall, dead before they hit the ground.",
+            'victim_msg': "The unyielding steel nails from {attacker_name}'s nail gun pierce your {hit_location}; you fall, dead before you hit the ground.",
+            'observer_msg': "The unyielding steel nails from {attacker_name}'s nail gun pierce {target_name}'s {hit_location}; they fall, dead before they hit the ground."
         },
         {
             'attacker_msg': "With a final, sharp hiss, you finish {target_name} with a nail through the forehead from the nail gun.",

--- a/world/combat/messages/nailed_board.py
+++ b/world/combat/messages/nailed_board.py
@@ -46,7 +46,7 @@ MESSAGES = {
             'observer_msg': "The board creaks. The nails click. {attacker_name} smiles faintly. This is going to get messy."
         },
         {
-            'attacker_msg': "The board leans against your shoulder. You tap it gently, like coaxing it to remember how it kills.",
+            'attacker_msg': "The board leans against your {hit_location}. You tap it gently, like coaxing it to remember how it kills.",
             'victim_msg': "The board leans against {attacker_name}'s shoulder. They tap it gently, like coaxing it to remember how it kills.",
             'observer_msg': "The board leans against {attacker_name}'s shoulder. They tap it gently, like coaxing it to remember how it kills."
         },
@@ -370,9 +370,9 @@ MESSAGES = {
             'observer_msg': "The board whistles past {target_name}. The nails bite air — but the threat stays."
         },
         {
-            'attacker_msg': "The board whooshes past {target_name}'s head, nails humming. They flinch, but the damage is in their heartbeat.",
-            'victim_msg': "The board whooshes past your head, nails humming. You flinch, but the damage is in your heartbeat.",
-            'observer_msg': "The board whooshes past {target_name}'s head, nails humming. They flinch, but the damage is in their heartbeat."
+            'attacker_msg': "The board whooshes past {target_name}'s {hit_location}, nails humming. They flinch, but the damage is in their heartbeat.",
+            'victim_msg': "The board whooshes past your {hit_location}, nails humming. You flinch, but the damage is in your heartbeat.",
+            'observer_msg': "The board whooshes past {target_name}'s {hit_location}, nails humming. They flinch, but the damage is in their heartbeat."
         },
         {
             'attacker_msg': "The nails catch the edge of a table and stick. You rip it loose, spraying splinters.",
@@ -380,9 +380,9 @@ MESSAGES = {
             'observer_msg': "The nails catch the edge of a table and stick. {attacker_name} rips it loose, spraying splinters."
         },
         {
-            'attacker_msg': "The nails cut the air where {target_name}'s face used to be. They retreat, eyes wide and blinking.",
-            'victim_msg': "The nails cut the air where your face used to be. You retreat, eyes wide and blinking.",
-            'observer_msg': "The nails cut the air where {target_name}'s face used to be. They retreat, eyes wide and blinking."
+            'attacker_msg': "The nails cut the air where {target_name}'s {hit_location} used to be. They retreat, eyes wide and blinking.",
+            'victim_msg': "The nails cut the air where your {hit_location} used to be. You retreat, eyes wide and blinking.",
+            'observer_msg': "The nails cut the air where {target_name}'s {hit_location} used to be. They retreat, eyes wide and blinking."
         },
         {
             'attacker_msg': "The nails tear a poster from the wall instead. You keep moving, undeterred.",
@@ -405,9 +405,9 @@ MESSAGES = {
             'observer_msg': "The swing hits empty space. The nails scream against wind, hungry and unsatisfied."
         },
         {
-            'attacker_msg': "The swing sails over {target_name}'s shoulder. Close enough that their skin tightens anyway.",
-            'victim_msg': "The swing sails over your shoulder. Close enough that your skin tightens anyway.",
-            'observer_msg': "The swing sails over {target_name}'s shoulder. Close enough that their skin tightens anyway."
+            'attacker_msg': "The swing sails over {target_name}'s {hit_location}. Close enough that their skin tightens anyway.",
+            'victim_msg': "The swing sails over your {hit_location}. Close enough that your skin tightens anyway.",
+            'observer_msg': "The swing sails over {target_name}'s {hit_location}. Close enough that their skin tightens anyway."
         },
         {
             'attacker_msg': "The weapon whistles by like a crude comet. {target_name} backs away, eyes wide, lucky for now.",
@@ -462,48 +462,48 @@ MESSAGES = {
             'observer_msg': "A crack, a crunch, a collapse. {attacker_name} doesn't even need to check. They know."
         },
         {
-            'attacker_msg': "A downward slam embeds nails into {target_name}'s chest. The removal rips out more than blood.",
-            'victim_msg': "A downward slam embeds nails into your chest. The removal rips out more than blood.",
-            'observer_msg': "A downward slam embeds nails into {target_name}'s chest. The removal rips out more than blood."
+            'attacker_msg': "A downward slam embeds nails into {target_name}'s {hit_location}. The removal rips out more than blood.",
+            'victim_msg': "A downward slam embeds nails into your {hit_location}. The removal rips out more than blood.",
+            'observer_msg': "A downward slam embeds nails into {target_name}'s {hit_location}. The removal rips out more than blood."
         },
         {
-            'attacker_msg': "A full swing caves in the side of {target_name}'s head. One nail enters the eye. Everything stops.",
-            'victim_msg': "A full swing caves in the side of your head. One nail enters the eye. Everything stops.",
-            'observer_msg': "A full swing caves in the side of {target_name}'s head. One nail enters the eye. Everything stops."
+            'attacker_msg': "A full swing caves in the side of {target_name}'s {hit_location}. One nail enters the eye. Everything stops.",
+            'victim_msg': "A full swing caves in the side of your {hit_location}. One nail enters the eye. Everything stops.",
+            'observer_msg': "A full swing caves in the side of {target_name}'s {hit_location}. One nail enters the eye. Everything stops."
         },
         {
-            'attacker_msg': "A nail pierces {target_name}'s throat. They gurgle. Fall. And then — silence.",
-            'victim_msg': "A nail pierces your throat. You gurgle. Fall. And then — silence.",
-            'observer_msg': "A nail pierces {target_name}'s throat. They gurgle. Fall. And then — silence."
+            'attacker_msg': "A nail pierces {target_name}'s {hit_location}. They gurgle. Fall. And then — silence.",
+            'victim_msg': "A nail pierces your {hit_location}. You gurgle. Fall. And then — silence.",
+            'observer_msg': "A nail pierces {target_name}'s {hit_location}. They gurgle. Fall. And then — silence."
         },
         {
             'attacker_msg': "A sharp upward jab lands under {target_name}'s chin. The nails exit through the top of their head.",
-            'victim_msg': "A sharp upward jab lands under your chin. The nails exit through the top of your head.",
+            'victim_msg': "A sharp upward jab lands under your chin. The nails exit through the top of your {hit_location}.",
             'observer_msg': "A sharp upward jab lands under {target_name}'s chin. The nails exit through the top of their head."
         },
         {
-            'attacker_msg': "A spinning strike caves in {target_name}'s skull. Nails disappear. They follow.",
-            'victim_msg': "A spinning strike caves in your skull. Nails disappear. You follow.",
-            'observer_msg': "A spinning strike caves in {target_name}'s skull. Nails disappear. They follow."
+            'attacker_msg': "A spinning strike caves in {target_name}'s {hit_location}. Nails disappear. They follow.",
+            'victim_msg': "A spinning strike caves in your {hit_location}. Nails disappear. You follow.",
+            'observer_msg': "A spinning strike caves in {target_name}'s {hit_location}. Nails disappear. They follow."
         },
         {
-            'attacker_msg': "A strike to the back of {target_name}'s head ends the argument. They drop, blood pooling into stillness.",
-            'victim_msg': "A strike to the back of your head ends the argument. You drop, blood pooling into stillness.",
-            'observer_msg': "A strike to the back of {target_name}'s head ends the argument. They drop, blood pooling into stillness."
+            'attacker_msg': "A strike to the back of {target_name}'s {hit_location} ends the argument. They drop, blood pooling into stillness.",
+            'victim_msg': "A strike to the back of your {hit_location} ends the argument. You drop, blood pooling into stillness.",
+            'observer_msg': "A strike to the back of {target_name}'s {hit_location} ends the argument. They drop, blood pooling into stillness."
         },
         {
             'attacker_msg': "A sweeping strike knocks {target_name} to their knees. The next embeds the nails in their spine. The fall is final.",
-            'victim_msg': "A sweeping strike knocks you to your knees. The next embeds the nails in your spine. The fall is final.",
+            'victim_msg': "A sweeping strike knocks you to your knees. The next embeds the nails in your {hit_location}. The fall is final.",
             'observer_msg': "A sweeping strike knocks {target_name} to their knees. The next embeds the nails in their spine. The fall is final."
         },
         {
-            'attacker_msg': "One nail pierces {target_name}'s heart. It wasn't aimed. It just happened. They fold in half and don't unfold.",
-            'victim_msg': "One nail pierces your heart. It wasn't aimed. It just happened. You fold in half and don't unfold.",
-            'observer_msg': "One nail pierces {target_name}'s heart. It wasn't aimed. It just happened. They fold in half and don't unfold."
+            'attacker_msg': "One nail pierces {target_name}'s {hit_location}. It wasn't aimed. It just happened. They fold in half and don't unfold.",
+            'victim_msg': "One nail pierces your {hit_location}. It wasn't aimed. It just happened. You fold in half and don't unfold.",
+            'observer_msg': "One nail pierces {target_name}'s {hit_location}. It wasn't aimed. It just happened. They fold in half and don't unfold."
         },
         {
             'attacker_msg': "One nail punctures {target_name}'s eye. The body crumples before the scream even leaves the lungs.",
-            'victim_msg': "One nail punctures your eye. Your body crumples before the scream even leaves your lungs.",
+            'victim_msg': "One nail punctures your eye. Your body crumples before the scream even leaves your {hit_location}.",
             'observer_msg': "One nail punctures {target_name}'s eye. The body crumples before the scream even leaves the lungs."
         },
         {
@@ -512,64 +512,64 @@ MESSAGES = {
             'observer_msg': "The blow catches {target_name} mid-breath. The nails cut off sound and life in one sickening gesture."
         },
         {
-            'attacker_msg': "The board crushes {target_name}'s ribs, then lung. They gasp once and breathe out steam. Then nothing.",
-            'victim_msg': "The board crushes your ribs, then lung. You gasp once and breathe out steam. Then nothing.",
-            'observer_msg': "The board crushes {target_name}'s ribs, then lung. They gasp once and breathe out steam. Then nothing."
+            'attacker_msg': "The board crushes {target_name}'s {hit_location}, then lung. They gasp once and breathe out steam. Then nothing.",
+            'victim_msg': "The board crushes your {hit_location}, then lung. You gasp once and breathe out steam. Then nothing.",
+            'observer_msg': "The board crushes {target_name}'s {hit_location}, then lung. They gasp once and breathe out steam. Then nothing."
         },
         {
-            'attacker_msg': "The board lands atop {target_name}'s skull. Nails punch in deep and stay. You let go. It holds itself.",
-            'victim_msg': "The board lands atop your skull. Nails punch in deep and stay. {attacker_name} lets go. It holds itself.",
-            'observer_msg': "The board lands atop {target_name}'s skull. Nails punch in deep and stay. {attacker_name} lets go. It holds itself."
+            'attacker_msg': "The board lands atop {target_name}'s {hit_location}. Nails punch in deep and stay. You let go. It holds itself.",
+            'victim_msg': "The board lands atop your {hit_location}. Nails punch in deep and stay. {attacker_name} lets go. It holds itself.",
+            'observer_msg': "The board lands atop {target_name}'s {hit_location}. Nails punch in deep and stay. {attacker_name} lets go. It holds itself."
         },
         {
-            'attacker_msg': "The board slaps across {target_name}'s jaw, and the nails do the rest. Teeth scatter like dice. Life flees.",
-            'victim_msg': "The board slaps across your jaw, and the nails do the rest. Teeth scatter like dice. Life flees.",
-            'observer_msg': "The board slaps across {target_name}'s jaw, and the nails do the rest. Teeth scatter like dice. Life flees."
+            'attacker_msg': "The board slaps across {target_name}'s {hit_location}, and the nails do the rest. Teeth scatter like dice. Life flees.",
+            'victim_msg': "The board slaps across your {hit_location}, and the nails do the rest. Teeth scatter like dice. Life flees.",
+            'observer_msg': "The board slaps across {target_name}'s {hit_location}, and the nails do the rest. Teeth scatter like dice. Life flees."
         },
         {
-            'attacker_msg': "The final blow rakes across {target_name}'s chest. Nails drag until they find something vital — and end it.",
-            'victim_msg': "The final blow rakes across your chest. Nails drag until they find something vital — and end it.",
-            'observer_msg': "The final blow rakes across {target_name}'s chest. Nails drag until they find something vital — and end it."
+            'attacker_msg': "The final blow rakes across {target_name}'s {hit_location}. Nails drag until they find something vital — and end it.",
+            'victim_msg': "The final blow rakes across your {hit_location}. Nails drag until they find something vital — and end it.",
+            'observer_msg': "The final blow rakes across {target_name}'s {hit_location}. Nails drag until they find something vital — and end it."
         },
         {
-            'attacker_msg': "The final hit is low, cruel, and sharp. Nails rupture {target_name}'s neck. Blood pours like confession.",
-            'victim_msg': "The final hit is low, cruel, and sharp. Nails rupture your neck. Blood pours like confession.",
-            'observer_msg': "The final hit is low, cruel, and sharp. Nails rupture {target_name}'s neck. Blood pours like confession."
+            'attacker_msg': "The final hit is low, cruel, and sharp. Nails rupture {target_name}'s {hit_location}. Blood pours like confession.",
+            'victim_msg': "The final hit is low, cruel, and sharp. Nails rupture your {hit_location}. Blood pours like confession.",
+            'observer_msg': "The final hit is low, cruel, and sharp. Nails rupture {target_name}'s {hit_location}. Blood pours like confession."
         },
         {
-            'attacker_msg': "The nailed board crashes into {target_name}'s skull. One nail buries deep. They drop mid-scream, twitching.",
-            'victim_msg': "The nailed board crashes into your skull. One nail buries deep. You drop mid-scream, twitching.",
-            'observer_msg': "The nailed board crashes into {target_name}'s skull. One nail buries deep. They drop mid-scream, twitching."
+            'attacker_msg': "The nailed board crashes into {target_name}'s {hit_location}. One nail buries deep. They drop mid-scream, twitching.",
+            'victim_msg': "The nailed board crashes into your {hit_location}. One nail buries deep. You drop mid-scream, twitching.",
+            'observer_msg': "The nailed board crashes into {target_name}'s {hit_location}. One nail buries deep. They drop mid-scream, twitching."
         },
         {
-            'attacker_msg': "The nails hit {target_name}'s throat and stay. They make a sound like a clogged drain. Then collapse.",
-            'victim_msg': "The nails hit your throat and stay. You make a sound like a clogged drain. Then collapse.",
-            'observer_msg': "The nails hit {target_name}'s throat and stay. They make a sound like a clogged drain. Then collapse."
+            'attacker_msg': "The nails hit {target_name}'s {hit_location} and stay. They make a sound like a clogged drain. Then collapse.",
+            'victim_msg': "The nails hit your {hit_location} and stay. You make a sound like a clogged drain. Then collapse.",
+            'observer_msg': "The nails hit {target_name}'s {hit_location} and stay. They make a sound like a clogged drain. Then collapse."
         },
         {
-            'attacker_msg': "The nails sink deep into {target_name}'s neck. When you pull away, nothing moves but red.",
-            'victim_msg': "The nails sink deep into your neck. When {attacker_name} pulls away, nothing moves but red.",
-            'observer_msg': "The nails sink deep into {target_name}'s neck. When {attacker_name} pulls away, nothing moves but red."
+            'attacker_msg': "The nails sink deep into {target_name}'s {hit_location}. When you pull away, nothing moves but red.",
+            'victim_msg': "The nails sink deep into your {hit_location}. When {attacker_name} pulls away, nothing moves but red.",
+            'observer_msg': "The nails sink deep into {target_name}'s {hit_location}. When {attacker_name} pulls away, nothing moves but red."
         },
         {
-            'attacker_msg': "The plank crashes into the back of {target_name}'s head. They slump like strings were cut. Blood bubbles from the mouth.",
-            'victim_msg': "The plank crashes into the back of your head. You slump like strings were cut. Blood bubbles from your mouth.",
-            'observer_msg': "The plank crashes into the back of {target_name}'s head. They slump like strings were cut. Blood bubbles from the mouth."
+            'attacker_msg': "The plank crashes into the back of {target_name}'s {hit_location}. They slump like strings were cut. Blood bubbles from the mouth.",
+            'victim_msg': "The plank crashes into the back of your {hit_location}. You slump like strings were cut. Blood bubbles from your mouth.",
+            'observer_msg': "The plank crashes into the back of {target_name}'s {hit_location}. They slump like strings were cut. Blood bubbles from the mouth."
         },
         {
-            'attacker_msg': "The plank lands like judgment. Three nails find {target_name}'s heart. The fourth? Just mean.",
-            'victim_msg': "The plank lands like judgment. Three nails find your heart. The fourth? Just mean.",
-            'observer_msg': "The plank lands like judgment. Three nails find {target_name}'s heart. The fourth? Just mean."
+            'attacker_msg': "The plank lands like judgment. Three nails find {target_name}'s {hit_location}. The fourth? Just mean.",
+            'victim_msg': "The plank lands like judgment. Three nails find your {hit_location}. The fourth? Just mean.",
+            'observer_msg': "The plank lands like judgment. Three nails find {target_name}'s {hit_location}. The fourth? Just mean."
         },
         {
-            'attacker_msg': "The third strike is the kill. The board lands across {target_name}'s neck with enough force to fold the body like laundry.",
-            'victim_msg': "The third strike is the kill. The board lands across your neck with enough force to fold your body like laundry.",
-            'observer_msg': "The third strike is the kill. The board lands across {target_name}'s neck with enough force to fold the body like laundry."
+            'attacker_msg': "The third strike is the kill. The board lands across {target_name}'s {hit_location} with enough force to fold the body like laundry.",
+            'victim_msg': "The third strike is the kill. The board lands across your {hit_location} with enough force to fold your body like laundry.",
+            'observer_msg': "The third strike is the kill. The board lands across {target_name}'s {hit_location} with enough force to fold the body like laundry."
         },
         {
-            'attacker_msg': "You bring the board down on {target_name}'s skull. The nails bury deep. The twitching stops before the board is pulled free.",
-            'victim_msg': "{attacker_name} brings the board down on your skull. The nails bury deep. Your twitching stops before the board is pulled free.",
-            'observer_msg': "{attacker_name} brings the board down on {target_name}'s skull. The nails bury deep. The twitching stops before the board is pulled free."
+            'attacker_msg': "You bring the board down on {target_name}'s {hit_location}. The nails bury deep. The twitching stops before the board is pulled free.",
+            'victim_msg': "{attacker_name} brings the board down on your {hit_location}. The nails bury deep. Your twitching stops before the board is pulled free.",
+            'observer_msg': "{attacker_name} brings the board down on {target_name}'s {hit_location}. The nails bury deep. The twitching stops before the board is pulled free."
         },
         {
             'attacker_msg': "You bury the board in {target_name}'s gut and yank upward. Their body opens like a zipper.",
@@ -577,9 +577,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} buries the board in {target_name}'s gut and yanks upward. Their body opens like a zipper."
         },
         {
-            'attacker_msg': "You drive the board into {target_name}'s throat. The nails tear through voice and artery. Silence follows.",
-            'victim_msg': "{attacker_name} drives the board into your throat. The nails tear through voice and artery. Silence follows.",
-            'observer_msg': "{attacker_name} drives the board into {target_name}'s throat. The nails tear through voice and artery. Silence follows."
+            'attacker_msg': "You drive the board into {target_name}'s {hit_location}. The nails tear through voice and artery. Silence follows.",
+            'victim_msg': "{attacker_name} drives the board into your {hit_location}. The nails tear through voice and artery. Silence follows.",
+            'observer_msg': "{attacker_name} drives the board into {target_name}'s {hit_location}. The nails tear through voice and artery. Silence follows."
         },
         {
             'attacker_msg': "You hook the board into {target_name}'s gut and *yank*. What's left can't be called alive.",
@@ -587,19 +587,19 @@ MESSAGES = {
             'observer_msg': "{attacker_name} hooks the board into {target_name}'s gut and *yanks*. What's left can't be called alive."
         },
         {
-            'attacker_msg': "You slam the board into {target_name}'s face. The nose breaks, then the cheek, then everything. The silence after is pure.",
-            'victim_msg': "{attacker_name} slams the board into your face. The nose breaks, then the cheek, then everything. The silence after is pure.",
-            'observer_msg': "{attacker_name} slams the board into {target_name}'s face. The nose breaks, then the cheek, then everything. The silence after is pure."
+            'attacker_msg': "You slam the board into {target_name}'s {hit_location}. The nose breaks, then the cheek, then everything. The silence after is pure.",
+            'victim_msg': "{attacker_name} slams the board into your {hit_location}. The nose breaks, then the cheek, then everything. The silence after is pure.",
+            'observer_msg': "{attacker_name} slams the board into {target_name}'s {hit_location}. The nose breaks, then the cheek, then everything. The silence after is pure."
         },
         {
-            'attacker_msg': "You smash the board into {target_name}'s ribs, then again. The third strike leaves nothing but stillness.",
-            'victim_msg': "{attacker_name} smashes the board into your ribs, then again. The third strike leaves nothing but stillness.",
-            'observer_msg': "{attacker_name} smashes the board into {target_name}'s ribs, then again. The third strike leaves nothing but stillness."
+            'attacker_msg': "You smash the board into {target_name}'s {hit_location}, then again. The third strike leaves nothing but stillness.",
+            'victim_msg': "{attacker_name} smashes the board into your {hit_location}, then again. The third strike leaves nothing but stillness.",
+            'observer_msg': "{attacker_name} smashes the board into {target_name}'s {hit_location}, then again. The third strike leaves nothing but stillness."
         },
         {
-            'attacker_msg': "You swing down, and the nails meet {target_name}'s spine. They fold at the waist, dead before the bend finishes.",
-            'victim_msg': "{attacker_name} swings down, and the nails meet your spine. You fold at the waist, dead before the bend finishes.",
-            'observer_msg': "{attacker_name} swings down, and the nails meet {target_name}'s spine. They fold at the waist, dead before the bend finishes."
+            'attacker_msg': "You swing down, and the nails meet {target_name}'s {hit_location}. They fold at the waist, dead before the bend finishes.",
+            'victim_msg': "{attacker_name} swings down, and the nails meet your {hit_location}. You fold at the waist, dead before the bend finishes.",
+            'observer_msg': "{attacker_name} swings down, and the nails meet {target_name}'s {hit_location}. They fold at the waist, dead before the bend finishes."
         },
         {
             'attacker_msg': "You swing upward, embedding nails in {target_name}'s lower jaw. You pull. They don't scream.",

--- a/world/combat/messages/nightstick.py
+++ b/world/combat/messages/nightstick.py
@@ -56,7 +56,7 @@ MESSAGES = {
             'observer_msg': "The nightstick extends with a click and a hiss. {attacker_name} doesn't smile. They don't need to."
         },
         {
-            'attacker_msg': "The nightstick rests against your forearm, a calm before a storm made of plastic and pain.",
+            'attacker_msg': "The nightstick rests against your {hit_location}, a calm before a storm made of plastic and pain.",
             'victim_msg': "The nightstick rests against {attacker_name}'s forearm, a calm before a storm made of plastic and pain.",
             'observer_msg': "The nightstick rests against {attacker_name}'s forearm, a calm before a storm made of plastic and pain."
         },
@@ -66,7 +66,7 @@ MESSAGES = {
             'observer_msg': "The nightstick spins once before locking into place. {attacker_name} doesn't look down — only forward."
         },
         {
-            'attacker_msg': "The polymer baton spins once in your hand. You catch it without looking.",
+            'attacker_msg': "The polymer baton spins once in your {hit_location}. You catch it without looking.",
             'victim_msg': "The polymer baton spins once in {attacker_name}'s hand. They catch it without looking.",
             'observer_msg': "The polymer baton spins once in {attacker_name}'s hand. They catch it without looking."
         },
@@ -76,7 +76,7 @@ MESSAGES = {
             'observer_msg': "The weapon extends with the practiced precision of someone who's done this before — and enjoyed it."
         },
         {
-            'attacker_msg': "The weapon is deceptively plain. In your hand, it becomes doctrine.",
+            'attacker_msg': "The weapon is deceptively plain. In your {hit_location}, it becomes doctrine.",
             'victim_msg': "The weapon is deceptively plain. In {attacker_name}'s hand, it becomes doctrine.",
             'observer_msg': "The weapon is deceptively plain. In {attacker_name}'s hand, it becomes doctrine."
         },
@@ -111,7 +111,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} holds the nightstick like a judge holds a gavel. The verdict is violence."
         },
         {
-            'attacker_msg': "You roll your wrist once, letting the stick spin into a ready grip. Control. Tension. Command.",
+            'attacker_msg': "You roll your {hit_location} once, letting the stick spin into a ready grip. Control. Tension. Command.",
             'victim_msg': "{attacker_name} rolls their wrist once, letting the stick spin into a ready grip. Control. Tension. Command.",
             'observer_msg': "{attacker_name} rolls their wrist once, letting the stick spin into a ready grip. Control. Tension. Command."
         },
@@ -141,7 +141,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} spins the nightstick in a slow circle, testing weight, distance, control — all dialed in."
         },
         {
-            'attacker_msg': "You tap the nightstick against your leg. Each knock feels like a countdown.",
+            'attacker_msg': "You tap the nightstick against your {hit_location}. Each knock feels like a countdown.",
             'victim_msg': "{attacker_name} taps the nightstick against their leg. Each knock feels like a countdown.",
             'observer_msg': "{attacker_name} taps the nightstick against their leg. Each knock feels like a countdown."
         },
@@ -274,7 +274,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You drive the baton into {target_name}'s {hit_location}. The breath leaves their lungs — and doesn't come {hit_location} quickly.",
-            'victim_msg': "{attacker_name} drives the baton into your {hit_location}. The breath leaves your lungs — and doesn't come {hit_location} quickly.",
+            'victim_msg': "{attacker_name} drives the baton into your {hit_location}. The breath leaves your {hit_location} — and doesn't come {hit_location} quickly.",
             'observer_msg': "{attacker_name} drives the baton into {target_name}'s {hit_location}. The breath leaves their lungs — and doesn't come {hit_location} quickly."
         },
         {
@@ -445,9 +445,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} lunges, but the stick glances off a pillar instead of skin."
         },
         {
-            'attacker_msg': "You spin too far. The stick whistles past {target_name}'s head by inches.",
-            'victim_msg': "{attacker_name} spins too far. The stick whistles past your head by inches.",
-            'observer_msg': "{attacker_name} spins too far. The stick whistles past {target_name}'s head by inches."
+            'attacker_msg': "You spin too far. The stick whistles past {target_name}'s {hit_location} by inches.",
+            'victim_msg': "{attacker_name} spins too far. The stick whistles past your {hit_location} by inches.",
+            'observer_msg': "{attacker_name} spins too far. The stick whistles past {target_name}'s {hit_location} by inches."
         },
         {
             'attacker_msg': "Your swing claps into a support beam. Steel-on-steel echoes in retreat.",
@@ -462,29 +462,29 @@ MESSAGES = {
             'observer_msg': "A brutal jab to {target_name}'s eye sends the body into seizures. The stillness afterward is eternal."
         },
         {
-            'attacker_msg': "A downward strike caves {target_name}'s chest in. They gasp, bleed, expire.",
-            'victim_msg': "A downward strike caves your chest in. You gasp, bleed, expire.",
-            'observer_msg': "A downward strike caves {target_name}'s chest in. They gasp, bleed, expire."
+            'attacker_msg': "A downward strike caves {target_name}'s {hit_location} in. They gasp, bleed, expire.",
+            'victim_msg': "A downward strike caves your {hit_location} in. You gasp, bleed, expire.",
+            'observer_msg': "A downward strike caves {target_name}'s {hit_location} in. They gasp, bleed, expire."
         },
         {
-            'attacker_msg': "A flurry of brutal jabs breaks {target_name}'s ribs, collapses lungs. They never recover.",
-            'victim_msg': "A flurry of brutal jabs breaks your ribs, collapses lungs. You never recover.",
-            'observer_msg': "A flurry of brutal jabs breaks {target_name}'s ribs, collapses lungs. They never recover."
+            'attacker_msg': "A flurry of brutal jabs breaks {target_name}'s {hit_location}, collapses lungs. They never recover.",
+            'victim_msg': "A flurry of brutal jabs breaks your {hit_location}, collapses lungs. You never recover.",
+            'observer_msg': "A flurry of brutal jabs breaks {target_name}'s {hit_location}, collapses lungs. They never recover."
         },
         {
-            'attacker_msg': "A savage strike to {target_name}'s jaw dislocates it with a pop. They fall, twitching, then still.",
-            'victim_msg': "A savage strike to your jaw dislocates it with a pop. You fall, twitching, then still.",
-            'observer_msg': "A savage strike to {target_name}'s jaw dislocates it with a pop. They fall, twitching, then still."
+            'attacker_msg': "A savage strike to {target_name}'s {hit_location} dislocates it with a pop. They fall, twitching, then still.",
+            'victim_msg': "A savage strike to your {hit_location} dislocates it with a pop. You fall, twitching, then still.",
+            'observer_msg': "A savage strike to {target_name}'s {hit_location} dislocates it with a pop. They fall, twitching, then still."
         },
         {
-            'attacker_msg': "A savage two-handed blow lands on {target_name}'s spine. They seize, then slump.",
-            'victim_msg': "A savage two-handed blow lands on your spine. You seize, then slump.",
-            'observer_msg': "A savage two-handed blow lands on {target_name}'s spine. They seize, then slump."
+            'attacker_msg': "A savage two-handed blow lands on {target_name}'s {hit_location}. They seize, then slump.",
+            'victim_msg': "A savage two-handed blow lands on your {hit_location}. You seize, then slump.",
+            'observer_msg': "A savage two-handed blow lands on {target_name}'s {hit_location}. They seize, then slump."
         },
         {
-            'attacker_msg': "A side-swing catches {target_name}'s jaw. Bone snaps. Brain bleeds. Death follows.",
-            'victim_msg': "A side-swing catches your jaw. Bone snaps. Brain bleeds. Death follows.",
-            'observer_msg': "A side-swing catches {target_name}'s jaw. Bone snaps. Brain bleeds. Death follows."
+            'attacker_msg': "A side-swing catches {target_name}'s {hit_location}. Bone snaps. Brain bleeds. Death follows.",
+            'victim_msg': "A side-swing catches your {hit_location}. Bone snaps. Brain bleeds. Death follows.",
+            'observer_msg': "A side-swing catches {target_name}'s {hit_location}. Bone snaps. Brain bleeds. Death follows."
         },
         {
             'attacker_msg': "A spinning blow lands behind {target_name}'s ear. The sound it makes is sickly, the silence afterward sicker.",
@@ -492,34 +492,34 @@ MESSAGES = {
             'observer_msg': "A spinning blow lands behind {target_name}'s ear. The sound it makes is sickly, the silence afterward sicker."
         },
         {
-            'attacker_msg': "A spinning strike crashes into {target_name}'s throat. The silence is immediate and complete.",
-            'victim_msg': "A spinning strike crashes into your throat. The silence is immediate and complete.",
-            'observer_msg': "A spinning strike crashes into {target_name}'s throat. The silence is immediate and complete."
+            'attacker_msg': "A spinning strike crashes into {target_name}'s {hit_location}. The silence is immediate and complete.",
+            'victim_msg': "A spinning strike crashes into your {hit_location}. The silence is immediate and complete.",
+            'observer_msg': "A spinning strike crashes into {target_name}'s {hit_location}. The silence is immediate and complete."
         },
         {
-            'attacker_msg': "A strike to {target_name}'s temple ends the movement mid-scream. It's over before it echoes.",
-            'victim_msg': "A strike to your temple ends the movement mid-scream. It's over before it echoes.",
-            'observer_msg': "A strike to {target_name}'s temple ends the movement mid-scream. It's over before it echoes."
+            'attacker_msg': "A strike to {target_name}'s {hit_location} ends the movement mid-scream. It's over before it echoes.",
+            'victim_msg': "A strike to your {hit_location} ends the movement mid-scream. It's over before it echoes.",
+            'observer_msg': "A strike to {target_name}'s {hit_location} ends the movement mid-scream. It's over before it echoes."
         },
         {
-            'attacker_msg': "One blow to the back of {target_name}'s skull. The collapse is total. Instant.",
-            'victim_msg': "One blow to the back of your skull. The collapse is total. Instant.",
-            'observer_msg': "One blow to the back of {target_name}'s skull. The collapse is total. Instant."
+            'attacker_msg': "One blow to the back of {target_name}'s {hit_location}. The collapse is total. Instant.",
+            'victim_msg': "One blow to the back of your {hit_location}. The collapse is total. Instant.",
+            'observer_msg': "One blow to the back of {target_name}'s {hit_location}. The collapse is total. Instant."
         },
         {
-            'attacker_msg': "One clean jab to {target_name}'s temple. They drop like a string was cut.",
-            'victim_msg': "One clean jab to your temple. You drop like a string was cut.",
-            'observer_msg': "One clean jab to {target_name}'s temple. They drop like a string was cut."
+            'attacker_msg': "One clean jab to {target_name}'s {hit_location}. They drop like a string was cut.",
+            'victim_msg': "One clean jab to your {hit_location}. You drop like a string was cut.",
+            'observer_msg': "One clean jab to {target_name}'s {hit_location}. They drop like a string was cut."
         },
         {
-            'attacker_msg': "One spinning strike. The stick collides with the base of {target_name}'s skull. They go stiff — then limp.",
-            'victim_msg': "One spinning strike. The stick collides with the base of your skull. You go stiff — then limp.",
-            'observer_msg': "One spinning strike. The stick collides with the base of {target_name}'s skull. They go stiff — then limp."
+            'attacker_msg': "One spinning strike. The stick collides with the base of {target_name}'s {hit_location}. They go stiff — then limp.",
+            'victim_msg': "One spinning strike. The stick collides with the base of your {hit_location}. You go stiff — then limp.",
+            'observer_msg': "One spinning strike. The stick collides with the base of {target_name}'s {hit_location}. They go stiff — then limp."
         },
         {
-            'attacker_msg': "One upward jab to {target_name}'s jaw. Their neck snaps. Their eyes don't blink again.",
-            'victim_msg': "One upward jab to your jaw. Your neck snaps. Your eyes don't blink again.",
-            'observer_msg': "One upward jab to {target_name}'s jaw. Their neck snaps. Their eyes don't blink again."
+            'attacker_msg': "One upward jab to {target_name}'s {hit_location}. Their neck snaps. Their eyes don't blink again.",
+            'victim_msg': "One upward jab to your {hit_location}. Your {hit_location} snaps. Your eyes don't blink again.",
+            'observer_msg': "One upward jab to {target_name}'s {hit_location}. Their neck snaps. Their eyes don't blink again."
         },
         {
             'attacker_msg': "Steel drives into {target_name}'s eye socket. The scream is brief. The stillness is longer.",
@@ -532,14 +532,14 @@ MESSAGES = {
             'observer_msg': "Steel-reinforced polymer drives into {target_name}'s eye socket. They collapse mid-scream."
         },
         {
-            'attacker_msg': "The baton breaks {target_name}'s jaw, the rhythm, the resistance. They go down and don't rise.",
-            'victim_msg': "The baton breaks your jaw, the rhythm, the resistance. You go down and don't rise.",
-            'observer_msg': "The baton breaks {target_name}'s jaw, the rhythm, the resistance. They go down and don't rise."
+            'attacker_msg': "The baton breaks {target_name}'s {hit_location}, the rhythm, the resistance. They go down and don't rise.",
+            'victim_msg': "The baton breaks your {hit_location}, the rhythm, the resistance. You go down and don't rise.",
+            'observer_msg': "The baton breaks {target_name}'s {hit_location}, the rhythm, the resistance. They go down and don't rise."
         },
         {
-            'attacker_msg': "The baton caves in the side of {target_name}'s skull. They don't fall — they drop like dead weight.",
-            'victim_msg': "The baton caves in the side of your skull. You don't fall — you drop like dead weight.",
-            'observer_msg': "The baton caves in the side of {target_name}'s skull. They don't fall — they drop like dead weight."
+            'attacker_msg': "The baton caves in the side of {target_name}'s {hit_location}. They don't fall — they drop like dead weight.",
+            'victim_msg': "The baton caves in the side of your {hit_location}. You don't fall — you drop like dead weight.",
+            'observer_msg': "The baton caves in the side of {target_name}'s {hit_location}. They don't fall — they drop like dead weight."
         },
         {
             'attacker_msg': "The baton comes down like a gavel. Final. {target_name} doesn't appeal.",
@@ -547,9 +547,9 @@ MESSAGES = {
             'observer_msg': "The baton comes down like a gavel. Final. {target_name} doesn't appeal."
         },
         {
-            'attacker_msg': "The baton comes down like a hammer to {target_name}'s chest. They stop moving, breathing, existing.",
-            'victim_msg': "The baton comes down like a hammer to your chest. You stop moving, breathing, existing.",
-            'observer_msg': "The baton comes down like a hammer to {target_name}'s chest. They stop moving, breathing, existing."
+            'attacker_msg': "The baton comes down like a hammer to {target_name}'s {hit_location}. They stop moving, breathing, existing.",
+            'victim_msg': "The baton comes down like a hammer to your {hit_location}. You stop moving, breathing, existing.",
+            'observer_msg': "The baton comes down like a hammer to {target_name}'s {hit_location}. They stop moving, breathing, existing."
         },
         {
             'attacker_msg': "The baton hits again. And again. And again. The floor ends the argument.",
@@ -557,23 +557,23 @@ MESSAGES = {
             'observer_msg': "The baton hits again. And again. And again. The floor ends the argument."
         },
         {
-            'attacker_msg': "The baton smashes {target_name}'s spine mid-run. They fold inward, legs twitching, then nothing.",
-            'victim_msg': "The baton smashes your spine mid-run. You fold inward, legs twitching, then nothing.",
-            'observer_msg': "The baton smashes {target_name}'s spine mid-run. They fold inward, legs twitching, then nothing."
+            'attacker_msg': "The baton smashes {target_name}'s {hit_location} mid-run. They fold inward, legs twitching, then nothing.",
+            'victim_msg': "The baton smashes your {hit_location} mid-run. You fold inward, legs twitching, then nothing.",
+            'observer_msg': "The baton smashes {target_name}'s {hit_location} mid-run. They fold inward, legs twitching, then nothing."
         },
         {
-            'attacker_msg': "The nightstick cracks down on the base of {target_name}'s skull. The lights go out. Permanently.",
-            'victim_msg': "The nightstick cracks down on the base of your skull. The lights go out. Permanently.",
-            'observer_msg': "The nightstick cracks down on the base of {target_name}'s skull. The lights go out. Permanently."
+            'attacker_msg': "The nightstick cracks down on the base of {target_name}'s {hit_location}. The lights go out. Permanently.",
+            'victim_msg': "The nightstick cracks down on the base of your {hit_location}. The lights go out. Permanently.",
+            'observer_msg': "The nightstick cracks down on the base of {target_name}'s {hit_location}. The lights go out. Permanently."
         },
         {
-            'attacker_msg': "The nightstick cracks {target_name}'s temple. They jerk once, then collapse, puppet strings cut.",
-            'victim_msg': "The nightstick cracks your temple. You jerk once, then collapse, puppet strings cut.",
-            'observer_msg': "The nightstick cracks {target_name}'s temple. They jerk once, then collapse, puppet strings cut."
+            'attacker_msg': "The nightstick cracks {target_name}'s {hit_location}. They jerk once, then collapse, puppet strings cut.",
+            'victim_msg': "The nightstick cracks your {hit_location}. You jerk once, then collapse, puppet strings cut.",
+            'observer_msg': "The nightstick cracks {target_name}'s {hit_location}. They jerk once, then collapse, puppet strings cut."
         },
         {
             'attacker_msg': "The nightstick crushes {target_name}'s windpipe. They clutch their throat and fall, soundless.",
-            'victim_msg': "The nightstick crushes your windpipe. You clutch your throat and fall, soundless.",
+            'victim_msg': "The nightstick crushes your windpipe. You clutch your {hit_location} and fall, soundless.",
             'observer_msg': "The nightstick crushes {target_name}'s windpipe. They clutch their throat and fall, soundless."
         },
         {
@@ -583,27 +583,27 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The spine gives. The collapse is awkward and permanent.",
-            'victim_msg': "Your spine gives. The collapse is awkward and permanent.",
+            'victim_msg': "Your {hit_location} gives. The collapse is awkward and permanent.",
             'observer_msg': "The spine gives. The collapse is awkward and permanent."
         },
         {
-            'attacker_msg': "You hook the baton around {target_name}'s neck and yank. The body drops. The soul doesn't linger.",
-            'victim_msg': "{attacker_name} hooks the baton around your neck and yanks. Your body drops. Your soul doesn't linger.",
-            'observer_msg': "{attacker_name} hooks the baton around {target_name}'s neck and yanks. The body drops. The soul doesn't linger."
+            'attacker_msg': "You hook the baton around {target_name}'s {hit_location} and yank. The body drops. The soul doesn't linger.",
+            'victim_msg': "{attacker_name} hooks the baton around your {hit_location} and yanks. Your body drops. Your soul doesn't linger.",
+            'observer_msg': "{attacker_name} hooks the baton around {target_name}'s {hit_location} and yanks. The body drops. The soul doesn't linger."
         },
         {
-            'attacker_msg': "You hook the stick around {target_name}'s head and pull. The slam to the ground does the rest.",
-            'victim_msg': "{attacker_name} hooks the stick around your head and pulls. The slam to the ground does the rest.",
-            'observer_msg': "{attacker_name} hooks the stick around {target_name}'s head and pulls. The slam to the ground does the rest."
+            'attacker_msg': "You hook the stick around {target_name}'s {hit_location} and pull. The slam to the ground does the rest.",
+            'victim_msg': "{attacker_name} hooks the stick around your {hit_location} and pulls. The slam to the ground does the rest.",
+            'observer_msg': "{attacker_name} hooks the stick around {target_name}'s {hit_location} and pulls. The slam to the ground does the rest."
         },
         {
-            'attacker_msg': "You slam the stick into {target_name}'s throat. They gurgle, claw, die in silence.",
-            'victim_msg': "{attacker_name} slams the stick into your throat. You gurgle, claw, die in silence.",
-            'observer_msg': "{attacker_name} slams the stick into {target_name}'s throat. They gurgle, claw, die in silence."
+            'attacker_msg': "You slam the stick into {target_name}'s {hit_location}. They gurgle, claw, die in silence.",
+            'victim_msg': "{attacker_name} slams the stick into your {hit_location}. You gurgle, claw, die in silence.",
+            'observer_msg': "{attacker_name} slams the stick into {target_name}'s {hit_location}. They gurgle, claw, die in silence."
         },
         {
             'attacker_msg': "You sweep {target_name}'s legs and drive the baton into their throat. They choke, jerk, die.",
-            'victim_msg': "{attacker_name} sweeps your legs and drives the baton into your throat. You choke, jerk, die.",
+            'victim_msg': "{attacker_name} sweeps your legs and drives the baton into your {hit_location}. You choke, jerk, die.",
             'observer_msg': "{attacker_name} sweeps {target_name}'s legs and drives the baton into their throat. They choke, jerk, die."
         }
     ]

--- a/world/combat/messages/nunchaku.py
+++ b/world/combat/messages/nunchaku.py
@@ -106,7 +106,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} draws the weapon in silence. The chain sways like a serpent learning hunger."
         },
         {
-            'attacker_msg': "You flick the chain once against your back. It snaps into readiness.",
+            'attacker_msg': "You flick the chain once against your {hit_location}. It snaps into readiness.",
             'victim_msg': "{attacker_name} flicks the chain once against their back. It snaps into readiness.",
             'observer_msg': "{attacker_name} flicks the chain once against their back. It snaps into readiness."
         },
@@ -116,7 +116,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} flicks the nunchaku upward and catches them again — no wasted motion, no wasted mercy."
         },
         {
-            'attacker_msg': "You let the chain coil around your forearm, then snap it free with surgical precision.",
+            'attacker_msg': "You let the chain coil around your {hit_location}, then snap it free with surgical precision.",
             'victim_msg': "{attacker_name} lets the chain coil around their forearm, then snaps it free with surgical precision.",
             'observer_msg': "{attacker_name} lets the chain coil around their forearm, then snaps it free with surgical precision."
         },
@@ -345,7 +345,7 @@ MESSAGES = {
             'observer_msg': "A whirling arc slams into a crate. Wood splinters. {target_name} doesn't wait around."
         },
         {
-            'attacker_msg': "One strike hits a railing. The vibration travels up your arm.",
+            'attacker_msg': "One strike hits a railing. The vibration travels up your {hit_location}.",
             'victim_msg': "One strike hits a railing. The vibration travels up {attacker_name}'s arm.",
             'observer_msg': "One strike hits a railing. The vibration travels up {attacker_name}'s arm."
         },
@@ -462,19 +462,19 @@ MESSAGES = {
             'observer_msg': "A brutal whip across {target_name}'s eyes. They collapse mid-scream, blood flowing from everywhere."
         },
         {
-            'attacker_msg': "A crack to {target_name}'s temple is all it takes. They stiffen — then fall, unmoving.",
-            'victim_msg': "A crack to your temple is all it takes. You stiffen — then fall, unmoving.",
-            'observer_msg': "A crack to {target_name}'s temple is all it takes. They stiffen — then fall, unmoving."
+            'attacker_msg': "A crack to {target_name}'s {hit_location} is all it takes. They stiffen — then fall, unmoving.",
+            'victim_msg': "A crack to your {hit_location} is all it takes. You stiffen — then fall, unmoving.",
+            'observer_msg': "A crack to {target_name}'s {hit_location} is all it takes. They stiffen — then fall, unmoving."
         },
         {
-            'attacker_msg': "A double spin ends with a crack to {target_name}'s temple. The lights go out for good.",
-            'victim_msg': "A double spin ends with a crack to your temple. The lights go out for good.",
-            'observer_msg': "A double spin ends with a crack to {target_name}'s temple. The lights go out for good."
+            'attacker_msg': "A double spin ends with a crack to {target_name}'s {hit_location}. The lights go out for good.",
+            'victim_msg': "A double spin ends with a crack to your {hit_location}. The lights go out for good.",
+            'observer_msg': "A double spin ends with a crack to {target_name}'s {hit_location}. The lights go out for good."
         },
         {
-            'attacker_msg': "A double-arc strike lands on both sides of {target_name}'s skull. They collapse in a heap.",
-            'victim_msg': "A double-arc strike lands on both sides of your skull. You collapse in a heap.",
-            'observer_msg': "A double-arc strike lands on both sides of {target_name}'s skull. They collapse in a heap."
+            'attacker_msg': "A double-arc strike lands on both sides of {target_name}'s {hit_location}. They collapse in a heap.",
+            'victim_msg': "A double-arc strike lands on both sides of your {hit_location}. You collapse in a heap.",
+            'observer_msg': "A double-arc strike lands on both sides of {target_name}'s {hit_location}. They collapse in a heap."
         },
         {
             'attacker_msg': "A downward slam snaps {target_name}'s clavicle — and something deeper. They are still before they hit the ground.",
@@ -482,59 +482,59 @@ MESSAGES = {
             'observer_msg': "A downward slam snaps {target_name}'s clavicle — and something deeper. They are still before they hit the ground."
         },
         {
-            'attacker_msg': "A downward smash caves in the top of {target_name}'s head. The follow-up never comes — it isn't needed.",
-            'victim_msg': "A downward smash caves in the top of your head. The follow-up never comes — it isn't needed.",
-            'observer_msg': "A downward smash caves in the top of {target_name}'s head. The follow-up never comes — it isn't needed."
+            'attacker_msg': "A downward smash caves in the top of {target_name}'s {hit_location}. The follow-up never comes — it isn't needed.",
+            'victim_msg': "A downward smash caves in the top of your {hit_location}. The follow-up never comes — it isn't needed.",
+            'observer_msg': "A downward smash caves in the top of {target_name}'s {hit_location}. The follow-up never comes — it isn't needed."
         },
         {
-            'attacker_msg': "A downward whip caves in the top of {target_name}'s head. You don't look away.",
-            'victim_msg': "A downward whip caves in the top of your head. {attacker_name} doesn't look away.",
-            'observer_msg': "A downward whip caves in the top of {target_name}'s head. {attacker_name} doesn't look away."
+            'attacker_msg': "A downward whip caves in the top of {target_name}'s {hit_location}. You don't look away.",
+            'victim_msg': "A downward whip caves in the top of your {hit_location}. {attacker_name} doesn't look away.",
+            'observer_msg': "A downward whip caves in the top of {target_name}'s {hit_location}. {attacker_name} doesn't look away."
         },
         {
-            'attacker_msg': "A rising strike drives into {target_name}'s face. Red sprays. The silence is immediate.",
-            'victim_msg': "A rising strike drives into your face. Red sprays. The silence is immediate.",
-            'observer_msg': "A rising strike drives into {target_name}'s face. Red sprays. The silence is immediate."
+            'attacker_msg': "A rising strike drives into {target_name}'s {hit_location}. Red sprays. The silence is immediate.",
+            'victim_msg': "A rising strike drives into your {hit_location}. Red sprays. The silence is immediate.",
+            'observer_msg': "A rising strike drives into {target_name}'s {hit_location}. Red sprays. The silence is immediate."
         },
         {
-            'attacker_msg': "A spinning strike slams into {target_name}'s neck. They fall like a felled post, twitching once.",
-            'victim_msg': "A spinning strike slams into your neck. You fall like a felled post, twitching once.",
-            'observer_msg': "A spinning strike slams into {target_name}'s neck. They fall like a felled post, twitching once."
+            'attacker_msg': "A spinning strike slams into {target_name}'s {hit_location}. They fall like a felled post, twitching once.",
+            'victim_msg': "A spinning strike slams into your {hit_location}. You fall like a felled post, twitching once.",
+            'observer_msg': "A spinning strike slams into {target_name}'s {hit_location}. They fall like a felled post, twitching once."
         },
         {
-            'attacker_msg': "One brutal jab to {target_name}'s chest sends ribs inward. They exhale their last.",
-            'victim_msg': "One brutal jab to your chest sends ribs inward. You exhale your last.",
-            'observer_msg': "One brutal jab to {target_name}'s chest sends ribs inward. They exhale their last."
+            'attacker_msg': "One brutal jab to {target_name}'s {hit_location} sends ribs inward. They exhale their last.",
+            'victim_msg': "One brutal jab to your {hit_location} sends ribs inward. You exhale your last.",
+            'observer_msg': "One brutal jab to {target_name}'s {hit_location} sends ribs inward. They exhale their last."
         },
         {
-            'attacker_msg': "One final blow to the base of {target_name}'s neck severs motion. They drop like a puppet cut free.",
-            'victim_msg': "One final blow to the base of your neck severs motion. You drop like a puppet cut free.",
-            'observer_msg': "One final blow to the base of {target_name}'s neck severs motion. They drop like a puppet cut free."
+            'attacker_msg': "One final blow to the base of {target_name}'s {hit_location} severs motion. They drop like a puppet cut free.",
+            'victim_msg': "One final blow to the base of your {hit_location} severs motion. You drop like a puppet cut free.",
+            'observer_msg': "One final blow to the base of {target_name}'s {hit_location} severs motion. They drop like a puppet cut free."
         },
         {
-            'attacker_msg': "One rising strike breaks {target_name}'s jaw. The next caves in the skull. The third isn't needed.",
-            'victim_msg': "One rising strike breaks your jaw. The next caves in your skull. The third isn't needed.",
-            'observer_msg': "One rising strike breaks {target_name}'s jaw. The next caves in the skull. The third isn't needed."
+            'attacker_msg': "One rising strike breaks {target_name}'s {hit_location}. The next caves in the skull. The third isn't needed.",
+            'victim_msg': "One rising strike breaks your {hit_location}. The next caves in your {hit_location}. The third isn't needed.",
+            'observer_msg': "One rising strike breaks {target_name}'s {hit_location}. The next caves in the skull. The third isn't needed."
         },
         {
-            'attacker_msg': "One savage blow caves the back of {target_name}'s skull inward. You don't stop to admire.",
-            'victim_msg': "One savage blow caves the back of your skull inward. {attacker_name} doesn't stop to admire.",
-            'observer_msg': "One savage blow caves the back of {target_name}'s skull inward. {attacker_name} doesn't stop to admire."
+            'attacker_msg': "One savage blow caves the back of {target_name}'s {hit_location} inward. You don't stop to admire.",
+            'victim_msg': "One savage blow caves the back of your {hit_location} inward. {attacker_name} doesn't stop to admire.",
+            'observer_msg': "One savage blow caves the back of {target_name}'s {hit_location} inward. {attacker_name} doesn't stop to admire."
         },
         {
-            'attacker_msg': "Steel and wood crash into {target_name}'s sternum. They fold over, then don't unfold.",
-            'victim_msg': "Steel and wood crash into your sternum. You fold over, then don't unfold.",
-            'observer_msg': "Steel and wood crash into {target_name}'s sternum. They fold over, then don't unfold."
+            'attacker_msg': "Steel and wood crash into {target_name}'s {hit_location}. They fold over, then don't unfold.",
+            'victim_msg': "Steel and wood crash into your {hit_location}. You fold over, then don't unfold.",
+            'observer_msg': "Steel and wood crash into {target_name}'s {hit_location}. They fold over, then don't unfold."
         },
         {
-            'attacker_msg': "The chain wraps around {target_name}'s neck and pulls. The fall is twitching and terminal.",
-            'victim_msg': "The chain wraps around your neck and pulls. The fall is twitching and terminal.",
-            'observer_msg': "The chain wraps around {target_name}'s neck and pulls. The fall is twitching and terminal."
+            'attacker_msg': "The chain wraps around {target_name}'s {hit_location} and pulls. The fall is twitching and terminal.",
+            'victim_msg': "The chain wraps around your {hit_location} and pulls. The fall is twitching and terminal.",
+            'observer_msg': "The chain wraps around {target_name}'s {hit_location} and pulls. The fall is twitching and terminal."
         },
         {
-            'attacker_msg': "The chain wraps briefly around {target_name}'s head before the sticks crush inward. Silence.",
-            'victim_msg': "The chain wraps briefly around your head before the sticks crush inward. Silence.",
-            'observer_msg': "The chain wraps briefly around {target_name}'s head before the sticks crush inward. Silence."
+            'attacker_msg': "The chain wraps briefly around {target_name}'s {hit_location} before the sticks crush inward. Silence.",
+            'victim_msg': "The chain wraps briefly around your {hit_location} before the sticks crush inward. Silence.",
+            'observer_msg': "The chain wraps briefly around {target_name}'s {hit_location} before the sticks crush inward. Silence."
         },
         {
             'attacker_msg': "The nunchaku blur in your hands. {target_name} catches every consequence.",
@@ -543,13 +543,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The nunchaku catch {target_name}'s nose and eye. The face crumples. So does everything else.",
-            'victim_msg': "The nunchaku catch your nose and eye. Your face crumples. So does everything else.",
+            'victim_msg': "The nunchaku catch your nose and eye. Your {hit_location} crumples. So does everything else.",
             'observer_msg': "The nunchaku catch {target_name}'s nose and eye. The face crumples. So does everything else."
         },
         {
-            'attacker_msg': "The nunchaku land across {target_name}'s throat. The chain crushes the windpipe. They drop silently.",
-            'victim_msg': "The nunchaku land across your throat. The chain crushes your windpipe. You drop silently.",
-            'observer_msg': "The nunchaku land across {target_name}'s throat. The chain crushes the windpipe. They drop silently."
+            'attacker_msg': "The nunchaku land across {target_name}'s {hit_location}. The chain crushes the windpipe. They drop silently.",
+            'victim_msg': "The nunchaku land across your {hit_location}. The chain crushes your windpipe. You drop silently.",
+            'observer_msg': "The nunchaku land across {target_name}'s {hit_location}. The chain crushes the windpipe. They drop silently."
         },
         {
             'attacker_msg': "The sticks land again and again. By the third hit, {target_name} is still. You are not.",
@@ -562,24 +562,24 @@ MESSAGES = {
             'observer_msg': "The sticks whip across {target_name}'s temples. Both sides. Both deadly."
         },
         {
-            'attacker_msg': "The weapon lands against {target_name}'s throat. They gag once and fold, motionless.",
-            'victim_msg': "The weapon lands against your throat. You gag once and fold, motionless.",
-            'observer_msg': "The weapon lands against {target_name}'s throat. They gag once and fold, motionless."
+            'attacker_msg': "The weapon lands against {target_name}'s {hit_location}. They gag once and fold, motionless.",
+            'victim_msg': "The weapon lands against your {hit_location}. You gag once and fold, motionless.",
+            'observer_msg': "The weapon lands against {target_name}'s {hit_location}. They gag once and fold, motionless."
         },
         {
-            'attacker_msg': "The weapon twists, wraps, and cracks against the side of {target_name}'s head. They are gone before gravity decides how.",
-            'victim_msg': "The weapon twists, wraps, and cracks against the side of your head. You are gone before gravity decides how.",
-            'observer_msg': "The weapon twists, wraps, and cracks against the side of {target_name}'s head. They are gone before gravity decides how."
+            'attacker_msg': "The weapon twists, wraps, and cracks against the side of {target_name}'s {hit_location}. They are gone before gravity decides how.",
+            'victim_msg': "The weapon twists, wraps, and cracks against the side of your {hit_location}. You are gone before gravity decides how.",
+            'observer_msg': "The weapon twists, wraps, and cracks against the side of {target_name}'s {hit_location}. They are gone before gravity decides how."
         },
         {
-            'attacker_msg': "The weapon wraps around {target_name}'s head and yanks them into the ground. The crack is final.",
-            'victim_msg': "The weapon wraps around your head and yanks you into the ground. The crack is final.",
-            'observer_msg': "The weapon wraps around {target_name}'s head and yanks them into the ground. The crack is final."
+            'attacker_msg': "The weapon wraps around {target_name}'s {hit_location} and yanks them into the ground. The crack is final.",
+            'victim_msg': "The weapon wraps around your {hit_location} and yanks you into the ground. The crack is final.",
+            'observer_msg': "The weapon wraps around {target_name}'s {hit_location} and yanks them into the ground. The crack is final."
         },
         {
-            'attacker_msg': "Two fast strikes to {target_name}'s skull drop them mid-step. They hit the ground wrong and don't rise.",
-            'victim_msg': "Two fast strikes to your skull drop you mid-step. You hit the ground wrong and don't rise.",
-            'observer_msg': "Two fast strikes to {target_name}'s skull drop them mid-step. They hit the ground wrong and don't rise."
+            'attacker_msg': "Two fast strikes to {target_name}'s {hit_location} drop them mid-step. They hit the ground wrong and don't rise.",
+            'victim_msg': "Two fast strikes to your {hit_location} drop you mid-step. You hit the ground wrong and don't rise.",
+            'observer_msg': "Two fast strikes to {target_name}'s {hit_location} drop them mid-step. They hit the ground wrong and don't rise."
         },
         {
             'attacker_msg': "You crash the weapon into both {target_name}'s temples in a flurry. They go rigid, then slack.",
@@ -587,9 +587,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} crashes the weapon into both {target_name}'s temples in a flurry. They go rigid, then slack."
         },
         {
-            'attacker_msg': "You land a clean blow to {target_name}'s throat. They clutch, convulse, collapse.",
-            'victim_msg': "{attacker_name} lands a clean blow to your throat. You clutch, convulse, collapse.",
-            'observer_msg': "{attacker_name} lands a clean blow to {target_name}'s throat. They clutch, convulse, collapse."
+            'attacker_msg': "You land a clean blow to {target_name}'s {hit_location}. They clutch, convulse, collapse.",
+            'victim_msg': "{attacker_name} lands a clean blow to your {hit_location}. You clutch, convulse, collapse.",
+            'observer_msg': "{attacker_name} lands a clean blow to {target_name}'s {hit_location}. They clutch, convulse, collapse."
         },
         {
             'attacker_msg': "You lash out with a blur of motion. The sticks land again, again, again. {target_name} stops moving after the second.",
@@ -597,9 +597,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} lashes out with a blur of motion. The sticks land again, again, again. {target_name} stops moving after the second."
         },
         {
-            'attacker_msg': "You slam the nunchaku into the back of {target_name}'s neck. The drop is limp and instant.",
-            'victim_msg': "{attacker_name} slams the nunchaku into the back of your neck. The drop is limp and instant.",
-            'observer_msg': "{attacker_name} slams the nunchaku into the back of {target_name}'s neck. The drop is limp and instant."
+            'attacker_msg': "You slam the nunchaku into the back of {target_name}'s {hit_location}. The drop is limp and instant.",
+            'victim_msg': "{attacker_name} slams the nunchaku into the back of your {hit_location}. The drop is limp and instant.",
+            'observer_msg': "{attacker_name} slams the nunchaku into the back of {target_name}'s {hit_location}. The drop is limp and instant."
         },
         {
             'attacker_msg': "You spin, leap, and end it mid-arc. The nunchaku do what they were made for.",

--- a/world/combat/messages/phonebook.py
+++ b/world/combat/messages/phonebook.py
@@ -11,7 +11,7 @@ MESSAGES = {
             'observer_msg': "With a desperate look, {attacker_name} grabs a nearby phonebook, preparing to use its bulk as a weapon."
         },
         {
-            'attacker_msg': "Your hand closes around the spine of a heavy phonebook, its cover crinkling.",
+            'attacker_msg': "Your {hit_location} closes around the spine of a heavy phonebook, its cover crinkling.",
             'victim_msg': "{attacker_name}'s hand closes around the spine of a heavy phonebook, its cover crinkling.",
             'observer_msg': "{attacker_name}'s hand closes around the spine of a heavy phonebook, its cover crinkling."
         },
@@ -36,7 +36,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} swings the phonebook experimentally, its weight and unwieldiness apparent."
         },
         {
-            'attacker_msg': "Dust and the faint smell of old paper emanate from the phonebook in your hand.",
+            'attacker_msg': "Dust and the faint smell of old paper emanate from the phonebook in your {hit_location}.",
             'victim_msg': "Dust and the faint smell of old paper emanate from the phonebook in {attacker_name}'s hand.",
             'observer_msg': "Dust and the faint smell of old paper emanate from the phonebook in {attacker_name}'s hand."
         },
@@ -61,12 +61,12 @@ MESSAGES = {
             'observer_msg': "The air around the phonebook seems to thrum with the threat of sudden, dull, and painful impacts."
         },
         {
-            'attacker_msg': "Your eyes are narrowed, sighting along the edge of the phonebook towards {target_name}'s head.",
-            'victim_msg': "{attacker_name}'s eyes are narrowed, sighting along the edge of the phonebook towards your head.",
-            'observer_msg': "{attacker_name}'s eyes are narrowed, sighting along the edge of the phonebook towards {target_name}'s head."
+            'attacker_msg': "Your eyes are narrowed, sighting along the edge of the phonebook towards {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s eyes are narrowed, sighting along the edge of the phonebook towards your {hit_location}.",
+            'observer_msg': "{attacker_name}'s eyes are narrowed, sighting along the edge of the phonebook towards {target_name}'s {hit_location}."
         },
         {
-            'attacker_msg': "The phonebook feels surprisingly heavy and unforgiving in your hand, a tool of pure, blunt desperation.",
+            'attacker_msg': "The phonebook feels surprisingly heavy and unforgiving in your {hit_location}, a tool of pure, blunt desperation.",
             'victim_msg': "The phonebook feels surprisingly heavy and unforgiving in {attacker_name}'s hand, a tool of pure, blunt desperation.",
             'observer_msg': "The phonebook feels surprisingly heavy and unforgiving in {attacker_name}'s hand, a tool of pure, blunt desperation."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your phonebook whooshes through the air, its heavy mass narrowly missing {target_name}'s head.",
-            'victim_msg': "{attacker_name}'s phonebook whooshes through the air, its heavy mass narrowly missing your head.",
-            'observer_msg': "{attacker_name}'s phonebook whooshes through the air, its heavy mass narrowly missing {target_name}'s head."
+            'attacker_msg': "Your phonebook whooshes through the air, its heavy mass narrowly missing {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s phonebook whooshes through the air, its heavy mass narrowly missing your {hit_location}.",
+            'observer_msg': "{attacker_name}'s phonebook whooshes through the air, its heavy mass narrowly missing {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "{target_name} stumbles back, avoiding the desperate swing of your phonebook by a hair's breadth, pages fluttering.",
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick retreat from {target_name} leaves {attacker_name}'s phonebook to impact nothing but air with a soft *whoomph*."
         },
         {
-            'attacker_msg': "The phonebook feels dangerously unwieldy in your hand as the intended crushing blow fails to connect.",
+            'attacker_msg': "The phonebook feels dangerously unwieldy in your {hit_location} as the intended crushing blow fails to connect.",
             'victim_msg': "The phonebook feels dangerously unwieldy in {attacker_name}'s hand as the intended crushing blow fails to connect.",
             'observer_msg': "The phonebook feels dangerously unwieldy in {attacker_name}'s hand as the intended crushing blow fails to connect."
         },
@@ -395,9 +395,9 @@ MESSAGES = {
             'observer_msg': "A growl of frustration from {attacker_name} as their phonebook attack is evaded by a nimble {target_name}."
         },
         {
-            'attacker_msg': "The phonebook kicks up dirt beside {target_name}'s foot, but draws no blood, only a cloud of dust.",
-            'victim_msg': "The phonebook kicks up dirt beside your foot, but draws no blood, only a cloud of dust.",
-            'observer_msg': "The phonebook kicks up dirt beside {target_name}'s foot, but draws no blood, only a cloud of dust."
+            'attacker_msg': "The phonebook kicks up dirt beside {target_name}'s {hit_location}, but draws no blood, only a cloud of dust.",
+            'victim_msg': "The phonebook kicks up dirt beside your {hit_location}, but draws no blood, only a cloud of dust.",
+            'observer_msg': "The phonebook kicks up dirt beside {target_name}'s {hit_location}, but draws no blood, only a cloud of dust."
         },
         {
             'attacker_msg': "Your straightforward attack with the phonebook is anticipated and dodged by {target_name}, who looks almost amused.",
@@ -457,24 +457,24 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You repeatedly smash the phonebook into {target_name}'s temple; they collapse, skull audibly cracking under the relentless, dull blows, succumbing to massive trauma.",
-            'victim_msg': "{attacker_name} repeatedly smashes the phonebook into your temple; you collapse, skull audibly cracking under the relentless, dull blows, succumbing to massive trauma.",
-            'observer_msg': "{attacker_name} repeatedly smashes the phonebook into {target_name}'s temple; they collapse, skull audibly cracking under the relentless, dull blows, succumbing to massive trauma."
+            'attacker_msg': "You repeatedly smash the phonebook into {target_name}'s {hit_location}; they collapse, skull audibly cracking under the relentless, dull blows, succumbing to massive trauma.",
+            'victim_msg': "{attacker_name} repeatedly smashes the phonebook into your {hit_location}; you collapse, skull audibly cracking under the relentless, dull blows, succumbing to massive trauma.",
+            'observer_msg': "{attacker_name} repeatedly smashes the phonebook into {target_name}'s {hit_location}; they collapse, skull audibly cracking under the relentless, dull blows, succumbing to massive trauma."
         },
         {
-            'attacker_msg': "The phonebook, driven again and again into {target_name}'s chest, crushes ribs and pulps organs, and they fall silent, life extinguished by blunt force.",
-            'victim_msg': "The phonebook, driven again and again into your chest, crushes ribs and pulps organs, and you fall silent, life extinguished by blunt force.",
-            'observer_msg': "The phonebook, driven again and again into {target_name}'s chest, crushes ribs and pulps organs, and they fall silent, life extinguished by blunt force."
+            'attacker_msg': "The phonebook, driven again and again into {target_name}'s {hit_location}, crushes ribs and pulps organs, and they fall silent, life extinguished by blunt force.",
+            'victim_msg': "The phonebook, driven again and again into your {hit_location}, crushes ribs and pulps organs, and you fall silent, life extinguished by blunt force.",
+            'observer_msg': "The phonebook, driven again and again into {target_name}'s {hit_location}, crushes ribs and pulps organs, and they fall silent, life extinguished by blunt force."
         },
         {
-            'attacker_msg': "With a final, brutal swing, you bring the phonebook down on {target_name}'s head with a sickening crunch, and they drop, twitching, then still.",
-            'victim_msg': "With a final, brutal swing, {attacker_name} brings the phonebook down on your head with a sickening crunch, and you drop, twitching, then still.",
-            'observer_msg': "With a final, brutal swing, {attacker_name} brings the phonebook down on {target_name}'s head with a sickening crunch, and they drop, twitching, then still."
+            'attacker_msg': "With a final, brutal swing, you bring the phonebook down on {target_name}'s {hit_location} with a sickening crunch, and they drop, twitching, then still.",
+            'victim_msg': "With a final, brutal swing, {attacker_name} brings the phonebook down on your {hit_location} with a sickening crunch, and you drop, twitching, then still.",
+            'observer_msg': "With a final, brutal swing, {attacker_name} brings the phonebook down on {target_name}'s {hit_location} with a sickening crunch, and they drop, twitching, then still."
         },
         {
-            'attacker_msg': "The heavy impact of the phonebook against {target_name}'s throat crushes their windpipe, causing them to asphyxiate in moments under the papery assault.",
-            'victim_msg': "The heavy impact of the phonebook against your throat crushes your windpipe, causing you to asphyxiate in moments under the papery assault.",
-            'observer_msg': "The heavy impact of the phonebook against {target_name}'s throat crushes their windpipe, causing them to asphyxiate in moments under the papery assault."
+            'attacker_msg': "The heavy impact of the phonebook against {target_name}'s {hit_location} crushes their windpipe, causing them to asphyxiate in moments under the papery assault.",
+            'victim_msg': "The heavy impact of the phonebook against your {hit_location} crushes your windpipe, causing you to asphyxiate in moments under the papery assault.",
+            'observer_msg': "The heavy impact of the phonebook against {target_name}'s {hit_location} crushes their windpipe, causing them to asphyxiate in moments under the papery assault."
         },
         {
             'attacker_msg': "You relentlessly bludgeon {target_name} with the phonebook until they slump, lifeless, in a bruised and broken heap.",
@@ -487,14 +487,14 @@ MESSAGES = {
             'observer_msg': "The phonebook, a desperate tool of death, delivers a killing blow as {target_name} is overcome by catastrophic, internal injuries from the repeated bludgeoning."
         },
         {
-            'attacker_msg': "A precise, savage blow with the edge of the phonebook to {target_name}'s spine ends their life with a sickening, dull crack.",
-            'victim_msg': "A precise, savage blow with the edge of the phonebook to your spine ends your life with a sickening, dull crack.",
-            'observer_msg': "A precise, savage blow with the edge of the phonebook to {target_name}'s spine ends their life with a sickening, dull crack."
+            'attacker_msg': "A precise, savage blow with the edge of the phonebook to {target_name}'s {hit_location} ends their life with a sickening, dull crack.",
+            'victim_msg': "A precise, savage blow with the edge of the phonebook to your {hit_location} ends your life with a sickening, dull crack.",
+            'observer_msg': "A precise, savage blow with the edge of the phonebook to {target_name}'s {hit_location} ends their life with a sickening, dull crack."
         },
         {
-            'attacker_msg': "You bring the phonebook down on {target_name}'s face until they stop moving, the features a bruised ruin, life extinguished by the mundane weapon.",
-            'victim_msg': "{attacker_name} brings the phonebook down on your face until you stop moving, the features a bruised ruin, life extinguished by the mundane weapon.",
-            'observer_msg': "{attacker_name} brings the phonebook down on {target_name}'s face until they stop moving, the features a bruised ruin, life extinguished by the mundane weapon."
+            'attacker_msg': "You bring the phonebook down on {target_name}'s {hit_location} until they stop moving, the features a bruised ruin, life extinguished by the mundane weapon.",
+            'victim_msg': "{attacker_name} brings the phonebook down on your {hit_location} until you stop moving, the features a bruised ruin, life extinguished by the mundane weapon.",
+            'observer_msg': "{attacker_name} brings the phonebook down on {target_name}'s {hit_location} until they stop moving, the features a bruised ruin, life extinguished by the mundane weapon."
         },
         {
             'attacker_msg': "The unyielding weight of the phonebook, slammed repeatedly, shatters something vital in {target_name}, who crumples, unmoving.",
@@ -502,9 +502,9 @@ MESSAGES = {
             'observer_msg': "The unyielding weight of the phonebook, slammed repeatedly, shatters something vital in {target_name}, who crumples, unmoving."
         },
         {
-            'attacker_msg': "With a final, desperate act, you use the phonebook to inflict a fatal, crushing wound to {target_name}'s skull.",
-            'victim_msg': "With a final, desperate act, {attacker_name} uses the phonebook to inflict a fatal, crushing wound to your skull.",
-            'observer_msg': "With a final, desperate act, {attacker_name} uses the phonebook to inflict a fatal, crushing wound to {target_name}'s skull."
+            'attacker_msg': "With a final, desperate act, you use the phonebook to inflict a fatal, crushing wound to {target_name}'s {hit_location}.",
+            'victim_msg': "With a final, desperate act, {attacker_name} uses the phonebook to inflict a fatal, crushing wound to your {hit_location}.",
+            'observer_msg': "With a final, desperate act, {attacker_name} uses the phonebook to inflict a fatal, crushing wound to {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "The phonebook, wielded with grim intent, turns {target_name} into a broken mess, their struggles quickly ceasing under the heavy, dull impacts.",
@@ -522,13 +522,13 @@ MESSAGES = {
             'observer_msg': "A merciless, heavy blow with the phonebook to the back of the head, and {target_name} is no more, overcome by the vicious, blunt trauma."
         },
         {
-            'attacker_msg': "The phonebook, now tattered and perhaps bloodied, drops from your hand as {target_name} lies lifeless and broken.",
+            'attacker_msg': "The phonebook, now tattered and perhaps bloodied, drops from your {hit_location} as {target_name} lies lifeless and broken.",
             'victim_msg': "The phonebook, now tattered and perhaps bloodied, drops from {attacker_name}'s hand as you lie lifeless and broken.",
             'observer_msg': "The phonebook, now tattered and perhaps bloodied, drops from {attacker_name}'s hand as {target_name} lies lifeless and broken."
         },
         {
             'attacker_msg': "You ensure {target_name} will not rise by repeatedly smashing their head with the phonebook until it's a bloody pulp.",
-            'victim_msg': "{attacker_name} ensures you will not rise by repeatedly smashing your head with the phonebook until it's a bloody pulp.",
+            'victim_msg': "{attacker_name} ensures you will not rise by repeatedly smashing your {hit_location} with the phonebook until it's a bloody pulp.",
             'observer_msg': "{attacker_name} ensures {target_name} will not rise by repeatedly smashing their head with the phonebook until it's a bloody pulp."
         },
         {
@@ -573,13 +573,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name}'s eyes widen in terror as your phonebook delivers the final, agonizing, crushing blow to their head.",
-            'victim_msg': "Your eyes widen in terror as {attacker_name}'s phonebook delivers the final, agonizing, crushing blow to your head.",
+            'victim_msg': "Your eyes widen in terror as {attacker_name}'s phonebook delivers the final, agonizing, crushing blow to your {hit_location}.",
             'observer_msg': "{target_name}'s eyes widen in terror as {attacker_name}'s phonebook delivers the final, agonizing, crushing blow to their head."
         },
         {
-            'attacker_msg': "A sickening crunch echoes as your phonebook fatally smashes {target_name}'s skull, ending their life.",
-            'victim_msg': "A sickening crunch echoes as {attacker_name}'s phonebook fatally smashes your skull, ending your life.",
-            'observer_msg': "A sickening crunch echoes as {attacker_name}'s phonebook fatally smashes {target_name}'s skull, ending their life."
+            'attacker_msg': "A sickening crunch echoes as your phonebook fatally smashes {target_name}'s {hit_location}, ending their life.",
+            'victim_msg': "A sickening crunch echoes as {attacker_name}'s phonebook fatally smashes your {hit_location}, ending your life.",
+            'observer_msg': "A sickening crunch echoes as {attacker_name}'s phonebook fatally smashes {target_name}'s {hit_location}, ending their life."
         },
         {
             'attacker_msg': "You discard the battered phonebook beside {target_name}'s corpse, a grim testament to its makeshift lethality.",

--- a/world/combat/messages/pipe.py
+++ b/world/combat/messages/pipe.py
@@ -81,7 +81,7 @@ MESSAGES = {
             'observer_msg': "The cold, unadorned steel of the metal pipe is visible, a testament to its crude but effective nature."
         },
         {
-            'attacker_msg': "You hold the metal pipe cocked over your shoulder, ready to bring its full, crushing weight down.",
+            'attacker_msg': "You hold the metal pipe cocked over your {hit_location}, ready to bring its full, crushing weight down.",
             'victim_msg': "{attacker_name} holds the metal pipe cocked over their shoulder, ready to bring its full, crushing weight down.",
             'observer_msg': "{attacker_name} holds the metal pipe cocked over their shoulder, ready to bring its full, crushing weight down."
         },
@@ -111,9 +111,9 @@ MESSAGES = {
             'observer_msg': "The metal pipe is a tool of raw, untamed aggression in {attacker_name}'s capable hands."
         },
         {
-            'attacker_msg': "You present the unyielding length of the metal pipe, its end aimed at {target_name}'s skull.",
-            'victim_msg': "{attacker_name} presents the unyielding length of the metal pipe, its end aimed at your skull.",
-            'observer_msg': "{attacker_name} presents the unyielding length of the metal pipe, its end aimed at {target_name}'s skull."
+            'attacker_msg': "You present the unyielding length of the metal pipe, its end aimed at {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name} presents the unyielding length of the metal pipe, its end aimed at your {hit_location}.",
+            'observer_msg': "{attacker_name} presents the unyielding length of the metal pipe, its end aimed at {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "A desperate measure, a brutal tool; you and the metal pipe are a dangerously crude combination.",
@@ -234,7 +234,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The metal pipe thuds heavily as it connects with {target_name}'s {hit_location}, driving the air from their lungs and cracking {hit_location}.",
-            'victim_msg': "The metal pipe thuds heavily as it connects with your {hit_location}, driving the air from your lungs and cracking {hit_location}.",
+            'victim_msg': "The metal pipe thuds heavily as it connects with your {hit_location}, driving the air from your {hit_location} and cracking {hit_location}.",
             'observer_msg': "The metal pipe thuds heavily as it connects with {target_name}'s {hit_location}, driving the air from their lungs and cracking {hit_location}."
         },
         {
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your metal pipe whistles through the air with considerable force, inches from {target_name}'s skull.",
-            'victim_msg': "{attacker_name}'s metal pipe whistles through the air with considerable force, inches from your skull.",
-            'observer_msg': "{attacker_name}'s metal pipe whistles through the air with considerable force, inches from {target_name}'s skull."
+            'attacker_msg': "Your metal pipe whistles through the air with considerable force, inches from {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s metal pipe whistles through the air with considerable force, inches from your {hit_location}.",
+            'observer_msg': "{attacker_name}'s metal pipe whistles through the air with considerable force, inches from {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "{target_name} narrowly avoids the heavy arc of your metal pipe with a desperate, flailing dodge.",
@@ -457,29 +457,29 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "Your metal pipe connects with {target_name}'s temple with a sickening, final crack; they drop, instantly still and lifeless.",
-            'victim_msg': "{attacker_name}'s metal pipe connects with your temple with a sickening, final crack; you drop, instantly still and lifeless.",
-            'observer_msg': "{attacker_name}'s metal pipe connects with {target_name}'s temple with a sickening, final crack; {target_name} drops, instantly still and lifeless."
+            'attacker_msg': "Your metal pipe connects with {target_name}'s {hit_location} with a sickening, final crack; they drop, instantly still and lifeless.",
+            'victim_msg': "{attacker_name}'s metal pipe connects with your {hit_location} with a sickening, final crack; you drop, instantly still and lifeless.",
+            'observer_msg': "{attacker_name}'s metal pipe connects with {target_name}'s {hit_location} with a sickening, final crack; {target_name} drops, instantly still and lifeless."
         },
         {
-            'attacker_msg': "A devastating overhead swing from the metal pipe crushes {target_name}'s skull like an eggshell, ending the fight brutally and decisively.",
-            'victim_msg': "A devastating overhead swing from the metal pipe crushes your skull like an eggshell, ending the fight brutally and decisively.",
-            'observer_msg': "A devastating overhead swing from the metal pipe crushes {target_name}'s skull like an eggshell, ending the fight brutally and decisively."
+            'attacker_msg': "A devastating overhead swing from the metal pipe crushes {target_name}'s {hit_location} like an eggshell, ending the fight brutally and decisively.",
+            'victim_msg': "A devastating overhead swing from the metal pipe crushes your {hit_location} like an eggshell, ending the fight brutally and decisively.",
+            'observer_msg': "A devastating overhead swing from the metal pipe crushes {target_name}'s {hit_location} like an eggshell, ending the fight brutally and decisively."
         },
         {
-            'attacker_msg': "With a final, focused strike, your metal pipe shatters {target_name}'s sternum and drives them to the ground, unmoving and dead.",
-            'victim_msg': "With a final, focused strike, {attacker_name}'s metal pipe shatters your sternum and drives you to the ground, unmoving and dead.",
-            'observer_msg': "With a final, focused strike, {attacker_name}'s metal pipe shatters {target_name}'s sternum and drives them to the ground, unmoving and dead."
+            'attacker_msg': "With a final, focused strike, your metal pipe shatters {target_name}'s {hit_location} and drives them to the ground, unmoving and dead.",
+            'victim_msg': "With a final, focused strike, {attacker_name}'s metal pipe shatters your {hit_location} and drives you to the ground, unmoving and dead.",
+            'observer_msg': "With a final, focused strike, {attacker_name}'s metal pipe shatters {target_name}'s {hit_location} and drives them to the ground, unmoving and dead."
         },
         {
-            'attacker_msg': "The heavy, cold steel of the metal pipe strikes {target_name}'s throat with a sickening thud, a swift and brutal end, silencing them forever.",
-            'victim_msg': "The heavy, cold steel of the metal pipe strikes your throat with a sickening thud, a swift and brutal end, silencing you forever.",
-            'observer_msg': "The heavy, cold steel of the metal pipe strikes {target_name}'s throat with a sickening thud, a swift and brutal end, silencing them forever."
+            'attacker_msg': "The heavy, cold steel of the metal pipe strikes {target_name}'s {hit_location} with a sickening thud, a swift and brutal end, silencing them forever.",
+            'victim_msg': "The heavy, cold steel of the metal pipe strikes your {hit_location} with a sickening thud, a swift and brutal end, silencing you forever.",
+            'observer_msg': "The heavy, cold steel of the metal pipe strikes {target_name}'s {hit_location} with a sickening thud, a swift and brutal end, silencing them forever."
         },
         {
-            'attacker_msg': "Your powerful swing with the metal pipe caves in {target_name}'s chest; they collapse, blood bubbling from their lips as they expire.",
-            'victim_msg': "{attacker_name}'s powerful swing with the metal pipe caves in your chest; you collapse, blood bubbling from your lips as you expire.",
-            'observer_msg': "{attacker_name}'s powerful swing with the metal pipe caves in {target_name}'s chest; they collapse, blood bubbling from their lips as they expire."
+            'attacker_msg': "Your powerful swing with the metal pipe caves in {target_name}'s {hit_location}; they collapse, blood bubbling from their lips as they expire.",
+            'victim_msg': "{attacker_name}'s powerful swing with the metal pipe caves in your {hit_location}; you collapse, blood bubbling from your lips as you expire.",
+            'observer_msg': "{attacker_name}'s powerful swing with the metal pipe caves in {target_name}'s {hit_location}; they collapse, blood bubbling from their lips as they expire."
         },
         {
             'attacker_msg': "The metal pipe, a simple tool of deadly force, delivers a killing blow, and {target_name}'s struggles cease in a broken heap.",
@@ -497,9 +497,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} drives the end of the metal pipe into {target_name}'s eye socket with brutal, unthinking force, the outcome grimly certain and fatal."
         },
         {
-            'attacker_msg': "The unyielding metal pipe breaks {target_name}'s neck with a sharp, horrifying snap; they fall, a lifeless puppet with lolling head.",
-            'victim_msg': "The unyielding metal pipe breaks your neck with a sharp, horrifying snap; you fall, a lifeless puppet with lolling head.",
-            'observer_msg': "The unyielding metal pipe breaks {target_name}'s neck with a sharp, horrifying snap; they fall, a lifeless puppet with lolling head."
+            'attacker_msg': "The unyielding metal pipe breaks {target_name}'s {hit_location} with a sharp, horrifying snap; they fall, a lifeless puppet with lolling head.",
+            'victim_msg': "The unyielding metal pipe breaks your {hit_location} with a sharp, horrifying snap; you fall, a lifeless puppet with lolling head.",
+            'observer_msg': "The unyielding metal pipe breaks {target_name}'s {hit_location} with a sharp, horrifying snap; they fall, a lifeless puppet with lolling head."
         },
         {
             'attacker_msg': "With a final, savage grunt, you finish {target_name} with a decisive, crushing strike from the metal pipe, leaving no doubt.",

--- a/world/combat/messages/pipe_wrench.py
+++ b/world/combat/messages/pipe_wrench.py
@@ -1,12 +1,12 @@
 MESSAGES = {
     "initiate": [
         {
-            'attacker_msg': "You hoist the heavy pipe wrench over one shoulder, letting it thud against your back with a dull, greasy smack.",
+            'attacker_msg': "You hoist the heavy pipe wrench over one shoulder, letting it thud against your {hit_location} with a dull, greasy smack.",
             'victim_msg': "{attacker_name} hoists the heavy pipe wrench over one shoulder, letting it thud against their back with a dull, greasy smack.",
             'observer_msg': "{attacker_name} hoists the heavy pipe wrench over one shoulder, letting it thud against their back with a dull, greasy smack."
         },
         {
-            'attacker_msg': "You spin the wrench once in your palm and crack your neck, eyes fixed on {target_name} with measured malice.",
+            'attacker_msg': "You spin the wrench once in your palm and crack your {hit_location}, eyes fixed on {target_name} with measured malice.",
             'victim_msg': "{attacker_name} spins the wrench once in their palm and cracks their neck, eyes fixed on you with measured malice.",
             'observer_msg': "{attacker_name} spins the wrench once in their palm and cracks their neck, eyes fixed on {target_name} with measured malice."
         },
@@ -31,7 +31,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} drags the wrench along a pipe behind them, raising a scream of metal on metal that echoes down the alley."
         },
         {
-            'attacker_msg': "You check the grip on the pipe wrench, rolling your shoulder like you're about to fix something—terminally.",
+            'attacker_msg': "You check the grip on the pipe wrench, rolling your {hit_location} like you're about to fix something—terminally.",
             'victim_msg': "{attacker_name} checks the grip on the pipe wrench, rolling their shoulder like they're about to fix something—terminally.",
             'observer_msg': "{attacker_name} checks the grip on the pipe wrench, rolling their shoulder like they're about to fix something—terminally."
         },
@@ -41,7 +41,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} brings the wrench up and lets it hang low, swinging with the weight of industrial intention."
         },
         {
-            'attacker_msg': "You rest the wrench across your forearm and grin at {target_name} with teeth too white for what's about to happen.",
+            'attacker_msg': "You rest the wrench across your {hit_location} and grin at {target_name} with teeth too white for what's about to happen.",
             'victim_msg': "{attacker_name} rests the wrench across their forearm and grins at you with teeth too white for what's about to happen.",
             'observer_msg': "{attacker_name} rests the wrench across their forearm and grins at {target_name} with teeth too white for what's about to happen."
         },
@@ -66,7 +66,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} rolls their shoulders and exhales. The wrench starts to swing slowly side to side."
         },
         {
-            'attacker_msg': "You swing the wrench behind your back in a wide arc, cracking it into the ground with finality.",
+            'attacker_msg': "You swing the wrench behind your {hit_location} in a wide arc, cracking it into the ground with finality.",
             'victim_msg': "{attacker_name} swings the wrench behind their back in a wide arc, cracking it into the ground with finality.",
             'observer_msg': "{attacker_name} swings the wrench behind their back in a wide arc, cracking it into the ground with finality."
         },
@@ -76,7 +76,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} balances the wrench across their forearms like a steel altar, the ritual about to begin."
         },
         {
-            'attacker_msg': "You lean the wrench against your shoulder like a soldier at rest. This is anything but peace.",
+            'attacker_msg': "You lean the wrench against your {hit_location} like a soldier at rest. This is anything but peace.",
             'victim_msg': "{attacker_name} leans the wrench against their shoulder like a soldier at rest. This is anything but peace.",
             'observer_msg': "{attacker_name} leans the wrench against their shoulder like a soldier at rest. This is anything but peace."
         },
@@ -141,7 +141,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} closes the wrench jaws around a pipe, then lets go with a snap—just a warm-up."
         },
         {
-            'attacker_msg': "You roll the wrench along your forearm before letting it drop into your grip with a thud.",
+            'attacker_msg': "You roll the wrench along your {hit_location} before letting it drop into your grip with a thud.",
             'victim_msg': "{attacker_name} rolls the wrench along their forearm before letting it drop into their grip with a thud.",
             'observer_msg': "{attacker_name} rolls the wrench along their forearm before letting it drop into their grip with a thud."
         },
@@ -305,9 +305,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your wrench whistles past {target_name}'s head, the wind alone enough to chill spines.",
-            'victim_msg': "{attacker_name}'s wrench whistles past your head, the wind alone enough to chill spines.",
-            'observer_msg': "{attacker_name}'s wrench whistles past {target_name}'s head, the wind alone enough to chill spines."
+            'attacker_msg': "Your wrench whistles past {target_name}'s {hit_location}, the wind alone enough to chill spines.",
+            'victim_msg': "{attacker_name}'s wrench whistles past your {hit_location}, the wind alone enough to chill spines.",
+            'observer_msg': "{attacker_name}'s wrench whistles past {target_name}'s {hit_location}, the wind alone enough to chill spines."
         },
         {
             'attacker_msg': "The heavy swing slams into the floor beside {target_name}, sending sparks and dust skyward.",
@@ -452,24 +452,24 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You bring the wrench down on {target_name}'s head with a thud that silences everything.",
-            'victim_msg': "{attacker_name} brings the wrench down on your head with a thud that silences everything.",
-            'observer_msg': "{attacker_name} brings the wrench down on {target_name}'s head with a thud that silences everything."
+            'attacker_msg': "You bring the wrench down on {target_name}'s {hit_location} with a thud that silences everything.",
+            'victim_msg': "{attacker_name} brings the wrench down on your {hit_location} with a thud that silences everything.",
+            'observer_msg': "{attacker_name} brings the wrench down on {target_name}'s {hit_location} with a thud that silences everything."
         },
         {
-            'attacker_msg': "The wrench slams into {target_name}'s temple. They twitch, then drop in a heap.",
-            'victim_msg': "The wrench slams into your temple. You twitch, then drop in a heap.",
-            'observer_msg': "The wrench slams into {target_name}'s temple. They twitch, then drop in a heap."
+            'attacker_msg': "The wrench slams into {target_name}'s {hit_location}. They twitch, then drop in a heap.",
+            'victim_msg': "The wrench slams into your {hit_location}. You twitch, then drop in a heap.",
+            'observer_msg': "The wrench slams into {target_name}'s {hit_location}. They twitch, then drop in a heap."
         },
         {
-            'attacker_msg': "A final blow caves in {target_name}'s chest. Their scream dies with the echo.",
-            'victim_msg': "A final blow caves in your chest. Your scream dies with the echo.",
-            'observer_msg': "A final blow caves in {target_name}'s chest. Their scream dies with the echo."
+            'attacker_msg': "A final blow caves in {target_name}'s {hit_location}. Their scream dies with the echo.",
+            'victim_msg': "A final blow caves in your {hit_location}. Your scream dies with the echo.",
+            'observer_msg': "A final blow caves in {target_name}'s {hit_location}. Their scream dies with the echo."
         },
         {
-            'attacker_msg': "The wrench lands full force across {target_name}'s face. Their skull doesn't hold.",
-            'victim_msg': "The wrench lands full force across your face. Your skull doesn't hold.",
-            'observer_msg': "The wrench lands full force across {target_name}'s face. Their skull doesn't hold."
+            'attacker_msg': "The wrench lands full force across {target_name}'s {hit_location}. Their skull doesn't hold.",
+            'victim_msg': "The wrench lands full force across your {hit_location}. Your {hit_location} doesn't hold.",
+            'observer_msg': "The wrench lands full force across {target_name}'s {hit_location}. Their skull doesn't hold."
         },
         {
             'attacker_msg': "A jab to the throat shatters cartilage. {target_name} collapses in a gurgle.",
@@ -478,13 +478,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Steel crashes into the base of the skull. {target_name} drops without ceremony.",
-            'victim_msg': "Steel crashes into the base of your skull. You drop without ceremony.",
+            'victim_msg': "Steel crashes into the base of your {hit_location}. You drop without ceremony.",
             'observer_msg': "Steel crashes into the base of the skull. {target_name} drops without ceremony."
         },
         {
-            'attacker_msg': "You drive the wrench into {target_name}'s neck. One twist. Done.",
-            'victim_msg': "{attacker_name} drives the wrench into your neck. One twist. Done.",
-            'observer_msg': "{attacker_name} drives the wrench into {target_name}'s neck. One twist. Done."
+            'attacker_msg': "You drive the wrench into {target_name}'s {hit_location}. One twist. Done.",
+            'victim_msg': "{attacker_name} drives the wrench into your {hit_location}. One twist. Done.",
+            'observer_msg': "{attacker_name} drives the wrench into {target_name}'s {hit_location}. One twist. Done."
         },
         {
             'attacker_msg': "A brutal swing folds {target_name} around the impact like paper.",
@@ -498,8 +498,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A clean hit to the back of the head ends everything immediately.",
-            'victim_msg': "A clean hit to the back of your head ends everything immediately.",
-            'observer_msg': "A clean hit to the back of {target_name}'s head ends everything immediately."
+            'victim_msg': "A clean hit to the back of your {hit_location} ends everything immediately.",
+            'observer_msg': "A clean hit to the back of {target_name}'s {hit_location} ends everything immediately."
         },
         {
             'attacker_msg': "One crushing downward swing caves in {target_name}'s ribcage. They die gasping.",
@@ -527,34 +527,34 @@ MESSAGES = {
             'observer_msg': "{attacker_name} grips the wrench with both hands and brings it down like a judge's gavel. Final."
         },
         {
-            'attacker_msg': "The jaws of the wrench crack open {target_name}'s skull. The floor gets painted.",
-            'victim_msg': "The jaws of the wrench crack open your skull. The floor gets painted.",
-            'observer_msg': "The jaws of the wrench crack open {target_name}'s skull. The floor gets painted."
+            'attacker_msg': "The jaws of the wrench crack open {target_name}'s {hit_location}. The floor gets painted.",
+            'victim_msg': "The jaws of the wrench crack open your {hit_location}. The floor gets painted.",
+            'observer_msg': "The jaws of the wrench crack open {target_name}'s {hit_location}. The floor gets painted."
         },
         {
             'attacker_msg': "The wrench lands square on the spine. {target_name} folds, twitches, stills.",
-            'victim_msg': "The wrench lands square on your spine. You fold, twitch, still.",
-            'observer_msg': "The wrench lands square on {target_name}'s spine. They fold, twitch, still."
+            'victim_msg': "The wrench lands square on your {hit_location}. You fold, twitch, still.",
+            'observer_msg': "The wrench lands square on {target_name}'s {hit_location}. They fold, twitch, still."
         },
         {
             'attacker_msg': "A twisting blow snaps the neck. {target_name}'s body folds and crumples.",
-            'victim_msg': "A twisting blow snaps your neck. Your body folds and crumples.",
-            'observer_msg': "A twisting blow snaps {target_name}'s neck. Their body folds and crumples."
+            'victim_msg': "A twisting blow snaps your {hit_location}. Your body folds and crumples.",
+            'observer_msg': "A twisting blow snaps {target_name}'s {hit_location}. Their body folds and crumples."
         },
         {
             'attacker_msg': "The wrench embeds in the face. You yank it loose with a grunt.",
-            'victim_msg': "The wrench embeds in your face. {attacker_name} yanks it loose with a grunt.",
-            'observer_msg': "The wrench embeds in {target_name}'s face. {attacker_name} yanks it loose with a grunt."
+            'victim_msg': "The wrench embeds in your {hit_location}. {attacker_name} yanks it loose with a grunt.",
+            'observer_msg': "The wrench embeds in {target_name}'s {hit_location}. {attacker_name} yanks it loose with a grunt."
         },
         {
             'attacker_msg': "A crushing strike to the chest caves it inward. The breathing stops.",
-            'victim_msg': "A crushing strike to your chest caves it inward. The breathing stops.",
-            'observer_msg': "A crushing strike to {target_name}'s chest caves it inward. The breathing stops."
+            'victim_msg': "A crushing strike to your {hit_location} caves it inward. The breathing stops.",
+            'observer_msg': "A crushing strike to {target_name}'s {hit_location} caves it inward. The breathing stops."
         },
         {
-            'attacker_msg': "You bring the wrench across {target_name}'s throat. The rest takes seconds.",
-            'victim_msg': "{attacker_name} brings the wrench across your throat. The rest takes seconds.",
-            'observer_msg': "{attacker_name} brings the wrench across {target_name}'s throat. The rest takes seconds."
+            'attacker_msg': "You bring the wrench across {target_name}'s {hit_location}. The rest takes seconds.",
+            'victim_msg': "{attacker_name} brings the wrench across your {hit_location}. The rest takes seconds.",
+            'observer_msg': "{attacker_name} brings the wrench across {target_name}'s {hit_location}. The rest takes seconds."
         },
         {
             'attacker_msg': "A wide swing lands square on {target_name}'s forehead. Lights out.",
@@ -563,8 +563,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The wrench crashes into the side of the head. Brain meets bone. Game over.",
-            'victim_msg': "The wrench crashes into the side of your head. Brain meets bone. Game over.",
-            'observer_msg': "The wrench crashes into the side of {target_name}'s head. Brain meets bone. Game over."
+            'victim_msg': "The wrench crashes into the side of your {hit_location}. Brain meets bone. Game over.",
+            'observer_msg': "The wrench crashes into the side of {target_name}'s {hit_location}. Brain meets bone. Game over."
         },
         {
             'attacker_msg': "Steel drives into the eye. {target_name} doesn't scream. They just fall.",
@@ -578,8 +578,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The blow breaks the skull—and whatever story {target_name} was going to tell.",
-            'victim_msg': "The blow breaks your skull—and whatever story you were going to tell.",
-            'observer_msg': "The blow breaks {target_name}'s skull—and whatever story they were going to tell."
+            'victim_msg': "The blow breaks your {hit_location}—and whatever story you were going to tell.",
+            'observer_msg': "The blow breaks {target_name}'s {hit_location}—and whatever story they were going to tell."
         },
         {
             'attacker_msg': "You swing hard. The body drops, limp and final.",
@@ -588,13 +588,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A fatal jab under the jaw. The wrench exits slick.",
-            'victim_msg': "A fatal jab under your jaw. The wrench exits slick.",
-            'observer_msg': "A fatal jab under {target_name}'s jaw. The wrench exits slick."
+            'victim_msg': "A fatal jab under your {hit_location}. The wrench exits slick.",
+            'observer_msg': "A fatal jab under {target_name}'s {hit_location}. The wrench exits slick."
         },
         {
             'attacker_msg': "You finish it with a heavy strike across the spine. Stillness.",
-            'victim_msg': "{attacker_name} finishes it with a heavy strike across your spine. Stillness.",
-            'observer_msg': "{attacker_name} finishes it with a heavy strike across {target_name}'s spine. Stillness."
+            'victim_msg': "{attacker_name} finishes it with a heavy strike across your {hit_location}. Stillness.",
+            'observer_msg': "{attacker_name} finishes it with a heavy strike across {target_name}'s {hit_location}. Stillness."
         },
         {
             'attacker_msg': "The wrench lands, and the fight ends with it.",

--- a/world/combat/messages/pool_cue.py
+++ b/world/combat/messages/pool_cue.py
@@ -66,7 +66,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} wipes the cue on their sleeve, as if it matters."
         },
         {
-            'attacker_msg': "You let the cue rest on your shoulder, casual as a hustler at closing time.",
+            'attacker_msg': "You let the cue rest on your {hit_location}, casual as a hustler at closing time.",
             'victim_msg': "{attacker_name} lets the cue rest on their shoulder, casual as a hustler at closing time.",
             'observer_msg': "{attacker_name} lets the cue rest on their shoulder, casual as a hustler at closing time."
         },
@@ -131,7 +131,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} holds the cue like a brush, ready to paint in red."
         },
         {
-            'attacker_msg': "You let the cue rest on your shoulder, eyes never leaving {target_name}.",
+            'attacker_msg': "You let the cue rest on your {hit_location}, eyes never leaving {target_name}.",
             'victim_msg': "{attacker_name} lets the cue rest on their shoulder, eyes never leaving you.",
             'observer_msg': "{attacker_name} lets the cue rest on their shoulder, eyes never leaving {target_name}."
         },
@@ -457,24 +457,24 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You bring the pool cue down on {target_name}'s skull. The wood splinters, blood and bone mixing.",
-            'victim_msg': "{attacker_name} brings the pool cue down on your skull. The wood splinters, blood and bone mixing.",
-            'observer_msg': "{attacker_name} brings the pool cue down on {target_name}'s skull. The wood splinters, blood and bone mixing."
+            'attacker_msg': "You bring the pool cue down on {target_name}'s {hit_location}. The wood splinters, blood and bone mixing.",
+            'victim_msg': "{attacker_name} brings the pool cue down on your {hit_location}. The wood splinters, blood and bone mixing.",
+            'observer_msg': "{attacker_name} brings the pool cue down on {target_name}'s {hit_location}. The wood splinters, blood and bone mixing."
         },
         {
-            'attacker_msg': "A heavy swing cracks {target_name}'s temple. They drop, twitching.",
-            'victim_msg': "A heavy swing cracks your temple. You drop, twitching.",
-            'observer_msg': "A heavy swing cracks {target_name}'s temple. They drop, twitching."
+            'attacker_msg': "A heavy swing cracks {target_name}'s {hit_location}. They drop, twitching.",
+            'victim_msg': "A heavy swing cracks your {hit_location}. You drop, twitching.",
+            'observer_msg': "A heavy swing cracks {target_name}'s {hit_location}. They drop, twitching."
         },
         {
-            'attacker_msg': "The tip jabs into {target_name}'s throat. They collapse, gasping for air that won't come.",
-            'victim_msg': "The tip jabs into your throat. You collapse, gasping for air that won't come.",
-            'observer_msg': "The tip jabs into {target_name}'s throat. They collapse, gasping for air that won't come."
+            'attacker_msg': "The tip jabs into {target_name}'s {hit_location}. They collapse, gasping for air that won't come.",
+            'victim_msg': "The tip jabs into your {hit_location}. You collapse, gasping for air that won't come.",
+            'observer_msg': "The tip jabs into {target_name}'s {hit_location}. They collapse, gasping for air that won't come."
         },
         {
-            'attacker_msg': "You carve a line across {target_name}'s neck. The blood is bright and fast.",
-            'victim_msg': "{attacker_name} carves a line across your neck. The blood is bright and fast.",
-            'observer_msg': "{attacker_name} carves a line across {target_name}'s neck. The blood is bright and fast."
+            'attacker_msg': "You carve a line across {target_name}'s {hit_location}. The blood is bright and fast.",
+            'victim_msg': "{attacker_name} carves a line across your {hit_location}. The blood is bright and fast.",
+            'observer_msg': "{attacker_name} carves a line across {target_name}'s {hit_location}. The blood is bright and fast."
         },
         {
             'attacker_msg': "A jab under the jaw sends the cue splintering into the brain. {target_name} goes limp instantly.",
@@ -517,9 +517,9 @@ MESSAGES = {
             'observer_msg': "The shaft slips between vertebrae. {target_name} drops, boneless."
         },
         {
-            'attacker_msg': "You carve a smile across {target_name}'s face. The grin is permanent.",
-            'victim_msg': "{attacker_name} carves a smile across your face. The grin is permanent.",
-            'observer_msg': "{attacker_name} carves a smile across {target_name}'s face. The grin is permanent."
+            'attacker_msg': "You carve a smile across {target_name}'s {hit_location}. The grin is permanent.",
+            'victim_msg': "{attacker_name} carves a smile across your {hit_location}. The grin is permanent.",
+            'observer_msg': "{attacker_name} carves a smile across {target_name}'s {hit_location}. The grin is permanent."
         },
         {
             'attacker_msg': "A jab to the heart. {target_name} collapses, eyes wide and empty.",

--- a/world/combat/messages/pump-action_shotgun.py
+++ b/world/combat/messages/pump-action_shotgun.py
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air is tense as {attacker_name} prepares to fire the pump-action shotgun, anticipating the powerful *BOOM* and the immediate, forceful cycle of the action."
         },
         {
-            'attacker_msg': "Your face is determined, finger ready on the trigger of the pump-action shotgun, poised to send a cloud of buckshot or a heavy slug.",
+            'attacker_msg': "Your {hit_location} is determined, finger ready on the trigger of the pump-action shotgun, poised to send a cloud of buckshot or a heavy slug.",
             'victim_msg': "{attacker_name}'s face is determined, finger ready on the trigger of the pump-action shotgun, poised to send a cloud of buckshot or a heavy slug.",
             'observer_msg': "{attacker_name}'s face is determined, finger ready on the trigger of the pump-action shotgun, poised to send a cloud of buckshot or a heavy slug."
         },
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} drops low just as your pump-action shotgun fires, pellets whistling over their head. You cycle the pump methodically, scanning.",
-            'victim_msg': "You drop low just as {attacker_name}'s pump-action shotgun fires, pellets whistling over your head. {attacker_name} cycles the pump methodically, scanning.",
+            'victim_msg': "You drop low just as {attacker_name}'s pump-action shotgun fires, pellets whistling over your {hit_location}. {attacker_name} cycles the pump methodically, scanning.",
             'observer_msg': "{target_name} drops low just as {attacker_name}'s pump-action shotgun fires, pellets whistling over their head. {attacker_name} cycles the pump methodically, scanning."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick sidestep from {target_name} leaves {attacker_name}'s pump-action shotgun to blast a pattern into a wall. {attacker_name} cycles the pump, unflinching, ready to fire again."
         },
         {
-            'attacker_msg': "The pump-action shotgun jumps in your shoulder as you miss. You cycle the pump, chambering a fresh, potent shell, correcting your stance.",
+            'attacker_msg': "The pump-action shotgun jumps in your {hit_location} as you miss. You cycle the pump, chambering a fresh, potent shell, correcting your stance.",
             'victim_msg': "The pump-action shotgun jumps in {attacker_name}'s shoulder as they miss. {attacker_name} cycles the pump, chambering a fresh, potent shell, correcting their stance.",
             'observer_msg': "The pump-action shotgun jumps in {attacker_name}'s shoulder as they miss. {attacker_name} cycles the pump, chambering a fresh, potent shell, correcting their stance."
         },
@@ -462,9 +462,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s pump-action shotgun erupts with a deafening *BOOM*, the concentrated blast tearing {target_name} apart; they collapse, lifeless. With a swift *SHUCK-SHUCK*, {attacker_name} cycles the pump, ejecting a smoking shell, the threat eliminated."
         },
         {
-            'attacker_msg': "The pump-action shotgun roars, and a heavy slug slams into {target_name}'s chest with fatal force, ending their fight instantly. You work the pump with a satisfying *CLACK-CLACK*, the job done.",
-            'victim_msg': "The pump-action shotgun roars, and a heavy slug slams into your chest with fatal force, ending your fight instantly. {attacker_name} works the pump with a satisfying *CLACK-CLACK*, the job done.",
-            'observer_msg': "The pump-action shotgun roars, and a heavy slug slams into {target_name}'s chest with fatal force, ending their fight instantly. {attacker_name} works the pump with a satisfying *CLACK-CLACK*, the job done."
+            'attacker_msg': "The pump-action shotgun roars, and a heavy slug slams into {target_name}'s {hit_location} with fatal force, ending their fight instantly. You work the pump with a satisfying *CLACK-CLACK*, the job done.",
+            'victim_msg': "The pump-action shotgun roars, and a heavy slug slams into your {hit_location} with fatal force, ending your fight instantly. {attacker_name} works the pump with a satisfying *CLACK-CLACK*, the job done.",
+            'observer_msg': "The pump-action shotgun roars, and a heavy slug slams into {target_name}'s {hit_location} with fatal force, ending their fight instantly. {attacker_name} works the pump with a satisfying *CLACK-CLACK*, the job done."
         },
         {
             'attacker_msg': "With a final, brutal blast to the head, your pump-action shotgun obliterates {target_name}. Smoke curls from the muzzle as you cycle the action with a forceful, final pump.",
@@ -477,9 +477,9 @@ MESSAGES = {
             'observer_msg': "A devastating point-blank discharge from {attacker_name}'s pump-action shotgun engulfs {target_name}, who is torn apart by the pellets. {attacker_name} pumps the forend, ejecting a spent shell, standing over the fallen."
         },
         {
-            'attacker_msg': "The pump-action shotgun's blast strikes {target_name}'s torso, the massive trauma instantly fatal. You quickly cycle the pump, another shell ready, though unneeded.",
-            'victim_msg': "The pump-action shotgun's blast strikes your torso, the massive trauma instantly fatal. {attacker_name} quickly cycles the pump, another shell ready, though unneeded.",
-            'observer_msg': "The pump-action shotgun's blast strikes {target_name}'s torso, the massive trauma instantly fatal. {attacker_name} quickly cycles the pump, another shell ready, though unneeded."
+            'attacker_msg': "The pump-action shotgun's blast strikes {target_name}'s {hit_location}, the massive trauma instantly fatal. You quickly cycle the pump, another shell ready, though unneeded.",
+            'victim_msg': "The pump-action shotgun's blast strikes your {hit_location}, the massive trauma instantly fatal. {attacker_name} quickly cycles the pump, another shell ready, though unneeded.",
+            'observer_msg': "The pump-action shotgun's blast strikes {target_name}'s {hit_location}, the massive trauma instantly fatal. {attacker_name} quickly cycles the pump, another shell ready, though unneeded."
         },
         {
             'attacker_msg': "The pump-action shotgun, an instrument of brutal close-quarters finality, delivers a killing blow as {target_name} is shredded. The action is cycled with a smooth, powerful *SHUCK-CHUNK*, silence falling.",
@@ -537,9 +537,9 @@ MESSAGES = {
             'observer_msg': "A devastating blast from the pump-action shotgun to {target_name}'s center mass ends the conflict. {attacker_name} cycles the pump, unflinching at the carnage."
         },
         {
-            'attacker_msg': "The pump-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s torso. You cycle the pump, chambering a fresh shell, the area now quiet.",
-            'victim_msg': "The pump-action shotgun's payload makes solid, brutal, and fatal contact with your torso. {attacker_name} cycles the pump, chambering a fresh shell, the area now quiet.",
-            'observer_msg': "The pump-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s torso. {attacker_name} cycles the pump, chambering a fresh shell, the area now quiet."
+            'attacker_msg': "The pump-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s {hit_location}. You cycle the pump, chambering a fresh shell, the area now quiet.",
+            'victim_msg': "The pump-action shotgun's payload makes solid, brutal, and fatal contact with your {hit_location}. {attacker_name} cycles the pump, chambering a fresh shell, the area now quiet.",
+            'observer_msg': "The pump-action shotgun's payload makes solid, brutal, and fatal contact with {target_name}'s {hit_location}. {attacker_name} cycles the pump, chambering a fresh shell, the area now quiet."
         },
         {
             'attacker_msg': "Your pump-action shotgun projectile cloud finds its mark with lethal precision. A spent shell arcs away as you cycle the pump over {target_name}'s still form.",
@@ -592,9 +592,9 @@ MESSAGES = {
             'observer_msg': "The projectile cloud from {attacker_name}'s pump-action shotgun hits {target_name} with overwhelming force, dropping them. The action is cycled, ejecting the shell smartly."
         },
         {
-            'attacker_msg': "Your pump-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}'s torso. The shotgun is cycled, the grim task complete.",
-            'victim_msg': "{attacker_name}'s pump-action shotgun delivers a wide, penetrating, and fatal impact to your torso. The shotgun is cycled, the grim task complete.",
-            'observer_msg': "{attacker_name}'s pump-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}'s torso. The shotgun is cycled, the grim task complete."
+            'attacker_msg': "Your pump-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}'s {hit_location}. The shotgun is cycled, the grim task complete.",
+            'victim_msg': "{attacker_name}'s pump-action shotgun delivers a wide, penetrating, and fatal impact to your {hit_location}. The shotgun is cycled, the grim task complete.",
+            'observer_msg': "{attacker_name}'s pump-action shotgun delivers a wide, penetrating, and fatal impact to {target_name}'s {hit_location}. The shotgun is cycled, the grim task complete."
         },
         {
             'attacker_msg': "A well-placed, devastating blast from the pump-action shotgun leaves {target_name} lifeless. You cycle the pump, the weapon's brutal efficiency clear.",

--- a/world/combat/messages/rapier.py
+++ b/world/combat/messages/rapier.py
@@ -27,7 +27,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} tests the rapier's flex, the thin blade quivering, eager for a thrust."
         },
         {
-            'attacker_msg': "The rapier flashes in your hand, a silver sliver ready to dance.",
+            'attacker_msg': "The rapier flashes in your {hit_location}, a silver sliver ready to dance.",
             'victim_msg': "The rapier flashes in {attacker_name}'s hand, a silver sliver ready to dance.",
             'observer_msg': "The rapier flashes in {attacker_name}'s hand, a silver sliver ready to dance."
         },
@@ -77,7 +77,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s eyes are like chips of ice, sighting down the length of the poised rapier."
         },
         {
-            'attacker_msg': "The rapier feels alive in your hand, a delicate instrument of deadly precision.",
+            'attacker_msg': "The rapier feels alive in your {hit_location}, a delicate instrument of deadly precision.",
             'victim_msg': "The rapier feels alive in {attacker_name}'s hand, a delicate instrument of deadly precision.",
             'observer_msg': "The rapier feels alive in {attacker_name}'s hand, a delicate instrument of deadly precision."
         },
@@ -122,9 +122,9 @@ MESSAGES = {
             'observer_msg': "The rapier is a surgeon's tool in {attacker_name}'s skilled hand, ready for precise incisions."
         },
         {
-            'attacker_msg': "You present the rapier, its slender blade aimed directly at {target_name}'s heart.",
-            'victim_msg': "{attacker_name} presents the rapier, its slender blade aimed directly at your heart.",
-            'observer_msg': "{attacker_name} presents the rapier, its slender blade aimed directly at {target_name}'s heart."
+            'attacker_msg': "You present the rapier, its slender blade aimed directly at {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name} presents the rapier, its slender blade aimed directly at your {hit_location}.",
+            'observer_msg': "{attacker_name} presents the rapier, its slender blade aimed directly at {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "A fencer's grace, a killer's intent; you and the rapier are perfectly matched.",
@@ -406,9 +406,9 @@ MESSAGES = {
             'observer_msg': "A soft curse from {attacker_name} as their rapier attack is neatly sidestepped."
         },
         {
-            'attacker_msg': "The rapier scores a thin line in the dirt beside {target_name}'s foot, but nothing more.",
-            'victim_msg': "The rapier scores a thin line in the dirt beside your foot, but nothing more.",
-            'observer_msg': "The rapier scores a thin line in the dirt beside {target_name}'s foot, but nothing more."
+            'attacker_msg': "The rapier scores a thin line in the dirt beside {target_name}'s {hit_location}, but nothing more.",
+            'victim_msg': "The rapier scores a thin line in the dirt beside your {hit_location}, but nothing more.",
+            'observer_msg': "The rapier scores a thin line in the dirt beside {target_name}'s {hit_location}, but nothing more."
         },
         {
             'attacker_msg': "Your intricate combination with the rapier is read by {target_name}, who evades.",
@@ -468,9 +468,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "Your rapier finds {target_name}'s heart with a single, perfect thrust, ending the duel.",
-            'victim_msg': "{attacker_name}'s rapier finds your heart with a single, perfect thrust, ending the duel.",
-            'observer_msg': "{attacker_name}'s rapier finds {target_name}'s heart with a single, perfect thrust, ending the duel."
+            'attacker_msg': "Your rapier finds {target_name}'s {hit_location} with a single, perfect thrust, ending the duel.",
+            'victim_msg': "{attacker_name}'s rapier finds your {hit_location} with a single, perfect thrust, ending the duel.",
+            'observer_msg': "{attacker_name}'s rapier finds {target_name}'s {hit_location} with a single, perfect thrust, ending the duel."
         },
         {
             'attacker_msg': "A lightning lunge, and the rapier pierces a vital organ; {target_name} collapses, silenced.",
@@ -483,9 +483,9 @@ MESSAGES = {
             'observer_msg': "With cold precision, {attacker_name}'s rapier delivers a fatal touch, and {target_name} falls."
         },
         {
-            'attacker_msg': "The slender blade of the rapier slides between {target_name}'s ribs, a swift and deadly conclusion.",
-            'victim_msg': "The slender blade of the rapier slides between your ribs, a swift and deadly conclusion.",
-            'observer_msg': "The slender blade of the rapier slides between {target_name}'s ribs, a swift and deadly conclusion."
+            'attacker_msg': "The slender blade of the rapier slides between {target_name}'s {hit_location}, a swift and deadly conclusion.",
+            'victim_msg': "The slender blade of the rapier slides between your {hit_location}, a swift and deadly conclusion.",
+            'observer_msg': "The slender blade of the rapier slides between {target_name}'s {hit_location}, a swift and deadly conclusion."
         },
         {
             'attacker_msg': "Your final, perfectly placed thrust with the rapier leaves {target_name} lifeless.",
@@ -543,9 +543,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} delivers a precise end with the rapier, ensuring {target_name} troubles them no further."
         },
         {
-            'attacker_msg': "Blood blossoms on {target_name}'s chest as your rapier finds its mark with fatal accuracy.",
-            'victim_msg': "Blood blossoms on your chest as {attacker_name}'s rapier finds its mark with fatal accuracy.",
-            'observer_msg': "Blood blossoms on {target_name}'s chest as {attacker_name}'s rapier finds its mark with fatal accuracy."
+            'attacker_msg': "Blood blossoms on {target_name}'s {hit_location} as your rapier finds its mark with fatal accuracy.",
+            'victim_msg': "Blood blossoms on your {hit_location} as {attacker_name}'s rapier finds its mark with fatal accuracy.",
+            'observer_msg': "Blood blossoms on {target_name}'s {hit_location} as {attacker_name}'s rapier finds its mark with fatal accuracy."
         },
         {
             'attacker_msg': "The point of the rapier slips through {target_name}'s guard, delivering a killing wound.",

--- a/world/combat/messages/rebar.py
+++ b/world/combat/messages/rebar.py
@@ -22,7 +22,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} scrapes the rebar across the ground, raising sparks and a warning."
         },
         {
-            'attacker_msg': "You twirl the rebar once and rest it against your shoulder, steel humming with promise.",
+            'attacker_msg': "You twirl the rebar once and rest it against your {hit_location}, steel humming with promise.",
             'victim_msg': "{attacker_name} twirls the rebar once and rests it against their shoulder, steel humming with promise.",
             'observer_msg': "{attacker_name} twirls the rebar once and rests it against their shoulder, steel humming with promise."
         },
@@ -42,7 +42,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} gives the rebar a lazy spin before cracking it against their palm with a dull, heavy sound."
         },
         {
-            'attacker_msg': "You roll your neck, then raise the rebar like you're about to knock on death's front door.",
+            'attacker_msg': "You roll your {hit_location}, then raise the rebar like you're about to knock on death's front door.",
             'victim_msg': "{attacker_name} rolls their neck, then raises the rebar like they're about to knock on death's front door.",
             'observer_msg': "{attacker_name} rolls their neck, then raises the rebar like they're about to knock on death's front door."
         },
@@ -127,7 +127,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} twitches the bar slightly—enough to make anyone watching tense."
         },
         {
-            'attacker_msg': "You tap the bar against your shoulder. A casual threat. A promise.",
+            'attacker_msg': "You tap the bar against your {hit_location}. A casual threat. A promise.",
             'victim_msg': "{attacker_name} taps the bar against their shoulder. A casual threat. A promise.",
             'observer_msg': "{attacker_name} taps the bar against their shoulder. A casual threat. A promise."
         },
@@ -189,9 +189,9 @@ MESSAGES = {
             'observer_msg': "The bar whistles before striking {target_name}'s {hit_location}. They buckle like steel under pressure."
         },
         {
-            'attacker_msg': "You bring the bar down hard. It bounces off {target_name}'s skull with a sickening thunk.",
-            'victim_msg': "{attacker_name} brings the bar down hard. It bounces off your skull with a sickening thunk.",
-            'observer_msg': "{attacker_name} brings the bar down hard. It bounces off {target_name}'s skull with a sickening thunk."
+            'attacker_msg': "You bring the bar down hard. It bounces off {target_name}'s {hit_location} with a sickening thunk.",
+            'victim_msg': "{attacker_name} brings the bar down hard. It bounces off your {hit_location} with a sickening thunk.",
+            'observer_msg': "{attacker_name} brings the bar down hard. It bounces off {target_name}'s {hit_location} with a sickening thunk."
         },
         {
             'attacker_msg': "Steel meets {hit_location}. {target_name} drops instantly, breath escaping like steam from a pipe.",
@@ -366,9 +366,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} jabs, but {target_name} shifts just enough to make it hurt less."
         },
         {
-            'attacker_msg': "The hook end of the bar misses {target_name}'s temple by a breath.",
-            'victim_msg': "The hook end of the bar misses your temple by a breath.",
-            'observer_msg': "The hook end of the bar misses {target_name}'s temple by a breath."
+            'attacker_msg': "The hook end of the bar misses {target_name}'s {hit_location} by a breath.",
+            'victim_msg': "The hook end of the bar misses your {hit_location} by a breath.",
+            'observer_msg': "The hook end of the bar misses {target_name}'s {hit_location} by a breath."
         },
         {
             'attacker_msg': "You pivot too late. The bar cuts through silence only.",
@@ -421,7 +421,7 @@ MESSAGES = {
             'observer_msg': "The rebar glances off a support beam. No damage. Just warning."
         },
         {
-            'attacker_msg': "Your strike clips a brick wall. The jolt runs up your arm.",
+            'attacker_msg': "Your strike clips a brick wall. The jolt runs up your {hit_location}.",
             'victim_msg': "{attacker_name}'s strike clips a brick wall. The jolt runs up their arm.",
             'observer_msg': "{attacker_name}'s strike clips a brick wall. The jolt runs up their arm."
         },
@@ -463,9 +463,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You bring the rebar down on {target_name}'s skull. The sound is final.",
-            'victim_msg': "{attacker_name} brings the rebar down on your skull. The sound is final.",
-            'observer_msg': "{attacker_name} brings the rebar down on {target_name}'s skull. The sound is final."
+            'attacker_msg': "You bring the rebar down on {target_name}'s {hit_location}. The sound is final.",
+            'victim_msg': "{attacker_name} brings the rebar down on your {hit_location}. The sound is final.",
+            'observer_msg': "{attacker_name} brings the rebar down on {target_name}'s {hit_location}. The sound is final."
         },
         {
             'attacker_msg': "Steel meets temple. {target_name} drops like a sack of wet cement.",
@@ -473,9 +473,9 @@ MESSAGES = {
             'observer_msg': "Steel meets temple. {target_name} drops like a sack of wet cement."
         },
         {
-            'attacker_msg': "A wide swing crashes into {target_name}'s chest. They crumple, mouth frozen in shock.",
-            'victim_msg': "A wide swing crashes into your chest. You crumple, mouth frozen in shock.",
-            'observer_msg': "A wide swing crashes into {target_name}'s chest. They crumple, mouth frozen in shock."
+            'attacker_msg': "A wide swing crashes into {target_name}'s {hit_location}. They crumple, mouth frozen in shock.",
+            'victim_msg': "A wide swing crashes into your {hit_location}. You crumple, mouth frozen in shock.",
+            'observer_msg': "A wide swing crashes into {target_name}'s {hit_location}. They crumple, mouth frozen in shock."
         },
         {
             'attacker_msg': "The bar punctures ribs and keeps going. {target_name} doesn't scream—they seize, then stop.",
@@ -488,14 +488,14 @@ MESSAGES = {
             'observer_msg': "A thrust to the throat caves in everything. {target_name} drops with a ragged wheeze."
         },
         {
-            'attacker_msg': "You hook the bar behind {target_name}'s neck and yank—hard enough to end it.",
-            'victim_msg': "{attacker_name} hooks the bar behind your neck and yanks—hard enough to end it.",
-            'observer_msg': "{attacker_name} hooks the bar behind {target_name}'s neck and yanks—hard enough to end it."
+            'attacker_msg': "You hook the bar behind {target_name}'s {hit_location} and yank—hard enough to end it.",
+            'victim_msg': "{attacker_name} hooks the bar behind your {hit_location} and yanks—hard enough to end it.",
+            'observer_msg': "{attacker_name} hooks the bar behind {target_name}'s {hit_location} and yanks—hard enough to end it."
         },
         {
-            'attacker_msg': "The bar caves in {target_name}'s chest like a kicked door. They fold.",
-            'victim_msg': "The bar caves in your chest like a kicked door. You fold.",
-            'observer_msg': "The bar caves in {target_name}'s chest like a kicked door. They fold."
+            'attacker_msg': "The bar caves in {target_name}'s {hit_location} like a kicked door. They fold.",
+            'victim_msg': "The bar caves in your {hit_location} like a kicked door. You fold.",
+            'observer_msg': "The bar caves in {target_name}'s {hit_location} like a kicked door. They fold."
         },
         {
             'attacker_msg': "A full-force swing cracks the spine. {target_name} doesn't rise.",
@@ -518,9 +518,9 @@ MESSAGES = {
             'observer_msg': "The bar lands square on the nose, driving bone deep. {target_name} convulses once, then nothing."
         },
         {
-            'attacker_msg': "One last backswing flattens {target_name}'s ribs. Their lungs collapse along with them.",
-            'victim_msg': "One last backswing flattens your ribs. Your lungs collapse along with you.",
-            'observer_msg': "One last backswing flattens {target_name}'s ribs. Their lungs collapse along with them."
+            'attacker_msg': "One last backswing flattens {target_name}'s {hit_location}. Their lungs collapse along with them.",
+            'victim_msg': "One last backswing flattens your {hit_location}. Your {hit_location} collapse along with you.",
+            'observer_msg': "One last backswing flattens {target_name}'s {hit_location}. Their lungs collapse along with them."
         },
         {
             'attacker_msg': "The bar crushes the windpipe. {target_name} dies trying to breathe around it.",
@@ -568,9 +568,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} swings upward. The bar enters beneath the ribs and rips."
         },
         {
-            'attacker_msg': "The bar smashes into the side of the head. {target_name}'s neck bends, then snaps.",
-            'victim_msg': "The bar smashes into the side of the head. Your neck bends, then snaps.",
-            'observer_msg': "The bar smashes into the side of the head. {target_name}'s neck bends, then snaps."
+            'attacker_msg': "The bar smashes into the side of the head. {target_name}'s {hit_location} bends, then snaps.",
+            'victim_msg': "The bar smashes into the side of the head. Your {hit_location} bends, then snaps.",
+            'observer_msg': "The bar smashes into the side of the head. {target_name}'s {hit_location} bends, then snaps."
         },
         {
             'attacker_msg': "The hook snags flesh and pulls. What remains isn't alive.",

--- a/world/combat/messages/rock.py
+++ b/world/combat/messages/rock.py
@@ -22,7 +22,7 @@ MESSAGES = {
             'observer_msg': "With a grim expression, {attacker_name} selects a fist-sized rock, ready to crush and bludgeon."
         },
         {
-            'attacker_msg': "Your hand closes around a rough, heavy rock, its surface gritty and unforgiving.",
+            'attacker_msg': "Your {hit_location} closes around a rough, heavy rock, its surface gritty and unforgiving.",
             'victim_msg': "{attacker_name}'s hand closes around a rough, heavy rock, its surface gritty and unforgiving.",
             'observer_msg': "{attacker_name}'s hand closes around a rough, heavy rock, its surface gritty and unforgiving."
         },
@@ -47,7 +47,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} points the heaviest end of the rock towards {target_name}, a clear, primitive threat."
         },
         {
-            'attacker_msg': "Dust and grit fall from the rock in your hand as you prepare to strike.",
+            'attacker_msg': "Dust and grit fall from the rock in your {hit_location} as you prepare to strike.",
             'victim_msg': "Dust and grit fall from the rock in {attacker_name}'s hand as they prepare to strike.",
             'observer_msg': "Dust and grit fall from the rock in {attacker_name}'s hand as they prepare to strike."
         },
@@ -72,12 +72,12 @@ MESSAGES = {
             'observer_msg': "The air around the rock seems to grow heavy with the threat of sudden, crushing impact."
         },
         {
-            'attacker_msg': "Your eyes are narrowed, sighting along the rock towards {target_name}'s skull.",
-            'victim_msg': "{attacker_name}'s eyes are narrowed, sighting along the rock towards your skull.",
-            'observer_msg': "{attacker_name}'s eyes are narrowed, sighting along the rock towards {target_name}'s skull."
+            'attacker_msg': "Your eyes are narrowed, sighting along the rock towards {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s eyes are narrowed, sighting along the rock towards your {hit_location}.",
+            'observer_msg': "{attacker_name}'s eyes are narrowed, sighting along the rock towards {target_name}'s {hit_location}."
         },
         {
-            'attacker_msg': "The rock feels solid and unforgiving in your hand, a tool of pure, blunt force.",
+            'attacker_msg': "The rock feels solid and unforgiving in your {hit_location}, a tool of pure, blunt force.",
             'victim_msg': "The rock feels solid and unforgiving in {attacker_name}'s hand, a tool of pure, blunt force.",
             'observer_msg': "The rock feels solid and unforgiving in {attacker_name}'s hand, a tool of pure, blunt force."
         },
@@ -316,9 +316,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "Your rock whistles through the air, its heavy mass narrowly missing {target_name}'s head.",
-            'victim_msg': "{attacker_name}'s rock whistles through the air, its heavy mass narrowly missing your head.",
-            'observer_msg': "{attacker_name}'s rock whistles through the air, its heavy mass narrowly missing {target_name}'s head."
+            'attacker_msg': "Your rock whistles through the air, its heavy mass narrowly missing {target_name}'s {hit_location}.",
+            'victim_msg': "{attacker_name}'s rock whistles through the air, its heavy mass narrowly missing your {hit_location}.",
+            'observer_msg': "{attacker_name}'s rock whistles through the air, its heavy mass narrowly missing {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "{target_name} stumbles back, avoiding the desperate swing of your rock by a hair's breadth.",
@@ -376,7 +376,7 @@ MESSAGES = {
             'observer_msg': "A quick retreat from {target_name} leaves {attacker_name}'s rock to impact nothing but air."
         },
         {
-            'attacker_msg': "The rock feels dangerously heavy in your hand as the intended crushing blow fails to connect.",
+            'attacker_msg': "The rock feels dangerously heavy in your {hit_location} as the intended crushing blow fails to connect.",
             'victim_msg': "The rock feels dangerously heavy in {attacker_name}'s hand as the intended crushing blow fails to connect.",
             'observer_msg': "The rock feels dangerously heavy in {attacker_name}'s hand as the intended crushing blow fails to connect."
         },
@@ -406,9 +406,9 @@ MESSAGES = {
             'observer_msg': "A growl of frustration from {attacker_name} as their rock attack is evaded by a nimble {target_name}."
         },
         {
-            'attacker_msg': "The rock kicks up dirt beside {target_name}'s foot, but draws no blood.",
-            'victim_msg': "The rock kicks up dirt beside your foot, but draws no blood.",
-            'observer_msg': "The rock kicks up dirt beside {target_name}'s foot, but draws no blood."
+            'attacker_msg': "The rock kicks up dirt beside {target_name}'s {hit_location}, but draws no blood.",
+            'victim_msg': "The rock kicks up dirt beside your {hit_location}, but draws no blood.",
+            'observer_msg': "The rock kicks up dirt beside {target_name}'s {hit_location}, but draws no blood."
         },
         {
             'attacker_msg': "Your straightforward attack with the rock is anticipated and dodged by {target_name}, who looks terrified.",
@@ -468,24 +468,24 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You smash the rock into {target_name}'s temple; they collapse, skull audibly cracking, succumbing to massive trauma.",
-            'victim_msg': "{attacker_name} smashes the rock into your temple; you collapse, skull audibly cracking, succumbing to massive trauma.",
-            'observer_msg': "{attacker_name} smashes the rock into {target_name}'s temple; they collapse, skull audibly cracking, succumbing to massive trauma."
+            'attacker_msg': "You smash the rock into {target_name}'s {hit_location}; they collapse, skull audibly cracking, succumbing to massive trauma.",
+            'victim_msg': "{attacker_name} smashes the rock into your {hit_location}; you collapse, skull audibly cracking, succumbing to massive trauma.",
+            'observer_msg': "{attacker_name} smashes the rock into {target_name}'s {hit_location}; they collapse, skull audibly cracking, succumbing to massive trauma."
         },
         {
-            'attacker_msg': "The rock, driven deep into {target_name}'s chest, crushes ribs and pulps organs, and they fall silent, life extinguished.",
-            'victim_msg': "The rock, driven deep into your chest, crushes ribs and pulps organs, and you fall silent, life extinguished.",
-            'observer_msg': "The rock, driven deep into {target_name}'s chest, crushes ribs and pulps organs, and they fall silent, life extinguished."
+            'attacker_msg': "The rock, driven deep into {target_name}'s {hit_location}, crushes ribs and pulps organs, and they fall silent, life extinguished.",
+            'victim_msg': "The rock, driven deep into your {hit_location}, crushes ribs and pulps organs, and you fall silent, life extinguished.",
+            'observer_msg': "The rock, driven deep into {target_name}'s {hit_location}, crushes ribs and pulps organs, and they fall silent, life extinguished."
         },
         {
-            'attacker_msg': "With a final, brutal swing, you bring the rock down on {target_name}'s head, and they drop, twitching, then still.",
-            'victim_msg': "With a final, brutal swing, {attacker_name} brings the rock down on your head, and you drop, twitching, then still.",
-            'observer_msg': "With a final, brutal swing, {attacker_name} brings the rock down on {target_name}'s head, and they drop, twitching, then still."
+            'attacker_msg': "With a final, brutal swing, you bring the rock down on {target_name}'s {hit_location}, and they drop, twitching, then still.",
+            'victim_msg': "With a final, brutal swing, {attacker_name} brings the rock down on your {hit_location}, and you drop, twitching, then still.",
+            'observer_msg': "With a final, brutal swing, {attacker_name} brings the rock down on {target_name}'s {hit_location}, and they drop, twitching, then still."
         },
         {
-            'attacker_msg': "The heavy impact of the rock against {target_name}'s throat crushes their windpipe, causing them to asphyxiate in moments.",
-            'victim_msg': "The heavy impact of the rock against your throat crushes your windpipe, causing you to asphyxiate in moments.",
-            'observer_msg': "The heavy impact of the rock against {target_name}'s throat crushes their windpipe, causing them to asphyxiate in moments."
+            'attacker_msg': "The heavy impact of the rock against {target_name}'s {hit_location} crushes their windpipe, causing them to asphyxiate in moments.",
+            'victim_msg': "The heavy impact of the rock against your {hit_location} crushes your windpipe, causing you to asphyxiate in moments.",
+            'observer_msg': "The heavy impact of the rock against {target_name}'s {hit_location} crushes their windpipe, causing them to asphyxiate in moments."
         },
         {
             'attacker_msg': "You repeatedly bludgeon {target_name} with the rock until they slump, lifeless, in a pool of their own blood and shattered bone.",
@@ -498,14 +498,14 @@ MESSAGES = {
             'observer_msg': "The rock, a desperate tool of death, delivers a killing blow as {target_name} is overcome by catastrophic, crushing wounds."
         },
         {
-            'attacker_msg': "A precise, savage blow with the rock to {target_name}'s spine ends their life with a sickening crunch.",
-            'victim_msg': "A precise, savage blow with the rock to your spine ends your life with a sickening crunch.",
-            'observer_msg': "A precise, savage blow with the rock to {target_name}'s spine ends their life with a sickening crunch."
+            'attacker_msg': "A precise, savage blow with the rock to {target_name}'s {hit_location} ends their life with a sickening crunch.",
+            'victim_msg': "A precise, savage blow with the rock to your {hit_location} ends your life with a sickening crunch.",
+            'observer_msg': "A precise, savage blow with the rock to {target_name}'s {hit_location} ends their life with a sickening crunch."
         },
         {
-            'attacker_msg': "You bring the rock down on {target_name}'s face until they stop moving, the features a bloody ruin, life extinguished.",
-            'victim_msg': "{attacker_name} brings the rock down on your face until you stop moving, the features a bloody ruin, life extinguished.",
-            'observer_msg': "{attacker_name} brings the rock down on {target_name}'s face until they stop moving, the features a bloody ruin, life extinguished."
+            'attacker_msg': "You bring the rock down on {target_name}'s {hit_location} until they stop moving, the features a bloody ruin, life extinguished.",
+            'victim_msg': "{attacker_name} brings the rock down on your {hit_location} until you stop moving, the features a bloody ruin, life extinguished.",
+            'observer_msg': "{attacker_name} brings the rock down on {target_name}'s {hit_location} until they stop moving, the features a bloody ruin, life extinguished."
         },
         {
             'attacker_msg': "The unyielding weight of the rock shatters something vital in {target_name}, who crumples, unmoving, amidst the spreading bloodstain.",
@@ -533,13 +533,13 @@ MESSAGES = {
             'observer_msg': "A merciless, heavy blow with the rock, and {target_name} is no more, overcome by the vicious, blunt trauma."
         },
         {
-            'attacker_msg': "The rock, now slick with gore, drops from your hand as {target_name} lies lifeless and broken.",
+            'attacker_msg': "The rock, now slick with gore, drops from your {hit_location} as {target_name} lies lifeless and broken.",
             'victim_msg': "The rock, now slick with gore, drops from {attacker_name}'s hand as you lie lifeless and broken.",
             'observer_msg': "The rock, now slick with gore, drops from {attacker_name}'s hand as {target_name} lies lifeless and broken."
         },
         {
             'attacker_msg': "You ensure {target_name} will not rise by repeatedly smashing their head with the rock until it's unrecognizable.",
-            'victim_msg': "{attacker_name} ensures you will not rise by repeatedly smashing your head with the rock until it's unrecognizable.",
+            'victim_msg': "{attacker_name} ensures you will not rise by repeatedly smashing your {hit_location} with the rock until it's unrecognizable.",
             'observer_msg': "{attacker_name} ensures {target_name} will not rise by repeatedly smashing their head with the rock until it's unrecognizable."
         },
         {
@@ -588,9 +588,9 @@ MESSAGES = {
             'observer_msg': "{target_name}'s eyes widen in terror as {attacker_name}'s rock delivers the final, agonizing, crushing blow."
         },
         {
-            'attacker_msg': "A sickening crunch echoes as your rock fatally smashes {target_name}'s skull.",
-            'victim_msg': "A sickening crunch echoes as {attacker_name}'s rock fatally smashes your skull.",
-            'observer_msg': "A sickening crunch echoes as {attacker_name}'s rock fatally smashes {target_name}'s skull."
+            'attacker_msg': "A sickening crunch echoes as your rock fatally smashes {target_name}'s {hit_location}.",
+            'victim_msg': "A sickening crunch echoes as {attacker_name}'s rock fatally smashes your {hit_location}.",
+            'observer_msg': "A sickening crunch echoes as {attacker_name}'s rock fatally smashes {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "You discard the bloody rock beside {target_name}'s corpse, a grim testament to its makeshift lethality.",

--- a/world/combat/messages/scalpel.py
+++ b/world/combat/messages/scalpel.py
@@ -457,9 +457,9 @@ SCALPEL_MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "You drive the scalpel into {target_name}'s throat. Blood spurts in a fine, surgical arc.",
-            'victim_msg': "The scalpel pierces your throat, blood arcing out in a surgical spray.",
-            'observer_msg': "Blood arcs from {target_name}'s throat as the scalpel finds its mark."
+            'attacker_msg': "You drive the scalpel into {target_name}'s {hit_location}. Blood spurts in a fine, surgical arc.",
+            'victim_msg': "The scalpel pierces your {hit_location}, blood arcing out in a surgical spray.",
+            'observer_msg': "Blood arcs from {target_name}'s {hit_location} as the scalpel finds its mark."
         },
         {
             'attacker_msg': "A quick slash opens {target_name}'s carotid. They drop, clutching at a wound that won't close.",
@@ -468,18 +468,18 @@ SCALPEL_MESSAGES = {
         },
         {
             'attacker_msg': "The blade slips between ribs and into the heart. {target_name} collapses, twitching.",
-            'victim_msg': "You feel the scalpel slide between your ribs and pierce your heart.",
-            'observer_msg': "The scalpel disappears between {target_name}'s ribs. They collapse, twitching once."
+            'victim_msg': "You feel the scalpel slide between your {hit_location} and pierce your {hit_location}.",
+            'observer_msg': "The scalpel disappears between {target_name}'s {hit_location}. They collapse, twitching once."
         },
         {
-            'attacker_msg': "You carve a line across {target_name}'s neck. The blood is bright and fast.",
-            'victim_msg': "The blade traces fire across your throat—bright arterial blood flows freely.",
-            'observer_msg': "A clean line appears across {target_name}'s throat, blood flowing in bright spurts."
+            'attacker_msg': "You carve a line across {target_name}'s {hit_location}. The blood is bright and fast.",
+            'victim_msg': "The blade traces fire across your {hit_location}—bright arterial blood flows freely.",
+            'observer_msg': "A clean line appears across {target_name}'s {hit_location}, blood flowing in bright spurts."
         },
         {
             'attacker_msg': "A jab under the jaw sends the scalpel into the brain. {target_name} goes limp instantly.",
-            'victim_msg': "The scalpel punches up through your jaw into your brain. Everything goes dark.",
-            'observer_msg': "The blade disappears under {target_name}'s jaw. They go limp immediately."
+            'victim_msg': "The scalpel punches up through your {hit_location} into your {hit_location}. Everything goes dark.",
+            'observer_msg': "The blade disappears under {target_name}'s {hit_location}. They go limp immediately."
         },
         {
             'attacker_msg': "The scalpel punctures the eye. {target_name} screams, then falls silent.",
@@ -493,38 +493,38 @@ SCALPEL_MESSAGES = {
         },
         {
             'attacker_msg': "A quick stab to the temple ends everything in a blink.",
-            'victim_msg': "The scalpel pierces your temple. Darkness comes instantly.",
-            'observer_msg': "The scalpel finds {target_name}'s temple. They drop without a sound."
+            'victim_msg': "The scalpel pierces your {hit_location}. Darkness comes instantly.",
+            'observer_msg': "The scalpel finds {target_name}'s {hit_location}. They drop without a sound."
         },
         {
             'attacker_msg': "The blade slips under the sternum. {target_name} gasps, then nothing.",
-            'victim_msg': "You feel the scalpel slide under your sternum, piercing your heart.",
-            'observer_msg': "The blade disappears beneath {target_name}'s sternum. They gasp once and still."
+            'victim_msg': "You feel the scalpel slide under your {hit_location}, piercing your {hit_location}.",
+            'observer_msg': "The blade disappears beneath {target_name}'s {hit_location}. They gasp once and still."
         },
         {
             'attacker_msg': "You draw the scalpel across the throat. The spray is arterial, the silence final.",
-            'victim_msg': "The blade opens your throat wide. Blood sprays as your voice dies forever.",
-            'observer_msg': "Arterial spray follows the scalpel across {target_name}'s throat. Silence follows."
+            'victim_msg': "The blade opens your {hit_location} wide. Blood sprays as your voice dies forever.",
+            'observer_msg': "Arterial spray follows the scalpel across {target_name}'s {hit_location}. Silence follows."
         },
         {
             'attacker_msg': "A downward stab buries the blade in the chest. {target_name} shudders, then stills.",
-            'victim_msg': "The scalpel drives down into your chest, piercing lung and heart alike.",
-            'observer_msg': "The scalpel buries itself in {target_name}'s chest. They shudder once and lie still."
+            'victim_msg': "The scalpel drives down into your {hit_location}, piercing lung and heart alike.",
+            'observer_msg': "The scalpel buries itself in {target_name}'s {hit_location}. They shudder once and lie still."
         },
         {
             'attacker_msg': "The scalpel slips between vertebrae. {target_name} drops, boneless.",
-            'victim_msg': "Your spine parts under the surgical blade. Your body simply shuts down.",
+            'victim_msg': "Your {hit_location} parts under the surgical blade. Your body simply shuts down.",
             'observer_msg': "The scalpel finds the gap between vertebrae. {target_name} collapses like a cut string."
         },
         {
-            'attacker_msg': "You carve a smile across {target_name}'s face. The grin is permanent.",
+            'attacker_msg': "You carve a smile across {target_name}'s {hit_location}. The grin is permanent.",
             'victim_msg': "The blade traces a grotesque smile from ear to ear. Your last expression is a grin.",
-            'observer_msg': "The scalpel carves a permanent smile across {target_name}'s face."
+            'observer_msg': "The scalpel carves a permanent smile across {target_name}'s {hit_location}."
         },
         {
             'attacker_msg': "A jab to the heart. {target_name} collapses, eyes wide and empty.",
-            'victim_msg': "The scalpel pierces your heart. You collapse as your eyes lose focus.",
-            'observer_msg': "The blade finds {target_name}'s heart. They fall, eyes staring at nothing."
+            'victim_msg': "The scalpel pierces your {hit_location}. You collapse as your eyes lose focus.",
+            'observer_msg': "The blade finds {target_name}'s {hit_location}. They fall, eyes staring at nothing."
         },
         {
             'attacker_msg': "The blade punctures a lung. {target_name} drowns on dry land.",
@@ -533,7 +533,7 @@ SCALPEL_MESSAGES = {
         },
         {
             'attacker_msg': "You slice the wrist, blood spraying in pulses.",
-            'victim_msg': "Your wrist opens wide, blood pulsing out with each failing heartbeat.",
+            'victim_msg': "Your {hit_location} opens wide, blood pulsing out with each failing heartbeat.",
             'observer_msg': "Blood pulses from {target_name}'s opened wrist in weakening spurts."
         },
         {
@@ -543,18 +543,18 @@ SCALPEL_MESSAGES = {
         },
         {
             'attacker_msg': "The scalpel slips behind the ear. {target_name} never sees it coming.",
-            'victim_msg': "You never see the blade that slides behind your ear into your brain.",
+            'victim_msg': "You never see the blade that slides behind your ear into your {hit_location}.",
             'observer_msg': "The scalpel disappears behind {target_name}'s ear. They never knew what happened."
         },
         {
             'attacker_msg': "A stab to the base of the skull ends it instantly.",
-            'victim_msg': "The scalpel finds the base of your skull. Death comes instantly.",
-            'observer_msg': "The blade pierces {target_name}'s skull at the base. Death is immediate."
+            'victim_msg': "The scalpel finds the base of your {hit_location}. Death comes instantly.",
+            'observer_msg': "The blade pierces {target_name}'s {hit_location} at the base. Death is immediate."
         },
         {
             'attacker_msg': "You carve a spiral down the chest. The pattern is red and final.",
-            'victim_msg': "The scalpel traces a spiral of death down your chest, each cut deeper than the last.",
-            'observer_msg': "The blade etches a deadly spiral down {target_name}'s chest, blood following each line."
+            'victim_msg': "The scalpel traces a spiral of death down your {hit_location}, each cut deeper than the last.",
+            'observer_msg': "The blade etches a deadly spiral down {target_name}'s {hit_location}, blood following each line."
         },
         {
             'attacker_msg': "The blade slips into the mouth, blood pouring out.",
@@ -563,13 +563,13 @@ SCALPEL_MESSAGES = {
         },
         {
             'attacker_msg': "A quick slash opens the abdomen. {target_name} folds, spilling.",
-            'victim_msg': "Your abdomen opens wide under the blade. You fold forward, contents spilling.",
+            'victim_msg': "Your {hit_location} opens wide under the blade. You fold forward, contents spilling.",
             'observer_msg': "{target_name} folds forward as the scalpel opens their abdomen, everything spilling."
         },
         {
             'attacker_msg': "The scalpel punctures the heart. {target_name} gasps, then nothing.",
-            'victim_msg': "You feel the scalpel pierce your heart. One final gasp, then peace.",
-            'observer_msg': "The blade finds {target_name}'s heart. They gasp once and are still."
+            'victim_msg': "You feel the scalpel pierce your {hit_location}. One final gasp, then peace.",
+            'observer_msg': "The blade finds {target_name}'s {hit_location}. They gasp once and are still."
         },
         {
             'attacker_msg': "You draw the blade across the eyes. The world goes dark.",
@@ -593,18 +593,18 @@ SCALPEL_MESSAGES = {
         },
         {
             'attacker_msg': "The blade slips into the chest, twisting. {target_name} is gone before they hit the ground.",
-            'victim_msg': "The scalpel enters your chest and twists. You're gone before you fall.",
-            'observer_msg': "The scalpel twists in {target_name}'s chest. They die before hitting the ground."
+            'victim_msg': "The scalpel enters your {hit_location} and twists. You're gone before you fall.",
+            'observer_msg': "The scalpel twists in {target_name}'s {hit_location}. They die before hitting the ground."
         },
         {
             'attacker_msg': "You carve a line across the throat. The spray is bright, the end abrupt.",
-            'victim_msg': "The blade opens your throat in one smooth line. The end comes in a bright spray.",
+            'victim_msg': "The blade opens your {hit_location} in one smooth line. The end comes in a bright spray.",
             'observer_msg': "One clean line across the throat. The spray is bright, {target_name}'s end abrupt."
         },
         {
             'attacker_msg': "A final stab to the heart. {target_name} sags, then falls.",
-            'victim_msg': "The scalpel finds your heart one last time. You sag, then fall into darkness.",
-            'observer_msg': "The final thrust pierces {target_name}'s heart. They sag and fall still."
+            'victim_msg': "The scalpel finds your {hit_location} one last time. You sag, then fall into darkness.",
+            'observer_msg': "The final thrust pierces {target_name}'s {hit_location}. They sag and fall still."
         }
     ]
 }

--- a/world/combat/messages/scimitar.py
+++ b/world/combat/messages/scimitar.py
@@ -11,7 +11,7 @@ SCIMITAR_MESSAGES = {
             'observer_msg': "With a flourish, {attacker_name} brings the scimitar to a flowing guard, its arc a deadly promise."
         },
         {
-            'attacker_msg': "You test the balance of the scimitar, the curved steel feeling light and swift in your hand.",
+            'attacker_msg': "You test the balance of the scimitar, the curved steel feeling light and swift in your {hit_location}.",
             'victim_msg': "{attacker_name} tests the balance of the scimitar, the curved steel feeling light and swift in their hand.",
             'observer_msg': "{attacker_name} tests the balance of the scimitar, the curved steel feeling light and swift in their hand."
         },
@@ -66,7 +66,7 @@ SCIMITAR_MESSAGES = {
             'observer_msg': "{attacker_name}'s eyes are like desert stars, sighting along the elegant curve of the scimitar."
         },
         {
-            'attacker_msg': "The scimitar feels like a living thing in your hand, a blade born for swift, decisive cuts.",
+            'attacker_msg': "The scimitar feels like a living thing in your {hit_location}, a blade born for swift, decisive cuts.",
             'victim_msg': "The scimitar feels like a living thing in {attacker_name}'s hand, a blade born for swift, decisive cuts.",
             'observer_msg': "The scimitar feels like a living thing in {attacker_name}'s hand, a blade born for swift, decisive cuts."
         },
@@ -385,9 +385,9 @@ SCIMITAR_MESSAGES = {
             'observer_msg': "A soft oath from {attacker_name} as their scimitar attack is neatly sidestepped."
         },
         {
-            'attacker_msg': "The scimitar scores a shallow arc in the dust beside {target_name}'s foot, but nothing more.",
-            'victim_msg': "The scimitar scores a shallow arc in the dust beside your foot, but nothing more.",
-            'observer_msg': "The scimitar scores a shallow arc in the dust beside {target_name}'s foot, but nothing more."
+            'attacker_msg': "The scimitar scores a shallow arc in the dust beside {target_name}'s {hit_location}, but nothing more.",
+            'victim_msg': "The scimitar scores a shallow arc in the dust beside your {hit_location}, but nothing more.",
+            'observer_msg': "The scimitar scores a shallow arc in the dust beside {target_name}'s {hit_location}, but nothing more."
         },
         {
             'attacker_msg': "Your intricate combination with the scimitar is read by {target_name}, who evades the deadly dance.",
@@ -462,9 +462,9 @@ SCIMITAR_MESSAGES = {
             'observer_msg': "With cold, flowing grace, {attacker_name}'s scimitar delivers a fatal cut, and {target_name} falls silent."
         },
         {
-            'attacker_msg': "The curved blade of the scimitar opens {target_name}'s throat from ear to ear, a swift and bloody end.",
-            'victim_msg': "The curved blade of the scimitar opens your throat from ear to ear, a swift and bloody end.",
-            'observer_msg': "The curved blade of the scimitar opens {target_name}'s throat from ear to ear, a swift and bloody end."
+            'attacker_msg': "The curved blade of the scimitar opens {target_name}'s {hit_location} from ear to ear, a swift and bloody end.",
+            'victim_msg': "The curved blade of the scimitar opens your {hit_location} from ear to ear, a swift and bloody end.",
+            'observer_msg': "The curved blade of the scimitar opens {target_name}'s {hit_location} from ear to ear, a swift and bloody end."
         },
         {
             'attacker_msg': "Your final, perfectly aimed slash with the scimitar leaves {target_name} mortally wounded.",

--- a/world/combat/messages/screwdriver.py
+++ b/world/combat/messages/screwdriver.py
@@ -6,7 +6,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} pulls a battered screwdriver from their pocket, spinning it once in their palm."
         },
         {
-            "attacker_msg": "You tap the screwdriver against your thigh, eyes locked on {target_name}.",
+            "attacker_msg": "You tap the screwdriver against your {hit_location}, eyes locked on {target_name}.",
             "victim_msg": "{attacker_name} taps the screwdriver against their thigh, eyes locked on you.",
             "observer_msg": "{attacker_name} taps the screwdriver against their thigh, eyes locked on {target_name}."
         },
@@ -66,7 +66,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} balances the screwdriver on a fingertip, then lets it drop into their grip."
         },
         {
-            "attacker_msg": "You trace the tip along your forearm, leaving a thin red line.",
+            "attacker_msg": "You trace the tip along your {hit_location}, leaving a thin red line.",
             "victim_msg": "{attacker_name} traces the tip along their forearm, leaving a thin red line.",
             "observer_msg": "{attacker_name} traces the tip along their forearm, leaving a thin red line."
         },
@@ -141,7 +141,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} holds the screwdriver like a brush, ready to paint in red."
         },
         {
-            "attacker_msg": "You let the screwdriver rest on your tongue for a heartbeat before spitting it into your hand.",
+            "attacker_msg": "You let the screwdriver rest on your tongue for a heartbeat before spitting it into your {hit_location}.",
             "victim_msg": "{attacker_name} lets the screwdriver rest on their tongue for a heartbeat before spitting it into their hand.",
             "observer_msg": "{attacker_name} lets the screwdriver rest on their tongue for a heartbeat before spitting it into their hand."
         },
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "You drive the screwdriver into {target_name}'s throat. Blood spurts in a fine, ugly arc.",
-            "victim_msg": "{attacker_name} drives the screwdriver into your throat. Blood spurts in a fine, ugly arc.",
-            "observer_msg": "{attacker_name} drives the screwdriver into {target_name}'s throat. Blood spurts in a fine, ugly arc."
+            "attacker_msg": "You drive the screwdriver into {target_name}'s {hit_location}. Blood spurts in a fine, ugly arc.",
+            "victim_msg": "{attacker_name} drives the screwdriver into your {hit_location}. Blood spurts in a fine, ugly arc.",
+            "observer_msg": "{attacker_name} drives the screwdriver into {target_name}'s {hit_location}. Blood spurts in a fine, ugly arc."
         },
         {
             "attacker_msg": "A quick stab opens {target_name}'s carotid. They drop, clutching at a wound that won't close.",
@@ -472,9 +472,9 @@ MESSAGES = {
             "observer_msg": "The tip slips between ribs and into the heart. {target_name} collapses, twitching."
         },
         {
-            "attacker_msg": "You carve a line across {target_name}'s neck. The blood is bright and fast.",
-            "victim_msg": "{attacker_name} carves a line across your neck. The blood is bright and fast.",
-            "observer_msg": "{attacker_name} carves a line across {target_name}'s neck. The blood is bright and fast."
+            "attacker_msg": "You carve a line across {target_name}'s {hit_location}. The blood is bright and fast.",
+            "victim_msg": "{attacker_name} carves a line across your {hit_location}. The blood is bright and fast.",
+            "observer_msg": "{attacker_name} carves a line across {target_name}'s {hit_location}. The blood is bright and fast."
         },
         {
             "attacker_msg": "A jab under the jaw sends the screwdriver into the brain. {target_name} goes limp instantly.",
@@ -517,9 +517,9 @@ MESSAGES = {
             "observer_msg": "The tip slips between vertebrae. {target_name} drops, boneless."
         },
         {
-            "attacker_msg": "You carve a smile across {target_name}'s face. The grin is permanent.",
-            "victim_msg": "{attacker_name} carves a smile across your face. The grin is permanent.",
-            "observer_msg": "{attacker_name} carves a smile across {target_name}'s face. The grin is permanent."
+            "attacker_msg": "You carve a smile across {target_name}'s {hit_location}. The grin is permanent.",
+            "victim_msg": "{attacker_name} carves a smile across your {hit_location}. The grin is permanent.",
+            "observer_msg": "{attacker_name} carves a smile across {target_name}'s {hit_location}. The grin is permanent."
         },
         {
             "attacker_msg": "A jab to the heart. {target_name} collapses, eyes wide and empty.",

--- a/world/combat/messages/semi-auto_rifle.py
+++ b/world/combat/messages/semi-auto_rifle.py
@@ -61,7 +61,7 @@ SEMI_AUTO_RIFLE_MESSAGES = {
             'observer_msg': "The air is tense as {attacker_name} prepares to fire the semi-automatic rifle, anticipating the sharp *CRACK* and the immediate cycling of the action."
         },
         {
-            'attacker_msg': "Your face is a mask of concentration, finger ready to make multiple, deliberate pulls on the semi-automatic rifle's trigger.",
+            'attacker_msg': "Your {hit_location} is a mask of concentration, finger ready to make multiple, deliberate pulls on the semi-automatic rifle's trigger.",
             'victim_msg': "{attacker_name}'s face is a mask of concentration, finger ready to make multiple, deliberate pulls on the semi-automatic rifle's trigger.",
             'observer_msg': "{attacker_name}'s face is a mask of concentration, finger ready to make multiple, deliberate pulls on the semi-automatic rifle's trigger."
         },
@@ -350,9 +350,9 @@ SEMI_AUTO_RIFLE_MESSAGES = {
             'observer_msg': "{attacker_name} fires the semi-automatic rifle, but their aim is off and {target_name} escapes harm. The rifle cycles, ready again."
         },
         {
-            'attacker_msg': "The semi-automatic rifle's bullet whizzes past {target_name}'s head. The rifle cycles, ejecting the spent case.",
-            'victim_msg': "The semi-automatic rifle's bullet whizzes past your head. The rifle cycles, ejecting the spent case.",
-            'observer_msg': "The semi-automatic rifle's bullet whizzes past {target_name}'s head. The rifle cycles, ejecting the spent case."
+            'attacker_msg': "The semi-automatic rifle's bullet whizzes past {target_name}'s {hit_location}. The rifle cycles, ejecting the spent case.",
+            'victim_msg': "The semi-automatic rifle's bullet whizzes past your {hit_location}. The rifle cycles, ejecting the spent case.",
+            'observer_msg': "The semi-automatic rifle's bullet whizzes past {target_name}'s {hit_location}. The rifle cycles, ejecting the spent case."
         },
         {
             'attacker_msg': "Your semi-automatic rifle shot goes astray, missing {target_name} entirely. The action cycles smoothly.",
@@ -395,9 +395,9 @@ SEMI_AUTO_RIFLE_MESSAGES = {
             'observer_msg': "The semi-automatic rifle barks, but the bullet misses {target_name} completely. The rifle cycles, ready for immediate follow-up."
         },
         {
-            'attacker_msg': "Your shot from the semi-automatic rifle sails over {target_name}'s shoulder. The rifle's action cycles with mechanical precision.",
-            'victim_msg': "{attacker_name}'s shot from the semi-automatic rifle sails over your shoulder. The rifle's action cycles with mechanical precision.",
-            'observer_msg': "{attacker_name}'s shot from the semi-automatic rifle sails over {target_name}'s shoulder. The rifle's action cycles with mechanical precision."
+            'attacker_msg': "Your shot from the semi-automatic rifle sails over {target_name}'s {hit_location}. The rifle's action cycles with mechanical precision.",
+            'victim_msg': "{attacker_name}'s shot from the semi-automatic rifle sails over your {hit_location}. The rifle's action cycles with mechanical precision.",
+            'observer_msg': "{attacker_name}'s shot from the semi-automatic rifle sails over {target_name}'s {hit_location}. The rifle's action cycles with mechanical precision."
         },
         {
             'attacker_msg': "The semi-automatic rifle's bullet misses {target_name}, striking a nearby wall. The rifle ejects and chambers smoothly.",

--- a/world/combat/messages/semi-auto_shotgun.py
+++ b/world/combat/messages/semi-auto_shotgun.py
@@ -346,7 +346,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} drops prone just as your semi-automatic shotgun fires a rapid series, pellets cracking the air inches above their head. The shotgun cycles, ready for {target_name} to reappear.",
-            'victim_msg': "You drop prone just as {attacker_name}'s semi-automatic shotgun fires a rapid series, pellets cracking the air inches above your head. The shotgun cycles, ready for you to reappear.",
+            'victim_msg': "You drop prone just as {attacker_name}'s semi-automatic shotgun fires a rapid series, pellets cracking the air inches above your {hit_location}. The shotgun cycles, ready for you to reappear.",
             'observer_msg': "{target_name} drops prone just as {attacker_name}'s semi-automatic shotgun fires a rapid series, pellets cracking the air inches above their head. The shotgun cycles, ready for {target_name} to reappear."
         },
         {
@@ -365,7 +365,7 @@ MESSAGES = {
             'observer_msg': "A quick sidestep from {target_name} leaves {attacker_name}'s semi-automatic shotgun to punch a pattern of holes in a nearby wall with rapid fire. The shotgun cycles, {attacker_name} maintaining their aim, ready to fire again."
         },
         {
-            'attacker_msg': "The semi-automatic shotgun bucks in your shoulder as you send a volley wide. The shotgun cycles, chambering fresh rounds, you quickly compensating for muzzle climb.",
+            'attacker_msg': "The semi-automatic shotgun bucks in your {hit_location} as you send a volley wide. The shotgun cycles, chambering fresh rounds, you quickly compensating for muzzle climb.",
             'victim_msg': "The semi-automatic shotgun bucks in {attacker_name}'s shoulder as they send a volley wide. The shotgun cycles, chambering fresh rounds, {attacker_name} quickly compensating for muzzle climb.",
             'observer_msg': "The semi-automatic shotgun bucks in {attacker_name}'s shoulder as they send a volley wide. The shotgun cycles, chambering fresh rounds, {attacker_name} quickly compensating for muzzle climb."
         },
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "Your semi-automatic shotgun erupts in a rapid volley, stitching fatal impacts across {target_name}'s chest; they collapse, riddled. The action cycles with a final *CHLACK*, ejecting a casing, the threat decisively neutralized by overwhelming firepower.",
-            'victim_msg': "{attacker_name}'s semi-automatic shotgun erupts in a rapid volley, stitching fatal impacts across your chest; you collapse, riddled. The action cycles with a final *CHLACK*, ejecting a casing, the threat decisively neutralized by overwhelming firepower.",
-            'observer_msg': "{attacker_name}'s semi-automatic shotgun erupts in a rapid volley, stitching fatal impacts across {target_name}'s chest; they collapse, riddled. The action cycles with a final *CHLACK*, ejecting a casing, the threat decisively neutralized by overwhelming firepower."
+            'attacker_msg': "Your semi-automatic shotgun erupts in a rapid volley, stitching fatal impacts across {target_name}'s {hit_location}; they collapse, riddled. The action cycles with a final *CHLACK*, ejecting a casing, the threat decisively neutralized by overwhelming firepower.",
+            'victim_msg': "{attacker_name}'s semi-automatic shotgun erupts in a rapid volley, stitching fatal impacts across your {hit_location}; you collapse, riddled. The action cycles with a final *CHLACK*, ejecting a casing, the threat decisively neutralized by overwhelming firepower.",
+            'observer_msg': "{attacker_name}'s semi-automatic shotgun erupts in a rapid volley, stitching fatal impacts across {target_name}'s {hit_location}; they collapse, riddled. The action cycles with a final *CHLACK*, ejecting a casing, the threat decisively neutralized by overwhelming firepower."
         },
         {
             'attacker_msg': "The semi-automatic shotgun barks a deadly staccato, and {target_name} crumples as multiple heavy slugs or buckshot blasts tear through vital areas, ending their fight instantly. The shotgun ejects hot casings, bolt locking back or ready for the next foe.",

--- a/world/combat/messages/shiv.py
+++ b/world/combat/messages/shiv.py
@@ -27,8 +27,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "{target_name} catches a glint in your sleeve too late. By the time their brain processes it, the distance is already closed.",
-            'victim_msg': "You catch a glint in {attacker_name}'s sleeve too late. By the time your brain processes it, the distance is already closed.",
-            'observer_msg': "{target_name} catches a glint in {attacker_name}'s sleeve too late. By the time {target_name}'s brain processes it, the distance is already closed."
+            'victim_msg': "You catch a glint in {attacker_name}'s sleeve too late. By the time your {hit_location} processes it, the distance is already closed.",
+            'observer_msg': "{target_name} catches a glint in {attacker_name}'s sleeve too late. By the time {target_name}'s {hit_location} processes it, the distance is already closed."
         },
         {
             'attacker_msg': "You peel back your sleeve like you're unwrapping something sacred. The shiv slips into view, and it doesn't glint—it glares.",
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "There's a pause, like the world is giving {target_name} one last chance to walk away. Then {attacker_name} breathes out, and the blade begins to move."
         },
         {
-            'attacker_msg': "You breathe in deep, the way some people pray. The shiv is already in your hand, and the moment is already lost.",
+            'attacker_msg': "You breathe in deep, the way some people pray. The shiv is already in your {hit_location}, and the moment is already lost.",
             'victim_msg': "{attacker_name} breathes in deep, the way some people pray. The shiv is already in their hand, and the moment is already lost.",
             'observer_msg': "{attacker_name} breathes in deep, the way some people pray. The shiv is already in their hand, and the moment is already lost."
         },
@@ -96,7 +96,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} pulls the shiv with fingers that tremble—not from fear, but anticipation. The room tightens around them like a drumskin. The blade doesn't hum—it waits. It knows it will be fed soon."
         },
         {
-            'attacker_msg': "You crack your neck and breathe out slow, as if violence is the only language you ever learned fluently. The shiv is your punctuation. In that flicker of steel, you can almost hear it whisper.",
+            'attacker_msg': "You crack your {hit_location} and breathe out slow, as if violence is the only language you ever learned fluently. The shiv is your punctuation. In that flicker of steel, you can almost hear it whisper.",
             'victim_msg': "{attacker_name} cracks their neck and breathes out slow, as if violence is the only language they ever learned fluently. The shiv is their punctuation. In that flicker of steel, you can almost hear it whisper.",
             'observer_msg': "{attacker_name} cracks their neck and breathes out slow, as if violence is the only language they ever learned fluently. The shiv is their punctuation. In that flicker of steel, you can almost hear it whisper."
         },
@@ -111,7 +111,7 @@ MESSAGES = {
             'observer_msg': "No theatrics. {attacker_name} just steps forward and opens the scene with a flick of steel. It's not a warning. It's a promise. The silence around them becomes dense, syrupy. The violence is implied."
         },
         {
-            'attacker_msg': "You tilt your head like you're listening to something distant. Then the shiv is in your hand, and the silence ends. You feel it, too—that crackle of static before something ruptures.",
+            'attacker_msg': "You tilt your {hit_location} like you're listening to something distant. Then the shiv is in your {hit_location}, and the silence ends. You feel it, too—that crackle of static before something ruptures.",
             'victim_msg': "{attacker_name} tilts their head like they're listening to something distant. Then the shiv is in their hand, and the silence ends. You feel it, too—that crackle of static before something ruptures.",
             'observer_msg': "{attacker_name} tilts their head like they're listening to something distant. Then the shiv is in their hand, and the silence ends. You feel it, too—that crackle of static before something ruptures."
         },
@@ -126,7 +126,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} draws the shiv like a memory they wish they could forget. The blade is crude, worn down to jagged metal. Their eyes say they don't plan to miss. Nothing about this is casual. The weight of the moment stains the air."
         },
         {
-            'attacker_msg': "You move slow, savoring the moment. The shiv glints like a broken promise in your grip, catching the light—and maybe {target_name}'s reflection. There's no tremble in your wrist. Just inevitability.",
+            'attacker_msg': "You move slow, savoring the moment. The shiv glints like a broken promise in your grip, catching the light—and maybe {target_name}'s reflection. There's no tremble in your {hit_location}. Just inevitability.",
             'victim_msg': "{attacker_name} moves slow, savoring the moment. The shiv glints like a broken promise in their grip, catching the light—and maybe your reflection. There's no tremble in their wrist. Just inevitability.",
             'observer_msg': "{attacker_name} moves slow, savoring the moment. The shiv glints like a broken promise in their grip, catching the light—and maybe {target_name}'s reflection. There's no tremble in their wrist. Just inevitability."
         },
@@ -218,9 +218,9 @@ MESSAGES = {
             'observer_msg': "The shiv finds the soft spot below {target_name}'s {hit_location} and whispers its way deeper. Their eyes flutter like they're trying to wake up from a dream they can't escape."
         },
         {
-            'attacker_msg': "You feel the resistance give way as the blade pierces {target_name}'s lung. Their breath becomes shallow, urgent—like they're trying to fill a bag with holes.",
-            'victim_msg': "You feel the resistance give way as the blade pierces your lung. Your breath becomes shallow, urgent—like you're trying to fill a bag with holes.",
-            'observer_msg': "You feel the resistance give way as the blade pierces {target_name}'s lung. Their breath becomes shallow, urgent—like they're trying to fill a bag with holes."
+            'attacker_msg': "You feel the resistance give way as the blade pierces {target_name}'s {hit_location}. Their breath becomes shallow, urgent—like they're trying to fill a bag with holes.",
+            'victim_msg': "You feel the resistance give way as the blade pierces your {hit_location}. Your breath becomes shallow, urgent—like you're trying to fill a bag with holes.",
+            'observer_msg': "You feel the resistance give way as the blade pierces {target_name}'s {hit_location}. Their breath becomes shallow, urgent—like they're trying to fill a bag with holes."
         },
         {
             'attacker_msg': "The thrust is intimate, almost tender. You guide the shiv between {target_name}'s {hit_location} like you're tucking them into bed. Forever.",
@@ -338,9 +338,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} guides the blade between {target_name}'s {hit_location} with the precision of someone threading a needle in dim light. {target_name} exhales once, long and slow, like they're letting go of something heavy they've been carrying for years."
         },
         {
-            'attacker_msg': "The tip finds {target_name}'s lung with surgical precision, and their breath becomes a wheeze, then a whisper, then nothing at all. You hold the hilt steady as their life drains away around the edges.",
-            'victim_msg': "The tip finds your lung with surgical precision, and your breath becomes a wheeze, then a whisper, then nothing at all. {attacker_name} holds the hilt steady as your life drains away around the edges.",
-            'observer_msg': "The tip finds {target_name}'s lung with surgical precision, and their breath becomes a wheeze, then a whisper, then nothing at all. {attacker_name} holds the hilt steady as {target_name}'s life drains away around the edges."
+            'attacker_msg': "The tip finds {target_name}'s {hit_location} with surgical precision, and their breath becomes a wheeze, then a whisper, then nothing at all. You hold the hilt steady as their life drains away around the edges.",
+            'victim_msg': "The tip finds your {hit_location} with surgical precision, and your breath becomes a wheeze, then a whisper, then nothing at all. {attacker_name} holds the hilt steady as your life drains away around the edges.",
+            'observer_msg': "The tip finds {target_name}'s {hit_location} with surgical precision, and their breath becomes a wheeze, then a whisper, then nothing at all. {attacker_name} holds the hilt steady as {target_name}'s life drains away around the edges."
         },
         {
             'attacker_msg': "You slide the shiv up under {target_name}'s {hit_location} with the tenderness of someone tucking a child into bed. They look at you with eyes that are already somewhere else, and their lips move around a word they can't quite form.",
@@ -365,9 +365,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s thrust slides past {target_name} like smoke through fingers. The shiv tastes only air, hungry and unsatisfied."
         },
         {
-            'attacker_msg': "The blade whispers past {target_name}'s ribs, close enough to count their heartbeats. Next time, you think. Next time.",
-            'victim_msg': "The blade whispers past your ribs, close enough to count your heartbeats. Next time, you think {attacker_name} thinks. Next time.",
-            'observer_msg': "The blade whispers past {target_name}'s ribs, close enough to count their heartbeats. Next time, {attacker_name} seems to think. Next time."
+            'attacker_msg': "The blade whispers past {target_name}'s {hit_location}, close enough to count their heartbeats. Next time, you think. Next time.",
+            'victim_msg': "The blade whispers past your {hit_location}, close enough to count your heartbeats. Next time, you think {attacker_name} thinks. Next time.",
+            'observer_msg': "The blade whispers past {target_name}'s {hit_location}, close enough to count their heartbeats. Next time, {attacker_name} seems to think. Next time."
         },
         {
             'attacker_msg': "{target_name} twists away at the last second, and your shiv cuts only shadow. The moment hangs in the air like smoke.",
@@ -425,9 +425,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} slices through the space {target_name} occupied a moment ago. The shiv trembles in {attacker_name}'s grip, frustrated by the absence of contact."
         },
         {
-            'attacker_msg': "The blade whispers past {target_name}'s throat, close enough to fog with their breath. Almost. Almost is the cruelest word.",
-            'victim_msg': "The blade whispers past your throat, close enough to fog with your breath. Almost. Almost is the cruelest word.",
-            'observer_msg': "The blade whispers past {target_name}'s throat, close enough to fog with their breath. Almost. Almost is the cruelest word."
+            'attacker_msg': "The blade whispers past {target_name}'s {hit_location}, close enough to fog with their breath. Almost. Almost is the cruelest word.",
+            'victim_msg': "The blade whispers past your {hit_location}, close enough to fog with your breath. Almost. Almost is the cruelest word.",
+            'observer_msg': "The blade whispers past {target_name}'s {hit_location}, close enough to fog with their breath. Almost. Almost is the cruelest word."
         },
         {
             'attacker_msg': "{target_name} flows around your strike like water around a rock. The shiv finds only empty space and the echo of possibility.",
@@ -490,9 +490,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s thrust goes wide, and the shiv parts air that tastes of missed opportunities. {target_name} is already three steps ahead of {attacker_name}'s intentions."
         },
         {
-            'attacker_msg': "The blade whispers past {target_name}'s ribs, close enough to steal warmth from their skin. Your jaw tightens—proximity is not contact.",
-            'victim_msg': "The blade whispers past your ribs, close enough to steal warmth from your skin. {attacker_name}'s jaw tightens—proximity is not contact.",
-            'observer_msg': "The blade whispers past {target_name}'s ribs, close enough to steal warmth from their skin. {attacker_name}'s jaw tightens—proximity is not contact."
+            'attacker_msg': "The blade whispers past {target_name}'s {hit_location}, close enough to steal warmth from their skin. Your {hit_location} tightens—proximity is not contact.",
+            'victim_msg': "The blade whispers past your {hit_location}, close enough to steal warmth from your skin. {attacker_name}'s jaw tightens—proximity is not contact.",
+            'observer_msg': "The blade whispers past {target_name}'s {hit_location}, close enough to steal warmth from their skin. {attacker_name}'s jaw tightens—proximity is not contact."
         },
         {
             'attacker_msg': "{target_name} weaves through your strike like smoke through a screen door. The shiv finds only empty space and the echo of what might have been violence.",
@@ -587,14 +587,14 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "The shiv finds {target_name}'s heart with the precision of a key finding its lock. They exhale once, long and slow, and the light goes out of their eyes like candles in a sudden wind.",
-            'victim_msg': "The shiv finds your heart with the precision of a key finding its lock. You exhale once, long and slow, and the light goes out of your eyes like candles in a sudden wind.",
-            'observer_msg': "The shiv finds {target_name}'s heart with the precision of a key finding its lock. {target_name} exhales once, long and slow, and the light goes out of their eyes like candles in a sudden wind."
+            'attacker_msg': "The shiv finds {target_name}'s {hit_location} with the precision of a key finding its lock. They exhale once, long and slow, and the light goes out of their eyes like candles in a sudden wind.",
+            'victim_msg': "The shiv finds your {hit_location} with the precision of a key finding its lock. You exhale once, long and slow, and the light goes out of your eyes like candles in a sudden wind.",
+            'observer_msg': "The shiv finds {target_name}'s {hit_location} with the precision of a key finding its lock. {target_name} exhales once, long and slow, and the light goes out of their eyes like candles in a sudden wind."
         },
         {
-            'attacker_msg': "You slide the blade up under {target_name}'s ribs with surgical precision. They look at you with eyes that are already somewhere else, and then they aren't looking at anything at all.",
-            'victim_msg': "{attacker_name} slides the blade up under your ribs with surgical precision. You look at them with eyes that are already somewhere else, and then you aren't looking at anything at all.",
-            'observer_msg': "{attacker_name} slides the blade up under {target_name}'s ribs with surgical precision. {target_name} looks at them with eyes that are already somewhere else, and then they aren't looking at anything at all."
+            'attacker_msg': "You slide the blade up under {target_name}'s {hit_location} with surgical precision. They look at you with eyes that are already somewhere else, and then they aren't looking at anything at all.",
+            'victim_msg': "{attacker_name} slides the blade up under your {hit_location} with surgical precision. You look at them with eyes that are already somewhere else, and then you aren't looking at anything at all.",
+            'observer_msg': "{attacker_name} slides the blade up under {target_name}'s {hit_location} with surgical precision. {target_name} looks at them with eyes that are already somewhere else, and then they aren't looking at anything at all."
         },
         {
             'attacker_msg': "The shiv parts {target_name}'s flesh like water, finding the space between heartbeats and staying there. They crumple like paper in rain, all structure suddenly gone.",
@@ -607,9 +607,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} feels {target_name}'s life leak out around the blade like secrets through cracked lips. {target_name}'s knees buckle, and they fold into the shape of surrender."
         },
         {
-            'attacker_msg': "The blade finds {target_name}'s lung with intimate precision. Their breath becomes a wheeze, then a whisper, then nothing. They collapse like a building whose foundation has been cut away.",
-            'victim_msg': "The blade finds your lung with intimate precision. Your breath becomes a wheeze, then a whisper, then nothing. You collapse like a building whose foundation has been cut away.",
-            'observer_msg': "The blade finds {target_name}'s lung with intimate precision. Their breath becomes a wheeze, then a whisper, then nothing. {target_name} collapses like a building whose foundation has been cut away."
+            'attacker_msg': "The blade finds {target_name}'s {hit_location} with intimate precision. Their breath becomes a wheeze, then a whisper, then nothing. They collapse like a building whose foundation has been cut away.",
+            'victim_msg': "The blade finds your {hit_location} with intimate precision. Your breath becomes a wheeze, then a whisper, then nothing. You collapse like a building whose foundation has been cut away.",
+            'observer_msg': "The blade finds {target_name}'s {hit_location} with intimate precision. Their breath becomes a wheeze, then a whisper, then nothing. {target_name} collapses like a building whose foundation has been cut away."
         },
         {
             'attacker_msg': "You twist the shiv like you're turning off a tap, and {target_name}'s life spills out around your fingers. They look at you with fading eyes that still hold questions they'll never get to ask.",
@@ -617,9 +617,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} twists the shiv like they're turning off a tap, and {target_name}'s life spills out around their fingers. {target_name} looks at them with fading eyes that still hold questions they'll never get to ask."
         },
         {
-            'attacker_msg': "The shiv slides between {target_name}'s ribs like a lover's promise. They exhale once, sharp and surprised, and then the sound fades like an echo in an empty room.",
-            'victim_msg': "The shiv slides between your ribs like a lover's promise. You exhale once, sharp and surprised, and then the sound fades like an echo in an empty room.",
-            'observer_msg': "The shiv slides between {target_name}'s ribs like a lover's promise. {target_name} exhales once, sharp and surprised, and then the sound fades like an echo in an empty room."
+            'attacker_msg': "The shiv slides between {target_name}'s {hit_location} like a lover's promise. They exhale once, sharp and surprised, and then the sound fades like an echo in an empty room.",
+            'victim_msg': "The shiv slides between your {hit_location} like a lover's promise. You exhale once, sharp and surprised, and then the sound fades like an echo in an empty room.",
+            'observer_msg': "The shiv slides between {target_name}'s {hit_location} like a lover's promise. {target_name} exhales once, sharp and surprised, and then the sound fades like an echo in an empty room."
         },
         {
             'attacker_msg': "You feel {target_name}'s heartbeat through the steel, rapid and urgent, then slower, then gone. They sink to the ground like they're genuflecting before death itself.",
@@ -627,9 +627,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} feels {target_name}'s heartbeat through the steel, rapid and urgent, then slower, then gone. {target_name} sinks to the ground like they're genuflecting before death itself."
         },
         {
-            'attacker_msg': "The blade finds the soft space below {target_name}'s sternum and whispers its way to their heart. They look down at the growing red stain with the detached curiosity of someone reading their own obituary.",
-            'victim_msg': "The blade finds the soft space below your sternum and whispers its way to your heart. You look down at the growing red stain with the detached curiosity of someone reading their own obituary.",
-            'observer_msg': "The blade finds the soft space below {target_name}'s sternum and whispers its way to their heart. {target_name} looks down at the growing red stain with the detached curiosity of someone reading their own obituary."
+            'attacker_msg': "The blade finds the soft space below {target_name}'s {hit_location} and whispers its way to their heart. They look down at the growing red stain with the detached curiosity of someone reading their own obituary.",
+            'victim_msg': "The blade finds the soft space below your {hit_location} and whispers its way to your {hit_location}. You look down at the growing red stain with the detached curiosity of someone reading their own obituary.",
+            'observer_msg': "The blade finds the soft space below {target_name}'s {hit_location} and whispers its way to their heart. {target_name} looks down at the growing red stain with the detached curiosity of someone reading their own obituary."
         },
         {
             'attacker_msg': "You slide the shiv home with the tenderness of someone tucking a child into bed. {target_name}'s eyes flutter once, twice, then go still as pond water on windless day.",
@@ -637,9 +637,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} slides the shiv home with the tenderness of someone tucking a child into bed. {target_name}'s eyes flutter once, twice, then go still as pond water on windless day."
         },
         {
-            'attacker_msg': "The shiv parts {target_name}'s ribs like curtains, and behind them you find the darkness they've been hiding. They collapse into it gratefully, like coming home.",
-            'victim_msg': "The shiv parts your ribs like curtains, and behind them {attacker_name} finds the darkness you've been hiding. You collapse into it gratefully, like coming home.",
-            'observer_msg': "The shiv parts {target_name}'s ribs like curtains, and behind them {attacker_name} finds the darkness they've been hiding. {target_name} collapses into it gratefully, like coming home."
+            'attacker_msg': "The shiv parts {target_name}'s {hit_location} like curtains, and behind them you find the darkness they've been hiding. They collapse into it gratefully, like coming home.",
+            'victim_msg': "The shiv parts your {hit_location} like curtains, and behind them {attacker_name} finds the darkness you've been hiding. You collapse into it gratefully, like coming home.",
+            'observer_msg': "The shiv parts {target_name}'s {hit_location} like curtains, and behind them {attacker_name} finds the darkness they've been hiding. {target_name} collapses into it gratefully, like coming home."
         },
         {
             'attacker_msg': "You twist the blade with surgical precision, and {target_name}'s life unravels like a sweater with a pulled thread. They fold to the ground as if gravity has finally remembered them.",
@@ -647,19 +647,19 @@ MESSAGES = {
             'observer_msg': "{attacker_name} twists the blade with surgical precision, and {target_name}'s life unravels like a sweater with a pulled thread. {target_name} folds to the ground as if gravity has finally remembered them."
         },
         {
-            'attacker_msg': "The shiv finds {target_name}'s heart with the inevitability of water finding the sea. They breathe out once, long and slow, and the sound carries everything they'll never say again.",
-            'victim_msg': "The shiv finds your heart with the inevitability of water finding the sea. You breathe out once, long and slow, and the sound carries everything you'll never say again.",
-            'observer_msg': "The shiv finds {target_name}'s heart with the inevitability of water finding the sea. {target_name} breathes out once, long and slow, and the sound carries everything they'll never say again."
+            'attacker_msg': "The shiv finds {target_name}'s {hit_location} with the inevitability of water finding the sea. They breathe out once, long and slow, and the sound carries everything they'll never say again.",
+            'victim_msg': "The shiv finds your {hit_location} with the inevitability of water finding the sea. You breathe out once, long and slow, and the sound carries everything you'll never say again.",
+            'observer_msg': "The shiv finds {target_name}'s {hit_location} with the inevitability of water finding the sea. {target_name} breathes out once, long and slow, and the sound carries everything they'll never say again."
         },
         {
-            'attacker_msg': "You feel the resistance give way as the blade punctures {target_name}'s lung. They gasp like fish on dry land, and then the gasping stops, and the silence is complete.",
-            'victim_msg': "You feel the resistance give way as the blade punctures your lung. You gasp like fish on dry land, and then the gasping stops, and the silence is complete.",
-            'observer_msg': "The resistance gives way as the blade punctures {target_name}'s lung. {target_name} gasps like fish on dry land, and then the gasping stops, and the silence is complete."
+            'attacker_msg': "You feel the resistance give way as the blade punctures {target_name}'s {hit_location}. They gasp like fish on dry land, and then the gasping stops, and the silence is complete.",
+            'victim_msg': "You feel the resistance give way as the blade punctures your {hit_location}. You gasp like fish on dry land, and then the gasping stops, and the silence is complete.",
+            'observer_msg': "The resistance gives way as the blade punctures {target_name}'s {hit_location}. {target_name} gasps like fish on dry land, and then the gasping stops, and the silence is complete."
         },
         {
-            'attacker_msg': "The shiv disappears into {target_name}'s chest with a sound like tearing silk. They look at you with eyes that are already going somewhere else, and then they arrive.",
-            'victim_msg': "The shiv disappears into your chest with a sound like tearing silk. You look at {attacker_name} with eyes that are already going somewhere else, and then you arrive.",
-            'observer_msg': "The shiv disappears into {target_name}'s chest with a sound like tearing silk. {target_name} looks at {attacker_name} with eyes that are already going somewhere else, and then they arrive."
+            'attacker_msg': "The shiv disappears into {target_name}'s {hit_location} with a sound like tearing silk. They look at you with eyes that are already going somewhere else, and then they arrive.",
+            'victim_msg': "The shiv disappears into your {hit_location} with a sound like tearing silk. You look at {attacker_name} with eyes that are already going somewhere else, and then you arrive.",
+            'observer_msg': "The shiv disappears into {target_name}'s {hit_location} with a sound like tearing silk. {target_name} looks at {attacker_name} with eyes that are already going somewhere else, and then they arrive."
         },
         {
             'attacker_msg': "You guide the blade between {target_name}'s fourth and fifth ribs like threading a needle in dim light. They exhale in syllables that spell surrender, and then there are no more words.",
@@ -672,9 +672,9 @@ MESSAGES = {
             'observer_msg': "The shiv finds the space between {target_name}'s heartbeats and stays there. {target_name} crumples like origami in rain, all their careful folds coming undone at once."
         },
         {
-            'attacker_msg': "You slide the blade up under {target_name}'s sternum with the precision of someone unlocking a door. They look at you with eyes that say they understand the joke, and then the laughter dies in their throat.",
-            'victim_msg': "{attacker_name} slides the blade up under your sternum with the precision of someone unlocking a door. You look at them with eyes that say you understand the joke, and then the laughter dies in your throat.",
-            'observer_msg': "{attacker_name} slides the blade up under {target_name}'s sternum with the precision of someone unlocking a door. {target_name} looks at them with eyes that say they understand the joke, and then the laughter dies in their throat."
+            'attacker_msg': "You slide the blade up under {target_name}'s {hit_location} with the precision of someone unlocking a door. They look at you with eyes that say they understand the joke, and then the laughter dies in their throat.",
+            'victim_msg': "{attacker_name} slides the blade up under your {hit_location} with the precision of someone unlocking a door. You look at them with eyes that say you understand the joke, and then the laughter dies in your {hit_location}.",
+            'observer_msg': "{attacker_name} slides the blade up under {target_name}'s {hit_location} with the precision of someone unlocking a door. {target_name} looks at them with eyes that say they understand the joke, and then the laughter dies in their throat."
         },
         {
             'attacker_msg': "The shiv parts {target_name}'s flesh like water, and behind it you find the silence they've been carrying. They sink into it like stones into a still pond.",
@@ -687,9 +687,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} feels {target_name}'s pulse through the hilt, rapid and frightened, then slower, then gone entirely. {target_name} folds to the ground as if they're genuflecting before something vast and dark."
         },
         {
-            'attacker_msg': "The blade finds {target_name}'s lung with surgical precision. Their breath becomes shallow, urgent, then stops entirely, like a song that's forgotten its next note.",
-            'victim_msg': "The blade finds your lung with surgical precision. Your breath becomes shallow, urgent, then stops entirely, like a song that's forgotten its next note.",
-            'observer_msg': "The blade finds {target_name}'s lung with surgical precision. Their breath becomes shallow, urgent, then stops entirely, like a song that's forgotten its next note."
+            'attacker_msg': "The blade finds {target_name}'s {hit_location} with surgical precision. Their breath becomes shallow, urgent, then stops entirely, like a song that's forgotten its next note.",
+            'victim_msg': "The blade finds your {hit_location} with surgical precision. Your breath becomes shallow, urgent, then stops entirely, like a song that's forgotten its next note.",
+            'observer_msg': "The blade finds {target_name}'s {hit_location} with surgical precision. Their breath becomes shallow, urgent, then stops entirely, like a song that's forgotten its next note."
         },
         {
             'attacker_msg': "You twist the shiv with the patience of someone solving a puzzle, and {target_name}'s life comes apart in your hands. They look at you with eyes that are already cataloguing their regrets.",
@@ -697,19 +697,19 @@ MESSAGES = {
             'observer_msg': "{attacker_name} twists the shiv with the patience of someone solving a puzzle, and {target_name}'s life comes apart in their hands. {target_name} looks at them with eyes that are already cataloguing their regrets."
         },
         {
-            'attacker_msg': "The shiv slides between {target_name}'s ribs like it belongs there, finding home in the spaces between certainties. They exhale everything they'll never say again.",
-            'victim_msg': "The shiv slides between your ribs like it belongs there, finding home in the spaces between certainties. You exhale everything you'll never say again.",
-            'observer_msg': "The shiv slides between {target_name}'s ribs like it belongs there, finding home in the spaces between certainties. {target_name} exhales everything they'll never say again."
+            'attacker_msg': "The shiv slides between {target_name}'s {hit_location} like it belongs there, finding home in the spaces between certainties. They exhale everything they'll never say again.",
+            'victim_msg': "The shiv slides between your {hit_location} like it belongs there, finding home in the spaces between certainties. You exhale everything you'll never say again.",
+            'observer_msg': "The shiv slides between {target_name}'s {hit_location} like it belongs there, finding home in the spaces between certainties. {target_name} exhales everything they'll never say again."
         },
         {
-            'attacker_msg': "You guide the blade to {target_name}'s heart with the tenderness of someone delivering a letter. They read it with their eyes, and understanding arrives just before the darkness.",
-            'victim_msg': "{attacker_name} guides the blade to your heart with the tenderness of someone delivering a letter. You read it with your eyes, and understanding arrives just before the darkness.",
-            'observer_msg': "{attacker_name} guides the blade to {target_name}'s heart with the tenderness of someone delivering a letter. {target_name} reads it with their eyes, and understanding arrives just before the darkness."
+            'attacker_msg': "You guide the blade to {target_name}'s {hit_location} with the tenderness of someone delivering a letter. They read it with their eyes, and understanding arrives just before the darkness.",
+            'victim_msg': "{attacker_name} guides the blade to your {hit_location} with the tenderness of someone delivering a letter. You read it with your eyes, and understanding arrives just before the darkness.",
+            'observer_msg': "{attacker_name} guides the blade to {target_name}'s {hit_location} with the tenderness of someone delivering a letter. {target_name} reads it with their eyes, and understanding arrives just before the darkness."
         },
         {
-            'attacker_msg': "The shiv finds the soft space below {target_name}'s ribs and whispers its way deeper. They collapse like a marionette whose strings have been cut all at once.",
-            'victim_msg': "The shiv finds the soft space below your ribs and whispers its way deeper. You collapse like a marionette whose strings have been cut all at once.",
-            'observer_msg': "The shiv finds the soft space below {target_name}'s ribs and whispers its way deeper. {target_name} collapses like a marionette whose strings have been cut all at once."
+            'attacker_msg': "The shiv finds the soft space below {target_name}'s {hit_location} and whispers its way deeper. They collapse like a marionette whose strings have been cut all at once.",
+            'victim_msg': "The shiv finds the soft space below your {hit_location} and whispers its way deeper. You collapse like a marionette whose strings have been cut all at once.",
+            'observer_msg': "The shiv finds the soft space below {target_name}'s {hit_location} and whispers its way deeper. {target_name} collapses like a marionette whose strings have been cut all at once."
         },
         {
             'attacker_msg': "You feel {target_name}'s heartbeat through the steel, desperate and rapid, then slower, then quiet as snow falling on abandoned streets. They sink to their knees like they're praying to gravity.",
@@ -727,9 +727,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} slides the shiv up under {target_name}'s ribcage like picking a lock to a door they've opened before. {target_name} exhales in broken syllables that spell regret, and then there's nothing left to spell."
         },
         {
-            'attacker_msg': "The shiv finds {target_name}'s heart with the inevitability of water finding cracks in concrete. They crumple like paper in rain, all their careful structure dissolving at once.",
-            'victim_msg': "The shiv finds your heart with the inevitability of water finding cracks in concrete. You crumple like paper in rain, all your careful structure dissolving at once.",
-            'observer_msg': "The shiv finds {target_name}'s heart with the inevitability of water finding cracks in concrete. {target_name} crumples like paper in rain, all their careful structure dissolving at once."
+            'attacker_msg': "The shiv finds {target_name}'s {hit_location} with the inevitability of water finding cracks in concrete. They crumple like paper in rain, all their careful structure dissolving at once.",
+            'victim_msg': "The shiv finds your {hit_location} with the inevitability of water finding cracks in concrete. You crumple like paper in rain, all your careful structure dissolving at once.",
+            'observer_msg': "The shiv finds {target_name}'s {hit_location} with the inevitability of water finding cracks in concrete. {target_name} crumples like paper in rain, all their careful structure dissolving at once."
         },
         {
             'attacker_msg': "You twist the blade with surgical precision, and {target_name}'s life unravels like thread pulled from cloth. They look at you with eyes that are already reading the punchline to a joke they don't want to understand.",
@@ -737,9 +737,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} twists the blade with surgical precision, and {target_name}'s life unravels like thread pulled from cloth. {target_name} looks at them with eyes that are already reading the punchline to a joke they don't want to understand."
         },
         {
-            'attacker_msg': "The shiv parts {target_name}'s ribs like curtains being drawn back, and behind them you find the darkness they've been hiding from. They step into it like coming home after a long, hard day.",
-            'victim_msg': "The shiv parts your ribs like curtains being drawn back, and behind them {attacker_name} finds the darkness you've been hiding from. You step into it like coming home after a long, hard day.",
-            'observer_msg': "The shiv parts {target_name}'s ribs like curtains being drawn back, and behind them {attacker_name} finds the darkness they've been hiding from. {target_name} steps into it like coming home after a long, hard day."
+            'attacker_msg': "The shiv parts {target_name}'s {hit_location} like curtains being drawn back, and behind them you find the darkness they've been hiding from. They step into it like coming home after a long, hard day.",
+            'victim_msg': "The shiv parts your {hit_location} like curtains being drawn back, and behind them {attacker_name} finds the darkness you've been hiding from. You step into it like coming home after a long, hard day.",
+            'observer_msg': "The shiv parts {target_name}'s {hit_location} like curtains being drawn back, and behind them {attacker_name} finds the darkness they've been hiding from. {target_name} steps into it like coming home after a long, hard day."
         },
         {
             'attacker_msg': "You feel {target_name}'s pulse through the hilt, rapid and frightened, then slower, then gone like echoes in an empty cathedral. They collapse as if they're genuflecting before something too vast to comprehend.",
@@ -757,9 +757,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} slides the shiv home with the precision of someone threading a needle in perfect darkness. {target_name} looks at them with eyes that are already somewhere else, somewhere quiet and far away from the sound of breaking."
         },
         {
-            'attacker_msg': "The shiv finds {target_name}'s lung with intimate precision. Their breath becomes shallow, urgent, then stops entirely, like a song that's forgotten how to continue. They fold to the ground as if gravity has finally won an argument they've been having their entire life.",
-            'victim_msg': "The shiv finds your lung with intimate precision. Your breath becomes shallow, urgent, then stops entirely, like a song that's forgotten how to continue. You fold to the ground as if gravity has finally won an argument you've been having your entire life.",
-            'observer_msg': "The shiv finds {target_name}'s lung with intimate precision. Their breath becomes shallow, urgent, then stops entirely, like a song that's forgotten how to continue. {target_name} folds to the ground as if gravity has finally won an argument they've been having their entire life."
+            'attacker_msg': "The shiv finds {target_name}'s {hit_location} with intimate precision. Their breath becomes shallow, urgent, then stops entirely, like a song that's forgotten how to continue. They fold to the ground as if gravity has finally won an argument they've been having their entire life.",
+            'victim_msg': "The shiv finds your {hit_location} with intimate precision. Your breath becomes shallow, urgent, then stops entirely, like a song that's forgotten how to continue. You fold to the ground as if gravity has finally won an argument you've been having your entire life.",
+            'observer_msg': "The shiv finds {target_name}'s {hit_location} with intimate precision. Their breath becomes shallow, urgent, then stops entirely, like a song that's forgotten how to continue. {target_name} folds to the ground as if gravity has finally won an argument they've been having their entire life."
         },
         {
             'attacker_msg': "You twist the blade like turning a page in a book you've read before, and {target_name}'s story comes to its inevitable conclusion. They look at you with eyes that hold all their unfinished sentences, and then the sentences dissolve into silence.",
@@ -767,9 +767,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} twists the blade like turning a page in a book they've read before, and {target_name}'s story comes to its inevitable conclusion. {target_name} looks at them with eyes that hold all their unfinished sentences, and then the sentences dissolve into silence."
         },
         {
-            'attacker_msg': "The shiv disappears into {target_name}'s chest with a sound like silk tearing in slow motion. They exhale everything they are and everything they might have been, and then there's nothing left to exhale.",
-            'victim_msg': "The shiv disappears into your chest with a sound like silk tearing in slow motion. You exhale everything you are and everything you might have been, and then there's nothing left to exhale.",
-            'observer_msg': "The shiv disappears into {target_name}'s chest with a sound like silk tearing in slow motion. {target_name} exhales everything they are and everything they might have been, and then there's nothing left to exhale."
+            'attacker_msg': "The shiv disappears into {target_name}'s {hit_location} with a sound like silk tearing in slow motion. They exhale everything they are and everything they might have been, and then there's nothing left to exhale.",
+            'victim_msg': "The shiv disappears into your {hit_location} with a sound like silk tearing in slow motion. You exhale everything you are and everything you might have been, and then there's nothing left to exhale.",
+            'observer_msg': "The shiv disappears into {target_name}'s {hit_location} with a sound like silk tearing in slow motion. {target_name} exhales everything they are and everything they might have been, and then there's nothing left to exhale."
         },
         {
             'attacker_msg': "You feel {target_name}'s heartbeat through the steel, desperate and rapid, then slower, then quiet as prayer in an empty church. They sink to their knees like they're finally surrendering to something they can't name.",

--- a/world/combat/messages/shovel.py
+++ b/world/combat/messages/shovel.py
@@ -111,7 +111,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} drags the edge across the ground. Sparks follow. So does certainty."
         },
         {
-            'attacker_msg': "You flip the shovel in your hand, blade first, like you're weighing more than steel.",
+            'attacker_msg': "You flip the shovel in your {hit_location}, blade first, like you're weighing more than steel.",
             'victim_msg': "{attacker_name} flips the shovel in their hand, blade first, like they're weighing more than steel.",
             'observer_msg': "{attacker_name} flips the shovel in their hand, blade first, like they're weighing more than steel."
         },
@@ -131,7 +131,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} grips the shovel's splintered handle like an old friend they've buried secrets with."
         },
         {
-            'attacker_msg': "You hoist the shovel over your shoulder like a grave digger with different plans.",
+            'attacker_msg': "You hoist the shovel over your {hit_location} like a grave digger with different plans.",
             'victim_msg': "{attacker_name} hoists the shovel over their shoulder like a grave digger with different plans.",
             'observer_msg': "{attacker_name} hoists the shovel over their shoulder like a grave digger with different plans."
         },
@@ -351,8 +351,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The shovel clangs off a pipe above their head. Close — but not close enough.",
-            'victim_msg': "The shovel clangs off a pipe above your head. Close — but not close enough.",
-            'observer_msg': "The shovel clangs off a pipe above {target_name}'s head. Close — but not close enough."
+            'victim_msg': "The shovel clangs off a pipe above your {hit_location}. Close — but not close enough.",
+            'observer_msg': "The shovel clangs off a pipe above {target_name}'s {hit_location}. Close — but not close enough."
         },
         {
             'attacker_msg': "The shovel gouges the floor where they stood a second ago.",
@@ -406,8 +406,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Your blade carves empty air where a head used to be.",
-            'victim_msg': "{attacker_name}'s blade carves empty air where your head used to be.",
-            'observer_msg': "{attacker_name}'s blade carves empty air where {target_name}'s head used to be."
+            'victim_msg': "{attacker_name}'s blade carves empty air where your {hit_location} used to be.",
+            'observer_msg': "{attacker_name}'s blade carves empty air where {target_name}'s {hit_location} used to be."
         },
         {
             'attacker_msg': "Your follow-through is flawless. The target is already gone.",
@@ -458,23 +458,23 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "A downward slam connects with the neck. The head jerks, then the body drops.",
-            'victim_msg': "A downward slam connects with your neck. Your head jerks, then your body drops.",
-            'observer_msg': "A downward slam connects with {target_name}'s neck. Their head jerks, then the body drops."
+            'victim_msg': "A downward slam connects with your {hit_location}. Your {hit_location} jerks, then your body drops.",
+            'observer_msg': "A downward slam connects with {target_name}'s {hit_location}. Their head jerks, then the body drops."
         },
         {
             'attacker_msg': "A full swing smashes into the head. The echo is brief. The result is forever.",
-            'victim_msg': "A full swing smashes into your head. The echo is brief. The result is forever.",
-            'observer_msg': "A full swing smashes into {target_name}'s head. The echo is brief. The result is forever."
+            'victim_msg': "A full swing smashes into your {hit_location}. The echo is brief. The result is forever.",
+            'observer_msg': "A full swing smashes into {target_name}'s {hit_location}. The echo is brief. The result is forever."
         },
         {
             'attacker_msg': "A rising swing caves in the jaw, then the silence. They are done.",
-            'victim_msg': "A rising swing caves in your jaw, then the silence. You are done.",
-            'observer_msg': "A rising swing caves in {target_name}'s jaw, then the silence. They are done."
+            'victim_msg': "A rising swing caves in your {hit_location}, then the silence. You are done.",
+            'observer_msg': "A rising swing caves in {target_name}'s {hit_location}, then the silence. They are done."
         },
         {
             'attacker_msg': "A sideways cleave to the head. They drop instantly, like the shovel hit the off switch.",
-            'victim_msg': "A sideways cleave to your head. You drop instantly, like the shovel hit the off switch.",
-            'observer_msg': "A sideways cleave to {target_name}'s head. They drop instantly, like the shovel hit the off switch."
+            'victim_msg': "A sideways cleave to your {hit_location}. You drop instantly, like the shovel hit the off switch.",
+            'observer_msg': "A sideways cleave to {target_name}'s {hit_location}. They drop instantly, like the shovel hit the off switch."
         },
         {
             'attacker_msg': "A vertical strike lands on the crown. They fold like fabric in a storm.",
@@ -483,8 +483,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "One crack to the side of the skull. The impact ends everything that came before.",
-            'victim_msg': "One crack to the side of your skull. The impact ends everything that came before.",
-            'observer_msg': "One crack to the side of {target_name}'s skull. The impact ends everything that came before."
+            'victim_msg': "One crack to the side of your {hit_location}. The impact ends everything that came before.",
+            'observer_msg': "One crack to the side of {target_name}'s {hit_location}. The impact ends everything that came before."
         },
         {
             'attacker_msg': "One jab under the chin and the edge tears upward. Blood arcs. They fall.",
@@ -493,28 +493,28 @@ MESSAGES = {
         },
         {
             'attacker_msg': "One sharp upward arc crashes into the chin. The head snaps back and never returns.",
-            'victim_msg': "One sharp upward arc crashes into your chin. Your head snaps back and never returns.",
+            'victim_msg': "One sharp upward arc crashes into your chin. Your {hit_location} snaps back and never returns.",
             'observer_msg': "One sharp upward arc crashes into {target_name}'s chin. Their head snaps back and never returns."
         },
         {
             'attacker_msg': "Steel crunches into their temple. What's left isn't standing.",
-            'victim_msg': "Steel crunches into your temple. What's left isn't standing.",
-            'observer_msg': "Steel crunches into {target_name}'s temple. What's left isn't standing."
+            'victim_msg': "Steel crunches into your {hit_location}. What's left isn't standing.",
+            'observer_msg': "Steel crunches into {target_name}'s {hit_location}. What's left isn't standing."
         },
         {
             'attacker_msg': "Steel hits spine. They collapse like architecture stripped of its load-bearing lie.",
-            'victim_msg': "Steel hits your spine. You collapse like architecture stripped of its load-bearing lie.",
-            'observer_msg': "Steel hits {target_name}'s spine. They collapse like architecture stripped of its load-bearing lie."
+            'victim_msg': "Steel hits your {hit_location}. You collapse like architecture stripped of its load-bearing lie.",
+            'observer_msg': "Steel hits {target_name}'s {hit_location}. They collapse like architecture stripped of its load-bearing lie."
         },
         {
             'attacker_msg': "Steel meets face. Face loses. What's left doesn't count as breathing.",
-            'victim_msg': "Steel meets your face. Your face loses. What's left doesn't count as breathing.",
-            'observer_msg': "Steel meets {target_name}'s face. Their face loses. What's left doesn't count as breathing."
+            'victim_msg': "Steel meets your {hit_location}. Your {hit_location} loses. What's left doesn't count as breathing.",
+            'observer_msg': "Steel meets {target_name}'s {hit_location}. Their face loses. What's left doesn't count as breathing."
         },
         {
             'attacker_msg': "The blade drives into the base of the spine. The fall is violent. The twitching, brief.",
-            'victim_msg': "The blade drives into the base of your spine. Your fall is violent. The twitching, brief.",
-            'observer_msg': "The blade drives into the base of {target_name}'s spine. Their fall is violent. The twitching, brief."
+            'victim_msg': "The blade drives into the base of your {hit_location}. Your fall is violent. The twitching, brief.",
+            'observer_msg': "The blade drives into the base of {target_name}'s {hit_location}. Their fall is violent. The twitching, brief."
         },
         {
             'attacker_msg': "The blade embeds in the gut. You wrench it sideways. They crumple in two.",
@@ -523,8 +523,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The blade lands in the chest with a wet crunch. They fall inward, like folding paper soaked in red.",
-            'victim_msg': "The blade lands in your chest with a wet crunch. You fall inward, like folding paper soaked in red.",
-            'observer_msg': "The blade lands in {target_name}'s chest with a wet crunch. They fall inward, like folding paper soaked in red."
+            'victim_msg': "The blade lands in your {hit_location} with a wet crunch. You fall inward, like folding paper soaked in red.",
+            'observer_msg': "The blade lands in {target_name}'s {hit_location} with a wet crunch. They fall inward, like folding paper soaked in red."
         },
         {
             'attacker_msg': "The edge of the shovel punches into the eye socket. The scream dies with the pressure.",
@@ -533,8 +533,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The edge tears through the temple. Their face goes slack before their legs.",
-            'victim_msg': "The edge tears through your temple. Your face goes slack before your legs.",
-            'observer_msg': "The edge tears through {target_name}'s temple. Their face goes slack before their legs."
+            'victim_msg': "The edge tears through your {hit_location}. Your {hit_location} goes slack before your legs.",
+            'observer_msg': "The edge tears through {target_name}'s {hit_location}. Their face goes slack before their legs."
         },
         {
             'attacker_msg': "The flat edge crushes the windpipe. They wheeze, choke, still.",
@@ -543,47 +543,47 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The flat smashes into the neck. Bone crumples. They don't breathe again.",
-            'victim_msg': "The flat smashes into your neck. Bone crumples. You don't breathe again.",
-            'observer_msg': "The flat smashes into {target_name}'s neck. Bone crumples. They don't breathe again."
+            'victim_msg': "The flat smashes into your {hit_location}. Bone crumples. You don't breathe again.",
+            'observer_msg': "The flat smashes into {target_name}'s {hit_location}. Bone crumples. They don't breathe again."
         },
         {
             'attacker_msg': "The handle punches into the base of the neck. The body seizes. Then drops.",
-            'victim_msg': "The handle punches into the base of your neck. Your body seizes. Then drops.",
-            'observer_msg': "The handle punches into the base of {target_name}'s neck. Their body seizes. Then drops."
+            'victim_msg': "The handle punches into the base of your {hit_location}. Your body seizes. Then drops.",
+            'observer_msg': "The handle punches into the base of {target_name}'s {hit_location}. Their body seizes. Then drops."
         },
         {
             'attacker_msg': "The shovel caves in the side of their skull. The rest follows gravity.",
-            'victim_msg': "The shovel caves in the side of your skull. The rest follows gravity.",
-            'observer_msg': "The shovel caves in the side of {target_name}'s skull. The rest follows gravity."
+            'victim_msg': "The shovel caves in the side of your {hit_location}. The rest follows gravity.",
+            'observer_msg': "The shovel caves in the side of {target_name}'s {hit_location}. The rest follows gravity."
         },
         {
             'attacker_msg': "The shovel spins once, then lands across the temple. The collapse is immediate — and permanent.",
-            'victim_msg': "The shovel spins once, then lands across your temple. The collapse is immediate — and permanent.",
-            'observer_msg': "The shovel spins once, then lands across {target_name}'s temple. The collapse is immediate — and permanent."
+            'victim_msg': "The shovel spins once, then lands across your {hit_location}. The collapse is immediate — and permanent.",
+            'observer_msg': "The shovel spins once, then lands across {target_name}'s {hit_location}. The collapse is immediate — and permanent."
         },
         {
             'attacker_msg': "You bury the blade into their skull. It doesn't come out clean.",
-            'victim_msg': "{attacker_name} buries the blade into your skull. It doesn't come out clean.",
-            'observer_msg': "{attacker_name} buries the blade into {target_name}'s skull. It doesn't come out clean."
+            'victim_msg': "{attacker_name} buries the blade into your {hit_location}. It doesn't come out clean.",
+            'observer_msg': "{attacker_name} buries the blade into {target_name}'s {hit_location}. It doesn't come out clean."
         },
         {
             'attacker_msg': "You bury the shovel in the throat. It gets quiet fast.",
-            'victim_msg': "{attacker_name} buries the shovel in your throat. It gets quiet fast.",
-            'observer_msg': "{attacker_name} buries the shovel in {target_name}'s throat. It gets quiet fast."
+            'victim_msg': "{attacker_name} buries the shovel in your {hit_location}. It gets quiet fast.",
+            'observer_msg': "{attacker_name} buries the shovel in {target_name}'s {hit_location}. It gets quiet fast."
         },
         {
             'attacker_msg': "You drive the blade into the chest and twist. The scream never makes it out.",
-            'victim_msg': "{attacker_name} drives the blade into your chest and twists. Your scream never makes it out.",
-            'observer_msg': "{attacker_name} drives the blade into {target_name}'s chest and twists. Their scream never makes it out."
+            'victim_msg': "{attacker_name} drives the blade into your {hit_location} and twists. Your scream never makes it out.",
+            'observer_msg': "{attacker_name} drives the blade into {target_name}'s {hit_location} and twists. Their scream never makes it out."
         },
         {
             'attacker_msg': "You drive the tool down onto the spine. The twitching stops before the shovel does.",
-            'victim_msg': "{attacker_name} drives the tool down onto your spine. The twitching stops before the shovel does.",
-            'observer_msg': "{attacker_name} drives the tool down onto {target_name}'s spine. The twitching stops before the shovel does."
+            'victim_msg': "{attacker_name} drives the tool down onto your {hit_location}. The twitching stops before the shovel does.",
+            'observer_msg': "{attacker_name} drives the tool down onto {target_name}'s {hit_location}. The twitching stops before the shovel does."
         },
         {
             'attacker_msg': "You hook the shovel behind their knees, yank, and drive it down across their head.",
-            'victim_msg': "{attacker_name} hooks the shovel behind your knees, yanks, and drives it down across your head.",
+            'victim_msg': "{attacker_name} hooks the shovel behind your knees, yanks, and drives it down across your {hit_location}.",
             'observer_msg': "{attacker_name} hooks the shovel behind {target_name}'s knees, yanks, and drives it down across their head."
         },
         {
@@ -593,18 +593,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You ram the flat into the throat. They drop mid-breath, still clutching.",
-            'victim_msg': "{attacker_name} rams the flat into your throat. You drop mid-breath, still clutching.",
-            'observer_msg': "{attacker_name} rams the flat into {target_name}'s throat. They drop mid-breath, still clutching."
+            'victim_msg': "{attacker_name} rams the flat into your {hit_location}. You drop mid-breath, still clutching.",
+            'observer_msg': "{attacker_name} rams the flat into {target_name}'s {hit_location}. They drop mid-breath, still clutching."
         },
         {
             'attacker_msg': "You stomp forward and slam the shovel into the chest. The ribs fold like cheap furniture.",
-            'victim_msg': "{attacker_name} stomps forward and slams the shovel into your chest. Your ribs fold like cheap furniture.",
-            'observer_msg': "{attacker_name} stomps forward and slams the shovel into {target_name}'s chest. Their ribs fold like cheap furniture."
+            'victim_msg': "{attacker_name} stomps forward and slams the shovel into your {hit_location}. Your {hit_location} fold like cheap furniture.",
+            'observer_msg': "{attacker_name} stomps forward and slams the shovel into {target_name}'s {hit_location}. Their ribs fold like cheap furniture."
         },
         {
             'attacker_msg': "You swing underhanded. The flat caves in the jaw. The scream never starts.",
-            'victim_msg': "{attacker_name} swings underhanded. The flat caves in your jaw. Your scream never starts.",
-            'observer_msg': "{attacker_name} swings underhanded. The flat caves in {target_name}'s jaw. Their scream never starts."
+            'victim_msg': "{attacker_name} swings underhanded. The flat caves in your {hit_location}. Your scream never starts.",
+            'observer_msg': "{attacker_name} swings underhanded. The flat caves in {target_name}'s {hit_location}. Their scream never starts."
         }
     ]
 }

--- a/world/combat/messages/shuriken.py
+++ b/world/combat/messages/shuriken.py
@@ -36,7 +36,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} grips the throwing star lightly, wrist coiled like a spring, ready to strike {target_name}."
         },
         {
-            'attacker_msg': "The shuriken spins once in your palm before you cock your arm back toward {target_name}.",
+            'attacker_msg': "The shuriken spins once in your palm before you cock your {hit_location} back toward {target_name}.",
             'victim_msg': "The shuriken spins once in {attacker_name}'s palm before they cock their arm back toward you.",
             'observer_msg': "The shuriken spins once in {attacker_name}'s palm before they cock their arm back toward {target_name}."
         },
@@ -158,8 +158,8 @@ MESSAGES = {
     "kill": [
         {
             'attacker_msg': "The shuriken spins once before one of its points finds their throat. They clutch their neck and fall.",
-            'victim_msg': "The shuriken spins once before one of its points finds your throat. You clutch your neck and fall.",
-            'observer_msg': "The shuriken spins once before one of its points finds {target_name}'s throat. They clutch their neck and fall."
+            'victim_msg': "The shuriken spins once before one of its points finds your {hit_location}. You clutch your {hit_location} and fall.",
+            'observer_msg': "The shuriken spins once before one of its points finds {target_name}'s {hit_location}. They clutch their neck and fall."
         },
         {
             'attacker_msg': "Silent death. The throwing star takes them in the temple, dropping them without a sound.",
@@ -168,7 +168,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "They gasp as the shuriken embeds itself between their ribs, puncturing something vital.",
-            'victim_msg': "You gasp as the shuriken embeds itself between your ribs, puncturing something vital.",
+            'victim_msg': "You gasp as the shuriken embeds itself between your {hit_location}, puncturing something vital.",
             'observer_msg': "{target_name} gasps as the shuriken embeds itself between their ribs, puncturing something vital."
         },
         {
@@ -183,8 +183,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The throwing star buries itself in their neck. They fall silently, blood pooling beneath them.",
-            'victim_msg': "The throwing star buries itself in your neck. You fall silently, blood pooling beneath you.",
-            'observer_msg': "The throwing star buries itself in {target_name}'s neck. They fall silently, blood pooling beneath them."
+            'victim_msg': "The throwing star buries itself in your {hit_location}. You fall silently, blood pooling beneath you.",
+            'observer_msg': "The throwing star buries itself in {target_name}'s {hit_location}. They fall silently, blood pooling beneath them."
         },
         {
             'attacker_msg': "Your blade finds its mark with lethal accuracy, the shuriken claiming their life.",
@@ -203,8 +203,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "One throw, one kill. The shuriken settles in their heart as they crumple to the ground.",
-            'victim_msg': "One throw, one kill. The shuriken settles in your heart as you crumple to the ground.",
-            'observer_msg': "One throw, one kill. The shuriken settles in {target_name}'s heart as they crumple to the ground."
+            'victim_msg': "One throw, one kill. The shuriken settles in your {hit_location} as you crumple to the ground.",
+            'observer_msg': "One throw, one kill. The shuriken settles in {target_name}'s {hit_location} as they crumple to the ground."
         }
     ]
 }

--- a/world/combat/messages/sledgehammer.py
+++ b/world/combat/messages/sledgehammer.py
@@ -86,7 +86,7 @@ MESSAGES = {
             'observer_msg': "The weapon hangs heavy in {attacker_name}'s grip. The silence stretches to meet it."
         },
         {
-            'attacker_msg': "The weight rests against your shoulder. It's not heavy. It's familiar.",
+            'attacker_msg': "The weight rests against your {hit_location}. It's not heavy. It's familiar.",
             'victim_msg': "The weight rests against {attacker_name}'s shoulder. It's not heavy. It's familiar.",
             'observer_msg': "The weight rests against {attacker_name}'s shoulder. It's not heavy. It's familiar."
         },
@@ -136,7 +136,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} plants both feet and leans into the grip. This is happening."
         },
         {
-            'attacker_msg': "You roll your neck, then the hammer — both promise pain.",
+            'attacker_msg': "You roll your {hit_location}, then the hammer — both promise pain.",
             'victim_msg': "{attacker_name} rolls their neck, then the hammer — both promise pain.",
             'observer_msg': "{attacker_name} rolls their neck, then the hammer — both promise pain."
         },
@@ -159,7 +159,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A brutal upswing clips the {hit_location}. Their head snaps back too far.",
-            'victim_msg': "A brutal upswing clips your {hit_location}. Your head snaps back too far.",
+            'victim_msg': "A brutal upswing clips your {hit_location}. Your {hit_location} snaps back too far.",
             'observer_msg': "A brutal upswing clips {target_name}'s {hit_location}. Their head snaps back too far."
         },
         {
@@ -169,7 +169,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A heavy downward crush lands on the {hit_location}. The arm hangs wrong after.",
-            'victim_msg': "A heavy downward crush lands on your {hit_location}. Your arm hangs wrong after.",
+            'victim_msg': "A heavy downward crush lands on your {hit_location}. Your {hit_location} hangs wrong after.",
             'observer_msg': "A heavy downward crush lands on {target_name}'s {hit_location}. Their arm hangs wrong after."
         },
         {
@@ -458,8 +458,8 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "A charge and a slam to the spine. They drop mid-scream.",
-            'victim_msg': "A charge and a slam to your spine. You drop mid-scream.",
-            'observer_msg': "A charge and a slam to {target_name}'s spine. They drop mid-scream."
+            'victim_msg': "A charge and a slam to your {hit_location}. You drop mid-scream.",
+            'observer_msg': "A charge and a slam to {target_name}'s {hit_location}. They drop mid-scream."
         },
         {
             'attacker_msg': "A rising blow launches them off the ground. They come down wrong and never get up.",
@@ -468,8 +468,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A sideways arc crushes the jaw. They hit the ground with no plan to get up.",
-            'victim_msg': "A sideways arc crushes your jaw. You hit the ground with no plan to get up.",
-            'observer_msg': "A sideways arc crushes {target_name}'s jaw. They hit the ground with no plan to get up."
+            'victim_msg': "A sideways arc crushes your {hit_location}. You hit the ground with no plan to get up.",
+            'observer_msg': "A sideways arc crushes {target_name}'s {hit_location}. They hit the ground with no plan to get up."
         },
         {
             'attacker_msg': "A sideways smash folds them into the wall. They don't come off it alive.",
@@ -478,33 +478,33 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A sideways strike caves in the temple. Stillness blooms immediately.",
-            'victim_msg': "A sideways strike caves in your temple. Stillness blooms immediately.",
-            'observer_msg': "A sideways strike caves in {target_name}'s temple. Stillness blooms immediately."
+            'victim_msg': "A sideways strike caves in your {hit_location}. Stillness blooms immediately.",
+            'observer_msg': "A sideways strike caves in {target_name}'s {hit_location}. Stillness blooms immediately."
         },
         {
             'attacker_msg': "A spinning swing splits the side of the head. They drop in sections.",
-            'victim_msg': "A spinning swing splits the side of your head. You drop in sections.",
-            'observer_msg': "A spinning swing splits the side of {target_name}'s head. They drop in sections."
+            'victim_msg': "A spinning swing splits the side of your {hit_location}. You drop in sections.",
+            'observer_msg': "A spinning swing splits the side of {target_name}'s {hit_location}. They drop in sections."
         },
         {
             'attacker_msg': "One arc, one hit — the jaw explodes in red. They never finish the scream.",
-            'victim_msg': "One arc, one hit — your jaw explodes in red. You never finish the scream.",
-            'observer_msg': "One arc, one hit — {target_name}'s jaw explodes in red. They never finish the scream."
+            'victim_msg': "One arc, one hit — your {hit_location} explodes in red. You never finish the scream.",
+            'observer_msg': "One arc, one hit — {target_name}'s {hit_location} explodes in red. They never finish the scream."
         },
         {
             'attacker_msg': "One blow to the back of the head. No twitch. Just down.",
-            'victim_msg': "One blow to the back of your head. No twitch. Just down.",
-            'observer_msg': "One blow to the back of {target_name}'s head. No twitch. Just down."
+            'victim_msg': "One blow to the back of your {hit_location}. No twitch. Just down.",
+            'observer_msg': "One blow to the back of {target_name}'s {hit_location}. No twitch. Just down."
         },
         {
             'attacker_msg': "One clean shot to the jaw. They spin, fall, don't move again.",
-            'victim_msg': "One clean shot to your jaw. You spin, fall, don't move again.",
-            'observer_msg': "One clean shot to {target_name}'s jaw. They spin, fall, don't move again."
+            'victim_msg': "One clean shot to your {hit_location}. You spin, fall, don't move again.",
+            'observer_msg': "One clean shot to {target_name}'s {hit_location}. They spin, fall, don't move again."
         },
         {
             'attacker_msg': "Steel meets temple. There's no blood at first — just stillness. Then both.",
-            'victim_msg': "Steel meets your temple. There's no blood at first — just stillness. Then both.",
-            'observer_msg': "Steel meets {target_name}'s temple. There's no blood at first — just stillness. Then both."
+            'victim_msg': "Steel meets your {hit_location}. There's no blood at first — just stillness. Then both.",
+            'observer_msg': "Steel meets {target_name}'s {hit_location}. There's no blood at first — just stillness. Then both."
         },
         {
             'attacker_msg': "The final swing splits bone and noise alike. They fall apart in motion.",
@@ -513,53 +513,53 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The hammer crushes their skull. The body drops like a puppet that lost faith.",
-            'victim_msg': "The hammer crushes your skull. Your body drops like a puppet that lost faith.",
-            'observer_msg': "The hammer crushes {target_name}'s skull. The body drops like a puppet that lost faith."
+            'victim_msg': "The hammer crushes your {hit_location}. Your body drops like a puppet that lost faith.",
+            'observer_msg': "The hammer crushes {target_name}'s {hit_location}. The body drops like a puppet that lost faith."
         },
         {
             'attacker_msg': "The hammer finds the base of the skull. They drop, twitchless and quiet.",
-            'victim_msg': "The hammer finds the base of your skull. You drop, twitchless and quiet.",
-            'observer_msg': "The hammer finds the base of {target_name}'s skull. They drop, twitchless and quiet."
+            'victim_msg': "The hammer finds the base of your {hit_location}. You drop, twitchless and quiet.",
+            'observer_msg': "The hammer finds the base of {target_name}'s {hit_location}. They drop, twitchless and quiet."
         },
         {
             'attacker_msg': "The hammer hits temple. They blink once. Then never again.",
-            'victim_msg': "The hammer hits your temple. You blink once. Then never again.",
-            'observer_msg': "The hammer hits {target_name}'s temple. They blink once. Then never again."
+            'victim_msg': "The hammer hits your {hit_location}. You blink once. Then never again.",
+            'observer_msg': "The hammer hits {target_name}'s {hit_location}. They blink once. Then never again."
         },
         {
             'attacker_msg': "The hammer hits their chest like a wrecking ball. They stop mid-motion, forever.",
-            'victim_msg': "The hammer hits your chest like a wrecking ball. You stop mid-motion, forever.",
-            'observer_msg': "The hammer hits {target_name}'s chest like a wrecking ball. They stop mid-motion, forever."
+            'victim_msg': "The hammer hits your {hit_location} like a wrecking ball. You stop mid-motion, forever.",
+            'observer_msg': "The hammer hits {target_name}'s {hit_location} like a wrecking ball. They stop mid-motion, forever."
         },
         {
             'attacker_msg': "The head drives into their chest. Bones give. Heart stops. It's all downhill from there.",
-            'victim_msg': "The head drives into your chest. Bones give. Heart stops. It's all downhill from there.",
-            'observer_msg': "The head drives into {target_name}'s chest. Bones give. Heart stops. It's all downhill from there."
+            'victim_msg': "The head drives into your {hit_location}. Bones give. Heart stops. It's all downhill from there.",
+            'observer_msg': "The head drives into {target_name}'s {hit_location}. Bones give. Heart stops. It's all downhill from there."
         },
         {
             'attacker_msg': "The head lands against the spine. Their scream stops halfway out.",
-            'victim_msg': "The head lands against your spine. Your scream stops halfway out.",
-            'observer_msg': "The head lands against {target_name}'s spine. Their scream stops halfway out."
+            'victim_msg': "The head lands against your {hit_location}. Your scream stops halfway out.",
+            'observer_msg': "The head lands against {target_name}'s {hit_location}. Their scream stops halfway out."
         },
         {
             'attacker_msg': "The head lands on the spine. The rest never moves again.",
-            'victim_msg': "The head lands on your spine. The rest never moves again.",
-            'observer_msg': "The head lands on {target_name}'s spine. The rest never moves again."
+            'victim_msg': "The head lands on your {hit_location}. The rest never moves again.",
+            'observer_msg': "The head lands on {target_name}'s {hit_location}. The rest never moves again."
         },
         {
             'attacker_msg': "The impact turns the chest into pulp. They die mid-gasp.",
-            'victim_msg': "The impact turns your chest into pulp. You die mid-gasp.",
-            'observer_msg': "The impact turns {target_name}'s chest into pulp. They die mid-gasp."
+            'victim_msg': "The impact turns your {hit_location} into pulp. You die mid-gasp.",
+            'observer_msg': "The impact turns {target_name}'s {hit_location} into pulp. They die mid-gasp."
         },
         {
             'attacker_msg': "The skull caves beneath the impact. It doesn't get back up.",
-            'victim_msg': "Your skull caves beneath the impact. It doesn't get back up.",
-            'observer_msg': "{target_name}'s skull caves beneath the impact. It doesn't get back up."
+            'victim_msg': "Your {hit_location} caves beneath the impact. It doesn't get back up.",
+            'observer_msg': "{target_name}'s {hit_location} caves beneath the impact. It doesn't get back up."
         },
         {
             'attacker_msg': "The sledge drives into the ribs and stays there. The breath leaves with everything else.",
-            'victim_msg': "The sledge drives into your ribs and stays there. Your breath leaves with everything else.",
-            'observer_msg': "The sledge drives into {target_name}'s ribs and stays there. Their breath leaves with everything else."
+            'victim_msg': "The sledge drives into your {hit_location} and stays there. Your breath leaves with everything else.",
+            'observer_msg': "The sledge drives into {target_name}'s {hit_location} and stays there. Their breath leaves with everything else."
         },
         {
             'attacker_msg': "The sledge lands like judgment. Their ribcage opens and then closes around stillness.",
@@ -568,23 +568,23 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The sledge punches through the neck. The blood is fast. The death, faster.",
-            'victim_msg': "The sledge punches through your neck. The blood is fast. The death, faster.",
-            'observer_msg': "The sledge punches through {target_name}'s neck. The blood is fast. The death, faster."
+            'victim_msg': "The sledge punches through your {hit_location}. The blood is fast. The death, faster.",
+            'observer_msg': "The sledge punches through {target_name}'s {hit_location}. The blood is fast. The death, faster."
         },
         {
             'attacker_msg': "The strike crushes half the face. The rest just follows gravity.",
-            'victim_msg': "The strike crushes half your face. The rest just follows gravity.",
-            'observer_msg': "The strike crushes half {target_name}'s face. The rest just follows gravity."
+            'victim_msg': "The strike crushes half your {hit_location}. The rest just follows gravity.",
+            'observer_msg': "The strike crushes half {target_name}'s {hit_location}. The rest just follows gravity."
         },
         {
             'attacker_msg': "You bring it down on the neck. The sound is awful. The result is worse.",
-            'victim_msg': "{attacker_name} brings it down on your neck. The sound is awful. The result is worse.",
-            'observer_msg': "{attacker_name} brings it down on {target_name}'s neck. The sound is awful. The result is worse."
+            'victim_msg': "{attacker_name} brings it down on your {hit_location}. The sound is awful. The result is worse.",
+            'observer_msg': "{attacker_name} brings it down on {target_name}'s {hit_location}. The sound is awful. The result is worse."
         },
         {
             'attacker_msg': "You bring the hammer down on their skull. The collapse is silent. The echo isn't.",
-            'victim_msg': "{attacker_name} brings the hammer down on your skull. The collapse is silent. The echo isn't.",
-            'observer_msg': "{attacker_name} brings the hammer down on {target_name}'s skull. The collapse is silent. The echo isn't."
+            'victim_msg': "{attacker_name} brings the hammer down on your {hit_location}. The collapse is silent. The echo isn't.",
+            'observer_msg': "{attacker_name} brings the hammer down on {target_name}'s {hit_location}. The collapse is silent. The echo isn't."
         },
         {
             'attacker_msg': "You charge and swing from the hip. They are lifted, broken, done.",
@@ -593,13 +593,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You slam down into the sternum. The bones collapse. So does the fight.",
-            'victim_msg': "{attacker_name} slams down into your sternum. Your bones collapse. So does the fight.",
-            'observer_msg': "{attacker_name} slams down into {target_name}'s sternum. Their bones collapse. So does the fight."
+            'victim_msg': "{attacker_name} slams down into your {hit_location}. Your bones collapse. So does the fight.",
+            'observer_msg': "{attacker_name} slams down into {target_name}'s {hit_location}. Their bones collapse. So does the fight."
         },
         {
             'attacker_msg': "You spin, swing, and slam the hammer into their sternum. The world falls quiet.",
-            'victim_msg': "{attacker_name} spins, swings, and slams the hammer into your sternum. The world falls quiet.",
-            'observer_msg': "{attacker_name} spins, swings, and slams the hammer into {target_name}'s sternum. The world falls quiet."
+            'victim_msg': "{attacker_name} spins, swings, and slams the hammer into your {hit_location}. The world falls quiet.",
+            'observer_msg': "{attacker_name} spins, swings, and slams the hammer into {target_name}'s {hit_location}. The world falls quiet."
         },
         {
             'attacker_msg': "You swing from below. The head crushes the chin and what's behind it.",

--- a/world/combat/messages/small_axe.py
+++ b/world/combat/messages/small_axe.py
@@ -126,7 +126,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} draws the small axe with a jerk. It sings a short, sharp note of promise."
         },
         {
-            'attacker_msg': "You flip the small axe in your hand. It spins fast, hungry.",
+            'attacker_msg': "You flip the small axe in your {hit_location}. It spins fast, hungry.",
             'victim_msg': "{attacker_name} flips the small axe in their hand. It spins fast, hungry.",
             'observer_msg': "{attacker_name} flips the small axe in their hand. It spins fast, hungry."
         },
@@ -326,8 +326,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A slash to the throat meets scarf, not skin. You curse.",
-            'victim_msg': "A slash to your throat meets scarf, not skin. {attacker_name} curses.",
-            'observer_msg': "A slash to {target_name}'s throat meets scarf, not skin. {attacker_name} curses."
+            'victim_msg': "A slash to your {hit_location} meets scarf, not skin. {attacker_name} curses.",
+            'observer_msg': "A slash to {target_name}'s {hit_location} meets scarf, not skin. {attacker_name} curses."
         },
         {
             'attacker_msg': "A spin goes wide. The blade hums and hits air.",
@@ -336,8 +336,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A swing whistles over their shoulder. They flinch late but survive.",
-            'victim_msg': "A swing whistles over your shoulder. You flinch late but survive.",
-            'observer_msg': "A swing whistles over {target_name}'s shoulder. They flinch late but survive."
+            'victim_msg': "A swing whistles over your {hit_location}. You flinch late but survive.",
+            'observer_msg': "A swing whistles over {target_name}'s {hit_location}. They flinch late but survive."
         },
         {
             'attacker_msg': "A swipe cuts air. They sidestep with inches to spare.",
@@ -385,7 +385,7 @@ MESSAGES = {
             'observer_msg': "The axe glances off shelving. The rain of junk is loud, not lethal."
         },
         {
-            'attacker_msg': "The axe tip chips concrete. The shiver travels up your spine.",
+            'attacker_msg': "The axe tip chips concrete. The shiver travels up your {hit_location}.",
             'victim_msg': "The axe tip chips concrete. The shiver travels up {attacker_name}'s spine.",
             'observer_msg': "The axe tip chips concrete. The shiver travels up {attacker_name}'s spine."
         },
@@ -458,8 +458,8 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "A clean slash opens the neck. Words die in red.",
-            'victim_msg': "A clean slash opens your neck. Words die in red.",
-            'observer_msg': "A clean slash opens {target_name}'s neck. Words die in red."
+            'victim_msg': "A clean slash opens your {hit_location}. Words die in red.",
+            'observer_msg': "A clean slash opens {target_name}'s {hit_location}. Words die in red."
         },
         {
             'attacker_msg': "A clean throat shot ends all noise. Permanently.",
@@ -468,28 +468,28 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A downward strike caves in the chest. What's left isn't worth screaming over.",
-            'victim_msg': "A downward strike caves in your chest. What's left isn't worth screaming over.",
-            'observer_msg': "A downward strike caves in {target_name}'s chest. What's left isn't worth screaming over."
+            'victim_msg': "A downward strike caves in your {hit_location}. What's left isn't worth screaming over.",
+            'observer_msg': "A downward strike caves in {target_name}'s {hit_location}. What's left isn't worth screaming over."
         },
         {
             'attacker_msg': "A fast chop splits the skull. Blood bubbles from what's left of words.",
-            'victim_msg': "A fast chop splits your skull. Blood bubbles from what's left of words.",
-            'observer_msg': "A fast chop splits {target_name}'s skull. Blood bubbles from what's left of words."
+            'victim_msg': "A fast chop splits your {hit_location}. Blood bubbles from what's left of words.",
+            'observer_msg': "A fast chop splits {target_name}'s {hit_location}. Blood bubbles from what's left of words."
         },
         {
             'attacker_msg': "A sharp jab sinks under the ribs. The blade jerks, and they don't move again.",
-            'victim_msg': "A sharp jab sinks under your ribs. The blade jerks, and you don't move again.",
-            'observer_msg': "A sharp jab sinks under {target_name}'s ribs. The blade jerks, and they don't move again."
+            'victim_msg': "A sharp jab sinks under your {hit_location}. The blade jerks, and you don't move again.",
+            'observer_msg': "A sharp jab sinks under {target_name}'s {hit_location}. The blade jerks, and they don't move again."
         },
         {
             'attacker_msg': "A sideways chop removes half the jaw. The collapse is immediate.",
-            'victim_msg': "A sideways chop removes half your jaw. The collapse is immediate.",
-            'observer_msg': "A sideways chop removes half {target_name}'s jaw. The collapse is immediate."
+            'victim_msg': "A sideways chop removes half your {hit_location}. The collapse is immediate.",
+            'observer_msg': "A sideways chop removes half {target_name}'s {hit_location}. The collapse is immediate."
         },
         {
             'attacker_msg': "A vertical chop splits the head. It's not symbolic. Just fatal.",
-            'victim_msg': "A vertical chop splits your head. It's not symbolic. Just fatal.",
-            'observer_msg': "A vertical chop splits {target_name}'s head. It's not symbolic. Just fatal."
+            'victim_msg': "A vertical chop splits your {hit_location}. It's not symbolic. Just fatal.",
+            'observer_msg': "A vertical chop splits {target_name}'s {hit_location}. It's not symbolic. Just fatal."
         },
         {
             'attacker_msg': "One clean strike takes them at the temple. Lights out — permanently.",
@@ -498,8 +498,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "One sideways strike takes half the face. The rest looks surprised.",
-            'victim_msg': "One sideways strike takes half your face. The rest looks surprised.",
-            'observer_msg': "One sideways strike takes half {target_name}'s face. The rest looks surprised."
+            'victim_msg': "One sideways strike takes half your {hit_location}. The rest looks surprised.",
+            'observer_msg': "One sideways strike takes half {target_name}'s {hit_location}. The rest looks surprised."
         },
         {
             'attacker_msg': "One slash across the eyes ends movement, memory, meaning.",
@@ -508,13 +508,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Steel drives into the spine. They spasm, then let go.",
-            'victim_msg': "Steel drives into your spine. You spasm, then let go.",
-            'observer_msg': "Steel drives into {target_name}'s spine. They spasm, then let go."
+            'victim_msg': "Steel drives into your {hit_location}. You spasm, then let go.",
+            'observer_msg': "Steel drives into {target_name}'s {hit_location}. They spasm, then let go."
         },
         {
             'attacker_msg': "Steel drives through the back. They arch, gasp, die.",
-            'victim_msg': "Steel drives through your back. You arch, gasp, die.",
-            'observer_msg': "Steel drives through {target_name}'s back. They arch, gasp, die."
+            'victim_msg': "Steel drives through your {hit_location}. You arch, gasp, die.",
+            'observer_msg': "Steel drives through {target_name}'s {hit_location}. They arch, gasp, die."
         },
         {
             'attacker_msg': "Steel enters the side. The scream starts but never completes.",
@@ -523,23 +523,23 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The axe carves through the throat. They gurgle, then crumple.",
-            'victim_msg': "The axe carves through your throat. You gurgle, then crumple.",
-            'observer_msg': "The axe carves through {target_name}'s throat. They gurgle, then crumple."
+            'victim_msg': "The axe carves through your {hit_location}. You gurgle, then crumple.",
+            'observer_msg': "The axe carves through {target_name}'s {hit_location}. They gurgle, then crumple."
         },
         {
             'attacker_msg': "The axe hits base of skull. Everything stops on contact.",
-            'victim_msg': "The axe hits base of your skull. Everything stops on contact.",
-            'observer_msg': "The axe hits base of {target_name}'s skull. Everything stops on contact."
+            'victim_msg': "The axe hits base of your {hit_location}. Everything stops on contact.",
+            'observer_msg': "The axe hits base of {target_name}'s {hit_location}. Everything stops on contact."
         },
         {
             'attacker_msg': "The axe hits temple. The collapse is sudden and irreversible.",
-            'victim_msg': "The axe hits your temple. The collapse is sudden and irreversible.",
-            'observer_msg': "The axe hits {target_name}'s temple. The collapse is sudden and irreversible."
+            'victim_msg': "The axe hits your {hit_location}. The collapse is sudden and irreversible.",
+            'observer_msg': "The axe hits {target_name}'s {hit_location}. The collapse is sudden and irreversible."
         },
         {
             'attacker_msg': "The axe lands in the neck. One twist, one spray, one silence.",
-            'victim_msg': "The axe lands in your neck. One twist, one spray, one silence.",
-            'observer_msg': "The axe lands in {target_name}'s neck. One twist, one spray, one silence."
+            'victim_msg': "The axe lands in your {hit_location}. One twist, one spray, one silence.",
+            'observer_msg': "The axe lands in {target_name}'s {hit_location}. One twist, one spray, one silence."
         },
         {
             'attacker_msg': "The axe lands mid-chest. No second swing needed.",
@@ -548,8 +548,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The axe slams into the sternum. They convulse — then nothing.",
-            'victim_msg': "The axe slams into your sternum. You convulse — then nothing.",
-            'observer_msg': "The axe slams into {target_name}'s sternum. They convulse — then nothing."
+            'victim_msg': "The axe slams into your {hit_location}. You convulse — then nothing.",
+            'observer_msg': "The axe slams into {target_name}'s {hit_location}. They convulse — then nothing."
         },
         {
             'attacker_msg': "The blade lands center-chest. It doesn't need to land twice.",
@@ -558,23 +558,23 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The edge embeds in the face. You pull it free with effort — and aftermath.",
-            'victim_msg': "The edge embeds in your face. {attacker_name} pulls it free with effort — and aftermath.",
-            'observer_msg': "The edge embeds in {target_name}'s face. {attacker_name} pulls it free with effort — and aftermath."
+            'victim_msg': "The edge embeds in your {hit_location}. {attacker_name} pulls it free with effort — and aftermath.",
+            'observer_msg': "The edge embeds in {target_name}'s {hit_location}. {attacker_name} pulls it free with effort — and aftermath."
         },
         {
             'attacker_msg': "The final hit is behind the knee — and then through the skull. Precise and pitiless.",
-            'victim_msg': "The final hit is behind your knee — and then through your skull. Precise and pitiless.",
-            'observer_msg': "The final hit is behind {target_name}'s knee — and then through their skull. Precise and pitiless."
+            'victim_msg': "The final hit is behind your {hit_location} — and then through your {hit_location}. Precise and pitiless.",
+            'observer_msg': "The final hit is behind {target_name}'s {hit_location} — and then through their skull. Precise and pitiless."
         },
         {
             'attacker_msg': "The small axe punches into the temple. The rest is fast and forgettable.",
-            'victim_msg': "The small axe punches into your temple. The rest is fast and forgettable.",
-            'observer_msg': "The small axe punches into {target_name}'s temple. The rest is fast and forgettable."
+            'victim_msg': "The small axe punches into your {hit_location}. The rest is fast and forgettable.",
+            'observer_msg': "The small axe punches into {target_name}'s {hit_location}. The rest is fast and forgettable."
         },
         {
             'attacker_msg': "The weapon punctures the lung. They sink with a wet rattle.",
-            'victim_msg': "The weapon punctures your lung. You sink with a wet rattle.",
-            'observer_msg': "The weapon punctures {target_name}'s lung. They sink with a wet rattle."
+            'victim_msg': "The weapon punctures your {hit_location}. You sink with a wet rattle.",
+            'observer_msg': "The weapon punctures {target_name}'s {hit_location}. They sink with a wet rattle."
         },
         {
             'attacker_msg': "You bring the blade down on the collar. It cracks deep — and stays broken.",
@@ -583,23 +583,23 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You bury the blade in the chest. The body doesn't finish falling — it folds.",
-            'victim_msg': "{attacker_name} buries the blade in your chest. Your body doesn't finish falling — it folds.",
-            'observer_msg': "{attacker_name} buries the blade in {target_name}'s chest. The body doesn't finish falling — it folds."
+            'victim_msg': "{attacker_name} buries the blade in your {hit_location}. Your body doesn't finish falling — it folds.",
+            'observer_msg': "{attacker_name} buries the blade in {target_name}'s {hit_location}. The body doesn't finish falling — it folds."
         },
         {
             'attacker_msg': "You drive the axe into the spine. They collapse with a twitch, then stillness.",
-            'victim_msg': "{attacker_name} drives the axe into your spine. You collapse with a twitch, then stillness.",
-            'observer_msg': "{attacker_name} drives the axe into {target_name}'s spine. They collapse with a twitch, then stillness."
+            'victim_msg': "{attacker_name} drives the axe into your {hit_location}. You collapse with a twitch, then stillness.",
+            'observer_msg': "{attacker_name} drives the axe into {target_name}'s {hit_location}. They collapse with a twitch, then stillness."
         },
         {
             'attacker_msg': "You hack down into the skull. It opens like wet fruit.",
-            'victim_msg': "{attacker_name} hacks down into your skull. It opens like wet fruit.",
-            'observer_msg': "{attacker_name} hacks down into {target_name}'s skull. It opens like wet fruit."
+            'victim_msg': "{attacker_name} hacks down into your {hit_location}. It opens like wet fruit.",
+            'observer_msg': "{attacker_name} hacks down into {target_name}'s {hit_location}. It opens like wet fruit."
         },
         {
             'attacker_msg': "You hook it under the ribs. The twist finishes the conversation.",
-            'victim_msg': "{attacker_name} hooks it under your ribs. The twist finishes the conversation.",
-            'observer_msg': "{attacker_name} hooks it under {target_name}'s ribs. The twist finishes the conversation."
+            'victim_msg': "{attacker_name} hooks it under your {hit_location}. The twist finishes the conversation.",
+            'observer_msg': "{attacker_name} hooks it under {target_name}'s {hit_location}. The twist finishes the conversation."
         },
         {
             'attacker_msg': "You slice across the midsection. Something important pours out.",

--- a/world/combat/messages/small_knife.py
+++ b/world/combat/messages/small_knife.py
@@ -36,7 +36,7 @@ MESSAGES = {
             'observer_msg': "No sheath. No belt. Just a hidden pocket and a moment's warning before violence begins."
         },
         {
-            'attacker_msg': "The blade is barely the length of a finger — but in your hand, it means so much more.",
+            'attacker_msg': "The blade is barely the length of a finger — but in your {hit_location}, it means so much more.",
             'victim_msg': "The blade is barely the length of a finger — but in {attacker_name}'s hand, it means so much more.",
             'observer_msg': "The blade is barely the length of a finger — but in {attacker_name}'s hand, it means so much more."
         },
@@ -46,7 +46,7 @@ MESSAGES = {
             'observer_msg': "The blade is barely visible — until {attacker_name} brings it to the light. Then it's all that exists."
         },
         {
-            'attacker_msg': "The blade is hidden until it's not. You lift your hand, and the light finds it instantly.",
+            'attacker_msg': "The blade is hidden until it's not. You lift your {hit_location}, and the light finds it instantly.",
             'victim_msg': "The blade is hidden until it's not. {attacker_name} lifts their hand, and the light finds it instantly.",
             'observer_msg': "The blade is hidden until it's not. {attacker_name} lifts their hand, and the light finds it instantly."
         },
@@ -56,7 +56,7 @@ MESSAGES = {
             'observer_msg': "The glint is brief. The danger is not. {attacker_name}'s stance changes the air."
         },
         {
-            'attacker_msg': "The handle barely fits your hand, but you make it work like an artist with a scalpel.",
+            'attacker_msg': "The handle barely fits your {hit_location}, but you make it work like an artist with a scalpel.",
             'victim_msg': "The handle barely fits the hand, but {attacker_name} makes it work like an artist with a scalpel.",
             'observer_msg': "The handle barely fits the hand, but {attacker_name} makes it work like an artist with a scalpel."
         },
@@ -146,7 +146,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} slips the small knife from a hidden pocket. It glints only once before vanishing into motion."
         },
         {
-            'attacker_msg': "You snap open the small knife with a flick of your wrist. The sound is soft, but final.",
+            'attacker_msg': "You snap open the small knife with a flick of your {hit_location}. The sound is soft, but final.",
             'victim_msg': "{attacker_name} snaps open the small knife with a flick of their wrist. The sound is soft, but final.",
             'observer_msg': "{attacker_name} snaps open the small knife with a flick of their wrist. The sound is soft, but final."
         }
@@ -316,12 +316,12 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A quick slash across the chest — but the blade finds only empty space.",
-            'victim_msg': "A quick slash across your chest — but the blade finds only empty space.",
+            'victim_msg': "A quick slash across your {hit_location} — but the blade finds only empty space.",
             'observer_msg': "A quick slash across the chest — but the blade finds only empty space."
         },
         {
             'attacker_msg': "A stab toward the shoulder glances off, harmless. The angle was wrong.",
-            'victim_msg': "A stab toward your shoulder glances off, harmless. The angle was wrong.",
+            'victim_msg': "A stab toward your {hit_location} glances off, harmless. The angle was wrong.",
             'observer_msg': "A stab toward the shoulder glances off, harmless. The angle was wrong."
         },
         {
@@ -331,7 +331,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "An attempt at the ribs goes wide. The blade skims harmlessly past.",
-            'victim_msg': "An attempt at your ribs goes wide. The blade skims harmlessly past.",
+            'victim_msg': "An attempt at your {hit_location} goes wide. The blade skims harmlessly past.",
             'observer_msg': "An attempt at the ribs goes wide. The blade skims harmlessly past."
         },
         {
@@ -366,12 +366,12 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The knife slides past the ribs, missing by millimeters. {target_name} gasps but remains uncut.",
-            'victim_msg': "The knife slides past your ribs, missing by millimeters. You gasp but remain uncut.",
+            'victim_msg': "The knife slides past your {hit_location}, missing by millimeters. You gasp but remain uncut.",
             'observer_msg': "The knife slides past the ribs, missing by millimeters. {target_name} gasps but remains uncut."
         },
         {
             'attacker_msg': "The knife swipes at the throat — but {target_name} ducks at exactly the right moment.",
-            'victim_msg': "The knife swipes at your throat — but you duck at exactly the right moment.",
+            'victim_msg': "The knife swipes at your {hit_location} — but you duck at exactly the right moment.",
             'observer_msg': "The knife swipes at the throat — but {target_name} ducks at exactly the right moment."
         },
         {
@@ -396,7 +396,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You aim for the arm, but the knife finds only air. {target_name} jerks back, safe.",
-            'victim_msg': "{attacker_name} aims for your arm, but the knife finds only air. You jerk back, safe.",
+            'victim_msg': "{attacker_name} aims for your {hit_location}, but the knife finds only air. You jerk back, safe.",
             'observer_msg': "{attacker_name} aims for the arm, but the knife finds only air. {target_name} jerks back, safe."
         },
         {
@@ -416,7 +416,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You flick the blade at the neck, but {target_name} pulls back in time.",
-            'victim_msg': "{attacker_name} flicks the blade at your neck, but you pull back in time.",
+            'victim_msg': "{attacker_name} flicks the blade at your {hit_location}, but you pull back in time.",
             'observer_msg': "{attacker_name} flicks the blade at the neck, but {target_name} pulls back in time."
         },
         {
@@ -426,22 +426,22 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You make a quick thrust toward the ribs, but the angle is off. The blade skims past.",
-            'victim_msg': "{attacker_name} makes a quick thrust toward your ribs, but the angle is off. The blade skims past.",
+            'victim_msg': "{attacker_name} makes a quick thrust toward your {hit_location}, but the angle is off. The blade skims past.",
             'observer_msg': "{attacker_name} makes a quick thrust toward the ribs, but the angle is off. The blade skims past."
         },
         {
             'attacker_msg': "You slice toward the shoulder, but {target_name} ducks under the blade.",
-            'victim_msg': "{attacker_name} slices toward your shoulder, but you duck under the blade.",
+            'victim_msg': "{attacker_name} slices toward your {hit_location}, but you duck under the blade.",
             'observer_msg': "{attacker_name} slices toward the shoulder, but {target_name} ducks under the blade."
         },
         {
             'attacker_msg': "You stab toward the chest, but {target_name} pivots away, leaving you grasping air.",
-            'victim_msg': "{attacker_name} stabs toward your chest, but you pivot away, leaving them grasping air.",
+            'victim_msg': "{attacker_name} stabs toward your {hit_location}, but you pivot away, leaving them grasping air.",
             'observer_msg': "{attacker_name} stabs toward the chest, but {target_name} pivots away, leaving {attacker_name} grasping air."
         },
         {
             'attacker_msg': "You strike for the stomach, but the blade meets nothing. {target_name} has moved.",
-            'victim_msg': "{attacker_name} strikes for your stomach, but the blade meets nothing. You have moved.",
+            'victim_msg': "{attacker_name} strikes for your {hit_location}, but the blade meets nothing. You have moved.",
             'observer_msg': "{attacker_name} strikes for the stomach, but the blade meets nothing. {target_name} has moved."
         },
         {
@@ -451,7 +451,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You thrust the blade toward the heart, but {target_name} twists aside. The knife tastes only wind.",
-            'victim_msg': "{attacker_name} thrusts the blade toward your heart, but you twist aside. The knife tastes only wind.",
+            'victim_msg': "{attacker_name} thrusts the blade toward your {hit_location}, but you twist aside. The knife tastes only wind.",
             'observer_msg': "{attacker_name} thrusts the blade toward the heart, but {target_name} twists aside. The knife tastes only wind."
         }
     ],
@@ -463,12 +463,12 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A nick to the artery. {target_name} clutches their throat as life spills red between their fingers.",
-            'victim_msg': "A nick to the artery. You clutch your throat as life spills red between your fingers.",
+            'victim_msg': "A nick to the artery. You clutch your {hit_location} as life spills red between your fingers.",
             'observer_msg': "A nick to the artery. {target_name} clutches their throat as life spills red between their fingers."
         },
         {
             'attacker_msg': "A quick slice along the throat. {target_name} gurgles once, then falls silent forever.",
-            'victim_msg': "A quick slice along your throat. You gurgle once, then fall silent forever.",
+            'victim_msg': "A quick slice along your {hit_location}. You gurgle once, then fall silent forever.",
             'observer_msg': "A quick slice along the throat. {target_name} gurgles once, then falls silent forever."
         },
         {
@@ -478,12 +478,12 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A swift jab to the temple. {target_name} drops like a stone, blade buried to the hilt.",
-            'victim_msg': "A swift jab to your temple. You drop like a stone, blade buried to the hilt.",
+            'victim_msg': "A swift jab to your {hit_location}. You drop like a stone, blade buried to the hilt.",
             'observer_msg': "A swift jab to the temple. {target_name} drops like a stone, blade buried to the hilt."
         },
         {
             'attacker_msg': "A thrust under the ribs finds the heart. {target_name} gasps once, then slumps forward, still.",
-            'victim_msg': "A thrust under your ribs finds your heart. You gasp once, then slump forward, still.",
+            'victim_msg': "A thrust under your {hit_location} finds your {hit_location}. You gasp once, then slump forward, still.",
             'observer_msg': "A thrust under the ribs finds the heart. {target_name} gasps once, then slumps forward, still."
         },
         {
@@ -503,12 +503,12 @@ MESSAGES = {
         },
         {
             'attacker_msg': "One thrust into the base of the skull. {target_name} doesn't even have time to scream.",
-            'victim_msg': "One thrust into the base of your skull. You don't even have time to scream.",
+            'victim_msg': "One thrust into the base of your {hit_location}. You don't even have time to scream.",
             'observer_msg': "One thrust into the base of the skull. {target_name} doesn't even have time to scream."
         },
         {
             'attacker_msg': "The blade enters just below the sternum and slides upward. {target_name} dies with a whimper.",
-            'victim_msg': "The blade enters just below your sternum and slides upward. You die with a whimper.",
+            'victim_msg': "The blade enters just below your {hit_location} and slides upward. You die with a whimper.",
             'observer_msg': "The blade enters just below the sternum and slides upward. {target_name} dies with a whimper."
         },
         {
@@ -518,17 +518,17 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The blade finds the soft spot beneath the jaw. {target_name} convulses once, then goes limp.",
-            'victim_msg': "The blade finds the soft spot beneath your jaw. You convulse once, then go limp.",
+            'victim_msg': "The blade finds the soft spot beneath your {hit_location}. You convulse once, then go limp.",
             'observer_msg': "The blade finds the soft spot beneath the jaw. {target_name} convulses once, then goes limp."
         },
         {
             'attacker_msg': "The blade pierces the lung. {target_name} drowns in their own blood, gasping for air that won't come.",
-            'victim_msg': "The blade pierces your lung. You drown in your own blood, gasping for air that won't come.",
+            'victim_msg': "The blade pierces your {hit_location}. You drown in your own blood, gasping for air that won't come.",
             'observer_msg': "The blade pierces the lung. {target_name} drowns in their own blood, gasping for air that won't come."
         },
         {
             'attacker_msg': "The blade slides between vertebrae. {target_name} crumples instantly, their spine severed.",
-            'victim_msg': "The blade slides between vertebrae. You crumple instantly, your spine severed.",
+            'victim_msg': "The blade slides between vertebrae. You crumple instantly, your {hit_location} severed.",
             'observer_msg': "The blade slides between vertebrae. {target_name} crumples instantly, their spine severed."
         },
         {
@@ -538,7 +538,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The knife punches through the ribs and into the heart. {target_name} dies before they hit the ground.",
-            'victim_msg': "The knife punches through your ribs and into your heart. You die before you hit the ground.",
+            'victim_msg': "The knife punches through your {hit_location} and into your {hit_location}. You die before you hit the ground.",
             'observer_msg': "The knife punches through the ribs and into the heart. {target_name} dies before they hit the ground."
         },
         {
@@ -563,7 +563,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You find the artery in the thigh. {target_name} tries to stanch the bleeding, but there's too much, too fast.",
-            'victim_msg': "{attacker_name} finds the artery in your thigh. You try to stanch the bleeding, but there's too much, too fast.",
+            'victim_msg': "{attacker_name} finds the artery in your {hit_location}. You try to stanch the bleeding, but there's too much, too fast.",
             'observer_msg': "{attacker_name} finds the artery in the thigh. {target_name} tries to stanch the bleeding, but there's too much, too fast."
         },
         {
@@ -572,38 +572,38 @@ MESSAGES = {
             'observer_msg': "{attacker_name} pierces the left lung. {target_name} coughs up blood, then collapses, gasping their last."
         },
         {
-            'attacker_msg': "You plant the blade in the small of {target_name}'s back. They arch, scream once, then slump forward, dead.",
-            'victim_msg': "{attacker_name} plants the blade in the small of your back. You arch, scream once, then slump forward, dead.",
-            'observer_msg': "{attacker_name} plants the blade in the small of {target_name}'s back. They arch, scream once, then slump forward, dead."
+            'attacker_msg': "You plant the blade in the small of {target_name}'s {hit_location}. They arch, scream once, then slump forward, dead.",
+            'victim_msg': "{attacker_name} plants the blade in the small of your {hit_location}. You arch, scream once, then slump forward, dead.",
+            'observer_msg': "{attacker_name} plants the blade in the small of {target_name}'s {hit_location}. They arch, scream once, then slump forward, dead."
         },
         {
             'attacker_msg': "You puncture the carotid artery. {target_name} clutches their neck, blood spurting between their fingers.",
-            'victim_msg': "{attacker_name} punctures your carotid artery. You clutch your neck, blood spurting between your fingers.",
+            'victim_msg': "{attacker_name} punctures your carotid artery. You clutch your {hit_location}, blood spurting between your fingers.",
             'observer_msg': "{attacker_name} punctures the carotid artery. {target_name} clutches their neck, blood spurting between their fingers."
         },
         {
             'attacker_msg': "You slide the knife between the ribs and into the liver. {target_name} doubles over and dies in agony.",
-            'victim_msg': "{attacker_name} slides the knife between your ribs and into your liver. You double over and die in agony.",
+            'victim_msg': "{attacker_name} slides the knife between your {hit_location} and into your {hit_location}. You double over and die in agony.",
             'observer_msg': "{attacker_name} slides the knife between the ribs and into the liver. {target_name} doubles over and dies in agony."
         },
         {
-            'attacker_msg': "You slice open {target_name}'s throat in one fluid motion. They fall to their knees, choking on blood.",
-            'victim_msg': "{attacker_name} slices open your throat in one fluid motion. You fall to your knees, choking on blood.",
-            'observer_msg': "{attacker_name} slices open {target_name}'s throat in one fluid motion. They fall to their knees, choking on blood."
+            'attacker_msg': "You slice open {target_name}'s {hit_location} in one fluid motion. They fall to their knees, choking on blood.",
+            'victim_msg': "{attacker_name} slices open your {hit_location} in one fluid motion. You fall to your knees, choking on blood.",
+            'observer_msg': "{attacker_name} slices open {target_name}'s {hit_location} in one fluid motion. They fall to their knees, choking on blood."
         },
         {
             'attacker_msg': "You stab upward under the ribcage, seeking the heart. You find it. {target_name} dies instantly.",
-            'victim_msg': "{attacker_name} stabs upward under your ribcage, seeking your heart. They find it. You die instantly.",
+            'victim_msg': "{attacker_name} stabs upward under your ribcage, seeking your {hit_location}. They find it. You die instantly.",
             'observer_msg': "{attacker_name} stabs upward under the ribcage, seeking the heart. They find it. {target_name} dies instantly."
         },
         {
-            'attacker_msg': "You thrust the blade into {target_name}'s temple. They drop like a marionette with cut strings.",
-            'victim_msg': "{attacker_name} thrusts the blade into your temple. You drop like a marionette with cut strings.",
-            'observer_msg': "{attacker_name} thrusts the blade into {target_name}'s temple. They drop like a marionette with cut strings."
+            'attacker_msg': "You thrust the blade into {target_name}'s {hit_location}. They drop like a marionette with cut strings.",
+            'victim_msg': "{attacker_name} thrusts the blade into your {hit_location}. You drop like a marionette with cut strings.",
+            'observer_msg': "{attacker_name} thrusts the blade into {target_name}'s {hit_location}. They drop like a marionette with cut strings."
         },
         {
             'attacker_msg': "You twist the blade as it enters the chest. {target_name}'s eyes roll back as life leaves them.",
-            'victim_msg': "{attacker_name} twists the blade as it enters your chest. Your eyes roll back as life leaves you.",
+            'victim_msg': "{attacker_name} twists the blade as it enters your {hit_location}. Your eyes roll back as life leaves you.",
             'observer_msg': "{attacker_name} twists the blade as it enters the chest. {target_name}'s eyes roll back as life leaves them."
         }
     ]

--- a/world/combat/messages/small_shield.py
+++ b/world/combat/messages/small_shield.py
@@ -81,7 +81,7 @@ MESSAGES = {
             'observer_msg': "The shield snaps into place with a clatter. The noise makes people flinch. So does {attacker_name}."
         },
         {
-            'attacker_msg': "The small shield thuds against your forearm. You smile. This one's personal.",
+            'attacker_msg': "The small shield thuds against your {hit_location}. You smile. This one's personal.",
             'victim_msg': "The small shield thuds against {attacker_name}'s forearm. They smile. This one's personal.",
             'observer_msg': "The small shield thuds against {attacker_name}'s forearm. They smile. This one's personal."
         },
@@ -101,12 +101,12 @@ MESSAGES = {
             'observer_msg': "{attacker_name} draws the shield like a duelist preparing for the final round."
         },
         {
-            'attacker_msg': "You draw the small shield across your chest and lock stance. It doesn't need to be big — just brutal.",
+            'attacker_msg': "You draw the small shield across your {hit_location} and lock stance. It doesn't need to be big — just brutal.",
             'victim_msg': "{attacker_name} draws the small shield across their chest and locks stance. It doesn't need to be big — just brutal.",
             'observer_msg': "{attacker_name} draws the small shield across their chest and locks stance. It doesn't need to be big — just brutal."
         },
         {
-            'attacker_msg': "You flick the shield into place with a snap of your wrist. The metal responds like it's been waiting.",
+            'attacker_msg': "You flick the shield into place with a snap of your {hit_location}. The metal responds like it's been waiting.",
             'victim_msg': "{attacker_name} flicks the shield into place with a snap of their wrist. The metal responds like it's been waiting.",
             'observer_msg': "{attacker_name} flicks the shield into place with a snap of their wrist. The metal responds like it's been waiting."
         },
@@ -316,7 +316,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A swing aimed at the head goes wide. {target_name} leans back just in time.",
-            'victim_msg': "A swing aimed at your head goes wide. You lean back just in time.",
+            'victim_msg': "A swing aimed at your {hit_location} goes wide. You lean back just in time.",
             'observer_msg': "A swing aimed at the head goes wide. {target_name} leans back just in time."
         },
         {
@@ -345,9 +345,9 @@ MESSAGES = {
             'observer_msg': "The shield clips only cloth. {target_name} spins away, leaving fabric behind."
         },
         {
-            'attacker_msg': "The shield edge grazes the air where {target_name}'s face was. They duck just in time.",
-            'victim_msg': "The shield edge grazes the air where your face was. You duck just in time.",
-            'observer_msg': "The shield edge grazes the air where {target_name}'s face was. They duck just in time."
+            'attacker_msg': "The shield edge grazes the air where {target_name}'s {hit_location} was. They duck just in time.",
+            'victim_msg': "The shield edge grazes the air where your {hit_location} was. You duck just in time.",
+            'observer_msg': "The shield edge grazes the air where {target_name}'s {hit_location} was. They duck just in time."
         },
         {
             'attacker_msg': "The shield rim whistles past {target_name}'s ear. Close, but not close enough.",
@@ -426,7 +426,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Your bash aims for the ribs, but {target_name} twists away. The shield hits nothing.",
-            'victim_msg': "{attacker_name}'s bash aims for your ribs, but you twist away. The shield hits nothing.",
+            'victim_msg': "{attacker_name}'s bash aims for your {hit_location}, but you twist away. The shield hits nothing.",
             'observer_msg': "{attacker_name}'s bash aims for the ribs, but {target_name} twists away. The shield hits nothing."
         },
         {
@@ -445,9 +445,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s shield cuts a swift arc through the air, but {target_name} is no longer there."
         },
         {
-            'attacker_msg': "Your shield edge seeks {target_name}'s temple, but they duck at the perfect moment.",
-            'victim_msg': "{attacker_name}'s shield edge seeks your temple, but you duck at the perfect moment.",
-            'observer_msg': "{attacker_name}'s shield edge seeks {target_name}'s temple, but they duck at the perfect moment."
+            'attacker_msg': "Your shield edge seeks {target_name}'s {hit_location}, but they duck at the perfect moment.",
+            'victim_msg': "{attacker_name}'s shield edge seeks your {hit_location}, but you duck at the perfect moment.",
+            'observer_msg': "{attacker_name}'s shield edge seeks {target_name}'s {hit_location}, but they duck at the perfect moment."
         },
         {
             'attacker_msg': "Your shield swings wide, but {target_name} slips inside your guard and stays safe.",
@@ -458,12 +458,12 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "A brutal bash to the base of the skull. {target_name} drops instantly, neck snapped.",
-            'victim_msg': "A brutal bash to the base of your skull. You drop instantly, neck snapped.",
+            'victim_msg': "A brutal bash to the base of your {hit_location}. You drop instantly, neck snapped.",
             'observer_msg': "A brutal bash to the base of the skull. {target_name} drops instantly, neck snapped."
         },
         {
             'attacker_msg': "A direct hit to the temple crushes bone. {target_name} collapses, skull caved in.",
-            'victim_msg': "A direct hit to your temple crushes bone. You collapse, skull caved in.",
+            'victim_msg': "A direct hit to your {hit_location} crushes bone. You collapse, skull caved in.",
             'observer_msg': "A direct hit to the temple crushes bone. {target_name} collapses, skull caved in."
         },
         {
@@ -473,42 +473,42 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A full-force blow to the throat crushes the larynx. {target_name} dies choking on blood.",
-            'victim_msg': "A full-force blow to your throat crushes your larynx. You die choking on blood.",
+            'victim_msg': "A full-force blow to your {hit_location} crushes your larynx. You die choking on blood.",
             'observer_msg': "A full-force blow to the throat crushes the larynx. {target_name} dies choking on blood."
         },
         {
             'attacker_msg': "A sharp edge to the neck severs the artery. {target_name} bleeds out in seconds.",
-            'victim_msg': "A sharp edge to your neck severs the artery. You bleed out in seconds.",
+            'victim_msg': "A sharp edge to your {hit_location} severs the artery. You bleed out in seconds.",
             'observer_msg': "A sharp edge to the neck severs the artery. {target_name} bleeds out in seconds."
         },
         {
             'attacker_msg': "A vicious bash caves in the chest. Ribs puncture lungs. {target_name} drowns in their own blood.",
-            'victim_msg': "A vicious bash caves in your chest. Ribs puncture lungs. You drown in your own blood.",
+            'victim_msg': "A vicious bash caves in your {hit_location}. Ribs puncture lungs. You drown in your own blood.",
             'observer_msg': "A vicious bash caves in the chest. Ribs puncture lungs. {target_name} drowns in their own blood."
         },
         {
             'attacker_msg': "One final slam to the heart. {target_name} staggers, gasps, then falls forward, dead.",
-            'victim_msg': "One final slam to your heart. You stagger, gasp, then fall forward, dead.",
+            'victim_msg': "One final slam to your {hit_location}. You stagger, gasp, then fall forward, dead.",
             'observer_msg': "One final slam to the heart. {target_name} staggers, gasps, then falls forward, dead."
         },
         {
             'attacker_msg': "The buckler rim punches through the eye socket and into the brain. {target_name} dies instantly.",
-            'victim_msg': "The buckler rim punches through your eye socket and into your brain. You die instantly.",
+            'victim_msg': "The buckler rim punches through your eye socket and into your {hit_location}. You die instantly.",
             'observer_msg': "The buckler rim punches through the eye socket and into the brain. {target_name} dies instantly."
         },
         {
             'attacker_msg': "The edge splits the skull like an egg. {target_name} crumples, brain matter leaking.",
-            'victim_msg': "The edge splits your skull like an egg. You crumple, brain matter leaking.",
+            'victim_msg': "The edge splits your {hit_location} like an egg. You crumple, brain matter leaking.",
             'observer_msg': "The edge splits the skull like an egg. {target_name} crumples, brain matter leaking."
         },
         {
             'attacker_msg': "The final blow caves in the sternum. {target_name} dies with a wet gasp.",
-            'victim_msg': "The final blow caves in your sternum. You die with a wet gasp.",
+            'victim_msg': "The final blow caves in your {hit_location}. You die with a wet gasp.",
             'observer_msg': "The final blow caves in the sternum. {target_name} dies with a wet gasp."
         },
         {
             'attacker_msg': "The rim punches into the soft spot below the ribs. {target_name} convulses, then goes still.",
-            'victim_msg': "The rim punches into the soft spot below your ribs. You convulse, then go still.",
+            'victim_msg': "The rim punches into the soft spot below your {hit_location}. You convulse, then go still.",
             'observer_msg': "The rim punches into the soft spot below the ribs. {target_name} convulses, then goes still."
         },
         {
@@ -518,48 +518,48 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The shield crushes the spine at the neck. {target_name} drops like a broken doll.",
-            'victim_msg': "The shield crushes your spine at the neck. You drop like a broken doll.",
+            'victim_msg': "The shield crushes your {hit_location} at the neck. You drop like a broken doll.",
             'observer_msg': "The shield crushes the spine at the neck. {target_name} drops like a broken doll."
         },
         {
             'attacker_msg': "The shield edge severs the jugular. {target_name} clutches their throat as life spurts away.",
-            'victim_msg': "The shield edge severs your jugular. You clutch your throat as life spurts away.",
+            'victim_msg': "The shield edge severs your jugular. You clutch your {hit_location} as life spurts away.",
             'observer_msg': "The shield edge severs the jugular. {target_name} clutches their throat as life spurts away."
         },
         {
             'attacker_msg': "The shield rim drives deep into the solar plexus, stopping the heart. {target_name} dies instantly.",
-            'victim_msg': "The shield rim drives deep into your solar plexus, stopping your heart. You die instantly.",
+            'victim_msg': "The shield rim drives deep into your solar plexus, stopping your {hit_location}. You die instantly.",
             'observer_msg': "The shield rim drives deep into the solar plexus, stopping the heart. {target_name} dies instantly."
         },
         {
-            'attacker_msg': "You bash the shield edge into {target_name}'s throat. They collapse, choking on blood.",
-            'victim_msg': "{attacker_name} bashes the shield edge into your throat. You collapse, choking on blood.",
-            'observer_msg': "{attacker_name} bashes the shield edge into {target_name}'s throat. They collapse, choking on blood."
+            'attacker_msg': "You bash the shield edge into {target_name}'s {hit_location}. They collapse, choking on blood.",
+            'victim_msg': "{attacker_name} bashes the shield edge into your {hit_location}. You collapse, choking on blood.",
+            'observer_msg': "{attacker_name} bashes the shield edge into {target_name}'s {hit_location}. They collapse, choking on blood."
         },
         {
             'attacker_msg': "You drive the buckler rim into {target_name}'s ear. It punches through to the brain.",
-            'victim_msg': "{attacker_name} drives the buckler rim into your ear. It punches through to your brain.",
+            'victim_msg': "{attacker_name} drives the buckler rim into your ear. It punches through to your {hit_location}.",
             'observer_msg': "{attacker_name} drives the buckler rim into {target_name}'s ear. It punches through to the brain."
         },
         {
-            'attacker_msg': "You drive the shield edge into {target_name}'s spine. They arch once, then go limp.",
-            'victim_msg': "{attacker_name} drives the shield edge into your spine. You arch once, then go limp.",
-            'observer_msg': "{attacker_name} drives the shield edge into {target_name}'s spine. They arch once, then go limp."
+            'attacker_msg': "You drive the shield edge into {target_name}'s {hit_location}. They arch once, then go limp.",
+            'victim_msg': "{attacker_name} drives the shield edge into your {hit_location}. You arch once, then go limp.",
+            'observer_msg': "{attacker_name} drives the shield edge into {target_name}'s {hit_location}. They arch once, then go limp."
         },
         {
-            'attacker_msg': "You slam the buckler down on {target_name}'s skull. It cracks like an egg.",
-            'victim_msg': "{attacker_name} slams the buckler down on your skull. It cracks like an egg.",
-            'observer_msg': "{attacker_name} slams the buckler down on {target_name}'s skull. It cracks like an egg."
+            'attacker_msg': "You slam the buckler down on {target_name}'s {hit_location}. It cracks like an egg.",
+            'victim_msg': "{attacker_name} slams the buckler down on your {hit_location}. It cracks like an egg.",
+            'observer_msg': "{attacker_name} slams the buckler down on {target_name}'s {hit_location}. It cracks like an egg."
         },
         {
-            'attacker_msg': "You slam the shield edge into {target_name}'s temple. They drop instantly, skull shattered.",
-            'victim_msg': "{attacker_name} slams the shield edge into your temple. You drop instantly, skull shattered.",
-            'observer_msg': "{attacker_name} slams the shield edge into {target_name}'s temple. They drop instantly, skull shattered."
+            'attacker_msg': "You slam the shield edge into {target_name}'s {hit_location}. They drop instantly, skull shattered.",
+            'victim_msg': "{attacker_name} slams the shield edge into your {hit_location}. You drop instantly, skull shattered.",
+            'observer_msg': "{attacker_name} slams the shield edge into {target_name}'s {hit_location}. They drop instantly, skull shattered."
         },
         {
-            'attacker_msg': "You smash the buckler into {target_name}'s face. Bone splinters, brain matter leaks.",
-            'victim_msg': "{attacker_name} smashes the buckler into your face. Bone splinters, brain matter leaks.",
-            'observer_msg': "{attacker_name} smashes the buckler into {target_name}'s face. Bone splinters, brain matter leaks."
+            'attacker_msg': "You smash the buckler into {target_name}'s {hit_location}. Bone splinters, brain matter leaks.",
+            'victim_msg': "{attacker_name} smashes the buckler into your {hit_location}. Bone splinters, brain matter leaks.",
+            'observer_msg': "{attacker_name} smashes the buckler into {target_name}'s {hit_location}. Bone splinters, brain matter leaks."
         },
         {
             'attacker_msg': "You strike with the shield rim, crushing {target_name}'s windpipe. They die gasping.",
@@ -567,13 +567,13 @@ MESSAGES = {
             'observer_msg': "{attacker_name} strikes with the shield rim, crushing {target_name}'s windpipe. They die gasping."
         },
         {
-            'attacker_msg': "You swing the buckler full force into {target_name}'s jaw. Their neck snaps with a wet crack.",
-            'victim_msg': "{attacker_name} swings the buckler full force into your jaw. Your neck snaps with a wet crack.",
-            'observer_msg': "{attacker_name} swings the buckler full force into {target_name}'s jaw. Their neck snaps with a wet crack."
+            'attacker_msg': "You swing the buckler full force into {target_name}'s {hit_location}. Their neck snaps with a wet crack.",
+            'victim_msg': "{attacker_name} swings the buckler full force into your {hit_location}. Your {hit_location} snaps with a wet crack.",
+            'observer_msg': "{attacker_name} swings the buckler full force into {target_name}'s {hit_location}. Their neck snaps with a wet crack."
         },
         {
             'attacker_msg': "You thrust the shield edge into {target_name}'s eye. It punches through to the back of the skull.",
-            'victim_msg': "{attacker_name} thrusts the shield edge into your eye. It punches through to the back of your skull.",
+            'victim_msg': "{attacker_name} thrusts the shield edge into your eye. It punches through to the back of your {hit_location}.",
             'observer_msg': "{attacker_name} thrusts the shield edge into {target_name}'s eye. It punches through to the back of the skull."
         },
         {
@@ -582,18 +582,18 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s buckler crushes {target_name}'s larynx. They fall backward, gasping their last."
         },
         {
-            'attacker_msg': "Your final bash caves in {target_name}'s chest. Ribs puncture the heart.",
-            'victim_msg': "{attacker_name}'s final bash caves in your chest. Ribs puncture your heart.",
-            'observer_msg': "{attacker_name}'s final bash caves in {target_name}'s chest. Ribs puncture the heart."
+            'attacker_msg': "Your final bash caves in {target_name}'s {hit_location}. Ribs puncture the heart.",
+            'victim_msg': "{attacker_name}'s final bash caves in your {hit_location}. Ribs puncture your {hit_location}.",
+            'observer_msg': "{attacker_name}'s final bash caves in {target_name}'s {hit_location}. Ribs puncture the heart."
         },
         {
-            'attacker_msg': "Your shield bash splits {target_name}'s skull wide open. They die before hitting the ground.",
-            'victim_msg': "{attacker_name}'s shield bash splits your skull wide open. You die before hitting the ground.",
-            'observer_msg': "{attacker_name}'s shield bash splits {target_name}'s skull wide open. They die before hitting the ground."
+            'attacker_msg': "Your shield bash splits {target_name}'s {hit_location} wide open. They die before hitting the ground.",
+            'victim_msg': "{attacker_name}'s shield bash splits your {hit_location} wide open. You die before hitting the ground.",
+            'observer_msg': "{attacker_name}'s shield bash splits {target_name}'s {hit_location} wide open. They die before hitting the ground."
         },
         {
             'attacker_msg': "Your shield crushes {target_name}'s nose into their brain. Death is instant.",
-            'victim_msg': "{attacker_name}'s shield crushes your nose into your brain. Death is instant.",
+            'victim_msg': "{attacker_name}'s shield crushes your nose into your {hit_location}. Death is instant.",
             'observer_msg': "{attacker_name}'s shield crushes {target_name}'s nose into their brain. Death is instant."
         },
         {
@@ -602,9 +602,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s shield edge severs {target_name}'s carotid artery. They bleed out in under a minute."
         },
         {
-            'attacker_msg': "Your shield rim punches a hole in {target_name}'s chest. They die clutching the wound.",
-            'victim_msg': "{attacker_name}'s shield rim punches a hole in your chest. You die clutching the wound.",
-            'observer_msg': "{attacker_name}'s shield rim punches a hole in {target_name}'s chest. They die clutching the wound."
+            'attacker_msg': "Your shield rim punches a hole in {target_name}'s {hit_location}. They die clutching the wound.",
+            'victim_msg': "{attacker_name}'s shield rim punches a hole in your {hit_location}. You die clutching the wound.",
+            'observer_msg': "{attacker_name}'s shield rim punches a hole in {target_name}'s {hit_location}. They die clutching the wound."
         }
     ]
 }

--- a/world/combat/messages/spraycan.py
+++ b/world/combat/messages/spraycan.py
@@ -62,7 +62,7 @@ MESSAGES = {
             "observer_msg": "Corporate branding on the can seems to mock the coming violence as {attacker_name} prepares to strike {target_name}."
         },
         {
-            "attacker_msg": "You weigh the spray can in your hand, imagining the satisfying crunch it will make against {target_name}'s skull.",
+            "attacker_msg": "You weigh the spray can in your {hit_location}, imagining the satisfying crunch it will make against {target_name}'s {hit_location}.",
             "victim_msg": "{attacker_name} weighs a spray can in their hand, their expression suggesting unpleasant thoughts about you.",
             "observer_msg": "{attacker_name} weighs the spray can in their hand, their expression suggesting unpleasant thoughts about {target_name}."
         },
@@ -224,9 +224,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} miscalculates the spray pattern, the toxic mist forming a useless cloud beside {target_name}."
         },
         {
-            "attacker_msg": "The aerosol can's weight throws off your aim, sending your strike sailing over {target_name}'s head.",
-            "victim_msg": "An aerosol can's weight throws off {attacker_name}'s aim, sending their strike sailing over your head.",
-            "observer_msg": "The aerosol can's weight throws off {attacker_name}'s aim, sending their strike sailing over {target_name}'s head."
+            "attacker_msg": "The aerosol can's weight throws off your aim, sending your strike sailing over {target_name}'s {hit_location}.",
+            "victim_msg": "An aerosol can's weight throws off {attacker_name}'s aim, sending their strike sailing over your {hit_location}.",
+            "observer_msg": "The aerosol can's weight throws off {attacker_name}'s aim, sending their strike sailing over {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "Corporate engineering fails you as the safety mechanism engages, stopping your spray attack on {target_name}.",
@@ -244,9 +244,9 @@ MESSAGES = {
             "observer_msg": "The pressurized container slips from {attacker_name}'s grasp mid-swing, tumbling uselessly toward {target_name}'s feet."
         },
         {
-            "attacker_msg": "You aim for {target_name}'s torso but the chemical stream arcs too high, creating a brief toxic rainbow.",
-            "victim_msg": "{attacker_name} aims for your torso but the chemical stream arcs too high, creating a brief toxic rainbow.",
-            "observer_msg": "{attacker_name} aims for {target_name}'s torso but the chemical stream arcs too high, creating a brief toxic rainbow."
+            "attacker_msg": "You aim for {target_name}'s {hit_location} but the chemical stream arcs too high, creating a brief toxic rainbow.",
+            "victim_msg": "{attacker_name} aims for your {hit_location} but the chemical stream arcs too high, creating a brief toxic rainbow.",
+            "observer_msg": "{attacker_name} aims for {target_name}'s {hit_location} but the chemical stream arcs too high, creating a brief toxic rainbow."
         },
         {
             "attacker_msg": "Industrial-grade irony strikes as the corporate weapon jams at the moment of truth against {target_name}.",
@@ -286,9 +286,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} blasts {target_name} directly in the eyes with a sustained spray, the chemicals burning and blinding."
         },
         {
-            "attacker_msg": "Your spray can cracks against {target_name}'s skull with a metallic clang, leaving them dazed.",
-            "victim_msg": "A spray can cracks against your skull with a metallic clang, leaving you dazed.",
-            "observer_msg": "The spray can cracks against {target_name}'s skull with a metallic clang, leaving them dazed."
+            "attacker_msg": "Your spray can cracks against {target_name}'s {hit_location} with a metallic clang, leaving them dazed.",
+            "victim_msg": "A spray can cracks against your {hit_location} with a metallic clang, leaving you dazed.",
+            "observer_msg": "The spray can cracks against {target_name}'s {hit_location} with a metallic clang, leaving them dazed."
         },
         {
             "attacker_msg": "You bring your spray can down hard on {target_name}'s {hit_location}, the impact denting the metal and splitting scalp.",
@@ -417,7 +417,7 @@ MESSAGES = {
         },
         {
             "attacker_msg": "You jab the spray can's bottom into {target_name}'s {hit_location}, knocking the wind from their lungs.",
-            "victim_msg": "{attacker_name} jabs a spray can's bottom into your {hit_location}, knocking the wind from your lungs.",
+            "victim_msg": "{attacker_name} jabs a spray can's bottom into your {hit_location}, knocking the wind from your {hit_location}.",
             "observer_msg": "{attacker_name} jabs the spray can's bottom into {target_name}'s {hit_location}, knocking the wind from their lungs."
         },
         {
@@ -453,29 +453,29 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "You drive the spray can's nozzle deep into {target_name}'s throat, then depress it, flooding their windpipe with toxic chemicals.",
-            "victim_msg": "{attacker_name} drives a spray can's nozzle deep into your throat, then depresses it, flooding your windpipe with toxic chemicals.",
-            "observer_msg": "{attacker_name} drives the spray can's nozzle deep into {target_name}'s throat, then depresses it, flooding their windpipe with toxic chemicals."
+            "attacker_msg": "You drive the spray can's nozzle deep into {target_name}'s {hit_location}, then depress it, flooding their windpipe with toxic chemicals.",
+            "victim_msg": "{attacker_name} drives a spray can's nozzle deep into your {hit_location}, then depresses it, flooding your windpipe with toxic chemicals.",
+            "observer_msg": "{attacker_name} drives the spray can's nozzle deep into {target_name}'s {hit_location}, then depresses it, flooding their windpipe with toxic chemicals."
         },
         {
-            "attacker_msg": "Your spray can ruptures against {target_name}'s skull with explosive force, paint and bone fragments mixing in a grotesque spray.",
-            "victim_msg": "A spray can ruptures against your skull with explosive force, paint and bone fragments mixing in a grotesque spray.",
-            "observer_msg": "The spray can ruptures against {target_name}'s skull with explosive force, paint and bone fragments mixing in a grotesque spray."
+            "attacker_msg": "Your spray can ruptures against {target_name}'s {hit_location} with explosive force, paint and bone fragments mixing in a grotesque spray.",
+            "victim_msg": "A spray can ruptures against your {hit_location} with explosive force, paint and bone fragments mixing in a grotesque spray.",
+            "observer_msg": "The spray can ruptures against {target_name}'s {hit_location} with explosive force, paint and bone fragments mixing in a grotesque spray."
         },
         {
             "attacker_msg": "You shove the spray can into {target_name}'s mouth and empty the entire contents, watching them convulse as toxic paint fills their lungs.",
-            "victim_msg": "{attacker_name} shoves a spray can into your mouth and empties the entire contents, toxic paint filling your lungs as you convulse.",
+            "victim_msg": "{attacker_name} shoves a spray can into your mouth and empties the entire contents, toxic paint filling your {hit_location} as you convulse.",
             "observer_msg": "{attacker_name} shoves the spray can into {target_name}'s mouth and empties the entire contents, watching them convulse as toxic paint fills their lungs."
         },
         {
-            "attacker_msg": "The pressurized cylinder becomes a brutal club as you cave in {target_name}'s temple, chemical residue mixing with brain matter.",
-            "victim_msg": "A pressurized cylinder becomes a brutal club as {attacker_name} caves in your temple, chemical residue mixing with brain matter.",
-            "observer_msg": "The pressurized cylinder becomes a brutal club as {attacker_name} caves in {target_name}'s temple, chemical residue mixing with brain matter."
+            "attacker_msg": "The pressurized cylinder becomes a brutal club as you cave in {target_name}'s {hit_location}, chemical residue mixing with brain matter.",
+            "victim_msg": "A pressurized cylinder becomes a brutal club as {attacker_name} caves in your {hit_location}, chemical residue mixing with brain matter.",
+            "observer_msg": "The pressurized cylinder becomes a brutal club as {attacker_name} caves in {target_name}'s {hit_location}, chemical residue mixing with brain matter."
         },
         {
-            "attacker_msg": "You spray continuously into {target_name}'s face until the toxic chemicals dissolve their features into an unrecognizable mess.",
-            "victim_msg": "{attacker_name} sprays continuously into your face until the toxic chemicals dissolve your features into an unrecognizable mess.",
-            "observer_msg": "{attacker_name} sprays continuously into {target_name}'s face until the toxic chemicals dissolve their features into an unrecognizable mess."
+            "attacker_msg": "You spray continuously into {target_name}'s {hit_location} until the toxic chemicals dissolve their features into an unrecognizable mess.",
+            "victim_msg": "{attacker_name} sprays continuously into your {hit_location} until the toxic chemicals dissolve your features into an unrecognizable mess.",
+            "observer_msg": "{attacker_name} sprays continuously into {target_name}'s {hit_location} until the toxic chemicals dissolve their features into an unrecognizable mess."
         },
         {
             "attacker_msg": "The aerosol can explodes in your grip as you drive it through {target_name}'s ribcage, pressurized death erupting from within.",
@@ -493,39 +493,39 @@ MESSAGES = {
             "observer_msg": "The improvised weapon crushes {target_name}'s windpipe with a wet crunch, chemical propellant hissing from the ruptured can."
         },
         {
-            "attacker_msg": "Corporate toxins become your instrument of death as you flood {target_name}'s lungs with industrial solvents.",
-            "victim_msg": "Corporate toxins become {attacker_name}'s instrument of death as they flood your lungs with industrial solvents.",
-            "observer_msg": "Corporate toxins become {attacker_name}'s instrument of death as they flood {target_name}'s lungs with industrial solvents."
+            "attacker_msg": "Corporate toxins become your instrument of death as you flood {target_name}'s {hit_location} with industrial solvents.",
+            "victim_msg": "Corporate toxins become {attacker_name}'s instrument of death as they flood your {hit_location} with industrial solvents.",
+            "observer_msg": "Corporate toxins become {attacker_name}'s instrument of death as they flood {target_name}'s {hit_location} with industrial solvents."
         },
         {
-            "attacker_msg": "You beat {target_name}'s skull to pulp with the metal cylinder, each impact spraying chemical-tainted gore.",
-            "victim_msg": "{attacker_name} beats your skull to pulp with the metal cylinder, each impact spraying chemical-tainted gore.",
-            "observer_msg": "{attacker_name} beats {target_name}'s skull to pulp with the metal cylinder, each impact spraying chemical-tainted gore."
+            "attacker_msg": "You beat {target_name}'s {hit_location} to pulp with the metal cylinder, each impact spraying chemical-tainted gore.",
+            "victim_msg": "{attacker_name} beats your {hit_location} to pulp with the metal cylinder, each impact spraying chemical-tainted gore.",
+            "observer_msg": "{attacker_name} beats {target_name}'s {hit_location} to pulp with the metal cylinder, each impact spraying chemical-tainted gore."
         },
         {
             "attacker_msg": "The spray can's pressurized contents explode outward as you ram it through {target_name}'s eye socket into their brain.",
-            "victim_msg": "A spray can's pressurized contents explode outward as {attacker_name} rams it through your eye socket into your brain.",
+            "victim_msg": "A spray can's pressurized contents explode outward as {attacker_name} rams it through your eye socket into your {hit_location}.",
             "observer_msg": "The spray can's pressurized contents explode outward as {attacker_name} rams it through {target_name}'s eye socket into their brain."
         },
         {
-            "attacker_msg": "You crack {target_name}'s skull like an egg with repeated blows from the aerosol canister, toxic paint leaking into the wounds.",
-            "victim_msg": "{attacker_name} cracks your skull like an egg with repeated blows from the aerosol canister, toxic paint leaking into the wounds.",
-            "observer_msg": "{attacker_name} cracks {target_name}'s skull like an egg with repeated blows from the aerosol canister, toxic paint leaking into the wounds."
+            "attacker_msg": "You crack {target_name}'s {hit_location} like an egg with repeated blows from the aerosol canister, toxic paint leaking into the wounds.",
+            "victim_msg": "{attacker_name} cracks your {hit_location} like an egg with repeated blows from the aerosol canister, toxic paint leaking into the wounds.",
+            "observer_msg": "{attacker_name} cracks {target_name}'s {hit_location} like an egg with repeated blows from the aerosol canister, toxic paint leaking into the wounds."
         },
         {
-            "attacker_msg": "Chemical warfare reaches its logical conclusion as you force the nozzle down {target_name}'s throat and empty the canister.",
-            "victim_msg": "Chemical warfare reaches its logical conclusion as {attacker_name} forces the nozzle down your throat and empties the canister.",
-            "observer_msg": "Chemical warfare reaches its logical conclusion as {attacker_name} forces the nozzle down {target_name}'s throat and empties the canister."
+            "attacker_msg": "Chemical warfare reaches its logical conclusion as you force the nozzle down {target_name}'s {hit_location} and empty the canister.",
+            "victim_msg": "Chemical warfare reaches its logical conclusion as {attacker_name} forces the nozzle down your {hit_location} and empties the canister.",
+            "observer_msg": "Chemical warfare reaches its logical conclusion as {attacker_name} forces the nozzle down {target_name}'s {hit_location} and empties the canister."
         },
         {
             "attacker_msg": "You cave in {target_name}'s chest cavity with the pressurized cylinder, their ribs cracking like kindling.",
-            "victim_msg": "{attacker_name} caves in your chest cavity with the pressurized cylinder, your ribs cracking like kindling.",
+            "victim_msg": "{attacker_name} caves in your chest cavity with the pressurized cylinder, your {hit_location} cracking like kindling.",
             "observer_msg": "{attacker_name} caves in {target_name}'s chest cavity with the pressurized cylinder, their ribs cracking like kindling."
         },
         {
-            "attacker_msg": "The corporate logo becomes a death mask as you press the hot canister into {target_name}'s face until it melts through flesh and bone.",
-            "victim_msg": "A corporate logo becomes a death mask as {attacker_name} presses the hot canister into your face until it melts through flesh and bone.",
-            "observer_msg": "The corporate logo becomes a death mask as {attacker_name} presses the hot canister into {target_name}'s face until it melts through flesh and bone."
+            "attacker_msg": "The corporate logo becomes a death mask as you press the hot canister into {target_name}'s {hit_location} until it melts through flesh and bone.",
+            "victim_msg": "A corporate logo becomes a death mask as {attacker_name} presses the hot canister into your {hit_location} until it melts through flesh and bone.",
+            "observer_msg": "The corporate logo becomes a death mask as {attacker_name} presses the hot canister into {target_name}'s {hit_location} until it melts through flesh and bone."
         },
         {
             "attacker_msg": "You methodically spray industrial solvent into {target_name}'s wounds until their screaming stops and their body goes still.",
@@ -533,9 +533,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} methodically sprays industrial solvent into {target_name}'s wounds until their screaming stops and their body goes still."
         },
         {
-            "attacker_msg": "The aerosol can becomes a piston of death as you drive it repeatedly into {target_name}'s sternum until it caves inward.",
-            "victim_msg": "An aerosol can becomes a piston of death as {attacker_name} drives it repeatedly into your sternum until it caves inward.",
-            "observer_msg": "The aerosol can becomes a piston of death as {attacker_name} drives it repeatedly into {target_name}'s sternum until it caves inward."
+            "attacker_msg": "The aerosol can becomes a piston of death as you drive it repeatedly into {target_name}'s {hit_location} until it caves inward.",
+            "victim_msg": "An aerosol can becomes a piston of death as {attacker_name} drives it repeatedly into your {hit_location} until it caves inward.",
+            "observer_msg": "The aerosol can becomes a piston of death as {attacker_name} drives it repeatedly into {target_name}'s {hit_location} until it caves inward."
         },
         {
             "attacker_msg": "You spray toxic chemicals directly onto {target_name}'s exposed brain through their cracked skull, watching consciousness flicker and die.",
@@ -553,9 +553,9 @@ MESSAGES = {
             "observer_msg": "The improvised weapon punctures {target_name}'s jugular, chemical propellant mixing with arterial spray in a grotesque fountain."
         },
         {
-            "attacker_msg": "You force the entire aerosol can down {target_name}'s throat, then puncture it from the outside, internal pressure tearing them apart.",
-            "victim_msg": "{attacker_name} forces the entire aerosol can down your throat, then punctures it from the outside, internal pressure tearing you apart.",
-            "observer_msg": "{attacker_name} forces the entire aerosol can down {target_name}'s throat, then punctures it from the outside, internal pressure tearing them apart."
+            "attacker_msg": "You force the entire aerosol can down {target_name}'s {hit_location}, then puncture it from the outside, internal pressure tearing them apart.",
+            "victim_msg": "{attacker_name} forces the entire aerosol can down your {hit_location}, then punctures it from the outside, internal pressure tearing you apart.",
+            "observer_msg": "{attacker_name} forces the entire aerosol can down {target_name}'s {hit_location}, then punctures it from the outside, internal pressure tearing them apart."
         },
         {
             "attacker_msg": "Corporate violence reaches its logical endpoint as you beat {target_name} to death with their own branded toxins.",
@@ -563,9 +563,9 @@ MESSAGES = {
             "observer_msg": "Corporate violence reaches its logical endpoint as {attacker_name} beats {target_name} to death with their own branded toxins."
         },
         {
-            "attacker_msg": "The pressurized canister becomes an instrument of cranial destruction as you systematically cave in {target_name}'s skull.",
-            "victim_msg": "A pressurized canister becomes an instrument of cranial destruction as {attacker_name} systematically caves in your skull.",
-            "observer_msg": "The pressurized canister becomes an instrument of cranial destruction as {attacker_name} systematically caves in {target_name}'s skull."
+            "attacker_msg": "The pressurized canister becomes an instrument of cranial destruction as you systematically cave in {target_name}'s {hit_location}.",
+            "victim_msg": "A pressurized canister becomes an instrument of cranial destruction as {attacker_name} systematically caves in your {hit_location}.",
+            "observer_msg": "The pressurized canister becomes an instrument of cranial destruction as {attacker_name} systematically caves in {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "You empty the spray can's toxic contents into {target_name}'s open wounds, watching chemical necrosis spread until they expire.",
@@ -573,9 +573,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} empties the spray can's toxic contents into {target_name}'s open wounds, watching chemical necrosis spread until they expire."
         },
         {
-            "attacker_msg": "The metal cylinder becomes a jackhammer of death as you pulverize {target_name}'s spine with mechanical precision.",
-            "victim_msg": "A metal cylinder becomes a jackhammer of death as {attacker_name} pulverizes your spine with mechanical precision.",
-            "observer_msg": "The metal cylinder becomes a jackhammer of death as {attacker_name} pulverizes {target_name}'s spine with mechanical precision."
+            "attacker_msg": "The metal cylinder becomes a jackhammer of death as you pulverize {target_name}'s {hit_location} with mechanical precision.",
+            "victim_msg": "A metal cylinder becomes a jackhammer of death as {attacker_name} pulverizes your {hit_location} with mechanical precision.",
+            "observer_msg": "The metal cylinder becomes a jackhammer of death as {attacker_name} pulverizes {target_name}'s {hit_location} with mechanical precision."
         }
     ]
 }

--- a/world/combat/messages/staff.py
+++ b/world/combat/messages/staff.py
@@ -71,7 +71,7 @@ MESSAGES = {
             'observer_msg': "The staff moves like memory — fast, fluid, practiced. {attacker_name} is already moving."
         },
         {
-            'attacker_msg': "The staff rests against your hip before snapping into place. The rhythm is muscle memory.",
+            'attacker_msg': "The staff rests against your {hit_location} before snapping into place. The rhythm is muscle memory.",
             'victim_msg': "The staff rests against {attacker_name}'s hip before snapping into place. The rhythm is muscle memory.",
             'observer_msg': "The staff rests against {attacker_name}'s hip before snapping into place. The rhythm is muscle memory."
         },
@@ -86,7 +86,7 @@ MESSAGES = {
             'observer_msg': "The wood creaks with motion. {attacker_name}'s hands know exactly where to hold."
         },
         {
-            'attacker_msg': "The wood spins across your back and into ready hands. This is ritual, not showmanship.",
+            'attacker_msg': "The wood spins across your {hit_location} and into ready hands. This is ritual, not showmanship.",
             'victim_msg': "The wood spins across {attacker_name}'s back and into ready hands. This is ritual, not showmanship.",
             'observer_msg': "The wood spins across {attacker_name}'s back and into ready hands. This is ritual, not showmanship."
         },
@@ -253,9 +253,9 @@ MESSAGES = {
             'observer_msg': "The tip jabs deep into {target_name}'s {hit_location}. They fold backward, gasping."
         },
         {
-            'attacker_msg': "The wood cracks against {target_name}'s skull. They stumble, dazed.",
-            'victim_msg': "The wood cracks against your skull. You stumble, dazed.",
-            'observer_msg': "The wood cracks against {target_name}'s skull. They stumble, dazed."
+            'attacker_msg': "The wood cracks against {target_name}'s {hit_location}. They stumble, dazed.",
+            'victim_msg': "The wood cracks against your {hit_location}. You stumble, dazed.",
+            'observer_msg': "The wood cracks against {target_name}'s {hit_location}. They stumble, dazed."
         },
         {
             'attacker_msg': "You bring the staff down hard on {target_name}'s {hit_location}. It snaps.",
@@ -331,12 +331,12 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A thrust aimed at the chest catches nothing but wind. {target_name} twists away.",
-            'victim_msg': "A thrust aimed at your chest catches nothing but wind. You twist away.",
+            'victim_msg': "A thrust aimed at your {hit_location} catches nothing but wind. You twist away.",
             'observer_msg': "A thrust aimed at the chest catches nothing but wind. {target_name} twists away."
         },
         {
             'attacker_msg': "The butt end swings toward the ribs, but {target_name} steps out of reach.",
-            'victim_msg': "The butt end swings toward your ribs, but you step out of reach.",
+            'victim_msg': "The butt end swings toward your {hit_location}, but you step out of reach.",
             'observer_msg': "The butt end swings toward the ribs, but {target_name} steps out of reach."
         },
         {
@@ -380,9 +380,9 @@ MESSAGES = {
             'observer_msg': "The thrust seeks center mass, but {target_name} pivots aside like smoke."
         },
         {
-            'attacker_msg': "The tip seeks {target_name}'s chest, but they lean back just enough.",
-            'victim_msg': "The tip seeks your chest, but you lean back just enough.",
-            'observer_msg': "The tip seeks {target_name}'s chest, but they lean back just enough."
+            'attacker_msg': "The tip seeks {target_name}'s {hit_location}, but they lean back just enough.",
+            'victim_msg': "The tip seeks your {hit_location}, but you lean back just enough.",
+            'observer_msg': "The tip seeks {target_name}'s {hit_location}, but they lean back just enough."
         },
         {
             'attacker_msg': "You arc the staff overhead, but {target_name} rolls away from the blow.",
@@ -450,45 +450,45 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s staff arcs in a deadly circle, but {target_name} slips away like water."
         },
         {
-            'attacker_msg': "Your staff seeks {target_name}'s head, but they duck at exactly the right moment.",
-            'victim_msg': "{attacker_name}'s staff seeks your head, but you duck at exactly the right moment.",
-            'observer_msg': "{attacker_name}'s staff seeks {target_name}'s head, but they duck at exactly the right moment."
+            'attacker_msg': "Your staff seeks {target_name}'s {hit_location}, but they duck at exactly the right moment.",
+            'victim_msg': "{attacker_name}'s staff seeks your {hit_location}, but you duck at exactly the right moment.",
+            'observer_msg': "{attacker_name}'s staff seeks {target_name}'s {hit_location}, but they duck at exactly the right moment."
         }
     ],
     'kill': [
         {
-            'attacker_msg': "A brutal downward strike splits {target_name}'s skull. They drop like a sack of meat.",
-            'victim_msg': "A brutal downward strike splits your skull. You drop like a sack of meat.",
-            'observer_msg': "A brutal downward strike splits {target_name}'s skull. They drop like a sack of meat."
+            'attacker_msg': "A brutal downward strike splits {target_name}'s {hit_location}. They drop like a sack of meat.",
+            'victim_msg': "A brutal downward strike splits your {hit_location}. You drop like a sack of meat.",
+            'observer_msg': "A brutal downward strike splits {target_name}'s {hit_location}. They drop like a sack of meat."
         },
         {
-            'attacker_msg': "A full-force thrust punches through {target_name}'s chest. They die with a wet gasp.",
-            'victim_msg': "A full-force thrust punches through your chest. You die with a wet gasp.",
-            'observer_msg': "A full-force thrust punches through {target_name}'s chest. They die with a wet gasp."
+            'attacker_msg': "A full-force thrust punches through {target_name}'s {hit_location}. They die with a wet gasp.",
+            'victim_msg': "A full-force thrust punches through your {hit_location}. You die with a wet gasp.",
+            'observer_msg': "A full-force thrust punches through {target_name}'s {hit_location}. They die with a wet gasp."
         },
         {
             'attacker_msg': "A precise jab to the temple crushes bone. {target_name} collapses instantly.",
-            'victim_msg': "A precise jab to your temple crushes bone. You collapse instantly.",
+            'victim_msg': "A precise jab to your {hit_location} crushes bone. You collapse instantly.",
             'observer_msg': "A precise jab to the temple crushes bone. {target_name} collapses instantly."
         },
         {
             'attacker_msg': "A savage blow to the base of the skull snaps the neck. {target_name} drops like a broken doll.",
-            'victim_msg': "A savage blow to the base of your skull snaps your neck. You drop like a broken doll.",
+            'victim_msg': "A savage blow to the base of your {hit_location} snaps your {hit_location}. You drop like a broken doll.",
             'observer_msg': "A savage blow to the base of the skull snaps the neck. {target_name} drops like a broken doll."
         },
         {
             'attacker_msg': "A thrust to the throat crushes the windpipe. {target_name} gurgles once, then goes silent.",
-            'victim_msg': "A thrust to your throat crushes your windpipe. You gurgle once, then go silent.",
+            'victim_msg': "A thrust to your {hit_location} crushes your windpipe. You gurgle once, then go silent.",
             'observer_msg': "A thrust to the throat crushes the windpipe. {target_name} gurgles once, then goes silent."
         },
         {
-            'attacker_msg': "A vicious strike caves in {target_name}'s chest. Ribs puncture the lungs.",
-            'victim_msg': "A vicious strike caves in your chest. Ribs puncture your lungs.",
-            'observer_msg': "A vicious strike caves in {target_name}'s chest. Ribs puncture the lungs."
+            'attacker_msg': "A vicious strike caves in {target_name}'s {hit_location}. Ribs puncture the lungs.",
+            'victim_msg': "A vicious strike caves in your {hit_location}. Ribs puncture your {hit_location}.",
+            'observer_msg': "A vicious strike caves in {target_name}'s {hit_location}. Ribs puncture the lungs."
         },
         {
             'attacker_msg': "One final thrust pierces the heart. {target_name} staggers, then falls forward, dead.",
-            'victim_msg': "One final thrust pierces your heart. You stagger, then fall forward, dead.",
+            'victim_msg': "One final thrust pierces your {hit_location}. You stagger, then fall forward, dead.",
             'observer_msg': "One final thrust pierces the heart. {target_name} staggers, then falls forward, dead."
         },
         {
@@ -502,63 +502,63 @@ MESSAGES = {
             'observer_msg': "The final blow crushes {target_name}'s larynx. They choke to death on blood."
         },
         {
-            'attacker_msg': "The staff end punches through {target_name}'s ribs and into the heart. Death is instant.",
-            'victim_msg': "The staff end punches through your ribs and into your heart. Death is instant.",
-            'observer_msg': "The staff end punches through {target_name}'s ribs and into the heart. Death is instant."
+            'attacker_msg': "The staff end punches through {target_name}'s {hit_location} and into the heart. Death is instant.",
+            'victim_msg': "The staff end punches through your {hit_location} and into your {hit_location}. Death is instant.",
+            'observer_msg': "The staff end punches through {target_name}'s {hit_location} and into the heart. Death is instant."
         },
         {
-            'attacker_msg': "The staff splits {target_name}'s skull like a melon. Brain matter spatters.",
-            'victim_msg': "The staff splits your skull like a melon. Brain matter spatters.",
-            'observer_msg': "The staff splits {target_name}'s skull like a melon. Brain matter spatters."
+            'attacker_msg': "The staff splits {target_name}'s {hit_location} like a melon. Brain matter spatters.",
+            'victim_msg': "The staff splits your {hit_location} like a melon. Brain matter spatters.",
+            'observer_msg': "The staff splits {target_name}'s {hit_location} like a melon. Brain matter spatters."
         },
         {
-            'attacker_msg': "The tip pierces {target_name}'s lung. They drown in their own blood.",
-            'victim_msg': "The tip pierces your lung. You drown in your own blood.",
-            'observer_msg': "The tip pierces {target_name}'s lung. They drown in their own blood."
+            'attacker_msg': "The tip pierces {target_name}'s {hit_location}. They drown in their own blood.",
+            'victim_msg': "The tip pierces your {hit_location}. You drown in your own blood.",
+            'observer_msg': "The tip pierces {target_name}'s {hit_location}. They drown in their own blood."
         },
         {
-            'attacker_msg': "The wood cracks {target_name}'s spine. They crumple, paralyzed and dying.",
-            'victim_msg': "The wood cracks your spine. You crumple, paralyzed and dying.",
-            'observer_msg': "The wood cracks {target_name}'s spine. They crumple, paralyzed and dying."
+            'attacker_msg': "The wood cracks {target_name}'s {hit_location}. They crumple, paralyzed and dying.",
+            'victim_msg': "The wood cracks your {hit_location}. You crumple, paralyzed and dying.",
+            'observer_msg': "The wood cracks {target_name}'s {hit_location}. They crumple, paralyzed and dying."
         },
         {
-            'attacker_msg': "You bring the staff down on {target_name}'s head. Skull fragments scatter.",
-            'victim_msg': "{attacker_name} brings the staff down on your head. Skull fragments scatter.",
-            'observer_msg': "{attacker_name} brings the staff down on {target_name}'s head. Skull fragments scatter."
+            'attacker_msg': "You bring the staff down on {target_name}'s {hit_location}. Skull fragments scatter.",
+            'victim_msg': "{attacker_name} brings the staff down on your {hit_location}. Skull fragments scatter.",
+            'observer_msg': "{attacker_name} brings the staff down on {target_name}'s {hit_location}. Skull fragments scatter."
         },
         {
-            'attacker_msg': "You drive the butt end through {target_name}'s temple. They convulse once, then still.",
-            'victim_msg': "{attacker_name} drives the butt end through your temple. You convulse once, then still.",
-            'observer_msg': "{attacker_name} drives the butt end through {target_name}'s temple. They convulse once, then still."
+            'attacker_msg': "You drive the butt end through {target_name}'s {hit_location}. They convulse once, then still.",
+            'victim_msg': "{attacker_name} drives the butt end through your {hit_location}. You convulse once, then still.",
+            'observer_msg': "{attacker_name} drives the butt end through {target_name}'s {hit_location}. They convulse once, then still."
         },
         {
-            'attacker_msg': "You drive the staff deep into {target_name}'s stomach. They fold over the weapon and die.",
-            'victim_msg': "{attacker_name} drives the staff deep into your stomach. You fold over the weapon and die.",
-            'observer_msg': "{attacker_name} drives the staff deep into {target_name}'s stomach. They fold over the weapon and die."
+            'attacker_msg': "You drive the staff deep into {target_name}'s {hit_location}. They fold over the weapon and die.",
+            'victim_msg': "{attacker_name} drives the staff deep into your {hit_location}. You fold over the weapon and die.",
+            'observer_msg': "{attacker_name} drives the staff deep into {target_name}'s {hit_location}. They fold over the weapon and die."
         },
         {
             'attacker_msg': "You impale {target_name} through the chest. The staff emerges bloody from their back.",
-            'victim_msg': "{attacker_name} impales you through the chest. The staff emerges bloody from your back.",
+            'victim_msg': "{attacker_name} impales you through the chest. The staff emerges bloody from your {hit_location}.",
             'observer_msg': "{attacker_name} impales {target_name} through the chest. The staff emerges bloody from their back."
         },
         {
-            'attacker_msg': "You pierce {target_name}'s throat with the staff tip. They gurgle and collapse.",
-            'victim_msg': "{attacker_name} pierces your throat with the staff tip. You gurgle and collapse.",
-            'observer_msg': "{attacker_name} pierces {target_name}'s throat with the staff tip. They gurgle and collapse."
+            'attacker_msg': "You pierce {target_name}'s {hit_location} with the staff tip. They gurgle and collapse.",
+            'victim_msg': "{attacker_name} pierces your {hit_location} with the staff tip. You gurgle and collapse.",
+            'observer_msg': "{attacker_name} pierces {target_name}'s {hit_location} with the staff tip. They gurgle and collapse."
         },
         {
-            'attacker_msg': "You slam the staff across {target_name}'s neck, snapping vertebrae. They drop instantly.",
-            'victim_msg': "{attacker_name} slams the staff across your neck, snapping vertebrae. You drop instantly.",
-            'observer_msg': "{attacker_name} slams the staff across {target_name}'s neck, snapping vertebrae. They drop instantly."
+            'attacker_msg': "You slam the staff across {target_name}'s {hit_location}, snapping vertebrae. They drop instantly.",
+            'victim_msg': "{attacker_name} slams the staff across your {hit_location}, snapping vertebrae. You drop instantly.",
+            'observer_msg': "{attacker_name} slams the staff across {target_name}'s {hit_location}, snapping vertebrae. They drop instantly."
         },
         {
             'attacker_msg': "You strike {target_name} in the solar plexus, stopping their heart. They die standing.",
-            'victim_msg': "{attacker_name} strikes you in the solar plexus, stopping your heart. You die standing.",
+            'victim_msg': "{attacker_name} strikes you in the solar plexus, stopping your {hit_location}. You die standing.",
             'observer_msg': "{attacker_name} strikes {target_name} in the solar plexus, stopping their heart. They die standing."
         },
         {
             'attacker_msg': "You thrust the staff through {target_name}'s eye and into their brain. Death is instant.",
-            'victim_msg': "{attacker_name} thrusts the staff through your eye and into your brain. Death is instant.",
+            'victim_msg': "{attacker_name} thrusts the staff through your eye and into your {hit_location}. Death is instant.",
             'observer_msg': "{attacker_name} thrusts the staff through {target_name}'s eye and into their brain. Death is instant."
         },
         {
@@ -568,7 +568,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Your staff crushes {target_name}'s orbital bone, driving fragments into their brain.",
-            'victim_msg': "{attacker_name}'s staff crushes your orbital bone, driving fragments into your brain.",
+            'victim_msg': "{attacker_name}'s staff crushes your orbital bone, driving fragments into your {hit_location}.",
             'observer_msg': "{attacker_name}'s staff crushes {target_name}'s orbital bone, driving fragments into their brain."
         },
         {
@@ -577,34 +577,34 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s staff pierces {target_name}'s kidney. They bleed out in under a minute."
         },
         {
-            'attacker_msg': "Your staff punches a hole through {target_name}'s sternum. Their heart stops.",
-            'victim_msg': "{attacker_name}'s staff punches a hole through your sternum. Your heart stops.",
-            'observer_msg': "{attacker_name}'s staff punches a hole through {target_name}'s sternum. Their heart stops."
+            'attacker_msg': "Your staff punches a hole through {target_name}'s {hit_location}. Their heart stops.",
+            'victim_msg': "{attacker_name}'s staff punches a hole through your {hit_location}. Your {hit_location} stops.",
+            'observer_msg': "{attacker_name}'s staff punches a hole through {target_name}'s {hit_location}. Their heart stops."
         },
         {
-            'attacker_msg': "Your staff severs {target_name}'s spine at the neck. They collapse like a marionette.",
-            'victim_msg': "{attacker_name}'s staff severs your spine at the neck. You collapse like a marionette.",
-            'observer_msg': "{attacker_name}'s staff severs {target_name}'s spine at the neck. They collapse like a marionette."
+            'attacker_msg': "Your staff severs {target_name}'s {hit_location} at the neck. They collapse like a marionette.",
+            'victim_msg': "{attacker_name}'s staff severs your {hit_location} at the neck. You collapse like a marionette.",
+            'observer_msg': "{attacker_name}'s staff severs {target_name}'s {hit_location} at the neck. They collapse like a marionette."
         },
         {
-            'attacker_msg': "Your staff splits {target_name}'s head open like a ripe fruit. Death is instant.",
-            'victim_msg': "{attacker_name}'s staff splits your head open like a ripe fruit. Death is instant.",
-            'observer_msg': "{attacker_name}'s staff splits {target_name}'s head open like a ripe fruit. Death is instant."
+            'attacker_msg': "Your staff splits {target_name}'s {hit_location} open like a ripe fruit. Death is instant.",
+            'victim_msg': "{attacker_name}'s staff splits your {hit_location} open like a ripe fruit. Death is instant.",
+            'observer_msg': "{attacker_name}'s staff splits {target_name}'s {hit_location} open like a ripe fruit. Death is instant."
         },
         {
-            'attacker_msg': "Your thrust penetrates {target_name}'s abdomen, severing the aorta. They bleed out fast.",
-            'victim_msg': "{attacker_name}'s thrust penetrates your abdomen, severing the aorta. You bleed out fast.",
-            'observer_msg': "{attacker_name}'s thrust penetrates {target_name}'s abdomen, severing the aorta. They bleed out fast."
+            'attacker_msg': "Your thrust penetrates {target_name}'s {hit_location}, severing the aorta. They bleed out fast.",
+            'victim_msg': "{attacker_name}'s thrust penetrates your {hit_location}, severing the aorta. You bleed out fast.",
+            'observer_msg': "{attacker_name}'s thrust penetrates {target_name}'s {hit_location}, severing the aorta. They bleed out fast."
         },
         {
-            'attacker_msg': "Your thrust pierces {target_name}'s lung, filling it with blood. They drown standing up.",
-            'victim_msg': "{attacker_name}'s thrust pierces your lung, filling it with blood. You drown standing up.",
-            'observer_msg': "{attacker_name}'s thrust pierces {target_name}'s lung, filling it with blood. They drown standing up."
+            'attacker_msg': "Your thrust pierces {target_name}'s {hit_location}, filling it with blood. They drown standing up.",
+            'victim_msg': "{attacker_name}'s thrust pierces your {hit_location}, filling it with blood. You drown standing up.",
+            'observer_msg': "{attacker_name}'s thrust pierces {target_name}'s {hit_location}, filling it with blood. They drown standing up."
         },
         {
-            'attacker_msg': "Your upward strike shatters {target_name}'s jaw and drives bone into their brain.",
-            'victim_msg': "{attacker_name}'s upward strike shatters your jaw and drives bone into your brain.",
-            'observer_msg': "{attacker_name}'s upward strike shatters {target_name}'s jaw and drives bone into their brain."
+            'attacker_msg': "Your upward strike shatters {target_name}'s {hit_location} and drives bone into their brain.",
+            'victim_msg': "{attacker_name}'s upward strike shatters your {hit_location} and drives bone into your {hit_location}.",
+            'observer_msg': "{attacker_name}'s upward strike shatters {target_name}'s {hit_location} and drives bone into their brain."
         }
     ]
 }

--- a/world/combat/messages/stake.py
+++ b/world/combat/messages/stake.py
@@ -326,22 +326,22 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A jab toward the ribs comes up short. {target_name} leans back just enough.",
-            'victim_msg': "A jab toward your ribs comes up short. You lean back just enough.",
+            'victim_msg': "A jab toward your {hit_location} comes up short. You lean back just enough.",
             'observer_msg': "A jab toward the ribs comes up short. {target_name} leans back just enough."
         },
         {
             'attacker_msg': "A quick thrust seeks the stomach, but {target_name} twists away gracefully.",
-            'victim_msg': "A quick thrust seeks your stomach, but you twist away gracefully.",
+            'victim_msg': "A quick thrust seeks your {hit_location}, but you twist away gracefully.",
             'observer_msg': "A quick thrust seeks the stomach, but {target_name} twists away gracefully."
         },
         {
             'attacker_msg': "A savage jab aimed at the chest catches only fabric. {target_name} spins away.",
-            'victim_msg': "A savage jab aimed at your chest catches only fabric. You spin away.",
+            'victim_msg': "A savage jab aimed at your {hit_location} catches only fabric. You spin away.",
             'observer_msg': "A savage jab aimed at the chest catches only fabric. {target_name} spins away."
         },
         {
             'attacker_msg': "A strike toward the face meets nothing. {target_name} jerks backward.",
-            'victim_msg': "A strike toward your face meets nothing. You jerk backward.",
+            'victim_msg': "A strike toward your {hit_location} meets nothing. You jerk backward.",
             'observer_msg': "A strike toward the face meets nothing. {target_name} jerks backward."
         },
         {
@@ -360,9 +360,9 @@ MESSAGES = {
             'observer_msg': "The stake arcs through empty space. {target_name} weaves away like smoke."
         },
         {
-            'attacker_msg': "The stake cuts the air where {target_name}'s head was. They duck at the perfect moment.",
-            'victim_msg': "The stake cuts the air where your head was. You duck at the perfect moment.",
-            'observer_msg': "The stake cuts the air where {target_name}'s head was. They duck at the perfect moment."
+            'attacker_msg': "The stake cuts the air where {target_name}'s {hit_location} was. They duck at the perfect moment.",
+            'victim_msg': "The stake cuts the air where your {hit_location} was. You duck at the perfect moment.",
+            'observer_msg': "The stake cuts the air where {target_name}'s {hit_location} was. They duck at the perfect moment."
         },
         {
             'attacker_msg': "The stake grazes cloth but not skin. {target_name} pulls back, unharmed.",
@@ -380,9 +380,9 @@ MESSAGES = {
             'observer_msg': "The stake whistles past {target_name}'s ear. Close, but not close enough."
         },
         {
-            'attacker_msg': "The tip seeks the center of {target_name}'s chest, but they pivot away.",
-            'victim_msg': "The tip seeks the center of your chest, but you pivot away.",
-            'observer_msg': "The tip seeks the center of {target_name}'s chest, but they pivot away."
+            'attacker_msg': "The tip seeks the center of {target_name}'s {hit_location}, but they pivot away.",
+            'victim_msg': "The tip seeks the center of your {hit_location}, but you pivot away.",
+            'observer_msg': "The tip seeks the center of {target_name}'s {hit_location}, but they pivot away."
         },
         {
             'attacker_msg': "You drive the stake forward, but {target_name} slips to the side.",
@@ -420,19 +420,19 @@ MESSAGES = {
             'observer_msg': "{attacker_name} thrusts hard with the point, but {target_name} sidesteps gracefully."
         },
         {
-            'attacker_msg': "You thrust the stake toward {target_name}'s chest, but they lean back just enough.",
-            'victim_msg': "{attacker_name} thrusts the stake toward your chest, but you lean back just enough.",
-            'observer_msg': "{attacker_name} thrusts the stake toward {target_name}'s chest, but they lean back just enough."
+            'attacker_msg': "You thrust the stake toward {target_name}'s {hit_location}, but they lean back just enough.",
+            'victim_msg': "{attacker_name} thrusts the stake toward your {hit_location}, but you lean back just enough.",
+            'observer_msg': "{attacker_name} thrusts the stake toward {target_name}'s {hit_location}, but they lean back just enough."
         },
         {
-            'attacker_msg': "Your jab seeks {target_name}'s stomach, but they step back, staying safe.",
-            'victim_msg': "{attacker_name}'s jab seeks your stomach, but you step back, staying safe.",
-            'observer_msg': "{attacker_name}'s jab seeks {target_name}'s stomach, but they step back, staying safe."
+            'attacker_msg': "Your jab seeks {target_name}'s {hit_location}, but they step back, staying safe.",
+            'victim_msg': "{attacker_name}'s jab seeks your {hit_location}, but you step back, staying safe.",
+            'observer_msg': "{attacker_name}'s jab seeks {target_name}'s {hit_location}, but they step back, staying safe."
         },
         {
-            'attacker_msg': "Your stake arcs toward {target_name}'s head, but they duck at the perfect moment.",
-            'victim_msg': "{attacker_name}'s stake arcs toward your head, but you duck at the perfect moment.",
-            'observer_msg': "{attacker_name}'s stake arcs toward {target_name}'s head, but they duck at the perfect moment."
+            'attacker_msg': "Your stake arcs toward {target_name}'s {hit_location}, but they duck at the perfect moment.",
+            'victim_msg': "{attacker_name}'s stake arcs toward your {hit_location}, but you duck at the perfect moment.",
+            'observer_msg': "{attacker_name}'s stake arcs toward {target_name}'s {hit_location}, but they duck at the perfect moment."
         },
         {
             'attacker_msg': "Your stake cuts a deadly path through air, but {target_name} is no longer there.",
@@ -445,9 +445,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s stake seeks flesh but finds only the space {target_name} vacated."
         },
         {
-            'attacker_msg': "Your thrust aims for {target_name}'s ribs, but they weave away like water.",
-            'victim_msg': "{attacker_name}'s thrust aims for your ribs, but you weave away like water.",
-            'observer_msg': "{attacker_name}'s thrust aims for {target_name}'s ribs, but they weave away like water."
+            'attacker_msg': "Your thrust aims for {target_name}'s {hit_location}, but they weave away like water.",
+            'victim_msg': "{attacker_name}'s thrust aims for your {hit_location}, but you weave away like water.",
+            'observer_msg': "{attacker_name}'s thrust aims for {target_name}'s {hit_location}, but they weave away like water."
         },
         {
             'attacker_msg': "Your thrust comes swift and sure, but {target_name} is swifter.",
@@ -457,28 +457,28 @@ MESSAGES = {
     ],
     'kill': [
         {
-            'attacker_msg': "A brutal thrust pierces {target_name}'s heart. They drop instantly, stake buried deep.",
-            'victim_msg': "A brutal thrust pierces your heart. You drop instantly, stake buried deep.",
-            'observer_msg': "A brutal thrust pierces {target_name}'s heart. They drop instantly, stake buried deep."
+            'attacker_msg': "A brutal thrust pierces {target_name}'s {hit_location}. They drop instantly, stake buried deep.",
+            'victim_msg': "A brutal thrust pierces your {hit_location}. You drop instantly, stake buried deep.",
+            'observer_msg': "A brutal thrust pierces {target_name}'s {hit_location}. They drop instantly, stake buried deep."
         },
         {
-            'attacker_msg': "A downward strike drives the stake through {target_name}'s skull. Death is instant.",
-            'victim_msg': "A downward strike drives the stake through your skull. Death is instant.",
-            'observer_msg': "A downward strike drives the stake through {target_name}'s skull. Death is instant."
+            'attacker_msg': "A downward strike drives the stake through {target_name}'s {hit_location}. Death is instant.",
+            'victim_msg': "A downward strike drives the stake through your {hit_location}. Death is instant.",
+            'observer_msg': "A downward strike drives the stake through {target_name}'s {hit_location}. Death is instant."
         },
         {
-            'attacker_msg': "A savage thrust punches through {target_name}'s lung. They drown in their own blood.",
-            'victim_msg': "A savage thrust punches through your lung. You drown in your own blood.",
-            'observer_msg': "A savage thrust punches through {target_name}'s lung. They drown in their own blood."
+            'attacker_msg': "A savage thrust punches through {target_name}'s {hit_location}. They drown in their own blood.",
+            'victim_msg': "A savage thrust punches through your {hit_location}. You drown in your own blood.",
+            'observer_msg': "A savage thrust punches through {target_name}'s {hit_location}. They drown in their own blood."
         },
         {
             'attacker_msg': "A thrust to the base of the skull severs the spine. {target_name} crumples like a broken puppet.",
-            'victim_msg': "A thrust to the base of your skull severs your spine. You crumple like a broken puppet.",
+            'victim_msg': "A thrust to the base of your {hit_location} severs your {hit_location}. You crumple like a broken puppet.",
             'observer_msg': "A thrust to the base of the skull severs the spine. {target_name} crumples like a broken puppet."
         },
         {
             'attacker_msg': "A thrust to the throat crushes the windpipe. {target_name} gurgles once, then goes silent.",
-            'victim_msg': "A thrust to your throat crushes your windpipe. You gurgle once, then go silent.",
+            'victim_msg': "A thrust to your {hit_location} crushes your windpipe. You gurgle once, then go silent.",
             'observer_msg': "A thrust to the throat crushes the windpipe. {target_name} gurgles once, then goes silent."
         },
         {
@@ -492,34 +492,34 @@ MESSAGES = {
             'observer_msg': "The point drives deep into {target_name}'s eye socket. They convulse once, then still."
         },
         {
-            'attacker_msg': "The point penetrates {target_name}'s temple. They drop like a sack of meat.",
-            'victim_msg': "The point penetrates your temple. You drop like a sack of meat.",
-            'observer_msg': "The point penetrates {target_name}'s temple. They drop like a sack of meat."
+            'attacker_msg': "The point penetrates {target_name}'s {hit_location}. They drop like a sack of meat.",
+            'victim_msg': "The point penetrates your {hit_location}. You drop like a sack of meat.",
+            'observer_msg': "The point penetrates {target_name}'s {hit_location}. They drop like a sack of meat."
         },
         {
-            'attacker_msg': "The stake drives through {target_name}'s chest and out their back. Blood spatters the ground.",
-            'victim_msg': "The stake drives through your chest and out your back. Blood spatters the ground.",
-            'observer_msg': "The stake drives through {target_name}'s chest and out their back. Blood spatters the ground."
+            'attacker_msg': "The stake drives through {target_name}'s {hit_location} and out their back. Blood spatters the ground.",
+            'victim_msg': "The stake drives through your {hit_location} and out your {hit_location}. Blood spatters the ground.",
+            'observer_msg': "The stake drives through {target_name}'s {hit_location} and out their back. Blood spatters the ground."
         },
         {
             'attacker_msg': "The stake finds {target_name}'s jugular. They clutch their throat as life spurts away.",
-            'victim_msg': "The stake finds your jugular. You clutch your throat as life spurts away.",
+            'victim_msg': "The stake finds your jugular. You clutch your {hit_location} as life spurts away.",
             'observer_msg': "The stake finds {target_name}'s jugular. They clutch their throat as life spurts away."
         },
         {
-            'attacker_msg': "The stake penetrates {target_name}'s liver. They fold over the weapon and die slowly.",
-            'victim_msg': "The stake penetrates your liver. You fold over the weapon and die slowly.",
-            'observer_msg': "The stake penetrates {target_name}'s liver. They fold over the weapon and die slowly."
+            'attacker_msg': "The stake penetrates {target_name}'s {hit_location}. They fold over the weapon and die slowly.",
+            'victim_msg': "The stake penetrates your {hit_location}. You fold over the weapon and die slowly.",
+            'observer_msg': "The stake penetrates {target_name}'s {hit_location}. They fold over the weapon and die slowly."
         },
         {
-            'attacker_msg': "The stake pierces {target_name}'s spine. They collapse, paralyzed and dying.",
-            'victim_msg': "The stake pierces your spine. You collapse, paralyzed and dying.",
-            'observer_msg': "The stake pierces {target_name}'s spine. They collapse, paralyzed and dying."
+            'attacker_msg': "The stake pierces {target_name}'s {hit_location}. They collapse, paralyzed and dying.",
+            'victim_msg': "The stake pierces your {hit_location}. You collapse, paralyzed and dying.",
+            'observer_msg': "The stake pierces {target_name}'s {hit_location}. They collapse, paralyzed and dying."
         },
         {
-            'attacker_msg': "The stake punches through {target_name}'s sternum and into their heart. Death is instant.",
-            'victim_msg': "The stake punches through your sternum and into your heart. Death is instant.",
-            'observer_msg': "The stake punches through {target_name}'s sternum and into their heart. Death is instant."
+            'attacker_msg': "The stake punches through {target_name}'s {hit_location} and into their heart. Death is instant.",
+            'victim_msg': "The stake punches through your {hit_location} and into your {hit_location}. Death is instant.",
+            'observer_msg': "The stake punches through {target_name}'s {hit_location} and into their heart. Death is instant."
         },
         {
             'attacker_msg': "The tip finds the carotid artery. {target_name} bleeds out in seconds.",
@@ -527,34 +527,34 @@ MESSAGES = {
             'observer_msg': "The tip finds the carotid artery. {target_name} bleeds out in seconds."
         },
         {
-            'attacker_msg': "You drive the stake deep into {target_name}'s abdomen. They die clutching the wound.",
-            'victim_msg': "{attacker_name} drives the stake deep into your abdomen. You die clutching the wound.",
-            'observer_msg': "{attacker_name} drives the stake deep into {target_name}'s abdomen. They die clutching the wound."
+            'attacker_msg': "You drive the stake deep into {target_name}'s {hit_location}. They die clutching the wound.",
+            'victim_msg': "{attacker_name} drives the stake deep into your {hit_location}. You die clutching the wound.",
+            'observer_msg': "{attacker_name} drives the stake deep into {target_name}'s {hit_location}. They die clutching the wound."
         },
         {
             'attacker_msg': "You drive the stake through {target_name}'s ear and into their brain. They twitch once, then still.",
-            'victim_msg': "{attacker_name} drives the stake through your ear and into your brain. You twitch once, then still.",
+            'victim_msg': "{attacker_name} drives the stake through your ear and into your {hit_location}. You twitch once, then still.",
             'observer_msg': "{attacker_name} drives the stake through {target_name}'s ear and into their brain. They twitch once, then still."
         },
         {
             'attacker_msg': "You impale {target_name} through the chest. The stake emerges bloody from their back.",
-            'victim_msg': "{attacker_name} impales you through the chest. The stake emerges bloody from your back.",
+            'victim_msg': "{attacker_name} impales you through the chest. The stake emerges bloody from your {hit_location}.",
             'observer_msg': "{attacker_name} impales {target_name} through the chest. The stake emerges bloody from their back."
         },
         {
-            'attacker_msg': "You pierce {target_name}'s lung. They cough up blood, then collapse and die.",
-            'victim_msg': "{attacker_name} pierces your lung. You cough up blood, then collapse and die.",
-            'observer_msg': "{attacker_name} pierces {target_name}'s lung. They cough up blood, then collapse and die."
+            'attacker_msg': "You pierce {target_name}'s {hit_location}. They cough up blood, then collapse and die.",
+            'victim_msg': "{attacker_name} pierces your {hit_location}. You cough up blood, then collapse and die.",
+            'observer_msg': "{attacker_name} pierces {target_name}'s {hit_location}. They cough up blood, then collapse and die."
         },
         {
-            'attacker_msg': "You punch the stake through {target_name}'s ribs and into their heart. They die standing.",
-            'victim_msg': "{attacker_name} punches the stake through your ribs and into your heart. You die standing.",
-            'observer_msg': "{attacker_name} punches the stake through {target_name}'s ribs and into their heart. They die standing."
+            'attacker_msg': "You punch the stake through {target_name}'s {hit_location} and into their heart. They die standing.",
+            'victim_msg': "{attacker_name} punches the stake through your {hit_location} and into your {hit_location}. You die standing.",
+            'observer_msg': "{attacker_name} punches the stake through {target_name}'s {hit_location} and into their heart. They die standing."
         },
         {
-            'attacker_msg': "You slam the stake into {target_name}'s neck, severing the spinal cord. They drop instantly.",
-            'victim_msg': "{attacker_name} slams the stake into your neck, severing your spinal cord. You drop instantly.",
-            'observer_msg': "{attacker_name} slams the stake into {target_name}'s neck, severing the spinal cord. They drop instantly."
+            'attacker_msg': "You slam the stake into {target_name}'s {hit_location}, severing the spinal cord. They drop instantly.",
+            'victim_msg': "{attacker_name} slams the stake into your {hit_location}, severing your spinal cord. You drop instantly.",
+            'observer_msg': "{attacker_name} slams the stake into {target_name}'s {hit_location}, severing the spinal cord. They drop instantly."
         },
         {
             'attacker_msg': "You stab the stake deep into {target_name}'s kidney. They scream once, then die.",
@@ -563,38 +563,38 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You thrust the stake into {target_name}'s solar plexus, stopping their heart. Death is instant.",
-            'victim_msg': "{attacker_name} thrusts the stake into your solar plexus, stopping your heart. Death is instant.",
+            'victim_msg': "{attacker_name} thrusts the stake into your solar plexus, stopping your {hit_location}. Death is instant.",
             'observer_msg': "{attacker_name} thrusts the stake into {target_name}'s solar plexus, stopping their heart. Death is instant."
         },
         {
             'attacker_msg': "You thrust the stake through {target_name}'s eye and into their brain. They convulse, then die.",
-            'victim_msg': "{attacker_name} thrusts the stake through your eye and into your brain. You convulse, then die.",
+            'victim_msg': "{attacker_name} thrusts the stake through your eye and into your {hit_location}. You convulse, then die.",
             'observer_msg': "{attacker_name} thrusts the stake through {target_name}'s eye and into their brain. They convulse, then die."
         },
         {
-            'attacker_msg': "Your final thrust pierces {target_name}'s throat. They gurgle and collapse, drowning in blood.",
-            'victim_msg': "{attacker_name}'s final thrust pierces your throat. You gurgle and collapse, drowning in blood.",
-            'observer_msg': "{attacker_name}'s final thrust pierces {target_name}'s throat. They gurgle and collapse, drowning in blood."
+            'attacker_msg': "Your final thrust pierces {target_name}'s {hit_location}. They gurgle and collapse, drowning in blood.",
+            'victim_msg': "{attacker_name}'s final thrust pierces your {hit_location}. You gurgle and collapse, drowning in blood.",
+            'observer_msg': "{attacker_name}'s final thrust pierces {target_name}'s {hit_location}. They gurgle and collapse, drowning in blood."
         },
         {
-            'attacker_msg': "Your stake finds the gap between {target_name}'s ribs. Their lung collapses instantly.",
-            'victim_msg': "{attacker_name}'s stake finds the gap between your ribs. Your lung collapses instantly.",
-            'observer_msg': "{attacker_name}'s stake finds the gap between {target_name}'s ribs. Their lung collapses instantly."
+            'attacker_msg': "Your stake finds the gap between {target_name}'s {hit_location}. Their lung collapses instantly.",
+            'victim_msg': "{attacker_name}'s stake finds the gap between your {hit_location}. Your {hit_location} collapses instantly.",
+            'observer_msg': "{attacker_name}'s stake finds the gap between {target_name}'s {hit_location}. Their lung collapses instantly."
         },
         {
-            'attacker_msg': "Your stake penetrates {target_name}'s liver. They die slowly, bleeding internally.",
-            'victim_msg': "{attacker_name}'s stake penetrates your liver. You die slowly, bleeding internally.",
-            'observer_msg': "{attacker_name}'s stake penetrates {target_name}'s liver. They die slowly, bleeding internally."
+            'attacker_msg': "Your stake penetrates {target_name}'s {hit_location}. They die slowly, bleeding internally.",
+            'victim_msg': "{attacker_name}'s stake penetrates your {hit_location}. You die slowly, bleeding internally.",
+            'observer_msg': "{attacker_name}'s stake penetrates {target_name}'s {hit_location}. They die slowly, bleeding internally."
         },
         {
-            'attacker_msg': "Your stake pierces {target_name}'s abdomen, severing the aorta. They bleed out fast.",
-            'victim_msg': "{attacker_name}'s stake pierces your abdomen, severing the aorta. You bleed out fast.",
-            'observer_msg': "{attacker_name}'s stake pierces {target_name}'s abdomen, severing the aorta. They bleed out fast."
+            'attacker_msg': "Your stake pierces {target_name}'s {hit_location}, severing the aorta. They bleed out fast.",
+            'victim_msg': "{attacker_name}'s stake pierces your {hit_location}, severing the aorta. You bleed out fast.",
+            'observer_msg': "{attacker_name}'s stake pierces {target_name}'s {hit_location}, severing the aorta. They bleed out fast."
         },
         {
-            'attacker_msg': "Your stake punches a hole in {target_name}'s chest. They die gasping for air.",
-            'victim_msg': "{attacker_name}'s stake punches a hole in your chest. You die gasping for air.",
-            'observer_msg': "{attacker_name}'s stake punches a hole in {target_name}'s chest. They die gasping for air."
+            'attacker_msg': "Your stake punches a hole in {target_name}'s {hit_location}. They die gasping for air.",
+            'victim_msg': "{attacker_name}'s stake punches a hole in your {hit_location}. You die gasping for air.",
+            'observer_msg': "{attacker_name}'s stake punches a hole in {target_name}'s {hit_location}. They die gasping for air."
         },
         {
             'attacker_msg': "Your stake severs {target_name}'s carotid artery. Blood spurts in dying pulses.",
@@ -602,9 +602,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name}'s stake severs {target_name}'s carotid artery. Blood spurts in dying pulses."
         },
         {
-            'attacker_msg': "Your thrust drives the stake through {target_name}'s skull and into their brain. Death is instant.",
-            'victim_msg': "{attacker_name}'s thrust drives the stake through your skull and into your brain. Death is instant.",
-            'observer_msg': "{attacker_name}'s thrust drives the stake through {target_name}'s skull and into their brain. Death is instant."
+            'attacker_msg': "Your thrust drives the stake through {target_name}'s {hit_location} and into their brain. Death is instant.",
+            'victim_msg': "{attacker_name}'s thrust drives the stake through your {hit_location} and into your {hit_location}. Death is instant.",
+            'observer_msg': "{attacker_name}'s thrust drives the stake through {target_name}'s {hit_location} and into their brain. Death is instant."
         }
     ]
 }

--- a/world/combat/messages/straight_razor.py
+++ b/world/combat/messages/straight_razor.py
@@ -51,7 +51,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} flicks the blade open with a practiced snap, the motion smooth and final."
         },
         {
-            'attacker_msg': "You trace the razor along your forearm, leaving a thin red line.",
+            'attacker_msg': "You trace the razor along your {hit_location}, leaving a thin red line.",
             'victim_msg': "{attacker_name} traces the razor along their forearm, leaving a thin red line.",
             'observer_msg': "{attacker_name} traces the razor along their forearm, leaving a thin red line."
         },
@@ -136,7 +136,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} presses the blade to their tongue, then grins at {target_name}."
         },
         {
-            'attacker_msg': "You let the razor rest on your shoulder, eyes never leaving {target_name}.",
+            'attacker_msg': "You let the razor rest on your {hit_location}, eyes never leaving {target_name}.",
             'victim_msg': "{attacker_name} lets the razor rest on their shoulder, eyes never leaving you.",
             'observer_msg': "{attacker_name} lets the razor rest on their shoulder, eyes never leaving {target_name}."
         },
@@ -340,7 +340,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} stabs at {target_name}, but the blade glances off armor."
         },
         {
-            'attacker_msg': "A flick of your wrist misses, the blade slicing only air.",
+            'attacker_msg': "A flick of your {hit_location} misses, the blade slicing only air.",
             'victim_msg': "A flick of {attacker_name}'s wrist misses, the blade slicing only air.",
             'observer_msg': "A flick of {attacker_name}'s wrist misses, the blade slicing only air."
         },
@@ -445,7 +445,7 @@ MESSAGES = {
             'observer_msg': "The blade glances off a boot, doing nothing."
         },
         {
-            'attacker_msg': "A flick of your wrist misses, the blade humming in the air.",
+            'attacker_msg': "A flick of your {hit_location} misses, the blade humming in the air.",
             'victim_msg': "A flick of {attacker_name}'s wrist misses, the blade humming in the air.",
             'observer_msg': "A flick of {attacker_name}'s wrist misses, the blade humming in the air."
         },
@@ -457,9 +457,9 @@ MESSAGES = {
     ],
     'kill': [
         {
-            'attacker_msg': "You draw the razor across {target_name}'s throat. Blood spurts in a fine, surgical arc.",
-            'victim_msg': "{attacker_name} draws the razor across your throat. Blood spurts in a fine, surgical arc.",
-            'observer_msg': "{attacker_name} draws the razor across {target_name}'s throat. Blood spurts in a fine, surgical arc."
+            'attacker_msg': "You draw the razor across {target_name}'s {hit_location}. Blood spurts in a fine, surgical arc.",
+            'victim_msg': "{attacker_name} draws the razor across your {hit_location}. Blood spurts in a fine, surgical arc.",
+            'observer_msg': "{attacker_name} draws the razor across {target_name}'s {hit_location}. Blood spurts in a fine, surgical arc."
         },
         {
             'attacker_msg': "A quick slash opens {target_name}'s carotid. They drop, clutching at a wound that won't close.",
@@ -468,18 +468,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The blade slips between ribs and into the heart. {target_name} collapses, twitching.",
-            'victim_msg': "The blade slips between your ribs and into your heart. You collapse, twitching.",
-            'observer_msg': "The blade slips between {target_name}'s ribs and into their heart. They collapse, twitching."
+            'victim_msg': "The blade slips between your {hit_location} and into your {hit_location}. You collapse, twitching.",
+            'observer_msg': "The blade slips between {target_name}'s {hit_location} and into their heart. They collapse, twitching."
         },
         {
-            'attacker_msg': "You carve a line across {target_name}'s neck. The blood is bright and fast.",
-            'victim_msg': "{attacker_name} carves a line across your neck. The blood is bright and fast.",
-            'observer_msg': "{attacker_name} carves a line across {target_name}'s neck. The blood is bright and fast."
+            'attacker_msg': "You carve a line across {target_name}'s {hit_location}. The blood is bright and fast.",
+            'victim_msg': "{attacker_name} carves a line across your {hit_location}. The blood is bright and fast.",
+            'observer_msg': "{attacker_name} carves a line across {target_name}'s {hit_location}. The blood is bright and fast."
         },
         {
             'attacker_msg': "A jab under the jaw sends the blade into the brain. {target_name} goes limp instantly.",
-            'victim_msg': "A jab under your jaw sends the blade into your brain. You go limp instantly.",
-            'observer_msg': "A jab under the jaw sends the blade into {target_name}'s brain. They go limp instantly."
+            'victim_msg': "A jab under your {hit_location} sends the blade into your {hit_location}. You go limp instantly.",
+            'observer_msg': "A jab under the jaw sends the blade into {target_name}'s {hit_location}. They go limp instantly."
         },
         {
             'attacker_msg': "The razor punctures the eye. {target_name} screams, then falls silent.",
@@ -493,23 +493,23 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A quick stab to the temple ends everything in a blink.",
-            'victim_msg': "A quick stab to your temple ends everything in a blink.",
-            'observer_msg': "A quick stab to {target_name}'s temple ends everything in a blink."
+            'victim_msg': "A quick stab to your {hit_location} ends everything in a blink.",
+            'observer_msg': "A quick stab to {target_name}'s {hit_location} ends everything in a blink."
         },
         {
             'attacker_msg': "The blade slips under the sternum. {target_name} gasps, then nothing.",
-            'victim_msg': "The blade slips under your sternum. You gasp, then nothing.",
-            'observer_msg': "The blade slips under {target_name}'s sternum. They gasp, then nothing."
+            'victim_msg': "The blade slips under your {hit_location}. You gasp, then nothing.",
+            'observer_msg': "The blade slips under {target_name}'s {hit_location}. They gasp, then nothing."
         },
         {
             'attacker_msg': "You draw the blade across the throat. The spray is arterial, the silence final.",
-            'victim_msg': "{attacker_name} draws the blade across your throat. The spray is arterial, the silence final.",
-            'observer_msg': "{attacker_name} draws the blade across {target_name}'s throat. The spray is arterial, the silence final."
+            'victim_msg': "{attacker_name} draws the blade across your {hit_location}. The spray is arterial, the silence final.",
+            'observer_msg': "{attacker_name} draws the blade across {target_name}'s {hit_location}. The spray is arterial, the silence final."
         },
         {
             'attacker_msg': "A downward slash buries the blade in the chest. {target_name} shudders, then stills.",
-            'victim_msg': "A downward slash buries the blade in your chest. You shudder, then still.",
-            'observer_msg': "A downward slash buries the blade in {target_name}'s chest. They shudder, then still."
+            'victim_msg': "A downward slash buries the blade in your {hit_location}. You shudder, then still.",
+            'observer_msg': "A downward slash buries the blade in {target_name}'s {hit_location}. They shudder, then still."
         },
         {
             'attacker_msg': "The blade slips between vertebrae. {target_name} drops, boneless.",
@@ -517,24 +517,24 @@ MESSAGES = {
             'observer_msg': "The blade slips between {target_name}'s vertebrae. They drop, boneless."
         },
         {
-            'attacker_msg': "You carve a smile across {target_name}'s face. The grin is permanent.",
-            'victim_msg': "{attacker_name} carves a smile across your face. The grin is permanent.",
-            'observer_msg': "{attacker_name} carves a smile across {target_name}'s face. The grin is permanent."
+            'attacker_msg': "You carve a smile across {target_name}'s {hit_location}. The grin is permanent.",
+            'victim_msg': "{attacker_name} carves a smile across your {hit_location}. The grin is permanent.",
+            'observer_msg': "{attacker_name} carves a smile across {target_name}'s {hit_location}. The grin is permanent."
         },
         {
             'attacker_msg': "A jab to the heart. {target_name} collapses, eyes wide and empty.",
-            'victim_msg': "A jab to your heart. You collapse, eyes wide and empty.",
-            'observer_msg': "A jab to {target_name}'s heart. They collapse, eyes wide and empty."
+            'victim_msg': "A jab to your {hit_location}. You collapse, eyes wide and empty.",
+            'observer_msg': "A jab to {target_name}'s {hit_location}. They collapse, eyes wide and empty."
         },
         {
             'attacker_msg': "The blade punctures a lung. {target_name} drowns on dry land.",
-            'victim_msg': "The blade punctures your lung. You drown on dry land.",
-            'observer_msg': "The blade punctures {target_name}'s lung. They drown on dry land."
+            'victim_msg': "The blade punctures your {hit_location}. You drown on dry land.",
+            'observer_msg': "The blade punctures {target_name}'s {hit_location}. They drown on dry land."
         },
         {
             'attacker_msg': "You slice the wrist, blood spraying in pulses.",
-            'victim_msg': "{attacker_name} slices your wrist, blood spraying in pulses.",
-            'observer_msg': "{attacker_name} slices {target_name}'s wrist, blood spraying in pulses."
+            'victim_msg': "{attacker_name} slices your {hit_location}, blood spraying in pulses.",
+            'observer_msg': "{attacker_name} slices {target_name}'s {hit_location}, blood spraying in pulses."
         },
         {
             'attacker_msg': "A quick flick opens the jugular. {target_name} drops in seconds.",
@@ -548,13 +548,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A stab to the base of the skull ends it instantly.",
-            'victim_msg': "A stab to the base of your skull ends it instantly.",
-            'observer_msg': "A stab to the base of {target_name}'s skull ends it instantly."
+            'victim_msg': "A stab to the base of your {hit_location} ends it instantly.",
+            'observer_msg': "A stab to the base of {target_name}'s {hit_location} ends it instantly."
         },
         {
             'attacker_msg': "You carve a spiral down the chest. The pattern is red and final.",
-            'victim_msg': "{attacker_name} carves a spiral down your chest. The pattern is red and final.",
-            'observer_msg': "{attacker_name} carves a spiral down {target_name}'s chest. The pattern is red and final."
+            'victim_msg': "{attacker_name} carves a spiral down your {hit_location}. The pattern is red and final.",
+            'observer_msg': "{attacker_name} carves a spiral down {target_name}'s {hit_location}. The pattern is red and final."
         },
         {
             'attacker_msg': "The blade slips into the mouth, blood pouring out.",
@@ -563,13 +563,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A quick slash opens the abdomen. {target_name} folds, spilling.",
-            'victim_msg': "A quick slash opens your abdomen. You fold, spilling.",
-            'observer_msg': "A quick slash opens {target_name}'s abdomen. They fold, spilling."
+            'victim_msg': "A quick slash opens your {hit_location}. You fold, spilling.",
+            'observer_msg': "A quick slash opens {target_name}'s {hit_location}. They fold, spilling."
         },
         {
             'attacker_msg': "The blade punctures the heart. {target_name} gasps, then nothing.",
-            'victim_msg': "The blade punctures your heart. You gasp, then nothing.",
-            'observer_msg': "The blade punctures {target_name}'s heart. They gasp, then nothing."
+            'victim_msg': "The blade punctures your {hit_location}. You gasp, then nothing.",
+            'observer_msg': "The blade punctures {target_name}'s {hit_location}. They gasp, then nothing."
         },
         {
             'attacker_msg': "You draw the blade across the eyes. The world goes dark.",
@@ -593,18 +593,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The blade slips into the chest, twisting. {target_name} is gone before they hit the ground.",
-            'victim_msg': "The blade slips into your chest, twisting. You are gone before you hit the ground.",
-            'observer_msg': "The blade slips into {target_name}'s chest, twisting. They are gone before they hit the ground."
+            'victim_msg': "The blade slips into your {hit_location}, twisting. You are gone before you hit the ground.",
+            'observer_msg': "The blade slips into {target_name}'s {hit_location}, twisting. They are gone before they hit the ground."
         },
         {
             'attacker_msg': "You carve a line across the throat. The spray is bright, the end abrupt.",
-            'victim_msg': "{attacker_name} carves a line across your throat. The spray is bright, the end abrupt.",
-            'observer_msg': "{attacker_name} carves a line across {target_name}'s throat. The spray is bright, the end abrupt."
+            'victim_msg': "{attacker_name} carves a line across your {hit_location}. The spray is bright, the end abrupt.",
+            'observer_msg': "{attacker_name} carves a line across {target_name}'s {hit_location}. The spray is bright, the end abrupt."
         },
         {
             'attacker_msg': "A final stab to the heart. {target_name} sags, then falls.",
-            'victim_msg': "A final stab to your heart. You sag, then fall.",
-            'observer_msg': "A final stab to {target_name}'s heart. They sag, then fall."
+            'victim_msg': "A final stab to your {hit_location}. You sag, then fall.",
+            'observer_msg': "A final stab to {target_name}'s {hit_location}. They sag, then fall."
         }
     ]
 }

--- a/world/combat/messages/stun_gun.py
+++ b/world/combat/messages/stun_gun.py
@@ -76,7 +76,7 @@ MESSAGES = {
             'observer_msg': "The stun gun crackles in rhythm with {attacker_name}'s heartbeat. A duet of malice."
         },
         {
-            'attacker_msg': "The stun gun hums to life in your hand, eager and impatient.",
+            'attacker_msg': "The stun gun hums to life in your {hit_location}, eager and impatient.",
             'victim_msg': "The stun gun hums to life in {attacker_name}'s hand, eager and impatient.",
             'observer_msg': "The stun gun hums to life in {attacker_name}'s hand, eager and impatient."
         },
@@ -179,7 +179,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A tight press to the base of the skull ends coordination. {target_name} folds.",
-            'victim_msg': "A tight press to the base of your skull ends coordination. You fold.",
+            'victim_msg': "A tight press to the base of your {hit_location} ends coordination. You fold.",
             'observer_msg': "A tight press to the base of the skull ends coordination. {target_name} folds."
         },
         {
@@ -288,9 +288,9 @@ MESSAGES = {
             'observer_msg': "Voltage cascades down {target_name}'s {hit_location}. The weapon clatters away."
         },
         {
-            'attacker_msg': "Voltage floods the {hit_location} cavity. {target_name} convulses, then crumples.",
-            'victim_msg': "Voltage floods your {hit_location} cavity. You convulse, then crumple.",
-            'observer_msg': "Voltage floods the {hit_location} cavity. {target_name} convulses, then crumples."
+            'attacker_msg': "Voltage floods the chest cavity. {target_name} convulses, then crumples.",
+            'victim_msg': "Voltage floods your chest cavity. You convulse, then crumple.",
+            'observer_msg': "Voltage floods the chest cavity. {target_name} convulses, then crumples."
         },
         {
             'attacker_msg': "Voltage pours into the {hit_location}. {target_name} staggers, then drops hard.",
@@ -310,9 +310,9 @@ MESSAGES = {
             'observer_msg': "A desperate jab glances off a bench. Static crackles — not pain."
         },
         {
-            'attacker_msg': "A jolt erupts an inch from {target_name}'s arm. Close isn't enough.",
-            'victim_msg': "A jolt erupts an inch from your arm. Close isn't enough.",
-            'observer_msg': "A jolt erupts an inch from {target_name}'s arm. Close isn't enough."
+            'attacker_msg': "A jolt erupts an inch from {target_name}'s {hit_location}. Close isn't enough.",
+            'victim_msg': "A jolt erupts an inch from your {hit_location}. Close isn't enough.",
+            'observer_msg': "A jolt erupts an inch from {target_name}'s {hit_location}. Close isn't enough."
         },
         {
             'attacker_msg': "A mistimed strike hits a railing. Sparks bite steel instead of skin.",
@@ -458,7 +458,7 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "A brutal hit to the chest. The body shakes once — then never again.",
-            'victim_msg': "A brutal hit to your chest. Your body shakes once — then never again.",
+            'victim_msg': "A brutal hit to your {hit_location}. Your body shakes once — then never again.",
             'observer_msg': "A brutal hit to the chest. The body shakes once — then never again."
         },
         {
@@ -468,7 +468,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A direct hit to the chest. The body spasms, jerks — then doesn't move again.",
-            'victim_msg': "A direct hit to your chest. Your body spasms, jerks — then doesn't move again.",
+            'victim_msg': "A direct hit to your {hit_location}. Your body spasms, jerks — then doesn't move again.",
             'observer_msg': "A direct hit to the chest. The body spasms, jerks — then doesn't move again."
         },
         {
@@ -478,22 +478,22 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A sharp jab to the throat ends with smoke and silence.",
-            'victim_msg': "A sharp jab to your throat ends with smoke and silence.",
+            'victim_msg': "A sharp jab to your {hit_location} ends with smoke and silence.",
             'observer_msg': "A sharp jab to the throat ends with smoke and silence."
         },
         {
             'attacker_msg': "Electricity dances across the spine. {target_name} seizes, then slumps hard.",
-            'victim_msg': "Electricity dances across your spine. You seize, then slump hard.",
+            'victim_msg': "Electricity dances across your {hit_location}. You seize, then slump hard.",
             'observer_msg': "Electricity dances across the spine. {target_name} seizes, then slumps hard."
         },
         {
             'attacker_msg': "Electricity roars through the spine. {target_name} drops mid-convulsion.",
-            'victim_msg': "Electricity roars through your spine. You drop mid-convulsion.",
+            'victim_msg': "Electricity roars through your {hit_location}. You drop mid-convulsion.",
             'observer_msg': "Electricity roars through the spine. {target_name} drops mid-convulsion."
         },
         {
             'attacker_msg': "One final burst floods the brain. The eyes go glassy. The rest is still.",
-            'victim_msg': "One final burst floods your brain. Your eyes go glassy. The rest is still.",
+            'victim_msg': "One final burst floods your {hit_location}. Your eyes go glassy. The rest is still.",
             'observer_msg': "One final burst floods the brain. The eyes go glassy. The rest is still."
         },
         {
@@ -513,7 +513,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Sparks bloom against the skull. When it's done, so is {target_name}.",
-            'victim_msg': "Sparks bloom against your skull. When it's done, so are you.",
+            'victim_msg': "Sparks bloom against your {hit_location}. When it's done, so are you.",
             'observer_msg': "Sparks bloom against the skull. When it's done, so is {target_name}."
         },
         {
@@ -523,17 +523,17 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The arc snaps across the temple. {target_name} seizes, then slumps against silence.",
-            'victim_msg': "The arc snaps across your temple. You seize, then slump against silence.",
+            'victim_msg': "The arc snaps across your {hit_location}. You seize, then slump against silence.",
             'observer_msg': "The arc snaps across the temple. {target_name} seizes, then slumps against silence."
         },
         {
-            'attacker_msg': "The charge rips through {target_name}'s head. Smoke curls. Nothing else moves.",
-            'victim_msg': "The charge rips through your head. Smoke curls. Nothing else moves.",
-            'observer_msg': "The charge rips through {target_name}'s head. Smoke curls. Nothing else moves."
+            'attacker_msg': "The charge rips through {target_name}'s {hit_location}. Smoke curls. Nothing else moves.",
+            'victim_msg': "The charge rips through your {hit_location}. Smoke curls. Nothing else moves.",
+            'observer_msg': "The charge rips through {target_name}'s {hit_location}. Smoke curls. Nothing else moves."
         },
         {
             'attacker_msg': "The current arcs into the heart. The beat stutters. Then stops.",
-            'victim_msg': "The current arcs into your heart. The beat stutters. Then stops.",
+            'victim_msg': "The current arcs into your {hit_location}. The beat stutters. Then stops.",
             'observer_msg': "The current arcs into the heart. The beat stutters. Then stops."
         },
         {
@@ -543,43 +543,43 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The prongs dig into the neck. The scream warps, then cuts off entirely.",
-            'victim_msg': "The prongs dig into your neck. Your scream warps, then cuts off entirely.",
+            'victim_msg': "The prongs dig into your {hit_location}. Your scream warps, then cuts off entirely.",
             'observer_msg': "The prongs dig into the neck. The scream warps, then cuts off entirely."
         },
         {
             'attacker_msg': "The stun gun locks against the heart. One long squeeze — and {target_name} goes still forever.",
-            'victim_msg': "The stun gun locks against your heart. One long squeeze — and you go still forever.",
+            'victim_msg': "The stun gun locks against your {hit_location}. One long squeeze — and you go still forever.",
             'observer_msg': "The stun gun locks against the heart. One long squeeze — and {target_name} goes still forever."
         },
         {
             'attacker_msg': "The stun gun presses to the temple. The shock shuts down everything. {target_name} slumps.",
-            'victim_msg': "The stun gun presses to your temple. The shock shuts down everything. You slump.",
+            'victim_msg': "The stun gun presses to your {hit_location}. The shock shuts down everything. You slump.",
             'observer_msg': "The stun gun presses to the temple. The shock shuts down everything. {target_name} slumps."
         },
         {
             'attacker_msg': "The stun gun rests against the jaw. The convulsions stop mid-sentence.",
-            'victim_msg': "The stun gun rests against your jaw. Your convulsions stop mid-sentence.",
+            'victim_msg': "The stun gun rests against your {hit_location}. Your convulsions stop mid-sentence.",
             'observer_msg': "The stun gun rests against the jaw. The convulsions stop mid-sentence."
         },
         {
             'attacker_msg': "The weapon buzzes through the spine. {target_name} twitches, stiffens, and falls like a snapped wire.",
-            'victim_msg': "The weapon buzzes through your spine. You twitch, stiffen, and fall like a snapped wire.",
+            'victim_msg': "The weapon buzzes through your {hit_location}. You twitch, stiffen, and fall like a snapped wire.",
             'observer_msg': "The weapon buzzes through the spine. {target_name} twitches, stiffens, and falls like a snapped wire."
         },
         {
-            'attacker_msg': "The zap is held too long. {target_name}'s heart forgets how to beat.",
-            'victim_msg': "The zap is held too long. Your heart forgets how to beat.",
-            'observer_msg': "The zap is held too long. {target_name}'s heart forgets how to beat."
+            'attacker_msg': "The zap is held too long. {target_name}'s {hit_location} forgets how to beat.",
+            'victim_msg': "The zap is held too long. Your {hit_location} forgets how to beat.",
+            'observer_msg': "The zap is held too long. {target_name}'s {hit_location} forgets how to beat."
         },
         {
             'attacker_msg': "Voltage pours through the chest. The breath catches — and never comes back.",
-            'victim_msg': "Voltage pours through your chest. Your breath catches — and never comes back.",
+            'victim_msg': "Voltage pours through your {hit_location}. Your breath catches — and never comes back.",
             'observer_msg': "Voltage pours through the chest. The breath catches — and never comes back."
         },
         {
-            'attacker_msg': "You drive the stun gun into {target_name}'s throat. One long jolt. One final breath.",
-            'victim_msg': "{attacker_name} drives the stun gun into your throat. One long jolt. One final breath.",
-            'observer_msg': "{attacker_name} drives the stun gun into {target_name}'s throat. One long jolt. One final breath."
+            'attacker_msg': "You drive the stun gun into {target_name}'s {hit_location}. One long jolt. One final breath.",
+            'victim_msg': "{attacker_name} drives the stun gun into your {hit_location}. One long jolt. One final breath.",
+            'observer_msg': "{attacker_name} drives the stun gun into {target_name}'s {hit_location}. One long jolt. One final breath."
         },
         {
             'attacker_msg': "You hold the current until even the twitching runs out.",
@@ -603,7 +603,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You press the arc into the skull. The lights flicker — in the room and behind {target_name}'s eyes.",
-            'victim_msg': "{attacker_name} presses the arc into your skull. The lights flicker — in the room and behind your eyes.",
+            'victim_msg': "{attacker_name} presses the arc into your {hit_location}. The lights flicker — in the room and behind your eyes.",
             'observer_msg': "{attacker_name} presses the arc into the skull. The lights flicker — in the room and behind {target_name}'s eyes."
         }
     ]

--- a/world/combat/messages/submachine_gun.py
+++ b/world/combat/messages/submachine_gun.py
@@ -61,7 +61,7 @@ MESSAGES = {
             'observer_msg': "The air crackles with anticipation as {attacker_name} prepares to unleash the submachine gun's rapid fire, a storm of lead imminent."
         },
         {
-            'attacker_msg': "Your face is set in concentration, ready to manage the submachine gun's climb during automatic fire.",
+            'attacker_msg': "Your {hit_location} is set in concentration, ready to manage the submachine gun's climb during automatic fire.",
             'victim_msg': "{attacker_name}'s face is set in concentration, ready to manage the submachine gun's climb during automatic fire.",
             'observer_msg': "{attacker_name}'s face is set in concentration, ready to manage the submachine gun's climb during automatic fire."
         },
@@ -136,7 +136,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} seems to focus, preparing to either carefully control the submachine gun's bursts or just hold the trigger down."
         },
         {
-            'attacker_msg': "Silence is broken by the subtle *thunk* of the submachine gun's stock settling against your shoulder.",
+            'attacker_msg': "Silence is broken by the subtle *thunk* of the submachine gun's stock settling against your {hit_location}.",
             'victim_msg': "Silence is broken by the subtle *thunk* of the submachine gun's stock settling against {attacker_name}'s shoulder.",
             'observer_msg': "Silence is broken by the subtle *thunk* of the submachine gun's stock settling against {attacker_name}'s shoulder."
         },
@@ -184,7 +184,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A direct hit! The submachine gun's burst smashes into {target_name}'s {hit_location}, driving the air from their lungs with a series of rapid, brutal *thuds*.",
-            'victim_msg': "A direct hit! The submachine gun's burst smashes into your {hit_location}, driving the air from your lungs with a series of rapid, brutal *thuds*.",
+            'victim_msg': "A direct hit! The submachine gun's burst smashes into your {hit_location}, driving the air from your {hit_location} with a series of rapid, brutal *thuds*.",
             'observer_msg': "A direct hit! The submachine gun's burst smashes into {target_name}'s {hit_location}, driving the air from their lungs with a series of rapid, brutal *thuds*."
         },
         {
@@ -320,9 +320,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} fires a burst, but the submachine gun's recoil throws their aim off, bullets stitching a line into the ground near {target_name}."
         },
         {
-            'attacker_msg': "The submachine gun's rapid fire goes high, bullets cracking over {target_name}'s head as you fight to control the weapon.",
-            'victim_msg': "The submachine gun's rapid fire goes high, bullets cracking over your head as {attacker_name} fights to control the weapon.",
-            'observer_msg': "The submachine gun's rapid fire goes high, bullets cracking over {target_name}'s head as {attacker_name} fights to control the weapon."
+            'attacker_msg': "The submachine gun's rapid fire goes high, bullets cracking over {target_name}'s {hit_location} as you fight to control the weapon.",
+            'victim_msg': "The submachine gun's rapid fire goes high, bullets cracking over your {hit_location} as {attacker_name} fights to control the weapon.",
+            'observer_msg': "The submachine gun's rapid fire goes high, bullets cracking over {target_name}'s {hit_location} as {attacker_name} fights to control the weapon."
         },
         {
             'attacker_msg': "Your burst from the submachine gun goes wide left, the bullets whipping past {target_name} as the weapon bucks in your grip.",
@@ -395,9 +395,9 @@ MESSAGES = {
             'observer_msg': "The submachine gun's burst misses wide right, {target_name} throwing themselves aside as bullets churn the air."
         },
         {
-            'attacker_msg': "You fire full auto, but the weapon pulls high, your shots going over {target_name}'s head in a lethal arc.",
-            'victim_msg': "{attacker_name} fires full auto, but the weapon pulls high, their shots going over your head in a lethal arc.",
-            'observer_msg': "{attacker_name} fires full auto, but the weapon pulls high, their shots going over {target_name}'s head in a lethal arc."
+            'attacker_msg': "You fire full auto, but the weapon pulls high, your shots going over {target_name}'s {hit_location} in a lethal arc.",
+            'victim_msg': "{attacker_name} fires full auto, but the weapon pulls high, their shots going over your {hit_location} in a lethal arc.",
+            'observer_msg': "{attacker_name} fires full auto, but the weapon pulls high, their shots going over {target_name}'s {hit_location} in a lethal arc."
         },
         {
             'attacker_msg': "The submachine gun sprays lead, but {target_name} hits the deck, the bullets passing through the space they occupied moments before.",
@@ -467,13 +467,13 @@ MESSAGES = {
             'observer_msg': "The submachine gun chatters its deadly song, multiple rounds punching through {target_name}'s vital organs, dropping them instantly."
         },
         {
-            'attacker_msg': "A devastating burst from your submachine gun stitches across {target_name}'s chest, the impacts shredding life from their body.",
-            'victim_msg': "A devastating burst from {attacker_name}'s submachine gun stitches across your chest, the impacts shredding life from your body.",
-            'observer_msg': "A devastating burst from {attacker_name}'s submachine gun stitches across {target_name}'s chest, the impacts shredding life from their body."
+            'attacker_msg': "A devastating burst from your submachine gun stitches across {target_name}'s {hit_location}, the impacts shredding life from their body.",
+            'victim_msg': "A devastating burst from {attacker_name}'s submachine gun stitches across your {hit_location}, the impacts shredding life from your body.",
+            'observer_msg': "A devastating burst from {attacker_name}'s submachine gun stitches across {target_name}'s {hit_location}, the impacts shredding life from their body."
         },
         {
             'attacker_msg': "The submachine gun roars, and {target_name} crumples as multiple bullets tear through their torso with mechanical precision.",
-            'victim_msg': "The submachine gun roars, and you crumple as multiple bullets tear through your torso with mechanical precision.",
+            'victim_msg': "The submachine gun roars, and you crumple as multiple bullets tear through your {hit_location} with mechanical precision.",
             'observer_msg': "The submachine gun roars, and {target_name} crumples as multiple bullets tear through their torso with mechanical precision."
         },
         {
@@ -498,7 +498,7 @@ MESSAGES = {
         },
         {
             'attacker_msg': "Your controlled burst becomes {target_name}'s execution, multiple rounds punching through their heart with deadly accuracy.",
-            'victim_msg': "{attacker_name}'s controlled burst becomes your execution, multiple rounds punching through your heart with deadly accuracy.",
+            'victim_msg': "{attacker_name}'s controlled burst becomes your execution, multiple rounds punching through your {hit_location} with deadly accuracy.",
             'observer_msg': "{attacker_name}'s controlled burst becomes {target_name}'s execution, multiple rounds punching through their heart with deadly accuracy."
         },
         {

--- a/world/combat/messages/tennis_racket.py
+++ b/world/combat/messages/tennis_racket.py
@@ -228,9 +228,9 @@ MESSAGES = {
             "observer_msg": "A return-of-serve motion drives the tennis racket into {target_name}'s {hit_location} with professional force."
         },
         {
-            "attacker_msg": "Your tennis racket finds its mark with a satisfying *ping*, the aluminum frame ringing against {target_name}'s skull.",
-            "victim_msg": "{attacker_name}'s tennis racket finds its mark with a satisfying *ping*, the aluminum frame ringing against your skull!",
-            "observer_msg": "The tennis racket finds its mark with a satisfying *ping*, the aluminum frame ringing against {target_name}'s skull."
+            "attacker_msg": "Your tennis racket finds its mark with a satisfying *ping*, the aluminum frame ringing against {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name}'s tennis racket finds its mark with a satisfying *ping*, the aluminum frame ringing against your {hit_location}!",
+            "observer_msg": "The tennis racket finds its mark with a satisfying *ping*, the aluminum frame ringing against {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "A textbook groundstroke with your tennis racket sweeps {target_name}'s {hit_location}s, sending them crashing down.",
@@ -392,19 +392,19 @@ MESSAGES = {
     ],
     "kill": [
         {
-            "attacker_msg": "Your final overhead smash with the tennis racket connects with {target_name}'s skull with a sickening crack - game, set, match.",
-            "victim_msg": "A final overhead smash from {attacker_name}'s tennis racket connects with your skull with a sickening crack - game, set, match.",
-            "observer_msg": "A final overhead smash from the tennis racket connects with {target_name}'s skull with a sickening crack - game, set, match."
+            "attacker_msg": "Your final overhead smash with the tennis racket connects with {target_name}'s {hit_location} with a sickening crack - game, set, match.",
+            "victim_msg": "A final overhead smash from {attacker_name}'s tennis racket connects with your {hit_location} with a sickening crack - game, set, match.",
+            "observer_msg": "A final overhead smash from the tennis racket connects with {target_name}'s {hit_location} with a sickening crack - game, set, match."
         },
         {
-            "attacker_msg": "Your tennis racket delivers a championship-winning blow to {target_name}'s temple, ending the match permanently.",
-            "victim_msg": "{attacker_name}'s tennis racket delivers a championship-winning blow to your temple, ending the match permanently.",
-            "observer_msg": "The tennis racket delivers a championship-winning blow to {target_name}'s temple, ending the match permanently."
+            "attacker_msg": "Your tennis racket delivers a championship-winning blow to {target_name}'s {hit_location}, ending the match permanently.",
+            "victim_msg": "{attacker_name}'s tennis racket delivers a championship-winning blow to your {hit_location}, ending the match permanently.",
+            "observer_msg": "The tennis racket delivers a championship-winning blow to {target_name}'s {hit_location}, ending the match permanently."
         },
         {
-            "attacker_msg": "A perfect ace with your tennis racket strikes {target_name}'s throat, serving up a lethal finish.",
-            "victim_msg": "A perfect ace from {attacker_name}'s tennis racket strikes your throat, serving up a lethal finish.",
-            "observer_msg": "A perfect ace from the tennis racket strikes {target_name}'s throat, serving up a lethal finish."
+            "attacker_msg": "A perfect ace with your tennis racket strikes {target_name}'s {hit_location}, serving up a lethal finish.",
+            "victim_msg": "A perfect ace from {attacker_name}'s tennis racket strikes your {hit_location}, serving up a lethal finish.",
+            "observer_msg": "A perfect ace from the tennis racket strikes {target_name}'s {hit_location}, serving up a lethal finish."
         },
         {
             "attacker_msg": "Your tennis racket's frame shatters {target_name}'s windpipe with the force of a 120mph serve.",
@@ -412,19 +412,19 @@ MESSAGES = {
             "observer_msg": "The tennis racket's frame shatters {target_name}'s windpipe with the force of a 120mph serve."
         },
         {
-            "attacker_msg": "Match point achieved as your tennis racket caves in {target_name}'s skull with athletic precision.",
-            "victim_msg": "Match point achieved as {attacker_name}'s tennis racket caves in your skull with athletic precision.",
-            "observer_msg": "Match point achieved as the tennis racket caves in {target_name}'s skull with athletic precision."
+            "attacker_msg": "Match point achieved as your tennis racket caves in {target_name}'s {hit_location} with athletic precision.",
+            "victim_msg": "Match point achieved as {attacker_name}'s tennis racket caves in your {hit_location} with athletic precision.",
+            "observer_msg": "Match point achieved as the tennis racket caves in {target_name}'s {hit_location} with athletic precision."
         },
         {
-            "attacker_msg": "Your backhand swing with the tennis racket snaps {target_name}'s neck with a sound like a broken string.",
-            "victim_msg": "{attacker_name}'s backhand swing with their tennis racket snaps your neck with a sound like a broken string.",
-            "observer_msg": "{attacker_name}'s backhand swing with the tennis racket snaps {target_name}'s neck with a sound like a broken string."
+            "attacker_msg": "Your backhand swing with the tennis racket snaps {target_name}'s {hit_location} with a sound like a broken string.",
+            "victim_msg": "{attacker_name}'s backhand swing with their tennis racket snaps your {hit_location} with a sound like a broken string.",
+            "observer_msg": "{attacker_name}'s backhand swing with the tennis racket snaps {target_name}'s {hit_location} with a sound like a broken string."
         },
         {
-            "attacker_msg": "The sweet spot of your tennis racket finds {target_name}'s heart, delivering a fatal winner.",
-            "victim_msg": "The sweet spot of {attacker_name}'s tennis racket finds your heart, delivering a fatal winner.",
-            "observer_msg": "The sweet spot of the tennis racket finds {target_name}'s heart, delivering a fatal winner."
+            "attacker_msg": "The sweet spot of your tennis racket finds {target_name}'s {hit_location}, delivering a fatal winner.",
+            "victim_msg": "The sweet spot of {attacker_name}'s tennis racket finds your {hit_location}, delivering a fatal winner.",
+            "observer_msg": "The sweet spot of the tennis racket finds {target_name}'s {hit_location}, delivering a fatal winner."
         },
         {
             "attacker_msg": "Your tennis racket's strings slice through {target_name}'s carotid artery like a wire through cheese.",
@@ -432,9 +432,9 @@ MESSAGES = {
             "observer_msg": "The tennis racket's strings slice through {target_name}'s carotid artery like a wire through cheese."
         },
         {
-            "attacker_msg": "A devastating passing shot with your tennis racket crushes {target_name}'s sternum, ending their rally.",
-            "victim_msg": "A devastating passing shot from {attacker_name}'s tennis racket crushes your sternum, ending your rally.",
-            "observer_msg": "A devastating passing shot from the tennis racket crushes {target_name}'s sternum, ending their rally."
+            "attacker_msg": "A devastating passing shot with your tennis racket crushes {target_name}'s {hit_location}, ending their rally.",
+            "victim_msg": "A devastating passing shot from {attacker_name}'s tennis racket crushes your {hit_location}, ending your rally.",
+            "observer_msg": "A devastating passing shot from the tennis racket crushes {target_name}'s {hit_location}, ending their rally."
         },
         {
             "attacker_msg": "Your tennis racket serves up death as it drives through {target_name}'s eye socket with unstoppable force.",
@@ -477,9 +477,9 @@ MESSAGES = {
             "observer_msg": "A service winner to the body line as the tennis racket ruptures {target_name}'s aorta with devastating force."
         },
         {
-            "attacker_msg": "Your tennis racket's final volley drives through {target_name}'s temple, ending the rally of life permanently.",
-            "victim_msg": "{attacker_name}'s tennis racket's final volley drives through your temple, ending the rally of life permanently.",
-            "observer_msg": "The tennis racket's final volley drives through {target_name}'s temple, ending the rally of life permanently."
+            "attacker_msg": "Your tennis racket's final volley drives through {target_name}'s {hit_location}, ending the rally of life permanently.",
+            "victim_msg": "{attacker_name}'s tennis racket's final volley drives through your {hit_location}, ending the rally of life permanently.",
+            "observer_msg": "The tennis racket's final volley drives through {target_name}'s {hit_location}, ending the rally of life permanently."
         },
         {
             "attacker_msg": "Set and match concluded as your tennis racket caves in {target_name}'s ribcage with athletic brutality.",
@@ -492,14 +492,14 @@ MESSAGES = {
             "observer_msg": "The tennis racket's strings snap from the force of crushing {target_name}'s larynx in a final death stroke."
         },
         {
-            "attacker_msg": "A perfect overhead kill shot with your tennis racket splits {target_name}'s skull like a ripe melon.",
-            "victim_msg": "A perfect overhead kill shot from {attacker_name}'s tennis racket splits your skull like a ripe melon.",
-            "observer_msg": "A perfect overhead kill shot from the tennis racket splits {target_name}'s skull like a ripe melon."
+            "attacker_msg": "A perfect overhead kill shot with your tennis racket splits {target_name}'s {hit_location} like a ripe melon.",
+            "victim_msg": "A perfect overhead kill shot from {attacker_name}'s tennis racket splits your {hit_location} like a ripe melon.",
+            "observer_msg": "A perfect overhead kill shot from the tennis racket splits {target_name}'s {hit_location} like a ripe melon."
         },
         {
-            "attacker_msg": "Your tennis racket serves up the final point, driving through {target_name}'s heart with championship force.",
-            "victim_msg": "{attacker_name}'s tennis racket serves up the final point, driving through your heart with championship force.",
-            "observer_msg": "The tennis racket serves up the final point, driving through {target_name}'s heart with championship force."
+            "attacker_msg": "Your tennis racket serves up the final point, driving through {target_name}'s {hit_location} with championship force.",
+            "victim_msg": "{attacker_name}'s tennis racket serves up the final point, driving through your {hit_location} with championship force.",
+            "observer_msg": "The tennis racket serves up the final point, driving through {target_name}'s {hit_location} with championship force."
         },
         {
             "attacker_msg": "Straight sets as your tennis racket's edge slices {target_name}'s jugular with surgical precision.",
@@ -517,9 +517,9 @@ MESSAGES = {
             "observer_msg": "Tournament champion as the tennis racket delivers the killing blow, {target_name} falling like a defeated opponent."
         },
         {
-            "attacker_msg": "Your tennis racket's grip tape provides perfect control for the fatal swing that snaps {target_name}'s spine.",
-            "victim_msg": "{attacker_name}'s tennis racket's grip tape provides perfect control for the fatal swing that snaps your spine.",
-            "observer_msg": "The tennis racket's grip tape provides perfect control for the fatal swing that snaps {target_name}'s spine."
+            "attacker_msg": "Your tennis racket's grip tape provides perfect control for the fatal swing that snaps {target_name}'s {hit_location}.",
+            "victim_msg": "{attacker_name}'s tennis racket's grip tape provides perfect control for the fatal swing that snaps your {hit_location}.",
+            "observer_msg": "The tennis racket's grip tape provides perfect control for the fatal swing that snaps {target_name}'s {hit_location}."
         },
         {
             "attacker_msg": "A Grand Slam of violence as your tennis racket's final impact reduces {target_name} to a broken champion.",
@@ -532,9 +532,9 @@ MESSAGES = {
             "observer_msg": "The tennis racket retires from the match as {target_name} lies defeated, the final score written in blood."
         },
         {
-            "attacker_msg": "Wimbledon-worthy precision as your tennis racket's final serve drives straight through {target_name}'s brain stem.",
-            "victim_msg": "Wimbledon-worthy precision as {attacker_name}'s tennis racket's final serve drives straight through your brain stem.",
-            "observer_msg": "Wimbledon-worthy precision as the tennis racket's final serve drives straight through {target_name}'s brain stem."
+            "attacker_msg": "Wimbledon-worthy precision as your tennis racket's final serve drives straight through {target_name}'s {hit_location} stem.",
+            "victim_msg": "Wimbledon-worthy precision as {attacker_name}'s tennis racket's final serve drives straight through your {hit_location} stem.",
+            "observer_msg": "Wimbledon-worthy precision as the tennis racket's final serve drives straight through {target_name}'s {hit_location} stem."
         }
     ]
 }

--- a/world/combat/messages/tessen.py
+++ b/world/combat/messages/tessen.py
@@ -56,7 +56,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} flicks the fan open with a snap, its blades shimmering like a predator’s smile.",
         },
         {
-            "attacker_msg": "The fan arcs in your hand, each blade a note in a deadly symphony.",
+            "attacker_msg": "The fan arcs in your {hit_location}, each blade a note in a deadly symphony.",
             "victim_msg": "The fan arcs in {attacker_name}'s hand, each blade a note in a deadly symphony.",
             "observer_msg": "The fan arcs in {attacker_name}'s hand, each blade a note in a deadly symphony.",
         },
@@ -93,7 +93,7 @@ MESSAGES = {
             "observer_msg": "{attacker_name} whirls in a sudden spin, steel petals carving a sharp line across {target_name}.",
         },
         {
-            "attacker_msg": "The fan dances in your hand, its edge kissing {target_name}'s {hit_location} with cold steel.",
+            "attacker_msg": "The fan dances in your {hit_location}, its edge kissing {target_name}'s {hit_location} with cold steel.",
             "victim_msg": "The fan dances in {attacker_name}'s hand, its edge kissing your {hit_location} with cold steel.",
             "observer_msg": "The fan dances in {attacker_name}'s hand, its edge kissing {target_name}'s {hit_location} with cold steel.",
         },

--- a/world/combat/messages/throwing_axe.py
+++ b/world/combat/messages/throwing_axe.py
@@ -11,7 +11,7 @@ MESSAGES = {
             'observer_msg': "The throwing axe gleams wickedly as {attacker_name} grips the handle, eyes fixed on {target_name}."
         },
         {
-            'attacker_msg': "You test the balance of your throwing axe, then cock your arm back toward {target_name}.",
+            'attacker_msg': "You test the balance of your throwing axe, then cock your {hit_location} back toward {target_name}.",
             'victim_msg': "{attacker_name} tests the balance of their throwing axe, then cocks their arm back toward you.",
             'observer_msg': "{attacker_name} tests the balance of their throwing axe, then cocks their arm back toward {target_name}."
         },
@@ -41,7 +41,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} grips the axe handle firmly, muscles tensing as they prepare to hurl it at {target_name}."
         },
         {
-            'attacker_msg': "The throwing axe feels heavy in your hand as you line up your shot on {target_name}.",
+            'attacker_msg': "The throwing axe feels heavy in your {hit_location} as you line up your shot on {target_name}.",
             'victim_msg': "The throwing axe feels heavy in {attacker_name}'s hand as they line up their shot on you.",
             'observer_msg': "The throwing axe feels heavy in {attacker_name}'s hand as they line up their shot on {target_name}."
         },
@@ -157,18 +157,18 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "The throwing axe spins once before the blade cleaves through {target_name}'s skull with a wet crack. They drop instantly.",
-            'victim_msg': "The throwing axe spins once before the blade cleaves through your skull with a wet crack. You drop instantly.",
-            'observer_msg': "The throwing axe spins once before the blade cleaves through {target_name}'s skull with a wet crack. They drop instantly."
+            'attacker_msg': "The throwing axe spins once before the blade cleaves through {target_name}'s {hit_location} with a wet crack. They drop instantly.",
+            'victim_msg': "The throwing axe spins once before the blade cleaves through your {hit_location} with a wet crack. You drop instantly.",
+            'observer_msg': "The throwing axe spins once before the blade cleaves through {target_name}'s {hit_location} with a wet crack. They drop instantly."
         },
         {
-            'attacker_msg': "Perfect aim and devastating force - the axe splits {target_name}'s chest open, ending their life immediately.",
-            'victim_msg': "Perfect aim and devastating force - the axe splits your chest open, ending your life immediately.",
-            'observer_msg': "Perfect aim and devastating force - the axe splits {target_name}'s chest open, ending their life immediately."
+            'attacker_msg': "Perfect aim and devastating force - the axe splits {target_name}'s {hit_location} open, ending their life immediately.",
+            'victim_msg': "Perfect aim and devastating force - the axe splits your {hit_location} open, ending your life immediately.",
+            'observer_msg': "Perfect aim and devastating force - the axe splits {target_name}'s {hit_location} open, ending their life immediately."
         },
         {
             'attacker_msg': "{target_name} looks down in shock at the throwing axe buried in their torso before collapsing in a pool of blood.",
-            'victim_msg': "You look down in shock at the throwing axe buried in your torso before collapsing in a pool of blood.",
+            'victim_msg': "You look down in shock at the throwing axe buried in your {hit_location} before collapsing in a pool of blood.",
             'observer_msg': "{target_name} looks down in shock at the throwing axe buried in their torso before collapsing in a pool of blood."
         },
         {
@@ -178,13 +178,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A single, brutal throw. The axe takes {target_name} in the neck, nearly severing their head.",
-            'victim_msg': "A single, brutal throw. The axe takes you in the neck, nearly severing your head.",
+            'victim_msg': "A single, brutal throw. The axe takes you in the neck, nearly severing your {hit_location}.",
             'observer_msg': "A single, brutal throw. The axe takes {target_name} in the neck, nearly severing their head."
         },
         {
-            'attacker_msg': "The throwing axe buries itself to the eye in {target_name}'s chest. They fall without another breath.",
-            'victim_msg': "The throwing axe buries itself to the eye in your chest. You fall without another breath.",
-            'observer_msg': "The throwing axe buries itself to the eye in {target_name}'s chest. They fall without another breath."
+            'attacker_msg': "The throwing axe buries itself to the eye in {target_name}'s {hit_location}. They fall without another breath.",
+            'victim_msg': "The throwing axe buries itself to the eye in your {hit_location}. You fall without another breath.",
+            'observer_msg': "The throwing axe buries itself to the eye in {target_name}'s {hit_location}. They fall without another breath."
         },
         {
             'attacker_msg': "Your blade finds the perfect spot, cleaving {target_name} nearly in two with one devastating blow.",

--- a/world/combat/messages/throwing_knife.py
+++ b/world/combat/messages/throwing_knife.py
@@ -1,7 +1,7 @@
 MESSAGES = {
     "initiate": [
         {
-            'attacker_msg': "You draw back your arm, throwing knife glinting as you take aim at {target_name}.",
+            'attacker_msg': "You draw back your {hit_location}, throwing knife glinting as you take aim at {target_name}.",
             'victim_msg': "{attacker_name} draws back their arm, throwing knife glinting as they take aim at you.",
             'observer_msg': "{attacker_name} draws back their arm, throwing knife glinting as they take aim at {target_name}."
         },
@@ -26,12 +26,12 @@ MESSAGES = {
             'observer_msg': "Steel flashes as {attacker_name} prepares to hurl their throwing knife at {target_name}."
         },
         {
-            'attacker_msg': "You draw your arm back, throwing knife poised like a deadly dart aimed at {target_name}.",
+            'attacker_msg': "You draw your {hit_location} back, throwing knife poised like a deadly dart aimed at {target_name}.",
             'victim_msg': "{attacker_name} draws their arm back, throwing knife poised like a deadly dart aimed at you.",
             'observer_msg': "{attacker_name} draws their arm back, throwing knife poised like a deadly dart aimed at {target_name}."
         },
         {
-            'attacker_msg': "The throwing knife spins once in your hand before you cock your arm back toward {target_name}.",
+            'attacker_msg': "The throwing knife spins once in your {hit_location} before you cock your {hit_location} back toward {target_name}.",
             'victim_msg': "The throwing knife spins once in {attacker_name}'s hand before they cock their arm back toward you.",
             'observer_msg': "The throwing knife spins once in {attacker_name}'s hand before they cock their arm back toward {target_name}."
         },
@@ -105,9 +105,9 @@ MESSAGES = {
     ],
     "miss": [
         {
-            'attacker_msg': "The throwing knife spins past {target_name}'s head, embedding itself in the wall with a sharp crack.",
-            'victim_msg': "The throwing knife spins past your head, embedding itself in the wall with a sharp crack.",
-            'observer_msg': "The throwing knife spins past {target_name}'s head, embedding itself in the wall with a sharp crack."
+            'attacker_msg': "The throwing knife spins past {target_name}'s {hit_location}, embedding itself in the wall with a sharp crack.",
+            'victim_msg': "The throwing knife spins past your {hit_location}, embedding itself in the wall with a sharp crack.",
+            'observer_msg': "The throwing knife spins past {target_name}'s {hit_location}, embedding itself in the wall with a sharp crack."
         },
         {
             'attacker_msg': "Your knife goes wide, clattering harmlessly across the ground.",
@@ -157,18 +157,18 @@ MESSAGES = {
     ],
     "kill": [
         {
-            'attacker_msg': "The throwing knife spins once, twice, then drives deep into {target_name}'s throat. They collapse, crimson spreading.",
-            'victim_msg': "The throwing knife spins once, twice, then drives deep into your throat. You collapse, crimson spreading.",
-            'observer_msg': "The throwing knife spins once, twice, then drives deep into {target_name}'s throat. They collapse, crimson spreading."
+            'attacker_msg': "The throwing knife spins once, twice, then drives deep into {target_name}'s {hit_location}. They collapse, crimson spreading.",
+            'victim_msg': "The throwing knife spins once, twice, then drives deep into your {hit_location}. You collapse, crimson spreading.",
+            'observer_msg': "The throwing knife spins once, twice, then drives deep into {target_name}'s {hit_location}. They collapse, crimson spreading."
         },
         {
-            'attacker_msg': "Perfect aim. The blade finds {target_name}'s heart with surgical precision, dropping them instantly.",
-            'victim_msg': "Perfect aim. The blade finds your heart with surgical precision, dropping you instantly.",
-            'observer_msg': "Perfect aim. The blade finds {target_name}'s heart with surgical precision, dropping them instantly."
+            'attacker_msg': "Perfect aim. The blade finds {target_name}'s {hit_location} with surgical precision, dropping them instantly.",
+            'victim_msg': "Perfect aim. The blade finds your {hit_location} with surgical precision, dropping you instantly.",
+            'observer_msg': "Perfect aim. The blade finds {target_name}'s {hit_location} with surgical precision, dropping them instantly."
         },
         {
             'attacker_msg': "{target_name} staggers, the throwing knife protruding from their chest, before falling lifeless to the ground.",
-            'victim_msg': "You stagger, the throwing knife protruding from your chest, before falling lifeless to the ground.",
+            'victim_msg': "You stagger, the throwing knife protruding from your {hit_location}, before falling lifeless to the ground.",
             'observer_msg': "{target_name} staggers, the throwing knife protruding from their chest, before falling lifeless to the ground."
         },
         {
@@ -182,9 +182,9 @@ MESSAGES = {
             'observer_msg': "A single, perfect throw. The knife takes {target_name} in the eye, ending their struggles immediately."
         },
         {
-            'attacker_msg': "The throwing knife buries itself to the hilt in {target_name}'s neck. They fall without a sound.",
-            'victim_msg': "The throwing knife buries itself to the hilt in your neck. You fall without a sound.",
-            'observer_msg': "The throwing knife buries itself to the hilt in {target_name}'s neck. They fall without a sound."
+            'attacker_msg': "The throwing knife buries itself to the hilt in {target_name}'s {hit_location}. They fall without a sound.",
+            'victim_msg': "The throwing knife buries itself to the hilt in your {hit_location}. You fall without a sound.",
+            'observer_msg': "The throwing knife buries itself to the hilt in {target_name}'s {hit_location}. They fall without a sound."
         },
         {
             'attacker_msg': "Your blade finds the gap in {target_name}'s defenses, striking a fatal blow.",

--- a/world/combat/messages/tiger_claws.py
+++ b/world/combat/messages/tiger_claws.py
@@ -56,7 +56,7 @@ MESSAGES = {
             'observer_msg': "The claws flick out with a click. {attacker_name} exhales slowly. The dance begins."
         },
         {
-            'attacker_msg': "The claws hum faintly as they lock. You roll your neck. Ready.",
+            'attacker_msg': "The claws hum faintly as they lock. You roll your {hit_location}. Ready.",
             'victim_msg': "The claws hum faintly as they lock. {attacker_name} rolls their neck. Ready.",
             'observer_msg': "The claws hum faintly as they lock. {attacker_name} rolls their neck. Ready."
         },
@@ -458,13 +458,13 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "A clean slash across the face leaves nothing behind the eyes.",
-            'victim_msg': "A clean slash across your face leaves nothing behind your eyes.",
-            'observer_msg': "A clean slash across {target_name}'s face leaves nothing behind their eyes."
+            'victim_msg': "A clean slash across your {hit_location} leaves nothing behind your eyes.",
+            'observer_msg': "A clean slash across {target_name}'s {hit_location} leaves nothing behind their eyes."
         },
         {
             'attacker_msg': "A clean stab to the temple. No blood right away. No breathing afterward.",
-            'victim_msg': "A clean stab to your temple. No blood right away. No breathing afterward.",
-            'observer_msg': "A clean stab to {target_name}'s temple. No blood right away. No breathing afterward."
+            'victim_msg': "A clean stab to your {hit_location}. No blood right away. No breathing afterward.",
+            'observer_msg': "A clean stab to {target_name}'s {hit_location}. No blood right away. No breathing afterward."
         },
         {
             'attacker_msg': "A full jab into the eye. The socket fills. The rest fades out.",
@@ -473,8 +473,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A lunge and hook drives the claws into the chest. {target_name} twitches, then slumps in place.",
-            'victim_msg': "A lunge and hook drives the claws into your chest. You twitch, then slump in place.",
-            'observer_msg': "A lunge and hook drives the claws into {target_name}'s chest. They twitch, then slump in place."
+            'victim_msg': "A lunge and hook drives the claws into your {hit_location}. You twitch, then slump in place.",
+            'observer_msg': "A lunge and hook drives the claws into {target_name}'s {hit_location}. They twitch, then slump in place."
         },
         {
             'attacker_msg': "A rising slash opens the ribcage. Everything inside starts spilling outside.",
@@ -483,38 +483,38 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A savage swipe opens the throat. Red decorates the floor before the body finds it.",
-            'victim_msg': "A savage swipe opens your throat. Red decorates the floor before your body finds it.",
-            'observer_msg': "A savage swipe opens {target_name}'s throat. Red decorates the floor before their body finds it."
+            'victim_msg': "A savage swipe opens your {hit_location}. Red decorates the floor before your body finds it.",
+            'observer_msg': "A savage swipe opens {target_name}'s {hit_location}. Red decorates the floor before their body finds it."
         },
         {
             'attacker_msg': "A single jab punctures the heart. The shock is fast. The end, faster.",
-            'victim_msg': "A single jab punctures your heart. The shock is fast. The end, faster.",
-            'observer_msg': "A single jab punctures {target_name}'s heart. The shock is fast. The end, faster."
+            'victim_msg': "A single jab punctures your {hit_location}. The shock is fast. The end, faster.",
+            'observer_msg': "A single jab punctures {target_name}'s {hit_location}. The shock is fast. The end, faster."
         },
         {
             'attacker_msg': "A stab to the heart. The twitching ends fast. The bleeding takes its time.",
-            'victim_msg': "A stab to your heart. Your twitching ends fast. The bleeding takes its time.",
-            'observer_msg': "A stab to {target_name}'s heart. Their twitching ends fast. The bleeding takes its time."
+            'victim_msg': "A stab to your {hit_location}. Your twitching ends fast. The bleeding takes its time.",
+            'observer_msg': "A stab to {target_name}'s {hit_location}. Their twitching ends fast. The bleeding takes its time."
         },
         {
-            'attacker_msg': "A vicious upswing opens {target_name}'s stomach. They drop, cradling nothing.",
-            'victim_msg': "A vicious upswing opens your stomach. You drop, cradling nothing.",
-            'observer_msg': "A vicious upswing opens {target_name}'s stomach. They drop, cradling nothing."
+            'attacker_msg': "A vicious upswing opens {target_name}'s {hit_location}. They drop, cradling nothing.",
+            'victim_msg': "A vicious upswing opens your {hit_location}. You drop, cradling nothing.",
+            'observer_msg': "A vicious upswing opens {target_name}'s {hit_location}. They drop, cradling nothing."
         },
         {
             'attacker_msg': "One clean strike across the spine. {target_name} folds like they were erased.",
-            'victim_msg': "One clean strike across your spine. You fold like you were erased.",
-            'observer_msg': "One clean strike across {target_name}'s spine. They fold like they were erased."
+            'victim_msg': "One clean strike across your {hit_location}. You fold like you were erased.",
+            'observer_msg': "One clean strike across {target_name}'s {hit_location}. They fold like they were erased."
         },
         {
             'attacker_msg': "One stab finds the temple. The claws sink deep. The thoughts stop immediately.",
-            'victim_msg': "One stab finds your temple. The claws sink deep. Your thoughts stop immediately.",
-            'observer_msg': "One stab finds {target_name}'s temple. The claws sink deep. Their thoughts stop immediately."
+            'victim_msg': "One stab finds your {hit_location}. The claws sink deep. Your thoughts stop immediately.",
+            'observer_msg': "One stab finds {target_name}'s {hit_location}. The claws sink deep. Their thoughts stop immediately."
         },
         {
             'attacker_msg': "Steel hooks the face. Skin, then bone, then stillness.",
-            'victim_msg': "Steel hooks your face. Skin, then bone, then stillness.",
-            'observer_msg': "Steel hooks {target_name}'s face. Skin, then bone, then stillness."
+            'victim_msg': "Steel hooks your {hit_location}. Skin, then bone, then stillness.",
+            'observer_msg': "Steel hooks {target_name}'s {hit_location}. Skin, then bone, then stillness."
         },
         {
             'attacker_msg': "The blades drive into the belly and lift. What comes out doesn't go back in.",
@@ -523,18 +523,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The claws bury into the back. The spine snaps like old wood.",
-            'victim_msg': "The claws bury into your back. Your spine snaps like old wood.",
-            'observer_msg': "The claws bury into {target_name}'s back. Their spine snaps like old wood."
+            'victim_msg': "The claws bury into your {hit_location}. Your {hit_location} snaps like old wood.",
+            'observer_msg': "The claws bury into {target_name}'s {hit_location}. Their spine snaps like old wood."
         },
         {
-            'attacker_msg': "The claws catch the jawline and pull. {target_name}'s head tilts, then topples.",
-            'victim_msg': "The claws catch your jawline and pull. Your head tilts, then topples.",
+            'attacker_msg': "The claws catch the jawline and pull. {target_name}'s {hit_location} tilts, then topples.",
+            'victim_msg': "The claws catch your jawline and pull. Your {hit_location} tilts, then topples.",
             'observer_msg': "The claws catch {target_name}'s jawline and pull. Their head tilts, then topples."
         },
         {
             'attacker_msg': "The claws drive into the neck. The body thrashes, then stills.",
-            'victim_msg': "The claws drive into your neck. Your body thrashes, then stills.",
-            'observer_msg': "The claws drive into {target_name}'s neck. Their body thrashes, then stills."
+            'victim_msg': "The claws drive into your {hit_location}. Your body thrashes, then stills.",
+            'observer_msg': "The claws drive into {target_name}'s {hit_location}. Their body thrashes, then stills."
         },
         {
             'attacker_msg': "The claws hook under the chin and yank. The snap is final. The fall is slow.",
@@ -543,8 +543,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The claws pierce the throat. {target_name} gargles red and falls silent.",
-            'victim_msg': "The claws pierce your throat. You gargle red and fall silent.",
-            'observer_msg': "The claws pierce {target_name}'s throat. They gargle red and fall silent."
+            'victim_msg': "The claws pierce your {hit_location}. You gargle red and fall silent.",
+            'observer_msg': "The claws pierce {target_name}'s {hit_location}. They gargle red and fall silent."
         },
         {
             'attacker_msg': "The claws pin {target_name} to the wall. What follows is silence, and slumping.",
@@ -553,23 +553,23 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The claws plunge into the chest. {target_name} makes a sound — almost.",
-            'victim_msg': "The claws plunge into your chest. You make a sound — almost.",
-            'observer_msg': "The claws plunge into {target_name}'s chest. They make a sound — almost."
+            'victim_msg': "The claws plunge into your {hit_location}. You make a sound — almost.",
+            'observer_msg': "The claws plunge into {target_name}'s {hit_location}. They make a sound — almost."
         },
         {
             'attacker_msg': "The claws rip the chest open in a cross. The body folds around the gesture.",
-            'victim_msg': "The claws rip your chest open in a cross. Your body folds around the gesture.",
-            'observer_msg': "The claws rip {target_name}'s chest open in a cross. Their body folds around the gesture."
+            'victim_msg': "The claws rip your {hit_location} open in a cross. Your body folds around the gesture.",
+            'observer_msg': "The claws rip {target_name}'s {hit_location} open in a cross. Their body folds around the gesture."
         },
         {
             'attacker_msg': "The claws sink into both lungs. {target_name} tries to speak. They shouldn't have.",
-            'victim_msg': "The claws sink into both your lungs. You try to speak. You shouldn't have.",
-            'observer_msg': "The claws sink into both {target_name}'s lungs. They try to speak. They shouldn't have."
+            'victim_msg': "The claws sink into both your {hit_location}. You try to speak. You shouldn't have.",
+            'observer_msg': "The claws sink into both {target_name}'s {hit_location}. They try to speak. They shouldn't have."
         },
         {
             'attacker_msg': "The curved blades bite into the spine. {target_name} arches once, then stays down.",
-            'victim_msg': "The curved blades bite into your spine. You arch once, then stay down.",
-            'observer_msg': "The curved blades bite into {target_name}'s spine. They arch once, then stay down."
+            'victim_msg': "The curved blades bite into your {hit_location}. You arch once, then stay down.",
+            'observer_msg': "The curved blades bite into {target_name}'s {hit_location}. They arch once, then stay down."
         },
         {
             'attacker_msg': "The final hit lands under the chin. The claws rise into silence.",
@@ -583,13 +583,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You drive all five points into the neck. The collapse is wet and absolute.",
-            'victim_msg': "{attacker_name} drives all five points into your neck. Your collapse is wet and absolute.",
-            'observer_msg': "{attacker_name} drives all five points into {target_name}'s neck. Their collapse is wet and absolute."
+            'victim_msg': "{attacker_name} drives all five points into your {hit_location}. Your collapse is wet and absolute.",
+            'observer_msg': "{attacker_name} drives all five points into {target_name}'s {hit_location}. Their collapse is wet and absolute."
         },
         {
             'attacker_msg': "You rake the chest in a cross pattern. Blood fountains from the intersect.",
-            'victim_msg': "{attacker_name} rakes your chest in a cross pattern. Blood fountains from the intersect.",
-            'observer_msg': "{attacker_name} rakes {target_name}'s chest in a cross pattern. Blood fountains from the intersect."
+            'victim_msg': "{attacker_name} rakes your {hit_location} in a cross pattern. Blood fountains from the intersect.",
+            'observer_msg': "{attacker_name} rakes {target_name}'s {hit_location} in a cross pattern. Blood fountains from the intersect."
         },
         {
             'attacker_msg': "You rip upward from gut to sternum. The insides lose their home.",
@@ -598,13 +598,13 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You slash side to side across the face. {target_name} crumples, identity gone.",
-            'victim_msg': "{attacker_name} slashes side to side across your face. You crumple, identity gone.",
-            'observer_msg': "{attacker_name} slashes side to side across {target_name}'s face. They crumple, identity gone."
+            'victim_msg': "{attacker_name} slashes side to side across your {hit_location}. You crumple, identity gone.",
+            'observer_msg': "{attacker_name} slashes side to side across {target_name}'s {hit_location}. They crumple, identity gone."
         },
         {
             'attacker_msg': "You tear through the throat. {target_name} stumbles backward — hands grasping at a wound that wins.",
-            'victim_msg': "{attacker_name} tears through your throat. You stumble backward — hands grasping at a wound that wins.",
-            'observer_msg': "{attacker_name} tears through {target_name}'s throat. They stumble backward — hands grasping at a wound that wins."
+            'victim_msg': "{attacker_name} tears through your {hit_location}. You stumble backward — hands grasping at a wound that wins.",
+            'observer_msg': "{attacker_name} tears through {target_name}'s {hit_location}. They stumble backward — hands grasping at a wound that wins."
         }
     ]
 }

--- a/world/combat/messages/tire_iron.py
+++ b/world/combat/messages/tire_iron.py
@@ -26,7 +26,7 @@ MESSAGES = {
             'observer_msg': "It's bent from past impacts. So is {attacker_name}."
         },
         {
-            'attacker_msg': "It's not balanced, not clean, but it fits your hand like a promise.",
+            'attacker_msg': "It's not balanced, not clean, but it fits your {hit_location} like a promise.",
             'victim_msg': "It's not balanced, not clean, but it fits {attacker_name}'s hand like a promise.",
             'observer_msg': "It's not balanced, not clean, but it fits {attacker_name}'s hand like a promise."
         },
@@ -66,7 +66,7 @@ MESSAGES = {
             'observer_msg': "The iron swings in a lazy arc before {attacker_name} catches it with purpose."
         },
         {
-            'attacker_msg': "The metal tool knocks against your knee once. Ritual complete.",
+            'attacker_msg': "The metal tool knocks against your {hit_location} once. Ritual complete.",
             'victim_msg': "The metal tool knocks against {attacker_name}'s knee once. Ritual complete.",
             'observer_msg': "The metal tool knocks against {attacker_name}'s knee once. Ritual complete."
         },
@@ -320,7 +320,7 @@ MESSAGES = {
             'observer_msg': "A heavy arc cuts through smoke. No flesh meets metal."
         },
         {
-            'attacker_msg': "A jab misses and thuds into a wall. The vibration crawls up your arm.",
+            'attacker_msg': "A jab misses and thuds into a wall. The vibration crawls up your {hit_location}.",
             'victim_msg': "A jab misses and thuds into a wall. The vibration crawls up {attacker_name}'s arm.",
             'observer_msg': "A jab misses and thuds into a wall. The vibration crawls up {attacker_name}'s arm."
         },
@@ -458,23 +458,23 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "A backswing crushes the spine. {target_name} falls and doesn't flinch again.",
-            'victim_msg': "A backswing crushes your spine. You fall and don't flinch again.",
-            'observer_msg': "A backswing crushes {target_name}'s spine. They fall and don't flinch again."
+            'victim_msg': "A backswing crushes your {hit_location}. You fall and don't flinch again.",
+            'observer_msg': "A backswing crushes {target_name}'s {hit_location}. They fall and don't flinch again."
         },
         {
             'attacker_msg': "A brutal smash caves in the ribs. {target_name} gasps once — then doesn't.",
-            'victim_msg': "A brutal smash caves in your ribs. You gasp once — then don't.",
-            'observer_msg': "A brutal smash caves in {target_name}'s ribs. They gasp once — then don't."
+            'victim_msg': "A brutal smash caves in your {hit_location}. You gasp once — then don't.",
+            'observer_msg': "A brutal smash caves in {target_name}'s {hit_location}. They gasp once — then don't."
         },
         {
-            'attacker_msg': "A downward smash silences the scream in {target_name}'s throat. Permanently.",
-            'victim_msg': "A downward smash silences the scream in your throat. Permanently.",
-            'observer_msg': "A downward smash silences the scream in {target_name}'s throat. Permanently."
+            'attacker_msg': "A downward smash silences the scream in {target_name}'s {hit_location}. Permanently.",
+            'victim_msg': "A downward smash silences the scream in your {hit_location}. Permanently.",
+            'observer_msg': "A downward smash silences the scream in {target_name}'s {hit_location}. Permanently."
         },
         {
             'attacker_msg': "A downward swing opens the skull. It doesn't close again.",
-            'victim_msg': "A downward swing opens your skull. It doesn't close again.",
-            'observer_msg': "A downward swing opens {target_name}'s skull. It doesn't close again."
+            'victim_msg': "A downward swing opens your {hit_location}. It doesn't close again.",
+            'observer_msg': "A downward swing opens {target_name}'s {hit_location}. It doesn't close again."
         },
         {
             'attacker_msg': "A rising blow breaks the nose and the brain behind it. {target_name} goes limp.",
@@ -483,8 +483,8 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A savage jab to the chest. The ribs give. {target_name} doesn't rise.",
-            'victim_msg': "A savage jab to your chest. Your ribs give. You don't rise.",
-            'observer_msg': "A savage jab to {target_name}'s chest. Their ribs give. They don't rise."
+            'victim_msg': "A savage jab to your {hit_location}. Your {hit_location} give. You don't rise.",
+            'observer_msg': "A savage jab to {target_name}'s {hit_location}. Their ribs give. They don't rise."
         },
         {
             'attacker_msg': "A sharp jab to the eye socket. The iron goes deep. {target_name} goes nowhere.",
@@ -493,18 +493,18 @@ MESSAGES = {
         },
         {
             'attacker_msg': "One blow to the back of the neck. {target_name} drops without a word or twitch.",
-            'victim_msg': "One blow to the back of your neck. You drop without a word or twitch.",
-            'observer_msg': "One blow to the back of {target_name}'s neck. They drop without a word or twitch."
+            'victim_msg': "One blow to the back of your {hit_location}. You drop without a word or twitch.",
+            'observer_msg': "One blow to the back of {target_name}'s {hit_location}. They drop without a word or twitch."
         },
         {
             'attacker_msg': "One brutal swing crushes the jaw. The body twitches and folds.",
-            'victim_msg': "One brutal swing crushes your jaw. Your body twitches and folds.",
-            'observer_msg': "One brutal swing crushes {target_name}'s jaw. Their body twitches and folds."
+            'victim_msg': "One brutal swing crushes your {hit_location}. Your body twitches and folds.",
+            'observer_msg': "One brutal swing crushes {target_name}'s {hit_location}. Their body twitches and folds."
         },
         {
             'attacker_msg': "One jab to the heart. The shock is instant. {target_name} folds slowly, confused.",
-            'victim_msg': "One jab to your heart. The shock is instant. You fold slowly, confused.",
-            'observer_msg': "One jab to {target_name}'s heart. The shock is instant. They fold slowly, confused."
+            'victim_msg': "One jab to your {hit_location}. The shock is instant. You fold slowly, confused.",
+            'observer_msg': "One jab to {target_name}'s {hit_location}. The shock is instant. They fold slowly, confused."
         },
         {
             'attacker_msg': "One swing. One strike. No movement after. You breathe out slow.",
@@ -513,48 +513,48 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The blunt end crushes the temple. {target_name} falls before the tool finishes swinging.",
-            'victim_msg': "The blunt end crushes your temple. You fall before the tool finishes swinging.",
-            'observer_msg': "The blunt end crushes {target_name}'s temple. They fall before the tool finishes swinging."
+            'victim_msg': "The blunt end crushes your {hit_location}. You fall before the tool finishes swinging.",
+            'observer_msg': "The blunt end crushes {target_name}'s {hit_location}. They fall before the tool finishes swinging."
         },
         {
             'attacker_msg': "The blunt end slams into the heart. The body stutters, then surrenders.",
-            'victim_msg': "The blunt end slams into your heart. Your body stutters, then surrenders.",
-            'observer_msg': "The blunt end slams into {target_name}'s heart. Their body stutters, then surrenders."
+            'victim_msg': "The blunt end slams into your {hit_location}. Your body stutters, then surrenders.",
+            'observer_msg': "The blunt end slams into {target_name}'s {hit_location}. Their body stutters, then surrenders."
         },
         {
             'attacker_msg': "The crossbar lands on the temple. {target_name} collapses like scaffolding hit by a wrecking ball.",
-            'victim_msg': "The crossbar lands on your temple. You collapse like scaffolding hit by a wrecking ball.",
-            'observer_msg': "The crossbar lands on {target_name}'s temple. They collapse like scaffolding hit by a wrecking ball."
+            'victim_msg': "The crossbar lands on your {hit_location}. You collapse like scaffolding hit by a wrecking ball.",
+            'observer_msg': "The crossbar lands on {target_name}'s {hit_location}. They collapse like scaffolding hit by a wrecking ball."
         },
         {
             'attacker_msg': "The crossbar punches the neck. The body falls like it forgot gravity first.",
-            'victim_msg': "The crossbar punches your neck. Your body falls like it forgot gravity first.",
-            'observer_msg': "The crossbar punches {target_name}'s neck. Their body falls like it forgot gravity first."
+            'victim_msg': "The crossbar punches your {hit_location}. Your body falls like it forgot gravity first.",
+            'observer_msg': "The crossbar punches {target_name}'s {hit_location}. Their body falls like it forgot gravity first."
         },
         {
             'attacker_msg': "The curved end buries into the throat. Breathing halts. Life does too.",
-            'victim_msg': "The curved end buries into your throat. Your breathing halts. Life does too.",
-            'observer_msg': "The curved end buries into {target_name}'s throat. Their breathing halts. Life does too."
+            'victim_msg': "The curved end buries into your {hit_location}. Your breathing halts. Life does too.",
+            'observer_msg': "The curved end buries into {target_name}'s {hit_location}. Their breathing halts. Life does too."
         },
         {
             'attacker_msg': "The hook gouges the throat. Red arcs. The rest falls away.",
-            'victim_msg': "The hook gouges your throat. Red arcs. The rest falls away.",
-            'observer_msg': "The hook gouges {target_name}'s throat. Red arcs. The rest falls away."
+            'victim_msg': "The hook gouges your {hit_location}. Red arcs. The rest falls away.",
+            'observer_msg': "The hook gouges {target_name}'s {hit_location}. Red arcs. The rest falls away."
         },
         {
             'attacker_msg': "The hook lands under the jaw. The body follows upward — then hits the ground.",
-            'victim_msg': "The hook lands under your jaw. Your body follows upward — then hits the ground.",
-            'observer_msg': "The hook lands under {target_name}'s jaw. Their body follows upward — then hits the ground."
+            'victim_msg': "The hook lands under your {hit_location}. Your body follows upward — then hits the ground.",
+            'observer_msg': "The hook lands under {target_name}'s {hit_location}. Their body follows upward — then hits the ground."
         },
         {
             'attacker_msg': "The iron arcs into the ribs, then deeper. {target_name} drops like breath left a building.",
-            'victim_msg': "The iron arcs into your ribs, then deeper. You drop like breath left a building.",
-            'observer_msg': "The iron arcs into {target_name}'s ribs, then deeper. They drop like breath left a building."
+            'victim_msg': "The iron arcs into your {hit_location}, then deeper. You drop like breath left a building.",
+            'observer_msg': "The iron arcs into {target_name}'s {hit_location}, then deeper. They drop like breath left a building."
         },
         {
-            'attacker_msg': "The iron crunches the side of {target_name}'s head. They hit the ground mid-spasm, post-life.",
-            'victim_msg': "The iron crunches the side of your head. You hit the ground mid-spasm, post-life.",
-            'observer_msg': "The iron crunches the side of {target_name}'s head. They hit the ground mid-spasm, post-life."
+            'attacker_msg': "The iron crunches the side of {target_name}'s {hit_location}. They hit the ground mid-spasm, post-life.",
+            'victim_msg': "The iron crunches the side of your {hit_location}. You hit the ground mid-spasm, post-life.",
+            'observer_msg': "The iron crunches the side of {target_name}'s {hit_location}. They hit the ground mid-spasm, post-life."
         },
         {
             'attacker_msg': "The iron embeds in the side. The withdrawal is wet, final.",
@@ -563,48 +563,48 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The spine gives out beneath the blow. {target_name} twitches and is no longer relevant.",
-            'victim_msg': "Your spine gives out beneath the blow. You twitch and are no longer relevant.",
-            'observer_msg': "{target_name}'s spine gives out beneath the blow. They twitch and are no longer relevant."
+            'victim_msg': "Your {hit_location} gives out beneath the blow. You twitch and are no longer relevant.",
+            'observer_msg': "{target_name}'s {hit_location} gives out beneath the blow. They twitch and are no longer relevant."
         },
         {
-            'attacker_msg': "The tire iron caves in {target_name}'s skull. The sound is wet, final.",
-            'victim_msg': "The tire iron caves in your skull. The sound is wet, final.",
-            'observer_msg': "The tire iron caves in {target_name}'s skull. The sound is wet, final."
+            'attacker_msg': "The tire iron caves in {target_name}'s {hit_location}. The sound is wet, final.",
+            'victim_msg': "The tire iron caves in your {hit_location}. The sound is wet, final.",
+            'observer_msg': "The tire iron caves in {target_name}'s {hit_location}. The sound is wet, final."
         },
         {
             'attacker_msg': "The tool lands in the chest and stays. When you pull it free, there's no more movement.",
-            'victim_msg': "The tool lands in your chest and stays. When {attacker_name} pulls it free, there's no more movement.",
-            'observer_msg': "The tool lands in {target_name}'s chest and stays. When {attacker_name} pulls it free, there's no more movement."
+            'victim_msg': "The tool lands in your {hit_location} and stays. When {attacker_name} pulls it free, there's no more movement.",
+            'observer_msg': "The tool lands in {target_name}'s {hit_location} and stays. When {attacker_name} pulls it free, there's no more movement."
         },
         {
             'attacker_msg': "You crack the temple clean. {target_name} slumps without resistance.",
-            'victim_msg': "{attacker_name} cracks your temple clean. You slump without resistance.",
-            'observer_msg': "{attacker_name} cracks {target_name}'s temple clean. They slump without resistance."
+            'victim_msg': "{attacker_name} cracks your {hit_location} clean. You slump without resistance.",
+            'observer_msg': "{attacker_name} cracks {target_name}'s {hit_location} clean. They slump without resistance."
         },
         {
             'attacker_msg': "You drive the tire iron into the side of the skull. It caves. So does everything else.",
-            'victim_msg': "{attacker_name} drives the tire iron into the side of your skull. It caves. So does everything else.",
-            'observer_msg': "{attacker_name} drives the tire iron into the side of {target_name}'s skull. It caves. So does everything else."
+            'victim_msg': "{attacker_name} drives the tire iron into the side of your {hit_location}. It caves. So does everything else.",
+            'observer_msg': "{attacker_name} drives the tire iron into the side of {target_name}'s {hit_location}. It caves. So does everything else."
         },
         {
             'attacker_msg': "You hook behind the head and yank hard. The thud is ugly. The silence worse.",
-            'victim_msg': "{attacker_name} hooks behind your head and yanks hard. The thud is ugly. The silence worse.",
-            'observer_msg': "{attacker_name} hooks behind {target_name}'s head and yanks hard. The thud is ugly. The silence worse."
+            'victim_msg': "{attacker_name} hooks behind your {hit_location} and yanks hard. The thud is ugly. The silence worse.",
+            'observer_msg': "{attacker_name} hooks behind {target_name}'s {hit_location} and yanks hard. The thud is ugly. The silence worse."
         },
         {
             'attacker_msg': "You hook the neck and yank. The snap echoes hard.",
-            'victim_msg': "{attacker_name} hooks your neck and yanks. The snap echoes hard.",
-            'observer_msg': "{attacker_name} hooks {target_name}'s neck and yanks. The snap echoes hard."
+            'victim_msg': "{attacker_name} hooks your {hit_location} and yanks. The snap echoes hard.",
+            'observer_msg': "{attacker_name} hooks {target_name}'s {hit_location} and yanks. The snap echoes hard."
         },
         {
             'attacker_msg': "You spin and strike. The crossbar hits spine. The body folds inward.",
-            'victim_msg': "{attacker_name} spins and strikes. The crossbar hits your spine. Your body folds inward.",
-            'observer_msg': "{attacker_name} spins and strikes. The crossbar hits {target_name}'s spine. Their body folds inward."
+            'victim_msg': "{attacker_name} spins and strikes. The crossbar hits your {hit_location}. Your body folds inward.",
+            'observer_msg': "{attacker_name} spins and strikes. The crossbar hits {target_name}'s {hit_location}. Their body folds inward."
         },
         {
             'attacker_msg': "You swing under the ribs. Something ruptures. {target_name} drops without flair.",
-            'victim_msg': "{attacker_name} swings under your ribs. Something ruptures. You drop without flair.",
-            'observer_msg': "{attacker_name} swings under {target_name}'s ribs. Something ruptures. They drop without flair."
+            'victim_msg': "{attacker_name} swings under your {hit_location}. Something ruptures. You drop without flair.",
+            'observer_msg': "{attacker_name} swings under {target_name}'s {hit_location}. Something ruptures. They drop without flair."
         }
     ]
 }

--- a/world/combat/messages/whip.py
+++ b/world/combat/messages/whip.py
@@ -26,7 +26,7 @@ MESSAGES = {
             'observer_msg': "Each step forward shortens the leash. The whip is ready. {attacker_name} is worse."
         },
         {
-            'attacker_msg': "Leather coils around your hand like a pet serpent. It's ready to bite.",
+            'attacker_msg': "Leather coils around your {hit_location} like a pet serpent. It's ready to bite.",
             'victim_msg': "Leather coils around {attacker_name}'s hand like a pet serpent. It's ready to bite.",
             'observer_msg': "Leather coils around {attacker_name}'s hand like a pet serpent. It's ready to bite."
         },
@@ -101,7 +101,7 @@ MESSAGES = {
             'observer_msg': "With no ceremony, {attacker_name} flicks the whip and lets the silence do the rest."
         },
         {
-            'attacker_msg': "You coil the whip around your arm, then flick it free. The air snaps.",
+            'attacker_msg': "You coil the whip around your {hit_location}, then flick it free. The air snaps.",
             'victim_msg': "{attacker_name} coils the whip around their arm, then flicks it free. The air snaps.",
             'observer_msg': "{attacker_name} coils the whip around their arm, then flicks it free. The air snaps."
         },
@@ -121,7 +121,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} loops the handle once, eyes locked on {target_name}. The rest is just echo."
         },
         {
-            'attacker_msg': "You roll your wrist. The whip slithers loose and twitching.",
+            'attacker_msg': "You roll your {hit_location}. The whip slithers loose and twitching.",
             'victim_msg': "{attacker_name} rolls their wrist. The whip slithers loose and twitching.",
             'observer_msg': "{attacker_name} rolls their wrist. The whip slithers loose and twitching."
         },
@@ -131,7 +131,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} snaps the whip once — not to intimidate, but to announce the end."
         },
         {
-            'attacker_msg': "You spin the whip behind your back. It arcs forward, tense and lethal.",
+            'attacker_msg': "You spin the whip behind your {hit_location}. It arcs forward, tense and lethal.",
             'victim_msg': "{attacker_name} spins the whip behind their back. It arcs forward, tense and lethal.",
             'observer_msg': "{attacker_name} spins the whip behind their back. It arcs forward, tense and lethal."
         },
@@ -141,7 +141,7 @@ MESSAGES = {
             'observer_msg': "{attacker_name} uncoils the whip in one slow movement. It slithers across the ground like it's hunting."
         },
         {
-            'attacker_msg': "You wind the whip around your wrist — then release it in one silent gesture.",
+            'attacker_msg': "You wind the whip around your {hit_location} — then release it in one silent gesture.",
             'victim_msg': "{attacker_name} winds the whip around their wrist — then releases it in one silent gesture.",
             'observer_msg': "{attacker_name} winds the whip around their wrist — then releases it in one silent gesture."
         },
@@ -458,17 +458,17 @@ MESSAGES = {
     'kill': [
         {
             'attacker_msg': "A final snap cracks open the skull. {target_name} hits the ground before the blood does.",
-            'victim_msg': "A final snap cracks open your skull. You hit the ground before the blood does.",
+            'victim_msg': "A final snap cracks open your {hit_location}. You hit the ground before the blood does.",
             'observer_msg': "A final snap cracks open the skull. {target_name} hits the ground before the blood does."
         },
         {
             'attacker_msg': "A flick of leather breaks the jaw. {target_name} chokes on the rest.",
-            'victim_msg': "A flick of leather breaks your jaw. You choke on the rest.",
+            'victim_msg': "A flick of leather breaks your {hit_location}. You choke on the rest.",
             'observer_msg': "A flick of leather breaks the jaw. {target_name} chokes on the rest."
         },
         {
             'attacker_msg': "A harsh crack to the temple ends both thought and breath.",
-            'victim_msg': "A harsh crack to your temple ends both thought and breath.",
+            'victim_msg': "A harsh crack to your {hit_location} ends both thought and breath.",
             'observer_msg': "A harsh crack to the temple ends both thought and breath."
         },
         {
@@ -483,12 +483,12 @@ MESSAGES = {
         },
         {
             'attacker_msg': "A tight flick breaks the jaw. The rest follows, slower but no less final.",
-            'victim_msg': "A tight flick breaks your jaw. The rest follows, slower but no less final.",
+            'victim_msg': "A tight flick breaks your {hit_location}. The rest follows, slower but no less final.",
             'observer_msg': "A tight flick breaks the jaw. The rest follows, slower but no less final."
         },
         {
             'attacker_msg': "Leather binds the arm and wrenches. The crack of bone is drowned by the fall.",
-            'victim_msg': "Leather binds your arm and wrenches. The crack of bone is drowned by your fall.",
+            'victim_msg': "Leather binds your {hit_location} and wrenches. The crack of bone is drowned by your fall.",
             'observer_msg': "Leather binds the arm and wrenches. The crack of bone is drowned by the fall."
         },
         {
@@ -498,17 +498,17 @@ MESSAGES = {
         },
         {
             'attacker_msg': "One strike caves the back inward. {target_name} drops like scaffolding giving up.",
-            'victim_msg': "One strike caves your back inward. You drop like scaffolding giving up.",
+            'victim_msg': "One strike caves your {hit_location} inward. You drop like scaffolding giving up.",
             'observer_msg': "One strike caves the back inward. {target_name} drops like scaffolding giving up."
         },
         {
             'attacker_msg': "One vicious crack splits the face. Blood sprays, and {target_name} doesn't get up.",
-            'victim_msg': "One vicious crack splits your face. Blood sprays, and you don't get up.",
+            'victim_msg': "One vicious crack splits your {hit_location}. Blood sprays, and you don't get up.",
             'observer_msg': "One vicious crack splits the face. Blood sprays, and {target_name} doesn't get up."
         },
         {
             'attacker_msg': "The crack splits the face. The collapse is boneless.",
-            'victim_msg': "The crack splits your face. Your collapse is boneless.",
+            'victim_msg': "The crack splits your {hit_location}. Your collapse is boneless.",
             'observer_msg': "The crack splits the face. The collapse is boneless."
         },
         {
@@ -523,58 +523,58 @@ MESSAGES = {
         },
         {
             'attacker_msg': "The lash snaps across the throat. Red sprays. The legs fold.",
-            'victim_msg': "The lash snaps across your throat. Red sprays. Your legs fold.",
+            'victim_msg': "The lash snaps across your {hit_location}. Red sprays. Your legs fold.",
             'observer_msg': "The lash snaps across the throat. Red sprays. The legs fold."
         },
         {
             'attacker_msg': "The lash spirals around the neck and yanks. Vertebrae snap like sticks.",
-            'victim_msg': "The lash spirals around your neck and yanks. Vertebrae snap like sticks.",
+            'victim_msg': "The lash spirals around your {hit_location} and yanks. Vertebrae snap like sticks.",
             'observer_msg': "The lash spirals around the neck and yanks. Vertebrae snap like sticks."
         },
         {
             'attacker_msg': "The lash wraps a leg, then pulls. The fall breaks more than bones.",
-            'victim_msg': "The lash wraps your leg, then pulls. The fall breaks more than bones.",
+            'victim_msg': "The lash wraps your {hit_location}, then pulls. The fall breaks more than bones.",
             'observer_msg': "The lash wraps a leg, then pulls. The fall breaks more than bones."
         },
         {
             'attacker_msg': "The lash wraps the skull. A tug, and {target_name} drops like a puppet without strings.",
-            'victim_msg': "The lash wraps your skull. A tug, and you drop like a puppet without strings.",
+            'victim_msg': "The lash wraps your {hit_location}. A tug, and you drop like a puppet without strings.",
             'observer_msg': "The lash wraps the skull. A tug, and {target_name} drops like a puppet without strings."
         },
         {
             'attacker_msg': "The leather tip finds the temple. The result is stillness, fast and absolute.",
-            'victim_msg': "The leather tip finds your temple. The result is stillness, fast and absolute.",
+            'victim_msg': "The leather tip finds your {hit_location}. The result is stillness, fast and absolute.",
             'observer_msg': "The leather tip finds the temple. The result is stillness, fast and absolute."
         },
         {
             'attacker_msg': "The whip bites deep into the throat. One twist — one final silence.",
-            'victim_msg': "The whip bites deep into your throat. One twist — one final silence.",
+            'victim_msg': "The whip bites deep into your {hit_location}. One twist — one final silence.",
             'observer_msg': "The whip bites deep into the throat. One twist — one final silence."
         },
         {
-            'attacker_msg': "The whip coils around {target_name}'s throat. One yank — one silence.",
-            'victim_msg': "The whip coils around your throat. One yank — one silence.",
-            'observer_msg': "The whip coils around {target_name}'s throat. One yank — one silence."
+            'attacker_msg': "The whip coils around {target_name}'s {hit_location}. One yank — one silence.",
+            'victim_msg': "The whip coils around your {hit_location}. One yank — one silence.",
+            'observer_msg': "The whip coils around {target_name}'s {hit_location}. One yank — one silence."
         },
         {
             'attacker_msg': "The whip lands across the chest. A second strike caves it inward.",
-            'victim_msg': "The whip lands across your chest. A second strike caves it inward.",
+            'victim_msg': "The whip lands across your {hit_location}. A second strike caves it inward.",
             'observer_msg': "The whip lands across the chest. A second strike caves it inward."
         },
         {
             'attacker_msg': "The whip lashes upward under the jaw. {target_name} shudders, then tips over slowly.",
-            'victim_msg': "The whip lashes upward under your jaw. You shudder, then tip over slowly.",
+            'victim_msg': "The whip lashes upward under your {hit_location}. You shudder, then tip over slowly.",
             'observer_msg': "The whip lashes upward under the jaw. {target_name} shudders, then tips over slowly."
         },
         {
             'attacker_msg': "The whip loops the neck. You yank — and {target_name} falls soundlessly.",
-            'victim_msg': "The whip loops your neck. {attacker_name} yanks — and you fall soundlessly.",
+            'victim_msg': "The whip loops your {hit_location}. {attacker_name} yanks — and you fall soundlessly.",
             'observer_msg': "The whip loops the neck. {attacker_name} yanks — and {target_name} falls soundlessly."
         },
         {
-            'attacker_msg': "The whip winds around {target_name}'s chest. A twist and pull collapses everything inside.",
-            'victim_msg': "The whip winds around your chest. A twist and pull collapses everything inside.",
-            'observer_msg': "The whip winds around {target_name}'s chest. A twist and pull collapses everything inside."
+            'attacker_msg': "The whip winds around {target_name}'s {hit_location}. A twist and pull collapses everything inside.",
+            'victim_msg': "The whip winds around your {hit_location}. A twist and pull collapses everything inside.",
+            'observer_msg': "The whip winds around {target_name}'s {hit_location}. A twist and pull collapses everything inside."
         },
         {
             'attacker_msg': "You crack the whip with such force that bone shatters beneath skin.",
@@ -583,27 +583,27 @@ MESSAGES = {
         },
         {
             'attacker_msg': "You drive the whip into the neck. The sound it makes isn't human.",
-            'victim_msg': "{attacker_name} drives the whip into your neck. The sound it makes isn't human.",
+            'victim_msg': "{attacker_name} drives the whip into your {hit_location}. The sound it makes isn't human.",
             'observer_msg': "{attacker_name} drives the whip into the neck. The sound it makes isn't human."
         },
         {
             'attacker_msg': "You hook the leg, pull, then finish the job as {target_name} tries to stand.",
-            'victim_msg': "{attacker_name} hooks your leg, pulls, then finishes the job as you try to stand.",
+            'victim_msg': "{attacker_name} hooks your {hit_location}, pulls, then finishes the job as you try to stand.",
             'observer_msg': "{attacker_name} hooks the leg, pulls, then finishes the job as {target_name} tries to stand."
         },
         {
             'attacker_msg': "You loop the lash around the skull. A jerk ends the conversation.",
-            'victim_msg': "{attacker_name} loops the lash around your skull. A jerk ends the conversation.",
+            'victim_msg': "{attacker_name} loops the lash around your {hit_location}. A jerk ends the conversation.",
             'observer_msg': "{attacker_name} loops the lash around the skull. A jerk ends the conversation."
         },
         {
             'attacker_msg': "You pull the whip tight across the chest. The crunch is quiet. The end isn't.",
-            'victim_msg': "{attacker_name} pulls the whip tight across your chest. The crunch is quiet. The end isn't.",
+            'victim_msg': "{attacker_name} pulls the whip tight across your {hit_location}. The crunch is quiet. The end isn't.",
             'observer_msg': "{attacker_name} pulls the whip tight across the chest. The crunch is quiet. The end isn't."
         },
         {
             'attacker_msg': "You snap the whip against the spine. The body jerks, then collapses completely.",
-            'victim_msg': "{attacker_name} snaps the whip against your spine. Your body jerks, then collapses completely.",
+            'victim_msg': "{attacker_name} snaps the whip against your {hit_location}. Your body jerks, then collapses completely.",
             'observer_msg': "{attacker_name} snaps the whip against the spine. The body jerks, then collapses completely."
         },
     ],


### PR DESCRIPTION
## Summary

Programmatic sweep replacing hardcoded anatomy with ``{hit_location}`` token across all weapon message files. Closes the original audit finding of 1882 hardcoded anatomy nouns across 63 weapon files.

**Conservative substitution rules:**
- ``{target_name}'s <anatomy>`` → ``{target_name}'s {hit_location}`` (3rd-person possessive points at target)
- ``your <anatomy>`` → ``your {hit_location}`` (1st-person possessive in victim_msg points at victim)
- ``their <anatomy>`` deliberately skipped (ambiguous; could refer to attacker)
- Non-possessive anatomy in multi-body-part combos (\"jaw, sternum, temple\") preserved as narrative

**Stats:**
- 3070 substitutions across 94 weapon files (target_name's: 1554, your: 1516)
- 18 compound-noun reverts (\"chest cavity\", \"rib cage\", singular \"skull bone\")
- Anatomy noun set covers all 24 originals plus shoulder/thigh/calf/forearm/wrist/ankle/groin

**Trade-offs accepted:**
- Some templates retain awkward \"your {hit_location} snaps\" / \"{hit_location} opens\" phrasings where the original prose implied a specific body part doing a specific action. These read acceptably on most hit locations and are good candidates for incremental polish; the architectural goal of kill prose following the engine's hit_location instead of hardcoded humanoid anatomy is achieved.

## Test plan

- [x] Full suite: 1766/1766 pass

Closes #333.