### PR TITLE
install picker filters by species + organ slot; lays cyberware hooks

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -491,6 +491,113 @@ def _list_donor_organs(caller):
     return out
 
 
+def _list_install_locations(target, donor_item):
+    """Return ``[(slot, status_tag)]`` for where ``donor_item`` can be
+    installed on ``target``.
+
+    Two paths converge through one helper:
+
+    * **Biological** — look up the donor's ``organ_name`` in the
+      target species' organ spec.  Heart → ``chest``; left_eye →
+      display surface ``left_eye``; etc.  Native anatomy drives the
+      slot choice.
+    * **Cyberware** — the item declares its own placement via
+      ``db.target_container`` and / or ``db.target_display_locations``.
+      A cybernetic eye sets
+      ``target_display_locations = ["left_eye", "right_eye"]`` and
+      the picker offers both.  Cyberware doesn't need an entry in
+      the species spec — the item's overrides drive everything.
+
+    Cross-species gate runs first: ``donor_item.db.compatible_species``
+    (set at harvest time to ``[source_species]``, freely declared on
+    cyberware) must include the target species or the picker shows
+    nothing.  Items predating this field fall back to
+    ``[source_species]`` for legacy compatibility.
+
+    Status tag is ``"empty"`` (target slot's current_hp is 0 — slot
+    is vacant) or ``"occupied"`` (slot is currently filled).  The
+    picker shows both so the player knows whether they're filling a
+    gap or replacing existing tissue.  Multi-slot extension (Doctor
+    Octopus arms, etc.) is future work; today every slot is binary.
+
+    Returns ``[]`` when the donor is cross-species, no matching slot
+    exists on the target species, or required fields are missing on
+    the donor item.  The picker treats an empty list as "cannot
+    install here" and routes the player back to the top.
+    """
+    target_species = (
+        getattr(getattr(target, "db", None), "species", None) or "human"
+    )
+    donor_db = getattr(donor_item, "db", None)
+    if donor_db is None:
+        return []
+
+    # Cross-species gate.  Legacy items pre-dating compatible_species
+    # fall back to a single-element list derived from source_species.
+    # If neither field is set the donor predates harvest provenance
+    # entirely — open the gate (don't silently refuse old items).
+    compatible = getattr(donor_db, "compatible_species", None)
+    if compatible is None:
+        source_species = getattr(donor_db, "source_species", None)
+        if source_species:
+            compatible = [source_species]
+    if compatible and target_species not in compatible:
+        return []
+
+    target_displays = getattr(donor_db, "target_display_locations", None)
+    target_container = getattr(donor_db, "target_container", None)
+    organ_name = getattr(donor_db, "organ_name", None)
+
+    if target_displays:
+        slots = list(target_displays)
+    elif target_container:
+        slots = [target_container]
+    elif organ_name:
+        # Biological — look up species spec.
+        try:
+            from world.anatomy import get_species_organs
+            spec = get_species_organs(target_species).get(organ_name)
+        except ImportError:
+            spec = None
+        if not spec:
+            return []
+        container = spec.get("container")
+        display = spec.get("display_location")
+        if display and display != container:
+            slots = [display]
+        elif container:
+            slots = [container]
+        else:
+            return []
+    else:
+        return []
+
+    # Occupancy tag.
+    state = getattr(target, "medical_state", None)
+    organs = getattr(state, "organs", {}) if state is not None else {}
+
+    out = []
+    for slot in slots:
+        if target_displays or target_container:
+            # Cyberware path — check the slot surface directly.
+            occupied = any(
+                getattr(organ, "current_hp", 0) > 0
+                and (getattr(organ, "container", None) == slot
+                     or getattr(organ, "display_location", None) == slot)
+                for organ in organs.values()
+            )
+        else:
+            # Biological path — check the specific organ slot the
+            # donor's organ_name will install into.
+            organ = organs.get(organ_name) if organ_name else None
+            occupied = (
+                organ is not None
+                and getattr(organ, "current_hp", 0) > 0
+            )
+        out.append((slot, "occupied" if occupied else "empty"))
+    return out
+
+
 def _list_open_incisions(target):
     """Return sorted list of locations with open incisions on
     ``target``."""
