### PR TITLE
fix: resolver-level incision gate + suture picker shows planned

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -443,6 +443,35 @@ def _list_open_incisions(target):
         return []
 
 
+def _list_planned_incisions(caller):
+    """Return locations slated to be opened by pending chart steps.
+
+    Walks the chart on the active target and returns
+    ``incise`` locations whose step is still in ``PENDING`` status.
+    Lets the suture picker include locations that *will* be open
+    by the time the suture step fires — important because the
+    chart authors planning a back-to-back ``incise → harvest →
+    suture`` chain has nothing currently open at the time they
+    pick the suture target.
+    """
+    target = getattr(caller.ndb, "_operate_target", None)
+    if target is None:
+        return []
+    chart = chart_lib.get_chart(target)
+    if not chart:
+        return []
+    out = []
+    for step in chart.get("steps", []) or ():
+        if step.get("status") != chart_lib.PENDING:
+            continue
+        if step.get("verb") != "incise":
+            continue
+        loc = (step.get("args") or {}).get("location")
+        if loc:
+            out.append(loc)
+    return out
+
+
 def _render_numbered(items, render_fn):
     """Format a numbered pickable list.
 
@@ -678,13 +707,15 @@ def _process_install_location(caller, raw_string, **kwargs):
 
 def _node_suture_location(caller, raw_string, **kwargs):
     target = caller.ndb._operate_target
-    open_locs = _list_open_incisions(target)
-    if not open_locs:
+    open_locs = set(_list_open_incisions(target))
+    planned_locs = set(_list_planned_incisions(caller))
+    all_locs = sorted(open_locs | planned_locs)
+    if not all_locs:
         text = (
             "\n|wSuture|n\n\n"
-            "No incisions currently open on this target.  Adding "
-            "a 'suture all' step anyway — useful if your chart "
-            "incises before suturing.\n\n"
+            "No incisions currently open and no incise steps in your "
+            "chart.  Adding a 'suture all' step anyway — useful if you "
+            "plan to add incise steps later.\n\n"
             "  |wEnter|n - add 'suture all' step\n"
             "  |wx|n     - Cancel"
         )
@@ -692,9 +723,21 @@ def _node_suture_location(caller, raw_string, **kwargs):
             {"key": "_default", "goto": _process_suture_no_open},
         )
         return text, options
-    options_list = [("|wall|n", "all open incisions")] + [
-        (loc.replace("_", " "), loc) for loc in open_locs
-    ]
+
+    # Label each entry with its source so the surgeon can see at
+    # a glance which are live state vs planned-by-chart.
+    options_list = [("|wall|n  |x(open + planned)|n",
+                     "all open incisions")]
+    for loc in all_locs:
+        humanized = loc.replace("_", " ")
+        if loc in open_locs and loc in planned_locs:
+            tag = "|x(open + planned)|n"
+        elif loc in open_locs:
+            tag = "|x(open)|n"
+        else:
+            tag = "|x(planned)|n"
+        options_list.append((f"{humanized}  {tag}", loc))
+
     caller.ndb._operate_pickable = options_list
     listing = "\n".join(
         f"  {idx}. {label}"

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -600,6 +600,24 @@ def _resolve_harvest(actor, target, *, organ_name: str, location: str,
     snapshot_organs = get_organ_snapshot(target).get("organs", {}) or {}
     organ_data = snapshot_organs.get(organ_name) or {}
 
+    # Access gate (#307 follow-up): the CmdHarvest command checks for
+    # an open incision before dispatch, but chart-commenced harvests
+    # call ``start_procedure`` directly and would otherwise bypass
+    # the gate.  Re-check at resolver time so both paths fail
+    # gracefully on closed-cavity targets.  Surface-accessible
+    # organs (display_location distinct from container — eyes, ears,
+    # face on humans) skip the requirement.
+    container = organ_data.get("container") or location
+    display = organ_data.get("display_location") or container
+    if display == container and not has_incision(target, container):
+        actor.msg(
+            f"You reach for the {organ_name.replace('_', ' ')} but "
+            f"{target.get_display_name(actor)}'s "
+            f"{container.replace('_', ' ')} isn't open — there's no "
+            f"incision to work through."
+        )
+        return
+
     # Decay tier → harvested condition.
     decay_stage = "fresh"
     stage_getter = getattr(target, "get_decay_stage", None)
@@ -673,6 +691,26 @@ def _resolve_install(actor, target, *, organ_item, location: str,
     """Resolve an ``install`` attempt: slot ``organ_item`` into
     ``target`` at ``location``."""
     from world.identity_utils import msg_room_identity
+
+    # Access gate (#307 follow-up): symmetric to harvest — chart-
+    # commenced installs that bypass CmdInstall's pre-dispatch
+    # gate must still fail gracefully on closed-cavity targets.
+    # Look up the destination organ's display_location from the
+    # snapshot to determine whether the location needs incising
+    # or is surface-accessible.
+    snapshot_organs = get_organ_snapshot(target).get("organs", {}) or {}
+    organ_name = getattr(getattr(organ_item, "db", None),
+                         "organ_name", None) or organ_item.key
+    slot = snapshot_organs.get(organ_name)
+    if slot is not None and hasattr(slot, "get"):
+        slot_display = slot.get("display_location") or location
+        if slot_display == location and not has_incision(target, location):
+            actor.msg(
+                f"You try to slot the {organ_item.key} in but "
+                f"{target.get_display_name(actor)}'s "
+                f"{location.replace('_', ' ')} isn't open."
+            )
+            return
 
     result = roll_procedure(actor, target)
     outcome = result["outcome"]


### PR DESCRIPTION
Two playtest callouts:

**1. Harvest/install can bypass the incision requirement when dispatched via chart commence.** The command-level gate doesn't fire because start_procedure is called directly. Fix: enforce the access check at the resolver too, so direct command and chart-dispatched paths share the same gate. Failure prose:

> You reach for the heart but the corpse's chest isn't open — there's no incision to work through.

Surface-accessible organs (eyes/ears/nose/jaw/tongue) continue to skip the requirement per PR-A.

**2. Suture picker doesn't see planned incisions from the chart.** Pre-fix only showed currently-open. Fix: walk pending incise steps in the chart, merge with live state, tag entries:

```
  1. all     (open + planned)
  2. chest   (planned)
  3. abdomen (planned)
```

Suite: 2014/2014.

Refs #307.