### PR TITLE
operate: edit chart (reorder/insert/remove) + accurate step status

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -228,7 +228,7 @@ def render_top_level(caller, target) -> str:
 
     options = [
         ("1", "Add procedure step"),
-        ("2", "View chart detail"),
+        ("2", "Edit chart  |x(view / reorder / remove)|n"),
         ("3", "Commence next step"),
         ("4", "Save and exit"),
         ("5", "Discard chart"),
@@ -281,6 +281,7 @@ def _menu_exit(caller, menu):
         "_operate_pickable",
         "_operate_install_donor",
         "_operate_pending_verb",
+        "_operate_insert_before",
     ):
         if hasattr(caller.ndb, attr):
             delattr(caller.ndb, attr)
@@ -313,7 +314,7 @@ def _process_top_choice(caller, raw_string, **kwargs):
     if choice == "1":
         return "node_add_verb"
     if choice == "2":
-        return "node_view_chart"
+        return "node_edit_chart"
     if choice == "3":
         return "node_commence"
     if choice == "4":
@@ -793,19 +794,37 @@ def _process_suture_location(caller, raw_string, **kwargs):
 
 
 def _add_step_to_chart(caller, verb: str, args: dict) -> None:
-    """Append a step to the chart on the active target, creating
-    the chart if absent.  Persists immediately."""
+    """Add a step to the chart on the active target.
+
+    Consults ``caller.ndb._operate_insert_before`` — when set by
+    the edit-chart node's ``i <N>`` command, inserts the new step
+    before the targeted step rather than appending.  The flag is
+    cleared after consumption so the next "Add procedure step"
+    invocation appends normally.
+
+    Creates the chart on demand if absent.  Persists immediately.
+    """
     target = caller.ndb._operate_target
     chart = chart_lib.get_chart(target) or chart_lib.new_chart(caller)
+    before_id = getattr(caller.ndb, "_operate_insert_before", None)
     try:
-        step = chart_lib.add_step(chart, verb, args)
+        if before_id is not None:
+            step = chart_lib.insert_step(
+                chart, verb, args, before_id=before_id,
+            )
+        else:
+            step = chart_lib.add_step(chart, verb, args)
     except ValueError as exc:
         caller.msg(f"|r{exc}|n")
         return
     chart_lib.save_chart(target, chart)
-    caller.msg(
-        f"|wStep added:|n {chart_lib.render_step_summary(step)}"
-    )
+    summary = chart_lib.render_step_summary(step)
+    if before_id is not None:
+        caller.msg(f"|wStep inserted:|n {summary}")
+        # Clear the insertion point so subsequent adds append.
+        delattr(caller.ndb, "_operate_insert_before")
+    else:
+        caller.msg(f"|wStep added:|n {summary}")
 
 
 # -------------------------------------------------------------------
@@ -813,31 +832,131 @@ def _add_step_to_chart(caller, verb: str, args: dict) -> None:
 # -------------------------------------------------------------------
 
 
-def _node_view_chart(caller, raw_string, **kwargs):
+def _node_edit_chart(caller, raw_string, **kwargs):
+    """Edit-chart node — view steps, reorder, remove, insert.
+
+    Steps are listed with Roman-numeral indices.  Action commands
+    are short prefix+number forms so editing is one keystroke per
+    step shuffled:
+
+      u <N>   move step N up
+      d <N>   move step N down
+      r <N>   remove step N
+      i <N>   insert a new step before step N
+      x       back to top
+
+    Insertion routes into the same verb-pick flow as ``Add
+    procedure step``; the insertion point is held on
+    ``caller.ndb._operate_insert_before`` and consumed when the
+    step is added.
+    """
     target = caller.ndb._operate_target
     chart = chart_lib.get_chart(target)
     if not chart or not (chart.get("steps") or []):
         text = (
-            "\n|wChart detail|n\n\n"
-            "The chart is empty.  Add steps from the top-level menu.\n\n"
+            "\n|wEdit chart|n\n\n"
+            "The chart is empty.  Add steps from the top-level "
+            "menu.\n\n"
             "|wEnter to return.|n"
         )
         options = ({"key": "_default", "goto": "node_top"},)
         return text, options
