### PR TITLE
Wound-healing tick channel (#307, PR-C)

### DIFF
--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -90,10 +90,33 @@ WOUND_CARE_PAIN_REDUCTION = 3          # severity points reduced on pain success
 
 #: Categories the wound_care dispatch resolves in parallel.  Each is
 #: one roll; failure of any one is stabilization-only for that
-#: category.  ``wound_healing`` and ``organ_repair`` are intentionally
-#: NOT in this list — wound_healing lands in PR-C (healing ticker);
-#: organ_repair lands in PR-D (surgical-grade direct repair).
+#: category.  ``wound_healing`` is dressing-tick driven (PR-C, not
+#: a per-application roll); ``organ_repair`` lands in PR-D
+#: (surgical-grade direct repair).
 WOUND_CARE_PARALLEL_CATEGORIES = ("bleeding", "infection", "pain")
+
+# ===================================================================
+# WOUND HEALING (DRESSING TICK) CONSTANTS (#307, PR-C)
+# ===================================================================
+#
+# Healing is the slow-recovery channel separate from stabilization.
+# An applied wound_care item registers its ``wound_healing``
+# effectiveness rating on the underlying organ; the medical script's
+# tick walks stabilized organs and restores HP proportional to the
+# stored rating.
+
+#: HP restored per medical tick per dressing-rate point.  Integer
+#: division — a low-rated dressing (rating 1-4) lands at 0 HP/tick
+#: which models the wound staying stable but not actively healing.
+#: Tuned for the existing 12s medical tick.  Balance knob.
+WOUND_HEALING_DIVISOR = 5
+
+#: Minimum HP recovered per tick when any dressing is registered
+#: (rating > 0).  Floor protects against integer-division-to-zero
+#: for low-rated dressings — a wound stays stable AND inches back
+#: even with weak dressing, just very slowly.  Set to 0 to disable
+#: the floor and let only high-rated dressings heal.
+WOUND_HEALING_FLOOR_HP_PER_TICK = 0
 
 # ===================================================================
 # MEDICAL CONDITION TICKER CONSTANTS (Phase 2.6)

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -103,7 +103,8 @@ class Organ:
         # conditions at this organ's location stop draining blood,
         # severity can't escalate, wound stage doesn't progress
         # toward "old".  Healing is a separate channel (PR-C) driven
-        # by the dressed item's ``wound_healing`` rating.
+        # by the dressed item's ``wound_healing`` rating, stored in
+        # ``dressing_rate`` below.
         #
         # Re-application of wound_care to a stabilized wound is a
         # no-op with a "they're already stable — get them to a
@@ -111,6 +112,19 @@ class Organ:
         # until the wound is surgically treated or the organ is
         # replaced.
         self.stabilized = False
+
+        # Dressing rate (#307, PR-C).  ``wound_healing`` effectiveness
+        # rating from the item that was applied at stabilization
+        # time.  Read by the medical script's healing tick to
+        # restore organ HP at a rate proportional to this value:
+        #
+        #     hp_per_tick = max(rating // DIVISOR, FLOOR)
+        #
+        # Stored as a number (not an item reference) — the item may
+        # be uses-depleted and deleted before the wound fully heals,
+        # but the rate persists.  Cleared on full heal or organ
+        # replacement.
+        self.dressing_rate = 0
         
     def is_destroyed(self):
         """Returns True if organ HP is 0 or below."""
@@ -288,6 +302,10 @@ class Organ:
             # wound is resolved.  Lets a future re-injury start with
             # a clean stabilization slate.
             self.stabilized = False
+            # PR-C: dressing rate also clears on full heal — the
+            # dressing has served its purpose and a future re-injury
+            # starts undressed.
+            self.dressing_rate = 0
         
         return self.current_hp - old_hp
         
@@ -424,6 +442,7 @@ class Organ:
             "injury_type": self.injury_type,
             "wound_timestamp": self.wound_timestamp,
             "stabilized": self.stabilized,
+            "dressing_rate": self.dressing_rate,
         }
         
     @classmethod
@@ -459,6 +478,13 @@ class Organ:
         # Stabilization (#307, PR-B).  Defaults to False so legacy
         # snapshots predating the field behave as untreated.
         organ.stabilized = bool(data.get("stabilized", False))
