### PR TITLE
wounds: emit synthetic severance wound for limb cut-points too

### DIFF
--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -288,14 +288,22 @@ def get_character_wounds(character):
                 if head_cluster_collapsed and location in head_cluster:
                     continue
 
-                # Cut-point filter: suppress severance wounds that are
-                # downstream of another severed container. Only the
-                # cut point renders a stump wound; the rest of the
-                # chain just went with it.
-                if stage == "severed":
-                    parent = LIMB_PARENT.get(location)
-                    if parent and parent in severed_containers:
-                        continue
+                # Limb-chain collapse — symmetric with head cluster:
+                # suppress every wound at any severed limb container
+                # (cut point, downstream chain, *and* pre-existing
+                # wounds that left with the limb).  One synthetic
+                # severance wound per chain root is emitted after the
+                # loop.  Without this, a severed humerus rendered as
+                # "blunt" / "left_humerus" / "severed" — keyed on
+                # the bone's own injury heuristic — while the corpse
+                # path lays down ``injury_type="severed"`` /
+                # ``organ=None`` and gets cleaner severance prose.
+                # Head-cluster locations are excluded so this doesn't
+                # double-handle anything the cluster block above
+                # already dropped.
+                if (location in severed_containers
+                        and location not in head_cluster):
+                    continue
 
                 wound_data = {
                     'injury_type': injury_type,
@@ -324,6 +332,30 @@ def get_character_wounds(character):
             "organ": None,
             "organ_obj": None,
         })
+
+    # Limb-chain cut-point wounds — symmetric with the head cluster
+    # synthesis above.  For every severed limb chain we emit exactly
+    # one wound at the chain root (the cut point: a severed container
+    # whose parent per ``LIMB_PARENT`` is either undefined or not
+    # itself severed).  Head-cluster containers are skipped so
+    # decapitation doesn't double-emit alongside the head wound.
+    # Same shape ``apply_sever_to_corpse`` writes so the live-body
+    # view and the corpse view render identical limb-severance prose.
+    for container in severed_containers:
+        if container in head_cluster:
+            continue
+        parent = LIMB_PARENT.get(container)
+        if parent and parent in severed_containers:
+            continue
+        if _is_wound_visible(character, container):
+            wounds.append({
+                "injury_type": "severed",
+                "location": container,
+                "severity": "Critical",
+                "stage": "old",
+                "organ": None,
+                "organ_obj": None,
+            })
 
     return wounds
 

--- a/world/tests/test_limb_downstream_chain.py
+++ b/world/tests/test_limb_downstream_chain.py
@@ -467,6 +467,24 @@ class CutPointFilterTests(TestCase):
         self.assertEqual(head_wounds[0]["injury_type"], "severed")
         self.assertIsNone(head_wounds[0]["organ"])
 
+    def test_limb_sever_emits_synthetic_cut_point_wound(self):
+        # The single surviving wound at the limb chain root must
+        # match the corpse-side ``apply_sever_to_corpse`` shape so
+        # the renderer routes through the same severance prose key:
+        # injury_type="severed", organ=None.  Without the synthesis,
+        # the wound's injury_type came from the bone organ's heuristic
+        # (e.g. "blunt" for a humerus) and the per-organ destruction
+        # prose rendered instead of the severance prose — the same
+        # mismatch the head cluster collapse already fixes.
+        from world.medical.wounds import get_character_wounds
+
+        char = self._char_with_severed_chain()
+        wounds = get_character_wounds(char)
+        shin_wounds = [w for w in wounds if w["location"] == "left_shin"]
+        self.assertEqual(len(shin_wounds), 1)
+        self.assertEqual(shin_wounds[0]["injury_type"], "severed")
+        self.assertIsNone(shin_wounds[0]["organ"])
+
     def test_solo_foot_sever_still_renders(self):
         # If only the foot is severed (foot directly cut, not as
         # downstream of shin), the wound should still render — the


### PR DESCRIPTION
**Follow-up to #421 — same root cause, symmetric fix.**

A live-severed limb survived the existing cut-point filter (downstream chain wounds correctly suppressed via LIMB_PARENT lookup), but the surviving cut-point wound carried per-organ data:
- `injury_type` from `_determine_injury_type_from_organ` — for a humerus this returns `"blunt"` via the bone heuristic
- `organ` = the bone organ name (e.g. `"left_humerus"`)

So `("blunt", "left_arm", "severed")` routed through the blunt-trauma message module instead of the severance one. The corpse-side `apply_sever_to_corpse` doesn't have this problem because it synthesises the stump wound with `injury_type="severed"` / `organ=None`.

**Fix:** apply the head-cluster pattern from #421 to limbs:
1. Suppress every wound at any severed limb location (incl. cut point) — not just downstream.
2. After the organ loop, emit one synthetic `{injury_type: "severed", location: <root>, organ: None, …}` wound per chain root (parent undefined or not severed). Head-cluster containers skipped to avoid double-emit alongside the head wound.

Live-body view during death progression now renders identical severance prose to the eventual corpse view for both head **and** limb amputation.

New test pins the shape (single wound at root, `injury_type="severed"`, `organ=None`). Existing location-uniqueness tests still pass.

Suite: 2046/2046.

Refs #307.