### PR TITLE
Species-aware mob_flavor + rat flavor data

### DIFF
--- a/commands/CmdSpawnMob.py
+++ b/commands/CmdSpawnMob.py
@@ -136,20 +136,15 @@ class CmdSpawnMob(Command):
                 mob.hair_style = choice(HAIR_STYLES)
 
         # Flavor pass — random short desc, longdescs, and look_place.
-        # /blank preserves the legacy minimal-flavor behavior.  Non-
-        # humans skip mob_flavor entirely (the entries are humanoid-
-        # specific) and get a minimal species-aware description.
-        if blank or species != "human":
-            if species == "human":
-                mob.db.desc = (
-                    "A breathing body without an identity."
-                    " Its eyes flicker, but it does not move."
-                )
-            else:
-                mob.db.desc = (
-                    f"A small {species}, twitching its whiskers and "
-                    f"watching the room with wary eyes."
-                )
+        # /blank preserves the legacy minimal-flavor behavior.
+        # ``apply_random_flavor`` is now species-aware (it dispatches
+        # to ``mob.db.species``'s flavor tables), so non-humans get
+        # rat-shaped / etc. prose automatically.
+        if blank:
+            mob.db.desc = (
+                "A breathing body without an identity."
+                " Its eyes flicker, but it does not move."
+            )
         else:
             apply_random_flavor(mob)
 

--- a/world/mob_flavor/__init__.py
+++ b/world/mob_flavor/__init__.py
@@ -12,9 +12,16 @@ Token conventions inherited from the longdesc/short-desc renderers:
   resolve per-observer to the mob's apparent gender. Capitalize the token
   (``{Their}``) to capitalize the resolved word.
 * For symmetric paired locations (eyes, ears, arms, hands, thighs, shins,
-  feet), wrap the body noun in braces (``{eyes}`` / ``{ears}``) so the
-  collapse-when-paired renderer can singularize it if one side is lost.
+  feet for humans; eyes, ears, forelegs, forepaws, hindlegs, hindpaws for
+  rats; etc.), wrap the body noun in braces (``{eyes}`` / ``{forelegs}``)
+  so the collapse-when-paired renderer can singularize it if one side is
+  lost.
 * Plain prose renders verbatim.
