### PR TITLE
consolidate: severance cut-points + sutured-stump shape into one module

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -501,87 +501,22 @@ def _list_open_incisions(target):
         return []
 
 
-def _sutured_stump_locations(target):
-    """Return the location set already recorded in ``sutured_stumps``.
-
-    Backward-compat shim — accepts the legacy list shape
-    (``["head", "left_arm"]``) and the current dict shape
-    (``{"head": "success", "left_arm": "partial"}``).  The dict is
-    keyed by cut-point location; the value is the suture roll outcome
-    so the renderer can pick an outcome-flavoured variant.
-    """
-    raw = getattr(getattr(target, "db", None), "sutured_stumps", None) or ()
-    if hasattr(raw, "keys"):
-        return set(raw.keys())
-    return set(raw)
-
-
 def _list_severed_locations(target):
-    """Return the *cut-point* containers carrying a severed organ.
+    """Return un-sutured cut-point containers on ``target``, sorted.
 
-    Mirrors the cluster + chain collapse rules the wound renderer
-    (``get_character_wounds``) applies so the picker presents one
-    entry per severance, not one per organ:
-
-    * Head-cluster collapse — every cluster peer (face / neck / eyes /
-      ears / hair-or-fur / snout, species-dependent) rolls up into a
-      single ``head`` entry when the head was severed.  Otherwise a
-      decapitation reads as ``head (stump)`` *plus* ``neck (stump)``
-      from the cervical spine, confusing what's actually one wound.
-    * Limb-chain cut-point — when a downstream container's parent
-      (per species ``limb_parent``) is also severed, only the chain
-      root is offered.  Thigh amputation reads as ``left_thigh``,
-      not ``left_thigh`` + ``left_shin`` + ``left_foot``.
-
-    Already-sutured stumps are filtered out — the picker offers them
-    again only when the medical state knows they're still raw.
+    Thin wrapper that asks
+    :func:`world.medical.severance.compute_cut_points` for the full
+    cut-point set, subtracts the
+    :func:`world.medical.severance.normalize_sutured_stumps` keys, and
+    returns the remainder sorted.  Both helpers are the single source
+    of truth used by the wound renderer and the runtime suture verb
+    so the picker shows exactly what's actually un-treated.
     """
-    state = getattr(target, "medical_state", None)
-    if state is None or not hasattr(state, "organs"):
-        return []
-
-    severed_containers = set()
-    for organ in state.organs.values():
-        if (getattr(organ, "wound_stage", None) == "severed"
-                and getattr(organ, "current_hp", 0) <= 0):
-            container = getattr(organ, "container", None)
-            if container:
-                severed_containers.add(container)
-    if not severed_containers:
-        return []
-
-    species = getattr(getattr(target, "db", None), "species", None)
-
-    head_cluster = frozenset()
-    if "head" in severed_containers:
-        try:
-            from world.anatomy import get_species_severed_head_locations
-            head_cluster = get_species_severed_head_locations(species)
-        except ImportError:
-            pass
-
-    try:
-        from world.anatomy import get_species_limb_parent
-        limb_parent = get_species_limb_parent(species)
-    except ImportError:
-        limb_parent = {}
-
-    already_sutured = _sutured_stump_locations(target)
-    seen = set()
-    out = []
-    for container in severed_containers:
-        # Head-cluster collapse: keep only the ``head`` cut point.
-        if head_cluster and container in head_cluster and container != "head":
-            continue
-        # Limb-chain cut-point: skip downstream containers.
-        parent = limb_parent.get(container)
-        if parent and parent in severed_containers:
-            continue
-        if container in already_sutured or container in seen:
-            continue
-        seen.add(container)
-        out.append(container)
-    return sorted(out)
+    from world.medical.severance import (
+        compute_cut_points, normalize_sutured_stumps,
+    )
+    already_sutured = set(normalize_sutured_stumps(target))
+    return sorted(compute_cut_points(target) - already_sutured)
 
 
 def _list_planned_incisions(caller):

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -820,60 +820,19 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
     result = roll_procedure(actor, target)
     outcome = result["outcome"]
 
-    # Build the set of un-sutured stump *cut points* so the verb can
-    # progress stump prose even when no open incision exists at the
-    # location.  Covers combat-driven amputation (which bypasses the
-    # ``open_incision`` call in ``_resolve_amputate``) and any
-    # already-amputated state the chart can't infer from pending
-    # steps.  Already-sutured stumps are filtered out so the verb
-    # doesn't claim to suture them twice.
-    #
-    # Cluster + chain collapse mirrors the picker
-    # (``_list_severed_locations``) and the wound renderer
-    # (``get_character_wounds``) — one cut point per severance, not
-    # one per chain organ.  Without this, ``suture all`` after a
-    # decapitation would record both ``head`` and ``neck`` into
-    # ``sutured_stumps``, and a leg amputation would record the
-    # thigh + shin + foot triple.
-    state_for_stumps = getattr(target, "medical_state", None)
-    sutured_raw = getattr(target.db, "sutured_stumps", None) or ()
-    if hasattr(sutured_raw, "keys"):
-        already_sutured = set(sutured_raw.keys())
-    else:
-        already_sutured = set(sutured_raw)
-    severed_containers = set()
-    if state_for_stumps is not None and hasattr(state_for_stumps, "organs"):
-        for organ in state_for_stumps.organs.values():
-            if getattr(organ, "wound_stage", None) != "severed":
-                continue
-            container = getattr(organ, "container", None)
-            if container:
-                severed_containers.add(container)
-
-    species = getattr(target.db, "species", None)
-    head_cluster = frozenset()
-    if "head" in severed_containers:
-        try:
-            from world.anatomy import get_species_severed_head_locations
-            head_cluster = get_species_severed_head_locations(species)
-        except ImportError:
-            pass
-    try:
-        from world.anatomy import get_species_limb_parent
-        limb_parent = get_species_limb_parent(species)
-    except ImportError:
-        limb_parent = {}
-
-    untreated_stumps = set()
-    for container in severed_containers:
-        if head_cluster and container in head_cluster and container != "head":
-            continue
-        parent = limb_parent.get(container)
-        if parent and parent in severed_containers:
-            continue
-        if container in already_sutured:
-            continue
-        untreated_stumps.add(container)
+    # Un-sutured cut points come from ``compute_cut_points`` (one
+    # location per severance, after the head cluster / limb chain
+    # collapse) minus anything already in ``sutured_stumps``.  This
+    # lets the verb progress stump prose even without an open
+    # incision at the location — covers combat-driven amputation
+    # (which bypasses the ``open_incision`` call in
+    # ``_resolve_amputate``) and any prior amputation whose chart
+    # step the picker can't infer from.
+    from world.medical.severance import (
+        compute_cut_points, normalize_sutured_stumps,
+    )
+    sutured = normalize_sutured_stumps(target)
+    untreated_stumps = compute_cut_points(target) - set(sutured)
 
     if location is None:
         closed_incisions = close_all_incisions(target)
@@ -906,23 +865,17 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
     # world.medical.wounds.wound_descriptions) so the synthetic
     # cut-point wound emitted by ``get_character_wounds`` reads
     # "treated" once this fires.
+    # Walk closed locations for two side effects:
+    #   * Harvested-organ wound_stage transitions (fresh → treated)
+    #     so the wound renderer reads as "surgical opening crudely
+    #     bandaged" rather than "still wet and red".
+    #   * Stump recording — anything in ``untreated_stumps`` that
+    #     just got closed lands in ``sutured_stumps`` with the roll
+    #     outcome as its value, so the renderer picks the matching
+    #     flavoured variant subset (success / partial / failure).
     state = getattr(target, "medical_state", None)
     if state is not None and hasattr(state, "organs"):
-        # Normalise the storage to dict-shape so legacy list-shaped
-        # values from earlier PRs still load cleanly.  Unknown
-        # outcomes from the legacy path are imported as ``"success"``
-        # — a benign default that picks the cleanest variant subset.
-        raw = getattr(target.db, "sutured_stumps", None)
-        if raw is None:
-            sutured = {}
-        elif hasattr(raw, "keys"):
-            sutured = dict(raw)
-        else:
-            sutured = {loc: "success" for loc in raw}
-
-        sutured_dirty = False
         for loc in closed:
-            stump_at_loc = False
             for organ in state.organs.values():
                 container = getattr(organ, "container", None)
                 display = getattr(organ, "display_location", None)
@@ -931,26 +884,12 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
                 if getattr(organ, "injury_type", None) == "harvested":
                     if getattr(organ, "wound_stage", None) == "fresh":
                         organ.wound_stage = "treated"
-                # Detect severance: ``sever_character_body`` zeroes
-                # chain organs and sets ``wound_stage="severed"``.
-                # Any such organ whose container / display surface
-                # matches the closed incision marks this as a stump.
-                if getattr(organ, "wound_stage", None) == "severed":
-                    stump_at_loc = True
-            # Stump detection AT THIS LOCATION also catches the
-            # cut-point case where ``loc`` itself is the severed
-            # container but no organ's display surface matches it
-            # directly (cluster collapse — ``loc="head"`` while the
-            # organs route through ``display_location`` like
-            # "left_eye").  Falls back to membership in the
-            # untreated_stumps set computed above.
-            if not stump_at_loc and loc in untreated_stumps:
-                stump_at_loc = True
-            if stump_at_loc and loc not in sutured:
-                sutured[loc] = outcome
-                sutured_dirty = True
-        if sutured_dirty:
-            target.db.sutured_stumps = sutured
+
+    just_treated = set(closed) & untreated_stumps
+    if just_treated:
+        for loc in just_treated:
+            sutured[loc] = outcome
+        target.db.sutured_stumps = sutured
 
     seed_pain(target, closed[0], CONSCIOUS_PAIN_SEVERITY["suture"])
 

--- a/world/medical/severance.py
+++ b/world/medical/severance.py
@@ -1,0 +1,139 @@
+"""Severance helpers — single source of truth for cut-point computation
+and sutured-stump bookkeeping.
+
+The picker (``CmdOperate._list_severed_locations``), the runtime suture
+verb (``_resolve_suture``), and the wound renderer
+(``get_character_wounds``) all need to agree on three things:
+
+1. Which body containers are currently carrying a severed organ.
+2. Which of those containers count as a *cut point* — the canonical
+   single entry per severance, after the head cluster (face / neck /
+   eyes / ears / hair-or-fur / snout) collapses into ``head`` and
+   downstream limb chain pieces collapse into the chain root.
+3. Which cut points have already been sutured, including the legacy
+   list-shaped storage from earlier PRs.
+
+Pre-consolidation each consumer answered these in its own way (three
+copies of the cluster + chain filter, three copies of the
+``hasattr(raw, "keys")`` backward-compat shim).  This module owns the
+answer; the consumers now ask.
+"""
+
+from __future__ import annotations
+
+
+# ---------------------------------------------------------------------
+# Sutured-stump storage shape
+# ---------------------------------------------------------------------
+
+
+def normalize_sutured_stumps(target) -> dict:
+    """Return ``target.db.sutured_stumps`` as a ``{location: outcome}`` dict.
+
+    Two storage shapes ever land here:
+
+    * **Current** — dict keyed by cut-point location, valued by the
+      suture-roll outcome (``"success"`` / ``"partial"`` /
+      ``"failure"``).
+    * **Legacy** — flat list of cut-point locations from before the
+      outcome-flavoured renderer landed.  Each entry is imported as
+      ``"success"`` outcome (matches the implicit flavour the older
+      ``treated`` stage subset rendered).
+
+    ``None`` and missing ``db`` resolve to an empty dict.  The returned
+    dict is a fresh copy; callers can mutate freely without affecting
+    the stored Attribute.
+    """
+    raw = getattr(getattr(target, "db", None), "sutured_stumps", None)
+    if raw is None:
+        return {}
+    if hasattr(raw, "keys"):
+        return dict(raw)
+    return {loc: "success" for loc in raw}
+
+
+# ---------------------------------------------------------------------
+# Severed-container set
+# ---------------------------------------------------------------------
+
+
+def compute_severed_containers(target) -> set:
+    """Return the set of containers carrying any severed organ on
+    ``target``.
+
+    A severed organ has ``wound_stage="severed"`` AND
+    ``current_hp <= 0`` — both gates so a partially-zeroed organ
+    isn't promoted to a severance.  ``sever_character_body`` is the
+    only writer that sets both fields together.
+    """
+    state = getattr(target, "medical_state", None)
+    if state is None or not hasattr(state, "organs"):
+        return set()
+    out = set()
+    for organ in state.organs.values():
+        if (getattr(organ, "wound_stage", None) == "severed"
+                and getattr(organ, "current_hp", 0) <= 0):
+            container = getattr(organ, "container", None)
+            if container:
+                out.add(container)
+    return out
+
+
+# ---------------------------------------------------------------------
+# Cut-point computation
+# ---------------------------------------------------------------------
+
+
+def compute_cut_points(target) -> set:
+    """Return the set of cut-point locations on ``target``.
+
+    A *cut point* is the canonical single location per severance:
+
+    * **Head-cluster collapse** — when the ``head`` container is in
+      the severed set (the brain lives there and ``sever_character_body``
+      always zeros it during decapitation), every cluster peer from
+      ``get_species_severed_head_locations`` (``neck`` / ``left_eye`` /
+      ``right_eye`` / ``left_ear`` / ``right_ear`` / face-or-snout /
+      hair-or-fur, species-dependent) collapses into ``head``.
+    * **Limb-chain collapse** — downstream containers whose
+      ``get_species_limb_parent`` ancestor is also severed collapse
+      into the chain root.  Thigh amputation surfaces as
+      ``left_thigh`` only; the shin and foot ride with it.
+
+    Returns the FULL cut-point set — callers that want only untreated
+    cut points should subtract ``normalize_sutured_stumps(target)``
+    keys.  This keeps the renderer (which needs every cut point) and
+    the picker / runtime (which need un-sutured cut points only)
+    sharing a single computation.
+    """
+    severed_containers = compute_severed_containers(target)
+    if not severed_containers:
+        return set()
+
+    species = getattr(getattr(target, "db", None), "species", None)
+
+    head_cluster = frozenset()
+    if "head" in severed_containers:
+        try:
+            from world.anatomy import get_species_severed_head_locations
+            head_cluster = get_species_severed_head_locations(species)
+        except ImportError:
+            pass
+
+    try:
+        from world.anatomy import get_species_limb_parent
+        limb_parent = get_species_limb_parent(species)
+    except ImportError:
+        limb_parent = {}
+
+    out = set()
+    for container in severed_containers:
+        # Head-cluster peers collapse into ``head``.
+        if head_cluster and container in head_cluster and container != "head":
+            continue
+        # Limb-chain downstream collapses into the chain root.
+        parent = limb_parent.get(container)
+        if parent and parent in severed_containers:
+            continue
+        out.add(container)
+    return out

--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -191,201 +191,104 @@ def _format_wound_grammar(description):
 def _stump_stage(character, location: str) -> str:
     """Return the renderer stage for a severance cut point.
 
