### PR TITLE
Rich rat sdesc: size × coat composition

### DIFF
--- a/commands/CmdSpawnMob.py
+++ b/commands/CmdSpawnMob.py
@@ -7,7 +7,10 @@ from world.namebank import (
     FIRST_NAMES_AMBIGUOUS,
     LAST_NAMES
 )
-from world.identity import HEIGHTS, BUILDS, HAIR_COLORS, HAIR_STYLES
+from world.identity import (
+    HEIGHTS, BUILDS, HAIR_COLORS, HAIR_STYLES,
+    RAT_SIZES, RAT_COATS,
+)
 from world.identity_utils import msg_room_identity
 from world.mob_flavor import apply_random_flavor
 
@@ -70,8 +73,10 @@ class CmdSpawnMob(Command):
         if randint(1, 10) <= 2:  # 20% chance to use ambiguous
             sex = "ambiguous"
 
-        # Name: humans pull from the name banks; non-humans get a
-        # species-flavored default key ("a rat") unless overridden.
+        # Name: humans pull from the name banks; non-humans compose
+        # a rich species-flavored sdesc key (a rat gets a size + coat
+        # pair like "a wiry brown rat" rather than the bare "a rat").
+        # See world.identity.RAT_SIZES / RAT_COATS.
         if species == "human":
             if sex == "male":
                 first = choice(FIRST_NAMES_MALE)
@@ -81,6 +86,10 @@ class CmdSpawnMob(Command):
                 first = choice(FIRST_NAMES_AMBIGUOUS)
             last = choice(LAST_NAMES)
             mob_name = raw_args or f"{first} {last}"
+        elif species == "rat":
+            mob_name = raw_args or (
+                f"a {choice(RAT_SIZES)} {choice(RAT_COATS)} rat"
+            )
         else:
             mob_name = raw_args or f"a {species}"
 

--- a/world/identity.py
+++ b/world/identity.py
@@ -49,6 +49,35 @@ BUILDS: tuple[str, ...] = (
     "heavyset",
 )
 
+
+# Rat sdesc descriptors (#356 follow-up).  Rats don't fit the
+# HEIGHTS × BUILDS table (humanoid scale doesn't apply to a small
+# mammal), so they compose their key from a parallel size × coat
+# pool.  ``CmdSpawnMob/rat`` picks one of each and writes the
+# composed string ("a wiry brown rat") as the mob's key, which
+# Character.get_sdesc falls back to when humanoid identity axes
+# (height / build) aren't set.
+RAT_SIZES: tuple[str, ...] = (
+    "small",
+    "thin",
+    "lean",
+    "scrawny",
+    "wiry",
+    "stocky",
+    "long-bodied",
+)
+
+RAT_COATS: tuple[str, ...] = (
+    "grey",
+    "brown",
+    "dusky",
+    "ragged",
+    "patchy",
+    "sleek",
+    "matted",
+    "scarred",
+)
+
 #: Physical descriptor table.  ``PHYSICAL_DESCRIPTOR_TABLE[height][build]``
 #: yields a single adjective describing the character's silhouette.
 #:


### PR DESCRIPTION
## Summary

Every rat spawned with the bare \"a rat\" key, making a room full of rats indistinguishable. Adds rat-specific sdesc composition.

- ``world.identity.RAT_SIZES`` — 7 entries (small / thin / lean / scrawny / wiry / stocky / long-bodied)
- ``world.identity.RAT_COATS`` — 8 entries (grey / brown / dusky / ragged / patchy / sleek / matted / scarred)
- ``CmdSpawnMob/rat`` composes ``\"a {size} {coat} rat\"`` (56 unique combinations) when no explicit name is given

``get_sdesc`` falls through to ``self.key`` on rats since humanoid identity axes aren't set, so the composed key becomes the visible sdesc throughout the identity / disguise / recognition systems with no further code changes.

## Sample output

\`\`\`
a small dusky rat
a thin matted rat
a scrawny brown rat
a stocky ragged rat
a wiry brown rat
a long-bodied ragged rat
\`\`\`

## Test plan

- [x] Full suite: 1763/1763 pass

Refs #356.