### PR TITLE
sever stage: event-driven stored stage replaces JIT recompute

### DIFF
--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -489,63 +489,53 @@ class Corpse(IdentityBearerMixin, Item):
             unique_wounds.append(wound_data)
         relevant_wounds = unique_wounds
 
-        # Severance-wound stage is JIT-computed at render time, not
-        # read off the stored dict.  Two ways the stage resolves:
-        #
-        # * **Sutured** — ``sutured_stumps`` carries an outcome at the
-        #   severance location → override to ``treated_<outcome>``.
-        # * **Unsutured** — recompute from the corpse's current decay
-        #   tier via ``stump_stage_for_corpse``.  A fresh corpse
-        #   severed-then-decayed renders the new tier on subsequent
-        #   looks (raw weeping → dried/desiccated as the corpse ages),
-        #   no write-back to the stored wound dict required.
-        #
-        # Non-severance wounds (bullet / cut / blunt / etc.) keep
-        # using the stored ``stage`` — those are death-preserved
-        # records of the killing injury, not actively evolving state.
-        from world.medical.severance import (
-            normalize_sutured_stumps, stump_stage_for_corpse,
-        )
-        sutured = normalize_sutured_stumps(self)
-        current_decay_stump_stage = stump_stage_for_corpse(self)
+        # Event-driven sync: refresh the stored severance-wound
+        # stages against current state (decay tier + sutured_stumps)
+        # before reading.  Suture writes also trigger this from
+        # ``_resolve_suture``, so most renders are a no-op (nothing
+        # changed since the last sync).  Renderer then trusts
+        # ``wound_data["stage"]`` directly — no JIT recomputation,
+        # no override.
+        from world.medical.severance import sync_severance_wound_stages
+        sync_severance_wound_stages(self)
+        # ``wounds_at_death`` may have been reassigned in place;
+        # re-read so ``relevant_wounds`` reflects the synced values.
+        wounds_at_death = self.db.wounds_at_death or []
+        relevant_wounds = wounds_at_death
+        if location:
+            relevant_wounds = [
+                w for w in wounds_at_death
+                if w.get('location') == location
+            ]
+        # Re-apply the dedupe pass against the freshly-synced list.
+        seen_keys = set()
+        unique_wounds = []
+        for wound_data in relevant_wounds:
+            key = (
+                wound_data.get('injury_type'),
+                wound_data.get('location'),
+                wound_data.get('stage'),
+            )
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            unique_wounds.append(wound_data)
+        relevant_wounds = unique_wounds
 
-        # Generate descriptions for each wound
         for wound_data in relevant_wounds:
             try:
                 from world.medical.wounds import get_wound_description
 
