### PR TITLE
Throw restructure: physics engine extracted, dead code deleted, excepts narrowed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ interactive menus), and `evennia.utils.utils` (general helpers). **Always check
 | Fix grappling mechanics | `world/combat/grappling.py` |
 | Add/change combat constants | `world/combat/constants.py` |
 | Modify attack/damage logic | `world/combat/utils.py` |
+| Modify throw flight/landing/deflection | `world/combat/throwing.py` |
 | Change combat messages | `world/combat/messages/*.py` |
 | Modify attack command | `commands/combat/core_actions.py` |
 | Add movement commands | `commands/combat/movement.py` |

--- a/commands/CmdExplosives.py
+++ b/commands/CmdExplosives.py
@@ -942,12 +942,9 @@ class CmdDetonate(Command):
         fuse_time = explosive.db.fuse_time if explosive.db.fuse_time is not None else 8
         setattr(explosive.ndb, NDB_COUNTDOWN_REMAINING, fuse_time)
 
-        # Start countdown using CmdPull's grenade ticker system
-        # Create temporary CmdPull instance to access start_grenade_ticker
-        from commands.CmdThrow import CmdPull
-        pull_cmd = CmdPull()
-        pull_cmd.caller = caller
-        pull_cmd.start_grenade_ticker(explosive)
+        # Start countdown using the shared sticky-aware ticker
+        from commands.explosion_utils import start_grenade_ticker
+        start_grenade_ticker(explosive)
 
         # Operator messaging
         caller.msg(
@@ -1018,11 +1015,9 @@ class CmdDetonate(Command):
             fuse_time = explosive.db.fuse_time if explosive.db.fuse_time is not None else 8
             setattr(explosive.ndb, NDB_COUNTDOWN_REMAINING, fuse_time)
 
-            # Start countdown
-            from commands.CmdThrow import CmdPull
-            pull_cmd = CmdPull()
-            pull_cmd.caller = caller
-            pull_cmd.start_grenade_ticker(explosive)
+            # Start countdown using the shared sticky-aware ticker
+            from commands.explosion_utils import start_grenade_ticker
+            start_grenade_ticker(explosive)
 
             detonated_count += 1
 

--- a/commands/CmdThrow.py
+++ b/commands/CmdThrow.py
@@ -1,24 +1,25 @@
 """
 Throw Command Implementation
 
-Comprehensive throwing system supporting:
-- Utility object transfer between rooms
-- Combat weapon deployment with damage
-- Grenade mechanics with proximity and timers
-- Flight state management and room announcements
-- Universal proximity system integration
-- Grenade deflection with melee weapons
+Command surface for the throwing system:
+- ``throw`` — parsing, validation, origin announcements
+- ``pull`` — grenade pin pulling
+- ``catch`` — intercepting flying objects
+
+The physics — flight timers, landing resolution, proximity
+assignment, grenade deflection — live in ``world/combat/throwing.py``
+(issue #471 step 2).  Behavioral contract:
+``world/tests/test_throw_characterization.py``.
 
 Part of the G.R.I.M. Combat System.
 """
 
 import random
-from evennia import Command, utils
+from evennia import Command
 from world.combat.debug import get_splattercast
 from world.combat.constants import (
     DB_CHAR,
     DB_GRAPPLED_BY_DBREF,
-    DB_GRAPPLING_DBREF,
     DEBUG_PREFIX_THROW,
     MSG_CATCH_FAILED,
     MSG_CATCH_FAILED_ROOM,
@@ -28,11 +29,6 @@ from world.combat.constants import (
     MSG_CATCH_SUCCESS,
     MSG_CATCH_SUCCESS_ROOM,
     MSG_CATCH_WHAT,
-    MSG_GRENADE_CHAIN_TRIGGER,
-    MSG_GRENADE_DAMAGE,
-    MSG_GRENADE_DAMAGE_ROOM,
-    MSG_GRENADE_DUD_ROOM,
-    MSG_GRENADE_EXPLODE_ROOM,
     MSG_PULL_ALREADY_PULLED,
     MSG_PULL_INVALID_SYNTAX,
     MSG_PULL_NO_HANDS,
@@ -44,16 +40,8 @@ from world.combat.constants import (
     MSG_PULL_SUCCESS_ROOM,
     MSG_PULL_TIMER_WARNING,
     MSG_PULL_WHAT,
-    MSG_THROW_ARRIVAL,
-    MSG_THROW_ARRIVAL_TARGETED,
-    MSG_THROW_ARRIVAL_TARGETED_VICTIM,
-    MSG_THROW_FLIGHT_SAMEROOM_GENERAL,
-    MSG_THROW_FLIGHT_SAMEROOM_TARGET,
-    MSG_THROW_FLIGHT_SAMEROOM_TARGET_VICTIM,
     MSG_THROW_GRAPPLED,
     MSG_THROW_INVALID_DIRECTION,
-    MSG_THROW_LANDING_PROXIMITY,
-    MSG_THROW_LANDING_ROOM,
     MSG_THROW_NO_AIM_CROSS_ROOM,
     MSG_THROW_NO_HANDS,
     MSG_THROW_NOTHING_WIELDED,
@@ -67,26 +55,18 @@ from world.combat.constants import (
     MSG_THROW_SUGGEST_AT_SYNTAX,
     MSG_THROW_TARGET_NOT_FOUND,
     MSG_THROW_TIMER_EXPIRED,
-    MSG_THROW_UTILITY_BOUNCE,
-    MSG_THROW_UTILITY_BOUNCE_VICTIM,
-    MSG_THROW_WEAPON_HIT,
-    MSG_THROW_WEAPON_HIT_VICTIM,
-    MSG_THROW_WEAPON_MISS,
-    MSG_THROW_WEAPON_MISS_VICTIM,
     NDB_AIMING_DIRECTION,
     NDB_COMBAT_HANDLER,
     NDB_COUNTDOWN_REMAINING,
     NDB_FLYING_OBJECTS,
-    NDB_GRENADE_TIMER,
-    NDB_PROXIMITY,
-    NDB_PROXIMITY_UNIVERSAL,
-    NDB_SKIP_ROUND,
-    THROW_FLIGHT_TIME,
 )
-# Note: apply_damage removed - using character.take_damage() for medical system integration
-from world.combat.handler import get_or_create_combat
-from world.combat.utils import get_display_name_safe
-from world.grammar import capitalize_first
+from world.combat.throwing import (
+    cancel_flight,
+    is_explosive,
+    select_most_magnetic_target_in_room,
+    select_random_target_in_room,
+    start_flight,
+)
 from world.identity_utils import msg_room_identity
 from commands._identity_targeting import resolve_character_target
 
@@ -94,59 +74,60 @@ from commands._identity_targeting import resolve_character_target
 class CmdThrow(Command):
     """
     Throw objects at targets or in directions.
-    
+
     Usage:
         throw <object>                    # Throw randomly in current room or aimed direction
         throw <object> at <target>        # Throw at specific target (requires aim for cross-room)
         throw <object> to <direction>     # Throw to adjacent room in specified direction
         throw <object> to here            # Throw randomly in current room
-    
+
     Examples:
         throw knife at bob               # Target Bob in current room or aimed room
         throw grenade to north           # Throw grenade north to adjacent room
         throw keys to here               # Throw keys randomly in current room
         throw rock                       # Throw rock in aimed direction or current room
-    
+
     The throw command serves dual purposes: utility object transfer and combat weapon
-    deployment. Objects with the 'is_throwing_weapon' property will trigger combat
-    mechanics, while utility objects transfer harmlessly between rooms.
-    
+    deployment. Objects with the 'is_throwing_weapon' property are combat weapons —
+    targeted throws route through the 'attack' command rather than the utility flight
+    path, so weapon throws use full combat resolution.
+
     Thrown objects have a 2-second flight time and appear in room descriptions during
     flight. Landing creates proximity relationships for grenade mechanics and chain
     reactions.
-    
+
     Special mechanics:
     - Grenades can be deflected by the TARGET if they're wielding a melee weapon (Motorics skill check)
-    - Deflected grenades may bounce back to the thrower or ricochet in random directions  
+    - Deflected grenades may bounce back to the thrower or ricochet in random directions
     - Melee weapons with 'deflection_bonus' property modify the deflection difficulty threshold
     - Impact grenades (future feature) cannot be deflected
     """
-    
+
     key = "throw"
     aliases = ["toss", "hurl"]
     locks = "cmd:all()"
     help_category = "Combat"
-    
+
     def parse(self):
         """Parse throw command with intelligent syntax detection."""
         self.args = self.args.strip()
-        
+
         # Initialize parsing results
         self.object_name = None
         self.target_name = None
         self.direction = None
         self.throw_type = None  # 'at_target', 'to_direction', 'to_here', 'fallback'
-        
+
         if not self.args:
             return
-        
+
         # Parse for "at" keyword - targeted throwing
         if " at " in self.args:
             parts = self.args.split(" at ", 1)
             if len(parts) == 2:
                 self.object_name = parts[0].strip()
                 target_part = parts[1].strip()
-                
+
                 # Handle "throw knife at here" -> convert to "throw knife to here"
                 if target_part.lower() == "here":
                     self.throw_type = "to_here"
@@ -154,14 +135,14 @@ class CmdThrow(Command):
                     self.target_name = target_part
                     self.throw_type = "at_target"
                 return
-        
+
         # Parse for "to" keyword - directional or here throwing
         if " to " in self.args:
             parts = self.args.split(" to ", 1)
             if len(parts) == 2:
                 self.object_name = parts[0].strip()
                 target_part = parts[1].strip()
-                
+
                 if target_part.lower() == "here":
                     self.throw_type = "to_here"
                 else:
@@ -169,28 +150,30 @@ class CmdThrow(Command):
                     self.direction = target_part
                     self.throw_type = "to_direction"
                 return
-        
+
         # Fallback - single object name
         self.object_name = self.args
         self.throw_type = "fallback"
-    
+
     def func(self):
         """Execute the throw command."""
         if not self.args:
             self.caller.msg("Throw what? Use 'throw <object>' or 'throw <object> at <target>'.")
             return
-        
+
         # Validate and get the object to throw
         obj = self.get_object_to_throw()
         if not obj:
             return
-        
+
         # Store object as instance variable for use in determine_destination
         self.obj_to_throw = obj
-        
-        # Check if this is a dedicated throwing weapon that should use attack command
+
+        # Dedicated throwing weapons use full combat resolution via the
+        # attack command — they never take the utility flight path.
+        # (Ammo/recovery tracking for thrown weapons is a future
+        # feature, alongside gun ammo.)
         if obj.db.is_throwing_weapon:
-            # If targeting someone, invoke attack command instead
             if self.target_name:
                 self.caller.msg(f"You ready your {obj.key} to attack...")
                 # Execute the attack command with the target
@@ -198,47 +181,38 @@ class CmdThrow(Command):
             else:
                 self.caller.msg("Throwing weapons are designed for combat. Use 'attack <target>' to fight, or 'throw <weapon> to <direction/here>' to discard it.")
             return
-        
+
         # Determine destination and target based on throw type
         destination, target = self.determine_destination()
         if destination is None:
             return
-        
-        # Check if this is a weapon throw and handle combat
-        is_weapon = self.is_throwing_weapon(obj)
-        if is_weapon and target:
-            if self.handle_weapon_throw(obj, target, destination):
-                return  # Combat handled the throw
-        
-        # Handle utility throw or weapon miss
+
         self.handle_utility_throw(obj, destination, target)
-    
+
     def get_object_to_throw(self):
         """Validate and return the object to throw."""
         if not self.object_name:
             self.caller.msg(MSG_THROW_NOTHING_WIELDED)
             return None
-        
+
         # Check if caller has hands (AttributeProperty compatible)
         caller_hands = getattr(self.caller, 'hands', None)
         if caller_hands is None:
             self.caller.msg(MSG_THROW_NOTHING_WIELDED)
             return None
-        
+
         # Check for empty hands dict (no hands at all)
         if not caller_hands:
             self.caller.msg(MSG_THROW_NO_HANDS)
             return None
-        
+
         # Find object in hands
         obj = None
-        hand_name = None
         for hand, wielded_obj in caller_hands.items():
             if wielded_obj and self.object_name.lower() in wielded_obj.key.lower():
                 obj = wielded_obj
-                hand_name = hand
                 break
-        
+
         if not obj:
             # Check if object exists but not wielded
             search_obj = self.caller.search(self.object_name, location=self.caller, quiet=True)
@@ -248,111 +222,103 @@ class CmdThrow(Command):
             else:
                 self.caller.msg(MSG_THROW_OBJECT_NOT_FOUND.format(object=self.object_name))
                 return None
-        
+
         # Check for special grenade validation
-        if self.is_explosive(obj):
+        if is_explosive(obj):
             if not self.validate_grenade_throw(obj):
                 return None
-        
+
         # Check if caller is grappled
-        if hasattr(self.caller, 'ndb') and hasattr(self.caller.ndb, NDB_COMBAT_HANDLER):
-            handler = getattr(self.caller.ndb, NDB_COMBAT_HANDLER)
-            if handler:
-                combatants_list = handler.db.combatants or []
-                combat_entry = next((e for e in combatants_list if e.get(DB_CHAR) == self.caller), None)
-                if combat_entry and combat_entry.get(DB_GRAPPLED_BY_DBREF):
-                    self.caller.msg(MSG_THROW_GRAPPLED)
-                    return None
-        
+        handler = getattr(self.caller.ndb, NDB_COMBAT_HANDLER, None)
+        if handler:
+            combatants_list = handler.db.combatants or []
+            combat_entry = next((e for e in combatants_list if e.get(DB_CHAR) == self.caller), None)
+            if combat_entry and combat_entry.get(DB_GRAPPLED_BY_DBREF):
+                self.caller.msg(MSG_THROW_GRAPPLED)
+                return None
+
         return obj
-    
+
     def validate_grenade_throw(self, obj):
         """Validate grenade-specific throwing requirements."""
         # Allow unpinned grenades to be thrown as inert objects
         # Players should be able to make tactical mistakes or intentional choices
-        
+
         # Only check if grenade timer has expired (explosion in hands)
-        if hasattr(obj.ndb, NDB_COUNTDOWN_REMAINING):
-            remaining = getattr(obj.ndb, NDB_COUNTDOWN_REMAINING, 0)
-            if remaining is not None and remaining <= 0:
-                self.caller.msg(MSG_THROW_TIMER_EXPIRED)
-                # Apply damage to caller using medical system
-                blast_damage = obj.db.blast_damage if obj.db.blast_damage is not None else 10
-                damage_type = obj.db.damage_type if obj.db.damage_type is not None else 'blast'  # Changed to 'blast' for explosive damage
-                self.caller.take_damage(blast_damage, location="chest", injury_type=damage_type)
-                obj.delete()
-                return False
-        
+        remaining = getattr(obj.ndb, NDB_COUNTDOWN_REMAINING, None)
+        if remaining is not None and remaining <= 0:
+            self.caller.msg(MSG_THROW_TIMER_EXPIRED)
+            # Apply damage to caller using medical system
+            blast_damage = obj.db.blast_damage if obj.db.blast_damage is not None else 10
+            damage_type = obj.db.damage_type if obj.db.damage_type is not None else 'blast'
+            self.caller.take_damage(blast_damage, location="chest", injury_type=damage_type)
+            obj.delete()
+            return False
+
         return True
-    
+
     def determine_destination(self):
         """Determine destination room and target based on throw type."""
         if self.throw_type == "to_here":
             # Just throw in current room with no specific target
             return self.caller.location, None
-        
+
         elif self.throw_type == "at_target":
             # Find target in current room or aimed room
             target = self.find_target()
             if not target:
                 return None, None
             return target.location, target
-        
+
         elif self.throw_type == "to_direction":
             # Validate direction and get destination room
             destination = self.get_destination_room(self.direction)
             if not destination:
                 return None, None
-            # For sticky grenades, prefer most magnetic character, fallback to random
-            if hasattr(self, 'obj_to_throw') and self.obj_to_throw.db.is_sticky:
-                target = self.select_most_magnetic_target_in_room(destination, self.obj_to_throw)
-                if not target:  # No viable magnetic targets, select random
-                    target = self.select_random_target_in_room(destination)
-            else:
-                target = self.select_random_target_in_room(destination)
-            return destination, target
-        
+            return destination, self._pick_room_target(destination)
+
         elif self.throw_type == "fallback":
             # Use aim state or current room
             aim_direction = getattr(self.caller.ndb, NDB_AIMING_DIRECTION, None)
             if aim_direction:
                 destination = self.get_destination_room(aim_direction)
                 if destination:
-                    # For sticky grenades, prefer most magnetic character, fallback to random
-                    if hasattr(self, 'obj_to_throw') and self.obj_to_throw.db.is_sticky:
-                        target = self.select_most_magnetic_target_in_room(destination, self.obj_to_throw)
-                        if not target:  # No viable magnetic targets, select random
-                            target = self.select_random_target_in_room(destination)
-                    else:
-                        target = self.select_random_target_in_room(destination)
-                    return destination, target
-            
+                    return destination, self._pick_room_target(destination)
+
             # Fallback to current room
-            # For sticky grenades in current room, prefer most magnetic character, fallback to random
-            if hasattr(self, 'obj_to_throw') and self.obj_to_throw.db.is_sticky:
-                target = self.select_most_magnetic_target_in_room(self.caller.location, self.obj_to_throw)
-                if not target:  # No viable magnetic targets, select random
-                    target = self.select_random_target_in_room(self.caller.location)
-            else:
-                target = self.select_random_target_in_room(self.caller.location)
-            return self.caller.location, target
-        
+            return self.caller.location, self._pick_room_target(self.caller.location)
+
         return None, None
-    
+
+    def _pick_room_target(self, room):
+        """Pick the landing target for an untargeted throw.
+
+        Sticky grenades prefer the most magnetic character in the
+        room; everything else (and sticky with no viable magnetic
+        target) lands near a random occupant.
+        """
+        obj = getattr(self, "obj_to_throw", None)
+        if obj is not None and obj.db.is_sticky:
+            target = select_most_magnetic_target_in_room(
+                room, obj, exclude=self.caller
+            )
+            if target:
+                return target
+        return select_random_target_in_room(room, exclude=self.caller)
+
     def find_target(self):
         """Find target for 'at' syntax throwing."""
         splattercast = get_splattercast()
-        
+
         if not self.target_name:
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: find_target: No target_name provided")
             return None
-        
+
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: find_target: Looking for target '{self.target_name}' in {self.caller.location}(#{self.caller.location.id})")
-        
+
         # First check current room (identity-aware character resolution)
         target = resolve_character_target(self.caller, self.target_name)
         target_hands = getattr(target, 'hands', None) if target else None
-        splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: find_target: identity-resolved target = {target}, has_hands = {target_hands is not None}")
 
         if target and target_hands is not None:  # Is a character with hands attribute
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: find_target: Found valid character target: {target}")
@@ -360,7 +326,6 @@ class CmdThrow(Command):
 
         # Check aimed room for cross-room targeting
         aim_direction = getattr(self.caller.ndb, NDB_AIMING_DIRECTION, None)
-        splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: find_target: aim_direction = {aim_direction}")
 
         if aim_direction:
             destination = self.get_destination_room(aim_direction)
@@ -371,7 +336,6 @@ class CmdThrow(Command):
                     candidates=destination.contents,
                 )
                 target_hands = getattr(target, 'hands', None) if target else None
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: find_target: cross-room identity-resolved target = {target}, has_hands = {target_hands is not None}")
                 if target and target_hands is not None:
                     return target
         else:
@@ -379,194 +343,57 @@ class CmdThrow(Command):
             if not target:
                 self.caller.msg(MSG_THROW_NO_AIM_CROSS_ROOM)
                 return None
-        
+
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_FAIL: find_target: No valid target found for '{self.target_name}'")
         self.caller.msg(MSG_THROW_TARGET_NOT_FOUND.format(target=self.target_name))
         return None
-    
+
     def get_destination_room(self, direction):
         """Get destination room for directional throwing."""
         splattercast = get_splattercast()
-        
+
         if not direction:
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: get_destination_room: No direction provided")
             return None
-        
-        splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: get_destination_room: Looking for exit '{direction}' in {self.caller.location}(#{self.caller.location.id})")
-        
+
         # Find exit in current room using standard Evennia patterns
         exit_search = self.caller.search(direction, location=self.caller.location, quiet=True)
-        
-        splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: get_destination_room: search result = {exit_search}")
-        
+
         # Handle search result - could be list or single object
         exit_obj = exit_search[0] if exit_search else None
-        
-        splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: get_destination_room: exit_obj = {exit_obj}")
-        
+
         # Check if we got a valid exit with destination (standard Evennia way)
         if exit_obj and hasattr(exit_obj, 'destination') and exit_obj.destination:
-            # Additional debug: check if destination is the same as current room
             current_room = self.caller.location
             destination_room = exit_obj.destination
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: get_destination_room: current_room = {current_room}(#{current_room.id}), destination_room = {destination_room}(#{destination_room.id})")
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: get_destination_room: rooms_are_same = {current_room == destination_room}")
-            
+
             if current_room == destination_room:
                 splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: get_destination_room: Exit {exit_obj} destination points back to same room!")
                 self.caller.msg(f"The exit '{direction}' seems to loop back to this room. Cannot throw that way.")
                 return None
-            
+
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: get_destination_room: Found valid exit {exit_obj} -> {exit_obj.destination}(#{exit_obj.destination.id})")
             return exit_obj.destination
-        
-        # Debug: log what we found if the exit is invalid
-        if exit_obj:
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: get_destination_room: Found object type: {type(exit_obj)}, destination: {getattr(exit_obj, 'destination', 'NONE')}")
-        
+
         # If not found or invalid, check if it might be a character name mistaken for direction
         if exit_obj:
             # Use typeclass check to distinguish characters from other objects
             from typeclasses.characters import Character
-            is_character = isinstance(exit_obj, Character)
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: get_destination_room: Found object but no destination, is_character = {is_character}")
-            
-            if is_character:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_TEMPLATE: get_destination_room: '{direction}' is a character, suggesting 'at' syntax")
+            if isinstance(exit_obj, Character):
                 self.caller.msg(MSG_THROW_SUGGEST_AT_SYNTAX.format(
                     object=self.object_name, target=direction))
                 return None
-        
+
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_FAIL: get_destination_room: Invalid direction '{direction}'")
         self.caller.msg(MSG_THROW_INVALID_DIRECTION.format(direction=direction))
         return None
-    
-    def select_random_target_in_room(self, room):
-        """Select random character in room for proximity assignment."""
-        if not room:
-            return None
-        
-        # Use typeclass check to distinguish characters (PCs and NPCs) from other objects
-        from typeclasses.characters import Character
-        characters = [obj for obj in room.contents if isinstance(obj, Character) and obj != self.caller]
-        if characters:
-            return random.choice(characters)
-        return None
-    
-    def select_most_magnetic_target_in_room(self, room, grenade):
-        """
-        Select the most magnetic character in room for sticky grenade targeting.
-        
-        For sticky grenades thrown without a specific target, this finds the character
-        with the highest magnetic armor to stick to.
-        
-        Args:
-            room: The room to search
-            grenade: The sticky grenade being thrown (for magnetic strength)
-            
-        Returns:
-            Character with highest magnetic armor, or None if no valid targets
-        """
-        if not room:
-            return None
-        
-        from typeclasses.characters import Character
-        from typeclasses.items import Item
-        from world.combat.utils import get_outermost_armor_at_location
-        
-        splattercast = get_splattercast()
-        
-        # Get all characters except thrower
-        characters = [obj for obj in room.contents if isinstance(obj, Character) and obj != self.caller]
-        if not characters:
-            return None
-        
-        # Get grenade magnetic strength for threshold checks
-        magnetic_strength = grenade.db.magnetic_strength if grenade.db.magnetic_strength is not None else 5
-        magnetic_threshold = magnetic_strength - 3
-        metal_threshold = magnetic_strength - 5
-        
-        # Find character with highest magnetic armor that meets thresholds
-        best_target = None
-        best_magnetic_score = 0
-        
-        for char in characters:
-            # Check armor at chest (primary target location)
-            armor = get_outermost_armor_at_location(char, "chest")
-            
-            if not armor:
-                continue
-            
-            # Get armor properties (including plate carrier check)
-            metal_level = armor.db.metal_level or 0
-            magnetic_level = armor.db.magnetic_level or 0
-            
-            # Check if plate carrier - use installed plates' values
-            is_plate_carrier = bool(armor.db.is_plate_carrier)
-            if is_plate_carrier:
-                installed_plates = armor.db.installed_plates or {}
-                for slot, plate_ref in installed_plates.items():
-                    if plate_ref:
-                        plate_metal = plate_ref.db.metal_level or 0
-                        plate_magnetic = plate_ref.db.magnetic_level or 0
-                        metal_level = max(metal_level, plate_metal)
-                        magnetic_level = max(magnetic_level, plate_magnetic)
-            
-            # Check if meets thresholds
-            if magnetic_level >= magnetic_threshold and metal_level >= metal_threshold:
-                # This target is viable - use magnetic level as score
-                if magnetic_level > best_magnetic_score:
-                    best_magnetic_score = magnetic_level
-                    best_target = char
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_TARGET: {char.key} viable with magnetic={magnetic_level}, metal={metal_level}")
-        
-        if best_target:
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_TARGET: Selected {best_target.key} (magnetic={best_magnetic_score})")
-        else:
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_TARGET: No viable magnetic targets in {room.key}")
-        
-        return best_target
-    
-    def is_throwing_weapon(self, obj):
-        """Check if object is a throwing weapon."""
-        return bool(obj.db.is_throwing_weapon)
-    
-    def is_explosive(self, obj):
-        """Check if object is explosive."""
-        return bool(obj.db.is_explosive)
-    
-    def handle_weapon_throw(self, obj, target, destination):
-        """Handle throwing weapon combat mechanics."""
-        # Enter combat if not already in combat
-        handler = get_or_create_combat(self.caller.location)
-        if not handler:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Failed to get combat handler for weapon throw")
-            return False
-        
-        # Add combatants to handler
-        handler.add_combatant(self.caller)
-        if target:
-            handler.add_combatant(target)
-        
-        # Consume combat turn (skip turn mechanic)
-        setattr(self.caller.ndb, NDB_SKIP_ROUND, True)
-        
-        # Remove object from hand before flight
-        self.remove_from_hand(obj)
-        
-        # Start flight with combat resolution
-        self.start_flight(obj, destination, target, is_weapon=True)
-        return True
-    
+
     def handle_utility_throw(self, obj, destination, target):
-        """Handle utility object throwing."""
-        # Remove object from hand
+        """Launch a utility throw: unhand, announce, start flight."""
         self.remove_from_hand(obj)
-        
-        # Start flight
-        self.start_flight(obj, destination, target, is_weapon=False)
-    
+        self.announce_throw_origin(obj, destination, target)
+        start_flight(self.caller, obj, destination, target)
+
     def remove_from_hand(self, obj):
         """Remove object from caller's hand.
 
@@ -580,63 +407,33 @@ class CmdThrow(Command):
                 caller_hands[hand_name] = None
                 self.caller.hands = caller_hands
                 break
-    
-    def start_flight(self, obj, destination, target, is_weapon=False):
-        """Start object flight with timer."""
-        # Announce throw in origin room
-        self.announce_throw_origin(obj, destination, target)
-        
-        # Add to room's flying objects - ensure we have a proper list
-        flying_objects = getattr(self.caller.location.ndb, NDB_FLYING_OBJECTS, None)
-        if not flying_objects:
-            setattr(self.caller.location.ndb, NDB_FLYING_OBJECTS, [])
-        
-        flying_objects = getattr(self.caller.location.ndb, NDB_FLYING_OBJECTS)
-        if flying_objects is None:
-            flying_objects = []
-            setattr(self.caller.location.ndb, NDB_FLYING_OBJECTS, flying_objects)
-        
-        flying_objects.append(obj)
-        
-        # Store flight data on object
-        obj.ndb.flight_destination = destination
-        obj.ndb.flight_target = target
-        obj.ndb.flight_origin = self.caller.location
-        obj.ndb.flight_is_weapon = is_weapon
-        obj.ndb.flight_thrower = self.caller
-        
-        # Start flight timer and store reference for potential cancellation
-        obj.ndb.flight_timer = utils.delay(THROW_FLIGHT_TIME, self.complete_flight, obj)
-        
-        splattercast = get_splattercast()
-        splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} started flight for {obj} to {destination}(#{destination.id})")
-    
+
     def announce_throw_origin(self, obj, destination, target):
         """Announce throw in origin room."""
         object_name = obj.key
         char_refs = {"actor": self.caller}
-        
+
         # Determine announcement based on throw type
         if self.throw_type == "to_direction":
             direction = self.direction
             template = MSG_THROW_ORIGIN_DIRECTIONAL.format(
                 thrower="{actor}", object=object_name, direction=direction)
-        
+
         elif self.throw_type == "at_target" and target and target.location == self.caller.location:
             template = MSG_THROW_ORIGIN_TARGETED_SAME.format(
                 thrower="{actor}", object=object_name, target="{target_char}")
             char_refs["target_char"] = target
-        
+
         elif self.throw_type == "at_target" and target:
             # Cross-room targeting
             aim_direction = getattr(self.caller.ndb, NDB_AIMING_DIRECTION, "that direction")
             template = MSG_THROW_ORIGIN_TARGETED_CROSS.format(
                 thrower="{actor}", object=object_name, direction=aim_direction)
-        
+
         elif self.throw_type == "to_here":
             template = MSG_THROW_ORIGIN_HERE.format(
                 thrower="{actor}", object=object_name)
-        
+
         else:  # fallback
             aim_direction = getattr(self.caller.ndb, NDB_AIMING_DIRECTION, "nearby")
             if aim_direction == "nearby":
@@ -645,7 +442,7 @@ class CmdThrow(Command):
             else:
                 template = MSG_THROW_ORIGIN_FALLBACK.format(
                     thrower="{actor}", object=object_name, direction=aim_direction)
-        
+
         # Broadcast to room using per-observer identity resolution
         msg_room_identity(
             location=self.caller.location,
@@ -654,732 +451,60 @@ class CmdThrow(Command):
             exclude=[self.caller],
         )
         self.caller.msg(f"You throw a {object_name}.")
-    
-    def complete_flight(self, obj):
-        """Complete the flight and handle landing."""
-        splattercast = None
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Starting complete_flight for {obj}")
-            
-            # Check if object is None or doesn't have ndb (deleted/caught)
-            if not obj or not hasattr(obj, 'ndb') or obj.ndb is None:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Object {obj} is None or missing ndb, skipping complete_flight")
-                return
-            
-            # Check if object was caught (flight data cleaned up)
-            if not hasattr(obj.ndb, 'flight_destination'):
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Object {obj} was caught, skipping complete_flight")
-                return
-            
-            # Get flight data with defensive checks - wrap in try-catch to handle race conditions
-            try:
-                destination = getattr(obj.ndb, 'flight_destination', None)
-                target = getattr(obj.ndb, 'flight_target', None)
-                origin = getattr(obj.ndb, 'flight_origin', None)
-                is_weapon = getattr(obj.ndb, 'flight_is_weapon', False)
-                thrower = getattr(obj.ndb, 'flight_thrower', None)
-            except (AttributeError, TypeError):
-                # Race condition - object state changed between checks
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Race condition detected during flight data access, skipping complete_flight")
-                return
-            
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Flight data - destination: {destination}, target: {target}, origin: {origin}")
-            
-            # Clean up origin room flying objects with additional safety
-            if origin and hasattr(origin, 'ndb') and origin.ndb is not None:
-                try:
-                    origin_flying_objects = getattr(origin.ndb, NDB_FLYING_OBJECTS, None)
-                    if origin_flying_objects and obj in origin_flying_objects:
-                        origin_flying_objects.remove(obj)
-                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Removed {obj} from origin flying objects")
-                except (AttributeError, TypeError, ValueError):
-                    # Safe to ignore - object cleanup isn't critical
-                    pass
-            
-            # Move object to destination
-            if destination:
-                try:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Moving {obj} to destination {destination}")
-                    obj.move_to(destination, quiet=True)  # Use quiet=True to suppress auto-messages
-                    
-                    # Announce arrival based on room relationship
-                    if destination != origin:
-                        # Cross-room throw - announce arrival
-                        arrival_dir = self.get_arrival_direction(origin, destination)
-                        if target and target.location == destination:
-                            # Send personal message to victim
-                            target.msg(MSG_THROW_ARRIVAL_TARGETED_VICTIM.format(object=obj.key, direction=arrival_dir))
-                            # Send observer message to everyone else
-                            msg_room_identity(
-                                location=destination,
-                                template=MSG_THROW_ARRIVAL_TARGETED.format(
-                                    object=obj.key, direction=arrival_dir, target="{target_char}"
-                                ),
-                                char_refs={"target_char": target},
-                                exclude=[target],
-                            )
-                        else:
-                            destination.msg_contents(MSG_THROW_ARRIVAL.format(object=obj.key, direction=arrival_dir))
-                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Cross-room arrival message sent")
-                    else:
-                        # Same-room throw - show flight message
-                        if target:
-                            # Send personal message to victim
-                            target.msg(MSG_THROW_FLIGHT_SAMEROOM_TARGET_VICTIM.format(object=obj.key))
-                            # Send observer message to everyone else (excluding thrower and victim)
-                            msg_room_identity(
-                                location=destination,
-                                template=MSG_THROW_FLIGHT_SAMEROOM_TARGET.format(
-                                    object=obj.key, target="{target_char}"
-                                ),
-                                char_refs={"target_char": target},
-                                exclude=[thrower, target],
-                            )
-                        else:
-                            destination.msg_contents(MSG_THROW_FLIGHT_SAMEROOM_GENERAL.format(object=obj.key), exclude=[thrower])
-                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Same-room flight message sent")
-                    
-                    # Check for grenade deflection before landing
-                    if self.is_explosive(obj) and destination:
-                        deflection_result = self.check_grenade_deflection(obj, destination, thrower)
-                        if deflection_result:
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Grenade was deflected, skipping normal landing")
-                            return  # Deflection handled everything, don't continue with normal landing
-                    
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: About to call handle_landing")
-                    # Handle landing and proximity
-                    self.handle_landing(obj, destination, target, is_weapon, thrower)
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Completed handle_landing")
-                    
-                    # Apply gravity if item landed in a sky room
-                    from commands.combat.movement import apply_gravity_to_items
-                    apply_gravity_to_items(destination)
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Applied gravity check to destination {destination}")
-                    
-                except Exception as e:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error during object movement/landing: {e}")
-                    # Try to move to origin as fallback
-                    if origin:
-                        try:
-                            obj.move_to(origin)
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Moved {obj} back to origin {origin} as fallback")
-                        except Exception:
-                            pass  # If even fallback fails, give up gracefully
-            
-            # Clean up flight data with defensive checks
-            try:
-                if hasattr(obj, 'ndb') and obj.ndb is not None:
-                    if hasattr(obj.ndb, 'flight_destination'):
-                        del obj.ndb.flight_destination
-                    if hasattr(obj.ndb, 'flight_target'):
-                        del obj.ndb.flight_target
-                    if hasattr(obj.ndb, 'flight_origin'):
-                        del obj.ndb.flight_origin
-                    if hasattr(obj.ndb, 'flight_is_weapon'):
-                        del obj.ndb.flight_is_weapon
-                    if hasattr(obj.ndb, 'flight_thrower'):
-                        del obj.ndb.flight_thrower
-                    if hasattr(obj.ndb, 'flight_timer'):
-                        del obj.ndb.flight_timer
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Cleaned up flight data for {obj}")
-            except (AttributeError, TypeError):
-                # Object state changed during cleanup - not critical
-                pass
-            
-        except Exception as e:
-            if splattercast:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Unexpected error in complete_flight: {e}")
-            # Final failsafe - try to put object somewhere safe
-            try:
-                if obj and hasattr(obj, 'move_to'):
-                    # Try to get origin from flight data if still available
-                    flight_origin = None
-                    if hasattr(obj, 'ndb') and obj.ndb and hasattr(obj.ndb, 'flight_origin'):
-                        flight_origin = getattr(obj.ndb, 'flight_origin', None)
-                    if flight_origin:
-                        obj.move_to(flight_origin)
-                        if splattercast:
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Emergency moved {obj} back to origin {flight_origin}")
-            except Exception:
-                pass  # If all else fails, give up gracefully
-    
-    def get_arrival_direction(self, origin, destination):
-        """Determine arrival direction for announcement."""
-        # Simple implementation - would need room connection mapping for accuracy
-        return "somewhere"
-    
-    def handle_landing(self, obj, destination, target, is_weapon, thrower):
-        """Handle object landing and proximity assignment."""
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: handle_landing called - obj: {obj}, destination: {destination}, target: {target}, is_weapon: {is_weapon}")
-            
-            # Track whether we've shown a target interaction message
-            showed_interaction = False
-            
-            # Weapon combat resolution
-            if is_weapon and target:
-                try:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Resolving weapon hit")
-                    self.resolve_weapon_hit(obj, target, thrower)
-                    showed_interaction = True  # Weapon hit/miss shows its own message
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: resolve_weapon_hit completed")
-                except Exception as e:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in resolve_weapon_hit: {e}")
-                    # Continue with landing even if weapon hit fails
-            
-            # Sticky grenade resolution (even for utility throws)
-            elif target and not is_weapon and obj.db.is_sticky:
-                try:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Sticky grenade utility throw - routing to weapon hit logic")
-                    self.resolve_weapon_hit(obj, target, thrower)
-                    showed_interaction = True  # Stick/bounce shows its own message
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Sticky grenade resolution completed")
-                except Exception as e:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in sticky grenade resolution: {e}")
-                    # Continue with landing even if stick check fails
-            
-            # Utility object bounce
-            elif target and not is_weapon:
-                try:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Utility object bounce")
-                    # Send personal message to victim
-                    target.msg(MSG_THROW_UTILITY_BOUNCE_VICTIM.format(object=obj.key))
-                    # Send observer message to room
-                    msg_room_identity(
-                        location=target.location,
-                        template=MSG_THROW_UTILITY_BOUNCE.format(
-                            object=obj.key, target="{target_char}"
-                        ),
-                        char_refs={"target_char": target},
-                        exclude=[target],
-                    )
-                    showed_interaction = True  # Bounce message already shown
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Utility bounce message sent")
-                except Exception as e:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in utility bounce: {e}")
-                    # Continue with landing even if bounce message fails
-            
-            # Assign proximity for universal proximity system
-            try:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Assigning landing proximity")
-                self.assign_landing_proximity(obj, target, thrower)
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: assign_landing_proximity completed")
-            except Exception as e:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in assign_landing_proximity: {e}")
-                # Continue with landing even if proximity assignment fails
-            
-            # Handle grenade-specific landing
-            if self.is_explosive(obj):
-                try:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Handling grenade landing")
-                    self.handle_grenade_landing(obj, target, thrower)
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: handle_grenade_landing completed")
-                except Exception as e:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in handle_grenade_landing: {e}")
-                    # Continue with landing even if grenade landing fails
-            
-            # General landing announcement - only if no target interaction was shown
-            if not showed_interaction:
-                try:
-                    if target:
-                        msg_room_identity(
-                            location=destination,
-                            template=MSG_THROW_LANDING_PROXIMITY.format(
-                                object=obj.key, target="{target_char}"
-                            ),
-                            char_refs={"target_char": target},
-                        )
-                    else:
-                        message = MSG_THROW_LANDING_ROOM.format(object=obj.key)
-                        destination.msg_contents(message)
-                    
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Landing message sent successfully")
-                except Exception as e:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in landing message: {e}")
-                    # Continue even if landing message fails
-            else:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Skipping landing message - interaction already shown")
-            
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: handle_landing completed successfully")
-            
-        except Exception as e:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Unexpected error in handle_landing: {e}")
-            # Don't re-raise - let the object land even if there are issues
-    
-    def resolve_weapon_hit(self, weapon, target, thrower):
-        """Resolve weapon throw hit/miss and damage."""
-        try:
-            # Simple hit resolution - could be enhanced with accuracy system
-            hit_chance = 0.7  # 70% base hit chance
-            
-            if random.random() <= hit_chance:
-                # STICKY GRENADE CHECK - Check for stick before damage
-                # Import required for sticky grenade logic
-                from world.combat.utils import (
-                    calculate_stick_chance, establish_stick,
-                    get_outermost_armor_at_location, debug_broadcast
-                )
-                
-                # Check if this is a sticky grenade
-                is_sticky = bool(weapon.db.is_sticky)
-                hit_location = "chest"  # Default hit location for throws
-                
-                if is_sticky:
-                    splattercast = get_splattercast()
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY: Sticky grenade {weapon.key} hit {target.key}")
-                    
-                    # Get outermost armor at hit location
-                    armor = get_outermost_armor_at_location(target, hit_location)
-                    
-                    if armor:
-                        # Calculate stick chance
-                        stick_chance = calculate_stick_chance(weapon, armor)
-                        roll = random.randint(1, 100)
-                        
-                        if roll <= stick_chance:
-                            # SUCCESS - Grenade sticks to armor
-                            if establish_stick(weapon, armor, hit_location):
-                                # Send stick messages - Spider-themed with telescoping legs
-                                target.msg(f"|rThe {weapon.key}'s articulated legs extend with mechanical precision, their electromagnetic tips skittering across your {armor.key} before *CLAMPING* tight with magnetic fury!|n")
-                                thrower.msg(f"Your {weapon.key}'s spider-legs deploy and latch onto {get_display_name_safe(target, thrower)}'s {armor.key} with a satisfying *CLACK-CLACK-CLACK* of magnetic adhesion!")
-                                msg_room_identity(
-                                    location=target.location,
-                                    template=f"The {weapon.key}'s eight legs telescope outward in a blur of motion, seeking metal across {{target_char}}'s {armor.key} before *SNAPPING* into electromagnetic lock!",
-                                    char_refs={"target_char": target},
-                                    exclude=[thrower, target],
-                                )
-                                
-                                splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_SUCCESS: {weapon.key} stuck to {armor.key} (roll {roll} <= {stick_chance})")
-                                
-                                # Skip normal landing - grenade is stuck to armor now
-                                return
-                            else:
-                                splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_ERROR: establish_stick failed")
-                        else:
-                            # FAIL - Grenade bounces off
-                            target.msg(f"The {weapon.key}'s legs extend and scrabble frantically across your {armor.key}, but the magnetic field is too weak - it bounces away with a frustrated clatter!")
-                            thrower.msg(f"Your {weapon.key}'s spider-legs fail to find purchase on {get_display_name_safe(target, thrower)}'s {armor.key}, bouncing off ineffectively!")
-                            msg_room_identity(
-                                location=target.location,
-                                template=f"The {weapon.key}'s articulated legs scrape and skitter across {{target_char}}'s {armor.key} before losing grip and clattering away!",
-                                char_refs={"target_char": target},
-                                exclude=[thrower, target],
-                            )
-                            
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_FAIL: {weapon.key} bounce (roll {roll} > {stick_chance})")
-                            # Continue to normal landing
-                    else:
-                        # No armor at hit location - bounce off
-                        target.msg(f"The {weapon.key} strikes your {hit_location} and its legs extend desperately, seeking metal that isn't there - it bounces away with a frustrated whir of servos!")
-                        thrower.msg(f"Your {weapon.key}'s electromagnetic sensors find no ferrous surface on {get_display_name_safe(target, thrower)}'s {hit_location} - the spider-legs retract as it falls away!")
-                        msg_room_identity(
-                            location=target.location,
-                            template=f"The {weapon.key}'s articulated legs extend and search frantically across {{target_char}}'s {hit_location} before retracting in defeat!",
-                            char_refs={"target_char": target},
-                            exclude=[thrower, target],
-                        )
-                        
-                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_FAIL: No armor at {hit_location}")
-                        # Continue to normal landing
-                
-                # Hit - apply damage (only for non-sticky or failed-stick weapons)
-                base_damage = weapon.db.damage if weapon.db.damage is not None else 1
-                total_damage = random.randint(1, 6) + base_damage
-                damage_type = weapon.db.damage_type if weapon.db.damage_type is not None else 'blunt'  # Get weapon damage type
-                
-                target.take_damage(total_damage, location="chest", injury_type=damage_type)
-                
-                # Send personal message to victim
-                target.msg(MSG_THROW_WEAPON_HIT_VICTIM.format(
-                    thrower=capitalize_first(get_display_name_safe(thrower, target)), weapon=weapon.key))
-                # Send personal message to thrower
-                thrower.msg(MSG_THROW_WEAPON_HIT.format(weapon=weapon.key, target=get_display_name_safe(target, thrower)))
-                # Observer message (everyone else in room)
-                msg_room_identity(
-                    location=target.location,
-                    template=f"{{actor}}'s {weapon.key} strikes {{target_char}}!",
-                    char_refs={"actor": thrower, "target_char": target},
-                    exclude=[thrower, target],
-                )
-                
-                # Establish proximity if hit (safe pattern)
-                proximity_list = getattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, None)
-                if not proximity_list:
-                    setattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, [])
-                    proximity_list = getattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, [])
-                
-                # Validate proximity_list is a list
-                if not isinstance(proximity_list, list):
-                    proximity_list = []
-                    setattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, proximity_list)
-                
-                if thrower and thrower not in proximity_list:
-                    proximity_list.append(thrower)
-            
-            else:
-                # Miss - send personal message to victim
-                target.msg(MSG_THROW_WEAPON_MISS_VICTIM.format(
-                    thrower=capitalize_first(get_display_name_safe(thrower, target)), weapon=weapon.key))
-                # Send personal message to thrower
-                thrower.msg(MSG_THROW_WEAPON_MISS.format(weapon=weapon.key, target=get_display_name_safe(target, thrower)))
-                # Observer message (everyone else in room)
-                msg_room_identity(
-                    location=target.location,
-                    template=f"{{actor}}'s {weapon.key} narrowly misses {{target_char}} and clatters to the ground.",
-                    char_refs={"actor": thrower, "target_char": target},
-                    exclude=[thrower, target],
-                )
-                
-        except Exception as e:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in resolve_weapon_hit: {e}")
-            # Don't re-raise - weapon hit failure shouldn't fail entire throw
-    
-    def assign_landing_proximity(self, obj, target, thrower=None):
-        """Assign proximity for universal proximity system."""
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: assign_landing_proximity called - obj: {obj}, target: {target}, thrower: {thrower}")
-            
-            # Ensure object has proximity list (use same pattern as drop command)
-            proximity_list = getattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, None)
-            if not proximity_list:
-                setattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, [])
-                proximity_list = getattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, [])
-            
-            # Validate proximity_list is actually a list
-            if not isinstance(proximity_list, list):
-                proximity_list = []
-                setattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, proximity_list)
-            
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: obj proximity_list: {proximity_list}")
-            
-            if target:
-                # Add target to object proximity
-                if target not in proximity_list:
-                    proximity_list.append(target)
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Added target {target} to obj proximity")
-                
-                # Inherit target's existing proximity relationships, but exclude the thrower
-                # Check both proximity systems:
-                
-                # 1. Object proximity system (NDB_PROXIMITY_UNIVERSAL)
-                target_proximity = getattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, None)
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: target_proximity (objects): {target_proximity}")
-                if target_proximity and isinstance(target_proximity, list):
-                    for character in target_proximity:
-                        # Filter out the thrower - they shouldn't be in proximity to their own thrown object
-                        if character and character not in proximity_list and character != thrower:
-                            proximity_list.append(character)
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Added {character} from target object proximity")
-                        elif character == thrower:
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Skipped thrower {character} from object proximity inheritance")
-                
-                # 2. Character proximity system (in_proximity_with)
-                character_proximity = getattr(target.ndb, NDB_PROXIMITY, None)
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: target_proximity (characters): {character_proximity}")
-                if character_proximity:
-                    # Convert set to list for consistent handling
-                    character_list = list(character_proximity) if hasattr(character_proximity, '__iter__') else []
-                    for character in character_list:
-                        # Filter out the thrower - they shouldn't be in proximity to their own thrown object
-                        if character and character not in proximity_list and character != thrower:
-                            proximity_list.append(character)
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Added {character} from target character proximity")
-                        elif character == thrower:
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Skipped thrower {character} from character proximity inheritance")
-            
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: assign_landing_proximity completed successfully")
-            
-        except Exception as e:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in assign_landing_proximity: {e}")
-            raise  # Re-raise to let handle_landing handle it
-    
-    def handle_grenade_landing(self, grenade, target, thrower=None):
-        """Handle grenade-specific landing mechanics."""
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: handle_grenade_landing called - grenade: {grenade}, target: {target}, thrower: {thrower}")
-            
-            # If grenade lands near someone, everyone in their proximity gets added
-            target_proximity = getattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, None) if target else None
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: target_proximity: {target_proximity}")
-            
-            if target_proximity and isinstance(target_proximity, list):
-                grenade_proximity = getattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, [])
-                if not isinstance(grenade_proximity, list):
-                    grenade_proximity = []
-                
-                for character in target_proximity:
-                    # Filter out the thrower - they shouldn't be in proximity to their own thrown grenade
-                    if character and character not in grenade_proximity and character != thrower:
-                        grenade_proximity.append(character)
-                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Added {character} to grenade proximity")
-                    elif character == thrower:
-                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Skipped thrower {character} from grenade proximity inheritance")
-                
-                setattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, grenade_proximity)
-            
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: Grenade {grenade} landed with proximity: {getattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, [])}")
-            
-        except Exception as e:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in handle_grenade_landing: {e}")
-            # Don't re-raise here - grenade landing failure shouldn't fail entire throw
-    
-    def check_grenade_deflection(self, grenade, destination, thrower):
-        """Check if the specific target can deflect the incoming grenade with a melee weapon."""
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: check_grenade_deflection called for {grenade} in {destination}")
-            
-            # Future-proofing: Skip deflection for impact grenades (explode on contact)
-            if grenade.db.impact_detonation:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Impact grenade {grenade} cannot be deflected")
-                return False
-            
-            # Get the specific target from flight data
-            target = getattr(grenade.ndb, 'flight_target', None)
-            if not target:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: No specific target for deflection check")
-                return False
-            
-            # Check if target is in the destination room
-            if target.location != destination:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Target {target} not in destination {destination}")
-                return False
-            
-            # Check if target is grappled or grappling (cannot deflect while restricted)
-            if hasattr(target, 'ndb') and hasattr(target.ndb, NDB_COMBAT_HANDLER):
-                handler = getattr(target.ndb, NDB_COMBAT_HANDLER)
-                if handler:
-                    combatants_list = handler.db.combatants or []
-                    combat_entry = next((e for e in combatants_list if e.get(DB_CHAR) == target), None)
-                    if combat_entry:
-                        grappled_by = combat_entry.get(DB_GRAPPLED_BY_DBREF)
-                        grappling = combat_entry.get(DB_GRAPPLING_DBREF)
-                        if grappled_by or grappling:
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Target {target} cannot deflect - grappled_by: {grappled_by}, grappling: {grappling}")
-                            return False
-            
-            # Check if target has hands and a melee weapon
-            target_hands = getattr(target, 'hands', None)
-            if not target_hands:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Target {target} has no hands")
-                return False
-            
-            # Find melee weapon in target's hands
-            melee_weapon = None
-            for hand, wielded_obj in target_hands.items():
-                if wielded_obj and self.is_melee_weapon(wielded_obj):
-                    melee_weapon = wielded_obj
-                    break
-            
-            if not melee_weapon:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Target {target} has no melee weapon")
-                return False
-            
-            # Perform Motorics skill check for deflection
-            from world.combat.utils import roll_stat
-            
-            # Roll Motorics skill
-            motorics_roll = roll_stat(target, 'motorics')
-            
-            # Base difficulty threshold (higher = easier)
-            base_threshold = 10  # Moderate difficulty
-            weapon_bonus = melee_weapon.db.deflection_bonus if melee_weapon.db.deflection_bonus is not None else 0.0  # Optional weapon property
-            
-            # Convert weapon bonus to threshold modifier (0.30 bonus = +6 to threshold)
-            threshold_modifier = int(weapon_bonus * 20)
-            final_threshold = base_threshold + threshold_modifier
-            
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: {target} Motorics deflection: rolled {motorics_roll} vs threshold {final_threshold}")
-            
-            if motorics_roll >= final_threshold:
-                # Successful deflection!
-                return self.perform_grenade_deflection(grenade, target, melee_weapon, thrower, destination)
-            else:
-                # Failed deflection attempt
-                target.msg(f"You attempt to deflect the {grenade.key} with your {melee_weapon.key}, but your reflexes aren't quick enough!")
-                msg_room_identity(
-                    location=destination,
-                    template=f"{{target_char}} swings their {melee_weapon.key} at the incoming {grenade.key} but fails to connect!",
-                    char_refs={"target_char": target},
-                    exclude=[target],
-                )
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: {target} failed deflection attempt")
-                return False
-                
-        except Exception as e:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in check_grenade_deflection: {e}")
-            return False
-    
-    def is_melee_weapon(self, obj):
-        """Check if object is a melee weapon suitable for deflection."""
-        # Melee weapons are those that are NOT ranged (default is melee)
-        is_ranged = bool(obj.db.is_ranged)
-        return not is_ranged
-    
-    def perform_grenade_deflection(self, grenade, deflector, weapon, original_thrower, current_location):
-        """Perform the actual grenade deflection."""
-        try:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: perform_grenade_deflection called")
-            
-            # Announce successful deflection
-            deflector.msg(f"|yYou successfully bat the {grenade.key} away with your {weapon.key}!|n")
-            msg_room_identity(
-                location=current_location,
-                template=f"|y{{actor}} deflects the incoming {grenade.key} with their {weapon.key}!|n",
-                char_refs={"actor": deflector},
-                exclude=[deflector],
-            )
-            
-            # Determine deflection target and destination
-            deflection_success = self.determine_deflection_target(grenade, deflector, original_thrower, current_location)
-            
-            if deflection_success:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Grenade deflection successful, new flight initiated")
-                return True
-            else:
-                # Deflection hit but grenade lands in same room
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Deflection hit but grenade stays in same room")
-                self.handle_landing(grenade, current_location, None, False, original_thrower)
-                return True
-                
-        except Exception as e:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in perform_grenade_deflection: {e}")
-            return False
-    
-    def determine_deflection_target(self, grenade, deflector, original_thrower, current_location):
-        """Determine where the deflected grenade goes."""
-        try:
-            splattercast = get_splattercast()
-            
-            # Get grenade's original flight data
-            origin = getattr(grenade.ndb, 'flight_origin', None)
-            
-            # 60% chance to deflect back toward origin/thrower if possible
-            # 40% chance to deflect in random direction
-            deflect_back_chance = 0.6
-            
-            if random.random() <= deflect_back_chance and origin and origin != current_location:
-                # Try to deflect back to origin room
-                new_destination = origin
-                new_target = original_thrower if original_thrower and original_thrower.location == origin else None
-                deflection_type = "back toward origin"
-                
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Deflecting back to origin {origin}")
-                
-            else:
-                # Deflect in random direction
-                available_exits = [obj for obj in current_location.contents 
-                                 if hasattr(obj, 'destination') and obj.destination 
-                                 and obj.destination != current_location]
-                
-                if available_exits:
-                    random_exit = random.choice(available_exits)
-                    new_destination = random_exit.destination
-                    new_target = self.select_random_target_in_room(new_destination)
-                    deflection_type = f"toward {random_exit.key}"
-                    
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Deflecting to random direction {random_exit.key}")
-                else:
-                    # No exits available, grenade lands in current room
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: No exits available for deflection")
-                    return False
-            
-            # Announce deflection direction
-            current_location.msg_contents(
-                f"The {grenade.key} ricochets {deflection_type}!"
-            )
-            
-            # Update flight data and restart flight
-            grenade.ndb.flight_destination = new_destination
-            grenade.ndb.flight_target = new_target
-            grenade.ndb.flight_origin = current_location
-            grenade.ndb.flight_thrower = deflector  # Deflector becomes new "thrower"
-            
-            # Start new flight with shorter timer (already partially through flight)
-            reduced_flight_time = max(1, THROW_FLIGHT_TIME - 1)  # At least 1 second
-            grenade.ndb.flight_timer = utils.delay(reduced_flight_time, self.complete_flight, grenade)
-            
-            # Add to current room's flying objects temporarily
-            flying_objects = getattr(current_location.ndb, NDB_FLYING_OBJECTS, None)
-            if not flying_objects:
-                setattr(current_location.ndb, NDB_FLYING_OBJECTS, [])
-                flying_objects = getattr(current_location.ndb, NDB_FLYING_OBJECTS)
-            
-            if grenade not in flying_objects:
-                flying_objects.append(grenade)
-            
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: Deflected {grenade} from {deflector} to {new_destination}")
-            return True
-            
-        except Exception as e:
-            splattercast = get_splattercast()
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in determine_deflection_target: {e}")
-            return False
 
 
 class CmdPull(Command):
     """
     Pull pins on grenades to arm them.
-    
+
     Usage:
         pull pin on <grenade>
-    
+
     Examples:
         pull pin on grenade
         pull pin on flashbang
-    
+
     Pulling the pin on a grenade starts its countdown timer. The grenade must be
     thrown or dropped before the timer expires, or it will explode in your hands.
     """
-    
+
     key = "pull"
     locks = "cmd:all()"
     help_category = "Combat"
-    
+
     def parse(self):
         """Parse pull command syntax."""
         self.args = self.args.strip()
-        
+
         # Expected syntax: "pin on <grenade>"
         if self.args.startswith("pin on "):
             self.grenade_name = self.args[7:].strip()
         else:
             self.grenade_name = None
-    
+
     def func(self):
         """Execute pull command."""
         if not self.args:
             self.caller.msg(MSG_PULL_WHAT)
             return
-        
+
         if not self.grenade_name:
             self.caller.msg(MSG_PULL_INVALID_SYNTAX)
             return
-        
+
         # Check for hands at all
         caller_hands = getattr(self.caller, 'hands', None)
         if caller_hands is None or not caller_hands:
             self.caller.msg(MSG_PULL_NO_HANDS)
             return
-        
+
         # Find grenade in hands
         grenade = None
         for hand, wielded_obj in caller_hands.items():
             if wielded_obj and self.grenade_name.lower() in wielded_obj.key.lower():
                 grenade = wielded_obj
                 break
-        
+
         if not grenade:
             # Check if exists but not wielded
             search_obj = self.caller.search(self.grenade_name, location=self.caller, quiet=True)
@@ -1389,38 +514,41 @@ class CmdPull(Command):
             else:
                 self.caller.msg(MSG_PULL_OBJECT_NOT_FOUND.format(object=self.grenade_name))
                 return
-        
+
         # Validate explosive
         if not grenade.db.is_explosive:
             self.caller.msg(MSG_PULL_NOT_EXPLOSIVE.format(object=grenade.key))
             return
-        
+
         # Check if requires pin
         requires_pin = grenade.db.requires_pin if grenade.db.requires_pin is not None else True
         if not requires_pin:
             self.caller.msg(MSG_PULL_NO_PIN_REQUIRED.format(object=grenade.key))
             return
-        
+
         # Check if already pulled
         if grenade.db.pin_pulled:
             self.caller.msg(MSG_PULL_ALREADY_PULLED.format(object=grenade.key))
             return
-        
+
         # Pull pin and start timer
         self.pull_pin(grenade)
-    
+
     def pull_pin(self, grenade):
         """Pull the pin and start countdown."""
         # Set pin pulled flag
         grenade.db.pin_pulled = True
-        
+
         # Get fuse time
         fuse_time = grenade.db.fuse_time if grenade.db.fuse_time is not None else 8
-        
-        # Start countdown with robust ticker system
+
+        # Start countdown with the sticky-aware grenade ticker (lives
+        # next to the explosion machinery; lazy import preserves the
+        # historical commands-module import graph)
         setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, fuse_time)
-        self.start_grenade_ticker(grenade)
-        
+        from commands.explosion_utils import start_grenade_ticker
+        start_grenade_ticker(grenade)
+
         # Announce
         self.caller.msg(MSG_PULL_SUCCESS.format(object=grenade.key))
         msg_room_identity(
@@ -1431,176 +559,77 @@ class CmdPull(Command):
             char_refs={"actor": self.caller},
             exclude=[self.caller],
         )
-        
+
         # Timer warning
         self.caller.msg(MSG_PULL_TIMER_WARNING.format(object=grenade.key, time=fuse_time))
-        
+
         splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} pulled pin on {grenade}, timer: {fuse_time}s")
-    
-    def start_grenade_ticker(self, grenade):
-        """Start a proper countdown ticker that decrements every second and survives deflections."""
-        def tick():
-            try:
-                # Check if grenade still exists and has countdown
-                if not grenade or not hasattr(grenade, 'ndb'):
-                    return  # Grenade was deleted or lost state
-                
-                remaining = getattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0)
-                
-                # Debug output
-                splattercast = get_splattercast()
-                if splattercast:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER: {grenade.key} countdown: {remaining}s remaining")
-                
-                if remaining > 1:
-                    # Continue countdown
-                    remaining -= 1
-                    setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, remaining)
-                    
-                    # STICKY GRENADE: Send appropriate countdown warnings
-                    from typeclasses.items import Item
-                    from typeclasses.characters import Character
-                    
-                    # Check if grenade is stuck to armor
-                    is_stuck = isinstance(grenade.location, Item) and grenade.db.stuck_to_armor is not None
-                    
-                    if is_stuck:
-                        # Grenade stuck to armor - send dramatic warnings
-                        armor = grenade.location
-                        stuck_location = grenade.db.stuck_to_location or 'unknown'
-                        
-                        # Check if armor is worn
-                        if armor.location and isinstance(armor.location, Character):
-                            wearer = armor.location
-                            # Warning to wearer
-                            wearer.msg(f"|R*** {remaining} SECONDS ***|n {grenade.key} magnetically clamped to your {armor.key}!")
-                            
-                            # Warning to room
-                            if wearer.location:
-                                msg_room_identity(
-                                    location=wearer.location,
-                                    template=f"|y{{target_char}} has a live {grenade.key} magnetically stuck to their {armor.key}! {remaining} seconds remaining!|n",
-                                    char_refs={"target_char": wearer},
-                                    exclude=[wearer],
-                                )
-                        else:
-                            # Armor on ground with stuck grenade
-                            room = armor.location
-                            if room:
-                                room.msg_contents(
-                                    f"|yA {grenade.key} magnetically stuck to a {armor.key} ticks down: {remaining} seconds!|n"
-                                )
-                    
-                    # Schedule next tick
-                    timer = utils.delay(1, tick)
-                    setattr(grenade.ndb, NDB_GRENADE_TIMER, timer)
-                    
-                    if splattercast:
-                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER: {grenade.key} scheduled next tick, {remaining}s remaining, stuck={is_stuck}")
-                
-                elif remaining == 1:
-                    # Final countdown - explode next tick
-                    setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0)
-                    
-                    # Create a proper closure that captures the explosion function
-                    def trigger_explosion():
-                        try:
-                            splattercast = get_splattercast()
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER: Triggering explosion for {grenade.key}")
-                            explode_standalone_grenade(grenade)
-                        except Exception as e:
-                            splattercast = get_splattercast()
-                            splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Error in trigger_explosion: {e}")
-                    
-                    timer = utils.delay(1, trigger_explosion)
-                    setattr(grenade.ndb, NDB_GRENADE_TIMER, timer)
-                    
-                    if splattercast:
-                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER: {grenade.key} final countdown - explosion scheduled")
-                
-                else:
-                    # Should not reach here - explosion should have been triggered
-                    if splattercast:
-                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: {grenade.key} reached 0 without explosion - triggering now")
-                    explode_standalone_grenade(grenade)
-                    
-            except Exception as e:
-                # Failsafe - if ticker fails, explode immediately to avoid duds
-                splattercast = get_splattercast()
-                if splattercast:
-                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Ticker error for {grenade.key}: {e} - triggering explosion")
-                try:
-                    explode_standalone_grenade(grenade)
-                except Exception:
-                    pass  # If even explosion fails, give up gracefully
-        
-        # Start the ticker
-        tick()
-    
+
+
 class CmdCatch(Command):
     """
     Catch thrown objects out of the air.
-    
+
     Usage:
         catch <object>
-    
+
     Examples:
         catch grenade
         catch knife
-    
+
     Attempt to catch objects that are currently flying through the air.
     Requires at least one free hand. Useful for catching and re-throwing
     live grenades or intercepting thrown weapons.
     """
-    
+
     key = "catch"
     locks = "cmd:all()"
     help_category = "Combat"
-    
+
     def func(self):
         """Execute catch command."""
         if not self.args:
             self.caller.msg(MSG_CATCH_WHAT)
             return
-        
+
         object_name = self.args.strip()
-        
+
         # Check for hands at all
         caller_hands = getattr(self.caller, 'hands', None)
         if caller_hands is None or not caller_hands:
             self.caller.msg(MSG_CATCH_NO_HANDS_AT_ALL)
             return
-        
+
         # Check for free hands
         free_hand = None
         for hand_name, wielded_obj in caller_hands.items():
             if wielded_obj is None:
                 free_hand = hand_name
                 break
-        
+
         if not free_hand:
             self.caller.msg(MSG_CATCH_NO_FREE_HANDS)
             return
-        
-        # Find flying object in current room with robust null safety
+
+        # Find flying object in current room
         flying_objects = getattr(self.caller.location.ndb, NDB_FLYING_OBJECTS, None)
-        if not flying_objects or not isinstance(flying_objects, list):
+        if not isinstance(flying_objects, list):
             flying_objects = []
-        
+
         target_obj = None
         for obj in flying_objects:
             if object_name.lower() in obj.key.lower():
                 target_obj = obj
                 break
-        
+
         if not target_obj:
             self.caller.msg(MSG_CATCH_OBJECT_NOT_FOUND.format(object=object_name))
             return
-        
+
         # Attempt catch (simple success/fail)
         catch_chance = 0.6  # 60% base catch chance
-        
+
         if random.random() <= catch_chance:
             # Success - catch object
             self.catch_object(target_obj, free_hand)
@@ -1615,22 +644,22 @@ class CmdCatch(Command):
                 char_refs={"actor": self.caller},
                 exclude=[self.caller],
             )
-    
+
     def catch_object(self, obj, hand_name):
         """Successfully catch the object."""
         # Remove from flying objects
         flying_objects = getattr(self.caller.location.ndb, NDB_FLYING_OBJECTS, [])
-        if obj in flying_objects:
+        if isinstance(flying_objects, list) and obj in flying_objects:
             flying_objects.remove(obj)
-        
-        # Cancel flight timer by moving to caller and wielding.
+
+        # Move to caller and wield.
         # PR-H2: snapshot + mutate + setter so the held_items
         # backing store persists.
         obj.move_to(self.caller)
         caller_hands = dict(getattr(self.caller, 'hands', {}))
         caller_hands[hand_name] = obj
         self.caller.hands = caller_hands
-        
+
         # Announce success
         self.caller.msg(MSG_CATCH_SUCCESS.format(object=obj.key))
         observer_template = MSG_CATCH_SUCCESS_ROOM.format(
@@ -1642,30 +671,13 @@ class CmdCatch(Command):
             char_refs={"actor": self.caller},
             exclude=[self.caller],
         )
-        
-        # Clean up flight data
-        if hasattr(obj.ndb, 'flight_destination'):
-            del obj.ndb.flight_destination
-        if hasattr(obj.ndb, 'flight_target'):
-            del obj.ndb.flight_target
-        if hasattr(obj.ndb, 'flight_origin'):
-            del obj.ndb.flight_origin
-        if hasattr(obj.ndb, 'flight_is_weapon'):
-            del obj.ndb.flight_is_weapon
-        if hasattr(obj.ndb, 'flight_thrower'):
-            del obj.ndb.flight_thrower
-        if hasattr(obj.ndb, 'flight_timer'):
-            # Cancel the pending flight timer so the object doesn't
-            # "arrive" or explode after being caught
-            try:
-                obj.ndb.flight_timer.cancel()
-            except Exception:
-                pass  # Timer may have already fired
-            del obj.ndb.flight_timer
-        
+
+        # Cancel the pending flight timer and clear flight state so
+        # the object doesn't "arrive" or explode after being caught
+        cancel_flight(obj)
+
         splattercast = get_splattercast()
-        if splattercast:
-            splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} caught {obj} mid-flight")
+        splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {self.caller} caught {obj} mid-flight")
 
 
 # ---------------------------------------------------------------------------

--- a/commands/explosion_utils.py
+++ b/commands/explosion_utils.py
@@ -122,16 +122,19 @@ def check_rigged_grenade(character, exit_obj):
     sticky_target = None
 
     if is_sticky:
-        # Use CmdThrow's magnetic targeting logic (lazy import to avoid circular)
-        from commands.CmdThrow import CmdThrow
-        cmd = CmdThrow()
-        cmd.caller = character  # Set caller for context
-        sticky_target = cmd.select_most_magnetic_target_in_room(character.location, rigged_grenade)
+        # Magnetic targeting / stick resolution from the throwing
+        # engine (lazy import keeps the historical import graph)
+        from world.combat.throwing import (
+            resolve_weapon_hit, select_most_magnetic_target_in_room,
+        )
+        sticky_target = select_most_magnetic_target_in_room(
+            character.location, rigged_grenade, exclude=character
+        )
 
         if sticky_target:
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_RIGGED_STICKY: Selected {sticky_target.key} as magnetic target")
-            # Use existing resolve_weapon_hit logic to handle stick attempt
-            cmd.resolve_weapon_hit(rigged_grenade, sticky_target, character)
+            # Use the throwing engine's hit resolver for the stick attempt
+            resolve_weapon_hit(rigged_grenade, sticky_target, character)
         else:
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_RIGGED_STICKY: No viable magnetic targets, treating as regular grenade")
 
@@ -324,6 +327,99 @@ def start_standalone_grenade_ticker(grenade, explosion_callback=None):
                     explode_standalone_grenade(grenade)
             except Exception:
                 pass  # If even explosion fails, give up gracefully
+
+    # Start the ticker
+    tick()
+
+
+def start_grenade_ticker(grenade):
+    """Sticky-aware countdown ticker for armed grenades.
+
+    Moved from ``CmdPull`` (issue #471 step 2) so remote detonators
+    and the pull command share one implementation instead of
+    instantiating a throwaway ``CmdPull`` for access.  Differs from
+    :func:`start_standalone_grenade_ticker` by broadcasting dramatic
+    per-second warnings while the grenade is magnetically stuck to
+    armor.  Candidates for unification once behavior requirements
+    converge.
+    """
+    def tick():
+        try:
+            # Check if grenade still exists and has countdown
+            if not grenade or not hasattr(grenade, 'ndb'):
+                return  # Grenade was deleted or lost state
+
+            remaining = getattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0)
+
+            splattercast = get_splattercast()
+            splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER: {grenade.key} countdown: {remaining}s remaining")
+
+            if remaining > 1:
+                # Continue countdown
+                remaining -= 1
+                setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, remaining)
+
+                # STICKY GRENADE: Send appropriate countdown warnings
+                from typeclasses.items import Item
+                from typeclasses.characters import Character
+
+                # Check if grenade is stuck to armor
+                is_stuck = isinstance(grenade.location, Item) and grenade.db.stuck_to_armor is not None
+
+                if is_stuck:
+                    # Grenade stuck to armor - send dramatic warnings
+                    armor = grenade.location
+
+                    # Check if armor is worn
+                    if armor.location and isinstance(armor.location, Character):
+                        wearer = armor.location
+                        # Warning to wearer
+                        wearer.msg(f"|R*** {remaining} SECONDS ***|n {grenade.key} magnetically clamped to your {armor.key}!")
+
+                        # Warning to room
+                        if wearer.location:
+                            msg_room_identity(
+                                location=wearer.location,
+                                template=f"|y{{target_char}} has a live {grenade.key} magnetically stuck to their {armor.key}! {remaining} seconds remaining!|n",
+                                char_refs={"target_char": wearer},
+                                exclude=[wearer],
+                            )
+                    else:
+                        # Armor on ground with stuck grenade
+                        room = armor.location
+                        if room:
+                            room.msg_contents(
+                                f"|yA {grenade.key} magnetically stuck to a {armor.key} ticks down: {remaining} seconds!|n"
+                            )
+
+                # Schedule next tick
+                timer = utils.delay(1, tick)
+                setattr(grenade.ndb, NDB_GRENADE_TIMER, timer)
+
+            elif remaining == 1:
+                # Final countdown - explode next tick
+                setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0)
+                timer = utils.delay(
+                    1, lambda: explode_standalone_grenade(grenade)
+                )
+                setattr(grenade.ndb, NDB_GRENADE_TIMER, timer)
+                splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER: {grenade.key} final countdown - explosion scheduled")
+
+            else:
+                # Should not reach here - explosion should have been triggered
+                splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: {grenade.key} reached 0 without explosion - triggering now")
+                explode_standalone_grenade(grenade)
+
+        except Exception as e:
+            # Deliberate failsafe (documented exception to the
+            # no-broad-except convention): a live grenade must never
+            # become a permanent dud because of a ticker bug.  Log
+            # the error, then explode — the loudest possible way to
+            # surface the failure.  If the explosion itself raises,
+            # that propagates to the server log.
+            splattercast = get_splattercast()
+            splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Ticker error for {grenade.key}: {e} - triggering explosion")
+            explode_standalone_grenade(grenade)
 
     # Start the ticker
     tick()

--- a/specs/THROW_COMMAND_SPEC.md
+++ b/specs/THROW_COMMAND_SPEC.md
@@ -4,28 +4,51 @@
 
 **Status**: ✅ **PRODUCTION READY** - All components implemented and tested
 
-### Test Coverage & Known Divergences (issue #471)
+### Architecture, Test Coverage & Known Divergences (issue #471)
 
-Current behavior is pinned by the characterization suite at
-`world/tests/test_throw_characterization.py` (56 tests: parsing,
-validation, flight, landing/proximity, weapon-hit resolution,
-deflection, pull, catch). That suite is the contract for the planned
-restructure. Two findings from the line-read it encodes:
+Behavior is pinned by the characterization suite at
+`world/tests/test_throw_characterization.py` (59 tests: parsing,
+validation, flight lifecycle, landing/proximity, hit resolution,
+deflection, pull, catch). That suite is the contract for any change
+to the system.
 
-- **Weapon-throw flight is dead code.** `func()` returns for *every*
-  `db.is_throwing_weapon` object (targeted → redirects to `attack`;
-  untargeted → guidance message), so the `handle_weapon_throw` /
-  `is_weapon=True` flight path is unreachable from the command. The
-  "Weapon Detection Flow" described below documents intent, not
-  current routing — `resolve_weapon_hit` only runs via the
-  sticky-grenade landing route today. The restructure should either
-  delete the dead path or deliberately wire it back.
-- **Catch announce fixed.** `catch_object` passed `room=` to
-  `msg_room_identity` (parameter is `location`), so every successful
-  catch raised TypeError before timer cancellation — the caught
-  object would "arrive" at its destination out of the catcher's
-  hands two seconds later, breaking the hot-potato mechanic. Fixed
-  with the characterization PR; the success-path test pins the
+**Layout (since the #471 restructure):**
+
+- `commands/CmdThrow.py` — command surface only: parsing,
+  validation, origin announcements (`throw` / `pull` / `catch`).
+- `world/combat/throwing.py` — the physics engine: flight timers,
+  landing resolution, proximity assignment, grenade deflection,
+  magnetic target selection. Importable by anything that launches
+  objects (rigged-grenade triggers use it directly — no more
+  instantiating throwaway command objects for access).
+- `commands/explosion_utils.py` — `start_grenade_ticker` (the
+  sticky-aware countdown, moved from `CmdPull`) lives next to the
+  explosion machinery. It and `start_standalone_grenade_ticker` are
+  candidates for unification.
+
+**Exception policy:** the engine has no broad excepts. Failures in
+the flight-timer callback surface in the server log; flight-state
+cleanup is guaranteed via `finally`, so a landing bug can never
+strand an object in the "flying" state. The one deliberate broad
+except is the grenade ticker's failsafe (a live grenade must never
+become a permanent dud — on ticker error it logs and explodes).
+
+**Resolved findings from the original line-read:**
+
+- **Weapon-throw flight was dead code — now deleted.** `func()`
+  returns for *every* `db.is_throwing_weapon` object (targeted →
+  redirects to `attack` for full combat resolution; untargeted →
+  guidance message). User confirmed this is the correct design.
+  `resolve_weapon_hit` survives as the sticky grenade's
+  stick/bounce/damage resolver, reached via the landing route. The
+  "Weapon Detection Flow" below describes the pre-#471 intent.
+  **Future:** ammo/recovery tracking for thrown weapons (alongside
+  gun ammo) is the missing piece before a true weapon-flight path
+  would be worth wiring back.
+- **Catch announce fixed** (step 1): `catch_object` passed `room=`
+  to `msg_room_identity` (parameter is `location`), so every
+  successful catch raised TypeError before timer cancellation —
+  breaking the hot-potato mechanic. The success-path test pins the
   repaired flow.
 
 ### **Implemented Components**

--- a/world/combat/throwing.py
+++ b/world/combat/throwing.py
@@ -1,0 +1,771 @@
+"""
+Throw flight / landing / deflection engine (issue #471 step 2).
+
+Extracted from ``commands/CmdThrow.py`` so the command owns parsing,
+validation, and announcements while the physics — flight timers,
+landing resolution, proximity assignment, grenade deflection — live
+here, importable by anything that launches objects (the throw
+command, rigged-grenade triggers in ``commands/explosion_utils.py``,
+future launchers).
+
+Behavioral contract: ``world/tests/test_throw_characterization.py``.
+The extraction is verbatim except for two deliberate changes:
+
+* **The dead weapon-flight path is gone.**  ``CmdThrow.func`` returns
+  for every ``is_throwing_weapon`` object (redirecting targeted
+  throws to ``attack``), so the old ``is_weapon=True`` plumbing was
+  unreachable.  ``resolve_weapon_hit`` remains — it is the sticky
+  grenade's stick/bounce/damage resolver, reached via
+  ``handle_landing``.  (When ammo tracking arrives for guns and
+  throwing weapons, a real weapon-flight path can be wired back
+  against the characterization suite.)
+* **No broad excepts** (#469).  The engine lets failures surface:
+  inside the flight-timer callback Twisted logs the traceback, and
+  ``complete_flight`` guarantees flight-state cleanup via ``finally``
+  so a mid-landing bug can never strand an object in the "flying"
+  state.  The only guards kept are narrow ones with a named, expected
+  failure (timer double-cancellation).
+"""
+
+import random
+
+from evennia import utils
+
+from twisted.internet.error import AlreadyCalled, AlreadyCancelled
+
+from world.combat.debug import get_splattercast
+from world.combat.constants import (
+    DB_CHAR,
+    DB_GRAPPLED_BY_DBREF,
+    DB_GRAPPLING_DBREF,
+    DEBUG_PREFIX_THROW,
+    MSG_THROW_ARRIVAL,
+    MSG_THROW_ARRIVAL_TARGETED,
+    MSG_THROW_ARRIVAL_TARGETED_VICTIM,
+    MSG_THROW_FLIGHT_SAMEROOM_GENERAL,
+    MSG_THROW_FLIGHT_SAMEROOM_TARGET,
+    MSG_THROW_FLIGHT_SAMEROOM_TARGET_VICTIM,
+    MSG_THROW_LANDING_PROXIMITY,
+    MSG_THROW_LANDING_ROOM,
+    MSG_THROW_UTILITY_BOUNCE,
+    MSG_THROW_UTILITY_BOUNCE_VICTIM,
+    MSG_THROW_WEAPON_HIT,
+    MSG_THROW_WEAPON_HIT_VICTIM,
+    MSG_THROW_WEAPON_MISS,
+    MSG_THROW_WEAPON_MISS_VICTIM,
+    NDB_COMBAT_HANDLER,
+    NDB_FLYING_OBJECTS,
+    NDB_PROXIMITY,
+    NDB_PROXIMITY_UNIVERSAL,
+    THROW_FLIGHT_TIME,
+)
+from world.combat.utils import get_display_name_safe
+from world.grammar import capitalize_first
+from world.identity_utils import msg_room_identity
+
+
+# ===================================================================
+# Object classification helpers
+# ===================================================================
+
+
+def is_explosive(obj):
+    """Check if object is explosive."""
+    return bool(obj.db.is_explosive)
+
+
+def is_melee_weapon(obj):
+    """Check if object is a melee weapon suitable for deflection."""
+    # Melee weapons are those that are NOT ranged (default is melee)
+    return not bool(obj.db.is_ranged)
+
+
+# ===================================================================
+# Target selection
+# ===================================================================
+
+
+def select_random_target_in_room(room, exclude=None):
+    """Select random character in room for proximity assignment."""
+    if not room:
+        return None
+
+    # Use typeclass check to distinguish characters (PCs and NPCs)
+    # from other objects
+    from typeclasses.characters import Character
+
+    characters = [
+        obj for obj in room.contents
+        if isinstance(obj, Character) and obj != exclude
+    ]
+    if characters:
+        return random.choice(characters)
+    return None
+
+
+def select_most_magnetic_target_in_room(room, grenade, exclude=None):
+    """
+    Select the most magnetic character in room for sticky grenade
+    targeting.
+
+    For sticky grenades thrown without a specific target, this finds
+    the character with the highest magnetic armor to stick to.
+
+    Args:
+        room: The room to search
+        grenade: The sticky grenade being thrown (for magnetic
+            strength)
+        exclude: Character to skip (typically the thrower)
+
+    Returns:
+        Character with highest magnetic armor, or None if no valid
+        targets
+    """
+    if not room:
+        return None
+
+    from typeclasses.characters import Character
+    from world.combat.utils import get_outermost_armor_at_location
+
+    splattercast = get_splattercast()
+
+    # Get all characters except the excluded one (thrower / triggerer)
+    characters = [
+        obj for obj in room.contents
+        if isinstance(obj, Character) and obj != exclude
+    ]
+    if not characters:
+        return None
+
+    # Get grenade magnetic strength for threshold checks
+    magnetic_strength = grenade.db.magnetic_strength if grenade.db.magnetic_strength is not None else 5
+    magnetic_threshold = magnetic_strength - 3
+    metal_threshold = magnetic_strength - 5
+
+    # Find character with highest magnetic armor that meets thresholds
+    best_target = None
+    best_magnetic_score = 0
+
+    for char in characters:
+        # Check armor at chest (primary target location)
+        armor = get_outermost_armor_at_location(char, "chest")
+
+        if not armor:
+            continue
+
+        # Get armor properties (including plate carrier check)
+        metal_level = armor.db.metal_level or 0
+        magnetic_level = armor.db.magnetic_level or 0
+
+        # Check if plate carrier - use installed plates' values
+        if bool(armor.db.is_plate_carrier):
+            installed_plates = armor.db.installed_plates or {}
+            for slot, plate_ref in installed_plates.items():
+                if plate_ref:
+                    plate_metal = plate_ref.db.metal_level or 0
+                    plate_magnetic = plate_ref.db.magnetic_level or 0
+                    metal_level = max(metal_level, plate_metal)
+                    magnetic_level = max(magnetic_level, plate_magnetic)
+
+        # Check if meets thresholds
+        if magnetic_level >= magnetic_threshold and metal_level >= metal_threshold:
+            # This target is viable - use magnetic level as score
+            if magnetic_level > best_magnetic_score:
+                best_magnetic_score = magnetic_level
+                best_target = char
+                splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_TARGET: {char.key} viable with magnetic={magnetic_level}, metal={metal_level}")
+
+    if best_target:
+        splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_TARGET: Selected {best_target.key} (magnetic={best_magnetic_score})")
+    else:
+        splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_TARGET: No viable magnetic targets in {room.key}")
+
+    return best_target
+
+
+# ===================================================================
+# Flight lifecycle
+# ===================================================================
+
+
+def start_flight(thrower, obj, destination, target):
+    """Stage flight state and start the landing timer.
+
+    The caller (command) is responsible for any origin-room
+    announcement and for removing the object from the thrower's
+    hands before launch.
+    """
+    origin = thrower.location
+
+    # Add to room's flying objects - ensure we have a proper list
+    flying_objects = getattr(origin.ndb, NDB_FLYING_OBJECTS, None)
+    if not isinstance(flying_objects, list):
+        flying_objects = []
+        setattr(origin.ndb, NDB_FLYING_OBJECTS, flying_objects)
+    flying_objects.append(obj)
+
+    # Store flight data on object
+    obj.ndb.flight_destination = destination
+    obj.ndb.flight_target = target
+    obj.ndb.flight_origin = origin
+    obj.ndb.flight_thrower = thrower
+
+    # Start flight timer and store reference for potential cancellation
+    obj.ndb.flight_timer = utils.delay(THROW_FLIGHT_TIME, complete_flight, obj)
+
+    splattercast = get_splattercast()
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: {thrower} started flight for {obj} to {destination}(#{getattr(destination, 'id', '?')})")
+
+
+def cancel_flight(obj):
+    """Clear flight state and cancel the pending landing timer.
+
+    Used by ``catch`` so a caught object doesn't "arrive" (or
+    explode) at its old destination after being plucked from the
+    air.
+    """
+    timer = obj.ndb.flight_timer
+    if timer is not None:
+        try:
+            timer.cancel()
+        except (AlreadyCalled, AlreadyCancelled):
+            pass  # Timer fired or was cancelled in the same tick.
+    _clear_flight_state(obj)
+
+
+def _clear_flight_state(obj):
+    """Remove all flight bookkeeping from the object."""
+    ndb = getattr(obj, "ndb", None)
+    if ndb is None:
+        return
+    for field in (
+        "flight_destination",
+        "flight_target",
+        "flight_origin",
+        "flight_thrower",
+        "flight_timer",
+    ):
+        if getattr(ndb, field, None) is not None:
+            delattr(ndb, field)
+
+
+def get_arrival_direction(origin, destination):
+    """Determine arrival direction for announcement."""
+    # Simple implementation - would need room connection mapping for
+    # accuracy
+    return "somewhere"
+
+
+def complete_flight(obj):
+    """Complete the flight and handle landing.
+
+    Runs as a delayed timer callback.  Flight-state cleanup is
+    guaranteed via ``finally`` — a bug anywhere in landing resolution
+    surfaces in the server log but can never strand the object in
+    the "flying" state.
+    """
+    splattercast = get_splattercast()
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Starting complete_flight for {obj}")
+
+    # Deleted objects lose their ndb handler; caught objects have had
+    # their flight state cleared (reads return None).
+    if not obj or getattr(obj, "ndb", None) is None:
+        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Object {obj} is None or missing ndb, skipping complete_flight")
+        return
+
+    destination = obj.ndb.flight_destination
+    target = obj.ndb.flight_target
+    origin = obj.ndb.flight_origin
+    thrower = obj.ndb.flight_thrower
+
+    if destination is None:
+        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Object {obj} has no flight destination (caught?), skipping complete_flight")
+        return
+
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Flight data - destination: {destination}, target: {target}, origin: {origin}")
+
+    # A successful deflection re-stages flight state for the new
+    # trajectory; the finally-cleanup below must not wipe it.
+    deflected = False
+    try:
+        # Clean up origin room flying objects
+        if origin is not None and getattr(origin, "ndb", None) is not None:
+            origin_flying_objects = getattr(origin.ndb, NDB_FLYING_OBJECTS, None)
+            if origin_flying_objects and obj in origin_flying_objects:
+                origin_flying_objects.remove(obj)
+                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Removed {obj} from origin flying objects")
+
+        # Move object to destination
+        obj.move_to(destination, quiet=True)  # quiet suppresses auto-messages
+
+        # Announce arrival based on room relationship
+        if destination != origin:
+            # Cross-room throw - announce arrival
+            arrival_dir = get_arrival_direction(origin, destination)
+            if target and target.location == destination:
+                # Send personal message to victim
+                target.msg(MSG_THROW_ARRIVAL_TARGETED_VICTIM.format(object=obj.key, direction=arrival_dir))
+                # Send observer message to everyone else
+                msg_room_identity(
+                    location=destination,
+                    template=MSG_THROW_ARRIVAL_TARGETED.format(
+                        object=obj.key, direction=arrival_dir, target="{target_char}"
+                    ),
+                    char_refs={"target_char": target},
+                    exclude=[target],
+                )
+            else:
+                destination.msg_contents(MSG_THROW_ARRIVAL.format(object=obj.key, direction=arrival_dir))
+        else:
+            # Same-room throw - show flight message
+            if target:
+                # Send personal message to victim
+                target.msg(MSG_THROW_FLIGHT_SAMEROOM_TARGET_VICTIM.format(object=obj.key))
+                # Send observer message to everyone else
+                msg_room_identity(
+                    location=destination,
+                    template=MSG_THROW_FLIGHT_SAMEROOM_TARGET.format(
+                        object=obj.key, target="{target_char}"
+                    ),
+                    char_refs={"target_char": target},
+                    exclude=[thrower, target],
+                )
+            else:
+                destination.msg_contents(MSG_THROW_FLIGHT_SAMEROOM_GENERAL.format(object=obj.key), exclude=[thrower])
+
+        # Check for grenade deflection before landing
+        if is_explosive(obj):
+            if check_grenade_deflection(obj, destination, thrower):
+                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Grenade was deflected, skipping normal landing")
+                deflected = True
+                return
+
+        # Handle landing and proximity
+        handle_landing(obj, destination, target, thrower)
+
+        # Apply gravity if item landed in a sky room (lazy import —
+        # commands package cross-import, resolved at call time)
+        from commands.combat.movement import apply_gravity_to_items
+        apply_gravity_to_items(destination)
+    finally:
+        if not deflected:
+            _clear_flight_state(obj)
+            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Cleaned up flight data for {obj}")
+
+
+# ===================================================================
+# Landing resolution
+# ===================================================================
+
+
+def handle_landing(obj, destination, target, thrower):
+    """Handle object landing and proximity assignment."""
+    splattercast = get_splattercast()
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: handle_landing called - obj: {obj}, destination: {destination}, target: {target}")
+
+    # Track whether we've shown a target interaction message
+    showed_interaction = False
+
+    # Sticky grenade resolution — the stick/bounce/damage resolver.
+    if target and obj.db.is_sticky:
+        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Sticky grenade landing - routing to hit resolution")
+        resolve_weapon_hit(obj, target, thrower)
+        showed_interaction = True  # Stick/bounce shows its own message
+
+    # Utility object bounce
+    elif target:
+        # Send personal message to victim
+        target.msg(MSG_THROW_UTILITY_BOUNCE_VICTIM.format(object=obj.key))
+        # Send observer message to room
+        msg_room_identity(
+            location=target.location,
+            template=MSG_THROW_UTILITY_BOUNCE.format(
+                object=obj.key, target="{target_char}"
+            ),
+            char_refs={"target_char": target},
+            exclude=[target],
+        )
+        showed_interaction = True  # Bounce message already shown
+
+    # Assign proximity for universal proximity system
+    assign_landing_proximity(obj, target, thrower)
+
+    # Handle grenade-specific landing
+    if is_explosive(obj):
+        handle_grenade_landing(obj, target, thrower)
+
+    # General landing announcement - only if no target interaction
+    # was shown
+    if not showed_interaction:
+        if target:
+            msg_room_identity(
+                location=destination,
+                template=MSG_THROW_LANDING_PROXIMITY.format(
+                    object=obj.key, target="{target_char}"
+                ),
+                char_refs={"target_char": target},
+            )
+        else:
+            destination.msg_contents(MSG_THROW_LANDING_ROOM.format(object=obj.key))
+
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: handle_landing completed")
+
+
+def resolve_weapon_hit(weapon, target, thrower):
+    """Resolve thrown-object hit/miss, stick attempts, and damage.
+
+    Reached via the sticky-grenade landing route (and rigged sticky
+    grenades in ``explosion_utils``).
+    """
+    # Simple hit resolution - could be enhanced with accuracy system
+    hit_chance = 0.7  # 70% base hit chance
+
+    if random.random() <= hit_chance:
+        # STICKY GRENADE CHECK - Check for stick before damage
+        from world.combat.utils import (
+            calculate_stick_chance, establish_stick,
+            get_outermost_armor_at_location,
+        )
+
+        is_sticky = bool(weapon.db.is_sticky)
+        hit_location = "chest"  # Default hit location for throws
+
+        if is_sticky:
+            splattercast = get_splattercast()
+            splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY: Sticky grenade {weapon.key} hit {target.key}")
+
+            # Get outermost armor at hit location
+            armor = get_outermost_armor_at_location(target, hit_location)
+
+            if armor:
+                # Calculate stick chance
+                stick_chance = calculate_stick_chance(weapon, armor)
+                roll = random.randint(1, 100)
+
+                if roll <= stick_chance:
+                    # SUCCESS - Grenade sticks to armor
+                    if establish_stick(weapon, armor, hit_location):
+                        # Send stick messages - Spider-themed with telescoping legs
+                        target.msg(f"|rThe {weapon.key}'s articulated legs extend with mechanical precision, their electromagnetic tips skittering across your {armor.key} before *CLAMPING* tight with magnetic fury!|n")
+                        thrower.msg(f"Your {weapon.key}'s spider-legs deploy and latch onto {get_display_name_safe(target, thrower)}'s {armor.key} with a satisfying *CLACK-CLACK-CLACK* of magnetic adhesion!")
+                        msg_room_identity(
+                            location=target.location,
+                            template=f"The {weapon.key}'s eight legs telescope outward in a blur of motion, seeking metal across {{target_char}}'s {armor.key} before *SNAPPING* into electromagnetic lock!",
+                            char_refs={"target_char": target},
+                            exclude=[thrower, target],
+                        )
+
+                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_SUCCESS: {weapon.key} stuck to {armor.key} (roll {roll} <= {stick_chance})")
+
+                        # Skip normal landing - grenade is stuck to armor now
+                        return
+                    else:
+                        splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_ERROR: establish_stick failed")
+                else:
+                    # FAIL - Grenade bounces off
+                    target.msg(f"The {weapon.key}'s legs extend and scrabble frantically across your {armor.key}, but the magnetic field is too weak - it bounces away with a frustrated clatter!")
+                    thrower.msg(f"Your {weapon.key}'s spider-legs fail to find purchase on {get_display_name_safe(target, thrower)}'s {armor.key}, bouncing off ineffectively!")
+                    msg_room_identity(
+                        location=target.location,
+                        template=f"The {weapon.key}'s articulated legs scrape and skitter across {{target_char}}'s {armor.key} before losing grip and clattering away!",
+                        char_refs={"target_char": target},
+                        exclude=[thrower, target],
+                    )
+
+                    splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_FAIL: {weapon.key} bounce (roll {roll} > {stick_chance})")
+                    # Continue to normal landing
+            else:
+                # No armor at hit location - bounce off
+                target.msg(f"The {weapon.key} strikes your {hit_location} and its legs extend desperately, seeking metal that isn't there - it bounces away with a frustrated whir of servos!")
+                thrower.msg(f"Your {weapon.key}'s electromagnetic sensors find no ferrous surface on {get_display_name_safe(target, thrower)}'s {hit_location} - the spider-legs retract as it falls away!")
+                msg_room_identity(
+                    location=target.location,
+                    template=f"The {weapon.key}'s articulated legs extend and search frantically across {{target_char}}'s {hit_location} before retracting in defeat!",
+                    char_refs={"target_char": target},
+                    exclude=[thrower, target],
+                )
+
+                splattercast.msg(f"{DEBUG_PREFIX_THROW}_STICKY_FAIL: No armor at {hit_location}")
+                # Continue to normal landing
+
+        # Hit - apply damage (only for non-sticky or failed-stick weapons)
+        base_damage = weapon.db.damage if weapon.db.damage is not None else 1
+        total_damage = random.randint(1, 6) + base_damage
+        damage_type = weapon.db.damage_type if weapon.db.damage_type is not None else 'blunt'
+
+        target.take_damage(total_damage, location="chest", injury_type=damage_type)
+
+        # Send personal message to victim
+        target.msg(MSG_THROW_WEAPON_HIT_VICTIM.format(
+            thrower=capitalize_first(get_display_name_safe(thrower, target)), weapon=weapon.key))
+        # Send personal message to thrower
+        thrower.msg(MSG_THROW_WEAPON_HIT.format(weapon=weapon.key, target=get_display_name_safe(target, thrower)))
+        # Observer message (everyone else in room)
+        msg_room_identity(
+            location=target.location,
+            template=f"{{actor}}'s {weapon.key} strikes {{target_char}}!",
+            char_refs={"actor": thrower, "target_char": target},
+            exclude=[thrower, target],
+        )
+
+        # Establish proximity if hit (safe pattern)
+        proximity_list = getattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, None)
+        if not isinstance(proximity_list, list):
+            proximity_list = []
+            setattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, proximity_list)
+
+        if thrower and thrower not in proximity_list:
+            proximity_list.append(thrower)
+
+    else:
+        # Miss - send personal message to victim
+        target.msg(MSG_THROW_WEAPON_MISS_VICTIM.format(
+            thrower=capitalize_first(get_display_name_safe(thrower, target)), weapon=weapon.key))
+        # Send personal message to thrower
+        thrower.msg(MSG_THROW_WEAPON_MISS.format(weapon=weapon.key, target=get_display_name_safe(target, thrower)))
+        # Observer message (everyone else in room)
+        msg_room_identity(
+            location=target.location,
+            template=f"{{actor}}'s {weapon.key} narrowly misses {{target_char}} and clatters to the ground.",
+            char_refs={"actor": thrower, "target_char": target},
+            exclude=[thrower, target],
+        )
+
+
+def assign_landing_proximity(obj, target, thrower=None):
+    """Assign proximity for universal proximity system."""
+    splattercast = get_splattercast()
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: assign_landing_proximity called - obj: {obj}, target: {target}, thrower: {thrower}")
+
+    # Ensure object has proximity list (use same pattern as drop command)
+    proximity_list = getattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, None)
+    if not isinstance(proximity_list, list):
+        proximity_list = []
+        setattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL, proximity_list)
+
+    if target:
+        # Add target to object proximity
+        if target not in proximity_list:
+            proximity_list.append(target)
+
+        # Inherit target's existing proximity relationships, but
+        # exclude the thrower - they shouldn't be in proximity to
+        # their own thrown object.  Check both proximity systems:
+
+        # 1. Object proximity system (NDB_PROXIMITY_UNIVERSAL)
+        target_proximity = getattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, None)
+        if isinstance(target_proximity, list):
+            for character in target_proximity:
+                if character and character not in proximity_list and character != thrower:
+                    proximity_list.append(character)
+
+        # 2. Character proximity system (in_proximity_with)
+        character_proximity = getattr(target.ndb, NDB_PROXIMITY, None)
+        if character_proximity:
+            # Convert set to list for consistent handling
+            character_list = list(character_proximity) if hasattr(character_proximity, '__iter__') else []
+            for character in character_list:
+                if character and character not in proximity_list and character != thrower:
+                    proximity_list.append(character)
+
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: assign_landing_proximity completed: {proximity_list}")
+
+
+def handle_grenade_landing(grenade, target, thrower=None):
+    """Handle grenade-specific landing mechanics."""
+    splattercast = get_splattercast()
+
+    # If grenade lands near someone, everyone in their proximity gets
+    # added
+    target_proximity = getattr(target.ndb, NDB_PROXIMITY_UNIVERSAL, None) if target else None
+
+    if isinstance(target_proximity, list):
+        grenade_proximity = getattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, [])
+        if not isinstance(grenade_proximity, list):
+            grenade_proximity = []
+
+        for character in target_proximity:
+            # Filter out the thrower - they shouldn't be in proximity
+            # to their own thrown grenade
+            if character and character not in grenade_proximity and character != thrower:
+                grenade_proximity.append(character)
+
+        setattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, grenade_proximity)
+
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: Grenade {grenade} landed with proximity: {getattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL, [])}")
+
+
+# ===================================================================
+# Grenade deflection
+# ===================================================================
+
+
+def check_grenade_deflection(grenade, destination, thrower):
+    """Check if the specific target can deflect the incoming grenade
+    with a melee weapon."""
+    splattercast = get_splattercast()
+
+    # Future-proofing: Skip deflection for impact grenades (explode
+    # on contact)
+    if grenade.db.impact_detonation:
+        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Impact grenade {grenade} cannot be deflected")
+        return False
+
+    # Get the specific target from flight data
+    target = getattr(grenade.ndb, 'flight_target', None)
+    if not target:
+        return False
+
+    # Check if target is in the destination room
+    if target.location != destination:
+        return False
+
+    # Check if target is grappled or grappling (cannot deflect while
+    # restricted)
+    handler = getattr(target.ndb, NDB_COMBAT_HANDLER, None)
+    if handler:
+        combatants_list = handler.db.combatants or []
+        combat_entry = next((e for e in combatants_list if e.get(DB_CHAR) == target), None)
+        if combat_entry:
+            grappled_by = combat_entry.get(DB_GRAPPLED_BY_DBREF)
+            grappling = combat_entry.get(DB_GRAPPLING_DBREF)
+            if grappled_by or grappling:
+                splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Target {target} cannot deflect - grappled_by: {grappled_by}, grappling: {grappling}")
+                return False
+
+    # Check if target has hands and a melee weapon
+    target_hands = getattr(target, 'hands', None)
+    if not target_hands:
+        return False
+
+    # Find melee weapon in target's hands
+    melee_weapon = None
+    for hand, wielded_obj in target_hands.items():
+        if wielded_obj and is_melee_weapon(wielded_obj):
+            melee_weapon = wielded_obj
+            break
+
+    if not melee_weapon:
+        return False
+
+    # Perform Motorics skill check for deflection
+    from world.combat.utils import roll_stat
+
+    # Roll Motorics skill
+    motorics_roll = roll_stat(target, 'motorics')
+
+    # Base difficulty threshold (higher = easier)
+    base_threshold = 10  # Moderate difficulty
+    weapon_bonus = melee_weapon.db.deflection_bonus if melee_weapon.db.deflection_bonus is not None else 0.0
+
+    # Convert weapon bonus to threshold modifier (0.30 bonus = +6 to
+    # threshold)
+    threshold_modifier = int(weapon_bonus * 20)
+    final_threshold = base_threshold + threshold_modifier
+
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: {target} Motorics deflection: rolled {motorics_roll} vs threshold {final_threshold}")
+
+    if motorics_roll >= final_threshold:
+        # Successful deflection!
+        return perform_grenade_deflection(grenade, target, melee_weapon, thrower, destination)
+    else:
+        # Failed deflection attempt
+        target.msg(f"You attempt to deflect the {grenade.key} with your {melee_weapon.key}, but your reflexes aren't quick enough!")
+        msg_room_identity(
+            location=destination,
+            template=f"{{target_char}} swings their {melee_weapon.key} at the incoming {grenade.key} but fails to connect!",
+            char_refs={"target_char": target},
+            exclude=[target],
+        )
+        return False
+
+
+def perform_grenade_deflection(grenade, deflector, weapon, original_thrower, current_location):
+    """Perform the actual grenade deflection."""
+    splattercast = get_splattercast()
+
+    # Announce successful deflection
+    deflector.msg(f"|yYou successfully bat the {grenade.key} away with your {weapon.key}!|n")
+    msg_room_identity(
+        location=current_location,
+        template=f"|y{{actor}} deflects the incoming {grenade.key} with their {weapon.key}!|n",
+        char_refs={"actor": deflector},
+        exclude=[deflector],
+    )
+
+    # Determine deflection target and destination
+    if determine_deflection_target(grenade, deflector, original_thrower, current_location):
+        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Grenade deflection successful, new flight initiated")
+        return True
+
+    # Deflection hit but grenade lands in same room
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Deflection hit but grenade stays in same room")
+    handle_landing(grenade, current_location, None, original_thrower)
+    return True
+
+
+def determine_deflection_target(grenade, deflector, original_thrower, current_location):
+    """Determine where the deflected grenade goes."""
+    splattercast = get_splattercast()
+
+    # Get grenade's original flight data
+    origin = getattr(grenade.ndb, 'flight_origin', None)
+
+    # 60% chance to deflect back toward origin/thrower if possible
+    # 40% chance to deflect in random direction
+    deflect_back_chance = 0.6
+
+    if random.random() <= deflect_back_chance and origin and origin != current_location:
+        # Try to deflect back to origin room
+        new_destination = origin
+        new_target = original_thrower if original_thrower and original_thrower.location == origin else None
+        deflection_type = "back toward origin"
+
+        splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Deflecting back to origin {origin}")
+
+    else:
+        # Deflect in random direction
+        available_exits = [obj for obj in current_location.contents
+                           if hasattr(obj, 'destination') and obj.destination
+                           and obj.destination != current_location]
+
+        if available_exits:
+            random_exit = random.choice(available_exits)
+            new_destination = random_exit.destination
+            new_target = select_random_target_in_room(
+                new_destination, exclude=original_thrower
+            )
+            deflection_type = f"toward {random_exit.key}"
+
+            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Deflecting to random direction {random_exit.key}")
+        else:
+            # No exits available, grenade lands in current room
+            splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: No exits available for deflection")
+            return False
+
+    # Announce deflection direction
+    current_location.msg_contents(
+        f"The {grenade.key} ricochets {deflection_type}!"
+    )
+
+    # Update flight data and restart flight
+    grenade.ndb.flight_destination = new_destination
+    grenade.ndb.flight_target = new_target
+    grenade.ndb.flight_origin = current_location
+    grenade.ndb.flight_thrower = deflector  # Deflector becomes new "thrower"
+
+    # Start new flight with shorter timer (already partially through
+    # flight)
+    reduced_flight_time = max(1, THROW_FLIGHT_TIME - 1)  # At least 1 second
+    grenade.ndb.flight_timer = utils.delay(reduced_flight_time, complete_flight, grenade)
+
+    # Add to current room's flying objects temporarily
+    flying_objects = getattr(current_location.ndb, NDB_FLYING_OBJECTS, None)
+    if not isinstance(flying_objects, list):
+        flying_objects = []
+        setattr(current_location.ndb, NDB_FLYING_OBJECTS, flying_objects)
+    if grenade not in flying_objects:
+        flying_objects.append(grenade)
+
+    splattercast.msg(f"{DEBUG_PREFIX_THROW}_SUCCESS: Deflected {grenade} from {deflector} to {new_destination}")
+    return True

--- a/world/tests/test_throw_characterization.py
+++ b/world/tests/test_throw_characterization.py
@@ -1,33 +1,29 @@
 """
-Characterization tests for the throw system (issue #471, step 1).
+Characterization tests for the throw system (issue #471).
 
-These tests pin down the **current, user-confirmed-correct behavior**
-of ``CmdThrow`` / ``CmdPull`` / ``CmdCatch`` ahead of the planned
-restructure and except-narrowing.  They are the refactor's contract:
-if a later change breaks one of these, it changed player-visible
-behavior.
+These tests pin the **user-confirmed-correct behavior** of the throw
+system.  Written against the original monolithic ``CmdThrow`` (step
+1), they now target the split layout (step 2): parsing / validation /
+announcements in ``commands/CmdThrow.py``, physics in
+``world/combat/throwing.py``.  The assertions are the contract — the
+restructure moved the seams, not the behavior.
 
-Notable behaviors documented here (discovered during the line-read,
-verified by these tests):
+Notable behaviors documented here:
 
-* **Dedicated throwing weapons never fly.**  ``func()`` returns for
-  every ``is_throwing_weapon`` object — targeted throws redirect to
-  the ``attack`` command, untargeted ones get a guidance message —
-  so the ``handle_weapon_throw`` / ``is_weapon=True`` flight path
-  below that check is unreachable from the command.  The weapon-hit
-  resolver still runs, but only via the sticky-grenade landing route.
-* **The ndb ``hasattr`` guards are no-ops in production.**  Evennia's
-  ndb handler returns ``None`` for unset attributes (never raises),
-  so ``hasattr(obj.ndb, ...)`` is always True.  The "was caught"
-  check in ``complete_flight`` actually works because the *values*
-  are None after cleanup, not because the attributes are absent.
-  The ``Bag`` stub below mimics this exactly.
-* **Catch announce fix.**  ``catch_object`` called
-  ``msg_room_identity(room=...)`` (the parameter is ``location``),
-  so every successful catch raised TypeError before timer
-  cancellation — the caught object would "arrive" at its destination
-  out of the catcher's hands two seconds later.  Fixed in this PR;
-  the success test asserts the repaired flow end-to-end.
+* **Dedicated throwing weapons never take the utility flight path.**
+  Targeted throws redirect to the ``attack`` command; untargeted
+  ones get a guidance message.  The old unreachable
+  ``is_weapon=True`` flight plumbing was deleted in step 2;
+  ``resolve_weapon_hit`` survives as the sticky grenade's
+  stick/bounce/damage resolver.  (Ammo tracking for thrown weapons
+  and guns is a future feature.)
+* **The ndb semantics matter.**  Evennia's ndb handler returns
+  ``None`` for unset attributes (never raises), so value checks —
+  not ``hasattr`` — are what gate the flight lifecycle.  The ``Bag``
+  stub below mimics this exactly.
+* **Catch must cancel the flight timer.**  Step 1 fixed the
+  ``room=`` → ``location=`` TypeError that aborted catch cleanup;
+  the success-path test pins the full repaired flow.
 
 Run via::
 
@@ -54,6 +50,7 @@ from world.combat.constants import (
     NDB_PROXIMITY_UNIVERSAL,
     THROW_FLIGHT_TIME,
 )
+from world.combat import throwing
 
 
 # ===================================================================
@@ -245,13 +242,8 @@ class TestGetObjectToThrow(TestCase):
 
 
 class TestThrowingWeaponRedirect(TestCase):
-    """``is_throwing_weapon`` objects redirect to ``attack``.
-
-    Because this check returns unconditionally, the
-    ``handle_weapon_throw`` flight path further down ``func()`` is
-    unreachable from the command — characterized here so the
-    restructure can delete it knowingly.
-    """
+    """``is_throwing_weapon`` objects redirect to ``attack`` and
+    never enter the utility flight path."""
 
     def test_targeted_weapon_throw_invokes_attack(self):
         knife = make_obj("knife", is_throwing_weapon=True)
@@ -270,15 +262,15 @@ class TestThrowingWeaponRedirect(TestCase):
             any("attack" in m for m in caller_messages(caller))
         )
 
-    def test_weapon_flight_path_is_unreachable(self):
-        """Even a targeted weapon throw never reaches
-        handle_weapon_throw — the redirect fires first."""
+    def test_weapon_never_takes_utility_flight(self):
+        """Even a targeted weapon throw never launches a utility
+        flight — the redirect fires first."""
         knife = make_obj("knife", is_throwing_weapon=True)
         caller = make_caller(hands={"right": knife})
         cmd = make_throw_cmd(caller, "knife at bob")
-        with patch.object(cmd, "handle_weapon_throw") as mock_hwt:
+        with patch.object(cmd, "handle_utility_throw") as mock_fly:
             cmd.func()
-        mock_hwt.assert_not_called()
+        mock_fly.assert_not_called()
 
 
 # ===================================================================
@@ -312,12 +304,12 @@ class TestDetermineDestination(TestCase):
         cmd = make_throw_cmd(caller, "rock to north")
         cmd.obj_to_throw = make_obj("rock")
         with patch.object(cmd, "get_destination_room", return_value=adjacent), \
-             patch.object(cmd, "select_random_target_in_room",
-                          return_value=bystander) as mock_pick:
+             patch("commands.CmdThrow.select_random_target_in_room",
+                   return_value=bystander) as mock_pick:
             destination, target = cmd.determine_destination()
         self.assertIs(destination, adjacent)
         self.assertIs(target, bystander)
-        mock_pick.assert_called_once_with(adjacent)
+        mock_pick.assert_called_once_with(adjacent, exclude=caller)
 
     def test_sticky_grenade_prefers_magnetic_target(self):
         caller = make_caller()
@@ -326,8 +318,8 @@ class TestDetermineDestination(TestCase):
         cmd = make_throw_cmd(caller, "spider to north")
         cmd.obj_to_throw = make_obj("spider grenade", is_sticky=True)
         with patch.object(cmd, "get_destination_room", return_value=adjacent), \
-             patch.object(cmd, "select_most_magnetic_target_in_room",
-                          return_value=magnetic_victim):
+             patch("commands.CmdThrow.select_most_magnetic_target_in_room",
+                   return_value=magnetic_victim):
             destination, target = cmd.determine_destination()
         self.assertIs(target, magnetic_victim)
 
@@ -338,10 +330,10 @@ class TestDetermineDestination(TestCase):
         cmd = make_throw_cmd(caller, "spider to north")
         cmd.obj_to_throw = make_obj("spider grenade", is_sticky=True)
         with patch.object(cmd, "get_destination_room", return_value=adjacent), \
-             patch.object(cmd, "select_most_magnetic_target_in_room",
-                          return_value=None), \
-             patch.object(cmd, "select_random_target_in_room",
-                          return_value=random_victim):
+             patch("commands.CmdThrow.select_most_magnetic_target_in_room",
+                   return_value=None), \
+             patch("commands.CmdThrow.select_random_target_in_room",
+                   return_value=random_victim):
             destination, target = cmd.determine_destination()
         self.assertIs(target, random_victim)
 
@@ -353,8 +345,8 @@ class TestDetermineDestination(TestCase):
         cmd.obj_to_throw = make_obj("rock")
         with patch.object(cmd, "get_destination_room",
                           return_value=aimed_room) as mock_dest, \
-             patch.object(cmd, "select_random_target_in_room",
-                          return_value=None):
+             patch("commands.CmdThrow.select_random_target_in_room",
+                   return_value=None):
             destination, target = cmd.determine_destination()
         mock_dest.assert_called_once_with("north")
         self.assertIs(destination, aimed_room)
@@ -363,8 +355,8 @@ class TestDetermineDestination(TestCase):
         caller = make_caller()
         cmd = make_throw_cmd(caller, "rock")
         cmd.obj_to_throw = make_obj("rock")
-        with patch.object(cmd, "select_random_target_in_room",
-                          return_value=None):
+        with patch("commands.CmdThrow.select_random_target_in_room",
+                   return_value=None):
             destination, target = cmd.determine_destination()
         self.assertIs(destination, caller.location)
 
@@ -432,33 +424,30 @@ class TestFindTarget(TestCase):
 
 
 # ===================================================================
-# Flight — start, complete, cleanup
+# Flight — start, complete, cleanup (world.combat.throwing)
 # ===================================================================
 
 
 class TestFlight(TestCase):
-    def _start(self, caller, obj, destination, target=None, is_weapon=False):
-        cmd = make_throw_cmd(caller, f"{obj.key} to here")
-        with patch.object(cmd, "announce_throw_origin"), \
-             patch("commands.CmdThrow.utils.delay") as mock_delay:
+    def _start(self, caller, obj, destination, target=None):
+        with patch("world.combat.throwing.utils.delay") as mock_delay:
             mock_delay.return_value = MagicMock()
-            cmd.start_flight(obj, destination, target, is_weapon=is_weapon)
-        return cmd, mock_delay
+            throwing.start_flight(caller, obj, destination, target)
+        return mock_delay
 
     def test_start_flight_stages_state_and_timer(self):
         caller = make_caller()
         obj = make_obj("rock")
         destination = make_room("dest")
-        cmd, mock_delay = self._start(caller, obj, destination)
+        mock_delay = self._start(caller, obj, destination)
 
         self.assertIs(obj.ndb.flight_destination, destination)
         self.assertIsNone(obj.ndb.flight_target)
         self.assertIs(obj.ndb.flight_origin, caller.location)
         self.assertIs(obj.ndb.flight_thrower, caller)
-        self.assertFalse(obj.ndb.flight_is_weapon)
         self.assertIn(obj, getattr(caller.location.ndb, NDB_FLYING_OBJECTS))
         mock_delay.assert_called_once_with(
-            THROW_FLIGHT_TIME, cmd.complete_flight, obj
+            THROW_FLIGHT_TIME, throwing.complete_flight, obj
         )
 
     def test_complete_flight_moves_object_and_cleans_up(self):
@@ -466,12 +455,12 @@ class TestFlight(TestCase):
         origin = caller.location
         obj = make_obj("rock")
         destination = make_room("dest")
-        cmd, _ = self._start(caller, obj, destination)
+        self._start(caller, obj, destination)
 
-        with patch.object(cmd, "handle_landing") as mock_landing, \
-             patch("commands.CmdThrow.msg_room_identity"), \
+        with patch("world.combat.throwing.handle_landing") as mock_landing, \
+             patch("world.combat.throwing.msg_room_identity"), \
              patch("commands.combat.movement.apply_gravity_to_items"):
-            cmd.complete_flight(obj)
+            throwing.complete_flight(obj)
 
         obj.move_to.assert_called_once_with(destination, quiet=True)
         mock_landing.assert_called_once()
@@ -483,27 +472,62 @@ class TestFlight(TestCase):
     def test_complete_flight_skips_object_with_cleared_state(self):
         """After catch cleanup, flight_destination reads None and the
         late-firing timer must not move the object."""
-        caller = make_caller()
         obj = make_obj("rock")
-        cmd = make_throw_cmd(caller, "rock to here")
-        # No flight state staged at all — as after catch cleanup.
-        cmd.complete_flight(obj)
+        throwing.complete_flight(obj)
         obj.move_to.assert_not_called()
 
     def test_complete_flight_explosive_checks_deflection_first(self):
         caller = make_caller()
         grenade = make_obj("grenade", is_explosive=True)
         destination = make_room("dest")
-        cmd, _ = self._start(caller, grenade, destination)
+        self._start(caller, grenade, destination)
 
-        with patch.object(cmd, "check_grenade_deflection",
-                          return_value=True) as mock_deflect, \
-             patch.object(cmd, "handle_landing") as mock_landing, \
-             patch("commands.CmdThrow.msg_room_identity"):
-            cmd.complete_flight(grenade)
+        with patch("world.combat.throwing.check_grenade_deflection",
+                   return_value=True) as mock_deflect, \
+             patch("world.combat.throwing.handle_landing") as mock_landing, \
+             patch("world.combat.throwing.msg_room_identity"):
+            throwing.complete_flight(grenade)
 
         mock_deflect.assert_called_once()
         mock_landing.assert_not_called()
+
+    def test_deflected_flight_state_survives_completion(self):
+        """A successful deflection re-stages flight state for the new
+        trajectory; complete_flight's cleanup must not wipe it."""
+        caller = make_caller()
+        grenade = make_obj("grenade", is_explosive=True)
+        destination = make_room("dest")
+        new_destination = make_room("ricochet")
+
+        def fake_deflect(obj, dest, thrower):
+            obj.ndb.flight_destination = new_destination
+            obj.ndb.flight_timer = MagicMock()
+            return True
+
+        self._start(caller, grenade, destination)
+        with patch("world.combat.throwing.check_grenade_deflection",
+                   side_effect=fake_deflect), \
+             patch("world.combat.throwing.msg_room_identity"):
+            throwing.complete_flight(grenade)
+
+        self.assertIs(grenade.ndb.flight_destination, new_destination)
+
+    def test_landing_failure_still_cleans_flight_state(self):
+        """A bug in landing resolution surfaces (raises) but can
+        never strand the object in the flying state."""
+        caller = make_caller()
+        obj = make_obj("rock")
+        destination = make_room("dest")
+        self._start(caller, obj, destination)
+
+        with patch("world.combat.throwing.handle_landing",
+                   side_effect=RuntimeError("boom")), \
+             patch("world.combat.throwing.msg_room_identity"):
+            with self.assertRaises(RuntimeError):
+                throwing.complete_flight(obj)
+
+        self.assertIsNone(obj.ndb.flight_destination)
+        self.assertIsNone(obj.ndb.flight_timer)
 
 
 # ===================================================================
@@ -512,28 +536,35 @@ class TestFlight(TestCase):
 
 
 class TestLanding(TestCase):
-    def _landing_cmd(self, caller):
-        return make_throw_cmd(caller, "rock to here")
-
     def test_utility_bounce_messages_target(self):
         caller = make_caller()
         target = MagicMock()
         target.ndb = Bag()
         obj = make_obj("rock")
-        cmd = self._landing_cmd(caller)
-        with patch("commands.CmdThrow.msg_room_identity") as mock_room:
-            cmd.handle_landing(obj, make_room("dest"), target,
-                               is_weapon=False, thrower=caller)
+        with patch("world.combat.throwing.msg_room_identity") as mock_room:
+            throwing.handle_landing(obj, make_room("dest"), target, caller)
         target.msg.assert_called()
         self.assertTrue(mock_room.called)
+
+    def test_sticky_landing_routes_to_hit_resolution(self):
+        """The stick/bounce/damage resolver is reached via the sticky
+        landing route — the only route since the dead weapon-flight
+        path was removed."""
+        caller = make_caller()
+        target = MagicMock()
+        target.ndb = Bag()
+        spider = make_obj("spider grenade", is_sticky=True, is_explosive=True)
+        with patch("world.combat.throwing.resolve_weapon_hit") as mock_hit, \
+             patch("world.combat.throwing.msg_room_identity"):
+            throwing.handle_landing(spider, make_room("dest"), target, caller)
+        mock_hit.assert_called_once_with(spider, target, caller)
 
     def test_landing_proximity_adds_target_to_object(self):
         caller = make_caller()
         target = MagicMock()
         target.ndb = Bag()
         obj = make_obj("rock")
-        cmd = self._landing_cmd(caller)
-        cmd.assign_landing_proximity(obj, target, caller)
+        throwing.assign_landing_proximity(obj, target, caller)
         self.assertIn(target, getattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL))
 
     def test_landing_proximity_inherits_targets_neighbors_not_thrower(self):
@@ -544,8 +575,7 @@ class TestLanding(TestCase):
         target = MagicMock()
         target.ndb = Bag(in_proximity_with={bystander, caller})
         obj = make_obj("grenade", is_explosive=True)
-        cmd = self._landing_cmd(caller)
-        cmd.assign_landing_proximity(obj, target, caller)
+        throwing.assign_landing_proximity(obj, target, caller)
         proximity = getattr(obj.ndb, NDB_PROXIMITY_UNIVERSAL)
         self.assertIn(bystander, proximity)
         self.assertNotIn(caller, proximity)
@@ -556,58 +586,52 @@ class TestLanding(TestCase):
         target = MagicMock()
         target.ndb = Bag(**{NDB_PROXIMITY_UNIVERSAL: [bystander, caller]})
         grenade = make_obj("grenade", is_explosive=True)
-        cmd = self._landing_cmd(caller)
-        cmd.handle_grenade_landing(grenade, target, caller)
+        throwing.handle_grenade_landing(grenade, target, caller)
         proximity = getattr(grenade.ndb, NDB_PROXIMITY_UNIVERSAL)
         self.assertIn(bystander, proximity)
         self.assertNotIn(caller, proximity)
 
 
 # ===================================================================
-# Weapon hit resolution (reachable only via sticky landing route)
+# Hit resolution (reachable via the sticky landing route)
 # ===================================================================
 
 
 class TestResolveWeaponHit(TestCase):
-    def _hit_cmd(self):
-        caller = make_caller()
-        cmd = make_throw_cmd(caller, "rock at bob")
-        return cmd, caller
-
     def _target(self):
         target = MagicMock()
         target.key = "Victim"
         target.ndb = Bag()
         return target
 
-    @patch("commands.CmdThrow.capitalize_first", side_effect=lambda s: s)
-    @patch("commands.CmdThrow.get_display_name_safe",
+    @patch("world.combat.throwing.capitalize_first", side_effect=lambda s: s)
+    @patch("world.combat.throwing.get_display_name_safe",
            side_effect=lambda t, o: getattr(t, "key", "x"))
-    @patch("commands.CmdThrow.msg_room_identity")
+    @patch("world.combat.throwing.msg_room_identity")
     def test_hit_applies_damage_and_proximity(self, mock_room, *_):
-        cmd, caller = self._hit_cmd()
+        caller = make_caller()
         target = self._target()
         weapon = make_obj("brick", damage=3, damage_type="blunt")
-        with patch("commands.CmdThrow.random") as mock_random:
+        with patch("world.combat.throwing.random") as mock_random:
             mock_random.random.return_value = 0.1   # under 0.7 → hit
             mock_random.randint.return_value = 4
-            cmd.resolve_weapon_hit(weapon, target, caller)
+            throwing.resolve_weapon_hit(weapon, target, caller)
         target.take_damage.assert_called_once_with(
             7, location="chest", injury_type="blunt"
         )
         self.assertIn(caller, getattr(target.ndb, NDB_PROXIMITY_UNIVERSAL))
 
-    @patch("commands.CmdThrow.capitalize_first", side_effect=lambda s: s)
-    @patch("commands.CmdThrow.get_display_name_safe",
+    @patch("world.combat.throwing.capitalize_first", side_effect=lambda s: s)
+    @patch("world.combat.throwing.get_display_name_safe",
            side_effect=lambda t, o: getattr(t, "key", "x"))
-    @patch("commands.CmdThrow.msg_room_identity")
+    @patch("world.combat.throwing.msg_room_identity")
     def test_miss_deals_no_damage(self, mock_room, *_):
-        cmd, caller = self._hit_cmd()
+        caller = make_caller()
         target = self._target()
         weapon = make_obj("brick", damage=3)
-        with patch("commands.CmdThrow.random") as mock_random:
+        with patch("world.combat.throwing.random") as mock_random:
             mock_random.random.return_value = 0.9   # over 0.7 → miss
-            cmd.resolve_weapon_hit(weapon, target, caller)
+            throwing.resolve_weapon_hit(weapon, target, caller)
         target.take_damage.assert_not_called()
         target.msg.assert_called()
 
@@ -637,73 +661,82 @@ class TestGrenadeDeflection(TestCase):
         else:
             target.ndb = Bag()
         grenade.ndb = Bag(flight_target=target)
-        cmd = make_throw_cmd(caller, "grenade at bob")
-        return cmd, grenade, destination, caller, target
+        return grenade, destination, caller, target
 
     def test_impact_grenades_cannot_be_deflected(self):
-        cmd, grenade, dest, caller, _ = self._setup(impact=True)
-        self.assertFalse(cmd.check_grenade_deflection(grenade, dest, caller))
+        grenade, dest, caller, _ = self._setup(impact=True)
+        self.assertFalse(
+            throwing.check_grenade_deflection(grenade, dest, caller)
+        )
 
     def test_untargeted_grenade_not_deflectable(self):
-        cmd, grenade, dest, caller, _ = self._setup()
+        grenade, dest, caller, _ = self._setup()
         grenade.ndb = Bag()  # no flight_target
-        self.assertFalse(cmd.check_grenade_deflection(grenade, dest, caller))
+        self.assertFalse(
+            throwing.check_grenade_deflection(grenade, dest, caller)
+        )
 
     def test_target_elsewhere_cannot_deflect(self):
-        cmd, grenade, dest, caller, _ = self._setup(target_present=False)
-        self.assertFalse(cmd.check_grenade_deflection(grenade, dest, caller))
+        grenade, dest, caller, _ = self._setup(target_present=False)
+        self.assertFalse(
+            throwing.check_grenade_deflection(grenade, dest, caller)
+        )
 
     def test_grappled_target_cannot_deflect(self):
         melee = make_obj("pipe")
-        cmd, grenade, dest, caller, _ = self._setup(
+        grenade, dest, caller, _ = self._setup(
             wielding={"right": melee}, grappled=True
         )
-        self.assertFalse(cmd.check_grenade_deflection(grenade, dest, caller))
+        self.assertFalse(
+            throwing.check_grenade_deflection(grenade, dest, caller)
+        )
 
     def test_ranged_weapon_cannot_deflect(self):
         gun = make_obj("pistol", is_ranged=True)
-        cmd, grenade, dest, caller, _ = self._setup(wielding={"right": gun})
-        self.assertFalse(cmd.check_grenade_deflection(grenade, dest, caller))
+        grenade, dest, caller, _ = self._setup(wielding={"right": gun})
+        self.assertFalse(
+            throwing.check_grenade_deflection(grenade, dest, caller)
+        )
 
     @patch("world.combat.utils.roll_stat", return_value=12)
     def test_motorics_roll_beats_base_threshold(self, mock_roll):
         """Roll 12 vs base threshold 10 → deflection attempt fires."""
         melee = make_obj("pipe")
-        cmd, grenade, dest, caller, target = self._setup(
+        grenade, dest, caller, target = self._setup(
             wielding={"right": melee}
         )
-        with patch.object(cmd, "perform_grenade_deflection",
-                          return_value=True) as mock_perform:
-            result = cmd.check_grenade_deflection(grenade, dest, caller)
+        with patch("world.combat.throwing.perform_grenade_deflection",
+                   return_value=True) as mock_perform:
+            result = throwing.check_grenade_deflection(grenade, dest, caller)
         self.assertTrue(result)
         mock_perform.assert_called_once()
 
     @patch("world.combat.utils.roll_stat", return_value=12)
-    @patch("commands.CmdThrow.msg_room_identity")
+    @patch("world.combat.throwing.msg_room_identity")
     def test_deflection_bonus_raises_threshold(self, mock_room, mock_roll):
         """deflection_bonus 0.30 → threshold 16; roll 12 now fails."""
         melee = make_obj("pipe", deflection_bonus=0.30)
-        cmd, grenade, dest, caller, target = self._setup(
+        grenade, dest, caller, target = self._setup(
             wielding={"right": melee}
         )
-        with patch.object(cmd, "perform_grenade_deflection") as mock_perform:
-            result = cmd.check_grenade_deflection(grenade, dest, caller)
+        with patch("world.combat.throwing.perform_grenade_deflection") as mock_perform:
+            result = throwing.check_grenade_deflection(grenade, dest, caller)
         self.assertFalse(result)
         mock_perform.assert_not_called()
 
     def test_deflected_grenade_rethrown_back_at_thrower(self):
         """60%-branch deflection re-targets origin; deflector becomes
         the new thrower and the timer restarts shortened."""
-        cmd, grenade, dest, caller, target = self._setup()
+        grenade, dest, caller, target = self._setup()
         origin = make_room("origin")
         caller.location = origin
         grenade.ndb = Bag(flight_target=target, flight_origin=origin)
         deflector = MagicMock()
         deflector.ndb = Bag()
-        with patch("commands.CmdThrow.random") as mock_random, \
-             patch("commands.CmdThrow.utils.delay") as mock_delay:
+        with patch("world.combat.throwing.random") as mock_random, \
+             patch("world.combat.throwing.utils.delay") as mock_delay:
             mock_random.random.return_value = 0.1  # under 0.6 → back
-            result = cmd.determine_deflection_target(
+            result = throwing.determine_deflection_target(
                 grenade, deflector, caller, dest
             )
         self.assertTrue(result)
@@ -715,12 +748,12 @@ class TestGrenadeDeflection(TestCase):
         )
 
     def test_deflection_with_no_exits_fails(self):
-        cmd, grenade, dest, caller, target = self._setup()
+        grenade, dest, caller, target = self._setup()
         dest.contents = []
         deflector = MagicMock()
-        with patch("commands.CmdThrow.random") as mock_random:
+        with patch("world.combat.throwing.random") as mock_random:
             mock_random.random.return_value = 0.9  # over 0.6 → random exit
-            result = cmd.determine_deflection_target(
+            result = throwing.determine_deflection_target(
                 grenade, deflector, caller, dest
             )
         self.assertFalse(result)
@@ -777,13 +810,13 @@ class TestCmdPull(TestCase):
             caller_messages(caller),
         )
 
+    @patch("commands.explosion_utils.start_grenade_ticker")
     @patch("commands.CmdThrow.msg_room_identity")
-    def test_pull_sets_flag_countdown_and_ticker(self, mock_room):
+    def test_pull_sets_flag_countdown_and_ticker(self, mock_room, mock_ticker):
         grenade = make_obj("grenade", is_explosive=True, fuse_time=8)
         caller = make_caller(hands={"right": grenade})
         cmd = self._cmd(caller, "pin on grenade")
-        with patch.object(cmd, "start_grenade_ticker") as mock_ticker:
-            cmd.func()
+        cmd.func()
         self.assertTrue(grenade.db.pin_pulled)
         self.assertEqual(
             getattr(grenade.ndb, NDB_COUNTDOWN_REMAINING), 8


### PR DESCRIPTION
Steps 2 and 3 of #471, executed against the 59-test characterization contract. Closes #471. Refs #469.

**Restructure.** `commands/CmdThrow.py` (1,698 → ~640 lines) keeps only the command surface — parsing, validation, origin announcements. The physics live in `world/combat/throwing.py`: flight timers, landing resolution, proximity assignment, grenade deflection, magnetic target selection. The sticky-aware grenade ticker moves from `CmdPull` to `explosion_utils`, next to the explosion machinery it drives.

**Dead code deleted** (user-confirmed correct design): the `is_weapon=True` flight path was unreachable — `func()` redirects every `is_throwing_weapon` object to `attack`. `handle_weapon_throw` and its combat-entry/skip-round plumbing are gone; `resolve_weapon_hit` survives as the sticky grenade's stick/bounce/damage resolver. Ammo tracking for thrown weapons (alongside gun ammo) is noted in the spec as the future piece.

**Anti-pattern removed:** `explosion_utils` no longer instantiates a throwaway `CmdThrow()` for magnetic targeting, and `CmdExplosives` no longer builds `CmdPull()` instances for the ticker — both import the shared functions.

**Excepts narrowed (#469):** `CmdThrow.py` 21 broad excepts → 0; the engine has none.
- `complete_flight` guarantees flight-state cleanup via `finally` — a landing bug surfaces in the server log but can never strand an object mid-flight (new test), and a deflection-restaged flight survives cleanup (new test, caught a real bug in my first draft of the `finally` logic).
- Timer cancellation catches only Twisted's `AlreadyCalled`/`AlreadyCancelled`.
- Two dead "race condition" handlers around ndb reads (which return `None`, never raise) deleted outright.
- One deliberate broad except remains: the grenade ticker failsafe — a live grenade must never become a permanent dud, so on ticker error it logs to the audit file and explodes. Documented in the spec's exception-policy section.

Repo broad excepts: 145 → 125.

Specs: `THROW_COMMAND_SPEC.md` gains the architecture/exception-policy section; AGENTS.md file map gains `world/combat/throwing.py`.

Test plan: characterization suite 59/59 (assertions unchanged, seams updated); full `world.tests` 2,317/2,317 in the container. Live reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)