### PR TITLE
refactor: surgical-state runtime tier + chart write batching (P1)

### DIFF
--- a/world/medical/charts.py
+++ b/world/medical/charts.py
@@ -143,14 +143,79 @@ def get_chart(target) -> Optional[dict]:
     return dict(raw)
 
 
+#: Process-local set of targets whose chart writes are currently
+#: being batched.  Populated by :class:`batch_chart_writes` on enter
+#: and drained on exit, when the deferred ``save_chart`` call lands.
+#: A target may only be batched once at a time (the chart runner is
+#: not re-entrant on a single subject), so a simple set suffices.
+_BATCHING_TARGETS: set = set()
+
+
 def save_chart(target, chart: dict) -> None:
     """Persist ``chart`` onto ``target.db.medical_chart``.
 
     Updates ``last_modified_at`` automatically; callers should not
     pre-stamp the timestamp themselves.
+
+    When called from inside a :class:`batch_chart_writes` block for
+    the same target, the descriptor write is skipped — the chart
+    mutates only in memory and the batched flush lands on context
+    exit.  This collapses the 3+ writes per chart-runner step into
+    a single write per commence pass.
     """
     chart["last_modified_at"] = time.time()
+    dbref = getattr(target, "dbref", None)
+    if dbref in _BATCHING_TARGETS:
+        # Stash the latest snapshot on the target so the batch
+        # context can flush it on exit.  Uses a runtime attribute
+        # (descriptor-free) so the staging cost is a dict lookup,
+        # not a pickle round-trip.
+        target._runtime_chart_pending_flush = chart
+        return
     target.db.medical_chart = chart
+
+
+class batch_chart_writes:
+    """Context manager that defers ``save_chart`` writes to a single
+    flush on exit.
+
+    The chart runner (``commence_chart``) calls ``save_chart``
+    multiple times per step transition (mark RUNNING, mark DONE,
+    attach result, advance to next step).  Wrapping the recursive
+    pass in this context replaces that with one descriptor write
+    at the end:
+
+        with batch_chart_writes(target):
+            commence_chart(target, actor)
+
+    Nested entries on the same target are no-ops (the outermost
+    context owns the flush).  Exceptions inside the block still
+    flush the most recent in-memory snapshot — partial progress is
+    worth more than nothing.
+    """
+
+    def __init__(self, target):
+        self.target = target
+        self._dbref = getattr(target, "dbref", None)
+        self._owns_batch = False
+
+    def __enter__(self):
+        if self._dbref is not None and self._dbref not in _BATCHING_TARGETS:
+            _BATCHING_TARGETS.add(self._dbref)
+            self._owns_batch = True
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if not self._owns_batch:
+            return False
+        _BATCHING_TARGETS.discard(self._dbref)
+        pending = getattr(
+            self.target, "_runtime_chart_pending_flush", None,
+        )
+        if pending is not None:
+            self.target.db.medical_chart = pending
+            self.target._runtime_chart_pending_flush = None
+        return False
 
 
 def discard_chart(target) -> None:
@@ -503,32 +568,39 @@ def commence_chart(target, actor) -> Optional[dict]:
         hook pops it onto the step's ``result`` field before
         saving, so the surgeon can re-read the finding later by
         reopening the chart.
