### PR TITLE
Sever drops wielded items to room + drop_to_room helper (#307, PR-H0)

### DIFF
--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -332,20 +332,13 @@ class CmdDrop(Command):
                 hand_name = hand
                 break
 
-        # Move the item to the room
-        obj.move_to(caller.location, quiet=True)
-
-        # Apply gravity if item is dropped in a sky room
-        from commands.combat.movement import apply_gravity_to_items
-        apply_gravity_to_items(caller.location)
-        
-        # Universal proximity assignment for all dropped objects
-        if not hasattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL):
-            setattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, [])
+        # Canonical "item lands on ground" pipeline — move + gravity
+        # + proximity scaffolding.  Caller-specific proximity is added
+        # below since CmdDrop wants the dropper themselves listed as
+        # near the dropped object.
+        from commands.combat.jump import drop_to_room
+        drop_to_room(obj, caller.location)
         proximity_list = getattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, [])
-        if proximity_list is None:
-            proximity_list = []
-            setattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, proximity_list)
         if caller not in proximity_list:
             proximity_list.append(caller)
         

--- a/commands/combat/jump.py
+++ b/commands/combat/jump.py
@@ -1327,11 +1327,52 @@ def apply_gravity_to_items(room):
         try:
             splattercast.msg(f"GRAVITY_ITEMS: Moving {item.key} from {room.key} to {ground_room.key} (fell {fall_distance} levels)")
             item.move_to(ground_room, quiet=True)
-            
+
             # Announce the item falling to the ground room
             ground_room.msg_contents(f"A {item.key} falls from above and lands with a clatter.")
             splattercast.msg(f"GRAVITY_ITEMS: Successfully moved {item.key} to {ground_room.key}")
-            
+
         except Exception as e:
             splattercast.msg(f"GRAVITY_ITEMS_ERROR: Failed to move {item.key}: {e}")
             # Continue with other items even if one fails
+
+
+def drop_to_room(item, room):
+    """Canonical "item lands on the ground" pipeline.
+
+    Performs the three physical effects that should happen whenever
+    an item ends up on the floor of a room, regardless of *why*:
+
+    1. Physical relocation via ``item.move_to(room, quiet=True)``.
+    2. Sky-room gravity check via :func:`apply_gravity_to_items` so
+       items dropped into a mid-air location fall to the ground room.
+    3. Proximity tracking via ``NDB_PROXIMITY_UNIVERSAL`` so the item
+       participates correctly in combat / throw / grappling distance
+       checks at its new resting location.
+
+    This helper deliberately does **not** emit player-facing messages.
+    Each caller has its own narrative context — a player ``drop``
+    command says "you drop the shiv", a sever pipeline says "the
+    shiv slips from her severed hand", a thrown-grenade resolution
+    says "the grenade clatters to the floor".  Centralising the
+    physics here lets each call site own the prose.
+
+    Args:
+        item: The object that should end up in ``room``.
+        room: The destination room (typically the actor's current
+            ``location``).  Sky-room gravity is applied to ``room``
+            after the move, so if ``room`` is mid-air the item will
+            continue falling automatically.
+    """
+    item.move_to(room, quiet=True)
+    apply_gravity_to_items(room)
+
+    # Universal proximity assignment so the item participates in
+    # combat / throw / grappling proximity checks at its new
+    # resting location.  Mirrors the assignment block previously
+    # inlined in CmdDrop.
+    from world.combat.constants import NDB_PROXIMITY_UNIVERSAL
+    proximity_list = getattr(item.ndb, NDB_PROXIMITY_UNIVERSAL, None)
+    if proximity_list is None:
+        proximity_list = []
+        setattr(item.ndb, NDB_PROXIMITY_UNIVERSAL, proximity_list)

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1882,8 +1882,14 @@ def detach_items_to_appendage(character, appendage, containers):
       the character when one arm is severed.
     * A **wielded** weapon in *any* hand whose container is in the
       severed chain (via :data:`world.combat.constants.SEVER_HAND_BY_CONTAINER`)
