### PR TITLE
Combat diagnostics: always-on audit file, gated channel, cached sink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,9 @@ interactive menus), and `evennia.utils.utils` (general helpers). **Always check
 ## When Stuck
 
 1. **`server/logs/server.log`** — tracebacks and errors.
-2. **The Splattercast channel** — combat debug output (see `specs/COMBAT_REFACTOR_SPEC.md`).
+2. **`server/logs/combat_audit.log`** — every combat/medical diagnostic, always on
+   (async writes via `world/combat/debug.py`).  For live in-game output, set
+   `SPLATTERCAST_LIVE = True` in settings to mirror it to the Splattercast channel.
 3. **Grep for the constant** — most strings live in a `constants.py`.
 4. **Trace from the command** — `commands/` calls into handler/system methods.
 5. **Check NDB state** — many bugs are stale `char.ndb.*` references.

--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -3,7 +3,7 @@ from evennia.utils.search import search_object
 from evennia.utils import delay
 from commands._identity_targeting import resolve_admin_target
 from world.combat.messages import get_combat_message
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 from world.weather import weather_system
 from world.weather.weather_messages import WEATHER_INTENSITY
 from world.identity_utils import msg_room_identity
@@ -331,19 +331,19 @@ class CmdTestDeath(Command):
                 
                 # Block if target outranks caller
                 if target_is_developer and not caller_is_developer:
-                    splattercast = ChannelDB.objects.get_channel("Splattercast")
+                    splattercast = get_splattercast()
                     splattercast.msg(f"MURDER_BLOCKED: {caller.key} attempted @murder on Developer {target.key} - insufficient permissions")
                     caller.msg(f"|rYou cannot use this command on {target.key} - insufficient permissions.|n")
                     return
                 elif target_is_admin and not (caller_is_developer or caller_is_admin):
-                    splattercast = ChannelDB.objects.get_channel("Splattercast")
+                    splattercast = get_splattercast()
                     splattercast.msg(f"MURDER_BLOCKED: {caller.key} attempted @murder on Admin {target.key} - insufficient permissions")
                     caller.msg(f"|rYou cannot use this command on {target.key} - insufficient permissions.|n")
                     return
                 elif (target_is_builder and caller_is_builder and 
                       not (caller_is_admin or caller_is_developer) and not force_test):
                     # Peer protection for builders
-                    splattercast = ChannelDB.objects.get_channel("Splattercast")
+                    splattercast = get_splattercast()
                     splattercast.msg(f"MURDER_BLOCKED: Builder {caller.key} attempted @murder on peer Builder {target.key} without 'force'")
                     caller.msg(f"|yWarning: Using this command on a peer staff member. Add 'force' if you're sure.|n")
                     return
@@ -484,7 +484,7 @@ class CmdTestDeath(Command):
                 # 5 x 10% blood loss per tick = 50% blood loss per tick = death in 2 ticks
                 
             # Log to splattercast for admin debugging
-            splattercast = ChannelDB.objects.get_channel("Splattercast")
+            splattercast = get_splattercast()
             splattercast.msg(f"MURDER_CMD: {caller.key} used @murder on {target.key} - applied arterial hemorrhage conditions")
             
             if force_test:
@@ -553,19 +553,19 @@ class CmdTestUnconscious(Command):
                 
                 # Block if target outranks caller
                 if target_is_developer and not caller_is_developer:
-                    splattercast = ChannelDB.objects.get_channel("Splattercast")
+                    splattercast = get_splattercast()
                     splattercast.msg(f"KNOCKOUT_BLOCKED: {caller.key} attempted @knockout on Developer {target.key} - insufficient permissions")
                     caller.msg(f"|rYou cannot use this command on {target.key} - insufficient permissions.|n")
                     return
                 elif target_is_admin and not (caller_is_developer or caller_is_admin):
-                    splattercast = ChannelDB.objects.get_channel("Splattercast")
+                    splattercast = get_splattercast()
                     splattercast.msg(f"KNOCKOUT_BLOCKED: {caller.key} attempted @knockout on Admin {target.key} - insufficient permissions")
                     caller.msg(f"|rYou cannot use this command on {target.key} - insufficient permissions.|n")
                     return
                 elif (target_is_builder and caller_is_builder and 
                       not (caller_is_admin or caller_is_developer) and not force_test):
                     # Peer protection for builders
-                    splattercast = ChannelDB.objects.get_channel("Splattercast")
+                    splattercast = get_splattercast()
                     splattercast.msg(f"KNOCKOUT_BLOCKED: Builder {caller.key} attempted @knockout on peer Builder {target.key} without 'force'")
                     caller.msg(f"|yWarning: Using this command on a peer staff member. Add 'force' if you're sure.|n")
                     return
@@ -633,7 +633,7 @@ class CmdTestUnconscious(Command):
                 # The medical system will process it organically
                 
             # Log to splattercast for admin debugging
-            splattercast = ChannelDB.objects.get_channel("Splattercast")
+            splattercast = get_splattercast()
             splattercast.msg(f"KNOCKOUT_CMD: {caller.key} used @knockout on {target.key} - applied consciousness suppression")
                 
             caller.msg(f"|r{target.key} has been given consciousness suppression via medical system.|n")
@@ -662,7 +662,7 @@ class CmdPeace(Command):
 
     def func(self):
         caller = self.caller
-        splattercast = ChannelDB.objects.get_channel("Splattercast")
+        splattercast = get_splattercast()
 
         # Default to caller's location
         location = caller.location

--- a/commands/CmdExplosives.py
+++ b/commands/CmdExplosives.py
@@ -14,13 +14,12 @@ Part of the G.R.I.M. Combat System.
 
 import random
 from evennia import Command, utils
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 from world.combat.constants import (
     DEBUG_PREFIX_THROW,
     NDB_PROXIMITY_UNIVERSAL,
     NDB_COUNTDOWN_REMAINING,
     NDB_GRENADE_TIMER,
-    SPLATTERCAST_CHANNEL,
     MSG_RIG_WHAT,
     MSG_RIG_INVALID_SYNTAX,
     MSG_RIG_NO_HANDS,
@@ -198,7 +197,7 @@ class CmdRig(Command):
         return_exit = self.find_return_exit(exit_obj)
         if return_exit:
             return_exit.db.rigged_grenade = grenade
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: Also rigged return exit {return_exit} in {return_exit.location}")
 
         # Cancel normal countdown and set up trigger
@@ -217,7 +216,7 @@ class CmdRig(Command):
             exclude=[self.caller],
         )
 
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} rigged {grenade} to {exit_obj}")
 
     def find_return_exit(self, exit_obj):
@@ -384,7 +383,7 @@ class CmdDefuse(Command):
                     other_char not in char_proximity):
                     char_proximity.append(other_char)
 
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         if splattercast:
             splattercast.msg(f"DEFUSE_PROXIMITY: {self.caller.key} established mutual proximity with {grenade.key} "
                            f"(grenade proximity: {[c.key if hasattr(c, 'key') else str(c) for c in grenade_proximity]})")
@@ -484,7 +483,7 @@ class CmdDefuse(Command):
             )
 
         # Debug output
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         if splattercast:
             grenade_type = "rigged" if is_rigged else "live"
             splattercast.msg(f"DEFUSE: {self.caller.key} rolled {combined_roll} vs difficulty {total_difficulty} "
@@ -523,13 +522,13 @@ class CmdDefuse(Command):
             exclude=[self.caller],
         )
 
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         if splattercast:
             splattercast.msg(f"DEFUSE_SUCCESS: {self.caller.key} defused {grenade.key}")
 
     def clear_grenade_proximity(self, grenade):
         """Clear all proximity relationships for a defused grenade."""
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         # Get grenade's proximity list
         grenade_proximity = getattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, [])
@@ -555,7 +554,7 @@ class CmdDefuse(Command):
         """Clean up rigging references when grenade is defused."""
         rigged_to_exit = grenade.db.rigged_to_exit
         if rigged_to_exit:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
 
             # Clean up main exit
             if rigged_to_exit.db.rigged_grenade is not None:
@@ -641,7 +640,7 @@ class CmdDefuse(Command):
             setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 1)
             utils.delay(1, self.trigger_early_explosion, grenade)
 
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             if splattercast:
                 splattercast.msg(f"DEFUSE_FAILURE: {self.caller.key} triggered early detonation of {grenade.key}")
 
@@ -655,7 +654,7 @@ class CmdDefuse(Command):
                 exclude=[self.caller],
             )
 
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             if splattercast:
                 splattercast.msg(f"DEFUSE_FAILURE: {self.caller.key} failed to defuse {grenade.key} (no early detonation)")
 
@@ -729,7 +728,7 @@ class CmdDefuse(Command):
             grenade.delete()
 
         except Exception as e:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in trigger_early_explosion: {e}")
 
 
@@ -824,7 +823,7 @@ class CmdScan(Command):
             )
 
             # Debug logging
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(
                 f"DETONATOR_SCAN: {caller.key} scanned e-{explosive.id} ({explosive.key}) "
                 f"into detonator #{detonator.id}. Capacity: {len(detonator.db.scanned_explosives)}/{detonator.db.max_capacity}"
@@ -979,7 +978,7 @@ class CmdDetonate(Command):
             caller.msg(f"|rThe {explosive.key} beeps and its light begins flashing!|n |y[{fuse_time} seconds]|n")
 
         # Debug logging
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(
             f"DETONATOR_SINGLE: {caller.key} remotely detonated e-{explosive_dbref} ({explosive.key}) "
             f"via detonator #{detonator.id}. Fuse: {fuse_time}s"
@@ -1074,7 +1073,7 @@ class CmdDetonate(Command):
                     )
 
         # Debug logging
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(
             f"DETONATOR_ALL: {caller.key} remotely detonated {detonated_count} explosives "
             f"via detonator #{detonator.id}. Already active: {already_active_count}"
@@ -1358,7 +1357,7 @@ class CmdClearDetonator(Command):
             )
 
             # Debug logging
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(
                 f"DETONATOR_CLEAR_SINGLE: {caller.key} cleared e-{explosive_dbref} from detonator #{detonator.id}"
             )
@@ -1396,7 +1395,7 @@ class CmdClearDetonator(Command):
         )
 
         # Debug logging
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(
             f"DETONATOR_CLEAR_ALL: {caller.key} cleared {count} explosives from detonator #{detonator.id}"
         )

--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -9,15 +9,14 @@
 # - CmdWrest: Non-combat item snatching with contest mechanics
 #
 from evennia import Command
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 from world.combat.constants import (
     NDB_COMBAT_HANDLER, NDB_PROXIMITY_UNIVERSAL,
     MSG_WREST_SUCCESS_CALLER, MSG_WREST_SUCCESS_TARGET, MSG_WREST_SUCCESS_ROOM,
     MSG_WREST_FAILED_CALLER, MSG_WREST_FAILED_TARGET, MSG_WREST_FAILED_ROOM,
     MSG_WREST_IN_COMBAT, MSG_WREST_NO_FREE_HANDS, MSG_WREST_TARGET_NOT_FOUND,
     MSG_WREST_OBJECT_NOT_IN_HANDS, DB_CHAR, DB_GRAPPLED_BY_DBREF,
-    STAT_GRIT, SPLATTERCAST_CHANNEL,
-)
+    STAT_GRIT, )
 from world.combat.utils import roll_stat, roll_with_disadvantage
 from world.identity_utils import msg_room_identity
 from commands._identity_targeting import resolve_character_target
