### PR TITLE
audit Phase 1 complete: docstrings, NEXT reframe, substrate index

### DIFF
--- a/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
+++ b/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
@@ -273,12 +273,16 @@ class DeathProgressionScript(DefaultScript):
         
     def _check_medical_revival_conditions(self, character):
         """Check if medical treatment has resolved fatal conditions"""
-        # NEXT: Brain death integration - check consciousness/brain state
-        # Brain-dead characters cannot be revived regardless of other medical improvements
+        # Brain death blocks revival — tracked as Phase 2 of the
+        # MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC remediation plan.
+        # Below is the intended shape; the live code in
+        # typeclasses/death_progression.py:_check_medical_revival_conditions
+        # currently only calls medical_state.is_dead() and will gain
+        # this guard when Phase 2 ships.
         brain_organ = character.medical_state.get_organ("brain")
         if brain_organ and brain_organ.current_hp <= 0:
             return False  # Brain death = no revival possible
-            
+
         # Check overall medical death status
         if character.medical_state and not character.medical_state.is_dead():
             return True  # Medical intervention successful

--- a/specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md
+++ b/specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md
@@ -20,7 +20,7 @@ work:
 
 | Phase | Status | Notes |
 |---|---|---|
-| Phase 1 — Documentation & Architectural Clarification | **Partial** | Task 1 (`LETHAL_CAPACITY_NAMES` comment in `world/medical/constants.py`) is done; the comment now explicitly states the union-of-lethal-and-targeting role. Tasks 2, 3, 4 (per-method docstrings, brain-death `# NEXT:` reframing in HEALTH spec, `MEDICAL_SUBSTRATE_READINESS.md` index) are not yet shipped. |
+| Phase 1 — Documentation & Architectural Clarification | **✅ Complete** | All four tasks shipped. Task 1: `LETHAL_CAPACITY_NAMES` comment in `world/medical/constants.py` now explicitly documents the union role. Task 2: `MedicalState.is_dead` / `is_unconscious` / `calculate_body_capacity` docstrings spell out the substrate-vs-runtime split and cross-reference the audit's phase numbers. Task 3: HEALTH spec's brain-death `# NEXT:` pseudo-code now explicitly points at audit Phase 2 instead of reading as an open design note. Task 4: `specs/MEDICAL_SUBSTRATE_READINESS.md` index lists every unconsumed flag with its intended consumer system and audit phase. |
 | Phase 2 — Brain Death Blocks Revival | Not started | `_check_medical_revival_conditions` still gates only on `is_dead()`. |
 | Phase 3 — Failure-Mode Surfacing | Not started | Empty-distribution / unbacked-container warnings not wired. |
 | Phase 4 — Vestigial-Flag Deletion | Not started | All flags listed under "Vestigial (delete)" still present. |

