### PR TITLE
operate charting menu (MVP) — #307 PR-OP1

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -1,0 +1,683 @@
+"""Operate command — charting menu over the procedure verbs (#307, PR-OP1).
+
+``operate <target>`` opens an EvMenu where a surgeon can build a
+medical chart (sequence of procedure steps) and either commence
+the next pending step or save the chart on the patient for later /
+handoff to a colleague.
+
+The chart data lives in ``world.medical.charts``; this module is
+the UI surface only.  Visual idiom mirrors ``armor comprehensive``:
+left-aligned, box-drawn section labels on the left
+(PATIENT / CHART / OPTIONS), tree-branched content on the right,
+Roman-numeral step ordering.  No centering.
+
+Scope for PR-OP1 (MVP):
+
+  ✓ Add procedure step (incise / harvest / install / suture)
+  ✓ View chart with rendered step list
+  ✓ Commence next pending step
+  ✓ Save chart and exit
+  ✓ Discard chart
+
+Deferred to follow-on PRs:
+
+  • Diagnose pane (skill-gated organ-state inspection)
+  • Add treatment step (apply / inject)
+  • Reorder / remove / annotate steps
+  • Resume from arbitrary step
+  • Auto-chaining (commence all steps back-to-back)
+  • Permission delegation (multi-author charts)
+  • Trust/consent integration for conscious targets
+
+# ===================================================================
+# VISUAL DESIGN
+# ===================================================================
+#
+# Mirrors ``armor comprehensive`` (commands/CmdArmor.py:_show_
+# comprehensive_view):
+#
+#   ╔═══════════════╗
+#   ║  PATIENT      ║──── the battered drifter
+#   ╚═══════════════╝
+#
+#   ╔═══════════════╗
+#   ║  CHART        ║──┬──  I. incise chest                [pending]
+#   ╚═══════════════╝  ├── II. harvest heart               [pending]
+#                      └── III. suture chest                [pending]
+#
+#   ╔═══════════════╗
+#   ║  OPTIONS      ║──┬── 1. Add procedure step
+#   ╚═══════════════╝  ├── 2. View chart detail
+#                      ├── 3. Commence next step
+#                      ├── 4. Save and exit
+#                      ├── 5. Discard chart
+#                      └── x. Exit (no save)
+#
+# Section labels are SHOUTING CAPS in a 17-char box; content
+# branches off via ────, ├──, └── glyphs.  Roman numerals for
+# chart steps (cosmetic — matches the procedure-as-clinical-act
+# vibe).  Per-line padding suppressed when ``center_headers`` is
+# disabled at session level.
+"""
+
+from __future__ import annotations
+
+from evennia import Command
+from evennia.utils.evmenu import EvMenu
+
+from world.medical import charts as chart_lib
+
+
+# ===================================================================
+# VISUAL CONSTANTS
+# ===================================================================
+
+LABEL_BOX_WIDTH = 15                # Content width inside ║...║
+LABEL_BOX_TOTAL = LABEL_BOX_WIDTH + 2  # Including ║ borders
+STEM = "────"
+JOIN_T = "──┬──"
+JOIN_MID = "├──"
+JOIN_END = "└──"
+EMPTY_GUTTER = " " * (LABEL_BOX_TOTAL + 2)  # Aligns sub-branches under stem
+
+
+# ===================================================================
+# RENDERING — left-aligned tree-branch chart display
+# ===================================================================
+
+
+def _roman(num: int) -> str:
+    """Roman-numeral conversion (1..50 covers any sensible chart)."""
+    if num <= 0:
+        return "0"
+    val = [50, 40, 10, 9, 5, 4, 1]
+    syms = ["L", "XL", "X", "IX", "V", "IV", "I"]
+    out = ""
+    for v, s in zip(val, syms):
+        while num >= v:
+            out += s
+            num -= v
+    return out
+
+
+def _label_box(label: str) -> tuple[str, str, str]:
+    """Build the three lines of a section-label box.
+
+    Returns ``(top, middle, bottom)`` as bare strings (no trailing
+    newline).  Middle includes the centered label inside the
+    box borders.
+    """
+    label = label.upper()
+    pad_left = (LABEL_BOX_WIDTH - len(label)) // 2
+    pad_right = LABEL_BOX_WIDTH - len(label) - pad_left
+    text = " " * pad_left + label + " " * pad_right
+    top = "╔" + "═" * LABEL_BOX_WIDTH + "╗"
+    mid = "║" + text + "║"
+    bot = "╚" + "═" * LABEL_BOX_WIDTH + "╝"
+    return top, mid, bot
+
+
+def _render_section(label: str, lines: list[str]) -> list[str]:
+    """Render one labeled section.
+
+    ``lines`` is the list of content lines that should branch off
+    the right side of the label box.  Single-line content uses a
+    simple ──── stem; multi-line uses ──┬── / ├── / └── tree.
+    Empty ``lines`` renders the box alone with no branch.
+    """
+    if not lines:
+        top, mid, bot = _label_box(label)
+        return [top, mid, bot]
+
+    top, mid, bot = _label_box(label)
+    out = []
+    if len(lines) == 1:
+        out.append(top)
+        out.append(f"{mid}{STEM} {lines[0]}")
+        out.append(bot)
+        return out
+
+    # Multi-line: branched tree.
+    out.append(top)
+    out.append(f"{mid}{JOIN_T} {lines[0]}")
+    out.append(bot)
+    for line in lines[1:-1]:
+        out.append(f"{EMPTY_GUTTER}{JOIN_MID} {line}")
+    out.append(f"{EMPTY_GUTTER}{JOIN_END} {lines[-1]}")
+    return out
+
+
+def _render_patient_lines(caller, target) -> list[str]:
+    """One identity line + vital-summary line(s) for the PATIENT
+    section."""
+    lines = [target.get_display_name(caller)]
+
+    state = getattr(target, "medical_state", None)
+    if state is not None:
+        vitals = []
+        is_unc = getattr(target, "is_unconscious", None)
+        if callable(is_unc) and is_unc():
+            vitals.append("unconscious")
+        is_dead = getattr(state, "is_dead", None)
+        if callable(is_dead) and is_dead():
+            vitals.append("|rdying|n")
+        conditions = getattr(state, "conditions", None) or []
+        if conditions:
+            count_by_type = {}
+            for c in conditions:
+                t = getattr(c, "condition_type", "condition")
+                count_by_type[t] = count_by_type.get(t, 0) + 1
+            for k, n in count_by_type.items():
+                tag = k.replace("_", " ")
+                vitals.append(f"{n}× {tag}" if n > 1 else tag)
+        if vitals:
+            lines.append(" · ".join(vitals))
+
+    # Open incisions from the surgical_state attr (set by procedures).
+    surgical_state = getattr(getattr(target, "db", None),
+                             "surgical_state", None)
+    if surgical_state:
+        open_locs = surgical_state.get("incisions") or []
+        if open_locs:
+            humanized = [loc.replace("_", " ") for loc in open_locs]
+            lines.append(f"open incision: {', '.join(humanized)}")
+
+    return lines
+
+
+def _render_chart_lines(chart: dict | None) -> list[str]:
+    """Render the chart's step list (or a placeholder when empty)."""
+    if not chart:
+        return ["no active chart — pick option 1 to add a step"]
+    steps = chart.get("steps") or []
+    if not steps:
+        return [
+            f"{chart.get('status', 'draft')} · 0 steps "
+            f"(empty — add procedure steps)"
+        ]
+    out = []
+    for idx, step in enumerate(steps, start=1):
+        roman = _roman(idx).rjust(4)
+        summary = chart_lib.render_step_summary(step)
+        status = step.get("status", "pending")
+        # Color cue per status — pending neutral, done green, failed red.
+        if status == chart_lib.DONE:
+            tag = "|gdone|n"
+        elif status == chart_lib.FAILED:
+            tag = "|rfailed|n"
+        elif status == chart_lib.SKIPPED:
+            tag = "|yskipped|n"
+        elif status == chart_lib.RUNNING:
+            tag = "|crunning|n"
+        else:
+            tag = "pending"
+        out.append(f"{roman}. {summary.ljust(36)} [{tag}]")
+    return out
+
+
+def _render_options_lines(option_numbers: list[tuple[str, str]]) -> list[str]:
+    """Format the OPTIONS block.  ``option_numbers`` is a list of
+    ``(label, description)`` tuples; we render as
+    ``  1. Description``."""
+    return [
+        f"{num}. {desc}" for num, desc in option_numbers
+    ]
+
+
+def render_top_level(caller, target) -> str:
+    """Compose the full top-level menu render: PATIENT → CHART →
+    OPTIONS, three labeled sections, blank-line separated."""
+    chart = chart_lib.get_chart(target)
+
+    options = [
+        ("1", "Add procedure step"),
+        ("2", "View chart detail"),
+        ("3", "Commence next step"),
+        ("4", "Save and exit"),
+        ("5", "Discard chart"),
+        ("x", "Exit (no save)"),
+    ]
+
+    blocks = []
+    blocks.append(_render_section("PATIENT",
+                                  _render_patient_lines(caller, target)))
+    blocks.append(_render_section("CHART", _render_chart_lines(chart)))
+    blocks.append(_render_section("OPTIONS", _render_options_lines(options)))
+
+    header = "|wSURGICAL CHART|n"
+    rule = "═" * 60
+    parts = [header, rule, ""]
+    for block in blocks:
+        parts.extend(block)
+        parts.append("")
+    parts.append("|wSelect an option:|n")
+    return "\n".join(parts)
+
+
+# ===================================================================
+# MENU — follows the describe pattern (suppress default decorations)
+# ===================================================================
+
+
+class _OperateMenu(EvMenu):
+    """EvMenu subclass that suppresses default decorations.
+
+    Each node renders its full content (header, sections, options,
+    prompt).  Default separators and auto-formatted option blocks
+    would conflict with the armor-comprehensive visual idiom.
+    """
+
+    def nodetext_formatter(self, nodetext):
+        return nodetext
+
+    def options_formatter(self, optionlist):
+        return ""
+
+    def node_formatter(self, nodetext, optionstext):
+        return nodetext
+
+
+def _menu_exit(caller, menu):
+    """Cleanup callback when the menu exits."""
+    for attr in ("_operate_target",):
+        if hasattr(caller.ndb, attr):
+            delattr(caller.ndb, attr)
+
+
+# ===================================================================
+# NODES
+# ===================================================================
+
+
+def _node_top(caller, raw_string, **kwargs):
+    """Top-level node — render PATIENT/CHART/OPTIONS and route
+    on input."""
+    target = getattr(caller.ndb, "_operate_target", None)
+    if target is None:
+        return "|rNo patient set; aborting.|n", None
+    text = render_top_level(caller, target)
+    options = ({"key": "_default", "goto": _process_top_choice},)
+    return text, options
+
+
+def _process_top_choice(caller, raw_string, **kwargs):
+    """Top-level option dispatcher.  Validates input and returns
+    the next node name."""
+    choice = raw_string.strip().lower()
+    if not choice:
+        return None  # Re-display top.
+    if choice in ("x", "exit"):
+        return "node_exit"
+    if choice == "1":
+        return "node_add_verb"
+    if choice == "2":
+        return "node_view_chart"
+    if choice == "3":
+        return "node_commence"
+    if choice == "4":
+        return "node_save_exit"
+    if choice == "5":
+        return "node_discard_confirm"
+    caller.msg("|rInvalid option. Enter 1-5 or x.|n")
+    return None
+
+
+# -------------------------------------------------------------------
+# Add-step flow: verb → arg(s) → confirm
+# -------------------------------------------------------------------
+
+
+def _node_add_verb(caller, raw_string, **kwargs):
+    """Prompt the surgeon for a procedure verb."""
+    text = (
+        "\n|wAdd procedure step|n\n\n"
+        "  1. incise\n"
+        "  2. harvest\n"
+        "  3. install\n"
+        "  4. suture\n"
+        "  x. Cancel\n\n"
+        "|wWhich verb?|n"
+    )
+    options = ({"key": "_default", "goto": _process_verb_choice},)
+    return text, options
+
+
+def _process_verb_choice(caller, raw_string, **kwargs):
+    choice = raw_string.strip().lower()
+    if choice in ("x", "exit", "cancel"):
+        return "node_top"
+    verb_map = {
+        "1": "incise", "incise": "incise",
+        "2": "harvest", "harvest": "harvest",
+        "3": "install", "install": "install",
+        "4": "suture", "suture": "suture",
+    }
+    verb = verb_map.get(choice)
+    if verb is None:
+        caller.msg("|rPick 1-4 or x to cancel.|n")
+        return None
+    caller.ndb._operate_pending_verb = verb
+    # Suture has optional location; the rest are required.
+    if verb == "suture":
+        return "node_suture_location"
+    if verb == "incise":
+        return "node_incise_location"
+    if verb == "harvest":
+        return "node_harvest_organ"
+    if verb == "install":
+        return "node_install_organ"
+    return "node_top"
+
+
+def _node_incise_location(caller, raw_string, **kwargs):
+    text = (
+        "\n|wIncise location|n\n\n"
+        "Enter the body location to incise (e.g. chest, abdomen, head).\n"
+        "Underscores will be normalised from spaces automatically.\n\n"
+        "|wLocation|n (or |yx|n to cancel):"
+    )
+    options = ({"key": "_default", "goto": _process_incise_location},)
+    return text, options
+
+
+def _process_incise_location(caller, raw_string, **kwargs):
+    if raw_string and raw_string.strip().lower() in ("x", "exit", "cancel"):
+        return "node_top"
+    if not raw_string or not raw_string.strip():
+        return None
+    location = raw_string.strip().lower().replace(" ", "_")
+    _add_step_to_chart(caller, "incise", {"location": location})
+    return "node_top"
+
+
+def _node_harvest_organ(caller, raw_string, **kwargs):
+    text = (
+        "\n|wHarvest organ|n\n\n"
+        "Enter the organ name to harvest (e.g. heart, left lung, "
+        "left kidney).\n\n"
+        "|wOrgan|n (or |yx|n to cancel):"
+    )
+    options = ({"key": "_default", "goto": _process_harvest_organ},)
+    return text, options
+
+
+def _process_harvest_organ(caller, raw_string, **kwargs):
+    if raw_string and raw_string.strip().lower() in ("x", "exit", "cancel"):
+        return "node_top"
+    if not raw_string or not raw_string.strip():
+        return None
+    organ = raw_string.strip().lower().replace(" ", "_")
+    _add_step_to_chart(caller, "harvest", {"organ_name": organ})
+    return "node_top"
+
+
+def _node_install_organ(caller, raw_string, **kwargs):
+    text = (
+        "\n|wInstall organ|n\n\n"
+        "Enter the donor-organ key from your inventory followed by "
+        "'in' and the target location.  Example:\n\n"
+        "  donor heart in chest\n\n"
+        "|wOrgan and location|n (or |yx|n to cancel):"
+    )
+    options = ({"key": "_default", "goto": _process_install_organ},)
+    return text, options
+
+
+def _process_install_organ(caller, raw_string, **kwargs):
+    if raw_string and raw_string.strip().lower() in ("x", "exit", "cancel"):
+        return "node_top"
+    if not raw_string or not raw_string.strip():
+        return None
+    raw = raw_string.strip()
+    if " in " not in raw:
+        caller.msg("|rExpected: <organ key> in <location>|n")
+        return None
+    organ_key, _, location = raw.partition(" in ")
+    organ_key = organ_key.strip().lower()
+    location = location.strip().lower().replace(" ", "_")
+    if not organ_key or not location:
+        caller.msg("|rBoth organ key and location are required.|n")
+        return None
+    _add_step_to_chart(caller, "install",
+                       {"organ_item_key": organ_key, "location": location})
+    return "node_top"
+
+
+def _node_suture_location(caller, raw_string, **kwargs):
+    text = (
+        "\n|wSuture location|n\n\n"
+        "Enter the location to suture, or press Enter to suture "
+        "all open incisions.\n\n"
+        "|wLocation|n (or |yx|n to cancel):"
+    )
+    options = ({"key": "_default", "goto": _process_suture_location},)
+    return text, options
+
+
+def _process_suture_location(caller, raw_string, **kwargs):
+    if raw_string and raw_string.strip().lower() in ("x", "exit", "cancel"):
+        return "node_top"
+    raw = (raw_string or "").strip()
+    args = {}
+    if raw:
+        args["location"] = raw.lower().replace(" ", "_")
+    _add_step_to_chart(caller, "suture", args)
+    return "node_top"
+
+
+def _add_step_to_chart(caller, verb: str, args: dict) -> None:
+    """Append a step to the chart on the active target, creating
+    the chart if absent.  Persists immediately."""
+    target = caller.ndb._operate_target
+    chart = chart_lib.get_chart(target) or chart_lib.new_chart(caller)
+    try:
+        step = chart_lib.add_step(chart, verb, args)
+    except ValueError as exc:
+        caller.msg(f"|r{exc}|n")
+        return
+    chart_lib.save_chart(target, chart)
+    caller.msg(
+        f"|wStep added:|n {chart_lib.render_step_summary(step)}"
+    )
+
+
+# -------------------------------------------------------------------
+# View / commence / save / discard
+# -------------------------------------------------------------------
+
+
+def _node_view_chart(caller, raw_string, **kwargs):
+    target = caller.ndb._operate_target
+    chart = chart_lib.get_chart(target)
+    if not chart or not (chart.get("steps") or []):
+        text = (
+            "\n|wChart detail|n\n\n"
+            "The chart is empty.  Add steps from the top-level menu.\n\n"
+            "|wEnter to return.|n"
+        )
+        options = ({"key": "_default", "goto": "node_top"},)
+        return text, options
+    parts = ["\n|wChart detail|n\n"]
+    for idx, step in enumerate(chart["steps"], start=1):
+        roman = _roman(idx)
+        summary = chart_lib.render_step_summary(step)
+        status = step.get("status", "pending")
+        outcome = step.get("outcome")
+        line = f"  {roman}. {summary}  [{status}]"
+        if outcome:
+            line += f"\n     └── outcome: {outcome}"
+        parts.append(line)
+    parts.append("\n|wEnter to return.|n")
+    text = "\n".join(parts)
+    options = ({"key": "_default", "goto": "node_top"},)
+    return text, options
+
+
+def _node_commence(caller, raw_string, **kwargs):
+    """Dispatch the next pending step and return to the top.
+
+    MVP design: fires ONE step per invocation.  Surgeon re-enters
+    ``operate`` between steps; chart state persists.  Auto-chaining
+    is deferred until we can hook completion callbacks into
+    ``start_procedure`` cleanly.
+    """
+    target = caller.ndb._operate_target
+    chart = chart_lib.get_chart(target)
+    if not chart:
+        caller.msg("|rNo chart to commence.|n")
+        return "node_top"
+
+    pending = chart_lib.pending_steps(chart)
+    if not pending:
+        caller.msg(
+            "|wChart complete — no pending steps.|n  "
+            "Use option 5 to discard if you're done."
+        )
+        return "node_top"
+
+    step = pending[0]
+    verb = step.get("verb")
+    args = dict(step.get("args") or {})
+
+    if verb not in chart_lib.PROCEDURE_VERBS:
+        caller.msg(
+            f"|rStep verb {verb!r} not supported yet.  "
+            f"Procedure verbs only in PR-OP1.|n"
+        )
+        return "node_top"
+
+    from world.medical.procedures import start_procedure
+    try:
+        start_procedure(target, verb=verb, actor=caller, **args)
+    except Exception as exc:
+        step["status"] = chart_lib.FAILED
+        step["outcome"] = f"dispatch error: {exc}"
+        chart_lib.save_chart(target, chart)
+        caller.msg(f"|rStep dispatch failed: {exc}|n")
+        return "node_top"
+
+    step["status"] = chart_lib.RUNNING
+    chart_lib.save_chart(target, chart)
+    caller.msg(
+        f"|wDispatched step:|n {chart_lib.render_step_summary(step)}"
+    )
+    caller.msg(
+        "|yRe-enter|n |woperate|n |yon this patient after the step "
+        "resolves to commence the next one.|n"
+    )
+    return "node_exit"
+
+
+def _node_save_exit(caller, raw_string, **kwargs):
+    target = caller.ndb._operate_target
+    chart = chart_lib.get_chart(target)
+    if chart is None:
+        caller.msg("No chart to save.")
+    else:
+        chart_lib.save_chart(target, chart)
+        caller.msg("|wChart saved on patient.|n")
+    return "node_exit"
+
+
+def _node_discard_confirm(caller, raw_string, **kwargs):
+    text = (
+        "\n|wDiscard chart|n\n\n"
+        "Permanently remove the chart from this patient?  "
+        "Pending steps will not be executed.\n\n"
+        "  |wy|n - yes, discard\n"
+        "  |wn|n - no, return to top\n"
+    )
+    options = ({"key": "_default", "goto": _process_discard_confirm},)
+    return text, options
+
+
+def _process_discard_confirm(caller, raw_string, **kwargs):
+    choice = (raw_string or "").strip().lower()
+    if choice in ("y", "yes"):
+        target = caller.ndb._operate_target
+        chart_lib.discard_chart(target)
+        caller.msg("|wChart discarded.|n")
+        return "node_exit"
+    if choice in ("n", "no"):
+        return "node_top"
+    caller.msg("|ry|n or |rn|n.")
+    return None
+
+
+def _node_exit(caller, raw_string, **kwargs):
+    return "", None
+
+
+# ===================================================================
+# COMMAND
+# ===================================================================
+
+
+class CmdOperate(Command):
+    """Open the surgical-chart menu for a patient.
+
+    Usage:
+        operate <target>
+
+    Examples:
+        operate bob
+        operate the woman
+        operate corpse
+        operate severed left arm
+
+    The chart persists on the patient between sessions — you can
+    save a draft, walk away, and have another surgeon (or yourself
+    later) commence the next step.  Conscious targets are gated by
+    the trust/consent system (not yet implemented); for now,
+    operate only resolves to unconscious / dead / severed targets
+    cleanly.
+
+    See ``help surgery`` for the procedure verbs underneath.
+    """
+
+    key = "operate"
+    aliases = ()
+    locks = "cmd:all()"
+    help_category = "Medical"
+
+    def func(self):
+        caller = self.caller
+        raw = (self.args or "").strip()
+        if not raw:
+            caller.msg("Usage: operate <target>")
+            return
+
+        # Reuse the same target-resolution chain as the surgical verbs
+        # so sdescs and inventory-held severed parts resolve identically.
+        from commands.CmdSurgical import _resolve_target
+        target = _resolve_target(caller, raw)
+        if target is None:
+            return  # _resolve_target / search emit their own messages
+
+        from world.medical.procedures import get_organ_snapshot
+        if not get_organ_snapshot(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} doesn't have an "
+                f"anatomy you can operate on."
+            )
+            return
+
+        caller.ndb._operate_target = target
+        _OperateMenu(
+            caller,
+            {
+                "node_top":              _node_top,
+                "node_add_verb":         _node_add_verb,
+                "node_incise_location":  _node_incise_location,
+                "node_harvest_organ":    _node_harvest_organ,
+                "node_install_organ":    _node_install_organ,
+                "node_suture_location":  _node_suture_location,
+                "node_view_chart":       _node_view_chart,
+                "node_commence":         _node_commence,
+                "node_save_exit":        _node_save_exit,
+                "node_discard_confirm":  _node_discard_confirm,
+                "node_exit":             _node_exit,
+            },
+            startnode="node_top",
+            cmd_on_exit=_menu_exit,
+        )

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -271,6 +271,13 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdSurgical.CmdInstall())
         self.add(CmdSurgical.CmdSuture())
 
