### PR TITLE
Incision rule via display_location + drop apply-gate (#307)

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -372,16 +372,14 @@ class CmdApply(ConsumptionCommand):
         is_self = (caller == target)
 
         # Location precision: if the player named a specific organ or
-        # internal container, gate it behind the incision requirement.
+        # body location, we still validate that the location is real on
+        # the target — but we don't gate on incision state.  Per the
+        # #307 design pass, substance application tolerates any delivery;
+        # the future drug-system rules will determine whether the item
+        # actually does anything useful at the chosen location.
         if location:
-            from world.medical.procedures import (
-                INTERNAL_CONTAINERS,
-                has_incision,
-                organs_at_location,
-            )
+            from world.medical.procedures import organs_at_location
 
-            # Resolve "location" — could be a body container OR an
-            # organ name.  If it's an organ, look up its container.
             container = location
             try:
                 state = target.medical_state
@@ -392,17 +390,10 @@ class CmdApply(ConsumptionCommand):
                 if organ is not None:
                     container = organ.container
 
-            if container in INTERNAL_CONTAINERS and not has_incision(target, container):
-                caller.msg(
-                    f"You can't reach {target.get_display_name(caller)}'s "
-                    f"{location.replace('_', ' ')} — "
-                    f"{container.replace('_', ' ')} isn't open. "
-                    f"Try ``incise {target.get_display_name(caller)} "
-                    f"at {container.replace('_', ' ')}`` first."
-                )
-                return
-
-            # Surface location with no organs at all → no target.
+            # Surface location with no organs at all → no anatomical
+            # slot on this target.  Reject as nonsense input rather
+            # than silently accepting an undefined location.  This is
+            # location-validity, not substance-gating.
             if not organs_at_location(target, container) and container == location:
                 caller.msg(
                     f"There's nothing at {location.replace('_', ' ')} on "

--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 from evennia import Command
 
 from world.medical.procedures import (
-    INTERNAL_CONTAINERS,
     PROCEDURE_DURATIONS,
     get_organ_snapshot,
     has_incision,
@@ -32,6 +31,26 @@ from world.medical.procedures import (
     organs_at_location,
     start_procedure,
 )
+
+
+def _incision_required(organ_data: dict) -> bool:
+    """Whether an organ at ``organ_data`` requires an open incision
+    at its container to be reached.
+
+    The rule, settled in the #307 design pass: an organ whose
+    ``display_location`` is *distinct* from its ``container`` has its
+    own surface (eyes, ears, nose, tongue, jaw on humans).  Those
+    organs are reachable without first opening the cavity that nominally
+    houses them.  Organs whose ``display_location`` falls back to their
+    ``container`` (the default when none is declared) live "inside"
+    and need the container incised before they can be touched.
+
+    Symmetric for harvest and install — the source/destination
+    location's slot data drives the call equally for either verb.
+    """
+    container = organ_data.get("container")
+    display = organ_data.get("display_location") or container
+    return display == container
 
 
 # ---------------------------------------------------------------------
@@ -309,8 +328,10 @@ class CmdHarvest(Command):
         organ_data = organs[organ_arg]
         container = organ_data.get("container")
 
-        # Incision requirement for internal containers.
-        if container in INTERNAL_CONTAINERS and not has_incision(target, container):
+        # Incision requirement: organs without a distinct display_location
+        # live inside the container and need it opened first.  Surface
+        # organs (eyes, ears, jaw, nose, tongue on humans) skip this.
+        if _incision_required(organ_data) and not has_incision(target, container):
             caller.msg(
                 f"You can't reach the {organ_arg.replace('_', ' ')} — "
                 f"{container.replace('_', ' ')} isn't open. "
@@ -412,7 +433,9 @@ class CmdInstall(Command):
 
         container = target_organ_data.get("container")
 
-        if container in INTERNAL_CONTAINERS and not has_incision(target, container):
+        # Symmetric to harvest: organs with a distinct display_location
+        # are surface-accessible and skip the incision requirement.
+        if _incision_required(target_organ_data) and not has_incision(target, container):
             caller.msg(
                 f"You can't reach the {organ_name.replace('_', ' ')} "
                 f"slot — {container.replace('_', ' ')} isn't open. "

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -74,14 +74,6 @@ CONSCIOUS_PAIN_SEVERITY = {
 #: the body location; the resulting condition is location-bound.
 FAILURE_INFECTION_SEVERITY = 2
 
-#: Internal body containers that require an open incision before a
-#: deep procedure (harvest / install / treat) can target an organ
-#: housed there.  Limb containers are externally accessible and
-#: skip the requirement.
-INTERNAL_CONTAINERS = frozenset({
-    "head", "chest", "abdomen", "back", "neck", "groin",
-})
-
 
 # ---------------------------------------------------------------------
 # Target accessor — works on every container type

--- a/world/tests/test_surgical_procedures.py
+++ b/world/tests/test_surgical_procedures.py
@@ -27,7 +27,6 @@ from unittest.mock import patch
 from world.medical.procedures import (
     ANESTHETIZED_DIFFICULTY_BONUS,
     CONSCIOUS_PATIENT_DIFFICULTY,
-    INTERNAL_CONTAINERS,
     PROCEDURE_BASE_DIFFICULTY,
     calculate_procedure_difficulty,
     calculate_procedure_skill,
@@ -315,20 +314,72 @@ class SeedPain(TestCase):
 # ---------------------------------------------------------------------
 
 
-class InternalContainersSet(TestCase):
-    """Internal containers require incision before deep procedures
-    can target organs housed there.  This pins the membership."""
+class IncisionRequiredHelper(TestCase):
+    """Contract for ``CmdSurgical._incision_required``: organs with a
+    distinct ``display_location`` are surface-accessible (no incision
+    needed); organs whose display_location falls back to their
+    container live inside and need it opened first.
 
-    def test_known_internal(self):
-        for loc in ("head", "chest", "abdomen", "back", "neck", "groin"):
-            with self.subTest(loc=loc):
-                self.assertIn(loc, INTERNAL_CONTAINERS)
+    This is the canonical rule settled in the #307 design pass —
+    eyes / ears / nose / tongue / jaw on humans bypass; brain /
+    heart / kidneys / etc. require incision.  Applies symmetrically
+    to harvest and install via the same helper.
+    """
 
-    def test_limbs_external(self):
-        for loc in ("left_arm", "right_arm", "left_hand", "right_hand",
-                    "left_thigh", "left_shin", "left_foot"):
-            with self.subTest(loc=loc):
-                self.assertNotIn(loc, INTERNAL_CONTAINERS)
+    def _organ_data(self, container, display_location=None):
+        """Build a snapshot-shaped organ entry."""
+        return {
+            "container": container,
+            "display_location": display_location or container,
+        }
+
+    def test_surface_organ_with_distinct_display_skips_incision(self):
+        from commands.CmdSurgical import _incision_required
+        # left_eye: container=head, display_location=left_eye → distinct.
+        eye = self._organ_data("head", "left_eye")
+        self.assertFalse(_incision_required(eye))
+
+    def test_face_organ_skips_incision(self):
+        """tongue / jaw / nose share display_location=face on humans."""
+        from commands.CmdSurgical import _incision_required
+        for organ in ("tongue", "jaw", "nose"):
+            with self.subTest(organ=organ):
+                data = self._organ_data("head", "face")
+                self.assertFalse(_incision_required(data))
+
+    def test_buried_organ_requires_incision(self):
+        from commands.CmdSurgical import _incision_required
+        # brain: container=head, no distinct display_location.
+        brain = self._organ_data("head")
+        self.assertTrue(_incision_required(brain))
+
+    def test_chest_organ_requires_incision(self):
+        from commands.CmdSurgical import _incision_required
+        heart = self._organ_data("chest")
+        self.assertTrue(_incision_required(heart))
+
+    def test_limb_bone_requires_incision(self):
+        """Limbs are not internal-cavity but their bones are still
+        buried inside the limb — incision required to harvest the
+        humerus from inside an arm, attached or severed."""
+        from commands.CmdSurgical import _incision_required
+        humerus = self._organ_data("left_arm")
+        self.assertTrue(_incision_required(humerus))
+
+    def test_explicit_display_equal_to_container_still_requires(self):
+        """Defensive: even if the snapshot redundantly stores
+        display_location equal to container, the rule still
+        requires incision (matches the Organ default behaviour)."""
+        from commands.CmdSurgical import _incision_required
+        data = {"container": "chest", "display_location": "chest"}
+        self.assertTrue(_incision_required(data))
+
+    def test_missing_display_falls_back_to_container(self):
+        """Snapshot without display_location key at all → fall back
+        to container → incision required (safe default)."""
+        from commands.CmdSurgical import _incision_required
+        data = {"container": "abdomen"}
+        self.assertTrue(_incision_required(data))
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three-part alignment pass from the design discussion in #307:

### 1. Incision rule via ``display_location``

Universal for ``harvest`` and ``install``:

- Organ's ``display_location`` distinct from ``container`` → surface-accessible → no incision needed (eyes / ears / nose / tongue / jaw)
- Organ's ``display_location`` equals ``container`` (or missing) → buried inside → incision required (brain / heart / kidneys / limb bones)

Helper ``CmdSurgical._incision_required(organ_data)`` is the single source of truth, used symmetrically by both verbs.

Falls out automatically:
- **Corpse harvest now requires incision** (original miss from PR #380)
- **Severed head still requires incision** — cranium is sealed whether attached or not
- **Severed limb still requires incision** — bones are buried inside
- Procedure model is now identical for living / corpse / severed; only consciousness branches differ

### 2. CmdApply: substance-tolerance

Per the design principle: medical system tolerates any application; substance/drug rules determine effect. Drops the ``INTERNAL_CONTAINERS`` incision gate from CmdApply entirely.

``apply bandage on bob's chest`` — accepted whether or not bob's chest is open. Whether the bandage actually helps a sucking chest wound is the bandage's effectiveness rules (PR-B / wound_care stabilization).

The location-validity check survives — ``apply bandage on bob's wing`` (no wings) still rejects. Structural sanity, not substance gating.

### 3. Retire ``procedures.py:INTERNAL_CONTAINERS``

Frozenset and its imports across CmdSurgical / CmdConsumption deleted. ``world/medical/core.py``'s separate ``internal_containers`` set (different purpose: destruction-vs-severance distinction) stays put.

## Test plan

- [x] ``world.tests.test_surgical_procedures`` — 39/39 (+7 IncisionRequiredHelper tests, -2 removed InternalContainersSet)
- [x] Full suite: 1808/1808 (+5 net)
- [x] Helper tested directly for: surface organs skip, face organs skip, brain requires, chest organs require, limb bones require, defensive missing-key and equal-to-container cases

Refs #307. Slice A of the design-pass implementation order; PR-B (stabilization channel) follows.