### PR TITLE
specs: catch up canonical docs after the surgery arc

### DIFF
--- a/specs/EVMENU_PATTERNS_SPEC.md
+++ b/specs/EVMENU_PATTERNS_SPEC.md
@@ -237,6 +237,105 @@ Commands: stat1 <value>, stat2 <value>, reset, done
     return text, options
 ```
 
+### Pattern D: Multi-Source Picker with Status Tags
+
+**Use Case:** Location / target pickers whose entries come from more than one underlying source — e.g. surgery's suture picker (open incisions + planned chart steps + severed-organ stumps), the install picker (species-valid slots tagged occupied/empty), the amputate picker (severable containers minus already-severed ones). Each source contributes the same kind of entry; tags on each row tell the player *why* an entry is there.
+
+**Use case characteristics:**
+
+* Picker draws from N independent data sources, each potentially contributing the same location/value.
+* When a single value has multiple sources, the row should tag *all* of them (`(open + planned)`) rather than appear N times.
+* An "all" sentinel entry up top lets the player apply the verb without picking one.
+* Empty-source path needs its own handling — when every source is empty, the menu either offers a sentinel action or short-circuits with an explanation rather than rendering an empty list.
+
+**Reference implementation:** `commands/CmdOperate.py` → `_node_suture_location`, drawing from `_list_open_incisions` (live surgical state) + `_list_planned_incisions` (pending chart steps) + `_list_severed_locations` (severed-organ stumps inferred from the medical state).
+
+```python
+def _node_picker(caller, raw_string, **kwargs):
+    target = caller.ndb._operate_target
+
+    # Pull each source as a set so union / membership is cheap.
+    open_locs    = set(_list_open_incisions(target))
+    planned_locs = set(_list_planned_incisions(caller))
+    stump_locs   = set(_list_severed_locations(target))
+    all_locs     = sorted(open_locs | planned_locs | stump_locs)
+
+    # Empty-source fall-through.  Offer the sentinel directly so the
+    # surgeon can still author a "suture all" step that'll find
+    # incisions later if/when they exist.
+    if not all_locs:
+        text = (
+            "\n|wSuture|n\n\n"
+            "No incisions currently open and no incise steps in your "
+            "chart.  Adding a 'suture all' step anyway — useful if you "
+            "plan to add incise steps later.\n\n"
+            "  |wEnter|n - add 'suture all' step\n"
+            "  |wx|n     - Cancel"
+        )
+        options = ({"key": "_default", "goto": _process_picker_no_open},)
+        return text, options
+
+    # Build the option list.  Index 0 is the "all" sentinel; subsequent
+    # entries are individual picker targets with tags assembled
+    # union-style from all matching sources.
+    options_list = [
+        (f"|wall|n  {MUTED}(open + planned + stumps)|n",
+         "all open incisions"),
+    ]
+    for loc in all_locs:
+        tags = []
+        if loc in open_locs:    tags.append("open")
+        if loc in planned_locs: tags.append("planned")
+        if loc in stump_locs:   tags.append("stump")
+        tag = f"{MUTED}({' + '.join(tags)})|n"
+        options_list.append((f"{loc.replace('_', ' ')}  {tag}", loc))
+
+    # Persist on ndb so the processor can resolve the surgeon's pick.
+    caller.ndb._operate_pickable = options_list
+    listing = "\n".join(
+        f"  {idx}. {label}"
+        for idx, (label, _val) in enumerate(options_list, start=1)
+    )
+    text = (
+        "\n|wSuture|n\n\n"
+        "Pick what to suture:\n\n"
+        f"{listing}\n\n"
+        "  x. Cancel\n\n"
+        "|wWhich?|n (number or name)"
+    )
+    options = ({"key": "_default", "goto": _process_picker},)
+    return text, options
+```
+
+**The processor unpacks `(label, value)`:**
+
+```python
+def _process_picker(caller, raw_string, **kwargs):
+    raw = (raw_string or "").strip()
+    if raw.lower() in ("x", "exit", "cancel"):
+        return "node_top"
+    if not raw:
+        return None
+    pick = _parse_pick(raw, caller.ndb._operate_pickable or [])
+    if pick is None:
+        caller.msg("|rNo match.|n")
+        return None
+    # Pickable entries are (label, value) tuples — unpack the value.
+    value = pick[1] if isinstance(pick, tuple) else pick
+    # ... record the chart step / fire the action ...
+    return "node_top"
+```
+
+**Status-tag conventions:**
+
+* Tag text wraps in `MUTED` (the orange `|520` accent code) so it visually de-emphasises beside the location name.
+* Multiple-source tags collapse with `" + "` so `open + planned` reads naturally.
+* The sentinel "all" row's tag describes the *broadest* set the action covers (`(open + planned + stumps)`).
+
+**Sources can be derived from any state.** The suture picker's "stump" source consults the medical state directly — `_list_severed_locations` reads `compute_cut_points` from the severance module so combat-driven amputation (which never goes through the chart) still surfaces. Picker design should ask *"what's the real source of truth for this entry?"* rather than enumerating the obvious surface (e.g. just open incisions). Multi-source pickers are the way to bridge surfaces that don't share a single backing store.
+
+**Testing.** Each source contributes via its own helper; the picker node is then a thin composition. Test the helpers individually and add a single node-level test for each *combination* you care about (a row that's both open and stump should tag both). See `world/tests/test_operate_menu.py` `SutureLocationPicker` for the regression-history-grounded pattern: each historical bug in the picker became one test.
+
 ---
 
 ## Key Takeaways

--- a/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
+++ b/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
@@ -2911,9 +2911,11 @@ class Prosthetic:
 - [ ] Advanced surgical procedures
 - [ ] `operate` charting menu (see below)
 
-### Proposed: `operate` Charting Command (Future)
+### Phase 2.9: `operate` Charting Command - ✅ COMPLETED (June 2026)
 
-The procedural verbs (`incise` / `harvest` / `install` / `suture` — see #307 / PR #380) give players direct, low-level control over surgery in real time. `operate` is the proposed high-level companion: a menu-driven UI, modelled on `describe`, that lets a surgeon build and persist a **medical chart** on a patient. The verbs stay the canonical "what's happening right now" layer; `operate` is the canonical "here is the plan" layer.
+PRs in the #307 follow-on arc shipped the `operate` charting command alongside the procedural verbs. The verbs stay the canonical "what's happening right now" layer; `operate` is the canonical "here is the plan" layer.
+
+This section was authored as a forward-looking proposal and is retained as the design rationale for the menu surface. Where the implementation diverged from the original plan, deviations are called out inline below — the design intent should be read alongside the **As Built** notes for current behaviour.
 
 #### Intent and Positioning
 
@@ -3201,6 +3203,123 @@ Each phase is independently useful and testable; nothing in a later phase requir
 - **Patient-authored "advance directives."** A patient pre-authors a chart on themselves while conscious (DNR, organ donor flags, allergies); other surgeons see it on diagnose. Probably stretch, but the schema accommodates it.
 - **NPC use.** Should NPC surgeons (faction medics, hospital staff) chart on patients to telegraph intent? Could be a strong narrative tool; needs AI behaviour design beyond this spec's scope.
 
+#### As Built — Deviations and Realisations
+
+The implementation matches the proposal at the chart-data-structure and procedure-dispatch level. The following deviations and additions are visible in the shipped menu:
+
+* **Visual layout** — the box-drawn `score`-style chrome was replaced with **tree-branched section labels** (`PATIENT` / `CHART` / `OPTIONS` connected with box-drawing characters). The `describe`-style flush-left layout was retained. The current design idiom matches `armor comprehensive`.
+* **Charting + treatment unified.** The proposal split "Add procedure step" from "Add treatment step." Implementation collapses to a single "Add procedure step" because treatment verbs (`apply` / `inject` / `spray` / `inhale`) are now dispatched through a future PR-OP3 path; they're skipped with an outcome note today and the surgeon adds them inline once that lands.
+* **`amputate` is a procedure verb.** Combat-side severance went through `apply_sever_to_character` / `spawn_severed_head_for_living` directly; the chart now exposes `amputate` as a fifth procedure verb that routes through the same severance pipeline (with surgical-kit gating instead of edged-weapon gating). `CmdSever` retains `amputate` as a command alias.
+* **Multi-source pickers.** The suture location picker reads from three sources (open incisions, planned chart steps, severed-organ stumps from the medical state); the install location picker filters slots by species + donor-organ compatibility. See [EVMENU_PATTERNS_SPEC.md](EVMENU_PATTERNS_SPEC.md) "Pattern D — Multi-Source Picker with Status Tags" for the canonical shape.
+* **Diagnose pane** is the only proposed sub-feature still pending — currently rolled into the patient panel header (status indicators + open-incision list). The proposal-grade dedicated pane with skill-gated reveal is open work.
+* **Target resolution** — `operate <mob>` now correctly finds the body even when severed parts are in the room. Identity-pipeline candidate set excludes `Appendage` / `SeveredHead` items at stage 1; the NPC-fallback in the sdesc matcher falls through to word-boundary when prefix doesn't fire (otherwise `operate rat` couldn't reach a `"a scrawny ragged rat"` mob — the article prefix would defeat the prefix-only match).
+* **Chart status fields** — `last_modified_by` is not stored separately; the chart's most-recent step author is implicit in `_step_finished` records. `diagnoses` field is reserved but unused pending the diagnose pane.
+* **Tests** — node-level coverage seeded in `world/tests/test_operate_menu.py` (42 tests across the suture picker, install picker, top-choice routing, verb-choice routing). Chart-data layer covered in `world/tests/test_operate_charts.py`.
+
+### Phase 2.10: Severance, Suture Stumps, and Install Picker - ✅ COMPLETED (June 2026)
+
+The procedural verbs and the operate menu went live on a model that mostly worked but accumulated playtest-driven gaps as soon as decapitation and amputation hit real bodies. This phase consolidates the corrective arc:
+
+#### Severance helper module (PR #427)
+
+`world/medical/severance.py` is the single source of truth for severance-related queries. Three functions:
+
+* `compute_severed_containers(target)` — the set of containers carrying at least one organ with `wound_stage="severed"` and `current_hp == 0`. Both gates so a partially-zeroed organ isn't promoted to a severance.
+* `compute_cut_points(target)` — the canonical *one-entry-per-severance* set after two collapse rules:
+  - **Head cluster** — when `"head"` is in the severed set (brain lives there and is zeroed by `sever_character_body` during any decapitation), every cluster peer from `get_species_severed_head_locations` (face / neck / eyes / ears / hair-or-fur, species-dependent) collapses into a single `"head"` cut point.
+  - **Limb chain** — downstream containers whose `get_species_limb_parent` ancestor is also severed collapse into the chain root. Thigh amputation surfaces as `"left_thigh"`; shin and foot ride with it.
+* `normalize_sutured_stumps(target)` — returns a `{location: outcome}` dict regardless of underlying storage shape. The legacy flat-list shape (pre-outcome-flavoured renderer) imports each entry as `"success"` outcome.
+
+Three consumers route through these helpers and agree on the answers:
+
+| Consumer | Reads | Purpose |
+|---|---|---|
+| `world.medical.wounds.wound_descriptions.get_character_wounds` | `compute_cut_points` | Synthetic cut-point wound emission |
+| `commands.CmdOperate._list_severed_locations` | `compute_cut_points` − `normalize_sutured_stumps.keys()` | Suture picker entries |
+| `world.medical.procedures._resolve_suture` | same | Runtime untreated-stumps set for `suture all` |
+
+Pre-consolidation each consumer reimplemented the cluster + chain filter and the storage-shape shim. Three copies of the same logic; the consolidation collapses to one.
+
+#### Synthetic severance wound contract (PRs #420 / #421 / #422)
+
+`get_character_wounds` was previously emitting one severance wound per severed organ, so a decapitation rendered as "brain destroyed" / "left eye destroyed" / "right ear destroyed" / etc. The renderer now:
+
+* Suppresses *every* per-organ wound at any container in `compute_severed_containers` (subsumes the old head-cluster + limb-chain dual-filter).
+* Emits **one** synthetic wound per entry in `compute_cut_points`, matching the corpse-side `apply_sever_to_corpse` shape exactly:
+  ```python
+  {
+      "injury_type": "severed",
+      "location": cut_point,
+      "severity": "Critical",
+      "stage": _stump_stage(character, cut_point),  # see below
+      "organ": None,
+      "organ_obj": None,
+  }
+  ```
+
+Same renderer key the corpse path uses, so the live-body view during the death-progression window and the eventual corpse view render identical prose. Routes through `world/medical/wounds/messages/severed.py`.
+
+#### Sutured stump progression (PRs #423 / #426)
+
+`_resolve_suture` now records each cut point it closes in `character.db.sutured_stumps` keyed by location, valued by the suture-roll outcome:
+
+```python
+character.db.sutured_stumps = {
+    "head": "success",
+    "left_arm": "partial",
+    "right_arm": "failure",
+}
+```
+
+`_stump_stage(character, location)` reads the outcome and routes the synthetic wound to one of three flavoured renderer stages — `treated_success`, `treated_partial`, `treated_failure`. `severed.py` carries 3–4 variants per subgroup, so a clean roll reads "carefully sutured shut, the dressing clean" while a botched roll reads "crudely bandaged, the seam pulling dirty." The failure subgroup aligns prose with the existing infection-condition seeding `_resolve_suture` does on a failure outcome.
+
+Backward-compat lives in `normalize_sutured_stumps`: a legacy flat-list `sutured_stumps` reads as `{loc: "success"}`. The picker and runtime never see the legacy shape.
+
+Time-based progression past `treated_<outcome>` (the `healing` and `scarred` stages already populated in severed.py) is parked — needs research on Evennia ticker semantics before wiring.
+
+#### Combat amputation symmetry (PR #428)
+
+`open_incision`'s `surgeon` parameter is now optional (default `None`). `apply_sever_to_character` and `spawn_severed_head_for_living` both call `open_incision` immediately after `sever_character_body`. Result: any severance — combat-driven via `ArmorMixin.take_damage`, chart-driven via `_resolve_amputate` — leaves a recorded incision at the cut point, so the suture verb finds an open wound to close regardless of how the stump came to be.
+
+`_resolve_amputate` retains its own `open_incision` call afterward, which overwrites the location entry to record the chart surgeon as `opened_by` (chart-attribution win); `opened_by` is forensic-only state with no readers. Combat keeps the attacker as `opened_by`.
+
+#### Decapitation pipeline ownership (PR #419)
+
+`spawn_severed_head_for_living` now sets both `head_severed_at_decap = True` *and* `decapitation_pending = True`. The corpse-side cleanup hook in `DeathProgressionScript._create_corpse_from_character` gates on `decapitation_pending` to strip head-cluster prose / wounds and synthesise the neck-stump wound on the corpse. Pre-fix the combat path set `decapitation_pending` upstream but the chart-amputate path didn't — so chart-driven decap left the corpse rendering wounds at every cluster location. Owning both flags inside the spawn makes the cleanup fire regardless of caller.
+
+#### Install picker species + organ filter (PR #431)
+
+`_node_install_location` was reading `_list_containers(target)` (every container on the target) so installing a heart offered every body region as a target. Replaced with `_list_install_locations(target, donor_item)` which converges two paths through one helper:
+
+| Path | When it fires | Source of truth |
+|---|---|---|
+| **Biological** | Donor's `db.organ_name` is in the target species' organ spec | `get_species_organs(target_species)[organ_name]` — picks display_location if distinct from container, else container |
+| **Cyberware** | Donor declares `db.target_container` and / or `db.target_display_locations` | Item-side overrides; the donor doesn't need an entry in the species spec |
+
+Cross-species gate runs first: `donor_item.db.compatible_species` (stamped `[source_species]` at harvest by `_configure_harvested_item`) must include the target's species or the picker shows nothing. Legacy items pre-dating this field fall back to `[source_species]` via the existing harvest provenance.
+
+Each slot is tagged `(empty)` or `(occupied)` based on the slot organ's current HP. Surgeon can still pick occupied slots — the resolver replaces — but the tag warns. Multi-slot capacity (cybernetic limb augmentation — Doctor Octopus arms) is future work and will plug into the same `target_display_locations` declaration without rework.
+
+#### Operate target resolution (PR #425)
+
+Two fixes, two surgical edits:
+
+1. **NPC-fallback in `_match_sdesc`** — when an NPC's `get_sdesc()` returns the bare key (no explicit sdesc set, the default for spawned mobs), the matcher tried prefix-only and silently failed for mob keys that started with an article (`"a scrawny ragged rat"`). Fixed by letting the NPC fallback fall through to the word-boundary check below — `"tom"` → `"Tom Hanks"` (prefix wins), `"rat"` → `"a scrawny ragged rat"` (word-boundary catches it).
+2. **Detached-parts filter in `_resolve_target`** — `SeveredHead` / `Appendage` participate in identity (forensic-chain `apparent_uid_at_death`) so they could theoretically end up as identity matches. Surgical commands target whole-body patients only. Filtering `isinstance(obj, Appendage)` out of the stage-1 candidate set means the picker never has detached parts to compete with the body. Detached parts continue routing through stages 2/3 where `autopsy` / `sever` / `harvest` find them.
+
+#### Files
+
+* `world/medical/severance.py` — single-source-of-truth helpers
+* `world/medical/wounds/wound_descriptions.py` — `_stump_stage`, simplified cut-point synthesis
+* `world/medical/wounds/messages/severed.py` — outcome-flavoured stages, prose stocked
+* `world/medical/procedures.py` — `open_incision` made surgeon-optional, `_resolve_suture` simplified via helpers, `_configure_harvested_item` stamps `compatible_species`
+* `typeclasses/items.py` — `apply_sever_to_character` + `spawn_severed_head_for_living` call `open_incision`; `apply_severed_head_overlay` drops redundant snapshot write (base `apply_organ_snapshot_overlay` owns it via the super-call)
+* `commands/CmdOperate.py` — multi-source suture picker, species-filtered install picker
+* `commands/CmdSurgical.py` — detached-parts filter in `_resolve_target`
+* `world/search.py` — NPC-fallback word-boundary fall-through
+* `world/tests/test_severance_helpers.py` — 13 tests covering the helper module
+* `world/tests/test_operate_menu.py` — 42 tests covering picker + routing nodes
+
 ## Medical System Summary
 
 This specification documents a comprehensive medical system architecture providing:
@@ -3235,7 +3354,10 @@ This specification documents a comprehensive medical system architecture providi
 - **Phase 2.5**: ✅ Extended consumption methods and inhalation mechanics (Completed September 2025)
 - **Phase 2.6**: ✅ Ticker-based medical conditions with time-based progression (Completed December 2024)
 - **Phase 2.7**: ✅ Unified medical messaging and forensic evidence systems (Completed September 2025) - *Forensic system is proof-of-concept only*
-- **Phase 3**: 🔮 Advanced features (cybernetics, complex procedures) - Future development
+- **Phase 2.8**: ✅ Procedural surgery system (`incise` / `harvest` / `install` / `suture` / `amputate`) (Completed June 2026)
+- **Phase 2.9**: ✅ `operate` charting command — menu-driven surgery planning (Completed June 2026)
+- **Phase 2.10**: ✅ Severance helper module, sutured-stump outcome flavour, install picker species filter, combat-amputation incision symmetry (Completed June 2026)
+- **Phase 3**: 🔮 Advanced features (cybernetics implementation, multi-slot capacity, healing-tick progression) - Future development
 
 **Key Features Delivered:**
 - Hospital-grade anatomical accuracy with individual bone tracking

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1329,6 +1329,57 @@ Canonical implementations of this pattern:
 - `commands/CmdSurgical.py:_resolve_target`
 - `commands/CmdClothing.py:_resolve_clothing_target`
 
+#### Detached-parts filter (Stage 1 carve-out, Phase 2.10)
+
+A second carve-out at the identity stage. `Appendage` / `SeveredHead` items participate in the identity surface — they carry `signature_at_death` / `apparent_uid_at_death` for forensic chain so investigators can trace a severed limb back to its source. But **surgical commands target whole-body patients only**; detached parts route through `autopsy` / `sever` / `harvest` instead. When a body and its severed head are in the same room (e.g. `operate 1st rat` after decapitation), the ordinal pick from the identity match could otherwise silently land on whichever the room iteration orders first — usually the head, since severed parts spawn after the body.
+
+`CmdSurgical._resolve_target` filters detached parts out of the stage-1 candidate set before invoking the identity helper:
+
+```python
+from typeclasses.items import Appendage  # base for SeveredHead too
+location = caller.location
+if location is not None:
+    whole_body_candidates = [
+        obj for obj in location.contents
+        if not isinstance(obj, Appendage)
+    ]
+else:
+    whole_body_candidates = None
+identity_match = resolve_character_target(
+    caller, raw_name,
+    candidates=whole_body_candidates,
+    allow_self=False,
+)
+```
+
+Detached parts then route through stages 2 / 3 normally (inventory then room fallback), where `autopsy` and item-targeting commands find them by key match. The filter is targeting-pattern-specific — commands that *do* want detached parts as identity candidates (none today) wouldn't apply it.
+
+#### NPC sdesc fallback (`_match_sdesc` word-boundary fall-through, Phase 2.10)
+
+When a candidate's `get_sdesc()` returns the bare `key` (the NPC default, no explicit sdesc set — the default for any spawned mob), the matcher used to prefix-match only:
+
+```python
+# Pre-fix — broken for article-prefixed keys.
+if sdesc == target_key:
+    return target_key.lower().startswith(query_lower)
+```
+
+`"rat".startswith("a scrawny ragged rat")` returns `False` — the key begins with an article. Identity-based commands like `operate rat` silently couldn't reach mobs whose keys started with `a` / `an` / `the` even though the body was clearly in the room. The matcher now lets the NPC fallback fall through to the word-boundary check below:
+
+```python
+# NPC fallback (sdesc defaults to key): try prefix first — covers
+# "tom" → "Tom Hanks".  Fall through to word-boundary below if
+# prefix doesn't fire, so "rat" still matches a mob whose key is
+# "a scrawny ragged rat".
+if sdesc == target_key:
+    if target_key.lower().startswith(query_lower):
+        return True
+# Word-boundary match: every word in the query must appear as a
+# complete word in the sdesc.
+```
+
+`"tom"` → `"Tom Hanks"` still wins by prefix. `"rat"` → `"a scrawny ragged rat"` now hits the word-boundary path. Single regression test pins the rat-key case in `world/tests/test_identity_search.py:test_npc_fallback_falls_through_to_word_boundary`.
+
 #### Canonical examples
 
 - **Same-room combat**: `commands/combat/core_actions.py` (`CmdAttack`)

--- a/specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md
+++ b/specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md
@@ -11,6 +11,39 @@ prioritised remediation plan with discrete phases.
 Status: **proposal**. Author: audit pass after the pelvis-in-groin fix
 (issue #325) surfaced broader questions about death model and dead metadata.
 
+## Implementation Progress (June 2026 true-up)
+
+This spec is a planning artifact; as phases land, their content gets
+absorbed into canonical specs and the corresponding section here is
+trimmed. The current state of the remediation plan against shipped
+work:
+
+| Phase | Status | Notes |
+|---|---|---|
+| Phase 1 — Documentation & Architectural Clarification | **Partial** | Task 1 (`LETHAL_CAPACITY_NAMES` comment in `world/medical/constants.py`) is done; the comment now explicitly states the union-of-lethal-and-targeting role. Tasks 2, 3, 4 (per-method docstrings, brain-death `# NEXT:` reframing in HEALTH spec, `MEDICAL_SUBSTRATE_READINESS.md` index) are not yet shipped. |
+| Phase 2 — Brain Death Blocks Revival | Not started | `_check_medical_revival_conditions` still gates only on `is_dead()`. |
+| Phase 3 — Failure-Mode Surfacing | Not started | Empty-distribution / unbacked-container warnings not wired. |
+| Phase 4 — Vestigial-Flag Deletion | Not started | All flags listed under "Vestigial (delete)" still present. |
+| Phase 5 — `LETHAL_CAPACITY_NAMES` Split | Not started | Split into `IS_DEAD_LETHAL_CAPACITIES` + `TARGETING_VITAL_CAPACITIES` not done. |
+| Phase 6 — Chronic Medical Conditions Framework (Track 2) | Not started | Substrate gate for kidney death + other long-term conditions. |
+| Phase 7 — Movement Policing Substrate (Track 2) | Not started | Substrate gate for `moving` incapacitation + paralysis. |
+| Phase 8 — Senses System (Track 2) | Not started | Substrate gate for blindness / deafness. |
+| Phase 9 — Equipment-Handling Substrate (Track 2) | Not started | Substrate gate for `manipulation` consequences. |
+| Phase 10–13 — Wiring & Cleanup (Track 3) | Blocked | Each phase has substrate dependencies that aren't met yet. |
+
+**Recent surgery work (June 2026) is orthogonal to this audit.** The
+procedural surgery system (Phase 2.8 in `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md`),
+the operate charting command (Phase 2.9), and the severance / suture-stump /
+install-picker / combat-incision-symmetry work (Phase 2.10) all sit *above*
+the substrate gaps this audit identified — the procedural verbs read /
+mutate organ HP and `wound_stage`, but none of them introduces or resolves
+a substrate consumer for things like `incapacitation_threshold`,
+`paralysis_if_destroyed`, or `total_loss_penalty`. Those substrate phases
+remain the right next focus for an audit-aligned arc.
+
+The audit's Core Insight ("schema without consumers") still stands and
+sequences correctly: build substrate before wiring schema to it.
+
 ---
 
 ## Core Insight — Schema Without Consumers