--- a/specs/MEDICAL_SUBSTRATE_READINESS.md
+++ b/specs/MEDICAL_SUBSTRATE_READINESS.md
@@ -1,0 +1,77 @@
+# Medical Substrate Readiness Index
+
+This document is the load-bearing artifact spun out of Phase 1 of `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md`. Its purpose is captured in that spec's Core Insight:
+
+> The medical system has a top-down anatomical schema whose bottom-up consumer systems were never built. Each declarative flag advertises a consumer system that hasn't been written yet. Deleting them would be deleting design documentation. The right work is *building the substrates*.
+
+The schema is mature (see `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` Phases 1 through 2.10). The substrates are not. This index is the table that tells a contributor — current or future — *what each unconsumed flag is waiting for, and which audit phase will wire it in*.
+
+The audit itself is the planning artifact and lifecycle: this is the at-a-glance map.
+
+---
+
+## How to use this document
+
+- **Adding a new flag** to `world/medical/constants.py` or a species `organs` spec? Add a row here too. If the flag has no current consumer, point at the substrate phase that will eventually read it.
+- **Wiring a flag into a runtime consumer**? Mark the row as live, link the audit phase that resolved it, and remove it on the next cleanup pass.
+- **Adding a new consumer system** (substrate)? Read down the table for which flags it should consume on first wiring.
+- **Re-validating the audit**? Cross-check this table against current code via the grep-counts column.
+
+---
+
+## Flag → Consumer System Map
+
+| Flag (declaration site) | Reads (current) | Intended consumer | Audit phase | Status |
+|---|---|---|---|---|
+| `vital` (Organ init from species spec) | 0 | None — superseded by data-driven `_get_vital_locations` reading `LETHAL_CAPACITY_NAMES` | Phase 4 — Vestigial-Flag Deletion | **Vestigial** — delete when Phase 4 lands |
+| `fatal_threshold` (BODY_CAPACITIES) | 0 | A data-driven `is_dead` that compares each lethal capacity against this threshold instead of the literal `<= 0.0` floor | Phase 5 — `LETHAL_CAPACITY_NAMES` Split | Keep until Phase 5 |
+| `directly_fatal` (BODY_CAPACITIES) | 0 (1 test) | Same as `fatal_threshold` — declares which capacities terminate life vs incapacitate | Phase 5 — `LETHAL_CAPACITY_NAMES` Split | Keep until Phase 5 |
+| `total_loss_fatal: True` on `blood_filtration` | 0 | **Chronic Conditions framework** — total kidney loss should spawn a fatal `RenalFailure` condition that kills via the tick path, not instant `is_dead` death | Phase 6 — Chronic Medical Conditions Framework + Phase 12 wiring | **Substrate gap** — chronic conditions |
+| `incapacitation_threshold: 0.15` on `moving` | 0 | **Movement Policing system** — when capacity is below this, character cannot move (movement commands refuse / sleep into low-stamina locomotion) | Phase 7 — Movement Policing Substrate + Phase 10 wiring | **Substrate gap** — movement policing |
+| `unconscious_threshold` (in `consciousness` capacity dict) | 0 | None — duplicated as top-level `CONSCIOUSNESS_UNCONSCIOUS_THRESHOLD` (the one `is_unconscious` actually reads) | Phase 4 — Vestigial-Flag Deletion | **Vestigial** — delete when Phase 4 lands |
+| `modifiers: [...]` on `consciousness` | 0 | None — the cascade (pain → consciousness, blood → consciousness, suppression → consciousness) is implemented imperatively in `update_vital_signs`; this list is design documentation only | Phase 4 — Vestigial-Flag Deletion (or convert to spec comment) | **Vestigial** — delete or document-only |
+| `affects: [...]` on capacities | 0 | None today — could drive a generic capacity-effect graph if such a substrate is ever built | Phase 4 — Vestigial-Flag Deletion (unless effect-graph substrate is in plan) | **Vestigial unless** the graph is on the roadmap |
+| `total_loss_penalty: "blindness"` on `sight` | 0 | **Senses System** — total sight loss spawns a `BlindCondition` that gates perception (combat targeting, look output, sdesc rendering) | Phase 8 — Senses System | **Substrate gap** — senses |
+| `total_loss_penalty: "deafness"` on `hearing` | 0 | **Senses System** — total hearing loss spawns a `DeafCondition` that gates audio perception (combat broadcasts, room sounds, conversation) | Phase 8 — Senses System | **Substrate gap** — senses |
+| `total_loss_effects: ["cannot_negotiate", ...]` on `talking` | 0 | **Social interaction substrate** — can't speak → can't negotiate / persuade / bid in trade | (No audit phase yet — open design) | **Substrate gap** — social policing (out of audit scope) |
+| `cannot_be_destroyed: True` on `thoracolumbar_spine` | 0 | `Organ.take_damage` floors at 1 HP for this organ | Phase 7 follow-up (movement policing wires this) | **Direct wire** — small fix, ~Phase 7 cleanup |
+| `paralysis_if_destroyed: True` on `thoracolumbar_spine` | 0 | **Movement Policing system** — produces a permanent `ParalysisCondition` that zeroes `moving` capacity | Phase 7 — Movement Policing Substrate + Phase 11 wiring | **Substrate gap** — movement policing |
+| `can_be_destroyed` (most organs) | 0 (1 test) | Inverse of `cannot_be_destroyed`; redundant once `cannot_be_destroyed` is wired | Phase 4 — Vestigial-Flag Deletion | **Vestigial** — delete after spine wiring |
+| `fracture_vulnerable` | 2 files | Bone-fracture condition spawn path (`world/medical/utils.py`, `commands/CmdConsumption.py`) | — (live) | **Live** — load-bearing |
+| `bone_type` | 3 files | Bone-fracture and severance routing (`world/medical/utils.py`, `world/medical/core.py`, `commands/CmdConsumption.py`) | — (live) | **Live** — load-bearing |
+
+---
+
+## Substrate → Phases the Audit Sequences
+
+Substrate work blocks the wiring phases that depend on it. Sequence per the audit:
+
+| Substrate | Build in | Wires up |
+|---|---|---|
+| Chronic Medical Conditions framework | Phase 6 | Phase 12 (kidney death via `RenalFailure`) |
+| Movement Policing | Phase 7 | Phase 10 (functional-capacity incapacitation), Phase 11 (paralysis) |
+| Senses System | Phase 8 | Blindness / deafness conditions and downstream perception gating |
+| Equipment-Handling (manipulation consequences) | Phase 9 | Weapon-drop / can't-wield on low `manipulation` capacity |
+| Social interaction substrate | (open — no audit phase) | `talking` total-loss effects (`cannot_negotiate`, etc.) |
+
+Phases 4 (Vestigial-Flag Deletion) and 5 (`LETHAL_CAPACITY_NAMES` Split) don't depend on substrates and can ship at any time.
+
+---
+
+## Contributor checklist when adding a new flag
+
+1. Decide whether the flag will be consumed by *existing* runtime code or by a future substrate.
+2. If existing runtime: wire it on the same PR. Don't add unconsumed declarative state.
+3. If future substrate: add a row to the table above with the substrate name and audit phase that will wire it. **An unconsumed flag without a row here is the symptom the audit catalogues** — that's how flag-debt accumulates.
+
+When the audit's Phases 4–13 land, prune rows here and remove the flag-debt in `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md`'s "Drift Quick Reference" headline list.
+
+---
+
+## See Also
+
+- `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md` — full audit catalogue, remediation phases, sequencing
+- `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` — the canonical health/medical spec; "Spinal Anatomy, Decapitation & Combat Severance" section is the canonical reference for how death wiring crosses the schema boundary
+- `world/medical/constants.py` — `LETHAL_CAPACITY_NAMES`, `BODY_CAPACITIES`, `CONSCIOUSNESS_UNCONSCIOUS_THRESHOLD`, `BLOOD_LOSS_DEATH_THRESHOLD`
+- `world/medical/core.py` — `MedicalState.is_dead`, `is_unconscious`, `calculate_body_capacity`
+- `world/anatomy/species.py` — per-species organ specs (where most of the unconsumed flags above are declared)

