### PR TITLE
Remove 60 dead try/except wrappers around debug calls

### DIFF
--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -314,11 +314,8 @@ def create_character_from_template(account, template, sex="ambiguous"):
     
     # Debug: Verify sex was set correctly
     from world.combat.debug import get_splattercast
-    try:
-        splattercast = get_splattercast()
-        splattercast.msg(f"CHARCREATE_SEX_SET: {char.key} sex set to '{sex}', current value: '{char.sex}', gender property: '{char.gender}'")
-    except Exception:
-        pass
+    splattercast = get_splattercast()
+    splattercast.msg(f"CHARCREATE_SEX_SET: {char.key} sex set to '{sex}', current value: '{char.sex}', gender property: '{char.gender}'")
     
     # Set defaults
     # death_count starts at 1 via AttributeProperty in Character class
@@ -410,11 +407,8 @@ def create_flash_clone(account, old_character):
     
     # Debug: Verify sex was inherited correctly
     from world.combat.debug import get_splattercast
-    try:
-        splattercast = get_splattercast()
-        splattercast.msg(f"FLASH_CLONE_SEX_INHERIT: {char.key} inherited sex '{old_character.sex}' from {old_character.key}, current value: '{char.sex}', gender property: '{char.gender}'")
-    except Exception:
-        pass
+    splattercast = get_splattercast()
+    splattercast.msg(f"FLASH_CLONE_SEX_INHERIT: {char.key} inherited sex '{old_character.sex}' from {old_character.key}, current value: '{char.sex}', gender property: '{char.gender}'")
     
     # INHERIT: death_count from old character
     # The old character's death_count was already incremented at death (at_death())
@@ -752,11 +746,8 @@ def respawn_finalize_template(caller, raw_string, **kwargs):
         # Error - show message and return to selection
         caller.msg(f"|rError creating character: {e}|n")
         from world.combat.debug import get_splattercast
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"CHARCREATE_ERROR: {e}")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"CHARCREATE_ERROR: {e}")
         return "respawn_welcome"
 
 
@@ -826,11 +817,8 @@ def respawn_flash_clone(caller, raw_string, **kwargs):
         # Error - show message and return to selection
         caller.msg(f"|rError creating flash clone: {e}|n")
         from world.combat.debug import get_splattercast
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"FLASH_CLONE_ERROR: {e}")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"FLASH_CLONE_ERROR: {e}")
         return "respawn_welcome"
 
 
@@ -1501,11 +1489,8 @@ def first_char_finalize(caller, raw_string, **kwargs):
         # Error - show message and return to confirmation
         caller.msg(f"|rError creating character: {e}|n")
         from world.combat.debug import get_splattercast
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"CHARCREATE_ERROR: {e}")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"CHARCREATE_ERROR: {e}")
         return "first_char_confirm"
 
 

--- a/typeclasses/armor_mixin.py
+++ b/typeclasses/armor_mixin.py
@@ -193,16 +193,13 @@ class ArmorMixin:
                     # hiccup, etc.) the corpse-side spawn in
                     # death_progression still fires as a fallback because
                     # ``head_severed_at_decap`` was never set.
-                    try:
-                        from world.combat.debug import get_splattercast
-                        splattercast = get_splattercast()
-                        splattercast.msg(
-                            f"DECAPITATION_LIVING_SPAWN_ERROR: "
-                            f"{getattr(self, 'key', '?')} - falling back "
-                            f"to corpse-side head spawn"
-                        )
-                    except Exception:
-                        pass
+                    from world.combat.debug import get_splattercast
+                    splattercast = get_splattercast()
+                    splattercast.msg(
+                        f"DECAPITATION_LIVING_SPAWN_ERROR: "
+                        f"{getattr(self, 'key', '?')} - falling back "
+                        f"to corpse-side head spawn"
+                    )
             return
 
         # Living limb severance: head is excluded (decapitation routes
@@ -270,15 +267,12 @@ class ArmorMixin:
                 )
         except Exception:
             # Don't break combat if the messaging layer hiccups.
