### PR TITLE
fix: inventory display, humanize hand keys

### DIFF
--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -248,13 +248,17 @@ class CmdInventory(Command):
                     lines.append(f"  {item_name}")
             lines.append("")
 
-        # Held (in hands)
+        # Held (in hands).  PR-H2: ``hand`` is the canonical
+        # anatomical key ("left_hand", "right_hand", ...) — humanize
+        # for display rather than appending a redundant " hand"
+        # suffix that would render "left_hand hand".
         lines.append("|wHeld:|n")
         for hand, item in hands.items():
+            display = hand.replace("_", " ")
             if item:
-                lines.append(f"A {item.get_display_name(caller)} is held in your {hand.lower()} hand.")
+                lines.append(f"A {item.get_display_name(caller)} is held in your {display}.")
             else:
-                lines.append(f"Nothing is in your {hand.lower()} hand.")
+                lines.append(f"Nothing is in your {display}.")
 
         caller.msg("\n".join(lines))
     


### PR DESCRIPTION
Held-items section was using raw left_hand / right_hand keys with a hard-coded " hand" suffix → "Nothing is in your right_hand hand." after PR-H2's anatomical keyspace.

Fix: humanize via hand.replace("_", " "), same pattern PR-H2 applied to the other consumers. list_held_items and the CmdDrop / give flows were already correct; this was the last leftover spot.

Tests: full suite 1956/1956 holds.

Refs #307.