### PR TITLE
Fix infection trigger: ghost damage types disabled the whole loop

### DIFF
--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -460,8 +460,17 @@ def create_condition_from_damage(damage_amount, damage_type, location=None):
         pain_severity = min(8, max(1, damage_amount // 2))
         conditions.append(PainCondition(pain_severity, location))
     
-    # Add infection risk for penetrating wounds
-    if damage_type in ['bullet', 'blade', 'pierce'] and damage_amount >= 8:
+    # Add infection risk for penetrating/dirty wounds.  #495: the old
+    # gate listed 'blade'/'pierce' — ghost types no caller ever sends
+    # (the real vocabulary is cut/stab/laceration/blunt/blast/bullet)
+    # — so only bullets could infect and the antiseptic loop was dead.
+    #
+    # INTERIM MODEL: flat chance on heavy penetrating hits.  The
+    # designed future model is circumstantial, not random-per-hit:
+    # poor wound treatment, environment (open wounds in sewers),
+    # and retained foreign bodies (an untreated bullet still in the
+    # wound) should drive infection instead.
+    if damage_type in ['bullet', 'cut', 'stab', 'laceration'] and damage_amount >= 8:
         if random.randint(1, 100) <= 25:  # 25% chance
             infection_severity = random.randint(1, 3)
             conditions.append(InfectionCondition(infection_severity, location))

--- a/world/tests/test_condition_creation.py
+++ b/world/tests/test_condition_creation.py
@@ -1,0 +1,62 @@
+"""Tests for damage → condition creation (issue #495).
+
+Pins the trigger vocabulary so ghost damage types can't silently
+disable a condition again — the old infection gate listed
+'blade'/'pierce', which no caller ever sends, leaving only bullets
+able to infect.
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_condition_creation
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.medical.conditions import create_condition_from_damage
+
+
+def _types(conditions):
+    return [c.condition_type for c in conditions]
+
+
+class TestInfectionTrigger(TestCase):
+    @patch("world.medical.conditions.random.randint", return_value=1)
+    def test_heavy_penetrating_wounds_can_infect(self, _r):
+        """All real penetrating types infect on a heavy hit (interim
+        random model; future model is circumstantial — treatment
+        quality, environment, retained foreign bodies)."""
+        for dtype in ("bullet", "cut", "stab", "laceration"):
+            conditions = create_condition_from_damage(10, dtype, "chest")
+            self.assertIn("infection", _types(conditions), dtype)
+
+    @patch("world.medical.conditions.random.randint", return_value=1)
+    def test_blunt_does_not_infect(self, _r):
+        """Closed trauma doesn't break skin — no infection path."""
+        conditions = create_condition_from_damage(10, "blunt", "chest")
+        self.assertNotIn("infection", _types(conditions))
+
+    @patch("world.medical.conditions.random.randint", return_value=1)
+    def test_light_wounds_do_not_infect(self, _r):
+        conditions = create_condition_from_damage(5, "cut", "chest")
+        self.assertNotIn("infection", _types(conditions))
+
+    @patch("world.medical.conditions.random.randint", return_value=100)
+    def test_infection_is_chance_based(self, _r):
+        """Roll of 100 > 25 → heavy cut, no infection this time."""
+        conditions = create_condition_from_damage(10, "cut", "chest")
+        self.assertNotIn("infection", _types(conditions))
+
+
+class TestBaselineConditions(TestCase):
+    @patch("world.medical.conditions.random.randint", return_value=100)
+    def test_any_damage_produces_pain(self, _r):
+        conditions = create_condition_from_damage(3, "blunt", "left_arm")
+        self.assertIn("pain", _types(conditions))
+
+    @patch("world.medical.conditions.random.randint", return_value=100)
+    def test_heavy_damage_produces_bleeding(self, _r):
+        conditions = create_condition_from_damage(10, "cut", "left_arm")
+        self.assertIn("minor_bleeding", _types(conditions))


### PR DESCRIPTION
Closes #495. The infection gate listed `blade`/`pierce` — damage types nothing ever sends — so only bullets could infect and antiseptics were dead content. Penetrating types (bullet/cut/stab/laceration) now infect at the existing heavy-hit 25% chance; blunt stays clean. Flat chance is documented as an interim placeholder per design discussion — the real model will be circumstantial (treatment quality, sewer-wading with open wounds, retained bullets). 6 new tests pin the vocabulary. Full suite 2,376/2,376. Live reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)