### PR TITLE
Serialized audit writer + server hang self-diagnostics

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -22,7 +22,41 @@ def at_server_init():
     """
     This is called first as the server is starting up, regardless of how.
     """
-    pass
+    _arm_hang_diagnostics()
+
+
+def _arm_hang_diagnostics():
+    """Arm faulthandler so a hung server can diagnose itself (#489).
+
+    Two reload-shutdown deadlocks (2026-06-11) left the Server alive
+    with every thread parked on a futex and no way to see the Python
+    stacks (Alpine/musl: no py-spy).  This arms two zero-cost probes:
+
+    * ``kill -USR1 <server pid>`` (from inside the container) dumps
+      every thread's stack to ``server/logs/hang_diagnostics.log``
+      on demand — run it WHILE the server is hung, before killing it.
+    * ``at_server_stop`` schedules an automatic dump 20s into any
+      shutdown — if shutdown completes normally the dump is
+      cancelled; if it deadlocks, the stacks land in the file with
+      no human in the loop.
+    """
+    import faulthandler
+    import os
+    import signal
+
+    from django.conf import settings
+
+    global _HANG_LOG
+    path = os.path.join(settings.LOG_DIR, "hang_diagnostics.log")
+    # Keep the handle open for the process lifetime — faulthandler
+    # needs a live fd at signal time.
+    _HANG_LOG = open(path, "a")
+    _HANG_LOG.write(f"\n=== armed (pid {os.getpid()}) ===\n")
+    _HANG_LOG.flush()
+    faulthandler.register(signal.SIGUSR1, file=_HANG_LOG, all_threads=True)
+
+
+_HANG_LOG = None
 
 
 def at_server_start():
