### PR TITLE
dress / undress + worn-on-severed appendages (#307, PR-H3)

### DIFF
--- a/commands/CmdClothing.py
+++ b/commands/CmdClothing.py
@@ -486,3 +486,366 @@ class CmdZip(Command):
             )
         else:
             caller.msg(f"You can't {action} the {item.key}.")
+
+
+# =====================================================================
+# Third-party clothing manipulation (#307, PR-H3)
+# =====================================================================
+#
+# Two new verbs surface the third-party clothing interface settled
+# in the design discussion:
+#
+#   dress <target> in <item>     — put clothing on someone / something
+#   undress <target> [<item>]    — remove clothing from someone / something
+#
+# Both verbs gate on the target being unwilling-or-incapacitated:
+#
+#   * Severed appendages (worn-on-severed structure introduced in
+#     this PR)
+#   * Unconscious characters
+#   * Dead characters / corpses
+#
+# Conscious cooperative dressing is intentionally deferred to the
+# future trust/consent layer (per the project memory:
+# project_gelatinous_trust_consent).  Until that ships, conscious
+# targets get a clear rejection that hints at the future system.
+# Do not paint into a corner by hard-coding rejection logic that
+# the consent layer can't gracefully extend.
+
+
+def _can_third_party_clothing(target):
+    """Permission gate for dress / undress (#307 PR-H3 + memory).
+
+    Returns True when the target is in a state where third-party
+    clothing manipulation is allowed without explicit consent:
+    severed appendage, unconscious character, dead character.
+    The trust/consent layer will extend this contract to cover
+    conscious cooperative targets; until then it's the limit.
+    """
+    from typeclasses.items import Appendage
+    if isinstance(target, Appendage):
+        return True
+
+    medical_state = getattr(target, "medical_state", None)
+    if medical_state is None:
+        return False
+    is_dead = getattr(medical_state, "is_dead", None)
+    is_unconscious = getattr(medical_state, "is_unconscious", None)
+    if callable(is_dead) and is_dead():
+        return True
+    if callable(is_unconscious) and is_unconscious():
+        return True
+    return False
+
+
+def _resolve_clothing_target(caller, target_phrase):
+    """Resolve a third-party clothing target.
+
+    Searches the caller's inventory first (so a severed limb the
+    caller is carrying gets matched without setting it down) then
+    falls back to the room.  Returns ``None`` and lets the search
+    helpers message the caller on miss.
+    """
+    raw = target_phrase.strip()
+    if not raw:
+        return None
+    candidates = list(caller.contents)
+    if candidates:
+        match = caller.search(raw, candidates=candidates, quiet=True)
+        if match:
+            return match[0] if isinstance(match, list) else match
+    return caller.search(raw)
+
+
+class CmdDress(Command):
+    """Dress another character or severed body part in a clothing item.
+
+    Usage:
+        dress <target> in <item>
+
+    Examples:
+        dress unconscious bob in jacket
+        dress severed left arm in leather glove
+        dress corpse in burial shroud
+
+    Target must be unconscious, dead, or a severed appendage —
+    conscious cooperative dressing requires the trust/consent
+    system, which isn't implemented yet.  The clothing item must
+    be in your inventory; it transfers to the target along with
+    the worn registration.
+
+    Related: undress, wear, remove.
+    """
+
+    key = "dress"
+    locks = "cmd:all()"
+    help_category = "Inventory"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+
+        if " in " not in args:
+            caller.msg("Usage: dress <target> in <item>")
+            return
+
+        target_phrase, _, item_phrase = args.partition(" in ")
+        target_phrase = target_phrase.strip()
+        item_phrase = item_phrase.strip()
+        if not target_phrase or not item_phrase:
+            caller.msg("Usage: dress <target> in <item>")
+            return
+
+        target = _resolve_clothing_target(caller, target_phrase)
+        if target is None:
+            return
+
+        item = caller.search(item_phrase, location=caller, quiet=True)
+        if not item:
+            caller.msg(f"You don't have '{item_phrase}'.")
+            return
+        if isinstance(item, list):
+            item = item[0]
+
+        if not _can_third_party_clothing(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} is conscious "
+                f"and would resist. (Cooperative dressing of a "
+                f"conscious target requires the trust/consent system, "
+                f"which isn't implemented yet.)"
+            )
+            return
+
+        if not hasattr(item, "is_wearable") or not item.is_wearable():
+            caller.msg(f"{item.get_display_name(caller)} can't be worn.")
+            return
+
+        from typeclasses.items import Appendage
+        if isinstance(target, Appendage):
+            success, message = self._dress_appendage(target, item)
+        elif hasattr(target, "wear_item"):
+            success, message = self._dress_character(target, item)
+        else:
+            caller.msg(
+                f"You can't dress {target.get_display_name(caller)}."
+            )
+            return
+
+        if not success:
+            caller.msg(message)
+            return
+
+        item_name_d = item.get_display_name(caller)
+        target_name_d = target.get_display_name(caller)
+        caller.msg(f"You dress {target_name_d} in {item_name_d}.")
+        if (
+            hasattr(target, "has_account")
+            and getattr(target, "has_account", False)
+            and hasattr(target, "msg")
+        ):
+            target.msg(
+                f"{caller.get_display_name(target)} dresses you in "
+                f"{item.get_display_name(target)}."
+            )
+        msg_room_identity(
+            location=caller.location,
+            template=f"{{actor}} dresses {{target}} in {item_name_d}.",
+            char_refs={"actor": caller, "target": target},
+            exclude=[caller, target],
+        )
+
+    def _dress_character(self, target, item):
+        """Move the item into ``target``'s inventory and call its
+        existing ``wear_item`` method.  On failure, roll the item
+        back to the caller so it isn't orphaned on a target that
+        wouldn't accept it."""
+        item.move_to(target, quiet=True)
+        success, message = target.wear_item(item)
+        if not success:
+            item.move_to(self.caller, quiet=True)
+        return success, message
+
+    def _dress_appendage(self, target, item):
+        """Worn-on-severed-appendage path.  Match the item's
+        coverage against the appendage's chain locations; wear at
+        the intersection.
+
+        Rejects items that don't cover any chain location (a right
+        glove can't wear on a severed left arm; a chest piece can't
+        wear on a severed leg).
+        """
+        chain = set(target.db.chain or (target.db.location_name,))
+        if hasattr(item, "get_current_coverage"):
+            coverage = set(item.get_current_coverage() or ())
+        else:
+            coverage = set()
+
+        applicable = coverage & chain
+        if not applicable:
+            return False, (
+                f"{item.get_display_name(self.caller)} doesn't fit on "
+                f"{target.get_display_name(self.caller)}."
+            )
+
+        item.move_to(target, quiet=True)
+        appendage_worn = dict(target.db.worn_items or {})
+        for loc in applicable:
+            existing = list(appendage_worn.get(loc) or ())
+            if item not in existing:
+                existing.append(item)
+                appendage_worn[loc] = existing
+        target.db.worn_items = appendage_worn
+        return True, ""
+
+
+class CmdUndress(Command):
+    """Remove clothing from another character or severed body part.
+
+    Usage:
+        undress <target>
+        undress <target> <item>
+
+    First form removes all worn items.  Second removes a single
+    item by name (substring match against the target's worn
+    items).  Removed items transfer to your inventory.
+
+    Target must be unconscious, dead, or a severed appendage —
+    same gate as ``dress``.
+
+    Related: dress, remove.
+    """
+
+    key = "undress"
+    locks = "cmd:all()"
+    help_category = "Inventory"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+        if not args:
+            caller.msg("Usage: undress <target> [<item>]")
+            return
+
+        # Greedy on target first — multi-word targets like
+        # ``severed left arm`` work.  Only narrow if the whole
+        # phrase doesn't resolve.
+        target = _resolve_clothing_target(caller, args)
+        item_phrase = None
+        if target is None:
+            tokens = args.rsplit(" ", 1)
+            if len(tokens) == 2:
+                maybe_target = tokens[0].strip()
+                maybe_item = tokens[1].strip()
+                target = _resolve_clothing_target(caller, maybe_target)
+                if target is not None:
+                    item_phrase = maybe_item
+        if target is None:
+            return
+
+        if not _can_third_party_clothing(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} is conscious "
+                f"and would resist. (Cooperative undressing of a "
+                f"conscious target requires the trust/consent "
+                f"system, which isn't implemented yet.)"
+            )
+            return
+
+        from typeclasses.items import Appendage
+        if isinstance(target, Appendage):
+            removed = self._undress_appendage(target, item_phrase)
+        elif hasattr(target, "get_worn_items"):
+            removed = self._undress_character(target, item_phrase)
+        else:
+            caller.msg(
+                f"You can't undress {target.get_display_name(caller)}."
+            )
+            return
+
+        if not removed:
+            if item_phrase:
+                caller.msg(
+                    f"{target.get_display_name(caller)} isn't wearing "
+                    f"'{item_phrase}'."
+                )
+            else:
+                caller.msg(
+                    f"{target.get_display_name(caller)} isn't wearing "
+                    f"anything."
+                )
+            return
+
+        for item in removed:
+            item.move_to(caller, quiet=True)
+
+        names = ", ".join(item.get_display_name(caller) for item in removed)
+        target_name = target.get_display_name(caller)
+        caller.msg(f"You undress {target_name}, taking: {names}.")
+        if (
+            hasattr(target, "has_account")
+            and getattr(target, "has_account", False)
+            and hasattr(target, "msg")
+        ):
+            target.msg(
+                f"{caller.get_display_name(target)} undresses you, "
+                f"taking your clothing."
+            )
+        msg_room_identity(
+            location=caller.location,
+            template=f"{{actor}} undresses {{target}}.",
+            char_refs={"actor": caller, "target": target},
+            exclude=[caller, target],
+        )
+
+    def _undress_character(self, target, item_phrase):
+        """Strip worn items off ``target`` and return the removed
+        list.  Uses ``remove_item`` so layer-conflict / state
+        cleanup runs the same way it does for self-removal."""
+        worn = target.get_worn_items() or []
+        if not worn:
+            return []
+
+        if item_phrase:
+            phrase = item_phrase.lower()
+            worn = [it for it in worn if phrase in it.key.lower()]
+            if not worn:
+                return []
+
+        removed = []
+        for item in worn:
+            success, _msg = target.remove_item(item)
+            if success:
+                removed.append(item)
+        return removed
+
+    def _undress_appendage(self, target, item_phrase):
+        """Strip worn items off a severed appendage and return the
+        removed list.  Updates the appendage's ``worn_items`` dict
+        in place to reflect the removal."""
+        worn_dict = dict(target.db.worn_items or {})
+        if not worn_dict:
+            return []
+
+        all_items = []
+        for items in worn_dict.values():
+            for item in (items or []):
+                if item not in all_items:
+                    all_items.append(item)
+
+        if item_phrase:
+            phrase = item_phrase.lower()
+            all_items = [
+                it for it in all_items if phrase in it.key.lower()
+            ]
+        if not all_items:
+            return []
+
+        new_worn = {}
+        for loc, items in worn_dict.items():
+            kept = [
+                it for it in (items or []) if it not in all_items
+            ]
+            if kept:
+                new_worn[loc] = kept
+        target.db.worn_items = new_worn
+        return all_items

