### PR TITLE
fix: apply vital consequences immediately on harvest/install

### DIFF
--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -677,6 +677,13 @@ def _resolve_install(actor, target, *, organ_item, location: str,
     except Exception:
         pass
 
+    # PR-393 follow-up: re-evaluate vitals on living recipient.
+    # Installing a vital organ (heart, brain replacement) during the
+    # death-progression window should fire the revival check
+    # immediately rather than waiting for the next medical-script
+    # tick — the dramatic transplant timing depends on this.
+    apply_vital_consequences(target)
+
 
 def _resolve_suture(actor, target, *, location: Optional[str] = None,
                     **_) -> None:
@@ -764,6 +771,85 @@ def _apply_collateral_damage(target, location: str, amount: int) -> None:
                 organ.wound_stage = "fresh"
 
 
+def apply_vital_consequences(target) -> bool:
+    """Re-evaluate ``target``'s vital state after a structural change.
+
+    Called by any code path that mutates organ HP / wound stage on a
+    living target — harvest, install, future destruction effects, the
+    sever pipeline (which should adopt this too).  Does four things:
+
+    1. ``update_vital_signs`` — recomputes pain / blood / consciousness
+       from the current organ HP, capacity contributions, and active
+       conditions.
+    2. ``save_medical_state`` — persists the change so it survives
+       reload / hand-off to the script.
+    3. ``is_dead`` check + ``at_death`` trigger — the procedure verbs
+       can lethally change a body's state directly (heart removed,
+       brain harvested) and the medical-script tick is *not*
+       guaranteed to be running on the target.  If the structural
+       change crosses the death threshold we surface that immediately
+       rather than waiting for whatever next tick happens to fire.
+       Guards against double-fire via ``ndb.death_processed``.
+    4. ``start_medical_script`` — ensures the per-character tick loop
+       runs so ongoing effects (bleeding from open wounds, infection
+       progression, healing on dressed wounds) continue to process.
+       Idempotent — returns the existing script if one's present.
+
+    Returns True if death was triggered this call; False otherwise.
+
+    Safe on test stubs that lack one or more of the surfaces — each
+    step is guarded.
+    """
+    state = getattr(target, "medical_state", None)
+    if state is None:
+        return False
+
+    update_vital_signs = getattr(state, "update_vital_signs", None)
+    if callable(update_vital_signs):
+        try:
+            update_vital_signs()
+        except Exception:
+            pass
+
+    save = getattr(target, "save_medical_state", None)
+    if callable(save):
+        try:
+            save()
+        except Exception:
+            pass
+
+    is_dead = getattr(state, "is_dead", None)
+    if callable(is_dead):
+        try:
+            if is_dead():
+                already_processed = bool(
+                    getattr(getattr(target, "ndb", None),
+                            "death_processed", False)
+                )
+                if not already_processed:
+                    at_death = getattr(target, "at_death", None)
+                    if callable(at_death):
+                        try:
+                            at_death()
+                            return True
+                        except Exception:
+                            pass
+        except Exception:
+            pass
+
+    # Even if not dead, keep the medical script ticking so any
+    # subsequent effects (bleeding, infection, dressing healing) get
+    # processed on the existing cadence.  Idempotent.
+    if hasattr(target, "scripts"):
+        try:
+            from world.medical.script import start_medical_script
+            start_medical_script(target)
+        except Exception:
+            pass
+
+    return False
+
+
 def _mark_organ_removed(target, organ_name: str) -> None:
     """Mark ``organ_name`` as removed from ``target``.
 
@@ -780,6 +866,12 @@ def _mark_organ_removed(target, organ_name: str) -> None:
        along onto the severed item).  Only synthesised when the target
        carries the ``wounds_at_death`` attribute (corpses / severed
        parts); living targets get the live-organ mutation instead.
+
+    For living targets, finishes by calling
+    :func:`apply_vital_consequences` so vital-organ removal
+    immediately triggers death detection rather than waiting for the
+    next medical-script tick (which may not be running on the
+    target — see #393 follow-up).
     """
     removed = getattr(target.db, "removed_organs", None) or []
     if organ_name not in removed:
@@ -835,6 +927,16 @@ def _mark_organ_removed(target, organ_name: str) -> None:
         target_db.wounds_at_death = wounds
         if snapshot:
             target_db.medical_state_at_death = snapshot
+
+    # PR-393 follow-up: re-evaluate vitals on living targets.  Vital
+    # organ removal needs immediate death detection — the medical
+    # script may not be running yet (fresh-spawned mob, fully-healed
+    # character with no conditions, etc.), so a tick-delay alone
+    # would leave the target indefinitely "walking dead".  Skip on
+    # corpse-shaped sources (already dead, no vitals to re-check).
+    if not (target_db is not None
+            and getattr(target_db, "medical_state_at_death", None) is not None):
+        apply_vital_consequences(target)
 
 
 def _configure_harvested_item(item, *, organ_name: str, condition: str,

--- a/world/tests/test_surgical_procedures.py
+++ b/world/tests/test_surgical_procedures.py
@@ -252,6 +252,99 @@ class OrgansAtLocationDuckTyping(TestCase):
         self.assertEqual(results, [])
 
 
+# ---------------------------------------------------------------------
+# apply_vital_consequences (#393 follow-up — death detection on
+# vital-organ removal when the medical script isn't running)
+# ---------------------------------------------------------------------
+
+
+class ApplyVitalConsequences(TestCase):
+    """Pin the contract that ``apply_vital_consequences`` fires the
+    death pipeline immediately after a structural change, rather
+    than depending on a medical-script tick that may not be running.
+    """
+
+    def _target(self, dead=False, organs_truthy=True):
+        """Build a target stub exposing the surfaces the helper reads."""
+        calls = []
+
+        class _State:
+            def __init__(self):
+                self.organs = {} if not organs_truthy else {"sentinel": object()}
+
+            def update_vital_signs(self):
+                calls.append("update_vital_signs")
+
+            def is_dead(self):
+                calls.append("is_dead")
+                return dead
+
+        target = SimpleNamespace()
+        target.medical_state = _State()
+        target.ndb = SimpleNamespace()
+        target.scripts = SimpleNamespace()
+
+        def _save():
+            calls.append("save_medical_state")
+
+        def _at_death():
+            calls.append("at_death")
+            target.ndb.death_processed = True
+
+        target.save_medical_state = _save
+        target.at_death = _at_death
+        target._calls = calls
+        return target
+
+    def test_living_with_vitals_intact_does_not_trigger_death(self):
+        from world.medical.procedures import apply_vital_consequences
+        target = self._target(dead=False)
+        died = apply_vital_consequences(target)
+        self.assertFalse(died)
+        self.assertIn("update_vital_signs", target._calls)
+        self.assertIn("save_medical_state", target._calls)
+        self.assertIn("is_dead", target._calls)
+        self.assertNotIn("at_death", target._calls)
+
+    def test_living_with_dead_state_triggers_at_death(self):
+        from world.medical.procedures import apply_vital_consequences
+        target = self._target(dead=True)
+        died = apply_vital_consequences(target)
+        self.assertTrue(died)
+        self.assertIn("at_death", target._calls)
+        # Order matters: update -> save -> is_dead -> at_death.
+        idx = target._calls.index
+        self.assertLess(idx("update_vital_signs"), idx("at_death"))
+        self.assertLess(idx("save_medical_state"), idx("at_death"))
+
+    def test_double_call_does_not_double_trigger_at_death(self):
+        """The ndb.death_processed guard prevents at_death from firing
+        twice if a follow-up structural change calls the helper
+        again after death already fired."""
+        from world.medical.procedures import apply_vital_consequences
+        target = self._target(dead=True)
+        apply_vital_consequences(target)
+        # Second call — at_death should not fire again.
+        target._calls.clear()
+        apply_vital_consequences(target)
+        self.assertNotIn("at_death", target._calls)
+
+    def test_no_medical_state_is_no_op(self):
+        from world.medical.procedures import apply_vital_consequences
+        target = SimpleNamespace()
+        # No medical_state surface.
+        died = apply_vital_consequences(target)
+        self.assertFalse(died)
+
+    def test_missing_save_method_does_not_raise(self):
+        from world.medical.procedures import apply_vital_consequences
+        target = self._target(dead=False)
+        del target.save_medical_state
+        # Should not raise.
+        apply_vital_consequences(target)
+        self.assertIn("update_vital_signs", target._calls)
+
+
 class OrgansAtLocation(TestCase):
 
     def test_living_chest_organs(self):


### PR DESCRIPTION
**Bug:** Vital organ removal via harvest left targets in a "walking dead" state when the medical script wasn't running. Fresh-spawned mobs with no conditions have no script — harvesting the heart zeroed the organ but never fired is_dead.

**Fix:** New apply_vital_consequences(target) helper does the canonical post-mutation re-evaluation: update_vital_signs + save + is_dead check (with at_death trigger) + idempotent script start. Wired into _mark_organ_removed (living branch) and _resolve_install.

The pattern was half-present already in apply_sever_to_character (update_vital_signs + save). Harvest is the procedure-verb-as-death-trigger case, so it needs the full pipeline.

Dramatic transplant timing still works — install during the death-progression window re-fires is_dead via the same helper, no tick-delay window.

**Tests:** New ApplyVitalConsequences class (5 tests). Suite: 1965/1965.

Refs #307.