### PR TITLE
Organ-bound condition tier + harvest pipeline (#307 follow-up)

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1068,6 +1068,23 @@ class Organ(Item):
         if composed:
             self.db.desc = composed
 
+        # Carry organ-bound conditions from the source corpse onto
+        # the harvested item (#307 three-tier model).  The corpse's
+        # medical snapshot stores each organ's ``conditions`` list
+        # in serialized-dict form via ``Organ.to_dict``; we copy it
+        # verbatim onto the harvested item so a future install
+        # pipeline (Phase 3.2 cybernetics in the spec) can re-attach
+        # the conditions to the recipient's organ slot.  Body-bound
+        # and location-bound conditions stay on the source corpse —
+        # only organ-bound state travels with the harvest.
+        try:
+            snapshot = corpse.get_medical_snapshot() or {}
+            organs = snapshot.get("organs") or {}
+            organ_data = organs.get(organ_name) or {}
+            self.db.organ_conditions = list(organ_data.get("conditions") or [])
+        except (AttributeError, TypeError):
+            self.db.organ_conditions = []
+
 
 class Appendage(Item):
     """A severed limb (or head) detached from a corpse via ``sever``.

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -261,12 +261,29 @@ class PainCondition(MedicalCondition):
     def apply_treatment(self, treatment_quality="adequate"):
         """Apply medical treatment to pain."""
         super().apply_treatment(treatment_quality)
-        
+
         # Pain treatment is very effective
         effectiveness = HEALING_EFFECTIVENESS.get(treatment_quality, 0.5)
         severity_reduction = max(1, int(self.severity * effectiveness * 1.5))  # Extra effective
-        
+
         self.severity = max(0, self.severity - severity_reduction)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Deserialize a pain condition from persistence.
+
+        Subclass override — same signature mismatch issue as
+        ``InfectionCondition.from_dict``.
+        """
+        condition = cls(
+            data.get("severity", 1),
+            data.get("location"),
+        )
+        condition.max_severity = data.get("max_severity", condition.severity)
+        condition.tick_interval = data.get("tick_interval", 120)
+        condition.requires_ticker = data.get("requires_ticker", True)
+        condition.treated = data.get("treated", False)
+        return condition
 
 
 class InfectionCondition(MedicalCondition):
@@ -316,6 +333,25 @@ class InfectionCondition(MedicalCondition):
     def should_end(self):
         """Infection ends when severity reaches 0."""
         return self.severity <= 0
+
+    @classmethod
+    def from_dict(cls, data):
+        """Deserialize an infection condition from persistence.
+
+        Overrides ``MedicalCondition.from_dict`` because the base
+        signature passes ``condition_type`` as the first positional,
+        but ``InfectionCondition.__init__`` takes ``(severity,
+        location)``.  Matches the pattern ``BleedingCondition`` uses.
+        """
+        condition = cls(
+            data.get("severity", 1),
+            data.get("location"),
+        )
+        condition.max_severity = data.get("max_severity", condition.severity)
+        condition.tick_interval = data.get("tick_interval", 300)
+        condition.requires_ticker = data.get("requires_ticker", True)
+        condition.treated = data.get("treated", False)
+        return condition
 
     def disables_organ_at_severity(self):
         """Critical infection (severity ≥ 10) disables organs at the
@@ -474,6 +510,35 @@ class ConsciousnessSuppressionCondition(MedicalCondition):
         condition.requires_ticker = data.get("requires_ticker", True)
         condition.treated = data.get("treated", False)
         return condition
+
+
+def deserialize_condition(condition_dict):
+    """Reconstruct a ``MedicalCondition`` from its ``to_dict`` form.
+
+    Centralises the condition-type → class dispatch that
+    ``MedicalState.from_dict`` used to do inline so any persistence
+    pipeline (organ snapshot, harvest item, install pipeline, etc.)
+    can deserialize a condition without reimplementing the factory.
+
+    Args:
+        condition_dict: Dict produced by ``MedicalCondition.to_dict``
+            (or a subclass's override).
+
+    Returns:
+        A condition instance of the appropriate subclass.  Unknown
+        condition types fall back to the ``MedicalCondition`` base
+        class so the data round-trips without crashing.
+    """
+    condition_type = condition_dict.get("condition_type", "unknown")
+    if condition_type == "minor_bleeding":
+        return BleedingCondition.from_dict(condition_dict)
+    if condition_type == "pain":
+        return PainCondition.from_dict(condition_dict)
+    if condition_type == "infection":
+        return InfectionCondition.from_dict(condition_dict)
+    if condition_type == "consciousness_suppression":
+        return ConsciousnessSuppressionCondition.from_dict(condition_dict)
+    return MedicalCondition.from_dict(condition_dict)
 
 
 def remove_condition_by_type(character, condition_type):

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -106,34 +106,44 @@ class Organ:
         return not self.is_destroyed() and not self._has_disabling_conditions()
         
     def _iter_relevant_conditions(self):
-        """Yield body-wide conditions whose location applies to this
-        organ (#307).
+        """Yield conditions that apply to this organ (#307).
 
-        Scans ``self.medical_state.conditions`` and filters by the
-        condition's ``location`` field:
+        Two sources, both included so modifiers compound:
 
-        * ``None`` / unset location → body-wide condition; included.
-          Its default ``get_organ_functionality_modifier`` is
-          ``1.0`` (no effect) unless the subclass overrides for an
-          organ-meaningful body-wide effect.
-        * Matches ``self.container`` OR ``self.display_location`` →
-          included.  Sensory organs (left_eye / right_eye) match on
-          display_location so a "left_eye" condition only affects
-          the left eye, not the right.
-        * Anything else → skipped.
+        1. **Body / location-bound** — entries on
+           ``self.medical_state.conditions``.  Filtered by
+           ``condition.location``: ``None`` (body-wide) always
+           matches; otherwise the location must equal this organ's
+           ``container`` or ``display_location``.  These live on the
+           body and stay with it when an organ is harvested or
+           swapped — sepsis doesn't follow a transplanted heart.
+        2. **Organ-bound** — entries on ``self.conditions``.  These
+           live on the organ itself and travel with it through
+           harvest / install pipelines — endocarditis goes with the
+           heart, kidney stones go with the kidney.  No location
+           filtering needed; if it's on this organ it applies.
 
-        Degrades gracefully (empty iterator) when
+        Degrades gracefully (no body-wide sweep) when
         ``self.medical_state`` is ``None`` — handles test stubs that
-        instantiate Organ standalone without a parent state.
+        instantiate Organ standalone without a parent state.  Organ-
+        bound conditions still surface in that case since they live
+        directly on ``self``.
+
+        See ``specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md`` line 1396+
+        for the per-condition treatment mapping that pairs with the
+        condition subclasses; the three-tier model categorises which
+        treatments target which conditions.
         """
         state = self.medical_state
-        if state is None:
-            return
-        relevant_locs = (self.container, self.display_location)
-        for condition in state.conditions:
-            loc = getattr(condition, "location", None)
-            if loc and loc not in relevant_locs:
-                continue
+        if state is not None:
+            relevant_locs = (self.container, self.display_location)
+            for condition in state.conditions:
+                loc = getattr(condition, "location", None)
+                if loc and loc not in relevant_locs:
+                    continue
+                yield condition
+        # Organ-bound (#307) — always applies, no location filter.
+        for condition in self.conditions:
             yield condition
 
     def _has_disabling_conditions(self):
@@ -372,7 +382,7 @@ class Organ:
     def to_dict(self):
         """
         Serialize organ state for persistence.
-        
+
         Returns:
             dict: Serialized organ state
         """
@@ -380,7 +390,15 @@ class Organ:
             "name": self.name,
             "current_hp": self.current_hp,
             "max_hp": self.max_hp,
-            "conditions": self.conditions.copy(),
+            # Organ-bound conditions (#307 three-tier model: body /
+            # location / organ).  Serialized via each condition's
+            # ``to_dict`` so the data round-trips cleanly through
+            # harvest / install / persistence layers rather than
+            # pickling the in-memory objects.
+            "conditions": [
+                c.to_dict() for c in self.conditions
+                if hasattr(c, "to_dict")
+            ],
             "container": self.container,
             "display_location": self.display_location,
             "wound_stage": self.wound_stage,
@@ -402,7 +420,19 @@ class Organ:
         organ = cls(data["name"])
         organ.current_hp = data.get("current_hp", organ.max_hp)
         organ.max_hp = data.get("max_hp", organ.max_hp)
-        organ.conditions = data.get("conditions", [])
+        # Restore organ-bound conditions through the proper factory
+        # (#307).  Each entry is either a serialized dict (post-#307)
+        # or a legacy MedicalCondition instance pickled by Evennia's
+        # attribute layer (pre-#307 snapshots).  Skip anything that
+        # doesn't recognise as one of those shapes — preserves
+        # forward-compat without choking on legacy data.
+        organ.conditions = []
+        from .conditions import MedicalCondition, deserialize_condition
+        for entry in data.get("conditions", []):
+            if isinstance(entry, dict):
+                organ.conditions.append(deserialize_condition(entry))
+            elif isinstance(entry, MedicalCondition):
+                organ.conditions.append(entry)
         organ.wound_stage = data.get("wound_stage")
         organ.injury_type = data.get("injury_type")
         organ.wound_timestamp = data.get("wound_timestamp")
@@ -823,40 +853,20 @@ class MedicalState:
             organ.medical_state = medical_state
             medical_state.organs[organ_name] = organ
             
-        # Restore conditions - using proper deserialization
-        condition_data = data.get("conditions", [])
-        for condition_dict in condition_data:
+        # Restore conditions via the shared factory (#307) so harvest /
+        # install / persistence layers all reconstruct conditions the
+        # same way.
+        from .conditions import deserialize_condition
+        for condition_dict in data.get("conditions", []):
             try:
-                # Import condition classes
-                from .conditions import (
-                    MedicalCondition, BleedingCondition, PainCondition,
-                    InfectionCondition, ConsciousnessSuppressionCondition,
-                )
-                
-                # Get condition type
-                condition_type = condition_dict.get("condition_type", "minor_bleeding")
-                
-                # Create appropriate condition using its from_dict method
-                if condition_type == "minor_bleeding":
-                    condition = BleedingCondition.from_dict(condition_dict)
-                elif condition_type == "pain":
-                    condition = PainCondition.from_dict(condition_dict) 
-                elif condition_type == "infection":
-                    condition = InfectionCondition.from_dict(condition_dict)
-                elif condition_type == "consciousness_suppression":
-                    condition = ConsciousnessSuppressionCondition.from_dict(condition_dict)
-                else:
-                    # Fallback to base class
-                    condition = MedicalCondition.from_dict(condition_dict)
-                
+                condition = deserialize_condition(condition_dict)
                 medical_state.conditions.append(condition)
                 # Re-start condition ticker if character is available and not archived
                 # Archived characters are permanently dead; dying characters can still be resuscitated
                 if character and not character.db.archived:
                     condition.start_condition(character)
-                    
-            except Exception as e:
-                # If condition restoration fails, skip it
+            except Exception:
+                # If condition restoration fails, skip it.
                 pass
             
         # Restore vital signs

--- a/world/tests/test_organ_bound_conditions.py
+++ b/world/tests/test_organ_bound_conditions.py
@@ -1,0 +1,346 @@
+"""Tests for the organ-bound condition tier (#307 follow-up).
+
+The #307 scaffolding shipped the body / location-bound tier
+(``MedicalState.conditions`` filtered by location).  This module
+covers the third tier: **organ-bound** conditions that live on the
+organ itself (``Organ.conditions``) and travel with it through
+harvest / install / serialization without sync logic.
+
+Three-tier model recap:
+
+1. **Body-bound** — no location; affects whole body (sepsis,
+   blood loss).  Stays on the body when an organ is swapped.
+2. **Location-bound** — location field set; affects every organ
+   at that container / display_location (chest-wall abscess).
+   Stays on the body when an organ is swapped.
+3. **Organ-bound** — lives on ``Organ.conditions``; affects this
+   organ specifically (endocarditis, kidney stones).  **Travels
+   with the organ** through harvest / swap.
+
+Together with the scan in ``Organ._iter_relevant_conditions``, the
+three tiers compound their modifiers — an inflamed heart in a body
+also leaking with sepsis takes both penalties multiplicatively.
+
+Specific architectural guarantees this module pins down:
+
+* Organ-bound conditions modify functionality the same way
+  body/location-bound do (no special-case rendering math).
+* Round-trip through ``to_dict`` / ``from_dict`` preserves
+  organ-bound conditions cleanly (via the
+  ``deserialize_condition`` factory).
+* Body-bound conditions do NOT travel through serialization onto
+  individual organs (negative control — that would break the
+  cyberware swap semantics from the #307 PR).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.conditions import (
+    InfectionCondition,
+    MedicalCondition,
+    deserialize_condition,
+)
+from world.medical.core import MedicalState, Organ
+
+
+def _human_character():
+    return SimpleNamespace(
+        db=SimpleNamespace(species="human", archived=False),
+        key="TestSubject",
+    )
+
+
+# ---------------------------------------------------------------------
+# Scan picks up organ-bound conditions
+# ---------------------------------------------------------------------
+
+
+class OrganBoundConditionAffectsOrgan(TestCase):
+
+    def test_organ_bound_infection_reduces_functionality(self):
+        state = MedicalState(_human_character())
+        heart = state.organs["heart"]
+        # Organ-bound (lives on the organ, no medical_state filter).
+        heart.conditions.append(InfectionCondition(severity=5))
+        # Severity 5 → moderate ladder → 0.75 modifier.
+        self.assertAlmostEqual(heart.get_functionality_percentage(), 0.75)
+
+    def test_organ_bound_at_severity_10_disables(self):
+        state = MedicalState(_human_character())
+        heart = state.organs["heart"]
+        heart.conditions.append(InfectionCondition(severity=10))
+        self.assertFalse(heart.is_functional())
+
+
+class TiersCompound(TestCase):
+    """Body-bound + organ-bound conditions stack multiplicatively
+    (the scan yields both, and ``get_functionality_percentage``
+    products all modifiers)."""
+
+    def test_chest_infection_plus_endocarditis_compound(self):
+        state = MedicalState(_human_character())
+        heart = state.organs["heart"]
+        # Body/location-bound: severity 3 (chest tissue) → 0.9
+        state.conditions.append(
+            InfectionCondition(severity=3, location="chest")
+        )
+        # Organ-bound: severity 3 (endocarditis) → 0.9
+        heart.conditions.append(InfectionCondition(severity=3))
+        # 0.9 × 0.9 = 0.81
+        self.assertAlmostEqual(heart.get_functionality_percentage(), 0.81)
+
+    def test_body_wide_no_location_compounds_too(self):
+        state = MedicalState(_human_character())
+        heart = state.organs["heart"]
+        # No-location condition — base modifier 1.0; doesn't penalize
+        # but confirms the no-effect path coexists with organ-bound.
+        state.conditions.append(MedicalCondition("phantom_pain", severity=5))
+        heart.conditions.append(InfectionCondition(severity=5))
+        # 1.0 × 0.75 = 0.75
+        self.assertAlmostEqual(heart.get_functionality_percentage(), 0.75)
+
+
+# ---------------------------------------------------------------------
+# Persistence: organ-bound conditions round-trip cleanly
+# ---------------------------------------------------------------------
+
+
+class SerializationRoundTrip(TestCase):
+
+    def test_to_dict_serializes_conditions_as_dicts(self):
+        organ = Organ("heart")
+        organ.conditions.append(InfectionCondition(severity=5))
+        snap = organ.to_dict()
+        # Conditions stored as list of dicts, not pickled instances.
+        self.assertEqual(len(snap["conditions"]), 1)
+        condition_dict = snap["conditions"][0]
+        self.assertIsInstance(condition_dict, dict)
+        self.assertEqual(condition_dict["condition_type"], "infection")
+        self.assertEqual(condition_dict["severity"], 5)
+
+    def test_from_dict_restores_organ_bound_conditions(self):
+        organ = Organ("heart")
+        organ.conditions.append(InfectionCondition(severity=5))
+        snap = organ.to_dict()
+        restored = Organ.from_dict(snap)
+        self.assertEqual(len(restored.conditions), 1)
+        c = restored.conditions[0]
+        self.assertIsInstance(c, InfectionCondition)
+        self.assertEqual(c.severity, 5)
+
+    def test_round_trip_preserves_functionality(self):
+        # End-to-end: restored organ's functionality matches the
+        # pre-serialization value.
+        state = MedicalState(_human_character())
+        heart = state.organs["heart"]
+        heart.conditions.append(InfectionCondition(severity=5))
+        before = heart.get_functionality_percentage()
+        snap = heart.to_dict()
+        restored = Organ.from_dict(snap)
+        self.assertAlmostEqual(restored.get_functionality_percentage(),
+                               before)
+
+    def test_legacy_instance_in_list_survives(self):
+        # Pre-#307 snapshots stored MedicalCondition instances
+        # directly (pickled by Evennia's attribute layer).  The
+        # ``from_dict`` factory accepts both shapes so old data
+        # round-trips without crashing.
+        instance = InfectionCondition(severity=3)
+        organ = Organ.from_dict({
+            "name": "heart",
+            "current_hp": 10, "max_hp": 15,
+            "conditions": [instance],  # legacy pickled instance
+            "wound_stage": None,
+            "injury_type": None,
+            "wound_timestamp": None,
+        })
+        self.assertEqual(len(organ.conditions), 1)
+        self.assertIs(organ.conditions[0], instance)
+
+    def test_invalid_entries_skipped(self):
+        # Defensive: malformed entries don't break the restore.
+        organ = Organ.from_dict({
+            "name": "heart",
+            "current_hp": 10, "max_hp": 15,
+            "conditions": ["not a condition", 42, None],
+            "wound_stage": None,
+            "injury_type": None,
+            "wound_timestamp": None,
+        })
+        self.assertEqual(organ.conditions, [])
+
+
+# ---------------------------------------------------------------------
+# Body-bound conditions do NOT migrate onto organs at serialization
+# ---------------------------------------------------------------------
+
+
+class BodyBoundStaysOnBody(TestCase):
+    """Negative control — confirms the cyberware swap semantics from
+    the #307 PR.  A chest infection on the body is in
+    ``MedicalState.conditions``, not ``Organ.conditions``; it must
+    not leak into an organ's serialized list during snapshot.
+    """
+
+    def test_body_bound_chest_infection_not_in_heart_snapshot(self):
+        state = MedicalState(_human_character())
+        state.conditions.append(
+            InfectionCondition(severity=5, location="chest")
+        )
+        heart = state.organs["heart"]
+        snap = heart.to_dict()
+        self.assertEqual(snap["conditions"], [])
+
+    def test_body_bound_stays_on_state_round_trip(self):
+        state = MedicalState(_human_character())
+        state.conditions.append(
+            InfectionCondition(severity=5, location="chest")
+        )
+        snap = state.to_dict()
+        restored = MedicalState.from_dict(snap)
+        # Body-wide list preserves the condition.
+        self.assertEqual(len(restored.conditions), 1)
+        # Organ-bound list on the heart stays empty.
+        self.assertEqual(restored.organs["heart"].conditions, [])
+
+
+# ---------------------------------------------------------------------
+# Harvest pipeline preserves organ-bound conditions
+# ---------------------------------------------------------------------
+
+
+class _FakeCorpse:
+    """Minimal corpse stub for ``Organ.configure_from_harvest``.
+
+    Carries a medical snapshot with organ-bound conditions on the
+    targeted organ.  Identity / decay fields are stubbed enough that
+    the configure call doesn't crash.
+    """
+
+    def __init__(self, organ_name, organ_conditions=None,
+                 species="human"):
+        snapshot = {
+            "organs": {
+                organ_name: {
+                    "container": "chest",
+                    "display_location": "chest",
+                    "conditions": list(organ_conditions or []),
+                },
+            },
+        }
+        self.db = SimpleNamespace(
+            signature_at_death=None,
+            apparent_uid_at_death=None,
+            species=species,
+            medical_state_at_death=snapshot,
+        )
+        self.dbref = "#testcorpse"
+
+    def get_medical_snapshot(self):
+        return self.db.medical_state_at_death
+
+    def get_decay_stage(self):
+        return "fresh"
+
+
+class HarvestPipelinePreservesOrganConditions(TestCase):
+    """``Organ.configure_from_harvest`` on the harvested-item Organ
+    typeclass pulls the source organ's conditions from the corpse
+    snapshot and stores them on the item's db for future install
+    integration (Phase 3.2 cybernetics)."""
+
+    def _make_harvested_item(self):
+        # Avoid the full Evennia typeclass dance for a unit test —
+        # exercise ``configure_from_harvest`` directly against a
+        # plain-Python stub that mimics the db namespace it touches.
+        from typeclasses.items import Organ as HarvestedOrgan
+
+        class _ItemStub:
+            db = SimpleNamespace()
+            key = ""
+
+        stub = _ItemStub()
+        # Bind the unbound method so it runs against our stub.
+        stub.configure_from_harvest = (
+            HarvestedOrgan.configure_from_harvest.__get__(stub)
+        )
+        return stub
+
+    def test_organ_bound_conditions_copied_to_harvested_item(self):
+        condition_dict = InfectionCondition(severity=4).to_dict()
+        corpse = _FakeCorpse(
+            organ_name="heart",
+            organ_conditions=[condition_dict],
+        )
+        item = self._make_harvested_item()
+        item.configure_from_harvest(
+            organ_name="heart",
+            condition="pristine",
+            corpse=corpse,
+        )
+        self.assertEqual(len(item.db.organ_conditions), 1)
+        # Serialized form preserved verbatim — install pipeline
+        # (Phase 3.2) will reconstruct condition objects from these
+        # dicts via ``deserialize_condition``.
+        self.assertEqual(
+            item.db.organ_conditions[0]["condition_type"], "infection",
+        )
+
+    def test_no_conditions_on_organ_yields_empty_list(self):
+        corpse = _FakeCorpse(organ_name="heart", organ_conditions=[])
+        item = self._make_harvested_item()
+        item.configure_from_harvest(
+            organ_name="heart",
+            condition="pristine",
+            corpse=corpse,
+        )
+        self.assertEqual(item.db.organ_conditions, [])
+
+    def test_missing_snapshot_handled_gracefully(self):
+        # Corpse with no ``get_medical_snapshot`` (test stubs that
+        # predate the snapshot layer).  Defensive empty list.
+        class _BareCorpse:
+            db = SimpleNamespace(
+                signature_at_death=None,
+                apparent_uid_at_death=None,
+                species="human",
+            )
+            dbref = "#bare"
+
+            def get_decay_stage(self):
+                return "fresh"
+
+        item = self._make_harvested_item()
+        item.configure_from_harvest(
+            organ_name="heart",
+            condition="pristine",
+            corpse=_BareCorpse(),
+        )
+        self.assertEqual(item.db.organ_conditions, [])
+
+
+# ---------------------------------------------------------------------
+# Factory dispatch
+# ---------------------------------------------------------------------
+
+
+class DeserializeConditionFactory(TestCase):
+
+    def test_infection_dispatches_correctly(self):
+        original = InfectionCondition(severity=5, location="chest")
+        snap = original.to_dict()
+        restored = deserialize_condition(snap)
+        self.assertIsInstance(restored, InfectionCondition)
+        self.assertEqual(restored.severity, 5)
+        self.assertEqual(restored.location, "chest")
+
+    def test_unknown_type_falls_through_to_base(self):
+        restored = deserialize_condition({
+            "condition_type": "future_condition_not_yet_classed",
+            "severity": 7,
+        })
+        self.assertIsInstance(restored, MedicalCondition)
+        self.assertEqual(restored.severity, 7)


### PR DESCRIPTION
## Summary

Adds the third tier of the three-tier condition model agreed in design:

1. Body-bound — no location; whole body (sepsis, blood loss). Stays on body across organ swap.
2. Location-bound — location set; affects organs at that container/display_location (chest-wall abscess). Stays on body.
3. **Organ-bound — lives on ``Organ.conditions``; affects this organ specifically (endocarditis, kidney stones). Travels with the organ through harvest / install.**

Tier 1 + 2 shipped in the base #307 PR; this adds tier 3.

### Scan extension

``Organ._iter_relevant_conditions`` yields from both ``medical_state.conditions`` (location-filtered) and ``self.conditions`` (no filter). Modifiers compound multiplicatively across all relevant conditions.

### Persistence

``Organ.to_dict`` serializes conditions via each ``condition.to_dict()`` so data round-trips as dicts. ``Organ.from_dict`` accepts both dict (post-#307) and legacy pickled-instance (pre-#307) shapes. New ``deserialize_condition`` factory in ``conditions.py`` centralises the dispatch — used by both organ and state restoration.

### Latent bug fix

``InfectionCondition.from_dict`` and ``PainCondition.from_dict`` didn't override the base — they inherited a signature that passed ``condition_type`` as the first positional arg, breaking deserialization for those subclasses. Adds proper overrides matching the ``BleedingCondition`` pattern.

### Harvest pipeline

``typeclasses.items.Organ.configure_from_harvest`` copies the source organ's conditions from the corpse snapshot onto ``self.db.organ_conditions`` on the harvested item. Body-bound and location-bound conditions stay on the corpse; only organ-bound state travels. Serialized-dict form is what the future install pipeline (Phase 3.2 cybernetics in the spec) consumes to re-attach to a recipient's organ slot.

### Out of scope

Per design discussion — option (a). The actual organ-bound condition **subclasses** (Endocarditis / KidneyStones / Tumor / etc.) are deferred until the design discussion on infection types and treatment correlation matures.

## Test plan

- [x] ``world.tests.test_organ_bound_conditions`` — 16/16 pass (scan picks up organ-bound, tiers compound, serialization round-trip with both dict and legacy shapes, body-bound doesn't migrate onto organs, harvest pipeline preserves organ.conditions onto item, factory dispatch)
- [x] Full suite: 1800/1800 pass

Refs #307.