### PR TITLE
Render-path scaling for NPC-heavy rooms

### DIFF
--- a/world/grammar.py
+++ b/world/grammar.py
@@ -15,6 +15,7 @@ See specs/GRAMMAR_ENGINE_SPEC.md for the full specification.
 from __future__ import annotations
 
 import re
+from functools import lru_cache
 
 import inflect
 
@@ -268,6 +269,18 @@ def get_article(noun_phrase: str, definite: bool = False) -> str:
     """
     if definite:
         return "the"
+    return _indefinite_article(noun_phrase)
+
+
+@lru_cache(maxsize=4096)
+def _indefinite_article(noun_phrase: str) -> str:
+    """Phoneme-aware "a"/"an" for ``noun_phrase``, memoized.
+
+    ``inflect``'s ``a()`` was profiled at ~84µs per call — roughly a
+    fifth of the per-observer display-name path — and the inputs are
+    a small, hot set (sdescs and item short descriptions), so the
+    cache pays for itself immediately (issue #462).
+    """
     result = _engine.a(noun_phrase)  # e.g. "a lanky man" or "an athletic dame"
     return result.split(" ", 1)[0]   # Extract just the article
 

--- a/world/identity_utils.py
+++ b/world/identity_utils.py
@@ -94,6 +94,18 @@ def msg_room_identity(
             continue
         if not hasattr(observer, "msg"):
             continue
+        # Session gate (issue #462): only render for observers with a
+        # connected session.  Everything in a room has ``.msg`` —
+        # items, corpses, and the hundreds of NPCs a scene can hold —
+        # and per-observer display-name resolution is the most
+        # expensive render path in the game.  Messages to session-less
+        # objects are discarded by Evennia anyway.  When NPC AI grows
+        # message-driven perception, it should hook the action source
+        # (e.g. combat handler events), not this player-facing
+        # broadcast.
+        sessions = getattr(observer, "sessions", None)
+        if sessions is None or not sessions.count():
+            continue
 
         resolved = template
         for placeholder, char in char_refs.items():

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -49,7 +49,7 @@ class Organ:
         
         # Core properties
         self.max_hp = self.data.get("max_hp", 10)
-        self.current_hp = self.max_hp  # Start at full health
+        self._current_hp = self.max_hp  # Start at full health
         self.container = self.data.get("container", "unknown")
         # Display surface for wound rendering (issue #346).  Most organs
         # render their wounds at the bulk container ("heart" wounds → the
@@ -125,6 +125,25 @@ class Organ:
         # replacement.
         self.dressing_rate = 0
         
+    @property
+    def current_hp(self):
+        return self._current_hp
+
+    @current_hp.setter
+    def current_hp(self, value):
+        """Set organ HP, invalidating the parent state's caches.
+
+        Every mutation path — combat damage, healing ticks, surgical
+        procedures, admin commands, severance — assigns this
+        attribute, so routing invalidation through the setter is what
+        makes the cached death verdict (issue #462) safe: no caller
+        discipline required.
+        """
+        self._current_hp = value
+        state = getattr(self, "medical_state", None)
+        if state is not None:
+            state._invalidate_derived_state()
+
     def is_destroyed(self):
         """Returns True if organ HP is 0 or below."""
         return self.current_hp <= 0
@@ -405,15 +424,25 @@ class Organ:
         # Auto-progression from healing → scarred is gated on the
         # Time System (#301) for time-based ticks.
         
+    def _invalidate_parent_state(self):
+        """Invalidate the owning state's caches (organ-bound
+        conditions feed functionality, hence capacities and the
+        death verdict)."""
+        state = getattr(self, "medical_state", None)
+        if state is not None:
+            state._invalidate_derived_state()
+
     def add_condition(self, condition):
         """Add a medical condition to this organ."""
         if condition not in self.conditions:
             self.conditions.append(condition)
-            
+            self._invalidate_parent_state()
+
     def remove_condition(self, condition):
         """Remove a medical condition from this organ."""
         if condition in self.conditions:
             self.conditions.remove(condition)
+            self._invalidate_parent_state()
             
     def to_dict(self):
         """
@@ -514,11 +543,19 @@ class MedicalState:
         self.organs = {}
         self.conditions = []
         
+        # Cached death verdict (issue #462).  ``None`` = stale,
+        # recomputed lazily by :meth:`is_dead`.  Invalidated by the
+        # ``blood_level`` / ``Organ.current_hp`` setters and by
+        # condition add/remove — every input that can flip the
+        # verdict.  Defined before the vital-sign assignments below
+        # so the ``blood_level`` property setter can touch it.
+        self._cached_is_dead = None
+
         # Vital signs
         self.blood_level = 100.0  # Percentage of normal blood volume
         self.pain_level = 0.0     # Current pain accumulation
         self.consciousness = 1.0  # Current consciousness level (0.0 to 1.0)
-        
+
         # Cache for expensive calculations
         self._capacity_cache = {}
         self._cache_dirty = True
@@ -547,6 +584,26 @@ class MedicalState:
             organ.medical_state = self
             self.organs[organ_name] = organ
             
+    @property
+    def blood_level(self):
+        return self._blood_level
+
+    @blood_level.setter
+    def blood_level(self, value):
+        """Set blood level, invalidating the cached death verdict.
+
+        Bleeding ticks, transfusions, and admin heals all assign this
+        attribute directly — the setter keeps the death cache honest
+        without requiring those callers to know about it.
+        """
+        self._blood_level = value
+        self._cached_is_dead = None
+
+    def _invalidate_derived_state(self):
+        """Mark all derived caches stale after a medical mutation."""
+        self._cached_is_dead = None
+        self._cache_dirty = True
+
     def get_organ(self, organ_name):
         """Get organ by name, creating if it doesn't exist.
 
@@ -696,6 +753,21 @@ class MedicalState:
         return self.consciousness < (CONSCIOUSNESS_UNCONSCIOUS_THRESHOLD / 100.0)
 
     def is_dead(self):
+        """Return the (cached) death verdict.
+
+        The full computation walks four body capacities (organ +
+        condition sweeps), and ``Character.msg`` consults this on
+        every message — so the verdict is cached and recomputed only
+        after a mutation invalidates it (issue #462).  Invalidation
+        rides the ``Organ.current_hp`` / ``blood_level`` setters and
+        condition add/remove, covering every input of
+        :meth:`_compute_is_dead`.
+        """
+        if self._cached_is_dead is None:
+            self._cached_is_dead = self._compute_is_dead()
+        return self._cached_is_dead
+
+    def _compute_is_dead(self):
         """Return True when the character has crossed a death threshold.
 
         Enforces exactly two death conditions, both organ-only and
@@ -844,7 +916,10 @@ class MedicalState:
             
         if condition not in self.conditions:
             self.conditions.append(condition)
-            
+            # Conditions can disable organs outright (capacity → 0),
+            # so they're a death-verdict input.
+            self._invalidate_derived_state()
+
             try:
                 from world.combat.debug import get_splattercast
                 splattercast = get_splattercast()
@@ -886,7 +961,8 @@ class MedicalState:
         """
         if condition in self.conditions:
             self.conditions.remove(condition)
-            
+            self._invalidate_derived_state()
+
             # Stop ticker if condition had one
             if hasattr(condition, 'stop_condition'):
                 condition.stop_condition()

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -7,6 +7,7 @@ ticking them at regular intervals and cleaning up when no conditions remain.
 
 from evennia import DefaultScript
 from world.combat.debug import get_splattercast
+from world.medical.constants import MEDICAL_TICK_INTERVAL
 
 
 # ---------------------------------------------------------------------
@@ -92,7 +93,12 @@ class MedicalScript(DefaultScript):
         """Called when script is first created."""
         self.key = "medical_script"  # Use consistent key for searching
         self.desc = f"Medical condition manager for {self.obj.key}"
-        self.interval = 12  # Tick every 12 seconds (was 60 for production)
+        # Production tick rate — the per-tick magnitudes in
+        # world/medical/constants.py (blood-loss %, recovery rates)
+        # are tuned against this interval.  The old hardcoded 12s was
+        # a testing leftover that ran medical progression (and its
+        # per-character CPU cost) 5x fast (issue #462).
+        self.interval = MEDICAL_TICK_INTERVAL
         self.persistent = True
         self.start_delay = True  # Wait before first regular execution
         


### PR DESCRIPTION
Closes #462

Four changes aimed at the stated scaling target — a consistent batch of hundreds of NPCs alongside 1–50 players:

1. **Cached death verdict** — `Character.msg()` consults `is_dead()` on every message, and the full computation walks four body capacities (organ + condition sweeps). `MedicalState` now caches the verdict. Invalidation rides new property setters on `Organ.current_hp` and `MedicalState.blood_level` plus condition add/remove — every input of the death computation — so no caller discipline is required and stale verdicts are impossible regardless of which path mutates medical state (combat, surgery, admin commands, severance, bleeding ticks, transfusions).

2. **Memoized article lookup** — `inflect`'s `a()` was profiled at ~84µs/call (~18% of the per-observer display-name path) over a small hot input set (sdescs, item shortdescs). `get_article` now backs onto an `lru_cache(4096)`.

3. **Session-gated `msg_room_identity`** — the broadcast rendered per-observer display names for everything in the room with `.msg`: items, corpses, and every NPC. Session-less observers are now skipped (Evennia discards messages to them anyway). When NPC AI grows message-driven perception, it should hook action sources (e.g. combat handler events), not this player-facing render path — documented at the gate.

4. **Medical tick at production rate** — the script hardcoded `interval = 12` (testing leftover; its own comment said "was 60 for production") while every per-tick magnitude in `constants.py` is tuned for `MEDICAL_TICK_INTERVAL = 60`. Now uses the constant, cutting per-wounded-character script work 5×. Note: already-running persisted scripts keep their stored 12s interval until they stop and recreate; new wounds tick at 60s.

Test plan: full `world.tests` sweep in the container — 2258 tests, all passing. Live server reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)