--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -511,7 +511,10 @@ class CmdBandage(ConsumptionCommand):
     """
     
     key = "bandage"
-    aliases = ["wrap", "dress"]
+    # PR-H3 (#307): ``dress`` reclaimed for third-party clothing.
+    # CmdBandage keeps ``bandage`` primary + ``wrap`` for the verb
+    # space; "dressing a wound" is colloquial but still covered.
+    aliases = ["wrap"]
     help_category = "Medical"
     
     def parse(self):

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -213,7 +213,14 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdClothing.CmdRemove())
         self.add(CmdClothing.CmdRollUp())
         self.add(CmdClothing.CmdZip())
-        
+
+        # Third-party clothing (#307, PR-H3).  Operates on
+        # unconscious / dead / severed-appendage targets; conscious
+        # cooperative path deferred to trust/consent layer.  See
+        # ``help dress`` and ``help undress``.
+        self.add(CmdClothing.CmdDress())
+        self.add(CmdClothing.CmdUndress())
+
         # Add armor system commands
         self.add(CmdArmor())
         self.add(CmdArmorRepair())

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1131,6 +1131,18 @@ class Appendage(Item):
         # without ``None`` checks.
         self.db.wounds_at_death = []
         self.db.longdesc_data = {}
+        # #307 PR-H3: worn-items carry-forward.  Severed appendages
+        # remember which items were worn on which body location at
+        # the moment of severance.  Structure mirrors
+        # ``Character.worn_items``:
+        #
+        #     {"left_hand": [glove_obj], "left_arm": [bracer_obj]}
+        #
+        # Populated by ``detach_items_to_appendage`` for any worn
+        # item whose coverage was fully contained in the severed
+        # cluster.  Read by ``return_appearance`` (forensic prose)
+        # and the third-party ``undress`` verb.
+        self.db.worn_items = {}
 
     def configure_from_sever(self, *, location_name, condition, corpse):
         """Populate forensic-chain fields immediately after spawn.
