### PR TITLE
Death progression: lifecycle characterization + except cleanup

### DIFF
--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -18,7 +18,7 @@ This creates urgency for medical response while making death less instantaneous.
 """
 
 from evennia import DefaultScript
-from evennia.utils import delay
+from evennia.utils import delay, logger
 from world.combat.debug import get_splattercast
 from world.combat.constants import (
     DEATH_PROGRESSION_DURATION,
@@ -226,14 +226,11 @@ class DeathProgressionScript(DefaultScript):
             return
             
         # Log medical revival
-        try:
-            splattercast = get_splattercast()
-            elapsed = time.time() - self.db.start_time
-            splattercast.msg(f"MEDICAL_REVIVAL: {character.key} revived by medical treatment after {elapsed:.1f}s")
-            splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script for {character.key} (medical revival)")
-        except Exception:
-            pass
-            
+        splattercast = get_splattercast()
+        elapsed = time.time() - (self.db.start_time or time.time())
+        splattercast.msg(f"MEDICAL_REVIVAL: {character.key} revived by medical treatment after {elapsed:.1f}s")
+        splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script for {character.key} (medical revival)")
+
         # Medical revival messages
         character.msg(
             "|gThe medical treatment takes effect! You feel life returning to your body.|n\n"
@@ -484,9 +481,18 @@ class DeathProgressionScript(DefaultScript):
             splattercast.msg(f"DEATH_COMPLETION: {character.key} -> Corpse created, character transitioned")
                 
         except Exception as e:
-            # Fallback - log error but don't crash the death progression
+            # Deliberate guard (#469): completion runs from at_repeat,
+            # so an uncaught error here would leave the script alive
+            # and retrying every tick — spawning a partial corpse each
+            # time.  Containing it means the progression always
+            # terminates; worst case is "archived without a corpse".
+            # Logged to the audit file AND the server log (traceback)
+            # so the failure is loud, just not player-breaking.
             splattercast = get_splattercast()
             splattercast.msg(f"DEATH_COMPLETION_ERROR: {getattr(character, 'key', '?')} - {e}")
+            logger.log_trace(
+                f"Death completion failed for {getattr(character, 'key', '?')}"
+            )
 
     def _create_corpse_from_character(self, character):
         """Create a corpse object that preserves forensic data from the character."""
@@ -562,6 +568,8 @@ class DeathProgressionScript(DefaultScript):
         # corpse; clearing after ensures the Character object carries no
         # stale disguise state into limbo or any future
         # resurrection/clone consumer.
+        # Deliberate stage guard (#469): an override-clearing bug must
+        # not abort corpse construction below (item transfer, wounds).
         try:
             from commands.CmdCharacter import _clear_all_overrides
             _clear_all_overrides(character)
@@ -588,17 +596,17 @@ class DeathProgressionScript(DefaultScript):
             # systems.  ``MedicalState.to_dict()`` is the canonical
             # serialization; pre-PR-186 corpses carry None and degrade
             # gracefully in :func:`world.forensics.render_forensic_report`.
+            # Deliberate stage guard (#469): a serialization bug must
+            # not abort corpse construction — autopsy degrades
+            # gracefully on a None snapshot.
             try:
                 corpse.db.medical_state_at_death = character.medical_state.to_dict()
-                try:
-                    splattercast = get_splattercast()
-                    organ_count = len(corpse.db.medical_state_at_death.get("organs", {}))
-                    splattercast.msg(
-                        f"DEATH_MEDICAL_SNAPSHOT: {organ_count} organs preserved "
-                        f"on corpse for {character.key}"
-                    )
-                except Exception:
-                    pass
+                splattercast = get_splattercast()
+                organ_count = len(corpse.db.medical_state_at_death.get("organs", {}))
+                splattercast.msg(
+                    f"DEATH_MEDICAL_SNAPSHOT: {organ_count} organs preserved "
+                    f"on corpse for {character.key}"
+                )
             except Exception as snapshot_err:
                 splattercast = get_splattercast()
                 splattercast.msg(
@@ -632,7 +640,8 @@ class DeathProgressionScript(DefaultScript):
                     splattercast = get_splattercast()
                     splattercast.msg(f"DEATH_WOUNDS_PRESERVED: {len(wound_data)} wounds preserved on corpse for {character.key}")
             except Exception as e:
-                # Don't fail death progression if wound preservation fails
+                # Deliberate stage guard (#469): wound preservation is
+                # forensic garnish — never fail the corpse over it.
                 splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_WOUNDS_ERROR: Failed to preserve wounds for {getattr(character, 'key', '?')}: {e}")
         
@@ -667,14 +676,11 @@ class DeathProgressionScript(DefaultScript):
             character.held_items = {}
         
         # Debug logging for item transfer
-        try:
-            splattercast = get_splattercast()
-            if transferred_items:
-                splattercast.msg(f"DEATH_ITEMS_TRANSFERRED: {len(transferred_items)} items moved to corpse: {', '.join(transferred_items)}")
-            else:
-                splattercast.msg(f"DEATH_ITEMS_TRANSFERRED: No items found on {character.key} to transfer")
-        except Exception:
-            pass
+        splattercast = get_splattercast()
+        if transferred_items:
+            splattercast.msg(f"DEATH_ITEMS_TRANSFERRED: {len(transferred_items)} items moved to corpse: {', '.join(transferred_items)}")
+        else:
+            splattercast.msg(f"DEATH_ITEMS_TRANSFERRED: No items found on {character.key} to transfer")
         
         # Set corpse description using sdesc (identity-aware)
         sdesc = corpse.db.sdesc_at_death if corpse.db.sdesc_at_death is not None else character.key
@@ -717,6 +723,9 @@ class DeathProgressionScript(DefaultScript):
                 else:
                     spawn_severed_head_for_corpse(corpse)
             except Exception as e:
+                # Deliberate stage guard (#469): the corpse must finish
+                # building even if the head-spawn bookkeeping fails —
+                # see the two-path design note above.
                 splattercast = get_splattercast()
                 splattercast.msg(
                     f"DEATH_DECAPITATION_ERROR: {getattr(character, 'key', '?')} - {e}"
@@ -757,31 +766,27 @@ class DeathProgressionScript(DefaultScript):
                     
                     # Verify deletion
                     still_exists = ScriptDB.objects.filter(id=script_id).exists()
-                    
-                    try:
-                        splattercast = get_splattercast()
-                        if still_exists:
-                            splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: Script #{script_id} for {character.key} still exists after delete!")
-                        else:
-                            splattercast.msg(f"DEATH_MEDICAL_CLEANUP: Successfully deleted script #{script_id} for {character.key}")
-                    except Exception:
-                        pass
+
+                    splattercast = get_splattercast()
+                    if still_exists:
+                        splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: Script #{script_id} for {character.key} still exists after delete!")
+                    else:
+                        splattercast.msg(f"DEATH_MEDICAL_CLEANUP: Successfully deleted script #{script_id} for {character.key}")
                 except Exception as e:
-                    try:
-                        splattercast = get_splattercast()
-                        splattercast.msg(f"DEATH_MEDICAL_CLEANUP_ERROR: {getattr(character, 'key', '?')} - {e}")
-                        import traceback
-                        splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
-                    except Exception:
-                        pass
+                    # Deliberate per-script guard (#469): one broken
+                    # script must not block deleting the rest, nor the
+                    # teleport/archive below.
+                    splattercast = get_splattercast()
+                    splattercast.msg(f"DEATH_MEDICAL_CLEANUP_ERROR: {getattr(character, 'key', '?')} - {e}")
+                    import traceback
+                    splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
         except Exception as e:
-            try:
-                splattercast = get_splattercast()
-                splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: {getattr(character, 'key', '?')} - {e}")
-                import traceback
-                splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
-            except Exception:
-                pass
+            # Deliberate stage guard (#469): cleanup-query failure must
+            # not block the teleport/unpuppet/archive sequence below.
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: {getattr(character, 'key', '?')} - {e}")
+            import traceback
+            splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
         
         # Move character to limbo/OOC room (Evennia's default limbo is #2)
         # Use move_hooks=False to prevent medical script spam on teleport
@@ -795,7 +800,10 @@ class DeathProgressionScript(DefaultScript):
             splattercast.msg(f"DEATH_TELEPORT_SUCCESS: {character.key} moved from {old_location} to {limbo_room}")
                 
         except Exception as e:
-            # Log the specific error instead of silently failing
+            # Deliberate stage guard (#469): a teleport failure (Limbo
+            # missing, move hook error) must not block the
+            # unpuppet/archive below — a dead body left in the room is
+            # recoverable, a half-archived character is not.
             splattercast = get_splattercast()
             splattercast.msg(f"DEATH_TELEPORT_ERROR: {getattr(character, 'key', '?')} - {e}")
         
@@ -857,7 +865,7 @@ def start_death_progression(character):
         DeathProgressionScript: The created script
     """
     # Check if character already has a death progression script