-      always follows the limb. Severing the upper arm carries the
-      sword that was in that hand.
+      **drops to the ground** at the character's current location
+      (PR-H0, #307). Severance loosens the dead hand's grip; the weapon
+      lands separately from the severed limb. Uses
+      :func:`commands.combat.jump.drop_to_room` so gravity / sky-room /
+      proximity tracking apply uniformly with the player ``drop``
+      command. Prior behaviour (weapon carried on the appendage) was
+      surprising during salvage — players couldn't pick up the sword
+      without first interacting with the severed arm.
 
     Bookkeeping (``worn_items`` / ``hands`` dicts) is updated purely and
     reassigned so the ``AttributeProperty`` persists.  The physical
@@ -1947,12 +1953,32 @@ def detach_items_to_appendage(character, appendage, containers):
     if hands_to_clear:
         hands = character.hands or {}
         new_hands = dict(hands)
+        # PR-H0: held items drop to the character's current location
+        # rather than relocating onto the severed appendage.  The
+        # severed limb is bookkept as "had a weapon in it before the
+        # cut", but the weapon itself falls free.  Use the canonical
+        # drop-to-room pipeline for gravity / proximity parity with
+        # the player ``drop`` command.
+        drop_room = getattr(character, "location", None)
         for hand in hands_to_clear:
             held = new_hands.get(hand)
             if held:
                 new_hands[hand] = None
-                _relocate_item(held, appendage)
-                moved.append(held)
+                if drop_room is not None:
+                    # Deferred import — ``commands.combat.jump`` pulls
+                    # in evennia.commands.Command which we don't want
+                    # at module load time for this typeclasses file.
+                    from commands.combat.jump import drop_to_room as _drop
+                    _drop(held, drop_room)
+                else:
+                    # Fall back to the legacy relocation if the
+                    # character has no location (test stubs, edge
+                    # cases) — keeps the dropped item somewhere
+                    # findable rather than orphaning it.
+                    _relocate_item(held, appendage)
+                # ``moved`` historically tracked items that travelled
+                # WITH the appendage.  Held weapons no longer travel
+                # there, so they are intentionally not appended.
         character.hands = new_hands
 
     return moved

--- a/world/tests/test_drop_to_room.py
+++ b/world/tests/test_drop_to_room.py
@@ -1,0 +1,157 @@
+"""Tests for :func:`commands.combat.jump.drop_to_room` (#307, PR-H0).
+
+The helper centralises the three physical effects that happen when
+an item lands on a room's floor — move + gravity + proximity init.
+It is deliberately message-free; each caller (CmdDrop, sever pipeline,
+future throw / disarm cleanups) owns its own narrative prose.
+
+Run via::
+
+    evennia test world.tests.test_drop_to_room
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.combat.constants import NDB_PROXIMITY_UNIVERSAL
+
+
+def _stub_room(is_sky=False):
+    """Minimal room stub with the surfaces apply_gravity_to_items reads."""
+    room = SimpleNamespace()
+    room.db = SimpleNamespace(is_sky_room=is_sky)
+    room.contents = []
+    room.key = "test room"
+    return room
+
+
+def _stub_item(key="test-item"):
+    item = SimpleNamespace()
+    item.key = key
+    item.ndb = SimpleNamespace()
+    item.moved_to = None
+
+    def _move_to(destination, quiet=False):
+        item.moved_to = destination
+
+    item.move_to = _move_to
+    return item
+
+
+class DropToRoomMove(TestCase):
+    """Item is physically relocated to the destination room."""
+
+    def test_moves_item_to_room(self):
+        from commands.combat.jump import drop_to_room
+        item = _stub_item()
+        room = _stub_room()
+        # Patch gravity — its real implementation logs to a channel
+        # that doesn't exist in the test environment.  We test
+        # gravity dispatch separately in DropToRoomGravity.
+        with patch("commands.combat.jump.apply_gravity_to_items"):
+            drop_to_room(item, room)
+        self.assertIs(item.moved_to, room)
+
+    def test_uses_quiet_move(self):
+        """Move-to is silent — callers handle their own messaging."""
+        from commands.combat.jump import drop_to_room
+        item = _stub_item()
+        room = _stub_room()
+        moved_with = {}
+
+        def capture_move(destination, quiet=False):
+            moved_with["destination"] = destination
+            moved_with["quiet"] = quiet
+
+        item.move_to = capture_move
+        with patch("commands.combat.jump.apply_gravity_to_items"):
+            drop_to_room(item, room)
+        self.assertIs(moved_with["destination"], room)
+        self.assertTrue(moved_with["quiet"])
+
+
+class DropToRoomGravity(TestCase):
+    """Gravity hook fires on the destination room."""
+
+    def test_apply_gravity_called_with_room(self):
+        with patch("commands.combat.jump.apply_gravity_to_items") as mock_gravity:
+            from commands.combat.jump import drop_to_room
+            item = _stub_item()
+            room = _stub_room(is_sky=True)
+            drop_to_room(item, room)
+        mock_gravity.assert_called_once_with(room)
+
+    def test_apply_gravity_called_for_ground_rooms_too(self):
+        """The gravity helper internally no-ops for non-sky rooms,
+        but the dispatch shouldn't pre-filter — keeps the contract
+        simple and lets gravity logic centralise."""
+        with patch("commands.combat.jump.apply_gravity_to_items") as mock_gravity:
+            from commands.combat.jump import drop_to_room
+            item = _stub_item()
+            room = _stub_room(is_sky=False)
+            drop_to_room(item, room)
+        mock_gravity.assert_called_once_with(room)
+
+
+class DropToRoomProximity(TestCase):
+    """Proximity list is initialised on the item's ndb."""
+
+    def test_creates_empty_proximity_list_when_missing(self):
+        from commands.combat.jump import drop_to_room
+        item = _stub_item()
+        room = _stub_room()
+        with patch("commands.combat.jump.apply_gravity_to_items"):
+            drop_to_room(item, room)
+        proximity = getattr(item.ndb, NDB_PROXIMITY_UNIVERSAL, None)
+        self.assertIsInstance(proximity, list)
+        self.assertEqual(proximity, [])
+
+    def test_preserves_existing_proximity_list(self):
+        """Re-dropping an item that already has proximity entries
+        keeps them — re-init only happens when the attribute is
+        absent / None."""
+        from commands.combat.jump import drop_to_room
+        item = _stub_item()
+        sentinel = SimpleNamespace()  # Pre-existing proximity entry
+        setattr(item.ndb, NDB_PROXIMITY_UNIVERSAL, [sentinel])
+        room = _stub_room()
+        with patch("commands.combat.jump.apply_gravity_to_items"):
+            drop_to_room(item, room)
+        proximity = getattr(item.ndb, NDB_PROXIMITY_UNIVERSAL, [])
+        self.assertIn(sentinel, proximity)
+
+    def test_reinits_when_existing_is_none(self):
+        """Defensive: an explicit ``None`` placeholder gets replaced
+        with a fresh list."""
+        from commands.combat.jump import drop_to_room
+        item = _stub_item()
+        setattr(item.ndb, NDB_PROXIMITY_UNIVERSAL, None)
+        room = _stub_room()
+        with patch("commands.combat.jump.apply_gravity_to_items"):
+            drop_to_room(item, room)
+        proximity = getattr(item.ndb, NDB_PROXIMITY_UNIVERSAL, None)
+        self.assertIsInstance(proximity, list)
+
+
+class DropToRoomNoMessages(TestCase):
+    """The helper does NOT emit player-facing messages.
+
+    Callers own their own narrative.  This pins the contract so
+    nobody adds a sneaky ``msg`` call without surfacing the
+    implication for sever / disarm / throw scenarios that all
+    have distinct prose.
+    """
+
+    def test_does_not_message_room_or_item(self):
+        from commands.combat.jump import drop_to_room
+        item = _stub_item()
+        item.msg = lambda *a, **k: self.fail("item should not be messaged")
+        room = _stub_room()
+        room.msg_contents = lambda *a, **k: self.fail(
+            "room should not be messaged"
+        )
+        with patch("commands.combat.jump.apply_gravity_to_items"):
+            drop_to_room(item, room)

--- a/world/tests/test_limb_downstream_chain.py
+++ b/world/tests/test_limb_downstream_chain.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest import TestCase
+from unittest.mock import patch
 
 from typeclasses.items import (
     detach_items_to_appendage,
@@ -315,14 +316,20 @@ class DetachItemsChainTests(TestCase):
         self.assertIn(boot, moved)
         self.assertNotIn("left_foot", char.worn_items)
 
-    def test_severing_arm_takes_wielded_weapon(self):
+    def test_severing_arm_drops_wielded_weapon_to_room(self):
+        """PR-H0: wielded weapon falls free of the severed limb chain
+        to the character's location, not onto the appendage."""
         sword = _FakeItem()
+        room = SimpleNamespace()
         char = self._char(hands={"left": sword, "right": None})
+        char.location = room
         app = self._appendage()
-        moved = detach_items_to_appendage(
-            char, app, ("left_arm", "left_hand")
-        )
-        self.assertIn(sword, moved)
+        with patch("commands.combat.jump.drop_to_room") as mock_drop:
+            moved = detach_items_to_appendage(
+                char, app, ("left_arm", "left_hand")
+            )
+        mock_drop.assert_called_once_with(sword, room)
+        self.assertNotIn(sword, moved)
         self.assertIsNone(char.hands["left"])
         # Right hand untouched.
         self.assertIsNone(char.hands["right"])

--- a/world/tests/test_living_sever.py
+++ b/world/tests/test_living_sever.py
@@ -23,7 +23,9 @@ Run via::
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest import TestCase
+from unittest.mock import patch
 
 from typeclasses.items import (
     apply_living_sever_overlay,
@@ -256,21 +258,53 @@ class DetachItemsToAppendageTests(TestCase):
         self.assertIn(jacket, char.worn_items["left_arm"])
         self.assertIn(jacket, char.worn_items["chest"])
 
-    def test_wielded_weapon_in_matching_hand_follows_limb(self):
+    def test_wielded_weapon_drops_to_room_when_hand_severed(self):
+        """PR-H0: weapon held in severed hand drops to the character's
+        location rather than travelling onto the appendage."""
         knife = _FakeItem("knife")
+        room = SimpleNamespace()
         char = _FakeCharacter(hands={"left": None, "right": knife})
+        char.location = room
         appendage = _FakeAppendage()
-        moved = detach_items_to_appendage(char, appendage, "right_hand")
-        self.assertIn(knife, moved)
-        self.assertEqual(knife.moved_to, appendage)
+        with patch("commands.combat.jump.drop_to_room") as mock_drop:
+            moved = detach_items_to_appendage(
+                char, appendage, "right_hand"
+            )
+        # Weapon dropped to the room, not relocated onto the appendage.
+        mock_drop.assert_called_once_with(knife, room)
+        # Weapon is NOT in the moved list (moved tracks items that
+        # travel WITH the appendage).
+        self.assertNotIn(knife, moved)
+        # Hand slot cleared.
         self.assertIsNone(char.hands["right"])
 
-    def test_wielded_weapon_follows_when_arm_severed(self):
+    def test_wielded_weapon_drops_to_room_when_arm_severed(self):
+        """Same drop-to-room rule when severance happens upstream of
+        the hand container (whole arm severed)."""
+        knife = _FakeItem("knife")
+        room = SimpleNamespace()
+        char = _FakeCharacter(hands={"left": None, "right": knife})
+        char.location = room
+        appendage = _FakeAppendage()
+        with patch("commands.combat.jump.drop_to_room") as mock_drop:
+            moved = detach_items_to_appendage(
+                char, appendage, "right_arm"
+            )
+        mock_drop.assert_called_once_with(knife, room)
+        self.assertNotIn(knife, moved)
+        self.assertIsNone(char.hands["right"])
+
+    def test_wielded_weapon_falls_back_to_appendage_without_location(self):
+        """Defensive: if the character has no location (orphaned test
+        stub, edge case), fall back to the legacy appendage-relocate
+        path so the weapon isn't lost."""
         knife = _FakeItem("knife")
         char = _FakeCharacter(hands={"left": None, "right": knife})
+        # No location attribute set on this character stub.
         appendage = _FakeAppendage()
-        moved = detach_items_to_appendage(char, appendage, "right_arm")
-        self.assertIn(knife, moved)
+        moved = detach_items_to_appendage(char, appendage, "right_hand")
+        # Legacy behaviour: weapon relocates to appendage.
+        self.assertEqual(knife.moved_to, appendage)
         self.assertIsNone(char.hands["right"])
 
     def test_wielded_weapon_in_other_hand_unaffected(self):
@@ -295,16 +329,26 @@ class DetachItemsToAppendageTests(TestCase):
         self.assertNotIn(knife, moved)
         self.assertEqual(char.hands["left"], knife)
 
-    def test_worn_and_wielded_both_move(self):
+    def test_worn_follows_limb_wielded_drops_to_room(self):
+        """PR-H0: combined case — worn glove travels with the
+        severed hand; wielded knife falls to the ground.  ``moved``
+        only contains the worn item; the knife is dispatched to
+        ``drop_to_room`` instead."""
         glove = _FakeItem("glove")
         knife = _FakeItem("knife")
+        room = SimpleNamespace()
         char = _FakeCharacter(
             worn_items={"right_hand": [glove]},
             hands={"left": None, "right": knife},
         )
+        char.location = room
         appendage = _FakeAppendage()
-        moved = detach_items_to_appendage(char, appendage, "right_hand")
-        self.assertEqual(set(moved), {glove, knife})
+        with patch("commands.combat.jump.drop_to_room") as mock_drop:
+            moved = detach_items_to_appendage(
+                char, appendage, "right_hand"
+            )
+        self.assertEqual(set(moved), {glove})
+        mock_drop.assert_called_once_with(knife, room)
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two changes that ride together:

### 1. Severed hands no longer carry their wielded weapons

When a hand or arm is severed, the held weapon falls free to the character's location instead of travelling onto the severed appendage. Worn items continue to follow the existing containment rule (gloves on the severed hand go with the limb; jackets spanning chest + arms stay on the body).

Rationale: severance loosens the grip; the weapon lands separately. Cleaner salvage UX (pick up arm, pick up sword — two distinct targets in the room) and reflects how players intuit dismemberment.

### 2. ``drop_to_room`` helper

New ``commands.combat.jump.drop_to_room(item, room)`` centralises the "item lands on the floor" pipeline: ``move_to`` + sky-room gravity + ``NDB_PROXIMITY_UNIVERSAL`` scaffolding.

Deliberately message-free — each caller owns its narrative context. CmdDrop refactors to use it; sever pipeline uses it for wielded-weapon drops; future throw / disarm / similar cleanups should also adopt.

## Files

- ``commands/combat/jump.py`` — add ``drop_to_room`` next to ``apply_gravity_to_items``
- ``commands/CmdInventory.py`` — CmdDrop calls the helper; caller-specific proximity stays in CmdDrop
- ``typeclasses/items.py`` — sever wielded-item branch dispatches through ``drop_to_room`` when character has a location; falls back to legacy appendage-relocate for stub-only cases

## Test plan

- [x] ``world.tests.test_drop_to_room`` (NEW) — 8 tests covering move, gravity dispatch, proximity init, no-message contract, defensive cases
- [x] ``world.tests.test_living_sever`` — three wielded-weapon tests rewritten for drop-to-room behaviour; one new defensive no-location-fallback test
- [x] ``world.tests.test_limb_downstream_chain`` — chain-severance wielded-weapon test rewritten
- [x] Full suite: 1851/1851 (+9 net)

## Position in the Mr. Hands restructure

Slice H0 — foundation behavior fix. PR-H1 (`is_grasping_appendage` anatomy markup) and PR-H2 (dynamic hands as derived view + `dress` / `undress` verbs) follow. Each is independently shippable.

Refs #307.