### PR TITLE
living-sever: preserve organ HP onto severed appendage

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1834,6 +1834,14 @@ def apply_living_sever_overlay(appendage, *, longdescs, wounds, locations):
         if wound.get("location") not in locs:
             continue
         organ_obj = wound.get("organ_obj")
+        # Read live HP *before* the caller mutates the body — mirrors
+        # the corpse-side death snapshot in
+        # ``death_progression._create_corpse_from_character`` which
+        # captures ``organ_obj.current_hp`` at the instant of death.
+        # Hardcoding zero here destroyed every carried organ on
+        # severance, breaking parity with the corpse-sever contract
+        # the comment below claims.
+        current_hp = getattr(organ_obj, "current_hp", 0) if organ_obj else 0
         max_hp = getattr(organ_obj, "max_hp", 0) if organ_obj else 0
         carried.append({
             "injury_type": wound.get("injury_type", "generic"),
@@ -1844,7 +1852,7 @@ def apply_living_sever_overlay(appendage, *, longdescs, wounds, locations):
             "stage": "old",
             "organ": wound.get("organ"),
             "organ_damage": {
-                "current_hp": 0,
+                "current_hp": current_hp,
                 "max_hp": max_hp,
                 "container": wound.get("location"),
             },

--- a/world/tests/test_living_sever.py
+++ b/world/tests/test_living_sever.py
@@ -150,6 +150,30 @@ class ApplyLivingSeverOverlayTests(TestCase):
         self.assertEqual(carried["organ_damage"]["current_hp"], 0)
         self.assertEqual(carried["organ_damage"]["max_hp"], 12)
 
+    def test_carried_organ_hp_preserves_live_value(self):
+        # Parity with the corpse-side death snapshot, which captures
+        # ``organ_obj.current_hp`` at the instant of death rather than
+        # zeroing it.  Severing a still-healthy arm should carry the
+        # arm's organs onto the appendage at their live HP, not at 0.
+        appendage = _FakeAppendage()
+        healthy_wound = {
+            "injury_type": "cut",
+            "location": "left_arm",
+            "severity": "Moderate",
+            "stage": "fresh",
+            "organ": "left_humerus",
+            "organ_obj": _FakeOrgan("left_arm", current_hp=8, max_hp=12),
+        }
+        apply_living_sever_overlay(
+            appendage,
+            longdescs={},
+            wounds=[healthy_wound],
+            locations=("left_arm",),
+        )
+        carried = appendage.db.wounds_at_death[0]
+        self.assertEqual(carried["organ_damage"]["current_hp"], 8)
+        self.assertEqual(carried["organ_damage"]["max_hp"], 12)
+
     def test_empty_text_longdesc_skipped(self):
         appendage = _FakeAppendage()
         apply_living_sever_overlay(


### PR DESCRIPTION
**Playtest bug:** amputating a limb appeared to destroy every organ in the severed container. User flagged that the corpse-side `sever` doesn't do this — the two paths should match.

**Root cause:** `apply_living_sever_overlay` hardcoded `current_hp: 0` in the carried wound's `organ_damage` block. The corpse path doesn't have this bug — it copies `wounds_at_death` dicts that were already synthesised at death-time from live `organ_obj.current_hp`.

The comment two lines above the bug explicitly claimed parity with the corpse-severed contract — so author intent was correct; the literal zero slipped in.

**Fix:** read `getattr(organ_obj, "current_hp", 0)` the same way the death-snapshot does. Living-severed appendages now carry forward the live HP the body had at the moment of the cut.

**Tests:**
- Existing test happened to feed a zero-HP organ, so the assertion kept passing — no regression.
- New `test_carried_organ_hp_preserves_live_value` pins the fix: severing a healthy arm preserves humerus HP at 8/12.

Suite: 2036/2036.

Refs #307.