-    Reads ``character.db.sutured_stumps`` and maps the recorded
-    suture outcome (``"success"`` / ``"partial"`` / ``"failure"``)
-    into one of three flavoured stages — ``"treated_success"`` /
+    Routes the recorded suture-roll outcome
+    (``"success"`` / ``"partial"`` / ``"failure"``) into one of
+    three flavoured stages — ``"treated_success"`` /
     ``"treated_partial"`` / ``"treated_failure"`` — so the renderer
-    picks variants that match the actual quality of the job.
-
-    Backward-compat: legacy entries stored as a flat list
-    (``["head", "left_arm"]``) treat membership as success — that's
-    the same flavour that was rendered before outcome propagation
-    landed.
-
-    No record at all → ``"fresh"`` (raw stump prose).
+    picks variants that match the actual quality of the job.  No
+    record at all → ``"fresh"`` (raw stump prose).  Backward-compat
+    is owned by :func:`world.medical.severance.normalize_sutured_stumps`.
     """
-    raw = getattr(
-        getattr(character, "db", None), "sutured_stumps", None,
-    )
-    if raw is None:
+    from world.medical.severance import normalize_sutured_stumps
+    sutured = normalize_sutured_stumps(character)
+    outcome = sutured.get(location)
+    if outcome is None:
         return "fresh"
-    if hasattr(raw, "get"):
-        outcome = raw.get(location)
-        if outcome is None:
-            return "fresh"
-        if outcome in ("success", "partial", "failure"):
-            return f"treated_{outcome}"
-        return "treated"
-    return "treated" if location in raw else "fresh"
+    if outcome in ("success", "partial", "failure"):
+        return f"treated_{outcome}"
+    return "treated"
 
 
 def get_character_wounds(character):
-    """
-    Analyze character's medical state and extract visible wounds.
-    Only returns wounds that are not concealed by clothing/armor.
-    Uses the flexible medical system to find actual damaged organs.
+    """Analyze ``character``'s medical state and extract visible wounds.
 
-    Cut-point filter (issue #339): when a limb chain has been severed
-    (e.g. shin + foot, thigh + shin + foot), the medical state has
-    every chain organ flagged ``wound_stage='severed'``. To avoid
-    rendering multiple severance wounds for what was a single cut, we
-    suppress downstream severance wounds — only the cut point shows.
-    A wound at ``left_foot`` is suppressed if ``left_shin`` (its parent
-    container per :data:`world.combat.constants.LIMB_PARENT`) is also
-    severed.
+    Returns wounds that are not concealed by clothing or armor.
 
-    Args:
-        character: Character object with medical state
+    Severance collapse: when a body region has been severed
+    (``wound_stage="severed"`` on its organs — set by
+    ``sever_character_body``), the per-organ wound rendering at every
+    container in the severed set is suppressed; the renderer emits
+    instead a single synthetic cut-point wound per severance.  Cut
+    points come from
+    :func:`world.medical.severance.compute_cut_points` — one entry
+    per anatomical severance after the head cluster and limb chain
+    collapse rules are applied.  This means a decapitation renders as
+    one ``head`` wound (no ``neck`` / ``left_eye`` / ear stragglers)
+    and a thigh amputation renders as one ``left_thigh`` wound (no
+    shin / foot stragglers).
 
-    Returns:
-        list: List of wound data dictionaries for visible wounds
+    The synthetic cut-point wound's ``stage`` comes from
+    :func:`_stump_stage` so a sutured stump reads as treated and an
+    untreated one reads as fresh.
     """
     wounds = []
 
