### PR TITLE
Consumption commands gate on delivery-method tags

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -8,6 +8,7 @@ Implements the universal consumption system with inject, apply, bandage, etc.
 from evennia import Command
 from commands._identity_targeting import resolve_character_target
 from world.identity_utils import msg_room_identity
+from world.consumables import supports_delivery
 from world.medical.utils import (
     is_medical_item, can_be_used, get_medical_type, get_stat_requirement,
     calculate_treatment_success, apply_medical_effects, use_item
@@ -268,10 +269,8 @@ class CmdInject(ConsumptionCommand):
         item, target = result["item"], result["target"]
         is_self = (caller == target)
         
-        # Check if item can be injected
-        injectable_types = ["pain_relief", "blood_restoration", "stimulant", "toxin"]
-        medical_type = get_medical_type(item)
-        if medical_type not in injectable_types:
+        # Check if item supports the inject delivery method
+        if not supports_delivery(item, "inject"):
             caller.msg(f"{item.get_display_name(caller)} cannot be injected.")
             return
             
@@ -401,15 +400,14 @@ class CmdApply(ConsumptionCommand):
                 )
                 return
         
-        # Check if item can be applied topically or orthopedically.
+        # Check if item supports the apply delivery method.
         # Surgical kits are NOT applicable — they're tools for the
         # procedure verbs (incise / harvest / install / suture).
         # See ``help procedures``.
-        applicable_types = ["burn_treatment", "antiseptic", "healing_salve", "wound_care", "fracture_treatment", "organ_repair"]
-        medical_type = get_medical_type(item)
-        if medical_type not in applicable_types:
+        if not supports_delivery(item, "apply"):
             caller.msg(f"{item.get_display_name(caller)} cannot be applied.")
             return
+        medical_type = get_medical_type(item)
             
         # Check medical requirements
         errors = self.check_medical_requirements(item, caller, target)
@@ -576,9 +574,7 @@ class CmdBandage(ConsumptionCommand):
             caller.msg(f"{item.get_display_name(caller)} is not a medical item.")
             return
             
-        bandage_types = ["wound_care", "bandage", "gauze"]
-        medical_type = get_medical_type(item)
-        if medical_type not in bandage_types:
+        if not supports_delivery(item, "bandage"):
             caller.msg(f"{item.get_display_name(caller)} cannot be used for bandaging.")
             return
             
@@ -664,10 +660,8 @@ class CmdEat(ConsumptionCommand):
         item, target = result["item"], result["target"]
         is_self = (caller == target)
         
-        # Check if item can be eaten
-        edible_types = ["pill", "tablet", "food", "ration", "medicine"]
-        medical_type = get_medical_type(item)
-        if medical_type not in edible_types:
+        # Check if item supports the eat delivery method
+        if not supports_delivery(item, "eat"):
             caller.msg(f"{item.get_display_name(caller)} cannot be eaten.")
             return
             
@@ -743,10 +737,8 @@ class CmdDrink(ConsumptionCommand):
         item, target = result["item"], result["target"]
         is_self = (caller == target)
         
-        # Check if item can be drunk
-        liquid_types = ["liquid_medicine", "water", "alcohol", "potion", "drink"]
-        medical_type = get_medical_type(item)
-        if medical_type not in liquid_types:
+        # Check if item supports the drink delivery method
+        if not supports_delivery(item, "drink"):
             caller.msg(f"{item.get_display_name(caller)} cannot be drunk.")
             return
             
@@ -822,10 +814,8 @@ class CmdInhale(ConsumptionCommand):
         item, target = result["item"], result["target"]
         is_self = (caller == target)
         
-        # Check if item can be inhaled
-        inhalable_types = ["oxygen", "anesthetic", "inhaler", "gas", "vapor"]
-        medical_type = get_medical_type(item)
-        if medical_type not in inhalable_types:
+        # Check if item supports the inhale delivery method
+        if not supports_delivery(item, "inhale"):
             caller.msg(f"{item.get_display_name(caller)} cannot be inhaled.")
             return
             
@@ -865,88 +855,6 @@ class CmdInhale(ConsumptionCommand):
         # Apply treatment effects
         result_msg = self.execute_treatment(item, caller, target)
         caller.msg(f"Inhalation result: {result_msg}")
