### PR TITLE
Explosion chain: fix ten broken broadcasts, audit-and-raise policy

### DIFF
--- a/commands/explosion_utils.py
+++ b/commands/explosion_utils.py
@@ -102,7 +102,7 @@ def check_rigged_grenade(character, exit_obj):
         object=rigged_grenade.key, victim="{target_char}"
     )
     msg_room_identity(
-        room=character.location,
+        location=character.location,
         template=observer_template,
         char_refs={"target_char": character},
         exclude=[character],
@@ -203,7 +203,7 @@ def check_rigged_grenade(character, exit_obj):
                                 victim="{target_char}", grenade=rigged_grenade.key
                             )
                             msg_room_identity(
-                                room=other_character.location,
+                                location=other_character.location,
                                 template=observer_template,
                                 char_refs={"target_char": other_character},
                                 exclude=[other_character],
@@ -231,8 +231,13 @@ def check_rigged_grenade(character, exit_obj):
             rigged_grenade.delete()
 
         except Exception as e:
+            # #469: log to the audit trail, then raise — explosion
+            # resolution runs in one-shot timer callbacks, so there is
+            # no retry loop to protect; a half-applied explosion must
+            # be loud (server log traceback), not silent.
             splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in explode_rigged_grenade: {e}")
+            raise
 
     # Start the timer
     start_standalone_grenade_ticker(rigged_grenade, explode_rigged_grenade)
@@ -316,17 +321,21 @@ def start_standalone_grenade_ticker(grenade, explosion_callback=None):
                     explode_standalone_grenade(grenade)
 
         except Exception as e:
-            # Failsafe - if ticker fails, explode immediately to avoid duds
+            # Deliberate failsafe (#469, same as start_grenade_ticker):
+            # a live grenade must never become a permanent dud because
+            # of a ticker bug — log, then explode.
             splattercast = get_splattercast()
-            if splattercast:
-                splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Ticker error for {grenade.key}: {e} - triggering explosion")
+            splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Ticker error for {grenade.key}: {e} - triggering explosion")
             try:
                 if explosion_callback:
                     explosion_callback()
                 else:
                     explode_standalone_grenade(grenade)
-            except Exception:
-                pass  # If even explosion fails, give up gracefully
+            except Exception as inner:
+                # Failsafe-of-the-failsafe: even the forced explosion
+                # failed.  Logged — a stuck live grenade is exactly
+                # what the audit trail exists to explain.
+                splattercast.msg(f"{DEBUG_PREFIX_THROW}_TICKER_ERROR: Forced explosion also failed for {grenade.key}: {inner}")
 
     # Start the ticker
     tick()
@@ -465,6 +474,9 @@ def get_unified_explosion_proximity(grenade):
         return unified_list
 
     except Exception as e:
+        # Deliberate degradation (#469): a proximity-merge bug falls
+        # back to the grenade's own proximity list — a smaller blast
+        # is better than no blast resolution at all.  Logged.
         splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in get_unified_explosion_proximity: {e}")
         # Return original proximity list as fallback
@@ -553,7 +565,7 @@ def explode_standalone_grenade(grenade):
                 # Announce to the room
                 if holder.location:
                     msg_room_identity(
-                        room=holder.location,
+                        location=holder.location,
                         template=f"|R{{target_char}}'s {grenade.key}, magnetically clamped to their {stuck_to_armor.key}, EXPLODES in a devastating blast!|n",
                         char_refs={"target_char": holder},
                         exclude=[holder],
@@ -565,7 +577,7 @@ def explode_standalone_grenade(grenade):
                 # Announce to the room
                 if holder.location:
                     msg_room_identity(
-                        room=holder.location,
+                        location=holder.location,
                         template=f"|r{{target_char}}'s {grenade.key} explodes in their hands!|n",
                         char_refs={"target_char": holder},
                         exclude=[holder],
@@ -619,7 +631,7 @@ def explode_standalone_grenade(grenade):
                                 victim="{target_char}", grenade=grenade.key
                             )
                             msg_room_identity(
-                                room=character.location,
+                                location=character.location,
                                 template=observer_template,
                                 char_refs={"target_char": character},
                                 exclude=[character],
@@ -647,8 +659,14 @@ def explode_standalone_grenade(grenade):
         grenade.delete()
 
     except Exception as e:
+        # #469: log to the audit trail, then raise — see
+        # explode_rigged_grenade.  This guard's former silence masked
+        # the room=/location= TypeError that aborted every explosion
+        # broadcast (and the damage loop behind it) since the identity
+        # migration.
         splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in explode_standalone_grenade: {e}")
+        raise
 
 
 def check_auto_defuse(character):
@@ -691,6 +709,9 @@ def check_auto_defuse(character):
             attempt_auto_defuse(character, grenade)
 
     except Exception as e:
+        # Deliberate boundary guard (#469): this runs from the room-
+        # entry hook — a grenade-detection bug must never break player
+        # movement.  Logged.
         splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in check_auto_defuse for {character.key}: {e}")
 
@@ -729,7 +750,7 @@ def attempt_auto_defuse(character, grenade):
         # Announce auto-defuse attempt (more subtle than manual)
         character.msg(f"You notice the live {grenade.key} and instinctively attempt to defuse it...")
         msg_room_identity(
-            room=character.location,
+            location=character.location,
             template=f"{{actor}} quickly works on defusing the {grenade.key}.",
             char_refs={"actor": character},
             exclude=[character],
@@ -746,6 +767,8 @@ def attempt_auto_defuse(character, grenade):
             handle_auto_defuse_failure(character, grenade)
 
     except Exception as e:
+        # Deliberate stage guard (#469): downstream of the room-entry
+        # hook — see check_auto_defuse.  Logged.
         splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in attempt_auto_defuse for {character.key} and {grenade.key}: {e}")
 
@@ -766,7 +789,7 @@ def handle_auto_defuse_success(character, grenade):
         # Success messages (more dramatic than manual defuse)
         character.msg(f"SUCCESS! You instinctively defuse the {grenade.key} just in time!")
         msg_room_identity(
-            room=character.location,
+            location=character.location,
             template=f"{{actor}} quickly defuses the {grenade.key}!",
             char_refs={"actor": character},
             exclude=[character],
@@ -776,6 +799,8 @@ def handle_auto_defuse_success(character, grenade):
         splattercast.msg(f"AUTO_DEFUSE_SUCCESS: {character.key} auto-defused {grenade.key}")
 
     except Exception as e:
+        # Deliberate stage guard (#469): downstream of the room-entry
+        # hook — see check_auto_defuse.  Logged.
         splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in handle_auto_defuse_success: {e}")
 
@@ -790,7 +815,7 @@ def handle_auto_defuse_failure(character, grenade):
             # Early detonation triggered
             character.msg(f"Your hasty defuse attempt accidentally triggers the {grenade.key}!")
             msg_room_identity(
-                room=character.location,
+                location=character.location,
                 template=f"{{actor}}'s defuse attempt accidentally triggers the {grenade.key}!",
                 char_refs={"actor": character},
                 exclude=[character],
@@ -812,7 +837,7 @@ def handle_auto_defuse_failure(character, grenade):
             # Failed but no early detonation (more subtle failure message)
             character.msg(f"You notice the {grenade.key} but can't defuse it in time.")
             msg_room_identity(
-                room=character.location,
+                location=character.location,
                 template=f"{{actor}} notices the {grenade.key} but can't defuse it.",
                 char_refs={"actor": character},
                 exclude=[character],
@@ -822,6 +847,8 @@ def handle_auto_defuse_failure(character, grenade):
             splattercast.msg(f"AUTO_DEFUSE_FAILURE: {character.key} failed to auto-defuse {grenade.key} (no early detonation)")
 
     except Exception as e:
+        # Deliberate stage guard (#469): downstream of the room-entry
+        # hook — see check_auto_defuse.  Logged.
         splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in handle_auto_defuse_failure: {e}")
 
@@ -871,7 +898,7 @@ def trigger_auto_defuse_explosion(grenade):
                             victim="{target_char}", grenade=grenade.key
                         )
                         msg_room_identity(
-                            room=character.location,
+                            location=character.location,
                             template=observer_template,
                             char_refs={"target_char": character},
                             exclude=[character],
@@ -897,5 +924,8 @@ def trigger_auto_defuse_explosion(grenade):
         grenade.delete()
 
     except Exception as e:
+        # #469: log + raise — one-shot timer callback, same policy as
+        # explode_standalone_grenade.
         splattercast = get_splattercast()
         splattercast.msg(f"AUTO_DEFUSE_ERROR: Error in trigger_auto_defuse_explosion: {e}")
+        raise

--- a/world/tests/test_explosion_chain.py
+++ b/world/tests/test_explosion_chain.py
@@ -1,0 +1,329 @@
+"""Characterization tests for the explosion chain (#469 queue 3/4).
+
+Pins the previously untested core of ``commands/explosion_utils.py``:
+unified proximity merging, standalone explosion resolution (room and
+in-hands), chain reactions, the auto-defuse pipeline, and the #469
+exception policy — explosion resolvers log to the audit trail AND
+raise (one-shot timer callbacks have no retry loop to protect).
+
+Backstory worth keeping: writing this suite exposed that **every**
+identity broadcast in this module passed ``room=`` to
+``msg_room_identity`` (the parameter is ``location``), raising
+TypeError — and the broad excepts swallowed it, silently aborting
+explosion damage loops, grenade cleanup, and chain reactions at the
+first announce.  The ``location=`` assertions below pin the fix.
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_explosion_chain
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from evennia.utils.test_resources import EvenniaTest
+
+from typeclasses.characters import Character
+from world.combat.constants import (
+    NDB_COUNTDOWN_REMAINING,
+    NDB_PROXIMITY,
+    NDB_PROXIMITY_UNIVERSAL,
+)
+
+
+class Bag:
+    """Evennia-style attribute holder: unset attributes read as None."""
+
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+    def __getattr__(self, name):
+        return None
+
+    def __delattr__(self, name):
+        self.__dict__.pop(name, None)
+
+
+def make_victim(key="victim"):
+    v = MagicMock()
+    v.key = key
+    v.ndb = Bag()
+    v.location = MagicMock()
+    return v
+
+
+def make_grenade(key="grenade", **db_fields):
+    g = MagicMock()
+    g.key = key
+    g.db = Bag(is_explosive=True, **db_fields)
+    g.ndb = Bag()
+    return g
+
+
+# ===================================================================
+# Unified proximity merge
+# ===================================================================
+
+
+class TestUnifiedProximity(TestCase):
+    def test_merges_character_proximity_of_object_proximity(self):
+        """Grappling partners of anyone near the grenade get pulled
+        into the blast list (human-shield mechanics)."""
+        from commands.explosion_utils import get_unified_explosion_proximity
+
+        bystander = make_victim("bystander")
+        grappler = make_victim("grappler")
+        bystander.ndb = Bag(**{NDB_PROXIMITY: {grappler}})
+        grenade = make_grenade()
+        grenade.ndb = Bag(**{NDB_PROXIMITY_UNIVERSAL: [bystander]})
+
+        unified = get_unified_explosion_proximity(grenade)
+        self.assertIn(bystander, unified)
+        self.assertIn(grappler, unified)
+
+    def test_does_not_mutate_original_proximity(self):
+        from commands.explosion_utils import get_unified_explosion_proximity
+
+        bystander = make_victim("bystander")
+        grappler = make_victim("grappler")
+        bystander.ndb = Bag(**{NDB_PROXIMITY: {grappler}})
+        grenade = make_grenade()
+        original = [bystander]
+        grenade.ndb = Bag(**{NDB_PROXIMITY_UNIVERSAL: original})
+
+        get_unified_explosion_proximity(grenade)
+        self.assertEqual(original, [bystander])
+
+
+# ===================================================================
+# Standalone explosion — room blast
+# ===================================================================
+
+
+class TestRoomExplosion(TestCase):
+    def _explode(self, grenade, shield_modifiers=None):
+        from commands.explosion_utils import explode_standalone_grenade
+
+        with patch("commands.explosion_utils.msg_room_identity") as mock_room, \
+             patch("commands.explosion_utils.notify_adjacent_rooms_of_explosion"), \
+             patch("world.combat.utils.check_grenade_human_shield",
+                   return_value=shield_modifiers or {}):
+            explode_standalone_grenade(grenade)
+        return mock_room
+
+    def test_all_proximity_victims_take_damage_and_grenade_deletes(self):
+        """The full damage loop runs for every victim — pinning the
+        behavior restored by the room= → location= fix (previously the
+        first announce raised and silently spared the rest)."""
+        v1, v2 = make_victim("v1"), make_victim("v2")
+        grenade = make_grenade(blast_damage=10, damage_type="blast")
+        grenade.location = MagicMock()  # a room (not Character/Item)
+        grenade.ndb = Bag(**{NDB_PROXIMITY_UNIVERSAL: [v1, v2]})
+
+        mock_room = self._explode(grenade)
+
+        v1.take_damage.assert_called_once_with(
+            10, location="chest", injury_type="blast"
+        )
+        v2.take_damage.assert_called_once_with(
+            10, location="chest", injury_type="blast"
+        )
+        grenade.delete.assert_called_once()
+        # Every identity broadcast used the correct keyword.
+        for call in mock_room.call_args_list:
+            self.assertIn("location", call.kwargs)
+            self.assertNotIn("room", call.kwargs)
+
+    def test_human_shield_modifiers_scale_damage(self):
+        """Grapplers take zero, their victims double."""
+        grappler, shieldee = make_victim("grappler"), make_victim("shieldee")
+        grenade = make_grenade(blast_damage=10)
+        grenade.location = MagicMock()
+        grenade.ndb = Bag(**{NDB_PROXIMITY_UNIVERSAL: [grappler, shieldee]})
+
+        self._explode(
+            grenade, shield_modifiers={grappler: 0.0, shieldee: 2.0}
+        )
+        grappler.take_damage.assert_not_called()
+        shieldee.take_damage.assert_called_once()
+        self.assertEqual(shieldee.take_damage.call_args.args[0], 20)
+
+    def test_chain_reaction_arms_nearby_explosives(self):
+        from commands.explosion_utils import explode_standalone_grenade
+
+        other_bomb = make_grenade("satchel")
+        grenade = make_grenade(blast_damage=5, chain_trigger=True)
+        grenade.location = MagicMock()
+        grenade.ndb = Bag(**{NDB_PROXIMITY_UNIVERSAL: [other_bomb]})
+
+        with patch("commands.explosion_utils.msg_room_identity"), \
+             patch("commands.explosion_utils.notify_adjacent_rooms_of_explosion"), \
+             patch("world.combat.utils.check_grenade_human_shield",
+                   return_value={}), \
+             patch("commands.explosion_utils.start_standalone_grenade_ticker") as mock_tick:
+            explode_standalone_grenade(grenade)
+
+        self.assertTrue(other_bomb.db.pin_pulled)
+        self.assertEqual(
+            getattr(other_bomb.ndb, NDB_COUNTDOWN_REMAINING), 1
+        )
+        mock_tick.assert_called_once_with(other_bomb)
+
+    def test_resolver_failure_is_audited_and_raised(self):
+        """The #469 policy: explosion resolvers log to the audit trail
+        and re-raise — never a silent half-explosion again."""
+        from commands.explosion_utils import explode_standalone_grenade
+
+        victim = make_victim()
+        grenade = make_grenade(blast_damage=5)
+        grenade.location = MagicMock()
+        grenade.ndb = Bag(**{NDB_PROXIMITY_UNIVERSAL: [victim]})
+
+        router = MagicMock()
+        with patch("commands.explosion_utils.msg_room_identity",
+                   side_effect=RuntimeError("broadcast broke")), \
+             patch("commands.explosion_utils.notify_adjacent_rooms_of_explosion"), \
+             patch("world.combat.utils.check_grenade_human_shield",
+                   return_value={}), \
+             patch("commands.explosion_utils.get_splattercast",
+                   return_value=router):
+            with self.assertRaises(RuntimeError):
+                explode_standalone_grenade(grenade)
+
+        logged = " ".join(
+            str(c.args[0]) for c in router.msg.call_args_list if c.args
+        )
+        self.assertIn("Error in explode_standalone_grenade", logged)
+
+
+# ===================================================================
+# Standalone explosion — in someone's hands (real Character)
+# ===================================================================
+
+
+class TestInHandsExplosion(EvenniaTest):
+    character_typeclass = Character
+
+    def test_holder_takes_double_damage_and_room_is_told(self):
+        from commands.explosion_utils import explode_standalone_grenade
+
+        grenade = make_grenade(blast_damage=10, damage_type="blast")
+        grenade.location = self.char1  # isinstance Character → holder
+        grenade.ndb = Bag(**{NDB_PROXIMITY_UNIVERSAL: []})
+
+        with patch.object(self.char1, "take_damage") as mock_damage, \
+             patch("commands.explosion_utils.msg_room_identity") as mock_room, \
+             patch("commands.explosion_utils.notify_adjacent_rooms_of_explosion"):
+            explode_standalone_grenade(grenade)
+
+        mock_damage.assert_called_once_with(
+            20, location="chest", injury_type="blast"
+        )
+        grenade.delete.assert_called_once()
+        self.assertTrue(mock_room.called)
+        self.assertIn("location", mock_room.call_args.kwargs)
+
+    def test_bystanders_shielded_by_holder_take_half(self):
+        from commands.explosion_utils import explode_standalone_grenade
+
+        bystander = make_victim("bystander")
+        grenade = make_grenade(blast_damage=10, damage_type="blast")
+        grenade.location = self.char1
+        grenade.ndb = Bag(**{NDB_PROXIMITY_UNIVERSAL: [bystander]})
+
+        with patch.object(self.char1, "take_damage"), \
+             patch("commands.explosion_utils.msg_room_identity"), \
+             patch("commands.explosion_utils.notify_adjacent_rooms_of_explosion"):
+            explode_standalone_grenade(grenade)
+
+        bystander.take_damage.assert_called_once_with(
+            5, location="chest", injury_type="blast"
+        )
+
+
+# ===================================================================
+# Auto-defuse pipeline
+# ===================================================================
+
+
+class TestAutoDefuse(TestCase):
+    def _character_in_room_with(self, *objects):
+        char = make_victim("sapper")
+        char.location = MagicMock()
+        char.location.contents = list(objects)
+        return char
+
+    def test_live_grenade_in_proximity_triggers_attempt(self):
+        from commands.explosion_utils import check_auto_defuse
+
+        char = self._character_in_room_with()
+        grenade = make_grenade(pin_pulled=True)
+        grenade.ndb = Bag(**{
+            NDB_COUNTDOWN_REMAINING: 5,
+            NDB_PROXIMITY_UNIVERSAL: [char],
+        })
+        char.location.contents = [grenade]
+
+        with patch("commands.explosion_utils.attempt_auto_defuse") as mock_attempt:
+            check_auto_defuse(char)
+        mock_attempt.assert_called_once_with(char, grenade)
+
+    def test_unpulled_or_expired_grenades_ignored(self):
+        from commands.explosion_utils import check_auto_defuse
+
+        char = self._character_in_room_with()
+        unpulled = make_grenade("unpulled", pin_pulled=False)
+        expired = make_grenade("expired", pin_pulled=True)
+        expired.ndb = Bag(**{
+            NDB_COUNTDOWN_REMAINING: 0,
+            NDB_PROXIMITY_UNIVERSAL: [char],
+        })
+        char.location.contents = [unpulled, expired]
+
+        with patch("commands.explosion_utils.attempt_auto_defuse") as mock_attempt:
+            check_auto_defuse(char)
+        mock_attempt.assert_not_called()
+
+    def test_one_attempt_per_character_per_grenade(self):
+        from commands.explosion_utils import check_auto_defuse
+
+        char = self._character_in_room_with()
+        grenade = make_grenade(pin_pulled=True)
+        grenade.ndb = Bag(**{
+            NDB_COUNTDOWN_REMAINING: 5,
+            NDB_PROXIMITY_UNIVERSAL: [char],
+            "defuse_attempted_by": [char],
+        })
+        char.location.contents = [grenade]
+
+        with patch("commands.explosion_utils.attempt_auto_defuse") as mock_attempt:
+            check_auto_defuse(char)
+        mock_attempt.assert_not_called()
+
+    def test_attempt_routes_on_skill_roll(self):
+        from commands.explosion_utils import attempt_auto_defuse
+
+        char = make_victim("sapper")
+        grenade = make_grenade(pin_pulled=True)
+        grenade.ndb = Bag(**{NDB_COUNTDOWN_REMAINING: 8})
+
+        # High roll → success handler (15 base + max(0, 10-8)=2 → 17).
+        with patch("world.combat.utils.roll_stat", return_value=20), \
+             patch("commands.explosion_utils.handle_auto_defuse_success") as ok, \
+             patch("commands.explosion_utils.handle_auto_defuse_failure") as bad:
+            attempt_auto_defuse(char, grenade)
+        ok.assert_called_once()
+        bad.assert_not_called()
+
+        # Low roll → failure handler; attempt recorded both times.
+        grenade2 = make_grenade(pin_pulled=True)
+        grenade2.ndb = Bag(**{NDB_COUNTDOWN_REMAINING: 8})
+        with patch("world.combat.utils.roll_stat", return_value=1), \
+             patch("commands.explosion_utils.handle_auto_defuse_success") as ok, \
+             patch("commands.explosion_utils.handle_auto_defuse_failure") as bad:
+            attempt_auto_defuse(char, grenade2)
+        bad.assert_called_once()
+        ok.assert_not_called()
+        self.assertIn(char, grenade2.ndb.defuse_attempted_by)


### PR DESCRIPTION
#469 queue 3/4. Refs #469.

**The find:** every identity broadcast in `explosion_utils.py` passed `room=` to `msg_room_identity` (the parameter is `location`) — **ten call sites** raising TypeError on every rigged-grenade trigger, in-hands explosion, room-explosion victim announce, and auto-defuse message. The module's broad excepts swallowed all of it. In production: a room explosion damaged its first victim, crashed on the announce, and **silently spared everyone else while the grenade survived undeleted and chain reactions never fired**. Same bug class as the catch fix (#472), same masking mechanism this sweep exists to remove. All ten fixed; tests pin `location=` usage on every broadcast.

**Exception policy by role:**
- Explosion resolvers → **log to audit, then raise.** One-shot timer callbacks have no retry loop to protect; a half-applied explosion must be loud (pinned by test: audited AND raised).
- Auto-defuse cluster → deliberate boundary guards, documented: `check_auto_defuse` runs from the room-entry hook and must never break player movement.
- Proximity merge → documented degradation (smaller blast beats no resolution).
- Standalone ticker failsafe → documented like its #473 sibling; the inner "give up gracefully" `pass` now logs (a stuck live grenade is exactly what the audit trail exists to explain).

**12 characterization tests** (`test_explosion_chain.py`): unified proximity merge (grappling partners pulled into blasts; original list unmutated), the full room-explosion damage loop + cleanup, human-shield modifiers (0× grappler / 2× shieldee), chain-reaction arming, in-hands double damage + bystander half damage (real Character), auto-defuse gating and skill routing.

**Player-visible change to flag:** grenades now work as designed — full proximity damage, chain reactions, proper cleanup. Explosions get meaningfully deadlier than the silently-broken behavior players may have gotten used to.

Test plan: new module 12/12; full `world.tests` 2,350/2,350. Live reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)