### PR TITLE
Species-key bleeding room prose + death-curtain templates

### DIFF
--- a/typeclasses/curtain_of_death.py
+++ b/typeclasses/curtain_of_death.py
@@ -272,33 +272,24 @@ class DeathCurtain:
         """Called when the animation completes."""
         from world.identity_utils import msg_room_identity
 
-        # Send a single, vivid death message that incorporates the cause
+        # Send a single, vivid death message that incorporates the cause.
+        # Species-aware (#356 follow-up): rats don't "clutch their
+        # chest" or "gasp" — the lookup routes to species overrides
+        # for the few cause-cells that need rat-flavored prose; the
+        # rest fall through to the human default which works for any
+        # small mammal ("eyes lose focus", "charred form crumples",
+        # etc.).
         if self.location:
             death_cause = None
             if hasattr(self.character, 'get_death_cause'):
                 death_cause = self.character.get_death_cause()
-            
-            if death_cause:
-                # Create vivid death descriptions based on cause
-                if 'blood loss' in death_cause.lower():
-                    death_template = "|R{actor}'s lifeblood pools crimson around their still form.|n"
-                elif 'heart failure' in death_cause.lower():
-                    death_template = "|R{actor} clutches their chest one last time before going still.|n"
-                elif 'head' in death_cause.lower() or 'brain' in death_cause.lower():
-                    death_template = "|R{actor}'s eyes lose focus as they collapse, unmoving.|n"
-                elif 'poison' in death_cause.lower():
-                    death_template = "|R{actor} convulses violently before falling silent.|n"
-                elif 'fire' in death_cause.lower() or 'burn' in death_cause.lower():
-                    death_template = "|R{actor}'s charred form crumples to the ground.|n"
-                elif 'stab' in death_cause.lower() or 'slash' in death_cause.lower():
-                    death_template = "|R{actor} gasps once, crimson flowing, then goes still.|n"
-                else:
-                    # Generic death message with cause hint
-                    death_template = "|R{actor} draws their final breath and grows still.|n"
-            else:
-                # No cause specified
-                death_template = "|R{actor} draws their final breath and grows still.|n"
-                
+
+            from world.medical.medical_messages import get_death_cause_template
+            species = getattr(
+                getattr(self.character, "db", None), "species", None,
+            )
+            death_template = get_death_cause_template(death_cause, species)
+
             msg_room_identity(
                 location=self.location,
                 template=death_template,

--- a/world/medical/medical_messages.py
+++ b/world/medical/medical_messages.py
@@ -1,0 +1,154 @@
+"""Species-aware medical / death prose lookup helpers.
+
+Centralises the room-visible tick prose for bleeding tiers and the
+cause-specific death-curtain observer templates so non-human species
+can override the humanoid-leaning entries (a rat "clutches their
+chest one last time" reads as nonsense).
+
+Falls back to human prose for any species without a registered
+override — works for the broad case where the prose is generic
+enough ("draws their final breath and grows still") and lets us
+ship rat-specific overrides sparsely, only where they're needed.
+"""
+
+from __future__ import annotations
+
+
+# Bleeding tier → species → room template.
+# Tiers cap at four severity bands matching the legacy if-cascade in
+# ``world.medical.script.MedicalScript._send_medical_messages``.
+BLEEDING_ROOM_BY_SPECIES: dict[str, dict[str, str]] = {
+    # Tier keys: "minor" (1-3), "moderate" (4-7), "severe" (8-12),
+    # "grievous" (13+).  Templates use the ``{actor}`` identity-aware
+    # token consumed by ``msg_room_identity``.
+    "human": {
+        "minor":    "Small droplets of blood fall from {actor}'s wounds.",
+        "moderate": "Blood steadily drips from {actor}, forming dark stains.",
+        "severe":   "Crimson flows freely from {actor}'s wounds, pooling on the ground.",
+        "grievous": "{actor} leaves a trail of blood, their wounds gushing freely.",
+    },
+    "rat": {
+        # Smaller-body imagery: thin trails, small dark spots, etc.
+        "minor":    "Small dark spots of blood mark the ground beneath {actor}.",
+        "moderate": "{actor} drags a thin trail of blood as they move.",
+        "severe":   "Blood weeps freely from {actor}, soaking into the fur.",
+        "grievous": "{actor} leaves a slick of blood, fur matted with it.",
+    },
+}
+
+
+# Death-cause keyword → species → observer template.
+# Keyword lookup is substring-based (matches the legacy
+# ``'heart failure' in death_cause.lower()`` cascade).  Order
+# matters for the lookup — first key whose token appears in the
+# cause string wins.  ``_DEATH_KEYWORD_ORDER`` enforces it.
+_DEATH_KEYWORD_ORDER = (
+    "blood loss",
+    "heart failure",
+    "head",
+    "brain",
+    "poison",
+    "fire",
+    "burn",
+    "stab",
+    "slash",
+)
+
+DEATH_CAUSE_TEMPLATES_BY_SPECIES: dict[str, dict[str, str]] = {
+    "human": {
+        "blood loss":    "|R{actor}'s lifeblood pools crimson around their still form.|n",
+        "heart failure": "|R{actor} clutches their chest one last time before going still.|n",
+        "head":          "|R{actor}'s eyes lose focus as they collapse, unmoving.|n",
+        "brain":         "|R{actor}'s eyes lose focus as they collapse, unmoving.|n",
+        "poison":        "|R{actor} convulses violently before falling silent.|n",
+        "fire":          "|R{actor}'s charred form crumples to the ground.|n",
+        "burn":          "|R{actor}'s charred form crumples to the ground.|n",
+        "stab":          "|R{actor} gasps once, crimson flowing, then goes still.|n",
+        "slash":         "|R{actor} gasps once, crimson flowing, then goes still.|n",
+    },
+    "rat": {
+        # Rat-flavored overrides only where the human prose breaks.
+        # Missing keys fall through to the human default — most prose
+        # ("eyes lose focus", "charred form", "convulses violently")
+        # works for any small mammal.
+        "heart failure": "|R{actor} stiffens, twitches once, then goes still.|n",
+        "stab":          "|R{actor} squeaks once, body shuddering, then goes limp.|n",
+        "slash":         "|R{actor} squeaks once, body shuddering, then goes limp.|n",
+    },
+}
+
+# Generic fallback when no cause matches.
+_GENERIC_DEATH_BY_SPECIES: dict[str, str] = {
+    "human": "|R{actor} draws their final breath and grows still.|n",
+    "rat":   "|R{actor}'s small body falls still.|n",
+}
+
+
+def get_bleeding_room_message(severity: int, species: str | None = None) -> str:
+    """Return the room-visible bleeding template for a tier and species.
+
+    Args:
+        severity: Numeric bleeding severity (1-3 / 4-7 / 8-12 / 13+).
+        species: Species identifier; ``None`` / unknown falls back to
+            ``"human"``.
+
+    Returns:
+        Template string with the ``{actor}`` token unsubstituted, for
+        ``msg_room_identity`` to render per-observer.
+    """
+    if severity <= 3:
+        tier = "minor"
+    elif severity <= 7:
+        tier = "moderate"
+    elif severity <= 12:
+        tier = "severe"
+    else:
+        tier = "grievous"
+    by_species = BLEEDING_ROOM_BY_SPECIES.get(species)
+    if by_species is None:
+        by_species = BLEEDING_ROOM_BY_SPECIES["human"]
+    return by_species.get(tier) or BLEEDING_ROOM_BY_SPECIES["human"][tier]
+
+
+def get_death_cause_template(death_cause: str | None,
+                             species: str | None = None) -> str:
+    """Return the room-visible death-curtain template for a cause + species.
+
+    Looks for known cause keywords (``"blood loss"``, ``"heart
+    failure"``, ``"head"`` / ``"brain"``, ``"poison"``, ``"fire"`` /
+    ``"burn"``, ``"stab"`` / ``"slash"``) as substrings in
+    ``death_cause`` (case-insensitive).  Falls back per axis:
+
+    * Species without an entry uses human's table.
+    * Species without an entry for THAT cause falls back to human's
+      entry for the same cause.
+    * Cause that doesn't match any keyword falls back to a generic
+      template (which is also species-keyed).
+
+    Args:
+        death_cause: Free-text death cause string (e.g.
+            ``"blood loss"`` / ``"head trauma"``).
+        species: Species identifier.
+
+    Returns:
+        Observer template string with ``{actor}`` token unsubstituted.
+    """
+    if death_cause:
+        cause_lower = death_cause.lower()
+        species_table = DEATH_CAUSE_TEMPLATES_BY_SPECIES.get(species) or {}
+        human_table = DEATH_CAUSE_TEMPLATES_BY_SPECIES["human"]
+        for keyword in _DEATH_KEYWORD_ORDER:
+            if keyword in cause_lower:
+                # Per-species, then human fallback for that cause.
+                return (
+                    species_table.get(keyword)
+                    or human_table.get(keyword)
+                    or _GENERIC_DEATH_BY_SPECIES.get(species, "")
+                    or _GENERIC_DEATH_BY_SPECIES["human"]
+                )
+
+    # No cause matched / no cause given → species-keyed generic.
+    return (
+        _GENERIC_DEATH_BY_SPECIES.get(species)
+        or _GENERIC_DEATH_BY_SPECIES["human"]
+    )

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -191,19 +191,31 @@ class MedicalScript(DefaultScript):
                 # Death curtain will handle death-related messaging
                 pass
             else:
-                # Normal living character bleeding messages
+                # Personal prose (|.msg() to the character) is humanoid
+                # and only fires for PCs (NPCs without accounts drop
+                # the msg silently), so the humanoid voice is
+                # appropriate here.  Room prose is species-aware
+                # (#356 follow-up) so a bleeding rat reads with
+                # small-mammal imagery instead of generic humanoid
+                # "trail of blood" prose.
+                from world.medical.medical_messages import (
+                    get_bleeding_room_message,
+                )
+                species = getattr(
+                    getattr(self.obj, "db", None), "species", None,
+                )
+                room_template = get_bleeding_room_message(
+                    bleeding_severity, species,
+                )
                 if bleeding_severity <= 3:
                     personal_parts.append("|rYou feel warm blood trickling from your wounds.|n")
-                    room_parts.append("Small droplets of blood fall from {actor}'s wounds.")
                 elif bleeding_severity <= 7:
                     personal_parts.append("|rBlood flows freely from your wounds, leaving crimson trails.|n")
-                    room_parts.append("Blood steadily drips from {actor}, forming dark stains.")
                 elif bleeding_severity <= 12:
                     personal_parts.append("|rYou feel your life ebbing away as blood pours from your wounds.|n")
-                    room_parts.append("Crimson flows freely from {actor}'s wounds, pooling on the ground.")
                 else:  # 13+
                     personal_parts.append("|rYour vision dims as life-blood gushes from grievous wounds.|n")
-                    room_parts.append("{actor} leaves a trail of blood, their wounds gushing freely.")
+                room_parts.append(room_template)
         
         # Add pain components if present (only for living characters)
         if pain_severity > 0 and not is_dead:


### PR DESCRIPTION
## Summary

Two surfaces had humanoid prose that reads wrong on non-human species:

1. **Death-curtain cause templates** (``typeclasses/curtain_of_death.py``). \"{actor} clutches their chest one last time before going still\" reads as nonsense on a rat. Two of seven cause templates were visibly humanoid (heart failure → clutching chest, stab/slash → gasping).
2. **Bleeding room prose** (``world/medical/script.py``). Generic-enough today but reads better with rat-scale imagery (\"thin trail of blood\" instead of \"trail of blood\", etc.).

New ``world/medical/medical_messages.py`` exposes ``get_bleeding_room_message(severity, species)`` and ``get_death_cause_template(cause, species)`` with species-keyed tables and per-axis human fallback. Rats override only where the human prose actually breaks.

Personal bleeding prose stays humanoid — only PCs see it (NPCs without accounts drop the msg silently).

## Test plan

- [x] Full suite: 1763/1763 pass

Refs #356.