### PR TITLE
Surgical procedure verbs: incise / harvest / install / suture (#307)

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -311,77 +311,110 @@ class CmdInject(ConsumptionCommand):
 class CmdApply(ConsumptionCommand):
     """
     Apply a medical treatment to yourself or another character.
-    
+
     Usage:
-        apply <item>
-        apply <item> <target>
-        apply <item> to <target>
-        
+        apply <item> on <target>
+        apply <item> on <target>'s <location>
+        apply <item> on <target>'s <organ>
+
     Examples:
-        apply burn gel
-        apply antiseptic to Alice
-        apply surgical kit to Bob
-        apply splint to Charlie
-        
-    Applicable items include burn gel, antiseptic, healing salves, surgical
-    kits, splints, and other medical treatments. Takes time to apply properly.
-    Surgery requires high medical skill (Intellect 3+).
+        apply burn gel on Alice
+        apply bandage on bob's chest
+        apply antibiotic on bob's heart      (needs open chest incision)
+        apply splint on charlie's left arm
+
+    Surface treatments (bandages, salves, antiseptics on skin) work
+    on any external location.  Deep treatments targeting internal
+    organs (heart, lungs, liver, etc.) require an open incision at
+    the organ's container — see ``incise``.
+
+    For actual surgical procedures (opening, harvesting organs,
+    installing organs, closing) see ``help procedures``.
+
+    Related:  incise, harvest, install, suture, inject, spray.
     """
-    
+
     key = "apply"
-    aliases = ["rub", "spread", "operate", "surgery"]
+    aliases = ["rub", "spread"]
     help_category = "Medical"
-    
+
     def func(self):
         """Execute the apply command."""
         caller = self.caller
-        
-        # Handle special surgery/operate aliases that auto-find surgical kits
-        if self.cmdstring.lower() in ["surgery", "operate"]:
-            # Look for surgical kit in caller's inventory
-            surgical_kits = [obj for obj in caller.contents 
-                           if hasattr(obj, 'attributes') and 
-                           obj.attributes.get('medical_type') == 'surgical_treatment']
-            
-            if not surgical_kits:
-                caller.msg("You don't have a surgical kit to perform surgery.")
-                return
-                
-            # Use the first surgical kit found
-            surgical_kit = surgical_kits[0]
-            
-            # Parse target (surgery/operate only takes target, no item name needed)
-            if not self.args.strip():
-                caller.msg("Surgery on whom? Usage: surgery <target>")
-                return
-                
-            # Get target via identity pipeline (allow self via me/self/myself).
-            target_name = self.args.strip()
-            if target_name.lower() in ("me", "myself", "self"):
-                target = caller
-            else:
-                target = resolve_character_target(caller, target_name)
-            if not target:
-                caller.msg(f"Cannot find '{target_name}'.")
-                return
-                
-            item = surgical_kit
-            is_self = (caller == target)
+
+        # Normalize "apply X to Y" → "apply X on Y" so both prepositions
+        # work.  The location-precision parser below splits on "on" or
+        # the possessive.
+        raw = (self.args or "").replace(" to ", " on ")
+
+        # Parse "<item> on <target>" / "<item> on <target>'s <location>"
+        # via a quick precision-aware split before falling through to
+        # the legacy item/target resolver.
+        location: str | None = None
+        if " on " in raw:
+            item_phrase, _, target_phrase = raw.partition(" on ")
+            target_phrase = target_phrase.strip()
+            if "'s " in target_phrase:
+                tname, _, location = target_phrase.partition("'s ")
+                target_phrase = tname.strip()
+                location = location.strip().replace(" ", "_")
+            args = f"{item_phrase.strip()} {target_phrase}"
         else:
-            # Handle normal "apply item to target" syntax
-            args = self.args.replace(" to ", " ")
-            
-            # Parse arguments
-            result = self.get_item_and_target(args)
-            if result["errors"]:
-                caller.msg(result["errors"][0])
+            args = raw
+
+        # Hand off to the legacy item/target parser.
+        result = self.get_item_and_target(args)
+        if result["errors"]:
+            caller.msg(result["errors"][0])
+            return
+
+        item, target = result["item"], result["target"]
+        is_self = (caller == target)
+
+        # Location precision: if the player named a specific organ or
+        # internal container, gate it behind the incision requirement.
+        if location:
+            from world.medical.procedures import (
+                INTERNAL_CONTAINERS,
+                has_incision,
+                organs_at_location,
+            )
+
+            # Resolve "location" — could be a body container OR an
+            # organ name.  If it's an organ, look up its container.
+            container = location
+            try:
+                state = target.medical_state
+            except AttributeError:
+                state = None
+            if state is not None and hasattr(state, "organs"):
+                organ = state.organs.get(location)
+                if organ is not None:
+                    container = organ.container
+
+            if container in INTERNAL_CONTAINERS and not has_incision(target, container):
+                caller.msg(
+                    f"You can't reach {target.get_display_name(caller)}'s "
+                    f"{location.replace('_', ' ')} — "
+                    f"{container.replace('_', ' ')} isn't open. "
+                    f"Try ``incise {target.get_display_name(caller)} "
+                    f"at {container.replace('_', ' ')}`` first."
+                )
                 return
-                
-            item, target = result["item"], result["target"]
-            is_self = (caller == target)
+
+            # Surface location with no organs at all → no target.
+            if not organs_at_location(target, container) and container == location:
+                caller.msg(
+                    f"There's nothing at {location.replace('_', ' ')} on "
+                    f"{target.get_display_name(caller)} to treat."
+                )
+                return
         
-        # Check if item can be applied (topically, surgically, or orthopedically)
-        applicable_types = ["burn_treatment", "antiseptic", "healing_salve", "wound_care", "surgical_treatment", "fracture_treatment"]
+        # Check if item can be applied topically or orthopedically.
+        # Surgical kits are NOT applicable — they're tools for the
+        # procedure verbs (incise / harvest / install / suture).
+        # See ``help procedures``.
+        applicable_types = ["burn_treatment", "antiseptic", "healing_salve", "wound_care", "fracture_treatment"]
         medical_type = get_medical_type(item)
         if medical_type not in applicable_types:
             caller.msg(f"{item.get_display_name(caller)} cannot be applied.")

--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -1,0 +1,521 @@
+"""Surgical procedure commands (#307 follow-up).
+
+Four verbs forming the canonical procedure loop:
+
+* ``incise <target> at <location>`` — open
+* ``harvest <organ> from <target>`` — extract
+* ``install <organ> in <target>`` — implant
+* ``suture <target>`` — close (alias: ``stitch``)
+
+All four route through :mod:`world.medical.procedures`.  Commands
+are thin: argument parsing, target / item resolution, validation
+(surgical kit, incision requirement, anesthesia hint), then
+``start_procedure`` schedules the delayed resolver.
+
+Surface treatments (bandages on skin, drugs into bloodstream)
+remain on ``apply`` / ``inject`` / ``spray`` — see
+:class:`commands.CmdConsumption.CmdApply` for the location-precision
+upgrade.
+"""
+
+from __future__ import annotations
+
+from evennia import Command
+
+from world.medical.procedures import (
+    INTERNAL_CONTAINERS,
+    PROCEDURE_DURATIONS,
+    get_organ_snapshot,
+    has_incision,
+    is_procedure_active,
+    open_incision_locations,
+    organs_at_location,
+    start_procedure,
+)
+
+
+# ---------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------
+
+
+def _find_surgical_kit(caller):
+    """Return the first surgical kit in ``caller``'s inventory, or None."""
+    for obj in caller.contents:
+        attrs = getattr(obj, "attributes", None)
+        if attrs is None:
+            continue
+        if attrs.get("medical_type") == "surgical_treatment":
+            return obj
+    return None
+
+
+def _resolve_target(caller, raw_name):
+    """Search the caller's location for a procedure target.
+
+    Returns the matched object or ``None`` (search() already
+    messages on ambiguity / not-found).
+    """
+    if raw_name.lower() in ("me", "self", "myself"):
+        return caller
+    return caller.search(raw_name, location=caller.location)
+
+
+def _is_body_container(target) -> bool:
+    """True when ``target`` exposes an organ snapshot."""
+    return bool(get_organ_snapshot(target))
+
+
+def _parse_target_with_location(args: str):
+    """Parse ``"<target>'s <location>"`` or ``"<target> at <location>"``.
+
+    Returns ``(target_phrase, location)`` with location normalised to
+    its canonical underscore form, or ``(args, None)`` when no
+    location qualifier is present.
+    """
+    args = args.strip()
+    if "'s " in args:
+        before, _, after = args.partition("'s ")
+        return before.strip(), after.strip().replace(" ", "_")
+    if " at " in args:
+        before, _, after = args.partition(" at ")
+        return before.strip(), after.strip().replace(" ", "_")
+    return args, None
+
+
+def _reject_if_busy(caller, target) -> bool:
+    """True (and message-sent) when the target already has an active
+    procedure that hasn't resolved yet."""
+    if is_procedure_active(target):
+        caller.msg(
+            f"{target.get_display_name(caller)} is already partway "
+            f"through a procedure. Wait for it to resolve or "
+            f"interrupt them."
+        )
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------
+# CmdIncise — open
+# ---------------------------------------------------------------------
+
+
+class CmdIncise(Command):
+    """Open an incision at a body location.
+
+    Usage:
+        incise <target> at <location>
+
+    Examples:
+        incise bob at chest
+        incise the corpse at abdomen
+        incise a severed left arm at left arm
+
+    Required for deep procedures (harvest, install, applying
+    treatments to internal organs).  Surface locations (limbs) and
+    surface treatments (bandages on skin) don't need this.
+
+    Requires a surgical kit in your inventory.  Conscious patients
+    add difficulty and accumulate pain; unconscious / anesthetized
+    patients are easier to work on.
+
+    Related:  harvest, install, suture, apply.
+    """
+
+    key = "incise"
+    aliases = ()
+    help_category = "Medical"
+
+    def func(self):
+        caller = self.caller
+        raw = (self.args or "").strip()
+        if not raw:
+            caller.msg("Usage: incise <target> at <location>")
+            return
+
+        target_phrase, location = _parse_target_with_location(raw)
+        if location is None:
+            caller.msg(
+                "Where do you want to make the incision? "
+                "Usage: incise <target> at <location>"
+            )
+            return
+
+        target = _resolve_target(caller, target_phrase)
+        if target is None:
+            return  # search() messaged
+
+        if not _is_body_container(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} isn't something "
+                f"you can perform surgery on."
+            )
+            return
+
+        if not organs_at_location(target, location):
+            caller.msg(
+                f"There's nothing at {location.replace('_', ' ')} on "
+                f"{target.get_display_name(caller)} to incise."
+            )
+            return
+
+        if has_incision(target, location):
+            caller.msg(
+                f"{target.get_display_name(caller)}'s "
+                f"{location.replace('_', ' ')} is already open."
+            )
+            return
+
+        if _reject_if_busy(caller, target):
+            return
+
+        kit = _find_surgical_kit(caller)
+        if kit is None:
+            caller.msg("You need a surgical kit to perform an incision.")
+            return
+
+        # Stage the procedure — delay-resolved in
+        # ``world.medical.procedures._resolve_incise``.
+        start_procedure(
+            target, verb="incise", actor=caller,
+            location=location,
+        )
+        duration = PROCEDURE_DURATIONS["incise"]
+        caller.msg(
+            f"You begin cutting into {target.get_display_name(caller)}'s "
+            f"{location.replace('_', ' ')}... ({duration}s)"
+        )
+
+
+# ---------------------------------------------------------------------
+# CmdHarvest — extract
+# ---------------------------------------------------------------------
+
+
+class CmdHarvest(Command):
+    """Extract an organ from a body container.
+
+    Usage:
+        harvest <organ> from <target>
+        harvest <target>        (lists harvestable organs)
+
+    Works on:
+        * Corpses
+        * Severed heads and limbs (each is an organ container)
+        * Unconscious living characters
+        * Conscious living characters (harder, more painful, organ
+          may come out damaged — anesthetize them first via
+          inject/apply)
+
+    Requires an open incision at the organ's container.  Use
+    ``incise`` first.  Surface anatomy (limbs) doesn't need
+    incision; internal containers (head, chest, abdomen, back,
+    neck, groin) do.
+
+    Related:  incise, install, suture.
+    """
+
+    key = "harvest"
+    aliases = ()
+    help_category = "Medical"
+
+    def func(self):  # noqa: C901
+        caller = self.caller
+        raw = (self.args or "").strip()
+        if not raw:
+            caller.msg("Usage: harvest <organ> from <target>")
+            return
+
+        # Two forms: with " from " (do the harvest), without (list).
+        if " from " in raw:
+            organ_arg, _, target_phrase = raw.partition(" from ")
+            organ_arg = organ_arg.strip().lower().replace(" ", "_")
+        else:
+            organ_arg = ""
+            target_phrase = raw
+
+        target = _resolve_target(caller, target_phrase)
+        if target is None:
+            return
+
+        if not _is_body_container(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} isn't something "
+                f"you can harvest from."
+            )
+            return
+
+        snapshot = get_organ_snapshot(target)
+        organs = snapshot.get("organs") or {}
+
+        # Build the harvestable set with the species-aware filter the
+        # legacy CmdHarvest used on corpses — checks ``can_be_harvested``
+        # against the proper organ spec, drops removed organs, drops
+        # organs whose container has been severed off (the heart in
+        # an arm-severed body is fine; in a torso-severed body it
+        # left with the torso), and drops destroyed organs.
+        from world.anatomy import get_organ_spec
+        species = getattr(getattr(target, "db", None), "species", None)
+        removed = set(getattr(target.db, "removed_organs", None) or [])
+        severed_locs = set(
+            getattr(target.db, "severed_locations", None) or []
+        )
+        harvestable = []
+        for name, data in organs.items():
+            if not isinstance(data, dict):
+                continue
+            spec = get_organ_spec(name, species) or {}
+            if not spec.get("can_be_harvested"):
+                continue
+            if name in removed:
+                continue
+            if data.get("container") in severed_locs:
+                continue
+            if data.get("current_hp", 0) <= 0:
+                continue
+            harvestable.append(name)
+        harvestable.sort()
+
+        if not organ_arg:
+            if not harvestable:
+                caller.msg(
+                    f"There are no harvestable organs in "
+                    f"{target.get_display_name(caller)}."
+                )
+                return
+            readable = ", ".join(o.replace("_", " ") for o in harvestable)
+            caller.msg(
+                f"Harvestable organs in {target.get_display_name(caller)}: "
+                f"{readable}.\nUsage: harvest <organ> from <target>"
+            )
+            return
+
+        if organ_arg not in organs:
+            caller.msg(
+                f"There is no {organ_arg.replace('_', ' ')} in "
+                f"{target.get_display_name(caller)}."
+            )
+            return
+
+        if organ_arg not in harvestable:
+            caller.msg(
+                f"The {organ_arg.replace('_', ' ')} in "
+                f"{target.get_display_name(caller)} cannot be harvested "
+                f"(already removed, destroyed, or not extractable)."
+            )
+            return
+
+        organ_data = organs[organ_arg]
+        container = organ_data.get("container")
+
+        # Incision requirement for internal containers.
+        if container in INTERNAL_CONTAINERS and not has_incision(target, container):
+            caller.msg(
+                f"You can't reach the {organ_arg.replace('_', ' ')} — "
+                f"{container.replace('_', ' ')} isn't open. "
+                f"Try ``incise {target_phrase} at {container.replace('_', ' ')}``."
+            )
+            return
+
+        if _reject_if_busy(caller, target):
+            return
+
+        kit = _find_surgical_kit(caller)
+        if kit is None:
+            caller.msg("You need a surgical kit to harvest an organ.")
+            return
+
+        start_procedure(
+            target, verb="harvest", actor=caller,
+            organ_name=organ_arg, location=container or "",
+        )
+        duration = PROCEDURE_DURATIONS["harvest"]
+        caller.msg(
+            f"You begin extracting the {organ_arg.replace('_', ' ')} "
+            f"from {target.get_display_name(caller)}... ({duration}s)"
+        )
+
+
+# ---------------------------------------------------------------------
+# CmdInstall — implant
+# ---------------------------------------------------------------------
+
+
+class CmdInstall(Command):
+    """Install a harvested organ into a patient.
+
+    Usage:
+        install <organ> in <target>
+
+    Examples:
+        install heart in bob
+        install left kidney in the corpse
+
+    Requires the named organ in your inventory and an open incision
+    at the appropriate body container on the target.  Use ``incise``
+    first.  The harvested organ's condition and any organ-bound
+    medical conditions (e.g. endocarditis from a previous host) travel
+    with the install — a putrid heart that's been infected installs
+    that way.
+
+    Related:  incise, harvest, suture.
+    """
+
+    key = "install"
+    aliases = ()
+    help_category = "Medical"
+
+    def func(self):  # noqa: C901
+        caller = self.caller
+        raw = (self.args or "").strip()
+        if " in " not in raw:
+            caller.msg("Usage: install <organ> in <target>")
+            return
+
+        item_phrase, _, target_phrase = raw.partition(" in ")
+        item_phrase = item_phrase.strip()
+        target_phrase = target_phrase.strip()
+
+        organ_item = caller.search(item_phrase, location=caller)
+        if organ_item is None:
+            return
+
+        organ_name = getattr(organ_item.db, "organ_name", None)
+        if not organ_name:
+            caller.msg(
+                f"{organ_item.get_display_name(caller)} isn't a "
+                f"harvested organ you can install."
+            )
+            return
+
+        target = _resolve_target(caller, target_phrase)
+        if target is None:
+            return
+
+        if not _is_body_container(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} isn't something "
+                f"you can install an organ into."
+            )
+            return
+
+        # Find the target organ slot and its container.
+        snapshot = get_organ_snapshot(target)
+        target_organ_data = (snapshot.get("organs") or {}).get(organ_name)
+        if target_organ_data is None:
+            caller.msg(
+                f"{target.get_display_name(caller)} has no slot for a "
+                f"{organ_name.replace('_', ' ')}."
+            )
+            return
+
+        container = target_organ_data.get("container")
+
+        if container in INTERNAL_CONTAINERS and not has_incision(target, container):
+            caller.msg(
+                f"You can't reach the {organ_name.replace('_', ' ')} "
+                f"slot — {container.replace('_', ' ')} isn't open. "
+                f"Try ``incise {target_phrase} at {container.replace('_', ' ')}``."
+            )
+            return
+
+        if _reject_if_busy(caller, target):
+            return
+
+        kit = _find_surgical_kit(caller)
+        if kit is None:
+            caller.msg("You need a surgical kit to install an organ.")
+            return
+
+        start_procedure(
+            target, verb="install", actor=caller,
+            organ_item=organ_item, location=container or "",
+        )
+        duration = PROCEDURE_DURATIONS["install"]
+        caller.msg(
+            f"You begin installing the {organ_item.key} into "
+            f"{target.get_display_name(caller)}... ({duration}s)"
+        )
+
+
+# ---------------------------------------------------------------------
+# CmdSuture — close
+# ---------------------------------------------------------------------
+
+
+class CmdSuture(Command):
+    """Close an open incision on a patient.
+
+    Usage:
+        suture <target>             (closes all open incisions)
+        suture <target>'s <location> (closes one specific incision)
+
+    Aliases:
+        stitch
+
+    Closes the wound created by ``incise``.  Leaving incisions open
+    is bad for the patient — they bleed and risk infection.  A botched
+    close seeds infection; a partial close holds but reads rough.
+
+    Related:  incise, harvest, install.
+    """
+
+    key = "suture"
+    aliases = ("stitch",)
+    help_category = "Medical"
+
+    def func(self):
+        caller = self.caller
+        raw = (self.args or "").strip()
+        if not raw:
+            caller.msg(
+                "Usage: suture <target>  (or)  "
+                "suture <target>'s <location>"
+            )
+            return
+
+        target_phrase, location = _parse_target_with_location(raw)
+        target = _resolve_target(caller, target_phrase)
+        if target is None:
+            return
+
+        if not _is_body_container(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} isn't something "
+                f"you can suture."
+            )
+            return
+
+        open_locs = open_incision_locations(target)
+        if not open_locs:
+            caller.msg(
+                f"{target.get_display_name(caller)} has no open "
+                f"incisions to close."
+            )
+            return
+
+        if location is not None and location not in open_locs:
+            caller.msg(
+                f"{target.get_display_name(caller)}'s "
+                f"{location.replace('_', ' ')} isn't incised."
+            )
+            return
+
+        if _reject_if_busy(caller, target):
+            return
+
+        kit = _find_surgical_kit(caller)
+        if kit is None:
+            caller.msg("You need a surgical kit to suture an incision.")
+            return
+
+        start_procedure(
+            target, verb="suture", actor=caller,
+            location=location,
+        )
+        duration = PROCEDURE_DURATIONS["suture"]
+        caller.msg(
+            f"You begin suturing "
+            f"{target.get_display_name(caller)}'s wound... ({duration}s)"
+        )

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -39,7 +39,8 @@ from commands.CmdGraffiti import CmdGraffiti, CmdPress
 from commands.CmdCharacter import CmdDescribe, CmdSkintone
 from commands.CmdCharacter import CmdRemember, CmdForget, CmdRecall, CmdMemory
 from commands.CmdCommunication import CmdSay, CmdWhisper, CmdEmote, CmdDotPose
