### PR TITLE
refactor: convert 4 of 6 boolean db flags to Tags (P3)

### DIFF
--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -322,7 +322,7 @@ def create_character_from_template(account, template, sex="ambiguous"):
     
     # Set defaults
     # death_count starts at 1 via AttributeProperty in Character class
-    char.db.archived = False
+    char.archived = False
     
     return char
 
@@ -435,7 +435,7 @@ def create_flash_clone(account, old_character):
         char.db.stack_id = str(uuid.uuid4())
     
     # Reset state
-    char.db.archived = False
+    char.archived = False
     char.db.current_sleeve_birth = time.time()
     
     return char
@@ -495,7 +495,7 @@ def _charcreate_exit_callback(caller, menu):
     Only disconnects if character creation was NOT completed.
     """
     # Check if they have any ACTIVE (non-archived) characters
-    active_characters = [char for char in caller.characters if not char.db.archived]
+    active_characters = [char for char in caller.characters if not char.archived]
     
     if active_characters:
         # They completed creation - just close menu, don't disconnect
@@ -1460,7 +1460,7 @@ def first_char_finalize(caller, raw_string, **kwargs):
         
         # Set defaults
         # death_count starts at 1 via AttributeProperty in Character class
-        char.db.archived = False
+        char.archived = False
         
         # Generate unique Stack ID
         import uuid

--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -158,7 +158,7 @@ class Account(DefaultAccount):
         # Count only active (non-archived) characters
         active_count = 0
         for char in self.characters:
-            if char.db.archived:
+            if char.archived:
                 continue
             active_count += 1
         
@@ -194,7 +194,7 @@ class Account(DefaultAccount):
         for char in self.characters:
             if not char:
                 continue
-            if char.db.archived:
+            if char.archived:
                 continue
             active_count += 1
         
@@ -217,7 +217,7 @@ class Account(DefaultAccount):
         active_chars = []
         for char in all_characters:
             # Only exclude if explicitly archived
-            if char.db.archived is True:
+            if char.archived is True:
                 continue
             active_chars.append(char)
         
@@ -234,7 +234,7 @@ class Account(DefaultAccount):
                     # Find most recently archived character
                     archived_chars = []
                     for char in all_characters:
-                        if char.db.archived is True:
+                        if char.archived is True:
                             archived_date = char.db.archived_date or 0
                             archived_chars.append((archived_date, char))
                     

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -111,6 +111,30 @@ class Character(
     # incremented in at_death so each subsequent clone advances the numeral.
     # Player-facing only — not consumed by any combat/identity mechanic.
     death_count = AttributeProperty(1, category='mortality', autocreate=True)
+
+    #: ``archived`` is a Tag (category ``character_state``) rather than
+    #: a ``db.X`` attribute — see the property accessors below.
+    #: AGENTS.md: prefer Tags for simple booleans.
+    _CHARACTER_STATE_CATEGORY = "character_state"
+
+    @property
+    def archived(self) -> bool:
+        """True when this character has been archived (death / retirement).
+        Tag-backed."""
+        return self.tags.has(
+            "archived", category=self._CHARACTER_STATE_CATEGORY,
+        )
+
+    @archived.setter
+    def archived(self, value: bool) -> None:
+        if value:
+            self.tags.add(
+                "archived", category=self._CHARACTER_STATE_CATEGORY,
+            )
+        else:
+            self.tags.remove(
+                "archived", category=self._CHARACTER_STATE_CATEGORY,
+            )
     
     # Appearance attributes - stored in db but no auto-creation for optional features
     # skintone is set via @skintone command and stored as db.skintone
@@ -487,7 +511,7 @@ class Character(
         self.death_count += 1
         
         # Set archive flags
-        self.db.archived = True
+        self.archived = True
         self.db.archived_reason = reason
         self.db.archived_date = time.time()
         

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -6,13 +6,40 @@ from .items import Item
 from .identity_bearer import IdentityBearerMixin
 import time
 
+#: Tag category for the boolean ``head_severed`` flag on Corpse.
+#: AGENTS.md prefers Tags for simple booleans — DB-indexed,
+#: no pickle round-trip on read.
+_CORPSE_STATE_CATEGORY = "corpse_state"
+
+
 class Corpse(IdentityBearerMixin, Item):
     """
     A corpse object that preserves forensic data and uses just-in-time decay.
     Decay is calculated on-demand when the corpse is looked at or referenced,
     rather than using continuous scripts.