-    # Get character's medical state
     try:
         medical_state = character.medical_state
     except AttributeError:
         return wounds
 
-    # First pass: build the set of severed containers so the cut-point
-    # filter knows whose parent is gone.
-    severed_containers = set()
-    for organ in medical_state.organs.values():
-        if (getattr(organ, "wound_stage", None) == "severed"
-                and organ.current_hp <= 0):
-            severed_containers.add(organ.container)
+    from world.medical.severance import (
+        compute_cut_points, compute_severed_containers,
+    )
+    severed_containers = compute_severed_containers(character)
+    cut_points = compute_cut_points(character)
 
-    # Issue #356 Phase 2: species-aware limb-parent map.  Rats have
-    # two-segment limbs (foreleg+forepaw, hindleg+hindpaw) so their
-    # parent map differs from human's three-segment chain.
-    species = getattr(character.db, "species", None) if hasattr(character, "db") else None
-    try:
-        from world.anatomy import get_species_limb_parent
-        LIMB_PARENT = get_species_limb_parent(species)
-    except ImportError:
-        LIMB_PARENT = {}
-
-    # Head-cluster cut-point: when the head has been severed off the
-    # body (decapitation — combat- or chart-driven), every cluster
-    # peer (face / neck / eyes / ears / hair-or-fur / snout, depending
-    # on species) collapses into a single wound at the "head" cut
-    # point.  The cluster forms a bundle, not a parent tree, so it
-    # doesn't fit the limb-parent shape — handled separately here.
-    # Detection: the brain sits in container="head" and gets zeroed
-    # by ``sever_character_body`` during head severance, so its
-    # presence in ``severed_containers`` is a reliable signal that
-    # the cluster left the body.
-    head_cluster_collapsed = "head" in severed_containers
-    if head_cluster_collapsed:
-        try:
-            from world.anatomy import get_species_severed_head_locations
-            head_cluster = get_species_severed_head_locations(species)
-        except ImportError:
-            head_cluster = frozenset()
-    else:
-        head_cluster = frozenset()
-
-    # Check all organs in the character's medical state for damage
     for organ_name, organ in medical_state.organs.items():