-            try:
-                from world.combat.debug import get_splattercast
-                splattercast = get_splattercast()
-                splattercast.msg(
-                    f"DECAPITATION_MSG_ERROR: {self.key} - failed to "
-                    f"broadcast decapitation message"
-                )
-            except Exception:
-                pass
+            from world.combat.debug import get_splattercast
+            splattercast = get_splattercast()
+            splattercast.msg(
+                f"DECAPITATION_MSG_ERROR: {getattr(self, 'key', '?')} - failed to "
+                f"broadcast decapitation message"
+            )
 
     def _calculate_armor_damage_reduction(self, damage, location, injury_type):
         """

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -321,11 +321,8 @@ class Character(
         
         # Prevent double unconsciousness processing
         if hasattr(self, 'ndb') and getattr(self.ndb, 'unconsciousness_processed', False):
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"UNCONSCIOUS_SKIP: {self.key} already processed unconsciousness, skipping")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"UNCONSCIOUS_SKIP: {self.key} already processed unconsciousness, skipping")
             return
             
         # Mark unconsciousness as processed
@@ -340,20 +337,14 @@ class Character(
         if is_in_combat:
             # Set flag for combat system to trigger unconsciousness message after attack message
             self.ndb.unconsciousness_pending = True
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"UNCONSCIOUS_COMBAT: {self.key} unconsciousness message deferred - in active combat")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"UNCONSCIOUS_COMBAT: {self.key} unconsciousness message deferred - in active combat")
             
             # Safety fallback - trigger message after 5 seconds if combat doesn't handle it
             def fallback_unconsciousness_message():
                 if hasattr(self.ndb, 'unconsciousness_pending') and self.ndb.unconsciousness_pending:
-                    try:
-                        splattercast = get_splattercast()
-                        splattercast.msg(f"UNCONSCIOUS_FALLBACK: {self.key} triggering fallback unconsciousness message")
-                    except Exception:
-                        pass
+                    splattercast = get_splattercast()
+                    splattercast.msg(f"UNCONSCIOUS_FALLBACK: {self.key} triggering fallback unconsciousness message")
                     self._show_unconsciousness_message()
                     self.ndb.unconsciousness_pending = False
             
@@ -470,11 +461,8 @@ class Character(
         
         # Log warning if archiving a staff character (shouldn't happen normally)
         if self.account and self.account.is_superuser:
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"WARNING: Archiving staff character {self.key} (Account: {self.account.key}, Reason: {reason})")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"WARNING: Archiving staff character {self.key} (Account: {self.account.key}, Reason: {reason})")
         
         # Set account's last_character for respawn flow
         if self.account:
@@ -498,11 +486,8 @@ class Character(
             self.move_to(limbo, quiet=True, move_hooks=False)
             
             # Log the move
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"ARCHIVE: Moved {self.key} from {current_location.key if current_location else 'None'} to Limbo")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"ARCHIVE: Moved {self.key} from {current_location.key if current_location else 'None'} to Limbo")
         
         # Disconnect any active sessions
         if self.sessions.all():
@@ -632,11 +617,8 @@ class Character(
         
         # Prevent double death processing using PERSISTENT db flag (survives server reload)
         if self.db.death_processed:
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"AT_DEATH_SKIP: {self.key} already processed death (db flag), skipping")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"AT_DEATH_SKIP: {self.key} already processed death (db flag), skipping")
             return
             
         # Mark death as processed IMMEDIATELY using db (persistent) to prevent ANY race conditions
@@ -672,20 +654,14 @@ class Character(
         if is_in_combat:
             # Set flag for combat system to trigger death curtain after kill message
             self.ndb.death_curtain_pending = True
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"AT_DEATH_COMBAT: {self.key} death curtain deferred - in active combat")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"AT_DEATH_COMBAT: {self.key} death curtain deferred - in active combat")
             
             # Safety fallback - trigger curtain after 5 seconds if combat doesn't handle it
             def fallback_death_curtain():
                 if hasattr(self.ndb, 'death_curtain_pending') and self.ndb.death_curtain_pending:
-                    try:
-                        splattercast = get_splattercast()
-                        splattercast.msg(f"AT_DEATH_FALLBACK: {self.key} triggering fallback death curtain")
-                    except Exception:
-                        pass
+                    splattercast = get_splattercast()
+                    splattercast.msg(f"AT_DEATH_FALLBACK: {self.key} triggering fallback death curtain")
                     show_death_curtain(self)
                     self.ndb.death_curtain_pending = False
             
@@ -844,10 +820,7 @@ class Character(
                     delay(0.1, script.at_repeat)
                     splattercast.msg(f"REVIVAL_IMMEDIATE_NEW: Forced immediate medical processing for new script for {self.key}")
             except Exception as e:
-                try:
-                    splattercast.msg(f"REVIVAL_ERROR: Failed to restart medical script for {self.key}: {e}")
-                except Exception:
-                    pass
+                splattercast.msg(f"REVIVAL_ERROR: Failed to restart medical script for {getattr(self, 'key', '?')}: {e}")
         
         # Clear death processing flags (both ndb and db)
         if hasattr(self.ndb, 'death_processed'):
@@ -880,11 +853,8 @@ class Character(
             self._death_cmdset_applied = True
         
         # Log final death
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"FINAL_DEATH: {self.key} has entered permanent death state")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"FINAL_DEATH: {self.key} has entered permanent death state")
 
     def validate_attack_target(self):
         """

