### PR TITLE
consumables / substances / delivery — foundational cleanup

### DIFF
--- a/commands/CmdSmoke.py
+++ b/commands/CmdSmoke.py
@@ -1,17 +1,22 @@
-"""Smoke / light / snuff commands (issue #454).
+"""Smoke / light / snuff commands.
+
+Issues #454 (initial) and #456 (substance / delivery-method
+generalisation).
 
 Three commands share the same shape:
 
-* They identify cigarettes / lighters by their role Tag
-  (``cigarette`` / ``lighter`` in the ``item_role`` category) —
-  prototype-defined items, not bespoke typeclasses.
+* Smokables are identified by the ``("smoke", "delivery_method")``
+  tag; lighters by ``("lighter", "item_role")``.  Future joints,
+  cigars, pipes carry the same smoke tag and route through these
+  commands unchanged.  See
+  ``specs/SUBSTANCES_AND_DELIVERY_SPEC.md`` for the layering.
 * They use the held-hand surface (``caller.hands``) to enforce
-  "the cigarette / lighter must be in your hand."
+  "the smokable / lighter must be in your hand."
 * Per-observer broadcasts route through
   :func:`world.identity_utils.msg_room_identity`.
 
 The interesting wrinkle is :class:`CmdLight`'s cross-character
-syntax: ``light bob's cigarette`` lights a cigarette held in Bob's
+syntax: ``light bob's cigarette`` lights a smokable held in Bob's
 hand using the caller's lighter.  ``parse_possessive_target`` in
 :mod:`world.smoke` does the split; ``resolve_character_target``
 from :mod:`commands._identity_targeting` does the identity-aware
@@ -23,12 +28,13 @@ from evennia import Command
 
 from commands._identity_targeting import resolve_character_target
 from world.identity_utils import msg_room_identity
