### PR TITLE
apply_severed_head_overlay: drop snapshot write (already done by super)

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -2356,13 +2356,11 @@ def apply_sever_to_character(character, container, *, injury_type="cut"):
 
 
 def apply_severed_head_overlay(head, corpse):
-    """Copy identity / decay / trimmed snapshot from ``corpse`` onto ``head``.
+    """Copy identity + decay-clock fields from ``corpse`` onto ``head``.
 
     Extracted from :meth:`SeveredHead.configure_from_sever` so unit
     tests can exercise the overlay logic against plain-Python stubs
-    without instantiating an Evennia typeclass (whose metaclass would
-    bind ``super()`` to the concrete class and reject duck-typed
-    ``self`` substitutes).
+    without instantiating an Evennia typeclass.
 
     Contract — after this call ``head.db`` has:
 
@@ -2376,26 +2374,20 @@ def apply_severed_head_overlay(head, corpse):
       forensic-recognition passes can match looker memory.
     * ``creation_time`` / ``death_time`` / ``death_cause`` shared with
       the corpse so the head ages on the same decay clock.
-    * ``medical_state_at_death`` = trimmed snapshot — only organs whose
-      ``container == "head"``; body-wide fields (conditions, blood,
-      pain, consciousness) blanked because they describe the whole
-      body and would lie if reported off a disembodied head.  Organs
-      are deep-copied to prevent aliasing with the corpse snapshot.
-    * ``removed_organs`` filtered to the head-container subset of the
-      corpse's removed-organ list (so pre-sever harvests stay visible).
 
-    Side-effect on ``corpse.db``:
+    The ``medical_state_at_death`` snapshot and ``removed_organs``
+    subset are NOT written here — :meth:`Appendage.configure_from_sever`
+    (the super-call that runs before this overlay) already lays them
+    down via :func:`apply_organ_snapshot_overlay` filtered to the
+    head chain.  This used to be a double-write that produced the
+    same data twice; collapsing to one keeps the head contract
+    identical without the redundant pass.
 
