### PR TITLE
diagnose: clinical pane for the operate chart's PATIENT block

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -21,7 +21,6 @@ Scope for PR-OP1 (MVP):
 
 Deferred to follow-on PRs:
 
-  • Diagnose pane (skill-gated organ-state inspection)
   • Add treatment step (apply / inject)
   • Reorder / remove / annotate steps
   • Resume from arbitrary step
@@ -66,6 +65,7 @@ from evennia import Command
 from evennia.utils.evmenu import EvMenu
 
 from world.medical import charts as chart_lib
+from world.medical import diagnose as diagnose_lib
 
 
 # ===================================================================
@@ -196,30 +196,16 @@ def _render_section(
 
 
 def _render_patient_lines(caller, target) -> list[str]:
-    """One identity line + vital-summary line(s) for the PATIENT
-    section."""
+    """One identity line + diagnose pane + vital summary for the
+    PATIENT section.  The diagnose pane (condition rung + clinical
+    findings) is the surgeon's privilege — clinical register vs.
+    the visceral ``look`` description the room sees."""
     lines = [target.get_display_name(caller)]
 
-    state = getattr(target, "medical_state", None)
-    if state is not None:
-        vitals = []
-        is_unc = getattr(target, "is_unconscious", None)
-        if callable(is_unc) and is_unc():
-            vitals.append("unconscious")
-        is_dead = getattr(state, "is_dead", None)
-        if callable(is_dead) and is_dead():
-            vitals.append("|rdying|n")
-        conditions = getattr(state, "conditions", None) or []
-        if conditions:
-            count_by_type = {}
-            for c in conditions:
-                t = getattr(c, "condition_type", "condition")
-                count_by_type[t] = count_by_type.get(t, 0) + 1
-            for k, n in count_by_type.items():
-                tag = k.replace("_", " ")
-                vitals.append(f"{n}× {tag}" if n > 1 else tag)
-        if vitals:
-            lines.append(" · ".join(vitals))
+    # Diagnose pane — condition rung + detected findings in
+    # clinical dialect.  The roll itself happens in ``func()``
+    # before the menu opens; this renderer just reads the cache.
+    lines.extend(diagnose_lib.render_diagnose_lines(caller, target))
 
     # Open incisions from the surgical_state attr (set by procedures).
     surgical_state = getattr(getattr(target, "db", None),
@@ -1393,6 +1379,24 @@ class CmdOperate(Command):
             return
 
         caller.ndb._operate_target = target
+
+        # Diagnose pane — roll Intellect vs each wound's
+        # obfuscation DC and cache the result per-physician on
+        # the patient.  Emits a room-facing examination pose only
+        # when a fresh roll occurred (cache miss or wound-set
+        # change); cache hits within the TTL re-enter the chart
+        # silently.
+        diagnose_result = diagnose_lib.perform_diagnose(caller, target)
+        if not diagnose_result.get("from_cache") and caller.location:
+            from world.identity_utils import msg_room_identity
+            msg_room_identity(
+                location=caller.location,
+                template=diagnose_lib.DIAGNOSE_POSE_ROOM,
+                char_refs={"physician": caller},
+                exclude=[caller],
+            )
+            caller.msg(diagnose_lib.DIAGNOSE_POSE_SELF)
+
         _OperateMenu(
             caller,
             {

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -870,3 +870,42 @@ LIMB_PARENT = dict(_HUMAN_SEVER.get("limb_parent") or {})
 
 del _HUMAN_SEVER
 del _SPECIES_DEFINITIONS_S
+
+# Diagnose pane (operate chart) ---------------------------------------
+# Per-injury baseline obfuscation DC for the surgeon's Intellect roll
+# on first :class:`~commands.CmdOperate.CmdOperate` of a patient.  The
+# diagnose pane in the chart's PATIENT block surfaces wounds whose DC
+# the physician beats; failures stay hidden.  Internal-cavity organs
+# (heart, lungs, liver, brain, etc.) add ``INTERNAL_ORGAN_OBFUSCATION_MOD``
+# to their type's baseline because there's no skin-surface tell.
+WOUND_OBFUSCATION_BY_TYPE = {
+    "severance":  0,   # missing limb / part — auto-detect
+    "harvested":  0,   # absent organ on a corpse — auto-detect
+    "burn":       1,
+    "cut":        2,
+    "laceration": 2,
+    "stab":       3,
+    "bullet":     3,
+    "blunt":      5,   # bruising hides depth without palpation
+    "generic":    4,
+}
+
+# Bump applied when the wounded organ lives in a body cavity (no
+# direct surface display).  Surface organs (eye, ear, nose, tongue,
+# jaw, limb bones at hand / foot containers) skip the bump.
+INTERNAL_ORGAN_OBFUSCATION_MOD = 5
+
+# Cache TTL for the per-(physician, patient) diagnose roll.  Long
+# enough that re-opening the chart inside a single scene doesn't
+# re-pose the examination; short enough that a fresh roll lands on
+# the next chart entry after a meaningful pause.  Wound-set changes
+# invalidate the cache regardless of TTL.
+DIAGNOSE_CACHE_TTL_SECONDS = 300
+
+# Conditions surfaced by the diagnose pane (condition_type → DC).
+# These layer on top of the per-organ wound rolls — separate roll
+# per condition.
+DIAGNOSE_CONDITION_DCS = {
+    "minor_bleeding": 1,    # active bleeding is obvious
+    "infection":      6,    # early infection requires palpation
+}

--- a/world/medical/diagnose.py
+++ b/world/medical/diagnose.py
@@ -1,0 +1,532 @@
+"""Diagnose pane for the operate chart menu.
+
+Translates the patient's visceral medical state into clinical
+dialect for the surgeon's chart pane.  Two layers:
+
+1. **Condition rung** — ``stable`` / ``tenuous`` / ``serious`` /
+   ``critical`` / ``moribund`` / ``deceased`` — derived from
+   :attr:`MedicalState.blood_level`, ``consciousness``,
+   ``pain_level``, and active bleeders.  Always visible to the
+   surgeon inside the chart.
+
+2. **Detected findings** — every injured organ rolls Intellect
+   against its obfuscation DC; passes render as a clinical phrase
+   under the rung.  Conditions (bleeding, infection) roll
+   separately against the condition DC table.
+
+The roll is cached per (physician, patient) on
+``patient.db.diagnose_cache`` keyed by physician sleeve UID (or
+dbref) with a 5-minute TTL.  Wound-set changes invalidate the
+cache so a freshly-arrived bleeder forces a new pose on the next
+chart entry.
+
+The pane only renders inside the operate chart (PATIENT block).
+The room-facing ``look`` description stays visceral — the
+clinical register is the surgeon's privilege.
+"""
+from __future__ import annotations
+
+import time
+
+from world.combat.constants import (
+    DIAGNOSE_CACHE_TTL_SECONDS,
+    DIAGNOSE_CONDITION_DCS,
+    INTERNAL_ORGAN_OBFUSCATION_MOD,
+    WOUND_OBFUSCATION_BY_TYPE,
+)
+from world.combat.dice import roll_stat
+
+
+# ===================================================================
+# Constants — module-local
+# ===================================================================
+
+DIAGNOSE_CACHE_ATTR = "diagnose_cache"
+
+# Body-cavity containers — organs whose ``display_location`` equals
+# their ``container`` AND whose container is in this set count as
+# internal for obfuscation purposes (no surface tell).  Sensory
+# organs and limb bones with explicit ``display_location`` (face,
+# left_eye, etc.) escape this check naturally.
+_INTERNAL_CONTAINERS = frozenset({"head", "chest", "abdomen", "back", "neck"})
+
+# Condition rung labels.
+RUNG_DECEASED = "deceased"
+RUNG_MORIBUND = "moribund"
+RUNG_CRITICAL = "critical"
+RUNG_SERIOUS = "serious"
+RUNG_TENUOUS = "tenuous"
+RUNG_STABLE = "stable"
+
+_RUNG_COLOUR = {
+    RUNG_DECEASED: "|x",
+    RUNG_MORIBUND: "|R",
+    RUNG_CRITICAL: "|r",
+    RUNG_SERIOUS: "|y",
+    RUNG_TENUOUS: "|c",
+    RUNG_STABLE: "|g",
+}
+
+# Pose templates broadcast on a fresh diagnostic roll.  Generic
+# enough to read across physician fictions.  The room template is
+# fed to :func:`world.identity_utils.msg_room_identity` so observer
+# views get the physician's per-observer display name; the actor
+# receives the self-form directly.
+DIAGNOSE_POSE_ROOM = (
+    "{physician}'s hands move methodically over the patient, "
+    "checking pulse points and listening at the ribs."
+)
+DIAGNOSE_POSE_SELF = (
+    "Your hands move methodically over the patient, checking "
+    "pulse points and listening at the ribs."
+)
+
+
+# ===================================================================
+# Condition rung classification
+# ===================================================================
+
+def classify_condition_rung(patient) -> str:
+    """Bucket the patient into one of the rung labels.
+
+    Reads :attr:`MedicalState.blood_level` (0-100),
+    ``consciousness`` (0.0-1.0), ``pain_level`` (accumulated),
+    and the active condition list.  No skill gate at this stage —
+    the rung is always visible to the surgeon inside the chart.
+
+    Corpses and severed parts (no live ``medical_state``) report
+    as :data:`RUNG_DECEASED` — detected by the presence of a
+    ``death_time`` attribute on ``.db``, which both
+    :class:`~typeclasses.corpse.Corpse` and
+    :class:`~typeclasses.items.SeveredHead` stamp at creation.
+    """
+    state = getattr(patient, "medical_state", None)
+    if state is None:
+        db = getattr(patient, "db", None)
+        if db is not None and getattr(db, "death_time", None) is not None:
+            return RUNG_DECEASED
+        return RUNG_STABLE
+
+    is_dead = getattr(state, "is_dead", None)
+    if callable(is_dead) and is_dead():
+        return RUNG_DECEASED
+
+    blood = float(getattr(state, "blood_level", 100.0))
+    consciousness = float(getattr(state, "consciousness", 1.0))
+    pain = float(getattr(state, "pain_level", 0.0))
+    conditions = list(getattr(state, "conditions", []) or [])
+    bleeders = [
+        c for c in conditions
+        if getattr(c, "condition_type", None) == "minor_bleeding"
+    ]
+
+    # Moribund — actively dying.
+    if blood < 30.0 or consciousness < 0.2 or len(bleeders) >= 3:
+        return RUNG_MORIBUND
+
+    # Critical — high risk of decompensation.
+    if blood < 55.0 or consciousness < 0.5 or pain > 70.0 or len(bleeders) >= 2:
+        return RUNG_CRITICAL
+
+    # Serious — significant injury, compensating.
+    if blood < 75.0 or consciousness < 0.75 or pain > 40.0 or bleeders:
+        return RUNG_SERIOUS
+
+    # Tenuous — minor disturbance, watch closely.
+    if blood < 90.0 or pain > 15.0 or conditions:
+        return RUNG_TENUOUS
+
+    return RUNG_STABLE
+
+
+# ===================================================================
+# Obfuscation & wound enumeration
+# ===================================================================
+
+def _is_internal_organ(organ) -> bool:
+    """An organ is internal when it lives in a body cavity and has
+    no separate surface display (``display_location == container``)."""
+    container = getattr(organ, "container", None)
+    display = getattr(organ, "display_location", None) or container
+    return container in _INTERNAL_CONTAINERS and display == container
+
+
+def wound_obfuscation_dc(organ) -> int:
+    """Per-organ obfuscation DC for the surgeon's Intellect roll."""
+    injury_type = getattr(organ, "injury_type", None) or "generic"
+    base = WOUND_OBFUSCATION_BY_TYPE.get(
+        injury_type, WOUND_OBFUSCATION_BY_TYPE["generic"],
+    )
+    if _is_internal_organ(organ):
+        base += INTERNAL_ORGAN_OBFUSCATION_MOD
+    return max(0, base)
+
+
+# ===================================================================
+# Clinical vocabulary
+# ===================================================================
+
+# Container → general clinical region.
+_REGION_BY_CONTAINER = {
+    "head":        "cranial",
+    "neck":        "cervical",
+    "chest":       "thoracic",
+    "abdomen":     "abdominal",
+    "back":        "dorsal",
+    "groin":       "pelvic",
+    "left_arm":    "left upper-arm",
+    "right_arm":   "right upper-arm",
+    "left_hand":   "left hand",
+    "right_hand":  "right hand",
+    "left_thigh":  "left femoral",
+    "right_thigh": "right femoral",
+    "left_shin":   "left tibial",
+    "right_shin":  "right tibial",
+    "left_foot":   "left foot",
+    "right_foot":  "right foot",
+}
+
+# Specific organ → clinical adjective phrase.  Wins over the
+# generic container-region lookup when a wound lands on a named
+# internal organ.
+_ORGAN_CLINICAL = {
+    "brain":               "intracranial",
+    "heart":               "cardiac",
+    "left_lung":           "left pulmonary",
+    "right_lung":          "right pulmonary",
+    "liver":               "hepatic",
+    "left_kidney":         "left renal",
+    "right_kidney":        "right renal",
+    "stomach":             "gastric",
+    "cervical_spine":      "cervical spinal",
+    "thoracolumbar_spine": "thoracolumbar spinal",
+    "left_eye":            "left ocular",
+    "right_eye":           "right ocular",
+    "left_ear":            "left auricular",
+    "right_ear":           "right auricular",
+    "tongue":              "lingual",
+    "jaw":                 "mandibular",
+    "nose":                "nasal",
+    "left_humerus":        "left humeral",
+    "right_humerus":       "right humeral",
+    "left_femur":          "left femoral",
+    "right_femur":         "right femoral",
+}
+
+# Injury type → clinical noun-phrase template.  ``{region}`` is
+# substituted with the organ-specific or container-derived label.
+_INJURY_PHRASE = {
+    "severance":  "open avulsion of the {region}",
+    "bullet":     "penetrating ballistic trauma to the {region}",
+    "stab":       "penetrating sharp-force injury to the {region}",
+    "cut":        "open incised wound to the {region}",
+    "laceration": "ragged laceration of the {region}",
+    "burn":       "thermal injury to the {region}",
+    "blunt":      "blunt-force trauma to the {region}",
+    "harvested":  "surgical extraction of the {region}",
+    "generic":    "trauma to the {region}",
+}
+
+# Wound stage → prefix qualifier for clinical severity reading.
+_STAGE_PREFIX = {
+    "fresh":     "active",
+    "destroyed": "non-viable",
+    "treated":   "stabilised",
+    "healing":   "convalescent",
+    "scarred":   "resolved",
+}
+
+
+def _region_for_organ(organ) -> str:
+    name = getattr(organ, "name", "") or ""
+    container = getattr(organ, "container", "") or ""
+    return (
+        _ORGAN_CLINICAL.get(name)
+        or _REGION_BY_CONTAINER.get(container)
+        or container.replace("_", " ")
+        or "unspecified"
+    )
+
+
+def clinical_phrase(organ) -> str:
+    """Translate an injured organ into a clinical noun phrase."""
+    stage = getattr(organ, "wound_stage", None) or "fresh"
+    injury_type = getattr(organ, "injury_type", None) or "generic"
+    region = _region_for_organ(organ)
+
+    # Severance reads as a completed event, not an ongoing state.
+    if stage == "severed" or injury_type == "severance":
+        return f"amputation at the {region} site"
+
+    base = _INJURY_PHRASE.get(injury_type, _INJURY_PHRASE["generic"]).format(
+        region=region,
+    )
+    prefix = _STAGE_PREFIX.get(stage)
+    return f"{prefix} {base}" if prefix else base
+
+
+_CONDITION_PHRASE = {
+    "minor_bleeding": "active haemorrhage from the {region}",
+    "infection":      "septic focus at the {region}",
+}
+
+
+class _WoundDictAdapter:
+    """Expose a ``wounds_at_death`` entry through the same surface
+    a live :class:`~world.medical.core.Organ` would, so the
+    phrasing / DC helpers stay uniform across living and deceased
+    subjects.
+
+    ``wounds_at_death`` entries are dicts (or ``_SaverDict`` for
+    persisted nested dicts — duck-typed via ``.get``) shaped like::
+
+        {"injury_type": ..., "location": <container>,
+         "severity": ..., "stage": "fresh" | "old" | "treated",
+         "organ": <specific_organ_name>, "organ_damage": {...}}
+    """
+
+    __slots__ = ("name", "container", "display_location",
+                 "injury_type", "wound_stage")
+
+    def __init__(self, wound_dict):
+        get = wound_dict.get
+        location = get("location") or ""
+        organ = get("organ") or ""
+        self.name = organ or location
+        self.container = location or organ
+        self.display_location = self.container
+        self.injury_type = get("injury_type") or "generic"
+        stage = get("stage") or "fresh"
+        # Death-snapshot wounds tagged ``old`` still carry clinical
+        # significance — they're old to the decay clock but the
+        # finding itself is still active.  Map to ``fresh`` so the
+        # clinical phrase reads "active …" rather than dropping
+        # the severity prefix entirely.
+        self.wound_stage = "fresh" if stage == "old" else stage
+
+
+def _condition_clinical(condition):
+    """Return ``(phrase, dc)`` or ``None`` if the condition has no
+    diagnose surface."""
+    ctype = getattr(condition, "condition_type", None)
+    if ctype not in _CONDITION_PHRASE:
+        return None
+    location = getattr(condition, "location", None) or ""
+    region = (
+        _REGION_BY_CONTAINER.get(location)
+        or location.replace("_", " ")
+        or "unspecified site"
+    )
+    phrase = _CONDITION_PHRASE[ctype].format(region=region)
+    dc = DIAGNOSE_CONDITION_DCS.get(ctype, 5)
+    return phrase, dc
+
+
+# ===================================================================
+# Roll + cache
+# ===================================================================
+
+def _iter_wound_targets(patient):
+    """Yield ``(detection_key, organ_like, dc)`` for every
+    diagnosable wound on the patient.
+
+    Living patients yield from :attr:`MedicalState.organs`;
+    corpses and severed body parts yield from
+    ``db.wounds_at_death``, wrapped through :class:`_WoundDictAdapter`
+    so the same phrasing / DC helpers work uniformly.
+    """
+    state = getattr(patient, "medical_state", None)
+    if state is not None:
+        organs = getattr(state, "organs", {}) or {}
+        for organ_name, organ in organs.items():
+            if not getattr(organ, "wound_stage", None):
+                continue
+            yield (
+                f"organ:{organ_name}",
+                organ,
+                wound_obfuscation_dc(organ),
+            )
+        return
+
+    db = getattr(patient, "db", None)
+    if db is None:
+        return
+    wounds = getattr(db, "wounds_at_death", None) or ()
+    for idx, raw in enumerate(wounds):
+        if not hasattr(raw, "get"):
+            continue
+        adapter = _WoundDictAdapter(raw)
+        if not adapter.wound_stage:
+            continue
+        yield (
+            f"wound:{idx}",
+            adapter,
+            wound_obfuscation_dc(adapter),
+        )
+
+
+def _wound_signature(patient) -> list[str]:
+    """Order-insensitive token list used to detect wound-set
+    changes for cache invalidation."""
+    sig: list[str] = []
+    for key, organ_like, _dc in _iter_wound_targets(patient):
+        stage = getattr(organ_like, "wound_stage", "") or ""
+        injury = getattr(organ_like, "injury_type", "") or "generic"
+        sig.append(f"{key}:{stage}:{injury}")
+    state = getattr(patient, "medical_state", None)
+    if state is not None:
+        for c in getattr(state, "conditions", []) or []:
+            ctype = getattr(c, "condition_type", None)
+            if ctype in _CONDITION_PHRASE:
+                loc = getattr(c, "location", None) or ""
+                sig.append(f"cond:{ctype}:{loc}")
+    sig.sort()
+    return sig
+
+
+def _physician_cache_key(physician) -> str:
+    """Per-physician cache key.  Uses ``sleeve_uid`` when present
+    so a re-sleeved physician still benefits from prior diagnostic
+    memory of the same patient; falls back to object id otherwise."""
+    db = getattr(physician, "db", None)
+    uid = getattr(db, "sleeve_uid", None) if db is not None else None
+    if uid:
+        return f"sleeve:{uid}"
+    obj_id = getattr(physician, "id", None) or id(physician)
+    return f"obj:{obj_id}"
+
+
+def _get_or_init_cache(patient) -> dict:
+    """Return the cache dict, initialising it on patient.db if
+    absent.  Duck-types ``_SaverDict`` (no ``isinstance(dict)``
+    check — Evennia wraps persisted nested dicts)."""
+    db = getattr(patient, "db", None)
+    if db is None:
+        return {}
+    cache = getattr(db, DIAGNOSE_CACHE_ATTR, None)
+    if cache is None:
+        cache = {}
+        setattr(db, DIAGNOSE_CACHE_ATTR, cache)
+        cache = getattr(db, DIAGNOSE_CACHE_ATTR, cache)
+    return cache
+
+
+def perform_diagnose(physician, patient, *, force_reroll: bool = False) -> dict:
+    """Roll Intellect against each wound's obfuscation DC.
+
+    Caches the result per-physician on the patient.  Returns the
+    cache entry with an additional ``from_cache`` boolean
+    signalling whether this call hit cache (caller decides whether
+    to emit the examination pose based on the flag).
+    """
+    cache_key = _physician_cache_key(physician)
+    cache = _get_or_init_cache(patient)
+    raw_entry = cache.get(cache_key) if hasattr(cache, "get") else None
+    now = time.time()
+    current_sig = _wound_signature(patient)
+
+    if not force_reroll and raw_entry is not None:
+        ts = (
+            raw_entry.get("timestamp", 0)
+            if hasattr(raw_entry, "get") else 0
+        )
+        prior_sig = (
+            list(raw_entry.get("wound_signature", []))
+            if hasattr(raw_entry, "get") else []
+        )
+        if (now - ts) < DIAGNOSE_CACHE_TTL_SECONDS and prior_sig == current_sig:
+            return {
+                "timestamp": ts,
+                "wound_signature": prior_sig,
+                "detected_wounds": list(raw_entry.get("detected_wounds", [])),
+                "detected_conditions": list(
+                    raw_entry.get("detected_conditions", [])
+                ),
+                "from_cache": True,
+            }
+
+    # Fresh roll.
+    detected_wounds: list[str] = []
+    detected_conditions: list[str] = []
+    for key, _organ_like, dc in _iter_wound_targets(patient):
+        if roll_stat(physician, "intellect") >= dc:
+            detected_wounds.append(key)
+    state = getattr(patient, "medical_state", None)
+    if state is not None:
+        for c in getattr(state, "conditions", []) or []:
+            rendered = _condition_clinical(c)
+            if rendered is None:
+                continue
+            _, dc = rendered
+            if roll_stat(physician, "intellect") >= dc:
+                # Use (type, location) so duplicate condition_types
+                # at different sites can be distinguished.
+                ctype = getattr(c, "condition_type", "")
+                loc = getattr(c, "location", "") or ""
+                detected_conditions.append(f"{ctype}@{loc}")
+
+    entry = {
+        "timestamp": now,
+        "wound_signature": current_sig,
+        "detected_wounds": detected_wounds,
+        "detected_conditions": detected_conditions,
+    }
+    cache[cache_key] = entry
+    return {**entry, "from_cache": False}
+
+
+# ===================================================================
+# Rendering
+# ===================================================================
+
+def render_diagnose_lines(physician, patient) -> list[str]:
+    """Render the diagnose lines for the chart PATIENT block.
+
+    Assumes ``perform_diagnose`` has already populated the cache;
+    on cache miss inside the renderer (rare — covers a chart-menu
+    re-entry edge case) the render falls back to the rung only,
+    without rolling, so the renderer never broadcasts a pose.
+    """
+    lines: list[str] = []
+    rung = classify_condition_rung(patient)
+    colour = _RUNG_COLOUR.get(rung, "|w")
+    lines.append(f"condition: {colour}{rung}|n")
+
+    cache = _get_or_init_cache(patient)
+    raw_entry = cache.get(_physician_cache_key(physician)) \
+        if hasattr(cache, "get") else None
+    if raw_entry is None:
+        return lines
+
+    detected_wound_keys = set(raw_entry.get("detected_wounds", []) or [])
+    detected_conditions = set(
+        raw_entry.get("detected_conditions", []) or []
+    )
+
+    findings: list[str] = []
+    for key, organ_like, _dc in _iter_wound_targets(patient):
+        if key not in detected_wound_keys:
+            continue
+        findings.append(clinical_phrase(organ_like))
+
+    state = getattr(patient, "medical_state", None)
+    if state is not None:
+        for c in getattr(state, "conditions", []) or []:
+            rendered = _condition_clinical(c)
+            if rendered is None:
+                continue
+            phrase, _ = rendered
+            ctype = getattr(c, "condition_type", "")
+            loc = getattr(c, "location", "") or ""
+            if f"{ctype}@{loc}" not in detected_conditions:
+                continue
+            findings.append(phrase)
+
+    if findings:
+        lines.append("findings:")
+        for f in findings:
+            lines.append(f"  · {f}")
+    else:
+        lines.append("findings: no abnormalities detected")
+
+    return lines

--- a/world/tests/test_diagnose.py
+++ b/world/tests/test_diagnose.py
@@ -1,0 +1,465 @@
+"""Unit tests for :mod:`world.medical.diagnose` — the diagnose
+pane that surfaces in the operate chart's PATIENT block.
+
+Covers:
+
+* :func:`classify_condition_rung` — bucket boundaries across
+  blood / consciousness / pain / bleeders.
+* :func:`wound_obfuscation_dc` — internal-cavity modifier applies
+  to internal organs, skips surface organs.
+* :func:`clinical_phrase` — injury-type + organ + stage combine
+  into clinical noun phrases.
+* :func:`perform_diagnose` — Intellect rolls, per-physician cache,
+  TTL hit/miss, wound-signature invalidation.
+* :func:`render_diagnose_lines` — renders rung + findings; only
+  detected wounds appear.
+"""
+from __future__ import annotations
+
+import time
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.medical import diagnose as dx
+
+
+# ---------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------
+
+class _DB:
+    """Bare attribute holder mimicking ``obj.db``."""
+
+
+class _FakeOrgan:
+    def __init__(self, *, name, container, display_location=None,
+                 wound_stage=None, injury_type=None):
+        self.name = name
+        self.container = container
+        self.display_location = display_location or container
+        self.wound_stage = wound_stage
+        self.injury_type = injury_type
+
+
+class _FakeCondition:
+    def __init__(self, *, condition_type, location=None):
+        self.condition_type = condition_type
+        self.location = location
+
+
+class _FakeState:
+    def __init__(self, *, blood_level=100.0, consciousness=1.0,
+                 pain_level=0.0, conditions=None, organs=None,
+                 dead=False):
+        self.blood_level = blood_level
+        self.consciousness = consciousness
+        self.pain_level = pain_level
+        self.conditions = conditions or []
+        self.organs = organs or {}
+        self._dead = dead
+
+    def is_dead(self):
+        return self._dead
+
+
+class _FakePatient:
+    def __init__(self, *, state=None):
+        self.medical_state = state
+        self.db = _DB()
+
+
+class _FakePhysician:
+    def __init__(self, *, intellect=10, sleeve_uid="phys-1", obj_id=99):
+        self.intellect = intellect
+        self.db = _DB()
+        self.db.sleeve_uid = sleeve_uid
+        self.id = obj_id
+
+
+# ---------------------------------------------------------------------
+# Condition rung classifier
+# ---------------------------------------------------------------------
+
+class TestClassifyConditionRung(TestCase):
+    def test_no_state_defaults_stable(self):
+        patient = _FakePatient(state=None)
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_STABLE)
+
+    def test_corpse_with_death_time_reports_deceased(self):
+        """Corpses lack a ``medical_state`` but stamp ``death_time``
+        on ``.db`` at creation — the classifier reads that as
+        deceased rather than defaulting to stable."""
+        patient = _FakePatient(state=None)
+        patient.db.death_time = time.time() - 60
+        self.assertEqual(
+            dx.classify_condition_rung(patient), dx.RUNG_DECEASED,
+        )
+
+    def test_dead_short_circuits(self):
+        patient = _FakePatient(state=_FakeState(dead=True))
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_DECEASED)
+
+    def test_healthy_baseline_stable(self):
+        patient = _FakePatient(state=_FakeState())
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_STABLE)
+
+    def test_minor_pain_tenuous(self):
+        patient = _FakePatient(state=_FakeState(pain_level=20.0))
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_TENUOUS)
+
+    def test_blood_loss_serious(self):
+        patient = _FakePatient(state=_FakeState(blood_level=70.0))
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_SERIOUS)
+
+    def test_single_bleeder_serious(self):
+        patient = _FakePatient(state=_FakeState(conditions=[
+            _FakeCondition(condition_type="minor_bleeding"),
+        ]))
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_SERIOUS)
+
+    def test_two_bleeders_critical(self):
+        patient = _FakePatient(state=_FakeState(conditions=[
+            _FakeCondition(condition_type="minor_bleeding"),
+            _FakeCondition(condition_type="minor_bleeding"),
+        ]))
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_CRITICAL)
+
+    def test_severe_blood_loss_critical(self):
+        patient = _FakePatient(state=_FakeState(blood_level=40.0))
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_CRITICAL)
+
+    def test_three_bleeders_moribund(self):
+        patient = _FakePatient(state=_FakeState(conditions=[
+            _FakeCondition(condition_type="minor_bleeding"),
+            _FakeCondition(condition_type="minor_bleeding"),
+            _FakeCondition(condition_type="minor_bleeding"),
+        ]))
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_MORIBUND)
+
+    def test_consciousness_collapse_moribund(self):
+        patient = _FakePatient(state=_FakeState(consciousness=0.1))
+        self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_MORIBUND)
+
+
+# ---------------------------------------------------------------------
+# Obfuscation DC
+# ---------------------------------------------------------------------
+
+class TestWoundObfuscationDC(TestCase):
+    def test_surface_organ_keeps_baseline(self):
+        # Eye has display_location != container, so it's external.
+        eye = _FakeOrgan(
+            name="left_eye", container="head",
+            display_location="left_eye",
+            wound_stage="fresh", injury_type="cut",
+        )
+        self.assertEqual(dx.wound_obfuscation_dc(eye), 2)
+
+    def test_internal_organ_bumps_dc(self):
+        heart = _FakeOrgan(
+            name="heart", container="chest",
+            wound_stage="fresh", injury_type="bullet",
+        )
+        # bullet baseline 3 + internal mod 5 = 8.
+        self.assertEqual(dx.wound_obfuscation_dc(heart), 8)
+
+    def test_severance_auto_detects(self):
+        limb = _FakeOrgan(
+            name="left_arm", container="left_arm",
+            wound_stage="severed", injury_type="severance",
+        )
+        # left_arm container not in internal containers → no bump.
+        self.assertEqual(dx.wound_obfuscation_dc(limb), 0)
+
+    def test_blunt_to_brain_high_dc(self):
+        brain = _FakeOrgan(
+            name="brain", container="head",
+            wound_stage="fresh", injury_type="blunt",
+        )
+        # blunt 5 + internal 5 = 10.
+        self.assertEqual(dx.wound_obfuscation_dc(brain), 10)
+
+
+# ---------------------------------------------------------------------
+# Clinical phrasing
+# ---------------------------------------------------------------------
+
+class TestClinicalPhrase(TestCase):
+    def test_organ_specific_name_wins(self):
+        heart = _FakeOrgan(
+            name="heart", container="chest",
+            wound_stage="fresh", injury_type="bullet",
+        )
+        phrase = dx.clinical_phrase(heart)
+        self.assertIn("cardiac", phrase)
+        self.assertIn("ballistic", phrase)
+        self.assertIn("active", phrase)
+
+    def test_container_region_fallback(self):
+        # Bare-container injury (no specific-organ name match).
+        shin = _FakeOrgan(
+            name="left_tibia", container="left_shin",
+            wound_stage="fresh", injury_type="laceration",
+        )
+        phrase = dx.clinical_phrase(shin)
+        self.assertIn("left tibial", phrase)
+        self.assertIn("laceration", phrase)
+
+    def test_severance_reads_as_amputation(self):
+        limb = _FakeOrgan(
+            name="right_arm", container="right_arm",
+            wound_stage="severed", injury_type="severance",
+        )
+        phrase = dx.clinical_phrase(limb)
+        self.assertIn("amputation", phrase)
+
+    def test_treated_prefix_applied(self):
+        liver = _FakeOrgan(
+            name="liver", container="abdomen",
+            wound_stage="treated", injury_type="stab",
+        )
+        phrase = dx.clinical_phrase(liver)
+        self.assertIn("stabilised", phrase)
+        self.assertIn("hepatic", phrase)
+
+
+# ---------------------------------------------------------------------
+# perform_diagnose — roll + cache
+# ---------------------------------------------------------------------
+
+class TestPerformDiagnose(TestCase):
+    def _patient_with_wounds(self):
+        organs = {
+            "heart": _FakeOrgan(
+                name="heart", container="chest",
+                wound_stage="fresh", injury_type="bullet",
+            ),
+            "left_eye": _FakeOrgan(
+                name="left_eye", container="head",
+                display_location="left_eye",
+                wound_stage="fresh", injury_type="cut",
+            ),
+        }
+        return _FakePatient(state=_FakeState(organs=organs))
+
+    def test_all_rolls_succeed_with_high_intellect(self):
+        patient = self._patient_with_wounds()
+        physician = _FakePhysician()
+        with patch.object(dx, "roll_stat", return_value=100):
+            result = dx.perform_diagnose(physician, patient)
+        self.assertFalse(result["from_cache"])
+        self.assertEqual(
+            set(result["detected_wounds"]), {"organ:heart", "organ:left_eye"},
+        )
+
+    def test_low_rolls_hide_internal_wound(self):
+        patient = self._patient_with_wounds()
+        physician = _FakePhysician()
+        # Roll = 3 → beats cut DC 2 but loses to heart DC 8.
+        with patch.object(dx, "roll_stat", return_value=3):
+            result = dx.perform_diagnose(physician, patient)
+        self.assertIn("organ:left_eye", result["detected_wounds"])
+        self.assertNotIn("organ:heart", result["detected_wounds"])
+
+    def test_cache_hit_within_ttl(self):
+        patient = self._patient_with_wounds()
+        physician = _FakePhysician()
+        with patch.object(dx, "roll_stat", return_value=100):
+            first = dx.perform_diagnose(physician, patient)
+        with patch.object(dx, "roll_stat") as mocked:
+            second = dx.perform_diagnose(physician, patient)
+            mocked.assert_not_called()
+        self.assertTrue(second["from_cache"])
+        self.assertEqual(
+            set(second["detected_wounds"]), set(first["detected_wounds"]),
+        )
+
+    def test_wound_signature_change_invalidates_cache(self):
+        patient = self._patient_with_wounds()
+        physician = _FakePhysician()
+        with patch.object(dx, "roll_stat", return_value=100):
+            first = dx.perform_diagnose(physician, patient)
+        # New wound appears between calls.
+        patient.medical_state.organs["liver"] = _FakeOrgan(
+            name="liver", container="abdomen",
+            wound_stage="fresh", injury_type="stab",
+        )
+        with patch.object(dx, "roll_stat", return_value=100):
+            second = dx.perform_diagnose(physician, patient)
+        self.assertFalse(second["from_cache"])
+        self.assertIn("organ:liver", second["detected_wounds"])
+        del first  # explicitly unused — clarifies intent
+
+    def test_ttl_expiry_reroll(self):
+        patient = self._patient_with_wounds()
+        physician = _FakePhysician()
+        with patch.object(dx, "roll_stat", return_value=100):
+            dx.perform_diagnose(physician, patient)
+        # Backdate the cache entry past TTL.
+        cache_key = dx._physician_cache_key(physician)
+        cache = patient.db.diagnose_cache
+        entry = cache[cache_key]
+        entry["timestamp"] = time.time() - dx.DIAGNOSE_CACHE_TTL_SECONDS - 1
+        cache[cache_key] = entry
+        with patch.object(dx, "roll_stat", return_value=100):
+            second = dx.perform_diagnose(physician, patient)
+        self.assertFalse(second["from_cache"])
+
+    def test_separate_physicians_have_independent_cache(self):
+        patient = self._patient_with_wounds()
+        good = _FakePhysician(sleeve_uid="senior")
+        novice = _FakePhysician(sleeve_uid="newbie")
+        with patch.object(dx, "roll_stat", return_value=100):
+            senior_result = dx.perform_diagnose(good, patient)
+        # Novice's first call must trigger its own roll regardless.
+        with patch.object(dx, "roll_stat", return_value=1) as mocked:
+            novice_result = dx.perform_diagnose(novice, patient)
+            self.assertTrue(mocked.called)
+        self.assertFalse(novice_result["from_cache"])
+        # Novice misses internal heart even though senior caught it.
+        self.assertNotIn("organ:heart", novice_result["detected_wounds"])
+        self.assertIn("organ:heart", senior_result["detected_wounds"])
+
+
+# ---------------------------------------------------------------------
+# render_diagnose_lines
+# ---------------------------------------------------------------------
+
+class TestRenderDiagnoseLines(TestCase):
+    def test_renders_rung_and_findings(self):
+        organs = {
+            "heart": _FakeOrgan(
+                name="heart", container="chest",
+                wound_stage="fresh", injury_type="bullet",
+            ),
+        }
+        patient = _FakePatient(state=_FakeState(
+            blood_level=50.0, organs=organs,
+        ))
+        physician = _FakePhysician()
+        with patch.object(dx, "roll_stat", return_value=100):
+            dx.perform_diagnose(physician, patient)
+        lines = dx.render_diagnose_lines(physician, patient)
+        joined = "\n".join(lines)
+        self.assertIn("critical", joined)   # blood_level 50 → critical
+        self.assertIn("cardiac", joined)
+        self.assertIn("ballistic", joined)
+
+    def test_undetected_wound_hidden_in_render(self):
+        organs = {
+            "heart": _FakeOrgan(
+                name="heart", container="chest",
+                wound_stage="fresh", injury_type="bullet",
+            ),
+        }
+        patient = _FakePatient(state=_FakeState(organs=organs))
+        physician = _FakePhysician()
+        with patch.object(dx, "roll_stat", return_value=1):
+            dx.perform_diagnose(physician, patient)
+        lines = dx.render_diagnose_lines(physician, patient)
+        joined = "\n".join(lines)
+        self.assertIn("no abnormalities detected", joined)
+        self.assertNotIn("cardiac", joined)
+
+    def test_render_without_cache_just_shows_rung(self):
+        # No perform_diagnose call → renderer falls back to
+        # rung-only output, doesn't crash.
+        patient = _FakePatient(state=_FakeState())
+        physician = _FakePhysician()
+        lines = dx.render_diagnose_lines(physician, patient)
+        self.assertTrue(any("condition" in l for l in lines))
+
+
+# ---------------------------------------------------------------------
+# Condition rendering
+# ---------------------------------------------------------------------
+
+class TestCorpseAndSeveredParts(TestCase):
+    """Subjects without a live ``medical_state`` (corpses, severed
+    heads, appendages) still surface a diagnose pane sourced from
+    ``db.wounds_at_death``."""
+
+    def _make_corpse(self, wounds):
+        patient = _FakePatient(state=None)
+        patient.db.death_time = time.time() - 60
+        patient.db.wounds_at_death = wounds
+        return patient
+
+    def test_corpse_wounds_render_clinically(self):
+        wounds = [
+            {"injury_type": "bullet", "location": "chest",
+             "stage": "old", "organ": "heart",
+             "severity": "Critical", "organ_damage": {}},
+            {"injury_type": "severance", "location": "neck",
+             "stage": "old", "severity": "Critical"},
+        ]
+        patient = self._make_corpse(wounds)
+        physician = _FakePhysician()
+        with patch.object(dx, "roll_stat", return_value=100):
+            dx.perform_diagnose(physician, patient)
+        lines = dx.render_diagnose_lines(physician, patient)
+        joined = "\n".join(lines)
+        self.assertIn("deceased", joined)
+        self.assertIn("cardiac", joined)
+        self.assertIn("amputation", joined)
+
+    def test_severed_head_with_brain_damage(self):
+        """SeveredHead carries a trimmed wounds_at_death scoped to
+        head-container findings."""
+        wounds = [
+            {"injury_type": "blunt", "location": "head",
+             "stage": "old", "organ": "brain",
+             "severity": "Critical", "organ_damage": {}},
+        ]
+        patient = self._make_corpse(wounds)
+        physician = _FakePhysician(intellect=20)
+        with patch.object(dx, "roll_stat", return_value=100):
+            dx.perform_diagnose(physician, patient)
+        lines = dx.render_diagnose_lines(physician, patient)
+        joined = "\n".join(lines)
+        self.assertIn("intracranial", joined)
+        self.assertIn("blunt-force", joined)
+
+    def test_low_roll_hides_corpse_finding(self):
+        wounds = [
+            {"injury_type": "bullet", "location": "chest",
+             "stage": "old", "organ": "heart",
+             "severity": "Critical", "organ_damage": {}},
+        ]
+        patient = self._make_corpse(wounds)
+        physician = _FakePhysician()
+        # Roll = 1 → loses to internal organ DC (3 + 5 = 8).
+        with patch.object(dx, "roll_stat", return_value=1):
+            result = dx.perform_diagnose(physician, patient)
+        self.assertEqual(result["detected_wounds"], [])
+
+    def test_harvested_organ_auto_detected(self):
+        wounds = [
+            {"injury_type": "harvested", "location": "heart",
+             "stage": "old", "organ": "heart",
+             "severity": "Critical", "organ_damage": {}},
+        ]
+        patient = self._make_corpse(wounds)
+        physician = _FakePhysician()
+        # DC 0 → any roll passes.
+        with patch.object(dx, "roll_stat", return_value=1):
+            dx.perform_diagnose(physician, patient)
+        lines = dx.render_diagnose_lines(physician, patient)
+        joined = "\n".join(lines)
+        self.assertIn("surgical extraction", joined)
+
+
+class TestConditionRendering(TestCase):
+    def test_bleeding_condition_renders_clinically(self):
+        patient = _FakePatient(state=_FakeState(
+            conditions=[_FakeCondition(
+                condition_type="minor_bleeding", location="chest",
+            )],
+        ))
+        physician = _FakePhysician()
+        with patch.object(dx, "roll_stat", return_value=100):
+            dx.perform_diagnose(physician, patient)
+        lines = dx.render_diagnose_lines(physician, patient)
+        joined = "\n".join(lines)
+        self.assertIn("haemorrhage", joined)
+        self.assertIn("thoracic", joined)


