### PR TITLE
fix: operate tree vertical connector (PR-OP1 follow-up)

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -137,10 +137,14 @@ def _render_section(label: str, lines: list[str]) -> list[str]:
         out.append(bot)
         return out
 
-    # Multi-line: branched tree.
+    # Multi-line: branched tree.  The bottom border of the label
+    # box gets a ``  │`` tail so the vertical connector lines up
+    # with the ``┬`` glyph on the middle-row branch above and the
+    # ``├`` / ``└`` glyphs on the subsequent rows below.  Mirrors
+    # ``armor comprehensive``'s ``loc_box_bot + "  │"`` line.
     out.append(top)
     out.append(f"{mid}{JOIN_T} {lines[0]}")
-    out.append(bot)
+    out.append(f"{bot}  │")
     for line in lines[1:-1]:
         out.append(f"{EMPTY_GUTTER}{JOIN_MID} {line}")
     out.append(f"{EMPTY_GUTTER}{JOIN_END} {lines[-1]}")


### PR DESCRIPTION
Multi-line tree branches were missing the │ that connects the box-bottom row to the ├ / └ glyphs below. Mirror the pattern armor comprehensive uses (loc_box_bot + "  │"). Render verified live via docker shell.

Suite: 1998/1998.

Refs #307.