-    * ``head_severed`` is set to ``True``.  Identity is *duplicated*
-      across head and corpse (the corpse retains
-      ``signature_at_death`` / ``apparent_uid_at_death`` /
-      ``sleeve_uid`` so :func:`world.forensics.extract_subject_from_corpse`
-      and the ``autopsy`` command keep working) — but the corpse's
-      look-time tertiary recognition is suppressed by
-      :meth:`typeclasses.corpse.Corpse.get_display_name` reading
-      this flag.  Game-mechanic justification: the face is the
-      dominant unaided-recognition cue; without it, only an explicit
-      autopsy can resolve the body's identity.
+    Identity is *duplicated* across head and corpse: the head carries
+    face-side recognition (sleeve_uid + forensic chain), the corpse
+    keeps its snapshot for autopsy.  Corpse-side ``head_severed`` is
+    set by :func:`apply_sever_to_corpse`, which runs in the command
+    path after this overlay.  See issue #208.
     """
     # IdentityBearerMixin contract — copy snapshotted identity.
     head.db.signature_at_death = corpse.db.signature_at_death
@@ -2408,35 +2400,6 @@ def apply_severed_head_overlay(head, corpse):
     head.db.creation_time = corpse.db.creation_time
     head.db.death_time = corpse.db.death_time
     head.db.death_cause = corpse.db.death_cause
-
-    # Trimmed head-container medical snapshot.
-    corpse_snapshot = corpse.get_medical_snapshot() or {}
-    organs = corpse_snapshot.get("organs") or {}
-    head_organs = {
-        name: dict(data)
-        for name, data in organs.items()
-        if (data.get("container") or "") == "head"
-    }
-    head.db.medical_state_at_death = {
-        "organs": head_organs,
-        "conditions": [],
-        "blood_level": None,
-        "pain_level": None,
-        "consciousness": None,
-    }
-
-    # Head-container subset of removed_organs.
-    corpse_removed = corpse.db.removed_organs or ()
-    head.db.removed_organs = [
-        name for name in corpse_removed if name in head_organs
-    ]
-
-    # Corpse-side ``head_severed`` flag is set by
-    # :func:`apply_sever_to_corpse`, which runs in the command path
-    # after this overlay.  Identity is *duplicated* across head and
-    # corpse: the head carries face-side recognition (sleeve_uid +
-    # forensic chain), while the corpse keeps its snapshot for
-    # autopsy.  See issue #208.
 
 
 def apply_severed_head_overlay_from_living(head, character):

--- a/world/tests/test_severed_head.py
+++ b/world/tests/test_severed_head.py
@@ -150,59 +150,15 @@ class SeveredHeadOverlayTests(TestCase):
             self.head.db.death_cause, self.corpse.db.death_cause
         )
 
-    def test_trimmed_snapshot_filters_to_head_container(self):
-        self._overlay()
-        organs = self.head.db.medical_state_at_death["organs"]
-        self.assertEqual(
-            set(organs.keys()), {"brain", "left_eye", "right_eye"}
-        )
-
-    def test_trimmed_snapshot_blanks_body_wide_fields(self):
-        self._overlay()
-        snap = self.head.db.medical_state_at_death
-        self.assertEqual(snap["conditions"], [])
-        self.assertIsNone(snap["blood_level"])
-        self.assertIsNone(snap["pain_level"])
-        self.assertIsNone(snap["consciousness"])
-
-    def test_removed_organs_carries_head_subset_only(self):
-        self.corpse.db.removed_organs = ["left_eye", "heart"]
-        self._overlay()
-        self.assertEqual(self.head.db.removed_organs, ["left_eye"])
-
-    def test_snapshot_organs_are_independent_copies(self):
-        """Mutating the head's snapshot must not bleed into the corpse."""
-        self._overlay()
-        self.head.db.medical_state_at_death["organs"]["brain"][
-            "current_hp"
-        ] = 0
-        self.assertEqual(
-            self.corpse.db.medical_state_at_death["organs"]["brain"][
-                "current_hp"
-            ],
-            10,
-        )
-
-    def test_no_corpse_snapshot_yields_empty_organs(self):
-        self.corpse.db.medical_state_at_death = None
-        self._overlay()
-        snap = self.head.db.medical_state_at_death
-        self.assertEqual(snap["organs"], {})
-
-    def test_get_medical_snapshot_returns_trimmed_dict(self):
-        """The accessor is a thin ``self.db.medical_state_at_death`` read."""
-        self._overlay()
-        result = SeveredHead.get_medical_snapshot(self.head)
-        self.assertIs(result, self.head.db.medical_state_at_death)
-
-    def test_non_head_organs_excluded_even_if_missing_container(self):
-        """Organs with no ``container`` key are excluded (defensive)."""
-        snapshot = _full_snapshot()
-        snapshot["organs"]["mystery_organ"] = {"current_hp": 1, "max_hp": 1}
-        self.corpse.db.medical_state_at_death = snapshot
-        self._overlay()
-        organs = self.head.db.medical_state_at_death["organs"]
-        self.assertNotIn("mystery_organ", organs)
+    # Trimmed-snapshot / removed_organs assertions moved out of this
+    # file when ``apply_severed_head_overlay`` stopped writing the
+    # snapshot itself (the base ``Appendage.configure_from_sever`` now
+    # owns that via ``apply_organ_snapshot_overlay`` with chain=("head",)).
+    # Equivalent coverage lives in ``test_sever_overlay.py``'s
+    # ``ApplyOrganSnapshotOverlayTests`` — container filter, blanked
+    # body-wide fields, ``None`` source handling, shallow-copy
+    # independence, and removed_organs filtering all pinned there
+    # against the helper that actually writes the snapshot now.
 
     def test_overlay_preserves_corpse_snapshot_keys(self):
         """Sanity: the overlay shouldn't mutate the corpse snapshot dict."""


### PR DESCRIPTION
Cleanup of the redundancy I flagged when PR #418 generalised the organ snapshot to every severed appendage.

`Appendage.configure_from_sever` (super-call) writes `medical_state_at_death` via `apply_organ_snapshot_overlay(chain=("head",))` — same trimmed shape `apply_severed_head_overlay` was writing afterwards. Double-write of identical data. Same for `removed_organs`.

`apply_severed_head_overlay` keeps:
- Identity copy (`signature_at_death` / `apparent_uid_at_death` / `sleeve_uid`)
- Decay clock copy (`creation_time` / `death_time` / `death_cause`)

Drops the snapshot + `removed_organs` writes. Super-call's `apply_organ_snapshot_overlay` produces the same result.

**Verified via docker smoke:** `SeveredHead` spawned from a real `Corpse` still has the trimmed head-container snapshot (brain + eyes + ears + jaw) plus identity and decay clock.

**Test consequences:** 6 `SeveredHeadOverlayTests` cases that asserted on the snapshot contract deleted here. Equivalent coverage already lives in `test_sever_overlay.py:ApplyOrganSnapshotOverlayTests` against the helper that actually writes the snapshot now. Remaining tests pin the work this helper genuinely owns.

Suite: 2078/2078.

Refs #307.