+
+Species awareness (#356 follow-up): the getters take an optional
+``species`` argument and dispatch to species-keyed data tables.
+Unknown / None falls back to ``"human"`` so existing call sites keep
+working unchanged.
 
 See ``specs/IDENTITY_RECOGNITION_SPEC.md`` and ``specs/LONGDESC_SYSTEM_SPEC.md``
 for the broader description rendering contract.
@@ -24,31 +31,60 @@ from __future__ import annotations
 
 from random import choice
 
-from world.combat.constants import PAIR_MERGE_KEYS
+from world.anatomy import get_species_pair_keys
 from world.mob_flavor.longdescs import LONGDESCS
+from world.mob_flavor.longdescs_rat import LONGDESCS_RAT
 from world.mob_flavor.look_places import LOOK_PLACES
+from world.mob_flavor.look_places_rat import LOOK_PLACES_RAT
 from world.mob_flavor.short_descs import SHORT_DESCS
+from world.mob_flavor.short_descs_rat import SHORT_DESCS_RAT
 
 
-def random_short_desc() -> str:
+# Species → data-table mappings. New species: add an entry per axis.
+_SHORT_DESCS_BY_SPECIES: dict[str, list[str]] = {
+    "human": SHORT_DESCS,
+    "rat":   SHORT_DESCS_RAT,
+}
+
+_LOOK_PLACES_BY_SPECIES: dict[str, list[str]] = {
+    "human": LOOK_PLACES,
+    "rat":   LOOK_PLACES_RAT,
+}
+
+_LONGDESCS_BY_SPECIES: dict[str, dict[str, list[str]]] = {
+    "human": LONGDESCS,
+    "rat":   LONGDESCS_RAT,
+}
+
+
+def _resolve_species(species):
+    """Fall back to ``human`` when species is unknown / None."""
+    return species if species in _SHORT_DESCS_BY_SPECIES else "human"
+
+
+def random_short_desc(species=None) -> str:
     """Return a random short-description template (token-bearing)."""
-    return choice(SHORT_DESCS)
+    table = _SHORT_DESCS_BY_SPECIES[_resolve_species(species)]
+    return choice(table)
 
 
-def random_look_place() -> str:
+def random_look_place(species=None) -> str:
     """Return a random look_place string (ends with terminal punctuation)."""
-    return choice(LOOK_PLACES)
+    table = _LOOK_PLACES_BY_SPECIES[_resolve_species(species)]
+    return choice(table)
 
 
-def random_longdesc(slot: str) -> str | None:
+def random_longdesc(slot: str, species=None) -> str | None:
     """Return a random longdesc template for ``slot``.
 
     ``slot`` is the data-side key — either a singular location (``"hair"``,
-    ``"face"``) or a pair-key (``"eyes"``, ``"hands"``) for symmetric pairs.
-    Returns ``None`` when no entries are seeded — extended anatomy and any
-    new locations fall into this case until flavor data is authored.
+    ``"face"``, ``"snout"``) or a pair-key (``"eyes"``, ``"forelegs"``)
+    for symmetric pairs. Returns ``None`` when no entries are seeded for
+    this species — extended anatomy and any new locations fall into this
+    case until flavor data is authored.
     """
-    entries = LONGDESCS.get(slot)
+    table = _LONGDESCS_BY_SPECIES[_resolve_species(species)]
+    entries = table.get(slot)
     if not entries:
         return None
     return choice(entries)
@@ -58,15 +94,22 @@ def apply_random_flavor(mob) -> None:
     """Fill a freshly-spawned mob with random short desc, longdescs, and
     look_place.
 
-    For symmetric pairs (eyes, ears, arms, hands, thighs, shins, feet) the
-    *same* random template is applied to both sides so the renderer's
-    paired-collapse path engages (rendering as a single plural line). If
-    only one side of a pair exists (extended anatomy or post-severance
-    mob), the pair entry is applied to that one side. Singular locations
-    are filled independently.
+    Species-aware: reads ``mob.db.species`` and dispatches to the matching
+    flavor tables. Unknown species fall back to ``"human"`` data, which
+    is generally wrong for non-humans but keeps the call safe.
+
+    For symmetric pairs (eyes / ears / arms / hands / thighs / shins /
+    feet for humans; eyes / ears / forelegs / forepaws / hindlegs /
+    hindpaws for rats) the *same* random template is applied to both
+    sides so the renderer's paired-collapse path engages (rendering as
+    a single plural line). If only one side of a pair exists (extended
+    anatomy or post-severance mob), the pair entry is applied to that
+    one side. Singular locations are filled independently.
     """
-    mob.db.desc = random_short_desc()
-    mob.look_place = random_look_place()
+    species = getattr(mob.db, "species", None) or "human"
+
+    mob.db.desc = random_short_desc(species)
+    mob.look_place = random_look_place(species)
 
     get_locations = getattr(mob, "get_available_locations", None)
     if get_locations is None:
@@ -74,20 +117,24 @@ def apply_random_flavor(mob) -> None:
     available = set(get_locations())
     handled: set[str] = set()
 
-    # Paired slots: one selection applied to both sides so they collapse.
-    for pair_key, (left, right) in PAIR_MERGE_KEYS.items():
+    # Paired slots — species-aware (rats pair forelegs/hindlegs/etc.,
+    # not arms/thighs).  One selection applied to both sides so they
+    # collapse.
+    pair_keys = get_species_pair_keys(species)
+    for pair_key, (left, right) in pair_keys.items():
         sides_present = [loc for loc in (left, right) if loc in available]
         if not sides_present:
             continue
-        entry = random_longdesc(pair_key)
+        entry = random_longdesc(pair_key, species)
         if entry is None:
             continue
         for side in sides_present:
             mob.set_longdesc(side, entry)
             handled.add(side)
 
-    # Remaining (singular) locations — keyed in LONGDESCS by location name.
+    # Remaining (singular) locations — keyed in the species' longdesc
+    # table by location name.
     for location in available - handled:
-        entry = random_longdesc(location)
+        entry = random_longdesc(location, species)
         if entry is not None:
             mob.set_longdesc(location, entry)

--- a/world/mob_flavor/longdescs_rat.py
+++ b/world/mob_flavor/longdescs_rat.py
@@ -1,0 +1,135 @@
+"""Longdesc templates for spawned rats.
+
+Per-location prose seeded into ``mob.longdesc[location]``. Same
+token conventions as the human module:
+
+* Pair-keyed nouns wrapped in braces (``{eyes}`` / ``{ears}`` /
+  ``{forelegs}`` / ``{forepaws}`` / ``{hindlegs}`` / ``{hindpaws}``)
+  so the renderer can flex them when one side collapses.
+* Verbs whose subject is a paired body noun braced too (e.g.
+  ``{Their} {eyes} {are} small`` → ``His left eye is small`` when
+  one side is severed).
+* Singular locations (``fur``, ``snout``, ``neck``, ``tail`` ...)
+  use plain prose with pronoun tokens.
+
+Slot keys mirror ``world/anatomy/species.py``'s rat
+``pair_keys`` / ``default_longdesc_locations``.
+"""
+
+from __future__ import annotations
+
+LONGDESCS_RAT: dict[str, list[str]] = {
+    # Head / face region
+    "fur": [
+        "{Their} fur is short and slate-grey, slightly oily where it covers the back.",
+        "{Their} coat is a patchwork of browns, scuffed at the shoulders and clean at the throat.",
+        "{Their} fur is dark and slick with the look of having been recently washed by rain or canal water.",
+        "{Their} coat is dusty with the pale residue of colony grit, finer than dust and harder to shed.",
+        "{Their} fur is the dull khaki of an animal that has lived on whatever fell to the floor.",
+        "{Their} coat is mottled charcoal and rust, the kind of colouring that goes invisible in shadow.",
+        "{Their} fur is short and bristly across the back, softer along the belly where it nearly disappears.",
+        "{Their} coat carries the faint, persistent smell of damp insulation and old food wrappers.",
+    ],
+    "snout": [
+        "{Their} snout is long and pink-tipped, whiskers fanning at every shift in the air.",
+        "{Their} snout twitches constantly, the nostrils flaring at smells too faint for anyone else to register.",
+        "{Their} snout carries the faint scar of a recent fight, a thin pale line across the bridge.",
+        "{Their} snout is dark and damp, the whiskers white at the tips and very long.",
+        "{Their} snout is foreshortened, blunt where most rats taper — a particular kind of breeding showing.",
+        "{Their} whiskers stand out from a long, narrow snout, fine as wire and very alert.",
+        "{Their} snout is pale and freckled with darker spots, weathered along the bridge.",
+    ],
+    "neck": [
+        "{Their} neck is thin and pliant, the spine working visibly when {they} turn {their} head.",
+        "{Their} neck disappears into the shoulders without much in the way of a clear transition.",
+        "{Their} neck carries the dark fur in a slightly thicker band, almost a collar marking.",
+    ],
+    "head": [
+        "{Their} skull is small and bullet-shaped, the bone visible under the fur at the temples.",
+        "The crown of {their} head is darker than the rest of the coat, almost black in the shadows.",
+        "{Their} head sits high on the neck when {they} {are} listening, low when {they} {are} feeding.",
+    ],
+    "eyes": [
+        "{Their} {eyes} {are} small and black, two bright pinpoints catching the light.",
+        "{Their} {eyes} {are} the dark wet glint of beads, set wide for almost panoramic sight.",
+        "{Their} {eyes} {hold} the constant twitching alertness of something that has never let its guard down.",
+        "{Their} {eyes} {are} pink-rimmed and dark-pupiled, faintly weeping in the colony air.",
+        "{Their} {eyes} {move} in tiny jumps between sources of motion, never resting long.",
+        "{Their} {eyes} {are} ruby-bright where the lighting hits them at the right angle.",
+        "{Their} {eyes} {sit} prominently from the sides of {their} head, watchful in every direction.",
+        "{Their} {eyes} {carry} the bright dilated quality of a small animal running on adrenaline.",
+    ],
+    "ears": [
+        "{Their} {ears} {are} oversized for the body, almost translucent at the edges.",
+        "{Their} {ears} {swivel} independently, tracking sounds from every direction.",
+        "{Their} {ears} {are} thin and papery, the veins visible when the light catches them.",
+        "{Their} {ears} {are} ragged at the tips, the souvenirs of past fights.",
+        "{Their} {ears} {carry} a faint dark fur along the back, almost velvet where it meets the head.",
+        "{Their} {ears} {fold} flat against the skull when {they} {are} surprised and spring back upright otherwise.",
+        "{Their} {ears} {are} pale and finely-veined, catching every small sound in the room.",
+    ],
+
+    # Torso region
+    "chest": [
+        "{Their} chest is small and barrel-curved, the ribs flexing with every quick breath.",
+        "{Their} chest fur is paler than the back, almost cream where it meets the throat.",
+        "{Their} chest moves with quick shallow breaths, the rhythm of a small body always slightly anxious.",
+    ],
+    "back": [
+        "{Their} back is arched and sinewy, the spine showing as a faint ridge through the fur.",
+        "{Their} back fur is darker than the rest of the coat, almost a stripe down the spine.",
+        "{Their} back carries the small scars of past tussles, faint pale lines through the fur.",
+    ],
+    "abdomen": [
+        "{Their} abdomen is pale-furred and soft, the skin showing pink through the thin pelt.",
+        "{Their} belly is a paler shade of the body fur, almost cream where it meets the legs.",
+        "{Their} abdomen is taut and visibly rising with quick shallow breaths.",
+    ],
+    "groin": [
+        "{Their} hips are narrow and quick-jointed, the muscle bunched for sudden movement.",
+        "{Their} groin region is pale-furred, the hindlegs joining at a sharp efficient angle.",
+    ],
+
+    # Forelimb region
+    "forelegs": [
+        "{Their} {forelegs} {are} thin and quick, the small bones visible under the short fur.",
+        "{Their} {forelegs} {are} dexterous and constantly busy — washing, gripping, picking at things.",
+        "{Their} {forelegs} {are} held close to the body when {they} {are} still, ready to move at the slightest provocation.",
+        "{Their} {forelegs} {are} nimble enough to manipulate small objects with disconcerting precision.",
+        "{Their} {forelegs} {carry} the same dark fur as the back, ending in paler digits.",
+    ],
+    "forepaws": [
+        "{Their} {forepaws} {are} tiny and pink, the digits ending in small dark claws.",
+        "{Their} {forepaws} {grip} things with surprising precision — small fingers in everything but name.",
+        "{Their} {forepaws} {are} dexterous and busy, almost never at rest.",
+        "{Their} {forepaws} {leave} small star-shaped prints when {they} {move} through dust.",
+        "{Their} {forepaws} {are} pale and freckled with darker spots, the digits long for the body's size.",
+    ],
+
+    # Hindlimb region
+    "hindlegs": [
+        "{Their} {hindlegs} {are} bunched with muscle, built for sudden bursts of speed.",
+        "{Their} {hindlegs} {fold} under the body when {they} {are} crouched, then spring open for movement.",
+        "{Their} {hindlegs} {are} longer than the forelegs, giving the body its forward-leaning poise.",
+        "{Their} {hindlegs} {carry} the same patchwork fur as the back, scarred at the joints from past scuffles.",
+        "{Their} {hindlegs} {are} thicker and stronger than the forelegs, the muscle clearly defined under the fur.",
+    ],
+    "hindpaws": [
+        "{Their} {hindpaws} {are} long-toed and surprisingly large for the body's size.",
+        "{Their} {hindpaws} {are} pale and clean of fur on the pads, with small dark claws at every toe.",
+        "{Their} {hindpaws} {leave} elongated star-shaped prints, longer than the forepaw set.",
+        "{Their} {hindpaws} {are} efficient launchpads — the body explodes off them when startled.",
+        "{Their} {hindpaws} {grip} narrow surfaces with surprising tenacity.",
+    ],
+
+    # Tail — rat-unique
+    "tail": [
+        "{Their} tail is long and ringed, pale and slightly translucent at the tip.",
+        "{Their} tail trails behind, scaled and pale, as long as the body again.",
+        "{Their} tail is scarred near the base — the legacy of something almost catching it.",
+        "{Their} tail is thick and dark, the rings of its hide clearly visible.",
+        "{Their} tail is bent slightly halfway down, an old injury that healed off-true.",
+        "{Their} tail is in constant slow motion when {they} {are} thinking, a small back-and-forth balance.",
+        "{Their} tail is the length of the body itself, used for balance during every quick turn.",
+    ],
+}

--- a/world/mob_flavor/look_places_rat.py
+++ b/world/mob_flavor/look_places_rat.py
@@ -1,0 +1,26 @@
+"""Look-place fragments for spawned rats.
+
+Where in the room the rat is, paired into ``mob.look_place`` for
+``$pron()``-style integration into the appearance composition.
+Each entry should be a complete sentence ending in terminal
+punctuation. Reads after the short-desc paragraph as positional
+detail — "It is here, doing X" — so phrasings should fit that
+slot naturally.
+"""
+
+from __future__ import annotations
+
+LOOK_PLACES_RAT: list[str] = [
+    "It is perched on a low ledge with its tail curled around its body.",
+    "It crouches in the shadow at the base of the wall, nose twitching.",
+    "It skitters along the baseboard with quick small bursts of motion.",
+    "It sits up on its hindlegs and watches with bright unblinking attention.",
+    "It is sniffing at something invisible on the ground, whiskers fanning.",
+    "It darts a short distance and freezes again, head cocked.",
+    "It washes one forepaw with quick precise licks, never breaking eye contact.",
+    "It grooms its whiskers with both forepaws, ears swiveling at every sound.",
+    "It is half-hidden behind something, only its bright eyes catching the light.",
+    "It moves in cautious arcs through the room, never quite committing to a path.",
+    "It rests on all fours with its head low, ready to spring in any direction.",
+    "It pauses mid-step with one forepaw raised, listening.",
+]

--- a/world/mob_flavor/short_descs_rat.py
+++ b/world/mob_flavor/short_descs_rat.py
@@ -1,0 +1,27 @@
+"""Short-description templates for randomly-spawned rats.
+
+Whole-body impressions of a rat. Per-part anatomy lives in
+``longdescs_rat.py``. Same token conventions as the human module —
+pronoun substitutions resolve per-observer, braced verbs flex for
+number/gender (singular-they vs gendered singular).
+"""
+
+from __future__ import annotations
+
+SHORT_DESCS_RAT: list[str] = [
+    "{They} {are} a small, lean rat, all wire-tense muscle and sudden movement.",
+    "There is a watchful tension in the line of {their} body — the wariness of something used to being prey and predator at once.",
+    "{They} {move} with the constant low twitchiness of a small mammal that never quite trusts the air.",
+    "{Their} coat carries the faint sour smell of damp and old food.",
+    "{They} {hold} {themselves} half-crouched, as though always a heartbeat from running.",
+    "Something about the set of {their} shoulders suggests {they} {have} learned the cost of being noticed.",
+    "{They} {move} with quick efficient little hops, never quite still for more than a breath.",
+    "There is the patient watchfulness of a creature that has learned to wait for its moment.",
+    "{They} {carry} {themselves} low and tight, body angled toward whatever moves last.",
+    "{Their} flanks rise and fall with the quick shallow breath of a small body running hot.",
+    "A faint tremor passes along {their} body at every change in the air — wariness held in muscle.",
+    "{They} {sit} back on {their} haunches with the precise alertness of something half-wild.",
+    "There is a darting quality to {them}, a sense that the body has rehearsed escape until it became reflex.",
+    "{They} {move} as though the floor were patterned with traps only {they} can see.",
+    "{Their} small body is taut with the constant low alertness of something that has been chased before.",
+]


### PR DESCRIPTION
## Summary

Spawning multiple rats produced identical hardcoded prose. This refactors ``mob_flavor`` to be species-aware and adds a rat data set.

- ``world/mob_flavor/short_descs_rat.py`` — 15 whole-body templates with rat register (twitchy, prey-and-predator, watchful)
- ``world/mob_flavor/longdescs_rat.py`` — per-slot prose for the rat anatomy (fur / snout / eyes / ears / forelegs / forepaws / hindlegs / hindpaws / tail / chest / back / abdomen / neck / head / groin)
- ``world/mob_flavor/look_places_rat.py`` — 12 positional fragments
- ``__init__`` wraps tables in species-keyed maps; getters take optional ``species`` and dispatch. Unknown / None falls back to human.
- ``apply_random_flavor`` reads ``mob.db.species`` and dispatches. Paired-slot loop uses ``get_species_pair_keys`` so rats pair forelegs/forepaws/hindlegs/hindpaws/eyes/ears.
- ``CmdSpawnMob`` calls ``apply_random_flavor`` for all species (``/blank`` still gives the minimal fallback).

## Live verification

\`\`\`
RAT short_desc: \"There is a darting quality to {them}, a sense that the body has rehearsed escape until it became reflex.\"
RAT look_place: \"It is half-hidden behind something, only its bright eyes catching the light.\"
RAT eyes:       \"{Their} {eyes} {are} the dark wet glint of beads, set wide for almost panoramic sight.\"
RAT tail:       \"{Their} tail is the length of the body itself, used for balance during every quick turn.\"
\`\`\`

Token conventions match human flavor: pronouns ({Their}/{their}), braced pair nouns, braced verbs for side-aware singular flex (#341) when a rat loses a forepaw or eye.

## Test plan

- [x] Full suite: 1771/1771 pass
- [x] Live shell: rat data dispatches correctly across all axes