### PR TITLE
combat templates: fix verb-position grammar drift

### DIFF
--- a/world/combat/messages/brass_knuckles.py
+++ b/world/combat/messages/brass_knuckles.py
@@ -238,9 +238,9 @@ MESSAGES = {
             "observer_msg": "The blow from {attacker_name} crunches into {target_name}'s {hit_location}. For a moment, everything pauses. Then the blood starts."
         },
         {
-            "attacker_msg": "Your blow isn't clean — it scrapes, digs, *sticks*. When you pull {hit_location}, there's a smear of blood across your brass like a signature. {target_name} stumbles, and the floor suddenly feels too far away to trust.",
-            "victim_msg": "The blow from {attacker_name} isn't clean — it scrapes, digs, *sticks*. When they pull {hit_location}, there's a smear of blood across the brass like a signature. You stumble, and the floor suddenly feels too far away to trust.",
-            "observer_msg": "The blow from {attacker_name} isn't clean — it scrapes, digs, *sticks*. When they pull {hit_location}, there's a smear of blood across the brass like a signature. {target_name} stumbles, and the floor suddenly feels too far away to trust."
+            "attacker_msg": "Your blow isn't clean — it scrapes, digs, *sticks*. When you pull back from the {hit_location}, there's a smear of blood across your brass like a signature. {target_name} stumbles, and the floor suddenly feels too far away to trust.",
+            "victim_msg": "The blow from {attacker_name} isn't clean — it scrapes, digs, *sticks*. When they pull back from your {hit_location}, there's a smear of blood across the brass like a signature. You stumble, and the floor suddenly feels too far away to trust.",
+            "observer_msg": "The blow from {attacker_name} isn't clean — it scrapes, digs, *sticks*. When they pull back from {target_name}'s {hit_location}, there's a smear of blood across the brass like a signature. {target_name} stumbles, and the floor suddenly feels too far away to trust."
         },
         {
             "attacker_msg": "Your brass slams into the {hit_location} of {target_name}'s {hit_location} with blunt finality. They reel like they forgot how legs work.",

--- a/world/combat/messages/catchpole.py
+++ b/world/combat/messages/catchpole.py
@@ -248,9 +248,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} slams the catchpole into {target_name}'s {hit_location}, snapping the bone with a deafening crack."
         },
         {
-            "attacker_msg": "You pull {hit_location} hard and the catchpole's hook tears through {target_name}'s {hit_location} in a jagged, explosive arc.",
-            "victim_msg": "{attacker_name} pulls {hit_location} hard and the catchpole's hook tears through your {hit_location} in a jagged, explosive arc.",
-            "observer_msg": "{attacker_name} pulls {hit_location} hard and the catchpole's hook tears through {target_name}'s {hit_location} in a jagged, explosive arc."
+            "attacker_msg": "You yank the catchpole hard and its hook tears through {target_name}'s {hit_location} in a jagged, explosive arc.",
+            "victim_msg": "{attacker_name} yanks the catchpole hard and its hook tears through your {hit_location} in a jagged, explosive arc.",
+            "observer_msg": "{attacker_name} yanks the catchpole hard and its hook tears through {target_name}'s {hit_location} in a jagged, explosive arc."
         },
         {
             "attacker_msg": "You hook {target_name} under the chin and jerk upward, the impact rattling {target_name}'s {hit_location}.",
@@ -288,9 +288,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} twists sharply, the catchpole carving a bloody arc across {target_name}'s {hit_location}."
         },
         {
-            "attacker_msg": "You drive the hook into {target_name}'s {hit_location} and pull {hit_location}, the sudden resistance ripping muscle.",
-            "victim_msg": "{attacker_name} drives the hook into your {hit_location} and pulls {hit_location}, the sudden resistance ripping muscle.",
-            "observer_msg": "{attacker_name} drives the hook into {target_name}'s {hit_location} and pulls {hit_location}, the sudden resistance ripping muscle."
+            "attacker_msg": "You drive the hook into {target_name}'s {hit_location} and pull hard, the sudden resistance ripping muscle.",
+            "victim_msg": "{attacker_name} drives the hook into your {hit_location} and pulls hard, the sudden resistance ripping muscle.",
+            "observer_msg": "{attacker_name} drives the hook into {target_name}'s {hit_location} and pulls hard, the sudden resistance ripping muscle."
         },
         {
             "attacker_msg": "You plant the catchpole's hook in {target_name}'s {hit_location}, the rip of flesh audible over the chaos.",

--- a/world/combat/messages/chainsaw.py
+++ b/world/combat/messages/chainsaw.py
@@ -208,9 +208,9 @@ MESSAGES = {
     ],
     'hit': [
         {
-            'attacker_msg': "A glancing blow becomes a tearing ruin. You pull {hit_location}, and what comes with the blade doesn't belong outside the body.",
-            'victim_msg': "A glancing blow becomes a tearing ruin. {attacker_name} pulls {hit_location}, and what comes with the blade doesn't belong outside your body.",
-            'observer_msg': "A glancing blow becomes a tearing ruin. {attacker_name} pulls {hit_location}, and what comes with the blade doesn't belong outside the body."
+            'attacker_msg': "A glancing blow becomes a tearing ruin. You wrench the blade from {target_name}'s {hit_location}, and what comes with it doesn't belong outside the body.",
+            'victim_msg': "A glancing blow becomes a tearing ruin. {attacker_name} wrenches the blade from your {hit_location}, and what comes with it doesn't belong outside your body.",
+            'observer_msg': "A glancing blow becomes a tearing ruin. {attacker_name} wrenches the blade from {target_name}'s {hit_location}, and what comes with it doesn't belong outside the body."
         },
         {
             'attacker_msg': "A horizontal sweep tears open a gash across {target_name}'s {hit_location}. Blood splashes hot against steel and keeps dripping long after the blade moves on.",

--- a/world/combat/messages/crowbar.py
+++ b/world/combat/messages/crowbar.py
@@ -298,9 +298,9 @@ MESSAGES = {
             "observer_msg": "{attacker_name} sweeps the {hit_location}s with the bar. {target_name} lands wrong. They don't get up right."
         },
         {
-            "attacker_msg": "You swing low. The bar hits {hit_location}. {target_name} hits floor.",
-            "victim_msg": "{attacker_name} swings low. The bar hits {hit_location}. You hit floor.",
-            "observer_msg": "{attacker_name} swings low. The bar hits {hit_location}. {target_name} hits floor."
+            "attacker_msg": "You swing low. The bar hits {target_name}'s {hit_location}. {target_name} hits the floor.",
+            "victim_msg": "{attacker_name} swings low. The bar hits your {hit_location}. You hit the floor.",
+            "observer_msg": "{attacker_name} swings low. The bar hits {target_name}'s {hit_location}. {target_name} hits the floor."
         }
     ],
     "miss": [

--- a/world/combat/messages/fire_axe.py
+++ b/world/combat/messages/fire_axe.py
@@ -208,19 +208,19 @@ MESSAGES = {
             'observer_msg': "It's not the edge but the weight that ruins {target_name}. They're struck flat, breath gone, {hit_location} shattered."
         },
         {
-            'attacker_msg': "Steel bites deep, lodging into flesh before you pull {hit_location} hard. {target_name} falls, clutching what's left.",
-            'victim_msg': "Steel bites deep, lodging into flesh before {attacker_name} pulls {hit_location} hard. You fall, clutching what's left.",
-            'observer_msg': "Steel bites deep, lodging into flesh before {attacker_name} pulls {hit_location} hard. {target_name} falls, clutching what's left."
+            'attacker_msg': "Steel bites deep, lodging into flesh before you yank it free of the {hit_location}. {target_name} falls, clutching what's left.",
+            'victim_msg': "Steel bites deep, lodging into flesh before {attacker_name} yanks it free of your {hit_location}. You fall, clutching what's left.",
+            'observer_msg': "Steel bites deep, lodging into flesh before {attacker_name} yanks it free of {target_name}'s {hit_location}. {target_name} falls, clutching what's left."
         },
         {
-            'attacker_msg': "Steel meets {hit_location}, and the sound is unforgettable. {target_name} jerks forward and collapses in half-silhouette.",
-            'victim_msg': "Steel meets {hit_location}, and the sound is unforgettable. You jerk forward and collapse in half-silhouette.",
-            'observer_msg': "Steel meets {hit_location}, and the sound is unforgettable. {target_name} jerks forward and collapses in half-silhouette."
+            'attacker_msg': "Steel meets the {hit_location}, and the sound is unforgettable. {target_name} jerks forward and collapses in half-silhouette.",
+            'victim_msg': "Steel meets your {hit_location}, and the sound is unforgettable. You jerk forward and collapse in half-silhouette.",
+            'observer_msg': "Steel meets the {hit_location}, and the sound is unforgettable. {target_name} jerks forward and collapses in half-silhouette."
         },
         {
-            'attacker_msg': "The axe bites through muscle like wet cloth. {target_name} chokes on blood and disbelief as you pull {hit_location} with something more than strength.",
-            'victim_msg': "The axe bites through muscle like wet cloth. You choke on blood and disbelief as {attacker_name} pulls {hit_location} with something more than strength.",
-            'observer_msg': "The axe bites through muscle like wet cloth. {target_name} chokes on blood and disbelief as {attacker_name} pulls {hit_location} with something more than strength."
+            'attacker_msg': "The axe bites through muscle like wet cloth. {target_name} chokes on blood and disbelief as you wrench the blade from the {hit_location} with something more than strength.",
+            'victim_msg': "The axe bites through muscle like wet cloth. You choke on blood and disbelief as {attacker_name} wrenches the blade from your {hit_location} with something more than strength.",
+            'observer_msg': "The axe bites through muscle like wet cloth. {target_name} chokes on blood and disbelief as {attacker_name} wrenches the blade from the {hit_location} with something more than strength."
         },
         {
             'attacker_msg': "The axe connects with brutal, direct force. There's no finesse. Just raw correction.",

--- a/world/combat/messages/hatchet.py
+++ b/world/combat/messages/hatchet.py
@@ -168,9 +168,9 @@ MESSAGES = {
             'observer_msg': "A fast jab sinks into the {hit_location}. {attacker_name} yanks it out with a noise that doesn't end."
         },
         {
-            'attacker_msg': "A heavy blow hits {hit_location}. Something cracks. {target_name} folds with a strangled cry.",
-            'victim_msg': "A heavy blow hits {hit_location}. Something cracks. You fold with a strangled cry.",
-            'observer_msg': "A heavy blow hits {hit_location}. Something cracks. {target_name} folds with a strangled cry."
+            'attacker_msg': "A heavy blow lands across the {hit_location}. Something cracks. {target_name} folds with a strangled cry.",
+            'victim_msg': "A heavy blow lands across your {hit_location}. Something cracks. You fold with a strangled cry.",
+            'observer_msg': "A heavy blow lands across the {hit_location}. Something cracks. {target_name} folds with a strangled cry."
         },
         {
             'attacker_msg': "A rising slash across the {hit_location} leaves a trail of blood like a drawn map to death.",

--- a/world/combat/messages/machete.py
+++ b/world/combat/messages/machete.py
@@ -213,7 +213,7 @@ MESSAGES = {
             'observer_msg': "Steel crashes against {target_name}'s {hit_location}. {target_name} shrieks and drops like bricks."
         },
         {
-            'attacker_msg': "Steel meets {hit_location}. {target_name} reels, blood pouring like confession.",
+            'attacker_msg': "Steel meets the {hit_location}. {target_name} reels, blood pouring like confession.",
             'victim_msg': "Steel meets your {hit_location}. You reel, blood pouring like confession.",
             'observer_msg': "Steel meets {target_name}'s {hit_location}. {target_name} reels, blood pouring like confession."
         },

--- a/world/combat/messages/nailed_board.py
+++ b/world/combat/messages/nailed_board.py
@@ -228,9 +228,9 @@ MESSAGES = {
             'observer_msg': "The board slams into {target_name}'s {hit_location}. A nail sticks briefly, then rips free with something attached."
         },
         {
-            'attacker_msg': "The board smashes into {target_name}'s {hit_location}. A nail catches and tears as it pulls {hit_location}. The scream is instant and ugly.",
-            'victim_msg': "The board smashes into your {hit_location}. A nail catches and tears as it pulls {hit_location}. The scream is instant and ugly.",
-            'observer_msg': "The board smashes into {target_name}'s {hit_location}. A nail catches and tears as it pulls {hit_location}. The scream is instant and ugly."
+            'attacker_msg': "The board smashes into {target_name}'s {hit_location}. A nail catches and tears as the board pulls free. The scream is instant and ugly.",
+            'victim_msg': "The board smashes into your {hit_location}. A nail catches and tears as the board pulls free. The scream is instant and ugly.",
+            'observer_msg': "The board smashes into {target_name}'s {hit_location}. A nail catches and tears as the board pulls free. The scream is instant and ugly."
         },
         {
             'attacker_msg': "The board spins, catches {target_name} across the {hit_location}. Nails scratch the scalp, drawing blood like rain.",

--- a/world/combat/messages/rebar.py
+++ b/world/combat/messages/rebar.py
@@ -194,9 +194,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} brings the bar down hard. It bounces off {target_name}'s {hit_location} with a sickening thunk."
         },
         {
-            'attacker_msg': "Steel meets {hit_location}. {target_name} drops instantly, breath escaping like steam from a pipe.",
-            'victim_msg': "Steel meets {hit_location}. You drop instantly, breath escaping like steam from a pipe.",
-            'observer_msg': "Steel meets {hit_location}. {target_name} drops instantly, breath escaping like steam from a pipe."
+            'attacker_msg': "Steel meets the {hit_location}. {target_name} drops instantly, breath escaping like steam from a pipe.",
+            'victim_msg': "Steel meets your {hit_location}. You drop instantly, breath escaping like steam from a pipe.",
+            'observer_msg': "Steel meets the {hit_location}. {target_name} drops instantly, breath escaping like steam from a pipe."
         },
         {
             'attacker_msg': "You slam the bar into {target_name}'s {hit_location}. Air and bile explode from their mouth.",

--- a/world/combat/messages/shiv.py
+++ b/world/combat/messages/shiv.py
@@ -233,9 +233,9 @@ MESSAGES = {
             'observer_msg': "{attacker_name} twists the blade like they're adjusting a screw, and {target_name}'s body tightens around it. Their mouth shapes words that never come."
         },
         {
-            'attacker_msg': "The shiv slides in smooth as silk, but pulls {hit_location} rough as concrete. {target_name}'s eyes widen like they're seeing the end of the world for the first time.",
-            'victim_msg': "The shiv slides in smooth as silk, but pulls {hit_location} rough as concrete. Your eyes widen like you're seeing the end of the world for the first time.",
-            'observer_msg': "The shiv slides in smooth as silk, but pulls {hit_location} rough as concrete. {target_name}'s eyes widen like they're seeing the end of the world for the first time."
+            'attacker_msg': "The shiv slides in smooth as silk, but pulls out of the {hit_location} rough as concrete. {target_name}'s eyes widen like they're seeing the end of the world for the first time.",
+            'victim_msg': "The shiv slides in smooth as silk, but pulls out of your {hit_location} rough as concrete. Your eyes widen like you're seeing the end of the world for the first time.",
+            'observer_msg': "The shiv slides in smooth as silk, but pulls out of {target_name}'s {hit_location} rough as concrete. {target_name}'s eyes widen like they're seeing the end of the world for the first time."
         },
         {
             'attacker_msg': "The blade bites deep, finding nerve clusters you didn't know existed. {target_name} jerks like they've been struck by lightning made of ice.",

--- a/world/combat/messages/sledgehammer.py
+++ b/world/combat/messages/sledgehammer.py
@@ -223,7 +223,7 @@ MESSAGES = {
             'observer_msg': "The hammer caves in {target_name}'s {hit_location}. They drop like scaffolding losing its anchor."
         },
         {
-            'attacker_msg': "The hammer hits {hit_location}. They fly backward like a broken hinge.",
+            'attacker_msg': "The hammer hits {target_name}'s {hit_location}. They fly backward like a broken hinge.",
             'victim_msg': "The hammer hits your {hit_location}. You fly backward like a broken hinge.",
             'observer_msg': "The hammer hits {target_name}'s {hit_location}. They fly backward like a broken hinge."
         },

--- a/world/combat/messages/small_axe.py
+++ b/world/combat/messages/small_axe.py
@@ -213,7 +213,7 @@ MESSAGES = {
             'observer_msg': "Steel digs into {target_name}'s {hit_location}. Not deep, but angry."
         },
         {
-            'attacker_msg': "Steel meets {hit_location}. The sound is worse than the scream.",
+            'attacker_msg': "Steel meets the {hit_location}. The sound is worse than the scream.",
             'victim_msg': "Steel meets your {hit_location}. The sound is worse than your scream.",
             'observer_msg': "Steel meets {target_name}'s {hit_location}. The sound is worse than their scream."
         },

--- a/world/combat/messages/small_knife.py
+++ b/world/combat/messages/small_knife.py
@@ -253,9 +253,9 @@ MESSAGES = {
             'observer_msg': "The knife punctures shallow, but the shock is deep. {target_name} stumbles backward, {hit_location} pressed to the wound."
         },
         {
-            'attacker_msg': "The knife slashes across the {hit_location}, opening skin in a swift arc. {target_name} yelps and pulls {hit_location}.",
-            'victim_msg': "The knife slashes across your {hit_location}, opening skin in a swift arc. You yelp and pull {hit_location}.",
-            'observer_msg': "The knife slashes across the {hit_location}, opening skin in a swift arc. {target_name} yelps and pulls {hit_location}."
+            'attacker_msg': "The knife slashes across the {hit_location}, opening skin in a swift arc. {target_name} yelps and recoils.",
+            'victim_msg': "The knife slashes across your {hit_location}, opening skin in a swift arc. You yelp and recoil.",
+            'observer_msg': "The knife slashes across the {hit_location}, opening skin in a swift arc. {target_name} yelps and recoils."
         },
         {
             'attacker_msg': "The knife slips between {hit_location} — not deep enough to kill, but more than enough to hurt. {target_name} gasps.",


### PR DESCRIPTION
Quality-pass sweep through `world/combat/messages/` for the `<action_verb> {hit_location}` pattern with no article or possessive — renders as `"pulls abdomen"` / `"hits abdomen"` / `"Steel meets abdomen"` etc. Caught during recent severance playtest.

**13 templates across 9 weapon files** fixed: shiv, chainsaw, crowbar, hatchet, fire_axe (×3), catchpole (×2), sledgehammer, rebar, machete, small_axe, nailed_board, brass_knuckles, small_knife.

Pattern of fix:
- "pulls / hits / meets {hit_location}" → "pulls back from / hits / meets THE {hit_location}" (or possessive variant for victim/observer)
- Where the bare-noun verb object was awkward semantically, swapped to a tighter construction (e.g. catchpole's doubled-{hit_location} → cleaner phrasing)

Final re-grep returns clean. Grammar fix only; no semantic change to combat outcomes.

Suite stable at 2142/2142.