+
+        Wrapped in :class:`batch_chart_writes` so the mark-done
+        write and the next-step's mark-running write collapse to
+        a single descriptor write per transition.  Skipped /
+        failed verbs in the recursive chain ride the same batch.
         """
-        latest = get_chart(target_arg)
-        if latest is None:
-            return
-        # Pop any pending step result the resolver left for us.
-        pending_result = None
-        target_db = getattr(target_arg, "db", None)
-        if target_db is not None:
-            state = getattr(target_db, "surgical_state", None) or {}
-            if hasattr(state, "get"):
-                pending_result = state.get("pending_step_result")
-                if pending_result is not None:
-                    state["pending_step_result"] = None
-                    target_db.surgical_state = state
-        # Find the step that was running, attach the result, and
-        # mark it done.
-        for s in latest.get("steps") or ():
-            if s.get("status") == RUNNING:
-                if pending_result is not None:
-                    s["result"] = pending_result
-                s["status"] = DONE
-                break
-        save_chart(target_arg, latest)
-        # Recursive advancement — runs the next pending step, or
-        # finalises the chart status if none remain.
-        commence_chart(target_arg, actor_arg)
+        with batch_chart_writes(target_arg):
+            latest = get_chart(target_arg)
+            if latest is None:
+                return
+            # Pop any pending step result the resolver left for us.
+            pending_result = None
+            target_db = getattr(target_arg, "db", None)
+            if target_db is not None:
+                state = getattr(target_db, "surgical_state", None) or {}
+                if hasattr(state, "get"):
+                    pending_result = state.get("pending_step_result")
+                    if pending_result is not None:
+                        state["pending_step_result"] = None
+                        target_db.surgical_state = state
+            # Find the step that was running, attach the result,
+            # and mark it done.
+            for s in latest.get("steps") or ():
+                if s.get("status") == RUNNING:
+                    if pending_result is not None:
+                        s["result"] = pending_result
+                    s["status"] = DONE
+                    break
+            save_chart(target_arg, latest)
+            # Recursive advancement — runs the next pending step,
+            # or finalises the chart status if none remain.  Both
+            # branches' writes ride the same batch.
+            commence_chart(target_arg, actor_arg)
 
     from world.medical.procedures import start_procedure
     try:

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -13,7 +13,7 @@ Design contract
   organ snapshot via :func:`get_organ_snapshot`.  Same dispatch path
   for every target type.
 * **Two-phase resolution.**  Each verb opens a procedure: the
-  attempt is staged on ``target.db.surgical_state["active_procedure"]``
+  attempt is staged on a runtime ``_runtime_active_procedure`` slot
   with a delay duration; resolution fires when the delay elapses,
   rolling skill and applying outcome.  Interruptions during the
   window route through :func:`interrupt_procedure`.
@@ -170,13 +170,43 @@ def organs_at_location(target, location: str) -> list[tuple[str, dict]]:
 
 
 def _state(target) -> dict:
-    """Lazy-init and return ``target.db.surgical_state``."""
+    """Lazy-init and return ``target.db.surgical_state``.
+
+    The persistent slice — incisions, sutured stumps, the
+    chart-runner's ``pending_step_result`` pickup slot.  The
+    in-flight ``active_procedure`` record lives separately on a
+    plain runtime attribute (``_runtime_active_procedure``), since
+    its lifetime is bounded by the in-process ``evennia_delay``
+    callback that can't survive a restart anyway.  See
+    :func:`get_active_procedure` / :func:`_set_active_procedure`.
+    """
     if target.db.surgical_state is None:
         target.db.surgical_state = {
             "incisions": {},
-            "active_procedure": None,
         }
     return target.db.surgical_state
+
+
+# ---------------------------------------------------------------------
+# active_procedure runtime tier
+# ---------------------------------------------------------------------
+#
+# The record is bound to an in-process ``evennia_delay`` callback —
+# a process restart drops the callback (we pass ``persistent=False``)
+# so any persisted record would be a half-truth.  Keep it as a plain
+# Python attribute on the target.  The chart's step ``status`` stays
+# persistent (the surgeon needs to re-commence post-restart); only the
+# transient procedure record is volatile.
+
+
+def get_active_procedure(target) -> Optional[dict]:
+    """Return the current in-flight procedure record, or ``None``."""
+    return getattr(target, "_runtime_active_procedure", None)
+
+
+def _set_active_procedure(target, record: Optional[dict]) -> None:
+    """Store ``record`` (or ``None`` to clear) on the runtime tier."""
+    setattr(target, "_runtime_active_procedure", record)
 
 
 def has_incision(target, location: str) -> bool:
@@ -244,8 +274,7 @@ def open_incision_locations(target) -> list[str]:
 
 def is_procedure_active(target) -> bool:
     """True when ``target`` has a procedure in-flight."""
-    state = _state(target)
-    return state.get("active_procedure") is not None
+    return get_active_procedure(target) is not None
 
 
 #: In-memory map of ``target.dbref`` → ``on_complete`` callable.
@@ -290,9 +319,10 @@ def start_procedure(
         "duration_s": duration,
         "kwargs": dict(kwargs),
     }
-    state = _state(target)
-    state["active_procedure"] = record
-    target.db.surgical_state = state
+    # active_procedure rides the runtime tier — the evennia_delay
+    # callback is in-process and would be lost on restart anyway,
+    # so persistence here would be a half-truth.
+    _set_active_procedure(target, record)
 
     if on_complete is not None:
         dbref = getattr(target, "dbref", None)
@@ -319,10 +349,8 @@ def interrupt_procedure(target, reason: str = "interrupted") -> Optional[dict]:
     is marked as ``FAILED`` with outcome ``"interrupted"`` so the
     surgeon can see why the chain stopped on re-entry.
     """