+        # Surgical charting menu (#307, PR-OP1).  EvMenu-driven
+        # planner over the procedure verbs — surgeon builds a
+        # multi-step chart on the patient and commences it.  See
+        # ``help operate``.
+        from commands.CmdOperate import CmdOperate
+        self.add(CmdOperate())
+
 class AccountCmdSet(default_cmds.AccountCmdSet):
     """
     This is the cmdset available to the Account at all times. It is

--- a/world/medical/charts.py
+++ b/world/medical/charts.py
@@ -1,0 +1,302 @@
+"""Surgical chart data layer (#307, PR-OP1).
+
+The ``operate`` command stores a structured chart on the patient's
+``db.medical_chart`` so a surgeon can sequence procedure steps,
+walk away, and either commence the chart or hand it off to a
+colleague.  This module is the pure data + dispatch surface; the
+EvMenu UI lives in ``commands.CmdOperate``.
+
+The chart structure was settled in the Phase 5 spec section of
+``HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md``.  Steps are stored as
+plain dicts so the persistence layer round-trips cleanly through
+Evennia's attribute system (no typeclass for the chart itself).
+
+# ===================================================================
+# CHART STRUCTURE
+# ===================================================================
+#
+# target.db.medical_chart = {
+#     "version":          1,
+#     "authored_by":      <dbref-str of the originating surgeon>,
+#     "authored_at":      <unix timestamp>,
+#     "last_modified_at": <unix timestamp>,
+#     "status":           "draft" | "in_progress" | "completed" | "aborted",
+#     "next_step_id":     <int>,
+#     "steps": [
+#         {
+#             "id":       <int, stable across edits>,
+#             "verb":     "incise" | "harvest" | "install" | "suture"
+#                         | "inject" | "apply",
+#             "args":     {...},      # verb-specific argument shape
+#             "notes":    <str>,
+#             "status":   "pending" | "running" | "done"
+#                         | "skipped" | "failed",
+#             "outcome":  <str | None>,
+#         },
+#         ...
+#     ],
+# }
+#
+# The chart is *additive* during authoring — steps are appended,
+# not inserted at arbitrary positions, to keep the data model
+# simple.  Reordering is a future feature.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+
+# ===================================================================
+# CHART STATUS LITERALS
+# ===================================================================
+
+DRAFT = "draft"
+IN_PROGRESS = "in_progress"
+COMPLETED = "completed"
+ABORTED = "aborted"
+
+CHART_STATUSES = (DRAFT, IN_PROGRESS, COMPLETED, ABORTED)
+
+
+# ===================================================================
+# STEP STATUS LITERALS
+# ===================================================================
+
+PENDING = "pending"
+RUNNING = "running"
+DONE = "done"
+SKIPPED = "skipped"
+FAILED = "failed"
+
+STEP_STATUSES = (PENDING, RUNNING, DONE, SKIPPED, FAILED)
+
+
+# ===================================================================
+# PROCEDURE VERBS RECOGNISED BY THE CHART DISPATCH
+# ===================================================================
+#
+# The chart can store these verbs as steps.  Procedure verbs
+# (incise/harvest/install/suture) dispatch via
+# ``world.medical.procedures.start_procedure``; treatment verbs
+# (apply/inject) dispatch via the consumption command surfaces.
+# Each verb declares its required and optional args so the menu
+# UI can validate input at chart-authoring time.
+
+PROCEDURE_VERBS = ("incise", "harvest", "install", "suture")
+TREATMENT_VERBS = ("apply", "inject")
+ALL_VERBS = PROCEDURE_VERBS + TREATMENT_VERBS
+
+VERB_ARG_SPEC = {
+    "incise":   {"required": ("location",),               "optional": ()},
+    "harvest":  {"required": ("organ_name",),             "optional": ()},
+    "install":  {"required": ("organ_item_key", "location"), "optional": ()},
+    "suture":   {"required": (),                          "optional": ("location",)},
+    "apply":    {"required": ("item_key", "location"),    "optional": ()},
+    "inject":   {"required": ("item_key",),               "optional": ("location",)},
+}
+
+
+# ===================================================================
+# CHART LIFECYCLE
+# ===================================================================
+
+
+def new_chart(surgeon) -> dict:
+    """Build a fresh empty chart authored by ``surgeon``.
+
+    The surgeon's identity is stored as a dbref string (not the
+    object reference itself) so the chart survives the surgeon
+    leaving / quitting / being deleted.  Resolution back to a
+    character happens at execute time.
+    """
+    now = time.time()
+    return {
+        "version":          1,
+        "authored_by":      getattr(surgeon, "dbref", None),
+        "authored_at":      now,
+        "last_modified_at": now,
+        "status":           DRAFT,
+        "next_step_id":     1,
+        "steps":            [],
+    }
+
+
+def get_chart(target) -> Optional[dict]:
+    """Read the chart stored on ``target``, or ``None`` when absent.
+
+    Coerces Evennia's ``_SaverDict`` to a plain dict so callers can
+    treat the result as a normal mapping without worrying about
+    write-through semantics on the snapshot.
+    """
+    db = getattr(target, "db", None)
+    if db is None:
+        return None
+    raw = getattr(db, "medical_chart", None)
+    if raw is None:
+        return None
+    return dict(raw)
+
+
+def save_chart(target, chart: dict) -> None:
+    """Persist ``chart`` onto ``target.db.medical_chart``.
+
+    Updates ``last_modified_at`` automatically; callers should not
+    pre-stamp the timestamp themselves.
+    """
+    chart["last_modified_at"] = time.time()
+    target.db.medical_chart = chart
+
+
+def discard_chart(target) -> None:
+    """Remove the chart from ``target``."""
+    if getattr(target, "db", None) is not None:
+        target.db.medical_chart = None
+
+
+# ===================================================================
+# STEP AUTHORING
+# ===================================================================
+
+
+def add_step(
+    chart: dict,
+    verb: str,
+    args: Optional[dict] = None,
+    notes: str = "",
+) -> dict:
+    """Append a new step to ``chart`` and return the step dict.
+
+    Validates ``verb`` against :data:`ALL_VERBS` and the supplied
+    ``args`` against the verb's required-arg list.  Raises
+    ``ValueError`` on unknown verb or missing required arg so the
+    UI can surface the failure cleanly.
+
+    Each step is assigned an ``id`` from ``chart["next_step_id"]``
+    that's stable across reorders / annotation passes — UI can
+    reference steps by id rather than list index.
+    """
+    if verb not in ALL_VERBS:
+        raise ValueError(
+            f"Unknown verb {verb!r}; expected one of {ALL_VERBS}."
+        )
+    spec = VERB_ARG_SPEC[verb]
+    args = dict(args or {})
+    missing = [key for key in spec["required"] if key not in args]
+    if missing:
+        raise ValueError(
+            f"Verb {verb!r} requires args {missing}."
+        )
+    step_id = chart.get("next_step_id", 1)
+    step = {
+        "id":      step_id,
+        "verb":    verb,
+        "args":    args,
+        "notes":   notes,
+        "status":  PENDING,
+        "outcome": None,
+    }
+    chart.setdefault("steps", []).append(step)
+    chart["next_step_id"] = step_id + 1
+    return step
+
+
+def remove_step(chart: dict, step_id: int) -> bool:
+    """Remove the step with ``step_id`` from ``chart``.
+
+    Returns True when a step was removed, False when no step with
+    that id existed.  The step list contracts in place; the
+    ``next_step_id`` counter is NOT rewound, so future additions
+    won't collide with the removed id.
+    """
+    steps = chart.get("steps", [])
+    for idx, step in enumerate(steps):
+        if step.get("id") == step_id:
+            del steps[idx]
+            return True
+    return False
+
+
+def find_step(chart: dict, step_id: int) -> Optional[dict]:
+    """Return the step dict for ``step_id``, or ``None`` when absent."""
+    for step in chart.get("steps", []):
+        if step.get("id") == step_id:
+            return step
+    return None
+
+
+# ===================================================================
+# CHART SUMMARY HELPERS — UI-friendly accessors
+# ===================================================================
+
+
+def pending_steps(chart: dict) -> list:
+    """Return the ordered list of pending steps in ``chart``."""
+    return [
+        s for s in chart.get("steps", [])
+        if s.get("status") == PENDING
+    ]
+
+
+def step_count(chart: dict) -> int:
+    """Total step count (all statuses)."""
+    return len(chart.get("steps", []))
+
+
+def is_chart_complete(chart: dict) -> bool:
+    """True when every step in ``chart`` is in a terminal status
+    (done / skipped / failed)."""
+    terminal = {DONE, SKIPPED, FAILED}
+    return all(
+        s.get("status") in terminal
+        for s in chart.get("steps", [])
+    )
+
+
+# ===================================================================
+# CHART DISPATCH — commence execution
+# ===================================================================
+
+
+def render_step_summary(step: dict) -> str:
+    """One-line UI rendering of a step for chart display.
+
+    Examples:
+        ``incise chest``
+        ``harvest left lung``
+        ``install donor heart in chest``
+        ``apply gauze on chest``
+    """
+    verb = step.get("verb", "?")
+    args = step.get("args") or {}
+    if verb == "incise":
+        return f"incise {_humanize(args.get('location'))}"
+    if verb == "harvest":
+        return f"harvest {_humanize(args.get('organ_name'))}"
+    if verb == "install":
+        organ = _humanize(args.get("organ_item_key"))
+        loc = _humanize(args.get("location"))
+        return f"install {organ} in {loc}"
+    if verb == "suture":
+        loc = args.get("location")
+        return f"suture {_humanize(loc)}" if loc else "suture all"
+    if verb == "apply":
+        item = _humanize(args.get("item_key"))
+        loc = _humanize(args.get("location"))
+        return f"apply {item} on {loc}"
+    if verb == "inject":
+        item = _humanize(args.get("item_key"))
+        loc = args.get("location")
+        if loc:
+            return f"inject {item} at {_humanize(loc)}"
+        return f"inject {item}"
+    return verb
+
+
+def _humanize(value) -> str:
+    """Underscore → space for display.  Falls back to ``"?"`` on
+    None / non-string."""
+    if not isinstance(value, str):
+        return "?"
+    return value.replace("_", " ")

--- a/world/tests/test_operate_charts.py
+++ b/world/tests/test_operate_charts.py
@@ -1,0 +1,314 @@
+"""Tests for the surgical chart data layer (#307, PR-OP1).
+
+The chart data layer (``world.medical.charts``) is a pure-function
+surface over the ``target.db.medical_chart`` dict.  Tests here pin
+the chart lifecycle, step authoring, and the rendering helpers the
+``operate`` menu uses.
+
+The EvMenu UI surface (CmdOperate.py) is tested via the live suite
+since it involves Evennia's session machinery.
+
+Run via::
+
+    evennia test world.tests.test_operate_charts
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical import charts
+
+
+def _surgeon(dbref="#42"):
+    return SimpleNamespace(dbref=dbref, key="Vance")
+
+
+def _target():
+    """Stub target with a writable db.medical_chart slot."""
+    target = SimpleNamespace()
+    target.db = SimpleNamespace(medical_chart=None)
+    return target
+
+
+# ===================================================================
+# Lifecycle
+# ===================================================================
+
+
+class NewChart(TestCase):
+
+    def test_new_chart_has_canonical_fields(self):
+        chart = charts.new_chart(_surgeon())
+        for key in ("version", "authored_by", "authored_at",
+                    "last_modified_at", "status", "next_step_id",
+                    "steps"):
+            with self.subTest(key=key):
+                self.assertIn(key, chart)
+
+    def test_new_chart_starts_in_draft(self):
+        chart = charts.new_chart(_surgeon())
+        self.assertEqual(chart["status"], charts.DRAFT)
+
+    def test_new_chart_has_empty_steps(self):
+        self.assertEqual(charts.new_chart(_surgeon())["steps"], [])
+
+    def test_new_chart_captures_surgeon_dbref(self):
+        chart = charts.new_chart(_surgeon(dbref="#99"))
+        self.assertEqual(chart["authored_by"], "#99")
+
+    def test_new_chart_step_id_starts_at_one(self):
+        self.assertEqual(charts.new_chart(_surgeon())["next_step_id"], 1)
+
+
+class ChartPersistence(TestCase):
+
+    def test_save_and_get_round_trip(self):
+        target = _target()
+        chart = charts.new_chart(_surgeon())
+        charts.save_chart(target, chart)
+        restored = charts.get_chart(target)
+        self.assertEqual(restored["status"], charts.DRAFT)
+        self.assertEqual(restored["authored_by"], "#42")
+
+    def test_get_chart_none_when_absent(self):
+        self.assertIsNone(charts.get_chart(_target()))
+
+    def test_save_updates_last_modified(self):
+        target = _target()
+        chart = charts.new_chart(_surgeon())
+        original = chart["last_modified_at"]
+        chart["status"] = charts.IN_PROGRESS
+        # Bump the timestamp to a later value so the assertion is
+        # robust against same-second saves.
+        chart["last_modified_at"] = original - 1
+        charts.save_chart(target, chart)
+        self.assertGreater(
+            charts.get_chart(target)["last_modified_at"], original - 1
+        )
+
+    def test_discard_removes_chart(self):
+        target = _target()
+        charts.save_chart(target, charts.new_chart(_surgeon()))
+        charts.discard_chart(target)
+        self.assertIsNone(charts.get_chart(target))
+
+
+# ===================================================================
+# Step authoring
+# ===================================================================
+
+
+class AddStep(TestCase):
+
+    def _chart(self):
+        return charts.new_chart(_surgeon())
+
+    def test_appends_incise_step(self):
+        chart = self._chart()
+        step = charts.add_step(chart, "incise", {"location": "chest"})
+        self.assertEqual(step["verb"], "incise")
+        self.assertEqual(step["args"]["location"], "chest")
+        self.assertEqual(step["status"], charts.PENDING)
+        self.assertEqual(len(chart["steps"]), 1)
+
+    def test_assigns_sequential_step_ids(self):
+        chart = self._chart()
+        s1 = charts.add_step(chart, "incise", {"location": "chest"})
+        s2 = charts.add_step(chart, "harvest", {"organ_name": "heart"})
+        self.assertEqual(s1["id"], 1)
+        self.assertEqual(s2["id"], 2)
+
+    def test_next_step_id_advances(self):
+        chart = self._chart()
+        charts.add_step(chart, "incise", {"location": "chest"})
+        self.assertEqual(chart["next_step_id"], 2)
+
+    def test_unknown_verb_raises(self):
+        chart = self._chart()
+        with self.assertRaises(ValueError):
+            charts.add_step(chart, "nonsense", {})
+
+    def test_missing_required_arg_raises(self):
+        chart = self._chart()
+        with self.assertRaises(ValueError):
+            charts.add_step(chart, "incise", {})
+
+    def test_install_requires_both_args(self):
+        chart = self._chart()
+        with self.assertRaises(ValueError):
+            charts.add_step(chart, "install", {"location": "chest"})
+        with self.assertRaises(ValueError):
+            charts.add_step(chart, "install",
+                            {"organ_item_key": "heart"})
+
+    def test_suture_has_no_required_args(self):
+        chart = self._chart()
+        step = charts.add_step(chart, "suture", {})
+        self.assertEqual(step["verb"], "suture")
+        self.assertEqual(step["args"], {})
+
+
+class RemoveStep(TestCase):
+
+    def _chart_with_two(self):
+        chart = charts.new_chart(_surgeon())
+        charts.add_step(chart, "incise", {"location": "chest"})
+        charts.add_step(chart, "harvest", {"organ_name": "heart"})
+        return chart
+
+    def test_remove_by_id(self):
+        chart = self._chart_with_two()
+        self.assertTrue(charts.remove_step(chart, 1))
+        ids = [s["id"] for s in chart["steps"]]
+        self.assertEqual(ids, [2])
+
+    def test_remove_unknown_id_returns_false(self):
+        chart = self._chart_with_two()
+        self.assertFalse(charts.remove_step(chart, 999))
+        self.assertEqual(len(chart["steps"]), 2)
+
+    def test_next_step_id_not_rewound_after_remove(self):
+        """Removing the last step doesn't decrement next_step_id —
+        prevents id collisions if a step is re-added."""
+        chart = self._chart_with_two()
+        original_next = chart["next_step_id"]
+        charts.remove_step(chart, 2)
+        self.assertEqual(chart["next_step_id"], original_next)
+
+
+class FindStep(TestCase):
+
+    def test_find_existing(self):
+        chart = charts.new_chart(_surgeon())
+        added = charts.add_step(chart, "suture", {})
+        found = charts.find_step(chart, added["id"])
+        self.assertIs(found, added)
+
+    def test_find_missing_returns_none(self):
+        self.assertIsNone(
+            charts.find_step(charts.new_chart(_surgeon()), 99)
+        )
+
+
+# ===================================================================
+# Summary helpers
+# ===================================================================
+
+
+class PendingSteps(TestCase):
+
+    def test_only_pending_returned(self):
+        chart = charts.new_chart(_surgeon())
+        s1 = charts.add_step(chart, "incise", {"location": "chest"})
+        s2 = charts.add_step(chart, "harvest", {"organ_name": "heart"})
+        s3 = charts.add_step(chart, "suture", {})
+        s1["status"] = charts.DONE
+        s2["status"] = charts.FAILED
+        pending = charts.pending_steps(chart)
+        self.assertEqual(pending, [s3])
+
+    def test_empty_chart_empty_pending(self):
+        self.assertEqual(
+            charts.pending_steps(charts.new_chart(_surgeon())),
+            [],
+        )
+
+
+class IsChartComplete(TestCase):
+
+    def _chart_with_step_at(self, status):
+        chart = charts.new_chart(_surgeon())
+        step = charts.add_step(chart, "incise", {"location": "chest"})
+        step["status"] = status
+        return chart
+
+    def test_empty_chart_is_complete(self):
+        # No steps → vacuously complete.
+        self.assertTrue(
+            charts.is_chart_complete(charts.new_chart(_surgeon()))
+        )
+
+    def test_done_step_complete(self):
+        self.assertTrue(
+            charts.is_chart_complete(self._chart_with_step_at(charts.DONE))
+        )
+
+    def test_pending_step_incomplete(self):
+        self.assertFalse(
+            charts.is_chart_complete(
+                self._chart_with_step_at(charts.PENDING)
+            )
+        )
+
+    def test_mixed_failed_and_done_complete(self):
+        chart = charts.new_chart(_surgeon())
+        s1 = charts.add_step(chart, "incise", {"location": "chest"})
+        s2 = charts.add_step(chart, "harvest", {"organ_name": "heart"})
+        s1["status"] = charts.DONE
+        s2["status"] = charts.FAILED
+        self.assertTrue(charts.is_chart_complete(chart))
+
+
+# ===================================================================
+# Step rendering
+# ===================================================================
+
+
+class RenderStepSummary(TestCase):
+
+    def test_incise_renders_location(self):
+        chart = charts.new_chart(_surgeon())
+        step = charts.add_step(chart, "incise", {"location": "chest"})
+        self.assertEqual(charts.render_step_summary(step), "incise chest")
+
+    def test_harvest_humanizes_organ(self):
+        chart = charts.new_chart(_surgeon())
+        step = charts.add_step(chart, "harvest",
+                               {"organ_name": "left_lung"})
+        self.assertEqual(
+            charts.render_step_summary(step), "harvest left lung"
+        )
+
+    def test_install_renders_organ_and_location(self):
+        chart = charts.new_chart(_surgeon())
+        step = charts.add_step(chart, "install",
+                               {"organ_item_key": "donor heart",
+                                "location": "chest"})
+        self.assertEqual(
+            charts.render_step_summary(step),
+            "install donor heart in chest",
+        )
+
+    def test_suture_without_location_says_all(self):
+        chart = charts.new_chart(_surgeon())
+        step = charts.add_step(chart, "suture", {})
+        self.assertEqual(charts.render_step_summary(step), "suture all")
+
+    def test_suture_with_location(self):
+        chart = charts.new_chart(_surgeon())
+        step = charts.add_step(chart, "suture", {"location": "chest"})
+        self.assertEqual(
+            charts.render_step_summary(step), "suture chest"
+        )
+
+
+# ===================================================================
+# Roman numeral helper (used by the UI render)
+# ===================================================================
+
+
+class RomanHelper(TestCase):
+    """The renderer's Roman-numeral helper is imported from
+    CmdOperate; pin a few key conversions so cosmetic regressions
+    surface."""
+
+    def test_basic_conversions(self):
+        from commands.CmdOperate import _roman
+        for n, r in [
+            (1, "I"), (2, "II"), (3, "III"), (4, "IV"), (5, "V"),
+            (6, "VI"), (9, "IX"), (10, "X"), (14, "XIV"), (50, "L"),
+        ]:
+            with self.subTest(n=n):
+                self.assertEqual(_roman(n), r)


### PR DESCRIPTION
## Summary

EvMenu-driven surgical chart planner over the procedure verbs. ``operate <target>`` opens a chart UI, surgeon sequences procedure steps, then either commences the next pending step or saves the chart on the patient for asynchronous handoff.

MVP slice of the Phase 5 spec section. Richer features (diagnose pane, reorder/annotate, auto-chaining, treatment verbs, trust/consent) come in follow-ons.

## Visual idiom

Per playtest direction: ``armor comprehensive`` style — left-aligned, box-drawn section labels on the left, tree-branched content on the right, Roman-numeral step ordering, no centering. Code style follows ``world/medical/constants.py`` (clean section dividers, documented purpose, organized categories).

```
SURGICAL CHART
════════════════════════════════════════════════════════════

╔═══════════════╗
║    PATIENT    ║──── human corpse
╚═══════════════╝

╔═══════════════╗
║     CHART     ║──┬──    I. incise chest         [pending]
╚═══════════════╝
                   ├──   II. harvest heart        [pending]
                   └──  III. suture chest         [pending]

╔═══════════════╗
║    OPTIONS    ║──┬── 1. Add procedure step
╚═══════════════╝
                   ├── 2. View chart detail
                   ├── 3. Commence next step
                   ├── 4. Save and exit
                   ├── 5. Discard chart
                   └── x. Exit (no save)
```

## What's in PR-OP1

- ``world/medical/charts.py`` (NEW) — pure chart data layer
- ``commands/CmdOperate.py`` (NEW) — menu surface
- ``commands/default_cmdsets.py`` — register
- Reuses ``CmdSurgical._resolve_target`` (identity-first chain)
- Supports the four procedure verbs (incise/harvest/install/suture); treatment verbs recognised by the spec but not dispatched from the menu yet

## Commence model

MVP fires one step per "Commence" — chart persists, surgeon re-enters ``operate`` between steps. Keeps failure-handling simple. Auto-chaining all pending steps back-to-back is deferred until ``start_procedure`` grows a completion callback hook.

## Test plan

- [x] ``world.tests.test_operate_charts`` (NEW, 33 tests) — lifecycle, persistence, step authoring, summary helpers, rendering
- [x] Full suite: 1998/1998 (+33 net)
- [x] Live visual render verified against a charted corpse via docker shell before committing

Refs #307.