-        if organ.current_hp < organ.max_hp:  # Organ is damaged
-            # Issue #346: file the wound at the organ's display surface,
-            # not its bulk container. Most organs (heart, lungs, liver)
-            # have ``display_location == container``; sensory organs
-            # (left_eye, right_eye, left_ear, right_ear) route to a more
-            # specific longdesc surface so the destruction reads at the
-            # right anatomical line. Visibility / coverage checks still
-            # consult the container — clothing covers the bulk region.
-            location = getattr(organ, "display_location", None) or organ.container
+        if organ.current_hp >= organ.max_hp:
+            continue
+        # Issue #346: file the wound at the organ's display surface,
+        # not its bulk container.  Sensory organs (eyes, ears) route
+        # to specific longdesc surfaces; bulk organs share container.
+        # Visibility / coverage checks still consult the container —
+        # clothing covers the bulk region.
+        location = getattr(organ, "display_location", None) or organ.container
+        if not _is_wound_visible(character, organ.container):
+            continue
 
-            # Only include if wound location is visible (not concealed by clothing)
-            if _is_wound_visible(character, organ.container):
-                # Determine injury type and stage based on organ condition
-                injury_type = _determine_injury_type_from_organ(organ)
-                stage = _determine_wound_stage_from_organ(organ)
-                severity = _determine_severity_from_damage(organ)
+        # Severance collapse: every per-organ wound whose container
+        # is part of any severance is suppressed.  The synthetic
+        # cut-point wound emitted after this loop covers the
+        # severance anatomically — including peers like eyes / ears
+        # that route to a non-container display surface but still
+        # left with the head.  Same rule subsumes the old
+        # head-cluster + limb-chain dual-check.
+        if organ.container in severed_containers:
+            continue
 