-    state = _state(target)
-    record = state.get("active_procedure")
-    state["active_procedure"] = None
-    target.db.surgical_state = state
+    record = get_active_procedure(target)
+    _set_active_procedure(target, None)
 
     dbref = getattr(target, "dbref", None)
     if dbref:
@@ -360,14 +388,12 @@ def _resolve_procedure_callback(target) -> None:
     intentionally idempotent: if the active_procedure was cleared in
     the meantime (interrupted, manually cancelled), we no-op.
     """
-    state = _state(target)
-    record = state.get("active_procedure")
+    record = get_active_procedure(target)
     if record is None:
         return  # interrupted / already resolved
     # Clear the slot first so a resolver-triggered side effect can't
     # re-enter.
-    state["active_procedure"] = None
-    target.db.surgical_state = state
+    _set_active_procedure(target, None)
 
     from evennia.objects.models import ObjectDB
     actor_dbref = record.get("actor_dbref")

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -179,11 +179,22 @@ def _state(target) -> dict:
     its lifetime is bounded by the in-process ``evennia_delay``
     callback that can't survive a restart anyway.  See
     :func:`get_active_procedure` / :func:`_set_active_procedure`.
+
+    Self-healing migration: legacy state dicts predating the
+    runtime-tier move carry an inert ``active_procedure: None`` key
+    that nothing reads anymore.  Strip it on access so the field
+    decays out of the database naturally as state mutates.
     """
-    if target.db.surgical_state is None:
-        target.db.surgical_state = {
-            "incisions": {},
-        }
+    state = target.db.surgical_state
+    if state is None:
+        target.db.surgical_state = {"incisions": {}}
+        return target.db.surgical_state
+    # Legacy-field prune — only writes back when there's actually
+    # something to remove, so steady-state access stays read-only.
+    if "active_procedure" in state:
+        state = dict(state)
+        state.pop("active_procedure", None)
+        target.db.surgical_state = state
     return target.db.surgical_state
 
 

