### PR TITLE
wounds: emit synthetic severance wound for head-cluster collapse

### DIFF
--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -274,6 +274,20 @@ def get_character_wounds(character):
                 stage = _determine_wound_stage_from_organ(organ)
                 severity = _determine_severity_from_damage(organ)
 
+                # Head-cluster collapse — suppress every wound at any
+                # cluster location (including peers like "left_eye" /
+                # "neck" AND the head itself).  We emit one synthetic
+                # cut-point wound after the loop, matching the corpse
+                # path in ``apply_sever_to_corpse``.  Mirroring that
+                # contract here means the live-body view and the
+                # eventual corpse view render with the same prose
+                # ("the head has been taken off the body") instead of
+                # the live body listing every cluster organ's own
+                # injury separately ("the brain is destroyed", "the
+                # left eye is destroyed", …) — see preamble.
+                if head_cluster_collapsed and location in head_cluster:
+                    continue
+
                 # Cut-point filter: suppress severance wounds that are
                 # downstream of another severed container. Only the
                 # cut point renders a stump wound; the rest of the
@@ -281,13 +295,6 @@ def get_character_wounds(character):
                 if stage == "severed":
                     parent = LIMB_PARENT.get(location)
                     if parent and parent in severed_containers:
-                        continue
-                    # Head-cluster collapse — see preamble.  Every
-                    # cluster peer rolls up into the single wound at
-                    # the "head" cut point.
-                    if (head_cluster_collapsed
-                            and location in head_cluster
-                            and location != "head"):
                         continue
 
                 wound_data = {
@@ -299,6 +306,24 @@ def get_character_wounds(character):
                     'organ_obj': organ
                 }
                 wounds.append(wound_data)
+
+    # Head-cluster collapse — emit the single synthetic cut-point
+    # wound that ``apply_sever_to_corpse`` would have laid down on the
+    # corpse-side path.  Same shape (injury_type="severed",
+    # location="head", organ=None) so the renderer routes to the
+    # severance prose ("the head has been taken off the body") rather
+    # than the per-organ-destruction prose the live body would have
+    # produced.  Visibility-gated on the head location so concealment
+    # via headwear (theoretical edge case) still works.
+    if head_cluster_collapsed and _is_wound_visible(character, "head"):
+        wounds.append({
+            "injury_type": "severed",
+            "location": "head",
+            "severity": "Critical",
+            "stage": "old",
+            "organ": None,
+            "organ_obj": None,
+        })
 
     return wounds
 

--- a/world/tests/test_limb_downstream_chain.py
+++ b/world/tests/test_limb_downstream_chain.py
@@ -458,6 +458,14 @@ class CutPointFilterTests(TestCase):
                 hidden, locations,
                 f"{hidden} should be suppressed when head cluster is severed",
             )
+        # Exactly one head wound, and it carries the synthetic
+        # cut-point shape (matches ``apply_sever_to_corpse``):
+        # injury_type="severed", organ=None — so the renderer routes
+        # to the severance prose, not the per-organ destruction prose.
+        head_wounds = [w for w in wounds if w["location"] == "head"]
+        self.assertEqual(len(head_wounds), 1)
+        self.assertEqual(head_wounds[0]["injury_type"], "severed")
+        self.assertIsNone(head_wounds[0]["organ"])
 
     def test_solo_foot_sever_still_renders(self):
         # If only the foot is severed (foot directly cut, not as


### PR DESCRIPTION
**Follow-up to #420.** Cluster peer wounds (eyes / ears / neck) were collapsed correctly, but two visible problems remained on the decapitated live body:

1. **`container="head"` holds multiple organs** (brain + jaw + …). Each emitted its own wound at `location="head"`, so the body read "A grievous wound and another wound surround the ruined head" — two wounds, not one.
2. **Per-organ `injury_type`** (defaulted from the zeroed-by-`sever_character_body` organ) didn't match the `injury_type="severed"` the corpse-side path produces. Different inputs → different prose. Live body said "the brain is destroyed" while the eventual corpse view said "the head has been taken off the body."

**Fix:** mirror the corpse-side contract from `apply_sever_to_corpse`. Suppress every wound at any cluster location (including `"head"` itself), then append one synthetic cut-point wound after the loop:

```python
{injury_type: "severed", location: "head",
 severity: "Critical", stage: "old",
 organ: None, organ_obj: None}
```

Same shape `apply_sever_to_corpse` writes, routes through the same renderer key, produces the same prose. Live-body view during death progression now matches the eventual corpse view.

Test updated to pin both uniqueness (exactly one head wound) and shape (`injury_type == "severed"`, `organ is None`).

Suite: 2045/2045.

Refs #307.