@@ -943,7 +942,7 @@ class CmdWrest(Command):
         success = caller_roll >= target_roll
         
         # Debug output for testing
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         if splattercast:
             grapple_status = " (grappled)" if target_is_grappled else ""
             splattercast.msg(f"WREST CONTEST: {caller.key} {caller_roll} vs {target.key} {target_roll}{grapple_status} - {'SUCCESS' if success else 'FAILURE'}")

--- a/commands/CmdThrow.py
+++ b/commands/CmdThrow.py
@@ -14,7 +14,7 @@ Part of the G.R.I.M. Combat System.
 
 import random
 from evennia import Command, utils
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 from world.combat.constants import (
     DB_CHAR,
     DB_GRAPPLED_BY_DBREF,
@@ -81,7 +81,6 @@ from world.combat.constants import (
     NDB_PROXIMITY,
     NDB_PROXIMITY_UNIVERSAL,
     NDB_SKIP_ROUND,
-    SPLATTERCAST_CHANNEL,
     THROW_FLIGHT_TIME,
 )
 # Note: apply_damage removed - using character.take_damage() for medical system integration
@@ -342,7 +341,7 @@ class CmdThrow(Command):
     
     def find_target(self):
         """Find target for 'at' syntax throwing."""
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         if not self.target_name:
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: find_target: No target_name provided")
@@ -387,7 +386,7 @@ class CmdThrow(Command):
     
     def get_destination_room(self, direction):
         """Get destination room for directional throwing."""
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         if not direction:
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: get_destination_room: No direction provided")
@@ -475,7 +474,7 @@ class CmdThrow(Command):
         from typeclasses.items import Item
         from world.combat.utils import get_outermost_armor_at_location
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # Get all characters except thrower
         characters = [obj for obj in room.contents if isinstance(obj, Character) and obj != self.caller]
@@ -541,7 +540,7 @@ class CmdThrow(Command):
         # Enter combat if not already in combat
         handler = get_or_create_combat(self.caller.location)
         if not handler:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Failed to get combat handler for weapon throw")
             return False
         
@@ -609,7 +608,7 @@ class CmdThrow(Command):
         # Start flight timer and store reference for potential cancellation
         obj.ndb.flight_timer = utils.delay(THROW_FLIGHT_TIME, self.complete_flight, obj)
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} started flight for {obj} to {destination}(#{destination.id})")
     
     def announce_throw_origin(self, obj, destination, target):
@@ -660,7 +659,7 @@ class CmdThrow(Command):
         """Complete the flight and handle landing."""
         splattercast = None
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Starting complete_flight for {obj}")
             
             # Check if object is None or doesn't have ndb (deleted/caught)
@@ -813,7 +812,7 @@ class CmdThrow(Command):
     def handle_landing(self, obj, destination, target, is_weapon, thrower):
         """Handle object landing and proximity assignment."""
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: handle_landing called - obj: {obj}, destination: {destination}, target: {target}, is_weapon: {is_weapon}")
             
             # Track whether we've shown a target interaction message
@@ -906,7 +905,7 @@ class CmdThrow(Command):
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: handle_landing completed successfully")
             
         except Exception as e:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Unexpected error in handle_landing: {e}")
             # Don't re-raise - let the object land even if there are issues
     
@@ -929,7 +928,7 @@ class CmdThrow(Command):
                 hit_location = "chest"  # Default hit location for throws
                 
                 if is_sticky:
-                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    splattercast = get_splattercast()
                     splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY: Sticky grenade {weapon.key} hit {target.key}")
                     
                     # Get outermost armor at hit location
@@ -1035,14 +1034,14 @@ class CmdThrow(Command):
                 )
                 
         except Exception as e:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in resolve_weapon_hit: {e}")
             # Don't re-raise - weapon hit failure shouldn't fail entire throw
     
     def assign_landing_proximity(self, obj, target, thrower=None):
         """Assign proximity for universal proximity system."""
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: assign_landing_proximity called - obj: {obj}, target: {target}, thrower: {thrower}")
             
             # Ensure object has proximity list (use same pattern as drop command)
@@ -1096,14 +1095,14 @@ class CmdThrow(Command):
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: assign_landing_proximity completed successfully")
             
         except Exception as e:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in assign_landing_proximity: {e}")
             raise  # Re-raise to let handle_landing handle it
     
     def handle_grenade_landing(self, grenade, target, thrower=None):
         """Handle grenade-specific landing mechanics."""
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: handle_grenade_landing called - grenade: {grenade}, target: {target}, thrower: {thrower}")
             
             # If grenade lands near someone, everyone in their proximity gets added
@@ -1128,14 +1127,14 @@ class CmdThrow(Command):
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: Grenade {grenade} landed with proximity: {getattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, [])}")
             
         except Exception as e:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in handle_grenade_landing: {e}")
             # Don't re-raise here - grenade landing failure shouldn't fail entire throw
     
     def check_grenade_deflection(self, grenade, destination, thrower):
         """Check if the specific target can deflect the incoming grenade with a melee weapon."""
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: check_grenade_deflection called for {grenade} in {destination}")
             
             # Future-proofing: Skip deflection for impact grenades (explode on contact)
@@ -1216,7 +1215,7 @@ class CmdThrow(Command):
                 return False
                 
         except Exception as e:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in check_grenade_deflection: {e}")
             return False
     
@@ -1229,7 +1228,7 @@ class CmdThrow(Command):
     def perform_grenade_deflection(self, grenade, deflector, weapon, original_thrower, current_location):
         """Perform the actual grenade deflection."""
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: perform_grenade_deflection called")
             
             # Announce successful deflection
@@ -1254,14 +1253,14 @@ class CmdThrow(Command):
                 return True
                 
         except Exception as e:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in perform_grenade_deflection: {e}")
             return False
     
     def determine_deflection_target(self, grenade, deflector, original_thrower, current_location):
         """Determine where the deflected grenade goes."""
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             
             # Get grenade's original flight data
             origin = getattr(grenade.ndb, 'flight_origin', None)
@@ -1324,7 +1323,7 @@ class CmdThrow(Command):
             return True
             
         except Exception as e:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in determine_deflection_target: {e}")
             return False
 
@@ -1436,7 +1435,7 @@ class CmdPull(Command):
         # Timer warning
         self.caller.msg(MSG_PULL_TIMER_WARNING.format(object=grenade.key, time=fuse_time))
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} pulled pin on {grenade}, timer: {fuse_time}s")
     
     def start_grenade_ticker(self, grenade):
@@ -1450,7 +1449,7 @@ class CmdPull(Command):
                 remaining = getattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0)
                 
                 # Debug output
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 if splattercast:
                     splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER: {grenade.key} countdown: {remaining}s remaining")
                 
@@ -1507,11 +1506,11 @@ class CmdPull(Command):
                     # Create a proper closure that captures the explosion function
                     def trigger_explosion():
                         try:
-                            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                            splattercast = get_splattercast()
                             splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER: Triggering explosion for {grenade.key}")
                             explode_standalone_grenade(grenade)
                         except Exception as e:
-                            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                            splattercast = get_splattercast()
                             splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Error in trigger_explosion: {e}")
                     
                     timer = utils.delay(1, trigger_explosion)
@@ -1528,7 +1527,7 @@ class CmdPull(Command):
                     
             except Exception as e:
                 # Failsafe - if ticker fails, explode immediately to avoid duds
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 if splattercast:
                     splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Ticker error for {grenade.key}: {e} - triggering explosion")
                 try:
@@ -1664,7 +1663,7 @@ class CmdCatch(Command):
                 pass  # Timer may have already fired
             del obj.ndb.flight_timer
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         if splattercast:
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} caught {obj} mid-flight")
 

--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -313,9 +313,9 @@ def create_character_from_template(account, template, sex="ambiguous"):
     # sdesc_keyword defaults via get_sdesc() based on gender
     
     # Debug: Verify sex was set correctly
-    from evennia.comms.models import ChannelDB
+    from world.combat.debug import get_splattercast
     try:
-        splattercast = ChannelDB.objects.get_channel("Splattercast")
+        splattercast = get_splattercast()
         splattercast.msg(f"CHARCREATE_SEX_SET: {char.key} sex set to '{sex}', current value: '{char.sex}', gender property: '{char.gender}'")
     except Exception:
         pass
@@ -409,9 +409,9 @@ def create_flash_clone(account, old_character):
     # empty brains and recognise nobody.
     
     # Debug: Verify sex was inherited correctly
-    from evennia.comms.models import ChannelDB
+    from world.combat.debug import get_splattercast
     try:
-        splattercast = ChannelDB.objects.get_channel("Splattercast")
+        splattercast = get_splattercast()
         splattercast.msg(f"FLASH_CLONE_SEX_INHERIT: {char.key} inherited sex '{old_character.sex}' from {old_character.key}, current value: '{char.sex}', gender property: '{char.gender}'")
     except Exception:
         pass
@@ -751,9 +751,9 @@ def respawn_finalize_template(caller, raw_string, **kwargs):
     except Exception as e:
         # Error - show message and return to selection
         caller.msg(f"|rError creating character: {e}|n")
-        from evennia.comms.models import ChannelDB
+        from world.combat.debug import get_splattercast
         try:
-            splattercast = ChannelDB.objects.get_channel("Splattercast")
+            splattercast = get_splattercast()
             splattercast.msg(f"CHARCREATE_ERROR: {e}")
         except Exception:
             pass
@@ -825,9 +825,9 @@ def respawn_flash_clone(caller, raw_string, **kwargs):
     except Exception as e:
         # Error - show message and return to selection
         caller.msg(f"|rError creating flash clone: {e}|n")
-        from evennia.comms.models import ChannelDB
+        from world.combat.debug import get_splattercast
         try:
-            splattercast = ChannelDB.objects.get_channel("Splattercast")
+            splattercast = get_splattercast()
             splattercast.msg(f"FLASH_CLONE_ERROR: {e}")
         except Exception:
             pass
@@ -1500,9 +1500,9 @@ def first_char_finalize(caller, raw_string, **kwargs):
     except Exception as e:
         # Error - show message and return to confirmation
         caller.msg(f"|rError creating character: {e}|n")
-        from evennia.comms.models import ChannelDB
+        from world.combat.debug import get_splattercast
         try:
-            splattercast = ChannelDB.objects.get_channel("Splattercast")
+            splattercast = get_splattercast()
             splattercast.msg(f"CHARCREATE_ERROR: {e}")
         except Exception:
             pass