@@ -1456,9 +1468,46 @@ class Appendage(Item):
                 chunks.append(rendered)
 
         body = " ".join(chunks)
+
+        # PR-H3 (#307): worn-items carry-forward.  Severed appendages
+        # remember the clothing that travelled with them and surface
+        # it in forensic prose ("the severed hand still wears a
+        # bloodstained glove").  Skip when nothing's there.
+        worn_line = self._build_worn_items_line(looker)
+        if worn_line:
+            body = f"{body} {worn_line}" if body else worn_line
+
         if not body:
             return base
         return f"{base} {body}" if base else body
+
+    def _build_worn_items_line(self, looker):
+        """Build the "still wearing ..." sentence for forensic prose.
+
+        Returns the empty string when no items are worn on the
+        appendage — keeps the calling renderer's whitespace handling
+        clean.
+        """
+        worn = self.db.worn_items or {}
+        # Collect each unique item once, preserving first-seen order
+        # (location iteration order, then within-list order).  A
+        # multi-location worn item (e.g. coat) wouldn't reach here in
+        # PR-H3 since the sever pipeline only registers items whose
+        # coverage was fully contained in the severed cluster, but
+        # the dedup is defensive for future expansion.
+        seen = []
+        for loc_items in worn.values():
+            for item in (loc_items or []):
+                if item not in seen:
+                    seen.append(item)
+        if not seen:
+            return ""
+        if len(seen) == 1:
+            name = seen[0].get_display_name(looker)
+            return f"It still wears {name}."
+        names = [item.get_display_name(looker) for item in seen]
+        joined = ", ".join(names[:-1]) + f", and {names[-1]}"
+        return f"It still wears {joined}."
 
 
 def apply_wound_and_longdesc_overlay(appendage, corpse, locations):