-    parts = ["\n|wChart detail|n\n"]
+    parts = ["\n|wEdit chart|n\n"]
     for idx, step in enumerate(chart["steps"], start=1):
-        roman = _roman(idx)
+        roman = _roman(idx).rjust(4)
         summary = chart_lib.render_step_summary(step)
         status = step.get("status", "pending")
         outcome = step.get("outcome")
-        line = f"  {roman}. {summary}  [{status}]"
+        if status == chart_lib.DONE:
+            tag = "|gdone|n"
+        elif status == chart_lib.FAILED:
+            tag = "|rfailed|n"
+        elif status == chart_lib.SKIPPED:
+            tag = "|yskipped|n"
+        elif status == chart_lib.RUNNING:
+            tag = "|crunning|n"
+        else:
+            tag = "pending"
+        line = f"  {roman}. {summary.ljust(36)} [{tag}]"
         if outcome:
-            line += f"\n     └── outcome: {outcome}"
+            line += f"\n          └── {outcome}"
         parts.append(line)
-    parts.append("\n|wEnter to return.|n")
+    parts.append("")
+    parts.append("|wActions|n  (lowercase):")
+    parts.append("  |wu|n <N>    move step |wN|n up")
+    parts.append("  |wd|n <N>    move step |wN|n down")
+    parts.append("  |wr|n <N>    remove step |wN|n")
+    parts.append("  |wi|n <N>    insert a new step before step |wN|n")
+    parts.append("  |wx|n        back to top")
+    parts.append("")
+    parts.append("|wAction?|n")
     text = "\n".join(parts)
-    options = ({"key": "_default", "goto": "node_top"},)
+    options = ({"key": "_default", "goto": _process_edit_choice},)
     return text, options
+
+
+def _process_edit_choice(caller, raw_string, **kwargs):
+    raw = (raw_string or "").strip().lower()
+    if raw in ("", "x", "exit", "back", "cancel"):
+        return "node_top"
+
+    parts = raw.split()
+    if len(parts) != 2 or parts[0] not in ("u", "d", "r", "i"):
+        caller.msg(
+            "|rExpected: |wu N|r, |wd N|r, |wr N|r, |wi N|r, or |wx|r.|n"
+        )
+        return None
+
+    cmd, num_str = parts
+    try:
+        num = int(num_str)
+    except ValueError:
+        caller.msg("|rN must be a number.|n")
+        return None
+
+    target = caller.ndb._operate_target
+    chart = chart_lib.get_chart(target)
+    if not chart:
+        return "node_top"
+    steps = chart.get("steps") or []
+    if not (1 <= num <= len(steps)):
+        caller.msg(f"|rNo step {num} in chart (1-{len(steps)}).|n")
+        return None
+
+    step = steps[num - 1]
+    step_id = step["id"]
+
+    if cmd == "u":
+        if chart_lib.move_step(chart, step_id, -1):
+            chart_lib.save_chart(target, chart)
+            caller.msg(f"|wMoved step {num} up.|n")
+        else:
+            caller.msg("|yAlready at top.|n")
+        return "node_edit_chart"
+
+    if cmd == "d":
+        if chart_lib.move_step(chart, step_id, +1):
+            chart_lib.save_chart(target, chart)
+            caller.msg(f"|wMoved step {num} down.|n")
+        else:
+            caller.msg("|yAlready at bottom.|n")
+        return "node_edit_chart"
+
+    if cmd == "r":
+        if chart_lib.remove_step(chart, step_id):
+            chart_lib.save_chart(target, chart)
+            caller.msg(f"|wRemoved step {num}.|n")
+        return "node_edit_chart"
+
+    if cmd == "i":
+        # Stash the insertion point and route into the verb-pick
+        # flow.  ``_add_step_to_chart`` reads
+        # ``_operate_insert_before`` and uses ``insert_step``
+        # instead of ``add_step``.
+        caller.ndb._operate_insert_before = step_id
+        return "node_add_verb"
+
+    return None
 
 
 def _node_commence(caller, raw_string, **kwargs):