-                # Head-cluster collapse — suppress every wound at any
-                # cluster location (including peers like "left_eye" /
-                # "neck" AND the head itself).  We emit one synthetic
-                # cut-point wound after the loop, matching the corpse
-                # path in ``apply_sever_to_corpse``.  Mirroring that
-                # contract here means the live-body view and the
-                # eventual corpse view render with the same prose
-                # ("the head has been taken off the body") instead of
-                # the live body listing every cluster organ's own
-                # injury separately ("the brain is destroyed", "the
-                # left eye is destroyed", …) — see preamble.
-                if head_cluster_collapsed and location in head_cluster:
-                    continue
-
-                # Limb-chain collapse — symmetric with head cluster:
-                # suppress every wound at any severed limb container
-                # (cut point, downstream chain, *and* pre-existing
-                # wounds that left with the limb).  One synthetic
-                # severance wound per chain root is emitted after the
-                # loop.  Without this, a severed humerus rendered as
-                # "blunt" / "left_humerus" / "severed" — keyed on
-                # the bone's own injury heuristic — while the corpse
-                # path lays down ``injury_type="severed"`` /
-                # ``organ=None`` and gets cleaner severance prose.
-                # Head-cluster locations are excluded so this doesn't
-                # double-handle anything the cluster block above
-                # already dropped.
-                if (location in severed_containers
-                        and location not in head_cluster):
-                    continue
-
-                wound_data = {
-                    'injury_type': injury_type,
-                    'location': location,
-                    'severity': severity,
-                    'stage': stage,
-                    'organ': organ_name,
-                    'organ_obj': organ
-                }
-                wounds.append(wound_data)
-
-    # Head-cluster collapse — emit the single synthetic cut-point
-    # wound that ``apply_sever_to_corpse`` would have laid down on the
-    # corpse-side path.  Same shape (injury_type="severed",
-    # location="head", organ=None) so the renderer routes to the
-    # severance prose ("the head has been taken off the body") rather
-    # than the per-organ-destruction prose the live body would have
-    # produced.  Visibility-gated on the head location so concealment
-    # via headwear (theoretical edge case) still works.
-    if head_cluster_collapsed and _is_wound_visible(character, "head"):
         wounds.append({
-            "injury_type": "severed",
-            "location": "head",
-            "severity": "Critical",
-            "stage": _stump_stage(character, "head"),
-            "organ": None,
-            "organ_obj": None,
+            'injury_type': _determine_injury_type_from_organ(organ),
+            'location': location,
+            'severity': _determine_severity_from_damage(organ),
+            'stage': _determine_wound_stage_from_organ(organ),
+            'organ': organ_name,
+            'organ_obj': organ,
         })
 
