### PR TITLE
Wound-care stabilization channel (#307, PR-B)

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -416,8 +416,56 @@ class CmdApply(ConsumptionCommand):
         if errors:
             caller.msg(errors[0])
             return
-            
-        # Execute application
+
+        # PR-B (#307): wound_care items applied with location precision
+        # route through the stabilization dispatch.  Single application
+        # both stabilizes the wound (always) and rolls per-category
+        # for bleeding / infection / pain reduction.  Repeat-application
+        # to a stabilized wound no-ops with a triage hint.
+        if medical_type == "wound_care" and location:
+            from world.medical.treatments import apply_wound_care
+            treatment_target_location = location
+            # Resolve location → container if the player named an organ.
+            try:
+                state = target.medical_state
+            except AttributeError:
+                state = None
+            if state is not None and hasattr(state, "organs"):
+                organ = state.organs.get(location)
+                if organ is not None:
+                    treatment_target_location = organ.container
+            outcome = apply_wound_care(
+                actor=caller, target=target, item=item,
+                location=treatment_target_location,
+            )
+            if is_self:
+                msg_room_identity(
+                    location=caller.location,
+                    template=(
+                        f"{{actor}} applies {item.key} to their "
+                        f"{treatment_target_location.replace('_', ' ')}."
+                    ),
+                    char_refs={"actor": caller},
+                    exclude=[caller],
+                )
+            else:
+                msg_room_identity(
+                    location=caller.location,
+                    template=(
+                        f"{{actor}} applies {item.key} to {{target}}'s "
+                        f"{treatment_target_location.replace('_', ' ')}."
+                    ),
+                    char_refs={"actor": caller, "target": target},
+                    exclude=[caller, target],
+                )
+            for line in outcome["messages"]:
+                caller.msg(line)
+                if not is_self:
+                    target.msg(line)
+            return
+
+        # Execute application (legacy flow — no location precision or
+        # non-wound_care medical types).
         if is_self:
             caller.msg(f"You carefully apply {item.get_display_name(caller)} to your wounds.")
             msg_room_identity(
@@ -435,11 +483,11 @@ class CmdApply(ConsumptionCommand):
                 char_refs={"actor": caller, "target": target},
                 exclude=[caller, target],
             )
-            
+
         # Apply treatment effects
         result_msg = self.execute_treatment(item, caller, target)
         caller.msg(f"Application result: {result_msg}")
-        
+
         if not is_self:
             target.msg(f"Treatment result: {result_msg}")
 

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -155,29 +155,66 @@ class BleedingCondition(MedicalCondition):
     def tick_effect(self, character):
         """Apply blood loss and potentially reduce severity."""
         from world.combat.constants import SPLATTERCAST_CHANNEL
-        
+
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        
+
         if not hasattr(character, 'medical_state'):
             return
-            
+
         medical_state = character.medical_state
-        
+
+        # PR-B (#307): if any damaged organ at this bleeding's location
+        # has been stabilized via wound_care, the bleeding is held in
+        # place — no further blood loss, no severity drift.  The
+        # surgeon still needs to address the underlying wound;
+        # stabilization is the "buying time" channel.
+        if self._location_stabilized(medical_state):
+            return
+
         # Calculate blood loss
         blood_loss = self.blood_loss_rate
         if self.treated:
             blood_loss = int(blood_loss * 0.3)  # Treated bleeding loses less blood
-            
+
         # Apply blood loss
         old_blood = medical_state.blood_level
         medical_state.blood_level = max(0, medical_state.blood_level - blood_loss)
-        
+
         splattercast.msg(f"BLOOD_LOSS: {character.key} loses {blood_loss} blood ({old_blood} -> {medical_state.blood_level})")
-        
+
         # Check for natural healing (random chance to reduce severity)
         if not self.treated and random.randint(1, 100) <= 10:  # 10% chance per tick
             self.severity = max(0, self.severity - 1)
             splattercast.msg(f"BLEEDING_HEAL: {character.key} bleeding severity reduced to {self.severity}")
+
+    def _location_stabilized(self, medical_state) -> bool:
+        """True when any damaged organ at this condition's location is
+        flagged ``stabilized``.
+
+        Stabilization is per-organ but bleeding is per-location;
+        this maps the two: a chest BleedingCondition is considered
+        stabilized when *any* damaged chest organ has been dressed.
+        Multiple damaged organs at one location can be stabilized
+        independently — once one is dressed, the location-level
+        bleeding stops because the soft-tissue site is sealed.
+        """
+        if self.location is None:
+            return False
+        organs = getattr(medical_state, "organs", None)
+        if not organs:
+            return False
+        for organ in organs.values():
+            container = getattr(organ, "container", None)
+            display = getattr(organ, "display_location", None)
+            if self.location not in (container, display):
+                continue
+            if getattr(organ, "stabilized", False):
+                # Only count stabilization on actually-damaged organs;
+                # a stabilized-but-undamaged organ shouldn't shield an
+                # unrelated bleeding source at the same location.
+                if organ.current_hp < organ.max_hp:
+                    return True
+        return False
             
         # Note: Individual bleeding messages removed - now handled by consolidated messaging in medical script
                 

--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -47,6 +47,55 @@ SURGERY_BASE_DIFFICULTY = 75          # Base difficulty for surgery
 INFECTION_CHANCE_BASE = 10            # Base infection chance %
 
 # ===================================================================
+# WOUND CARE TREATMENT CONSTANTS (#307, PR-B stabilization channel)
+# ===================================================================
+#
+# Roll math for wound_care application:
+#
+#     roll   = 3d6 + medical_effectiveness + item.effectiveness[category]
+#     target = WOUND_CARE_BASE_DIFFICULTY + severity_modifier + depth_modifier
+#
+# Outcome thresholds mirror the procedure verbs (success / partial /
+# failure).  Numbers below are placeholders for early playtesting —
+# all live in this single module so balancing is one-file work.
+
+WOUND_CARE_BASE_DIFFICULTY = 12        # Matches PROCEDURE_BASE_DIFFICULTY for parity
+
+#: Severity modifier added to the difficulty target.  Keys map the
+#: wound's string severity ("Minor" / "Moderate" / "Severe" / "Critical")
+#: as set by ``_determine_severity_from_damage`` in wound rendering.
+#: Unknown severities default to MODERATE.
+WOUND_CARE_SEVERITY_MODIFIERS = {
+    "Minor":    0,
+    "Moderate": 3,
+    "Severe":   6,
+    "Critical": 9,
+}
+
+#: Depth modifier added when the wound is at an internal-cavity
+#: container and the item lacks an internal-effectiveness rating.
+#: Soft scale per design — desperate medics get diminishing returns
+#: rather than outright refusal.
+WOUND_CARE_DEPTH_MODIFIER = 5
+
+#: Outcome thresholds vs final roll.  Success: full effect; partial:
+#: half effect; failure: stabilization only.
+WOUND_CARE_SUCCESS_THRESHOLD = 18      # >= → success
+WOUND_CARE_PARTIAL_THRESHOLD = 12      # >= → partial; < → failure
+
+#: Per-category effect amounts on success.  Numbers are knobs.
+WOUND_CARE_BLEEDING_REDUCTION = 2      # severity points reduced on bleeding success
+WOUND_CARE_INFECTION_REDUCTION = 2     # severity points reduced on infection success
+WOUND_CARE_PAIN_REDUCTION = 3          # severity points reduced on pain success
+
+#: Categories the wound_care dispatch resolves in parallel.  Each is
+#: one roll; failure of any one is stabilization-only for that
+#: category.  ``wound_healing`` and ``organ_repair`` are intentionally
+#: NOT in this list — wound_healing lands in PR-C (healing ticker);
+#: organ_repair lands in PR-D (surgical-grade direct repair).
+WOUND_CARE_PARALLEL_CATEGORIES = ("bleeding", "infection", "pain")
+
+# ===================================================================
 # MEDICAL CONDITION TICKER CONSTANTS (Phase 2.6)
 # ===================================================================
 

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -96,6 +96,21 @@ class Organ:
         self.wound_stage = None      # fresh, treated, healing, scarred
         self.injury_type = None      # bullet, cut, stab, blunt, generic
         self.wound_timestamp = None  # When the wound occurred (for future healing)
+
+        # Stabilization flag (#307, PR-B).  Set True when wound_care
+        # has been applied to a damaged organ at this location.  A
+        # stabilized organ does not deteriorate further — bleeding
+        # conditions at this organ's location stop draining blood,
+        # severity can't escalate, wound stage doesn't progress
+        # toward "old".  Healing is a separate channel (PR-C) driven
+        # by the dressed item's ``wound_healing`` rating.
+        #
+        # Re-application of wound_care to a stabilized wound is a
+        # no-op with a "they're already stable — get them to a
+        # surgeon" hint to the caller.  The stable state persists
+        # until the wound is surgically treated or the organ is
+        # replaced.
+        self.stabilized = False
         
     def is_destroyed(self):
         """Returns True if organ HP is 0 or below."""
@@ -269,6 +284,10 @@ class Organ:
         if self.current_hp == self.max_hp and hasattr(self, 'wound_stage'):
             self.wound_stage = None  # No wound if fully healed
             self.injury_type = None
+            # PR-B: stabilization is wound-scoped; clears when the
+            # wound is resolved.  Lets a future re-injury start with
+            # a clean stabilization slate.
+            self.stabilized = False
         
         return self.current_hp - old_hp
         
@@ -403,7 +422,8 @@ class Organ:
             "display_location": self.display_location,
             "wound_stage": self.wound_stage,
             "injury_type": self.injury_type,
-            "wound_timestamp": self.wound_timestamp
+            "wound_timestamp": self.wound_timestamp,
+            "stabilized": self.stabilized,
         }
         
     @classmethod
