### PR TITLE
corpse stumps: decay-aware stage + visible suture progression

### DIFF
--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -489,11 +489,35 @@ class Corpse(IdentityBearerMixin, Item):
             unique_wounds.append(wound_data)
         relevant_wounds = unique_wounds
 
+        # Suture progression for corpse stumps — when ``sutured_stumps``
+        # records a treatment outcome at a severance location, override
+        # the wound's stored stage with the outcome-flavoured variant.
+        # Same pattern as the living-body renderer's ``_stump_stage``
+        # but applied at corpse render time (the live wound data on
+        # the corpse stays unchanged — this is a presentation overlay).
+        # Lets a surgeon's post-death suture work visibly progress the
+        # stump prose without mutating the death-preserved wound dict.
+        from world.medical.severance import normalize_sutured_stumps
+        sutured = normalize_sutured_stumps(self)
+
         # Generate descriptions for each wound
         for wound_data in relevant_wounds:
             try:
                 from world.medical.wounds import get_wound_description
-                
+
+                # Default stage: the death-preserved value on the
+                # wound dict.  Severance wounds at sutured cut points
+                # are overridden to ``treated_<outcome>`` so corpse
+                # stumps progress visually after suture.
+                render_stage = wound_data.get('stage', 'fresh')
+                if (wound_data.get('injury_type') == 'severed'
+                        and wound_data.get('location') in sutured):
+                    outcome = sutured.get(wound_data.get('location'))
+                    if outcome in ("success", "partial", "failure"):
+                        render_stage = f"treated_{outcome}"
+                    else:
+                        render_stage = "treated"
+
                 # Generate wound description using preserved data.
                 # Use the preserved wound stage so severed limbs render
                 # severed-stage prose, destroyed organs render destroyed
@@ -506,7 +530,7 @@ class Corpse(IdentityBearerMixin, Item):
                     injury_type=wound_data['injury_type'],
                     location=wound_data['location'],
                     severity=wound_data['severity'],
-                    stage=wound_data.get('stage', 'fresh'),
+                    stage=render_stage,
                     organ=wound_data.get('organ'),
                     character=self  # Pass corpse as character for any skintone processing
                 )

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1735,12 +1735,29 @@ def apply_sever_to_corpse(corpse, location_arg, *, head_locations=None):
         if wound.get("location") not in locs
     ]
     # Synthesized stump wound — single entry at the canonical sever