-        
-        if not is_self:
-            target.msg(f"Treatment result: {result_msg}")
-
-
-class CmdSmoke(ConsumptionCommand):
-    """
-    Smoke medicinal herbs, cigarettes, or combustible treatments.
-    
-    Usage:
-        smoke <item>
-        help <target> smoke <item>
-        
-    Examples:
-        smoke medicinal herb
-        smoke pain-relief cigarette
-        help Bob smoke calming herb
-        
-    Smoking is used for dried herbs, medicinal cigarettes, and other
-    combustible medical substances. Creates smoke and may affect others nearby.
-    """
-    
-    key = "smoke"
-    aliases = ["light", "burn"]
-    help_category = "Medical"
-    
-    def func(self):
-        """Execute the smoke command."""
-        caller = self.caller
-        
-        # Parse arguments
-        result = self.get_item_and_target(self.args)
-        if result["errors"]:
-            caller.msg(result["errors"][0])
-            return
-            
-        item, target = result["item"], result["target"]
-        is_self = (caller == target)
-        
-        # Check if item can be smoked
-        smokable_types = ["herb", "cigarette", "medicinal_plant", "dried_medicine"]
-        medical_type = get_medical_type(item)
-        if medical_type not in smokable_types:
-            caller.msg(f"{item.get_display_name(caller)} cannot be smoked.")
-            return
-            
-        # Check if target is conscious (required for smoking)
-        if target.is_unconscious():
-            if is_self:
-                caller.msg("You cannot smoke while unconscious.")
-            else:
-                caller.msg(f"{target.get_display_name(caller)} is unconscious and cannot smoke.")
-            return
-            
-        # Check medical requirements
-        errors = self.check_medical_requirements(item, caller, target)
-        if errors:
-            caller.msg(errors[0])
-            return
-            
-        # Execute smoking
-        if is_self:
-            caller.msg(f"You light and smoke {item.get_display_name(caller)}, inhaling the medicinal smoke.")
-            msg_room_identity(
-                location=caller.location,
-                template=f"{{actor}} lights and smokes {item.key}, creating aromatic smoke.",
-                char_refs={"actor": caller},
-                exclude=[caller],
-            )
-        else:
-            caller.msg(f"You help {target.get_display_name(caller)} smoke {item.get_display_name(caller)}.")
-            target.msg(f"{caller.get_display_name(target)} helps you smoke {item.get_display_name(target)}.")
-            msg_room_identity(
-                location=caller.location,
-                template=f"{{actor}} helps {{target}} smoke {item.key}.",
-                char_refs={"actor": caller, "target": target},
-                exclude=[caller, target],
-            )
-            
-        # Apply treatment effects
-        result_msg = self.execute_treatment(item, caller, target)
-        caller.msg(f"Smoking result: {result_msg}")
         
         if not is_self:
             target.msg(f"Treatment result: {result_msg}")

--- a/specs/SUBSTANCES_AND_DELIVERY_SPEC.md
+++ b/specs/SUBSTANCES_AND_DELIVERY_SPEC.md
@@ -174,10 +174,10 @@ A single item can declare multiple delivery methods.  A pill
 might support `eat` only.  A vial might support `inject` and
 `drink`.  A pipe loaded with a substance supports `smoke`.
 
-The currently-shipped `CmdConsumption` commands (`eat`, `drink`,
-`inhale`, `inject`, `apply`, `bandage`) check for `medical_type`
-strings rather than delivery-method tags.  They'll migrate to
-this scheme when the substance registry lands.
+The `CmdConsumption` commands (`eat`, `drink`, `inhale`,
+`inject`, `apply`, `bandage`) gate on delivery-method tags via
+`world/consumables.py:supports_delivery` (#474), with lazy legacy
+migration from the old `medical_type` strings.
 
 ## 5 · Current state vs target state
 
@@ -200,9 +200,11 @@ this scheme when the substance registry lands.
   entries, `apply_substance` pipeline feeding the medical
   condition system, per-substance dose bookkeeping on
   `db.substance_doses`.
-* **`commands/CmdConsumption.py`** — the older medical /
-  substance command cluster (eat/drink/inhale/inject/apply/
-  bandage).  Pre-dates the layering.
+* **`commands/CmdConsumption.py`** — the medical / substance
+  command cluster (eat/drink/inhale/inject/apply/bandage).
+  Delivery gating migrated to tags in #474; treatment effects
+  still key off `medical_type` pending the substance-entry
+  migration (item 6).
 
 ### Gaps to close (separate PRs)
 
@@ -211,9 +213,17 @@ this scheme when the substance registry lands.
 2. ~~**Effect pipeline** — `apply_substance`~~ — ✅ shipped v1 in
    #458 with the severity-based vocabulary (`pain_relief`,
    `sedation`).
