### PR TITLE
specs: editorial pass for autopsy → inspect rename

### DIFF
--- a/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
+++ b/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
@@ -102,7 +102,7 @@ CONSUMPTION_RULES = {
 
 **Organ Harvesting and Biotech Foundation (Phase 3.1 → shipped as Phase 2.8):**
 - **✅ Organ viability system** - Time-based organ deterioration after death drives harvested-organ condition (`ORGAN_CONDITION_BY_DECAY`)
-- **✅ Corpse examination** - `autopsy <corpse>` renders organ inventory with harvested / severed marked absent (PR #186)
+- **✅ Corpse examination** - `inspect <corpse>` (alias `autopsy`) renders organ inventory with harvested / severed marked absent (PR #186 / renamed PR #441)
 - **✅ Organ harvesting commands** - `harvest <organ> from <target>` works on corpses, severed parts, unconscious, AND conscious living targets via the procedure verb set (PR #380, #307)
 - **✅ Harvested organ inventory** - Organ items spawn with condition (`pristine` / `damaged` / `putrid`) tracking decay tier at extraction time
 - **✅ Foundation for cybernetics** - `install <organ> in <target>` is the inverse of harvest; organ-bound conditions travel with the organ on transfer (PR #379)
@@ -472,7 +472,7 @@ def _process_delayed_attack(self, attacker, target, attacker_entry, combatants_l
 
 **Phase 3.1 - Organ Harvesting & Biotech Foundation (✅ MOSTLY SHIPPED — see Phase 2.8):**
 - **✅ Organ harvesting commands** - `harvest <organ> from <target>` via procedure verb set (PR #380); works on corpses, severed parts, unconscious, and conscious targets
-- **✅ Corpse examination system** - `autopsy <corpse>` (PR #186); organ inventory with absent / damaged status
+- **✅ Corpse examination system** - `inspect <corpse>` with `autopsy` alias (PR #186 / PR #441); organ inventory with absent / damaged status; also accepts severed heads and blood pools
 - **✅ Harvested organ inventory management** - Organ items spawn with decay-tier condition; PR #200's sever-overlay carries harvest provenance onto severed items
 - **✅ Foundation for cybernetics integration** - `install` is the inverse of `harvest`; three-tier condition model (PR #378/#379) ensures organ-bound conditions travel correctly during transfer
 - **🎯 Death progression message enhancement** - Narrative theme refinement still pending

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -1576,12 +1576,14 @@ photos). It exposes:
   axis-by-axis (reserved for future linking gameplay; no command
   exposes it).
 
-**Shipped consumer**: `commands/forensics.py:CmdAutopsy` (single-tier)
-routes corpses through the engine.
-
-**Data prep only**: blood pools have the `signature` / `apparent_uid`
-fields wired in `BloodPool.add_bleeding_incident` and the medical
-script, but no player-facing command consumes them yet.
+**Shipped consumer**: `commands/forensics.py:CmdInspect` (key
+`inspect`, alias `autopsy` for muscle-memory continuity) routes
+corpses, severed heads, AND blood pools through the engine. Single-
+tier report.  Slated to retire as a standalone command when
+`inspect` becomes a procedure type under `operate` (only
+performable on a deceased body the surgeon is operating on);
+the alias keeps the legacy command name working through the
+migration.
 
 **Out of scope (deferred)**: photo capture/display (extractor stub
 raises `NotImplementedError`), multi-UID linking gameplay,
@@ -1665,21 +1667,34 @@ an assigned name* — invariant across evidence types.
   shared_apparent_uid, shared_axes)` — diagnostic only, no
   command exposes it yet.
 
-### Consumer: `autopsy` command
+### Consumer: `inspect` command (alias `autopsy`)
 
-`commands/forensics.py:CmdAutopsy` (keyed `autopsy`, no switches,
-help category `Forensics`):
+`commands/forensics.py:CmdInspect` (keyed `inspect`, alias `autopsy`,
+no switches, help category `Forensics`):
 
-- `autopsy <corpse>` — Intellect vs `AUTOPSY_DC_BASIC` → unified
-  five-section report (identity axes, fuzzy ToD, cause, wounds,
-  organ inventory, worn essentials).
-- Skeletal corpses short-circuit with a "too far decomposed" message
-  before rolling.
+- `inspect <corpse|severed_head|blood_pool>` — Intellect vs
+  `AUTOPSY_DC_BASIC` → forensic report.
+- **Corpses / severed heads** render the unified five-section
+  report (identity axes, fuzzy ToD, cause, wounds, organ
+  inventory, worn essentials).
+- **Blood pools** dedupe `bleeding_incidents` by `apparent_uid`
+  and render distinguishable bleeders (recognized OR carrying at
+  least one non-None signature axis) individually; bare-sleeve
+  passersby aggregate into a single count line, failed rolls into
+  another. See PR #441 / #442.
+- Skeletal corpses short-circuit with a "too far decomposed"
+  message before rolling.
 - Pre-roll room broadcast via `msg_room_identity` so observers
   see the investigation regardless of outcome.
 - Concatenates the recognized-name header only when the looker
   already holds the revealed UID in `recognition_memory` with an
   `assigned_name` set.
+
+**Forward path**: `inspect` is slated to become a procedure type
+under the `operate` charting menu — only performable on a deceased
+body the surgeon is operating on.  When that lands, this
+standalone command surface retires.  The `autopsy` alias remains
+for muscle-memory continuity through the transition.
 
 ### DC tuning (provisional)
 
@@ -1725,17 +1740,29 @@ careful examination and prevents Intellect re-roll abuse.
 ### Out of scope (deferred)
 
 - Photo capture/display gameplay.
-- Blood-pool forensic consumer command (data field is wired so
-  future consumers have something to read).
 - Multi-UID linking gameplay (`link_subjects` is a primitive).
 - Memory decay & active impersonation detection (spec L1668
   Phase 5).
 - Sleeve-swap awareness (blocked on resleeving system).
 - Skeletal-bone harvest (cracked-bone marrow extraction) — deferred
-  past PR-186; skeletal corpses currently refuse autopsy and harvest.
+  past PR-186; skeletal corpses currently refuse `inspect` and
+  harvest.
 - ~~Severed-head super-item carrying full identity signature~~ —
   ✅ shipped in PR #194 (`SeveredHead`); see "Severed-Head
   Super-Item" subsection below.
+- ~~Blood-pool forensic consumer command~~ — ✅ shipped in PR #441
+  (`inspect <blood pool>`) with bucketing polish in PR #442.
+- Blood trail tracking (the same apparent UID appearing in multiple
+  rooms across time, surfacing as "the wounded individual went
+  this way") — parked future direction; the data model
+  (`BloodPool` per room with `bleeding_incidents`) already
+  supports aggregation across pools, only a query/render layer is
+  missing.
+- DNA hash / cross-sleeve identifier (a new identity axis stamped
+  at character creation that persists across resleeving, separate
+  from `sleeve_uid`) — parked future direction; would slot as a
+  sixth element on the identity signature 5-tuple and propagate
+  through forensic chain via the existing copy mechanics.
 
 ---
 
@@ -2040,13 +2067,15 @@ the head is a first-class forensic peer of the source corpse:
 - **Severing a SeveredHead is refused**: heads are terminal; the
   `CmdSever` isinstance gate remains `Corpse`-only.
 
-**Accepted targets ✅ (PR #196)**: `CmdAutopsy` and `CmdHarvest`
-accept either a `Corpse` or a `SeveredHead` — the isinstance gate
-is `(Corpse, SeveredHead)`.  Autopsy on a head renders the standard
-five-section report against the trimmed head-container snapshot
-(brain / eyes / ears / etc.); harvest extracts head-container organs
-honoring the carry-forward `removed_organs` list.  `CmdSever`
-remains `Corpse`-only.
+**Accepted targets ✅ (PR #196 / PR #441)**: `CmdInspect` (key
+`inspect`, alias `autopsy`) and `CmdHarvest` accept either a
+`Corpse` or a `SeveredHead` — the isinstance gate is
+`(Corpse, SeveredHead)`.  `CmdInspect` additionally accepts a
+`BloodPool` for room-floor bleeder forensics.  Inspecting a head
+renders the standard five-section report against the trimmed
+head-container snapshot (brain / eyes / ears / etc.); harvest
+extracts head-container organs honoring the carry-forward
+`removed_organs` list.  `CmdSever` remains `Corpse`-only.
 
 **Deferred** (post PR-C): the snapshot represents the
 *body's* identity at sever time, not consciousness; sleeve-swap


### PR DESCRIPTION
## Summary
- Update `IDENTITY_RECOGNITION_SPEC.md` and `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` to reflect the PR #441 / #442 command rename (`CmdAutopsy` → `CmdInspect`, alias `autopsy`).
- Move blood-pool forensic consumer from the "deferred" list to "shipped" with PR references.
- Add forward-path note: `inspect` is slated to become a procedure type under `operate` (only on a deceased body the surgeon is operating on); the `autopsy` alias bridges muscle memory through that migration.
- Park two future directions on the identity spec: blood-trail tracking (cross-room aggregation of same apparent UID) and a DNA-hash cross-sleeve identifier.

Spec catch-up only — no code changes.

## Test plan
- [x] `grep -rn "CmdAutopsy" specs/` returns no stale class references
- [x] `grep -rn "\`autopsy <\`" specs/` returns no stale command-syntax references (generic "autopsy narrative/output/procedure-surface" semantic usage preserved)
- [x] Live dir synced (`/Users/rocket/gelatinous/game/specs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)