### PR TITLE
suture: collapse cluster + chain in picker; outcome flavours stump prose

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -501,35 +501,87 @@ def _list_open_incisions(target):
         return []
 
 
-def _list_severed_locations(target):
-    """Return every container on ``target`` carrying a severed organ.
+def _sutured_stump_locations(target):
+    """Return the location set already recorded in ``sutured_stumps``.
 
-    Direct read off the live medical state — catches stumps the chart
-    can't infer from pending steps (combat-driven amputation, prior
-    surgical amputation whose chart step is no longer ``PENDING``,
-    or any other path that bypasses chart authoring entirely).
-    Already-sutured stumps are filtered out so the picker doesn't
-    re-offer them.
+    Backward-compat shim — accepts the legacy list shape
+    (``["head", "left_arm"]``) and the current dict shape
+    (``{"head": "success", "left_arm": "partial"}``).  The dict is
+    keyed by cut-point location; the value is the suture roll outcome
+    so the renderer can pick an outcome-flavoured variant.
+    """
+    raw = getattr(getattr(target, "db", None), "sutured_stumps", None) or ()
+    if hasattr(raw, "keys"):
+        return set(raw.keys())
+    return set(raw)
+
+
+def _list_severed_locations(target):
+    """Return the *cut-point* containers carrying a severed organ.
+
+    Mirrors the cluster + chain collapse rules the wound renderer
+    (``get_character_wounds``) applies so the picker presents one
+    entry per severance, not one per organ:
+
+    * Head-cluster collapse — every cluster peer (face / neck / eyes /
+      ears / hair-or-fur / snout, species-dependent) rolls up into a
+      single ``head`` entry when the head was severed.  Otherwise a
+      decapitation reads as ``head (stump)`` *plus* ``neck (stump)``
+      from the cervical spine, confusing what's actually one wound.
+    * Limb-chain cut-point — when a downstream container's parent
+      (per species ``limb_parent``) is also severed, only the chain
+      root is offered.  Thigh amputation reads as ``left_thigh``,
+      not ``left_thigh`` + ``left_shin`` + ``left_foot``.
+
+    Already-sutured stumps are filtered out — the picker offers them
+    again only when the medical state knows they're still raw.
     """
     state = getattr(target, "medical_state", None)
     if state is None or not hasattr(state, "organs"):
         return []
-    already_sutured = set(
-        getattr(getattr(target, "db", None), "sutured_stumps", None) or ()
-    )
+
+    severed_containers = set()
+    for organ in state.organs.values():
+        if (getattr(organ, "wound_stage", None) == "severed"
+                and getattr(organ, "current_hp", 0) <= 0):
+            container = getattr(organ, "container", None)
+            if container:
+                severed_containers.add(container)
+    if not severed_containers:
+        return []
+
+    species = getattr(getattr(target, "db", None), "species", None)
+
+    head_cluster = frozenset()
+    if "head" in severed_containers:
+        try:
+            from world.anatomy import get_species_severed_head_locations
+            head_cluster = get_species_severed_head_locations(species)
+        except ImportError:
+            pass
+
+    try:
+        from world.anatomy import get_species_limb_parent
+        limb_parent = get_species_limb_parent(species)
+    except ImportError:
+        limb_parent = {}
+
+    already_sutured = _sutured_stump_locations(target)
     seen = set()
     out = []
-    for organ in state.organs.values():
-        if getattr(organ, "wound_stage", None) != "severed":
+    for container in severed_containers:
+        # Head-cluster collapse: keep only the ``head`` cut point.
+        if head_cluster and container in head_cluster and container != "head":
             continue
-        container = getattr(organ, "container", None)
-        if not container or container in seen:
+        # Limb-chain cut-point: skip downstream containers.
+        parent = limb_parent.get(container)
+        if parent and parent in severed_containers:
             continue
-        if container in already_sutured:
+        if container in already_sutured or container in seen:
             continue
         seen.add(container)
         out.append(container)
-    return out
+    return sorted(out)
 
 
 def _list_planned_incisions(caller):

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -820,25 +820,60 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
     result = roll_procedure(actor, target)
     outcome = result["outcome"]
 
-    # Build the set of un-sutured stump containers so the verb can
+    # Build the set of un-sutured stump *cut points* so the verb can
     # progress stump prose even when no open incision exists at the
     # location.  Covers combat-driven amputation (which bypasses the
     # ``open_incision`` call in ``_resolve_amputate``) and any
     # already-amputated state the chart can't infer from pending
     # steps.  Already-sutured stumps are filtered out so the verb
     # doesn't claim to suture them twice.
+    #
+    # Cluster + chain collapse mirrors the picker
+    # (``_list_severed_locations``) and the wound renderer
+    # (``get_character_wounds``) — one cut point per severance, not
+    # one per chain organ.  Without this, ``suture all`` after a
+    # decapitation would record both ``head`` and ``neck`` into
+    # ``sutured_stumps``, and a leg amputation would record the
+    # thigh + shin + foot triple.
     state_for_stumps = getattr(target, "medical_state", None)
-    already_sutured = set(
-        getattr(target.db, "sutured_stumps", None) or ()
-    )
-    untreated_stumps = set()
+    sutured_raw = getattr(target.db, "sutured_stumps", None) or ()
+    if hasattr(sutured_raw, "keys"):
+        already_sutured = set(sutured_raw.keys())
+    else:
+        already_sutured = set(sutured_raw)
+    severed_containers = set()
     if state_for_stumps is not None and hasattr(state_for_stumps, "organs"):
         for organ in state_for_stumps.organs.values():
             if getattr(organ, "wound_stage", None) != "severed":
                 continue
             container = getattr(organ, "container", None)
-            if container and container not in already_sutured:
-                untreated_stumps.add(container)
+            if container:
+                severed_containers.add(container)
+
+    species = getattr(target.db, "species", None)
+    head_cluster = frozenset()
+    if "head" in severed_containers:
+        try:
+            from world.anatomy import get_species_severed_head_locations
+            head_cluster = get_species_severed_head_locations(species)
+        except ImportError:
+            pass
+    try:
+        from world.anatomy import get_species_limb_parent
+        limb_parent = get_species_limb_parent(species)
+    except ImportError:
+        limb_parent = {}
+
+    untreated_stumps = set()
+    for container in severed_containers:
+        if head_cluster and container in head_cluster and container != "head":
+            continue
+        parent = limb_parent.get(container)
+        if parent and parent in severed_containers:
+            continue
+        if container in already_sutured:
+            continue
+        untreated_stumps.add(container)
 
     if location is None:
         closed_incisions = close_all_incisions(target)
@@ -873,9 +908,18 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
     # "treated" once this fires.
     state = getattr(target, "medical_state", None)
     if state is not None and hasattr(state, "organs"):
-        sutured = list(
-            getattr(target.db, "sutured_stumps", None) or ()
-        )
+        # Normalise the storage to dict-shape so legacy list-shaped
+        # values from earlier PRs still load cleanly.  Unknown
+        # outcomes from the legacy path are imported as ``"success"``
+        # — a benign default that picks the cleanest variant subset.
+        raw = getattr(target.db, "sutured_stumps", None)
+        if raw is None:
+            sutured = {}
+        elif hasattr(raw, "keys"):
+            sutured = dict(raw)
+        else:
+            sutured = {loc: "success" for loc in raw}
+
         sutured_dirty = False
         for loc in closed:
             stump_at_loc = False
@@ -893,8 +937,17 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
                 # matches the closed incision marks this as a stump.
                 if getattr(organ, "wound_stage", None) == "severed":
                     stump_at_loc = True
+            # Stump detection AT THIS LOCATION also catches the
+            # cut-point case where ``loc`` itself is the severed
+            # container but no organ's display surface matches it
+            # directly (cluster collapse — ``loc="head"`` while the
+            # organs route through ``display_location`` like
+            # "left_eye").  Falls back to membership in the
+            # untreated_stumps set computed above.
+            if not stump_at_loc and loc in untreated_stumps:
+                stump_at_loc = True
             if stump_at_loc and loc not in sutured:
-                sutured.append(loc)
+                sutured[loc] = outcome
                 sutured_dirty = True
         if sutured_dirty:
             target.db.sutured_stumps = sutured

--- a/world/medical/wounds/messages/severed.py
+++ b/world/medical/wounds/messages/severed.py
@@ -9,19 +9,29 @@ on a freshly-amputated body routes through this module so the live
 view and the eventual corpse view share prose.
 
 Stages:
-    fresh:   Just cut.  Raw stump.  Default on a living body until
-             the suture verb runs, and on a fresh corpse spawned by
-             :func:`commands.forensics._apply_sever_to_corpse`.
-    treated: Recently sutured.  Bandaged stump, stitches visible.
-             Lives only on a living body — transitioned from ``fresh``
-             by ``_resolve_suture`` via ``character.db.sutured_stumps``.
-    healing: Sutures dissolving, new tissue knitting over.  Future
-             use — slotted for the time-based progression tick.
-    scarred: Long-healed.  Future use — terminal stage of progression.
-    old:     Corpse-preserved variant.  Frozen at death.  Renders the
-             dried / desiccated stump on long-dead corpses.
-    destroyed: Catastrophic mangling (e.g. blast amputation that
-             didn't leave a clean cut).
+    fresh:             Just cut.  Raw stump.  Default on a living
+                       body until the suture verb runs, and on a
+                       fresh corpse spawned by
+                       :func:`commands.forensics._apply_sever_to_corpse`.
+    treated_success:   Sutured cleanly.  Picked when the roll
+                       outcome was ``"success"``.
+    treated_partial:   Sutured but the seam is rough.  Picked when
+                       the outcome was ``"partial"``.
+    treated_failure:   Botched suture — dirty seam, infection seeded
+                       by ``_resolve_suture``.  Picked when the
+                       outcome was ``"failure"``.
+    treated:           Generic-treated fallback — covers legacy
+                       ``sutured_stumps`` entries stored as a flat
+                       list (no outcome recorded) and any other
+                       caller that lands here without a flavour.
+    healing:           Sutures dissolving, new tissue knitting over.
+                       Stocked now; time-based progression to come.
+    scarred:           Long-healed.  Terminal stage of progression.
+    old:               Corpse-preserved variant.  Frozen at death.
+                       Renders the dried / desiccated stump on
+                       long-dead corpses.
+    destroyed:         Catastrophic mangling (e.g. blast amputation
+                       that didn't leave a clean cut).
 
 All templates expect the ``{location}`` token; the
 ``{skintone}`` / ``{severity}`` / ``{organ}`` / ``{injury_type}``
@@ -44,11 +54,31 @@ WOUND_DESCRIPTIONS = {
         "|rThe {location} is missing — the stump long since congealed and stiff|n",
         "|rA stump marks where the {location} used to be, the wound long dry|n",
     ],
+    "treated_success": [
+        "|rThe {location} stump has been carefully sutured shut, the dressing clean|n",
+        "{skintone}neat rows of stitches close the {location} stump, the bandage still fresh|n",
+        "{skintone}a {severity} sutured stump where the {location} used to be, the cut held closed|n",
+        "{skintone}the {location} stump is bound in clean gauze, the suture line straight and tight|n",
+    ],
+    "treated_partial": [
+        "|rThe {location} stump has been sutured shut, the line of stitches uneven but holding|n",
+        "{skintone}the {location} stump shows a rough seam, the bandage stained but secure|n",
+        "{skintone}a {severity} stump where the {location} once was, the suture line ragged but closed|n",
+        "{skintone}the {location} stump is closed with stitches that wander, the dressing patchy|n",
+    ],
+    "treated_failure": [
+        "|rThe stump where the {location} used to be has been crudely bandaged, the seam pulling dirty|n",
+        "{skintone}the {location} stump is closed with uneven stitches and the dressing is already weeping|n",
+        "{skintone}a {severity} stump at the {location} site, the suture line dirty and the bandage stained|n",
+        "{skintone}the {location} stump has been hastily bound, the wound clearly leaking under the gauze|n",
+    ],
+    # Backward-compat fallback for legacy ``sutured_stumps`` list-shaped
+    # entries (no recorded outcome) — mirrors the success variants
+    # since that's the implicit flavour the older code path produced.
     "treated": [
         "|rThe {location} stump has been carefully sutured shut, the dressing clean|n",
         "{skintone}neat rows of stitches close the {location} stump, the bandage still fresh|n",
         "{skintone}a {severity} sutured stump where the {location} used to be, the cut held closed|n",
-        "|rThe stump where the {location} used to be has been crudely bandaged|n",
     ],
     "healing": [
         "{skintone}the {location} stump shows pink new tissue knitting over the closed wound|n",

--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -191,21 +191,32 @@ def _format_wound_grammar(description):
 def _stump_stage(character, location: str) -> str:
     """Return the renderer stage for a severance cut point.
 
