### PR TITLE
add amputate procedure verb + CmdSever alias (#307)

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -382,6 +382,7 @@ def _node_add_verb(caller, raw_string, **kwargs):
         "  2. harvest\n"
         "  3. install\n"
         "  4. suture\n"
+        "  5. amputate\n"
         "  x. Cancel\n\n"
         "|wWhich verb?|n"
     )
@@ -394,14 +395,15 @@ def _process_verb_choice(caller, raw_string, **kwargs):
     if choice in ("x", "exit", "cancel"):
         return "node_top"
     verb_map = {
-        "1": "incise", "incise": "incise",
-        "2": "harvest", "harvest": "harvest",
-        "3": "install", "install": "install",
-        "4": "suture", "suture": "suture",
+        "1": "incise",   "incise":   "incise",
+        "2": "harvest",  "harvest":  "harvest",
+        "3": "install",  "install":  "install",
+        "4": "suture",   "suture":   "suture",
+        "5": "amputate", "amputate": "amputate",
     }
     verb = verb_map.get(choice)
     if verb is None:
-        caller.msg("|rPick 1-4 or x to cancel.|n")
+        caller.msg("|rPick 1-5 or x to cancel.|n")
         return None
     caller.ndb._operate_pending_verb = verb
     # Suture has optional location; the rest are required.
@@ -413,6 +415,8 @@ def _process_verb_choice(caller, raw_string, **kwargs):
         return "node_harvest_organ"
     if verb == "install":
         return "node_install_organ"
+    if verb == "amputate":
+        return "node_amputate_location"
     return "node_top"
 
 
@@ -594,6 +598,61 @@ def _process_incise_location(caller, raw_string, **kwargs):
         caller.msg("|rPick a number from the list, or type the name.|n")
         return None
     _add_step_to_chart(caller, "incise", {"location": pick})
+    return "node_top"
+
+
+# ===================================================================
+# Amputate picker
+# ===================================================================
+
+
+def _list_severable_containers(target):
+    """Return sorted list of severable containers for ``target``'s
+    species — limbs and head per the species table."""
+    from world.anatomy import get_species_severable_containers
+    species = getattr(getattr(target, "db", None), "species", None)
+    try:
+        return sorted(get_species_severable_containers(species))
+    except Exception:
+        return []
+
+
+def _node_amputate_location(caller, raw_string, **kwargs):
+    target = caller.ndb._operate_target
+    locations = _list_severable_containers(target)
+    if not locations:
+        caller.msg(
+            "|rNo severable locations on this target.  Amputation "
+            "requires species anatomy that declares severable "
+            "containers (limbs / head).|n"
+        )
+        return "node_top"
+    caller.ndb._operate_pickable = locations
+    listing = _render_numbered(
+        locations, lambda loc: loc.replace("_", " "),
+    )
+    text = (
+        "\n|wAmputate location|n\n\n"
+        "Pick a body location to amputate:\n\n"
+        f"{listing}\n\n"
+        "  x. Cancel\n\n"
+        "|wWhich location?|n (number or name)"
+    )
+    options = ({"key": "_default", "goto": _process_amputate_location},)
+    return text, options
+
+
+def _process_amputate_location(caller, raw_string, **kwargs):
+    raw = (raw_string or "").strip()
+    if raw.lower() in ("x", "exit", "cancel"):
+        return "node_top"
+    if not raw:
+        return None
+    pick = _parse_pick(raw, caller.ndb._operate_pickable or [])
+    if pick is None:
+        caller.msg("|rPick a number from the list, or type the name.|n")
+        return None
+    _add_step_to_chart(caller, "amputate", {"location": pick})
     return "node_top"
 
 
@@ -1157,6 +1216,7 @@ class CmdOperate(Command):
                 "node_install_organ":    _node_install_organ,
                 "node_install_location": _node_install_location,
                 "node_suture_location":  _node_suture_location,
+                "node_amputate_location":_node_amputate_location,
                 "node_edit_chart":       _node_edit_chart,
                 "node_commence":         _node_commence,
                 "node_save_exit":        _node_save_exit,