### PR DESCRIPTION
## Summary
- Add a diagnose pane that surfaces inside the operate chart's PATIENT block — condition rung (stable / tenuous / serious / critical / moribund / deceased) plus detected findings rendered in clinical dialect.
- The point is to teach the player roleplaying a medic the *vocabulary* — visceral look-descriptions stay on \`look\`; the clinical register is the surgeon's privilege inside the chart.
- Internal organ wounds gate behind an Intellect-vs-obfuscation roll; surface findings show automatically. Roll caches per-(physician, patient) for 5 minutes, invalidated by wound-set changes.
- Corpses and severed parts iterate \`db.wounds_at_death\` through a \`_WoundDictAdapter\` so the pane works the same for living, deceased, and detached subjects.

## How it works
- \`classify_condition_rung\` buckets from \`blood_level\`, \`consciousness\`, \`pain_level\`, active bleeders. Corpses (no \`medical_state\`, \`db.death_time\` stamped) map to \`deceased\`.
- \`WOUND_OBFUSCATION_BY_TYPE\` per-injury DCs in \`world/combat/constants.py\`; \`INTERNAL_ORGAN_OBFUSCATION_MOD\` adds 5 to body-cavity organs.
- First roll broadcasts a generic physician pose via \`msg_room_identity\`; cache hits re-enter silently.

## Test plan
- [x] 33 new unit tests in \`world/tests/test_diagnose.py\`
- [x] Full \`world.tests\` regression sweep — 2175 passed
- [x] Live playtest on master via \`operate <wounded NPC>\`, \`operate <carcass>\`, \`operate <severed head>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)