### PR TITLE
suture: amputation stumps progress fresh → treated; severed.py prose filled out

### DIFF
--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -836,13 +836,21 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
     # harvested-injury organs from ``fresh`` to ``treated`` so the
     # wound renderer reads as "surgical opening has been crudely
     # bandaged" rather than "still wet and red".  Severance wounds
-    # (limb-loss injury_type, not "harvested") are untouched —
-    # suturing the stump doesn't undo the limb loss but the
-    # ``harvested`` injury type IS appropriate for an organ
-    # extracted via the procedure pipeline.
+    # (limb-loss injury_type, not "harvested") leave the limb gone
+    # — suture won't grow it back — but the *stump prose* should
+    # progress from raw to bandaged.  Tracked separately on
+    # ``target.db.sutured_stumps`` (see ``_stump_stage`` in
+    # world.medical.wounds.wound_descriptions) so the synthetic
+    # cut-point wound emitted by ``get_character_wounds`` reads
+    # "treated" once this fires.
     state = getattr(target, "medical_state", None)
     if state is not None and hasattr(state, "organs"):
+        sutured = list(
+            getattr(target.db, "sutured_stumps", None) or ()
+        )
+        sutured_dirty = False
         for loc in closed:
+            stump_at_loc = False
             for organ in state.organs.values():
                 container = getattr(organ, "container", None)
                 display = getattr(organ, "display_location", None)
@@ -851,6 +859,17 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
                 if getattr(organ, "injury_type", None) == "harvested":
                     if getattr(organ, "wound_stage", None) == "fresh":
                         organ.wound_stage = "treated"
+                # Detect severance: ``sever_character_body`` zeroes
+                # chain organs and sets ``wound_stage="severed"``.
+                # Any such organ whose container / display surface
+                # matches the closed incision marks this as a stump.
+                if getattr(organ, "wound_stage", None) == "severed":
+                    stump_at_loc = True
+            if stump_at_loc and loc not in sutured:
+                sutured.append(loc)
+                sutured_dirty = True
+        if sutured_dirty:
+            target.db.sutured_stumps = sutured
 
     seed_pain(target, closed[0], CONSCIOUS_PAIN_SEVERITY["suture"])
 