-                # Default stage: the death-preserved value on the
-                # wound dict.  Severance wounds get JIT-recomputed
-                # below so the rendered stage tracks current state
-                # (decay tier or suture progression).
-                render_stage = wound_data.get('stage', 'fresh')
-                if wound_data.get('injury_type') == 'severed':
-                    if wound_data.get('location') in sutured:
-                        outcome = sutured.get(wound_data.get('location'))
-                        if outcome in ("success", "partial", "failure"):
-                            render_stage = f"treated_{outcome}"
-                        else:
-                            render_stage = "treated"
-                    else:
-                        # JIT decay-derived stage — re-evaluated on
-                        # every look, so a corpse that decays after
-                        # severance renders the right tier without
-                        # any stored-state write-back.
-                        render_stage = current_decay_stump_stage
-
-                # Generate wound description using preserved data.
-                # Use the preserved wound stage so severed limbs render
-                # severed-stage prose, destroyed organs render destroyed
-                # prose, etc. Pre-fix this hardcoded ``stage='old'``,
-                # which doesn't exist in any wound-message dict —
-                # ``get_wound_description`` then fell back to ``fresh``,
-                # making every corpse wound read as an active injury
-                # regardless of the actual state at death (issue #335).
+                # Generate wound description using stored stage —
+                # severance stages are kept current by the sync hook
+                # in ``return_appearance``; non-severance stages are
+                # death-preserved records of the killing injury and
+                # don't evolve.
                 wound_desc = get_wound_description(
                     injury_type=wound_data['injury_type'],
                     location=wound_data['location'],
                     severity=wound_data['severity'],
-                    stage=render_stage,
+                    stage=wound_data.get('stage', 'fresh'),
                     organ=wound_data.get('organ'),
                     character=self  # Pass corpse as character for any skintone processing
                 )

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -900,6 +900,15 @@ def _resolve_suture(actor, target, *, location: Optional[str] = None,
         for loc in just_treated:
             sutured[loc] = outcome
         target.db.sutured_stumps = sutured
+        # Corpse-shaped targets: refresh stored severance-wound stages
+        # so a subsequent render reads the ``treated_<outcome>`` value
+        # without round-tripping through the corpse renderer first.
+        # No-op for living targets (their stage routes through
+        # ``_stump_stage`` in ``get_character_wounds`` — no stored
+        # field to update).  Helper is defensive on missing
+        # ``wounds_at_death`` so it's safe to call unconditionally.
+        from world.medical.severance import sync_severance_wound_stages
+        sync_severance_wound_stages(target)
 
     seed_pain(target, closed[0], CONSCIOUS_PAIN_SEVERITY["suture"])
 

--- a/world/medical/severance.py
+++ b/world/medical/severance.py
@@ -123,18 +123,16 @@ _DECAY_TO_STUMP_STAGE = {
 
 def stump_stage_for_corpse(corpse) -> str:
     """Return the severed.py prose stage for ``corpse``'s current
-    decay tier — JIT computed.
+    decay tier.
 
     Falls back to ``"old"`` when the corpse lacks a decay accessor
     or returns an unknown tier (defensive — old prose is the safer
     miss; weeping prose on a long-dead corpse would be jarring).
 
-    Consumed at render time by
-    :meth:`typeclasses.corpse.Corpse.get_wound_descriptions_for_location`
-    so a corpse severed when fresh and later decayed to ``advanced``
-    renders the dried-stump prose on subsequent looks, without any
-    write-back to the stored wound dict.  Wounds-as-time-stamped-state
-    + JIT presentation: forensics-friendly contract.
+    Consumed by :func:`sync_severance_wound_stages` when refreshing
+    the stored stage on a corpse's severance wounds, and by
+    :func:`typeclasses.items.apply_sever_to_corpse` to set the
+    initial stored stage at sever time.
     """
     decay_getter = getattr(corpse, "get_decay_stage", None)
     if not callable(decay_getter):
@@ -144,6 +142,82 @@ def stump_stage_for_corpse(corpse) -> str:
     except Exception:
         return "old"
     return _DECAY_TO_STUMP_STAGE.get(decay_stage, "old")
+
+
+def severance_wound_stage_for(corpse, location: str) -> str:
+    """Return the *current correct* stored stage for a severance wound
+    on ``corpse`` at ``location``.
+
+    Resolution order:
+      1. ``sutured_stumps[location]`` → ``"treated_<outcome>"``
+         (or generic ``"treated"`` for unknown outcomes).
+      2. Otherwise decay-tier-derived from
+         :func:`stump_stage_for_corpse`.
+
+    Used by :func:`sync_severance_wound_stages` as the per-wound
+    target stage when walking ``wounds_at_death``.
+    """
+    sutured = normalize_sutured_stumps(corpse)
+    if location in sutured:
+        outcome = sutured.get(location)
+        if outcome in ("success", "partial", "failure"):
+            return f"treated_{outcome}"
+        return "treated"
+    return stump_stage_for_corpse(corpse)
+
+
+def sync_severance_wound_stages(corpse) -> bool:
+    """Refresh stored ``stage`` on every severance wound in
+    ``corpse.db.wounds_at_death`` to match current state.
+
+    The "current state" combines:
+      * Corpse decay tier (drives the fresh/old prose split for
+        untreated stumps).
+      * ``sutured_stumps`` mapping (overrides decay-derived stage with
+        a ``treated_<outcome>`` flavour for sutured cut points).
+
+    Event-driven contract: the stored ``stage`` on each severance
+    wound is treated as authoritative by readers (corpse renderer,
+    autopsy, anything formatting wound dicts).  This helper is the
+    single writer that keeps that contract honest.  Idempotent —
+    safe to call repeatedly; only mutates wounds whose stored stage
+    is already out of date.
+
+    Called from:
+      * :meth:`typeclasses.corpse.Corpse.return_appearance` (renderer)
+      * :func:`world.medical.procedures._resolve_suture` (post-write)
+      * Any future consumer that needs fresh stages without going
+        through the renderer.
+
+    Returns True if any wound was updated (useful for logging /
+    event hooks); False if everything was already current.
+    """
+    db = getattr(corpse, "db", None)
+    if db is None:
+        return False
+    wounds = getattr(db, "wounds_at_death", None)
+    if not wounds:
+        return False
+
+    changed = False
+    refreshed = list(wounds)
+    for i, wound in enumerate(refreshed):
+        if not hasattr(wound, "get"):
+            continue
+        if wound.get("injury_type") != "severed":
+            continue
+        location = wound.get("location")
+        if not location:
+            continue
+        target_stage = severance_wound_stage_for(corpse, location)
+        if wound.get("stage") != target_stage:
+            updated = dict(wound)
+            updated["stage"] = target_stage
+            refreshed[i] = updated
+            changed = True
+    if changed:
+        corpse.db.wounds_at_death = refreshed
+    return changed
 
 
 # ---------------------------------------------------------------------

--- a/world/tests/test_severance_helpers.py
+++ b/world/tests/test_severance_helpers.py
@@ -233,6 +233,189 @@ class StumpStageForCorpse(TestCase):
 
 
 # ---------------------------------------------------------------------
+# severance_wound_stage_for — per-wound stored-stage resolver
+# ---------------------------------------------------------------------
+
+
+class SeveranceWoundStageFor(TestCase):
+    """Resolution table for the *correct stored stage* at any moment.
+    Combines suture state with decay tier — the same logic
+    ``sync_severance_wound_stages`` writes back onto wound dicts.
+    """
+
+    def _corpse(self, decay_stage="fresh", sutured_stumps=None):
+        return SimpleNamespace(
+            get_decay_stage=lambda: decay_stage,
+            db=SimpleNamespace(sutured_stumps=sutured_stumps),
+        )
+
+    def test_unsutured_fresh_corpse_returns_fresh(self):
+        from world.medical.severance import severance_wound_stage_for
+        self.assertEqual(
+            severance_wound_stage_for(self._corpse("fresh"), "head"),
+            "fresh",
+        )
+
+    def test_unsutured_decayed_corpse_returns_old(self):
+        from world.medical.severance import severance_wound_stage_for
+        self.assertEqual(
+            severance_wound_stage_for(self._corpse("advanced"), "head"),
+            "old",
+        )
+
+    def test_sutured_overrides_decay(self):
+        # Even on a long-dead corpse, a sutured stump renders the
+        # treatment outcome — sutured wins over decay.
+        from world.medical.severance import severance_wound_stage_for
+        target = self._corpse(
+            "skeletal",
+            sutured_stumps={"head": "success"},
+        )
+        self.assertEqual(
+            severance_wound_stage_for(target, "head"), "treated_success",
+        )
+
+    def test_partial_outcome_routes_to_treated_partial(self):
+        from world.medical.severance import severance_wound_stage_for
+        target = self._corpse(
+            "fresh",
+            sutured_stumps={"left_arm": "partial"},
+        )
+        self.assertEqual(
+            severance_wound_stage_for(target, "left_arm"),
+            "treated_partial",
+        )
+
+    def test_failure_outcome_routes_to_treated_failure(self):
+        from world.medical.severance import severance_wound_stage_for
+        target = self._corpse(
+            "fresh",
+            sutured_stumps={"left_arm": "failure"},
+        )
+        self.assertEqual(
+            severance_wound_stage_for(target, "left_arm"),
+            "treated_failure",
+        )
+
+    def test_unknown_outcome_routes_to_generic_treated(self):
+        # Legacy / corrupted data falls back to the generic
+        # ``treated`` stage rather than crashing.
+        from world.medical.severance import severance_wound_stage_for
+        target = self._corpse(
+            "fresh",
+            sutured_stumps={"head": "mystery"},
+        )
+        self.assertEqual(
+            severance_wound_stage_for(target, "head"), "treated",
+        )
+
+
+# ---------------------------------------------------------------------
+# sync_severance_wound_stages — event-driven stored-stage refresh
+# ---------------------------------------------------------------------
+
+
+class SyncSeveranceWoundStages(TestCase):
+    """Event-driven write-back contract: stored ``stage`` on
+    severance wounds tracks current corpse state, refreshed at the
+    suture write event and corpse render event."""
+
+    def _corpse(self, *, decay_stage="fresh", sutured_stumps=None,
+                wounds=None):
+        target = SimpleNamespace(get_decay_stage=lambda: decay_stage)
+        target.db = SimpleNamespace(
+            sutured_stumps=sutured_stumps,
+            wounds_at_death=wounds or [],
+        )
+        return target
+
+    def test_no_wounds_returns_false(self):
+        from world.medical.severance import sync_severance_wound_stages
+        target = self._corpse(wounds=None)
+        self.assertFalse(sync_severance_wound_stages(target))
+
+    def test_already_current_returns_false(self):
+        from world.medical.severance import sync_severance_wound_stages
+        target = self._corpse(
+            decay_stage="fresh",
+            wounds=[
+                {"injury_type": "severed", "location": "head",
+                 "stage": "fresh"},
+            ],
+        )
+        self.assertFalse(sync_severance_wound_stages(target))
+
+    def test_stale_decay_stage_updated(self):
+        # Corpse stored "fresh" at sever time, then decayed.  Sync
+        # writes back "old".
+        from world.medical.severance import sync_severance_wound_stages
+        target = self._corpse(
+            decay_stage="advanced",
+            wounds=[
+                {"injury_type": "severed", "location": "head",
+                 "stage": "fresh"},
+            ],
+        )
+        self.assertTrue(sync_severance_wound_stages(target))
+        self.assertEqual(
+            target.db.wounds_at_death[0]["stage"], "old",
+        )
+
+    def test_suture_writes_treated_outcome(self):
+        # Sutured + decayed corpse: sutured wins, writes back the
+        # outcome-flavoured stage.
+        from world.medical.severance import sync_severance_wound_stages
+        target = self._corpse(
+            decay_stage="advanced",
+            sutured_stumps={"head": "success"},
+            wounds=[
+                {"injury_type": "severed", "location": "head",
+                 "stage": "old"},
+            ],
+        )
+        self.assertTrue(sync_severance_wound_stages(target))
+        self.assertEqual(
+            target.db.wounds_at_death[0]["stage"], "treated_success",
+        )
+
+    def test_non_severance_wounds_untouched(self):
+        # Bullet / cut / blunt wounds keep their death-preserved
+        # stage — they're records of the killing injury, not
+        # evolving state.
+        from world.medical.severance import sync_severance_wound_stages
+        target = self._corpse(
+            decay_stage="advanced",
+            wounds=[
+                {"injury_type": "bullet", "location": "chest",
+                 "stage": "old"},
+                {"injury_type": "cut", "location": "left_arm",
+                 "stage": "fresh"},
+            ],
+        )
+        self.assertFalse(sync_severance_wound_stages(target))
+        # Same stages back.
+        self.assertEqual(
+            target.db.wounds_at_death[0]["stage"], "old",
+        )
+        self.assertEqual(
+            target.db.wounds_at_death[1]["stage"], "fresh",
+        )
+
+    def test_idempotent_repeated_calls(self):
+        # Second call after a successful sync should be a no-op.
+        from world.medical.severance import sync_severance_wound_stages
+        target = self._corpse(
+            decay_stage="advanced",
+            wounds=[
+                {"injury_type": "severed", "location": "head",
+                 "stage": "fresh"},
+            ],
+        )
+        self.assertTrue(sync_severance_wound_stages(target))
+        self.assertFalse(sync_severance_wound_stages(target))
+
+
+# ---------------------------------------------------------------------
 # compute_cut_points
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
Switching from JIT (#436) to event-driven stored-stage per playtester call. Stored `wound_data['stage']` is now authoritative — readers trust it, the sync helper keeps it current.

**Helpers in `world.medical.severance`:**
- `severance_wound_stage_for(corpse, location)` — pure resolver combining `sutured_stumps` (winning) with decay-tier fallback.
- `sync_severance_wound_stages(corpse)` — walks `wounds_at_death`, refreshes severance wound stages. Idempotent. Skips non-severance wounds (death-preserved injury records).

**Sync hooks:**
- `Corpse.get_preserved_wound_descriptions` — lazy on render. Most calls are no-ops. Doesn't violate the "pure look" contract (issue #230) — that was about display fields affecting targeting; wound stages don't touch those.
- `_resolve_suture` — fires after writing `sutured_stumps[loc] = outcome`. Downstream consumers read fresh values immediately.

**Why event-driven over JIT:** every reader can trust `wound_data['stage']` without needing to know a JIT helper exists. Single source of truth. Scales when more consumers (autopsy, forum export, medical-info) grow off `wounds_at_death` — none need per-consumer recompute logic.

**Smoke-tested live** (same as #436): fresh sever → decay advances → suture, all three render correctly. Sync updates stored stage in place on each transition.

Coverage: 12 new tests covering resolver matrix + sync contract. Suite: 2142/2142.