### PR TITLE
Fix look crash on severed organs with injury_type=None

### DIFF
--- a/world/medical/wounds/longdesc_hooks.py
+++ b/world/medical/wounds/longdesc_hooks.py
@@ -492,7 +492,17 @@ def _resolve_compound_template(injury_type, stage):
             template set is available (caller falls back to inline prose).
     """
     compound = None
-    module = getattr(messages, injury_type, None)
+    # Defensive: ``getattr`` requires a string attribute name.  Earlier
+    # callers occasionally produced a ``None`` ``injury_type`` for
+    # severed organs whose ``injury_type`` field was never populated
+    # (sever_character_body sets current_hp/wound_stage but not
+    # injury_type).  Fall through to the generic compound table when
+    # the injury type is missing or non-string.
+    module = (
+        getattr(messages, injury_type, None)
+        if isinstance(injury_type, str)
+        else None
+    )
     if module is not None:
         compound = getattr(module, 'COMPOUND_DESCRIPTIONS', None)
     if not compound:

--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -302,8 +302,16 @@ def _determine_injury_type_from_organ(organ):
     Returns:
         str: Injury type (bullet, cut, blunt, etc.)
     """
-    # First check if the organ has stored injury type from when damage was applied
-    if hasattr(organ, 'injury_type') and organ.injury_type != "generic":
+    # First check if the organ has stored injury type from when damage
+    # was applied.  Guard against ``None`` — severed organs have their
+    # current_hp set to 0 by ``sever_character_body`` without going
+    # through ``take_damage``, so ``organ.injury_type`` is still its
+    # init-time ``None``.  Without the guard, ``None != "generic"`` is
+    # True and we return None, which downstream
+    # ``getattr(messages, None)`` rejects with a TypeError.
+    if (hasattr(organ, 'injury_type')
+            and organ.injury_type
+            and organ.injury_type != "generic"):
         return organ.injury_type
     
     # Check organ conditions for injury type clues

--- a/world/tests/test_wound_injury_type_none.py
+++ b/world/tests/test_wound_injury_type_none.py
@@ -1,0 +1,82 @@
+"""Regression test for the severed-organ injury_type=None crash.
+
+Playtest surfaced a traceback when looking at a living rat that had
+been severed: ``getattr(messages, None)`` raised ``TypeError:
+attribute name must be string, not 'NoneType'``.
+
+Root cause: ``sever_character_body`` sets ``current_hp = 0`` and
+``wound_stage = \"severed\"`` directly on the organ but never goes
+through ``Organ.take_damage``, so ``organ.injury_type`` stays at
+its init-time ``None``.
+
+``_determine_injury_type_from_organ`` then hit
+``if hasattr(organ, 'injury_type') and organ.injury_type != \"generic\"``
+— ``None != \"generic\"`` evaluates True, so it returned ``None``,
+which downstream ``getattr(messages, None)`` rejected.
+
+Fix: guard the truthy check and the consumer's ``getattr`` against
+non-string input.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.wounds.longdesc_hooks import _resolve_compound_template
+from world.medical.wounds.wound_descriptions import (
+    _determine_injury_type_from_organ,
+)
+
+
+def _organ(name="tail_vertebrae", injury_type=None):
+    return SimpleNamespace(
+        name=name,
+        injury_type=injury_type,
+        conditions=[],
+    )
+
+
+class DetermineInjuryTypeHandlesNone(TestCase):
+
+    def test_none_falls_through_to_default(self):
+        # An organ with no recorded injury_type (severed via
+        # sever_character_body, never went through take_damage) used
+        # to return None; now falls through to a safe default.
+        out = _determine_injury_type_from_organ(_organ(injury_type=None))
+        self.assertIsNotNone(out)
+        self.assertIsInstance(out, str)
+
+    def test_generic_falls_through(self):
+        # Generic was already in the fall-through path; sanity-check
+        # nothing regressed.
+        out = _determine_injury_type_from_organ(
+            _organ(injury_type="generic")
+        )
+        self.assertEqual(out, "generic")
+
+    def test_specific_injury_type_preserved(self):
+        out = _determine_injury_type_from_organ(
+            _organ(injury_type="cut")
+        )
+        self.assertEqual(out, "cut")
+
+
+class ResolveCompoundTemplateHandlesNoneInjuryType(TestCase):
+
+    def test_none_does_not_raise(self):
+        # Defensive: even if a stale ``None`` injury_type slips
+        # through the wound list, the renderer must not crash with
+        # ``TypeError: attribute name must be string``.
+        try:
+            _resolve_compound_template(None, "fresh")
+        except TypeError as exc:
+            self.fail(
+                f"_resolve_compound_template raised on None injury_type: {exc}"
+            )
+
+    def test_non_string_does_not_raise(self):
+        try:
+            _resolve_compound_template(123, "fresh")
+        except TypeError as exc:
+            self.fail(f"raised on non-string injury_type: {exc}")


### PR DESCRIPTION
## Summary

User playtest hit a TypeError looking at a living rat: ``getattr(messages, None) — attribute name must be string, not 'NoneType'``.

Two bugs compounded:

1. ``_determine_injury_type_from_organ`` checked ``hasattr(organ, 'injury_type') and organ.injury_type != \"generic\"``. For organs severed via ``sever_character_body`` (which sets current_hp / wound_stage directly, bypassing ``take_damage``), ``organ.injury_type`` stays at its init-time ``None``. ``None != \"generic\"`` is True, so the function returned None.

2. ``_resolve_compound_template`` received the None and passed it straight to ``getattr(messages, None)``, which TypeError'd.

Fixes both: truthy-guard the determiner, isinstance-guard the resolver. Adds regression tests.

## Test plan

- [x] ``world.tests.test_wound_injury_type_none`` — 5/5 pass
- [x] Full suite: 1771/1771 pass