--- a/world/medical/wounds/messages/severed.py
+++ b/world/medical/wounds/messages/severed.py
@@ -1,19 +1,34 @@
 """
 Severed wound descriptions.
 
-These render on a corpse where a limb has been removed (PR #198).
-The wound record is synthesized by
-:func:`commands.forensics._apply_sever_to_corpse` immediately after
-``CmdSever`` succeeds, with ``injury_type='severed'`` and the
-canonical body-location name (e.g. ``left_arm``, ``head``).
+These render on a corpse where a limb has been removed (PR #198), AND
+on living characters at the cut point after an amputation — the
+synthetic ``injury_type="severed"`` cut-point wound emitted by
+:func:`world.medical.wounds.wound_descriptions.get_character_wounds`
+on a freshly-amputated body routes through this module so the live
+view and the eventual corpse view share prose.
 
 Stages:
-    fresh: Used immediately after sever (the cut is recent prose-wise).
-    old:   Used on long-dead corpses; the stump is dried / desiccated.
+    fresh:   Just cut.  Raw stump.  Default on a living body until
+             the suture verb runs, and on a fresh corpse spawned by
+             :func:`commands.forensics._apply_sever_to_corpse`.
+    treated: Recently sutured.  Bandaged stump, stitches visible.
+             Lives only on a living body — transitioned from ``fresh``
+             by ``_resolve_suture`` via ``character.db.sutured_stumps``.
+    healing: Sutures dissolving, new tissue knitting over.  Future
+             use — slotted for the time-based progression tick.
+    scarred: Long-healed.  Future use — terminal stage of progression.
+    old:     Corpse-preserved variant.  Frozen at death.  Renders the
+             dried / desiccated stump on long-dead corpses.
+    destroyed: Catastrophic mangling (e.g. blast amputation that
+             didn't leave a clean cut).
 
-All templates expect the ``{location}`` token, which resolves through
-:func:`world.medical.wounds.constants.get_location_display_name` and
-yields readable strings like ``"left arm"`` or ``"head"``.
+All templates expect the ``{location}`` token; the
+``{skintone}`` / ``{severity}`` / ``{organ}`` / ``{injury_type}``
+tokens are also available.  The renderer
+(:func:`world.medical.wounds.wound_descriptions.get_wound_description`)
+auto-prepends a skintone colour code for ``treated`` / ``healing`` /
+``scarred`` stages when a character context is supplied.
 """
 
 WOUND_DESCRIPTIONS = {
@@ -29,16 +44,23 @@ WOUND_DESCRIPTIONS = {
         "|rThe {location} is missing — the stump long since congealed and stiff|n",
         "|rA stump marks where the {location} used to be, the wound long dry|n",
     ],
-    # Aliases so the renderer's defensive stage fallbacks don't fall
-    # through to a different injury_type's templates.
     "treated": [
+        "|rThe {location} stump has been carefully sutured shut, the dressing clean|n",
+        "{skintone}neat rows of stitches close the {location} stump, the bandage still fresh|n",
+        "{skintone}a {severity} sutured stump where the {location} used to be, the cut held closed|n",
         "|rThe stump where the {location} used to be has been crudely bandaged|n",
     ],
     "healing": [
-        "|rThe stump where the {location} used to be shows callused, knotted scar tissue|n",
+        "{skintone}the {location} stump shows pink new tissue knitting over the closed wound|n",
+        "{skintone}healing flesh covers the {location} stump, the sutures long since dissolved|n",
+        "{skintone}the {location} stump is closing well, the scar still pink and tight|n",
+        "{skintone}callused, knotted tissue forms the {location} stump, the wound nearly closed|n",
     ],
     "scarred": [
-        "|rA smooth, pale scar marks where the {location} was severed long ago|n",
+        "{skintone}a smooth, pale scar marks where the {location} was lost long ago|n",
+        "{skintone}a faded, ridged scar tells of the {location} severed years past|n",
+        "{skintone}the {location} ends in a smooth healed stump, the flesh long since closed|n",
+        "{skintone}a pale, knotted scar caps the old severance site at the {location}|n",
     ],
     "destroyed": [
         "|RThe {location} has been violently torn away, leaving a mangled, ruined stump|n",

--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -188,6 +188,26 @@ def _format_wound_grammar(description):
     return result
 
 
+def _stump_stage(character, location: str) -> str:
+    """Return the renderer stage for a severance cut point.
+
+    Today this is binary: ``"treated"`` if the cut point has been
+    sutured (recorded in ``character.db.sutured_stumps``), else
+    ``"fresh"``.  The suture verb populates the set after closing an
+    incision at a location whose organs are all severed.
+
+    Time-based progression past ``treated`` (``"healing"`` /
+    ``"scarred"``) is future work — when the per-cut-point stage
+    store grows from a flat membership set to a per-location stage
+    value, the lookup will replace this helper without rippling
+    through the synthesis call sites.
+    """
+    sutured = getattr(
+        getattr(character, "db", None), "sutured_stumps", None,
+    ) or ()
+    return "treated" if location in sutured else "fresh"
+
+
 def get_character_wounds(character):
     """
     Analyze character's medical state and extract visible wounds.
@@ -328,7 +348,7 @@ def get_character_wounds(character):
             "injury_type": "severed",
             "location": "head",
             "severity": "Critical",
-            "stage": "old",
+            "stage": _stump_stage(character, "head"),
             "organ": None,
             "organ_obj": None,
         })
@@ -352,7 +372,7 @@ def get_character_wounds(character):
                 "injury_type": "severed",
                 "location": container,
                 "severity": "Critical",
-                "stage": "old",
+                "stage": _stump_stage(character, container),
                 "organ": None,
                 "organ_obj": None,
             })

--- a/world/tests/test_limb_downstream_chain.py
+++ b/world/tests/test_limb_downstream_chain.py
@@ -485,6 +485,32 @@ class CutPointFilterTests(TestCase):
         self.assertEqual(shin_wounds[0]["injury_type"], "severed")
         self.assertIsNone(shin_wounds[0]["organ"])
 
+    def test_stump_renders_fresh_when_unsutured(self):
+        # A freshly-severed limb cut point has no entry in
+        # ``db.sutured_stumps``; the synthetic stump wound should
+        # render at stage="fresh" so the renderer routes through
+        # severed.py's raw / weeping prose.
+        from world.medical.wounds import get_character_wounds
+
+        char = self._char_with_severed_chain()
+        # No sutured_stumps attribute at all → behave as empty set.
+        wounds = get_character_wounds(char)
+        shin_wounds = [w for w in wounds if w["location"] == "left_shin"]
+        self.assertEqual(shin_wounds[0]["stage"], "fresh")
+
+    def test_stump_renders_treated_when_sutured(self):
+        # Once the cut point is recorded in ``db.sutured_stumps`` (by
+        # ``_resolve_suture`` closing an incision at a severance
+        # location), the renderer transitions to stage="treated" so
+        # severed.py's bandaged-stump prose fires instead.
+        from world.medical.wounds import get_character_wounds
+
+        char = self._char_with_severed_chain()
+        char.db.sutured_stumps = ["left_shin"]
+        wounds = get_character_wounds(char)
+        shin_wounds = [w for w in wounds if w["location"] == "left_shin"]
+        self.assertEqual(shin_wounds[0]["stage"], "treated")
+
     def test_solo_foot_sever_still_renders(self):
         # If only the foot is severed (foot directly cut, not as
         # downstream of shin), the wound should still render — the

--- a/world/tests/test_severed_prose.py
+++ b/world/tests/test_severed_prose.py
@@ -72,6 +72,42 @@ class SeveredStageProseTests(TestCase):
                         )
 
 
+class SeveredStumpProgressionStagesTests(TestCase):
+    """``severed.py`` carries the post-amputation stump progression
+    (``treated`` / ``healing`` / ``scarred``) — previously single-line
+    placeholders, now real prose so suture / healing / time-progressed
+    stumps render distinct flavour."""
+
+    def setUp(self):
+        import world.medical.wounds.messages.severed as severed
+        self.descriptions = severed.WOUND_DESCRIPTIONS
+
+    def test_treated_stage_has_multiple_variants(self):
+        # Suture transitions the synthetic cut-point wound from
+        # ``fresh`` to ``treated``; the renderer picks one at random
+        # — so multiple variants prevent repetitive prose on a body
+        # with multiple amputations.
+        self.assertGreaterEqual(len(self.descriptions["treated"]), 3)
+
+    def test_healing_stage_has_multiple_variants(self):
+        # Slotted for the time-based progression tick (future work).
+        # Prose stocked now so the tick has somewhere to land.
+        self.assertGreaterEqual(len(self.descriptions["healing"]), 3)
+
+    def test_scarred_stage_has_multiple_variants(self):
+        # Terminal stage of stump progression.
+        self.assertGreaterEqual(len(self.descriptions["scarred"]), 3)
+
+    def test_progression_templates_reference_location(self):
+        # Every stump-progression template must accept the
+        # ``{location}`` token — the renderer fills it with the
+        # cut-point body part ("left arm", "head") at format time.
+        for stage in ("treated", "healing", "scarred"):
+            for template in self.descriptions[stage]:
+                with self.subTest(stage=stage, template=template):
+                    self.assertIn("{location}", template)
+
+
 class LacerationFileTests(TestCase):
     """The laceration injury type now has its own wound-message file."""
 

--- a/world/tests/test_surgical_procedures.py
+++ b/world/tests/test_surgical_procedures.py
@@ -689,6 +689,40 @@ class ResolveSuture(TestCase):
         _resolve_suture(self.actor, self.target, location="chest")
         self.assertEqual(open_incision_locations(self.target), ["abdomen"])
 
+    @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_suture_at_stump_records_sutured_stump(self, _r):
+        # Suture closing an incision at a location whose organs are
+        # all severed (wound_stage="severed") records the location in
+        # ``target.db.sutured_stumps`` so the wound renderer
+        # transitions the synthetic cut-point wound from ``fresh`` to
+        # ``treated``.  Mirrors the harvested-organ ``fresh→treated``
+        # transition the same verb already does — same idea applied
+        # to the stump-prose progression.
+        from world.medical.procedures import _resolve_suture
+        # Mark every organ in the left_arm container as severed,
+        # mimicking what ``sever_character_body`` does post-amputation.
+        for organ in self.target.medical_state.organs.values():
+            if organ.container == "left_arm":
+                organ.current_hp = 0
+                organ.wound_stage = "severed"
+        open_incision(self.target, "left_arm", surgeon=self.actor)
+        _resolve_suture(self.actor, self.target, location="left_arm")
+        sutured = self.target.db.sutured_stumps or []
+        self.assertIn("left_arm", sutured)
+
+    @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_suture_at_unsevered_location_does_not_mark_stump(self, _r):
+        # Closing an incision at a location with intact organs (the
+        # normal surgical case — opened for harvest / install) must
+        # not pollute ``sutured_stumps`` with locations that aren't
+        # actually amputation sites.  Only locations whose organs are
+        # ``wound_stage="severed"`` qualify.
+        from world.medical.procedures import _resolve_suture
+        open_incision(self.target, "chest", surgeon=self.actor)
+        _resolve_suture(self.actor, self.target, location="chest")
+        sutured = getattr(self.target.db, "sutured_stumps", None) or []
+        self.assertNotIn("chest", sutured)
+
     @patch("world.medical.procedures.random.randint", return_value=1)
     def test_failure_seeds_infection_but_still_closes(self, _r):
         # Per design: botched suture closes but seeds infection.  The


### PR DESCRIPTION
Three wired pieces closing the post-amputation suture gap:

1. **`_stump_stage` helper in `wound_descriptions`** — returns `"treated"` if the cut point is in `character.db.sutured_stumps`, else `"fresh"`. Both synthesis points (head cluster + limb chain) call it instead of hardcoding `"old"` (which was the corpse contract leaking onto the live-body path).
2. **`_resolve_suture` extension** — after closing an incision, walks organs at the closed location; if any are `wound_stage="severed"`, records the location in `db.sutured_stumps`. Conservative — normal surgical incisions (intact organs) leave the list alone.
3. **`severed.py` prose** — replaced single-line stub aliases for `treated` / `healing` / `scarred` with 4 variants each. Stage docstrings clarify which side of the pipeline (live body / corpse / future progression tick) each stage represents.

Drop-in plug for the time-based progression tick later — when `sutured_stumps` grows from a membership set to a per-location stage value, only `_stump_stage` changes; the synthesis call sites stay the same.

Coverage: 4 new tests across stump rendering / suture wiring, 4 more pinning severed.py multi-variant coverage.

Suite: 2054/2054.

Refs #307.