--- a/commands/forensics.py
+++ b/commands/forensics.py
@@ -254,7 +254,12 @@ class CmdSever(Command):
     """
 
     key = "sever"
-    aliases = ()
+    # ``amputate`` is the medical-context alias.  Same command,
+    # same dispatch — the operate menu uses ``amputate`` as the
+    # procedure-verb name to align with surgical vocabulary, and
+    # direct-command users can reach the same severance from
+    # either verb.
+    aliases = ("amputate",)
     locks = "cmd:all()"
     help_category = "Forensics"
 

--- a/world/medical/charts.py
+++ b/world/medical/charts.py
@@ -84,7 +84,9 @@ STEP_STATUSES = (PENDING, RUNNING, DONE, SKIPPED, FAILED)
 # Each verb declares its required and optional args so the menu
 # UI can validate input at chart-authoring time.
 
-PROCEDURE_VERBS = ("incise", "harvest", "install", "suture")
+PROCEDURE_VERBS = (
+    "incise", "harvest", "install", "suture", "amputate",
+)
 TREATMENT_VERBS = ("apply", "inject")
 ALL_VERBS = PROCEDURE_VERBS + TREATMENT_VERBS
 
@@ -93,6 +95,7 @@ VERB_ARG_SPEC = {
     "harvest":  {"required": ("organ_name",),             "optional": ()},
     "install":  {"required": ("organ_item_key", "location"), "optional": ()},
     "suture":   {"required": (),                          "optional": ("location",)},
+    "amputate": {"required": ("location",),               "optional": ()},
     "apply":    {"required": ("item_key", "location"),    "optional": ()},
     "inject":   {"required": ("item_key",),               "optional": ("location",)},
 }
@@ -368,6 +371,8 @@ def render_step_summary(step: dict) -> str:
     args = step.get("args") or {}
     if verb == "incise":
         return f"incise {_humanize(args.get('location'))}"
+    if verb == "amputate":
+        return f"amputate {_humanize(args.get('location'))}"
     if verb == "harvest":
         return f"harvest {_humanize(args.get('organ_name'))}"
     if verb == "install":
@@ -548,6 +553,11 @@ def _resolve_step_args(verb: str, chart_args: dict, target, actor) -> dict:
     if verb == "incise":
         if "location" not in chart_args:
             raise _StepResolutionError("incise requires a location")
+        return {"location": chart_args["location"]}
+
+    if verb == "amputate":
+        if "location" not in chart_args:
+            raise _StepResolutionError("amputate requires a location")
         return {"location": chart_args["location"]}
 
     if verb == "harvest":

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -55,19 +55,21 @@ ANESTHETIZED_DIFFICULTY_BONUS = 3
 #: interactive; long enough that mid-combat surgery is genuinely
 #: tense.  Balance numbers — adjust freely.
 PROCEDURE_DURATIONS = {
-    "incise": 6,
-    "harvest": 18,
-    "install": 18,
-    "suture": 9,
+    "incise":   6,
+    "harvest":  18,
+    "install":  18,
+    "suture":   9,
+    "amputate": 12,
 }
 
 #: Pain severity seeded on a conscious patient when a procedure
 #: completes on them (per verb).  Unconscious patients skip this.
 CONSCIOUS_PAIN_SEVERITY = {
-    "incise": 3,
-    "harvest": 5,
-    "install": 4,
-    "suture": 2,
+    "incise":   3,
+    "harvest":  5,
+    "install":  4,
+    "suture":   2,
+    "amputate": 8,   # severance is the most painful procedure
 }
 
 #: Infection severity seeded as a failure consequence.  Caller passes
@@ -883,12 +885,118 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
         )
 
 
+def _resolve_amputate(actor, target, *, location: str, **_) -> None:
+    """Resolve an ``amputate`` attempt — surgical limb removal.
+
+    Wraps the existing severance pipeline
+    (``typeclasses.items.apply_sever_to_character`` for living
+    targets, ``apply_sever_to_corpse`` for the dead) in the
+    procedure-verb dispatch shape so charts can include
+    ``amputate <location>`` steps.
+
+    The CmdSever command path expects a wielded edged weapon, but
+    amputation in a surgical context is performed with the kit;
+    we skip the weapon check at the resolver level (the chart
+    runner already requires the surgical kit at chart-author
+    time via the procedure-verb infrastructure).
+
+    Failure consequences are placeholder per design: infection
+    seed on partial / failure rolls, pain on conscious patient.
+    Severance itself either lands or doesn't — partial-success
+    semantics for "almost cut it off" don't model cleanly, so
+    we treat partial as success-with-infection-seed.
+    """
+    from world.identity_utils import msg_room_identity
+
+    result = roll_procedure(actor, target)
+    outcome = result["outcome"]
+
+    if outcome == "failure":
+        # Botched cut — no severance, infection + pain seeded.
+        seed_infection(target, location)
+        seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["amputate"])
+        actor.msg(
+            f"Your cut goes wrong — you tear at "
+            f"{target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')} but the bone holds.  "
+            f"Blood and mess; no severance."
+        )
+        return
+
+    # Dispatch to the right severance pipeline based on target shape.
+    appendage = None
+    is_living = (
+        getattr(target, "medical_state", None) is not None
+        and getattr(target.medical_state, "organs", None)
+    )
+    if is_living:
+        from typeclasses.items import apply_sever_to_character
+        try:
+            appendage = apply_sever_to_character(
+                target, location, injury_type="cut",
+            )
+        except Exception as exc:
+            actor.msg(
+                f"The cut cannot proceed: {exc}"
+            )
+            return
+    else:
+        # Corpse-shaped target.
+        from typeclasses.items import apply_sever_to_corpse
+        try:
+            appendage = apply_sever_to_corpse(target, location)
+        except Exception as exc:
+            actor.msg(f"The cut cannot proceed: {exc}")
+            return
+
+    if appendage is None:
+        actor.msg(
+            f"The cut won't take — "
+            f"{target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')} can't be severed here."
+        )
+        return
+
+    # Partial success: severance landed but infection seeded.
+    if outcome == "partial":
+        seed_infection(target, location)
+        seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["amputate"])
+        actor.msg(
+            f"You hack through {target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')} — the cut holds but the "
+            f"edges are ragged."
+        )
+    else:
+        seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["amputate"])
+        actor.msg(
+            f"You sever {target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')} cleanly at the joint."
+        )
+
+    room = actor.location
+    if room is not None:
+        msg_room_identity(
+            location=room,
+            template=(
+                f"{{actor}} severs {{patient}}'s "
+                f"{location.replace('_', ' ')}."
+            ),
+            char_refs={"actor": actor, "patient": target},
+            exclude=[actor, target] if target is not actor else [actor],
+        )
+
+    # Vital-consequences pass — severance can be lethal (decapitation,
+    # spine-bearing cuts).  Re-uses the same path harvest goes through.
+    apply_vital_consequences(target)
+
+
 # Mapping consumed by ``_resolve_procedure_callback``.
 _VERB_RESOLVERS = {
-    "incise": _resolve_incise,
-    "harvest": _resolve_harvest,
-    "install": _resolve_install,
-    "suture": _resolve_suture,
+    "incise":   _resolve_incise,
+    "harvest":  _resolve_harvest,
+    "install":  _resolve_install,
+    "suture":   _resolve_suture,
+    "amputate": _resolve_amputate,
 }
 
 

--- a/world/tests/test_operate_charts.py
+++ b/world/tests/test_operate_charts.py
@@ -670,6 +670,47 @@ class ResolveStepArgs(TestCase):
         )
         self.assertEqual(result, {})
 
+    def test_amputate_passes_location_through(self):
+        from world.medical.charts import _resolve_step_args
+        result = _resolve_step_args(
+            "amputate", {"location": "left_arm"},
+            target=None, actor=None,
+        )
+        self.assertEqual(result, {"location": "left_arm"})
+
+    def test_amputate_missing_location_raises(self):
+        from world.medical.charts import (
+            _resolve_step_args, _StepResolutionError,
+        )
+        with self.assertRaises(_StepResolutionError):
+            _resolve_step_args(
+                "amputate", {}, target=None, actor=None,
+            )
+
+
+class AmputateInVerbSpec(TestCase):
+    """``amputate`` is a procedure verb (chartable + dispatched
+    via the procedure infrastructure, not a treatment verb)."""
+
+    def test_amputate_in_procedure_verbs(self):
+        self.assertIn("amputate", charts.PROCEDURE_VERBS)
+
+    def test_amputate_in_all_verbs(self):
+        self.assertIn("amputate", charts.ALL_VERBS)
+
+    def test_amputate_arg_spec_requires_location(self):
+        spec = charts.VERB_ARG_SPEC["amputate"]
+        self.assertEqual(spec["required"], ("location",))
+
+    def test_amputate_step_renders_with_location(self):
+        chart = charts.new_chart(_surgeon())
+        step = charts.add_step(
+            chart, "amputate", {"location": "left_arm"},
+        )
+        self.assertEqual(
+            charts.render_step_summary(step), "amputate left arm",
+        )
+
 
 class InterruptMarksRunningStepFailed(TestCase):
     """``interrupt_procedure`` should mark any RUNNING chart step


### PR DESCRIPTION
Adds amputate as the fifth procedure verb (incise/harvest/install/suture/**amputate**). Chartable via the operate menu, dispatched through the existing severance pipeline.

- _resolve_amputate wraps apply_sever_to_character / apply_sever_to_corpse in the procedure-verb shape; success/partial/failure outcomes; vital consequences pass at end (decapitation-via-amputate fires death detection immediately)
- PROCEDURE_DURATIONS = 12 (between incise 6 and harvest 18)
- CONSCIOUS_PAIN_SEVERITY = 8 — highest of the procedure verbs
- CmdSever gains "amputate" alias — direct-command users can type either verb
- Operate menu: 5th verb pick → species-aware severable-containers picker

Suite: 2035/2035 (+6 net).

Refs #307.