### PR TITLE
Drop redundant condition prefix from severed-part / organ descriptions

### DIFF
--- a/world/anatomy/conditions.py
+++ b/world/anatomy/conditions.py
@@ -1,97 +1,49 @@
-"""Freshness-condition presentation helpers (issue #221, #223).
+"""Freshness-condition presentation helpers.
 
-Centralises the condition sentence prepended to an item's
-``db.desc`` so the ``look`` output explicitly conveys the freshness
-state (``pristine`` / ``damaged`` / ``putrid`` / ``desiccated``).
+Originally (#221 / #223) prepended an explicit condition sentence
+("It is a pristine specimen.") to every severed / harvested item's
+``db.desc``, on the theory that the prose alone wouldn't convey
+freshness.  In playtest the sentence read as overbearing — the
+decay-tier prose (``pristine`` vs ``damaged`` vs ``putrid`` in
+``ORGAN_DISPLAY`` / ``SEVERED_PART_DESCRIPTIONS``) was already
+self-describing: "A glistening pinkish-grey mass..." vs "A dulled
+brain, its folds slack...".  Prepending "It is a damaged specimen."
+on top of "A dulled brain..." just doubled up the signal.
 
-Design notes
-============
+Both helpers are now no-ops: ``format_condition_tagline`` returns
+the empty string for every condition, and ``prepend_condition_to_desc``
+returns the desc untouched.  The ``condition`` argument is still
+the upstream signal that selects which decay-tier prose to fetch
+(via ``get_organ_default_description`` / ``get_severed_part_description``);
+these helpers used to *also* mention it in player-facing prose,
+which was the redundancy.
 
-* **Single source of truth**: both :class:`typeclasses.items.Organ`
-  and :class:`typeclasses.items.Appendage` consume this helper at
-  ``configure_from_harvest`` / ``configure_from_sever`` time so the
-  sentence travels in ``self.db.desc`` and the engine renderer slots
-  it in naturally (AGENTS.md "populate ``db.desc`` the Evennia-
-  standard way" contract; cf. PR #204).
-
-* **Decoupled from key composition**: the condition word was removed
-  from the item key in issue #212 (keys now carry species + decay
-  tier).  This helper surfaces the condition information that the
-  key intentionally dropped.
-
-* **Plain sentence form** (issue #223): the original #221 cut used a
-  colour-coded standalone tagline (``|gPristine.|n``) separated from
-  the prose by a blank line.  In practice that read as two distinct
-  blocks rather than one description.  The replacement is a single
-  uniform sentence (``"It is a pristine specimen."``) joined to the
-  prose with a single space (issue #225) so the whole description
-  flows as one paragraph rather than two visible lines.
-
-* **Defensive empty for unknown / refuse**: callers prepend the
-  helper's output unconditionally; an empty string means "no
-  sentence" and the engine renderer falls through to the prose
-  alone.  ``refuse`` is the gameplay-internal condition for
-  skeletal-stage harvest (refused at the command gate), so leaking
-  the term would be a UX bug.
+Kept as no-op shims rather than deleted because four configure-time
+call sites (Organ, Appendage corpse / living, SeveredHead) still
+import them.  Each can drop the call independently; the helper API
+stays stable in the meantime.
 """
 
 from __future__ import annotations
 
-#: Set of condition identifiers the helper recognises.  Any other
-#: value (``None``, ``""``, ``"refuse"``, ``"phlegmatic"``, ...)
-#: yields an empty sentence.  Kept as a frozenset rather than an
-#: explicit per-condition mapping because the rendered sentence is
-#: now purely formulaic — ``"It is a {condition} specimen."`` — so a
-#: dict would just duplicate the keys.
-_RECOGNISED_CONDITIONS = frozenset(
-    {"pristine", "damaged", "putrid", "desiccated"}
-)
-
 
 def format_condition_tagline(condition: str | None) -> str:
-    """Return a plain condition sentence for the given freshness state.
+    """Return ``""`` for every condition (kept as no-op shim).
 
-    Args:
-        condition: One of ``pristine`` / ``damaged`` / ``putrid`` /
-            ``desiccated``.  ``None``, empty, ``refuse``, or any
-            unregistered condition returns an empty string so callers
-            can prepend the output unconditionally without leaking
-            internal vocabulary.
-
-    Returns:
-        The sentence (e.g. ``"It is a pristine specimen."``) or ``""``.
+    Callers used to receive a sentence like ``"It is a pristine
+    specimen."`` that they prepended to the item's prose.  The decay-
+    tier prose is now the sole vehicle for communicating freshness.
     """
-    if not condition or condition not in _RECOGNISED_CONDITIONS:
-        return ""
-    return f"It is a {condition} specimen."
+    return ""
 
 
 def prepend_condition_to_desc(condition: str | None, desc: str | None) -> str:
-    """Compose a final ``db.desc`` value with a condition sentence prefix.
+    """Return ``desc`` untouched (kept as no-op shim).
 
-    Centralised so both :class:`typeclasses.items.Organ` and
-    :class:`typeclasses.items.Appendage` produce identical formatting:
-    sentence joined to the prose with a single space so the whole
-    description renders as one continuous paragraph on a single line
-    (issue #225 — the prior ``"\\n"`` join broke onto two visible
-    lines, which read as two separate blocks).
-
-    Args:
-        condition: Freshness condition identifier.
-        desc: The base prose description, typically from
-            :func:`world.anatomy.organs.get_organ_default_description`
-            or :func:`world.anatomy.severed_parts.get_severed_part_description`.
-            May be empty / ``None`` when no prose is registered.
-
-    Returns:
-        ``"{sentence} {desc}"`` when both are present; ``sentence``
-        alone when prose is empty; ``desc`` alone when the condition
-        has no sentence; ``""`` when both are empty.
+    The condition is no longer surfaced as a separate sentence — the
+    decay-tier prose carries the freshness signal alone.  The
+    ``condition`` argument is preserved in the signature because
+    callers pass it through other channels (organ name composition,
+    key choice); only the prose-prepend behaviour is gone.
     """
-    sentence = format_condition_tagline(condition)
-    body = desc or ""
-    if sentence and body:
-        return f"{sentence} {body}"
-    if sentence:
-        return sentence
-    return body
+    return desc or ""

--- a/world/tests/test_condition_tagline.py
+++ b/world/tests/test_condition_tagline.py
@@ -1,8 +1,16 @@
-"""Tests for the condition-sentence helper (issue #221 / #223).
+"""Tests for the condition-sentence helper shims.
 
-Covers :mod:`world.anatomy.conditions` — the small helper module that
-formats the plain freshness sentence prepended to a harvested organ
-or severed appendage's ``look`` output.
+Originally (#221 / #223) ``format_condition_tagline`` produced a
+literal sentence ("It is a pristine specimen.") that
+``prepend_condition_to_desc`` prepended to harvested-organ and
+severed-part prose.  In playtest the sentence read as redundant —
+the decay-tier prose itself is already self-describing of
+freshness — so both helpers are now no-op shims that always return
+empty / desc-unchanged.
+
+These tests guard the shim contract so any caller still consuming
+the API doesn't break, and so the redundant-sentence regression
+doesn't reappear silently.
 """
 
 from __future__ import annotations
@@ -15,116 +23,56 @@ from world.anatomy import (
 )
 
 
-class TestFormatConditionTagline(TestCase):
-    """Sentence rendering for each recognised condition."""
+class TestFormatConditionTaglineReturnsEmpty(TestCase):
+    """Every condition returns the empty string now (no-op shim)."""
 
-    def test_pristine_sentence(self):
-        self.assertEqual(
-            format_condition_tagline("pristine"),
-            "It is a pristine specimen.",
-        )
+    def test_pristine_empty(self):
+        self.assertEqual(format_condition_tagline("pristine"), "")
 
-    def test_damaged_sentence(self):
-        self.assertEqual(
-            format_condition_tagline("damaged"),
-            "It is a damaged specimen.",
-        )
+    def test_damaged_empty(self):
+        self.assertEqual(format_condition_tagline("damaged"), "")
 
-    def test_putrid_sentence(self):
-        self.assertEqual(
-            format_condition_tagline("putrid"),
-            "It is a putrid specimen.",
-        )
+    def test_putrid_empty(self):
+        self.assertEqual(format_condition_tagline("putrid"), "")
 
-    def test_desiccated_sentence(self):
-        self.assertEqual(
-            format_condition_tagline("desiccated"),
-            "It is a desiccated specimen.",
-        )
+    def test_desiccated_empty(self):
+        self.assertEqual(format_condition_tagline("desiccated"), "")
 
-    def test_refuse_renders_empty(self):
-        # ``refuse`` is the gameplay-internal skeletal-stage harvest
-        # condition; leaking the term in look output would be a UX bug.
-        self.assertEqual(format_condition_tagline("refuse"), "")
-
-    def test_none_renders_empty(self):
+    def test_none_empty(self):
         self.assertEqual(format_condition_tagline(None), "")
 
-    def test_empty_string_renders_empty(self):
-        self.assertEqual(format_condition_tagline(""), "")
-
-    def test_unknown_condition_renders_empty(self):
+    def test_unknown_empty(self):
         self.assertEqual(format_condition_tagline("phlegmatic"), "")
 
-    def test_no_ansi_colour_codes(self):
-        # Issue #223 regression guard: the original #221 cut wrapped
-        # the tagline in |g / |y / |r / |R colour codes which read as
-        # a separate UI block.  The plain-sentence form must stay
-        # free of ANSI escapes so it blends into the description.
+
+class TestPrependConditionToDescReturnsDescUntouched(TestCase):
+    """The prepend helper now returns the desc verbatim."""
+
+    def test_returns_desc_for_every_condition(self):
+        for condition in ("pristine", "damaged", "putrid",
+                          "desiccated", "refuse", None, "", "unknown"):
+            with self.subTest(condition=condition):
+                self.assertEqual(
+                    prepend_condition_to_desc(condition, "A clean cut."),
+                    "A clean cut.",
+                )
+
+    def test_empty_desc_returns_empty(self):
+        for condition in ("pristine", "damaged", None):
+            with self.subTest(condition=condition):
+                self.assertEqual(
+                    prepend_condition_to_desc(condition, ""), "",
+                )
+                self.assertEqual(
+                    prepend_condition_to_desc(condition, None), "",
+                )
+
+    def test_does_not_prepend_any_sentence(self):
+        # Regression guard: previously prepended "It is a pristine
+        # specimen." style sentences.  Make sure no condition variant
+        # injects that vocabulary back.
         for condition in ("pristine", "damaged", "putrid", "desiccated"):
             with self.subTest(condition=condition):
-                self.assertNotIn("|", format_condition_tagline(condition))
-
-
-class TestPrependConditionToDesc(TestCase):
-    """Composition rules for ``{sentence} {desc}`` (single-space join)."""
-
-    def test_sentence_and_desc_compose_with_single_space(self):
-        result = prepend_condition_to_desc(
-            "pristine", "A fresh human heart, glistening."
-        )
-        self.assertEqual(
-            result,
-            "It is a pristine specimen. A fresh human heart, glistening.",
-        )
-
-    def test_no_newline_between_sentence_and_prose(self):
-        # Issue #225 regression guard: the prior cut joined with ``\n``,
-        # producing two visible lines under the item name.  The composed
-        # output must be a single continuous paragraph.
-        result = prepend_condition_to_desc("damaged", "Some prose.")
-        self.assertNotIn("\n", result)
-
-    def test_no_double_space_between_sentence_and_prose(self):
-        # Defensive: the period belongs to the sentence; the prose
-        # starts with a capital and no leading whitespace.  We must
-        # join with exactly one space.
-        result = prepend_condition_to_desc("putrid", "Some prose.")
-        self.assertNotIn("  ", result)
-
-    def test_sentence_only_when_desc_empty(self):
-        self.assertEqual(
-            prepend_condition_to_desc("damaged", ""),
-            "It is a damaged specimen.",
-        )
-
-    def test_sentence_only_when_desc_none(self):
-        self.assertEqual(
-            prepend_condition_to_desc("damaged", None),
-            "It is a damaged specimen.",
-        )
-
-    def test_desc_only_when_condition_has_no_sentence(self):
-        # ``refuse`` / unknown conditions yield no sentence — caller's
-        # prose passes through unchanged.
-        self.assertEqual(
-            prepend_condition_to_desc("refuse", "A withered remnant."),
-            "A withered remnant.",
-        )
-
-    def test_empty_when_both_inputs_empty(self):
-        self.assertEqual(prepend_condition_to_desc("refuse", ""), "")
-        self.assertEqual(prepend_condition_to_desc(None, None), "")
-        self.assertEqual(prepend_condition_to_desc("", ""), "")
-
-    def test_all_four_conditions_round_trip(self):
-        # Exhaustive contract: every recognised condition produces a
-        # non-empty composed result when paired with prose, joined by a
-        # single space into one continuous paragraph.
-        for condition in ("pristine", "damaged", "putrid", "desiccated"):
-            with self.subTest(condition=condition):
-                result = prepend_condition_to_desc(condition, "Body part.")
-                self.assertIn("Body part.", result)
-                self.assertTrue(result.startswith("It is a "))
-                self.assertIn(" specimen. ", result)
-                self.assertNotIn("\n", result)
+                out = prepend_condition_to_desc(condition, "Body part.")
+                self.assertNotIn("specimen", out)
+                self.assertEqual(out, "Body part.")

--- a/world/tests/test_organ_display.py
+++ b/world/tests/test_organ_display.py
@@ -267,11 +267,10 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         )
         self.assertTrue(organ.db.desc)
         self.assertIn("heart", organ.db.desc.lower())
-        # Issue #221 / #223 / #225: plain condition sentence joined to
-        # the prose with a single space (one continuous paragraph).
-        self.assertTrue(
-            organ.db.desc.startswith("It is a pristine specimen. ")
-        )
+        # Condition prefix is no longer prepended (overbearing
+        # redundant signal — decay-tier prose already conveys
+        # freshness).  Just confirm desc contains organ prose.
+        self.assertNotIn("specimen", organ.db.desc)
 
     def test_damaged_condition_uses_damaged_prose(self):
         organ = self._fake_organ()
@@ -282,9 +281,7 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         self.assertTrue(organ.db.desc)
         # Damaged prose typically signals decay-onset vocabulary.
         self.assertIn("liver", organ.db.desc.lower())
-        self.assertTrue(
-            organ.db.desc.startswith("It is a damaged specimen. ")
-        )
+        self.assertNotIn("specimen", organ.db.desc)
 
     def test_putrid_condition_uses_putrid_prose(self):
         organ = self._fake_organ()
@@ -294,9 +291,7 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
         )
         self.assertTrue(organ.db.desc)
         self.assertIn("brain", organ.db.desc.lower())
-        self.assertTrue(
-            organ.db.desc.startswith("It is a putrid specimen. ")
-        )
+        self.assertNotIn("specimen", organ.db.desc)
 
     def test_unknown_organ_leaves_desc_untouched(self):
         organ = self._fake_organ()
@@ -304,10 +299,10 @@ class TestOrganConfigureFromHarvestPopulatesDesc(TestCase):
             organ_name="flux_capacitor", condition="pristine",
             corpse=self._fake_corpse(),
         )
-        # Issue #221: even when no prose is registered, the condition
-        # sentence alone surfaces so the player gets *some* freshness
-        # signal in the look output.
-        self.assertEqual(organ.db.desc, "It is a pristine specimen.")
+        # No registered prose for an unknown organ + condition prefix
+        # is no longer surfaced → desc stays empty (or whatever the
+        # default-renderer fallback was).
+        self.assertNotIn("specimen", organ.db.desc or "")
 
     def test_refuse_condition_leaves_desc_untouched(self):
         organ = self._fake_organ()

--- a/world/tests/test_severed_part_descriptions.py
+++ b/world/tests/test_severed_part_descriptions.py
@@ -154,11 +154,10 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("left arm", app.db.desc.lower())
-        # Issue #221 / #223 / #225: plain sentence joined to prose with
-        # a single space (one continuous paragraph).
-        self.assertTrue(
-            app.db.desc.startswith("It is a pristine specimen. ")
-        )
+        # Condition prefix is no longer prepended (overbearing
+        # redundant signal — decay-tier prose already conveys
+        # freshness).  Just confirm desc contains location prose.
+        self.assertNotIn("specimen", app.db.desc)
 
     def test_damaged_right_thigh_populates_desc(self):
         app = self._fake_appendage()
@@ -168,9 +167,7 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("right thigh", app.db.desc.lower())
-        self.assertTrue(
-            app.db.desc.startswith("It is a damaged specimen. ")
-        )
+        self.assertNotIn("specimen", app.db.desc)
 
     def test_putrid_head_populates_desc(self):
         app = self._fake_appendage()
@@ -180,9 +177,7 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertTrue(app.db.desc)
         self.assertIn("head", app.db.desc.lower())
-        self.assertTrue(
-            app.db.desc.startswith("It is a putrid specimen. ")
-        )
+        self.assertNotIn("specimen", app.db.desc)
 
     def test_unknown_location_leaves_desc_untouched(self):
         app = self._fake_appendage()
@@ -190,9 +185,9 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
             location_name="tentacle", condition="pristine",
             corpse=self._fake_corpse(),
         )
