### PR TITLE
fix: corpse snapshot routing in get_organ_snapshot

### DIFF
--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -91,12 +91,23 @@ def get_organ_snapshot(target) -> dict:
     * **Corpse / SeveredHead / Appendage** → reads from
       ``target.get_medical_snapshot()`` (death-time dict snapshot).
 
+    The "live" branch is gated on ``medical_state.organs`` being
+    actually populated.  Corpses can expose a truthy-but-empty
+    ``medical_state`` attribute through Evennia's attribute
+    resolution (the live state was transferred to ``medical_state_
+    at_death`` when the character died); without this guard the
+    live branch would short-circuit to ``{"organs": {}}`` and the
+    real death-time snapshot would never be reached.
+
     Returns an empty dict when no snapshot is available (target
     predates the medical pipeline or isn't a body container).
     """
-    # Living: medical_state attribute with live organs.
+    # Living: medical_state attribute with live organs.  Gated on
+    # the organs dict being populated — corpse-shaped targets that
+    # surface ``medical_state`` but with empty organs fall through
+    # to the snapshot path so their death-time data is used.
     medical_state = getattr(target, "medical_state", None)
-    if medical_state is not None and hasattr(medical_state, "organs"):
+    if medical_state is not None and getattr(medical_state, "organs", None):
         return {
             "organs": {
                 name: organ.to_dict()

--- a/world/tests/test_surgical_procedures.py
+++ b/world/tests/test_surgical_procedures.py
@@ -124,6 +124,54 @@ class GetOrganSnapshot(TestCase):
         target = SimpleNamespace()
         self.assertEqual(get_organ_snapshot(target), {})
 
+    def test_corpse_with_empty_live_state_falls_through_to_snapshot(self):
+        """Regression: a corpse can expose ``medical_state`` through
+        Evennia's attribute resolution but with an empty ``organs``
+        dict (the live state was transferred to
+        ``medical_state_at_death`` at death time).  Without the
+        ``getattr(..., "organs", None)`` truthiness guard, the live
+        branch returned ``{"organs": {}}`` and the procedure verbs
+        saw a corpse as having no anatomy.
+
+        Reproduces the 2026-06-05 playtest report where
+        ``incise corpse at abdomen`` rejected with "nothing at
+        abdomen" despite the autopsy showing intact liver/kidney/
+        stomach in the snapshot.
+        """
+        # Build a corpse stub that surfaces BOTH paths: an empty
+        # live medical_state AND a populated death-time snapshot.
+        snapshot = {
+            "organs": {
+                "liver": {
+                    "container": "abdomen",
+                    "display_location": "abdomen",
+                    "current_hp": 20, "max_hp": 20, "conditions": [],
+                },
+            },
+        }
+        corpse = SimpleNamespace()
+        empty_state = SimpleNamespace(organs={})
+        corpse.medical_state = empty_state
+        corpse.get_medical_snapshot = lambda: snapshot
+        snap = get_organ_snapshot(corpse)
+        self.assertIn("liver", snap.get("organs") or {})
+
+    def test_living_with_populated_state_takes_live_path(self):
+        """Counter-test: a living character with populated organs
+        still uses the live medical_state path (not the
+        get_medical_snapshot fallback).  Pins the gate condition."""
+        char = _human_character()
+        # Sentinel snapshot that would shadow the live path if it
+        # ran — assert the live organs win.
+        sentinel_snapshot = {
+            "organs": {"sentinel_organ": {"container": "nowhere"}},
+        }
+        char.get_medical_snapshot = lambda: sentinel_snapshot
+        snap = get_organ_snapshot(char)
+        organs = snap.get("organs") or {}
+        self.assertIn("heart", organs)
+        self.assertNotIn("sentinel_organ", organs)
+
 
 class OrgansAtLocation(TestCase):
 


### PR DESCRIPTION
**Bug:** incise corpse at abdomen rejected with "nothing at abdomen" despite autopsy showing intact liver/kidney/stomach. Same for any procedure verb against any corpse since PR-A.

**Cause:** get_organ_snapshot took the "live" path whenever target.medical_state existed. Corpses expose a truthy medical_state through Evennia's attribute machinery but with an empty organs dict (live state was transferred to medical_state_at_death on death). Result: empty match, snapshot never consulted.

**Fix:** Gate the live path on medical_state.organs being actually populated. Empty-organs case falls through to get_medical_snapshot(). One defensive truthiness check.

**Diagnosis:** User ran py corpse.get_medical_snapshot()["organs"].get("liver") and confirmed snapshot was complete with container: 'abdomen' — proving routing was the bug.

**Tests:** Pinned regression case + counter-test for the live-path-still-fires case. Suite: 1958/1958.

Refs #307.