--- a/specs/README.md
+++ b/specs/README.md
@@ -13,6 +13,7 @@ Design specifications for game systems and features. 37 spec files covering comb
 | `GRAPPLE_SYSTEM_SPEC.md` | Grappling and restraint mechanics |
 | `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` | Medical/trauma system design; canonical source of truth for anatomy (spinal organs, neck integrity) and death/decapitation conditions |
 | `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md` | **Planning artifact** — end-to-end audit of medical/combat/death systems and a phased remediation plan. Content gets absorbed into canonical specs as each phase lands, then this document retires. |
+| `MEDICAL_SUBSTRATE_READINESS.md` | Index of unconsumed declarative flags in the medical schema → intended consumer system → audit phase. Use when adding new flags or wiring substrates. |
 | `CLOTHING_SYSTEM_SPEC.md` | Clothing and layering system |
 | `MODULAR_ARMOR_SYSTEM_SPEC.md` | Armor coverage and damage reduction |
 | `SHOP_SYSTEM_SPEC.md` | Shop pricing and inventory |

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -580,14 +580,31 @@ class MedicalState:
         return total_loss
         
     def calculate_body_capacity(self, capacity_name):
-        """
-        Calculate current level of a body capacity.
-        
+        """Return the organ-only floor for ``capacity_name``.
+
+        This is the **schema layer's** answer to "how much of this
+        capacity does the body have left?" — derived purely from
+        organ health, weighted by each organ's declared contribution
+        to that capacity (see ``world.medical.constants.BODY_CAPACITIES``
+        and species overrides in ``world.anatomy.species``).
+
+        Pain, blood loss, condition-driven suppression, and other
+        runtime modifiers are NOT applied here.  Those flow through
+        :meth:`update_vital_signs` (which writes
+        ``self.consciousness`` / ``self.pain_level`` / ``self.blood_level``)
+        and are read by :meth:`is_unconscious`.  Conflating the two
+        would re-derive runtime state from organ HP every call,
+        breaking the substrate-readiness contract that the audit's
+        Phase 6 chronic-conditions framework is built on.
+
         Args:
             capacity_name (str): Name of capacity to calculate
-            
+                (``"blood_pumping"``, ``"breathing"``, ``"sight"``,
+                ``"moving"``, etc.).
+
         Returns:
-            float: 0.0 to 1.0 representing capacity level
+            float: 0.0 to 1.0 representing the organ-only capacity
+            floor, clamped and cached until ``_cache_dirty`` flips.
         """
         if not self._cache_dirty and capacity_name in self._capacity_cache:
             return self._capacity_cache[capacity_name]
@@ -661,16 +678,53 @@ class MedicalState:
         return capacity_level
         
     def is_unconscious(self):
-        """Returns True if character is unconscious."""
-        # Use the final consciousness value that includes all penalties:
-        # - organ damage penalties (from calculate_body_capacity)
-        # - pain penalties 
-        # - blood loss penalties
-        # - consciousness suppression penalties from conditions
+        """Return True when the character is currently unconscious.
+
+        Reads the **runtime ``self.consciousness`` value** — *not* the
+        raw consciousness capacity floor from
+        :meth:`calculate_body_capacity`.  The runtime value already
+        bakes in pain penalty, blood-loss penalty, and
+        condition-driven consciousness suppression (see
+        :meth:`update_vital_signs` for how those modifiers stack).
+
+        Brain damage feeds in indirectly: a destroyed brain drops
+        the ``consciousness`` capacity floor to zero, which
+        ``update_vital_signs`` writes into ``self.consciousness``
+        on each tick, which trips the threshold here.  This is the
+        canonical "brain destruction is unconsciousness, not death"
+        path documented in the HEALTH spec.
+        """
         return self.consciousness < (CONSCIOUSNESS_UNCONSCIOUS_THRESHOLD / 100.0)
-        
+
     def is_dead(self):
-        """Returns True if character should be considered dead."""
+        """Return True when the character has crossed a death threshold.
+
+        Enforces exactly two death conditions, both organ-only and
+        capacity-derived:
+
+        1. **Lethal capacity floor** — any of ``blood_pumping`` /
+           ``breathing`` / ``digestion`` / ``neck_integrity`` hits
+           zero.  These are the four entries in
+           ``LETHAL_CAPACITY_NAMES`` that drive vital-location
+           targeting bias *and* enforce death (the fifth entry,
+           ``consciousness``, is intentionally NOT a death gate —
+           see :meth:`is_unconscious`).
+        2. **Blood-loss floor** — total blood level falls below
+           ``BLOOD_LOSS_DEATH_THRESHOLD``.
+
+        Notes for the audit's substrate work:
+
+        * Brain destruction lands as unconsciousness here (not
+          death).  Eventual revival blocking lives in
+          :meth:`death_progression.DeathProgressionScript._check_medical_revival_conditions`
+          per the audit's Phase 2.
+        * Kidney loss is **declared fatal** in the schema
+          (``blood_filtration.total_loss_fatal``) but not enforced
+          here — the runtime treats it as a survivable injury until
+          the audit's Phase 6 chronic-conditions substrate ships a
+          ``RenalFailure`` condition that produces death via the
+          condition tick path.
+        """
         # Death from vital organ failure
         if self.calculate_body_capacity("blood_pumping") <= 0.0:
             return True
@@ -680,11 +734,11 @@ class MedicalState:
             return True  # Liver failure
         if self.calculate_body_capacity("neck_integrity") <= 0.0:
             return True  # Decapitation - cervical spine severed (#243)
-            
+
         # Death from blood loss
         if self.blood_level <= (100.0 - BLOOD_LOSS_DEATH_THRESHOLD):
             return True
-            
+
         return False
         
     def update_vital_signs(self):


### PR DESCRIPTION
Closes the three remaining tasks of the audit's Phase 1.

**Task 2** — `MedicalState.is_dead` / `is_unconscious` / `calculate_body_capacity` docstrings spell out the substrate-vs-runtime split and cross-reference audit phases. Stops future contributors from conflating runtime modifiers with the organ-only capacity floor.

**Task 3** — HEALTH spec's brain-death `# NEXT:` pseudo-code now explicitly points at audit Phase 2 instead of reading as an open design note.

**Task 4** — New `specs/MEDICAL_SUBSTRATE_READINESS.md` index. Maps every unconsumed declarative flag → intended consumer system → audit phase that wires it. Includes a contributor checklist so flag-debt stops accumulating silently — adding an unconsumed flag without a row here is the symptom the audit catalogues.

Audit status table updated: Phase 1 ✅ Complete. Phases 2–13 still pending as the spec's progress table predicts.

No behavioural code change. Suite stable at 2142/2142.