+        # Dressing rate (#307, PR-C).  Defaults to 0 so legacy
+        # snapshots predating the field behave as untreated /
+        # not-healing.
+        try:
+            organ.dressing_rate = int(data.get("dressing_rate", 0) or 0)
+        except (TypeError, ValueError):
+            organ.dressing_rate = 0
         # Issue #346: persisted organs may predate ``display_location`` —
         # the ``cls(data["name"])`` constructor already seeded it from
         # the ORGANS spec, so only override when the snapshot carries

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -10,6 +10,74 @@ from evennia.comms.models import ChannelDB
 from world.combat.constants import SPLATTERCAST_CHANNEL
 
 
+# ---------------------------------------------------------------------
+# Healing tick helpers (#307, PR-C)
+# ---------------------------------------------------------------------
+
+
+def _has_healing_work(medical_state) -> bool:
+    """True when any organ has stabilized + dressed wound that still
+    needs HP recovery.
+
+    Used by ``MedicalScript`` to decide whether to keep ticking after
+    all active conditions are gone — a freshly-dressed wound on an
+    otherwise-healthy character needs the tick to fire even with
+    zero conditions on the medical state.
+    """
+    organs = getattr(medical_state, "organs", None) or {}
+    for organ in organs.values():
+        if not getattr(organ, "stabilized", False):
+            continue
+        if getattr(organ, "dressing_rate", 0) <= 0:
+            continue
+        if organ.current_hp >= organ.max_hp:
+            continue
+        return True
+    return False
+
+
+def _hp_per_tick(dressing_rate: int) -> int:
+    """Calculate HP restored per tick for a given dressing rate.
+
+    Integer math: ``rating // DIVISOR``, then floored at
+    ``WOUND_HEALING_FLOOR_HP_PER_TICK`` so weak dressings still
+    inch wounds back when the floor is non-zero (default 0 keeps
+    them stable-but-not-healing).
+    """
+    from world.medical.constants import (
+        WOUND_HEALING_DIVISOR,
+        WOUND_HEALING_FLOOR_HP_PER_TICK,
+    )
+    base = int(dressing_rate) // max(1, WOUND_HEALING_DIVISOR)
+    return max(base, WOUND_HEALING_FLOOR_HP_PER_TICK)
+
+
+def _process_healing(character, medical_state) -> list:
+    """Walk stabilized + dressed organs; restore HP per dressing rate.
+
+    Returns the list of organs that received HP this tick (used by
+    the caller for logging).  Organs that reach full HP clear their
+    ``stabilized`` + ``dressing_rate`` automatically via the
+    ``Organ.heal`` code path.
+    """
+    healed = []
+    organs = getattr(medical_state, "organs", None) or {}
+    for organ in organs.values():
+        if not getattr(organ, "stabilized", False):
+            continue
+        rate = getattr(organ, "dressing_rate", 0)
+        if rate <= 0:
+            continue
+        if organ.current_hp >= organ.max_hp:
+            continue
+        hp_gain = _hp_per_tick(rate)
+        if hp_gain <= 0:
+            continue
+        organ.heal(hp_gain)
+        healed.append(organ)
+    return healed
+
+
 class MedicalScript(DefaultScript):
     """
     Per-character script that manages all medical conditions.
@@ -53,8 +121,15 @@ class MedicalScript(DefaultScript):
                 
             medical_state = self.obj.medical_state
             conditions = medical_state.conditions.copy()  # Copy to avoid modification during iteration
-            
-            if not conditions:
+
+            # PR-C (#307): stabilized wounds with a dressing rate
+            # keep the script alive so the healing tick can run
+            # even when there are no active conditions.  Without
+            # this check, dressing a wound on an otherwise-healthy
+            # character would never tick HP back.
+            has_healing_work = _has_healing_work(medical_state)
+
+            if not conditions and not has_healing_work:
                 splattercast.msg(f"MEDICAL_SCRIPT: {self.obj.key} has no conditions, stopping and deleting script")
                 self.stop()
                 self.delete()
@@ -106,7 +181,19 @@ class MedicalScript(DefaultScript):
             for condition in conditions_to_remove:
                 medical_state.conditions.remove(condition)
                 splattercast.msg(f"MEDICAL_SCRIPT: Removed {condition.condition_type}")
-            
+
+            # PR-C (#307): healing tick.  Walk stabilized organs that
+            # carry a dressing rate; restore HP proportional to the
+            # rate.  Cheap in-memory pass — no per-organ DB hits
+            # beyond the medical_state fetch already done above.
+            healed_organs = _process_healing(self.obj, medical_state)
+            if healed_organs:
+                splattercast.msg(
+                    f"MEDICAL_SCRIPT: Healing tick restored HP on "
+                    f"{len(healed_organs)} organ(s) for "
+                    f"{self.obj.key}"
+                )
+
             # Update vital signs after processing all conditions
             # This ensures consciousness includes all penalties (pain, blood loss, suppression)
             medical_state.update_vital_signs()
@@ -149,8 +236,11 @@ class MedicalScript(DefaultScript):
                         splattercast.msg(f"MEDICAL_SCRIPT_CLEAR_UNCONSCIOUS: Clearing unconscious override_place for {self.obj.key}")
                         self.obj.override_place = None
             
-            # Check if we should stop (no conditions left)
-            if not medical_state.conditions:
+            # Check if we should stop (no conditions left AND no
+            # stabilized wounds still healing).  PR-C: keep the
+            # script alive while there's healing work to do.
+            if (not medical_state.conditions
+                    and not _has_healing_work(medical_state)):
                 splattercast.msg(f"MEDICAL_SCRIPT: All conditions processed, stopping and deleting script for {self.obj.key}")
                 self.stop()
                 self.delete()

--- a/world/medical/treatments.py
+++ b/world/medical/treatments.py
@@ -286,12 +286,33 @@ def apply_wound_care(actor, target, item, location: str) -> dict:
     # current state — the act of dressing a wound stops it from
     # getting worse, even if the surgeon will need to redo the
     # work later.
+    #
+    # PR-C: also register the dressing's wound_healing rating on
+    # each stabilized organ so the medical script's healing tick
+    # can restore HP over time.  Rate is stored on the organ as a
+    # number (not an item reference) so item depletion doesn't
+    # affect ongoing recovery.
+    wound_healing_rating = int(effectiveness.get("wound_healing", 0) or 0)
     for organ in wounded_organs:
         organ.stabilized = True
+        organ.dressing_rate = wound_healing_rating
     result["stabilized"] = True
     result["messages"].append(
         f"The wound at {location.replace('_', ' ')} is stabilized."
     )
+
+    # PR-C: ensure the medical script is running so the healing
+    # tick can fire.  Idempotent — returns the existing script if
+    # one is already present.  Skips on test stubs that don't have
+    # the ``scripts`` accessor.
+    if wound_healing_rating > 0 and hasattr(target, "scripts"):
+        try:
+            from world.medical.script import start_medical_script
+            start_medical_script(target)
+        except Exception:
+            # Don't let script-start failures break the treatment
+            # outcome — the stabilization landed regardless.
+            pass
 
     # Consume one use of the item.
     _consume_use(item)

--- a/world/tests/test_wound_healing_tick.py
+++ b/world/tests/test_wound_healing_tick.py
@@ -1,0 +1,338 @@
+"""Tests for the wound-healing tick channel (#307, PR-C).
+
+Healing is the slow-recovery channel separate from stabilization
+(PR-B).  An applied wound_care item registers its ``wound_healing``
+effectiveness rating on the underlying organ via ``dressing_rate``;
+the medical script's tick walks stabilized organs and restores HP
+proportional to the stored rating.
+
+This module exercises the pure helpers and lifecycle around the
+healing channel.  Full ``MedicalScript`` integration (Evennia
+script machinery) is covered separately in the live suite — here
+we test the pieces the script consumes.
+
+Run via::
+
+    evennia test world.tests.test_wound_healing_tick
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.medical.core import MedicalState, Organ
+from world.medical.script import (
+    _has_healing_work,
+    _hp_per_tick,
+    _process_healing,
+)
+from world.medical.constants import (
+    WOUND_HEALING_DIVISOR,
+    WOUND_HEALING_FLOOR_HP_PER_TICK,
+)
+
+
+# ---------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------
+
+
+def _patient():
+    char = SimpleNamespace()
+    char.db = SimpleNamespace(
+        species="human", archived=False, surgical_state=None,
+        removed_organs=None, severed_locations=None,
+    )
+    char.key = "TestPatient"
+    char.medical_state = MedicalState(char)
+    return char
+
+
+def _wound_organ(patient, organ_name, hp_loss_fraction=0.5):
+    organ = patient.medical_state.organs[organ_name]
+    damage = int(organ.max_hp * hp_loss_fraction)
+    organ.current_hp = max(0, organ.max_hp - damage)
+    organ.wound_stage = "fresh"
+    return organ
+
+
+def _item(effectiveness, uses_left=3):
+    attrs_store = {
+        "effectiveness": effectiveness,
+        "uses_left": uses_left,
+        "medical_type": "wound_care",
+    }
+
+    class _Attrs:
+        def get(self, key):
+            return attrs_store.get(key)
+
+        def add(self, key, value):
+            attrs_store[key] = value
+
+    item = SimpleNamespace()
+    item.attributes = _Attrs()
+    item.key = "test-bandage"
+    item._store = attrs_store
+    return item
+
+
+# ---------------------------------------------------------------------
+# Organ.dressing_rate lifecycle
+# ---------------------------------------------------------------------
+
+
+class OrganDressingRateAttribute(TestCase):
+
+    def test_default_zero(self):
+        organ = Organ("heart", species="human")
+        self.assertEqual(organ.dressing_rate, 0)
+
+    def test_serializes_to_dict(self):
+        organ = Organ("heart", species="human")
+        organ.dressing_rate = 6
+        data = organ.to_dict()
+        self.assertIn("dressing_rate", data)
+        self.assertEqual(data["dressing_rate"], 6)
+
+    def test_round_trips_through_from_dict(self):
+        organ = Organ("heart", species="human")
+        organ.current_hp = 5
+        organ.wound_stage = "fresh"
+        organ.stabilized = True
+        organ.dressing_rate = 8
+        restored = Organ.from_dict(organ.to_dict())
+        self.assertEqual(restored.dressing_rate, 8)
+
+    def test_legacy_dict_without_field_defaults_zero(self):
+        organ = Organ("heart", species="human")
+        data = organ.to_dict()
+        data.pop("dressing_rate", None)
+        restored = Organ.from_dict(data)
+        self.assertEqual(restored.dressing_rate, 0)
+
+    def test_non_integer_dressing_rate_coerces_to_zero(self):
+        """Defensive: corrupt persistence shouldn't blow up
+        deserialization."""
+        organ = Organ("heart", species="human")
+        data = organ.to_dict()
+        data["dressing_rate"] = "garbage"
+        restored = Organ.from_dict(data)
+        self.assertEqual(restored.dressing_rate, 0)
+
+    def test_full_heal_clears_dressing_rate(self):
+        """Heal-to-full clears both stabilized and dressing_rate so
+        a future re-injury starts clean."""
+        organ = Organ("heart", species="human")
+        organ.current_hp = 5
+        organ.wound_stage = "fresh"
+        organ.stabilized = True
+        organ.dressing_rate = 8
+        organ.heal(organ.max_hp)
+        self.assertEqual(organ.current_hp, organ.max_hp)
+        self.assertEqual(organ.dressing_rate, 0)
+        self.assertFalse(organ.stabilized)
+
+
+# ---------------------------------------------------------------------
+# _hp_per_tick
+# ---------------------------------------------------------------------
+
+
+class HpPerTick(TestCase):
+
+    def test_zero_rating_returns_floor(self):
+        self.assertEqual(_hp_per_tick(0), WOUND_HEALING_FLOOR_HP_PER_TICK)
+
+    def test_low_rating_below_divisor_returns_floor(self):
+        """Ratings below the divisor land at floor (0 by default —
+        wound stays stable but doesn't actively heal)."""
+        # WOUND_HEALING_DIVISOR is 5 by default.
+        self.assertEqual(_hp_per_tick(3), WOUND_HEALING_FLOOR_HP_PER_TICK)
+
+    def test_rating_equal_to_divisor_returns_one(self):
+        """Rating = DIVISOR → 1 HP/tick."""
+        # 5 // 5 = 1
+        self.assertEqual(_hp_per_tick(WOUND_HEALING_DIVISOR), 1)
+
+    def test_high_rating_scales(self):
+        """Higher ratings produce more HP per tick."""
+        # 10 // 5 = 2
+        self.assertEqual(_hp_per_tick(10), 2)
+
+    def test_very_high_rating_scales(self):
+        # 30 // 5 = 6
+        self.assertEqual(_hp_per_tick(30), 6)
+
+
+# ---------------------------------------------------------------------
+# _has_healing_work
+# ---------------------------------------------------------------------
+
+
+class HasHealingWork(TestCase):
+
+    def test_no_organs_returns_false(self):
+        state = SimpleNamespace(organs={})
+        self.assertFalse(_has_healing_work(state))
+
+    def test_unstabilized_wounded_organ_returns_false(self):
+        patient = _patient()
+        _wound_organ(patient, "heart", hp_loss_fraction=0.5)
+        # No stabilization, no dressing.
+        self.assertFalse(_has_healing_work(patient.medical_state))
+
+    def test_stabilized_but_no_dressing_returns_false(self):
+        """Stabilization alone doesn't heal — needs a dressing rate."""
+        patient = _patient()
+        organ = _wound_organ(patient, "heart", hp_loss_fraction=0.5)
+        organ.stabilized = True
+        organ.dressing_rate = 0
+        self.assertFalse(_has_healing_work(patient.medical_state))
+
+    def test_stabilized_with_dressing_returns_true(self):
+        patient = _patient()
+        organ = _wound_organ(patient, "heart", hp_loss_fraction=0.5)
+        organ.stabilized = True
+        organ.dressing_rate = 6
+        self.assertTrue(_has_healing_work(patient.medical_state))
+
+    def test_fully_healed_organ_returns_false(self):
+        """Even with dressing_rate set, a fully-healed organ has
+        no work left."""
+        patient = _patient()
+        organ = patient.medical_state.organs["heart"]
+        organ.stabilized = True
+        organ.dressing_rate = 6
+        # current_hp == max_hp by default.
+        self.assertFalse(_has_healing_work(patient.medical_state))
+
+    def test_multiple_organs_returns_true_if_any_needs_healing(self):
+        patient = _patient()
+        healthy = patient.medical_state.organs["heart"]
+        # Heart is healthy.
+        self.assertEqual(healthy.current_hp, healthy.max_hp)
+        # Lung is wounded + dressed.
+        lung = _wound_organ(patient, "left_lung")
+        lung.stabilized = True
+        lung.dressing_rate = 6
+        self.assertTrue(_has_healing_work(patient.medical_state))
+
+
+# ---------------------------------------------------------------------
+# _process_healing
+# ---------------------------------------------------------------------
+
+
+class ProcessHealing(TestCase):
+
+    def test_unstabilized_organ_not_healed(self):
+        patient = _patient()
+        organ = _wound_organ(patient, "heart", hp_loss_fraction=0.5)
+        before = organ.current_hp
+        _process_healing(patient, patient.medical_state)
+        self.assertEqual(organ.current_hp, before)
+
+    def test_stabilized_with_dressing_heals(self):
+        patient = _patient()
+        organ = _wound_organ(patient, "heart", hp_loss_fraction=0.6)
+        organ.stabilized = True
+        organ.dressing_rate = 10  # 10 // 5 = 2 HP/tick
+        before = organ.current_hp
+        healed = _process_healing(patient, patient.medical_state)
+        self.assertIn(organ, healed)
+        self.assertEqual(organ.current_hp, before + 2)
+
+    def test_zero_rate_organ_does_not_heal(self):
+        """Stabilization with rating below the divisor (which
+        rounds to 0) keeps the wound stable but doesn't heal."""
+        patient = _patient()
+        organ = _wound_organ(patient, "heart", hp_loss_fraction=0.5)
+        organ.stabilized = True
+        organ.dressing_rate = 3  # 3 // 5 = 0 HP/tick
+        before = organ.current_hp
+        healed = _process_healing(patient, patient.medical_state)
+        self.assertEqual(organ.current_hp, before)
+        self.assertNotIn(organ, healed)
+
+    def test_full_heal_clears_dressing_state(self):
+        """When healing brings the organ to max HP, ``heal`` clears
+        the stabilized + dressing_rate fields automatically."""
+        patient = _patient()
+        organ = patient.medical_state.organs["heart"]
+        organ.current_hp = organ.max_hp - 2  # Need 2 HP to fully heal
+        organ.wound_stage = "fresh"
+        organ.stabilized = True
+        organ.dressing_rate = 10  # 2 HP/tick
+        _process_healing(patient, patient.medical_state)
+        self.assertEqual(organ.current_hp, organ.max_hp)
+        self.assertFalse(organ.stabilized)
+        self.assertEqual(organ.dressing_rate, 0)
+
+    def test_multiple_dressed_organs_all_heal(self):
+        patient = _patient()
+        heart = _wound_organ(patient, "heart")
+        heart.stabilized = True
+        heart.dressing_rate = 10
+        lung = _wound_organ(patient, "left_lung")
+        lung.stabilized = True
+        lung.dressing_rate = 10
+        heart_before = heart.current_hp
+        lung_before = lung.current_hp
+        healed = _process_healing(patient, patient.medical_state)
+        self.assertEqual(heart.current_hp, heart_before + 2)
+        self.assertEqual(lung.current_hp, lung_before + 2)
+        self.assertEqual(len(healed), 2)
+
+    def test_returns_empty_for_no_healing_work(self):
+        """Defensive: when nothing's stabilized, the helper
+        returns an empty list without mutating anything."""
+        patient = _patient()
+        result = _process_healing(patient, patient.medical_state)
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------
+# Integration: apply_wound_care sets dressing_rate
+# ---------------------------------------------------------------------
+
+
+class ApplyWoundCareSetsDressingRate(TestCase):
+    """Pin the integration between PR-B's stabilization application
+    and PR-C's dressing-rate registration."""
+
+    def _setup_patient_with_wound(self):
+        patient = _patient()
+        organ = _wound_organ(patient, "heart", hp_loss_fraction=0.5)
+        return patient, organ
+
+    @patch("world.medical.treatments.random.randint", return_value=6)
+    def test_application_registers_dressing_rate(self, _r):
+        from world.medical.treatments import apply_wound_care
+        patient, organ = self._setup_patient_with_wound()
+        medic = _patient()
+        medic.intellect = 3
+        medic.motorics = 3
+        item = _item({
+            "bleeding": 7, "infection": 8, "pain": 3,
+            "wound_healing": 6,
+        })
+        apply_wound_care(medic, patient, item, "chest")
+        self.assertEqual(organ.dressing_rate, 6)
+        self.assertTrue(organ.stabilized)
+
+    @patch("world.medical.treatments.random.randint", return_value=6)
+    def test_item_without_wound_healing_rating_sets_zero(self, _r):
+        """Items that lack a wound_healing rating (or set it to 0)
+        stabilize the wound but don't register healing."""
+        from world.medical.treatments import apply_wound_care
+        patient, organ = self._setup_patient_with_wound()
+        medic = _patient()
+        medic.intellect = 3
+        medic.motorics = 3
+        item = _item({"bleeding": 5})  # No wound_healing.
+        apply_wound_care(medic, patient, item, "chest")
+        self.assertTrue(organ.stabilized)
+        self.assertEqual(organ.dressing_rate, 0)


### PR DESCRIPTION
## Summary

Slow-recovery channel separate from stabilization. Dressed wounds restore organ HP over time at a rate driven by the dressing's ``wound_healing`` effectiveness rating.

### Design recap

Two distinct channels under the wound_care umbrella:

- **Stabilization** (PR-B) — freezes wound state, fires on every application
- **Healing** (this PR) — slowly restores organ HP, ticks through the existing ``MedicalScript`` infrastructure

### Tick-load discipline

Per the user's risk-flag on Evennia tick infrastructure: this PR **adds no new tickers**. The implementation piggybacks on the existing per-character ``MedicalScript.at_repeat`` loop. Tick cost amortises across the work the script already does:

- One ``MedicalScript`` per character (already true) — auto-starts on first condition, auto-stops when nothing's left
- New healing pass walks ``medical_state.organs`` in memory (no DB hits beyond the existing state fetch)
- Stop check extended to consider stabilized+dressed wounds — script keeps ticking only while there's actual healing work to do

### What's stored

``Organ.dressing_rate`` — a number (not an item reference) set by ``apply_wound_care``. Items can be uses-depleted and deleted; the rate persists. Clears on full heal alongside ``stabilized`` + ``wound_stage``.

### Balance knobs

In ``constants.py`` per the make-it-modifiable principle:

- ``WOUND_HEALING_DIVISOR = 5`` — gauze (rating 6) → 1 HP/tick; high-rated dressing (10) → 2 HP/tick
- ``WOUND_HEALING_FLOOR_HP_PER_TICK = 0`` — low-rated dressings stay stable but don't actively heal

## Files

- ``world/medical/constants.py`` — new constants
- ``world/medical/core.py`` — ``Organ.dressing_rate`` field with full lifecycle
- ``world/medical/treatments.py`` — ``apply_wound_care`` records rate + starts script
- ``world/medical/script.py`` — healing helpers + ``at_repeat`` integration

## Test plan

- [x] ``world.tests.test_wound_healing_tick`` (NEW) — 25 tests: ``dressing_rate`` lifecycle, ``_hp_per_tick`` math, ``_has_healing_work`` predicate, ``_process_healing`` walk, ``apply_wound_care`` integration
- [x] Full suite: 1940/1940 (+25 net)

## Position

- PR-A (#382), PR-B (#383), PR-H0-H3 (#384-#387) — shipped
- **PR-C** (this PR) — wound_healing tick channel
- PR-D (next) — ``organ_repair`` + ``SURGICAL_SEALANT`` prototype

Refs #307.