### PR TITLE
chart-amputate on corpse: actually spawn the appendage + dedupe wound prose

### DIFF
--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -465,7 +465,30 @@ class Corpse(IdentityBearerMixin, Item):
         relevant_wounds = wounds_at_death
         if location:
             relevant_wounds = [w for w in wounds_at_death if w.get('location') == location]
-        
+
+        # Dedupe by (injury_type, location, stage) — multiple destroyed
+        # organs in the same container at death produce one wound entry
+        # each, all with the same renderer key.  Without this dedupe a
+        # corpse killed by an abdomen-wide injury renders "the abdomen
+        # is shredded" once per dead organ (often three or four lines,
+        # sometimes duplicate variants from random.choice).  Same (type,
+        # location, stage) → one rendered description.  Different
+        # injury_types or stages at the same location still render
+        # independently — a cut AND a bullet at the chest are distinct.
+        seen_keys = set()
+        unique_wounds = []
+        for wound_data in relevant_wounds:
+            key = (
+                wound_data.get('injury_type'),
+                wound_data.get('location'),
+                wound_data.get('stage'),
+            )
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            unique_wounds.append(wound_data)
+        relevant_wounds = unique_wounds
+
         # Generate descriptions for each wound
         for wound_data in relevant_wounds:
             try:

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1694,6 +1694,17 @@ def apply_sever_to_corpse(corpse, location_arg, *, head_locations=None):
             getattr(getattr(corpse, "db", None), "species", None)
         )
 
+    # Idempotency guard: if a synthetic stump wound at ``location_arg``
+    # already exists in ``wounds_at_death``, a previous invocation
+    # already ran this mutation.  Re-running would duplicate the stump
+    # wound and re-clear longdescs that aren't there.  Bail cleanly.
+    src_wounds_for_check = corpse.db.wounds_at_death or ()
+    for existing in src_wounds_for_check:
+        if (existing.get("injury_type") == "severed"
+                and existing.get("location") == location_arg
+                and existing.get("organ") is None):
+            return
+
     if location_arg == "head":
         locs = frozenset(head_locations)
     else:
@@ -1752,60 +1763,108 @@ def apply_sever_to_corpse(corpse, location_arg, *, head_locations=None):
         corpse.db.head_severed = True
 
 
+def spawn_severed_part_from_corpse(corpse, location_arg):
+    """Spawn + configure a severed appendage from a corpse.
+
+    Generalises the head-only ``spawn_severed_head_for_corpse`` to any
+    severable location.  Pattern mirrors :class:`commands.forensics.CmdSever`
+    inline:
+
+    1. Idempotency check — if ``location_arg`` is already in
+       ``corpse.db.severed_locations``, return ``None``.
+    2. Choose typeclass: ``SeveredHead`` for ``"head"``,
+       ``Appendage`` for anything else.
+    3. ``create_object`` with a species-aware decay-flavoured key.
+    4. ``configure_from_sever`` to copy provenance / decay / wounds
+       / longdescs / snapshot off the corpse.
+    5. Record the sever in ``corpse.db.severed_locations``.
+    6. ``apply_sever_to_corpse`` to mutate the corpse (drop cluster
+       longdescs / wounds, synthesise the stump wound, flip
+       ``head_severed`` on head).
+
+    Used by:
+
+    * ``commands.forensics.CmdSever`` — manual weapon-driven severance.
+    * ``world.medical.procedures._resolve_amputate`` (corpse branch) —
+      chart-driven amputation on a corpse.
+    * ``spawn_severed_head_for_corpse`` (legacy alias, head-only) —
+      death-progression combat decapitation.
+
+    Args:
+        corpse: Source corpse.
+        location_arg: Canonical severable container name
+            (member of ``get_species_severable_containers(corpse.db.species)``).
+
+    Returns:
+        The spawned :class:`Appendage` / :class:`SeveredHead`, or
+        ``None`` if the corpse has no room or the location was already
+        severed.
+    """
+    from evennia import create_object
+    from world.combat.constants import ORGAN_CONDITION_BY_DECAY
+    from world.anatomy import get_species_part_name
+
+    room = corpse.location
+    if room is None:
+        return None
+    if location_arg in (corpse.db.severed_locations or ()):
+        return None
+
+    get_decay_stage = getattr(corpse, "get_decay_stage", None)
+    decay_stage = get_decay_stage() if callable(get_decay_stage) else "fresh"
+    condition = ORGAN_CONDITION_BY_DECAY.get(decay_stage, "damaged")
+    species = (
+        getattr(getattr(corpse, "db", None), "species", None) or "human"
+    )
+
+    if location_arg == "head":
+        typeclass = "typeclasses.items.SeveredHead"
+        readable_name = "head"
+    else:
+        typeclass = "typeclasses.items.Appendage"
+        # Species-aware readable name for the item key.
+        try:
+            readable_name = get_species_part_name(
+                species, location_arg, decay_stage,
+            ) or location_arg.replace("_", " ")
+        except Exception:
+            readable_name = location_arg.replace("_", " ")
+
+    appendage = create_object(
+        typeclass,
+        key=f"{condition} {readable_name}",
+        location=room,
+    )
+    appendage.configure_from_sever(
+        location_name=location_arg, condition=condition, corpse=corpse,
+    )
+
+    severed_list = list(corpse.db.severed_locations or ())
+    if location_arg not in severed_list:
+        severed_list.append(location_arg)
+        corpse.db.severed_locations = severed_list
+
+    apply_sever_to_corpse(corpse, location_arg)
+
+    return appendage
+
+
 def spawn_severed_head_for_corpse(corpse):