@@ -1939,9 +1988,33 @@ def detach_items_to_appendage(character, appendage, containers):
             if kept:
                 new_worn[loc] = kept
         character.worn_items = new_worn
+
+        # PR-H3 (#307): register the moved items in the appendage's
+        # own worn_items dict so they remain structurally "worn at
+        # location X of this severed part" rather than degrading to
+        # generic contents.  Each item lands at every location it
+        # was worn at on the original body (a glove worn solely at
+        # left_hand registers at left_hand on the appendage; a coat
+        # spanning chest+arms wouldn't reach this branch because its
+        # coverage isn't ⊆ severed_locs).
+        #
+        # Test stubs that don't carry a ``db`` surface skip the
+        # carry-forward bookkeeping; physical relocation still
+        # happens so the basic sever contract is preserved.
+        appendage_db = getattr(appendage, "db", None)
+        appendage_worn = None
+        if appendage_db is not None:
+            appendage_worn = dict(
+                getattr(appendage_db, 'worn_items', None) or {}
+            )
         for item in items_to_move:
             _relocate_item(item, appendage)
             moved.append(item)
+            if appendage_worn is not None:
+                for loc in item_locations.get(item, ()):
+                    appendage_worn.setdefault(loc, []).append(item)
+        if appendage_db is not None:
+            appendage_db.worn_items = appendage_worn
 
     # --- Wielded weapons in any chain-hand --------------------------
     hands_to_clear = set()

