### PR TITLE
combat amputation opens an incision; suture model unified

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1899,6 +1899,20 @@ def spawn_severed_head_for_living(character, *, injury_type="cut"):
     # change regardless of caller.
     character.db.decapitation_pending = True
 
+    # Severance leaves an open stump at the cut point.  Recording it
+    # in ``surgical_state["incisions"]`` makes the suture verb work
+    # uniformly across combat-driven decap (which goes through here)
+    # and chart-driven amputation (which double-records via
+    # ``_resolve_amputate`` — second call overwrites with the
+    # surgeon as ``opened_by``, the right semantic).  Attacker
+    # attribution is forensic-only; ``opened_by`` is write-only state.
+    try:
+        from world.medical.procedures import open_incision
+        attacker = getattr(character.ndb, "_last_damage_attacker", None)
+        open_incision(character, "head", surgeon=attacker)
+    except Exception:
+        pass
+
     return head
 
 
@@ -2274,6 +2288,20 @@ def apply_sever_to_character(character, container, *, injury_type="cut"):
     if callable(update_vital_signs):
         update_vital_signs()
     character.save_medical_state()
+
+    # Severance leaves an open stump at the cut point.  Recording the
+    # incision here means the suture verb finds the same open wound
+    # whether the severance came from combat (which calls us
+    # directly via ``ArmorMixin.take_damage``) or from chart-driven
+    # amputation (``_resolve_amputate`` calls us, then double-records
+    # via its own ``open_incision`` to attribute the surgeon as
+    # ``opened_by``).  Attacker attribution is forensic-only here.
+    try:
+        from world.medical.procedures import open_incision
+        attacker = getattr(character.ndb, "_last_damage_attacker", None)
+        open_incision(character, container, surgeon=attacker)
+    except Exception:
+        pass
 
     detach_items_to_appendage(character, appendage, chain)
 

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -180,11 +180,21 @@ def has_incision(target, location: str) -> bool:
     return location in state["incisions"]
 
 
-def open_incision(target, location: str, surgeon, tool=None) -> None:
+def open_incision(target, location: str, surgeon=None, tool=None) -> None:
     """Record a new incision at ``location``.
 
     Multiple simultaneous incisions are allowed — useful for
     thoracoabdominal procedures and other multi-cavity work.
+
+    ``surgeon`` is optional — defaults to ``None`` so combat-driven
+    severance (which calls this from inside
+    ``apply_sever_to_character`` / ``spawn_severed_head_for_living``
+    where the attacker isn't always a surgeon) can record an
+    incision without a surgical attribution.  The chart-driven path
+    in ``_resolve_amputate`` calls ``open_incision`` again after the
+    severance returns, overwriting with the actual surgeon as
+    ``opened_by`` — that's the right semantic since the field is
+    forensic-chain attribution.
     """
     state = _state(target)
     state["incisions"][location] = {

--- a/world/tests/test_head_spawn_at_decap.py
+++ b/world/tests/test_head_spawn_at_decap.py
@@ -329,6 +329,22 @@ class SpawnSeveredHeadForLivingTests(TestCase):
         spawn_severed_head_for_living(char)
         self.assertTrue(char.db.decapitation_pending)
 
+    def test_open_incision_recorded_at_head(self):
+        # Severance leaves a stump.  Recording the incision *inside*
+        # the spawn (rather than relying on every caller to do it)
+        # means the suture verb finds an open wound to close whether
+        # the decap came from combat (this is the only call) or from
+        # ``_resolve_amputate`` (which calls again afterward to
+        # attribute the surgeon as ``opened_by`` — both writes target
+        # the same location so the second wins on attribution).
+        char = _FakeCharacter(organs=_head_organs())
+        # Surgical state must exist for ``_state`` to lazy-init it.
+        char.db.surgical_state = None
+        char.ndb = SimpleNamespace(_last_damage_attacker=None)
+        spawn_severed_head_for_living(char)
+        incisions = char.db.surgical_state["incisions"]
+        self.assertIn("head", incisions)
+
     def test_vital_signs_recomputed(self):
         char = _FakeCharacter(organs=_head_organs())
         spawn_severed_head_for_living(char)


### PR DESCRIPTION
Pre-fix the surgical state diverged by severance path: chart-driven amputation called `open_incision` from `_resolve_amputate`, but combat-driven severance went through `apply_sever_to_character` / `spawn_severed_head_for_living` without any incision record. The body had a stump but no surgical state.

**Fix:** the severance functions own the incision themselves. Severance *leaves* a stump as part of the event — any future caller (scripted NPCs, world events) gets the incision automatically. `open_incision`'s `surgeon` parameter becomes optional (default `None`).

**Chart-driven unchanged on the surface:** the in-severance call records with the attacker (or None), then `_resolve_amputate` overwrites at the same location with the surgeon — final state attributes the surgeon as before. `opened_by` is forensic-only with no readers, so the default is harmless.

**Side effect:** PR #424's `untreated_stumps` fallback in `_resolve_suture` is now reachable only from narrower corpse-style paths. Not removing it; safety net is correct and zero-cost.

Tests: new `test_open_incision_recorded_at_head`. Limb path verified via docker smoke (requires `create_object`, too heavyweight for stub).

Suite: 2085/2085.

Refs #307.