-    """Spawn + configure a :class:`SeveredHead` for a decapitated corpse.
+    """Legacy alias — head-only wrapper around
+    :func:`spawn_severed_part_from_corpse`.
 
     Combat-driven decapitation (Phase C, issue #245 follow-up) cannot
     reach the corpse synchronously: a lethal edged neck hit flags the
     dying character, the asynchronous death pipeline builds the corpse,
     and this helper is invoked at the tail of
     :meth:`typeclasses.death_progression.DeathProgressionScript._create_corpse_from_character`
-    once the corpse is fully populated.  It mirrors the manual
-    :class:`commands.forensics.CmdSever` head path: spawn the
-    super-item, copy the corpse's identity / decay / trimmed snapshot
-    onto it via :meth:`SeveredHead.configure_from_sever`, record the
-    sever, and clear the head-cluster prose off the corpse via
-    :func:`apply_sever_to_corpse`.
-
-    Idempotent: if the head has already been severed (``"head"`` in
-    ``corpse.db.severed_locations``) this is a no-op returning ``None``.
-
-    Args:
-        corpse: The freshly built corpse to decapitate.
+    once the corpse is fully populated.
 
     Returns:
         The spawned :class:`SeveredHead`, or ``None`` if the corpse has
         no location or the head was already severed.
     """
-    from evennia import create_object
-    from world.combat.constants import ORGAN_CONDITION_BY_DECAY
-
-    room = corpse.location
-    if room is None:
-        return None
-    if "head" in (corpse.db.severed_locations or ()):
-        return None
-
-    get_decay_stage = getattr(corpse, "get_decay_stage", None)
-    decay_stage = get_decay_stage() if callable(get_decay_stage) else "fresh"
-    condition = ORGAN_CONDITION_BY_DECAY.get(decay_stage, "damaged")
-
-    head = create_object(
-        "typeclasses.items.SeveredHead",
-        key=f"{condition} head",
-        location=room,
-    )
-    head.configure_from_sever(
-        location_name="head", condition=condition, corpse=corpse,
-    )
-
-    severed_list = list(corpse.db.severed_locations or ())
-    severed_list.append("head")
-    corpse.db.severed_locations = severed_list
-
-    apply_sever_to_corpse(corpse, "head")
-
-    return head
+    return spawn_severed_part_from_corpse(corpse, "head")
 
 
 def spawn_severed_head_for_living(character, *, injury_type="cut"):

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -1010,10 +1010,15 @@ def _resolve_amputate(actor, target, *, location: str, **_) -> None:
                 )
                 return
     else:
-        # Corpse-shaped target.
-        from typeclasses.items import apply_sever_to_corpse
+        # Corpse-shaped target.  ``apply_sever_to_corpse`` only mutates
+        # the corpse — it doesn't spawn the appendage item.
+        # ``spawn_severed_part_from_corpse`` is the full path: spawn the
+        # right typeclass (SeveredHead / Appendage), configure provenance,
+        # record the sever, then mutate the corpse.  Same path
+        # ``CmdSever`` follows for manual weapon-driven severance.
+        from typeclasses.items import spawn_severed_part_from_corpse
         try:
-            appendage = apply_sever_to_corpse(target, location)
+            appendage = spawn_severed_part_from_corpse(target, location)
         except Exception as exc:
             actor.msg(f"The cut cannot proceed: {exc}")
             return


### PR DESCRIPTION
Three bugs from the same playtest, all related to the corpse-side severance path.

**Bug #2 (load-bearing):** `operate carcass` → `amputate head` failed with "head can't be severed here". Root cause: `_resolve_amputate` corpse branch called `apply_sever_to_corpse` directly, which only *mutates* the corpse but doesn't spawn the SeveredHead/Appendage item. Resolver bailed AFTER mutating state — leaving the corpse half-severed.

**Fix:** Generalised `spawn_severed_head_for_corpse` → `spawn_severed_part_from_corpse(corpse, location_arg)` covering head AND limbs. `_resolve_amputate` corpse branch now calls it. Legacy head wrapper retained for the combat-decap death-progression call.

**Bug #3 (downstream of #2):** The user fell back to `sever head from carcass`, but the resulting head item rendered "The head is missing — the stump long since congealed and stiff" on its own prose. Root cause: bug #2 had already mutated the corpse (stump wound at "head" added to `wounds_at_death`); when `sever` ran, `configure_from_sever` copied that stump wound onto the head item.

**Fix:** Bug #2's fix prevents the leak at the source. Plus defence-in-depth — made `apply_sever_to_corpse` idempotent via a stump-wound existence check.

**Bug #1 (separate):** Chainsaw-to-abdomen produced 4 near-identical wound lines on the corpse, sometimes duplicates from random.choice.

**Fix:** Dedupe by `(injury_type, location, stage)` triple in `Corpse.get_wound_descriptions_for_location` before rendering. Same renderer key → one description. Distinct keys still render independently.

Smoke-tested live: chart-amputate on rat corpse now spawns the head, `head_severed=True`, head item carries zero "head" stump wounds.

Suite: 2120/2120.