### PR TITLE
Cannabis, alcohol, opium + pharmacology on every ingestion verb

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -27,13 +27,19 @@ class ConsumptionCommand(Command):
     - Time-based actions (multi-round procedures)
     """
     
-    def get_item_and_target(self, args, allow_body_location=False):
+    def get_item_and_target(self, args, allow_body_location=False,
+                            require_medical=True):
         """
         Parse command arguments to get item and target.
         
         Args:
             args (str): Command arguments
             allow_body_location (bool): Whether to parse body location
+            require_medical (bool): Reject non-medical items.  The
+                ingestion verbs (eat/drink/inhale) pass False since
+                #475 made the delivery-method tag their real gate —
+                a bottle of rotgut is drinkable without being a
+                medical item (#487).
             
         Returns:
             dict: Contains item, target, body_location, errors
@@ -65,8 +71,9 @@ class ConsumptionCommand(Command):
         
         result["item"] = item[0]
         
-        # Check if it's a medical item
-        if not is_medical_item(result["item"]):
+        # Check if it's a medical item (skipped for tag-gated
+        # ingestion verbs — see require_medical above)
+        if require_medical and not is_medical_item(result["item"]):
             result["errors"].append(f"{result['item'].get_display_name(caller)} is not a medical item.")
             return result
             
@@ -90,6 +97,30 @@ class ConsumptionCommand(Command):
             
         return result
         
+    def _apply_substance_dose(self, item, target):
+        """Apply one dose of the item's substance to ``target``.
+
+        The §1 layering (#487): the command validates the delivery,
+        the substance entry owns the pharmacology.  Unknown/missing
+        substances no-op, so flavor-only consumables stay legitimate.
+        """
+        from world.substances import apply_substance
+        dose_result = apply_substance(target, item.db.substance)
+        for line in dose_result.get("feedback", ()):
+            target.msg(f"|c{line}|n")
+
+    def _consume(self, item):
+        """Spend one use of a non-medical consumable.
+
+        Items with uses_left tracking decrement-and-delete via the
+        shared lifecycle helper; legacy untracked items are consumed
+        whole.
+        """
+        from world.consumables import consume_use
+        outcome = consume_use(item)
+        if not outcome["success"]:
+            item.delete()
+
     def check_medical_requirements(self, item, user, target):
         """
         Check if medical requirements are met for using the item.
@@ -652,7 +683,7 @@ class CmdEat(ConsumptionCommand):
         caller = self.caller
         
         # Parse arguments  
-        result = self.get_item_and_target(self.args)
+        result = self.get_item_and_target(self.args, require_medical=False)
         if result["errors"]:
             caller.msg(result["errors"][0])
             return
@@ -697,10 +728,13 @@ class CmdEat(ConsumptionCommand):
             caller.msg(f"Effects: {result_msg}")
             if not is_self:
                 target.msg(f"You feel the effects: {result_msg}")
+            self._apply_substance_dose(item, target)
         else:
-            # Regular food item
+            # Regular food item — pharmacology (if any) rides the
+            # delivery, then the generic consumable lifecycle.
             caller.msg(f"You consumed {item.get_display_name(caller)}.")
-            item.delete()  # Regular food items are consumed completely
+            self._apply_substance_dose(item, target)
+            self._consume(item)
 
 
 class CmdDrink(ConsumptionCommand):
@@ -729,7 +763,7 @@ class CmdDrink(ConsumptionCommand):
         caller = self.caller
         
         # Parse arguments
-        result = self.get_item_and_target(self.args)
+        result = self.get_item_and_target(self.args, require_medical=False)
         if result["errors"]:
             caller.msg(result["errors"][0])
             return
@@ -774,10 +808,13 @@ class CmdDrink(ConsumptionCommand):
             caller.msg(f"Effects: {result_msg}")
             if not is_self:
                 target.msg(f"You feel the effects: {result_msg}")
+            self._apply_substance_dose(item, target)
         else:
-            # Regular drink
+            # Regular drink — pharmacology (if any) rides the
+            # delivery, then the generic consumable lifecycle.
             caller.msg(f"You drank {item.get_display_name(caller)}.")
-            item.delete()  # Regular drinks are consumed completely
+            self._apply_substance_dose(item, target)
+            self._consume(item)
 
 
 class CmdInhale(ConsumptionCommand):
@@ -806,7 +843,7 @@ class CmdInhale(ConsumptionCommand):
         caller = self.caller
         
         # Parse arguments
-        result = self.get_item_and_target(self.args)
+        result = self.get_item_and_target(self.args, require_medical=False)
         if result["errors"]:
             caller.msg(result["errors"][0])
             return
@@ -827,11 +864,13 @@ class CmdInhale(ConsumptionCommand):
                 caller.msg(f"{target.get_display_name(caller)} is unconscious and cannot inhale.")
             return
             
-        # Check medical requirements
-        errors = self.check_medical_requirements(item, caller, target)
-        if errors:
-            caller.msg(errors[0])
-            return
+        # Check medical requirements (medical items only — non-medical
+        # inhalables are gated by the delivery tag, #487)
+        if is_medical_item(item):
+            errors = self.check_medical_requirements(item, caller, target)
+            if errors:
+                caller.msg(errors[0])
+                return
             
         # Execute inhalation
         if is_self:
@@ -852,9 +891,15 @@ class CmdInhale(ConsumptionCommand):
                 exclude=[caller, target],
             )
             
-        # Apply treatment effects
-        result_msg = self.execute_treatment(item, caller, target)
-        caller.msg(f"Inhalation result: {result_msg}")
-        
-        if not is_self:
-            target.msg(f"Treatment result: {result_msg}")
+        # Apply treatment effects (medical items) and any substance
+        # pharmacology riding the delivery (#487)
+        if is_medical_item(item):
+            result_msg = self.execute_treatment(item, caller, target)
+            caller.msg(f"Inhalation result: {result_msg}")
+
+            if not is_self:
+                target.msg(f"Treatment result: {result_msg}")
+            self._apply_substance_dose(item, target)
+        else:
+            self._apply_substance_dose(item, target)
+            self._consume(item)

--- a/specs/SUBSTANCES_AND_DELIVERY_SPEC.md
+++ b/specs/SUBSTANCES_AND_DELIVERY_SPEC.md
@@ -249,10 +249,22 @@ migration from the old `medical_type` strings.
 5. **Roll-your-own** — `roll` command that consumes raw
    substance + paper + filter and spawns a cigarette / joint
    prototype with the substance baked on.
-6. **More substances** — cannabis, alcohol, opium.  Each likely
-   needs one or two new effect kinds (euphoria, stimulation,
-   coordination penalty) — grow the vocabulary per substance,
-   not speculatively.
+6. ~~**More substances**~~ — ✅ cannabis, alcohol, opium shipped
+   in #487, all expressible in the existing severity vocabulary
+   (pain_relief + sedation at different magnitudes/caps): cannabis
+   is mellow (cap 2), alcohol numbs to properly-drunk (cap 4 =
+   0.60 consciousness penalty, standing), opium is the serious
+   analgesic (3 pain relief/dose, sedation to the nod at cap 5)
+   and hooks in ten doses.  New effect kinds (euphoria,
+   stimulation, coordination penalty) remain future vocabulary —
+   grown per substance when one actually needs them.
+   Also in #487: **eat/drink/inhale now call ``apply_substance``**
+   (previously only smoke delivered pharmacology), non-medical
+   consumables route through ``consume_use``, and the ingestion
+   verbs no longer require ``medical_item`` — the delivery tag is
+   the gate (a bottle of rotgut is drinkable without being a
+   medkit).  Prototypes: HAND_ROLLED_JOINT, ROTGUT_BOTTLE,
+   OPIUM_CIGARETTE.
 
 ## 6 · Anti-patterns to avoid
 

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2136,6 +2136,54 @@ PAIN_RELIEF_CIGARETTE = {
 }
 
 # =============================================================================
+# RECREATIONAL SUBSTANCE PROTOTYPES (#487)
+# =============================================================================
+# Substance pharmacology lives in world/substances/registry.py; these
+# items just carry the substance id + delivery tag (spec §1/§2).
+
+HAND_ROLLED_JOINT = {
+    "key": "hand-rolled joint",
+    "typeclass": "typeclasses.items.Item",
+    "aliases": ["joint", "spliff"],
+    "desc": "A crooked hand-rolled joint, packed with sweet-smelling "
+            "resinous flower. The paper crackles when squeezed.",
+    "tags": [("smoke", "delivery_method")],
+    "attrs": [
+        ("substance", "cannabis"),
+        ("uses_left", 4),
+        ("max_uses", 4),
+    ],
+}
+
+ROTGUT_BOTTLE = {
+    "key": "bottle of rotgut",
+    "typeclass": "typeclasses.items.Item",
+    "aliases": ["rotgut", "bottle", "booze"],
+    "desc": "An unlabeled glass bottle of harsh colonial liquor. It "
+            "smells like fuel and bad decisions, in that order.",
+    "tags": [("drink", "delivery_method")],
+    "attrs": [
+        ("substance", "alcohol"),
+        ("uses_left", 4),
+        ("max_uses", 4),
+    ],
+}
+
+OPIUM_CIGARETTE = {
+    "key": "tar-black opium cigarette",
+    "typeclass": "typeclasses.items.Item",
+    "aliases": ["opium cigarette", "opium", "tar cigarette"],
+    "desc": "A thin cigarette rolled around tar-black resin. Heavy, "
+            "sweet, and patient — it will wait as long as you can.",
+    "tags": [("smoke", "delivery_method")],
+    "attrs": [
+        ("substance", "opium"),
+        ("uses_left", 3),
+        ("max_uses", 3),
+    ],
+}
+
+# =============================================================================
 # SHOP MERCHANT PROTOTYPES
 # =============================================================================
 

--- a/world/smoke.py
+++ b/world/smoke.py
@@ -58,6 +58,8 @@ DEFAULT_PACK_CAPACITY = 10
 #: stylistic variants (e.g. tobacco_neutral, tobacco_noir).
 SUBSTANCE_TOBACCO_NEUTRAL = "tobacco_neutral"
 SUBSTANCE_TOBACCO_NOIR = "tobacco_noir"
+SUBSTANCE_CANNABIS = "cannabis"
+SUBSTANCE_OPIUM = "opium"
 
 # Pre-#456 brand attribute values that mapped to these substances.
 # ``pick_smoke_message`` honours both via this table during the
@@ -197,6 +199,57 @@ SMOKE_MESSAGES: dict[str, list[tuple[str, str]]] = {
             "{actor} takes a slow drag from their cigarette, the "
             "smoke filling their senses before they let it escape "
             "in a gentle, steady stream.",
+        ),
+    ],
+    SUBSTANCE_CANNABIS: [
+        (
+            "You pull a slow drag from the joint, sweet resin "
+            "crackling, and hold it until the room softens at the "
+            "edges.",
+            "{actor} pulls a slow drag from a joint, the sweet "
+            "smell of resin drifting outward as the smoke leaves "
+            "them in no particular hurry.",
+        ),
+        (
+            "You take an unhurried puff, exhaling green-smelling "
+            "smoke that hangs in the air like it pays rent.",
+            "{actor} takes an unhurried puff, exhaling "
+            "green-smelling smoke that hangs in the air like it "
+            "pays rent.",
+        ),
+        (
+            "You draw deep and let it sit. Somewhere in your chest, "
+            "a clenched fist you'd forgotten about opens.",
+            "{actor} draws deep on a joint and goes very still for "
+            "a moment, shoulders dropping a visible inch.",
+        ),
+        (
+            "The paper crackles. The smoke tastes like a field that "
+            "never existed. You exhale and so does the day.",
+            "{actor} exhales a lazy ribbon of smoke, eyelids at "
+            "half-mast.",
+        ),
+    ],
+    SUBSTANCE_OPIUM: [
+        (
+            "You draw the dark smoke in and the world's volume drops "
+            "by half. The sweetness sits heavy on the back of your "
+            "tongue, old and patient.",
+            "{actor} draws in dark, sweet-smelling smoke, and "
+            "something in their face goes distant and smoothed-over.",
+        ),
+        (
+            "The resin bubbles faintly. You inhale, and the ache "
+            "doesn't leave so much as it forgets your address.",
+            "{actor} inhales slowly over bubbling resin, exhaling a "
+            "heavy, honeyed smoke that sinks rather than rises.",
+        ),
+        (
+            "You breathe it in and your bones swap themselves for "
+            "something warmer. The room is the same. You are "
+            "elsewhere.",
+            "{actor} breathes in the dark smoke and settles, limbs "
+            "arranging themselves like things set down gently.",
         ),
     ],
     SUBSTANCE_TOBACCO_NOIR: [

--- a/world/substances/registry.py
+++ b/world/substances/registry.py
@@ -153,6 +153,60 @@ SUBSTANCES: dict[str, Substance] = {
             threshold_doses=25, craving_after=7200, prose_key="tobacco",
         ),
     ),
+    "cannabis": Substance(
+        id="cannabis",
+        display_name="cannabis",
+        effects=(
+            # Mellow analgesic drift — kinder than tobacco on the
+            # pain, heavier on the eyelids.
+            SubstanceEffect(kind="pain_relief", magnitude=1),
+            SubstanceEffect(kind="sedation", magnitude=1, max_stack=2),
+        ),
+        flavor_bank_key="cannabis",
+        tolerance=ToleranceSpec(
+            points_per_level=10, decay_per_hour=1.0, max_level=1,
+        ),
+        addiction=AddictionSpec(
+            threshold_doses=60, craving_after=14400, prose_key="cannabis",
+        ),
+    ),
+    "alcohol": Substance(
+        id="alcohol",
+        display_name="alcohol",
+        effects=(
+            # Numbs more than it heals; the cap of 4 (0.60
+            # consciousness penalty) is properly drunk — heavily
+            # impaired, still standing.  Blackout stays out of v1.
+            SubstanceEffect(kind="pain_relief", magnitude=1),
+            SubstanceEffect(kind="sedation", magnitude=1, max_stack=4),
+        ),
+        flavor_bank_key="alcohol",
+        tolerance=ToleranceSpec(
+            points_per_level=12, decay_per_hour=0.75, max_level=1,
+        ),
+        addiction=AddictionSpec(
+            threshold_doses=40, craving_after=10800, prose_key="alcohol",
+        ),
+    ),
+    "opium": Substance(
+        id="opium",
+        display_name="opium",
+        effects=(
+            # The serious analgesic — three points of pain relief per
+            # dose, and a sedative pull that can take a chasing user
+            # to the nod (cap 5 = 0.75 consciousness penalty: barely
+            # present, not unconscious).  Its danger is its identity.
+            SubstanceEffect(kind="pain_relief", magnitude=3),
+            SubstanceEffect(kind="sedation", magnitude=2, max_stack=5),
+        ),
+        flavor_bank_key="opium",
+        tolerance=ToleranceSpec(
+            points_per_level=8, decay_per_hour=0.25, max_level=2,
+        ),
+        addiction=AddictionSpec(
+            threshold_doses=10, craving_after=5400, prose_key="opium",
+        ),
+    ),
 }
 
 
@@ -198,6 +252,31 @@ CRAVING_PROSE: dict[str, list[str]] = {
         "your ribs.",
         "Your hands keep looking for something to do. You know "
         "exactly what.",
+    ],
+    "cannabis": [
+        "The world has corners again. You remember when it didn't.",
+        "Everything is slightly too loud and nothing is funny. This "
+        "feels correctable.",
+        "Your thoughts keep arriving on time. You miss when they "
+        "wandered in late, smiling.",
+    ],
+    "alcohol": [
+        "Your mouth is dry in a way water has repeatedly failed to "
+        "fix.",
+        "There's a glass-shaped absence in your hand. It has opinions.",
+        "Sobriety is a fluorescent light. You remember somewhere "
+        "dimmer, warmer.",
+        "Your hands have a fine grammar of tremors this morning, "
+        "spelling out a familiar request.",
+    ],
+    "opium": [
+        "The pain isn't worse. The world is just made of it again.",
+        "Somewhere under your skin, a tide has gone out, and "
+        "everything the water covered is bare and aching.",
+        "You can feel your whole skeleton. No one should feel their "
+        "whole skeleton.",
+        "The smoke knew your name. Everything since has been "
+        "introductions.",
     ],
     "tobacco": [
         "Your fingers miss the weight of a cigarette. They make the "

--- a/world/tests/test_consumption_rendering.py
+++ b/world/tests/test_consumption_rendering.py
@@ -87,10 +87,13 @@ def _make_room(contents):
 
 def _make_item(key="medkit"):
     """Non-character item (no msg attribute, deliberately empty spec)."""
-    item = MagicMock(spec=["key", "get_display_name", "delete"])
+    item = MagicMock(spec=["key", "get_display_name", "delete", "db"])
     item.key = key
     # Stub get_display_name so caller-side first-person msgs don't blow up.
     item.get_display_name = lambda looker=None: key
+    # No substance — the #487 dose hook no-ops on None.
+    item.db = MagicMock()
+    item.db.substance = None
     return item
 
 

--- a/world/tests/test_substances.py
+++ b/world/tests/test_substances.py
@@ -466,3 +466,132 @@ class TestAddictionCondition(TestCase):
         self.assertEqual(restored.craving_after, 1234)
         self.assertEqual(restored.last_dose_time, 1000.0)
         self.assertFalse(restored.should_end())
+
+
+# ---------------------------------------------------------------------
+# Cannabis / alcohol / opium (#487)
+# ---------------------------------------------------------------------
+
+
+class TestNewSubstances(TestCase):
+    def test_entries_resolve_with_specs(self):
+        for sid in ("cannabis", "alcohol", "opium"):
+            entry = get_substance_entry(sid)
+            self.assertIsNotNone(entry, sid)
+            self.assertIsNotNone(entry.tolerance, sid)
+            self.assertIsNotNone(entry.addiction, sid)
+            # Every addiction prose key has a craving bank.
+            from world.substances.registry import CRAVING_PROSE
+            self.assertIn(entry.addiction.prose_key, CRAVING_PROSE)
+
+    def test_opium_is_the_serious_analgesic(self):
+        consumer = _FakeConsumer(conditions=[_pain(5)])
+        result = apply_substance(consumer, "opium")
+        self.assertEqual(result["applied"]["pain_relief"], 3)
+        self.assertEqual(consumer.medical_state.conditions[0].severity, 2)
+        self.assertEqual(result["applied"]["sedation"], 2)
+
+    def test_alcohol_sedation_caps_at_properly_drunk(self):
+        """Six shots: sedative severity climbs to the cap of 4
+        (0.60 consciousness penalty — drunk, standing) and stops."""
+        consumer = _FakeConsumer()
+        for _ in range(6):
+            apply_substance(consumer, "alcohol")
+        sedatives = [
+            c for c in consumer.medical_state.conditions
+            if getattr(c, "condition_type", None) == "consciousness_suppression"
+        ]
+        total = sum(int(c.severity) for c in sedatives)
+        self.assertEqual(total, 4)
+
+    def test_opium_hooks_fast(self):
+        """Ten doses is all it takes."""
+        consumer = _FakeConsumer(conditions=[_pain(3)])
+        consumer.db.substance_doses = {"opium": 9}
+        apply_substance(consumer, "opium")
+        addictions = [
+            c for c in consumer.medical_state.conditions
+            if getattr(c, "condition_type", None) == "addiction"
+        ]
+        self.assertEqual(len(addictions), 1)
+        self.assertEqual(addictions[0].prose_key, "opium")
+
+
+# ---------------------------------------------------------------------
+# Delivery wiring (#487): eat/drink/inhale carry pharmacology
+# ---------------------------------------------------------------------
+
+
+class TestDeliveryWiring(TestCase):
+    def _drink_cmd(self, item, target):
+        from unittest.mock import MagicMock
+        from commands.CmdConsumption import CmdDrink
+
+        cmd = CmdDrink()
+        cmd.caller = MagicMock()
+        cmd.caller.location = MagicMock()
+        cmd.args = "rotgut"
+        parse_result = {
+            "item": item, "target": target,
+            "body_location": None, "errors": [],
+        }
+        return cmd, parse_result
+
+    def test_drink_applies_dose_and_spends_a_use(self):
+        from unittest.mock import MagicMock, patch
+
+        item = MagicMock()
+        item.db = _FakeDB(substance="alcohol")
+        item.get_display_name = lambda looker=None: "bottle of rotgut"
+        target = MagicMock()
+        cmd, parse_result = self._drink_cmd(item, target)
+        # Drinking yourself: target is the caller.
+        target = cmd.caller
+        parse_result["target"] = target
+
+        with patch.object(cmd, "get_item_and_target",
+                          return_value=parse_result), \
+             patch("commands.CmdConsumption.supports_delivery",
+                   return_value=True), \
+             patch("commands.CmdConsumption.is_medical_item",
+                   return_value=False), \
+             patch("commands.CmdConsumption.msg_room_identity"), \
+             patch("world.substances.apply_substance",
+                   return_value={"feedback": ["The room tilts agreeably."]}
+                   ) as mock_dose, \
+             patch("world.consumables.consume_use",
+                   return_value={"success": True, "destroyed": False}
+                   ) as mock_use:
+            cmd.func()
+
+        mock_dose.assert_called_once_with(target, "alcohol")
+        mock_use.assert_called_once_with(item)
+        item.delete.assert_not_called()
+        sent = " ".join(
+            str(c.args[0]) for c in target.msg.call_args_list if c.args
+        )
+        self.assertIn("The room tilts agreeably.", sent)
+
+    def test_untracked_item_consumed_whole(self):
+        """Items without uses_left tracking fall back to full
+        deletion (legacy regular-food behavior preserved)."""
+        from unittest.mock import MagicMock, patch
+
+        item = MagicMock()
+        item.db = _FakeDB()  # no substance, no uses
+        item.get_display_name = lambda looker=None: "mystery snack"
+        cmd, parse_result = self._drink_cmd(item, None)
+        parse_result["target"] = cmd.caller
+
+        with patch.object(cmd, "get_item_and_target",
+                          return_value=parse_result), \
+             patch("commands.CmdConsumption.supports_delivery",
+                   return_value=True), \
+             patch("commands.CmdConsumption.is_medical_item",
+                   return_value=False), \
+             patch("commands.CmdConsumption.msg_room_identity"), \
+             patch("world.consumables.consume_use",
+                   return_value={"success": False, "destroyed": False}):
+            cmd.func()
+
+        item.delete.assert_called_once()


### PR DESCRIPTION
Closes #487 (spec §5 item 6; PR 2 of the #485 v1 scope).

**Three substances**, all expressible in the existing severity vocabulary — no new effect kinds needed yet:
- **Cannabis**: mellow (pain 1 + sedation cap 2), forgiving tolerance, slow 60-dose hook. *"The world has corners again. You remember when it didn't."*
- **Alcohol**: numbs to properly-drunk — sedation cap 4 = 0.60 consciousness penalty, impaired but standing. Blackout deliberately out of v1.
- **Opium**: the serious analgesic (pain relief 3/dose, sedation 2 toward the nod at cap 5), hooks in **ten doses**, slowest-decaying tolerance. Its danger is its identity.

Each gets a craving prose bank; cannabis and opium get smoke flavor banks in the house voice.

**Delivery wiring** — the §1 layering realized: `CmdEat`/`CmdDrink`/`CmdInhale` now call `apply_substance` after their item effects (previously **only smoke delivered pharmacology**). Non-medical consumables route through `consume_use` with legacy whole-item deletion as fallback. And the ingestion verbs no longer require `medical_item` — since #475 the delivery tag is the real gate, which also un-deadends the "regular drink/food" code paths that were previously unreachable.

**Prototypes:** `HAND_ROLLED_JOINT` (4 puffs), `ROTGUT_BOTTLE` (4 swigs), `OPIUM_CIGARETTE` (3 draws).

Test plan: 6 new tests (entries/specs/prose-bank integrity, opium analgesia, the six-shot alcohol cap, ten-dose opium hook, drink wiring incl. consume_use routing and legacy fallback); full `world.tests` 2,366/2,366. Verified end-to-end against real objects in the container: spawned bottle drinkable, six real shots → sedation 4, consciousness 0.40, doses recorded. Deployed with discrete steps; server healthy (fresh post-incident process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)