+from world.consumables import consume_use
 from world.smoke import (
-    consume_puff,
-    find_held_cigarette,
     find_held_lighter,
-    is_cigarette,
+    find_held_smokable,
+    get_substance,
     is_lit,
+    is_smokable,
     parse_possessive_target,
     pick_burnt_out_message,
     pick_light_other_message,
@@ -62,14 +68,14 @@ def _aliases_of(item) -> list[str]:
         return []
 
 
-def _find_held_cigarette_matching(character, phrase: str):
-    """Return the cigarette in ``character``'s hand that matches
+def _find_held_smokable_matching(character, phrase: str):
+    """Return the smokable in ``character``'s hand that matches
     ``phrase`` (case-insensitive substring against key / aliases),
     or None.  When ``phrase`` is empty, returns the first held
-    cigarette."""
+    smokable."""
     phrase = (phrase or "").strip().lower()
     hands = getattr(character, "hands", None) or {}
-    candidates = [item for item in hands.values() if item and is_cigarette(item)]
+    candidates = [item for item in hands.values() if item and is_smokable(item)]
     if not phrase:
         return candidates[0] if candidates else None
     for item in candidates:
@@ -132,7 +138,7 @@ class CmdLight(Command):
         self._light_other(caller, owner_phrase, cigarette_phrase, lighter)
 
     def _light_own(self, caller, phrase, lighter):
-        cigarette = _find_held_cigarette_matching(caller, phrase)
+        cigarette = _find_held_smokable_matching(caller, phrase)
         if cigarette is None:
             caller.msg(
                 "You aren't holding a cigarette matching that."
@@ -168,7 +174,7 @@ class CmdLight(Command):
             self._light_own(caller, cigarette_phrase, lighter)
             return
 
-        cigarette = _find_held_cigarette_matching(target, cigarette_phrase)
+        cigarette = _find_held_smokable_matching(target, cigarette_phrase)
         if cigarette is None:
             tname = target.get_display_name(caller)
             caller.msg(f"{tname} isn't holding a cigarette matching that.")
@@ -229,20 +235,25 @@ class CmdSmoke(Command):
     def func(self):
         caller = self.caller
         args = (self.args or "").strip()
-        cigarette = _find_held_cigarette_matching(caller, args)
+        if not args:
+            caller.msg(
+                "Smoke what?  Name a smokable you're holding "
+                "(``smoke cigarette`` / ``smoke smoke`` / "
+                "``smoke joint``)."
+            )
+            return
+        cigarette = _find_held_smokable_matching(caller, args)
         if cigarette is None:
             caller.msg(
-                "You aren't holding a cigarette matching that."
-                if args else
-                "You aren't holding a cigarette."
+                f"You aren't holding a smokable matching '{args}'."
             )
             return
         if not is_lit(cigarette):
             caller.msg("It isn't lit.  Light it first.")
             return
 
-        brand = cigarette.db.brand
-        self_msg, room_template = pick_smoke_message(brand)
+        substance = get_substance(cigarette)
+        self_msg, room_template = pick_smoke_message(substance)
         caller.msg(self_msg)
         if caller.location is not None:
             msg_room_identity(
@@ -252,10 +263,10 @@ class CmdSmoke(Command):
                 exclude=[caller],
             )
 
-        # Decrement puff count.  ``consume_puff`` deletes the
-        # cigarette when the last puff goes; we emit the burnout
-        # broadcast on that transition.
-        outcome = consume_puff(cigarette)
+        # Decrement puff count via the unified consumable helper.
+        # When the last puff goes the item deletes itself; we emit
+        # the burnout broadcast on that transition.
+        outcome = consume_use(cigarette)
         if outcome.get("destroyed"):
             burnt_self, burnt_room = pick_burnt_out_message()
             caller.msg(burnt_self)
@@ -295,12 +306,13 @@ class CmdSnuff(Command):
     def func(self):
         caller = self.caller
         args = (self.args or "").strip()
-        cigarette = _find_held_cigarette_matching(caller, args)
+        if not args:
+            caller.msg("Snuff what?  Name a smokable you're holding.")
+            return
+        cigarette = _find_held_smokable_matching(caller, args)
         if cigarette is None:
             caller.msg(
-                "You aren't holding a cigarette matching that."
-                if args else
-                "You aren't holding a cigarette."
+                f"You aren't holding a smokable matching '{args}'."
             )
             return
         if not is_lit(cigarette):

--- a/specs/SUBSTANCES_AND_DELIVERY_SPEC.md
+++ b/specs/SUBSTANCES_AND_DELIVERY_SPEC.md
@@ -1,0 +1,231 @@
+# Substances and Delivery Spec
+
+**Status**: descriptive of the three-layer model and how
+current code maps onto it.  Substance registry + effect →
+condition pipeline are scoped for a future PR, not implemented
+here.
+
+## 0 · Purpose
+
+Items that introduce substances into a body — cigarettes, joints,
+pills, vials, drinks, food, inhalers, patches — share more than
+they differ.  This spec names the layers so future commands and
+items align on the same shape instead of each inventing its own
+item-type validation.
+
+The smoke system (issue #454, then refactored under #456) is the
+working example.  Medical consumption (`CmdConsumption` —
+`eat`/`drink`/`inhale`/`inject`/`apply`/`bandage`) is the older
+example that pre-dates this layering and will be migrated
+incrementally.
+
+## 1 · The three layers
+
+```
+   ┌────────────────────────────────────────────────────────┐
+   │ ITEM         cigarette / joint / pill / vial / beer    │
+   │              - holds a substance id                    │
+   │              - declares its delivery method(s) via tag │
+   │              - tracks uses_left, state (lit/sealed/…)  │
+   └─────────────────┬──────────────────────────────────────┘
+                     │ resolves
+                     ▼
+   ┌────────────────────────────────────────────────────────┐
+   │ SUBSTANCE    tobacco / cannabis / opium / alcohol / …  │
+   │              - effects (pain, consciousness, mood)     │
+   │              - conditions caused (addiction, tolerance,│
+   │                lung damage, withdrawal)                │
+   │              - flavor bank (per substance, possibly    │
+   │                per-style within the substance)         │
+   └─────────────────┬──────────────────────────────────────┘
+                     │ applies via
+                     ▼
+   ┌────────────────────────────────────────────────────────┐
+   │ DELIVERY     smoke / inject / inhale / drink / eat /   │
+   │              snort / apply                             │
+   │              - command surface (CmdSmoke, CmdInject…)  │
+   │              - magnitude modifier (smoking ≠ injection)│
+   │              - prerequisites (smoke needs ignition;    │
+   │                inject needs vein access)               │
+   └────────────────────────────────────────────────────────┘
+```
+
+Three layers, three independent axes:
+
+* **Item** is what the player holds.  One item, one substance,
+  one or more delivery methods declared via tag.
+* **Substance** is what's actually doing pharmacology to the
+  consumer.  Lives in a registry keyed by id.  Effects compose
+  through the existing `MedicalState.conditions` system — no new
+  runtime infrastructure needed.
+* **Delivery** is the verb-level entry point.  Each delivery
+  method has a command (`CmdSmoke`, `CmdInject`, etc.) that
+  validates "this item supports this delivery" and applies the
+  substance's effects modulated by the delivery's magnitude /
+  speed.
+
+## 2 · Encoding on items
+
+Three pieces of metadata per consumable item:
+
+| Field | Where | Shape | Example |
+|---|---|---|---|
+| Substance | `db.substance` (attribute) | string id into the registry | `"tobacco_neutral"`, `"cannabis"`, `"opium"` |
+| Delivery method(s) | Tag, category `delivery_method` | one or more | `("smoke", "delivery_method")`, `("inject", "delivery_method")` |
+| Usage | `db.uses_left` / `db.max_uses` (attributes) | int | `6` puffs per cigarette, `1` per pill |
+
+Optional state:
+
+| Field | Where | Shape |
+|---|---|---|
+| Lit | Tag `("lit", "cigarette_state")` (smoke only) | bool |
+| Sealed / opened | Tag (TBD when bottles arrive) | bool |
+| Loaded (pipe) | `db.substance` set to non-null when loaded | implicit |
+
+**Why tags for booleans + delivery method**: per AGENTS.md.  DB-
+indexed, no pickle round-trip.
+
+**Why an attribute for substance**: substance ids are open-ended
+strings, not a fixed enum, and we'll want to read them as keys
+into the registry from many places.  Attribute fits better than
+tag here.
+
+## 3 · Substance registry (planned, not built)
+
+When ready, lives at `world/substances/registry.py`:
+
+```python
+@dataclass(frozen=True)
+class Substance:
+    id: str
+    display_name: str
+    effects: list[Effect]           # immediate per-dose effects
+    conditions: list[ConditionSpec] # tolerance, addiction, damage
+    flavor_bank_key: str            # which bank in world/smoke.py
+                                    # (or world/drink.py etc.) to use
+
+
+SUBSTANCES: dict[str, Substance] = {
+    "tobacco_neutral": Substance(
+        id="tobacco_neutral",
+        display_name="standard tobacco",
+        effects=[
+            Effect("pain_level", magnitude=-0.5, duration=60),
+            Effect("consciousness", magnitude=+0.02, duration=120),
+        ],
+        conditions=[
+            ConditionSpec("tobacco_tolerance", on_use=True, ...),
+            ConditionSpec("lung_damage", on_threshold=100, ...),
+        ],
+        flavor_bank_key="tobacco_neutral",
+    ),
+    "tobacco_noir": Substance(
+        id="tobacco_noir",
+        ...,
+        flavor_bank_key="tobacco_noir",
+    ),
+    "cannabis": Substance(...),
+    "opium": Substance(...),
+}
+```
+
+Effects and conditions compose through the existing
+`MedicalState` runtime — substances *declare*, the medical
+script *applies and ticks*.
+
+## 4 · Delivery methods
+
+Initial set, mapped to existing or planned commands:
+
+| Method | Command | Tag value | Prerequisites |
+|---|---|---|---|
+| smoke | `CmdSmoke` | `smoke` | lit; ignition source (lighter / match) for `CmdLight` |
+| inject | `CmdInject` | `inject` | vein access (skin not heavily armored) |
+| inhale | `CmdInhale` | `inhale` | conscious |
+| drink | `CmdDrink` | `drink` | conscious; mouth not gagged |
+| eat | `CmdEat` | `eat` | conscious; mouth not gagged |
+| snort | `CmdSnort` | `snort` | conscious; nose not destroyed |
+| apply | `CmdApply` | `apply` | skin contact |
+
+A single item can declare multiple delivery methods.  A pill
+might support `eat` only.  A vial might support `inject` and
+`drink`.  A pipe loaded with a substance supports `smoke`.
+
+The currently-shipped `CmdConsumption` commands (`eat`, `drink`,
+`inhale`, `inject`, `apply`, `bandage`) check for `medical_type`
+strings rather than delivery-method tags.  They'll migrate to
+this scheme when the substance registry lands.
+
+## 5 · Current state vs target state
+
+### What exists today
+
+* **`world/consumables.py:consume_use`** — generic
+  decrement-and-delete.  Smoke and medical both delegate.
+* **`world/smoke.py`** — flavor banks per substance,
+  `get_substance` with legacy `brand` migration, `is_smokable`
+  with legacy-tag migration, helpers for lit-state and
+  held-item lookup, possessive-name parser.
+* **`world/medical/utils.py:use_item`** — medical-item-gated
+  wrapper over `consume_use` with "crumbles away" broadcast.
+* **`commands/CmdSmoke.py`** — `light` / `smoke` / `snuff`
+  routing on the `("smoke", "delivery_method")` tag.  Cross-
+  character syntax via possessive parser.
+* **`commands/CmdConsumption.py`** — the older medical /
+  substance command cluster (eat/drink/inhale/inject/apply/
+  bandage).  Pre-dates the layering.
+
+### Gaps to close (separate PRs)
+
+1. **Substance registry** at `world/substances/`.  Centralises
+   substance metadata; replaces the implicit registry in flavor
+   banks.
+2. **Effect pipeline** — `apply_substance(substance, consumer)`
+   that emits effects into the medical condition system.
+3. **`CmdConsumption` migration** — switch from `medical_type`
+   strings to `("eat", "delivery_method")` / `("drink", ...)`
+   tags.  Same shape as the smoke commands.
+4. **Tolerance / addiction conditions** — concrete
+   `ConditionSpec` examples + medical-script tick integration.
+5. **Roll-your-own** — `roll` command that consumes raw
+   substance + paper + filter and spawns a cigarette / joint
+   prototype with the substance baked on.
+
+## 6 · Anti-patterns to avoid
+
+* **Per-item-type command validation.** `CmdSmoke` should not
+  ask "is this a Cigarette typeclass" or "does the item key
+  contain 'cig'."  Always check the delivery-method tag.
+* **Brand-as-substance.** The substance id is the substance,
+  not a brand.  Tobacco is tobacco regardless of which company
+  bagged it.  Style variants live as substance ids
+  (`tobacco_neutral` vs `tobacco_noir`) or eventually as a
+  separate `style` axis within a substance entry.
+* **Effects in the command.** Don't put pharmacology in
+  `CmdSmoke.func()`.  Effects live in the substance entry; the
+  command's job is to identify the item, validate the delivery,
+  and call the apply-substance pipeline.
+* **Hardcoded delivery prerequisites.** The "smoke needs a
+  lighter" check belongs near the smoke delivery, not buried
+  in CmdSmoke.  When other ignition sources exist (matches,
+  embers, plasma cutter) the check should still pass.
+
+## 7 · Fire as a separate concern
+
+Out of scope here.  The smoke system's "lit cigarette" state is
+*not* a fire — it's a tag.  When the broader fire system arrives
+(propagation, incendiary explosives, controlled burns), it will
+sit alongside this layering rather than being entangled with it.
+Ignition sources (lighter, match, ember) will gain a "can ignite"
+verb that the smoke delivery's `light` step delegates to.
+
+## 8 · Maintenance contract
+
+* **§1 (layers)** is stable design.  Don't change without a
+  refactor PR.
+* **§3 (registry)** is the next implementation target; expect
+  this section to evolve as the registry lands.
+* **§4 (delivery methods)** can grow — add new methods as the
+  game introduces them.
+* **§5 (current state)** ages quickly; refresh when substantive
+  PRs land.

--- a/typeclasses/smoke.py
+++ b/typeclasses/smoke.py
@@ -11,51 +11,54 @@ from evennia.prototypes.spawner import spawn
 
 from typeclasses.items import Item
 from world.smoke import (
-    BRAND_NEUTRAL,
     DEFAULT_PACK_CAPACITY,
+    SUBSTANCE_TOBACCO_NEUTRAL,
 )
 
 
 class CigarettePack(Item):
-    """A container that ships pre-filled with cigarettes of its brand.
+    """A container that ships pre-filled with cigarettes of its substance.
 
     Pack attributes (settable via prototype):
 
-    * ``brand`` (str) — propagated to each spawned cigarette.
+    * ``substance`` (str) — propagated to each spawned cigarette so
+      ``smoke`` picks the right flavor bank.
     * ``cigarette_prototype`` (str) — prototype key spawned to fill
       the pack (e.g. ``"CIGARETTE_NEUTRAL"``).
     * ``capacity`` (int) — how many cigarettes to spawn at creation.
       Defaults to :data:`world.smoke.DEFAULT_PACK_CAPACITY`.
 
-    Existing inventory commands (``get``, ``put``) just work — the
-    pack is an ordinary container.  Once emptied it does not refill;
-    a fresh pack must be spawned for more.
+    Legacy ``brand`` attribute on existing packs (pre-#456) is
+    transparently honoured — it migrates to ``substance`` on first
+    access via :func:`world.smoke.get_substance`.
     """
 
     def at_object_creation(self):
         super().at_object_creation()
         # Defensive defaults so prototypes that forget to set the
-        # fields don't crash creation.
-        if self.db.brand is None:
-            self.db.brand = BRAND_NEUTRAL
+        # fields don't crash creation.  Honour legacy ``brand`` from
+        # any pre-#456 packs.
+        if self.db.substance is None:
+            legacy_brand = self.db.brand
+            self.db.substance = legacy_brand or SUBSTANCE_TOBACCO_NEUTRAL
         if self.db.capacity is None:
             self.db.capacity = DEFAULT_PACK_CAPACITY
         if self.db.cigarette_prototype is None:
-            # Brand-matched default — neutral pack spawns neutral
-            # cigarettes.  Override in the prototype if you want a
-            # branded pack to ship NOIR cigarettes, etc.
+            # Substance-matched default — neutral pack spawns neutral
+            # cigarettes.  Override in the prototype to ship NOIR
+            # cigarettes, etc.
             self.db.cigarette_prototype = "CIGARETTE_NEUTRAL"
 
         self._fill_with_cigarettes()
 
     def _fill_with_cigarettes(self):
         """Spawn ``self.db.capacity`` cigarettes into the pack with
-        the pack's brand stamped on each.  No-op when the pack
+        the pack's substance stamped on each.  No-op when the pack
         already contains cigarettes (idempotent across reloads)."""
         if self.contents:
             return
         proto_key = self.db.cigarette_prototype
-        brand = self.db.brand
+        substance = self.db.substance
         capacity = int(self.db.capacity or 0)
         for _ in range(capacity):
             spawned = spawn(proto_key)
@@ -63,7 +66,7 @@ class CigarettePack(Item):
                 continue
             cig = spawned[0]
             cig.location = self
-            # Imprint the pack's brand on the cigarette so the smoke
-            # command picks the right flavor bank even after the
-            # cigarette has been removed from the pack.
-            cig.db.brand = brand
+            # Imprint the pack's substance on the cigarette so the
+            # smoke command picks the right flavor bank even after
+            # the cigarette has been removed from the pack.
+            cig.db.substance = substance

--- a/world/consumables.py
+++ b/world/consumables.py
@@ -1,0 +1,67 @@
+"""Generic consumable-item lifecycle helpers.
+
+A consumable is any item that carries ``uses_left`` and ``max_uses``
+attributes and gets destroyed when its remaining uses reach zero.
+Cigarettes, medical bandages, pills, vials, drinks, food — same
+shape, same decrement-and-delete logic.
+
+This module hosts the single decrement helper that every consumable
+verb in the codebase should delegate to.  Callers that need
+specialised flavor on destruction wrap with a callback rather than
+forking the helper.
+
+See ``specs/SUBSTANCES_AND_DELIVERY_SPEC.md`` for the architectural
+context — this is the lowest layer in the item → substance →
+delivery stack.
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+
+def consume_use(
+    item,
+    *,
+    on_destroy: Optional[Callable] = None,
+) -> dict:
+    """Decrement ``item``'s ``uses_left`` by one, delete on zero.
+
+    Args:
+        item: The consumable to decrement.  Must expose
+            ``item.attributes`` with ``.get(key, default)`` and
+            ``.add(key, value)`` semantics matching Evennia's
+            ``AttributeHandler``.
+        on_destroy: Optional zero-arg callable invoked just before
+            the item is deleted.  Use for "tossed away" / "crumbles"
+            broadcasts — the helper does not emit any messages of
+            its own.
+
+    Returns:
+        ``{"success": bool, "destroyed": bool}``.  ``success=False``
+        when the item had zero uses left to begin with (or no
+        ``attributes`` surface); ``destroyed=True`` when the call
+        consumed the final use and the item is now gone.
+    """
+    attrs = getattr(item, "attributes", None)
+    if attrs is None:
+        return {"success": False, "destroyed": False}
+    uses_left = int(attrs.get("uses_left", 0) or 0)
+    if uses_left <= 0:
+        return {"success": False, "destroyed": False}
+    uses_left -= 1
+    attrs.add("uses_left", uses_left)
+    if uses_left <= 0:
+        if on_destroy is not None:
+            try:
+                on_destroy()
+            except Exception:
+                # A bad on_destroy callback should not prevent the
+                # item from being deleted — the lifecycle invariant
+                # (zero uses ⇒ gone) is more important.
+                pass
+        try:
+            item.delete()
+        except AttributeError:
+            pass
+        return {"success": True, "destroyed": True}
+    return {"success": True, "destroyed": False}

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -654,50 +654,56 @@ def can_be_used(item):
 def use_item(item):
     """
     Use the item, reducing uses left. Destroys item when uses reach 0.
-    
+
     Returns:
         dict: {"success": bool, "destroyed": bool, "message": str}
+
+    Medical-specific wrapper around
+    :func:`world.consumables.consume_use` — adds the medical-item
+    role gate and the "crumbles away" broadcast on destruction.
+    Future medical commands and the smoke commands share the same
+    decrement core via the generic helper.
     """
+    from world.consumables import consume_use
+
     if not is_medical_item(item):
         return {"success": False, "destroyed": False, "message": "Item is not a medical item"}
-        
+
     uses_left = item.attributes.get("uses_left", 1)
-    max_uses = item.attributes.get("max_uses", 1)
-    
     if uses_left <= 0:
         return {"success": False, "destroyed": False, "message": "Item is already empty"}
-    
-    # Reduce uses by 1
+
+    max_uses = item.attributes.get("max_uses", 1)
+    item_name = item.get_display_name()
+
+    def _broadcast_destroyed():
+        # Notify holders/location before destruction.
+        loc = getattr(item, "location", None)
+        if loc is None:
+            return
+        if hasattr(loc, "msg"):
+            # Item is held by a character.
+            loc.msg(f"{item_name} is now empty and crumbles away.")
+        elif hasattr(loc, "msg_contents"):
+            # Item is in a room.
+            loc.msg_contents(f"{item_name} crumbles away, now empty.")
+
+    outcome = consume_use(item, on_destroy=_broadcast_destroyed)
+    if outcome["destroyed"]:
+        return {
+            "success": True,
+            "destroyed": True,
+            "message": (
+                f"{item_name} used up and destroyed "
+                f"({max_uses}/{max_uses} uses)"
+            ),
+        }
     new_uses = uses_left - 1
-    item.attributes.add("uses_left", new_uses)
-    
-    # Check if item should be destroyed
-    if new_uses <= 0:
-        item_name = item.get_display_name()
-        
-        # Notify holders/location before destruction
-        if hasattr(item, 'location') and item.location:
-            if hasattr(item.location, 'msg'):
-                # Item is held by a character
-                item.location.msg(f"{item_name} is now empty and crumbles away.")
-            elif hasattr(item.location, 'msg_contents'):
-                # Item is in a room
-                item.location.msg_contents(f"{item_name} crumbles away, now empty.")
-        
-        # Destroy the item
-        item.delete()
-        
-        return {
-            "success": True, 
-            "destroyed": True, 
-            "message": f"{item_name} used up and destroyed ({max_uses}/{max_uses} uses)"
-        }
-    else:
-        return {
-            "success": True, 
-            "destroyed": False, 
-            "message": f"Item used ({max_uses - new_uses}/{max_uses} uses)"
-        }
+    return {
+        "success": True,
+        "destroyed": False,
+        "message": f"Item used ({max_uses - new_uses}/{max_uses} uses)",
+    }
 
 
 def get_stat_requirement(item):

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2440,12 +2440,14 @@ CIGARETTE_BASE = {
     "aliases": ["cig", "smoke"],
     "desc": "A slim, hand-rolled cigarette.",
     "attrs": [
-        ("brand", "neutral"),
+        ("substance", "tobacco_neutral"),
         ("uses_left", 6),
         ("max_uses", 6),
     ],
     "tags": [
-        ("cigarette", "item_role"),
+        # Delivery-method classification (#456) — what verbs apply
+        # to this item.  Joints, cigars, pipes will share this tag.
+        ("smoke", "delivery_method"),
     ],
 }
 
@@ -2454,34 +2456,34 @@ CIGARETTE_NEUTRAL = {
     "key": "cigarette",
     "desc": "A standard filtered cigarette, mild tobacco wrapped in white paper.",
     "attrs": [
-        ("brand", "neutral"),
+        ("substance", "tobacco_neutral"),
     ],
 }
 
 CIGARETTE_NOIR = {
     "prototype_parent": "CIGARETTE_BASE",
     "key": "Noir cigarette",
-    "aliases": ["noir cig", "noir", "cig"],
+    "aliases": ["noir cig", "noir", "cig", "smoke"],
     "desc": (
         "An unfiltered cigarette in dark paper, the brand stamp on "
         "the side faded to near-illegible.  Smells of something "
         "older than tobacco."
     ),
     "attrs": [
-        ("brand", "noir"),
+        ("substance", "tobacco_noir"),
     ],
 }
 
 
 # Pack — auto-spawns ``capacity`` cigarettes of ``cigarette_prototype``
-# at creation, stamping each with the pack's ``brand``.
+# at creation, stamping each with the pack's ``substance``.
 CIGARETTE_PACK_BASE = {
     "typeclass": "typeclasses.smoke.CigarettePack",
     "key": "pack of cigarettes",
     "aliases": ["pack", "cigarettes"],
     "desc": "A cardboard pack of cigarettes.",
     "attrs": [
-        ("brand", "neutral"),
+        ("substance", "tobacco_neutral"),
         ("capacity", 10),
         ("cigarette_prototype", "CIGARETTE_NEUTRAL"),
     ],
@@ -2495,7 +2497,7 @@ CIGARETTE_PACK_NEUTRAL = {
         "lettering is generic block print, no logo, no flourish."
     ),
     "attrs": [
-        ("brand", "neutral"),
+        ("substance", "tobacco_neutral"),
         ("cigarette_prototype", "CIGARETTE_NEUTRAL"),
     ],
 }
@@ -2509,7 +2511,7 @@ CIGARETTE_PACK_NOIR = {
         "tarnished silver.  Heavier than it looks."
     ),
     "attrs": [
-        ("brand", "noir"),
+        ("substance", "tobacco_noir"),
         ("cigarette_prototype", "CIGARETTE_NOIR"),
     ],
 }

--- a/world/smoke.py
+++ b/world/smoke.py
@@ -28,15 +28,20 @@ from typing import Optional
 
 #: Tag namespaces.
 CIGARETTE_STATE_CATEGORY = "cigarette_state"
-ITEM_ROLE_CATEGORY = "item_role"
+DELIVERY_METHOD_CATEGORY = "delivery_method"
+ITEM_ROLE_CATEGORY = "item_role"  # Lighter still uses item_role.
 
-#: Item-role tags.  ``light`` and ``smoke`` use these to identify
-#: cigarettes / lighters by role rather than by typeclass, so
-#: prototype-defined items don't need a bespoke typeclass.
-CIGARETTE_ROLE = "cigarette"
+#: Delivery-method tag.  Cigarettes, joints, cigars, pipes — anything
+#: that can be smoked carries this.  See
+#: ``specs/SUBSTANCES_AND_DELIVERY_SPEC.md`` for the architectural
+#: model.  Replaces the legacy ``("cigarette", "item_role")`` tag —
+#: ``is_smokable`` migrates that automatically on first access.
+SMOKE_DELIVERY = "smoke"
+
+#: Item-role tag for lighters.  Distinct axis from delivery method.
 LIGHTER_ROLE = "lighter"
 
-#: Lit-state tag carried on individual cigarettes.
+#: Lit-state tag carried on individual smokables.
 LIT_TAG = "lit"
 
 #: Default puffs per cigarette.
@@ -45,21 +50,40 @@ DEFAULT_CIGARETTE_PUFFS = 6
 #: Default cigarettes per pack.
 DEFAULT_PACK_CAPACITY = 10
 
-#: Brand identifiers.  Add more here when new brands arrive; banks
-#: below are keyed by these constants.
-BRAND_NEUTRAL = "neutral"
-BRAND_NOIR = "noir"
+#: Substance identifiers.  Add more here as substances are defined;
+#: banks below are keyed by these constants.  Naming convention:
+#: ``<substance>_<style>`` when the same substance has multiple
+#: stylistic variants (e.g. tobacco_neutral, tobacco_noir).
+SUBSTANCE_TOBACCO_NEUTRAL = "tobacco_neutral"
+SUBSTANCE_TOBACCO_NOIR = "tobacco_noir"
+
+# Pre-#456 brand attribute values that mapped to these substances.
+# ``pick_smoke_message`` honours both via this table during the
+# migration window — old cigarettes already in the live DB still
+# resolve the right flavor bank.
+_LEGACY_BRAND_MAP = {
+    "neutral": SUBSTANCE_TOBACCO_NEUTRAL,
+    "noir": SUBSTANCE_TOBACCO_NOIR,
+}
+
+# Legacy back-compat aliases — kept so any third-party code (and
+# this codebase's own tests during the transition window) doesn't
+# break.  Prefer the SUBSTANCE_* names in new code.
+BRAND_NEUTRAL = SUBSTANCE_TOBACCO_NEUTRAL
+BRAND_NOIR = SUBSTANCE_TOBACCO_NOIR
+CIGARETTE_ROLE = "cigarette"  # legacy item_role tag value
 
 
 # ---------------------------------------------------------------------
 # Smoke message banks
 # ---------------------------------------------------------------------
 
-#: Per-brand smoke flavor.  ``smoke <cigarette>`` picks a random
-#: entry; the actor receives the ``self`` form and the room gets the
-#: ``room`` template rendered through :func:`msg_room_identity`.
+#: Per-substance smoke flavor.  ``smoke <smokable>`` picks a random
+#: entry from the substance's bank; the actor receives the ``self``
+#: form and the room gets the ``room`` template rendered through
+#: :func:`msg_room_identity`.
 SMOKE_MESSAGES: dict[str, list[tuple[str, str]]] = {
-    BRAND_NEUTRAL: [
+    SUBSTANCE_TOBACCO_NEUTRAL: [
         (
             "You draw deeply from your cigarette, the ember flaring "
             "briefly as you inhale, before slowly releasing a thick "
@@ -173,7 +197,7 @@ SMOKE_MESSAGES: dict[str, list[tuple[str, str]]] = {
             "in a gentle, steady stream.",
         ),
     ],
-    BRAND_NOIR: [
+    SUBSTANCE_TOBACCO_NOIR: [
         (
             "You drag on your cigarette, the smoke curling around "
             "your fingers like a secret you're not ready to share. "
@@ -421,12 +445,17 @@ BURNT_OUT_MESSAGES: list[tuple[str, str]] = [
 # Pickers
 # ---------------------------------------------------------------------
 
-def pick_smoke_message(brand: str | None) -> tuple[str, str]:
-    """Return a random ``(self, room_template)`` for ``brand``.
+def pick_smoke_message(substance: str | None) -> tuple[str, str]:
+    """Return a random ``(self, room_template)`` for ``substance``.
 
-    Unknown brands fall back to :data:`BRAND_NEUTRAL`.
+    Honours legacy brand keys (``"neutral"`` / ``"noir"``) via the
+    :data:`_LEGACY_BRAND_MAP` translation so cigarettes spawned
+    pre-#456 still render flavor.  Unknown / missing substance
+    falls back to :data:`SUBSTANCE_TOBACCO_NEUTRAL`.
     """
-    bank = SMOKE_MESSAGES.get(brand or BRAND_NEUTRAL) or SMOKE_MESSAGES[BRAND_NEUTRAL]
+    key = substance or SUBSTANCE_TOBACCO_NEUTRAL
+    key = _LEGACY_BRAND_MAP.get(key, key)
+    bank = SMOKE_MESSAGES.get(key) or SMOKE_MESSAGES[SUBSTANCE_TOBACCO_NEUTRAL]
     return random.choice(bank)
 
 
@@ -450,14 +479,33 @@ def pick_burnt_out_message() -> tuple[str, str]:
 # Item helpers
 # ---------------------------------------------------------------------
 
-def is_cigarette(item) -> bool:
-    """True when ``item`` carries the cigarette role tag."""
+def is_smokable(item) -> bool:
+    """True when ``item`` supports the ``smoke`` delivery method.
+
+    Self-heals items that still carry the pre-#456
+    ``("cigarette", "item_role")`` tag — they're migrated to
+    ``("smoke", "delivery_method")`` on first inspection so any
+    cigarette spawned before this PR keeps working.
+    """
     if item is None:
         return False
     tags = getattr(item, "tags", None)
     if tags is None:
         return False
-    return tags.has(CIGARETTE_ROLE, category=ITEM_ROLE_CATEGORY)
+    if tags.has(SMOKE_DELIVERY, category=DELIVERY_METHOD_CATEGORY):
+        return True
+    # Legacy migration: pre-#456 cigarettes carried this older tag.
+    if tags.has(CIGARETTE_ROLE, category=ITEM_ROLE_CATEGORY):
+        tags.remove(CIGARETTE_ROLE, category=ITEM_ROLE_CATEGORY)
+        tags.add(SMOKE_DELIVERY, category=DELIVERY_METHOD_CATEGORY)
+        return True
+    return False
+
+
+# Legacy back-compat alias — keep the old name callable for any
+# external code that referenced it.  Internal call sites use
+# ``is_smokable``.
+is_cigarette = is_smokable
 
 
 def is_lighter(item) -> bool:
@@ -503,9 +551,13 @@ def find_held(character, predicate) -> Optional[object]:
     return None
 
 
-def find_held_cigarette(character) -> Optional[object]:
-    """Convenience wrapper — first cigarette in ``character``'s hands."""
-    return find_held(character, is_cigarette)
+def find_held_smokable(character) -> Optional[object]:
+    """Convenience wrapper — first smokable in ``character``'s hands."""
+    return find_held(character, is_smokable)
+
+
+# Legacy back-compat alias.
+find_held_cigarette = find_held_smokable
 
 
 def find_held_lighter(character) -> Optional[object]:
@@ -513,32 +565,41 @@ def find_held_lighter(character) -> Optional[object]:
     return find_held(character, is_lighter)
 
 
-def consume_puff(cigarette) -> dict:
-    """Decrement ``cigarette.attributes['uses_left']`` by one.
+def get_substance(item) -> str | None:
+    """Read ``item``'s substance attribute, migrating from the
+    legacy ``brand`` attribute when present.
 
-    When the result reaches zero the cigarette is deleted and the
-    return dict's ``destroyed`` flag is set so callers can emit the
-    burnout broadcast.
-
-    Returns:
-        ``{"success": bool, "destroyed": bool}`` — ``success=False``
-        when the cigarette had no puffs left to begin with.
+    Pre-#456 cigarettes stored the substance identifier under
+    ``db.brand``.  This helper transparently copies it to
+    ``db.substance`` on first read so the pickers and any future
+    substance-registry lookups see a single field.
     """
-    attrs = getattr(cigarette, "attributes", None)
-    if attrs is None:
-        return {"success": False, "destroyed": False}
-    uses_left = int(attrs.get("uses_left", 0) or 0)
-    if uses_left <= 0:
-        return {"success": False, "destroyed": False}
-    uses_left -= 1
-    attrs.add("uses_left", uses_left)
-    if uses_left <= 0:
-        try:
-            cigarette.delete()
-        except AttributeError:
-            pass
-        return {"success": True, "destroyed": True}
-    return {"success": True, "destroyed": False}
+    if item is None:
+        return None
+    db = getattr(item, "db", None)
+    if db is None:
+        return None
+    substance = getattr(db, "substance", None)
+    if substance:
+        return substance
+    legacy_brand = getattr(db, "brand", None)
+    if legacy_brand:
+        # Stamp the new field; leave brand in place to avoid
+        # surprising anything else that reads it during migration.
+        db.substance = legacy_brand
+        return legacy_brand
+    return None
+
+
+def consume_puff(cigarette) -> dict:
+    """Decrement a smokable's remaining puffs.
+
+    Thin wrapper over :func:`world.consumables.consume_use`; kept
+    for callers that want the smoke-specific name.  See the generic
+    helper for the contract.
+    """
+    from world.consumables import consume_use
+    return consume_use(cigarette)
 
 
 # ---------------------------------------------------------------------

--- a/world/tests/test_consumables.py
+++ b/world/tests/test_consumables.py
@@ -1,0 +1,100 @@
+"""Tests for the generic consumable decrement helper
+(:func:`world.consumables.consume_use`).
+
+The smoke commands and the medical ``use_item`` wrapper both
+delegate here.  These tests pin the contract independent of
+either consumer.
+"""
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.consumables import consume_use
+
+
+class _Attributes:
+    def __init__(self, **initial):
+        self._values = dict(initial)
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+    def add(self, key, value):
+        self._values[key] = value
+
+
+class _Item:
+    def __init__(self, uses_left=3, max_uses=3, *, with_attrs=True):
+        if with_attrs:
+            self.attributes = _Attributes(
+                uses_left=uses_left, max_uses=max_uses,
+            )
+        self.deleted = False
+
+    def delete(self):
+        self.deleted = True
+
+
+class TestConsumeUseBasic(TestCase):
+    def test_decrements_uses_left(self):
+        item = _Item(uses_left=3)
+        outcome = consume_use(item)
+        self.assertEqual(outcome["success"], True)
+        self.assertEqual(outcome["destroyed"], False)
+        self.assertEqual(item.attributes.get("uses_left"), 2)
+        self.assertFalse(item.deleted)
+
+    def test_destroys_on_final_use(self):
+        item = _Item(uses_left=1)
+        outcome = consume_use(item)
+        self.assertEqual(outcome["destroyed"], True)
+        self.assertTrue(item.deleted)
+        self.assertEqual(item.attributes.get("uses_left"), 0)
+
+    def test_zero_uses_returns_failure(self):
+        item = _Item(uses_left=0)
+        outcome = consume_use(item)
+        self.assertEqual(outcome["success"], False)
+        self.assertEqual(outcome["destroyed"], False)
+        self.assertFalse(item.deleted)
+
+    def test_no_attributes_surface_returns_failure(self):
+        # Object without ``.attributes`` — degrades gracefully.
+        item = _Item(with_attrs=False)
+        outcome = consume_use(item)
+        self.assertEqual(outcome["success"], False)
+        self.assertFalse(item.deleted)
+
+
+class TestConsumeUseDestroyCallback(TestCase):
+    def test_callback_fires_just_before_delete(self):
+        item = _Item(uses_left=1)
+        events = []
+
+        def _on_destroy():
+            # Callback runs BEFORE the item is deleted — the
+            # cigarette-side burnout broadcast wants to reference
+            # the still-extant item for display name etc.
+            events.append(("on_destroy_called", item.deleted))
+
+        consume_use(item, on_destroy=_on_destroy)
+        self.assertEqual(events, [("on_destroy_called", False)])
+        self.assertTrue(item.deleted)
+
+    def test_callback_only_fires_on_destruction(self):
+        item = _Item(uses_left=3)
+        fired = []
+        consume_use(item, on_destroy=lambda: fired.append(True))
+        self.assertEqual(fired, [])
+
+    def test_callback_exception_does_not_block_delete(self):
+        """The lifecycle invariant (zero uses ⇒ gone) is more
+        important than a buggy flavor callback."""
+        item = _Item(uses_left=1)
+
+        def _bad_callback():
+            raise RuntimeError("boom")
+
+        outcome = consume_use(item, on_destroy=_bad_callback)
+        self.assertEqual(outcome["destroyed"], True)
+        self.assertTrue(item.deleted)

--- a/world/tests/test_smoke.py
+++ b/world/tests/test_smoke.py
@@ -78,16 +78,24 @@ class _FakeItem:
         key="cigarette",
         aliases=None,
         role_tags: list[tuple[str, str]] | None = None,
-        brand="neutral",
+        substance="tobacco_neutral",
         uses_left=6,
         max_uses=6,
+        legacy_brand=None,
     ):
         self.key = key
         self.aliases = list(aliases or [])
         self.tags = _FakeTags()
         for tag, category in (role_tags or []):
             self.tags.add(tag, category=category)
-        self.db = _FakeDB(brand=brand)
+        # ``legacy_brand`` covers pre-#456 items: db.brand but no
+        # db.substance.  ``substance`` covers the post-#456 shape.
+        db_kwargs = {}
+        if legacy_brand is not None:
+            db_kwargs["brand"] = legacy_brand
+        else:
+            db_kwargs["substance"] = substance
+        self.db = _FakeDB(**db_kwargs)
         self.attributes = _FakeAttributes(
             uses_left=uses_left, max_uses=max_uses,
         )
@@ -97,10 +105,10 @@ class _FakeItem:
         self.deleted = True
 
 
-def _cigarette(brand="neutral", **kw):
+def _cigarette(substance="tobacco_neutral", **kw):
     return _FakeItem(
-        role_tags=[(sm.CIGARETTE_ROLE, sm.ITEM_ROLE_CATEGORY)],
-        brand=brand,
+        role_tags=[(sm.SMOKE_DELIVERY, sm.DELIVERY_METHOD_CATEGORY)],
+        substance=substance,
         **kw,
     )
 
@@ -109,7 +117,7 @@ def _lighter():
     return _FakeItem(
         key="lighter",
         role_tags=[(sm.LIGHTER_ROLE, sm.ITEM_ROLE_CATEGORY)],
-        brand=None,
+        substance=None,
     )
 
 
@@ -204,6 +212,65 @@ class TestHeldItems(TestCase):
 # ---------------------------------------------------------------------
 
 
+class TestIsSmokableLegacyMigration(TestCase):
+    """The new delivery-method tag is the source of truth, but
+    pre-#456 cigarettes still carry the old ``("cigarette",
+    "item_role")`` tag.  ``is_smokable`` migrates them on first
+    access."""
+
+    def test_new_tag_recognised(self):
+        item = _cigarette()
+        self.assertTrue(sm.is_smokable(item))
+
+    def test_legacy_tag_migrated_in_place(self):
+        item = _FakeItem(
+            role_tags=[(sm.CIGARETTE_ROLE, sm.ITEM_ROLE_CATEGORY)],
+        )
+        # First access returns True AND mutates the tag set.
+        self.assertTrue(sm.is_smokable(item))
+        self.assertTrue(
+            item.tags.has(
+                sm.SMOKE_DELIVERY, category=sm.DELIVERY_METHOD_CATEGORY,
+            )
+        )
+        self.assertFalse(
+            item.tags.has(
+                sm.CIGARETTE_ROLE, category=sm.ITEM_ROLE_CATEGORY,
+            )
+        )
+
+    def test_no_tag_is_not_smokable(self):
+        item = _FakeItem(role_tags=[])
+        self.assertFalse(sm.is_smokable(item))
+
+
+class TestGetSubstance(TestCase):
+    def test_reads_substance_attribute(self):
+        item = _cigarette(substance="tobacco_noir")
+        self.assertEqual(sm.get_substance(item), "tobacco_noir")
+
+    def test_legacy_brand_promoted_to_substance(self):
+        """Pre-#456 cigarettes stored the identifier in ``db.brand``.
+        ``get_substance`` returns it AND copies the value to
+        ``db.substance`` so future reads see a single field."""
+        item = _FakeItem(
+            role_tags=[(sm.SMOKE_DELIVERY, sm.DELIVERY_METHOD_CATEGORY)],
+            legacy_brand="noir",
+        )
+        self.assertEqual(sm.get_substance(item), "noir")
+        # Now stamped onto db.substance.
+        self.assertEqual(item.db.substance, "noir")
+
+    def test_returns_none_when_neither_attribute_set(self):
+        item = _FakeItem(
+            role_tags=[(sm.SMOKE_DELIVERY, sm.DELIVERY_METHOD_CATEGORY)],
+            substance=None,
+        )
+        # Clear the substance the helper might have stamped in init.
+        item.db = _FakeDB()
+        self.assertIsNone(sm.get_substance(item))
+
+
 class TestLitState(TestCase):
     def test_unlit_by_default(self):
         cig = _cigarette()
@@ -228,22 +295,44 @@ class TestLitState(TestCase):
 
 class TestMessagePicker(TestCase):
     def test_neutral_picks_from_neutral_bank(self):
-        self_msg, room_template = sm.pick_smoke_message(sm.BRAND_NEUTRAL)
+        self_msg, room_template = sm.pick_smoke_message(
+            sm.SUBSTANCE_TOBACCO_NEUTRAL,
+        )
         self.assertIn(
-            (self_msg, room_template), sm.SMOKE_MESSAGES[sm.BRAND_NEUTRAL],
+            (self_msg, room_template),
+            sm.SMOKE_MESSAGES[sm.SUBSTANCE_TOBACCO_NEUTRAL],
         )
 
     def test_noir_picks_from_noir_bank(self):
-        self_msg, room_template = sm.pick_smoke_message(sm.BRAND_NOIR)
+        self_msg, room_template = sm.pick_smoke_message(
+            sm.SUBSTANCE_TOBACCO_NOIR,
+        )
         self.assertIn(
-            (self_msg, room_template), sm.SMOKE_MESSAGES[sm.BRAND_NOIR],
+            (self_msg, room_template),
+            sm.SMOKE_MESSAGES[sm.SUBSTANCE_TOBACCO_NOIR],
         )
 
-    def test_unknown_brand_falls_back_to_neutral(self):
-        self_msg, room_template = sm.pick_smoke_message("unknown-brand")
+    def test_unknown_substance_falls_back_to_neutral(self):
+        self_msg, room_template = sm.pick_smoke_message("unknown-substance")
         self.assertIn(
-            (self_msg, room_template), sm.SMOKE_MESSAGES[sm.BRAND_NEUTRAL],
+            (self_msg, room_template),
+            sm.SMOKE_MESSAGES[sm.SUBSTANCE_TOBACCO_NEUTRAL],
         )
+
+    def test_legacy_brand_keys_still_resolve(self):
+        """Pre-#456 cigarettes had ``brand=\"neutral\"`` /
+        ``brand=\"noir\"`` — the picker honours those values via
+        the legacy mapping."""
+        legacy_neutral, _ = sm.pick_smoke_message("neutral")
+        legacy_noir, _ = sm.pick_smoke_message("noir")
+        all_neutral_self = [
+            s for s, _ in sm.SMOKE_MESSAGES[sm.SUBSTANCE_TOBACCO_NEUTRAL]
+        ]
+        all_noir_self = [
+            s for s, _ in sm.SMOKE_MESSAGES[sm.SUBSTANCE_TOBACCO_NOIR]
+        ]
+        self.assertIn(legacy_neutral, all_neutral_self)
+        self.assertIn(legacy_noir, all_noir_self)
 
     def test_room_templates_use_actor_placeholder(self):
         for brand, bank in sm.SMOKE_MESSAGES.items():
@@ -303,7 +392,7 @@ class TestCmdLight(TestCase):
 
     def test_other_light_routes_via_identity(self):
         room = _FakeRoom()
-        target_cig = _cigarette(brand="noir")
+        target_cig = _cigarette(substance="tobacco_noir")
         target = _FakeCharacter(
             key="Bob", location=room,
             hands={"left_hand": target_cig},
@@ -338,9 +427,9 @@ class TestCmdSmoke(TestCase):
         with patch("commands.CmdSmoke.msg_room_identity"):
             cmd.func()
 
-    def _setup(self, *, brand="neutral", uses_left=6, lit=True):
+    def _setup(self, *, substance="tobacco_neutral", uses_left=6, lit=True):
         room = _FakeRoom()
-        cig = _cigarette(brand=brand, uses_left=uses_left, max_uses=6)
+        cig = _cigarette(substance=substance, uses_left=uses_left, max_uses=6)
         if lit:
             sm.set_lit(cig, True)
         caller = _FakeCharacter(


### PR DESCRIPTION
Closes #456.

## Summary
Three opportunistic items + a spec, ahead of the larger substance-registry work.

1. **Unified consumable decrement** — new \`world/consumables.py:consume_use\`.  \`smoke.consume_puff\` and \`medical.use_item\` both delegate.
2. **\`brand\` → \`substance\`** on smokables.  Transparent legacy fallback via \`get_substance(item)\`; flavor picker honours legacy \`brand\` keys.
3. **Smoke role-tag → delivery-method tag**: \`(\"cigarette\", \"item_role\")\` → \`(\"smoke\", \"delivery_method\")\`.  Future joints, cigars, pipes share the same tag.  \`is_smokable\` self-heals existing items.
4. **\`specs/SUBSTANCES_AND_DELIVERY_SPEC.md\`** — three-layer model (Item → Substance → Delivery), maps current state, calls out next-PR work and anti-patterns.

## Playtest feedback (this session)
- \`smoke\` / \`snuff\` now require explicit item arg
- \`CIGARETTE_NOIR\` keeps the \`smoke\` alias so \`smoke smoke\` works
- Held-item check uses \`caller.hands\` (species-aware grasping containers) — non-hand appendages already covered

## Test plan
- [x] 14 new tests for the helpers + migrations
- [x] Full \`world.tests\` sweep — **2239 passed**
- [x] Live reload exercises the migration shims without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)