### PR TITLE
Wire condition modifiers to organ functionality (scan-based) (#307)

### DIFF
--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -76,7 +76,33 @@ class MedicalCondition:
     def get_blood_loss_rate(self):
         """Return blood loss rate from this condition. Override in subclasses."""
         return 0  # Base conditions don't cause blood loss by default
-        
+
+    def disables_organ_at_severity(self):
+        """Return ``True`` when this condition's current state fully
+        disables organs in its location (#307).
+
+        Default ``False`` — most conditions degrade function gradually
+        via :meth:`get_organ_functionality_modifier` rather than
+        flipping a binary cutoff.  Subclasses with a clear "tissue is
+        no longer working" threshold (e.g. critical infection)
+        override.
+        """
+        return False
+
+    def get_organ_functionality_modifier(self):
+        """Return a multiplier in ``[0.0, 1.0]`` applied to organ
+        functionality at this condition's location (#307).
+
+        Default ``1.0`` — no effect.  Body-wide conditions (pain,
+        blood loss, consciousness suppression) keep the default since
+        their impact propagates through other channels (pain →
+        consciousness, blood loss → blood_level → consciousness, etc.)
+        rather than directly reducing individual organ output.
+        Location-bound conditions whose biology actually impairs the
+        tissue at that site (infection inflammation) override.
+        """
+        return 1.0
+
     @property
     def type(self):
         """Alias for condition_type for backward compatibility."""
@@ -290,7 +316,38 @@ class InfectionCondition(MedicalCondition):
     def should_end(self):
         """Infection ends when severity reaches 0."""
         return self.severity <= 0
-        
+
+    def disables_organ_at_severity(self):
+        """Critical infection (severity ≥ 10) disables organs at the
+        affected location entirely — inflammation has overwhelmed
+        the tissue (#307).
+        """
+        return self.severity >= 10
+
+    def get_organ_functionality_modifier(self):
+        """Inflammation progressively impairs organ function (#307).
+
+        Severity ladder, matching the 1-10 scale used elsewhere:
+
+        * 0:   ``1.0`` — cleared, awaiting removal
+        * 1-3: ``0.9`` — minor; small functional drag
+        * 4-6: ``0.75`` — moderate; noticeable impairment
+        * 7-9: ``0.5`` — severe; organ at half-function
+        * 10+: ``0.0`` — handled via :meth:`disables_organ_at_severity`
+
+        Numbers are scaffolding — balance pass owed (proof-of-concept
+        per the user; spec line 1418 also defers exact mechanics).
+        """
+        if self.severity <= 0:
+            return 1.0
+        if self.severity <= 3:
+            return 0.9
+        if self.severity <= 6:
+            return 0.75
+        if self.severity <= 9:
+            return 0.5
+        return 0.0  # severity 10+ — disabling check catches it too
+
     def apply_treatment(self, treatment_quality="adequate"):
         """Apply medical treatment to infection."""
         super().apply_treatment(treatment_quality)

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -67,8 +67,30 @@ class Organ:
         self.capacities = self.data.get("capacities", [])
         self.contribution = self.data.get("contribution", "minor")
         
-        # Medical conditions affecting this organ
+        # Medical conditions affecting this organ.  Kept for legacy
+        # callers (``add_condition`` / ``remove_condition``) — the
+        # canonical source of truth is ``MedicalState.conditions``
+        # (body-wide list).  ``_has_disabling_conditions`` and
+        # ``get_functionality_percentage`` scan the parent state via
+        # ``self.medical_state`` rather than mirroring conditions
+        # here.  See :meth:`_iter_relevant_conditions`.
         self.conditions = []
+
+        # Back-reference to the owning ``MedicalState``, set by
+        # ``MedicalState`` at organ-creation / restore time so the
+        # organ can scan the body-wide condition list for entries
+        # matching its location.  ``None`` until wired — methods
+        # degrade gracefully when absent (e.g. organ instantiated
+        # outside a MedicalState in a test stub).
+        #
+        # Scan-based design (over mirroring) is the cyberware-safe
+        # answer: replacing this flesh organ with a cyberware
+        # equivalent leaves any chest / abdomen / etc. infections
+        # in place on the body without sync logic, since conditions
+        # never lived on the organ.  See spec line 564 ("Prosthetic
+        # Integration: New artificial limbs add new hit locations
+        # with their own organ mappings").
+        self.medical_state = None
         
         # Wound state tracking for longdesc integration
         self.wound_stage = None      # fresh, treated, healing, scarred
@@ -83,29 +105,76 @@ class Organ:
         """Returns True if organ can perform its function."""
         return not self.is_destroyed() and not self._has_disabling_conditions()
         
-    def _has_disabling_conditions(self):
-        """Check if any conditions disable this organ's function."""
-        # For now, return False - will be expanded in later phases
-        return False
-        
-    def get_functionality_percentage(self):
+    def _iter_relevant_conditions(self):
+        """Yield body-wide conditions whose location applies to this
+        organ (#307).
+
+        Scans ``self.medical_state.conditions`` and filters by the
+        condition's ``location`` field:
+
+        * ``None`` / unset location → body-wide condition; included.
+          Its default ``get_organ_functionality_modifier`` is
+          ``1.0`` (no effect) unless the subclass overrides for an
+          organ-meaningful body-wide effect.
+        * Matches ``self.container`` OR ``self.display_location`` →
+          included.  Sensory organs (left_eye / right_eye) match on
+          display_location so a "left_eye" condition only affects
+          the left eye, not the right.
+        * Anything else → skipped.
+
+        Degrades gracefully (empty iterator) when
+        ``self.medical_state`` is ``None`` — handles test stubs that
+        instantiate Organ standalone without a parent state.
         """
-        Returns the percentage of normal function this organ provides.
-        
+        state = self.medical_state
+        if state is None:
+            return
+        relevant_locs = (self.container, self.display_location)
+        for condition in state.conditions:
+            loc = getattr(condition, "location", None)
+            if loc and loc not in relevant_locs:
+                continue
+            yield condition
+
+    def _has_disabling_conditions(self):
+        """Return True when any relevant condition is at a severity
+        that fully disables this organ (#307).
+
+        Consults ``disables_organ_at_severity()`` on each condition
+        matching this organ's location.  Base
+        :class:`world.medical.conditions.MedicalCondition` returns
+        ``False`` by default; subclasses with a clear cutoff
+        (e.g. critical infection) override.
+        """
+        for condition in self._iter_relevant_conditions():
+            if condition.disables_organ_at_severity():
+                return True
+        return False
+
+    def get_functionality_percentage(self):
+        """Return the percentage of normal function this organ
+        provides (#307).
+
+        Multiplies HP-driven base function by the product of each
+        relevant condition's ``get_organ_functionality_modifier()``
+        — so an inflamed organ runs below capacity even when its HP
+        is intact.  Body-wide conditions whose modifier defaults to
+        ``1.0`` (pain, blood loss, consciousness suppression) leave
+        the result untouched.
+
         Returns:
-            float: 0.0 to 1.0 representing functional capacity
+            float: ``0.0`` to ``1.0`` representing functional capacity.
         """
         if self.is_destroyed():
             return 0.0
-            
-        # Base functionality based on current HP
+
         base_function = self.current_hp / self.max_hp
-        
-        # TODO: Apply condition modifiers in later phases
-        # condition_modifier = self._get_condition_penalty()
-        # return max(0.0, base_function * condition_modifier)
-        
-        return base_function
+
+        modifier = 1.0
+        for condition in self._iter_relevant_conditions():
+            modifier *= condition.get_organ_functionality_modifier()
+
+        return max(0.0, base_function * modifier)
         
     def take_damage(self, amount, injury_type="generic"):
         """
@@ -197,18 +266,52 @@ class Organ:
         """
         Apply medical treatment to this organ's wound.
         Future-proofing method for medical treatment system.
-        
+
         Args:
             treatment_type (str): Type of treatment applied
+
+        Deferred design (#307 follow-up).  The current implementation
+        only advances the wound stage; the spec describes a much
+        richer treatment pipeline that's deferred to a deeper pass
+        because exact mechanics need balance work first.  See
+        ``specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md``:
+
+        * **G.R.I.M. skill roll** (line 1432-1478):
+          ``medical_effectiveness = (intellect * 0.75) + (motorics * 0.25)``;
+          d20 + skill vs difficulty threshold.
+        * **Tri-modal outcomes** (line 1473): success /
+          partial_success / failure with distinct effects.
+        * **Tool appropriateness table** (line 1396-1419): each
+          tool has per-condition effectiveness; mismatched tools
+          either fail or have ``failure_consequences`` (e.g.
+          ``"infection_risk_scar_tissue"``).
+        * **Healing bonuses** belong here once the heal-rate
+          plumbing exists (currently absent; gated on the Time
+          System #301 for time-based healing ticks anyway).
+
+        For the destroyed → severed branch (clean amputation), the
+        deferred design space is wider still:
+
+        * **Order of operations**: tourniquet placement before vs
+          after the cut changes blood-loss outcome.
+        * **Care quality**: clean surgical amputation vs field-cut
+          drives pain reduction, infection arrest at the site, and
+          long-term wound stage.
+        * **Painkiller interaction**: prior / concurrent painkiller
+          use modifies pain consequences (spec line 1092).
+        * **``amputation_risk`` injury types** (spec line 925):
+          frostbite explicitly triggers amputation as a treatment
+          path, not just as a sever-from-damage path.
+
+        Until that pass, this method only flips the stage so the
+        wound rendering picks the correct decay tier.
         """
         if hasattr(self, 'wound_stage'):
             if self.wound_stage == 'fresh':
                 self.wound_stage = 'treated'
-                # TODO: Add treatment effects, healing bonuses, etc.
             elif self.wound_stage == 'destroyed':
                 # Medical treatment of destroyed organs results in clean amputation/severance
                 self.wound_stage = 'severed'
-                # TODO: Add surgical amputation effects, pain management, etc.
     
     def advance_healing_stage(self):
         """
@@ -231,13 +334,30 @@ class Organ:
         }
         
         self.wound_stage = stage_progression.get(self.wound_stage, self.wound_stage)
-        
+
         # Scarred stage only applies to organs that still have HP (non-destroyed)
         if self.wound_stage == 'scarred' and self.current_hp <= 0:
             # Destroyed organs can't become scars - they stay destroyed
             self.wound_stage = 'destroyed'
-            # TODO: Consider if we want visible scars for non-destroyed organs
-            pass
+
+        # Scar policy (#307 follow-up): scars are **cosmetic only**.
+        # Scarred-stage organs render the scarred wound prose via the
+        # existing message modules (``world/medical/wounds/messages/<itype>.py``
+        # ``"scarred"`` cell) and do NOT carry a functionality penalty.
+        # This is intentionally distinct from two related but separate
+        # mechanics the spec calls out as deferred design space:
+        #
+        # * **Permanent damage** (spec line 879, 923): some injury
+        #   types (burn, frostbite) have ``permanent_damage_chance``.
+        #   Permanent damage is FUNCTIONAL — likely modelled as
+        #   reduced max_hp or a persistent functionality multiplier.
+        #   Separate from scarring.
+        # * **Improper healing** (spec line 1149): a failed splint
+        #   has ``failure_consequences = "improper_healing_permanent_reduced_function"``.
+        #   Also functional, triggered by failed treatment.
+        #
+        # Auto-progression from healing → scarred is gated on the
+        # Time System (#301) for time-based ticks.
         
     def add_condition(self, condition):
         """Add a medical condition to this organ."""
@@ -335,7 +455,9 @@ class MedicalState:
         unknown species falls back to the human organ table.  Each
         organ is constructed with the species so its spec lookup
         targets the right table — a rat's medical state doesn't
-        accidentally get a left_humerus.
+        accidentally get a left_humerus.  Sets the back-reference
+        (#307) so the organ can scan ``self.conditions`` for
+        location-matching entries during functionality checks.
         """
         from world.anatomy import get_species_organs
 
@@ -343,20 +465,25 @@ class MedicalState:
         if self.character is not None:
             species = getattr(self.character.db, "species", None)
         for organ_name in get_species_organs(species).keys():
-            self.organs[organ_name] = Organ(organ_name, species=species)
+            organ = Organ(organ_name, species=species)
+            organ.medical_state = self
+            self.organs[organ_name] = organ
             
     def get_organ(self, organ_name):
         """Get organ by name, creating if it doesn't exist.
 
         Species-aware (issue #356 Phase 1) — lazily-created organs
         consult the owning character's species so the spec lookup
-        targets the right table.
+        targets the right table.  Sets the parent back-reference
+        (#307) on newly-created organs.
         """
         if organ_name not in self.organs:
             species = None
             if self.character is not None:
                 species = getattr(self.character.db, "species", None)
-            self.organs[organ_name] = Organ(organ_name, species=species)
+            organ = Organ(organ_name, species=species)
+            organ.medical_state = self
+            self.organs[organ_name] = organ
         return self.organs[organ_name]
         
     def get_conditions_by_location(self, location):
@@ -685,10 +812,16 @@ class MedicalState:
         """Deserialize medical state from persistence."""
         medical_state = cls(character)
         
-        # Restore organs
+        # Restore organs.  Wire the back-reference (#307) so restored
+        # organs can scan ``medical_state.conditions`` for relevant
+        # entries — needed for ``get_functionality_percentage`` /
+        # ``_has_disabling_conditions`` to fire correctly on
+        # post-restore organs.
         organ_data = data.get("organs", {})
         for organ_name, organ_dict in organ_data.items():
-            medical_state.organs[organ_name] = Organ.from_dict(organ_dict)
+            organ = Organ.from_dict(organ_dict)
+            organ.medical_state = medical_state
+            medical_state.organs[organ_name] = organ
             
         # Restore conditions - using proper deserialization
         condition_data = data.get("conditions", [])

--- a/world/tests/test_organ_condition_modifiers.py
+++ b/world/tests/test_organ_condition_modifiers.py
@@ -1,0 +1,313 @@
+"""Tests for condition-driven organ functionality modifiers (#307).
+
+Pre-fix, ``Organ._has_disabling_conditions`` returned ``False``
+unconditionally and ``get_functionality_percentage`` ignored
+conditions — conditions were a decorative layer that didn't affect
+capacity calculations.
+
+The scan-based wiring (#307) gives each ``Organ`` a back-reference
+to its parent ``MedicalState`` and filters body-wide conditions by
+location at lookup time:
+
+* Conditions with no location (body-wide) apply to every organ but
+  default modifier ``1.0`` means no effect — pain / blood loss /
+  consciousness suppression propagate through other channels.
+* Location-bound conditions apply only when the organ's
+  ``container`` or ``display_location`` matches the condition's
+  ``location``.
+
+``InfectionCondition`` overrides both hooks: progressive
+functionality modifier (0.9 / 0.75 / 0.5) plus a binary cutoff at
+severity 10.
+
+Architectural note: scan-based design (rather than mirroring
+conditions onto each organ) is the cyberware-safe pattern.  A
+flesh heart swapped for a cyberware heart leaves any chest
+infection in place on the body without sync logic, since the
+condition never lived on the organ.  Tests cover this case
+explicitly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.conditions import (
+    BleedingCondition,
+    InfectionCondition,
+    MedicalCondition,
+)
+from world.medical.core import MedicalState, Organ
+
+
+def _human_character():
+    """Plain-Python stub character for MedicalState init.
+
+    ``archived`` and ``key`` are read by ``MedicalCondition.start_condition``
+    when conditions are added; default values keep that path quiet
+    so tests can focus on the modifier wiring.
+    """
+    return SimpleNamespace(
+        db=SimpleNamespace(species="human", archived=False),
+        key="TestSubject",
+    )
+
+
+# ---------------------------------------------------------------------
+# Base class defaults
+# ---------------------------------------------------------------------
+
+
+class BaseConditionDefaults(TestCase):
+    """The base ``MedicalCondition`` returns no-effect defaults so
+    legacy condition subclasses (and future body-wide conditions)
+    don't accidentally penalize organ function."""
+
+    def test_disables_default_false(self):
+        c = MedicalCondition("test", severity=5)
+        self.assertFalse(c.disables_organ_at_severity())
+
+    def test_modifier_default_one(self):
+        c = MedicalCondition("test", severity=5)
+        self.assertEqual(c.get_organ_functionality_modifier(), 1.0)
+
+
+class BleedingDoesNotPenalizeOrgan(TestCase):
+    """Bleeding's biology is "the body is losing volume" not "this
+    organ is impaired", so it stays body-wide via blood_level rather
+    than reducing per-organ functionality.  Regression guard against
+    double-counting."""
+
+    def test_bleeding_modifier_is_one(self):
+        c = BleedingCondition(severity=8, location="chest")
+        self.assertEqual(c.get_organ_functionality_modifier(), 1.0)
+
+    def test_bleeding_does_not_disable(self):
+        c = BleedingCondition(severity=10, location="chest")
+        self.assertFalse(c.disables_organ_at_severity())
+
+
+# ---------------------------------------------------------------------
+# Infection ladder
+# ---------------------------------------------------------------------
+
+
+class InfectionFunctionalityLadder(TestCase):
+
+    def test_severity_zero_no_effect(self):
+        c = InfectionCondition(severity=0)
+        self.assertEqual(c.get_organ_functionality_modifier(), 1.0)
+
+    def test_minor_severity_small_drag(self):
+        # 1-3
+        for s in (1, 2, 3):
+            with self.subTest(severity=s):
+                self.assertEqual(
+                    InfectionCondition(severity=s).get_organ_functionality_modifier(),
+                    0.9,
+                )
+
+    def test_moderate_severity_quarter_off(self):
+        # 4-6
+        for s in (4, 5, 6):
+            with self.subTest(severity=s):
+                self.assertEqual(
+                    InfectionCondition(severity=s).get_organ_functionality_modifier(),
+                    0.75,
+                )
+
+    def test_severe_severity_half_function(self):
+        # 7-9
+        for s in (7, 8, 9):
+            with self.subTest(severity=s):
+                self.assertEqual(
+                    InfectionCondition(severity=s).get_organ_functionality_modifier(),
+                    0.5,
+                )
+
+    def test_critical_severity_disables(self):
+        c = InfectionCondition(severity=10)
+        self.assertTrue(c.disables_organ_at_severity())
+
+
+# ---------------------------------------------------------------------
+# Organ scan logic
+# ---------------------------------------------------------------------
+
+
+class OrganBackRefWired(TestCase):
+    """``MedicalState`` sets ``organ.medical_state`` on the organs
+    it creates so the scan can find the body-wide condition list."""
+
+    def test_init_default_organs_sets_back_ref(self):
+        state = MedicalState(_human_character())
+        for name, organ in state.organs.items():
+            with self.subTest(organ=name):
+                self.assertIs(organ.medical_state, state)
+
+    def test_lazy_get_organ_sets_back_ref(self):
+        state = MedicalState(_human_character())
+        # Drop an organ then re-fetch via get_organ.
+        del state.organs["heart"]
+        heart = state.get_organ("heart")
+        self.assertIs(heart.medical_state, state)
+
+
+class OrganScanFiltersConditionsByLocation(TestCase):
+
+    def setUp(self):
+        self.state = MedicalState(_human_character())
+        self.heart = self.state.organs["heart"]      # container="chest"
+        self.liver = self.state.organs["liver"]      # container="abdomen"
+        self.left_eye = self.state.organs["left_eye"]
+        # left_eye.display_location == "left_eye" via #346 routing
+        # but container == "head"
+
+    def test_no_conditions_full_function(self):
+        self.assertEqual(self.heart.get_functionality_percentage(), 1.0)
+
+    def test_body_wide_no_location_does_not_modify(self):
+        # No-location condition reaches every organ via the scan but
+        # base modifier 1.0 means no effect.
+        self.state.conditions.append(MedicalCondition("test", severity=5))
+        self.assertEqual(self.heart.get_functionality_percentage(), 1.0)
+        self.assertEqual(self.liver.get_functionality_percentage(), 1.0)
+
+    def test_chest_infection_affects_heart_not_liver(self):
+        self.state.conditions.append(
+            InfectionCondition(severity=5, location="chest")
+        )
+        # Heart (chest container) takes a moderate hit.
+        self.assertAlmostEqual(
+            self.heart.get_functionality_percentage(), 0.75,
+        )
+        # Liver (abdomen container) untouched.
+        self.assertEqual(self.liver.get_functionality_percentage(), 1.0)
+
+    def test_left_eye_condition_matches_display_location(self):
+        # Sensory organs surface at their display_location (#346).
+        # A condition at "left_eye" should hit the left eye organ
+        # via display_location matching even though container="head".
+        self.state.conditions.append(
+            InfectionCondition(severity=5, location="left_eye")
+        )
+        self.assertAlmostEqual(
+            self.left_eye.get_functionality_percentage(), 0.75,
+        )
+        # Right eye unaffected.
+        right_eye = self.state.organs["right_eye"]
+        self.assertEqual(right_eye.get_functionality_percentage(), 1.0)
+
+    def test_head_container_condition_affects_all_head_organs(self):
+        # Infection at "head" container — brain, eyes, ears etc.
+        # all have container=head and pick it up.
+        self.state.conditions.append(
+            InfectionCondition(severity=4, location="head")
+        )
+        for name in ("brain", "left_eye", "right_eye", "left_ear"):
+            with self.subTest(organ=name):
+                self.assertAlmostEqual(
+                    self.state.organs[name].get_functionality_percentage(),
+                    0.75,
+                )
+
+    def test_critical_infection_disables_organ(self):
+        self.state.conditions.append(
+            InfectionCondition(severity=10, location="chest")
+        )
+        self.assertFalse(self.heart.is_functional())
+
+    def test_no_back_ref_degrades_gracefully(self):
+        # Standalone organ without medical_state back-ref shouldn't
+        # crash — just returns no-modifier defaults.
+        organ = Organ("heart")
+        self.assertIsNone(organ.medical_state)
+        self.assertFalse(organ._has_disabling_conditions())
+        self.assertEqual(organ.get_functionality_percentage(), 1.0)
+
+
+# ---------------------------------------------------------------------
+# Cyberware / hot-swap scenario
+# ---------------------------------------------------------------------
+
+
+class CyberwareHotSwapPreservesConditions(TestCase):
+    """A chest infection sits on the body, not on the heart.  When
+    the flesh heart is replaced with a cyberware equivalent
+    (modelled here as a fresh ``Organ`` object replacing the old in
+    ``self.organs``), the infection persists naturally with no sync
+    logic — because the scan-based design never mirrored it onto
+    the heart in the first place."""
+
+    def test_chest_infection_persists_through_heart_swap(self):
+        state = MedicalState(_human_character())
+        state.conditions.append(
+            InfectionCondition(severity=5, location="chest")
+        )
+
+        old_heart = state.organs["heart"]
+        # Verify infection is impairing the old heart.
+        self.assertLess(
+            old_heart.get_functionality_percentage(), 1.0,
+        )
+
+        # Swap in a "cyberware" heart — fresh Organ object, full HP.
+        # Real cyberware replacement is far more elaborate, but the
+        # core invariant we want to test is that body-wide condition
+        # state is decoupled from individual organ identity.
+        new_heart = Organ("heart")
+        new_heart.medical_state = state
+        state.organs["heart"] = new_heart
+
+        # Body-wide infection is still there.
+        self.assertEqual(len(state.conditions), 1)
+        # And it still impairs the new heart (same chest container).
+        self.assertLess(
+            new_heart.get_functionality_percentage(), 1.0,
+        )
+
+    def test_abdomen_condition_does_not_follow_a_chest_swap(self):
+        # Negative control — a liver-located condition shouldn't
+        # follow when a chest organ is replaced.  Sanity-check that
+        # the per-organ scan filters by location correctly.
+        state = MedicalState(_human_character())
+        state.conditions.append(
+            InfectionCondition(severity=5, location="abdomen")
+        )
+
+        # Swap heart out.
+        new_heart = Organ("heart")
+        new_heart.medical_state = state
+        state.organs["heart"] = new_heart
+
+        # New heart: full function (abdomen condition doesn't match).
+        self.assertEqual(new_heart.get_functionality_percentage(), 1.0)
+        # Liver: still impaired.
+        self.assertLess(
+            state.organs["liver"].get_functionality_percentage(), 1.0,
+        )
+
+
+# ---------------------------------------------------------------------
+# Capacity integration smoke test
+# ---------------------------------------------------------------------
+
+
+class CapacityScoreReflectsConditionModifiers(TestCase):
+
+    def test_infection_reduces_capacity_via_organ_functionality(self):
+        state = MedicalState(_human_character())
+        # Baseline.
+        base = state.calculate_body_capacity("blood_pumping")
+        self.assertAlmostEqual(base, 1.0)
+
+        # Severe chest infection → heart at 0.5 functionality →
+        # blood_pumping capacity drops accordingly.
+        state.conditions.append(
+            InfectionCondition(severity=8, location="chest")
+        )
+        # Force the capacity cache off.
+        state._cache_dirty = True
+        impaired = state.calculate_body_capacity("blood_pumping")
+        self.assertLess(impaired, base)


### PR DESCRIPTION
## Summary

Scaffolding pass against the four code-level TODOs flagged in #307. Conditions now actually impair organ function (infection only for now); the deeper treatment / amputation / scar mechanics become forward-pointing notes that capture the spec-described design space.

### Scan-based architecture

``Organ`` gets a back-reference to its parent ``MedicalState`` and filters body-wide conditions at lookup time:

- ``condition.location == None`` (body-wide) → applied to every organ; defaults make this a no-op for pain / blood loss / consciousness suppression
- ``condition.location`` matches ``organ.container`` or ``organ.display_location`` → applied

This is the cyberware-safe pattern (spec line 564). Replacing a flesh heart with a cyberware heart leaves chest-located infections in place without sync logic — regression test covers the swap scenario explicitly.

### Infection-only modifier

- ``InfectionCondition.get_organ_functionality_modifier`` — 0.9 / 0.75 / 0.5 progressive ladder against severity tiers
- ``InfectionCondition.disables_organ_at_severity`` — True at severity 10
- ``BleedingCondition``, ``PainCondition``, ``ConsciousnessSuppressionCondition`` stay body-wide via their existing channels (not double-counted)

Numbers are scaffolding — balance owed (proof-of-concept per the user; spec line 1418 also defers exact mechanics).

### Deferred TODOs → policy notes

The three remaining TODOs (treatment depth, amputation effects, scars) become forward-pointing notes pointing at the spec destination:

- **Treatment**: G.R.I.M. roll, tri-modal outcomes, tool appropriateness table (spec line 1432-1478, 1396-1419)
- **Amputation**: order-of-operations (tourniquet timing), care quality, painkiller interaction, amputation_risk injury types (spec line 925)
- **Scars**: cosmetic-only policy. Distinct from "permanent damage" (line 879/923) and "improper healing" (line 1149) which are functional mechanics with different triggers.

## Test plan

- [x] ``world.tests.test_organ_condition_modifiers`` — 21/21 pass (base defaults, bleeding non-penalty, infection ladder, scan filter, sensory-organ display_location matching, critical-infection disabling, graceful degradation without back-ref, **cyberware hot-swap preserves body-wide conditions**, capacity integration smoke test)
- [x] Full suite: 1784/1784 pass

Refs #307.