### PR TITLE
Spec-track combat audit logging; narrow audit-sink excepts

### DIFF
--- a/specs/COMBAT_AUDIT_LOGGING_SPEC.md
+++ b/specs/COMBAT_AUDIT_LOGGING_SPEC.md
@@ -1,0 +1,123 @@
+# Combat Audit Logging Spec
+
+**Status:** shipped (issues #461 / #464; fail-safe excepts + this
+spec under #466).  Describes current behavior; the code in
+`world/combat/debug.py` is the source of truth.
+
+## 0 · Purpose
+
+Combat and medical systems emit a large volume of diagnostic
+messages — contest rolls, condition transitions, death progression,
+explosive resolution, grapple state. Historically these went to an
+in-game **Splattercast** channel via a raw
+`ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)` lookup at every
+call site (~200 of them across 24 files).
+
+That had two problems:
+
+* **No durable record.** The channel is ephemeral — once the
+  messages scroll past, they're gone. When a player reports a bug,
+  claims another player cheated, or disputes a combat outcome, there
+  was nothing to review.
+* **Always-on cost.** Every diagnostic did a DB channel lookup and a
+  full channel-distribution fan-out to subscribers, on the hot
+  combat path, whether or not anyone was listening.
+
+This spec defines the single-sink replacement.
+
+## 1 · The sink
+
+All diagnostics route through one module: `world/combat/debug.py`.
+Call sites never touch `ChannelDB` directly. The entry points:
+
+| Function | Use |
+|---|---|
+| `get_splattercast()` | Returns the audit router (an object with `.msg()`). The backward-compatible entry point — the ~200 migrated `splattercast = get_splattercast(); splattercast.msg(...)` call sites. |
+| `debug_broadcast(message, prefix, status)` | Fire-and-forget `PREFIX_STATUS: message`. |
+| `log_debug(prefix, action, message, character=None)` | Structured `PREFIX_ACTION: message (char_key)`. |
+| `log_combat_action(character, action_type, target, success, details)` | Higher-level action logger used by commands. |
+
+`get_splattercast()` returns a process-wide `_AuditRouter`
+singleton. It is **always truthy**, so the legacy `if splattercast:`
+guards at call sites keep working, and it duck-types the single
+method call sites use (`.msg()`), so it stands in for the channel
+object everywhere.
+
+## 2 · Two destinations, one call
+
+Every `.msg()` on the router does up to two things:
+
+1. **Audit file — always on.** The message is appended to
+   `server/logs/combat_audit.log` via Evennia's async file logger
+   (`evennia.utils.logger.log_file`). Writes happen on the logger's
+   thread pool, never blocking the Twisted reactor. This is the
+   durable record for investigating bug reports, cheating
+   accusations, and combat disputes.
+
+2. **Splattercast channel — gated.** Only when
+   `settings.SPLATTERCAST_LIVE` is `True`. This is the live in-game
+   mirror for active debugging sessions. Default `False`. The
+   channel object is resolved once and cached per process
+   (`_CHANNEL_CACHE`) — no per-message DB lookup.
+
+```
+call site → get_splattercast().msg("PREFIX_STATUS: ...")
+                 │
+                 ├─ logger.log_file(...)            ← always
+                 │     → server/logs/combat_audit.log
+                 │
+                 └─ if settings.SPLATTERCAST_LIVE:   ← opt-in
+                       cached_channel.msg(...)
+                          → in-game Splattercast listeners
+```
+
+## 3 · Failure handling
+
+The two destinations have deliberately different failure postures,
+following the "no broad `except Exception`" convention by catching
+only the expected, narrow failure of each:
+
+* **Audit file write** is player-facing-critical: a filesystem
+  hiccup must never crash combat for connected players. The `OSError`
+  raised by an I/O failure is swallowed; anything else surfaces as a
+  real bug.
+* **Channel resolution** tolerates the early-startup race only —
+  `DatabaseError` / `AppRegistryNotReady` while the DB or app
+  registry isn't ready yet returns `None` (uncached, so the next
+  call retries). Any other resolution failure surfaces.
+* **Channel broadcast** is deliberately **unguarded**. If a developer
+  has turned on `SPLATTERCAST_LIVE`, they're in an active debugging
+  session and want failures to surface, not be silently eaten.
+
+## 4 · Configuration
+
+```python
+# server/conf/settings.py
+SPLATTERCAST_LIVE = False   # mirror diagnostics to the channel
+```
+
+Flip to `True` (and reload) to watch combat live in-game. Leave
+`False` in production — the audit file captures everything either
+way.
+
+## 5 · Conventions for call sites
+
+* **Never** `ChannelDB.objects.get_channel(...)` for diagnostics.
+  Import from `world/combat/debug.py`.
+* `world/medical/{core,conditions,utils}.py` import
+  `get_splattercast` **function-locally**, not at module level: the
+  `world.combat` package `__init__` reaches `world.medical.utils`
+  through `handler → attack`, so a module-level import there would be
+  circular.
+* The audit file is line-oriented `PREFIX_STATUS: message` text.
+  Keep messages greppable — lead with a stable uppercase prefix.
+
+## 6 · Relationship to other specs
+
+* `COMBAT_REFACTOR_SPEC.md` predates this and references the old
+  per-call-site `get_channel` idiom and a "147 splattercast calls"
+  count as part of its decomposition planning. Those references
+  describe the *pre-#464* state; this spec supersedes them for the
+  diagnostics-routing question.
+* Splattercast is intended to eventually go away as a player-facing
+  channel; the audit file is the durable mechanism that outlives it.