--- a/world/tests/test_surgical_state_runtime.py
+++ b/world/tests/test_surgical_state_runtime.py
@@ -1,0 +1,169 @@
+"""Tests for the surgical-state runtime tier and chart batching.
+
+After PR #451 the four recognition caches moved off the descriptor
+hot path.  This PR extends the same idea to two more surfaces:
+
+1. ``active_procedure`` no longer rides ``target.db.surgical_state``.
+   It lives on a plain ``_runtime_active_procedure`` attribute since
+   its lifetime is bounded by an in-process ``evennia_delay``
+   callback that doesn't survive restart anyway.
+
+2. Chart-runner writes batch through ``batch_chart_writes`` —
+   ``commence_chart`` produces one descriptor write per step
+   transition instead of three.
+
+These tests pin both contracts against stubs (no Evennia DB).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.medical import charts
+from world.medical import procedures as proc
+
+
+# ---------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------
+
+
+def _make_target():
+    """Stub target with the minimum surface the procedure / chart
+    modules need: a writable ``db`` slot, a ``dbref``."""
+    target = SimpleNamespace()
+    target.dbref = "#42"
+    target.db = SimpleNamespace(
+        surgical_state=None,
+        medical_chart=None,
+    )
+    return target
+
+
+# ---------------------------------------------------------------------
+# active_procedure runtime tier
+# ---------------------------------------------------------------------
+
+
+class TestActiveProcedureRuntime(TestCase):
+    def test_get_active_procedure_defaults_to_none(self):
+        target = _make_target()
+        self.assertIsNone(proc.get_active_procedure(target))
+        self.assertFalse(proc.is_procedure_active(target))
+
+    def test_set_and_get_round_trips(self):
+        target = _make_target()
+        record = {"verb": "incise", "actor_dbref": "#1"}
+        proc._set_active_procedure(target, record)
+        self.assertEqual(proc.get_active_procedure(target), record)
+        self.assertTrue(proc.is_procedure_active(target))
+
+    def test_clear_removes_record(self):
+        target = _make_target()
+        proc._set_active_procedure(target, {"verb": "harvest"})
+        proc._set_active_procedure(target, None)
+        self.assertIsNone(proc.get_active_procedure(target))
+
+    def test_surgical_state_dict_does_not_carry_active_procedure(self):
+        """After the runtime move, ``surgical_state`` should NOT
+        include an ``active_procedure`` key — the field lives off
+        the descriptor path entirely."""
+        target = _make_target()
+        proc._set_active_procedure(target, {"verb": "incise"})
+        state = proc._state(target)
+        self.assertNotIn("active_procedure", state)
+
+
+# ---------------------------------------------------------------------
+# Chart write batching
+# ---------------------------------------------------------------------
+
+
+class TestChartBatchWrites(TestCase):
+    def test_batch_collapses_multiple_writes_to_one(self):
+        target = _make_target()
+        chart = {"version": 1, "steps": [], "status": "draft"}
+
+        # Spy on the underlying descriptor write — count assignments
+        # to target.db.medical_chart.
+        writes = []
+        original_db = target.db
+
+        class _SpyDB:
+            def __getattr__(self, name):
+                return getattr(original_db, name)
+
+            def __setattr__(self, name, value):
+                if name == "medical_chart":
+                    writes.append(value)
+                setattr(original_db, name, value)
+
+        target.db = _SpyDB()
+
+        with charts.batch_chart_writes(target):
+            charts.save_chart(target, chart)
+            chart["status"] = "in_progress"
+            charts.save_chart(target, chart)
+            chart["status"] = "completed"
+            charts.save_chart(target, chart)
+
+        # Three saves, one descriptor write.
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0]["status"], "completed")
+
+    def test_batch_writes_outside_context_persist_immediately(self):
+        target = _make_target()
+        chart = {"version": 1, "steps": [], "status": "draft"}
+        charts.save_chart(target, chart)
+        self.assertEqual(target.db.medical_chart["status"], "draft")
+        chart["status"] = "in_progress"
+        charts.save_chart(target, chart)
+        self.assertEqual(
+            target.db.medical_chart["status"], "in_progress",
+        )
+
+    def test_nested_batches_outer_owns_flush(self):
+        target = _make_target()
+        chart = {"version": 1, "steps": [], "status": "draft"}
+        writes = []
+        original_db = target.db
+
+        class _SpyDB:
+            def __getattr__(self, name):
+                return getattr(original_db, name)
+
+            def __setattr__(self, name, value):
+                if name == "medical_chart":
+                    writes.append(value)
+                setattr(original_db, name, value)
+
+        target.db = _SpyDB()
+
+        with charts.batch_chart_writes(target):
+            charts.save_chart(target, chart)
+            with charts.batch_chart_writes(target):
+                chart["status"] = "in_progress"
+                charts.save_chart(target, chart)
+            # Inner context exit must not have flushed.
+            self.assertEqual(len(writes), 0)
+            chart["status"] = "completed"
+            charts.save_chart(target, chart)
+        # Outer context exit flushes once.
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0]["status"], "completed")
+
+    def test_batch_target_without_dbref_falls_through(self):
+        """Targets without a ``dbref`` bypass the batch path so the
+        write still lands somewhere."""
+        target = SimpleNamespace(
+            dbref=None,
+            db=SimpleNamespace(medical_chart=None),
+        )
+        chart = {"version": 1, "steps": [], "status": "draft"}
+        with charts.batch_chart_writes(target):
+            charts.save_chart(target, chart)
+        # Write landed even without a batch.
+        self.assertEqual(
+            target.db.medical_chart["status"], "draft",
+        )

--- a/world/tests/test_surgical_state_runtime.py
+++ b/world/tests/test_surgical_state_runtime.py
@@ -74,6 +74,25 @@ class TestActiveProcedureRuntime(TestCase):
         state = proc._state(target)
         self.assertNotIn("active_procedure", state)
 
+    def test_state_self_heals_legacy_active_procedure_field(self):
+        """Existing characters carry an inert ``active_procedure``
+        key in ``db.surgical_state`` from before the runtime-tier
+        move.  ``_state`` strips it on access so the field decays
+        out naturally; no separate migration needed."""
+        target = _make_target()
+        # Pre-seed the legacy shape that production data carries.
+        target.db.surgical_state = {
+            "incisions": {},
+            "active_procedure": None,
+        }
+        state = proc._state(target)
+        self.assertNotIn("active_procedure", state)
+        # And the descriptor write landed — next access sees a
+        # clean dict without re-pruning.
+        self.assertNotIn(
+            "active_procedure", target.db.surgical_state,
+        )
+
 
 # ---------------------------------------------------------------------
 # Chart write batching


### PR DESCRIPTION
> **Stacked on #451**.  Once #451 lands, this rebases onto master cleanly.

## Summary
Stage 2 of the storage-patterns remediation roadmap (#450 §5.2 + §5.3).

Two surfaces, both runtime-aligned:

### 1. \`active_procedure\` runtime tier
Moves off \`target.db.surgical_state[\"active_procedure\"]\` and onto a plain \`_runtime_active_procedure\` attribute.  The record's lifetime is bounded by an in-process \`evennia_delay\` callback that we pass \`persistent=False\` to anyway — persisting it was a half-truth.  Chart step status stays on \`db.medical_chart\` (the surgeon needs to re-commence post-restart); only the transient procedure record was misplaced.

New helpers: \`get_active_procedure\`, \`_set_active_procedure\` in \`world/medical/procedures.py\`.

### 2. Chart write batching
New \`batch_chart_writes\` context manager.  Previously \`commence_chart\` produced 3+ descriptor writes per step transition (mark RUNNING, mark DONE, advance to next).  Wrapping the chain-recursion \`_advance\` hook in a batch collapses them to one write per transition.

\`save_chart\` checks a process-local \`_BATCHING_TARGETS\` set; when batching, the chart mutates a runtime \`_runtime_chart_pending_flush\` slot instead of writing through.  Context exit performs the single descriptor write.  Nested batches no-op cleanly.

## Test plan
- [x] 8 new tests in \`world/tests/test_surgical_state_runtime.py\` pin runtime/persistence boundary + batch-collapse
- [x] Full \`world.tests\` regression sweep — **2224 passed** (8 added)
- [x] Live playtest: server reload + operate flow without crash; chart pane unchanged from surgeon's POV

## Next
Stage C (PR pending): convert 6 boolean \`db.X\` flags to Tags per AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)