### PR TITLE
Rat severance message library

### DIFF
--- a/world/combat/messages/severance/__init__.py
+++ b/world/combat/messages/severance/__init__.py
@@ -49,6 +49,7 @@ from world.grammar import capitalize_first
 
 # Pair-key shorthands accepted as location aliases for the limb files.
 _LIMB_ALIASES = {
+    # Human limbs.
     "left_arm": "arms",
     "right_arm": "arms",
     "left_hand": "hands",
@@ -60,9 +61,22 @@ _LIMB_ALIASES = {
     "left_foot": "feet",
     "right_foot": "feet",
     # The neck container is the routing site for decapitation;
-    # narrative lives in head.py.
+    # narrative lives in head.py (works for any species — head /
+    # neck severance prose is generic).
     "neck": "head",
     "head": "head",
+    # Rat limbs (#356 follow-up).  Rat severance fires through
+    # the same lookup; species-specific module names route the
+    # rat anatomy.
+    "left_foreleg": "forelegs",
+    "right_foreleg": "forelegs",
+    "left_forepaw": "forepaws",
+    "right_forepaw": "forepaws",
+    "left_hindleg": "hindlegs",
+    "right_hindleg": "hindlegs",
+    "left_hindpaw": "hindpaws",
+    "right_hindpaw": "hindpaws",
+    "tail": "tail",
 }
 
 _VALID_SEVERITIES = ("grievous", "minor")
@@ -74,7 +88,12 @@ def _resolve_module_name(location: str) -> str:
     if location in _LIMB_ALIASES:
         return _LIMB_ALIASES[location]
     # Already a module name (e.g. ``"arms"``) or a singular pair key.
-    if location in ("arms", "hands", "thighs", "shins", "feet"):
+    if location in (
+        # Human pair keys.
+        "arms", "hands", "thighs", "shins", "feet",
+        # Rat pair keys (#356 follow-up).
+        "forelegs", "hindlegs", "forepaws", "hindpaws", "tail",
+    ):
         return location
     return location  # Caller passed something we don't recognise — fall
                     # through and the importlib lookup below will fail

--- a/world/combat/messages/severance/forelegs.py
+++ b/world/combat/messages/severance/forelegs.py
@@ -1,0 +1,82 @@
+"""Rat foreleg severance templates — left or right foreleg detached.
+
+Fires when an edged hit destroys a foreleg bone on a rat. The
+``{hit_location}`` kwarg resolves to ``"left foreleg"`` or
+``"right foreleg"``.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade catches {target_name}'s {hit_location} clean at the shoulder. The small limb spins away in a thin red arc.",
+                "victim_msg": "{attacker_name}'s blade catches your {hit_location} clean at the shoulder. The limb spins away.",
+                "observer_msg": "{attacker_name}'s blade catches {target_name}'s {hit_location} clean at the shoulder. The small limb spins away in a thin red arc.",
+            },
+            {
+                "attacker_msg": "The cut shears through {target_name}'s {hit_location} at the joint and the foreleg falls free, paw still curled.",
+                "victim_msg": "{attacker_name}'s cut shears through your {hit_location} at the joint and the foreleg falls free.",
+                "observer_msg": "{attacker_name}'s cut shears through {target_name}'s {hit_location} at the joint. The foreleg falls free, paw still curled.",
+            },
+            {
+                "attacker_msg": "You take {target_name}'s {hit_location} off in a single sweep. The small body lurches sideways, no longer braced on that side.",
+                "victim_msg": "{attacker_name} takes your {hit_location} off in a single sweep. Your body lurches sideways.",
+                "observer_msg": "{attacker_name} takes {target_name}'s {hit_location} off in a single sweep. The small body lurches sideways.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A neat stroke parts {target_name}'s {hit_location} at the shoulder. The cut is almost clinical.",
+                "victim_msg": "{attacker_name}'s neat stroke parts your {hit_location} at the shoulder.",
+                "observer_msg": "{attacker_name}'s neat stroke parts {target_name}'s {hit_location} at the shoulder.",
+            },
+            {
+                "attacker_msg": "The edge finds the gap between bones and {target_name}'s {hit_location} comes away easily.",
+                "victim_msg": "{attacker_name}'s edge finds the gap between bones and your {hit_location} comes away.",
+                "observer_msg": "{attacker_name}'s edge finds the gap between bones and {target_name}'s {hit_location} comes away.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point in under {target_name}'s {hit_location} and lever. The thin bone snaps and the limb tears free.",
+                "victim_msg": "{attacker_name} drives the point in under your {hit_location} and levers. The bone snaps and the limb tears free.",
+                "observer_msg": "{attacker_name} drives the point in under {target_name}'s {hit_location} and levers. The thin bone snaps and the limb tears free.",
+            },
+            {
+                "attacker_msg": "A thrust under {target_name}'s {hit_location} pries it loose from the body in one motion.",
+                "victim_msg": "{attacker_name}'s thrust under your {hit_location} pries it loose from your body in one motion.",
+                "observer_msg": "{attacker_name}'s thrust under {target_name}'s {hit_location} pries it loose from the body.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A controlled thrust pops {target_name}'s {hit_location} free at the joint with minimal mess.",
+                "victim_msg": "{attacker_name}'s controlled thrust pops your {hit_location} free at the joint.",
+                "observer_msg": "{attacker_name}'s controlled thrust pops {target_name}'s {hit_location} free at the joint.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "The torn edge of your blow rips {target_name}'s {hit_location} away in a spray of red and tissue.",
+                "victim_msg": "{attacker_name}'s torn blow rips your {hit_location} away in a spray of red and tissue.",
+                "observer_msg": "{attacker_name}'s torn blow rips {target_name}'s {hit_location} away in a spray of red and tissue.",
+            },
+            {
+                "attacker_msg": "You tear {target_name}'s {hit_location} loose along a ragged seam, fur and flesh going together.",
+                "victim_msg": "{attacker_name} tears your {hit_location} loose along a ragged seam.",
+                "observer_msg": "{attacker_name} tears {target_name}'s {hit_location} loose along a ragged seam.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A ragged tear takes {target_name}'s {hit_location} off in pieces.",
+                "victim_msg": "{attacker_name}'s ragged tear takes your {hit_location} off in pieces.",
+                "observer_msg": "{attacker_name}'s ragged tear takes {target_name}'s {hit_location} off in pieces.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/forepaws.py
+++ b/world/combat/messages/severance/forepaws.py
@@ -1,0 +1,61 @@
+"""Rat forepaw severance templates — left or right forepaw shorn off.
+
+Fires when an edged hit destroys the small forepaw bones on a rat.
+The ``{hit_location}`` resolves to ``"left forepaw"`` / ``"right forepaw"``.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade shears {target_name}'s {hit_location} off at the wrist. The small paw with its dark claws drops away.",
+                "victim_msg": "{attacker_name}'s blade shears your {hit_location} off at the wrist. The paw drops away.",
+                "observer_msg": "{attacker_name}'s blade shears {target_name}'s {hit_location} off at the wrist. The small paw drops away.",
+            },
+            {
+                "attacker_msg": "The cut takes {target_name}'s {hit_location} cleanly through the joint. The paw lands fingers-up, claws still gripping.",
+                "victim_msg": "{attacker_name}'s cut takes your {hit_location} cleanly through the joint.",
+                "observer_msg": "{attacker_name}'s cut takes {target_name}'s {hit_location} cleanly through the joint. The paw lands fingers-up.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A neat stroke parts {target_name}'s {hit_location} at the wrist.",
+                "victim_msg": "{attacker_name}'s neat stroke parts your {hit_location} at the wrist.",
+                "observer_msg": "{attacker_name}'s neat stroke parts {target_name}'s {hit_location} at the wrist.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point in at {target_name}'s {hit_location} and twist. The small paw pops free at the joint.",
+                "victim_msg": "{attacker_name} drives the point in at your {hit_location} and twists. The paw pops free.",
+                "observer_msg": "{attacker_name} drives the point in at {target_name}'s {hit_location} and twists. The small paw pops free at the joint.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A controlled thrust takes {target_name}'s {hit_location} off cleanly at the wrist.",
+                "victim_msg": "{attacker_name}'s controlled thrust takes your {hit_location} off cleanly at the wrist.",
+                "observer_msg": "{attacker_name}'s controlled thrust takes {target_name}'s {hit_location} off cleanly at the wrist.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "The torn blow rips {target_name}'s {hit_location} away in a small spray of red.",
+                "victim_msg": "{attacker_name}'s torn blow rips your {hit_location} away in a small spray of red.",
+                "observer_msg": "{attacker_name}'s torn blow rips {target_name}'s {hit_location} away in a small spray of red.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A ragged tear takes {target_name}'s {hit_location} off at the wrist.",
+                "victim_msg": "{attacker_name}'s ragged tear takes your {hit_location} off at the wrist.",
+                "observer_msg": "{attacker_name}'s ragged tear takes {target_name}'s {hit_location} off at the wrist.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/hindlegs.py
+++ b/world/combat/messages/severance/hindlegs.py
@@ -1,0 +1,82 @@
+"""Rat hindleg severance templates — left or right hindleg detached.
+
+Fires when an edged hit destroys a hindleg bone on a rat. The
+``{hit_location}`` kwarg resolves to ``"left hindleg"`` or
+``"right hindleg"``.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade takes {target_name}'s {hit_location} off at the hip in a single arc. The limb kicks once and falls still.",
+                "victim_msg": "{attacker_name}'s blade takes your {hit_location} off at the hip. The limb kicks once and falls still.",
+                "observer_msg": "{attacker_name}'s blade takes {target_name}'s {hit_location} off at the hip in a single arc. The limb kicks once and falls still.",
+            },
+            {
+                "attacker_msg": "The chop parts {target_name}'s {hit_location} from the body. The small frame collapses sideways, no longer balanced.",
+                "victim_msg": "{attacker_name}'s chop parts your {hit_location} from your body. You collapse sideways.",
+                "observer_msg": "{attacker_name}'s chop parts {target_name}'s {hit_location} from the body. The small frame collapses sideways.",
+            },
+            {
+                "attacker_msg": "You cleave {target_name}'s {hit_location} off and the bone snaps cleanly through the long muscle.",
+                "victim_msg": "{attacker_name} cleaves your {hit_location} off and the bone snaps cleanly through the muscle.",
+                "observer_msg": "{attacker_name} cleaves {target_name}'s {hit_location} off and the bone snaps cleanly through the long muscle.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A clean stroke separates {target_name}'s {hit_location} at the hip joint.",
+                "victim_msg": "{attacker_name}'s clean stroke separates your {hit_location} at the hip joint.",
+                "observer_msg": "{attacker_name}'s clean stroke separates {target_name}'s {hit_location} at the hip joint.",
+            },
+            {
+                "attacker_msg": "The edge finds the joint and {target_name}'s {hit_location} comes away with little resistance.",
+                "victim_msg": "{attacker_name}'s edge finds the joint and your {hit_location} comes away.",
+                "observer_msg": "{attacker_name}'s edge finds the joint and {target_name}'s {hit_location} comes away.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point in at the hip and lever. {target_name}'s {hit_location} tears free along snapping ligaments.",
+                "victim_msg": "{attacker_name} drives the point in at your hip and levers. Your {hit_location} tears free.",
+                "observer_msg": "{attacker_name} drives the point in at {target_name}'s hip and levers. The {hit_location} tears free along snapping ligaments.",
+            },
+            {
+                "attacker_msg": "A thrust under {target_name}'s {hit_location} pries the limb loose with a wet, popping sound.",
+                "victim_msg": "{attacker_name}'s thrust under your {hit_location} pries the limb loose.",
+                "observer_msg": "{attacker_name}'s thrust under {target_name}'s {hit_location} pries the limb loose.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A precise thrust pops {target_name}'s {hit_location} free at the hip socket.",
+                "victim_msg": "{attacker_name}'s precise thrust pops your {hit_location} free at the hip socket.",
+                "observer_msg": "{attacker_name}'s precise thrust pops {target_name}'s {hit_location} free at the hip socket.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "The torn blow rips {target_name}'s {hit_location} away through muscle and skin.",
+                "victim_msg": "{attacker_name}'s torn blow rips your {hit_location} away through muscle and skin.",
+                "observer_msg": "{attacker_name}'s torn blow rips {target_name}'s {hit_location} away through muscle and skin.",
+            },
+            {
+                "attacker_msg": "You tear {target_name}'s {hit_location} loose with a ragged pull, fur and bone parting together.",
+                "victim_msg": "{attacker_name} tears your {hit_location} loose with a ragged pull.",
+                "observer_msg": "{attacker_name} tears {target_name}'s {hit_location} loose with a ragged pull.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A ragged tear takes {target_name}'s {hit_location} off at the hip.",
+                "victim_msg": "{attacker_name}'s ragged tear takes your {hit_location} off at the hip.",
+                "observer_msg": "{attacker_name}'s ragged tear takes {target_name}'s {hit_location} off at the hip.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/hindpaws.py
+++ b/world/combat/messages/severance/hindpaws.py
@@ -1,0 +1,61 @@
+"""Rat hindpaw severance templates — left or right hindpaw shorn off.
+
+Fires when an edged hit destroys the small hindpaw bones on a rat.
+The ``{hit_location}`` resolves to ``"left hindpaw"`` / ``"right hindpaw"``.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade shears {target_name}'s {hit_location} off at the ankle. The long-toed paw drops away.",
+                "victim_msg": "{attacker_name}'s blade shears your {hit_location} off at the ankle. The paw drops away.",
+                "observer_msg": "{attacker_name}'s blade shears {target_name}'s {hit_location} off at the ankle. The long-toed paw drops away.",
+            },
+            {
+                "attacker_msg": "The cut takes {target_name}'s {hit_location} cleanly off. The body lists hard as the support disappears.",
+                "victim_msg": "{attacker_name}'s cut takes your {hit_location} cleanly off. You list hard as the support disappears.",
+                "observer_msg": "{attacker_name}'s cut takes {target_name}'s {hit_location} cleanly off. The body lists hard as the support disappears.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A neat stroke parts {target_name}'s {hit_location} at the ankle.",
+                "victim_msg": "{attacker_name}'s neat stroke parts your {hit_location} at the ankle.",
+                "observer_msg": "{attacker_name}'s neat stroke parts {target_name}'s {hit_location} at the ankle.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point in at {target_name}'s {hit_location} and pry. The paw tears free.",
+                "victim_msg": "{attacker_name} drives the point in at your {hit_location} and pries. The paw tears free.",
+                "observer_msg": "{attacker_name} drives the point in at {target_name}'s {hit_location} and pries. The paw tears free.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A controlled thrust takes {target_name}'s {hit_location} off at the ankle.",
+                "victim_msg": "{attacker_name}'s controlled thrust takes your {hit_location} off at the ankle.",
+                "observer_msg": "{attacker_name}'s controlled thrust takes {target_name}'s {hit_location} off at the ankle.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "The torn blow rips {target_name}'s {hit_location} away in a spray of red.",
+                "victim_msg": "{attacker_name}'s torn blow rips your {hit_location} away in a spray of red.",
+                "observer_msg": "{attacker_name}'s torn blow rips {target_name}'s {hit_location} away in a spray of red.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A ragged tear takes {target_name}'s {hit_location} off at the ankle.",
+                "victim_msg": "{attacker_name}'s ragged tear takes your {hit_location} off at the ankle.",
+                "observer_msg": "{attacker_name}'s ragged tear takes {target_name}'s {hit_location} off at the ankle.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/tail.py
+++ b/world/combat/messages/severance/tail.py
@@ -1,0 +1,77 @@
+"""Rat tail severance templates — tail detached at the base.
+
+Fires when an edged hit destroys the tail vertebrae on a rat.
+The ``{hit_location}`` resolves to ``"tail"``.  Unique to rat
+anatomy; no human equivalent.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade catches {target_name}'s {hit_location} at the base. The long, ringed length whips away across the ground.",
+                "victim_msg": "{attacker_name}'s blade catches your {hit_location} at the base. The long length whips away.",
+                "observer_msg": "{attacker_name}'s blade catches {target_name}'s {hit_location} at the base. The long, ringed length whips away across the ground.",
+            },
+            {
+                "attacker_msg": "The cut takes {target_name}'s {hit_location} off cleanly at the base. The tail twitches once and lies still.",
+                "victim_msg": "{attacker_name}'s cut takes your {hit_location} off cleanly at the base.",
+                "observer_msg": "{attacker_name}'s cut takes {target_name}'s {hit_location} off cleanly at the base. The tail twitches once and lies still.",
+            },
+            {
+                "attacker_msg": "You sever {target_name}'s {hit_location} with a single sharp stroke. The body lurches without its counterweight.",
+                "victim_msg": "{attacker_name} severs your {hit_location} with a single stroke. The balance goes out from under you.",
+                "observer_msg": "{attacker_name} severs {target_name}'s {hit_location} with a single sharp stroke. The body lurches without its counterweight.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A neat stroke takes {target_name}'s {hit_location} off at the base.",
+                "victim_msg": "{attacker_name}'s neat stroke takes your {hit_location} off at the base.",
+                "observer_msg": "{attacker_name}'s neat stroke takes {target_name}'s {hit_location} off at the base.",
+            },
+            {
+                "attacker_msg": "Your edge finds the joint between vertebrae and {target_name}'s {hit_location} parts cleanly.",
+                "victim_msg": "{attacker_name}'s edge finds the joint and your {hit_location} parts cleanly.",
+                "observer_msg": "{attacker_name}'s edge finds the joint and {target_name}'s {hit_location} parts cleanly.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point in at the base of {target_name}'s {hit_location} and lever. The tail snaps off through the vertebrae.",
+                "victim_msg": "{attacker_name} drives the point in at the base of your {hit_location} and levers. The tail snaps off.",
+                "observer_msg": "{attacker_name} drives the point in at the base of {target_name}'s {hit_location} and levers. The tail snaps off through the vertebrae.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A controlled thrust pops {target_name}'s {hit_location} free at a vertebral joint.",
+                "victim_msg": "{attacker_name}'s controlled thrust pops your {hit_location} free at a vertebral joint.",
+                "observer_msg": "{attacker_name}'s controlled thrust pops {target_name}'s {hit_location} free at a vertebral joint.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "The torn blow rips {target_name}'s {hit_location} away with a wet snap. The base of the spine shows in the ruin.",
+                "victim_msg": "{attacker_name}'s torn blow rips your {hit_location} away. The base of your spine is exposed.",
+                "observer_msg": "{attacker_name}'s torn blow rips {target_name}'s {hit_location} away with a wet snap. The base of the spine shows in the ruin.",
+            },
+            {
+                "attacker_msg": "You tear {target_name}'s {hit_location} loose at the base, hide parting along the ringed scales.",
+                "victim_msg": "{attacker_name} tears your {hit_location} loose at the base, hide parting along the rings.",
+                "observer_msg": "{attacker_name} tears {target_name}'s {hit_location} loose at the base, hide parting along the ringed scales.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A ragged tear takes {target_name}'s {hit_location} off at the base.",
+                "victim_msg": "{attacker_name}'s ragged tear takes your {hit_location} off at the base.",
+                "observer_msg": "{attacker_name}'s ragged tear takes {target_name}'s {hit_location} off at the base.",
+            },
+        ],
+    },
+}


### PR DESCRIPTION
## Summary

Adds rat-flavored severance prose for fore/hindleg/paw/tail. Previously rat severance fell through to the generic fallback template.

- Five new modules: ``forelegs.py``, ``hindlegs.py``, ``forepaws.py``, ``hindpaws.py``, ``tail.py``
- Each covers cut / stab / laceration × grievous / minor
- Small-mammal imagery (small limb, ringed length, body lurches without counterweight, etc.)
- ``_LIMB_ALIASES`` updated to route rat containers
- ``_resolve_module_name`` singular-pair list extended

``head.py`` keeps serving rat decapitation — that prose is generic enough.

## Live smoke test

\`\`\`
tail:         \"...catches a rat's tail at the base. The long, ringed length whips away across the ground.\"
left_foreleg: \"...catches a rat's left foreleg clean at the shoulder. The small limb spins away in a thin red arc.\"
\`\`\`

## Test plan

- [x] Full suite: 1763/1763 pass

Refs #356.