-    Today this is binary: ``"treated"`` if the cut point has been
-    sutured (recorded in ``character.db.sutured_stumps``), else
-    ``"fresh"``.  The suture verb populates the set after closing an
-    incision at a location whose organs are all severed.
+    Reads ``character.db.sutured_stumps`` and maps the recorded
+    suture outcome (``"success"`` / ``"partial"`` / ``"failure"``)
+    into one of three flavoured stages — ``"treated_success"`` /
+    ``"treated_partial"`` / ``"treated_failure"`` — so the renderer
+    picks variants that match the actual quality of the job.
 
-    Time-based progression past ``treated`` (``"healing"`` /
-    ``"scarred"``) is future work — when the per-cut-point stage
-    store grows from a flat membership set to a per-location stage
-    value, the lookup will replace this helper without rippling
-    through the synthesis call sites.
+    Backward-compat: legacy entries stored as a flat list
+    (``["head", "left_arm"]``) treat membership as success — that's
+    the same flavour that was rendered before outcome propagation
+    landed.
+
+    No record at all → ``"fresh"`` (raw stump prose).
     """
-    sutured = getattr(
+    raw = getattr(
         getattr(character, "db", None), "sutured_stumps", None,
-    ) or ()
-    return "treated" if location in sutured else "fresh"
+    )
+    if raw is None:
+        return "fresh"
+    if hasattr(raw, "get"):
+        outcome = raw.get(location)
+        if outcome is None:
+            return "fresh"
+        if outcome in ("success", "partial", "failure"):
+            return f"treated_{outcome}"
+        return "treated"
+    return "treated" if location in raw else "fresh"
 
 
 def get_character_wounds(character):

--- a/world/tests/test_limb_downstream_chain.py
+++ b/world/tests/test_limb_downstream_chain.py
@@ -501,8 +501,10 @@ class CutPointFilterTests(TestCase):
     def test_stump_renders_treated_when_sutured(self):
         # Once the cut point is recorded in ``db.sutured_stumps`` (by
         # ``_resolve_suture`` closing an incision at a severance
-        # location), the renderer transitions to stage="treated" so
-        # severed.py's bandaged-stump prose fires instead.
+        # location), the renderer transitions to a treated-flavoured
+        # stage so severed.py's bandaged-stump prose fires instead.
+        # Legacy list shape → generic ``"treated"`` (the success
+        # variant subset, preserving prior renderer behaviour).
         from world.medical.wounds import get_character_wounds
 
         char = self._char_with_severed_chain()
@@ -510,6 +512,25 @@ class CutPointFilterTests(TestCase):
         wounds = get_character_wounds(char)
         shin_wounds = [w for w in wounds if w["location"] == "left_shin"]
         self.assertEqual(shin_wounds[0]["stage"], "treated")
+
+    def test_stump_outcome_routes_to_flavoured_stage(self):
+        # Dict-shape ``sutured_stumps`` records the suture outcome;
+        # the renderer picks an outcome-flavoured subgroup so a
+        # successful close reads clean, a partial close reads rough,
+        # and a botched close reads dirty.  Same prose module routes
+        # through different stage keys in severed.py.
+        from world.medical.wounds import get_character_wounds
+
+        for outcome in ("success", "partial", "failure"):
+            with self.subTest(outcome=outcome):
+                char = self._char_with_severed_chain()
+                char.db.sutured_stumps = {"left_shin": outcome}
+                wounds = get_character_wounds(char)
+                shin_wounds = [w for w in wounds
+                               if w["location"] == "left_shin"]
+                self.assertEqual(
+                    shin_wounds[0]["stage"], f"treated_{outcome}",
+                )
 
     def test_solo_foot_sever_still_renders(self):
         # If only the foot is severed (foot directly cut, not as

--- a/world/tests/test_operate_charts.py
+++ b/world/tests/test_operate_charts.py
@@ -763,9 +763,14 @@ class InterruptMarksRunningStepFailed(TestCase):
 
 
 class _FakeOrgan:
-    def __init__(self, container, *, wound_stage=None):
+    def __init__(self, container, *, wound_stage=None, current_hp=0):
         self.container = container
         self.wound_stage = wound_stage
+        # ``_list_severed_locations`` gates on ``current_hp <= 0``
+        # for severed-stage organs (matches the wound renderer's
+        # gate in ``get_character_wounds``).  Default zero so the
+        # fixture lines up with the "severed and gone" shape.
+        self.current_hp = current_hp
 
 
 class _FakeMedical:
@@ -813,6 +818,57 @@ class ListSeveredLocations(TestCase):
             sutured_stumps=["left_arm"],
         )
         self.assertEqual(_list_severed_locations(target), [])
+
+    def test_dict_shape_sutured_stumps_also_filtered(self):
+        # ``sutured_stumps`` is dict-shaped after PR-outcomes —
+        # ``{location: outcome}``.  The picker honours that too.
+        from commands.CmdOperate import _list_severed_locations
+        target = self._target(
+            {"left_humerus": _FakeOrgan("left_arm", wound_stage="severed")},
+            sutured_stumps={"left_arm": "success"},
+        )
+        self.assertEqual(_list_severed_locations(target), [])
+
+    def test_head_cluster_collapses_to_head_only(self):
+        # Decapitation: brain (container=head) AND cervical_spine
+        # (container=neck) both flagged severed.  The picker should
+        # show ONE entry — "head" — not head + neck.  Mirrors the
+        # wound renderer's head-cluster collapse (PR #421) so the
+        # surgeon doesn't see "neck (stump)" as a second option for
+        # what is anatomically one wound.
+        from commands.CmdOperate import _list_severed_locations
+        target = self._target(
+            {
+                "brain": _FakeOrgan("head", wound_stage="severed"),
+                "cervical_spine": _FakeOrgan("neck", wound_stage="severed"),
+                "left_eye": _FakeOrgan("head", wound_stage="severed"),
+            },
+        )
+        # _target() defaults species to None; explicitly set human
+        # so get_species_severed_head_locations resolves.
+        target.db.species = "human"
+        # Spell-out: brain triggers head_cluster_collapsed, neck is
+        # a cluster peer and gets suppressed.
+        self.assertEqual(_list_severed_locations(target), ["head"])
+
+    def test_limb_chain_collapses_to_root(self):
+        # Thigh amputation: chain organs at thigh + shin + foot all
+        # severed.  Picker shows ONE entry at the chain root
+        # (left_thigh) — same cut-point rule the wound renderer
+        # applies via LIMB_PARENT.
+        from commands.CmdOperate import _list_severed_locations
+        target = self._target(
+            {
+                "left_femur": _FakeOrgan("left_thigh",
+                                          wound_stage="severed"),
+                "left_tibia": _FakeOrgan("left_shin",
+                                          wound_stage="severed"),
+                "left_metatarsals": _FakeOrgan("left_foot",
+                                                wound_stage="severed"),
+            },
+        )
+        target.db.species = "human"
+        self.assertEqual(_list_severed_locations(target), ["left_thigh"])
 
     def test_empty_when_no_severed_organs(self):
         from commands.CmdOperate import _list_severed_locations

--- a/world/tests/test_severed_prose.py
+++ b/world/tests/test_severed_prose.py
@@ -107,6 +107,27 @@ class SeveredStumpProgressionStagesTests(TestCase):
                 with self.subTest(stage=stage, template=template):
                     self.assertIn("{location}", template)
 
+    def test_treated_outcome_subgroups_present(self):
+        # Suture roll outcome (``success`` / ``partial`` /
+        # ``failure``) routes the renderer into an outcome-flavoured
+        # subgroup so the prose matches the actual quality of the
+        # job.  Each subgroup needs at least a couple of variants so
+        # multiple amputations don't read identically.
+        for subgroup in ("treated_success", "treated_partial",
+                         "treated_failure"):
+            with self.subTest(subgroup=subgroup):
+                self.assertIn(subgroup, self.descriptions)
+                self.assertGreaterEqual(
+                    len(self.descriptions[subgroup]), 3,
+                )
+
+    def test_treated_subgroups_reference_location(self):
+        for subgroup in ("treated_success", "treated_partial",
+                         "treated_failure"):
+            for template in self.descriptions[subgroup]:
+                with self.subTest(subgroup=subgroup, template=template):
+                    self.assertIn("{location}", template)
+
 
 class LacerationFileTests(TestCase):
     """The laceration injury type now has its own wound-message file."""

--- a/world/tests/test_surgical_procedures.py
+++ b/world/tests/test_surgical_procedures.py
@@ -707,8 +707,58 @@ class ResolveSuture(TestCase):
                 organ.wound_stage = "severed"
         open_incision(self.target, "left_arm", surgeon=self.actor)
         _resolve_suture(self.actor, self.target, location="left_arm")
-        sutured = self.target.db.sutured_stumps or []
+        sutured = self.target.db.sutured_stumps or {}
         self.assertIn("left_arm", sutured)
+
+    @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_suture_records_outcome_in_sutured_stumps(self, _r):
+        # Records are dict-shaped: ``{location: outcome}`` so the
+        # renderer can pick an outcome-flavoured variant subset.
+        # A success roll → ``"success"`` recorded.
+        from world.medical.procedures import _resolve_suture
+        for organ in self.target.medical_state.organs.values():
+            if organ.container == "left_arm":
+                organ.current_hp = 0
+                organ.wound_stage = "severed"
+        open_incision(self.target, "left_arm", surgeon=self.actor)
+        _resolve_suture(self.actor, self.target, location="left_arm")
+        sutured = self.target.db.sutured_stumps
+        self.assertEqual(sutured.get("left_arm"), "success")
+
+    @patch("world.medical.procedures.random.randint", return_value=1)
+    def test_suture_failure_records_failure_outcome(self, _r):
+        # A botched suture still closes the wound (per design) but
+        # the outcome lands as ``"failure"`` so the renderer picks
+        # the dirty-seam variant subset.
+        from world.medical.procedures import _resolve_suture
+        for organ in self.target.medical_state.organs.values():
+            if organ.container == "left_arm":
+                organ.current_hp = 0
+                organ.wound_stage = "severed"
+        open_incision(self.target, "left_arm", surgeon=self.actor)
+        _resolve_suture(self.actor, self.target, location="left_arm")
+        sutured = self.target.db.sutured_stumps
+        self.assertEqual(sutured.get("left_arm"), "failure")
+
+    @patch("world.medical.procedures.random.randint", return_value=6)
+    def test_legacy_list_sutured_stumps_migrated_to_dict(self, _r):
+        # Earlier PR shipped a flat list of locations.  Reads must
+        # still load it; writes upgrade to the dict shape so future
+        # reads see the new schema.  Legacy entries get ``"success"``
+        # as their outcome — matches the implicit flavour the older
+        # renderer picked.
+        from world.medical.procedures import _resolve_suture
+        self.target.db.sutured_stumps = ["right_arm"]  # legacy shape
+        for organ in self.target.medical_state.organs.values():
+            if organ.container == "left_arm":
+                organ.current_hp = 0
+                organ.wound_stage = "severed"
+        open_incision(self.target, "left_arm", surgeon=self.actor)
+        _resolve_suture(self.actor, self.target, location="left_arm")
+        sutured = self.target.db.sutured_stumps
+        self.assertTrue(hasattr(sutured, "keys"))
+        self.assertEqual(sutured.get("right_arm"), "success")  # migrated
+        self.assertEqual(sutured.get("left_arm"), "success")  # new
 
     @patch("world.medical.procedures.random.randint", return_value=6)
     def test_suture_all_treats_unincised_stumps(self, _r):


### PR DESCRIPTION
Two follow-ups from playtest review.

**(1) Picker doesn't double-list cluster peers.** Was enumerating raw `severed_containers` — decapitation surfaced as `head (open + stump)` + `neck (stump)`; thigh amputation as `left_thigh` + `left_shin` + `left_foot`. The wound renderer already collapses these. Now `_list_severed_locations` mirrors that: head-cluster peers fold into `head`, downstream limb containers fold into the chain root. Same logic mirrored into `_resolve_suture`'s `untreated_stumps` so the runtime doesn't double-record either.

**(2) Outcome flavours the stump-prose variant subset.** `treated` stage was a mixed bag — a clean roll could surface 'crudely bandaged'. Schema upgrade: `db.sutured_stumps` grows from a flat list to `{location: outcome}`. `_stump_stage` routes to `treated_success` / `treated_partial` / `treated_failure` subgroups in severed.py (4 variants each, distinct flavour). Failure variants align with the infection seed `_resolve_suture` already drops on bad rolls.

Backward-compat: `_stump_stage` accepts both list and dict shapes; `_resolve_suture` migrates list → dict on write with each legacy entry imported as `success`.

Coverage: 9 new tests, 2071/2071 total. Smoke-tested end-to-end — amputate head → `head (stump)` (single entry) → suture all (success) → `{"head": "success"}` recorded → prose reads `"The head stump has been carefully sutured shut, the dressing clean."`

Refs #307.