### PR TITLE
Pass hit_location to miss messages (#333 follow-up)

### DIFF
--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -530,14 +530,25 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
                 f"{actual_damage} damage."
             )
     else:
-        # Miss — get miss messages from the message system
+        # Miss — get miss messages from the message system.
+        # Issue #333 follow-up: miss templates may reference
+        # ``{hit_location}`` to narrate the intended target location
+        # ("lunges for {target_name}'s shoulder and skids past").
+        # The attacker still chose where to swing; only the contact
+        # failed.  Compute the intended location with the same
+        # selector used for hits — it surfaces as the attacker's
+        # *aim*, not the actual contact.
         weapon_type = WEAPON_TYPE_UNARMED
         if weapon and hasattr(weapon, "db") and weapon.db.weapon_type:
             weapon_type = weapon.db.weapon_type
 
+        intended_hit_location = select_hit_location(
+            target, attacker_roll - target_roll, attacker,
+        )
         miss_messages = get_combat_message(
             weapon_type, "miss",
             attacker=attacker, target=target, item=weapon,
+            hit_location=intended_hit_location,
         )
 
         attacker.msg(miss_messages["attacker_msg"])


### PR DESCRIPTION
## Summary

Playtest surfaced literal ``{hit_location}`` tokens leaking in rat miss messages. Cause: the #333 sweep parameterized anatomy in 239 miss-template references but the engine's miss branch never passed ``hit_location`` to ``get_combat_message``.

Semantically a miss can still narrate what the attacker was aiming for (\"lunges for {shoulder} and skids past\"). Computes the intended ``hit_location`` for the miss path using the same selector the hit path uses.

## Before / after

Before: \"a rat darts in toward Frank's ``{hit_location}`` and pulls back...\"
After:  \"a rat's tail-whip sweeps wide of Frank's left arm.\"

## Test plan

- [x] Live shell verification: rat miss now renders with intended hit_location resolved.
- [x] Full suite: 1766/1766 pass.