--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -545,12 +545,9 @@ class Corpse(IdentityBearerMixin, Item):
                     
             except Exception as e:
                 # Don't break corpse display if wound description fails
-                try:
-                    from world.combat.debug import get_splattercast
-                    splattercast = get_splattercast()
-                    splattercast.msg(f"CORPSE_WOUND_ERROR: Failed to generate wound description for {self.key}: {e}")
-                except Exception:
-                    pass
+                from world.combat.debug import get_splattercast
+                splattercast = get_splattercast()
+                splattercast.msg(f"CORPSE_WOUND_ERROR: Failed to generate wound description for {getattr(self, 'key', '?')}: {e}")
                 continue
         
         return wound_descriptions
@@ -1006,12 +1003,9 @@ class Corpse(IdentityBearerMixin, Item):
                 item.move_to(self.location, quiet=True)
                 
         # Log the decay completion
-        try:
-            from world.combat.debug import get_splattercast
-            splattercast = get_splattercast()
-            splattercast.msg(f"CORPSE_DECAY: {self.key} completely decayed and removed from {self.location}")
-        except Exception:
-            pass
+        from world.combat.debug import get_splattercast
+        splattercast = get_splattercast()
+        splattercast.msg(f"CORPSE_DECAY: {self.key} completely decayed and removed from {self.location}")
             
         # Remove the corpse
         self.delete()

--- a/typeclasses/curtain_of_death.py
+++ b/typeclasses/curtain_of_death.py
@@ -303,21 +303,15 @@ class DeathCurtain:
             script = start_death_progression(self.character)
             
             # Debug logging
-            try:
-                from world.combat.debug import get_splattercast
-                splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_CURTAIN: Death progression started for {self.character.key}, script: {script}")
-            except Exception:
-                pass
+            from world.combat.debug import get_splattercast
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_CURTAIN: Death progression started for {self.character.key}, script: {script}")
                 
         except Exception as e:
             # Debug logging for any errors
-            try:
-                from world.combat.debug import get_splattercast
-                splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_CURTAIN_ERROR: Failed to start death progression for {self.character.key}: {e}")
-            except Exception:
-                pass
+            from world.combat.debug import get_splattercast
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_CURTAIN_ERROR: Failed to start death progression for {getattr(self.character, 'key', '?')}: {e}")
 
 
 def show_death_curtain(character, message=None):

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -134,16 +134,13 @@ class DeathProgressionScript(DefaultScript):
         self.interval = DEATH_PROGRESSION_CHECK_INTERVAL
         
         # Debug logging
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(
-                f"DEATH_PROGRESSION: Script at_script_creation for {self.obj.key} "
-                f"(duration: {DEATH_PROGRESSION_DURATION}s, "
-                f"interval: {DEATH_PROGRESSION_CHECK_INTERVAL}s, "
-                f"messages: {DEATH_PROGRESSION_MESSAGE_COUNT})"
-            )
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(
+            f"DEATH_PROGRESSION: Script at_script_creation for {self.obj.key} "
+            f"(duration: {DEATH_PROGRESSION_DURATION}s, "
+            f"interval: {DEATH_PROGRESSION_CHECK_INTERVAL}s, "
+            f"messages: {DEATH_PROGRESSION_MESSAGE_COUNT})"
+        )
         
     def at_start(self):
         """Called when script starts."""