+
+    The ``head_severed`` flag is Tag-backed (category
+    ``corpse_state``); see the property accessors below.
     """
-    
+
+    @property
+    def head_severed(self) -> bool:
+        """True when the corpse's head has been removed — Tag-backed."""
+        return self.tags.has(
+            "head_severed", category=_CORPSE_STATE_CATEGORY,
+        )
+
+    @head_severed.setter
+    def head_severed(self, value: bool) -> None:
+        if value:
+            self.tags.add(
+                "head_severed", category=_CORPSE_STATE_CATEGORY,
+            )
+        else:
+            self.tags.remove(
+                "head_severed", category=_CORPSE_STATE_CATEGORY,
+            )
+
     def at_object_creation(self):
         """Initialize corpse with decay tracking."""
         super().at_object_creation()
@@ -65,7 +92,7 @@ class Corpse(IdentityBearerMixin, Item):
         # short-circuits to the decay-stage fallback when ``True``,
         # suppressing both natural and forensic look-time recognition.
         # Set by :func:`typeclasses.items.apply_severed_head_overlay`.
-        self.db.head_severed = False
+        self.head_severed = False  # Tag-backed (see property above)
         
         # Preserve character appearance data for proper display
         self.db.original_skintone = None
@@ -176,7 +203,7 @@ class Corpse(IdentityBearerMixin, Item):
         """Decay-stage fallback when the head has been severed.
 
         PR #208: a headless corpse loses the face — the dominant
-        unaided-recognition cue.  When ``self.db.head_severed`` is
+        unaided-recognition cue.  When ``self.head_severed`` is
         ``True`` we short-circuit to the bare decay-stage name,
         suppressing both natural recognition (Pass 1 in the mixin —
         live degraded-UID lookup) and the forensic-recovery Intellect
@@ -198,7 +225,7 @@ class Corpse(IdentityBearerMixin, Item):
         :class:`world.tests.test_corpse_decay_recognition._FakeDecayCorpse`)
         still resolve the recognition pipeline correctly.
         """
-        if self.db.head_severed:
+        if self.head_severed:
             return self._decay_display_name()
         return IdentityBearerMixin.get_display_name(self, looker, **kwargs)
 

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1770,7 +1770,7 @@ def apply_sever_to_corpse(corpse, location_arg, *, head_locations=None):
     # ``specs/IDENTITY_RECOGNITION_SPEC.md`` §"Sever-Head Identity
     # Surface" for the rationale.
     if location_arg == "head":
-        corpse.db.head_severed = True
+        corpse.head_severed = True  # Tag-backed via Corpse property
 
 
 def spawn_severed_part_from_corpse(corpse, location_arg):

--- a/typeclasses/shopkeeper.py
+++ b/typeclasses/shopkeeper.py
@@ -23,17 +23,40 @@ class ShopContainer(DefaultObject):
     Attributes:
         db.prototype_inventory (dict): {prototype_key: price} for infinite mode
         db.item_inventory (dict): {prototype_key: quantity} for limited mode
