### PR TITLE
Straggler excepts: unwrap dead wrappers, narrow, de-silence, document

### DIFF
--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -191,6 +191,8 @@ class CmdHeal(Command):
                     del target.db._test_unconscious_state
                 
                 # Remove any medical state restrictions (death/unconscious cmdsets)
+                # Deliberate (#469): the state may simply not be
+                # applied — clearing it is an expected no-op then.
                 try:
                     target.remove_death_state()
                 except Exception:

--- a/commands/CmdBug.py
+++ b/commands/CmdBug.py
@@ -49,11 +49,8 @@ def _run_github_call(caller, thread_fn, on_success, failure_msg):
     """
     def _on_err(failure):
         caller.msg(f"|r{failure_msg}|n")
-        try:
-            from evennia.utils import logger
-            logger.log_err(f"@bug GitHub call failed: {failure}")
-        except Exception:
-            pass
+        from evennia.utils import logger
+        logger.log_err(f"@bug GitHub call failed: {failure}")
 
     run_async(thread_fn, at_return=on_success, at_err=_on_err)
 
@@ -225,6 +222,8 @@ class CmdBug(MuxCommand):
             ]
             
             # Also try calculating from this file's location
+            # Deliberate (#469): best-effort path probes — every
+            # failure here just feeds the "unknown" hash fallback.
             try:
                 git_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
                 possible_paths.append(os.path.join(git_dir, '.git', 'refs', 'heads', 'master'))
@@ -251,9 +250,12 @@ class CmdBug(MuxCommand):
                 if result.returncode == 0:
                     return result.stdout.strip()
             except Exception:
+                # Deliberate (#469): subprocess probe — falls through
+                # to the "unknown" hash.
                 pass
-                
+
         except Exception:
+            # Deliberate (#469): the whole resolver is best-effort.
             pass
         
         return "unknown"

--- a/commands/CmdExplosives.py
+++ b/commands/CmdExplosives.py
@@ -728,8 +728,11 @@ class CmdDefuse(Command):
             grenade.delete()
 
         except Exception as e:
+            # #469: log + raise — one-shot timer callback, same policy
+            # as the explosion_utils resolvers (#481).
             splattercast = get_splattercast()
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in trigger_early_explosion: {e}")
+            raise
 
 
 # =============================================================================

--- a/commands/combat/jump.py
+++ b/commands/combat/jump.py
@@ -13,6 +13,7 @@ CmdJump handles three distinct sub-systems:
 """
 
 from evennia import Command, search_object