@@ -153,15 +150,12 @@ class DeathProgressionScript(DefaultScript):
             return
             
         # Log start of death progression with configurable duration
-        try:
-            splattercast = get_splattercast()
-            duration_minutes = DEATH_PROGRESSION_DURATION / 60
-            splattercast.msg(
-                f"DEATH_PROGRESSION: Started for {character.key} - "
-                f"{duration_minutes:.1f} minute revival window"
-            )
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        duration_minutes = DEATH_PROGRESSION_DURATION / 60
+        splattercast.msg(
+            f"DEATH_PROGRESSION: Started for {character.key} - "
+            f"{duration_minutes:.1f} minute revival window"
+        )
             
         # Send initial dying message
         self._send_initial_message()
@@ -171,11 +165,8 @@ class DeathProgressionScript(DefaultScript):
         character = self.obj
         if not character:
             # Log cleanup for invalid character
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script (invalid character)")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script (invalid character)")
             self.stop()
             self.delete()
             return
@@ -184,11 +175,8 @@ class DeathProgressionScript(DefaultScript):
         elapsed = current_time - self.db.start_time
         
         # Debug logging
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"DEATH_PROGRESSION: at_repeat for {character.key}, elapsed: {elapsed:.1f}s")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"DEATH_PROGRESSION: at_repeat for {character.key}, elapsed: {elapsed:.1f}s")
         
         # Check if medical conditions have been resolved and character should be revived
         if self._check_medical_revival_conditions(character):
@@ -354,11 +342,8 @@ class DeathProgressionScript(DefaultScript):
         # Skip observer messages during progression - they tick too fast and overwhelm
             
         # Log progression
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"DEATH_PROGRESSION: {character.key} at {interval}s (msg {message_index + 1}/{len(messages_list)}) - {minutes_remaining}m remaining")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"DEATH_PROGRESSION: {character.key} at {interval}s (msg {message_index + 1}/{len(messages_list)}) - {minutes_remaining}m remaining")
             
     def _get_progression_messages(self):
         """Get the progression messages as an ordered list."""
@@ -464,12 +449,9 @@ class DeathProgressionScript(DefaultScript):
         self._handle_corpse_creation_and_transition(character)
             
         # Log completion
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"DEATH_PROGRESSION: {character.key} completed - corpse created, character transitioned")
-            splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script for {character.key}")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"DEATH_PROGRESSION: {character.key} completed - corpse created, character transitioned")
+        splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script for {character.key}")
             
         # Stop and delete the script to clean up completely
         self.stop()
@@ -498,19 +480,13 @@ class DeathProgressionScript(DefaultScript):
                 self._initiate_new_character_creation(account, character, session)
                 
             # 5. Log the transition
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_COMPLETION: {character.key} -> Corpse created, character transitioned")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_COMPLETION: {character.key} -> Corpse created, character transitioned")
                 
         except Exception as e:
             # Fallback - log error but don't crash the death progression
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_COMPLETION_ERROR: {character.key} - {e}")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_COMPLETION_ERROR: {getattr(character, 'key', '?')} - {e}")
 
     def _create_corpse_from_character(self, character):
         """Create a corpse object that preserves forensic data from the character."""
@@ -590,13 +566,10 @@ class DeathProgressionScript(DefaultScript):
             from commands.CmdCharacter import _clear_all_overrides
             _clear_all_overrides(character)
         except Exception as e:
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(
-                    f"DEATH_OVERRIDE_CLEAR_ERROR: {character.key} - {e}"
-                )
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(
+                f"DEATH_OVERRIDE_CLEAR_ERROR: {getattr(character, 'key', '?')} - {e}"
+            )
         
         # Preserve character appearance data for proper corpse display
         corpse.db.original_gender = getattr(character, 'gender', 'neutral')
@@ -627,14 +600,11 @@ class DeathProgressionScript(DefaultScript):
                 except Exception:
                     pass
             except Exception as snapshot_err:
-                try:
-                    splattercast = get_splattercast()
-                    splattercast.msg(
-                        f"DEATH_MEDICAL_SNAPSHOT_ERROR: Failed to snapshot "
-                        f"medical state for {character.key}: {snapshot_err}"
-                    )
-                except Exception:
-                    pass
+                splattercast = get_splattercast()
+                splattercast.msg(
+                    f"DEATH_MEDICAL_SNAPSHOT_ERROR: Failed to snapshot "
+                    f"medical state for {getattr(character, 'key', '?')}: {snapshot_err}"
+                )
             
             # Transfer wound data for corpse wound descriptions
             try:
@@ -659,18 +629,12 @@ class DeathProgressionScript(DefaultScript):
                         }
                         corpse.db.wounds_at_death.append(wound_record)
                     
-                    try:
-                        splattercast = get_splattercast()
-                        splattercast.msg(f"DEATH_WOUNDS_PRESERVED: {len(wound_data)} wounds preserved on corpse for {character.key}")
-                    except Exception:
-                        pass
+                    splattercast = get_splattercast()
+                    splattercast.msg(f"DEATH_WOUNDS_PRESERVED: {len(wound_data)} wounds preserved on corpse for {character.key}")
             except Exception as e:
                 # Don't fail death progression if wound preservation fails
-                try:
-                    splattercast = get_splattercast()
-                    splattercast.msg(f"DEATH_WOUNDS_ERROR: Failed to preserve wounds for {character.key}: {e}")
-                except Exception:
-                    pass
+                splattercast = get_splattercast()
+                splattercast.msg(f"DEATH_WOUNDS_ERROR: Failed to preserve wounds for {getattr(character, 'key', '?')}: {e}")
         
         # Transfer character description data
         if hasattr(character, 'longdesc') and character.longdesc:
@@ -753,13 +717,10 @@ class DeathProgressionScript(DefaultScript):
                 else:
                     spawn_severed_head_for_corpse(corpse)
             except Exception as e:
-                try:
-                    splattercast = get_splattercast()
-                    splattercast.msg(
-                        f"DEATH_DECAPITATION_ERROR: {character.key} - {e}"
-                    )
-                except Exception:
-                    pass
+                splattercast = get_splattercast()
+                splattercast.msg(
+                    f"DEATH_DECAPITATION_ERROR: {getattr(character, 'key', '?')} - {e}"
+                )
             character.db.decapitation_pending = False
         
         return corpse
@@ -783,11 +744,8 @@ class DeathProgressionScript(DefaultScript):
             )
             
             script_count = medical_scripts.count()
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_MEDICAL_CLEANUP: Found {script_count} medical scripts for {character.key}")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_MEDICAL_CLEANUP: Found {script_count} medical scripts for {character.key}")
             
             for script in medical_scripts:
                 try:
@@ -811,7 +769,7 @@ class DeathProgressionScript(DefaultScript):
                 except Exception as e:
                     try:
                         splattercast = get_splattercast()
-                        splattercast.msg(f"DEATH_MEDICAL_CLEANUP_ERROR: {character.key} - {e}")
+                        splattercast.msg(f"DEATH_MEDICAL_CLEANUP_ERROR: {getattr(character, 'key', '?')} - {e}")
                         import traceback
                         splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
                     except Exception:
@@ -819,7 +777,7 @@ class DeathProgressionScript(DefaultScript):
         except Exception as e:
             try:
                 splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: {character.key} - {e}")
+                splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: {getattr(character, 'key', '?')} - {e}")
                 import traceback
                 splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
             except Exception:
@@ -833,19 +791,13 @@ class DeathProgressionScript(DefaultScript):
             character.move_to(limbo_room, quiet=True, move_hooks=False)
             
             # Debug logging for successful teleportation
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_TELEPORT_SUCCESS: {character.key} moved from {old_location} to {limbo_room}")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_TELEPORT_SUCCESS: {character.key} moved from {old_location} to {limbo_room}")
                 
         except Exception as e:
             # Log the specific error instead of silently failing
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_TELEPORT_ERROR: {character.key} - {e}")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_TELEPORT_ERROR: {getattr(character, 'key', '?')} - {e}")
         
         # Unpuppet character from account
         if account:
@@ -858,11 +810,8 @@ class DeathProgressionScript(DefaultScript):
             if session:
                 account.unpuppet_object(session)
                 
-                try:
-                    splattercast = get_splattercast()
-                    splattercast.msg(f"DEATH_UNPUPPET: {character.key} unpuppeted from {account.key}")
-                except Exception:
-                    pass
+                splattercast = get_splattercast()
+                splattercast.msg(f"DEATH_UNPUPPET: {character.key} unpuppeted from {account.key}")
         
         # Archive the dead character (also handles any lingering sessions)
         character.archive_character(reason="death")
@@ -886,11 +835,8 @@ class DeathProgressionScript(DefaultScript):
             account.msg("|yCharacter creation system is under development.|n")
             account.msg("|yPlease contact staff for assistance creating a new character.|n")
             
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"CHARCREATE_IMPORT_ERROR: {e}")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"CHARCREATE_IMPORT_ERROR: {e}")
         account.msg("")
         
         # TODO: Future implementation might:
@@ -913,28 +859,19 @@ def start_death_progression(character):
     # Check if character already has a death progression script
     existing_script = character.scripts.get("death_progression")
     if existing_script:
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"DEATH_PROGRESSION: Existing script found for {character.key}")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"DEATH_PROGRESSION: Existing script found for {character.key}")
         return existing_script
         
     # Create new death progression script
-    try:
-        splattercast = get_splattercast()
-        splattercast.msg(f"DEATH_PROGRESSION: Creating new script for {character.key}")
-    except Exception:
-        pass
+    splattercast = get_splattercast()
+    splattercast.msg(f"DEATH_PROGRESSION: Creating new script for {character.key}")
         
     # Create script using the same pattern as medical script
     script = character.scripts.add(DeathProgressionScript)
     
-    try:
-        splattercast = get_splattercast()
-        splattercast.msg(f"DEATH_PROGRESSION: Script created and started: {script} for {character.key}")
-    except Exception:
-        pass
+    splattercast = get_splattercast()
+    splattercast.msg(f"DEATH_PROGRESSION: Script created and started: {script} for {character.key}")
         
     return script
 def get_death_progression_script(character):

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -99,12 +99,9 @@ class Room(ObjectParent, DefaultRoom):
                             pass
                     
                     # Log and delete
-                    try:
-                        from world.combat.debug import get_splattercast
-                        splattercast = get_splattercast()
-                        splattercast.msg(f"CORPSE_DECAY_JIT: {corpse.key} decayed on room entry to {self.key}")
-                    except Exception:
-                        pass
+                    from world.combat.debug import get_splattercast
+                    splattercast = get_splattercast()
+                    splattercast.msg(f"CORPSE_DECAY_JIT: {corpse.key} decayed on room entry to {self.key}")
                     
                     corpse.delete()
             except Exception:

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -905,13 +905,10 @@ class MedicalState:
         # Dying characters can still be resuscitated, so they should keep conditions
         character = self._get_character_reference()
         if character and character.db.archived:
-            try:
-                from world.combat.debug import get_splattercast
-                splattercast = get_splattercast()
-                char_name = character.key if character else "unknown"
-                splattercast.msg(f"ADD_CONDITION: {char_name} is archived, not adding {condition.condition_type}")
-            except Exception:
-                pass
+            from world.combat.debug import get_splattercast
+            splattercast = get_splattercast()
+            char_name = character.key if character else "unknown"
+            splattercast.msg(f"ADD_CONDITION: {char_name} is archived, not adding {condition.condition_type}")
             return
             
         if condition not in self.conditions:
@@ -920,12 +917,9 @@ class MedicalState:
             # so they're a death-verdict input.
             self._invalidate_derived_state()
 
-            try:
-                from world.combat.debug import get_splattercast
-                splattercast = get_splattercast()
-                splattercast.msg(f"ADD_CONDITION: Added {condition.condition_type} severity {condition.severity}")
-            except Exception:
-                pass
+            from world.combat.debug import get_splattercast
+            splattercast = get_splattercast()
+            splattercast.msg(f"ADD_CONDITION: Added {condition.condition_type} severity {condition.severity}")
             
             # Start ticker if condition requires it
             if hasattr(condition, 'requires_ticker') and condition.requires_ticker:
@@ -933,20 +927,14 @@ class MedicalState:
                 # doesn't directly hold character reference
                 character = self._get_character_reference()
                 if character:
-                    try:
-                        from world.combat.debug import get_splattercast
-                        splattercast = get_splattercast()
-                        splattercast.msg(f"ADD_CONDITION: Starting ticker for {condition.condition_type} on {character.key}")
-                    except Exception:
-                        pass
+                    from world.combat.debug import get_splattercast
+                    splattercast = get_splattercast()
+                    splattercast.msg(f"ADD_CONDITION: Starting ticker for {condition.condition_type} on {character.key}")
                     condition.start_condition(character)
                 else:
-                    try:
-                        from world.combat.debug import get_splattercast
-                        splattercast = get_splattercast()
-                        splattercast.msg(f"ADD_CONDITION: No character reference found for {condition.condition_type}")
-                    except Exception:
-                        pass
+                    from world.combat.debug import get_splattercast
+                    splattercast = get_splattercast()
+                    splattercast.msg(f"ADD_CONDITION: No character reference found for {condition.condition_type}")
             
             # Save medical state after adding condition to ensure persistence
             if self.character:

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -251,21 +251,15 @@ class MedicalScript(DefaultScript):
                 self.delete()
                 
         except Exception as e:
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"MEDICAL_SCRIPT_CRITICAL_ERROR: {self.obj.key}: {e}")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"MEDICAL_SCRIPT_CRITICAL_ERROR: {getattr(self.obj, 'key', '?')}: {e}")
             self.stop()
             self.delete()
     
     def at_stop(self):
         """Called when script stops."""
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"MEDICAL_SCRIPT_STOP: Medical script stopped for {self.obj.key}")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"MEDICAL_SCRIPT_STOP: Medical script stopped for {self.obj.key}")
     
     def _send_medical_messages(self, bleeding_severity, pain_severity, infection_severity=0):
         """Send consolidated medical messages combining bleeding, pain, and infection."""
@@ -412,45 +406,30 @@ def start_medical_script(character):
     Returns:
         MedicalScript: The active medical script
     """
-    try:
-        splattercast = get_splattercast()
-        splattercast.msg(f"START_MEDICAL_SCRIPT: Checking for existing script on {character.key}")
-    except Exception:
-        pass
+    splattercast = get_splattercast()
+    splattercast.msg(f"START_MEDICAL_SCRIPT: Checking for existing script on {character.key}")
         
     # Don't create scripts for dead characters
     if hasattr(character, 'medical_state') and character.medical_state.is_dead():
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"START_MEDICAL_SCRIPT: {character.key} is dead, not creating medical script")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"START_MEDICAL_SCRIPT: {character.key} is dead, not creating medical script")
         return None
         
     # Check if script already exists
     existing_script = character.scripts.get("medical_script")
     if existing_script:
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"START_MEDICAL_SCRIPT: Found existing script for {character.key}")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"START_MEDICAL_SCRIPT: Found existing script for {character.key}")
         return existing_script.first() if existing_script else None
     
     # Create new script
-    try:
-        splattercast = get_splattercast()
-        splattercast.msg(f"START_MEDICAL_SCRIPT: Creating new script for {character.key}")
-    except Exception:
-        pass
+    splattercast = get_splattercast()
+    splattercast.msg(f"START_MEDICAL_SCRIPT: Creating new script for {character.key}")
         
     script = character.scripts.add(MedicalScript)
     
-    try:
-        splattercast = get_splattercast()
-        splattercast.msg(f"START_MEDICAL_SCRIPT: Script created: {script}")
-    except Exception:
-        pass
+    splattercast = get_splattercast()
+    splattercast.msg(f"START_MEDICAL_SCRIPT: Script created: {script}")
         
     return script
 
@@ -462,26 +441,17 @@ def stop_medical_script(character):
     Args:
         character: The character to stop medical script for
     """
