### PR TITLE
auto-chain chart commence (#307, PR-OP1.1)

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -520,12 +520,16 @@ def _node_view_chart(caller, raw_string, **kwargs):
 
 
 def _node_commence(caller, raw_string, **kwargs):
-    """Dispatch the next pending step and return to the top.
+    """Commence the chart — auto-chains all pending steps back-to-
+    back via :func:`world.medical.charts.commence_chart`.
 
-    MVP design: fires ONE step per invocation.  Surgeon re-enters
-    ``operate`` between steps; chart state persists.  Auto-chaining
-    is deferred until we can hook completion callbacks into
-    ``start_procedure`` cleanly.
+    The runner registers an ``on_complete`` hook on
+    ``start_procedure`` so each step advances to the next when its
+    resolver fires.  Interruption (combat, target movement, death)
+    halts the chain via the procedure dispatch's
+    ``interrupt_procedure`` path; the running step gets marked
+    ``failed`` with outcome ``"interrupted"`` so the surgeon can
+    see the abort reason on re-entry.
     """
     target = caller.ndb._operate_target
     chart = chart_lib.get_chart(target)
@@ -541,35 +545,19 @@ def _node_commence(caller, raw_string, **kwargs):
         )
         return "node_top"
 
-    step = pending[0]
-    verb = step.get("verb")
-    args = dict(step.get("args") or {})
-
-    if verb not in chart_lib.PROCEDURE_VERBS:
-        caller.msg(
-            f"|rStep verb {verb!r} not supported yet.  "
-            f"Procedure verbs only in PR-OP1.|n"
-        )
+    step = chart_lib.commence_chart(target, caller)
+    if step is None:
+        caller.msg("|wChart complete.|n")
         return "node_top"
 
-    from world.medical.procedures import start_procedure
-    try:
-        start_procedure(target, verb=verb, actor=caller, **args)
-    except Exception as exc:
-        step["status"] = chart_lib.FAILED
-        step["outcome"] = f"dispatch error: {exc}"
-        chart_lib.save_chart(target, chart)
-        caller.msg(f"|rStep dispatch failed: {exc}|n")
-        return "node_top"
-
-    step["status"] = chart_lib.RUNNING
-    chart_lib.save_chart(target, chart)
+    summary = chart_lib.render_step_summary(step)
     caller.msg(
-        f"|wDispatched step:|n {chart_lib.render_step_summary(step)}"
+        f"|wDispatched chart:|n {len(pending)} pending steps, "
+        f"running back-to-back."
     )
     caller.msg(
-        "|yRe-enter|n |woperate|n |yon this patient after the step "
-        "resolves to commence the next one.|n"
+        f"|yFirst step in flight:|n {summary}.  Subsequent steps "
+        "auto-chain on completion."
     )
     return "node_exit"
 

--- a/world/medical/charts.py
+++ b/world/medical/charts.py
@@ -300,3 +300,109 @@ def _humanize(value) -> str:
     if not isinstance(value, str):
         return "?"
     return value.replace("_", " ")
+
+
+# ===================================================================
+# CHART RUNNER — auto-chain pending steps back-to-back
+# ===================================================================
+#
+# Single entry point: :func:`commence_chart`.  Dispatches the first
+# pending step via ``start_procedure`` with an ``on_complete`` hook
+# that recursively advances to the next pending step.  Stops when:
+#
+#   * No pending steps remain → chart marked ``COMPLETED``
+#   * A step's verb isn't a procedure verb yet (treatment verbs
+#     ``apply`` / ``inject``) → step marked ``SKIPPED``, chain
+#     continues to the next step
+#   * The procedure is interrupted → ``interrupt_procedure`` clears
+#     the hook AND marks the running step as ``FAILED``; chain
+#     dies cleanly because the hook never fires
+#   * Process restart mid-chain → hook is in-memory only, chain
+#     dies but chart state persists so the surgeon can re-commence
+
+
+def commence_chart(target, actor) -> Optional[dict]:
+    """Run the chart on ``target`` from its first pending step.
+
+    Dispatches one procedure step via
+    ``world.medical.procedures.start_procedure`` with an
+    ``on_complete`` hook that re-enters ``commence_chart`` after
+    the step's resolver fires.  The full chain executes back-to-
+    back without further input from the surgeon.
+
+    Returns the dispatched step dict (so callers can render
+    "dispatching step X" prose), or ``None`` when the chart was
+    already complete / had no dispatchable steps.
+
+    Treatment verbs (``apply`` / ``inject``) aren't dispatched
+    through ``start_procedure`` — they're skipped with an outcome
+    note so the chain continues to whatever procedure step comes
+    next.  Treatment-step dispatch is deferred to a follow-on PR.
+    """
+    chart = get_chart(target)
+    if chart is None:
+        return None
+
+    pending = pending_steps(chart)
+    if not pending:
+        chart["status"] = COMPLETED
+        save_chart(target, chart)
+        return None
+
+    step = pending[0]
+    verb = step.get("verb")
+    args = dict(step.get("args") or {})
+
+    # Treatment verbs aren't wired yet — skip them and chain forward.
+    if verb in TREATMENT_VERBS:
+        step["status"] = SKIPPED
+        step["outcome"] = (
+            f"treatment verb {verb!r} not yet dispatchable from "
+            "chart — deferred to PR-OP3"
+        )
+        save_chart(target, chart)
+        return commence_chart(target, actor)
+
+    if verb not in PROCEDURE_VERBS:
+        step["status"] = SKIPPED
+        step["outcome"] = f"unknown verb {verb!r}"
+        save_chart(target, chart)
+        return commence_chart(target, actor)
+
+    step["status"] = RUNNING
+    chart["status"] = IN_PROGRESS
+    save_chart(target, chart)
+
+    def _advance(target_arg, actor_arg):
+        """on_complete hook — mark the running step done, then
+        chain to the next pending step."""
+        latest = get_chart(target_arg)
+        if latest is None:
+            return
+        # Find the step that was running and mark it done.
+        for s in latest.get("steps") or ():
+            if s.get("status") == RUNNING:
+                s["status"] = DONE
+                break
+        save_chart(target_arg, latest)
+        # Recursive advancement — runs the next pending step, or
+        # finalises the chart status if none remain.
+        commence_chart(target_arg, actor_arg)
+
+    from world.medical.procedures import start_procedure
+    try:
+        start_procedure(
+            target, verb=verb, actor=actor,
+            on_complete=_advance, **args,
+        )
+    except Exception as exc:
+        # Dispatch failure (e.g. surgeon dropped their kit between
+        # chart authoring and commence).  Mark the step failed and
+        # advance to the next so a recoverable later step still gets
+        # a shot.
+        step["status"] = FAILED
+        step["outcome"] = f"dispatch error: {exc}"
+        save_chart(target, chart)
+        return commence_chart(target, actor)
+
+    return step

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -231,7 +231,21 @@ def is_procedure_active(target) -> bool:
     return state.get("active_procedure") is not None
 
 
-def start_procedure(target, *, verb: str, actor, **kwargs) -> dict:
+#: In-memory map of ``target.dbref`` → ``on_complete`` callable.
+#: Populated by :func:`start_procedure` when an ``on_complete`` hook
+#: is provided; consumed by :func:`_resolve_procedure_callback` after
+#: the verb resolver runs; cleared by :func:`interrupt_procedure`.
+#:
+#: Not persisted — the hook is in-memory only, so process restarts
+#: mid-procedure drop the chain.  Acceptable for the chart-runner
+#: use case since restarts are rare and the chart state itself is
+#: persistent (a surgeon can re-commence after restart).
+_PROCEDURE_COMPLETE_HOOKS = {}
+
+
+def start_procedure(
+    target, *, verb: str, actor, on_complete=None, **kwargs,
+) -> dict:
     """Stage an active procedure on ``target``.
 
     Schedules :func:`_resolve_procedure_callback` to fire after the
@@ -244,6 +258,12 @@ def start_procedure(target, *, verb: str, actor, **kwargs) -> dict:
     resolution callback can re-fetch the actor / tool / target_organ
     without closures over Python objects that may not survive a
     process restart.
+
+    ``on_complete`` (optional) — a callable ``fn(target, actor)``
+    invoked after the verb resolver runs.  Used by the chart runner
+    (``world.medical.charts.commence_chart``) to chain successive
+    steps back-to-back.  Stored in-memory only; interruption clears
+    it (chain dies on combat / disconnect / death).
     """
     duration = PROCEDURE_DURATIONS.get(verb, 6)
     record = {
@@ -256,6 +276,11 @@ def start_procedure(target, *, verb: str, actor, **kwargs) -> dict:
     state = _state(target)
     state["active_procedure"] = record
     target.db.surgical_state = state
+
+    if on_complete is not None:
+        dbref = getattr(target, "dbref", None)
+        if dbref:
+            _PROCEDURE_COMPLETE_HOOKS[dbref] = on_complete
 
     evennia_delay(
         duration,
@@ -271,11 +296,41 @@ def interrupt_procedure(target, reason: str = "interrupted") -> Optional[dict]:
 
     Used by combat / movement / death hooks.  Returns the cleared
     record so callers can render an interruption message.
+
+    Also clears any pending ``on_complete`` hook so a chart chain
+    in progress halts cleanly.  The chart's currently-running step
+    is marked as ``FAILED`` with outcome ``"interrupted"`` so the
+    surgeon can see why the chain stopped on re-entry.
     """
     state = _state(target)
     record = state.get("active_procedure")
     state["active_procedure"] = None
     target.db.surgical_state = state
+
+    dbref = getattr(target, "dbref", None)
+    if dbref:
+        _PROCEDURE_COMPLETE_HOOKS.pop(dbref, None)
+
+    # Mark a running chart step as failed-with-interrupted outcome
+    # so the surgeon sees the abort reason on re-entry to ``operate``.
+    target_db = getattr(target, "db", None)
+    if target_db is not None:
+        chart = getattr(target_db, "medical_chart", None)
+        if chart:
+            chart = dict(chart)
+            steps = list(chart.get("steps") or ())
+            mutated = False
+            for step in steps:
+                if step.get("status") == "running":
+                    step["status"] = "failed"
+                    step["outcome"] = f"interrupted: {reason}"
+                    mutated = True
+                    break
+            if mutated:
+                chart["steps"] = steps
+                chart["status"] = "aborted"
+                target_db.medical_chart = chart
+
     return record
 
 
@@ -318,6 +373,19 @@ def _resolve_procedure_callback(target) -> None:
     if resolver is None:
         return
     resolver(actor, target, **kwargs)
+
+    # Fire the chart-runner advancement hook if one's registered.
+    # Cleared from the map regardless so a re-entered chain doesn't
+    # double-fire.  Errors swallowed so a buggy hook can't break
+    # the procedure resolution it's tacked onto.
+    dbref = getattr(target, "dbref", None)
+    if dbref:
+        hook = _PROCEDURE_COMPLETE_HOOKS.pop(dbref, None)
+        if hook is not None:
+            try:
+                hook(target, actor)
+            except Exception:
+                pass
 
 
 # ---------------------------------------------------------------------

--- a/world/tests/test_operate_charts.py
+++ b/world/tests/test_operate_charts.py
@@ -312,3 +312,172 @@ class RomanHelper(TestCase):
         ]:
             with self.subTest(n=n):
                 self.assertEqual(_roman(n), r)