-        db.is_infinite (bool): Whether shop has unlimited stock
+        is_infinite (bool, Tag-backed): Whether shop has unlimited stock
         db.markup_percent (int): Price markup percentage (default 0)
         db.shop_name (str): Display name for the shop
         db.container_type (str): "shelf", "rack", "counter", "crate", etc.
     """
     
+    #: Tag category used for the boolean ``is_infinite`` flag.  Per
+    #: AGENTS.md, prefer Tags over ``db.X`` for simple booleans —
+    #: indexed at the DB level, no pickle round-trip.
+    _SHOP_STATE_CATEGORY = "shop_state"
+
+    @property
+    def is_infinite(self) -> bool:
+        """True when the shop has unlimited stock — Tag-backed."""
+        return self.tags.has(
+            "is_infinite", category=self._SHOP_STATE_CATEGORY,
+        )
+
+    @is_infinite.setter
+    def is_infinite(self, value: bool) -> None:
+        if value:
+            self.tags.add(
+                "is_infinite", category=self._SHOP_STATE_CATEGORY,
+            )
+        else:
+            self.tags.remove(
+                "is_infinite", category=self._SHOP_STATE_CATEGORY,
+            )
+
     def at_object_creation(self):
         """Initialize shop container attributes."""
         self.db.prototype_inventory = {}
         self.db.item_inventory = {}
-        self.db.is_infinite = True
+        self.is_infinite = True  # Tag-backed (see property above)
         self.db.markup_percent = 0
         self.db.shop_name = "Shop"
         self.db.container_type = "shelf"
@@ -76,7 +99,7 @@ class ShopContainer(DefaultObject):
         self.db.prototype_inventory[prototype_key] = price
         
         if quantity is not None:
-            self.db.is_infinite = False
+            self.is_infinite = False
             self.db.item_inventory[prototype_key] = quantity
         
         return True
@@ -118,9 +141,9 @@ class ShopContainer(DefaultObject):
         if prototype_key not in self.db.prototype_inventory:
             return False
         
-        if self.db.is_infinite:
+        if self.is_infinite:
             return True
-        
+
         quantity = self.db.item_inventory.get(prototype_key, 0)
         return quantity > 0
     
@@ -171,7 +194,7 @@ class ShopContainer(DefaultObject):
         buyer.tokens -= price
         
         # Update inventory for limited stock
-        if not self.db.is_infinite:
+        if not self.is_infinite:
             self.db.item_inventory[prototype_key] -= 1
         
         return True, item
@@ -227,7 +250,7 @@ class ShopContainer(DefaultObject):
         
         for prototype_key, price in items:
             # Skip out-of-stock items in limited inventory mode
-            if not self.db.is_infinite:
+            if not self.is_infinite:
                 quantity = self.db.item_inventory.get(prototype_key, 0)
                 if quantity <= 0:
                     continue

--- a/web/website/views/characters.py
+++ b/web/website/views/characters.py
@@ -52,7 +52,7 @@ class CharacterCreateView(EvenniaCharacterCreateView):
                 _ = old_char.key
                 
                 # Check if character is actually archived/dead (default False for legacy)
-                is_archived = old_char.db.archived or False
+                is_archived = old_char.archived or False
                 
                 # If not archived, they're alive - clear last_character and proceed to normal creation
                 if not is_archived:
@@ -71,7 +71,7 @@ class CharacterCreateView(EvenniaCharacterCreateView):
             # Defensive check - ensure character is accessible
             if not char:
                 continue
-            archived = char.db.archived or False
+            archived = char.archived or False
             if not archived:
                 active_characters.append(char)
         
@@ -124,8 +124,8 @@ class CharacterCreateView(EvenniaCharacterCreateView):
                 # so they always exist on Character instances - no need to check/set.
                 
                 # Ensure archived attribute exists (db attribute, not AttributeProperty)
-                if old_character.db.archived is None:
-                    old_character.db.archived = False  # Legacy characters were active when they died
+                if old_character.archived is None:
+                    old_character.archived = False  # Legacy characters were active when they died
                     
             except (AttributeError, TypeError, Exception) as e:
                 # Old character reference is invalid/deleted - clear it
@@ -267,7 +267,7 @@ class CharacterCreateView(EvenniaCharacterCreateView):
         active_characters = []
         for char in account.characters:
             # Access archived status via db.archived (returns None if unset)
-            archived = char.db.archived or False
+            archived = char.archived or False
             if not archived:
                 active_characters.append(char)
         
@@ -334,7 +334,7 @@ class CharacterCreateView(EvenniaCharacterCreateView):
             character.db.stack_id = str(uuid.uuid4())
             character.db.original_creation = time.time()
             character.db.current_sleeve_birth = time.time()
-            character.db.archived = False
+            character.archived = False
             # death_count defaults to 1 via AttributeProperty in Character class
             
             # WEB-CREATED CHARACTERS: Make invisible until puppeted
@@ -372,7 +372,7 @@ class CharacterArchiveView(LoginRequiredMixin, CharacterMixin, View):
     """
     Archive a character instead of deleting it.
     
