### PR TITLE
substances: registry + effect pipeline, wired into smoke

### DIFF
--- a/commands/CmdSmoke.py
+++ b/commands/CmdSmoke.py
@@ -29,6 +29,7 @@ from evennia import Command
 from commands._identity_targeting import resolve_character_target
 from world.identity_utils import msg_room_identity
 from world.consumables import consume_use
+from world.substances import apply_substance
 from world.smoke import (
     find_held_lighter,
     find_held_smokable,
@@ -262,6 +263,15 @@ class CmdSmoke(Command):
                 char_refs={"actor": caller},
                 exclude=[caller],
             )
+
+        # Pharmacology — one dose per puff through the substance
+        # pipeline (issue #458).  Unregistered substances no-op
+        # (flavor-only items are legitimate).  The subtle feedback
+        # line only renders when an effect actually landed, so a
+        # pain-free smoker just gets the flavor message.
+        dose_result = apply_substance(caller, substance)
+        for line in dose_result.get("feedback", ()):
+            caller.msg(f"|c{line}|n")
 
         # Decrement puff count via the unified consumable helper.
         # When the last puff goes the item deletes itself; we emit

--- a/specs/SUBSTANCES_AND_DELIVERY_SPEC.md
+++ b/specs/SUBSTANCES_AND_DELIVERY_SPEC.md
@@ -90,9 +90,32 @@ strings, not a fixed enum, and we'll want to read them as keys
 into the registry from many places.  Attribute fits better than
 tag here.
 
-## 3 · Substance registry (planned, not built)
+## 3 · Substance registry (✅ v1 shipped — issue #458)
 
