### PR TITLE
amputate(head) → decapitation pipeline so patient dies

### DIFF
--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -930,16 +930,36 @@ def _resolve_amputate(actor, target, *, location: str, **_) -> None:
         and getattr(target.medical_state, "organs", None)
     )
     if is_living:
-        from typeclasses.items import apply_sever_to_character
-        try:
-            appendage = apply_sever_to_character(
-                target, location, injury_type="cut",
-            )
-        except Exception as exc:
-            actor.msg(
-                f"The cut cannot proceed: {exc}"
-            )
-            return
+        if location == "head":
+            # Decapitation has its own pipeline.  The limb-severance
+            # chain map has no "head" entry, so routing head through
+            # ``apply_sever_to_character`` only zeros head-container
+            # organs (brain, eyes) — the cervical_spine sits in
+            # container "neck" and ``is_dead()`` keys off
+            # ``neck_integrity``, so the patient ends up unconscious
+            # but alive.  ``spawn_severed_head_for_living`` uses the
+            # species head-cluster (which includes "neck") so the
+            # spine collapses and ``apply_vital_consequences`` below
+            # triggers death.  Also yields a proper ``SeveredHead``.
+            from typeclasses.items import spawn_severed_head_for_living
+            try:
+                appendage = spawn_severed_head_for_living(
+                    target, injury_type="cut",
+                )
+            except Exception as exc:
+                actor.msg(f"The cut cannot proceed: {exc}")
+                return
+        else:
+            from typeclasses.items import apply_sever_to_character
+            try:
+                appendage = apply_sever_to_character(
+                    target, location, injury_type="cut",
+                )
+            except Exception as exc:
+                actor.msg(
+                    f"The cut cannot proceed: {exc}"
+                )
+                return
     else:
         # Corpse-shaped target.
         from typeclasses.items import apply_sever_to_corpse


### PR DESCRIPTION
**Playtest bug:** amputating the head on a living rat via the operate chart left the rat unconscious but alive — expected dead.

**Root cause:** `_resolve_amputate` routed living head amputation through `apply_sever_to_character`, whose chain comes from `get_species_limb_downstream_chain`. Neither species has a `"head"` entry there, so the chain collapsed to `("head",)` and `sever_character_body` only zeroed organs whose `container == "head"` (brain, eyes, ears). The `cervical_spine` lives in `container="neck"` — and `is_dead()` keys decapitation off `neck_integrity`, which the spine contributes to. Spine untouched → `neck_integrity` at 100% → `is_dead()` False → `at_death()` never fires. Brain zeroing did drag consciousness to 0 — hence unconscious-but-alive.

**Fix:** route living-target head amputation through the existing `spawn_severed_head_for_living` pipeline, which uses `get_species_severed_head_locations` (the head-cluster bundle that **includes** `"neck"`) and spawns a proper `SeveredHead` super-item. `apply_vital_consequences` then sees `neck_integrity == 0` and fires `at_death()` immediately.

**Side benefit:** the severed head now drops as a proper `SeveredHead` (face-side identity, shared decay clock, autopsy-able) rather than a generic "severed limb" Appendage.

Other locations (arm/thigh/etc.) continue through `apply_sever_to_character` unchanged.

Suite: 2035/2035.

Refs #307.