-    Sets character.db.archived = True rather than deleting from database.
+    Sets character.archived = True rather than deleting from database.
     This preserves Stack tracking and death history.
     """
     

--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -148,10 +148,20 @@ def get_or_create_combat(location):
     return new_script
 
 
+#: Tag category for the combat-running boolean flag.  Per AGENTS.md,
+#: simple booleans should be Tags rather than ``db.X`` — indexed at
+#: the DB level, no pickle round-trip on read.
+_COMBAT_STATE_CATEGORY = "combat_handler_state"
+
+
 class CombatHandler(DefaultScript):
     """
     Script that manages turn-based combat for all combatants in a location.
-    
+
+    The ``combat_is_running`` flag is a Tag (category
+    ``combat_handler_state``), not a ``db.X`` attribute — see
+    :attr:`combat_is_running` for the property accessors.
+
     This is the central orchestrator of combat encounters, handling:
     - Combat state management and lifecycle
     - Turn-based initiative and action resolution
@@ -172,6 +182,25 @@ class CombatHandler(DefaultScript):
     - is_yielding: Whether they're actively attacking
     """
 
+    @property
+    def combat_is_running(self) -> bool:
+        """True when the combat loop is actively ticking — Tag-backed
+        per AGENTS.md convention."""
+        return self.tags.has(
+            "combat_is_running", category=_COMBAT_STATE_CATEGORY,
+        )
+
+    @combat_is_running.setter
+    def combat_is_running(self, value: bool) -> None:
+        if value:
+            self.tags.add(
+                "combat_is_running", category=_COMBAT_STATE_CATEGORY,
+            )
+        else:
+            self.tags.remove(
+                "combat_is_running", category=_COMBAT_STATE_CATEGORY,
+            )
+
     def at_script_creation(self):
         """
         Initialize combat handler script attributes.
@@ -187,7 +216,7 @@ class CombatHandler(DefaultScript):
         self.db.combatants = []
         self.db.round = 0
         self.db.managed_rooms = [self.obj]  # Initially manages only its host room
-        self.db.combat_is_running = False
+        self.combat_is_running = False  # Tag-backed (see property)
         
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         managed_rooms = self.db.managed_rooms or []
@@ -205,7 +234,7 @@ class CombatHandler(DefaultScript):
 
         # Use super().is_active to check Evennia's ticker status
         evennia_ticker_is_active = super().is_active
-        combat_is_running = self.db.combat_is_running
+        combat_is_running = self.combat_is_running
 
         if combat_is_running and evennia_ticker_is_active:
             splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_START: Handler {self.key} on {self.obj.key} - combat logic and Evennia ticker are already active. Skipping redundant start.")
@@ -216,7 +245,7 @@ class CombatHandler(DefaultScript):
         
         if not combat_is_running:
             splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_START_DETAIL: Setting {DB_COMBAT_RUNNING} = True for {self.key}.")
-            self.db.combat_is_running = True
+            self.combat_is_running = True
         
         if not evennia_ticker_is_active:
             splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_START_DETAIL: Evennia ticker for {self.key} is not active (super().is_active=False). Calling force_repeat().")
@@ -244,7 +273,7 @@ class CombatHandler(DefaultScript):
         
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
         
-        combat_was_running = self.db.combat_is_running
+        combat_was_running = self.combat_is_running
         
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_{DEBUG_CLEANUP}: Handler {self.key} stopping combat logic. Was running: {combat_was_running}, cleanup_combatants: {cleanup_combatants}")
 
@@ -285,7 +314,7 @@ class CombatHandler(DefaultScript):
         
         # Only reach here if handler was NOT deleted
         # Now it's safe to modify db attributes (self.pk is still valid)
