### PR TITLE
Raise audit-log rotation to 10MB

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -167,6 +167,13 @@ DEBUG = False
 # Combat audit logging
 ######################################################################
 
+# Rotation size for all logger.log_file()-based logs — most
+# importantly server/logs/combat_audit.log (Evennia's 1MB default
+# rotated six times on day one; investigations want history in one
+# file).  Shared with channel logs; rotated generations have no
+# count cap, so this changes granularity, not total disk use.
+CHANNEL_LOG_ROTATE_SIZE = 10_000_000  # 10MB
+
 # Combat diagnostics always go to server/logs/combat_audit.log
 # (async file writes — see world/combat/debug.py).  Set this True to
 # additionally broadcast them live to the Splattercast channel for

--- a/specs/COMBAT_AUDIT_LOGGING_SPEC.md
+++ b/specs/COMBAT_AUDIT_LOGGING_SPEC.md
@@ -93,8 +93,14 @@ only the expected, narrow failure of each:
 
 ```python
 # server/conf/settings.py
-SPLATTERCAST_LIVE = False   # mirror diagnostics to the channel
+SPLATTERCAST_LIVE = False           # mirror diagnostics to the channel
+CHANNEL_LOG_ROTATE_SIZE = 10_000_000  # audit-log rotation size (10MB)
 ```
+
+Rotation produces numbered generations (`combat_audit.log.1`, …)
+with no count cap — the size knob controls granularity per file,
+not total disk use.  The knob is Evennia's and is shared by
+channel logs.
 
 Flip to `True` (and reload) to watch combat live in-game. Leave
 `False` in production — the audit file captures everything either


### PR DESCRIPTION
Closes #483.

`combat_audit.log` hit its sixth 1MB rotation on day one — test sweeps inflate the volume, but the granularity was too fine either way: investigations want a fight's history in one file, not stitched across generations.

`CHANNEL_LOG_ROTATE_SIZE` is Evennia's knob for all `logger.log_file()`-based logs (verified in `evennia/utils/logger.py:_open_log_file`); it's shared with channel logs, which is harmless at our volume. Rotated generations have no count cap, so this changes per-file granularity, not total disk use.

Verified live: reload picks it up (`settings.CHANNEL_LOG_ROTATE_SIZE → 10000000` in the running container). Spec's configuration section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)