-from commands.forensics import CmdAutopsy, CmdHarvest, CmdSever
+from commands.forensics import CmdAutopsy, CmdSever
+from commands import CmdSurgical
 from world.emote_templates import SOCIAL_COMMANDS
 from commands.CmdArmor import CmdArmor, CmdArmorRepair, CmdSlot, CmdUnslot
 from commands.shop import CmdBuy
@@ -251,8 +252,17 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
 
         # Add forensic command surfaces (PR-E)
         self.add(CmdAutopsy())
-        self.add(CmdHarvest())
         self.add(CmdSever())
+
+        # Surgical procedure commands (#307 follow-up).
+        # Replaces the legacy ``surgery`` / ``operate`` aliases with
+        # the procedural verb set: incise → harvest / install →
+        # suture.  ``apply`` is now location-precision aware for
+        # deep treatments.  See ``help procedures``.
+        self.add(CmdSurgical.CmdIncise())
+        self.add(CmdSurgical.CmdHarvest())
+        self.add(CmdSurgical.CmdInstall())
+        self.add(CmdSurgical.CmdSuture())
 
 class AccountCmdSet(default_cmds.AccountCmdSet):
     """

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -1,0 +1,837 @@
+"""Surgical procedure pipeline (#307 follow-up).
+
+Centralises the engine that backs ``incise`` / ``harvest`` / ``install`` /
+``suture`` and the location-aware ``apply`` upgrades.  Commands are
+thin wrappers; the heavy lifting (target accessor, state mutations,
+skill rolls, time delays, failure consequences) lives here.
+
+Design contract
+================
+
+* **Procedures act on bodies and body-derived containers.**  Living
+  characters, corpses, severed heads, and severed limbs all expose an
+  organ snapshot via :func:`get_organ_snapshot`.  Same dispatch path
+  for every target type.
+* **Two-phase resolution.**  Each verb opens a procedure: the
+  attempt is staged on ``target.db.surgical_state["active_procedure"]``
+  with a delay duration; resolution fires when the delay elapses,
+  rolling skill and applying outcome.  Interruptions during the
+  window route through :func:`interrupt_procedure`.
+* **Anesthesia is condition-driven, not a verb.**  Unconscious
+  patients (via ``character.is_unconscious()`` or absence of an
+  account on a sedated target) get bonuses and skip pain seeding.
+  Conscious patients add a difficulty modifier and accumulate pain
+  while procedures run on them.
+* **Failure modes are placeholders** (#307 design pass):
+  - Botched incise → mild organ damage at the cut location.
+  - Botched harvest → organ comes out one condition worse.
+  - Botched install → organ doesn't take, infection seeded.
+  - Botched treat / suture → infection seeded at location.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Optional
+
+from evennia.utils import delay as evennia_delay
+
+# ---------------------------------------------------------------------
+# Constants — placeholders subject to balance pass (#307)
+# ---------------------------------------------------------------------
+
+#: Base difficulty for procedure rolls (spec line 704 / 1466 reference).
+PROCEDURE_BASE_DIFFICULTY = 12
+
+#: Difficulty bump for operating on a conscious patient (no anesthesia).
+CONSCIOUS_PATIENT_DIFFICULTY = 5
+
+#: Difficulty discount for operating on an unconscious / anesthetised
+#: patient — they don't resist and the surgeon can work with full focus.
+ANESTHETIZED_DIFFICULTY_BONUS = 3
+
+#: Tick durations (in seconds) per verb.  Short enough to feel
+#: interactive; long enough that mid-combat surgery is genuinely
+#: tense.  Balance numbers — adjust freely.
+PROCEDURE_DURATIONS = {
+    "incise": 6,
+    "harvest": 18,
+    "install": 18,
+    "suture": 9,
+}
+
+#: Pain severity seeded on a conscious patient when a procedure
+#: completes on them (per verb).  Unconscious patients skip this.
+CONSCIOUS_PAIN_SEVERITY = {
+    "incise": 3,
+    "harvest": 5,
+    "install": 4,
+    "suture": 2,
+}
+
+#: Infection severity seeded as a failure consequence.  Caller passes
+#: the body location; the resulting condition is location-bound.
+FAILURE_INFECTION_SEVERITY = 2
+
+#: Internal body containers that require an open incision before a
+#: deep procedure (harvest / install / treat) can target an organ
+#: housed there.  Limb containers are externally accessible and
+#: skip the requirement.
+INTERNAL_CONTAINERS = frozenset({
+    "head", "chest", "abdomen", "back", "neck", "groin",
+})
+
+
+# ---------------------------------------------------------------------
+# Target accessor — works on every container type
+# ---------------------------------------------------------------------
+
+
+def get_organ_snapshot(target) -> dict:
+    """Return the organ snapshot for any procedure target.
+
+    Unifies the four supported target types behind one accessor so the
+    dispatch never branches on ``isinstance``:
+
+    * **Living character** → reads from ``target.medical_state`` (live
+      ``Organ`` objects).
+    * **Corpse / SeveredHead / Appendage** → reads from
+      ``target.get_medical_snapshot()`` (death-time dict snapshot).
+
+    Returns an empty dict when no snapshot is available (target
+    predates the medical pipeline or isn't a body container).
+    """
+    # Living: medical_state attribute with live organs.
+    medical_state = getattr(target, "medical_state", None)
+    if medical_state is not None and hasattr(medical_state, "organs"):
+        return {
+            "organs": {
+                name: organ.to_dict()
+                for name, organ in medical_state.organs.items()
+            },
+        }
+
+    # Item / corpse: get_medical_snapshot() returns the snapshot dict.
+    accessor = getattr(target, "get_medical_snapshot", None)
+    if callable(accessor):
+        return accessor() or {}
+
+    return {}
+
+
+def organs_at_location(target, location: str) -> list[tuple[str, dict]]:
+    """Return ``(organ_name, organ_data)`` pairs at ``location``.
+
+    Matches against either the organ's ``container`` or
+    ``display_location`` (the latter handles sensory organs like the
+    eyes that surface at a more specific render location than their
+    bulk container).
+    """
+    snapshot = get_organ_snapshot(target)
+    organs = snapshot.get("organs") or {}
+    out = []
+    for name, data in organs.items():
+        if not isinstance(data, dict):
+            continue
+        container = data.get("container")
+        display = data.get("display_location")
+        if location in (container, display):
+            out.append((name, data))
+    return out
+
+
+# ---------------------------------------------------------------------
+# Surgical state on the target
+# ---------------------------------------------------------------------
+
+
+def _state(target) -> dict:
+    """Lazy-init and return ``target.db.surgical_state``."""
+    if target.db.surgical_state is None:
+        target.db.surgical_state = {
+            "incisions": {},
+            "active_procedure": None,
+        }
+    return target.db.surgical_state
+
+
+def has_incision(target, location: str) -> bool:
+    """True when ``location`` is currently incised on ``target``."""
+    state = _state(target)
+    return location in state["incisions"]
+
+
+def open_incision(target, location: str, surgeon, tool=None) -> None:
+    """Record a new incision at ``location``.
+
+    Multiple simultaneous incisions are allowed — useful for
+    thoracoabdominal procedures and other multi-cavity work.
+    """
+    state = _state(target)
+    state["incisions"][location] = {
+        "opened_at": time.time(),
+        "opened_by": getattr(surgeon, "dbref", None),
+        "tool": getattr(tool, "dbref", None),
+    }
+    # Persist back so AttributeProperty fires.
+    target.db.surgical_state = state
+
+
+def close_incision(target, location: str) -> bool:
+    """Remove an incision at ``location``.  Returns True if one was
+    actually closed, False if no incision existed there.
+    """
+    state = _state(target)
+    if location not in state["incisions"]:
+        return False
+    del state["incisions"][location]
+    target.db.surgical_state = state
+    return True
+
+
+def close_all_incisions(target) -> list[str]:
+    """Close every open incision; return the list of closed locations."""
+    state = _state(target)
+    closed = list(state["incisions"].keys())
+    state["incisions"] = {}
+    target.db.surgical_state = state
+    return closed
+
+
+def open_incision_locations(target) -> list[str]:
+    """Return the locations currently incised on ``target``."""
+    return list(_state(target)["incisions"].keys())
+
+
+# ---------------------------------------------------------------------
+# Active procedure tracking (time delays)
+# ---------------------------------------------------------------------
+
+
+def is_procedure_active(target) -> bool:
+    """True when ``target`` has a procedure in-flight."""
+    state = _state(target)
+    return state.get("active_procedure") is not None
+
+
+def start_procedure(target, *, verb: str, actor, **kwargs) -> dict:
+    """Stage an active procedure on ``target``.
+
+    Schedules :func:`_resolve_procedure_callback` to fire after the
+    verb's duration via ``evennia.utils.delay``.  The actor / target
+    can still be interrupted in the meantime (combat damage,
+    physical separation, target dies); see
+    :func:`interrupt_procedure`.
+
+    Stores enough context on ``target.db.surgical_state`` that the
+    resolution callback can re-fetch the actor / tool / target_organ
+    without closures over Python objects that may not survive a
+    process restart.
+    """
+    duration = PROCEDURE_DURATIONS.get(verb, 6)
+    record = {
+        "verb": verb,
+        "actor_dbref": getattr(actor, "dbref", None),
+        "started_at": time.time(),
+        "duration_s": duration,
+        "kwargs": dict(kwargs),
+    }
+    state = _state(target)
+    state["active_procedure"] = record
+    target.db.surgical_state = state
+
+    evennia_delay(
+        duration,
+        _resolve_procedure_callback,
+        target,
+        persistent=False,
+    )
+    return record
+
+
+def interrupt_procedure(target, reason: str = "interrupted") -> Optional[dict]:
+    """Clear the active procedure without resolving it.
+
+    Used by combat / movement / death hooks.  Returns the cleared
+    record so callers can render an interruption message.
+    """
+    state = _state(target)
+    record = state.get("active_procedure")
+    state["active_procedure"] = None
+    target.db.surgical_state = state
+    return record
+
+
+def _resolve_procedure_callback(target) -> None:
+    """Fire when a staged procedure's delay elapses.
+
+    Re-reads the active procedure off ``target.db.surgical_state``,
+    confirms it's still valid (target alive enough / actor reachable),
+    and dispatches to the verb-specific resolver.  Resolution is
+    intentionally idempotent: if the active_procedure was cleared in
+    the meantime (interrupted, manually cancelled), we no-op.
+    """
+    state = _state(target)
+    record = state.get("active_procedure")
+    if record is None:
+        return  # interrupted / already resolved
+    # Clear the slot first so a resolver-triggered side effect can't
+    # re-enter.
+    state["active_procedure"] = None
+    target.db.surgical_state = state
+
+    from evennia.objects.models import ObjectDB
+    actor_dbref = record.get("actor_dbref")
+    if actor_dbref:
+        try:
+            actor = ObjectDB.objects.get(id=int(actor_dbref.lstrip("#")))
+        except (ObjectDB.DoesNotExist, ValueError):
+            actor = None
+    else:
+        actor = None
+
+    if actor is None:
+        # Actor has gone away (logged out, deleted).  Per design (E):
+        # leave the patient as-is; the incision stays open and bleeds.
+        return
+
+    verb = record["verb"]
+    kwargs = record.get("kwargs") or {}
+    resolver = _VERB_RESOLVERS.get(verb)
+    if resolver is None:
+        return
+    resolver(actor, target, **kwargs)
+
+
+# ---------------------------------------------------------------------
+# Skill rolls — spec line 1434
+# ---------------------------------------------------------------------
+
+
+def calculate_procedure_skill(actor) -> float:
+    """Return the actor's medical-procedure skill.
+
+    Per spec line 1434:
+    ``medical_effectiveness = (intellect * 0.75) + (motorics * 0.25)``
+    """
+    intellect = getattr(actor, "intellect", 1) or 1
+    motorics = getattr(actor, "motorics", 1) or 1
+    return (intellect * 0.75) + (motorics * 0.25)
+
+
+def calculate_procedure_difficulty(target, *, conscious_modifier: bool = True) -> int:
+    """Return the difficulty target for a procedure on ``target``.
+
+    ``conscious_modifier``: when True (default), apply the +5
+    difficulty for conscious unanesthetised patients and the −3
+    bonus for unconscious / anesthetized ones.  Corpses are treated
+    as unconscious (full bonus) since there's no resistance to deal
+    with.
+    """
+    difficulty = PROCEDURE_BASE_DIFFICULTY
+    if not conscious_modifier:
+        return difficulty
+
+    # Corpses: max bonus (no resistance).
+    from typeclasses.corpse import Corpse
+    if isinstance(target, Corpse):
+        return difficulty - ANESTHETIZED_DIFFICULTY_BONUS
+
+    # Severed items: same — no resistance.
+    try:
+        from typeclasses.items import Appendage, SeveredHead, Organ
+        if isinstance(target, (Appendage, SeveredHead, Organ)):
+            return difficulty - ANESTHETIZED_DIFFICULTY_BONUS
+    except ImportError:
+        pass
+
+    # Living character: depends on consciousness.
+    is_unconscious = False
+    checker = getattr(target, "is_unconscious", None)
+    if callable(checker):
+        try:
+            is_unconscious = bool(checker())
+        except Exception:
+            is_unconscious = False
+    if is_unconscious:
+        return difficulty - ANESTHETIZED_DIFFICULTY_BONUS
+    return difficulty + CONSCIOUS_PATIENT_DIFFICULTY
+
+
+def roll_procedure(actor, target, *, conscious_modifier: bool = True) -> dict:
+    """Roll a procedure check.
+
+    Returns a dict with ``roll``, ``skill``, ``total``, ``difficulty``,
+    ``outcome`` (``"success"`` / ``"partial"`` / ``"failure"``).  Uses
+    3d6 + skill vs difficulty matching the existing
+    ``calculate_treatment_success`` shape so existing UX prose
+    integrates cleanly.
+    """
+    skill = calculate_procedure_skill(actor)
+    difficulty = calculate_procedure_difficulty(
+        target, conscious_modifier=conscious_modifier,
+    )
+    roll = sum(random.randint(1, 6) for _ in range(3))
+    total = roll + skill
+
+    if total >= difficulty + 5:
+        outcome = "success"
+    elif total >= difficulty:
+        outcome = "partial"
+    else:
+        outcome = "failure"
+
+    return {
+        "roll": roll,
+        "skill": skill,
+        "total": total,
+        "difficulty": difficulty,
+        "outcome": outcome,
+    }
+
+
+# ---------------------------------------------------------------------
+# Failure-consequence helpers
+# ---------------------------------------------------------------------
+
+
+def seed_infection(target, location: str, severity: int = FAILURE_INFECTION_SEVERITY) -> None:
+    """Add a location-bound infection condition to ``target``.
+
+    Used as a placeholder failure consequence for botched procedures
+    (#307 design pass: refine when the deeper treatment mechanics
+    land).  Only applies to living targets that have a
+    ``medical_state.conditions`` list; corpses and severed items are
+    no-ops.
+    """
+    state = getattr(target, "medical_state", None)
+    if state is None or not hasattr(state, "conditions"):
+        return
+    try:
+        from world.medical.conditions import InfectionCondition
+    except ImportError:
+        return
+    state.conditions.append(InfectionCondition(severity, location))
+
+
+def seed_pain(target, location: Optional[str], severity: int) -> None:
+    """Add a pain condition to a conscious living target.
+
+    Skips the seed when the target is unconscious / anesthetized (no
+    pain perceived) or isn't a living character (no medical_state).
+    """
+    state = getattr(target, "medical_state", None)
+    if state is None or not hasattr(state, "conditions"):
+        return
+    is_unconscious = False
+    checker = getattr(target, "is_unconscious", None)
+    if callable(checker):
+        try:
+            is_unconscious = bool(checker())
+        except Exception:
+            is_unconscious = False
+    if is_unconscious:
+        return
+    try:
+        from world.medical.conditions import PainCondition
+    except ImportError:
+        return
+    state.conditions.append(PainCondition(severity, location))
+
+
+# ---------------------------------------------------------------------
+# Verb resolvers — invoked by ``_resolve_procedure_callback`` after the
+# delay elapses.  Each resolver reads its kwargs from the staged
+# procedure record, rolls the skill check, applies the outcome, and
+# messages the actor + target + room.
+# ---------------------------------------------------------------------
+
+
+def _resolve_incise(actor, target, *, location: str, **_) -> None:
+    """Resolve an ``incise`` attempt at ``location``.
+
+    Outcomes:
+    * **success** — incision opens cleanly.
+    * **partial** — incision opens but with extra damage to an organ
+      at the location (placeholder failure detail).
+    * **failure** — no incision; minor organ damage seeded.
+    """
+    from world.identity_utils import msg_room_identity
+
+    result = roll_procedure(actor, target)
+    outcome = result["outcome"]
+
+    if outcome in ("success", "partial"):
+        open_incision(target, location, surgeon=actor)
+        seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["incise"])
+
+    if outcome == "success":
+        actor.msg(
+            f"You cut a clean incision through {_possessive(target)} "
+            f"{location.replace('_', ' ')}."
+        )
+        if hasattr(target, "msg") and target is not actor:
+            target.msg(
+                f"{actor.key}'s blade opens a clean incision through "
+                f"your {location.replace('_', ' ')}."
+            )
+        if actor.location is not None:
+            msg_room_identity(
+                location=actor.location,
+                template=(
+                    f"{{actor}} cuts a clean incision through "
+                    f"{{patient}}'s {location.replace('_', ' ')}."
+                ),
+                char_refs={"actor": actor, "patient": target},
+                exclude=[actor, target] if target is not actor else [actor],
+            )
+    elif outcome == "partial":
+        _apply_collateral_damage(target, location, amount=2)
+        actor.msg(
+            f"You open {_possessive(target)} {location.replace('_', ' ')} "
+            f"— but the cut runs deeper than you meant."
+        )
+    else:  # failure
+        _apply_collateral_damage(target, location, amount=3)
+        seed_infection(target, location)
+        actor.msg(
+            f"The blade slips. {_possessive(target).capitalize()} "
+            f"{location.replace('_', ' ')} is gashed but not properly "
+            f"opened."
+        )
+
+
+def _resolve_harvest(actor, target, *, organ_name: str, location: str,
+                     **_) -> None:
+    """Resolve a ``harvest`` attempt for ``organ_name`` at ``location``."""
+    from evennia import create_object
+    from world.identity_utils import msg_room_identity
+    from world.combat.constants import ORGAN_CONDITION_BY_DECAY
+
+    result = roll_procedure(actor, target)
+    outcome = result["outcome"]
+
+    # Fetch the source organ data from the snapshot.
+    snapshot_organs = get_organ_snapshot(target).get("organs", {}) or {}
+    organ_data = snapshot_organs.get(organ_name) or {}
+
+    # Decay tier → harvested condition.
+    decay_stage = "fresh"
+    stage_getter = getattr(target, "get_decay_stage", None)
+    if callable(stage_getter):
+        try:
+            decay_stage = stage_getter() or "fresh"
+        except Exception:
+            decay_stage = "fresh"
+    condition = ORGAN_CONDITION_BY_DECAY.get(decay_stage, "pristine")
+
+    # Outcome → condition fidelity.  Botched living-harvest produces
+    # damaged organs even from a fresh body (placeholder failure rule
+    # per design D: organ damage risk when harvesting from a conscious
+    # patient).
+    if outcome == "partial" and condition == "pristine":
+        condition = "damaged"
+    elif outcome == "failure":
+        condition = "damaged" if condition == "pristine" else "putrid"
+        seed_infection(target, location)
+        seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["harvest"])
+        actor.msg(
+            f"Your hands slip mid-extraction. The {organ_name.replace('_', ' ')} "
+            f"comes out badly mangled."
+        )
+        # Even failed harvest tears the organ out — mark it removed
+        # on the source so the player knows the procedure happened.
+        _mark_organ_removed(target, organ_name)
+        return
+
+    # Success / partial: spawn the harvested item.
+    from typeclasses.items import Organ as HarvestedOrgan
+    room = actor.location
+    harvested = create_object(
+        typeclass=HarvestedOrgan,
+        key=organ_name,
+        location=actor,
+    )
+    # Reuse the existing harvest configuration path so identity /
+    # decay / prose are all set the same way as corpse-harvest.
+    # ``configure_from_harvest`` expects a corpse-shaped source for
+    # signature / decay; for living targets we adapt via a thin shim.
+    _configure_harvested_item(
+        harvested, organ_name=organ_name, condition=condition,
+        source=target, organ_data=organ_data,
+    )
+
+    # Mark the organ removed on the source so repeat harvests can't
+    # spawn duplicates.
+    _mark_organ_removed(target, organ_name)
+
+    seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["harvest"])
+
+    actor.msg(
+        f"You extract the {organ_name.replace('_', ' ')} from "
+        f"{target.get_display_name(actor)}'s {location.replace('_', ' ')}."
+    )
+    if room is not None:
+        msg_room_identity(
+            location=room,
+            template=(
+                f"{{actor}} extracts the {organ_name.replace('_', ' ')} "
+                f"from {{patient}}'s {location.replace('_', ' ')}."
+            ),
+            char_refs={"actor": actor, "patient": target},
+            exclude=[actor, target] if target is not actor else [actor],
+        )
+
+
+def _resolve_install(actor, target, *, organ_item, location: str,
+                     **_) -> None:
+    """Resolve an ``install`` attempt: slot ``organ_item`` into
+    ``target`` at ``location``."""
+    from world.identity_utils import msg_room_identity
+
+    result = roll_procedure(actor, target)
+    outcome = result["outcome"]
+
+    if outcome == "failure":
+        # Botched install: organ doesn't take, infection seeded.
+        seed_infection(target, location)
+        seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["install"])
+        actor.msg(
+            f"The graft won't take. The {organ_item.key} stays loose "
+            f"in your hands."
+        )
+        return
+
+    # Success / partial: organ installs.  Living target: restore HP and
+    # attach any organ-bound conditions from the harvested item to the
+    # corresponding organ on the recipient.
+    state = getattr(target, "medical_state", None)
+    if state is not None:
+        organ = state.organs.get(organ_item.db.organ_name)
+        if organ is not None:
+            # Reset HP based on harvested condition.
+            condition_hp = {
+                "pristine": organ.max_hp,
+                "damaged": int(organ.max_hp * 0.6),
+                "putrid": int(organ.max_hp * 0.3),
+            }
+            organ.current_hp = condition_hp.get(
+                organ_item.db.condition or "pristine", organ.max_hp,
+            )
+            organ.wound_stage = None if organ.current_hp == organ.max_hp else "fresh"
+            # Attach organ-bound conditions from the harvested item.
+            for condition_dict in (organ_item.db.organ_conditions or []):
+                try:
+                    from world.medical.conditions import deserialize_condition
+                    organ.conditions.append(deserialize_condition(condition_dict))
+                except Exception:
+                    pass
+
+    seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["install"])
+
+    if outcome == "partial":
+        # Partial: success but with infection seed.
+        seed_infection(target, location)
+        actor.msg(
+            f"You install the {organ_item.key} — but the graft is "
+            f"sloppy. Time will tell."
+        )
+    else:
+        actor.msg(
+            f"You install the {organ_item.key} into "
+            f"{target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')}."
+        )
+
+    if actor.location is not None:
+        msg_room_identity(
+            location=actor.location,
+            template=(
+                f"{{actor}} installs a {organ_item.key} into "
+                f"{{patient}}'s {location.replace('_', ' ')}."
+            ),
+            char_refs={"actor": actor, "patient": target},
+            exclude=[actor, target] if target is not actor else [actor],
+        )
+
+    # Consume the harvested item.
+    try:
+        organ_item.delete()
+    except Exception:
+        pass
+
+
+def _resolve_suture(actor, target, *, location: Optional[str] = None,
+                    **_) -> None:
+    """Resolve a ``suture`` attempt.  ``location=None`` closes all
+    open incisions; a specific location closes just one."""
+    from world.identity_utils import msg_room_identity
+
+    result = roll_procedure(actor, target)
+    outcome = result["outcome"]
+
+    if location is None:
+        closed = close_all_incisions(target)
+    else:
+        closed = [location] if close_incision(target, location) else []
+
+    if not closed:
+        actor.msg(
+            f"There's nothing to suture on "
+            f"{target.get_display_name(actor)}."
+        )
+        return
+
+    seed_pain(target, closed[0], CONSCIOUS_PAIN_SEVERITY["suture"])
+
+    if outcome == "failure":
+        # Botched close: infection seeded at the location.
+        for loc in closed:
+            seed_infection(target, loc)
+        actor.msg(
+            f"You close the wound — but the stitches are uneven and "
+            f"the seam pulls dirty."
+        )
+    elif outcome == "partial":
+        actor.msg(
+            f"You suture the incision shut. The line is rough but "
+            f"will hold."
+        )
+    else:
+        actor.msg(
+            f"You suture the incision shut with neat, even stitches."
+        )
+
+    if actor.location is not None:
+        location_str = ", ".join(loc.replace("_", " ") for loc in closed)
+        msg_room_identity(
+            location=actor.location,
+            template=(
+                f"{{actor}} sutures {{patient}}'s "
+                f"{location_str} closed."
+            ),
+            char_refs={"actor": actor, "patient": target},
+            exclude=[actor, target] if target is not actor else [actor],
+        )
+
+
+# Mapping consumed by ``_resolve_procedure_callback``.
+_VERB_RESOLVERS = {
+    "incise": _resolve_incise,
+    "harvest": _resolve_harvest,
+    "install": _resolve_install,
+    "suture": _resolve_suture,
+}
+
+
+# ---------------------------------------------------------------------
+# Supporting helpers
+# ---------------------------------------------------------------------
+
+
+def _possessive(target) -> str:
+    """Cheap possessive — ``"the rat's"`` / ``"Bob's"``."""
+    name = getattr(target, "key", "the patient")
+    return f"{name}'s"
+
+
+def _apply_collateral_damage(target, location: str, amount: int) -> None:
+    """Damage organs at ``location`` (placeholder failure detail)."""
+    state = getattr(target, "medical_state", None)
+    if state is None or not hasattr(state, "organs"):
+        return
+    for organ in state.organs.values():
+        if organ.container == location or organ.display_location == location:
+            organ.current_hp = max(0, organ.current_hp - amount)
+            if organ.wound_stage is None:
+                organ.wound_stage = "fresh"
+
+
+def _mark_organ_removed(target, organ_name: str) -> None:
+    """Append ``organ_name`` to the target's removed-organ list and
+    zero its snapshot HP.  Mirrors what ``CmdHarvest`` does today on
+    a corpse so post-harvest renders show the organ as gone.
+    """
+    removed = getattr(target.db, "removed_organs", None) or []
+    if organ_name not in removed:
+        removed = list(removed) + [organ_name]
+        target.db.removed_organs = removed
+
+    # Living: zero HP on the live organ so downstream rendering / capacity
+    # math reflects the absence.
+    state = getattr(target, "medical_state", None)
+    if state is not None and hasattr(state, "organs"):
+        organ = state.organs.get(organ_name)
+        if organ is not None:
+            organ.current_hp = 0
+            organ.wound_stage = "severed"
+
+    # Corpse / severed item: mutate the snapshot organ entry the same
+    # way CmdHarvest does today so autopsy / repeat-harvest agree.
+    snapshot = None
+    accessor = getattr(target, "get_medical_snapshot", None)
+    if callable(accessor):
+        try:
+            snapshot = accessor()
+        except Exception:
+            snapshot = None
+    if snapshot:
+        organs = snapshot.get("organs") or {}
+        entry = organs.get(organ_name)
+        if isinstance(entry, dict):
+            entry["current_hp"] = 0
+            entry["wound_stage"] = "severed"
+
+
+def _configure_harvested_item(item, *, organ_name: str, condition: str,
+                              source, organ_data: dict) -> None:
+    """Set the harvested ``item``'s db fields without relying on the
+    corpse-shaped ``configure_from_harvest`` flow.
+
+    The legacy ``Organ.configure_from_harvest`` assumes a corpse with
+    identity-signature and decay-stage attributes; living targets and
+    severed items don't fit that contract uniformly.  We populate
+    fields directly here so harvest works against any source.
+    """
+    from world.anatomy import (
+        get_organ_default_description,
+        get_species_organ_name,
+    )
+
+    item.db.organ_name = organ_name
+    item.db.condition = condition
+    item.db.source_corpse_dbref = getattr(source, "dbref", None)
+
+    # Identity provenance — copy from the source when present.
+    source_db = getattr(source, "db", None)
+    item.db.source_signature = (
+        getattr(source_db, "signature_at_death", None)
+        if source_db is not None else None
+    )
+    item.db.source_apparent_uid = (
+        getattr(source_db, "apparent_uid_at_death", None)
+        if source_db is not None else None
+    )
+
+    # Species + decay-aware display key.
+    species = getattr(source_db, "species", None) or "human"
+    item.db.source_species = species
+
+    stage_getter = getattr(source, "get_decay_stage", None)
+    if callable(stage_getter):
+        try:
+            decay_stage = stage_getter() or "fresh"
+        except Exception:
+            decay_stage = "fresh"
+    else:
+        decay_stage = "fresh"
+
+    item.key = get_species_organ_name(species, organ_name, decay_stage)
+
+    prose = get_organ_default_description(organ_name, condition)
+    if prose:
+        item.db.desc = prose
+
+    # Organ-bound conditions travel with the organ (#307 follow-up).
+    item.db.organ_conditions = list(organ_data.get("conditions") or [])