-        self.db.combat_is_running = False
+        self.combat_is_running = False
         self.db.round = 0
         
         # Stop the ticker if the script is saved to the database
@@ -473,13 +502,13 @@ class CombatHandler(DefaultScript):
         the ``attack``, ``movement_resolution``, and ``actions`` modules.
         """
         splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        if not self.db.combat_is_running:
+        if not self.combat_is_running:
             splattercast.msg(f"AT_REPEAT: Handler {self.key} on {self.obj.key} combat logic is not running ({DB_COMBAT_RUNNING}=False). Returning.")
             return
 
         if not super().is_active:
              splattercast.msg(f"AT_REPEAT: Handler {self.key} on {self.obj.key} Evennia script.is_active=False. Marking {DB_COMBAT_RUNNING}=False and returning.")
-             self.db.combat_is_running = False
+             self.combat_is_running = False
              return
 
         # Convert SaverList to regular list to avoid corruption during modifications

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -44,7 +44,7 @@ class MedicalCondition:
         
         # Don't add conditions to archived characters (permanently dead)
         # Dying characters can still be resuscitated, so they should keep conditions
-        if character.db.archived:
+        if character.archived:
             splattercast.msg(f"CONDITION_START: {character.key} is archived, not adding {self.condition_type}")
             return
         

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -833,7 +833,7 @@ class MedicalState:
         # Don't add conditions if character is archived (permanently dead)
         # Dying characters can still be resuscitated, so they should keep conditions
         character = self._get_character_reference()
-        if character and character.db.archived:
+        if character and character.archived:
             try:
                 from world.combat.constants import SPLATTERCAST_CHANNEL
                 splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
@@ -966,7 +966,7 @@ class MedicalState:
                 medical_state.conditions.append(condition)
                 # Re-start condition ticker if character is available and not archived
                 # Archived characters are permanently dead; dying characters can still be resuscitated
-                if character and not character.db.archived:
+                if character and not character.archived:
                     condition.start_condition(character)
             except Exception:
                 # If condition restoration fails, skip it.

--- a/world/tests/test_cmd_sever.py
+++ b/world/tests/test_cmd_sever.py
@@ -577,7 +577,7 @@ class CmdSeverTests(TestCase):
         self.assertFalse(getattr(corpse.db, "head_severed", False))
         with _sever_env(create_return=MagicMock()):
             _make_cmd(caller=caller, args="head from corpse").func()
-        self.assertTrue(corpse.db.head_severed)
+        self.assertTrue(corpse.head_severed)
 
     def test_limb_sever_does_not_mark_head_severed(self):
         """Severing a non-head limb must NOT set head_severed."""

--- a/world/tests/test_corpse_decay_recognition.py
+++ b/world/tests/test_corpse_decay_recognition.py
@@ -92,7 +92,7 @@ class _FakeDecayCorpse:
         self.db.forensic_recognition_cache = None
         # PR #208: default to head-intact; tests that exercise the
         # head-severed look-suppression flip this to True.
-        self.db.head_severed = False
+        self.head_severed = False
         self.contents = list(contents or [])
         self.ndb = type("_NDB", (), {})()
         self._stage = stage
@@ -513,7 +513,7 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_blocks_natural_recognition_fresh(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="fresh")
-        corpse.db.head_severed = True
+        corpse.head_severed = True
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -524,7 +524,7 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_blocks_natural_recognition_early(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="early")
-        corpse.db.head_severed = True
+        corpse.head_severed = True
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -535,7 +535,7 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_blocks_forensic_recovery_at_moderate(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
-        corpse.db.head_severed = True
+        corpse.head_severed = True
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -552,7 +552,7 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_blocks_forensic_recovery_at_advanced(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="advanced")
-        corpse.db.head_severed = True
+        corpse.head_severed = True
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -568,7 +568,7 @@ class TestHeadSeveredSuppression(TestCase):
     def test_head_intact_preserves_natural_recognition(self):
         """Regression guard — head-severed defaults False; recognition still flows."""
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="fresh")
-        # corpse.db.head_severed is False by default.
+        # corpse.head_severed is False by default.
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -579,14 +579,14 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_none_looker_still_returns_decay_name(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
-        corpse.db.head_severed = True
+        corpse.head_severed = True
         self.assertEqual(
             corpse.get_display_name(None), "rotting corpse",
         )
 
     def test_headless_skeletal_still_returns_decay_name(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="skeletal")
-        corpse.db.head_severed = True
+        corpse.head_severed = True
         self.assertEqual(
             corpse.get_display_name(None), "skeletal remains",
         )

--- a/world/tests/test_severed_head.py
+++ b/world/tests/test_severed_head.py
@@ -84,7 +84,7 @@ class _FakeCorpse:
         self.db.sleeve_uid = sleeve_uid
         # PR #208: overlay sets ``head_severed = True`` on the corpse;
         # tests can assert against this.
-        self.db.head_severed = False
+        self.head_severed = False
         self.db.creation_time = creation_time or (time.time() - 100)
         self.db.death_time = death_time or self.db.creation_time
         self.db.death_cause = death_cause
@@ -231,15 +231,15 @@ class SeveredHeadIdentityPropagationTests(TestCase):
         ``head_severed`` gate that
         :meth:`typeclasses.corpse.Corpse.get_display_name` reads."""
         from typeclasses.items import apply_sever_to_corpse
