### PR TITLE
corpse stumps: JIT decay-tracking render (no write-back)

### DIFF
--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -489,16 +489,25 @@ class Corpse(IdentityBearerMixin, Item):
             unique_wounds.append(wound_data)
         relevant_wounds = unique_wounds
 
-        # Suture progression for corpse stumps — when ``sutured_stumps``
-        # records a treatment outcome at a severance location, override
-        # the wound's stored stage with the outcome-flavoured variant.
-        # Same pattern as the living-body renderer's ``_stump_stage``
-        # but applied at corpse render time (the live wound data on
-        # the corpse stays unchanged — this is a presentation overlay).
-        # Lets a surgeon's post-death suture work visibly progress the
-        # stump prose without mutating the death-preserved wound dict.
-        from world.medical.severance import normalize_sutured_stumps
+        # Severance-wound stage is JIT-computed at render time, not
+        # read off the stored dict.  Two ways the stage resolves:
+        #
+        # * **Sutured** — ``sutured_stumps`` carries an outcome at the
+        #   severance location → override to ``treated_<outcome>``.
+        # * **Unsutured** — recompute from the corpse's current decay
+        #   tier via ``stump_stage_for_corpse``.  A fresh corpse
+        #   severed-then-decayed renders the new tier on subsequent
+        #   looks (raw weeping → dried/desiccated as the corpse ages),
+        #   no write-back to the stored wound dict required.
+        #
+        # Non-severance wounds (bullet / cut / blunt / etc.) keep
+        # using the stored ``stage`` — those are death-preserved
+        # records of the killing injury, not actively evolving state.
+        from world.medical.severance import (
+            normalize_sutured_stumps, stump_stage_for_corpse,
+        )
         sutured = normalize_sutured_stumps(self)
+        current_decay_stump_stage = stump_stage_for_corpse(self)
 
         # Generate descriptions for each wound
         for wound_data in relevant_wounds:
@@ -506,17 +515,23 @@ class Corpse(IdentityBearerMixin, Item):
                 from world.medical.wounds import get_wound_description
 
                 # Default stage: the death-preserved value on the
-                # wound dict.  Severance wounds at sutured cut points
-                # are overridden to ``treated_<outcome>`` so corpse
-                # stumps progress visually after suture.
+                # wound dict.  Severance wounds get JIT-recomputed
+                # below so the rendered stage tracks current state
+                # (decay tier or suture progression).
                 render_stage = wound_data.get('stage', 'fresh')
-                if (wound_data.get('injury_type') == 'severed'
-                        and wound_data.get('location') in sutured):
-                    outcome = sutured.get(wound_data.get('location'))
-                    if outcome in ("success", "partial", "failure"):
-                        render_stage = f"treated_{outcome}"
+                if wound_data.get('injury_type') == 'severed':
+                    if wound_data.get('location') in sutured:
+                        outcome = sutured.get(wound_data.get('location'))
+                        if outcome in ("success", "partial", "failure"):
+                            render_stage = f"treated_{outcome}"
+                        else:
+                            render_stage = "treated"
                     else:
-                        render_stage = "treated"
+                        # JIT decay-derived stage — re-evaluated on
+                        # every look, so a corpse that decays after
+                        # severance renders the right tier without
+                        # any stored-state write-back.
+                        render_stage = current_decay_stump_stage
 
                 # Generate wound description using preserved data.
                 # Use the preserved wound stage so severed limbs render

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1735,29 +1735,22 @@ def apply_sever_to_corpse(corpse, location_arg, *, head_locations=None):
         if wound.get("location") not in locs
     ]
     # Synthesized stump wound — single entry at the canonical sever