@@ -436,6 +456,9 @@ class Organ:
         organ.wound_stage = data.get("wound_stage")
         organ.injury_type = data.get("injury_type")
         organ.wound_timestamp = data.get("wound_timestamp")
+        # Stabilization (#307, PR-B).  Defaults to False so legacy
+        # snapshots predating the field behave as untreated.
+        organ.stabilized = bool(data.get("stabilized", False))
         # Issue #346: persisted organs may predate ``display_location`` —
         # the ``cls(data["name"])`` constructor already seeded it from
         # the ORGANS spec, so only override when the snapshot carries

--- a/world/medical/treatments.py
+++ b/world/medical/treatments.py
@@ -1,0 +1,403 @@
+"""Wound-care treatment dispatch (#307, PR-B stabilization channel).
+
+Single entry point: :func:`apply_wound_care`.  Called by ``CmdApply``
+when a player applies a ``wound_care``-typed item at a location on a
+target.  Resolves stabilization (always) and per-category effect
+rolls in parallel (bleeding / infection / pain), then consumes one
+use of the item.
+
+The substance-tolerance principle settled in the design pass means
+the system accepts any wound_care item on any wound.  The item's
+``effectiveness`` ratings, combined with the wound's severity and
+depth, determine what the application actually does — anywhere from
+"slowed the worst of it but they need a surgeon" (failure) to
+"stopped the bleeding, closed the infection, dulled the pain" (full
+success across all categories).
+
+Channels intentionally NOT handled here:
+
+* ``wound_healing`` — slow-tick organ HP recovery via the medical
+  script (PR-C).
+* ``organ_repair`` — instant HP refund on surgical-grade items
+  applied during an open procedure (PR-D).
+
+Both ride the same application path eventually, just gated on
+later infrastructure that doesn't exist yet.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+from world.medical.constants import (
+    WOUND_CARE_BASE_DIFFICULTY,
+    WOUND_CARE_BLEEDING_REDUCTION,
+    WOUND_CARE_DEPTH_MODIFIER,
+    WOUND_CARE_INFECTION_REDUCTION,
+    WOUND_CARE_PAIN_REDUCTION,
+    WOUND_CARE_PARALLEL_CATEGORIES,
+    WOUND_CARE_PARTIAL_THRESHOLD,
+    WOUND_CARE_SEVERITY_MODIFIERS,
+    WOUND_CARE_SUCCESS_THRESHOLD,
+)
+
+
+# ---------------------------------------------------------------------
+# Outcome literals — strings rather than enums to keep test stubs
+# inspectable without an import.
+# ---------------------------------------------------------------------
+
+SUCCESS = "success"
+PARTIAL = "partial"
+FAILURE = "failure"
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+
+
+def calculate_treatment_skill(actor) -> float:
+    """G.R.I.M. medical effectiveness for treatment rolls.
+
+    Same formula as the procedure verbs: intellect-weighted, with
+    motorics contributing for steady hands.  Matches the formula at
+    HEALTH_AND_SUBSTANCE_SYSTEM_SPEC line 1434.
+    """
+    intellect = getattr(actor, "intellect", 0) or 0
+    motorics = getattr(actor, "motorics", 0) or 0
+    return (intellect * 0.75) + (motorics * 0.25)
+
+
+def calculate_treatment_difficulty(
+    wound_severity: str,
+    item_internal_effective: bool,
+    is_internal_wound: bool,
+) -> int:
+    """Compose the treatment-roll target.
+
+    Args:
+        wound_severity: One of the keys in
+            :data:`WOUND_CARE_SEVERITY_MODIFIERS` (string severity
+            from wound rendering).  Unknown → treated as Moderate.
+        item_internal_effective: Whether the item's effectiveness
+            includes a non-zero ``organ_repair`` rating (i.e. it's
+            a deep-treatment item designed for open procedures).
+        is_internal_wound: Whether the wound sits at an internal-
+            cavity container (head / chest / abdomen / etc. — the
+            ``core.py`` ``internal_containers`` distinction).
+
+    Adds:
+        + severity modifier from the ladder
+        + depth modifier when the wound is internal AND the item
+          isn't internal-effective
+    """
+    target = WOUND_CARE_BASE_DIFFICULTY
+    target += WOUND_CARE_SEVERITY_MODIFIERS.get(
+        wound_severity, WOUND_CARE_SEVERITY_MODIFIERS["Moderate"]
+    )
+    if is_internal_wound and not item_internal_effective:
+        target += WOUND_CARE_DEPTH_MODIFIER
+    return target
+
+
+def roll_treatment(actor, target_difficulty: int, item_rating: int) -> dict:
+    """3d6 + skill + item rating vs target.
+
+    Returns a dict with ``roll`` (the 3d6 sum), ``total`` (after
+    bonuses), ``target`` (the difficulty), and ``outcome``
+    (success / partial / failure based on the threshold ladder).
+    """
+    roll = sum(random.randint(1, 6) for _ in range(3))
+    skill = calculate_treatment_skill(actor)
+    total = roll + int(skill) + int(item_rating)
+    if total >= WOUND_CARE_SUCCESS_THRESHOLD:
+        outcome = SUCCESS
+    elif total >= WOUND_CARE_PARTIAL_THRESHOLD:
+        outcome = PARTIAL
+    else:
+        outcome = FAILURE
+    return {
+        "roll": roll,
+        "skill": skill,
+        "item_rating": item_rating,
+        "total": total,
+        "target": target_difficulty,
+        "outcome": outcome,
+    }
+
+
+def damaged_organs_at_location(target, location: str) -> list:
+    """Return the live ``Organ`` instances at ``location`` that have
+    HP loss.  Matches by ``container`` or ``display_location`` so the
+    surface-organ rule lines up with the access rule from PR-A.
+    """
+    state = getattr(target, "medical_state", None)
+    if state is None or not hasattr(state, "organs"):
+        return []
+    out = []
+    for organ in state.organs.values():
+        if organ.current_hp >= organ.max_hp:
+            continue  # Healthy — no wound to stabilize.
+        container = getattr(organ, "container", None)
+        display = getattr(organ, "display_location", None)
+        if location in (container, display):
+            out.append(organ)
+    return out
+
+
+def _wound_severity_from_organ(organ) -> str:
+    """Map an organ's HP-loss tier to the wound severity ladder.
+
+    Mirrors ``_determine_severity_from_damage`` in wound rendering
+    closely enough for the difficulty math.  The full renderer
+    accounts for organ-specific maxes; here we use the percentage of
+    HP lost.
+    """
+    if organ.max_hp <= 0:
+        return "Moderate"
+    pct_lost = (organ.max_hp - organ.current_hp) / organ.max_hp
+    if pct_lost >= 0.75:
+        return "Critical"
+    if pct_lost >= 0.5:
+        return "Severe"
+    if pct_lost >= 0.25:
+        return "Moderate"
+    return "Minor"
+
+
+def _is_internal_container(container: str) -> bool:
+    """Whether ``container`` is an internal body cavity.
+
+    Uses the duck-typed match: anything not in the limb set is
+    treated as internal.  Same distinction ``world/medical/core.py``
+    makes for the destruction-vs-severance pipeline.
+    """
+    limb_containers = {
+        "left_arm", "right_arm", "left_hand", "right_hand",
+        "left_thigh", "right_thigh", "left_shin", "right_shin",
+        "left_foot", "right_foot", "tail", "left_wing", "right_wing",
+    }
+    if container is None:
+        return False
+    if container in limb_containers:
+        return False
+    if "tentacle_" in container or "_leg_" in container or "_arm_" in container:
+        return False
+    return True
+
+
+def _conditions_at_location(
+    medical_state, location: str, condition_cls
+) -> list:
+    """Return conditions of ``condition_cls`` at ``location`` (or at
+    the same location resolved via the organ's display vs container).
+    """
+    out = []
+    for condition in getattr(medical_state, "conditions", []):
+        if not isinstance(condition, condition_cls):
+            continue
+        if condition.location == location:
+            out.append(condition)
+    return out
+
+
+# ---------------------------------------------------------------------
+# Main dispatch
+# ---------------------------------------------------------------------
+
+
+def apply_wound_care(actor, target, item, location: str) -> dict:
+    """Apply a wound_care item at ``location`` on ``target``.
+
+    Returns a result dict with ``stabilized`` (bool), ``rolls``
+    (per-category result dicts), ``messages`` (list of user-facing
+    strings the caller can msg), and ``no_op_reason`` when nothing
+    happens (already stabilized, no wound at location, etc.).
+
+    Side effects:
+        * Marks any damaged organs at the location as stabilized.
+        * Reduces BleedingCondition / InfectionCondition /
+          PainCondition severities at the location per the per-
+          category roll outcome.
+        * Consumes one use of ``item`` (decrements ``uses_left``).
+    """
+    result = {
+        "stabilized": False,
+        "rolls": {},
+        "messages": [],
+        "no_op_reason": None,
+    }
+
+    wounded_organs = damaged_organs_at_location(target, location)
+    if not wounded_organs:
+        result["no_op_reason"] = "no_wound"
+        result["messages"].append(
+            f"There's no wound at "
+            f"{location.replace('_', ' ')} to treat."
+        )
+        return result
+
+    # If any wounded organ at this location is already stabilized,
+    # the location as a whole is being held — re-applying does
+    # nothing useful.  Triage hint to the caller.
+    if any(getattr(o, "stabilized", False) for o in wounded_organs):
+        result["no_op_reason"] = "already_stabilized"
+        result["messages"].append(
+            f"The wound at {location.replace('_', ' ')} is already "
+            f"stabilized — they need a surgeon now, not more dressing."
+        )
+        return result
+
+    # Determine the difficulty floor for the rolls.  We use the worst
+    # (highest-severity) wound at the location as the target driver,
+    # so stabilizing a critically damaged organ is harder than a
+    # minor one even if both share the location.
+    worst_severity = max(
+        (_wound_severity_from_organ(o) for o in wounded_organs),
+        key=lambda s: WOUND_CARE_SEVERITY_MODIFIERS.get(s, 0),
+    )
+    container = wounded_organs[0].container
+    is_internal_wound = _is_internal_container(container)
+
+    effectiveness = _item_effectiveness(item)
+    item_internal_effective = bool(effectiveness.get("organ_repair", 0))
+
+    difficulty = calculate_treatment_difficulty(
+        wound_severity=worst_severity,
+        item_internal_effective=item_internal_effective,
+        is_internal_wound=is_internal_wound,
+    )
+
+    # Resolve each category in parallel.  Each gets its own roll
+    # against the same difficulty target, using the item's per-
+    # category effectiveness rating as the modifier.
+    for category in WOUND_CARE_PARALLEL_CATEGORIES:
+        rating = int(effectiveness.get(category, 0))
+        roll_result = roll_treatment(actor, difficulty, rating)
+        result["rolls"][category] = roll_result
+        _apply_category_outcome(
+            target, location, category, roll_result["outcome"], result,
+        )
+
+    # Stabilization is unconditional on any application.  Even a
+    # failed roll across all categories still pins the wound at its
+    # current state — the act of dressing a wound stops it from
+    # getting worse, even if the surgeon will need to redo the
+    # work later.
+    for organ in wounded_organs:
+        organ.stabilized = True
+    result["stabilized"] = True
+    result["messages"].append(
+        f"The wound at {location.replace('_', ' ')} is stabilized."
+    )
+
+    # Consume one use of the item.
+    _consume_use(item)
+
+    return result
+
+
+def _apply_category_outcome(
+    target, location: str, category: str, outcome: str, result: dict
+) -> None:
+    """Side-effect: mutate the relevant condition at ``location`` per
+    the per-category outcome.  Appends a user-facing line to
+    ``result["messages"]``.
+    """
+    from world.medical.conditions import (
+        BleedingCondition,
+        InfectionCondition,
+        PainCondition,
+    )
+
+    medical_state = getattr(target, "medical_state", None)
+    if medical_state is None:
+        return
+
+    if category == "bleeding":
+        conditions = _conditions_at_location(
+            medical_state, location, BleedingCondition,
+        )
+        reduction = _category_reduction("bleeding", outcome)
+        for cond in conditions:
+            cond.severity = max(0, cond.severity - reduction)
+        if conditions and reduction > 0:
+            result["messages"].append(
+                f"Bleeding at {location.replace('_', ' ')} "
+                f"reduced by {reduction}."
+            )
+
+    elif category == "infection":
+        conditions = _conditions_at_location(
+            medical_state, location, InfectionCondition,
+        )
+        reduction = _category_reduction("infection", outcome)
+        for cond in conditions:
+            cond.severity = max(0, cond.severity - reduction)
+        if conditions and reduction > 0:
+            result["messages"].append(
+                f"Infection at {location.replace('_', ' ')} "
+                f"reduced by {reduction}."
+            )
+
+    elif category == "pain":
+        conditions = _conditions_at_location(
+            medical_state, location, PainCondition,
+        )
+        reduction = _category_reduction("pain", outcome)
+        for cond in conditions:
+            cond.severity = max(0, cond.severity - reduction)
+        if conditions and reduction > 0:
+            result["messages"].append(
+                f"Pain at {location.replace('_', ' ')} "
+                f"reduced by {reduction}."
+            )
+
+
+def _category_reduction(category: str, outcome: str) -> int:
+    """Effect amount for a category given its roll outcome.
+
+    Full effect on success, half (rounded down) on partial, zero on
+    failure — the stabilization channel still fires on failure but
+    no per-category reduction lands.
+    """
+    base = {
+        "bleeding": WOUND_CARE_BLEEDING_REDUCTION,
+        "infection": WOUND_CARE_INFECTION_REDUCTION,
+        "pain": WOUND_CARE_PAIN_REDUCTION,
+    }.get(category, 0)
+    if outcome == SUCCESS:
+        return base
+    if outcome == PARTIAL:
+        return base // 2
+    return 0
+
+
+def _item_effectiveness(item) -> dict:
+    """Return the item's ``effectiveness`` dict, or empty when absent.
+
+    Items declare effectiveness as an AttributeProperty / db attr;
+    we read defensively because some test stubs use plain dicts.
+    """
+    attrs = getattr(item, "attributes", None)
+    if attrs is None:
+        # Direct attribute access for plain test stubs.
+        return getattr(item, "effectiveness", {}) or {}
+    if hasattr(attrs, "get"):
+        return attrs.get("effectiveness") or {}
+    return {}
+
+
+def _consume_use(item) -> None:
+    """Decrement ``uses_left`` on the item.  Items without
+    ``uses_left`` (single-use disposables relying on deletion, or
+    legacy items) are left alone — the caller is responsible for
+    those cases."""
+    attrs = getattr(item, "attributes", None)
+    if attrs is None or not hasattr(attrs, "get"):
+        return
+    uses = attrs.get("uses_left")
+    if isinstance(uses, int) and uses > 0:
+        attrs.add("uses_left", uses - 1)

--- a/world/tests/test_wound_care.py
+++ b/world/tests/test_wound_care.py
@@ -1,0 +1,487 @@
+"""Tests for the wound_care stabilization channel (#307, PR-B).
+
+Covers:
+
+* ``world.medical.treatments.apply_wound_care`` — main dispatch
+* ``Organ.stabilized`` lifecycle (set on application, cleared on
+  full heal, serialised across to_dict/from_dict)
+* ``BleedingCondition._location_stabilized`` — bleed-tick stops
+  bleeding loss when the wounded organ is stabilized
+* Repeat-application no-op (triage hint)
+* Per-category roll outcomes (success / partial / failure)
+* Item ``uses_left`` consumed on application
+
+The treatment dispatch uses ``random.randint`` for the 3d6 roll;
+tests patch it to drive deterministic outcomes.
+
+Run via::
+
+    evennia test world.tests.test_wound_care
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.medical.core import MedicalState, Organ
+from world.medical.conditions import (
+    BleedingCondition,
+    InfectionCondition,
+    PainCondition,
+)
+from world.medical.treatments import (
+    FAILURE,
+    PARTIAL,
+    SUCCESS,
+    _category_reduction,
+    _is_internal_container,
+    _wound_severity_from_organ,
+    apply_wound_care,
+    calculate_treatment_difficulty,
+    calculate_treatment_skill,
+    damaged_organs_at_location,
+)
+from world.medical.constants import (
+    WOUND_CARE_BASE_DIFFICULTY,
+    WOUND_CARE_BLEEDING_REDUCTION,
+    WOUND_CARE_DEPTH_MODIFIER,
+    WOUND_CARE_PAIN_REDUCTION,
+    WOUND_CARE_SEVERITY_MODIFIERS,
+)
+
+
+# ---------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------
+
+
+def _patient(intellect=2, motorics=2, conscious=True):
+    """Minimal living target with a real MedicalState."""
+    char = SimpleNamespace()
+    char.intellect = intellect
+    char.motorics = motorics
+    char.is_unconscious = lambda: not conscious
+    char.db = SimpleNamespace(
+        species="human", archived=False, surgical_state=None,
+        removed_organs=None, severed_locations=None,
+    )
+    char.key = "TestPatient"
+    char.medical_state = MedicalState(char)
+    return char
+
+
+def _medic(intellect=3, motorics=3):
+    return _patient(intellect=intellect, motorics=motorics)
+
+
+def _wound_organ(patient, organ_name: str, hp_loss_fraction: float = 0.5):
+    """Reduce ``organ_name`` HP on ``patient`` by ``hp_loss_fraction``."""
+    organ = patient.medical_state.organs[organ_name]
+    damage = int(organ.max_hp * hp_loss_fraction)
+    organ.current_hp = max(0, organ.max_hp - damage)
+    organ.wound_stage = "fresh"
+    return organ
+
+
+def _item(effectiveness: dict, uses_left: int = 3,
+          medical_type: str = "wound_care"):
+    """Stub item with the attributes the treatments dispatch reads."""
+    attrs_store = {
+        "effectiveness": effectiveness,
+        "uses_left": uses_left,
+        "medical_type": medical_type,
+    }
+
+    class _Attrs:
+        def get(self, key):
+            return attrs_store.get(key)
+
+        def add(self, key, value):
+            attrs_store[key] = value
+
+    item = SimpleNamespace()
+    item.attributes = _Attrs()
+    item.key = "test-bandage"
+    # Snapshot for inspection in tests:
+    item._store = attrs_store
+    return item
+
+
+# ---------------------------------------------------------------------
+# Organ.stabilized lifecycle
+# ---------------------------------------------------------------------
+
+
+class OrganStabilizedAttribute(TestCase):
+
+    def test_default_false(self):
+        organ = Organ("heart", species="human")
+        self.assertFalse(organ.stabilized)
+
+    def test_serializes_to_dict(self):
+        organ = Organ("heart", species="human")
+        organ.stabilized = True
+        data = organ.to_dict()
+        self.assertIn("stabilized", data)
+        self.assertTrue(data["stabilized"])
+
+    def test_round_trips_through_from_dict(self):
+        organ = Organ("heart", species="human")
+        organ.stabilized = True
+        organ.current_hp = 5
+        organ.wound_stage = "fresh"
+        restored = Organ.from_dict(organ.to_dict())
+        self.assertTrue(restored.stabilized)
+
+    def test_legacy_dict_without_field_defaults_false(self):
+        organ = Organ("heart", species="human")
+        data = organ.to_dict()
+        data.pop("stabilized", None)
+        restored = Organ.from_dict(data)
+        self.assertFalse(restored.stabilized)
+
+    def test_full_heal_clears_stabilization(self):
+        organ = Organ("heart", species="human")
+        organ.current_hp = 5
+        organ.wound_stage = "fresh"
+        organ.stabilized = True
+        organ.heal(organ.max_hp)
+        self.assertEqual(organ.current_hp, organ.max_hp)
+        self.assertFalse(organ.stabilized)
+
+
+# ---------------------------------------------------------------------
+# BleedingCondition stabilization interaction
+# ---------------------------------------------------------------------
+
+
+class BleedingStabilization(TestCase):
+
+    def _patient_with_chest_bleed(self):
+        patient = _patient()
+        _wound_organ(patient, "heart", hp_loss_fraction=0.5)
+        bleed = BleedingCondition(severity=5, location="chest")
+        patient.medical_state.conditions.append(bleed)
+        return patient, bleed
+
+    @patch("world.medical.conditions.ChannelDB")
+    def test_unstabilized_bleed_drains_blood(self, mock_channel):
+        mock_channel.objects.get_channel.return_value = MagicMock()
+        patient, bleed = self._patient_with_chest_bleed()
+        initial_blood = patient.medical_state.blood_level
+        # Pin natural-healing roll high so severity doesn't drift.
+        with patch("world.medical.conditions.random.randint",
+                   return_value=100):
+            bleed.tick_effect(patient)
+        self.assertLess(
+            patient.medical_state.blood_level, initial_blood,
+            "Unstabilized bleeding should drain blood on tick.",
+        )
+
+    @patch("world.medical.conditions.ChannelDB")
+    def test_stabilized_bleed_holds_blood(self, mock_channel):
+        mock_channel.objects.get_channel.return_value = MagicMock()
+        patient, bleed = self._patient_with_chest_bleed()
+        patient.medical_state.organs["heart"].stabilized = True
+        initial_blood = patient.medical_state.blood_level
+        with patch("world.medical.conditions.random.randint",
+                   return_value=100):
+            bleed.tick_effect(patient)
+        self.assertEqual(
+            patient.medical_state.blood_level, initial_blood,
+            "Stabilized bleeding should not drain blood on tick.",
+        )
+
+    @patch("world.medical.conditions.ChannelDB")
+    def test_stabilized_undamaged_organ_does_not_shield(self, mock_channel):
+        """A stabilized-but-undamaged organ at the location shouldn't
+        protect an unrelated bleeding source there."""
+        mock_channel.objects.get_channel.return_value = MagicMock()
+        patient = _patient()
+        # Lung wounded + bleeding; heart untouched but flagged
+        # stabilized (degenerate scenario, but stress the guard).
+        _wound_organ(patient, "left_lung", hp_loss_fraction=0.5)
+        patient.medical_state.organs["heart"].stabilized = True
+        bleed = BleedingCondition(severity=3, location="chest")
+        patient.medical_state.conditions.append(bleed)
+        initial_blood = patient.medical_state.blood_level
+        with patch("world.medical.conditions.random.randint",
+                   return_value=100):
+            bleed.tick_effect(patient)
+        self.assertLess(patient.medical_state.blood_level, initial_blood)
+
+
+# ---------------------------------------------------------------------
+# Skill and difficulty calculation
+# ---------------------------------------------------------------------
+
+
+class TreatmentSkill(TestCase):
+
+    def test_skill_formula(self):
+        actor = SimpleNamespace(intellect=4, motorics=2)
+        # 4 * 0.75 + 2 * 0.25 = 3.0 + 0.5 = 3.5
+        self.assertEqual(calculate_treatment_skill(actor), 3.5)
+
+    def test_skill_missing_stats_defaults_zero(self):
+        actor = SimpleNamespace()
+        self.assertEqual(calculate_treatment_skill(actor), 0.0)
+
+
+class TreatmentDifficulty(TestCase):
+
+    def test_base_difficulty_at_minor_external(self):
+        diff = calculate_treatment_difficulty(
+            "Minor", item_internal_effective=False,
+            is_internal_wound=False,
+        )
+        self.assertEqual(diff, WOUND_CARE_BASE_DIFFICULTY)
+
+    def test_severity_modifier_applied(self):
+        for severity, expected_mod in WOUND_CARE_SEVERITY_MODIFIERS.items():
+            with self.subTest(severity=severity):
+                diff = calculate_treatment_difficulty(
+                    severity, item_internal_effective=False,
+                    is_internal_wound=False,
+                )
+                self.assertEqual(
+                    diff, WOUND_CARE_BASE_DIFFICULTY + expected_mod
+                )
+
+    def test_depth_modifier_for_internal_wound_with_surface_item(self):
+        diff = calculate_treatment_difficulty(
+            "Moderate", item_internal_effective=False,
+            is_internal_wound=True,
+        )
+        self.assertEqual(
+            diff,
+            WOUND_CARE_BASE_DIFFICULTY +
+            WOUND_CARE_SEVERITY_MODIFIERS["Moderate"] +
+            WOUND_CARE_DEPTH_MODIFIER,
+        )
+
+    def test_depth_modifier_skipped_for_internal_item(self):
+        """Surgical-grade items skip the depth penalty even when used
+        on internal wounds."""
+        diff = calculate_treatment_difficulty(
+            "Moderate", item_internal_effective=True,
+            is_internal_wound=True,
+        )
+        self.assertEqual(
+            diff,
+            WOUND_CARE_BASE_DIFFICULTY +
+            WOUND_CARE_SEVERITY_MODIFIERS["Moderate"],
+        )
+
+
+# ---------------------------------------------------------------------
+# Wound severity from organ
+# ---------------------------------------------------------------------
+
+
+class WoundSeverityFromOrgan(TestCase):
+
+    def _organ_at_hp(self, current, maximum=20):
+        organ = Organ("heart", species="human")
+        organ.max_hp = maximum
+        organ.current_hp = current
+        return organ
+
+    def test_full_hp_returns_minor(self):
+        # No HP loss → Minor — never actually called this way but
+        # behaviourally safe.
+        organ = self._organ_at_hp(20)
+        self.assertEqual(_wound_severity_from_organ(organ), "Minor")
+
+    def test_quarter_loss_returns_moderate(self):
+        organ = self._organ_at_hp(15)  # 25% lost
+        self.assertEqual(_wound_severity_from_organ(organ), "Moderate")
+
+    def test_half_loss_returns_severe(self):
+        organ = self._organ_at_hp(10)  # 50% lost
+        self.assertEqual(_wound_severity_from_organ(organ), "Severe")
+
+    def test_three_quarter_loss_returns_critical(self):
+        organ = self._organ_at_hp(5)  # 75% lost
+        self.assertEqual(_wound_severity_from_organ(organ), "Critical")
+
+
+# ---------------------------------------------------------------------
+# Category reduction
+# ---------------------------------------------------------------------
+
+
+class CategoryReduction(TestCase):
+
+    def test_success_full_reduction(self):
+        self.assertEqual(
+            _category_reduction("bleeding", SUCCESS),
+            WOUND_CARE_BLEEDING_REDUCTION,
+        )
+        self.assertEqual(
+            _category_reduction("pain", SUCCESS),
+            WOUND_CARE_PAIN_REDUCTION,
+        )
+
+    def test_partial_half_reduction(self):
+        self.assertEqual(
+            _category_reduction("bleeding", PARTIAL),
+            WOUND_CARE_BLEEDING_REDUCTION // 2,
+        )
+
+    def test_failure_zero_reduction(self):
+        self.assertEqual(_category_reduction("bleeding", FAILURE), 0)
+        self.assertEqual(_category_reduction("pain", FAILURE), 0)
+
+
+# ---------------------------------------------------------------------
+# Internal container classification
+# ---------------------------------------------------------------------
+
+
+class InternalContainerClassification(TestCase):
+
+    def test_internal_cavities(self):
+        for loc in ("head", "chest", "abdomen", "back", "neck", "groin"):
+            with self.subTest(loc=loc):
+                self.assertTrue(_is_internal_container(loc))
+
+    def test_limbs_not_internal(self):
+        for loc in ("left_arm", "right_arm", "left_hand", "left_thigh",
+                    "left_shin", "left_foot", "tail"):
+            with self.subTest(loc=loc):
+                self.assertFalse(_is_internal_container(loc))
+
+    def test_none_not_internal(self):
+        self.assertFalse(_is_internal_container(None))
+
+
+# ---------------------------------------------------------------------
+# damaged_organs_at_location
+# ---------------------------------------------------------------------
+
+
+class DamagedOrgansAtLocation(TestCase):
+
+    def test_finds_damaged_chest_organ(self):
+        patient = _patient()
+        _wound_organ(patient, "heart", hp_loss_fraction=0.3)
+        results = damaged_organs_at_location(patient, "chest")
+        names = [o.name for o in results]
+        self.assertIn("heart", names)
+
+    def test_skips_healthy_organs(self):
+        patient = _patient()
+        # No wounding — chest is healthy.
+        results = damaged_organs_at_location(patient, "chest")
+        self.assertEqual(results, [])
+
+    def test_matches_via_display_location(self):
+        """Eye damage surfaces at display_location='left_eye' rather
+        than container='head'."""
+        patient = _patient()
+        _wound_organ(patient, "left_eye", hp_loss_fraction=0.4)
+        results = damaged_organs_at_location(patient, "left_eye")
+        names = [o.name for o in results]
+        self.assertIn("left_eye", names)
+
+
+# ---------------------------------------------------------------------
+# apply_wound_care dispatch
+# ---------------------------------------------------------------------
+
+
+class ApplyWoundCareDispatch(TestCase):
+
+    def _setup_wounded_patient(self):
+        patient = _patient()
+        organ = _wound_organ(patient, "heart", hp_loss_fraction=0.4)
+        bleed = BleedingCondition(severity=4, location="chest")
+        infect = InfectionCondition(severity=3, location="chest")
+        pain = PainCondition(severity=5, location="chest")
+        patient.medical_state.conditions.extend([bleed, infect, pain])
+        return patient, organ, bleed, infect, pain
+
+    def test_no_wound_at_location_returns_no_op(self):
+        patient = _patient()
+        medic = _medic()
+        item = _item({"bleeding": 5})
+        result = apply_wound_care(medic, patient, item, "chest")
+        self.assertEqual(result["no_op_reason"], "no_wound")
+        self.assertFalse(result["stabilized"])
+
+    @patch("world.medical.treatments.random.randint", return_value=6)
+    def test_success_stabilizes_and_reduces_categories(self, _r):
+        patient, organ, bleed, infect, pain = self._setup_wounded_patient()
+        medic = _medic()
+        item = _item({"bleeding": 7, "infection": 8, "pain": 3})
+        result = apply_wound_care(medic, patient, item, "chest")
+        self.assertTrue(result["stabilized"])
+        self.assertTrue(organ.stabilized)
+        # All three categories full-reduced.
+        self.assertEqual(
+            bleed.severity, 4 - WOUND_CARE_BLEEDING_REDUCTION
+        )
+        self.assertEqual(
+            infect.severity, 3 - WOUND_CARE_BLEEDING_REDUCTION
+        )
+        self.assertEqual(pain.severity, 5 - WOUND_CARE_PAIN_REDUCTION)
+
+    @patch("world.medical.treatments.random.randint", return_value=1)
+    def test_failure_still_stabilizes(self, _r):
+        """Even with worst possible rolls, the act of dressing the
+        wound stabilizes — buys time for a surgeon."""
+        patient, organ, bleed, _i, _p = self._setup_wounded_patient()
+        medic = _medic()
+        item = _item({"bleeding": 0})
+        original_bleed = bleed.severity
+        result = apply_wound_care(medic, patient, item, "chest")
+        self.assertTrue(result["stabilized"])
+        self.assertTrue(organ.stabilized)
+        # Severity unchanged on failure.
+        self.assertEqual(bleed.severity, original_bleed)
+
+    @patch("world.medical.treatments.random.randint", return_value=6)
+    def test_repeat_application_no_ops(self, _r):
+        patient, organ, bleed, _i, _p = self._setup_wounded_patient()
+        medic = _medic()
+        item = _item({"bleeding": 7, "infection": 8, "pain": 3})
+        apply_wound_care(medic, patient, item, "chest")
+        bleed_after_first = bleed.severity
+        # Second application — should bail with already_stabilized.
+        result = apply_wound_care(medic, patient, item, "chest")
+        self.assertEqual(result["no_op_reason"], "already_stabilized")
+        # Severity unchanged from the no-op.
+        self.assertEqual(bleed.severity, bleed_after_first)
+
+    @patch("world.medical.treatments.random.randint", return_value=6)
+    def test_consumes_one_use(self, _r):
+        patient, *_ = self._setup_wounded_patient()
+        medic = _medic()
+        item = _item({"bleeding": 7}, uses_left=3)
+        apply_wound_care(medic, patient, item, "chest")
+        self.assertEqual(item._store["uses_left"], 2)
+
+    @patch("world.medical.treatments.random.randint", return_value=6)
+    def test_marks_all_damaged_organs_at_location_stabilized(self, _r):
+        patient = _patient()
+        heart = _wound_organ(patient, "heart", hp_loss_fraction=0.3)
+        lung = _wound_organ(patient, "left_lung", hp_loss_fraction=0.4)
+        medic = _medic()
+        item = _item({"bleeding": 5})
+        apply_wound_care(medic, patient, item, "chest")
+        self.assertTrue(heart.stabilized)
+        self.assertTrue(lung.stabilized)
+
+    @patch("world.medical.treatments.random.randint", return_value=6)
+    def test_does_not_stabilize_unrelated_locations(self, _r):
+        patient = _patient()
+        chest_organ = _wound_organ(patient, "heart", hp_loss_fraction=0.3)
+        abdomen_organ = _wound_organ(patient, "liver", hp_loss_fraction=0.3)
+        medic = _medic()
+        item = _item({"bleeding": 5})
+        apply_wound_care(medic, patient, item, "chest")
+        self.assertTrue(chest_organ.stabilized)
+        self.assertFalse(abdomen_organ.stabilized)


### PR DESCRIPTION
## Summary

Implements the stabilization layer settled in the #307 design pass. Applying a ``wound_care`` item to a wound:

- **Always** stabilizes — freezes wound state, stops bleeding loss, halts severity escalation
- **Rolls in parallel** for bleeding / infection / pain reduction, each using item's per-category effectiveness rating + medic skill vs severity-derived difficulty
- **Re-application no-ops** with a triage hint ("already stabilized, get them to a surgeon")

Substance-tolerance principle holds: system accepts any wound_care item on any wound at any location. Effectiveness determines what lands; failure still stabilizes because the act of dressing the wound stops it from getting worse.

### Channels deferred

- ``wound_healing`` slow-tick HP recovery → **PR-C**
- ``organ_repair`` instant HP refund for surgical-grade items → **PR-D**

## Files

- ``world/medical/constants.py`` — severity ladder, base difficulty, per-category reductions, outcome thresholds (all knobs in one place per "readily modifiable" guidance)
- ``world/medical/core.py`` — ``Organ.stabilized`` flag with full lifecycle (default False, serialised, clears on full heal)
- ``world/medical/conditions.py`` — ``BleedingCondition`` tick early-returns when wounded organ at its location is stabilized
- ``world/medical/treatments.py`` (NEW) — ``apply_wound_care`` dispatch, skill/difficulty/roll composition, helpers
- ``commands/CmdConsumption.py`` — CmdApply routes wound_care + location through the dispatch; legacy flow preserved for other medical_types

## Roll math

```
roll   = 3d6 + medical_effectiveness + item.effectiveness[category]
target = WOUND_CARE_BASE_DIFFICULTY + severity_modifier + depth_modifier
```

- ``medical_effectiveness = (intellect * 0.75) + (motorics * 0.25)`` (matches procedure verbs)
- Severity ladder: Minor +0 / Moderate +3 / Severe +6 / Critical +9
- Depth: +5 when wound is internal AND item lacks ``organ_repair`` rating
- Outcomes: success ≥ 18, partial ≥ 12, else failure
- Reductions: full on success, half (floor) on partial, zero on failure

All values are placeholders; balancing per the design pass guidance ("readily modifiable, modicum of sense").

## Test plan

- [x] ``world.tests.test_wound_care`` — 34/34 covering Organ.stabilized lifecycle, BleedingCondition interaction, skill/difficulty/severity composition, dispatch outcomes (success / failure / repeat / multi-organ / cross-location)
- [x] Full suite: 1842/1842 (+34 net, no regressions)
- [x] Manual sanity: ``apply gauze on bob's chest`` stabilizes wounded heart; ``apply gauze on bob's chest`` again returns triage hint; heart fully heals → stabilization clears

Refs #307. Slice B of the design-pass implementation order; PR-C and PR-D follow.