-        self.assertFalse(self.corpse.db.head_severed)
+        self.assertFalse(self.corpse.head_severed)
         apply_sever_to_corpse(self.corpse, "head")
-        self.assertTrue(self.corpse.db.head_severed)
+        self.assertTrue(self.corpse.head_severed)
 
     def test_limb_sever_does_not_mark_corpse_head_severed(self):
         """Non-head sever leaves ``head_severed`` unchanged."""
         from typeclasses.items import apply_sever_to_corpse
         apply_sever_to_corpse(self.corpse, "left_arm")
-        self.assertFalse(self.corpse.db.head_severed)
+        self.assertFalse(self.corpse.head_severed)
 
     def test_overlay_preserves_corpse_identity_for_autopsy(self):
         """Identity is duplicated, not transferred — corpse keeps snapshot."""


### PR DESCRIPTION
> **Stacked on #452**.  Rebases onto master cleanly once the parent lands.

## Summary
Stage 3 of the storage-patterns remediation roadmap (#450 §3.4).  Per AGENTS.md: prefer the Tag system over \`db.X\` for simple booleans — Tags are indexed at the DB level and skip the pickle round-trip.

## Converted (typeclass-property accessors)

| Flag | Typeclass | Category |
|---|---|---|
| \`is_infinite\` | \`ShopContainer\` | \`shop_state\` |
| \`combat_is_running\` | \`CombatHandler\` | \`combat_handler_state\` |
| \`head_severed\` | \`Corpse\` | \`corpse_state\` |
| \`archived\` | \`Character\` | \`character_state\` |

Each typeclass gets a Python property wrapping \`tags.add\` / \`tags.remove\` / \`tags.has\`.  Call sites switch from \`obj.db.flag\` to \`obj.flag\` — minimal fanout, no API change for consumers.

## Deferred (per spec §3.4 — not worth a sweeping migration)

- **\`pin_pulled\`** — 15 sites across \`CmdExplosives\`, \`CmdThrow\`, \`explosion_utils\`.  No shared typeclass to host a property; would require inline Tag access at every site.
- **\`integrate\`** — 9 sites across multiple typeclass paths.  Cleaner to handle per-touch when something else changes those files.

The spec called this exact tradeoff out: *\"Worth doing per-flag on first touch; not worth a sweeping migration PR.\"*  This PR ships the 4 conversions that fit cleanly into a property wrapper; the other two can land when those areas next get attention.

## Test plan
- [x] Fake-stub test fixtures (\`self.db.flag = X\` in fakes) moved to \`self.flag = X\` so they exercise the same access path as production
- [x] Test assertions updated from \`obj.db.flag\` to \`obj.flag\`
- [x] Full \`world.tests\` regression sweep — **2225 passed**
- [x] Live server reload exercises Tag-backed paths without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)