-When ready, lives at `world/substances/registry.py`:
+Lives at `world/substances/registry.py`.  The shipped v1 differs
+from the original sketch below in two deliberate ways:
+
+* **Effect vocabulary is severity-based, not float-magnitude.**
+  Effects translate into the existing condition system's integer
+  severities rather than carrying their own magnitude/duration
+  model: `pain_relief` shaves `PainCondition` severity,
+  `sedation` adds/stacks a capped
+  `ConsciousnessSuppressionCondition(suppression_type="sedative")`.
+  Decay rides the conditions' own tick recovery — no parallel
+  timing model.
+* **`ConditionSpec` (tolerance / addiction / organ damage) is not
+  built yet.**  The substrate hook shipped instead:
+  `apply_substance` increments `consumer.db.substance_doses`
+  per dose, so the future tolerance system has historical data
+  from day one.
+
+Shipped entries: `tobacco_neutral` (pain_relief 1/dose),
+`tobacco_noir` (pain_relief 1 + sedation 1 capped at 2 total —
+woozy ceiling, never blackout).  `apply_substance(consumer, id)`
+is the single pipeline entry point; unknown ids no-op so
+flavor-only items stay legitimate.
+
+Original sketch (kept for the ConditionSpec direction):
 
 ```python
 @dataclass(frozen=True)
@@ -170,26 +193,38 @@ this scheme when the substance registry lands.
   wrapper over `consume_use` with "crumbles away" broadcast.
 * **`commands/CmdSmoke.py`** — `light` / `smoke` / `snuff`
   routing on the `("smoke", "delivery_method")` tag.  Cross-
-  character syntax via possessive parser.
+  character syntax via possessive parser.  Each puff applies one
+  dose through `apply_substance` (#458).
+* **`world/substances/`** (#458) — `Substance` /
+  `SubstanceEffect` dataclasses, registry with the two tobacco
+  entries, `apply_substance` pipeline feeding the medical
+  condition system, per-substance dose bookkeeping on
+  `db.substance_doses`.
 * **`commands/CmdConsumption.py`** — the older medical /
   substance command cluster (eat/drink/inhale/inject/apply/
   bandage).  Pre-dates the layering.
 
 ### Gaps to close (separate PRs)
 
-1. **Substance registry** at `world/substances/`.  Centralises
-   substance metadata; replaces the implicit registry in flavor
-   banks.
-2. **Effect pipeline** — `apply_substance(substance, consumer)`
-   that emits effects into the medical condition system.
+1. ~~**Substance registry** at `world/substances/`~~ — ✅ shipped
+   v1 in #458 (see §3).
+2. ~~**Effect pipeline** — `apply_substance`~~ — ✅ shipped v1 in
+   #458 with the severity-based vocabulary (`pain_relief`,
+   `sedation`).
 3. **`CmdConsumption` migration** — switch from `medical_type`
    strings to `("eat", "delivery_method")` / `("drink", ...)`
    tags.  Same shape as the smoke commands.
 4. **Tolerance / addiction conditions** — concrete
    `ConditionSpec` examples + medical-script tick integration.
+   The dose history (`db.substance_doses`, recorded since #458)
+   is the input data.
 5. **Roll-your-own** — `roll` command that consumes raw
    substance + paper + filter and spawns a cigarette / joint
    prototype with the substance baked on.
+6. **More substances** — cannabis, alcohol, opium.  Each likely
+   needs one or two new effect kinds (euphoria, stimulation,
+   coordination penalty) — grow the vocabulary per substance,
+   not speculatively.
 
 ## 6 · Anti-patterns to avoid
 

--- a/world/substances/__init__.py
+++ b/world/substances/__init__.py
@@ -1,0 +1,31 @@
+"""Substance layer — registry + effect pipeline (issue #458).
+
+Middle layer of the Item → Substance → Delivery model documented
+in ``specs/SUBSTANCES_AND_DELIVERY_SPEC.md``.  Items carry a
+``db.substance`` id; delivery commands (smoke today, the
+``CmdConsumption`` cluster after migration) resolve that id here
+and call :func:`apply_substance` per dose.
+
+Public surface:
+
+* :class:`Substance` / :class:`SubstanceEffect` — declaration
+  dataclasses.
+* :data:`SUBSTANCES` — the registry dict.
+* :func:`get_substance_entry` — id → entry lookup.
+* :func:`apply_substance` — the effect pipeline.
+"""
+from world.substances.registry import (
+    SUBSTANCES,
+    Substance,
+    SubstanceEffect,
+    apply_substance,
+    get_substance_entry,
+)
+
+__all__ = [
+    "SUBSTANCES",
+    "Substance",
+    "SubstanceEffect",
+    "apply_substance",
+    "get_substance_entry",
+]

--- a/world/substances/registry.py
+++ b/world/substances/registry.py
@@ -1,0 +1,301 @@
+"""Substance registry and effect pipeline (issue #458).
+
+Substances *declare* their effects; the existing medical condition
+system *applies and ticks* them.  No new runtime infrastructure —
+``apply_substance`` translates declarations into mutations on the
+consumer's :class:`~world.medical.core.MedicalState` and lets the
+medical script's 12-second tick handle decay/recovery from there.
+
+Effect vocabulary (v1) — deliberately limited to what the medical
+system supports today:
+
+* ``pain_relief`` — shaves severity off existing ``PainCondition``
+  entries.  A smoke takes the edge off; an opiate (later) takes a
+  lot more off.  No-op when the consumer isn't in pain.
+* ``sedation`` — adds or stacks a
+  :class:`~world.medical.conditions.ConsciousnessSuppressionCondition`
+  with ``suppression_type="sedative"``.  Stacking is capped by the
+  effect's ``max_stack`` so chain-smoking can't knock a character
+  unconscious unboundedly — the cap is the substance's ceiling on
+  total sedative severity from any source.
+
+Future vocabulary (tolerance, addiction, stimulation, euphoria,
+organ damage) lands in follow-up PRs per
+``specs/SUBSTANCES_AND_DELIVERY_SPEC.md`` §5.
+
+Dose tracking: every successful ``apply_substance`` increments
+``consumer.db.substance_doses[substance_id]``.  Nothing consumes
+this yet — it's the substrate hook for the future tolerance /
+addiction system, recorded now so the data exists when that system
+arrives.  One descriptor write per dose is a meaningful-event
+write, consistent with the storage-patterns guidance.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+# ---------------------------------------------------------------------
+# Declaration dataclasses
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SubstanceEffect:
+    """One declared per-dose effect.
+
+    Attributes:
+        kind: Effect vocabulary entry — ``"pain_relief"`` or
+            ``"sedation"`` in v1.
+        magnitude: Severity points applied per dose.
+        max_stack: For stacking effects (sedation), the cap on the
+            consumer's *total* severity from this effect kind.
+            Ignored for non-stacking effects (pain_relief shaves
+            and bottoms out at zero naturally).
+    """
+
+    kind: str
+    magnitude: int
+    max_stack: int = 0
+
+
+@dataclass(frozen=True)
+class Substance:
+    """A registered substance.
+
+    Attributes:
+        id: Registry key.  Items reference this via ``db.substance``.
+        display_name: Human-readable name for messages / inspection.
+        effects: Per-dose effects, applied in order.
+        flavor_bank_key: Which flavor bank the delivery command's
+            message picker uses (see ``world/smoke.py:SMOKE_MESSAGES``
+            for the smoke banks).
+    """
+
+    id: str
+    display_name: str
+    effects: tuple[SubstanceEffect, ...]
+    flavor_bank_key: str
+
+
+# ---------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------
+
+SUBSTANCES: dict[str, Substance] = {
+    "tobacco_neutral": Substance(
+        id="tobacco_neutral",
+        display_name="tobacco",
+        effects=(
+            # A smoke takes the edge off — one point of pain relief
+            # per puff.  Pure no-op on a pain-free consumer.
+            SubstanceEffect(kind="pain_relief", magnitude=1),
+        ),
+        flavor_bank_key="tobacco_neutral",
+    ),
+    "tobacco_noir": Substance(
+        id="tobacco_noir",
+        display_name="Noir tobacco",
+        effects=(
+            SubstanceEffect(kind="pain_relief", magnitude=1),
+            # "Smells of something older than tobacco."  Mild
+            # sedative bite, capped at 2 total severity (0.30
+            # consciousness penalty) — woozy, never blackout.
+            SubstanceEffect(kind="sedation", magnitude=1, max_stack=2),
+        ),
+        flavor_bank_key="tobacco_noir",
+    ),
+}
+
+
+def get_substance_entry(substance_id: str | None) -> Optional[Substance]:
+    """Return the registry entry for ``substance_id``, or ``None``.
+
+    Unknown / missing ids are not an error — items with no (or an
+    unregistered) substance simply have no pharmacology.  Flavor
+    banks have their own fallback path in the message pickers.
+    """
+    if not substance_id:
+        return None
+    return SUBSTANCES.get(substance_id)
+
+
+# ---------------------------------------------------------------------
+# Player-facing feedback per effect kind
+# ---------------------------------------------------------------------
+#
+# Rendered by the delivery command when an effect actually landed
+# (magnitude > 0 after caps).  Deliberately subtle — the flavor
+# message carries the scene; this line carries the mechanics.
+
+EFFECT_FEEDBACK: dict[str, str] = {
+    "pain_relief": "The ache dulls a little.",
+    "sedation": "A slow heaviness settles behind your eyes.",
+}
+
+
+# ---------------------------------------------------------------------
+# Effect pipeline
+# ---------------------------------------------------------------------
+
+
+def _apply_pain_relief(medical_state, magnitude: int) -> int:
+    """Shave up to ``magnitude`` severity off existing pain.
+
+    Walks the consumer's ``PainCondition`` entries in list order,
+    reducing each until the budget is spent.  Conditions that hit
+    zero are left for the medical script's ``should_end`` sweep to
+    remove on its next tick.
+
+    Returns:
+        Total severity actually relieved (0 when pain-free).
+    """
+    relieved = 0
+    budget = magnitude
+    for condition in getattr(medical_state, "conditions", []) or []:
+        if budget <= 0:
+            break
+        if getattr(condition, "condition_type", None) != "pain":
+            continue
+        severity = int(getattr(condition, "severity", 0) or 0)
+        if severity <= 0:
+            continue
+        shave = min(budget, severity)
+        condition.severity = severity - shave
+        budget -= shave
+        relieved += shave
+    return relieved
+
+
+def _apply_sedation(medical_state, magnitude: int, max_stack: int) -> int:
+    """Add or stack sedative consciousness suppression, capped.
+
+    The cap applies to the consumer's **total** severity across
+    sedative-typed suppression conditions — so two different
+    sedative substances share one ceiling rather than each getting
+    their own.  Conservative by design; per-substance source
+    attribution can come with the tolerance work.
+
+    Returns:
+        Severity actually added after the cap (0 when at cap).
+    """
+    from world.medical.conditions import ConsciousnessSuppressionCondition
+
+    existing = [
+        c for c in (getattr(medical_state, "conditions", []) or [])
+        if getattr(c, "condition_type", None) == "consciousness_suppression"
+        and getattr(c, "suppression_type", None) == "sedative"
+    ]
+    current_total = sum(int(getattr(c, "severity", 0) or 0) for c in existing)
+    headroom = max(0, max_stack - current_total)
+    add = min(magnitude, headroom)
+    if add <= 0:
+        return 0
+
+    if existing:
+        condition = existing[0]
+        condition.severity = int(condition.severity) + add
+        # Keep the cached penalty in sync — the constructor formula
+        # (0.15 per severity point, capped at 1.0).
+        condition.consciousness_penalty = min(
+            1.0, condition.severity * 0.15,
+        )
+    else:
+        condition = ConsciousnessSuppressionCondition(
+            add, suppression_type="sedative",
+        )
+        medical_state.add_condition(condition)
+    return add
+
+
+def apply_substance(consumer, substance_id: str | None, *, doses: int = 1) -> dict:
+    """Apply ``doses`` of a substance to ``consumer``.
+
+    The single entry point delivery commands call after their own
+    validation (item in hand, lit, etc.).  Translates the
+    substance's declared effects into medical-state mutations,
+    records the dose, refreshes vitals, and flushes.
+
+    Args:
+        consumer: Character receiving the substance.  Must expose
+            ``medical_state``; consumers without one (objects,
+            corpses) no-op safely.
+        substance_id: Registry key, usually from the item's
+            ``db.substance``.  Unknown ids no-op (flavor-only
+            items are legitimate).
+        doses: Number of doses to apply (default one — one puff,
+            one sip, one pill).
+
+    Returns:
+        Summary dict::
+
+            {
+                "substance": <id or None>,
+                "known": bool,          # id resolved in registry
+                "applied": {kind: total_magnitude, ...},
+                "feedback": [str, ...], # player-facing lines for
+                                        # effects that landed
+            }
+    """
+    result = {
+        "substance": substance_id,
+        "known": False,
+        "applied": {},
+        "feedback": [],
+    }
+    entry = get_substance_entry(substance_id)
+    if entry is None:
+        return result
+    result["known"] = True
+
+    medical_state = getattr(consumer, "medical_state", None)
+    if medical_state is None:
+        return result
+
+    for _ in range(max(1, int(doses))):
+        for effect in entry.effects:
+            if effect.kind == "pain_relief":
+                landed = _apply_pain_relief(medical_state, effect.magnitude)
+            elif effect.kind == "sedation":
+                landed = _apply_sedation(
+                    medical_state, effect.magnitude, effect.max_stack,
+                )
+            else:
+                # Unknown effect kind — declared ahead of its
+                # implementation.  Skip rather than crash so the
+                # registry can grow ahead of the pipeline.
+                continue
+            if landed > 0:
+                result["applied"][effect.kind] = (
+                    result["applied"].get(effect.kind, 0) + landed
+                )
+
+    # Player-facing feedback for effects that actually landed.
+    for kind in result["applied"]:
+        line = EFFECT_FEEDBACK.get(kind)
+        if line:
+            result["feedback"].append(line)
+
+    # Dose bookkeeping — substrate for future tolerance/addiction.
+    db = getattr(consumer, "db", None)
+    if db is not None:
+        doses_map = getattr(db, "substance_doses", None)
+        if doses_map is None:
+            db.substance_doses = {substance_id: int(doses)}
+        else:
+            doses_map[substance_id] = (
+                int(doses_map.get(substance_id, 0)) + int(doses)
+            )
+
+    # Refresh vitals so consciousness reflects new penalties
+    # immediately, then flush — dose application is a meaningful
+    # event per the storage-patterns guidance.
+    update_vitals = getattr(medical_state, "update_vital_signs", None)
+    if callable(update_vitals):
+        update_vitals()
+    save = getattr(consumer, "save_medical_state", None)
+    if callable(save):
+        save()
+
+    return result

--- a/world/tests/test_substances.py
+++ b/world/tests/test_substances.py
@@ -1,0 +1,316 @@
+"""Tests for the substance registry + effect pipeline (issue #458).
+
+Pure-function coverage against fakes — no Evennia DB.  Pins:
+
+* Registry lookups (known / unknown / None).
+* ``pain_relief`` shaves PainCondition severity, bottoms at zero,
+  no-ops on a pain-free consumer.
+* ``sedation`` adds a sedative ConsciousnessSuppressionCondition,
+  stacks onto an existing one, and respects the per-substance cap
+  (including across repeated doses — the chain-smoking case).
+* Dose bookkeeping increments ``db.substance_doses``.
+* Vitals refresh + medical-state flush fire after application.
+* ``CmdSmoke`` integration: a puff applies one dose and renders
+  the feedback line only when an effect landed.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.substances import (
+    SUBSTANCES,
+    apply_substance,
+    get_substance_entry,
+)
+
+
+# ---------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------
+
+
+class _FakeCondition(SimpleNamespace):
+    """Duck-typed condition — only the attributes the pipeline reads."""
+
+
+def _pain(severity, location=None):
+    return _FakeCondition(
+        condition_type="pain", severity=severity, location=location,
+    )
+
+
+def _sedative(severity):
+    return _FakeCondition(
+        condition_type="consciousness_suppression",
+        suppression_type="sedative",
+        severity=severity,
+        consciousness_penalty=min(1.0, severity * 0.15),
+    )
+
+
+class _FakeMedicalState:
+    def __init__(self, conditions=None):
+        self.conditions = list(conditions or [])
+        self.vitals_updated = 0
+
+    def add_condition(self, condition):
+        self.conditions.append(condition)
+
+    def update_vital_signs(self):
+        self.vitals_updated += 1
+
+
+class _FakeDB(SimpleNamespace):
+    def __getattribute__(self, name):
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            return None
+
+
+class _FakeConsumer:
+    def __init__(self, conditions=None):
+        self.medical_state = _FakeMedicalState(conditions)
+        self.db = _FakeDB()
+        self.saves = 0
+
+    def save_medical_state(self):
+        self.saves += 1
+
+
+# ---------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------
+
+
+class TestRegistry(TestCase):
+    def test_known_substances_resolve(self):
+        self.assertIsNotNone(get_substance_entry("tobacco_neutral"))
+        self.assertIsNotNone(get_substance_entry("tobacco_noir"))
+
+    def test_unknown_substance_returns_none(self):
+        self.assertIsNone(get_substance_entry("unobtainium"))
+
+    def test_none_returns_none(self):
+        self.assertIsNone(get_substance_entry(None))
+        self.assertIsNone(get_substance_entry(""))
+
+    def test_entries_carry_flavor_bank_keys(self):
+        for substance_id, entry in SUBSTANCES.items():
+            self.assertEqual(entry.id, substance_id)
+            self.assertTrue(entry.flavor_bank_key)
+
+
+# ---------------------------------------------------------------------
+# pain_relief
+# ---------------------------------------------------------------------
+
+
+class TestPainRelief(TestCase):
+    def test_shaves_pain_severity(self):
+        consumer = _FakeConsumer(conditions=[_pain(5)])
+        result = apply_substance(consumer, "tobacco_neutral")
+        self.assertEqual(result["applied"], {"pain_relief": 1})
+        self.assertEqual(consumer.medical_state.conditions[0].severity, 4)
+
+    def test_no_ops_when_pain_free(self):
+        consumer = _FakeConsumer()
+        result = apply_substance(consumer, "tobacco_neutral")
+        self.assertEqual(result["applied"], {})
+        self.assertEqual(result["feedback"], [])
+
+    def test_bottoms_out_at_zero(self):
+        consumer = _FakeConsumer(conditions=[_pain(1)])
+        apply_substance(consumer, "tobacco_neutral")
+        self.assertEqual(consumer.medical_state.conditions[0].severity, 0)
+        # Second dose has nothing to relieve.
+        result = apply_substance(consumer, "tobacco_neutral")
+        self.assertEqual(result["applied"], {})
+
+    def test_feedback_line_present_when_landed(self):
+        consumer = _FakeConsumer(conditions=[_pain(3)])
+        result = apply_substance(consumer, "tobacco_neutral")
+        self.assertTrue(result["feedback"])
+
+
+# ---------------------------------------------------------------------
+# sedation
+# ---------------------------------------------------------------------
+
+
+class TestSedation(TestCase):
+    def test_first_dose_adds_sedative_condition(self):
+        consumer = _FakeConsumer()
+        result = apply_substance(consumer, "tobacco_noir")
+        self.assertEqual(result["applied"].get("sedation"), 1)
+        sedatives = [
+            c for c in consumer.medical_state.conditions
+            if getattr(c, "condition_type", None)
+            == "consciousness_suppression"
+        ]
+        self.assertEqual(len(sedatives), 1)
+        self.assertEqual(sedatives[0].severity, 1)
+        self.assertEqual(sedatives[0].suppression_type, "sedative")
+
+    def test_second_dose_stacks_onto_existing(self):
+        consumer = _FakeConsumer()
+        apply_substance(consumer, "tobacco_noir")
+        apply_substance(consumer, "tobacco_noir")
+        sedatives = [
+            c for c in consumer.medical_state.conditions
+            if getattr(c, "condition_type", None)
+            == "consciousness_suppression"
+        ]
+        # Stacked in place — still one condition, severity 2.
+        self.assertEqual(len(sedatives), 1)
+        self.assertEqual(sedatives[0].severity, 2)
+
+    def test_cap_blocks_third_dose(self):
+        """tobacco_noir's sedation max_stack is 2 — the chain-
+        smoking case.  Third puff relieves pain (if any) but adds
+        no further sedation."""
+        consumer = _FakeConsumer()
+        apply_substance(consumer, "tobacco_noir")
+        apply_substance(consumer, "tobacco_noir")
+        result = apply_substance(consumer, "tobacco_noir")
+        self.assertNotIn("sedation", result["applied"])
+        sedatives = [
+            c for c in consumer.medical_state.conditions
+            if getattr(c, "condition_type", None)
+            == "consciousness_suppression"
+        ]
+        self.assertEqual(sedatives[0].severity, 2)
+
+    def test_cap_shared_with_preexisting_sedatives(self):
+        """The cap counts ALL sedative-typed suppression — a
+        consumer already sedated to the cap gets nothing more."""
+        consumer = _FakeConsumer(conditions=[_sedative(2)])
+        result = apply_substance(consumer, "tobacco_noir")
+        self.assertNotIn("sedation", result["applied"])
+
+    def test_penalty_kept_in_sync_on_stack(self):
+        consumer = _FakeConsumer()
+        apply_substance(consumer, "tobacco_noir")
+        apply_substance(consumer, "tobacco_noir")
+        sedative = [
+            c for c in consumer.medical_state.conditions
+            if getattr(c, "condition_type", None)
+            == "consciousness_suppression"
+        ][0]
+        self.assertAlmostEqual(sedative.consciousness_penalty, 0.30)
+
+
+# ---------------------------------------------------------------------
+# Bookkeeping + lifecycle
+# ---------------------------------------------------------------------
+
+
+class TestBookkeeping(TestCase):
+    def test_dose_counter_increments(self):
+        consumer = _FakeConsumer()
+        apply_substance(consumer, "tobacco_neutral")
+        apply_substance(consumer, "tobacco_neutral")
+        apply_substance(consumer, "tobacco_noir")
+        self.assertEqual(
+            consumer.db.substance_doses,
+            {"tobacco_neutral": 2, "tobacco_noir": 1},
+        )
+
+    def test_vitals_and_save_fire_per_application(self):
+        consumer = _FakeConsumer(conditions=[_pain(3)])
+        apply_substance(consumer, "tobacco_neutral")
+        self.assertEqual(consumer.medical_state.vitals_updated, 1)
+        self.assertEqual(consumer.saves, 1)
+
+    def test_unknown_substance_no_ops_cleanly(self):
+        consumer = _FakeConsumer(conditions=[_pain(3)])
+        result = apply_substance(consumer, "unobtainium")
+        self.assertFalse(result["known"])
+        self.assertEqual(result["applied"], {})
+        # No mutation, no save.
+        self.assertEqual(consumer.medical_state.conditions[0].severity, 3)
+        self.assertEqual(consumer.saves, 0)
+
+    def test_consumer_without_medical_state_no_ops(self):
+        consumer = SimpleNamespace(medical_state=None, db=_FakeDB())
+        result = apply_substance(consumer, "tobacco_neutral")
+        self.assertTrue(result["known"])
+        self.assertEqual(result["applied"], {})
+
+
+# ---------------------------------------------------------------------
+# CmdSmoke integration
+# ---------------------------------------------------------------------
+
+
+class TestCmdSmokeIntegration(TestCase):
+    def _run_smoke(self, caller, args):
+        from commands.CmdSmoke import CmdSmoke
+        cmd = CmdSmoke()
+        cmd.caller = caller
+        cmd.args = " " + args
+        with patch("commands.CmdSmoke.msg_room_identity"):
+            cmd.func()
+
+    def _smoking_caller(self, *, substance, conditions=None):
+        from world import smoke as sm
+
+        class _Tags:
+            def __init__(self):
+                self._t = set()
+
+            def has(self, key, category=None):
+                return (key, category) in self._t
+
+            def add(self, key, category=None):
+                self._t.add((key, category))
+
+            def remove(self, key, category=None):
+                self._t.discard((key, category))
+
+        cig = SimpleNamespace(
+            key="cigarette",
+            aliases=[],
+            tags=_Tags(),
+            db=_FakeDB(substance=substance),
+            attributes=SimpleNamespace(
+                get=lambda k, d=None, _v={"uses_left": 6, "max_uses": 6}:
+                    _v.get(k, d),
+                add=lambda k, v: None,
+            ),
+        )
+        cig.tags.add(sm.SMOKE_DELIVERY, category=sm.DELIVERY_METHOD_CATEGORY)
+        cig.tags.add(sm.LIT_TAG, category=sm.CIGARETTE_STATE_CATEGORY)
+
+        caller = _FakeConsumer(conditions=conditions)
+        caller.location = SimpleNamespace(contents=[])
+        caller.hands = {"left_hand": cig}
+        caller.msgs = []
+        caller.msg = lambda text: caller.msgs.append(text)
+        caller.get_display_name = lambda looker=None: "Tester"
+        return caller
+
+    def test_puff_applies_dose_and_renders_feedback(self):
+        caller = self._smoking_caller(
+            substance="tobacco_neutral", conditions=[_pain(4)],
+        )
+        self._run_smoke(caller, "cigarette")
+        # Pain shaved by one.
+        self.assertEqual(caller.medical_state.conditions[0].severity, 3)
+        # Dose recorded.
+        self.assertEqual(
+            caller.db.substance_doses, {"tobacco_neutral": 1},
+        )
+        # Feedback line rendered (colour-wrapped).
+        joined = "\n".join(caller.msgs)
+        self.assertIn("ache dulls", joined)
+
+    def test_pain_free_puff_renders_no_feedback(self):
+        caller = self._smoking_caller(substance="tobacco_neutral")
+        self._run_smoke(caller, "cigarette")
+        joined = "\n".join(caller.msgs)
+        self.assertNotIn("ache dulls", joined)
+        # Flavor message still arrived (something got rendered).
+        self.assertTrue(caller.msgs)


### PR DESCRIPTION
Closes #458.

## Summary
First implementation slice of the substance layer from `specs/SUBSTANCES_AND_DELIVERY_SPEC.md` — **smoking now actually does something.**

- New `world/substances/` package: `Substance` / `SubstanceEffect` dataclasses + registry + `apply_substance` pipeline.
- Substances *declare* effects; the existing medical condition system *applies and ticks* them. No new runtime infrastructure.
- Effect vocabulary v1: `pain_relief` (shaves PainCondition severity) and `sedation` (capped sedative ConsciousnessSuppressionCondition).
- Entries: `tobacco_neutral` (mild pain relief) and `tobacco_noir` (pain relief + sedation capped at 2 total severity — woozy ceiling, never blackout, even chain-smoking).
- Dose bookkeeping on `db.substance_doses` — substrate hook for future tolerance/addiction, recorded from day one.
- CmdSmoke applies one dose per puff; subtle cyan feedback line renders only when an effect landed.

## Design deltas from the spec sketch (documented in §3)
- Severity-based effect vocabulary instead of float magnitude/duration — composes directly with the condition system's integer severities and tick recovery.
- `ConditionSpec` (tolerance/addiction/organ damage) deferred to its own PR; the dose-history substrate ships now.

## Test plan
- [x] 19 new tests in `world/tests/test_substances.py` — registry, pain-relief shave/bottom-out, sedation stack + cap (chain-smoking + pre-sedated cases), dose bookkeeping, lifecycle, CmdSmoke integration
- [x] Full `world.tests` sweep — **2258 passed**
- [x] Live server reloaded on this code

## Playtest suggestions
- Take damage, light a cigarette, `smoke` while in pain → "The ache dulls a little."
- Chain-smoke a Noir cigarette → two "slow heaviness" lines, then no more sedation (cap working); `medical info` should show the sedative suppression condition ticking back down over ~3 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)