--- a/specs/SPECIES_AUTHORING.md
+++ b/specs/SPECIES_AUTHORING.md
@@ -134,3 +134,25 @@ The architecture is now complete enough to ship anatomically distinct species. T
 
 - `LONGDESC_FLEX_NOUNS` (`SPECIES_DEFINITIONS[species]["longdesc_flex_nouns"]`). Rats add `tail` / `snout` / `fur` / `whisker` / `paw` / `claw`; pair-keyed singulars flow through `pair_keys` automatically. Use `get_species_longdesc_flex_nouns(species)`.
 - `BODY_CAPACITIES` (`SPECIES_DEFINITIONS[species]["body_capacities"]`). Rat's `moving` references hindleg/hindpaw bones; `manipulation` references foreleg/forepaw bones; `talking` is intentionally absent (rats squeak, they don't talk). Use `get_species_body_capacities(species)`. Consumers updated: `MedicalState.calculate_body_capacity`, `world.medical.utils._get_vital_locations`.
+
+## Item-level compatibility layer (Phase 2.10 follow-up)
+
+The species spec answers *"what slots does a species have?"* Organ items (harvested or cyberware) layer a complementary question on top: *"can this particular organ instance be installed in this target?"* This is item-side, not species-side — both layers coexist.
+
+Three item-side fields land on every donor organ:
+
+| Item attribute | Source | Purpose |
+|---|---|---|
+| `db.compatible_species` | Stamped `[source_species]` at harvest by `_configure_harvested_item`; freely declared on cyberware at item creation | Cross-species gate. Picker / install resolver refuses if target's species isn't in the list. Legacy items pre-dating this field fall back to `[db.source_species]` via the existing harvest provenance. |
+| `db.target_container` | Cyberware only; biological harvest doesn't set it | Override for items that don't have an `organ_name` matching the species spec (cyberware bulk-slot replacements — artificial heart, etc.). |
+| `db.target_display_locations` | Cyberware only; list of valid display surfaces | Override for items installable at multiple display locations (cybernetic eye → `["left_eye", "right_eye"]`). |
+
+Picker flow (`CmdOperate._list_install_locations`):
+
+1. **Cross-species gate.** If `donor.db.compatible_species` is set and doesn't include the target's species, return empty (picker refuses).
+2. **Candidate slots.** If the item declares `target_display_locations` (cyberware paired-slot path), use those. Else if it declares `target_container` (cyberware bulk-slot path), use that. Else look up the donor's `organ_name` in `get_species_organs(target_species)` (biological path) and use `display_location` if distinct from `container`, otherwise `container`.
+3. **Status tag.** Each candidate is tagged `(empty)` or `(occupied)` based on the current HP of the organ at that slot.
+
+The cybernetic-eye case validates the model end-to-end: a single item declares `compatible_species = ["human", "rat", "lizard"]` and `target_display_locations = ["left_eye", "right_eye"]` — the picker offers both eye sockets on whichever recipient species the item supports, and refuses on uncompatible species. Cyberware items don't need entries in any species spec.
+
+Multi-slot capacity (Doctor Octopus arms — installing multiple instances of the same organ type into augmented anatomy) is future work and will need a `state.organs` → `state.slots` schema change. It plugs into the same `target_display_locations` declaration without rework.


### PR DESCRIPTION
16 surgical PRs shipped without spec updates. This catches the five most-relevant canonical docs up to current behaviour.

**HEALTH spec** — `Proposed: operate Charting Command (Future)` promoted to `Phase 2.9 (Completed)` with an "As Built" appendix for deviations; new `Phase 2.10` covers severance module, suture stump outcome flavour, install picker filter, combat amputation incision symmetry.

**EVMENU patterns** — `Pattern D: Multi-Source Picker with Status Tags` documenting the suture / install picker shape.

**Identity spec** — Detached-parts filter + NPC sdesc word-boundary fall-through.

**Species authoring** — Item-level `compatible_species` + cyberware overrides layer.

**Medical audit** — Status table added. Phase 1 task 1 done; rest pending. Recent surgery work explicitly orthogonal to the audit's substrate-gap remediation plan.

No code changes. Suite stable at 2120/2120.

Refs #307.