--- a/world/tests/test_dress_undress.py
+++ b/world/tests/test_dress_undress.py
@@ -1,0 +1,346 @@
+"""Tests for the third-party clothing verbs (#307, PR-H3).
+
+Two new commands surface third-party clothing manipulation:
+
+* ``dress <target> in <item>`` — put clothing on someone / something
+* ``undress <target> [<item>]`` — remove clothing from same
+
+Both gate on:
+
+* Severed appendage (Appendage typeclass)
+* Unconscious character (medical_state.is_unconscious())
+* Dead character (medical_state.is_dead())
+
+Conscious targets are rejected with a message hinting at the
+future trust/consent layer.
+
+This module exercises the permission helper plus the sever
+pipeline's worn-items carry-forward.  Full Command.func()
+integration tests require Evennia search infrastructure and are
+covered separately via the live suite.
+
+Run via::
+
+    evennia test world.tests.test_dress_undress
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from commands.CmdClothing import _can_third_party_clothing
+
+
+# ---------------------------------------------------------------------
+# Permission gate
+# ---------------------------------------------------------------------
+
+
+class _MedicalState:
+    """Minimal medical-state stub with ``is_dead`` / ``is_unconscious``
+    callable surfaces."""
+
+    def __init__(self, dead=False, unconscious=False):
+        self._dead = dead
+        self._unconscious = unconscious
+
+    def is_dead(self):
+        return self._dead
+
+    def is_unconscious(self):
+        return self._unconscious
+
+
+def _conscious_char():
+    char = SimpleNamespace(key="bob")
+    char.medical_state = _MedicalState(dead=False, unconscious=False)
+    return char
+
+
+def _unconscious_char():
+    char = SimpleNamespace(key="bob")
+    char.medical_state = _MedicalState(unconscious=True)
+    return char
+
+
+def _dead_char():
+    char = SimpleNamespace(key="bob")
+    char.medical_state = _MedicalState(dead=True)
+    return char
+
+
+def _no_medical_target():
+    """Random object with no medical_state — e.g. a room or generic
+    item.  Should be rejected for safety."""
+    return SimpleNamespace(key="rock")
+
+
+class PermissionGate(TestCase):
+
+    def test_conscious_character_rejected(self):
+        self.assertFalse(_can_third_party_clothing(_conscious_char()))
+
+    def test_unconscious_character_allowed(self):
+        self.assertTrue(_can_third_party_clothing(_unconscious_char()))
+
+    def test_dead_character_allowed(self):
+        self.assertTrue(_can_third_party_clothing(_dead_char()))
+
+    def test_target_without_medical_state_rejected(self):
+        """Defensive: targets that have no medical surface and aren't
+        an Appendage should not silently slip through.  Future
+        non-character clothing targets (mannequins, idols) will need
+        their own path."""
+        self.assertFalse(
+            _can_third_party_clothing(_no_medical_target())
+        )
+
+    def test_severed_appendage_allowed(self):
+        """Appendage targets are universally dressable (no consent
+        required — it's an object now).
+
+        Patches the Appendage import inside the gate so we can use
+        a lightweight stub class for ``isinstance``.  This isolates
+        the test from Evennia typeclass spawn machinery."""
+        class _FakeAppendage:
+            pass
+        # The gate imports Appendage inside the function body, so
+        # patching ``typeclasses.items.Appendage`` is what matters.
+        with patch("typeclasses.items.Appendage", _FakeAppendage):
+            sentinel = _FakeAppendage()
+            self.assertTrue(_can_third_party_clothing(sentinel))
+
+
+# ---------------------------------------------------------------------
+# Worn-items carry-forward via the sever pipeline
+# ---------------------------------------------------------------------
+
+
+class _DB:
+    """Plain attribute container — mimics Evennia ``obj.db``."""
+
+
+class _FakeItem:
+    def __init__(self, key="item"):
+        self.key = key
+        self.moved_to = None
+
+    def move_to(self, destination, quiet=False):
+        self.moved_to = destination
+
+
+class _FakeAppendage:
+    def __init__(self):
+        self.db = _DB()
+        self.db.wounds_at_death = []
+        self.db.longdesc_data = {}
+        self.db.worn_items = {}
+
+
+class _FakeCharacter:
+    def __init__(self, worn_items=None, hands=None, species="human"):
+        self.worn_items = {
+            loc: list(items) for loc, items in (worn_items or {}).items()
+        }
+        self.hands = dict(hands or {"left": None, "right": None})
+        self.longdesc = {}
+        self.medical_state = SimpleNamespace(
+            organs={}, vital_signs_updated=False,
+            update_vital_signs=lambda: None,
+        )
+        self.db = SimpleNamespace(species=species)
+
+
+class WornItemsCarryForward(TestCase):
+    """Sever pipeline now writes worn items into the appendage's
+    own worn_items dict so the third-party undress verb can read
+    them and the renderer can surface forensic prose."""
+
+    def test_glove_registered_at_left_hand_on_appendage(self):
+        from typeclasses.items import detach_items_to_appendage
+        glove = _FakeItem("glove")
+        char = _FakeCharacter(worn_items={"left_hand": [glove]})
+        appendage = _FakeAppendage()
+        detach_items_to_appendage(char, appendage, "left_hand")
+        self.assertIn("left_hand", appendage.db.worn_items)
+        self.assertIn(glove, appendage.db.worn_items["left_hand"])
+
+    def test_multi_location_item_registers_at_each_severed_loc(self):
+        """A boot worn at left_foot only follows a severed left_shin
+        (chain includes left_shin + left_foot).  It registers at
+        left_foot on the appendage."""
+        from typeclasses.items import detach_items_to_appendage
+        boot = _FakeItem("boot")
+        char = _FakeCharacter(worn_items={"left_foot": [boot]})
+        appendage = _FakeAppendage()
+        detach_items_to_appendage(
+            char, appendage, ("left_shin", "left_foot")
+        )
+        self.assertIn("left_foot", appendage.db.worn_items)
+        self.assertIn(boot, appendage.db.worn_items["left_foot"])
+
+    def test_character_worn_items_cleared_for_moved_items(self):
+        """Worn items that travel with the limb are removed from
+        the character's worn_items dict."""
+        from typeclasses.items import detach_items_to_appendage
+        glove = _FakeItem("glove")
+        char = _FakeCharacter(worn_items={"left_hand": [glove]})
+        appendage = _FakeAppendage()
+        detach_items_to_appendage(char, appendage, "left_hand")
+        # Either the key is gone, or its list doesn't contain glove.
+        worn = char.worn_items
+        self.assertNotIn(glove, worn.get("left_hand", ()))
+
+    def test_spanning_item_does_not_register_on_appendage(self):
+        """A jacket spanning chest + both arms shouldn't register on
+        a severed arm — it stays on the character."""
+        from typeclasses.items import detach_items_to_appendage
+        jacket = _FakeItem("jacket")
+        char = _FakeCharacter(worn_items={
+            "chest": [jacket],
+            "left_arm": [jacket],
+            "right_arm": [jacket],
+        })
+        appendage = _FakeAppendage()
+        detach_items_to_appendage(
+            char, appendage, ("left_arm", "left_hand")
+        )
+        self.assertEqual(appendage.db.worn_items, {})
+        # Jacket still on the character.
+        self.assertIn(jacket, char.worn_items["chest"])
+
+    def test_appendage_worn_items_initialised_empty(self):
+        """A fresh Appendage's worn_items defaults to empty dict so
+        renderers / undress can iterate without None checks."""
+        appendage = _FakeAppendage()
+        self.assertEqual(appendage.db.worn_items, {})
+
+
+# ---------------------------------------------------------------------
+# Appendage.return_appearance worn-items rendering
+# ---------------------------------------------------------------------
+
+
+class WornItemsRendering(TestCase):
+    """``Appendage._build_worn_items_line`` surfaces the "still
+    wears" forensic line in the appendage's appearance prose."""
+
+    def _appendage_with_worn(self, worn_dict):
+        """Build an object exposing the same _build_worn_items_line
+        method without instantiating a real Appendage (which would
+        need full Evennia DB setup)."""
+        from typeclasses.items import Appendage
+
+        class _Stub(Appendage):
+            pass
+
+        # Patch the at_object_creation guard so we can construct
+        # without going through Evennia's typeclass machinery.
+        stub = SimpleNamespace()
+        stub.db = SimpleNamespace(worn_items=worn_dict)
+        stub.get_display_name = lambda looker: "stub"
+        # Bind the unbound method.
+        stub._build_worn_items_line = (
+            Appendage._build_worn_items_line.__get__(stub, type(stub))
+        )
+        return stub
+
+    def test_empty_returns_empty_string(self):
+        stub = self._appendage_with_worn({})
+        self.assertEqual(stub._build_worn_items_line(None), "")
+
+    def test_single_item_renders(self):
+        glove = SimpleNamespace(get_display_name=lambda lk: "a glove")
+        stub = self._appendage_with_worn({"left_hand": [glove]})
+        line = stub._build_worn_items_line(None)
+        self.assertIn("a glove", line)
+        self.assertTrue(line.startswith("It still wears"))
+
+    def test_two_items_renders_with_and(self):
+        glove = SimpleNamespace(get_display_name=lambda lk: "a glove")
+        ring = SimpleNamespace(get_display_name=lambda lk: "a ring")
+        stub = self._appendage_with_worn({
+            "left_hand": [glove, ring],
+        })
+        line = stub._build_worn_items_line(None)
+        self.assertIn("a glove", line)
+        self.assertIn("a ring", line)
+        self.assertIn("and", line)
+
+    def test_three_items_uses_comma_and_and(self):
+        items = [
+            SimpleNamespace(get_display_name=lambda lk, n=n: n)
+            for n in ("a glove", "a ring", "a bracelet")
+        ]
+        stub = self._appendage_with_worn({"left_hand": items})
+        line = stub._build_worn_items_line(None)
+        self.assertIn("a glove,", line)
+        self.assertIn("a ring,", line)
+        self.assertIn("and a bracelet", line)
+
+    def test_dedup_across_locations(self):
+        """An item registered at multiple locations renders once."""
+        coat = SimpleNamespace(get_display_name=lambda lk: "a coat")
+        stub = self._appendage_with_worn({
+            "chest": [coat],
+            "left_arm": [coat],
+        })
+        line = stub._build_worn_items_line(None)
+        # "a coat" should appear once, not twice.
+        self.assertEqual(line.count("a coat"), 1)
+
+
+# ---------------------------------------------------------------------
+# CmdBandage no longer claims "dress"
+# ---------------------------------------------------------------------
+
+
+class CmdBandageAliases(TestCase):
+    """``dress`` was reclaimed from CmdBandage for the new
+    third-party clothing command.  CmdBandage keeps ``bandage``
+    primary and ``wrap`` alias."""
+
+    def test_dress_not_in_bandage_aliases(self):
+        from commands.CmdConsumption import CmdBandage
+        self.assertNotIn("dress", CmdBandage.aliases)
+
+    def test_wrap_still_in_bandage_aliases(self):
+        from commands.CmdConsumption import CmdBandage
+        self.assertIn("wrap", CmdBandage.aliases)
+
+    def test_bandage_key_unchanged(self):
+        from commands.CmdConsumption import CmdBandage
+        self.assertEqual(CmdBandage.key, "bandage")
+
+
+# ---------------------------------------------------------------------
+# Command class registration contract
+# ---------------------------------------------------------------------
+
+
+class CommandRegistration(TestCase):
+
+    def test_dress_command_exists(self):
+        from commands.CmdClothing import CmdDress
+        self.assertEqual(CmdDress.key, "dress")
+
+    def test_undress_command_exists(self):
+        from commands.CmdClothing import CmdUndress
+        self.assertEqual(CmdUndress.key, "undress")
+
+    def test_dress_in_default_cmdset(self):
+        """CmdDress is registered on the character cmdset."""
+        from commands.default_cmdsets import CharacterCmdSet
+        cmdset = CharacterCmdSet()
+        cmdset.at_cmdset_creation()
+        keys = [cmd.key for cmd in cmdset.commands]
+        self.assertIn("dress", keys)
+
+    def test_undress_in_default_cmdset(self):
+        from commands.default_cmdsets import CharacterCmdSet
+        cmdset = CharacterCmdSet()
+        cmdset.at_cmdset_creation()
+        keys = [cmd.key for cmd in cmdset.commands]
+        self.assertIn("undress", keys)


### PR DESCRIPTION
## Summary

Closes the Mr. Hands restructure arc with third-party clothing manipulation and worn-items-on-severed-appendages forensic prose.

### Worn-items-on-severed-appendage (Option B)

Severed limbs carry a ``worn_items`` dict mirroring ``Character.worn_items``. Sever pipeline populates it for items whose coverage was fully contained in the severed cluster. ``Appendage.return_appearance`` adds a forensic "It still wears ..." line with Oxford-list formatting.

### ``CmdDress``

``dress <target> in <item>`` — gated to unconscious / dead / severed-appendage targets per the design + trust/consent memory. Character dispatch reuses ``wear_item``; appendage dispatch matches item coverage against the severed chain.

### ``CmdUndress``

``undress <target>`` (all worn items) or ``undress <target> <item>`` (specific). Items transfer to caller's inventory. Character dispatch reuses ``remove_item``; appendage dispatch updates ``worn_items`` directly.

### Reclaim ``dress`` alias

CmdBandage drops ``dress`` (was an alias for "dress a wound"). Keeps ``bandage`` + ``wrap``.

## Test plan

- [x] ``world.tests.test_dress_undress`` (NEW) — 22 tests: permission gate, worn-items carry-forward, appendage rendering, CmdBandage aliases, cmdset registration
- [x] Full suite: 1915/1915 (+22 net)

## Position in the Mr. Hands restructure

- PR-H0 (#384) — sever drops wielded items to room
- PR-H1 (#385) — anatomy markup
- PR-H2 (#386) — dynamic hands derived view
- **PR-H3** (this PR) — worn-on-severed + dress/undress

Next: PR-C (wound_healing ticker) and PR-D (organ_repair + SURGICAL_SEALANT prototype).

Refs #307.