-    # Limb-chain cut-point wounds — symmetric with the head cluster
-    # synthesis above.  For every severed limb chain we emit exactly
-    # one wound at the chain root (the cut point: a severed container
-    # whose parent per ``LIMB_PARENT`` is either undefined or not
-    # itself severed).  Head-cluster containers are skipped so
-    # decapitation doesn't double-emit alongside the head wound.
-    # Same shape ``apply_sever_to_corpse`` writes so the live-body
-    # view and the corpse view render identical limb-severance prose.
-    for container in severed_containers:
-        if container in head_cluster:
-            continue
-        parent = LIMB_PARENT.get(container)
-        if parent and parent in severed_containers:
-            continue
-        if _is_wound_visible(character, container):
+    # One synthetic cut-point wound per severance.  Same shape
+    # ``apply_sever_to_corpse`` writes on the corpse path so the
+    # live-body view and the eventual corpse view render identical
+    # severance prose.  ``stage`` comes from ``_stump_stage`` so
+    # ``sutured_stumps`` outcome flavours the variant subset.
+    for cut_point in cut_points:
+        if _is_wound_visible(character, cut_point):
             wounds.append({
-                "injury_type": "severed",
-                "location": container,
-                "severity": "Critical",
-                "stage": _stump_stage(character, container),
-                "organ": None,
-                "organ_obj": None,
+                'injury_type': 'severed',
+                'location': cut_point,
+                'severity': 'Critical',
+                'stage': _stump_stage(character, cut_point),
+                'organ': None,
+                'organ_obj': None,
             })
 
     return wounds

--- a/world/tests/test_limb_downstream_chain.py
+++ b/world/tests/test_limb_downstream_chain.py
@@ -502,16 +502,19 @@ class CutPointFilterTests(TestCase):
         # Once the cut point is recorded in ``db.sutured_stumps`` (by
         # ``_resolve_suture`` closing an incision at a severance
         # location), the renderer transitions to a treated-flavoured
-        # stage so severed.py's bandaged-stump prose fires instead.
-        # Legacy list shape → generic ``"treated"`` (the success
-        # variant subset, preserving prior renderer behaviour).
+        # stage so severed.py's bandaged-stump prose fires.  Legacy
+        # list-shape storage normalises to a ``{loc: "success"}``
+        # dict via ``normalize_sutured_stumps`` — preserving the
+        # implicit success flavour the older renderer picked, but
+        # now routed explicitly so the variant subset is the curated
+        # ``treated_success`` set rather than the generic fallback.
         from world.medical.wounds import get_character_wounds
 
         char = self._char_with_severed_chain()
         char.db.sutured_stumps = ["left_shin"]
         wounds = get_character_wounds(char)
         shin_wounds = [w for w in wounds if w["location"] == "left_shin"]
-        self.assertEqual(shin_wounds[0]["stage"], "treated")
+        self.assertEqual(shin_wounds[0]["stage"], "treated_success")
 
     def test_stump_outcome_routes_to_flavoured_stage(self):
         # Dict-shape ``sutured_stumps`` records the suture outcome;