--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -12,7 +12,7 @@ by players during combat encounters.
 from random import randint
 
 from evennia import Command
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 from evennia.utils.utils import inherits_from
 
 from world.combat.constants import (
@@ -23,8 +23,7 @@ from world.combat.constants import (
     DEBUG_PREFIX_ATTACK, DEBUG_FAILSAFE, DEBUG_SUCCESS, DEBUG_FAIL,
     DB_COMBAT_ACTION, DB_COMBAT_ACTION_TARGET, DB_IS_YIELDING,
     NDB_PROXIMITY, NDB_COMBAT_HANDLER, NDB_AIMING_AT, NDB_AIMED_AT_BY,
-    NDB_AIMING_DIRECTION, SPLATTERCAST_CHANNEL,
-)
+    NDB_AIMING_DIRECTION, )
 from commands._identity_targeting import resolve_character_target
 from world.combat.handler import get_or_create_combat
 from world.combat.messages import get_combat_message
@@ -57,7 +56,7 @@ class CmdAttack(Command):
     def func(self):
         caller = self.caller
         args = self.args.strip()
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         if not args:
             caller.msg(MSG_ATTACK_WHO)

--- a/commands/combat/jump.py
+++ b/commands/combat/jump.py
@@ -14,13 +14,11 @@ CmdJump handles three distinct sub-systems:
 
 from evennia import Command, search_object
 from evennia.utils.utils import delay
-from evennia.comms.models import ChannelDB
 
 from world.combat.constants import (
     NDB_COMBAT_HANDLER,
     NDB_COUNTDOWN_REMAINING,
     NDB_GRENADE_TIMER,
-    SPLATTERCAST_CHANNEL,
     NDB_PROXIMITY,
     NDB_SKIP_ROUND,
 )
@@ -34,16 +32,7 @@ from world.combat.handler import get_or_create_combat
 from world.grammar import capitalize_first
 from world.identity_utils import msg_room_identity
 
-# Module-level cache for the Splattercast debug channel
-_splattercast_cache = None
-
-
-def _get_splattercast():
-    """Return the cached Splattercast channel, fetching once from DB."""
-    global _splattercast_cache
-    if _splattercast_cache is None:
-        _splattercast_cache = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-    return _splattercast_cache
+from world.combat.debug import get_splattercast
 
 
 class CmdJump(Command):
@@ -143,7 +132,7 @@ class CmdJump(Command):
     
     def handle_explosive_sacrifice(self):
         """Handle jumping on explosive for heroic sacrifice."""
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         
         # Check if caller is being grappled (can't sacrifice while restrained)
         handler = getattr(self.caller.ndb, NDB_COMBAT_HANDLER, None)
@@ -425,7 +414,7 @@ class CmdJump(Command):
     
     def handle_edge_descent(self):
         """Handle jumping off edge for tactical descent."""
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         
         # Initialize grappled_victim variable
         grappled_victim = None
@@ -580,7 +569,7 @@ class CmdJump(Command):
     
     def handle_gap_jump(self):
         """Handle jumping across gap between same-level areas."""
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         
         # Check if caller is being grappled (can't jump while restrained)
         handler = getattr(self.caller.ndb, NDB_COMBAT_HANDLER, None)
@@ -673,7 +662,7 @@ class CmdJump(Command):
     
     def execute_successful_gap_jump(self, exit_obj, destination):
         """Execute a successful gap jump with sky room transit."""
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         
         # Get sky room directly from the exit object
         sky_room_id = exit_obj.db.sky_room
@@ -732,7 +721,7 @@ class CmdJump(Command):
     
     def finalize_successful_gap_jump(self, destination, origin_room):
         """Finalize successful gap jump with cleanup and messaging."""
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         
         # Clear combat state if fleeing via gap
         handler = getattr(self.caller.ndb, NDB_COMBAT_HANDLER, None)
@@ -801,7 +790,7 @@ class CmdJump(Command):
     
     def handle_gap_jump_failure(self, exit_obj, destination):
         """Handle failed gap jump with fall consequences."""
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         
         # Find or use existing sky room for this gap
         sky_room = self.get_sky_room_for_gap(self.caller.location, destination, self.direction)
@@ -878,7 +867,7 @@ class CmdJump(Command):
     
     def handle_fall_failure(self, exit_obj, destination, fall_type, grappled_victim=None):
         """Handle general fall failure (for edge descent failures)."""
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         
         # For edge descent failure, apply damage but stay in current room
         fall_damage = exit_obj.db.fall_damage if exit_obj.db.fall_damage is not None else 8  # Default moderate damage
@@ -901,7 +890,7 @@ class CmdJump(Command):
     
     def get_sky_room_for_gap(self, origin, destination, direction):
         """Get the sky room associated with this gap, checking both directions."""
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         
         # First try: look for sky room on the exit from origin
         exit_obj = origin.search(direction, quiet=True)
@@ -978,7 +967,7 @@ class CmdJump(Command):
 
     def handle_edge_fall_and_landing(self, exit_obj, destination, grappled_victim=None):
         """Handle fall mechanics and landing after jumping off an edge."""
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         
         # Check for preserved bodyshield relationship
         bodyshield_victim = getattr(self.caller.ndb, "bodyshield_victim", None)
@@ -1217,7 +1206,7 @@ class CmdJump(Command):
         Returns:
             tuple: (final_room, rooms_fallen)
         """
-        splattercast = _get_splattercast()
+        splattercast = get_splattercast()
         current_room = start_room
         rooms_fallen = 0
         max_depth = 10  # Safety limit to prevent infinite loops
@@ -1274,7 +1263,7 @@ def apply_gravity_to_items(room):
     Args:
         room: The room to check for items that need to fall
     """
-    splattercast = _get_splattercast()
+    splattercast = get_splattercast()
     
     # Check if this is a sky room
     is_sky_room = room.db.is_sky_room