+
+
+# ===================================================================
+# commence_chart runner — auto-chain pending steps
+# ===================================================================
+
+
+class CommenceChartRunner(TestCase):
+    """The chart runner dispatches the first pending step via
+    ``start_procedure`` with an ``on_complete`` hook that advances
+    to the next step.  Tests stub ``start_procedure`` so the
+    procedure dispatch isn't exercised — we just verify the chain
+    bookkeeping."""
+
+    def _chart_target_with_steps(self, *verb_args):
+        target = _target()
+        chart = charts.new_chart(_surgeon())
+        for verb, args in verb_args:
+            charts.add_step(chart, verb, args)
+        charts.save_chart(target, chart)
+        return target
+
+    def _patch_start(self, calls):
+        """Patch start_procedure to capture calls and remember the
+        on_complete hook for manual invocation."""
+        from unittest.mock import patch
+
+        def _fake(target, *, verb, actor, on_complete=None, **kwargs):
+            calls.append({
+                "target": target, "verb": verb, "actor": actor,
+                "on_complete": on_complete, "kwargs": kwargs,
+            })
+        return patch("world.medical.procedures.start_procedure", _fake)
+
+    def test_empty_chart_returns_none(self):
+        target = _target()
+        charts.save_chart(target, charts.new_chart(_surgeon()))
+        self.assertIsNone(charts.commence_chart(target, _surgeon()))
+
+    def test_no_chart_returns_none(self):
+        target = _target()
+        self.assertIsNone(charts.commence_chart(target, _surgeon()))
+
+    def test_dispatches_first_pending_step(self):
+        target = self._chart_target_with_steps(
+            ("incise", {"location": "chest"}),
+            ("harvest", {"organ_name": "heart"}),
+        )
+        calls = []
+        with self._patch_start(calls):
+            step = charts.commence_chart(target, _surgeon())
+        self.assertEqual(step["verb"], "incise")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["verb"], "incise")
+        self.assertEqual(calls[0]["kwargs"], {"location": "chest"})
+
+    def test_dispatched_step_marked_running(self):
+        target = self._chart_target_with_steps(
+            ("incise", {"location": "chest"}),
+        )
+        calls = []
+        with self._patch_start(calls):
+            charts.commence_chart(target, _surgeon())
+        chart = charts.get_chart(target)
+        self.assertEqual(chart["steps"][0]["status"], charts.RUNNING)
+        self.assertEqual(chart["status"], charts.IN_PROGRESS)
+
+    def test_on_complete_advances_to_next_step(self):
+        target = self._chart_target_with_steps(
+            ("incise", {"location": "chest"}),
+            ("harvest", {"organ_name": "heart"}),
+        )
+        calls = []
+        with self._patch_start(calls):
+            charts.commence_chart(target, _surgeon())
+            # Simulate the procedure finishing — invoke the hook.
+            hook = calls[0]["on_complete"]
+            self.assertIsNotNone(hook)
+            hook(target, _surgeon())
+
+        # First step done; second step dispatched.
+        chart = charts.get_chart(target)
+        self.assertEqual(chart["steps"][0]["status"], charts.DONE)
+        self.assertEqual(chart["steps"][1]["status"], charts.RUNNING)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1]["verb"], "harvest")
+
+    def test_chain_completes_chart_after_last_step(self):
+        target = self._chart_target_with_steps(
+            ("incise", {"location": "chest"}),
+        )
+        calls = []
+        with self._patch_start(calls):
+            charts.commence_chart(target, _surgeon())
+            calls[0]["on_complete"](target, _surgeon())
+
+        chart = charts.get_chart(target)
+        self.assertEqual(chart["status"], charts.COMPLETED)
+        self.assertEqual(chart["steps"][0]["status"], charts.DONE)
+
+    def test_treatment_verbs_skip_and_advance(self):
+        """``apply`` / ``inject`` aren't dispatchable yet — the
+        runner skips them and continues to the next step."""
+        target = _target()
+        chart = charts.new_chart(_surgeon())
+        charts.add_step(chart, "apply",
+                        {"item_key": "gauze", "location": "chest"})
+        charts.add_step(chart, "incise", {"location": "chest"})
+        charts.save_chart(target, chart)
+        calls = []
+        with self._patch_start(calls):
+            step = charts.commence_chart(target, _surgeon())
+
+        # The treatment step is skipped; incise is dispatched.
+        chart = charts.get_chart(target)
+        self.assertEqual(chart["steps"][0]["status"], charts.SKIPPED)
+        self.assertEqual(chart["steps"][1]["status"], charts.RUNNING)
+        self.assertEqual(step["verb"], "incise")
+        self.assertEqual(len(calls), 1)
+
+
+# ===================================================================
+# Interrupt path
+# ===================================================================
+
+
+class InterruptMarksRunningStepFailed(TestCase):
+    """``interrupt_procedure`` should mark any RUNNING chart step
+    as FAILED with outcome ``"interrupted"`` so the surgeon can
+    see why the chain halted on re-entry to ``operate``."""
+
+    def test_interrupt_marks_running_step_failed(self):
+        from world.medical.procedures import interrupt_procedure
+
+        target = _target()
+        target.dbref = "#5000"
+        target.db.surgical_state = {
+            "active_procedure": {
+                "verb": "incise",
+                "actor_dbref": "#42",
+                "started_at": 0.0,
+                "duration_s": 6,
+                "kwargs": {"location": "chest"},
+            },
+            "incisions": [],
+        }
+        chart = charts.new_chart(_surgeon())
+        step = charts.add_step(chart, "incise", {"location": "chest"})
+        step["status"] = charts.RUNNING
+        chart["status"] = charts.IN_PROGRESS
+        charts.save_chart(target, chart)
+
+        interrupt_procedure(target, reason="combat")
+
+        latest = charts.get_chart(target)
+        self.assertEqual(latest["steps"][0]["status"], charts.FAILED)
+        self.assertIn("interrupted", latest["steps"][0]["outcome"])
+        self.assertEqual(latest["status"], charts.ABORTED)
+
+    def test_interrupt_no_chart_doesnt_explode(self):
+        from world.medical.procedures import interrupt_procedure
+        target = _target()
+        target.dbref = "#5001"
+        target.db.surgical_state = {
+            "active_procedure": None,
+            "incisions": [],
+        }
+        # No chart on target — should no-op cleanly.
+        interrupt_procedure(target, reason="combat")


### PR DESCRIPTION
Per playtest direction — replace one-step-per-commence with full-chart-auto-chain. One "Commence next step" press runs every pending step back-to-back, only halting on interruption.

**How:** start_procedure gains an optional on_complete callable. commence_chart(target, actor) dispatches one step with a hook that re-enters the runner. Hook is in-memory only (chain dies on restart; chart state persists).

**Interruption:** interrupt_procedure clears the hook AND marks the RUNNING chart step FAILED with outcome "interrupted: <reason>" so the surgeon sees the abort reason on re-entry.

**Tests:** 9 new (CommenceChartRunner + InterruptMarksRunningStepFailed). Suite: 2007/2007 (+9 net).

Refs #307.