### PR TITLE
wounds: collapse head-cluster severance into one cut-point wound

### DIFF
--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -228,12 +228,32 @@ def get_character_wounds(character):
     # Issue #356 Phase 2: species-aware limb-parent map.  Rats have
     # two-segment limbs (foreleg+forepaw, hindleg+hindpaw) so their
     # parent map differs from human's three-segment chain.
+    species = getattr(character.db, "species", None) if hasattr(character, "db") else None
     try:
         from world.anatomy import get_species_limb_parent
-        species = getattr(character.db, "species", None) if hasattr(character, "db") else None
         LIMB_PARENT = get_species_limb_parent(species)
     except ImportError:
         LIMB_PARENT = {}
+
+    # Head-cluster cut-point: when the head has been severed off the
+    # body (decapitation — combat- or chart-driven), every cluster
+    # peer (face / neck / eyes / ears / hair-or-fur / snout, depending
+    # on species) collapses into a single wound at the "head" cut
+    # point.  The cluster forms a bundle, not a parent tree, so it
+    # doesn't fit the limb-parent shape — handled separately here.
+    # Detection: the brain sits in container="head" and gets zeroed
+    # by ``sever_character_body`` during head severance, so its
+    # presence in ``severed_containers`` is a reliable signal that
+    # the cluster left the body.
+    head_cluster_collapsed = "head" in severed_containers
+    if head_cluster_collapsed:
+        try:
+            from world.anatomy import get_species_severed_head_locations
+            head_cluster = get_species_severed_head_locations(species)
+        except ImportError:
+            head_cluster = frozenset()
+    else:
+        head_cluster = frozenset()
 
     # Check all organs in the character's medical state for damage
     for organ_name, organ in medical_state.organs.items():
@@ -261,6 +281,13 @@ def get_character_wounds(character):
                 if stage == "severed":
                     parent = LIMB_PARENT.get(location)
                     if parent and parent in severed_containers:
+                        continue
+                    # Head-cluster collapse — see preamble.  Every
+                    # cluster peer rolls up into the single wound at
+                    # the "head" cut point.
+                    if (head_cluster_collapsed
+                            and location in head_cluster
+                            and location != "head"):
                         continue
 
                 wound_data = {

--- a/world/tests/test_limb_downstream_chain.py
+++ b/world/tests/test_limb_downstream_chain.py
@@ -404,6 +404,61 @@ class CutPointFilterTests(TestCase):
         self.assertIn("left_shin", locations)
         self.assertNotIn("left_foot", locations)
 
+    def test_head_severance_collapses_cluster_to_single_wound(self):
+        # Decapitation: ``sever_character_body`` zeros every organ in
+        # the head cluster.  Without the cluster filter, every cluster
+        # peer (eyes, ears, neck) renders its own severance wound on
+        # the headless body — confusing both visually and narratively
+        # ("the left ear is missing" on a body whose entire head is
+        # gone).  The cluster filter collapses every peer wound into
+        # a single wound at the "head" cut point, mirroring the
+        # corpse-side cleanup in ``apply_sever_to_corpse``.
+        from world.medical.wounds import get_character_wounds
+
+        # Eyes and ears live in ``container="head"`` but render at a
+        # specific ``display_location``; need both fields wired here.
+        def _head_organ(name, *, display_location=None):
+            organ = _FakeOrgan("head", name=name)
+            organ.current_hp = 0
+            organ.wound_stage = "severed"
+            if display_location is not None:
+                organ.display_location = display_location
+            return organ
+
+        organs = {
+            "brain": _head_organ("brain"),
+            "left_eye": _head_organ("left_eye",
+                                     display_location="left_eye"),
+            "right_eye": _head_organ("right_eye",
+                                      display_location="right_eye"),
+            "left_ear": _head_organ("left_ear",
+                                     display_location="left_ear"),
+            "right_ear": _head_organ("right_ear",
+                                      display_location="right_ear"),
+        }
+        # Cervical spine lives in container="neck" — also severed by
+        # the head-cluster cut, and we want its wound suppressed too.
+        spine = _FakeOrgan("neck", name="cervical_spine")
+        spine.current_hp = 0
+        spine.wound_stage = "severed"
+        organs["cervical_spine"] = spine
+
+        char = SimpleNamespace(
+            medical_state=_FakeMedical(organs),
+            is_location_covered=lambda loc: False,
+            db=SimpleNamespace(skintone=None, species="human"),
+        )
+        wounds = get_character_wounds(char)
+        locations = {w["location"] for w in wounds}
+        # Single cut-point wound at "head" — everything else suppressed.
+        self.assertIn("head", locations)
+        for hidden in ("left_eye", "right_eye", "left_ear",
+                       "right_ear", "neck", "face"):
+            self.assertNotIn(
+                hidden, locations,
+                f"{hidden} should be suppressed when head cluster is severed",
+            )
+
     def test_solo_foot_sever_still_renders(self):
         # If only the foot is severed (foot directly cut, not as
         # downstream of shin), the wound should still render — the


### PR DESCRIPTION
**Playtest:** after amputating a rat's head, the headless body shows separate wounds for every cluster peer — both eyes, both ears, neck, head — stacking up on a body whose entire head left in one swing.

**Root cause:** the existing cut-point filter in `get_character_wounds` suppresses downstream *limb* wounds via parent-tree lookup (`LIMB_PARENT`). The head cluster isn't a tree — face / neck / eyes / ears / hair are peers under one cut point — so the filter never fires for them and every cluster organ emits its own wound. The corpse-side cleanup (`apply_sever_to_corpse`) handles this correctly but only runs inside `_create_corpse_from_character` ~90s after death. During the death-progression window the player is still looking at the character body — exactly where this bug surfaces.

**Fix:** handle cluster collapse inside `get_character_wounds` alongside the existing limb filter. Detection: `"head" in severed_containers` (brain lives in `container="head"` and is always zeroed by `sever_character_body` during decapitation, so works for combat- and chart-driven head severance alike). Cluster set sourced from the existing `get_species_severed_head_locations` — same set the corpse-side cleanup uses, so live-body and corpse views agree on which locations leave with the head.

**Why not extend LIMB_PARENT?** Tried it. Breaks `test_parent_map_consistent_with_chain` because that invariant requires every parent to have a chain entry in `LIMB_DOWNSTREAM_CHAIN` — and `"head"` isn't a limb chain root.

**Combat eye damage stays unaffected:** only `sever_character_body` writes `wound_stage="severed"`; combat uses `"destroyed"` / other stages.

New test `test_head_severance_collapses_cluster_to_single_wound` pins the contract.

Suite: 2045/2045.

Refs #307.