@@ -994,7 +1113,7 @@ class CmdOperate(Command):
                 "node_install_organ":    _node_install_organ,
                 "node_install_location": _node_install_location,
                 "node_suture_location":  _node_suture_location,
-                "node_view_chart":       _node_view_chart,
+                "node_edit_chart":       _node_edit_chart,
                 "node_commence":         _node_commence,
                 "node_save_exit":        _node_save_exit,
                 "node_discard_confirm":  _node_discard_confirm,

--- a/world/medical/charts.py
+++ b/world/medical/charts.py
@@ -226,6 +226,102 @@ def find_step(chart: dict, step_id: int) -> Optional[dict]:
     return None
 
 
+def move_step(chart: dict, step_id: int, direction: int) -> bool:
+    """Swap step ``step_id`` with its neighbour in ``direction``.
+
+    ``direction`` is -1 (up / earlier) or +1 (down / later).
+    Returns True when the move succeeded, False when the step is
+    already at the edge or doesn't exist.
+    """
+    if direction not in (-1, 1):
+        return False
+    steps = chart.get("steps", [])
+    for idx, step in enumerate(steps):
+        if step.get("id") != step_id:
+            continue
+        new_idx = idx + direction
+        if not (0 <= new_idx < len(steps)):
+            return False
+        steps[idx], steps[new_idx] = steps[new_idx], steps[idx]
+        return True
+    return False
+
+
+def insert_step(
+    chart: dict,
+    verb: str,
+    args: Optional[dict] = None,
+    notes: str = "",
+    before_id: Optional[int] = None,
+) -> dict:
+    """Insert a new step before ``before_id`` (or append when None).
+
+    Identical to :func:`add_step` except for the insertion point.
+    Validates ``verb`` and required args; raises ``ValueError`` on
+    failure so the UI can surface it cleanly.
+
+    When ``before_id`` is None or no step matches, the step
+    appends to the end (matches ``add_step`` semantics).
+    """
+    if verb not in ALL_VERBS:
+        raise ValueError(
+            f"Unknown verb {verb!r}; expected one of {ALL_VERBS}."
+        )
+    spec = VERB_ARG_SPEC[verb]
+    args = dict(args or {})
+    missing = [key for key in spec["required"] if key not in args]
+    if missing:
+        raise ValueError(f"Verb {verb!r} requires args {missing}.")
+
+    step_id = chart.get("next_step_id", 1)
+    step = {
+        "id":      step_id,
+        "verb":    verb,
+        "args":    args,
+        "notes":   notes,
+        "status":  PENDING,
+        "outcome": None,
+    }
+    chart["next_step_id"] = step_id + 1
+    steps = chart.setdefault("steps", [])
+
+    insert_idx = len(steps)
+    if before_id is not None:
+        for idx, s in enumerate(steps):
+            if s.get("id") == before_id:
+                insert_idx = idx
+                break
+
+    steps.insert(insert_idx, step)
+    return step
+
+
+def mark_running_step_failed(target, outcome: str) -> bool:
+    """Find any RUNNING step in ``target``'s chart and mark it FAILED
+    with ``outcome``.  Returns True when a step was mutated.
+
+    Used by resolvers that early-return without performing the
+    actual procedure work (e.g. access-gate denials).  Without
+    this, the on_complete chain hook would advance the step from
+    RUNNING → DONE, masking the failure as success.
+
+    No-op when the target has no chart or no RUNNING step.
+    """
+    chart = get_chart(target)
+    if not chart:
+        return False
+    mutated = False
+    for step in chart.get("steps") or ():
+        if step.get("status") == RUNNING:
+            step["status"] = FAILED
+            step["outcome"] = outcome
+            mutated = True
+            break
+    if mutated:
+        save_chart(target, chart)
+    return mutated
+
+
 # ===================================================================
 # CHART SUMMARY HELPERS — UI-friendly accessors
 # ===================================================================

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -616,6 +616,16 @@ def _resolve_harvest(actor, target, *, organ_name: str, location: str,
             f"{container.replace('_', ' ')} isn't open — there's no "
             f"incision to work through."
         )
