### PR TITLE
fix: rat look_place templates duplicate the copula

### DIFF
--- a/world/mob_flavor/look_places_rat.py
+++ b/world/mob_flavor/look_places_rat.py
@@ -1,26 +1,32 @@
 """Look-place fragments for spawned rats.
 
-Where in the room the rat is, paired into ``mob.look_place`` for
-``$pron()``-style integration into the appearance composition.
-Each entry should be a complete sentence ending in terminal
-punctuation. Reads after the short-desc paragraph as positional
-detail — "It is here, doing X" — so phrasings should fit that
-slot naturally.
+Each string is consumed as ``mob.look_place`` and rendered by the
+room appearance system as ``<Name> is <look_place>`` (e.g. "A
+wiry sleek rat is perched on a low ledge.").  Entries should:
+
+* Begin with the verb phrase or adjective phrase — *not* a leading
+  "It is" / "It [verb]", which the renderer supplies the copula
+  for and otherwise produces "A rat is It is sniffing...".
+* End with a period.
+* Read as something a small rodent would plausibly be doing in
+  any room of the colony.
+
+Mirrors the contract in ``look_places.py`` for human mobs.
 """
 
 from __future__ import annotations
 
 LOOK_PLACES_RAT: list[str] = [
-    "It is perched on a low ledge with its tail curled around its body.",
-    "It crouches in the shadow at the base of the wall, nose twitching.",
-    "It skitters along the baseboard with quick small bursts of motion.",
-    "It sits up on its hindlegs and watches with bright unblinking attention.",
-    "It is sniffing at something invisible on the ground, whiskers fanning.",
-    "It darts a short distance and freezes again, head cocked.",
-    "It washes one forepaw with quick precise licks, never breaking eye contact.",
-    "It grooms its whiskers with both forepaws, ears swiveling at every sound.",
-    "It is half-hidden behind something, only its bright eyes catching the light.",
-    "It moves in cautious arcs through the room, never quite committing to a path.",
-    "It rests on all fours with its head low, ready to spring in any direction.",
-    "It pauses mid-step with one forepaw raised, listening.",
+    "perched on a low ledge with its tail curled around its body.",
+    "crouched in the shadow at the base of the wall, nose twitching.",
+    "skittering along the baseboard with quick small bursts of motion.",
+    "sitting up on its hindlegs and watching with bright unblinking attention.",
+    "sniffing at something invisible on the ground, whiskers fanning.",
+    "darting a short distance and freezing again, head cocked.",
+    "washing one forepaw with quick precise licks, never breaking eye contact.",
+    "grooming its whiskers with both forepaws, ears swiveling at every sound.",
+    "half-hidden behind something, only its bright eyes catching the light.",
+    "moving in cautious arcs through the room, never quite committing to a path.",
+    "resting on all fours with its head low, ready to spring in any direction.",
+    "pausing mid-step with one forepaw raised, listening.",
 ]


### PR DESCRIPTION
Rats appeared as A wiry ragged rat is It is sniffing at something invisible... — the rat LOOK_PLACES_RAT fragments were written as full It is … sentences, but the renderer composes <Name> is <look_place> and expects the fragment to start with a verb/adjective phrase (human LOOK_PLACES follow that contract correctly).

All 12 entries rewritten:

```
Before: It is perched on a low ledge with its tail curled…
After:  perched on a low ledge with its tail curled…
```

Module docstring updated to mirror the human contract.

Existing rats in the world keep their old attribute text until a re-roll cycle.

Suite: 2029/2029.