--- a/world/tests/test_severance_helpers.py
+++ b/world/tests/test_severance_helpers.py
@@ -1,0 +1,202 @@
+"""Unit tests for ``world.medical.severance``.
+
+This module owns the single sources of truth for sutured-stump shape
+(``normalize_sutured_stumps``) and cut-point computation
+(``compute_cut_points`` / ``compute_severed_containers``).  The wound
+renderer, the operate picker, and the runtime suture verb all read
+through these helpers, so the round-trip cases need pinning here
+rather than scattered across the consumer tests.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+
+class _FakeOrgan:
+    def __init__(self, container, *, wound_stage=None, current_hp=10,
+                 max_hp=10):
+        self.container = container
+        self.wound_stage = wound_stage
+        self.current_hp = current_hp
+        self.max_hp = max_hp
+
+
+class _FakeMedical:
+    def __init__(self, organs):
+        self.organs = organs
+
+
+def _target(organs, *, species="human", sutured_stumps=None):
+    target = SimpleNamespace()
+    target.medical_state = _FakeMedical(organs)
+    target.db = SimpleNamespace(
+        species=species, sutured_stumps=sutured_stumps,
+    )
+    return target
+
+
+# ---------------------------------------------------------------------
+# normalize_sutured_stumps
+# ---------------------------------------------------------------------
+
+
+class NormalizeSuturedStumps(TestCase):
+
+    def test_none_returns_empty_dict(self):
+        from world.medical.severance import normalize_sutured_stumps
+        target = _target({})
+        self.assertEqual(normalize_sutured_stumps(target), {})
+
+    def test_dict_shape_returned_as_fresh_copy(self):
+        # The returned dict should be a copy — callers mutate without
+        # touching the stored Attribute.
+        from world.medical.severance import normalize_sutured_stumps
+        original = {"head": "success"}
+        target = _target({}, sutured_stumps=original)
+        out = normalize_sutured_stumps(target)
+        self.assertEqual(out, original)
+        out["head"] = "failure"
+        self.assertEqual(original["head"], "success")
+
+    def test_legacy_list_shape_maps_to_success_outcomes(self):
+        # Pre-outcome storage was a flat list — each entry imports as
+        # ``"success"`` so the renderer picks the clean variant set,
+        # matching what the older code path produced.
+        from world.medical.severance import normalize_sutured_stumps
+        target = _target({}, sutured_stumps=["head", "left_arm"])
+        self.assertEqual(
+            normalize_sutured_stumps(target),
+            {"head": "success", "left_arm": "success"},
+        )
+
+    def test_missing_db_handled(self):
+        from world.medical.severance import normalize_sutured_stumps
+        target = SimpleNamespace()  # no .db at all
+        self.assertEqual(normalize_sutured_stumps(target), {})
+
+
+# ---------------------------------------------------------------------
+# compute_severed_containers
+# ---------------------------------------------------------------------
+
+
+class ComputeSeveredContainers(TestCase):
+
+    def test_includes_only_severed_zero_hp_organs(self):
+        from world.medical.severance import compute_severed_containers
+        target = _target({
+            "brain": _FakeOrgan("head", wound_stage="severed", current_hp=0),
+            "heart": _FakeOrgan("chest"),  # intact
+            "left_eye": _FakeOrgan("head", wound_stage="severed",
+                                    current_hp=0),
+        })
+        self.assertEqual(
+            compute_severed_containers(target), {"head"},
+        )
+
+    def test_severed_stage_with_positive_hp_excluded(self):
+        # Defensive guard: only count organs that are *actually* zeroed.
+        from world.medical.severance import compute_severed_containers
+        target = _target({
+            "brain": _FakeOrgan("head", wound_stage="severed", current_hp=3),
+        })
+        self.assertEqual(compute_severed_containers(target), set())
+
+    def test_no_medical_state_returns_empty(self):
+        from world.medical.severance import compute_severed_containers
+        target = SimpleNamespace(
+            medical_state=None,
+            db=SimpleNamespace(species="human"),
+        )
+        self.assertEqual(compute_severed_containers(target), set())
+
+
+# ---------------------------------------------------------------------
+# compute_cut_points
+# ---------------------------------------------------------------------
+
+
+class ComputeCutPoints(TestCase):
+
+    def test_head_cluster_collapses_to_head(self):
+        # Decapitation: brain (container=head) + cervical_spine
+        # (container=neck) both severed.  Cut points should be just
+        # ``{"head"}`` — the neck collapses into the head cluster.
+        from world.medical.severance import compute_cut_points
+        target = _target({
+            "brain": _FakeOrgan("head", wound_stage="severed", current_hp=0),
+            "cervical_spine": _FakeOrgan("neck", wound_stage="severed",
+                                          current_hp=0),
+        })
+        self.assertEqual(compute_cut_points(target), {"head"})
+
+    def test_limb_chain_collapses_to_root(self):
+        # Thigh amputation: chain organs at thigh + shin + foot all
+        # severed.  Cut points should be just ``{"left_thigh"}``.
+        from world.medical.severance import compute_cut_points
+        target = _target({
+            "left_femur": _FakeOrgan("left_thigh", wound_stage="severed",
+                                       current_hp=0),
+            "left_tibia": _FakeOrgan("left_shin", wound_stage="severed",
+                                       current_hp=0),
+            "left_metatarsals": _FakeOrgan("left_foot",
+                                             wound_stage="severed",
+                                             current_hp=0),
+        })
+        self.assertEqual(compute_cut_points(target), {"left_thigh"})
+
+    def test_solo_severance_renders_as_cut_point(self):
+        # Single-container severance (e.g. a forearm cut where the
+        # downstream hand happens not to also be severed) — the lone
+        # severed container IS the cut point.
+        from world.medical.severance import compute_cut_points
+        target = _target({
+            "left_humerus": _FakeOrgan("left_arm", wound_stage="severed",
+                                         current_hp=0),
+        })
+        self.assertEqual(compute_cut_points(target), {"left_arm"})
+
+    def test_multiple_severances_each_emit_a_cut_point(self):
+        # Two unrelated severances — head and a leg — should both
+        # appear, each collapsed to one entry.
+        from world.medical.severance import compute_cut_points
+        target = _target({
+            "brain": _FakeOrgan("head", wound_stage="severed", current_hp=0),
+            "left_femur": _FakeOrgan("left_thigh", wound_stage="severed",
+                                       current_hp=0),
+            "left_tibia": _FakeOrgan("left_shin", wound_stage="severed",
+                                       current_hp=0),
+        })
+        self.assertEqual(
+            compute_cut_points(target), {"head", "left_thigh"},
+        )
+
+    def test_empty_when_nothing_severed(self):
+        from world.medical.severance import compute_cut_points
+        target = _target({
+            "heart": _FakeOrgan("chest"),
+        })
+        self.assertEqual(compute_cut_points(target), set())
+
+    def test_rat_species_uses_rat_cluster_set(self):
+        # Sanity: species lookup feeds the cluster set.  Rat-specific
+        # cluster includes ``snout`` / ``fur``; verify a snout-
+        # container severance also collapses into ``head``.
+        from world.medical.severance import compute_cut_points
+        target = _target(
+            {
+                "brain": _FakeOrgan("head", wound_stage="severed",
+                                      current_hp=0),
+                # cervical_spine is in container "neck" for rats too;
+                # we don't need a snout-container organ to verify the
+                # collapse, since the cluster set drives suppression
+                # regardless of which peer triggers it.
+                "cervical_spine": _FakeOrgan("neck",
+                                               wound_stage="severed",
+                                               current_hp=0),
+            },
+            species="rat",
+        )
+        self.assertEqual(compute_cut_points(target), {"head"})


### PR DESCRIPTION
Pre-consolidation each of three consumers — wound renderer, operate picker, runtime suture — independently answered the same two questions (which containers are severed? which count as cut points?) and each had its own copy of the legacy list-shape backward-compat shim for `sutured_stumps`. Three copies of the cluster + chain filter, three copies of the shape normalisation, hand-kept in lock-step.

**New module `world/medical/severance.py`:**
- `compute_severed_containers(target)` — set of containers with severed zeroed organs
- `compute_cut_points(target)` — full cut-point set after head-cluster + limb-chain collapse
- `normalize_sutured_stumps(target)` — backward-compat shim, returns {location: outcome} dict; legacy list entries import as `"success"`

**Consumer collapses:**
- `get_character_wounds`: dual head-cluster + limb-parent filter → single `organ.container in severed_containers` check (subsumes both). Two synthesis blocks → one loop over `compute_cut_points`. ~70 lines → ~20.
- `_list_severed_locations`: ~50 lines → three-line wrapper.
- `_resolve_suture`: ~40-line cluster-collapse + shape-normalisation block → two helper calls.
- `_stump_stage`: one-liner via the normalizer.

**Behaviour change worth flagging:** legacy list-shape `sutured_stumps` previously routed to generic `"treated"` stage; now routes to `"treated_success"` via the normalizer's outcome import. Both stages exist in severed.py; the new mapping is *more* specific (curated success variant rather than generic fallback). One test updated to expect explicit routing.

Coverage: 13 new tests in `test_severance_helpers.py`. Suite: 2084/2084.

Refs #307.