@@ -790,20 +897,58 @@ def _process_install_donor(caller, raw_string, **kwargs):
             return None
     item, organ_name = pick
     caller.ndb._operate_install_donor = item.key
+    # Stash the item object too so the install-location picker can
+    # read its compatibility / placement attrs (db.organ_name,
+    # db.compatible_species, db.target_container, db.target_display_locations).
+    caller.ndb._operate_install_donor_item = item
     # Now ask for the install location.
     return "node_install_location"
 
 
 def _node_install_location(caller, raw_string, **kwargs):
     target = caller.ndb._operate_target
-    containers = _list_containers(target)
     donor_key = getattr(caller.ndb, "_operate_install_donor", "?")
-    if not containers:
-        caller.msg("|rNo install locations on this target.|n")
+    donor_item = getattr(caller.ndb, "_operate_install_donor_item", None)
+
+    if donor_item is None:
+        # Fallback for stale state — re-resolve from caller inventory
+        # by key.  Shouldn't normally fire (the donor picker stashes
+        # the item directly) but keeps the menu robust.
+        for obj in (getattr(caller, "contents", None) or ()):
+            if getattr(obj, "key", None) == donor_key:
+                donor_item = obj
+                break
+
+    if donor_item is None:
+        caller.msg(
+            f"|r{donor_key} is no longer in your inventory.|n"
+        )
         return "node_top"