-3. **`CmdConsumption` migration** — switch from `medical_type`
-   strings to `("eat", "delivery_method")` / `("drink", ...)`
-   tags.  Same shape as the smoke commands.
+3. ~~**`CmdConsumption` migration**~~ — ✅ shipped in #474.
+   Delivery gating runs on `("eat", "delivery_method")` tags via
+   `world/consumables.py:supports_delivery`, which self-heals
+   pre-#474 items from their legacy `medical_type` (the
+   `is_smokable` pattern).  `medical_type` remains the
+   pharmacology key for the treatment system.  The dead
+   `CmdConsumption.CmdSmoke` (unregistered since #454) was
+   deleted.  Known preserved gap: `healing_acceleration` (the
+   stim auto-injector) maps to no delivery verb — it was not
+   consumable before and stays that way until its substance entry
+   exists.
 4. **Tolerance / addiction conditions** — concrete
    `ConditionSpec` examples + medical-script tick integration.
    The dose history (`db.substance_doses`, recorded since #458)

--- a/world/consumables.py
+++ b/world/consumables.py
@@ -18,6 +18,91 @@ from __future__ import annotations
 
 from typing import Callable, Optional
 
+#: Tag category for delivery-method tags — ``("eat", "delivery_method")``,
+#: ``("inject", ...)``, etc.  See SUBSTANCES_AND_DELIVERY_SPEC §2/§4.
+DELIVERY_METHOD_CATEGORY = "delivery_method"
+
+#: Pre-#474 medical items declared *how they enter the body* via their
+#: ``medical_type`` string (which also keys their pharmacology).  This
+#: table maps each legacy type to the delivery method(s) the old
+#: command gates accepted, so already-spawned items self-heal to tags
+#: on first use.  ``medical_type`` itself stays — it remains the
+#: pharmacology key for the treatment system.
+LEGACY_MEDICAL_TYPE_DELIVERIES: dict[str, tuple[str, ...]] = {
+    # CmdInject's old injectable_types
+    "pain_relief": ("inject",),
+    "blood_restoration": ("inject",),
+    "stimulant": ("inject",),
+    "toxin": ("inject",),
+    # CmdApply's old applicable_types (wound_care doubled as a
+    # bandage type)
+    "burn_treatment": ("apply",),
+    "antiseptic": ("apply",),
+    "healing_salve": ("apply",),
+    "wound_care": ("apply", "bandage"),
+    "fracture_treatment": ("apply",),
+    "organ_repair": ("apply",),
+    # CmdBandage's old bandage_types
+    "bandage": ("bandage",),
+    "gauze": ("bandage",),
+    # CmdEat's old edible_types
+    "pill": ("eat",),
+    "tablet": ("eat",),
+    "food": ("eat",),
+    "ration": ("eat",),
+    "medicine": ("eat",),
+    # CmdDrink's old liquid_types
+    "liquid_medicine": ("drink",),
+    "water": ("drink",),
+    "alcohol": ("drink",),
+    "potion": ("drink",),
+    "drink": ("drink",),
+    # CmdInhale's old inhalable_types
+    "oxygen": ("inhale",),
+    "anesthetic": ("inhale",),
+    "inhaler": ("inhale",),
+    "gas": ("inhale",),
+    "vapor": ("inhale",),
+    # The retired CmdConsumption.CmdSmoke's smokable_types — mapped
+    # to the canonical smoke delivery so old medicinal herbs work
+    # with commands/CmdSmoke.py (flavor-only until they get a
+    # ``substance`` id).
+    "herb": ("smoke",),
+    "cigarette": ("smoke",),
+    "medicinal_plant": ("smoke",),
+    "dried_medicine": ("smoke",),
+}
+
+
+def supports_delivery(item, method: str) -> bool:
+    """True when ``item`` supports the ``method`` delivery verb.
+
+    The delivery check for every consumption command (eat / drink /
+    inhale / inject / apply / bandage / smoke).  Reads the
+    ``(method, "delivery_method")`` tag; items that predate the tag
+    scheme are self-healed from their legacy ``medical_type`` —
+    the implied tags are written back so the migration happens once
+    per item (the ``is_smokable`` pattern from #456).
+    """
+    if item is None:
+        return False
+    tags = getattr(item, "tags", None)
+    if tags is None:
+        return False
+    if tags.has(method, category=DELIVERY_METHOD_CATEGORY):
+        return True
+    # Legacy migration: derive delivery tags from medical_type once.
+    attributes = getattr(item, "attributes", None)
+    if attributes is None:
+        return False
+    medical_type = attributes.get("medical_type", "")
+    implied = LEGACY_MEDICAL_TYPE_DELIVERIES.get(medical_type, ())
+    if implied:
+        for verb in implied:
+            tags.add(verb, category=DELIVERY_METHOD_CATEGORY)
+        return method in implied
+    return False
+
 
 def consume_use(
     item,

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -1849,7 +1849,7 @@ BLOOD_BAG = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["iv", "blood", "transfusion"],
     "desc": "A sterile IV blood bag with attached tubing for emergency transfusion. Contains 500ml of universal donor blood.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("inject", "delivery_method")],
     "attrs": [
         ("medical_type", "blood_restoration"),
         ("uses_left", 1),
@@ -1871,7 +1871,7 @@ PAINKILLER = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["syringe", "morphine", "pain meds"],
     "desc": "A medical syringe containing powerful analgesic medication. Multiple doses available.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("inject", "delivery_method")],
     "attrs": [
         ("medical_type", "pain_relief"),
         ("uses_left", 3),
@@ -1893,7 +1893,7 @@ GAUZE_BANDAGES = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["gauze", "bandages", "dressing"],
     "desc": "Sterile gauze bandages for wound dressing and bleeding control. Multiple applications available.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("apply", "delivery_method"), ("bandage", "delivery_method")],
     "attrs": [
         ("medical_type", "wound_care"),
         ("uses_left", 5),
@@ -1915,7 +1915,7 @@ SPLINT = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["splint", "brace"],
     "desc": "A universal medical splint that adapts to immobilize fractured appendages. Works on arms, legs, tentacles, wings, and other limbs.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("apply", "delivery_method")],
     "attrs": [
         ("medical_type", "fracture_treatment"),
         ("uses_left", 1),
@@ -1971,7 +1971,7 @@ SURGICAL_SEALANT = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["sealant", "tissue sealant", "bioseal"],
     "desc": "A single-dose ampule of biocompatible tissue sealant. Applied directly to damaged organ tissue during open procedures to bond and seal lacerations. Inert on closed skin; requires an active surgical field to do anything meaningful.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("apply", "delivery_method")],
     "attrs": [
         ("medical_type", "organ_repair"),
         ("uses_left", 3),
@@ -2017,7 +2017,7 @@ ANTISEPTIC = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["antiseptic", "disinfectant", "spray"],
     "desc": "Medical-grade antiseptic spray for wound cleaning and infection prevention. Multiple applications per bottle.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("apply", "delivery_method")],
     "attrs": [
         ("medical_type", "antiseptic"),
         ("uses_left", 8),
@@ -2042,7 +2042,7 @@ OXYGEN_TANK = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["oxygen", "o2", "tank"],
     "desc": "Portable oxygen tank with breathing mask. Essential for respiratory emergencies and consciousness recovery.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("inhale", "delivery_method")],
     "attrs": [
         ("medical_type", "oxygen"),
         ("uses_left", 10),
@@ -2062,7 +2062,7 @@ STIMPAK_INHALER = {
     "typeclass": "typeclasses.items.Item", 
     "aliases": ["inhaler", "stimpak vapor", "medical inhaler"],
     "desc": "Pressurized inhaler containing vaporized stimpak for rapid respiratory absorption. Single use only.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("inhale", "delivery_method")],
     "attrs": [
         ("medical_type", "vapor"),
         ("uses_left", 1),
@@ -2082,7 +2082,7 @@ ANESTHETIC_GAS = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["anesthetic", "knockout gas", "medical gas"],
     "desc": "Medical anesthetic gas canister. Reduces pain but may cause drowsiness. Use with caution.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("inhale", "delivery_method")],
     "attrs": [
         ("medical_type", "anesthetic"),
         ("uses_left", 5),
@@ -2101,7 +2101,7 @@ MEDICINAL_HERB = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["herb", "healing herb", "dried herb"],
     "desc": "Dried medicinal herb that can be smoked for natural pain relief and calming effects. Organic treatment option.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("smoke", "delivery_method")],
     "attrs": [
         ("medical_type", "herb"),
         ("uses_left", 3),
@@ -2121,7 +2121,7 @@ PAIN_RELIEF_CIGARETTE = {
     "typeclass": "typeclasses.items.Item",
     "aliases": ["med cigarette", "medical cigarette", "pain cigarette"],
     "desc": "Specially formulated cigarette infused with mild pain-relieving compounds. For medicinal use only.",
-    "tags": [("medical_item", "item_type")],
+    "tags": [("medical_item", "item_type"), ("smoke", "delivery_method")],
     "attrs": [
         ("medical_type", "cigarette"),
         ("uses_left", 1),

--- a/world/smoke.py
+++ b/world/smoke.py
@@ -28,7 +28,9 @@ from typing import Optional
 
 #: Tag namespaces.
 CIGARETTE_STATE_CATEGORY = "cigarette_state"
-DELIVERY_METHOD_CATEGORY = "delivery_method"
+# Single-sourced from world.consumables (the bottom layer of the
+# item -> substance -> delivery stack).
+from world.consumables import DELIVERY_METHOD_CATEGORY, supports_delivery
 ITEM_ROLE_CATEGORY = "item_role"  # Lighter still uses item_role.
 
 #: Delivery-method tag.  Cigarettes, joints, cigars, pipes — anything
@@ -499,7 +501,10 @@ def is_smokable(item) -> bool:
         tags.remove(CIGARETTE_ROLE, category=ITEM_ROLE_CATEGORY)
         tags.add(SMOKE_DELIVERY, category=DELIVERY_METHOD_CATEGORY)
         return True
-    return False
+    # Legacy migration: pre-#474 medicinal herbs/cigarettes declared
+    # smokability via medical_type — supports_delivery self-heals
+    # them to delivery tags.
+    return supports_delivery(item, SMOKE_DELIVERY)
 
 
 # Legacy back-compat alias — keep the old name callable for any

--- a/world/tests/test_consumables.py
+++ b/world/tests/test_consumables.py
@@ -98,3 +98,88 @@ class TestConsumeUseDestroyCallback(TestCase):
         outcome = consume_use(item, on_destroy=_bad_callback)
         self.assertEqual(outcome["destroyed"], True)
         self.assertTrue(item.deleted)
+
+
+# ===================================================================
+# supports_delivery — delivery tags + legacy medical_type migration
+# ===================================================================
+
+
+class _Tags:
+    """Tag-handler stub matching Evennia's (value, category) calls."""
+
+    def __init__(self, *pairs):
+        self._tags = set(pairs)
+
+    def has(self, value, category=None):
+        return (value, category) in self._tags
+
+    def add(self, value, category=None):
+        self._tags.add((value, category))
+
+
+class _TaggedItem:
+    def __init__(self, *, tags=(), medical_type=None):
+        self.tags = _Tags(*tags)
+        attrs = {}
+        if medical_type is not None:
+            attrs["medical_type"] = medical_type
+        self.attributes = _Attributes(**attrs)
+
+
+class TestSupportsDelivery(TestCase):
+    def test_tagged_item_supports_its_method(self):
+        from world.consumables import supports_delivery
+
+        item = _TaggedItem(tags=[("inject", "delivery_method")])
+        self.assertTrue(supports_delivery(item, "inject"))
+        self.assertFalse(supports_delivery(item, "eat"))
+
+    def test_none_item_unsupported(self):
+        from world.consumables import supports_delivery
+
+        self.assertFalse(supports_delivery(None, "eat"))
+
+    def test_legacy_medical_type_self_heals_to_tags(self):
+        """A pre-#474 item (medical_type, no tags) is migrated on
+        first check: implied tags written, correct verb accepted."""
+        from world.consumables import supports_delivery
+
+        item = _TaggedItem(medical_type="pain_relief")
+        self.assertTrue(supports_delivery(item, "inject"))
+        # Tag was written back — the migration is once-per-item.
+        self.assertTrue(item.tags.has("inject", category="delivery_method"))
+
+    def test_legacy_wound_care_supports_both_apply_and_bandage(self):
+        from world.consumables import supports_delivery
+
+        item = _TaggedItem(medical_type="wound_care")
+        self.assertTrue(supports_delivery(item, "bandage"))
+        self.assertTrue(item.tags.has("apply", category="delivery_method"))
+        self.assertTrue(item.tags.has("bandage", category="delivery_method"))
+
+    def test_legacy_type_rejects_wrong_method(self):
+        from world.consumables import supports_delivery
+
+        item = _TaggedItem(medical_type="oxygen")
+        self.assertFalse(supports_delivery(item, "eat"))
+        # Migration still happened toward the implied verb.
+        self.assertTrue(item.tags.has("inhale", category="delivery_method"))
+
+    def test_unknown_medical_type_unsupported(self):
+        """Types with no delivery mapping (surgical_treatment,
+        healing_acceleration) stay non-consumable — preserved
+        behavior."""
+        from world.consumables import supports_delivery
+
+        for mtype in ("surgical_treatment", "healing_acceleration", ""):
+            item = _TaggedItem(medical_type=mtype)
+            for verb in ("eat", "drink", "inject", "apply", "inhale",
+                         "bandage", "smoke"):
+                self.assertFalse(supports_delivery(item, verb))
+
+    def test_legacy_smokables_map_to_smoke_delivery(self):
+        from world.consumables import supports_delivery
+
+        item = _TaggedItem(medical_type="herb")
+        self.assertTrue(supports_delivery(item, "smoke"))

--- a/world/tests/test_consumption_rendering.py
+++ b/world/tests/test_consumption_rendering.py
@@ -161,6 +161,12 @@ def _run_consumption_cmd(
             "commands.CmdConsumption.get_medical_type",
             return_value=medical_type,
         ),
+        # Delivery gating (#474) is tag-driven and tested in
+        # test_consumables; these tests exercise the rendering branch.
+        patch(
+            "commands.CmdConsumption.supports_delivery",
+            return_value=True,
+        ),
     ]
     if not is_bandage:
         patches.insert(
@@ -366,24 +372,6 @@ class TestConsumptionPerObserverRendering(TestCase):
         self.assertIn("gaunt man", _observer_text(self.stranger))
 
     # ---- smoke ---------------------------------------------------
-
-    def test_smoke_other_broadcast(self):
-        from commands.CmdConsumption import CmdSmoke
-
-        _run_consumption_cmd(
-            CmdSmoke,
-            caller=self.actor,
-            target=self.patient,
-            item=self.item,
-            medical_type="herb",
-        )
-
-        ktext = _observer_text(self.knower)
-        self.assertIn("Jorge", ktext)
-        self.assertIn("Maria", ktext)
-        stext = _observer_text(self.stranger)
-        self.assertIn("gaunt man", stext)
-        self.assertIn("compact woman", stext)
 
     # ---- exclusion / first-person guard --------------------------
 


### PR DESCRIPTION
Closes #474 (SUBSTANCES_AND_DELIVERY_SPEC §5 item 3).

Delivery validation for eat/drink/inhale/inject/apply/bandage moves from per-command `medical_type` string lists to `("eat", "delivery_method")` tags — the same shape as the smoke commands. The single gate is `world/consumables.py:supports_delivery`, which self-heals pre-#474 items: implied delivery tags are derived from the legacy `medical_type` and written back on first check (the `is_smokable` pattern from #456). Verified end-to-end against a real item in the container (attribute-only item → `inject` accepted, tag written, `eat` rejected).

`medical_type` stays as the pharmacology key — *how an item enters the body* (tag) is now separate from *what it does* (treatment data), which is the point of the three-layer model.

Also in this PR:
- **Dead `CmdConsumption.CmdSmoke` deleted** (unregistered since #454, superseded by `commands/CmdSmoke.py`). Its rendering test went with it; canonical smoke is covered in `test_smoke.py`.
- `world/smoke.py` single-sources `DELIVERY_METHOD_CATEGORY` from `world/consumables.py` and falls through to `supports_delivery` — legacy medicinal herbs become smokable by the canonical smoke command (flavor-only until they get substance ids).
- 11 medical prototypes tagged with their delivery methods.
- **Known gap preserved + documented in the spec:** `healing_acceleration` (the stim auto-injector) was accepted by no consumption command before this change, and still isn't — it maps to no delivery verb until its substance entry exists. Flagging rather than fixing per the stability-over-polish rule.

Test plan: `supports_delivery` contract suite added to `test_consumables`; rendering harness patches the new gate seam; full `world.tests` 2,323/2,323 in the container. Live reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)