-    existing_script = character.scripts.get("death_progression")
+    existing_script = get_death_progression_script(character)
     if existing_script:
         splattercast = get_splattercast()
         splattercast.msg(f"DEATH_PROGRESSION: Existing script found for {character.key}")
@@ -884,7 +892,13 @@ def get_death_progression_script(character):
     Returns:
         DeathProgressionScript or None: The script if found, None otherwise
     """
-    return character.scripts.get("death_progression")
+    # ScriptHandler.get returns a queryset/list — and a queryset's
+    # ``.db`` is Django's database-alias *string*, so returning it raw
+    # made get_death_progression_status crash with
+    # "'str' object has no attribute 'start_time'" for any character
+    # actually in progression (caught by the #477 lifecycle tests).
+    scripts = character.scripts.get("death_progression")
+    return scripts[0] if scripts else None
 
 
 def get_death_progression_status(character):

--- a/world/tests/test_death_progression_lifecycle.py
+++ b/world/tests/test_death_progression_lifecycle.py
@@ -1,0 +1,228 @@
+"""Characterization tests for the death-progression lifecycle
+(issue #477, the #469 close-out queue).
+
+``_create_corpse_from_character`` is already covered by
+``test_corpse_medical_snapshot`` / ``test_death_identity_snapshot`` /
+``test_head_spawn_at_decap``.  This suite pins the previously
+untested *lifecycle*: script setup, the ``at_repeat`` decision tree
+(revival check → message scheduling → completion), the medical
+revival path, the PC/NPC prose gate, completion orchestration, and —
+critically — the deliberate failure semantics of the corpse-handoff
+guard: a corpse-creation bug must be logged loudly but may never
+strand the progression in a 30-second retry loop spawning corpses.
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_death_progression_lifecycle
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+from evennia import create_object, create_script
+from evennia.utils.test_resources import EvenniaTest
+
+from typeclasses.characters import Character
+from typeclasses.death_progression import (
+    DeathProgressionScript,
+    get_death_progression_status,
+    start_death_progression,
+)
+from world.combat.constants import (
+    DEATH_PROGRESSION_DURATION,
+    DEATH_PROGRESSION_MESSAGE_COUNT,
+)
+
+
+class _LifecycleBase(EvenniaTest):
+    character_typeclass = Character
+
+    def setUp(self):
+        super().setUp()
+        # Touch medical state so the lazy initializer wires organs.
+        _ = self.char1.medical_state
+        # A dying character: total blood loss crosses the death
+        # threshold, which is what holds the progression open.
+        self.char1.medical_state.blood_level = 0.0
+        self.script = create_script(DeathProgressionScript, obj=self.char1)
+
+    def tearDown(self):
+        if self.script and self.script.pk:
+            self.script.stop()
+            self.script.delete()
+        super().tearDown()
+
+
+class TestScriptSetup(_LifecycleBase):
+    def test_creation_initializes_progression_state(self):
+        self.assertEqual(self.script.db.total_duration, DEATH_PROGRESSION_DURATION)
+        self.assertEqual(
+            len(self.script.db.message_intervals), DEATH_PROGRESSION_MESSAGE_COUNT
+        )
+        spacing = DEATH_PROGRESSION_DURATION // DEATH_PROGRESSION_MESSAGE_COUNT
+        self.assertEqual(self.script.db.message_intervals[0], spacing)
+        self.assertEqual(self.script.db.messages_sent, [])
+        self.assertTrue(self.script.db.can_be_revived)
+        self.assertIsNotNone(self.script.db.start_time)
+
+    def test_start_death_progression_reuses_existing_script(self):
+        first = start_death_progression(self.char1)
+        second = start_death_progression(self.char1)
+        self.assertTrue(first)
+        self.assertTrue(second)
+        # Still exactly one progression script on the character.
+        scripts = self.char1.scripts.get("death_progression")
+        self.assertEqual(len(scripts), 1)
+
+    def test_status_reports_progression(self):
+        status = get_death_progression_status(self.char1)
+        self.assertTrue(status["in_progression"])
+        self.assertEqual(status["total_duration"], DEATH_PROGRESSION_DURATION)
+        self.assertTrue(status["can_be_revived"])
+        self.assertGreater(status["time_remaining"], 0)
+
+    def test_status_without_script(self):
+        npc = create_object(Character, key="statusless", location=self.room1)
+        try:
+            self.assertEqual(
+                get_death_progression_status(npc), {"in_progression": False}
+            )
+        finally:
+            npc.delete()
+
+
+class TestRevivalCheck(_LifecycleBase):
+    def test_dead_character_not_revived(self):
+        self.assertFalse(
+            self.script._check_medical_revival_conditions(self.char1)
+        )
+
+    def test_recovered_character_flagged_for_revival(self):
+        self.char1.medical_state.blood_level = 100.0
+        self.assertTrue(
+            self.script._check_medical_revival_conditions(self.char1)
+        )
+
+    def test_revival_path_restores_and_cleans_up(self):
+        """Medical recovery during at_repeat → revival messages, death
+        state removed, script stopped and deleted."""
+        self.char1.medical_state.blood_level = 100.0
+        self.char1.msg = MagicMock()
+        with patch.object(
+            self.char1, "remove_death_state", create=True
+        ) as mock_restore:
+            self.script.at_repeat()
+        mock_restore.assert_called_once()
+        sent = " ".join(
+            str(c.args[0]) for c in self.char1.msg.call_args_list if c.args
+        )
+        self.assertIn("medical treatment", sent.lower())
+        # Script removed itself.
+        self.assertFalse(self.char1.scripts.get("death_progression"))
+        self.script = None  # tearDown guard
+
+
+class TestProgressionMessages(_LifecycleBase):
+    def test_message_sent_once_per_interval(self):
+        first_interval = self.script.db.message_intervals[0]
+        self.script.db.start_time = time.time() - (first_interval + 1)
+        self.char1.msg = MagicMock()
+
+        self.script.at_repeat()
+        self.assertIn(first_interval, self.script.db.messages_sent)
+        first_count = self.char1.msg.call_count
+        self.assertGreater(first_count, 0)
+        # Dying prose arrives attributed to the script.
+        self.assertIs(
+            self.char1.msg.call_args.kwargs.get("from_obj"), self.script
+        )
+
+        # Same elapsed window again: no duplicate message.
+        self.script.at_repeat()
+        self.assertEqual(self.char1.msg.call_count, first_count)
+
+    def test_npc_skips_dying_prose(self):
+        """The surreal dying monologue is PC-only (issue #356) — the
+        timer still runs for NPCs, but the prose is suppressed."""
+        npc = create_object(Character, key="dying rat", location=self.room1)
+        _ = npc.medical_state
+        npc.medical_state.blood_level = 0.0
+        npc_script = create_script(DeathProgressionScript, obj=npc)
+        try:
+            self.assertFalse(npc_script._is_player_character())
+            npc.msg = MagicMock()
+            npc_script._send_initial_message()
+            first = npc_script.db.message_intervals[0]
+            npc_script._send_progression_message(first)
+            npc.msg.assert_not_called()
+        finally:
+            if npc_script.pk:
+                npc_script.stop()
+                npc_script.delete()
+            npc.delete()
+
+    def test_pc_gate_is_account_presence(self):
+        self.assertTrue(self.script._is_player_character())
+
+
+class TestCompletion(_LifecycleBase):
+    def test_at_repeat_triggers_completion_after_duration(self):
+        self.script.db.start_time = time.time() - (
+            DEATH_PROGRESSION_DURATION + 1
+        )
+        self.char1.msg = MagicMock()
+        with patch.object(
+            self.script, "_complete_death_progression"
+        ) as mock_complete:
+            self.script.at_repeat()
+        mock_complete.assert_called_once()
+
+    def test_completion_orchestration(self):
+        """Completion: revival window closes, room is told, the corpse
+        handoff runs, and the script removes itself."""
+        self.char1.msg = MagicMock()
+        with patch.object(
+            self.script, "_handle_corpse_creation_and_transition"
+        ) as mock_handoff, patch.object(
+            self.char1, "apply_final_death_state", create=True
+        ) as mock_final, patch(
+            "world.identity_utils.msg_room_identity"
+        ):
+            self.script._complete_death_progression()
+
+        self.assertFalse(self.script.db.can_be_revived if self.script.pk else False)
+        mock_handoff.assert_called_once_with(self.char1)
+        mock_final.assert_called_once()
+        # PC got the final fade-out prose.
+        self.assertTrue(self.char1.msg.called)
+        # Script removed itself.
+        self.assertFalse(self.char1.scripts.get("death_progression"))
+        self.script = None  # tearDown guard
+
+    def test_corpse_handoff_failure_is_contained_and_loud(self):
+        """The deliberate guard: a corpse-creation bug is logged to the
+        audit sink AND the server log, does not raise, and therefore
+        cannot strand the progression in a 30s retry loop that spawns
+        a corpse per tick."""
+        router = MagicMock()
+        with patch.object(
+            self.script,
+            "_create_corpse_from_character",
+            side_effect=RuntimeError("corpse forge exploded"),
+        ), patch(
+            "typeclasses.death_progression.get_splattercast",
+            return_value=router,
+        ), patch(
+            "typeclasses.death_progression.logger"
+        ) as mock_logger:
+            # Must not raise.
+            self.script._handle_corpse_creation_and_transition(self.char1)
+
+        audit_lines = " ".join(
+            str(c.args[0]) for c in router.msg.call_args_list if c.args
+        )
+        self.assertIn("DEATH_COMPLETION_ERROR", audit_lines)
+        # Mirrored to the server log with traceback.
+        mock_logger.log_trace.assert_called_once()


### PR DESCRIPTION
Closes #477 (#469 queue 1/4 — the agreed subsystem-by-subsystem close-out).

**13 lifecycle tests** (`test_death_progression_lifecycle.py`) pin the previously untested core: script setup/interval math, the `at_repeat` decision tree (revival check → message scheduling → completion), the medical revival path end-to-end (real character, real medical state — blood restored mid-progression revives and cleans up), the PC/NPC dying-prose gate, completion orchestration, and the failure semantics of the corpse-handoff guard. (`_create_corpse_from_character` was already covered by three existing test files; not duplicated.)

**The tests immediately caught a real bug:** `get_death_progression_script` returned `ScriptHandler.get()`'s queryset raw — and a queryset's `.db` is Django's database-alias *string*, so `get_death_progression_status` crashed with `'str' object has no attribute 'start_time'` for any character actually in progression. Now returns the first script or None.

**Excepts 14 → 8.** Six dead debug wrappers unwrapped (the audit router can't raise since #464). The remaining eight are *deliberate stage guards of an irreversible pipeline*, each documented in place: death completion runs from a script tick, so an uncaught error would leave the script retrying every 30 seconds, spawning a partial corpse per tick. Containment means the progression always terminates — worst case is "archived without a corpse", which is recoverable; a retry storm is not. The big completion guard now also mirrors its traceback to the server log via `logger.log_trace` (pinned by test: contained, audit-logged, AND server-logged).

Test plan: lifecycle suite 13/13; full `world.tests` 2,336/2,336. Live reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)