-    # location, regardless of head-cluster size.
+    # location, regardless of head-cluster size.  Stage tracks the
+    # corpse's current decay tier so a freshly-killed corpse just
+    # severed reads as a raw weeping stump (severed.py "fresh") and
+    # an old corpse reads as the dried / desiccated prose
+    # ("old").  Two-tier mapping matches the existing severed.py
+    # cells; a finer gradient would need new stages.  Subsequent
+    # corpse-side suturing overrides this at render time via
+    # ``sutured_stumps`` (see ``Corpse.get_wound_descriptions_for_location``).
+    decay_to_stump_stage = {
+        "fresh":    "fresh",
+        "early":    "fresh",
+        "moderate": "old",
+        "advanced": "old",
+        "skeletal": "old",
+    }
+    decay_getter = getattr(corpse, "get_decay_stage", None)
+    decay_stage = decay_getter() if callable(decay_getter) else "fresh"
+    stump_stage = decay_to_stump_stage.get(decay_stage, "old")
     remaining.append({
         "injury_type": "severed",
         "location": location_arg,
         "severity": "Critical",
-        "stage": "old",
+        "stage": stump_stage,
         "organ": None,
         "organ_damage": {
             "current_hp": 0,

--- a/world/medical/severance.py
+++ b/world/medical/severance.py
@@ -61,21 +61,45 @@ def compute_severed_containers(target) -> set:
     """Return the set of containers carrying any severed organ on
     ``target``.
 
-    A severed organ has ``wound_stage="severed"`` AND
-    ``current_hp <= 0`` — both gates so a partially-zeroed organ
-    isn't promoted to a severance.  ``sever_character_body`` is the
-    only writer that sets both fields together.
+    Two target shapes supported:
+
+    * **Living character** — reads ``target.medical_state.organs``
+      for any organ at ``wound_stage="severed"`` AND
+      ``current_hp <= 0`` (both gates so a partially-zeroed organ
+      isn't promoted to a severance).  ``sever_character_body`` is
+      the only writer that sets both fields together.
+    * **Corpse-shaped** (Corpse, SeveredHead, Appendage) — the live
+      ``medical_state`` is empty post-death, so we fall back to
+      ``target.db.wounds_at_death`` and treat any entry with
+      ``injury_type="severed"`` as a stump.  ``apply_sever_to_corpse``
+      is the writer.  Lets the suture verb detect post-death stumps
+      so corpse stumps can progress to ``treated_<outcome>`` prose.
     """
     state = getattr(target, "medical_state", None)
-    if state is None or not hasattr(state, "organs"):
+    organs = getattr(state, "organs", None) if state is not None else None
+    if organs:
+        out = set()
+        for organ in organs.values():
+            if (getattr(organ, "wound_stage", None) == "severed"
+                    and getattr(organ, "current_hp", 0) <= 0):
+                container = getattr(organ, "container", None)
+                if container:
+                    out.add(container)
+        return out
+
+    # Corpse-shaped fallback: derive from wounds_at_death.
+    db = getattr(target, "db", None)
+    if db is None:
         return set()
+    wounds = getattr(db, "wounds_at_death", None) or ()
     out = set()
-    for organ in state.organs.values():
-        if (getattr(organ, "wound_stage", None) == "severed"
-                and getattr(organ, "current_hp", 0) <= 0):
-            container = getattr(organ, "container", None)
-            if container:
-                out.add(container)
+    for wound in wounds:
+        if not hasattr(wound, "get"):
+            continue
+        if wound.get("injury_type") == "severed":
+            loc = wound.get("location")
+            if loc:
+                out.add(loc)
     return out
 
 

--- a/world/tests/test_severance_helpers.py
+++ b/world/tests/test_severance_helpers.py
@@ -112,6 +112,53 @@ class ComputeSeveredContainers(TestCase):
         )
         self.assertEqual(compute_severed_containers(target), set())
 
+    def test_corpse_shaped_target_reads_wounds_at_death(self):
+        # Corpses have empty live ``medical_state.organs`` post-death.
+        # The helper falls back to ``wounds_at_death`` and treats any
+        # ``injury_type="severed"`` entry as a stump container.  Lets
+        # the suture verb detect post-death stumps so corpse stumps
+        # can progress to ``treated_<outcome>`` prose.
+        from world.medical.severance import compute_severed_containers
+        target = SimpleNamespace()
+        target.medical_state = SimpleNamespace(organs={})  # empty
+        target.db = SimpleNamespace(
+            species="human",
+            wounds_at_death=[
+                {"injury_type": "severed", "location": "head",
+                 "stage": "fresh"},
+                {"injury_type": "bullet", "location": "chest",
+                 "stage": "old"},  # not a stump
+                {"injury_type": "severed", "location": "left_arm",
+                 "stage": "old"},
+            ],
+        )
+        self.assertEqual(
+            compute_severed_containers(target),
+            {"head", "left_arm"},
+        )
+
+    def test_living_path_wins_when_organs_populated(self):
+        # When both surfaces have data (test setup or transitional
+        # state), the live ``medical_state.organs`` path takes
+        # precedence — that's the source of truth for living targets.
+        from world.medical.severance import compute_severed_containers
+        target = SimpleNamespace()
+        target.medical_state = SimpleNamespace(organs={
+            "brain": _FakeOrgan("head", wound_stage="severed",
+                                  current_hp=0),
+        })
+        target.db = SimpleNamespace(
+            species="human",
+            wounds_at_death=[
+                {"injury_type": "severed", "location": "left_arm",
+                 "stage": "old"},
+            ],
+        )
+        # Live path wins — only "head" returned.
+        self.assertEqual(
+            compute_severed_containers(target), {"head"},
+        )
+
 
 # ---------------------------------------------------------------------
 # compute_cut_points


### PR DESCRIPTION
**Two corpse-side rendering gaps surfaced in playtest.**

**(1) Hardcoded `stage="old"` on `apply_sever_to_corpse`.** A freshly-killed corpse just decapitated rendered as "the stump long since congealed and stiff" — desiccated prose on a body still warm. Fix: two-tier mapping off the corpse's current decay tier (fresh/early → severed.py `"fresh"`, moderate/advanced/skeletal → `"old"`).

**(2) Suture on corpse didn't visibly progress prose.** Corpse render read `wound_data['stage']` directly; `sutured_stumps` was never consulted. Living rendering goes through `_stump_stage`; corpse didn't have an equivalent. Fix: presentation overlay at corpse render time — when a wound is `injury_type="severed"` AND location is in `normalize_sutured_stumps(corpse)`, override render stage to `treated_<outcome>`. Stored wound data unchanged.

**Prerequisite:** `compute_severed_containers` was living-only (iterated `medical_state.organs` which is empty on corpses post-death). Added a fallback that derives severed locations from `wounds_at_death` entries with `injury_type="severed"`. Living path wins when both surfaces have data.

**Smoke-tested live:**
- Fresh corpse + amputate head → "The head is gone — cleaved away at the joint, the wound still glistening."
- Same corpse + suture (success) → "Neat rows of stitches close the head stump, the bandage still fresh."

Coverage: 2 new tests for the corpse-shaped fallback. Suite: 2122/2122.

Refs #307.