### PR TITLE
fix: harvested organs no longer render as severed body parts

### DIFF
--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -774,6 +774,26 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
         )
         return
 
+    # Walk organs at each closed location and transition any
+    # harvested-injury organs from ``fresh`` to ``treated`` so the
+    # wound renderer reads as "surgical opening has been crudely
+    # bandaged" rather than "still wet and red".  Severance wounds
+    # (limb-loss injury_type, not "harvested") are untouched —
+    # suturing the stump doesn't undo the limb loss but the
+    # ``harvested`` injury type IS appropriate for an organ
+    # extracted via the procedure pipeline.
+    state = getattr(target, "medical_state", None)
+    if state is not None and hasattr(state, "organs"):
+        for loc in closed:
+            for organ in state.organs.values():
+                container = getattr(organ, "container", None)
+                display = getattr(organ, "display_location", None)
+                if loc not in (container, display):
+                    continue
+                if getattr(organ, "injury_type", None) == "harvested":
+                    if getattr(organ, "wound_stage", None) == "fresh":
+                        organ.wound_stage = "treated"
+
     seed_pain(target, closed[0], CONSCIOUS_PAIN_SEVERITY["suture"])
 
     if outcome == "failure":
@@ -951,7 +971,21 @@ def _mark_organ_removed(target, organ_name: str) -> None:
         organ = state.organs.get(organ_name)
         if organ is not None:
             organ.current_hp = 0
-            organ.wound_stage = "severed"
+            # PR follow-up: route the wound renderer to
+            # ``messages/harvested.py`` rather than letting it fall
+            # through to ``generic.py``'s "severed at the joint"
+            # prose.  Severance (limb-fell-off) and harvest
+            # (organ-was-surgically-removed) are different events
+            # narratively; the same misnamed ``wound_stage`` was
+            # routing both into the limb-loss vocabulary.
+            #
+            # Fresh stage gets the open-extraction-site prose
+            # ("a precise incision marks where the stomach was
+            # extracted").  The suture verb transitions this to
+            # ``treated`` so post-op prose reads as
+            # surgically-closed rather than limb-lost.
+            organ.injury_type = "harvested"
+            organ.wound_stage = "fresh"
 
     snapshot = None
     accessor = getattr(target, "get_medical_snapshot", None)


### PR DESCRIPTION
**Bug:** After operate → incise → harvest → suture, looking at the patient described the location as "severed at the joint, leaving a ragged stump" — limb-loss vocabulary for a surgical extraction.

**Cause:** _mark_organ_removed set wound_stage="severed" without injury_type. Renderer fell through to generic.py's severed-stage prose. Bug isn't species-specific; the user noticed it on a rat because the smaller anatomy made the misrouted line stand out.

**Fix:** Two coordinated changes:
1. _mark_organ_removed sets injury_type="harvested" + wound_stage="fresh" → routes to messages/harvested.py
2. _resolve_suture walks organs at each closed location and bumps harvested ones from fresh → treated

Live-verified before/after on a fresh rat. Limb-severance pipeline goes through a different path and continues to read as limb-loss correctly.

Suite: 2014/2014.

Refs #307.