@@ -38,6 +72,15 @@ def at_server_stop():
     This is called just before the server is shut down, regardless
     of it is for a reload, reset or shutdown.
     """
+    # #489: if this shutdown deadlocks (see _arm_hang_diagnostics),
+    # dump all thread stacks to the hang log 20s in.  A clean
+    # shutdown exits the process before the timer fires; a hung one
+    # self-reports.  cancel_dump… is unnecessary on clean exit.
+    import faulthandler
+    if _HANG_LOG is not None:
+        _HANG_LOG.write("\n=== shutdown began; auto-dump armed (20s) ===\n")
+        _HANG_LOG.flush()
+        faulthandler.dump_traceback_later(20, file=_HANG_LOG)
     pass
 
 

--- a/specs/COMBAT_AUDIT_LOGGING_SPEC.md
+++ b/specs/COMBAT_AUDIT_LOGGING_SPEC.md
@@ -48,11 +48,20 @@ object everywhere.
 Every `.msg()` on the router does up to two things:
 
 1. **Audit file — always on.** The message is appended to
-   `server/logs/combat_audit.log` via Evennia's async file logger
-   (`evennia.utils.logger.log_file`). Writes happen on the logger's
-   thread pool, never blocking the Twisted reactor. This is the
-   durable record for investigating bug reports, cheating
-   accusations, and combat disputes.
+   `server/logs/combat_audit.log` by the sink's own serialized
+   async writer (`_AuditFileWriter`, #489) — NOT
+   `evennia.utils.logger.log_file`, whose handle-recycling races
+   in-flight thread writes under burst load and whose errback
+   destroys the real error (the `NoneType: None` floods; every
+   line a silently dropped write). The writer chains every write
+   on one deferred (strict serialization, reactor never blocked),
+   rotates timestamped generations inside that chain
+   (`CHANNEL_LOG_ROTATE_SIZE`), reports failures with their real
+   traceback as `AUDIT_WRITE_FAILED` in the server log, and
+   reopens after any failure. **Test processes skip the file
+   entirely** — they share `server/logs/` with the live server,
+   and their writes both polluted the audit record and triggered
+   cross-process rotation races.
 
 2. **Splattercast channel — gated.** Only when
    `settings.SPLATTERCAST_LIVE` is `True`. This is the live in-game

--- a/world/combat/debug.py
+++ b/world/combat/debug.py
@@ -32,6 +32,10 @@ Functions:
 
 from __future__ import annotations
 
+import os
+import sys
+import time
+
 from django.conf import settings
 from django.core.exceptions import AppRegistryNotReady
 from django.db import Error as DatabaseError
@@ -42,6 +46,88 @@ from evennia.utils import logger
 from .constants import SPLATTERCAST_CHANNEL
 
 COMBAT_AUDIT_FILENAME = "combat_audit.log"
+
+#: Test processes share the game dir with the live server; their
+#: audit traffic must not touch production logs (it both pollutes
+#: them and triggers cross-process rotation races — issue #489).
+_UNDER_TEST = "test" in sys.argv
+
+
+class _AuditFileWriter:
+    """Serialized async writer for the combat audit log (#489).
+
+    Replaces ``evennia.utils.logger.log_file`` for audit traffic.
+    That helper has two diagnosed failure modes under burst load:
+    it closes its cached handle every 500 accesses while deferred
+    writes are still in flight (write-after-close), and its errback
+    discards the real failure and formats the absent *current*
+    exception — the infamous ``NoneType: None`` server-log flood,
+    each line a silently dropped write.
+
+    This writer:
+
+    * funnels every write through ONE deferred chain — writes are
+      strictly serialized, so no thread ever touches a handle
+      another thread (or a close) is using;
+    * rotates inside that same chain (timestamped generations, size
+      from ``settings.CHANNEL_LOG_ROTATE_SIZE``), so rotation can't
+      race a write;
+    * reports failures with their REAL traceback to the server log
+      (``AUDIT_WRITE_FAILED``) and reopens the handle for the next
+      write — one bad write never wedges the stream.
+    """
+
+    def __init__(self, filename: str):
+        self.filename = filename
+        self._handle = None
+        self._tail = None  # tail of the serialized write chain
+
+    # -- thread-side (always serialized) ---------------------------
+
+    def _path(self) -> str:
+        return os.path.join(settings.LOG_DIR, self.filename)
+
+    def _rotate_size(self) -> int:
+        return max(1000, getattr(settings, "CHANNEL_LOG_ROTATE_SIZE", 1000000))
+
+    def _write_sync(self, line: str) -> None:
+        if self._handle is None or self._handle.closed:
+            self._handle = open(self._path(), "a", encoding="utf-8")
+        self._handle.write(line)
+        self._handle.flush()
+        if self._handle.tell() >= self._rotate_size():
+            self._handle.close()
+            self._handle = None
+            os.replace(self._path(), f"{self._path()}.{int(time.time())}")
+
+    # -- reactor-side ----------------------------------------------
+
+    def _report_failure(self, failure):
+        # The whole point of #489: never lose the real traceback.
+        logger.log_err(
+            f"AUDIT_WRITE_FAILED ({self.filename}): "
+            f"{failure.getTraceback()}"
+        )
+        self._handle = None  # force reopen on the next write
+        return None  # consume the failure; the chain continues
+
+    def write(self, message: str) -> None:
+        from twisted.internet.defer import succeed
+        from twisted.internet.threads import deferToThread
+
+        stamp = time.strftime("%y-%m-%d %H:%M:%S")
+        line = f"\n{stamp} [-] {str(message).strip()}"
+        if self._tail is None:
+            self._tail = succeed(None)
+        # Chain: each write starts only after the previous finished —
+        # fired callbacks are consumed, so the chain doesn't grow.
+        self._tail = self._tail.addCallback(
+            lambda _result: deferToThread(self._write_sync, line)
+        )
+        self._tail.addErrback(self._report_failure)
+
+
+_AUDIT_WRITER = _AuditFileWriter(COMBAT_AUDIT_FILENAME)
 
 class _NullChannel:
     """No-op message sink.
@@ -85,13 +171,12 @@ class _AuditRouter:
     """
 
     def msg(self, message, **kwargs):
-        # Always-on audit write.  A filesystem failure here must never
-        # break combat for players, so the (and only the) expected I/O
-        # failure mode is swallowed; anything else surfaces.
-        try:
-            logger.log_file(str(message), filename=COMBAT_AUDIT_FILENAME)
-        except OSError:
-            pass
+        # Always-on audit write via the serialized writer (#489) —
+        # failures are reported reactor-side with real tracebacks and
+        # can never break combat for players.  Test processes skip
+        # the file entirely (shared log dir with the live server).
+        if not _UNDER_TEST:
+            _AUDIT_WRITER.write(message)
         # Opt-in live mirror.  A developer who set SPLATTERCAST_LIVE is
         # in an active debugging session and *wants* failures to
         # surface, so this path is deliberately unguarded.

--- a/world/tests/test_audit_writer.py
+++ b/world/tests/test_audit_writer.py
@@ -1,0 +1,79 @@
+"""Tests for the serialized audit-log writer (issue #489).
+
+The writer replaced ``evennia.utils.logger.log_file`` for audit
+traffic after diagnosing that helper's burst-load failure modes:
+handle recycling racing in-flight thread writes, and an errback that
+destroys the real error (the ``NoneType: None`` server-log floods —
+each line a silently dropped audit write).
+
+These tests drive the thread-side internals synchronously; the
+serialization property itself is structural (one deferred chain).
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_audit_writer
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.combat.debug import _AuditFileWriter
+
+
+class TestAuditWriterSync(TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.writer = _AuditFileWriter("audit_test.log")
+        patcher = patch("world.combat.debug.settings")
+        self.mock_settings = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.mock_settings.LOG_DIR = self.tmp.name
+        self.mock_settings.CHANNEL_LOG_ROTATE_SIZE = 1_000_000
+        self.addCleanup(self.tmp.cleanup)
+
+    def _read(self):
+        with open(os.path.join(self.tmp.name, "audit_test.log")) as f:
+            return f.read()
+
+    def test_writes_append_and_flush(self):
+        self.writer._write_sync("\nline one")
+        self.writer._write_sync("\nline two")
+        content = self._read()
+        self.assertIn("line one", content)
+        self.assertIn("line two", content)
+
+    def test_rotation_inside_the_write_path(self):
+        """Crossing the size threshold renames the file to a
+        timestamped generation; the next write starts fresh."""
+        self.mock_settings.CHANNEL_LOG_ROTATE_SIZE = 1000
+        self.writer._write_sync("\n" + "x" * 1200)
+        self.writer._write_sync("\nafter rotation")
+
+        names = os.listdir(self.tmp.name)
+        rotated = [n for n in names if n.startswith("audit_test.log.")]
+        self.assertEqual(len(rotated), 1)
+        self.assertIn("after rotation", self._read())
+        self.assertNotIn("xxx", self._read())
+
+    def test_failure_reports_real_traceback_and_recovers(self):
+        """The #489 contract: a failed write logs the actual
+        traceback (never NoneType: None) and the next write reopens."""
+        failure = MagicMock()
+        failure.getTraceback.return_value = "Traceback: the real error"
+        with patch("world.combat.debug.logger") as mock_logger:
+            self.writer._handle = MagicMock()  # poisoned handle
+            result = self.writer._report_failure(failure)
+
+        self.assertIsNone(result)  # failure consumed; chain continues
+        self.assertIsNone(self.writer._handle)  # reopen forced
+        logged = str(mock_logger.log_err.call_args)
+        self.assertIn("AUDIT_WRITE_FAILED", logged)
+        self.assertIn("the real error", logged)
+
+        # Next write recovers cleanly.
+        self.writer._write_sync("\nrecovered")
+        self.assertIn("recovered", self._read())


### PR DESCRIPTION
Closes #489.

**Diagnosis** (`NoneType: None` floods): `evennia.utils.logger.log_file`'s errback discards the failure and calls `log_trace()`, which formats the *current* exception — of which there is none in an errback. Every failed async write prints literally `NoneType: None` and destroys the real error. Failure sources: the handle cache closes every 500 accesses while writes are in flight, plus test processes sharing `server/logs/` and rotating `combat_audit.log` under the live server. Timeline: 1–17/day before the audit sink existed → 842/day after → bursts of 100–233/second exactly at test-suite runs. **Every line was a silently dropped audit write** (1,478 total).

**Fix:** the sink owns its writer. `_AuditFileWriter` chains every write on one deferred (strict serialization, reactor never blocks), rotates timestamped generations inside that chain, reports failures with their **real traceback** (`AUDIT_WRITE_FAILED`), reopens after any failure. Test processes skip production file writes entirely.

**Hang self-diagnosis:** two reload-shutdown deadlocks today left the Server futex-parked with no Python-level visibility (Alpine/musl: no py-spy). `at_server_init` arms `faulthandler` — `kill -USR1` dumps all stacks on demand, and `at_server_stop` schedules an automatic dump 20s into any shutdown, so a hung reload writes its own autopsy. The deadlock is **not yet attributed** (new today; my own changes are prime suspects) — this instrumentation exists to name it.

**Verified post-restart:** zero `NoneType` since boot (every prior boot accumulated them in minutes), zero write failures, audit file taking live medical-tick traffic through the new writer. 3 new writer tests; full `world.tests` 2,369/2,369.

Follow-ups: upstream Evennia bug report; possible stdlib QueueListener swap per best-practice discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)