--- a/specs/COMBAT_REFACTOR_SPEC.md
+++ b/specs/COMBAT_REFACTOR_SPEC.md
@@ -25,6 +25,11 @@ Total: ~3,200 lines with significant cross-file duplication
 - **Cross-File Duplication**: Same patterns repeated across both files
   - Contest patterns: `handler.py` (6 instances) + `utils.py` (inconsistent dice patterns)
   - Debug messages: `handler.py` (128) + `utils.py` (19) = 147 total splattercast calls
+    *(routing superseded — diagnostics now go through the single
+    `world/combat/debug.py` sink, not raw
+    `ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)` lookups; see
+    `COMBAT_AUDIT_LOGGING_SPEC.md`. The raw idiom referenced
+    throughout this doc was retired in #464.)*
   - Attribute access: Defensive `getattr` patterns in both files
 - **Utility Dumping Ground**: `utils.py` became catch-all with mixed responsibilities:
   - Dice rolling + debug logging + weapon handling + combat entry management

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,6 +1,6 @@
 # specs/
 
-Design specifications for game systems and features. 37 spec files covering combat, commands, UI, medical, identity, communication, and integrations.
+Design specifications for game systems and features. 43 spec files covering combat, commands, UI, medical, identity, communication, and integrations.
 
 ## Core Systems
 
@@ -8,6 +8,7 @@ Design specifications for game systems and features. 37 spec files covering comb
 |------|-------------|
 | `COMBAT_SYSTEM.md` | Overall combat system design |
 | `COMBAT_REFACTOR_SPEC.md` | Combat module decomposition plan |
+| `COMBAT_AUDIT_LOGGING_SPEC.md` | Single-sink combat/medical diagnostics: always-on audit file + gated Splattercast channel (`world/combat/debug.py`) |
 | `COMBAT_MESSAGE_FORMAT_SPEC.md` | Combat messaging and template system |
 | `PROXIMITY_SYSTEM_SPEC.md` | Tactical positioning mechanics |
 | `GRAPPLE_SYSTEM_SPEC.md` | Grappling and restraint mechanics |

--- a/world/combat/debug.py
+++ b/world/combat/debug.py
@@ -33,6 +33,8 @@ Functions:
 from __future__ import annotations
 
 from django.conf import settings
+from django.core.exceptions import AppRegistryNotReady
+from django.db import Error as DatabaseError
 
 from evennia.comms.models import ChannelDB
 from evennia.utils import logger
@@ -58,14 +60,19 @@ _CHANNEL_CACHE: list = []
 
 
 def _get_live_channel():
-    """Return the Splattercast channel, resolved once per process."""
+    """Return the Splattercast channel, resolved once per process.
+
+    Returns ``None`` (without caching) when the DB / app registry
+    isn't ready yet — a legitimate, expected condition during early
+    startup — so the next call retries.  Any other failure is a real
+    bug and is left to surface.
+    """
     if not _CHANNEL_CACHE:
         try:
             _CHANNEL_CACHE.append(
                 ChannelDB.objects.get_channel(SPLATTERCAST_CHANNEL)
             )
-        except Exception:
-            # DB not ready (early startup) — retry next call.
+        except (DatabaseError, AppRegistryNotReady):
             return None
     return _CHANNEL_CACHE[0]
 
@@ -78,18 +85,20 @@ class _AuditRouter:
     """
 
     def msg(self, message, **kwargs):
+        # Always-on audit write.  A filesystem failure here must never
+        # break combat for players, so the (and only the) expected I/O
+        # failure mode is swallowed; anything else surfaces.
         try:
             logger.log_file(str(message), filename=COMBAT_AUDIT_FILENAME)
-        except Exception:
-            # Auditing must never take combat down with it.
+        except OSError:
             pass
+        # Opt-in live mirror.  A developer who set SPLATTERCAST_LIVE is
+        # in an active debugging session and *wants* failures to
+        # surface, so this path is deliberately unguarded.
         if getattr(settings, "SPLATTERCAST_LIVE", False):
             channel = _get_live_channel()
             if channel:
-                try:
-                    channel.msg(message, **kwargs)
-                except Exception:
-                    pass
+                channel.msg(message, **kwargs)
 
 
 _ROUTER = _AuditRouter()


### PR DESCRIPTION
Closes #466. Follow-up to #461/#464 closing two AGENTS.md alignment gaps surfaced in review.

**Specs track code.** Adds `specs/COMBAT_AUDIT_LOGGING_SPEC.md` documenting the single-sink diagnostics architecture: the always-on `combat_audit.log` write, the `SPLATTERCAST_LIVE`-gated channel mirror, the `get_splattercast()` router and its backward-compat contract, the per-process channel cache, and the function-local-import rule for `world/medical/{core,conditions,utils}.py` (circular-import avoidance). Marks the stale "147 splattercast calls" / raw `get_channel` references in `COMBAT_REFACTOR_SPEC.md` as superseded, and indexes the new spec in `specs/README.md` (also corrects the already-drifted "37 spec files" count to 43).

**No broad `except Exception`.** Narrows the audit sink's fail-safe catches to the expected failure mode of each path:
- Channel resolution: `(DatabaseError, AppRegistryNotReady)` only — the early-startup race is legitimate (returns `None`, retries next call); anything else surfaces.
- Always-on file write: `OSError` only — a filesystem hiccup must never crash combat for connected players.
- Opt-in live channel broadcast: now **unguarded** — a developer who set `SPLATTERCAST_LIVE` is debugging and wants failures to surface, not be silently eaten.

Test plan: full `world.tests` sweep in the container — 2258 tests, all passing. Live server reloaded. Docs + a fail-safe-only code change; no behavioral change on the default (`SPLATTERCAST_LIVE = False`) path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)