+from twisted.internet.error import AlreadyCalled, AlreadyCancelled
 from evennia.utils.utils import delay
 
 from world.combat.constants import (
@@ -210,8 +211,8 @@ class CmdJump(Command):
                     try:
                         timer.cancel()  # Cancel the utils.delay timer
                         splattercast.msg(f"JUMP_SACRIFICE: Cancelled original grenade timer on {explosive.key}")
-                    except Exception:
-                        splattercast.msg(f"JUMP_SACRIFICE: Failed to cancel original grenade timer on {explosive.key}")
+                    except (AlreadyCalled, AlreadyCancelled):
+                        splattercast.msg(f"JUMP_SACRIFICE: Original grenade timer on {explosive.key} already fired/cancelled")
                 delattr(explosive.ndb, NDB_GRENADE_TIMER)
             
             # Stop any timer scripts

--- a/typeclasses/armor_mixin.py
+++ b/typeclasses/armor_mixin.py
@@ -319,36 +319,28 @@ class ArmorMixin:
                     # Check if this is a plate carrier - needs special handling
                     if (hasattr(item, 'is_plate_carrier') and
                             getattr(item, 'is_plate_carrier', False)):
-                        # DEBUG: Log plate carrier detection
-                        try:
-                            from world.combat.utils import debug_broadcast
-                            installed = getattr(item, 'installed_plates', {})
-                            debug_broadcast(
-                                f"PLATE_CARRIER detected: {item.key} for {location}, "
-                                f"installed_plates={list(installed.keys())}",
-                                "ARMOR_CALC", "DEBUG",
-                            )
-                        except Exception:
-                            pass
+                        from world.combat.utils import debug_broadcast
+                        installed = getattr(item, 'installed_plates', {})
+                        debug_broadcast(
+                            f"PLATE_CARRIER detected: {item.key} for {location}, "
+                            f"installed_plates={list(installed.keys())}",
+                            "ARMOR_CALC", "DEBUG",
+                        )
                         # Expand plate carrier into multiple sequential layers
                         carrier_layers = self._expand_plate_carrier_layers(item, location)
-                        # DEBUG: Log expansion results
-                        try:
-                            from world.combat.utils import debug_broadcast
+                        from world.combat.utils import debug_broadcast
+                        debug_broadcast(
+                            f"PLATE_EXPAND: {len(carrier_layers)} layers created "
+                            f"from {item.key}",
+                            "ARMOR_CALC", "DEBUG",
+                        )
+                        for layer in carrier_layers:
                             debug_broadcast(
-                                f"PLATE_EXPAND: {len(carrier_layers)} layers created "
-                                f"from {item.key}",
+                                f"  Layer {layer['layer']}: {layer['item'].key} "
+                                f"({layer['armor_type']}, "
+                                f"rating={layer['armor_rating']})",
                                 "ARMOR_CALC", "DEBUG",
                             )
-                            for layer in carrier_layers:
-                                debug_broadcast(
-                                    f"  Layer {layer['layer']}: {layer['item'].key} "
-                                    f"({layer['armor_type']}, "
-                                    f"rating={layer['armor_rating']})",
-                                    "ARMOR_CALC", "DEBUG",
-                                )
-                        except Exception:
-                            pass
                         armor_layers.extend(carrier_layers)
                     else:
                         # Regular armor - single layer
@@ -463,65 +455,49 @@ class ArmorMixin:
             installed_plates = carrier.db.installed_plates or {}
             slot_coverage = carrier.db.plate_slot_coverage or {}
 
-            # DEBUG: Log what we're working with
-            try:
-                from world.combat.utils import debug_broadcast
-                debug_broadcast(
-                    f"PLATE_LOOP: Processing {len(installed_plates)} slots "
-                    f"for {location}",
-                    "ARMOR_CALC", "DEBUG",
-                )
-                debug_broadcast(
-                    f"PLATE_LOOP: installed_plates type={type(installed_plates)}, "
-                    f"value={installed_plates}",
-                    "ARMOR_CALC", "DEBUG",
-                )
-                debug_broadcast(
-                    f"PLATE_LOOP: slot_coverage={slot_coverage}",
-                    "ARMOR_CALC", "DEBUG",
-                )
-            except Exception:
-                pass
+            from world.combat.utils import debug_broadcast
+            debug_broadcast(
+                f"PLATE_LOOP: Processing {len(installed_plates)} slots "
+                f"for {location}",
+                "ARMOR_CALC", "DEBUG",
+            )
+            debug_broadcast(
+                f"PLATE_LOOP: installed_plates type={type(installed_plates)}, "
+                f"value={installed_plates}",
+                "ARMOR_CALC", "DEBUG",
+            )
+            debug_broadcast(
+                f"PLATE_LOOP: slot_coverage={slot_coverage}",
+                "ARMOR_CALC", "DEBUG",
+            )
 
             for slot_name, plate in installed_plates.items():
-                # DEBUG: Log each slot
-                try:
-                    from world.combat.utils import debug_broadcast
-                    plate_type = type(plate).__name__ if plate else "None"
-                    plate_key = plate.key if plate and hasattr(plate, 'key') else "N/A"
-                    plate_layer = (
-                        getattr(plate, 'layer', 'MISSING') if plate else "N/A"
-                    )
-                    debug_broadcast(
-                        f"PLATE_SLOT: slot={slot_name}, type={plate_type}, "
-                        f"key={plate_key}, layer={plate_layer}, "
-                        f"has_rating="
-                        f"{hasattr(plate, 'armor_rating') if plate else False}",
-                        "ARMOR_CALC", "DEBUG",
-                    )
-                except Exception as e:
-                    from world.combat.utils import debug_broadcast
-                    debug_broadcast(
-                        f"PLATE_SLOT_ERROR: {e}", "ARMOR_CALC", "ERROR"
-                    )
-                    pass
+                from world.combat.utils import debug_broadcast
+                plate_type = type(plate).__name__ if plate else "None"
+                plate_key = plate.key if plate and hasattr(plate, 'key') else "N/A"
+                plate_layer = (
+                    getattr(plate, 'layer', 'MISSING') if plate else "N/A"
+                )
+                debug_broadcast(
+                    f"PLATE_SLOT: slot={slot_name}, type={plate_type}, "
+                    f"key={plate_key}, layer={plate_layer}, "
+                    f"has_rating="
+                    f"{hasattr(plate, 'armor_rating') if plate else False}",
+                    "ARMOR_CALC", "DEBUG",
+                )
 
                 if not plate or not hasattr(plate, 'armor_rating'):
                     continue
 
                 # Check if this plate protects the hit location
                 protected_locations = slot_coverage.get(slot_name, [])
-                # DEBUG: Log coverage check
-                try:
-                    from world.combat.utils import debug_broadcast
-                    debug_broadcast(
-                        f"PLATE_COVERAGE: slot={slot_name}, "
-                        f"protects={protected_locations}, location={location}, "
-                        f"match={location in protected_locations}",
-                        "ARMOR_CALC", "DEBUG",
-                    )
-                except Exception:
-                    pass
+                from world.combat.utils import debug_broadcast
+                debug_broadcast(
+                    f"PLATE_COVERAGE: slot={slot_name}, "
+                    f"protects={protected_locations}, location={location}, "
+                    f"match={location in protected_locations}",
+                    "ARMOR_CALC", "DEBUG",
+                )
                 if location not in protected_locations:
                     continue
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -372,19 +372,13 @@ class Character(
         if combat_handler:
             try:
                 combat_handler.remove_combatant(self)
-                # Optional: Debug broadcast for tracking
-                try:
-                    from world.combat.utils import debug_broadcast
-                    debug_broadcast(f"{self.key} removed from combat due to unconsciousness", "MEDICAL", "UNCONSCIOUS")
-                except ImportError:
-                    pass  # debug_broadcast not available
+                from world.combat.utils import debug_broadcast
+                debug_broadcast(f"{self.key} removed from combat due to unconsciousness", "MEDICAL", "UNCONSCIOUS")
             except Exception as e:
-                # Optional: Debug broadcast for tracking errors
-                try:
-                    from world.combat.utils import debug_broadcast
-                    debug_broadcast(f"Error removing {self.key} from combat on unconsciousness: {e}", "MEDICAL", "ERROR")
-                except ImportError:
-                    pass  # debug_broadcast not available
+                # Deliberate guard (#469): a combat-removal bug must not
+                # abort the unconsciousness transition itself.  Logged.
+                from world.combat.utils import debug_broadcast
+                debug_broadcast(f"Error removing {self.key} from combat on unconsciousness: {e}", "MEDICAL", "ERROR")
         
         # Optional: Debug broadcast for tracking
         try:
@@ -639,14 +633,11 @@ class Character(
         # Set death placement description for persistent visual indication
         self.override_place = "lying motionless and deceased."
         
-        # Always show death analysis when character dies
-        try:
-            splattercast = get_splattercast()
-            death_analysis = self.debug_death_analysis()
-            splattercast.msg(death_analysis)
-        except Exception as e:
-            # Fallback if splattercast channel not available
-            pass
+        # Always show death analysis when character dies.
+        # debug_death_analysis is fail-soft internally and the audit
+        # router cannot raise (#464), so no wrapper is needed.
+        splattercast = get_splattercast()
+        splattercast.msg(self.debug_death_analysis())
         
         # Check if character is in active combat - if so, defer death curtain
         is_in_combat = hasattr(self.ndb, NDB_COMBAT_HANDLER) and getattr(self.ndb, NDB_COMBAT_HANDLER) is not None
@@ -694,7 +685,9 @@ class Character(
         try:
             self.cmdset.remove_default()
         except Exception:
-            pass  # No default cmdset to remove, that's fine
+            # Deliberate (#469): removing an absent default cmdset is a
+            # legitimate no-op during state transitions.
+            pass
             
         from commands.default_cmdsets import UnconsciousCmdSet
         self.cmdset.add_default(UnconsciousCmdSet)
@@ -734,7 +727,9 @@ class Character(
             try:
                 self.cmdset.remove_default()
             except Exception:
-                pass  # No default cmdset to remove, that's fine
+                # Deliberate (#469): removing an absent default cmdset
+                # is a legitimate no-op during state transitions.
+                pass
                 
             from commands.default_cmdsets import DeathCmdSet
             self.cmdset.add_default(DeathCmdSet)
@@ -750,7 +745,9 @@ class Character(
             # Remove current default cmdset (should be unconscious cmdset)
             self.cmdset.remove_default()
         except Exception:
-            pass  # No default cmdset to remove, that's fine
+            # Deliberate (#469): removing an absent default cmdset is a
+            # legitimate no-op during state transitions.
+            pass
             
         # Restore normal character cmdset
         from commands.default_cmdsets import CharacterCmdSet
@@ -780,7 +777,9 @@ class Character(
             # Remove current default cmdset (should be death cmdset)
             self.cmdset.remove_default()
         except Exception:
-            pass  # No default cmdset to remove, that's fine
+            # Deliberate (#469): removing an absent default cmdset is a
+            # legitimate no-op during state transitions.
+            pass
             
         # Restore normal character cmdset
         from commands.default_cmdsets import CharacterCmdSet

--- a/typeclasses/curtain_of_death.py
+++ b/typeclasses/curtain_of_death.py
@@ -308,7 +308,9 @@ class DeathCurtain:
             splattercast.msg(f"DEATH_CURTAIN: Death progression started for {self.character.key}, script: {script}")
                 
         except Exception as e:
-            # Debug logging for any errors
+            # Deliberate guard (#469): the curtain animation chain must
+            # finish even if progression startup fails — the failure is
+            # logged loudly here either way.
             from world.combat.debug import get_splattercast
             splattercast = get_splattercast()
             splattercast.msg(f"DEATH_CURTAIN_ERROR: Failed to start death progression for {getattr(self.character, 'key', '?')}: {e}")

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1980,6 +1980,8 @@ def spawn_severed_head_for_living(character, *, injury_type="cut"):
         attacker = getattr(character.ndb, "_last_damage_attacker", None)
         open_incision(character, "head", surgeon=attacker)
     except Exception:
+        # Deliberate (#469): incision recording is forensic-only —
+        # never block the severance over its bookkeeping.
         pass
 
     return head
@@ -2370,6 +2372,8 @@ def apply_sever_to_character(character, container, *, injury_type="cut"):
         attacker = getattr(character.ndb, "_last_damage_attacker", None)
         open_incision(character, container, surgeon=attacker)
     except Exception:
+        # Deliberate (#469): incision recording is forensic-only —
+        # never block the severance over its bookkeeping.
         pass
 
     detach_items_to_appendage(character, appendage, chain)

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -85,18 +85,27 @@ class Room(ObjectParent, DefaultRoom):
                 # Issue #230: refresh corpse key to current decay stage.
                 # ``look`` is now a pure read; key advancement on stage
                 # transitions runs here, triggered by character entry.
+                # Deliberate (#469): cosmetic key refresh must not
+                # block decay cleanup.
                 try:
                     corpse._refresh_decay_key_if_changed()
                 except Exception:
-                    pass  # Don't let key refresh block decay cleanup.
+                    pass
 
                 if corpse.check_complete_decay():
                     # Drop items to room
                     for item in list(corpse.contents):
                         try:
                             item.move_to(self, quiet=True)
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            # Deliberate (#469) — but a failed rescue
+                            # means the item is destroyed with the
+                            # corpse, so it is audit-logged.
+                            from world.combat.debug import get_splattercast
+                            get_splattercast().msg(
+                                f"CORPSE_DECAY_ITEM_LOST: {item.key} "
+                                f"in {corpse.key}: {e}"
+                            )
                     
                     # Log and delete
                     from world.combat.debug import get_splattercast
@@ -105,7 +114,10 @@ class Room(ObjectParent, DefaultRoom):
                     
                     corpse.delete()
             except Exception:
-                pass  # Corpse may have been deleted or be in invalid state
+                # Deliberate guard (#469): just-in-time decay cleanup
+                # runs on room entry — a broken corpse must never block
+                # a character walking into the room.
+                pass
     
     # Override the appearance template to use our custom footer for exits
     # and custom things display to handle @integrate objects

--- a/world/emote.py
+++ b/world/emote.py
@@ -364,6 +364,8 @@ def build_char_candidates(
                     if char.key not in [n for n, _rc in names]:
                         names.append((char.key, False))
             except Exception:
+                # Deliberate (#469): a lock-check hiccup just skips the
+                # builder-only true-name match candidate.
                 pass
 
         for name, requires_capital in names:

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -888,10 +888,18 @@ class MedicalState:
             from .conditions import create_condition_from_damage
             conditions = create_condition_from_damage(damage_amount, injury_type, location)
             return conditions
-        except ImportError as e:
+        except ImportError:
             # Fallback if conditions module not available
             return []
         except Exception as e:
+            # Deliberate guard (#469): a condition-creation bug must not
+            # abort damage application — but a wound silently producing
+            # no bleeding/pain is the cheating class of failure, so it
+            # is audit-logged.
+            from world.combat.debug import get_splattercast
+            get_splattercast().msg(
+                f"CONDITION_CREATE_ERROR: {injury_type} at {location}: {e}"
+            )
             return []
             
     def add_condition(self, condition):
@@ -1031,9 +1039,15 @@ class MedicalState:
                 # Archived characters are permanently dead; dying characters can still be resuscitated
                 if character and not character.db.archived:
                     condition.start_condition(character)
-            except Exception:
-                # If condition restoration fails, skip it.
-                pass
+            except Exception as e:
+                # Deliberate guard (#469): one corrupt persisted
+                # condition skips, the rest restore.  Audit-logged so
+                # vanishing conditions are diagnosable.
+                from world.combat.debug import get_splattercast
+                get_splattercast().msg(
+                    f"CONDITION_RESTORE_ERROR: skipped condition for "
+                    f"{getattr(character, 'key', '?')}: {e}"
+                )
             
         # Restore vital signs
         medical_state.blood_level = data.get("blood_level", 100.0)

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -251,6 +251,9 @@ class MedicalScript(DefaultScript):
                 self.delete()
                 
         except Exception as e:
+            # Deliberate guard (#469): a critical tick error stops and
+            # deletes the script rather than retrying the same failure
+            # every tick.  Logged; the next wound re-creates the script.
             splattercast = get_splattercast()
             splattercast.msg(f"MEDICAL_SCRIPT_CRITICAL_ERROR: {getattr(self.obj, 'key', '?')}: {e}")
             self.stop()

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -985,8 +985,10 @@ def apply_medical_effects(item, user, target, **kwargs):
             splattercast.msg(f"REVIVAL_DEBUG: {target.key} blood_level={blood_level:.1f}%, is_dead={is_dead}")
         else:
             splattercast.msg(f"REVIVAL_DEBUG: {target.key} has no medical_state")
-    except Exception:
-        pass
+    except Exception as e:
+        # Deliberate guard (#469): diagnostic state-peek must not block
+        # the revival check below.  Logged instead of silent.
+        splattercast.msg(f"REVIVAL_DEBUG_ERROR: {getattr(target, 'key', '?')}: {e}")
     
     if death_scripts:
         try:


### PR DESCRIPTION
#469 queue 4/4 — the final pass. Closes #469.

**Unwrapped** (dead since the #464 router made debug calls unable to raise): five plate-carrier debug wrappers in `armor_mixin`, the death-analysis wrapper + nested ImportError noise in `characters.py`, the revival-debug peek in `medical/utils`, the logger fallback in CmdBug's async error handler.

**Narrowed:** jump.py's grenade-timer cancel → `(AlreadyCalled, AlreadyCancelled)`, matching `cancel_flight`.

**Policy applied:** `CmdExplosives.trigger_early_explosion` logs + raises (the #481 explosion-resolver policy).

**De-silenced** (kept, now audit-logged): condition-creation failure (a wound silently producing no bleeding/pain is the cheating class of failure), corrupt persisted-condition restore skips, corpse-decay item-rescue failure (item destroyed with corpse = a loss event worth a trail).

**Documented as deliberate:** cmdset-removal no-ops, admin heal state-clears, CmdBug's best-effort git-hash probes, room-entry decay cleanup, medical script stop-on-critical-error (prevents per-tick retry storms), curtain progression startup, forensic incision recording, emote lock probe. Handlers that already surface errors to players/admins/templates were left as-is — self-evidently deliberate.

**#469 final scorecard:** 205 broad excepts at the start of the arc → ~109 remaining, every one either carrying a written rationale or a handler body that visibly surfaces the error. Zero silent-`pass`-no-comment handlers outside tests. Along the way the sweep caught: the catch-command crash (#472), the death-progression status crash (#478), and ten broken explosion broadcasts that had silently neutered grenade damage loops (#481).

Test plan: full `world.tests` 2,350/2,350. Live reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)