-    try:
-        splattercast = get_splattercast()
-        splattercast.msg(f"STOP_MEDICAL_SCRIPT: Looking for medical scripts on {character.key}")
-    except Exception:
-        pass
+    splattercast = get_splattercast()
+    splattercast.msg(f"STOP_MEDICAL_SCRIPT: Looking for medical scripts on {character.key}")
     
     # Find and delete all medical scripts (active or stopped)
     existing_scripts = character.scripts.get("medical_script")
     if existing_scripts:
         for script in existing_scripts:
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"STOP_MEDICAL_SCRIPT: Found script {script}, deleting it")
-            except Exception:
-                pass
+            splattercast = get_splattercast()
+            splattercast.msg(f"STOP_MEDICAL_SCRIPT: Found script {script}, deleting it")
             script.stop()
             script.delete()
     else:
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"STOP_MEDICAL_SCRIPT: No medical scripts found on {character.key}")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        splattercast.msg(f"STOP_MEDICAL_SCRIPT: No medical scripts found on {character.key}")

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -995,12 +995,9 @@ def apply_medical_effects(item, user, target, **kwargs):
                     hasattr(script, '_check_medical_revival_conditions')):
                     
                     # Debug the revival condition check
-                    try:
-                        from world.combat.debug import get_splattercast
-                        splattercast = get_splattercast()
-                        splattercast.msg(f"REVIVAL_DEBUG: Checking revival conditions for {target.key}")
-                    except Exception:
-                        pass
+                    from world.combat.debug import get_splattercast
+                    splattercast = get_splattercast()
+                    splattercast.msg(f"REVIVAL_DEBUG: Checking revival conditions for {target.key}")
                     
                     if script._check_medical_revival_conditions(target):
                         from world.combat.debug import get_splattercast
@@ -1009,20 +1006,14 @@ def apply_medical_effects(item, user, target, **kwargs):
                         script._handle_medical_revival()
                         break  # Revival handled, stop checking
                     else:
-                        try:
-                            from world.combat.debug import get_splattercast
-                            splattercast = get_splattercast()
-                            splattercast.msg(f"REVIVAL_DEBUG: {target.key} does not meet revival conditions")
-                        except Exception:
-                            pass
+                        from world.combat.debug import get_splattercast
+                        splattercast = get_splattercast()
+                        splattercast.msg(f"REVIVAL_DEBUG: {target.key} does not meet revival conditions")
         except Exception as e:
             # Don't let revival check errors break medical treatment
-            try:
-                from world.combat.debug import get_splattercast
-                splattercast = get_splattercast()
-                splattercast.msg(f"REVIVAL_CHECK_ERROR: {target.key}: {e}")
-            except Exception:
-                pass
+            from world.combat.debug import get_splattercast
+            splattercast = get_splattercast()
+            splattercast.msg(f"REVIVAL_CHECK_ERROR: {getattr(target, 'key', '?')}: {e}")
     
     return result_msg
 


### PR DESCRIPTION
Closes #468.

**What:** Removes the `try: ... except Exception: pass` scaffolding around pure debug calls — dead since #464 made `get_splattercast()` an always-truthy router whose `.msg()` cannot raise. Net −180 lines.

**How:** AST-verified surgery, not blind sed. Only try blocks matching the strict shape were unwrapped: body purely debug plumbing (router assignment, local debug import, `splattercast.msg` / `log_debug` / `debug_broadcast` calls, call-free message prep), single bare `except Exception:` handler containing only `pass`, no else/finally. 60 blocks across 10 files. Function-local `get_splattercast` imports in `world/medical` preserved per the circular-import rule. Try blocks that mix debug calls with real logic were deliberately left alone — those are #469 territory.

**What the removal caught:** Two test failures exposed a real fragility class the wrappers had been masking — exception-handler log lines that dereference the same game entity whose broken state caused the original exception (`DECAPITATION_MSG_ERROR` formatting `self.key` right after `self` was the thing that failed). Instead of re-wrapping, all 14 such handler log lines now use the codebase's established `getattr(entity, 'key', '?')` pattern, so error logging can never re-raise.

**Convention scorecard:** broad excepts 205 → 145. The remaining ~84 wrap real logic and are documented debt in #469, to be narrowed opportunistically.

Test plan: full `world.tests` sweep in the container — 2258 tests, all passing (including the two that initially failed and drove the handler-log hardening). Live server reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)