### PR TITLE
spawn_severed_head_for_living: own decapitation_pending too

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1887,6 +1887,17 @@ def spawn_severed_head_for_living(character, *, injury_type="cut"):
     character.save_medical_state()
 
     character.db.head_severed_at_decap = True
+    # The death-progression hook in
+    # ``DeathProgressionScript._create_corpse_from_character`` gates
+    # corpse-side cleanup (head-cluster prose / wound removal +
+    # synthesised neck stump) on ``decapitation_pending``.  Combat sets
+    # this flag *before* calling us, but chart-driven amputation goes
+    # straight through this function — without the flag the corpse
+    # would render wounds at every head-cluster location even though
+    # those organs left with the severed head.  Owning both flags here
+    # makes "head severed off a living body" a single coherent state
+    # change regardless of caller.
+    character.db.decapitation_pending = True
 
     return head
 

--- a/world/tests/test_head_spawn_at_decap.py
+++ b/world/tests/test_head_spawn_at_decap.py
@@ -317,6 +317,18 @@ class SpawnSeveredHeadForLivingTests(TestCase):
         spawn_severed_head_for_living(char)
         self.assertTrue(char.db.head_severed_at_decap)
 
+    def test_decapitation_pending_flag_set(self):
+        # The death-progression hook in
+        # ``_create_corpse_from_character`` gates corpse-side cleanup
+        # (head-cluster prose / wound stripping, synthesised neck
+        # stump) on ``decapitation_pending``.  Combat sets this flag
+        # before calling the spawn, but chart-driven amputation routes
+        # straight through here — owning the flag inside the spawn
+        # makes the cleanup fire for both pipelines.
+        char = _FakeCharacter(organs=_head_organs())
+        spawn_severed_head_for_living(char)
+        self.assertTrue(char.db.decapitation_pending)
+
     def test_vital_signs_recomputed(self):
         char = _FakeCharacter(organs=_head_organs())
         spawn_severed_head_for_living(char)


### PR DESCRIPTION
**Playtest:** amputate head via operate chart → head spawns, rat dies, but carcass renders wounds at every head-cluster location (left_eye, right_eye, head, neck, left_ear, right_ear). Those organs left with the head — the corpse should show one stump wound at the neck.

**Root cause:** death-progression's corpse-cleanup hook (`apply_sever_to_corpse(corpse, "head")` at line 737 of `death_progression.py`) is gated on `character.db.decapitation_pending`. Combat sets that flag in `ArmorMixin.take_damage` **before** calling `spawn_severed_head_for_living`. The operate chart path goes straight through the spawn without setting the flag, so the hook never fires and the death snapshot's head-cluster wounds end up on the corpse.

**Fix:** own `decapitation_pending` inside `spawn_severed_head_for_living` itself. The function already owns `head_severed_at_decap`; both flags describe the same event — "head just severed off a living body, do downstream cleanup." Single coherent state change regardless of caller. Combat's pre-set becomes redundant but harmless (separate cleanup if desired).

New unit test pins the flag.

Suite: 2044/2044.

Refs #307.