-    # location, regardless of head-cluster size.  Stage tracks the
-    # corpse's current decay tier so a freshly-killed corpse just
-    # severed reads as a raw weeping stump (severed.py "fresh") and
-    # an old corpse reads as the dried / desiccated prose
-    # ("old").  Two-tier mapping matches the existing severed.py
-    # cells; a finer gradient would need new stages.  Subsequent
-    # corpse-side suturing overrides this at render time via
-    # ``sutured_stumps`` (see ``Corpse.get_wound_descriptions_for_location``).
-    decay_to_stump_stage = {
-        "fresh":    "fresh",
-        "early":    "fresh",
-        "moderate": "old",
-        "advanced": "old",
-        "skeletal": "old",
-    }
-    decay_getter = getattr(corpse, "get_decay_stage", None)
-    decay_stage = decay_getter() if callable(decay_getter) else "fresh"
-    stump_stage = decay_to_stump_stage.get(decay_stage, "old")
+    # location, regardless of head-cluster size.  Stage at this
+    # moment is captured as a sever-time snapshot (useful for any
+    # forensics consumer that wants "what did this look like when
+    # severed"), but the corpse renderer ignores this stored stage
+    # for severance wounds and recomputes JIT via
+    # :func:`world.medical.severance.stump_stage_for_corpse` — so a
+    # fresh-then-decayed corpse renders the correct tier on each
+    # look without write-back.  Sutured stumps override at render
+    # time via ``sutured_stumps`` (see
+    # ``Corpse.get_wound_descriptions_for_location``).
+    from world.medical.severance import stump_stage_for_corpse
     remaining.append({
         "injury_type": "severed",
         "location": location_arg,
         "severity": "Critical",
-        "stage": stump_stage,
+        "stage": stump_stage_for_corpse(corpse),
         "organ": None,
         "organ_damage": {
             "current_hp": 0,

--- a/world/medical/severance.py
+++ b/world/medical/severance.py
@@ -104,6 +104,49 @@ def compute_severed_containers(target) -> set:
 
 
 # ---------------------------------------------------------------------
+# Corpse stump prose stage
+# ---------------------------------------------------------------------
+
+
+# Two-tier mapping between the corpse's decay tier and the severed.py
+# prose stage for an unsutured stump.  Defined here so the JIT renderer
+# (``Corpse.get_wound_descriptions_for_location``) and the sever-time
+# writer (``apply_sever_to_corpse``) both consult the same table.
+_DECAY_TO_STUMP_STAGE = {
+    "fresh":    "fresh",
+    "early":    "fresh",
+    "moderate": "old",
+    "advanced": "old",
+    "skeletal": "old",
+}
+
+
+def stump_stage_for_corpse(corpse) -> str:
+    """Return the severed.py prose stage for ``corpse``'s current
+    decay tier — JIT computed.
+
+    Falls back to ``"old"`` when the corpse lacks a decay accessor
+    or returns an unknown tier (defensive — old prose is the safer
+    miss; weeping prose on a long-dead corpse would be jarring).
+
+    Consumed at render time by
+    :meth:`typeclasses.corpse.Corpse.get_wound_descriptions_for_location`
+    so a corpse severed when fresh and later decayed to ``advanced``
+    renders the dried-stump prose on subsequent looks, without any
+    write-back to the stored wound dict.  Wounds-as-time-stamped-state
+    + JIT presentation: forensics-friendly contract.
+    """
+    decay_getter = getattr(corpse, "get_decay_stage", None)
+    if not callable(decay_getter):
+        return "old"
+    try:
+        decay_stage = decay_getter() or "fresh"
+    except Exception:
+        return "old"
+    return _DECAY_TO_STUMP_STAGE.get(decay_stage, "old")
+
+
+# ---------------------------------------------------------------------
 # Cut-point computation
 # ---------------------------------------------------------------------
 

--- a/world/tests/test_severance_helpers.py
+++ b/world/tests/test_severance_helpers.py
@@ -161,6 +161,78 @@ class ComputeSeveredContainers(TestCase):
 
 
 # ---------------------------------------------------------------------
+# stump_stage_for_corpse — JIT decay → severed.py stage mapping
+# ---------------------------------------------------------------------
+
+
+class StumpStageForCorpse(TestCase):
+    """``stump_stage_for_corpse`` consults the corpse's *current* decay
+    tier on each call, so the renderer can pick the right stage at
+    look time without a write-back to the stored wound dict.  Lets a
+    fresh corpse that's severed-then-decayed render the correct tier
+    on subsequent looks — the JIT-feels contract.
+    """
+
+    def _corpse(self, decay_stage):
+        return SimpleNamespace(get_decay_stage=lambda: decay_stage)
+
+    def test_fresh_decay_maps_to_fresh_stage(self):
+        from world.medical.severance import stump_stage_for_corpse
+        self.assertEqual(
+            stump_stage_for_corpse(self._corpse("fresh")), "fresh",
+        )
+
+    def test_early_decay_still_maps_to_fresh_stage(self):
+        from world.medical.severance import stump_stage_for_corpse
+        self.assertEqual(
+            stump_stage_for_corpse(self._corpse("early")), "fresh",
+        )
+
+    def test_moderate_decay_maps_to_old_stage(self):
+        from world.medical.severance import stump_stage_for_corpse
+        self.assertEqual(
+            stump_stage_for_corpse(self._corpse("moderate")), "old",
+        )
+
+    def test_advanced_decay_maps_to_old_stage(self):
+        from world.medical.severance import stump_stage_for_corpse
+        self.assertEqual(
+            stump_stage_for_corpse(self._corpse("advanced")), "old",
+        )
+
+    def test_skeletal_decay_maps_to_old_stage(self):
+        from world.medical.severance import stump_stage_for_corpse
+        self.assertEqual(
+            stump_stage_for_corpse(self._corpse("skeletal")), "old",
+        )
+
+    def test_missing_decay_accessor_defaults_to_old(self):
+        # Defensive: severed.py "old" prose is safer than weeping
+        # prose on something whose decay we can't read.
+        from world.medical.severance import stump_stage_for_corpse
+        self.assertEqual(
+            stump_stage_for_corpse(SimpleNamespace()), "old",
+        )
+
+    def test_decay_accessor_raising_defaults_to_old(self):
+        # Defensive: corpse stubs or DB hiccups shouldn't crash the
+        # renderer; fall back to old prose.
+        from world.medical.severance import stump_stage_for_corpse
+        def raising_getter():
+            raise RuntimeError("DB hiccup")
+        target = SimpleNamespace(get_decay_stage=raising_getter)
+        self.assertEqual(stump_stage_for_corpse(target), "old")
+
+    def test_unknown_decay_tier_defaults_to_old(self):
+        # Defensive: unknown tier (a hypothetical future stage)
+        # falls back to old until the mapping table is extended.
+        from world.medical.severance import stump_stage_for_corpse
+        self.assertEqual(
+            stump_stage_for_corpse(self._corpse("mummified")), "old",
+        )
+
+
+# ---------------------------------------------------------------------
 # compute_cut_points
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #435: closes the staleness window where decay-aware stage was captured at sever time and never re-evaluated. A corpse severed when fresh kept rendering weeping prose even after decaying to `advanced`.

**Fix:** decay → stage computation moves into a JIT helper `stump_stage_for_corpse(corpse)`. `Corpse.get_preserved_wound_descriptions` calls it on every look. Same two-tier mapping (fresh/early → severed.py `fresh`, moderate/advanced/skeletal → `old`); the difference is *when* it resolves.

**Stored `wound_data['stage']` is now ignored for severance wounds.** `apply_sever_to_corpse` still writes a snapshot at sever time (forensics-friendly), but the renderer doesn't read it. Non-severance wounds keep using stored stage — those are death-preserved records, not evolving state.

JIT pattern matches the project's wounds + forensics + JIT-feels contract. No tick required — corpse decay already advances naturally via `get_decay_stage()` reading `time.time() - creation_time`.

**Smoke-tested live:**
- Fresh corpse + sever: "ragged, weeping stump"
- Same corpse + decay advanced (no re-sever): "long since congealed and stiff"
- Same corpse + suture: "bound in clean gauze, the suture line straight and tight"

All three from the same stored wound dict.

Coverage: 8 new tests covering all five decay tiers + defensive fallbacks. Suite: 2130/2130.

Refs #307.