-    caller.ndb._operate_pickable = containers
-    listing = _render_numbered(
-        containers, lambda loc: loc.replace("_", " "),
+
+    slots = _list_install_locations(target, donor_item)
+    if not slots:
+        target_species = (
+            getattr(getattr(target, "db", None), "species", None) or "human"
+        )
+        caller.msg(
+            f"|r{donor_key} can't install on this patient — "
+            f"cross-species mismatch or no matching {target_species} "
+            f"slot for this organ.|n"
+        )
+        return "node_top"
+
+    # Picker entries: (label, location_value).  Tag shows whether
+    # the slot is currently filled — surgeons can still pick an
+    # occupied slot (the resolver replaces existing tissue) but the
+    # tag warns them they're doing it.
+    options_list = [
+        (f"{loc.replace('_', ' ')}  {MUTED}({tag})|n", loc)
+        for loc, tag in slots
+    ]
+    caller.ndb._operate_pickable = options_list
+    listing = "\n".join(
+        f"  {idx}. {label}"
+        for idx, (label, _val) in enumerate(options_list, start=1)
     )
     text = (
         f"\n|wInstall {donor_key} — pick the location|n\n\n"
@@ -826,13 +971,16 @@ def _process_install_location(caller, raw_string, **kwargs):
     if pick is None:
         caller.msg("|rPick a number or location name.|n")
         return None
+    # Picker entries are ``(label, location)`` tuples — unpack the
+    # underlying location value before recording on the chart step.
+    location_value = pick[1] if isinstance(pick, tuple) else pick
     donor_key = getattr(caller.ndb, "_operate_install_donor", None)
     if not donor_key:
         caller.msg("|rDonor selection lost; please retry from the top.|n")
         return "node_top"
     _add_step_to_chart(
         caller, "install",
-        {"organ_item_key": donor_key, "location": pick},
+        {"organ_item_key": donor_key, "location": location_value},
     )
     return "node_top"
 

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -1314,6 +1314,14 @@ def _configure_harvested_item(item, *, organ_name: str, condition: str,
     species = getattr(source_db, "species", None) or "human"
     item.db.source_species = species
 
+    # Install-compatibility list — single-element for a freshly
+    # harvested biological organ.  Cyberware items declare a wider
+    # list at creation (e.g. ``["human", "rat"]`` for a cybernetic
+    # eye), and ``CmdOperate._list_install_locations`` reads this to
+    # gate cross-species installs.  Legacy items pre-dating this
+    # field fall back to ``[source_species]`` at picker time.
+    item.db.compatible_species = [species]
+
     stage_getter = getattr(source, "get_decay_stage", None)
     if callable(stage_getter):
         try:

--- a/world/tests/test_operate_menu.py
+++ b/world/tests/test_operate_menu.py
@@ -429,3 +429,195 @@ class VerbChoiceRouting(TestCase):
         result, caller = self._process("4")
         self.assertEqual(result, "node_suture_location")
         self.assertEqual(caller.ndb._operate_pending_verb, "suture")
+
+
+# ---------------------------------------------------------------------
+# Install location helper
+# ---------------------------------------------------------------------
+
+
+def _make_donor(*, organ_name=None, source_species=None,
+                 compatible_species=None,
+                 target_container=None, target_display_locations=None,
+                 key="harvested heart"):
+    """Build a donor-item stub for the install picker."""
+    donor = SimpleNamespace(key=key)
+    donor.db = SimpleNamespace(
+        organ_name=organ_name,
+        source_species=source_species,
+        compatible_species=compatible_species,
+        target_container=target_container,
+        target_display_locations=target_display_locations,
+    )
+    return donor
+
+
+class ListInstallLocations(TestCase):
+    """``_list_install_locations`` — the helper that turns
+    ``"every body region"`` (broken old picker) into the slot(s)
+    where the specific donor can actually go.  Two paths converge:
+    biological (lookup by organ_name in species spec) and cyberware
+    (item-declared overrides).  Cross-species refusal sits in front
+    of both."""
+
+    # -- Biological path ---------------------------------------------
+
+    def test_biological_heart_occupied_when_slot_intact(self):
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={
+            "heart": _make_organ("chest", current_hp=15),
+        })
+        donor = _make_donor(organ_name="heart", source_species="human",
+                             compatible_species=["human"])
+        self.assertEqual(
+            _list_install_locations(target, donor),
+            [("chest", "occupied")],
+        )
+
+    def test_biological_heart_empty_when_slot_harvested(self):
+        # Heart's been harvested (current_hp=0) → slot is empty,
+        # ready for a fresh donor.
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={
+            "heart": _make_organ("chest", current_hp=0),
+        })
+        donor = _make_donor(organ_name="heart", source_species="human",
+                             compatible_species=["human"])
+        self.assertEqual(
+            _list_install_locations(target, donor),
+            [("chest", "empty")],
+        )
+
+    def test_biological_eye_picks_display_location(self):
+        # Eyes have container="head" but display_location="left_eye"
+        # — the display surface is the install target, not the bulk
+        # container.  Same rule the wound renderer follows.
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={
+            "left_eye": _make_organ("head", current_hp=0),
+        })
+        target.medical_state.organs["left_eye"].display_location = "left_eye"
+        donor = _make_donor(organ_name="left_eye", source_species="human",
+                             compatible_species=["human"])
+        result = _list_install_locations(target, donor)
+        self.assertEqual([loc for loc, _tag in result], ["left_eye"])
+
+    # -- Cross-species gate ------------------------------------------
+
+    def test_cross_species_donor_refused(self):
+        # Rat heart in a human → empty list (picker shows refusal).
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={
+            "heart": _make_organ("chest"),
+        })
+        donor = _make_donor(organ_name="heart", source_species="rat",
+                             compatible_species=["rat"])
+        self.assertEqual(_list_install_locations(target, donor), [])
+
+    def test_legacy_donor_falls_back_to_source_species(self):
+        # Items harvested before ``compatible_species`` was added
+        # carry only ``source_species``.  The helper synthesises the
+        # list so cross-species refusal still works for legacy data.
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={
+            "heart": _make_organ("chest", current_hp=0),
+        })
+        donor = _make_donor(organ_name="heart", source_species="rat",
+                             compatible_species=None)  # legacy
+        self.assertEqual(_list_install_locations(target, donor), [])
+
+    def test_legacy_donor_same_species_passes(self):
+        # Same fallback — but when source species matches target,
+        # the install proceeds.
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={
+            "heart": _make_organ("chest", current_hp=0),
+        })
+        donor = _make_donor(organ_name="heart", source_species="human",
+                             compatible_species=None)  # legacy
+        self.assertEqual(
+            _list_install_locations(target, donor),
+            [("chest", "empty")],
+        )
+
+    # -- Cyberware path ----------------------------------------------
+
+    def test_cyberware_with_target_display_locations(self):
+        # Cybernetic eye declares both eye sockets as valid targets.
+        # Picker should offer both — surgeon chooses which side.
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={})
+        donor = _make_donor(
+            key="cybernetic eye v2",
+            organ_name=None,  # cyberware needn't match species spec
+            compatible_species=["human", "rat", "lizard"],
+            target_display_locations=["left_eye", "right_eye"],
+        )
+        result = _list_install_locations(target, donor)
+        self.assertEqual(
+            sorted([loc for loc, _tag in result]),
+            ["left_eye", "right_eye"],
+        )
+
+    def test_cyberware_compatible_with_multiple_species(self):
+        # Same cybernetic eye lands on a rat just fine.
+        from commands.CmdOperate import _list_install_locations
+        target_rat = _make_target(species="rat", organs={})
+        donor = _make_donor(
+            key="cybernetic eye v2",
+            organ_name=None,
+            compatible_species=["human", "rat"],
+            target_display_locations=["left_eye", "right_eye"],
+        )
+        result = _list_install_locations(target_rat, donor)
+        self.assertEqual(len(result), 2)
+
+    def test_cyberware_refused_for_uncompatible_species(self):
+        from commands.CmdOperate import _list_install_locations
+        target_lizard = _make_target(species="lizard", organs={})
+        donor = _make_donor(
+            key="cybernetic eye v2",
+            organ_name=None,
+            compatible_species=["human", "rat"],
+            target_display_locations=["left_eye", "right_eye"],
+        )
+        self.assertEqual(_list_install_locations(target_lizard, donor), [])
+
+    def test_cyberware_with_target_container_only(self):
+        # Simpler cyberware — bulk slot replacement.  Just container,
+        # no per-side display_location list.
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={
+            "heart": _make_organ("chest", current_hp=0),
+        })
+        donor = _make_donor(
+            key="artificial heart",
+            organ_name=None,
+            compatible_species=["human"],
+            target_container="chest",
+        )
+        result = _list_install_locations(target, donor)
+        self.assertEqual([loc for loc, _tag in result], ["chest"])
+
+    # -- No-go cases --------------------------------------------------
+
+    def test_unknown_organ_name_returns_empty(self):
+        # Donor's organ_name doesn't exist in the target species'
+        # spec — no install target, picker refuses cleanly.
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={})
+        donor = _make_donor(
+            organ_name="quantum_synapse",  # made up
+            source_species="human",
+            compatible_species=["human"],
+        )
+        self.assertEqual(_list_install_locations(target, donor), [])
+
+    def test_donor_with_no_organ_name_or_overrides_returns_empty(self):
+        from commands.CmdOperate import _list_install_locations
+        target = _make_target(species="human", organs={})
+        donor = _make_donor(
+            organ_name=None,
+            compatible_species=["human"],
+        )
+        self.assertEqual(_list_install_locations(target, donor), [])


