### PR TITLE
Web views: finish Splattercast migration, document deliberate guards

### DIFF
--- a/web/website/views/accounts.py
+++ b/web/website/views/accounts.py
@@ -124,7 +124,10 @@ class TurnstileAccountCreateView(EvenniaAccountCreateView):
             return result.get('success', False)
             
         except Exception as e:
-            # Log error and fail verification
+            # Deliberate fail-closed guard: ANY failure verifying the
+            # captcha with Cloudflare (network, JSON, timeout) must
+            # reject the registration attempt, never wave it through
+            # or 500. Logged for diagnosis.
             logger.error("Turnstile verification error: %s", e)
             return False
     

--- a/web/website/views/characters.py
+++ b/web/website/views/characters.py
@@ -218,17 +218,15 @@ class CharacterCreateView(EvenniaCharacterCreateView):
             character.db.prelogout_location = spawn_location
             character.location = None
             
-            # Debug logging
-            from evennia.comms.models import ChannelDB
-            try:
-                splattercast = ChannelDB.objects.get_channel("Splattercast")
-                splattercast.msg(
-                    f"WEB_CHAR_CREATE: {character.key} created via web (respawn), "
-                    f"location set to None for invisibility. "
-                    f"Will be restored to {character.db.prelogout_location.key} on telnet login."
-                )
-            except Exception:
-                pass
+            # Debug logging via the combat audit sink (lazy import —
+            # keep web module load independent of the game packages)
+            from world.combat.debug import get_splattercast
+            get_splattercast().msg(
+                f"WEB_CHAR_CREATE: {character.key} created via web (respawn), "
+                f"location set to None for invisibility. "
+                f"Will be restored to "
+                f"{getattr(spawn_location, 'key', '?')} on telnet login."
+            )
             
             # Clear last_character after successful respawn
             # (archive_character() will set it again when this character is archived)
@@ -240,6 +238,10 @@ class CharacterCreateView(EvenniaCharacterCreateView):
             return HttpResponseRedirect(self.success_url)
             
         except Exception:
+            # Deliberate request-handler guard: log the full traceback,
+            # show the player a friendly error instead of a Django 500.
+            # For web views this IS the "let the unexpected surface"
+            # posture — it surfaces in the log, not on the player.
             import logging
             logging.getLogger('evennia').exception(
                 "Sleeve decantation failed for account %s", account.key
@@ -344,17 +346,15 @@ class CharacterCreateView(EvenniaCharacterCreateView):
             character.db.prelogout_location = spawn_location
             character.location = None
             
-            # Debug logging
-            from evennia.comms.models import ChannelDB
-            try:
-                splattercast = ChannelDB.objects.get_channel("Splattercast")
-                splattercast.msg(
-                    f"WEB_CHAR_CREATE: {character.key} created via web (first-time), "
-                    f"location set to None for invisibility. "
-                    f"Will be restored to {character.db.prelogout_location.key} on telnet login."
-                )
-            except Exception:
-                pass
+            # Debug logging via the combat audit sink (lazy import —
+            # keep web module load independent of the game packages)
+            from world.combat.debug import get_splattercast
+            get_splattercast().msg(
+                f"WEB_CHAR_CREATE: {character.key} created via web (first-time), "
+                f"location set to None for invisibility. "
+                f"Will be restored to "
+                f"{getattr(spawn_location, 'key', '?')} on telnet login."
+            )
             
             messages.success(
                 self.request,
@@ -525,6 +525,8 @@ class OwnerOnlyCharacterDetailView(EvenniaCharacterDetailView):
                 messages.error(request, "You can only view your own characters.")
                 return HttpResponseRedirect(reverse_lazy("character-manage"))
         except Exception:
+            # Deliberate guard: bad/forged pk or lookup failure on an
+            # access-control path → safe redirect, never a 500.
             messages.error(request, "Character not found.")
             return HttpResponseRedirect(reverse_lazy("index"))
         
@@ -571,6 +573,8 @@ class OwnerOnlyCharacterUpdateView(EvenniaCharacterUpdateView):
                 messages.error(request, "You can only edit your own characters.")
                 return HttpResponseRedirect(reverse_lazy("character-manage"))
         except Exception:
+            # Deliberate guard: bad/forged pk or lookup failure on an
+            # access-control path → safe redirect, never a 500.
             messages.error(request, "Character not found.")
             return HttpResponseRedirect(reverse_lazy("index"))
         

--- a/web/website/views/discourse_sso.py
+++ b/web/website/views/discourse_sso.py
@@ -111,6 +111,9 @@ def discourse_sso(request):
         decoded_payload = base64.b64decode(payload).decode('utf-8')
         params = parse_qs(decoded_payload)
     except Exception as e:
+        # Deliberate guard: the payload is attacker-controllable
+        # external input — anything malformed gets a clean HTTP 400
+        # (logged with traceback), never a 500.
         logger.exception("Failed to decode or parse SSO payload")
         return HttpResponseBadRequest("Invalid payload")
     

--- a/web/website/views/logout_with_discourse.py
+++ b/web/website/views/logout_with_discourse.py
@@ -62,6 +62,8 @@ def get_discourse_user_id(user):
                 response.status_code, user.id, url,
             )
     except Exception:
+        # Deliberate best-effort guard: forum lookup failure is logged
+        # but must never block the game-side logout flow.
         logger.exception("Discourse user lookup error for external_id=%s", user.id)
     
     return None
@@ -105,6 +107,8 @@ def logout_discourse_user(discourse_user_id):
             )
             return False
     except Exception:
+        # Deliberate best-effort guard: forum logout failure is logged
+        # but must never block the game-side logout flow.
         logger.exception("Discourse logout error for discourse_user_id=%s", discourse_user_id)
         return False
 


### PR DESCRIPTION
Refs #469.

**Completes the #464/#470 audit-sink migration for `web/`** — the original migration greps covered `commands/`, `typeclasses/`, and `world/` but never `web/`, so two `WEB_CHAR_CREATE` debug sites still did raw `ChannelDB.objects.get_channel("Splattercast")` inside dead try/except wrappers. They now route through `get_splattercast()` (lazy import keeps web module load independent of game packages), and the message formatting uses `getattr(spawn_location, 'key', '?')` per the #470 handler-log rule — `spawn_location` can legitimately be None on the fallback path, and the f-string was relying on the wrapper to swallow that.

**The remaining seven broad excepts in `web/` are deliberate and now say so**, closing the web bucket of #469 as documented-by-design rather than removed:
- Turnstile captcha verification **fails closed** on any error — never waves a registration through, never 500s.
- Malformed SSO payloads (attacker-controllable input) → clean HTTP 400 with logged traceback.
- Discourse lookup/logout are **best-effort** — forum failure never blocks game-side logout.
- Character create/dispatch guards log the full traceback and show a friendly error instead of a Django 500 — for request handlers, "let the unexpected surface" means the log, not the player's browser.

**No exception types changed, no flow restructured** — per the "web is important but not the focus" constraint, this is the minimum-risk pass: finish my own missed migration, document intent.

Test plan: full `world.tests` 2,323/2,323; live reload; HTTP smoke test — homepage, login, register, and character-manage all return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)