-        # Issue #221: even without registered prose, the condition
-        # sentence alone surfaces — a meaningful freshness signal.
-        self.assertEqual(app.db.desc, "It is a pristine specimen.")
+        # No registered prose for an unknown location + condition
+        # prefix is no longer surfaced → desc stays empty.
+        self.assertNotIn("specimen", app.db.desc or "")
 
     def test_key_still_assigned_alongside_desc(self):
         # Regression guard for the species-aware key path.


### PR DESCRIPTION
## Summary

Playtest observation: every harvested organ and severed body part prepended ``"It is a pristine specimen."`` (or damaged / putrid / desiccated) to its decay-tier prose. The decay-tier prose itself already conveys freshness (\"A glistening pinkish-grey mass\" vs \"A dulled brain, its folds slack...\"), making the prepended sentence redundant and overbearing.

Reduces both helpers in ``world/anatomy/conditions.py`` to no-op shims. The ``condition`` argument is still the upstream signal that picks which decay-tier prose to fetch; only the prose-prepend behaviour is gone.

Helper signatures preserved so the four configure-time call sites keep working without churn.

Updates the three test modules that asserted the old prepended-sentence behaviour. ``test_condition_tagline`` now guards the no-op shim contract.

## Before / after

\`\`\`
Before: \"It is a pristine specimen. A severed rat's head, the snout still twitching as if ready to sniff and the cut at the neck weeping fresh blood.\"
After:  \"A severed rat's head, the snout still twitching as if ready to sniff and the cut at the neck weeping fresh blood.\"
\`\`\`

## Test plan

- [x] Full suite: 1763/1763 pass