--- a/commands/combat/movement.py
+++ b/commands/combat/movement.py
@@ -13,7 +13,7 @@ commands/combat/jump.py and are re-exported here for backward compatibility.
 
 from evennia import Command
 from random import choice
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 
 from world.combat.constants import (
     MSG_NOTHING_TO_FLEE, MSG_FLEE_NO_EXITS, MSG_FLEE_PINNED_BY_AIM, MSG_FLEE_TRAPPED_IN_COMBAT,
@@ -26,7 +26,6 @@ from world.combat.constants import (
     DEBUG_FAIL, DEBUG_ERROR,
     DB_COMBAT_ACTION, DB_COMBAT_ACTION_TARGET,
     NDB_COMBAT_HANDLER, NDB_AIMING_AT, NDB_AIMED_AT_BY, NDB_PROXIMITY, NDB_SKIP_ROUND,
-    SPLATTERCAST_CHANNEL,
     COMBAT_ACTION_RETREAT, MSG_RETREAT_PREPARE,
     COMBAT_ACTION_ADVANCE, MSG_ADVANCE_PREPARE,
     COMBAT_ACTION_CHARGE, MSG_CHARGE_PREPARE,
@@ -70,7 +69,7 @@ class CmdFlee(Command):
 
     def func(self):
         caller = self.caller
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # Check if player has already attempted to flee this combat round
         if hasattr(caller.ndb, "flee_attempted_this_round") and caller.ndb.flee_attempted_this_round:
@@ -450,7 +449,7 @@ class CmdRetreat(Command):
 
     def func(self):
         caller = self.caller
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         handler = getattr(caller.ndb, NDB_COMBAT_HANDLER, None)
 
         if not handler:
@@ -517,7 +516,7 @@ class CmdAdvance(Command):
     def func(self):
         caller = self.caller
         args = self.args.strip()
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # Use robust handler validation to catch merge-related issues
         from world.combat.utils import validate_character_handler_reference
@@ -609,7 +608,7 @@ class CmdCharge(Command):
     def func(self):
         caller = self.caller
         args = self.args.strip()
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         handler = getattr(caller.ndb, NDB_COMBAT_HANDLER, None)
 
         if not handler:

--- a/commands/combat/special_actions.py
+++ b/commands/combat/special_actions.py
@@ -15,7 +15,7 @@ and add complexity to combat encounters.
 import random
 
 from evennia import Command
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 from evennia.utils.utils import inherits_from
 
 from world.combat.constants import (
@@ -27,7 +27,7 @@ from world.combat.constants import (
     MSG_NOT_IN_COMBAT, MSG_DISARM_NO_TARGET, MSG_DISARM_NOT_IN_PROXIMITY,
     MSG_DISARM_PREPARE,
     MSG_AIM_WHO_WHAT, MSG_AIM_SELF_TARGET, MSG_GRAPPLE_ESCAPE_VIOLENT_SWITCH,
-    MSG_STOP_NOT_AIMING, SPLATTERCAST_CHANNEL, NDB_PROXIMITY,
+    MSG_STOP_NOT_AIMING, NDB_PROXIMITY,
     NDB_COMBAT_HANDLER, NDB_AIMING_AT, NDB_AIMED_AT_BY, NDB_AIMING_DIRECTION,
     DB_COMBAT_ACTION, DB_COMBAT_ACTION_TARGET, DB_IS_YIELDING,
     COMBAT_ACTION_DISARM,
@@ -318,7 +318,7 @@ class CmdDisarm(Command):
         caller.msg(MSG_DISARM_PREPARE.format(target=target.get_display_name(caller)))
         
         # Debug message
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         if splattercast:
             splattercast.msg(f"DISARM: {caller.key} queued disarm action on {target.key} for next turn.")
 
@@ -348,7 +348,7 @@ class CmdAim(Command):
     def func(self):
         caller = self.caller
         args = self.args.strip()
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # Debug: Verify our enhanced aim command is being called
         splattercast.msg(f"ENHANCED_AIM: {caller.key} called enhanced aim command with args='{args}'")

--- a/commands/explosion_utils.py
+++ b/commands/explosion_utils.py
@@ -18,7 +18,7 @@ Part of the G.R.I.M. Combat System.
 
 import random
 from evennia import utils
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 from world.identity_utils import msg_room_identity
 from world.combat.constants import (
     DEBUG_PREFIX_THROW,
@@ -30,7 +30,6 @@ from world.combat.constants import (
     DB_CHAR,
     DB_GRAPPLED_BY_DBREF,
     DB_GRAPPLING_DBREF,
-    SPLATTERCAST_CHANNEL,
     MSG_GRENADE_EXPLODE_ROOM,
     MSG_GRENADE_EXPLODE_ADJACENT,
     MSG_GRENADE_DAMAGE,
@@ -83,7 +82,7 @@ def notify_adjacent_rooms_of_explosion(explosion_room):
 def check_rigged_grenade(character, exit_obj):
     """Check if character triggers a rigged grenade. Character should already be at destination."""
     # Initialize Splattercast for debug logging
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
 
     # Check if there's a rigged grenade on this exit
     rigged_grenade = exit_obj.db.rigged_grenade
@@ -154,7 +153,7 @@ def check_rigged_grenade(character, exit_obj):
         if character not in proximity_list:
             proximity_list.append(character)
 
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     splattercast.msg(f"{DEBUG_PREFIX_THROW}_RIGGED: Established proximity for {rigged_grenade.key}: {[char.key for char in proximity_list]}")
 
     # Start countdown timer
@@ -229,7 +228,7 @@ def check_rigged_grenade(character, exit_obj):
             rigged_grenade.delete()
 
         except Exception as e:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in explode_rigged_grenade: {e}")
 
     # Start the timer
@@ -250,14 +249,14 @@ def check_rigged_grenade(character, exit_obj):
                 obj.destination == character_room and
                 obj.db.rigged_grenade == rigged_grenade):
                 obj.db.rigged_grenade = None
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: Cleaned up return exit rigging on {obj}")
                 break
 
     # Announce timer start
     character.location.msg_contents(f"The {rigged_grenade.key} starts counting down! {fuse_time} seconds!")
 
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     splattercast.msg(f"{DEBUG_PREFIX_THROW}_RIGGED: {character.key} triggered rigged {rigged_grenade.key} on {exit_obj.key}, timer: {fuse_time}s")
 
     # Return True to indicate explosion timer started
@@ -275,7 +274,7 @@ def start_standalone_grenade_ticker(grenade, explosion_callback=None):
             remaining = getattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0)
 
             # Debug output
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             if splattercast:
                 splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER: {grenade.key} countdown: {remaining}s remaining")
 
@@ -315,7 +314,7 @@ def start_standalone_grenade_ticker(grenade, explosion_callback=None):
 
         except Exception as e:
             # Failsafe - if ticker fails, explode immediately to avoid duds
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             if splattercast:
                 splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Ticker error for {grenade.key}: {e} - triggering explosion")
             try:
@@ -339,7 +338,7 @@ def get_unified_explosion_proximity(grenade):
     relationships were established relative to grenade placement.
     """
     try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         # Start with grenade's existing proximity list
         proximity_list = getattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, [])
@@ -370,7 +369,7 @@ def get_unified_explosion_proximity(grenade):
         return unified_list
 
     except Exception as e:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in get_unified_explosion_proximity: {e}")
         # Return original proximity list as fallback
         return getattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, [])
@@ -382,7 +381,7 @@ def explode_standalone_grenade(grenade):
         # Note: Using character.take_damage() for medical system integration
 
         # Debug: Confirm this function is being called
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: explode_standalone_grenade called for {grenade}")
 
         # Debug: Check dud chance
@@ -552,7 +551,7 @@ def explode_standalone_grenade(grenade):
         grenade.delete()
 
     except Exception as e:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in explode_standalone_grenade: {e}")
 
 
@@ -596,14 +595,14 @@ def check_auto_defuse(character):
             attempt_auto_defuse(character, grenade)
 
     except Exception as e:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in check_auto_defuse for {character.key}: {e}")
 
 
 def attempt_auto_defuse(character, grenade):
     """Attempt automatic defuse when entering proximity of live grenade."""
     try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         # Mark attempt to prevent spam (same as manual defuse)
         attempted_by = getattr(grenade.ndb, 'defuse_attempted_by', [])
@@ -651,7 +650,7 @@ def attempt_auto_defuse(character, grenade):
             handle_auto_defuse_failure(character, grenade)
 
     except Exception as e:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in attempt_auto_defuse for {character.key} and {grenade.key}: {e}")
 
 
@@ -677,11 +676,11 @@ def handle_auto_defuse_success(character, grenade):
             exclude=[character],
         )
 
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_SUCCESS: {character.key} auto-defused {grenade.key}")
 
     except Exception as e:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in handle_auto_defuse_success: {e}")
 
 
@@ -710,7 +709,7 @@ def handle_auto_defuse_failure(character, grenade):
             setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 1)
             utils.delay(1, trigger_auto_defuse_explosion, grenade)
 
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"AUTO_DEFUSE_FAILURE: {character.key} triggered early detonation of {grenade.key}")
 
         else:
@@ -723,11 +722,11 @@ def handle_auto_defuse_failure(character, grenade):
                 exclude=[character],
             )
 
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"AUTO_DEFUSE_FAILURE: {character.key} failed to auto-defuse {grenade.key} (no early detonation)")
 
     except Exception as e:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in handle_auto_defuse_failure: {e}")
 
 
@@ -802,5 +801,5 @@ def trigger_auto_defuse_explosion(grenade):
         grenade.delete()
 
     except Exception as e:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in trigger_auto_defuse_explosion: {e}")

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -164,6 +164,17 @@ DISCOURSE_SSO_SECRET = ""
 DEBUG = False
 
 ######################################################################
+# Combat audit logging
+######################################################################
+
+# Combat diagnostics always go to server/logs/combat_audit.log
+# (async file writes — see world/combat/debug.py).  Set this True to
+# additionally broadcast them live to the Splattercast channel for
+# in-game debugging sessions.  Keep False in production: the live
+# broadcast renders and sends every diagnostic to channel listeners.
+SPLATTERCAST_LIVE = False
+
+######################################################################
 # Logging Configuration
 ######################################################################
 

--- a/typeclasses/armor_mixin.py
+++ b/typeclasses/armor_mixin.py
@@ -194,11 +194,8 @@ class ArmorMixin:
                     # death_progression still fires as a fallback because
                     # ``head_severed_at_decap`` was never set.
                     try:
-                        from evennia.comms.models import ChannelDB
-                        from world.combat.constants import SPLATTERCAST_CHANNEL
-                        splattercast = ChannelDB.objects.get_channel(
-                            SPLATTERCAST_CHANNEL
-                        )
+                        from world.combat.debug import get_splattercast
+                        splattercast = get_splattercast()
                         splattercast.msg(
                             f"DECAPITATION_LIVING_SPAWN_ERROR: "
                             f"{getattr(self, 'key', '?')} - falling back "
@@ -274,11 +271,8 @@ class ArmorMixin:
         except Exception:
             # Don't break combat if the messaging layer hiccups.
             try:
-                from evennia.comms.models import ChannelDB
-                from world.combat.constants import SPLATTERCAST_CHANNEL
-                splattercast = ChannelDB.objects.get_channel(
-                    SPLATTERCAST_CHANNEL
-                )
+                from world.combat.debug import get_splattercast
+                splattercast = get_splattercast()
                 splattercast.msg(
                     f"DECAPITATION_MSG_ERROR: {self.key} - failed to "
                     f"broadcast decapitation message"

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -10,7 +10,7 @@ creation commands.
 
 from evennia.objects.objects import DefaultCharacter
 from evennia.typeclasses.attributes import AttributeProperty
-from evennia.comms.models import ChannelDB  # Ensure this is imported
+from world.combat.debug import get_splattercast
 
 from world.combat.constants import NDB_AIMED_AT_BY, NDB_AIMING_AT, NDB_AIMING_DIRECTION, NDB_COMBAT_HANDLER
 from world.identity_utils import msg_room_identity
@@ -316,14 +316,13 @@ class Character(
         Provides unconsciousness messaging to character and room.
         Triggers removal from combat if currently fighting.
         """
-        from evennia.comms.models import ChannelDB
-        from world.combat.constants import SPLATTERCAST_CHANNEL, NDB_COMBAT_HANDLER
+        from world.combat.constants import NDB_COMBAT_HANDLER
         from evennia.utils.utils import delay
         
         # Prevent double unconsciousness processing
         if hasattr(self, 'ndb') and getattr(self.ndb, 'unconsciousness_processed', False):
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"UNCONSCIOUS_SKIP: {self.key} already processed unconsciousness, skipping")
             except Exception:
                 pass
@@ -342,7 +341,7 @@ class Character(
             # Set flag for combat system to trigger unconsciousness message after attack message
             self.ndb.unconsciousness_pending = True
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"UNCONSCIOUS_COMBAT: {self.key} unconsciousness message deferred - in active combat")
             except Exception:
                 pass
@@ -351,7 +350,7 @@ class Character(
             def fallback_unconsciousness_message():
                 if hasattr(self.ndb, 'unconsciousness_pending') and self.ndb.unconsciousness_pending:
                     try:
-                        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                        splattercast = get_splattercast()
                         splattercast.msg(f"UNCONSCIOUS_FALLBACK: {self.key} triggering fallback unconsciousness message")
                     except Exception:
                         pass
@@ -472,8 +471,7 @@ class Character(
         # Log warning if archiving a staff character (shouldn't happen normally)
         if self.account and self.account.is_superuser:
             try:
-                from world.combat.constants import SPLATTERCAST_CHANNEL
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"WARNING: Archiving staff character {self.key} (Account: {self.account.key}, Reason: {reason})")
             except Exception:
                 pass
@@ -501,8 +499,7 @@ class Character(
             
             # Log the move
             try:
-                from world.combat.constants import SPLATTERCAST_CHANNEL
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"ARCHIVE: Moved {self.key} from {current_location.key if current_location else 'None'} to Limbo")
             except Exception:
                 pass
@@ -630,14 +627,13 @@ class Character(
         Shows death curtain which will then start the death progression system.
         """
         from .curtain_of_death import show_death_curtain
-        from evennia.comms.models import ChannelDB
-        from world.combat.constants import SPLATTERCAST_CHANNEL, NDB_COMBAT_HANDLER
+        from world.combat.constants import NDB_COMBAT_HANDLER
         from evennia.utils.utils import delay
         
         # Prevent double death processing using PERSISTENT db flag (survives server reload)
         if self.db.death_processed:
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"AT_DEATH_SKIP: {self.key} already processed death (db flag), skipping")
             except Exception:
                 pass
@@ -663,7 +659,7 @@ class Character(
         
         # Always show death analysis when character dies
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             death_analysis = self.debug_death_analysis()
             splattercast.msg(death_analysis)
         except Exception as e:
@@ -677,7 +673,7 @@ class Character(
             # Set flag for combat system to trigger death curtain after kill message
             self.ndb.death_curtain_pending = True
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"AT_DEATH_COMBAT: {self.key} death curtain deferred - in active combat")
             except Exception:
                 pass
@@ -686,7 +682,7 @@ class Character(
             def fallback_death_curtain():
                 if hasattr(self.ndb, 'death_curtain_pending') and self.ndb.death_curtain_pending:
                     try:
-                        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                        splattercast = get_splattercast()
                         splattercast.msg(f"AT_DEATH_FALLBACK: {self.key} triggering fallback death curtain")
                     except Exception:
                         pass
@@ -822,9 +818,7 @@ class Character(
         if (hasattr(self, 'medical_state') and self.medical_state and 
             self.medical_state.conditions):
             try:
-                from evennia.comms.models import ChannelDB
-                from world.combat.constants import SPLATTERCAST_CHANNEL
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 
                 # Find stopped medical script and restart it
                 medical_scripts = self.scripts.get("medical_script")
@@ -876,8 +870,6 @@ class Character(
         Apply final death state after death progression completes.
         This is permanent death until manual revival by admin.
         """
-        from evennia.comms.models import ChannelDB
-        from world.combat.constants import SPLATTERCAST_CHANNEL
         
         # Update placement description for permanent death
         self.override_place = "lying motionless and deceased."
@@ -889,7 +881,7 @@ class Character(
         
         # Log final death
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"FINAL_DEATH: {self.key} has entered permanent death state")
         except Exception:
             pass
@@ -1782,8 +1774,7 @@ class Character(
         Returns:
             bool: True if an aim state was actually cleared, False otherwise.
         """
-        from world.combat.constants import SPLATTERCAST_CHANNEL
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         stopped_aiming_message_parts = []
         log_message_parts = []
         action_taken = False

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -546,9 +546,8 @@ class Corpse(IdentityBearerMixin, Item):
             except Exception as e:
                 # Don't break corpse display if wound description fails
                 try:
-                    from evennia.comms.models import ChannelDB
-                    from world.combat.constants import SPLATTERCAST_CHANNEL
-                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    from world.combat.debug import get_splattercast
+                    splattercast = get_splattercast()
                     splattercast.msg(f"CORPSE_WOUND_ERROR: Failed to generate wound description for {self.key}: {e}")
                 except Exception:
                     pass
@@ -1008,9 +1007,8 @@ class Corpse(IdentityBearerMixin, Item):
                 
         # Log the decay completion
         try:
-            from evennia.comms.models import ChannelDB
-            from world.combat.constants import SPLATTERCAST_CHANNEL
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            from world.combat.debug import get_splattercast
+            splattercast = get_splattercast()
             splattercast.msg(f"CORPSE_DECAY: {self.key} completely decayed and removed from {self.location}")
         except Exception:
             pass

--- a/typeclasses/curtain_of_death.py
+++ b/typeclasses/curtain_of_death.py
@@ -304,8 +304,8 @@ class DeathCurtain:
             
             # Debug logging
             try:
-                from evennia.comms.models import ChannelDB
-                splattercast = ChannelDB.objects.get_channel("Splattercast")
+                from world.combat.debug import get_splattercast
+                splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_CURTAIN: Death progression started for {self.character.key}, script: {script}")
             except Exception:
                 pass
@@ -313,8 +313,8 @@ class DeathCurtain:
         except Exception as e:
             # Debug logging for any errors
             try:
-                from evennia.comms.models import ChannelDB
-                splattercast = ChannelDB.objects.get_channel("Splattercast")
+                from world.combat.debug import get_splattercast
+                splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_CURTAIN_ERROR: Failed to start death progression for {self.character.key}: {e}")
             except Exception:
                 pass

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -19,12 +19,11 @@ This creates urgency for medical response while making death less instantaneous.
 
 from evennia import DefaultScript
 from evennia.utils import delay
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 from world.combat.constants import (
     DEATH_PROGRESSION_DURATION,
     DEATH_PROGRESSION_CHECK_INTERVAL,
     DEATH_PROGRESSION_MESSAGE_COUNT,
-    SPLATTERCAST_CHANNEL,
 )
 import random
 import time
@@ -136,7 +135,7 @@ class DeathProgressionScript(DefaultScript):
         
         # Debug logging
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(
                 f"DEATH_PROGRESSION: Script at_script_creation for {self.obj.key} "
                 f"(duration: {DEATH_PROGRESSION_DURATION}s, "
@@ -155,7 +154,7 @@ class DeathProgressionScript(DefaultScript):
             
         # Log start of death progression with configurable duration
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             duration_minutes = DEATH_PROGRESSION_DURATION / 60
             splattercast.msg(
                 f"DEATH_PROGRESSION: Started for {character.key} - "
@@ -173,7 +172,7 @@ class DeathProgressionScript(DefaultScript):
         if not character:
             # Log cleanup for invalid character
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script (invalid character)")
             except Exception:
                 pass
@@ -186,7 +185,7 @@ class DeathProgressionScript(DefaultScript):
         
         # Debug logging
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"DEATH_PROGRESSION: at_repeat for {character.key}, elapsed: {elapsed:.1f}s")
         except Exception:
             pass
@@ -240,7 +239,7 @@ class DeathProgressionScript(DefaultScript):
             
         # Log medical revival
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             elapsed = time.time() - self.db.start_time
             splattercast.msg(f"MEDICAL_REVIVAL: {character.key} revived by medical treatment after {elapsed:.1f}s")
             splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script for {character.key} (medical revival)")
@@ -356,7 +355,7 @@ class DeathProgressionScript(DefaultScript):
             
         # Log progression
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"DEATH_PROGRESSION: {character.key} at {interval}s (msg {message_index + 1}/{len(messages_list)}) - {minutes_remaining}m remaining")
         except Exception:
             pass
@@ -466,7 +465,7 @@ class DeathProgressionScript(DefaultScript):
             
         # Log completion
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"DEATH_PROGRESSION: {character.key} completed - corpse created, character transitioned")
             splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script for {character.key}")
         except Exception:
@@ -500,7 +499,7 @@ class DeathProgressionScript(DefaultScript):
                 
             # 5. Log the transition
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_COMPLETION: {character.key} -> Corpse created, character transitioned")
             except Exception:
                 pass
@@ -508,7 +507,7 @@ class DeathProgressionScript(DefaultScript):
         except Exception as e:
             # Fallback - log error but don't crash the death progression
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_COMPLETION_ERROR: {character.key} - {e}")
             except Exception:
                 pass
@@ -592,7 +591,7 @@ class DeathProgressionScript(DefaultScript):
             _clear_all_overrides(character)
         except Exception as e:
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(
                     f"DEATH_OVERRIDE_CLEAR_ERROR: {character.key} - {e}"
                 )
@@ -619,7 +618,7 @@ class DeathProgressionScript(DefaultScript):
             try:
                 corpse.db.medical_state_at_death = character.medical_state.to_dict()
                 try:
-                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    splattercast = get_splattercast()
                     organ_count = len(corpse.db.medical_state_at_death.get("organs", {}))
                     splattercast.msg(
                         f"DEATH_MEDICAL_SNAPSHOT: {organ_count} organs preserved "
@@ -629,7 +628,7 @@ class DeathProgressionScript(DefaultScript):
                     pass
             except Exception as snapshot_err:
                 try:
-                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    splattercast = get_splattercast()
                     splattercast.msg(
                         f"DEATH_MEDICAL_SNAPSHOT_ERROR: Failed to snapshot "
                         f"medical state for {character.key}: {snapshot_err}"
@@ -661,14 +660,14 @@ class DeathProgressionScript(DefaultScript):
                         corpse.db.wounds_at_death.append(wound_record)
                     
                     try:
-                        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                        splattercast = get_splattercast()
                         splattercast.msg(f"DEATH_WOUNDS_PRESERVED: {len(wound_data)} wounds preserved on corpse for {character.key}")
                     except Exception:
                         pass
             except Exception as e:
                 # Don't fail death progression if wound preservation fails
                 try:
-                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    splattercast = get_splattercast()
                     splattercast.msg(f"DEATH_WOUNDS_ERROR: Failed to preserve wounds for {character.key}: {e}")
                 except Exception:
                     pass
@@ -705,7 +704,7 @@ class DeathProgressionScript(DefaultScript):
         
         # Debug logging for item transfer
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             if transferred_items:
                 splattercast.msg(f"DEATH_ITEMS_TRANSFERRED: {len(transferred_items)} items moved to corpse: {', '.join(transferred_items)}")
             else:
@@ -755,7 +754,7 @@ class DeathProgressionScript(DefaultScript):
                     spawn_severed_head_for_corpse(corpse)
             except Exception as e:
                 try:
-                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    splattercast = get_splattercast()
                     splattercast.msg(
                         f"DEATH_DECAPITATION_ERROR: {character.key} - {e}"
                     )
@@ -785,7 +784,7 @@ class DeathProgressionScript(DefaultScript):
             
             script_count = medical_scripts.count()
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_MEDICAL_CLEANUP: Found {script_count} medical scripts for {character.key}")
             except Exception:
                 pass
@@ -802,7 +801,7 @@ class DeathProgressionScript(DefaultScript):
                     still_exists = ScriptDB.objects.filter(id=script_id).exists()
                     
                     try:
-                        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                        splattercast = get_splattercast()
                         if still_exists:
                             splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: Script #{script_id} for {character.key} still exists after delete!")
                         else:
@@ -811,7 +810,7 @@ class DeathProgressionScript(DefaultScript):
                         pass
                 except Exception as e:
                     try:
-                        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                        splattercast = get_splattercast()
                         splattercast.msg(f"DEATH_MEDICAL_CLEANUP_ERROR: {character.key} - {e}")
                         import traceback
                         splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
@@ -819,7 +818,7 @@ class DeathProgressionScript(DefaultScript):
                         pass
         except Exception as e:
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: {character.key} - {e}")
                 import traceback
                 splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
@@ -835,7 +834,7 @@ class DeathProgressionScript(DefaultScript):
             
             # Debug logging for successful teleportation
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_TELEPORT_SUCCESS: {character.key} moved from {old_location} to {limbo_room}")
             except Exception:
                 pass
@@ -843,7 +842,7 @@ class DeathProgressionScript(DefaultScript):
         except Exception as e:
             # Log the specific error instead of silently failing
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_TELEPORT_ERROR: {character.key} - {e}")
             except Exception:
                 pass
@@ -860,7 +859,7 @@ class DeathProgressionScript(DefaultScript):
                 account.unpuppet_object(session)
                 
                 try:
-                    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                    splattercast = get_splattercast()
                     splattercast.msg(f"DEATH_UNPUPPET: {character.key} unpuppeted from {account.key}")
                 except Exception:
                     pass
@@ -888,7 +887,7 @@ class DeathProgressionScript(DefaultScript):
             account.msg("|yPlease contact staff for assistance creating a new character.|n")
             
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"CHARCREATE_IMPORT_ERROR: {e}")
             except Exception:
                 pass
@@ -915,7 +914,7 @@ def start_death_progression(character):
     existing_script = character.scripts.get("death_progression")
     if existing_script:
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"DEATH_PROGRESSION: Existing script found for {character.key}")
         except Exception:
             pass
@@ -923,7 +922,7 @@ def start_death_progression(character):
         
     # Create new death progression script
     try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"DEATH_PROGRESSION: Creating new script for {character.key}")
     except Exception:
         pass
@@ -932,7 +931,7 @@ def start_death_progression(character):
     script = character.scripts.add(DeathProgressionScript)
     
     try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"DEATH_PROGRESSION: Script created and started: {script} for {character.key}")
     except Exception:
         pass

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -8,7 +8,7 @@ for allowing Characters to traverse the exit to its destination.
 """
 
 from evennia.objects.objects import DefaultExit
-from evennia.comms.models import ChannelDB
+from world.combat.debug import get_splattercast
 from world.combat.handler import get_or_create_combat 
 from world.combat.constants import (
     DB_CHAR,
@@ -21,7 +21,6 @@ from world.combat.constants import (
     NDB_COMBAT_HANDLER,
     NDB_PROXIMITY,
     NDB_PROXIMITY_UNIVERSAL,
-    SPLATTERCAST_CHANNEL,
 )
 
 
@@ -64,7 +63,7 @@ class Exit(DefaultExit):
         return self.get_display_desc(looker, **kwargs)
 
     def at_traverse(self, traversing_object, target_location):
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # --- SKY ROOM RESTRICTION CHECK ---
         # Block normal traversal to/from sky rooms - these are transit-only spaces

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -100,8 +100,8 @@ class Room(ObjectParent, DefaultRoom):
                     
                     # Log and delete
                     try:
-                        from evennia.comms.models import ChannelDB
-                        splattercast = ChannelDB.objects.get_channel("Splattercast")
+                        from world.combat.debug import get_splattercast
+                        splattercast = get_splattercast()
                         splattercast.msg(f"CORPSE_DECAY_JIT: {corpse.key} decayed on room entry to {self.key}")
                     except Exception:
                         pass

--- a/world/combat/actions.py
+++ b/world/combat/actions.py
@@ -14,14 +14,12 @@ script instance) instead of operating as methods on the class.
 
 from random import randint
 
-from evennia.comms.models import ChannelDB
 
 from world.combat.messages import get_combat_message
 from world.grammar import capitalize_first
 from world.identity_utils import msg_room_identity
 
 from .constants import (
-    SPLATTERCAST_CHANNEL,
     DEBUG_PREFIX_HANDLER,
     DB_CHAR, DB_COMBAT_ACTION, DB_COMBAT_ACTION_TARGET,
     DB_IS_YIELDING,
@@ -33,7 +31,7 @@ from .constants import (
     MSG_DISARM_SUCCESS_ATTACKER, MSG_DISARM_SUCCESS_VICTIM,
     MSG_DISARM_SUCCESS_OBSERVER,
 )
-from .debug import log_combat_action
+from .debug import get_splattercast, log_combat_action
 from .dice import roll_stat
 from .utils import (
     get_numeric_stat, initialize_proximity_ndb,
@@ -54,7 +52,7 @@ def resolve_disarm(handler, char, entry):
         char: The character attempting to disarm.
         entry: The character's combat entry dict.
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     target = entry.get(DB_COMBAT_ACTION_TARGET)
 
     if not target:
@@ -203,7 +201,7 @@ def resolve_grapple_attempt(handler, char, entry, combatants_list):
         entry: The character's combat entry dict.
         combatants_list: List of all combat entry dicts.
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     combat_action = entry.get(DB_COMBAT_ACTION)
 
     action_target_char = combat_action.get("target")
@@ -394,7 +392,7 @@ def resolve_escape_grapple(handler, char, entry, combatants_list):
     Returns:
         bool: ``True`` if the action consumed the turn.
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
 
     grappler = handler.get_grappled_by_obj(entry)
     if grappler and any(
@@ -500,7 +498,7 @@ def resolve_auto_escape(handler, char, entry, combatants_list):
         MSG_GRAPPLE_AUTO_ESCAPE_VIOLENT,
     )
 
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
 
     grappler = handler.get_grappled_by_obj(entry)
     if not grappler:

--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -11,13 +11,12 @@ script instance) instead of operating as methods on the class.
 
 from random import randint
 
-from evennia.comms.models import ChannelDB
+from .debug import get_splattercast
 
 from world.combat.messages import get_combat_message
 from world.medical.utils import select_hit_location, select_target_organ
 
 from .constants import (
-    SPLATTERCAST_CHANNEL,
     DB_CHAR, DB_IS_YIELDING,
     NDB_CHARGE_BONUS,
     NDB_PROXIMITY,
@@ -76,7 +75,7 @@ def process_delayed_attack(handler, attacker, target, attacker_entry, combatants
         combatants_list: List of all combat entry dicts (snapshot at
             scheduling time).
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
 
     # Validate that combat is still active
     if not handler.db.combat_is_running:
@@ -283,7 +282,7 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
         attacker_entry: The attacker's combat entry dict.
         combatants_list: List of all combat entry dicts.
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
 
     # Check if target is already dead or unconscious
     if target.is_dead():
@@ -586,7 +585,7 @@ def _handle_kill(
         hit_location: The body location that was hit.
         combatants_list: List of all combat entry dicts.
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
 
     kill_messages = get_combat_message(
         weapon_type, "kill",

--- a/world/combat/debug.py
+++ b/world/combat/debug.py
@@ -1,48 +1,109 @@
 """
-Combat Debug & Logging Utilities
+Combat Audit Logging & Debug Broadcasting
 
-Centralised helpers for broadcasting debug messages to the Splattercast
-channel.  Every module in the combat package that needs debug output
-should import from here rather than creating its own channel lookups.
+Single sink for combat diagnostics (issue #461).  Every module that
+needs combat debug/audit output imports from here rather than doing
+its own channel lookups.
 
-Extracted from ``world/combat/utils.py`` during Phase 2 refactoring.
+Two destinations, one entry point:
+
+* **Audit file** (always on) — every message is appended to
+  ``server/logs/combat_audit.log`` via Evennia's async file logger.
+  This is the long-term record for investigating player bug reports,
+  cheating accusations, and combat disputes.  File writes happen on
+  the logger's thread pool, never blocking the reactor.
+* **Splattercast channel** (gated) — live in-game broadcast for
+  active debugging sessions.  Off by default; enable by setting
+  ``SPLATTERCAST_LIVE = True`` in ``server/conf/settings.py``.
+  The channel object is cached per process — no per-message DB
+  lookup.
+
+``get_splattercast()`` returns a router exposing ``.msg()`` so the
+hundreds of existing ``splattercast.msg(...)`` call sites work
+unchanged.  The router is always truthy, so ``if splattercast:``
+guards also keep working.
 
 Functions:
-    debug_broadcast — fire-and-forget message to Splattercast
-    get_splattercast — safe channel retrieval (returns ``_NullChannel``
-                       when the channel is unavailable)
+    get_splattercast — the audit router (always available)
+    debug_broadcast — fire-and-forget ``PREFIX_STATUS: message``
     log_debug — structured ``PREFIX_ACTION: message (char)`` format
     log_combat_action — higher-level action logger used by commands
 """
 
 from __future__ import annotations
 
+from django.conf import settings
+
 from evennia.comms.models import ChannelDB
+from evennia.utils import logger
 
 from .constants import SPLATTERCAST_CHANNEL
 
-
-# ------------------------------------------------------------------
-# Channel helpers
-# ------------------------------------------------------------------
+COMBAT_AUDIT_FILENAME = "combat_audit.log"
 
 class _NullChannel:
-    """No-op channel stand-in when Splattercast is unavailable."""
+    """No-op message sink.
+
+    Kept for backward compatibility — tests and callers use it as a
+    silent stand-in wherever a ``.msg()`` duck-type is expected.
+    """
 
     def msg(self, *args, **kwargs):  # noqa: D401
         pass
 
 
+# Per-process channel cache — reset naturally on server reload.
+# Empty list = not yet resolved; [channel-or-None] once resolved.
+_CHANNEL_CACHE: list = []
+
+
+def _get_live_channel():
+    """Return the Splattercast channel, resolved once per process."""
+    if not _CHANNEL_CACHE:
+        try:
+            _CHANNEL_CACHE.append(
+                ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            )
+        except Exception:
+            # DB not ready (early startup) — retry next call.
+            return None
+    return _CHANNEL_CACHE[0]
+
+
+class _AuditRouter:
+    """Message sink: audit file always, channel when live.
+
+    Duck-types the one method call sites use (``msg``) so it can
+    stand in for the channel object everywhere.
+    """
+
+    def msg(self, message, **kwargs):
+        try:
+            logger.log_file(str(message), filename=COMBAT_AUDIT_FILENAME)
+        except Exception:
+            # Auditing must never take combat down with it.
+            pass
+        if getattr(settings, "SPLATTERCAST_LIVE", False):
+            channel = _get_live_channel()
+            if channel:
+                try:
+                    channel.msg(message, **kwargs)
+                except Exception:
+                    pass
+
+
+_ROUTER = _AuditRouter()
+
+
 def get_splattercast():
     """
-    Safely retrieve the Splattercast debug channel.
+    Return the combat audit router.
 
-    Returns:
-        The channel object, or a ``_NullChannel`` stand-in if
-        unavailable.
+    Always returns a usable (truthy) object — messages go to the
+    audit file unconditionally and to the Splattercast channel when
+    ``settings.SPLATTERCAST_LIVE`` is enabled.
     """
-    channel = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-    return channel if channel else _NullChannel()
+    return _ROUTER
 
 
 # ------------------------------------------------------------------
@@ -55,21 +116,14 @@ def debug_broadcast(
     status: str = "INFO",
 ) -> None:
     """
-    Broadcast a debug message to the Splattercast channel.
+    Route a debug message through the audit sink.
 
     Args:
-        message: Debug message to broadcast.
+        message: Debug message to log/broadcast.
         prefix: Prefix for the debug message (e.g. ``"STICKY_GRENADE"``).
         status: Status level (``"INFO"``, ``"SUCCESS"``, ``"ERROR"``, …).
     """
-    try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        if splattercast:
-            formatted_msg = f"{prefix}_{status}: {message}"
-            splattercast.msg(formatted_msg)
-    except Exception:
-        # Fail silently if channel not available
-        pass
+    _ROUTER.msg(f"{prefix}_{status}: {message}")
 
 
 def log_debug(
@@ -79,7 +133,7 @@ def log_debug(
     character=None,
 ) -> None:
     """
-    Send a standardised debug message to Splattercast.
+    Route a standardised debug message through the audit sink.
 
     Format: ``PREFIX_ACTION: message (character_key)``
 
@@ -89,15 +143,8 @@ def log_debug(
         message: The debug message.
         character: Optional character for context.
     """
-    try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
-        if splattercast:
-            char_context = f" ({character.key})" if character else ""
-            full_message = f"{prefix}_{action}: {message}{char_context}"
-            splattercast.msg(full_message)
-    except Exception:
-        # Fail silently if channel doesn't exist
-        pass
+    char_context = f" ({character.key})" if character else ""
+    _ROUTER.msg(f"{prefix}_{action}: {message}{char_context}")
 
 
 def log_combat_action(

--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -20,11 +20,10 @@ method acts as a thin dispatcher that delegates to those modules.
 
 from evennia import DefaultScript, create_script
 from evennia.utils.utils import delay
-from evennia.comms.models import ChannelDB
+from .debug import get_splattercast
 
 from .constants import (
-    COMBAT_SCRIPT_KEY, SPLATTERCAST_CHANNEL,
-    DB_COMBATANTS, DB_COMBAT_RUNNING, DB_MANAGED_ROOMS,
+    COMBAT_SCRIPT_KEY,     DB_COMBATANTS, DB_COMBAT_RUNNING, DB_MANAGED_ROOMS,
     DB_CHAR, DB_TARGET_DBREF, DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF,
     DB_IS_YIELDING,
     DB_COMBAT_ACTION, DB_COMBAT_ACTION_TARGET, DB_INITIATIVE,
@@ -88,7 +87,7 @@ def get_or_create_combat(location):
     Returns:
         CombatHandler: The combat handler managing this location
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     
     # First, check if 'location' is already managed by ANY active CombatHandler
     # This requires iterating through all scripts, which can be slow.
@@ -189,7 +188,7 @@ class CombatHandler(DefaultScript):
         self.db.managed_rooms = [self.obj]  # Initially manages only its host room
         self.db.combat_is_running = False
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         managed_rooms = self.db.managed_rooms or []
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_CREATE: New handler {self.key} created on {self.obj.key}, initially managing: {[r.key for r in managed_rooms]}. Combat logic initially not running.")
 
@@ -201,7 +200,7 @@ class CombatHandler(DefaultScript):
         This method ensures the combat handler is properly running and handles
         cases where the internal state might be out of sync with Evennia's ticker.
         """
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         # Use super().is_active to check Evennia's ticker status
         evennia_ticker_is_active = super().is_active
@@ -242,7 +241,7 @@ class CombatHandler(DefaultScript):
         if not self.pk or not self.id:
             return
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         combat_was_running = self.db.combat_is_running
         
@@ -321,7 +320,7 @@ class CombatHandler(DefaultScript):
         if not self.pk or not self.id:
             return
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_STOP: Handler {self.key} at_stop() called. Cleaning up combat state.")
         
         # Skip cleanup if merge is in progress to preserve combatant references
@@ -353,7 +352,7 @@ class CombatHandler(DefaultScript):
         Args:
             other_handler: The CombatHandler to merge into this one
         """
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # Defensive logging to understand the merge scenario
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_MERGE_DEBUG: self={self} (key={self.key}, id={getattr(self, 'id', 'None')}, obj={self.obj.key})")
@@ -472,7 +471,7 @@ class CombatHandler(DefaultScript):
         attack processing, movement resolution, and special actions to
         the ``attack``, ``movement_resolution``, and ``actions`` modules.
         """
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         if not self.db.combat_is_running:
             splattercast.msg(f"AT_REPEAT: Handler {self.key} on {self.obj.key} combat logic is not running ({DB_COMBAT_RUNNING}=False). Returning.")
             return
@@ -659,7 +658,7 @@ class CombatHandler(DefaultScript):
         Returns:
             list: Filtered list of valid combat entry dicts.
         """
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         valid = []
         managed_rooms = self.db.managed_rooms or []
         for entry in combatants_list:
@@ -692,7 +691,7 @@ class CombatHandler(DefaultScript):
         Returns:
             bool: ``True`` if combat was ended peacefully.
         """
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         all_yielding = all(
             entry.get(DB_IS_YIELDING, False) for entry in combatants_list
@@ -731,7 +730,7 @@ class CombatHandler(DefaultScript):
             char: The character whose flags to clean.
             entry: The character's combat entry dict.
         """
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         if hasattr(char.ndb, NDB_CHARGE_VULNERABILITY):
             splattercast.msg(f"AT_REPEAT_START_TURN_CLEANUP: Clearing charging_vulnerability_active for {char.key} (was active from their own previous charge).")
@@ -756,7 +755,7 @@ class CombatHandler(DefaultScript):
             char: The yielding character.
             entry: The character's combat entry dict.
         """
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         grappling_target = self.get_grappling_obj(entry)
         if grappling_target:
@@ -797,7 +796,7 @@ class CombatHandler(DefaultScript):
         Returns:
             bool: ``True`` if the action consumed the turn.
         """
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"AT_REPEAT: {char.key} has action_intent: {combat_action}")
 
         if isinstance(combat_action, str):
@@ -899,7 +898,7 @@ class CombatHandler(DefaultScript):
             combatants_list: List of all combat entry dicts.
             initiative_order: List of entries sorted by initiative.
         """
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         target = self.get_target(char)
         splattercast.msg(f"AT_REPEAT: After get_target(), {char.key} target is {target.key if target else None}")
@@ -956,7 +955,7 @@ class CombatHandler(DefaultScript):
     
     def set_target(self, char, target):
         """Set the target for a given character."""
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # Follow the same pattern as utils.py functions:
         # 1. Get a copy of the combatants list

--- a/world/combat/movement_resolution.py
+++ b/world/combat/movement_resolution.py
@@ -13,10 +13,9 @@ script instance) instead of operating as methods on the class.
 
 from random import randint
 
-from evennia.comms.models import ChannelDB
+from .debug import get_splattercast
 
 from .constants import (
-    SPLATTERCAST_CHANNEL,
     DEBUG_PREFIX_HANDLER,
     DB_CHAR, DB_COMBAT_ACTION, DB_COMBAT_ACTION_TARGET,
     DB_IS_YIELDING, DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF,
@@ -51,7 +50,7 @@ def resolve_retreat(handler, char, entry):
         char: The character attempting to retreat.
         entry: The character's combat entry dict.
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
 
     splattercast.msg(
         f"{DEBUG_PREFIX_HANDLER}_RETREAT: {char.key} executing retreat "
@@ -202,7 +201,7 @@ def resolve_advance(handler, char, entry):
         char: The character attempting to advance.
         entry: The character's combat entry dict.
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     target = entry.get(DB_COMBAT_ACTION_TARGET)
 
     if not target:
@@ -622,7 +621,7 @@ def resolve_charge(handler, char, entry, combatants_list):
         entry: The character's combat entry dict.
         combatants_list: List of all combat entry dicts.
     """
-    splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+    splattercast = get_splattercast()
     target = entry.get(DB_COMBAT_ACTION_TARGET)
 
     if not target:

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -417,7 +417,7 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
         initial_is_yielding: Whether the character starts yielding
     """
     from .constants import (
-        SPLATTERCAST_CHANNEL, DB_COMBATANTS, DB_CHAR, DB_TARGET_DBREF,
+        DB_COMBATANTS, DB_CHAR, DB_TARGET_DBREF,
         DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, DB_IS_YIELDING, 
         NDB_PROXIMITY, NDB_COMBAT_HANDLER, DB_COMBAT_RUNNING
     )

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -6,7 +6,6 @@ like bleeding. Conditions are managed by per-character MedicalScript instances.
 """
 
 import random
-from evennia.comms.models import ChannelDB
 from .constants import (
     INJURY_SEVERITY_MULTIPLIERS,
     BLOOD_LOSS_PER_SEVERITY,
@@ -37,10 +36,9 @@ class MedicalCondition:
     def start_condition(self, character):
         """Begin condition management for character."""
         from world.medical.script import start_medical_script
-        from evennia.comms.models import ChannelDB
-        from world.combat.constants import SPLATTERCAST_CHANNEL
+        from world.combat.debug import get_splattercast
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # Don't add conditions to archived characters (permanently dead)
         # Dying characters can still be resuscitated, so they should keep conditions
@@ -154,9 +152,9 @@ class BleedingCondition(MedicalCondition):
         
     def tick_effect(self, character):
         """Apply blood loss and potentially reduce severity."""
-        from world.combat.constants import SPLATTERCAST_CHANNEL
+        from world.combat.debug import get_splattercast
 
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
 
         if not hasattr(character, 'medical_state'):
             return
@@ -276,9 +274,9 @@ class PainCondition(MedicalCondition):
         
     def tick_effect(self, character):
         """Pain naturally diminishes over time."""
-        from world.combat.constants import SPLATTERCAST_CHANNEL
+        from world.combat.debug import get_splattercast
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # Natural pain reduction
         if random.randint(1, 100) <= 20:  # 20% chance per tick
@@ -334,10 +332,10 @@ class InfectionCondition(MedicalCondition):
         
     def tick_effect(self, character):
         """Infection can worsen if untreated, or improve if treated."""
-        from world.combat.constants import SPLATTERCAST_CHANNEL
+        from world.combat.debug import get_splattercast
         import time
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         current_time = time.time()
         
         # Initialize timing tracking if needed
@@ -486,9 +484,9 @@ class ConsciousnessSuppressionCondition(MedicalCondition):
         
     def tick_effect(self, character):
         """Consciousness suppression naturally diminishes over time."""
-        from world.combat.constants import SPLATTERCAST_CHANNEL
+        from world.combat.debug import get_splattercast
         
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         
         # Natural recovery from consciousness suppression 
         # Different types recover at different rates
@@ -614,14 +612,13 @@ def set_infection_environmental_risk(character, modifier, reason="environmental 
     if not hasattr(character, 'medical_state'):
         return
         
-    from world.combat.constants import SPLATTERCAST_CHANNEL
-    from evennia.comms.models import ChannelDB
+    from world.combat.debug import get_splattercast
     
     medical_state = character.medical_state
     infection_conditions = [c for c in medical_state.conditions if c.condition_type == "infection"]
     
     if infection_conditions:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         for condition in infection_conditions:
             condition.set_environmental_modifier(modifier)
         

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -5,7 +5,6 @@ Core classes for tracking organ health, medical conditions, and medical state
 persistence. These form the foundation of the medical system.
 """
 
-from evennia.comms.models import ChannelDB
 from .constants import (
     CONTRIBUTION_VALUES,
     CONSCIOUSNESS_UNCONSCIOUS_THRESHOLD, BLOOD_LOSS_DEATH_THRESHOLD,
@@ -835,8 +834,8 @@ class MedicalState:
         character = self._get_character_reference()
         if character and character.db.archived:
             try:
-                from world.combat.constants import SPLATTERCAST_CHANNEL
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                from world.combat.debug import get_splattercast
+                splattercast = get_splattercast()
                 char_name = character.key if character else "unknown"
                 splattercast.msg(f"ADD_CONDITION: {char_name} is archived, not adding {condition.condition_type}")
             except Exception:
@@ -847,8 +846,8 @@ class MedicalState:
             self.conditions.append(condition)
             
             try:
-                from world.combat.constants import SPLATTERCAST_CHANNEL
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                from world.combat.debug import get_splattercast
+                splattercast = get_splattercast()
                 splattercast.msg(f"ADD_CONDITION: Added {condition.condition_type} severity {condition.severity}")
             except Exception:
                 pass
@@ -860,16 +859,16 @@ class MedicalState:
                 character = self._get_character_reference()
                 if character:
                     try:
-                        from world.combat.constants import SPLATTERCAST_CHANNEL
-                        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                        from world.combat.debug import get_splattercast
+                        splattercast = get_splattercast()
                         splattercast.msg(f"ADD_CONDITION: Starting ticker for {condition.condition_type} on {character.key}")
                     except Exception:
                         pass
                     condition.start_condition(character)
                 else:
                     try:
-                        from world.combat.constants import SPLATTERCAST_CHANNEL
-                        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                        from world.combat.debug import get_splattercast
+                        splattercast = get_splattercast()
                         splattercast.msg(f"ADD_CONDITION: No character reference found for {condition.condition_type}")
                     except Exception:
                         pass

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -6,8 +6,7 @@ ticking them at regular intervals and cleaning up when no conditions remain.
 """
 
 from evennia import DefaultScript
-from evennia.comms.models import ChannelDB
-from world.combat.constants import SPLATTERCAST_CHANNEL
+from world.combat.debug import get_splattercast
 
 
 # ---------------------------------------------------------------------
@@ -111,7 +110,7 @@ class MedicalScript(DefaultScript):
         """Process all medical conditions for this character."""
         try:
             # Get splattercast for debugging
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             
             # Get character's medical state
             if not hasattr(self.obj, 'medical_state'):
@@ -247,7 +246,7 @@ class MedicalScript(DefaultScript):
                 
         except Exception as e:
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"MEDICAL_SCRIPT_CRITICAL_ERROR: {self.obj.key}: {e}")
             except Exception:
                 pass
@@ -257,7 +256,7 @@ class MedicalScript(DefaultScript):
     def at_stop(self):
         """Called when script stops."""
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"MEDICAL_SCRIPT_STOP: Medical script stopped for {self.obj.key}")
         except Exception:
             pass
@@ -408,7 +407,7 @@ def start_medical_script(character):
         MedicalScript: The active medical script
     """
     try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"START_MEDICAL_SCRIPT: Checking for existing script on {character.key}")
     except Exception:
         pass
@@ -416,7 +415,7 @@ def start_medical_script(character):
     # Don't create scripts for dead characters
     if hasattr(character, 'medical_state') and character.medical_state.is_dead():
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"START_MEDICAL_SCRIPT: {character.key} is dead, not creating medical script")
         except Exception:
             pass
@@ -426,7 +425,7 @@ def start_medical_script(character):
     existing_script = character.scripts.get("medical_script")
     if existing_script:
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"START_MEDICAL_SCRIPT: Found existing script for {character.key}")
         except Exception:
             pass
@@ -434,7 +433,7 @@ def start_medical_script(character):
     
     # Create new script
     try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"START_MEDICAL_SCRIPT: Creating new script for {character.key}")
     except Exception:
         pass
@@ -442,7 +441,7 @@ def start_medical_script(character):
     script = character.scripts.add(MedicalScript)
     
     try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"START_MEDICAL_SCRIPT: Script created: {script}")
     except Exception:
         pass
@@ -458,7 +457,7 @@ def stop_medical_script(character):
         character: The character to stop medical script for
     """
     try:
-        splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+        splattercast = get_splattercast()
         splattercast.msg(f"STOP_MEDICAL_SCRIPT: Looking for medical scripts on {character.key}")
     except Exception:
         pass
@@ -468,7 +467,7 @@ def stop_medical_script(character):
     if existing_scripts:
         for script in existing_scripts:
             try:
-                splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+                splattercast = get_splattercast()
                 splattercast.msg(f"STOP_MEDICAL_SCRIPT: Found script {script}, deleting it")
             except Exception:
                 pass
@@ -476,7 +475,7 @@ def stop_medical_script(character):
             script.delete()
     else:
         try:
-            splattercast = ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
+            splattercast = get_splattercast()
             splattercast.msg(f"STOP_MEDICAL_SCRIPT: No medical scripts found on {character.key}")
         except Exception:
             pass

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -227,8 +227,8 @@ def select_hit_location(character, success_margin=0, attacker=None):
     # Debug output for targeting analysis
     if attacker:
         try:
-            from evennia.comms.models import ChannelDB
-            splattercast = ChannelDB.objects.get_channel("Splattercast")
+            from world.combat.debug import get_splattercast
+            splattercast = get_splattercast()
             
             # Show targeting abilities and top weighted locations
             top_locations = sorted(location_weights.items(), key=lambda x: x[1], reverse=True)[:3]
@@ -975,8 +975,8 @@ def apply_medical_effects(item, user, target, **kwargs):
     death_scripts = target.scripts.get("death_progression")
     
     try:
-        from evennia.comms.models import ChannelDB
-        splattercast = ChannelDB.objects.get_channel("Splattercast")
+        from world.combat.debug import get_splattercast
+        splattercast = get_splattercast()
         splattercast.msg(f"REVIVAL_DEBUG: {target.key} has {len(death_scripts)} death scripts")
         
         if hasattr(target, 'medical_state') and target.medical_state:
@@ -996,30 +996,30 @@ def apply_medical_effects(item, user, target, **kwargs):
                     
                     # Debug the revival condition check
                     try:
-                        from evennia.comms.models import ChannelDB
-                        splattercast = ChannelDB.objects.get_channel("Splattercast")
+                        from world.combat.debug import get_splattercast
+                        splattercast = get_splattercast()
                         splattercast.msg(f"REVIVAL_DEBUG: Checking revival conditions for {target.key}")
                     except Exception:
                         pass
                     
                     if script._check_medical_revival_conditions(target):
-                        from evennia.comms.models import ChannelDB
-                        splattercast = ChannelDB.objects.get_channel("Splattercast")
+                        from world.combat.debug import get_splattercast
+                        splattercast = get_splattercast()
                         splattercast.msg(f"IMMEDIATE_REVIVAL_CHECK: {target.key} revival triggered by medical treatment")
                         script._handle_medical_revival()
                         break  # Revival handled, stop checking
                     else:
                         try:
-                            from evennia.comms.models import ChannelDB
-                            splattercast = ChannelDB.objects.get_channel("Splattercast")
+                            from world.combat.debug import get_splattercast
+                            splattercast = get_splattercast()
                             splattercast.msg(f"REVIVAL_DEBUG: {target.key} does not meet revival conditions")
                         except Exception:
                             pass
         except Exception as e:
             # Don't let revival check errors break medical treatment
             try:
-                from evennia.comms.models import ChannelDB
-                splattercast = ChannelDB.objects.get_channel("Splattercast")
+                from world.combat.debug import get_splattercast
+                splattercast = get_splattercast()
                 splattercast.msg(f"REVIVAL_CHECK_ERROR: {target.key}: {e}")
             except Exception:
                 pass

--- a/world/tests/test_inventory_command_identity.py
+++ b/world/tests/test_inventory_command_identity.py
@@ -147,7 +147,7 @@ class TestCmdThrowIdentityTargeting(TestCase):
         cmd.caller.ndb = MagicMock()
         return cmd
 
-    @patch("commands.CmdThrow.ChannelDB")
+    @patch("commands.CmdThrow.get_splattercast")
     @patch("commands.CmdThrow.resolve_character_target")
     def test_same_room_lookup_uses_helper(self, mock_resolve, _mock_channel):
         target = MagicMock()
@@ -165,7 +165,7 @@ class TestCmdThrowIdentityTargeting(TestCase):
         self.assertEqual(same_room_call.args, (cmd.caller, "man"))
         self.assertIs(result, target)
 
-    @patch("commands.CmdThrow.ChannelDB")
+    @patch("commands.CmdThrow.get_splattercast")
     @patch("commands.CmdThrow.resolve_character_target")
     def test_no_target_no_aim_messages_no_aim_error(
         self, mock_resolve, _mock_channel
@@ -180,7 +180,7 @@ class TestCmdThrowIdentityTargeting(TestCase):
         # Should hit the NO_AIM_CROSS_ROOM branch
         self.assertTrue(msg_calls)
 
-    @patch("commands.CmdThrow.ChannelDB")
+    @patch("commands.CmdThrow.get_splattercast")
     @patch("commands.CmdThrow.resolve_character_target")
     def test_cross_room_lookup_passes_destination_contents(
         self, mock_resolve, _mock_channel
@@ -211,7 +211,7 @@ class TestCmdThrowIdentityTargeting(TestCase):
             cross_call.kwargs.get("candidates"), destination.contents
         )
 
-    @patch("commands.CmdThrow.ChannelDB")
+    @patch("commands.CmdThrow.get_splattercast")
     @patch("commands.CmdThrow.resolve_character_target")
     def test_does_not_use_caller_search_for_target(
         self, mock_resolve, _mock_channel

--- a/world/tests/test_wound_care.py
+++ b/world/tests/test_wound_care.py
@@ -166,7 +166,7 @@ class BleedingStabilization(TestCase):
         patient.medical_state.conditions.append(bleed)
         return patient, bleed
 
-    @patch("world.medical.conditions.ChannelDB")
+    @patch("world.combat.debug.get_splattercast")
     def test_unstabilized_bleed_drains_blood(self, mock_channel):
         mock_channel.objects.get_channel.return_value = MagicMock()
         patient, bleed = self._patient_with_chest_bleed()
@@ -180,7 +180,7 @@ class BleedingStabilization(TestCase):
             "Unstabilized bleeding should drain blood on tick.",
         )
 
-    @patch("world.medical.conditions.ChannelDB")
+    @patch("world.combat.debug.get_splattercast")
     def test_stabilized_bleed_holds_blood(self, mock_channel):
         mock_channel.objects.get_channel.return_value = MagicMock()
         patient, bleed = self._patient_with_chest_bleed()
@@ -194,7 +194,7 @@ class BleedingStabilization(TestCase):
             "Stabilized bleeding should not drain blood on tick.",
         )
 
-    @patch("world.medical.conditions.ChannelDB")
+    @patch("world.combat.debug.get_splattercast")
     def test_stabilized_undamaged_organ_does_not_shield(self, mock_channel):
         """A stabilized-but-undamaged organ at the location shouldn't
         protect an unrelated bleeding source there."""


### PR DESCRIPTION
Closes #461

`world/combat/debug.py` becomes the single sink for combat/medical diagnostics:

- **Audit file (always on)** — every diagnostic appends to `server/logs/combat_audit.log` via Evennia's async file logger (thread pool, never blocks the reactor). This is the durable record for player bug reports, cheating accusations, and combat disputes — the "better form of Splattercast for auditing" discussed in the review.
- **Splattercast channel (gated)** — live broadcast is now opt-in: `SPLATTERCAST_LIVE = True` in `server/conf/settings.py` (default False). The channel object is cached per process — no more per-message `ChannelDB.objects.get_channel()` DB lookup.

`get_splattercast()` returns an always-truthy router exposing `.msg()`, so the ~820 existing `splattercast.msg(...)` call sites work unchanged. Migration details:

- ~200 raw channel lookups across 24 files replaced (both the `SPLATTERCAST_CHANNEL` constant form and the `"Splattercast"` string-literal form in CmdAdmin, charcreate, rooms, curtain_of_death, medical/utils).
- Also fixes a latent `AttributeError`: several sites called `.msg()` on the lookup result without a None guard.
- Dead `ChannelDB`/`SPLATTERCAST_CHANNEL` imports removed; `world/medical/{core,conditions,utils}.py` keep function-local imports because the `world.combat` package init imports `world.medical.utils` (module-level would be circular).
- `jump.py`'s private channel cache replaced by the central one.
- Tests that patched `ChannelDB` in migrated modules now patch `get_splattercast`.
- AGENTS.md "When Stuck" updated to point at the audit log.

Test plan: full `world.tests` sweep in the container — 2258 tests, all passing. Live server reloaded cleanly; `combat_audit.log` created in `server/logs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)