+        # Mark any running chart step as failed so the auto-chain
+        # surfaces the gate accurately rather than reporting "done".
+        from world.medical.charts import mark_running_step_failed
+        mark_running_step_failed(
+            target,
+            outcome=(
+                f"no incision at {container.replace('_', ' ')} — "
+                f"harvest blocked"
+            ),
+        )
         return
 
     # Decay tier → harvested condition.
@@ -709,6 +719,14 @@ def _resolve_install(actor, target, *, organ_item, location: str,
                 f"You try to slot the {organ_item.key} in but "
                 f"{target.get_display_name(actor)}'s "
                 f"{location.replace('_', ' ')} isn't open."
+            )
+            from world.medical.charts import mark_running_step_failed
+            mark_running_step_failed(
+                target,
+                outcome=(
+                    f"no incision at {location.replace('_', ' ')} — "
+                    f"install blocked"
+                ),
             )
             return
 

--- a/world/tests/test_operate_charts.py
+++ b/world/tests/test_operate_charts.py
@@ -192,6 +192,135 @@ class FindStep(TestCase):
         )
 
 
+class MoveStep(TestCase):
+
+    def _chart_with_three(self):
+        chart = charts.new_chart(_surgeon())
+        charts.add_step(chart, "incise", {"location": "chest"})
+        charts.add_step(chart, "harvest", {"organ_name": "heart"})
+        charts.add_step(chart, "suture", {"location": "chest"})
+        return chart
+
+    def test_move_up_swaps_with_previous(self):
+        chart = self._chart_with_three()
+        # Move step 2 (harvest) up — should swap with step 1 (incise).
+        self.assertTrue(charts.move_step(chart, 2, -1))
+        verbs = [s["verb"] for s in chart["steps"]]
+        self.assertEqual(verbs, ["harvest", "incise", "suture"])
+
+    def test_move_down_swaps_with_next(self):
+        chart = self._chart_with_three()
+        self.assertTrue(charts.move_step(chart, 2, +1))
+        verbs = [s["verb"] for s in chart["steps"]]
+        self.assertEqual(verbs, ["incise", "suture", "harvest"])
+
+    def test_move_top_up_no_op(self):
+        chart = self._chart_with_three()
+        self.assertFalse(charts.move_step(chart, 1, -1))
+        verbs = [s["verb"] for s in chart["steps"]]
+        self.assertEqual(verbs, ["incise", "harvest", "suture"])
+
+    def test_move_bottom_down_no_op(self):
+        chart = self._chart_with_three()
+        self.assertFalse(charts.move_step(chart, 3, +1))
+        verbs = [s["verb"] for s in chart["steps"]]
+        self.assertEqual(verbs, ["incise", "harvest", "suture"])
+
+    def test_move_unknown_id_no_op(self):
+        chart = self._chart_with_three()
+        self.assertFalse(charts.move_step(chart, 999, -1))
+
+    def test_invalid_direction_no_op(self):
+        chart = self._chart_with_three()
+        self.assertFalse(charts.move_step(chart, 2, 0))
+        self.assertFalse(charts.move_step(chart, 2, 5))
+
+
+class InsertStep(TestCase):
+
+    def _chart_with_two(self):
+        chart = charts.new_chart(_surgeon())
+        charts.add_step(chart, "incise", {"location": "chest"})
+        charts.add_step(chart, "suture", {"location": "chest"})
+        return chart
+
+    def test_insert_before_existing_step(self):
+        chart = self._chart_with_two()
+        # Insert harvest before suture (step 2).
+        charts.insert_step(
+            chart, "harvest", {"organ_name": "heart"}, before_id=2,
+        )
+        verbs = [s["verb"] for s in chart["steps"]]
+        self.assertEqual(verbs, ["incise", "harvest", "suture"])
+
+    def test_insert_at_position_1(self):
+        chart = self._chart_with_two()
+        charts.insert_step(
+            chart, "harvest", {"organ_name": "heart"}, before_id=1,
+        )
+        verbs = [s["verb"] for s in chart["steps"]]
+        self.assertEqual(verbs, ["harvest", "incise", "suture"])
+
+    def test_insert_with_none_appends(self):
+        chart = self._chart_with_two()
+        charts.insert_step(
+            chart, "harvest", {"organ_name": "heart"}, before_id=None,
+        )
+        verbs = [s["verb"] for s in chart["steps"]]
+        self.assertEqual(verbs, ["incise", "suture", "harvest"])
+
+    def test_insert_with_unknown_id_appends(self):
+        """Defensive: unknown before_id appends at the end."""
+        chart = self._chart_with_two()
+        charts.insert_step(
+            chart, "harvest", {"organ_name": "heart"}, before_id=999,
+        )
+        verbs = [s["verb"] for s in chart["steps"]]
+        self.assertEqual(verbs, ["incise", "suture", "harvest"])
+
+    def test_insert_assigns_unique_id(self):
+        chart = self._chart_with_two()
+        new_step = charts.insert_step(
+            chart, "harvest", {"organ_name": "heart"}, before_id=1,
+        )
+        existing_ids = {s["id"] for s in chart["steps"] if s is not new_step}
+        self.assertNotIn(new_step["id"], existing_ids)
+
+    def test_insert_validates_required_args(self):
+        chart = self._chart_with_two()
+        with self.assertRaises(ValueError):
+            charts.insert_step(chart, "incise", {}, before_id=1)
+
+
+class MarkRunningStepFailed(TestCase):
+
+    def test_marks_running_step_failed(self):
+        target = _target()
+        chart = charts.new_chart(_surgeon())
+        step = charts.add_step(chart, "harvest", {"organ_name": "heart"})
+        step["status"] = charts.RUNNING
+        charts.save_chart(target, chart)
+        self.assertTrue(charts.mark_running_step_failed(
+            target, outcome="no incision — harvest blocked",
+        ))
+        latest = charts.get_chart(target)
+        self.assertEqual(latest["steps"][0]["status"], charts.FAILED)
+        self.assertIn("blocked", latest["steps"][0]["outcome"])
+
+    def test_no_chart_returns_false(self):
+        target = _target()
+        # No chart saved.
+        self.assertFalse(charts.mark_running_step_failed(target, "x"))
+
+    def test_no_running_step_returns_false(self):
+        target = _target()
+        chart = charts.new_chart(_surgeon())
+        charts.add_step(chart, "harvest", {"organ_name": "heart"})
+        # Step is PENDING, not RUNNING.
+        charts.save_chart(target, chart)
+        self.assertFalse(charts.mark_running_step_failed(target, "x"))
+
+
 # ===================================================================
 # Summary helpers
 # ===================================================================


### PR DESCRIPTION
Two playtest callouts:

**1. Step status reported "done" when the resolver actually gated.** When the resolver-level incision gate fired, the resolver early-returned cleanly — no exception, so the on_complete hook advanced the step from RUNNING → DONE. Display showed false success.

Fix: mark_running_step_failed(target, outcome) helper, called from harvest + install resolver gates. Flips RUNNING → FAILED with the gate reason before returning. Chain still advances, but the failed step keeps accurate status.

**2. Edit chart UX.** Top-level menu now has "Edit chart (view / reorder / remove)" replacing the read-only view. New edit node accepts short commands:

```
u <N>    move step N up
d <N>    move step N down
r <N>    remove step N
i <N>    insert a new step before step N
x        back to top
```

Insertion routes into the same verb-pick flow via an ndb slot.

Three new chart helpers (move_step, insert_step, mark_running_step_failed).

Suite: 2029/2029 (+15 new tests).

Refs #307.