### PR DESCRIPTION
**User-reported bug:** install picker offered every body region as install target for a heart — when the heart only fits the chest.

**Fix:** `_list_install_locations(target, donor_item)` — returns just the valid slot(s). Two paths converge:

- **Biological:** look up donor's `organ_name` in `get_species_organs(target_species)`. Heart → chest; eyes → display_location.
- **Cyberware:** items declare their own placement via `db.target_container` / `db.target_display_locations`. A cybernetic eye sets `["left_eye", "right_eye"]` and picker offers both. No species spec entry needed.

**Cross-species gate:** `donor.db.compatible_species` (stamped `[source_species]` at harvest, freely declared on cyberware) must include target's species. Legacy items pre-dating this field fall back to `source_species` — no migration needed.

**Occupied / empty tag** on each slot reflects current HP. Surgeon can still pick an occupied slot (resolver replaces) but the tag warns. Multi-slot extension (Doctor Octopus) plugs into the same overrides later.

**End-to-end verified via docker smoke:**
- Human heart → `compatible_species=['human']` stamped at harvest
- Install in human (intact): `[('chest', 'occupied')]`
- Install in human (harvested): `[('chest', 'empty')]`
- Install in rat (cross-species): `[]` → picker refuses

12 new tests in `ListInstallLocations`. Suite: 2120/2120.

**Out of scope:** resolver-side picked-location validation, in-world cyberware content, multi-slot capacity schema change.

Refs #307.