### PR TITLE
suture: picker + runtime find stumps even without an open incision

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -501,6 +501,37 @@ def _list_open_incisions(target):
         return []
 
 
+def _list_severed_locations(target):
+    """Return every container on ``target`` carrying a severed organ.
+
+    Direct read off the live medical state — catches stumps the chart
+    can't infer from pending steps (combat-driven amputation, prior
+    surgical amputation whose chart step is no longer ``PENDING``,
+    or any other path that bypasses chart authoring entirely).
+    Already-sutured stumps are filtered out so the picker doesn't
+    re-offer them.
+    """
+    state = getattr(target, "medical_state", None)
+    if state is None or not hasattr(state, "organs"):
+        return []
+    already_sutured = set(
+        getattr(getattr(target, "db", None), "sutured_stumps", None) or ()
+    )
+    seen = set()
+    out = []
+    for organ in state.organs.values():
+        if getattr(organ, "wound_stage", None) != "severed":
+            continue
+        container = getattr(organ, "container", None)
+        if not container or container in seen:
+            continue
+        if container in already_sutured:
+            continue
+        seen.add(container)
+        out.append(container)
+    return out
+
+
 def _list_planned_incisions(caller):
     """Return locations slated to have an open wound after pending
     chart steps fire.
@@ -828,7 +859,8 @@ def _node_suture_location(caller, raw_string, **kwargs):
     target = caller.ndb._operate_target
     open_locs = set(_list_open_incisions(target))
     planned_locs = set(_list_planned_incisions(caller))
-    all_locs = sorted(open_locs | planned_locs)
+    stump_locs = set(_list_severed_locations(target))
+    all_locs = sorted(open_locs | planned_locs | stump_locs)
     if not all_locs:
         text = (
             "\n|wSuture|n\n\n"
@@ -844,18 +876,22 @@ def _node_suture_location(caller, raw_string, **kwargs):
         return text, options
 
     # Label each entry with its source so the surgeon can see at
-    # a glance which are live state vs planned-by-chart.
+    # a glance which are live state vs planned-by-chart vs already-
+    # severed (combat or prior procedure).
     options_list = [
-        (f"|wall|n  {MUTED}(open + planned)|n", "all open incisions"),
+        (f"|wall|n  {MUTED}(open + planned + stumps)|n",
+         "all open incisions"),
     ]
     for loc in all_locs:
         humanized = loc.replace("_", " ")
-        if loc in open_locs and loc in planned_locs:
-            tag = f"{MUTED}(open + planned)|n"
-        elif loc in open_locs:
-            tag = f"{MUTED}(open)|n"
-        else:
-            tag = f"{MUTED}(planned)|n"
+        tags = []
+        if loc in open_locs:
+            tags.append("open")
+        if loc in planned_locs:
+            tags.append("planned")
+        if loc in stump_locs:
+            tags.append("stump")
+        tag = f"{MUTED}({' + '.join(tags)})|n"
         options_list.append((f"{humanized}  {tag}", loc))
 
     caller.ndb._operate_pickable = options_list

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -820,10 +820,38 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
     result = roll_procedure(actor, target)
     outcome = result["outcome"]
 
+    # Build the set of un-sutured stump containers so the verb can
+    # progress stump prose even when no open incision exists at the
+    # location.  Covers combat-driven amputation (which bypasses the
+    # ``open_incision`` call in ``_resolve_amputate``) and any
+    # already-amputated state the chart can't infer from pending
+    # steps.  Already-sutured stumps are filtered out so the verb
+    # doesn't claim to suture them twice.
+    state_for_stumps = getattr(target, "medical_state", None)
+    already_sutured = set(
+        getattr(target.db, "sutured_stumps", None) or ()
+    )
+    untreated_stumps = set()
+    if state_for_stumps is not None and hasattr(state_for_stumps, "organs"):
+        for organ in state_for_stumps.organs.values():
+            if getattr(organ, "wound_stage", None) != "severed":
+                continue
+            container = getattr(organ, "container", None)
+            if container and container not in already_sutured:
+                untreated_stumps.add(container)
+
     if location is None:
-        closed = close_all_incisions(target)
+        closed_incisions = close_all_incisions(target)
+        # Stumps without open incisions still get the suture
+        # treatment — they don't contribute to ``closed_incisions``
+        # but they DO need a row of stitches.
+        closed = sorted(set(closed_incisions) | untreated_stumps)
     else:
-        closed = [location] if close_incision(target, location) else []
+        opened_then_closed = close_incision(target, location)
+        if opened_then_closed or location in untreated_stumps:
+            closed = [location]
+        else:
+            closed = []
 
     if not closed:
         actor.msg(

--- a/world/tests/test_operate_charts.py
+++ b/world/tests/test_operate_charts.py
@@ -755,3 +755,72 @@ class InterruptMarksRunningStepFailed(TestCase):
         }
         # No chart on target — should no-op cleanly.
         interrupt_procedure(target, reason="combat")
+
+
+# ===================================================================
+# Suture picker: severed-organ inference
+# ===================================================================
+
+
+class _FakeOrgan:
+    def __init__(self, container, *, wound_stage=None):
+        self.container = container
+        self.wound_stage = wound_stage
+
+
+class _FakeMedical:
+    def __init__(self, organs):
+        self.organs = organs
+
+
+class ListSeveredLocations(TestCase):
+    """``_list_severed_locations`` is the third source feeding the
+    suture picker.  Without it, combat-driven amputation (which
+    doesn't go through ``_resolve_amputate``'s ``open_incision`` call)
+    leaves the picker showing nothing to suture even though the body
+    clearly has stumps."""
+
+    def _target(self, organs, sutured_stumps=None):
+        target = SimpleNamespace()
+        target.medical_state = _FakeMedical(organs)
+        target.db = SimpleNamespace(sutured_stumps=sutured_stumps)
+        return target
+
+    def test_finds_severed_organ_containers(self):
+        from commands.CmdOperate import _list_severed_locations
+        target = self._target({
+            "left_humerus": _FakeOrgan("left_arm", wound_stage="severed"),
+            "heart": _FakeOrgan("chest"),  # intact, no stage
+        })
+        self.assertEqual(_list_severed_locations(target), ["left_arm"])
+
+    def test_dedups_multi_organ_chains(self):
+        # Multiple severed organs in the same container yield one entry.
+        from commands.CmdOperate import _list_severed_locations
+        target = self._target({
+            "brain": _FakeOrgan("head", wound_stage="severed"),
+            "left_eye": _FakeOrgan("head", wound_stage="severed"),
+            "right_eye": _FakeOrgan("head", wound_stage="severed"),
+        })
+        self.assertEqual(_list_severed_locations(target), ["head"])
+
+    def test_filters_already_sutured_stumps(self):
+        # A stump that's been sutured shouldn't re-appear in the
+        # picker; the surgeon already treated it.
+        from commands.CmdOperate import _list_severed_locations
+        target = self._target(
+            {"left_humerus": _FakeOrgan("left_arm", wound_stage="severed")},
+            sutured_stumps=["left_arm"],
+        )
+        self.assertEqual(_list_severed_locations(target), [])
+
+    def test_empty_when_no_severed_organs(self):
+        from commands.CmdOperate import _list_severed_locations
+        target = self._target({"heart": _FakeOrgan("chest")})
+        self.assertEqual(_list_severed_locations(target), [])
+
+    def test_handles_missing_medical_state(self):
+        from commands.CmdOperate import _list_severed_locations
+        target = SimpleNamespace(medical_state=None,
+                                 db=SimpleNamespace(sutured_stumps=None))
+        self.assertEqual(_list_severed_locations(target), [])

--- a/world/tests/test_surgical_procedures.py
+++ b/world/tests/test_surgical_procedures.py
@@ -711,6 +711,35 @@ class ResolveSuture(TestCase):
         self.assertIn("left_arm", sutured)
 
     @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_suture_all_treats_unincised_stumps(self, _r):
+        # Combat-driven amputation bypasses the ``open_incision`` call
+        # that ``_resolve_amputate`` makes — so the body carries
+        # severed organs with no surgical state to match.  The verb
+        # must still treat those stumps when ``suture all`` is run,
+        # not bail with "nothing to suture."
+        from world.medical.procedures import _resolve_suture
+        # Mark left_arm organs severed but DON'T open an incision.
+        for organ in self.target.medical_state.organs.values():
+            if organ.container == "left_arm":
+                organ.current_hp = 0
+                organ.wound_stage = "severed"
+        _resolve_suture(self.actor, self.target)  # location=None
+        sutured = self.target.db.sutured_stumps or []
+        self.assertIn("left_arm", sutured)
+
+    @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_suture_specific_unincised_stump_treats_it(self, _r):
+        # Same scenario but the surgeon names the stump explicitly.
+        from world.medical.procedures import _resolve_suture
+        for organ in self.target.medical_state.organs.values():
+            if organ.container == "left_arm":
+                organ.current_hp = 0
+                organ.wound_stage = "severed"
+        _resolve_suture(self.actor, self.target, location="left_arm")
+        sutured = self.target.db.sutured_stumps or []
+        self.assertIn("left_arm", sutured)
+
+    @patch("world.medical.procedures.random.randint", return_value=6)
     def test_suture_at_unsevered_location_does_not_mark_stump(self, _r):
         # Closing an incision at a location with intact organs (the
         # normal surgical case — opened for harvest / install) must


### PR DESCRIPTION
**Playtest:** suture picker showed nothing after amputation; `suture all` claimed the same. User reported "the amputation point isn't listed as a suture option in the chart."

**Root cause:** picker + runtime both consulted only `open_incisions` (procedure path's `open_incision()` call) and `planned_incisions` (PENDING chart steps). Combat-driven amputation (`ArmorMixin.take_damage` → `apply_sever_to_character`) doesn't call `open_incision`; chart steps drop from `planned` once they transition to `DONE`. Either gap leaves the picker empty even when the body obviously has a stump.

**Truth source:** the medical state itself — after `sever_character_body`, every chain organ sits at `wound_stage="severed"`. Reading that gives the real set of stumps regardless of path.

**Fix:**
- New `_list_severed_locations(target)` helper — returns severed-organ containers, filtered against `db.sutured_stumps` so already-treated stumps don't re-appear.
- `_node_suture_location` consults it as a third source alongside open + planned. Tags union-style: `(open + stump)`, `(stump)`, etc.
- `_resolve_suture` builds the same untreated-stumps set. `suture all` closes incisions AND treats every untreated stump; specific-location suture treats a stump even with no open incision.

Coverage: picker dedup / sutured-filter / no-state-safety + runtime suture-all-on-unincised-stumps + specific-location stump treatment.

Suite: 2061/2061.

Refs #307.