--- a/world/tests/test_consumption_command_identity.py
+++ b/world/tests/test_consumption_command_identity.py
@@ -88,83 +88,12 @@ class TestGetItemAndTargetIdentity(TestCase):
 
 
 # ===================================================================
-# CmdApply — surgery/operate branch (separate from get_item_and_target)
+# CmdApply surgery / operate aliases removed (#307 follow-up).
+# Surgical procedures are now the explicit verb set:
+# incise / harvest / install / suture.  ``apply`` is for surface
+# treatments and location-precision deep treatments only.  Tests
+# for the removed surgery alias path were dropped.
 # ===================================================================
-
-
-class TestCmdApplySurgeryIdentity(TestCase):
-    """``surgery`` / ``operate`` target lookup uses identity helper."""
-
-    def _make_cmd(self, key="surgery", args="man"):
-        from commands.CmdConsumption import CmdApply
-
-        cmd = CmdApply()
-        cmd.key = key
-        cmd.cmdstring = key
-        cmd.args = args
-        cmd.caller = MagicMock()
-        cmd.caller.location = MagicMock()
-        # Provide a surgical kit in caller's contents.
-        kit = MagicMock()
-        kit.attributes.get = lambda name: (
-            "surgical_treatment" if name == "medical_type" else None
-        )
-        cmd.caller.contents = [kit]
-        return cmd, kit
-
-    @patch("commands.CmdConsumption.apply_medical_effects")
-    @patch("commands.CmdConsumption.calculate_treatment_success")
-    @patch("commands.CmdConsumption.get_medical_type",
-           return_value="surgical_treatment")
-    @patch("commands.CmdConsumption.is_medical_item", return_value=True)
-    @patch("commands.CmdConsumption.resolve_character_target")
-    def test_surgery_uses_identity_helper(
-        self, mock_resolve, _is_med, _gmt, _cts, _ame
-    ):
-        target = MagicMock()
-        target.medical_state = MagicMock()
-        target.is_unconscious = lambda: False
-        mock_resolve.return_value = target
-        cmd, _kit = self._make_cmd(args="man")
-        # Best-effort func call; short-circuit on first downstream error.
-        try:
-            cmd.func()
-        except Exception:
-            pass
-        mock_resolve.assert_called_with(cmd.caller, "man")
-
-    @patch("commands.CmdConsumption.is_medical_item", return_value=True)
-    @patch("commands.CmdConsumption.get_medical_type",
-           return_value="surgical_treatment")
-    @patch("commands.CmdConsumption.resolve_character_target")
-    def test_surgery_self_token_skips_helper(
-        self, mock_resolve, _gmt, _is_med
-    ):
-        cmd, _kit = self._make_cmd(args="myself")
-        try:
-            cmd.func()
-        except Exception:
-            pass
-        mock_resolve.assert_not_called()
-
-    @patch("commands.CmdConsumption.is_medical_item", return_value=True)
-    @patch("commands.CmdConsumption.get_medical_type",
-           return_value="surgical_treatment")
-    @patch("commands.CmdConsumption.resolve_character_target")
-    def test_surgery_target_not_found_messages_caller(
-        self, mock_resolve, _gmt, _is_med
-    ):
-        mock_resolve.return_value = None
-        cmd, _kit = self._make_cmd(args="ghost")
-        try:
-            cmd.func()
-        except Exception:
-            pass
-        msg_calls = [c.args[0] for c in cmd.caller.msg.call_args_list]
-        self.assertTrue(
-            any("ghost" in m for m in msg_calls),
-            f"messages={msg_calls}",
-        )
 
 
 # ===================================================================

