### PR TITLE
operate <mob> finds the body, not its severed parts

### DIFF
--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -98,9 +98,34 @@ def _resolve_target(caller, raw_name):
         return caller
 
     # Stage 1 — identity pipeline (only path to character targets).
+    #
+    # Detached body parts (``SeveredHead``, ``Appendage``) participate in
+    # identity for forensic chain / autopsy purposes — they have a
+    # ``get_sdesc`` and carry an ``apparent_uid_at_death``.  But surgical
+    # commands target whole-body patients, not detached parts.  When
+    # both a body and its severed head are in the room (e.g.
+    # ``operate 1st rat`` after decapitation), the ordinal pick from
+    # the identity match would silently land on whichever the room
+    # iteration orders first — usually the head, since severed parts
+    # spawn after the body.  Filtering detached parts out at this
+    # stage means the identity matcher's candidate set only contains
+    # whole-body patients, so the ordinal picks among them
+    # unambiguously and detached parts route through stages 2/3 (where
+    # ``autopsy`` / ``sever`` / ``harvest`` find them).
     from commands._identity_targeting import resolve_character_target
+    from typeclasses.items import Appendage  # base for SeveredHead too
+    location = caller.location
+    if location is not None:
+        whole_body_candidates = [
+            obj for obj in location.contents
+            if not isinstance(obj, Appendage)
+        ]
+    else:
+        whole_body_candidates = None
     identity_match = resolve_character_target(
-        caller, raw_name, allow_self=False,
+        caller, raw_name,
+        candidates=whole_body_candidates,
+        allow_self=False,
     )
     if identity_match is not None:
         return identity_match

--- a/world/search.py
+++ b/world/search.py
@@ -202,10 +202,19 @@ def _match_sdesc(target: object, query: str) -> bool:
     query_lower = query.lower()
     sdesc_lower = sdesc.lower()
 
-    # If sdesc is just the key (NPC fallback), allow prefix matching
+    # NPC fallback (sdesc defaults to key): try prefix first — covers
+    # "tom" → "Tom Hanks".  Fall through to the word-boundary check
+    # below if prefix doesn't fire, so "rat" still matches a mob
+    # whose key is "a scrawny ragged rat" (the leading article on
+    # the key would otherwise defeat the prefix path).  Before this
+    # fall-through the NPC-fallback path early-returned False on a
+    # prefix miss, so identity-based commands like ``operate rat``
+    # silently couldn't reach mobs whose sdesc/key starts with an
+    # article — even though the body was clearly in the room.
     target_key = getattr(target, "key", "")
     if sdesc == target_key:
-        return target_key.lower().startswith(query_lower)
+        if target_key.lower().startswith(query_lower):
+            return True
 
     # Word-boundary match: every word in the query must appear as a
     # complete word in the sdesc.

--- a/world/tests/test_identity_search.py
+++ b/world/tests/test_identity_search.py
@@ -396,6 +396,30 @@ class TestIdentityMatchCharacters(TestCase):
         # get_sdesc() returns self.key when height/build missing
         self.assertEqual(result, [npc])
 
+    def test_npc_fallback_falls_through_to_word_boundary(self):
+        # Spawned mobs (rats, etc.) get a key like "a scrawny ragged rat"
+        # with no explicit sdesc — so ``get_sdesc()`` returns the key.
+        # Players type "rat" to target them; the NPC-fallback prefix
+        # path ("rat" vs. "a scrawny...") doesn't fire, so the matcher
+        # must continue to the word-boundary check.  Without that
+        # fall-through, identity-based commands like ``operate rat``
+        # silently failed to find mobs whose keys start with an
+        # article, and surgical resolvers fell through to the
+        # room-search stage which returned a severed limb or head
+        # item instead — that's how decapitation-recovery surgery
+        # ended up targeting the wrong thing.
+        rat = _make_character(
+            key="a scrawny ragged rat",
+            height=None,
+            build=None,
+            sleeve_uid="uid-rat",
+        )
+        candidates = [self.searcher, rat]
+        result = identity_match_characters(
+            self.searcher, "rat", candidates,
+        )
+        self.assertEqual(result, [rat])
+
     def test_match_droog_keyword(self):
         """Setting-specific keyword 'droog' matches Viktor."""
         result = identity_match_characters(


### PR DESCRIPTION
**Playtest:** after decapitating a rat, `operate 1st rat` opened the menu on the severed *head* item instead of the body. `suture all` then had nothing to suture (the body had the open incision, not the head) and the picker empty-branched.

**Two root causes, two fixes:**

**(1) `_match_sdesc` NPC-fallback was prefix-only.** When `sdesc == key` (spawned mobs with no explicit sdesc), the matcher early-returned on a prefix mismatch. `"rat"` doesn't prefix-match `"a scrawny ragged rat"` because the key starts with an article — so identity-based commands silently couldn't reach mobs whose keys begin with `a`/`an`/`the`. Fixed by letting the fallback fall through to word-boundary matching below.

Pre-decapitation this never surfaced — only one rat-shaped thing in the room, so the stage-3 room-search fallback returned the body anyway. Decapitation adds a second match (the severed head item, different shape — `key="rat head"`, no `get_sdesc`), revealing the gap.

**(2) `_resolve_target` stage-1 candidate set now excludes detached parts.** Belt-and-suspenders: `Appendage` / `SeveredHead` participate in the identity surface (forensic chain). Surgery targets whole-body patients only. Filtering them out at candidate construction ensures the identity matcher never has detached parts to compete with the body — the ordinal pick lands on the body unambiguously. Detached parts continue routing through stages 2/3 where `autopsy` / `sever` / `harvest` find them.

New test pins the rat-key word-boundary path.

Suite: 2062/2062.

Refs #307.