--- a/world/tests/test_surgical_procedures.py
+++ b/world/tests/test_surgical_procedures.py
@@ -1,0 +1,434 @@
+"""Tests for the surgical procedure pipeline (#307 follow-up).
+
+Covers:
+
+* ``world.medical.procedures`` — the dispatch module that the four
+  procedure verbs route through.
+* Multi-source organ accessor (``get_organ_snapshot``) — works on
+  living, corpse, severed.
+* Incision state lifecycle (open / close / multi-incision / lookup).
+* Skill roll formula (intellect * 0.75 + motorics * 0.25) and
+  difficulty modifiers for consciousness state.
+* Resolver outcomes for each verb (success / partial / failure
+  branches) including failure consequences (collateral damage,
+  infection seed).
+
+The procedure verbs use ``evennia.utils.delay`` to stage resolution
+asynchronously.  Tests substitute a synchronous shim so the
+resolver runs in-line and side effects are observable immediately.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.medical.procedures import (
+    ANESTHETIZED_DIFFICULTY_BONUS,
+    CONSCIOUS_PATIENT_DIFFICULTY,
+    INTERNAL_CONTAINERS,
+    PROCEDURE_BASE_DIFFICULTY,
+    calculate_procedure_difficulty,
+    calculate_procedure_skill,
+    close_all_incisions,
+    close_incision,
+    get_organ_snapshot,
+    has_incision,
+    open_incision,
+    open_incision_locations,
+    organs_at_location,
+    roll_procedure,
+    seed_infection,
+    seed_pain,
+)
+from world.medical.core import MedicalState
+
+
+def _human_character(intellect=2, motorics=2, conscious=True):
+    """Plain-Python stub character with the surfaces the procedure
+    pipeline touches.
+
+    The ``intellect`` / ``motorics`` values land on the bare object
+    (not ``db``) because that's where ``calculate_procedure_skill``
+    reads them — matching the AttributeProperty access pattern on
+    real Characters.
+    """
+    char = SimpleNamespace()
+    char.intellect = intellect
+    char.motorics = motorics
+    char.is_unconscious = lambda: not conscious
+    # ``db.surgical_state`` is touched by the state helpers; provide
+    # the slot.  ``db.archived`` for MedicalState init paths.
+    char.db = SimpleNamespace(
+        species="human", archived=False, surgical_state=None,
+        removed_organs=None, severed_locations=None,
+    )
+    char.key = "TestSubject"
+    char.medical_state = MedicalState(char)
+    return char
+
+
+def _corpse_target():
+    """Minimal corpse-shaped stub exposing get_medical_snapshot."""
+    snapshot = {
+        "organs": {
+            "heart": {
+                "container": "chest", "current_hp": 15, "max_hp": 15,
+                "conditions": [],
+            },
+            "left_lung": {
+                "container": "chest", "current_hp": 20, "max_hp": 20,
+                "conditions": [],
+            },
+            "left_humerus": {
+                "container": "left_arm", "current_hp": 25, "max_hp": 25,
+                "conditions": [],
+            },
+        },
+    }
+    corpse = SimpleNamespace()
+    corpse.get_medical_snapshot = lambda: snapshot
+    corpse.db = SimpleNamespace(
+        surgical_state=None,
+        removed_organs=None, severed_locations=None,
+        species="human",
+    )
+    corpse.key = "the corpse"
+    return corpse
+
+
+# ---------------------------------------------------------------------
+# Organ snapshot accessor
+# ---------------------------------------------------------------------
+
+
+class GetOrganSnapshot(TestCase):
+
+    def test_living_character_snapshot(self):
+        char = _human_character()
+        snap = get_organ_snapshot(char)
+        organs = snap.get("organs") or {}
+        # Spot-check a few human organs.
+        for must in ("brain", "heart", "left_lung", "left_humerus"):
+            with self.subTest(organ=must):
+                self.assertIn(must, organs)
+
+    def test_corpse_snapshot(self):
+        corpse = _corpse_target()
+        snap = get_organ_snapshot(corpse)
+        organs = snap.get("organs") or {}
+        self.assertIn("heart", organs)
+
+    def test_object_with_no_snapshot_returns_empty(self):
+        # A plain object with neither medical_state nor get_medical_snapshot.
+        target = SimpleNamespace()
+        self.assertEqual(get_organ_snapshot(target), {})
+
+
+class OrgansAtLocation(TestCase):
+
+    def test_living_chest_organs(self):
+        char = _human_character()
+        results = organs_at_location(char, "chest")
+        names = [n for n, _ in results]
+        self.assertIn("heart", names)
+        self.assertIn("left_lung", names)
+        # Brain is NOT at chest.
+        self.assertNotIn("brain", names)
+
+    def test_sensory_organ_at_display_location(self):
+        # left_eye has container="head" and display_location="left_eye"
+        # — the helper should match both.
+        char = _human_character()
+        at_eye = [n for n, _ in organs_at_location(char, "left_eye")]
+        self.assertIn("left_eye", at_eye)
+        at_head = [n for n, _ in organs_at_location(char, "head")]
+        # left_eye container is head → also matches "head" lookup.
+        self.assertIn("left_eye", at_head)
+
+
+# ---------------------------------------------------------------------
+# Incision state
+# ---------------------------------------------------------------------
+
+
+class IncisionLifecycle(TestCase):
+
+    def test_open_then_check(self):
+        char = _human_character()
+        open_incision(char, "chest", surgeon=char)
+        self.assertTrue(has_incision(char, "chest"))
+
+    def test_close_clears(self):
+        char = _human_character()
+        open_incision(char, "chest", surgeon=char)
+        closed = close_incision(char, "chest")
+        self.assertTrue(closed)
+        self.assertFalse(has_incision(char, "chest"))
+
+    def test_close_nothing_returns_false(self):
+        char = _human_character()
+        self.assertFalse(close_incision(char, "chest"))
+
+    def test_multiple_incisions_allowed(self):
+        char = _human_character()
+        open_incision(char, "chest", surgeon=char)
+        open_incision(char, "abdomen", surgeon=char)
+        locs = open_incision_locations(char)
+        self.assertEqual(set(locs), {"chest", "abdomen"})
+
+    def test_close_all_returns_list(self):
+        char = _human_character()
+        open_incision(char, "chest", surgeon=char)
+        open_incision(char, "abdomen", surgeon=char)
+        closed = close_all_incisions(char)
+        self.assertEqual(set(closed), {"chest", "abdomen"})
+        self.assertEqual(open_incision_locations(char), [])
+
+
+# ---------------------------------------------------------------------
+# Skill formula (spec line 1434)
+# ---------------------------------------------------------------------
+
+
+class SkillRoll(TestCase):
+
+    def test_skill_formula(self):
+        actor = _human_character(intellect=4, motorics=2)
+        # 4*0.75 + 2*0.25 = 3.0 + 0.5 = 3.5
+        self.assertAlmostEqual(calculate_procedure_skill(actor), 3.5)
+
+    def test_default_when_stats_missing(self):
+        actor = SimpleNamespace()  # no intellect / motorics
+        # Both default to 1; 1*0.75 + 1*0.25 = 1.0
+        self.assertAlmostEqual(calculate_procedure_skill(actor), 1.0)
+
+
+class Difficulty(TestCase):
+
+    def test_conscious_patient_harder(self):
+        char = _human_character(conscious=True)
+        diff = calculate_procedure_difficulty(char)
+        self.assertEqual(
+            diff, PROCEDURE_BASE_DIFFICULTY + CONSCIOUS_PATIENT_DIFFICULTY,
+        )
+
+    def test_unconscious_patient_easier(self):
+        char = _human_character(conscious=False)
+        diff = calculate_procedure_difficulty(char)
+        self.assertEqual(
+            diff, PROCEDURE_BASE_DIFFICULTY - ANESTHETIZED_DIFFICULTY_BONUS,
+        )
+
+    def test_conscious_modifier_off(self):
+        char = _human_character(conscious=True)
+        diff = calculate_procedure_difficulty(char, conscious_modifier=False)
+        self.assertEqual(diff, PROCEDURE_BASE_DIFFICULTY)
+
+
+# ---------------------------------------------------------------------
+# Roll mechanics — patches RNG so outcomes are deterministic
+# ---------------------------------------------------------------------
+
+
+class RollOutcomes(TestCase):
+
+    def setUp(self):
+        # Unconscious target → difficulty = 12 - 3 = 9.
+        # Skill = (3*0.75) + (1*0.25) = 2.5.
+        # So total = roll + 2.5; need roll ≥ 11.5 for partial, ≥ 16.5 for success.
+        self.actor = _human_character(intellect=3, motorics=1)
+        self.target = _human_character(conscious=False)
+
+    @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_high_roll_is_success(self, _r):
+        # roll = 6+6+6 = 18, total = 20.5, difficulty = 9, ≥ 14 → success
+        result = roll_procedure(self.actor, self.target)
+        self.assertEqual(result["outcome"], "success")
+
+    @patch("world.medical.procedures.random.randint", return_value=3)
+    def test_mid_roll_is_partial(self, _r):
+        # roll = 9, total = 11.5, difficulty = 9, < 14 but ≥ 9 → partial
+        result = roll_procedure(self.actor, self.target)
+        self.assertEqual(result["outcome"], "partial")
+
+    @patch("world.medical.procedures.random.randint", return_value=1)
+    def test_low_roll_is_failure(self, _r):
+        # roll = 3, total = 5.5, < 9 → failure
+        result = roll_procedure(self.actor, self.target)
+        self.assertEqual(result["outcome"], "failure")
+
+
+# ---------------------------------------------------------------------
+# Failure consequence helpers
+# ---------------------------------------------------------------------
+
+
+class SeedInfection(TestCase):
+
+    def test_seeds_location_bound_infection_on_living(self):
+        char = _human_character()
+        seed_infection(char, "chest", severity=3)
+        from world.medical.conditions import InfectionCondition
+        infections = [
+            c for c in char.medical_state.conditions
+            if isinstance(c, InfectionCondition)
+        ]
+        self.assertEqual(len(infections), 1)
+        self.assertEqual(infections[0].location, "chest")
+        self.assertEqual(infections[0].severity, 3)
+
+    def test_no_op_on_corpse(self):
+        corpse = _corpse_target()
+        # Corpses don't have medical_state.conditions; should no-op.
+        seed_infection(corpse, "chest", severity=3)
+        # No exceptions; no state changed.
+
+
+class SeedPain(TestCase):
+
+    def test_conscious_patient_gets_pain(self):
+        char = _human_character(conscious=True)
+        seed_pain(char, "chest", severity=4)
+        from world.medical.conditions import PainCondition
+        pains = [
+            c for c in char.medical_state.conditions
+            if isinstance(c, PainCondition)
+        ]
+        self.assertEqual(len(pains), 1)
+        self.assertEqual(pains[0].severity, 4)
+
+    def test_unconscious_patient_no_pain(self):
+        char = _human_character(conscious=False)
+        seed_pain(char, "chest", severity=4)
+        from world.medical.conditions import PainCondition
+        pains = [
+            c for c in char.medical_state.conditions
+            if isinstance(c, PainCondition)
+        ]
+        self.assertEqual(pains, [])
+
+
+# ---------------------------------------------------------------------
+# INTERNAL_CONTAINERS contract
+# ---------------------------------------------------------------------
+
+
+class InternalContainersSet(TestCase):
+    """Internal containers require incision before deep procedures
+    can target organs housed there.  This pins the membership."""
+
+    def test_known_internal(self):
+        for loc in ("head", "chest", "abdomen", "back", "neck", "groin"):
+            with self.subTest(loc=loc):
+                self.assertIn(loc, INTERNAL_CONTAINERS)
+
+    def test_limbs_external(self):
+        for loc in ("left_arm", "right_arm", "left_hand", "right_hand",
+                    "left_thigh", "left_shin", "left_foot"):
+            with self.subTest(loc=loc):
+                self.assertNotIn(loc, INTERNAL_CONTAINERS)
+
+
+# ---------------------------------------------------------------------
+# Verb resolvers (in-process via _resolve_procedure_callback shim)
+# ---------------------------------------------------------------------
+
+
+class ResolveIncise(TestCase):
+    """Tests for the ``_resolve_incise`` resolver (success / partial
+    / failure branches) — calls the resolver directly rather than
+    routing through the delay system, so outcomes are observable
+    synchronously."""
+
+    def setUp(self):
+        # Skill 3 (int 3, mot 3) → 3.0; unconscious target → diff 9.
+        # Roll outcomes:
+        #  roll = 18 (6+6+6) → total 21 → success
+        #  roll = 9  (3+3+3) → total 12 → partial
+        #  roll = 3  (1+1+1) → total 6  → failure
+        self.actor = _human_character(intellect=3, motorics=3)
+        self.target = _human_character(conscious=False)
+        self.actor.location = None
+        self.target.location = None
+        # ``location_utils`` calls need both to have ``msg``; stubs.
+        self.actor.msg = lambda *a, **k: None
+        self.target.msg = lambda *a, **k: None
+
+    @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_success_opens_incision(self, _r):
+        from world.medical.procedures import _resolve_incise
+        _resolve_incise(self.actor, self.target, location="chest")
+        self.assertTrue(has_incision(self.target, "chest"))
+
+    @patch("world.medical.procedures.random.randint", return_value=3)
+    def test_partial_opens_incision_with_collateral(self, _r):
+        from world.medical.procedures import _resolve_incise
+        heart_hp_before = self.target.medical_state.organs["heart"].current_hp
+        _resolve_incise(self.actor, self.target, location="chest")
+        self.assertTrue(has_incision(self.target, "chest"))
+        heart_hp_after = self.target.medical_state.organs["heart"].current_hp
+        # Collateral damage applied to at least one chest organ.
+        chest_organs_damaged = any(
+            self.target.medical_state.organs[name].current_hp < self.target.medical_state.organs[name].max_hp
+            for name in ("heart", "left_lung", "right_lung")
+        )
+        self.assertTrue(chest_organs_damaged)
+
+    @patch("world.medical.procedures.random.randint", return_value=1)
+    def test_failure_seeds_infection_no_incision(self, _r):
+        from world.medical.procedures import _resolve_incise
+        _resolve_incise(self.actor, self.target, location="chest")
+        self.assertFalse(has_incision(self.target, "chest"))
+        # Infection seeded.
+        from world.medical.conditions import InfectionCondition
+        infections = [
+            c for c in self.target.medical_state.conditions
+            if isinstance(c, InfectionCondition) and c.location == "chest"
+        ]
+        self.assertEqual(len(infections), 1)
+
+
+class ResolveSuture(TestCase):
+    """Tests for ``_resolve_suture``: must consume existing incisions
+    and produce per-outcome side effects."""
+
+    def setUp(self):
+        self.actor = _human_character(intellect=3, motorics=3)
+        self.target = _human_character(conscious=False)
+        self.actor.location = None
+        self.target.location = None
+        self.actor.msg = lambda *a, **k: None
+        self.target.msg = lambda *a, **k: None
+
+    @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_success_closes_all_incisions(self, _r):
+        from world.medical.procedures import _resolve_suture
+        open_incision(self.target, "chest", surgeon=self.actor)
+        open_incision(self.target, "abdomen", surgeon=self.actor)
+        _resolve_suture(self.actor, self.target)
+        self.assertEqual(open_incision_locations(self.target), [])
+
+    @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_success_with_location_closes_one(self, _r):
+        from world.medical.procedures import _resolve_suture
+        open_incision(self.target, "chest", surgeon=self.actor)
+        open_incision(self.target, "abdomen", surgeon=self.actor)
+        _resolve_suture(self.actor, self.target, location="chest")
+        self.assertEqual(open_incision_locations(self.target), ["abdomen"])
+
+    @patch("world.medical.procedures.random.randint", return_value=1)
+    def test_failure_seeds_infection_but_still_closes(self, _r):
+        # Per design: botched suture closes but seeds infection.  The
+        # wound is "closed" but dirty.
+        from world.medical.procedures import _resolve_suture
+        open_incision(self.target, "chest", surgeon=self.actor)
+        _resolve_suture(self.actor, self.target)
+        self.assertEqual(open_incision_locations(self.target), [])
+        from world.medical.conditions import InfectionCondition
+        infections = [
+            c for c in self.target.medical_state.conditions
+            if isinstance(c, InfectionCondition) and c.location == "chest"
+        ]
+        self.assertEqual(len(infections), 1)


### PR DESCRIPTION
## Summary

Replaces ``surgery <target>`` with a procedural verb set giving the player onus on order of operations:

- ``incise <target> at <location>`` — open
- ``harvest <organ> from <target>`` — extract
- ``install <organ> in <target>`` — implant
- ``suture <target>`` (alias: ``stitch``) — close

Same flow on living / corpse / severed (head OR limb — both are organ containers per the harvest-extension design). Multi-source via a unified ``get_organ_snapshot`` accessor.

### Skill / difficulty

Per spec line 1434: ``(intellect * 0.75) + (motorics * 0.25)``. Difficulty 12 base, +5 conscious, −3 anesthetized / corpse / severed.

### Tri-modal outcomes per verb

- ``incise`` success → clean cut; partial → collateral organ damage; failure → no incision + infection seed
- ``harvest`` success/partial → organ at correct condition; failure → mangled organ (one tier worse) + infection + pain
- ``install`` success → organ slotted, organ-bound conditions follow; partial → installed but seeded; failure → graft doesn't take
- ``suture`` success → clean close; partial → rough but holds; failure → closes but seeded

### Anesthesia = drug, not verb

``inject anesthetic into bob`` → ``is_unconscious() == True`` → procedure dispatch reads it → difficulty bonus + no pain seeding. Conscious patients accumulate ``PainCondition`` during procedures.

### Time delay = tension

incise 6s / harvest 18s / install 18s / suture 9s. Surgeon disconnect leaves the patient open, bleeding.

### CmdApply upgrade

- Removed ``surgery`` / ``operate`` aliases
- Added ``apply <item> on <target>'s <location>`` precision
- Internal containers gate behind open incision; surface treatments don't
- Surgical kits removed from ``apply``-able list — they're tools for procedure verbs

## Test plan

- [x] ``world.tests.test_surgical_procedures`` — 30/30 pass (organ snapshot, organs-at-location, incision lifecycle, skill formula, difficulty ladder, roll mechanics, failure consequence seeders, INTERNAL_CONTAINERS contract, resolver outcomes for incise & suture)
- [x] Full suite: 1827/1827 pass

Refs #307.