### PR TITLE
Cadence Phase 1: elapsed-time condition rates

### DIFF
--- a/world/medical/clock.py
+++ b/world/medical/clock.py
@@ -1,0 +1,23 @@
+"""The medical clock seam (CONDITION_CADENCE_SPEC §4.1, issue #501).
+
+All condition-rate math reads elapsed time through this one
+function.  Today it is wall-clock; when the in-game time system
+(#301) arrives, it plugs in here and every condition inherits it
+for free.  No condition or script may call ``time.time()`` for rate
+math directly.
+"""
+from __future__ import annotations
+
+import time
+
+
+def now() -> float:
+    """Current clock value (seconds).  The swap point for #301."""
+    return time.time()
+
+
+def elapsed_game_minutes(since: float, current: float | None = None) -> float:
+    """Real minutes elapsed since ``since`` (never negative)."""
+    if current is None:
+        current = now()
+    return max(0.0, (current - since) / 60.0)

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -11,10 +11,30 @@ from .constants import (
     INJURY_SEVERITY_MULTIPLIERS,
     BLOOD_LOSS_PER_SEVERITY,
     HEALING_EFFECTIVENESS,
-    CONDITION_INTERVALS, 
-    BLEEDING_DAMAGE_THRESHOLDS, 
-    CONDITION_TRIGGERS
+    BLEEDING_DAMAGE_THRESHOLDS,
+    CONDITION_TRIGGERS,
+    BLEEDING_CLOT_HAZARD_PER_MINUTE,
+    PAIN_DECAY_HAZARD_PER_MINUTE,
+    INFECTION_IMPROVE_HAZARD_PER_MINUTE,
+    INFECTION_WORSEN_HAZARD_PER_MINUTE,
+    CONSCIOUSNESS_RECOVERY_HAZARD_PER_MINUTE,
+    ELAPSED_CAP_MINUTES,
 )
+from .clock import elapsed_game_minutes
+from .clock import now as clock_now
+
+
+def hazard_fires(p_per_minute: float, elapsed_minutes: float) -> bool:
+    """Sample a per-minute hazard over an elapsed window (spec §4.4).
+
+    ``1 - (1 - p) ** t`` — the probability the event fired at least
+    once during ``t`` minutes.  Cadence-independent: six 10s samples
+    and one 60s sample have identical distributions.
+    """
+    if p_per_minute <= 0 or elapsed_minutes <= 0:
+        return False
+    p = min(0.95, p_per_minute)
+    return random.random() < 1 - (1 - p) ** elapsed_minutes
 
 
 class MedicalCondition:
@@ -33,6 +53,29 @@ class MedicalCondition:
         self.tick_interval = tick_interval  # Not used directly anymore, but kept for compatibility
         self.requires_ticker = True
         self.treated = False
+        # CONDITION_CADENCE_SPEC (#501): when this condition last had
+        # time applied.  Rates are per real minute; ticks just sample.
+        self.last_processed = clock_now()
+
+    def process(self, character, current=None):
+        """Apply elapsed time to this condition (spec §4.2).
+
+        The only entry point carriers (medical script today, the
+        tactical tier later) should call.  Computes capped elapsed
+        minutes since ``last_processed``, hands them to
+        ``tick_effect``, and advances the marker.  The cap (§4.3)
+        means reloads/crashes never bill more than one extra
+        sampling gap.
+        """
+        if current is None:
+            current = clock_now()
+        elapsed = min(
+            elapsed_game_minutes(self.last_processed, current),
+            ELAPSED_CAP_MINUTES,
+        )
+        self.last_processed = current
+        if elapsed > 0:
+            self.tick_effect(character, elapsed)
         
     def start_condition(self, character):
         """Begin condition management for character."""
@@ -60,8 +103,11 @@ class MedicalCondition:
         else:
             splattercast.msg(f"CONDITION_START: Failed to start medical script for {character.key}")
             
-    def tick_effect(self, character):
-        """Override in subclasses to implement specific effects."""
+    def tick_effect(self, character, elapsed_minutes=1.0):
+        """Apply ``elapsed_minutes`` of this condition's per-minute
+        rates.  Override in subclasses.  The default of 1.0 keeps
+        direct callers (tests, legacy) equivalent to one old-style
+        60s tick."""
         pass
         
     def should_end(self):
@@ -116,7 +162,8 @@ class MedicalCondition:
             "location": self.location,
             "tick_interval": self.tick_interval,
             "requires_ticker": self.requires_ticker,
-            "treated": self.treated
+            "treated": self.treated,
+            "last_processed": self.last_processed,
         }
         
     @classmethod
@@ -131,6 +178,7 @@ class MedicalCondition:
         condition.tick_interval = data.get("tick_interval", 60)
         condition.requires_ticker = data.get("requires_ticker", True)
         condition.treated = data.get("treated", False)
+        condition.last_processed = data.get("last_processed", clock_now())
         return condition
         
     def end_condition(self, character):
@@ -151,8 +199,8 @@ class BleedingCondition(MedicalCondition):
         super().__init__("minor_bleeding", severity, location, tick_interval=60)
         self.blood_loss_rate = BLOOD_LOSS_PER_SEVERITY.get(severity, 1)
         
-    def tick_effect(self, character):
-        """Apply blood loss and potentially reduce severity."""
+    def tick_effect(self, character, elapsed_minutes=1.0):
+        """Apply ``elapsed_minutes`` of blood loss; chance to clot."""
         from world.combat.debug import get_splattercast
 
         splattercast = get_splattercast()
@@ -170,19 +218,23 @@ class BleedingCondition(MedicalCondition):
         if self._location_stabilized(medical_state):
             return
 
-        # Calculate blood loss
-        blood_loss = self.blood_loss_rate
+        # Per-minute blood loss x elapsed.  NOTE: the treated path
+        # keeps the historical int() truncation deliberately — at
+        # common severities int(rate * 0.3) is 0, i.e. "treated"
+        # currently means *stopped*.  Preserved for equivalence
+        # (#501 §5); retune as a separate balance decision.
+        rate_per_minute = self.blood_loss_rate
         if self.treated:
-            blood_loss = int(blood_loss * 0.3)  # Treated bleeding loses less blood
+            rate_per_minute = int(rate_per_minute * 0.3)
+        blood_loss = rate_per_minute * elapsed_minutes
 
-        # Apply blood loss
-        old_blood = medical_state.blood_level
-        medical_state.blood_level = max(0, medical_state.blood_level - blood_loss)
+        if blood_loss > 0:
+            old_blood = medical_state.blood_level
+            medical_state.blood_level = max(0, medical_state.blood_level - blood_loss)
+            splattercast.msg(f"BLOOD_LOSS: {character.key} loses {blood_loss:.2f} blood ({old_blood:.1f} -> {medical_state.blood_level:.1f})")
 
-        splattercast.msg(f"BLOOD_LOSS: {character.key} loses {blood_loss} blood ({old_blood} -> {medical_state.blood_level})")
-
-        # Check for natural healing (random chance to reduce severity)
-        if not self.treated and random.randint(1, 100) <= 10:  # 10% chance per tick
+        # Natural clotting — per-minute hazard sampled over elapsed.
+        if not self.treated and hazard_fires(BLEEDING_CLOT_HAZARD_PER_MINUTE, elapsed_minutes):
             self.severity = max(0, self.severity - 1)
             splattercast.msg(f"BLEEDING_HEAL: {character.key} bleeding severity reduced to {self.severity}")
 
@@ -264,6 +316,7 @@ class BleedingCondition(MedicalCondition):
         condition.requires_ticker = data.get("requires_ticker", True)
         condition.treated = data.get("treated", False)
         condition.blood_loss_rate = data.get("blood_loss_rate", condition.blood_loss_rate)
+        condition.last_processed = data.get("last_processed", clock_now())
         return condition
 
 
@@ -273,14 +326,14 @@ class PainCondition(MedicalCondition):
     def __init__(self, severity, location=None):
         super().__init__("pain", severity, location, tick_interval=120)  # Longer interval
         
-    def tick_effect(self, character):
+    def tick_effect(self, character, elapsed_minutes=1.0):
         """Pain naturally diminishes over time."""
         from world.combat.debug import get_splattercast
         
         splattercast = get_splattercast()
         
-        # Natural pain reduction
-        if random.randint(1, 100) <= 20:  # 20% chance per tick
+        # Natural pain reduction — per-minute hazard over elapsed.
+        if hazard_fires(PAIN_DECAY_HAZARD_PER_MINUTE, elapsed_minutes):
             self.severity = max(0, self.severity - 1)
             splattercast.msg(f"PAIN_HEAL: {character.key} pain severity reduced to {self.severity}")
             
@@ -319,6 +372,7 @@ class PainCondition(MedicalCondition):
         condition.tick_interval = data.get("tick_interval", 120)
         condition.requires_ticker = data.get("requires_ticker", True)
         condition.treated = data.get("treated", False)
+        condition.last_processed = data.get("last_processed", clock_now())
         return condition
 
 
@@ -331,34 +385,29 @@ class InfectionCondition(MedicalCondition):
         self.last_progression_check = 0  # Track time for proper progression timing
         self.environmental_modifier = 1.0  # Multiplier for environmental conditions (sewers, etc.)
         
-    def tick_effect(self, character):
-        """Infection can worsen if untreated, or improve if treated."""
+    def tick_effect(self, character, elapsed_minutes=1.0):
+        """Infection can worsen if untreated, or improve if treated.
+
+        #501 §5 RESTORATION: the per-tick numbers had drifted 5x from
+        their design (authored against the old 12s tick).  These
+        hazards restore the documented pacing — treated infection
+        "improves every ~5 minutes", untreated follows the
+        "realistic ~20min progression", scaled by the environmental
+        modifier (the future sewers-and-neglect lever).
+        """
         from world.combat.debug import get_splattercast
-        import time
-        
+
         splattercast = get_splattercast()
-        current_time = time.time()
-        
-        # Initialize timing tracking if needed
-        if self.last_progression_check == 0:
-            self.last_progression_check = current_time
-            return  # Skip first tick to establish baseline
-        
+
         if self.treated:
-            # Treated infection improves every ~5 minutes (25 ticks at 12s intervals)
-            if random.randint(1, 100) <= 12:  # ~30% chance over 25 ticks = 1.2% per tick
+            if hazard_fires(INFECTION_IMPROVE_HAZARD_PER_MINUTE, elapsed_minutes):
                 self.severity = max(0, self.severity - 1)
                 splattercast.msg(f"INFECTION_HEAL: {character.key} infection severity reduced to {self.severity}")
         else:
-            # Calculate effective progression chance based on timing and environment
-            effective_chance = self.base_progression_chance * self.environmental_modifier
-            
-            # Untreated infection can worsen - designed for realistic ~20min progression
-            if random.randint(1, 10000) <= int(effective_chance * 100):  # More granular probability
+            worsen_hazard = INFECTION_WORSEN_HAZARD_PER_MINUTE * self.environmental_modifier
+            if hazard_fires(worsen_hazard, elapsed_minutes):
                 self.severity = min(10, self.severity + 1)  # Cap at 10
                 splattercast.msg(f"INFECTION_WORSEN: {character.key} infection severity increased to {self.severity} (env modifier: {self.environmental_modifier}x)")
-                
-        self.last_progression_check = current_time
     
     def set_environmental_modifier(self, modifier):
         """Set environmental infection risk modifier (e.g., 3.0 for sewers, 0.5 for sterile conditions)"""
@@ -387,6 +436,7 @@ class InfectionCondition(MedicalCondition):
         condition.tick_interval = data.get("tick_interval", 300)
         condition.requires_ticker = data.get("requires_ticker", True)
         condition.treated = data.get("treated", False)
+        condition.last_processed = data.get("last_processed", clock_now())
         return condition
 
     def disables_organ_at_severity(self):
@@ -492,24 +542,18 @@ class ConsciousnessSuppressionCondition(MedicalCondition):
         self.suppression_type = suppression_type  # "knockout", "sedative", "anesthesia", "trauma"
         self.consciousness_penalty = min(1.0, severity * 0.15)  # Up to 1.5 consciousness reduction at severity 10
         
-    def tick_effect(self, character):
+    def tick_effect(self, character, elapsed_minutes=1.0):
         """Consciousness suppression naturally diminishes over time."""
         from world.combat.debug import get_splattercast
         
         splattercast = get_splattercast()
         
-        # Natural recovery from consciousness suppression 
-        # Different types recover at different rates
-        recovery_rates = {
-            "knockout": 25,      # Fast recovery from blunt trauma
-            "sedative": 15,      # Moderate recovery from drugs  
-            "anesthesia": 10,    # Slower recovery from medical anesthesia
-            "trauma": 20         # Moderate recovery from head trauma
-        }
+        # Natural recovery — per-minute hazard by suppression type.
+        recovery_hazard = CONSCIOUSNESS_RECOVERY_HAZARD_PER_MINUTE.get(
+            self.suppression_type, 0.20,
+        )
         
-        recovery_chance = recovery_rates.get(self.suppression_type, 20)
-        
-        if random.randint(1, 100) <= recovery_chance:
+        if hazard_fires(recovery_hazard, elapsed_minutes):
             self.severity = max(0, self.severity - 1)
             # Recalculate consciousness penalty
             self.consciousness_penalty = min(1.0, self.severity * 0.15)
@@ -554,6 +598,7 @@ class ConsciousnessSuppressionCondition(MedicalCondition):
         condition.tick_interval = data.get("tick_interval", 180)
         condition.requires_ticker = data.get("requires_ticker", True)
         condition.treated = data.get("treated", False)
+        condition.last_processed = data.get("last_processed", clock_now())
         return condition
 
 
@@ -586,7 +631,7 @@ class AddictionCondition(MedicalCondition):
         self.prose_key = prose_key
         self.craving_after = craving_after
         self.last_dose_time = time.time()
-        self._overdue_ticks = 0  # transient; not persisted
+        self._last_prose_time = 0.0  # transient; not persisted
 
     # -- state ---------------------------------------------------
 
@@ -598,7 +643,7 @@ class AddictionCondition(MedicalCondition):
     def record_dose(self):
         """A dose landed — cravings (and their ache) reset."""
         self.last_dose_time = time.time()
-        self._overdue_ticks = 0
+        self._last_prose_time = 0.0
 
     # -- condition contract ---------------------------------------
 
@@ -609,15 +654,17 @@ class AddictionCondition(MedicalCondition):
     def get_pain_contribution(self):
         return 1 if self.is_craving() else 0
 
-    def tick_effect(self, character):
+    def tick_effect(self, character, elapsed_minutes=1.0):
         if not self.is_craving():
-            self._overdue_ticks = 0
+            self._last_prose_time = 0.0
             return
-        self._overdue_ticks = getattr(self, "_overdue_ticks", 0) + 1
-        # Surface prose on the first overdue tick, then every ~5
-        # ticks (≈5 minutes at the production interval) — pressure,
-        # not spam.
-        if self._overdue_ticks % 5 == 1:
+        # Surface prose immediately on becoming overdue, then every
+        # ~5 minutes of real time — pressure, not spam.  (#501:
+        # converted from tick-counting to elapsed time.)
+        current = clock_now()
+        last = getattr(self, "_last_prose_time", 0.0)
+        if current - last >= 300 or last == 0.0:
+            self._last_prose_time = current
             from world.substances.registry import pick_craving_line
             line = pick_craving_line(self.prose_key)
             if line and hasattr(character, "msg"):
@@ -647,6 +694,7 @@ class AddictionCondition(MedicalCondition):
         condition.max_severity = data.get("max_severity", condition.severity)
         condition.treated = data.get("treated", False)
         condition.last_dose_time = data.get("last_dose_time", time.time())
+        condition.last_processed = data.get("last_processed", clock_now())
         return condition
 
 

--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -157,20 +157,36 @@ ORGAN_REPAIR_PARTIAL_DENOMINATOR = 2
 # MEDICAL CONDITION TICKER CONSTANTS (Phase 2.6)
 # ===================================================================
 
-# Ticker intervals for different condition types
-COMBAT_TICK_INTERVAL = 6              # Combat speed (matches combat rounds)
-SEVERE_BLEEDING_INTERVAL = 12         # 2 combat rounds - balanced threat
-MEDICAL_TICK_INTERVAL = 60            # Medical progression speed
+# Medical progression sampling interval.  CONDITION_CADENCE_SPEC:
+# rates below are PER MINUTE OF REAL TIME; this interval is just how
+# often the medical script samples them.  Changing it does not change
+# game balance.  (The old CONDITION_INTERVALS per-condition table was
+# dead config from an abandoned design — deleted in #501 Phase 1; the
+# future tactical tier rides the combat handler, not this constant.)
+MEDICAL_TICK_INTERVAL = 60
 
-# Condition type to ticker interval mapping
-CONDITION_INTERVALS = {
-    "burning": COMBAT_TICK_INTERVAL,           # 6s - immediate tactical threat
-    "acid_exposure": COMBAT_TICK_INTERVAL,     # 6s - immediate tactical threat  
-    "severe_bleeding": SEVERE_BLEEDING_INTERVAL, # 12s - significant but manageable
-    "minor_bleeding": MEDICAL_TICK_INTERVAL,   # 60s - natural clotting
-    "wound_healing": MEDICAL_TICK_INTERVAL,    # 60s - progression over time
-    "infection": MEDICAL_TICK_INTERVAL,        # 60s - slow development
-    "pain": MEDICAL_TICK_INTERVAL              # 60s - gradual reduction
+# Downtime cap (spec §4.3): a single process() applies at most this
+# many minutes of effect, so reloads/crashes never bill players for
+# server downtime.  2x the expected sampling gap.
+ELAPSED_CAP_MINUTES = 2.0
+
+# Per-minute hazards for chance-based condition drift (spec §4.4).
+# Authored per minute; sampled at any cadence via
+# 1 - (1 - p) ** elapsed_minutes.
+BLEEDING_CLOT_HAZARD_PER_MINUTE = 0.10      # untreated natural clotting
+PAIN_DECAY_HAZARD_PER_MINUTE = 0.20         # pain fading one severity
+INFECTION_IMPROVE_HAZARD_PER_MINUTE = 0.07  # treated: ~"improves every
+                                            # ~5 minutes" per the
+                                            # original design comment
+                                            # (1-(1-.07)^5 ≈ 30%/5min)
+INFECTION_WORSEN_HAZARD_PER_MINUTE = 0.05   # untreated, x environmental
+                                            # modifier: the documented
+                                            # "~20min progression"
+CONSCIOUSNESS_RECOVERY_HAZARD_PER_MINUTE = {
+    "knockout": 0.25,
+    "sedative": 0.15,
+    "anesthesia": 0.10,
+    "trauma": 0.20,
 }
 
 # Condition severity thresholds based on damage amounts

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -124,6 +124,9 @@ class Organ:
         # but the rate persists.  Cleared on full heal or organ
         # replacement.
         self.dressing_rate = 0
+        # Fractional HP progress toward the next whole point of
+        # dressed healing (#501) — persisted with the organ.
+        self.dressing_progress = 0.0
         
     @property
     def current_hp(self):
@@ -471,6 +474,7 @@ class Organ:
             "wound_timestamp": self.wound_timestamp,
             "stabilized": self.stabilized,
             "dressing_rate": self.dressing_rate,
+            "dressing_progress": getattr(self, "dressing_progress", 0.0),
         }
         
     @classmethod
@@ -511,6 +515,7 @@ class Organ:
         # not-healing.
         try:
             organ.dressing_rate = int(data.get("dressing_rate", 0) or 0)
+            organ.dressing_progress = float(data.get("dressing_progress", 0.0) or 0.0)
         except (TypeError, ValueError):
             organ.dressing_rate = 0
         # Issue #346: persisted organs may predate ``display_location`` —

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -52,13 +52,17 @@ def _hp_per_tick(dressing_rate: int) -> int:
     return max(base, WOUND_HEALING_FLOOR_HP_PER_TICK)
 
 
-def _process_healing(character, medical_state) -> list:
+def _process_healing(character, medical_state, elapsed_minutes=1.0) -> list:
     """Walk stabilized + dressed organs; restore HP per dressing rate.
 
-    Returns the list of organs that received HP this tick (used by
-    the caller for logging).  Organs that reach full HP clear their
-    ``stabilized`` + ``dressing_rate`` automatically via the
-    ``Organ.heal`` code path.
+    #501: the rate is per MINUTE (the old per-tick value 1:1, since
+    the tick was 60s).  Fractional progress accumulates on the organ
+    (``dressing_progress``, persisted) and converts to whole HP via
+    ``Organ.heal`` — granularity-independent like everything else.
+
+    Returns the list of organs that received HP this pass.  Organs
+    that reach full HP clear their ``stabilized`` + ``dressing_rate``
+    automatically via the ``Organ.heal`` code path.
     """
     healed = []
     organs = getattr(medical_state, "organs", None) or {}
@@ -70,11 +74,16 @@ def _process_healing(character, medical_state) -> list:
             continue
         if organ.current_hp >= organ.max_hp:
             continue
-        hp_gain = _hp_per_tick(rate)
-        if hp_gain <= 0:
+        hp_per_minute = _hp_per_tick(rate)
+        if hp_per_minute <= 0:
             continue
-        organ.heal(hp_gain)
-        healed.append(organ)
+        progress = getattr(organ, "dressing_progress", 0.0) or 0.0
+        progress += hp_per_minute * elapsed_minutes
+        whole = int(progress)
+        organ.dressing_progress = progress - whole
+        if whole > 0:
+            organ.heal(whole)
+            healed.append(organ)
     return healed
 
 
@@ -152,7 +161,7 @@ class MedicalScript(DefaultScript):
                 try:
                     if hasattr(condition, 'requires_ticker') and condition.requires_ticker:
                         splattercast.msg(f"MEDICAL_SCRIPT: Ticking {condition.condition_type} severity {condition.severity}")
-                        condition.tick_effect(self.obj)
+                        condition.process(self.obj)
                         
                         # Track bleeding severity for consolidated messaging
                         if condition.condition_type == "minor_bleeding":
@@ -191,7 +200,24 @@ class MedicalScript(DefaultScript):
             # carry a dressing rate; restore HP proportional to the
             # rate.  Cheap in-memory pass — no per-organ DB hits
             # beyond the medical_state fetch already done above.
-            healed_organs = _process_healing(self.obj, medical_state)
+            # Healing elapsed: same clock seam as conditions (#501).
+            from world.medical.clock import elapsed_game_minutes
+            from world.medical.clock import now as clock_now
+            from world.medical.constants import ELAPSED_CAP_MINUTES
+            # ndb deliberately (#501 hygiene / DB-write doctrine):
+            # a per-tick persisted write here measured 4.5x tick cost
+            # at N=1000.  Reload resets the marker to "now", which is
+            # exactly the downtime cap's intent anyway.
+            heal_now = clock_now()
+            last_heal = self.ndb.last_heal_process or heal_now
+            heal_elapsed = min(
+                elapsed_game_minutes(last_heal, heal_now),
+                ELAPSED_CAP_MINUTES,
+            )
+            self.ndb.last_heal_process = heal_now
+            healed_organs = _process_healing(
+                self.obj, medical_state, elapsed_minutes=heal_elapsed,
+            )
             if healed_organs:
                 splattercast.msg(
                     f"MEDICAL_SCRIPT: Healing tick restored HP on "

--- a/world/tests/test_condition_cadence.py
+++ b/world/tests/test_condition_cadence.py
@@ -1,0 +1,176 @@
+"""Phase 1 test contract for CONDITION_CADENCE_SPEC (issue #501).
+
+Pins the guarantees of the elapsed-time rates refactor:
+
+* equivalence — one process() spanning a minute behaves like one
+  old-style 60s tick;
+* granularity-independence — six 10s samples equal one 60s sample
+  for continuous quantities, and hazards share one closed form;
+* the downtime cap — a process() after long downtime applies at
+  most ELAPSED_CAP_MINUTES of effect;
+* restoration — infection runs at its documented pacing, not the
+  5x drift;
+* persistence — last_processed and dressing_progress round-trip.
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_condition_cadence
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.medical.conditions import (
+    BleedingCondition,
+    InfectionCondition,
+    PainCondition,
+    deserialize_condition,
+    hazard_fires,
+)
+from world.medical.constants import (
+    ELAPSED_CAP_MINUTES,
+    INFECTION_IMPROVE_HAZARD_PER_MINUTE,
+    INFECTION_WORSEN_HAZARD_PER_MINUTE,
+)
+from world.medical.core import MedicalState
+
+
+def _patient():
+    state = MedicalState(character=None)
+    target = SimpleNamespace(medical_state=state, key="cadence-test")
+    return target, state
+
+
+class TestHazardMath(TestCase):
+    def test_zero_elapsed_never_fires(self):
+        with patch("world.medical.conditions.random.random", return_value=0.0):
+            self.assertFalse(hazard_fires(0.5, 0.0))
+
+    def test_closed_form_is_cadence_independent(self):
+        """P(fire over 1 min) sampled once == sampled in six 10s
+        slices: 1-(1-p)^1 vs 1-((1-p)^(1/6))^6 — identical by
+        construction; verify the boundary behavior numerically."""
+        p = 0.10
+        once = 1 - (1 - p) ** 1.0
+        six = 1 - ((1 - p) ** (1 / 6)) ** 6
+        self.assertAlmostEqual(once, six, places=12)
+
+    def test_threshold_behavior(self):
+        # Just under the fire threshold → fires; just over → doesn't.
+        with patch("world.medical.conditions.random.random", return_value=0.0999):
+            self.assertTrue(hazard_fires(0.10, 1.0))
+        with patch("world.medical.conditions.random.random", return_value=0.1001):
+            self.assertFalse(hazard_fires(0.10, 1.0))
+
+
+class TestBleedingEquivalence(TestCase):
+    def test_one_minute_equals_one_old_tick(self):
+        """Severity 3 = 1.5 blood per old 60s tick; one process()
+        spanning exactly one minute loses exactly that."""
+        target, state = _patient()
+        condition = BleedingCondition(3, "chest")
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        with patch("world.medical.conditions.random.random", return_value=0.99):
+            condition.process(target, current=1060.0)  # +60s
+        self.assertAlmostEqual(state.blood_level, 100.0 - 1.5)
+
+    def test_six_small_samples_equal_one_big_sample(self):
+        target_a, state_a = _patient()
+        cond_a = BleedingCondition(3, "chest")
+        state_a.add_condition(cond_a)
+        cond_a.last_processed = 1000.0
+
+        target_b, state_b = _patient()
+        cond_b = BleedingCondition(3, "chest")
+        state_b.add_condition(cond_b)
+        cond_b.last_processed = 1000.0
+
+        with patch("world.medical.conditions.random.random", return_value=0.99):
+            cond_a.process(target_a, current=1060.0)
+            for i in range(1, 7):
+                cond_b.process(target_b, current=1000.0 + i * 10)
+
+        self.assertAlmostEqual(state_a.blood_level, state_b.blood_level)
+
+    def test_treated_truncation_preserved(self):
+        """Historical behavior kept deliberately: treated bleeding at
+        common severities loses zero blood (int truncation)."""
+        target, state = _patient()
+        condition = BleedingCondition(3, "chest")
+        condition.treated = True
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        with patch("world.medical.conditions.random.random", return_value=0.99):
+            condition.process(target, current=1060.0)
+        self.assertEqual(state.blood_level, 100.0)
+
+
+class TestDowntimeCap(TestCase):
+    def test_long_downtime_bills_at_most_the_cap(self):
+        """A 30-minute gap (reload, crash) applies at most
+        ELAPSED_CAP_MINUTES of bleeding."""
+        target, state = _patient()
+        condition = BleedingCondition(3, "chest")  # 1.5/min
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        with patch("world.medical.conditions.random.random", return_value=0.99):
+            condition.process(target, current=1000.0 + 30 * 60)
+        expected_loss = 1.5 * ELAPSED_CAP_MINUTES
+        self.assertAlmostEqual(state.blood_level, 100.0 - expected_loss)
+
+    def test_marker_still_advances_past_the_gap(self):
+        """After a capped catch-up, the next normal tick is normal —
+        the gap isn't re-billed."""
+        target, state = _patient()
+        condition = BleedingCondition(3, "chest")
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        with patch("world.medical.conditions.random.random", return_value=0.99):
+            condition.process(target, current=1000.0 + 30 * 60)
+            after_gap = state.blood_level
+            condition.process(target, current=1000.0 + 30 * 60 + 60)
+        self.assertAlmostEqual(state.blood_level, after_gap - 1.5)
+
+
+class TestInfectionRestoration(TestCase):
+    def test_documented_pacing_constants(self):
+        """Treated ≈ 'improves every ~5 minutes' (30% over 5);
+        untreated = the documented ~20-minute progression."""
+        five_min = 1 - (1 - INFECTION_IMPROVE_HAZARD_PER_MINUTE) ** 5
+        self.assertGreater(five_min, 0.25)
+        self.assertLess(five_min, 0.35)
+        self.assertAlmostEqual(1 / INFECTION_WORSEN_HAZARD_PER_MINUTE, 20.0)
+
+    def test_environmental_modifier_scales_worsening(self):
+        """The sewers lever: env modifier multiplies the hazard."""
+        target, state = _patient()
+        condition = InfectionCondition(2, "chest")
+        condition.set_environmental_modifier(3.0)
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        # 0.05 * 3 = 0.15/min; roll just under that fires.
+        with patch("world.medical.conditions.random.random", return_value=0.149):
+            condition.process(target, current=1060.0)
+        self.assertEqual(condition.severity, 3)
+
+
+class TestPersistence(TestCase):
+    def test_last_processed_round_trips(self):
+        condition = PainCondition(4, "chest")
+        condition.last_processed = 12345.0
+        restored = deserialize_condition(condition.to_dict())
+        self.assertEqual(restored.last_processed, 12345.0)
+
+    def test_legacy_dict_defaults_to_now(self):
+        """Pre-#501 persisted conditions lack last_processed — they
+        must not be billed retroactively at upgrade."""
+        condition = PainCondition(4, "chest")
+        data = condition.to_dict()
+        del data["last_processed"]
+        before = __import__("time").time()
+        restored = deserialize_condition(data)
+        self.assertGreaterEqual(restored.last_processed, before - 1)


### PR DESCRIPTION
Refs #501 — Phase 1 of `CONDITION_CADENCE_SPEC.md`. Phase 2 (script hygiene) follows separately.

**The refactor:** time moves out of the tick and into conditions. One clock seam (`world/medical/clock.py`, the #301 plug point); `process()` on the base class computes capped elapsed minutes and hands them to `tick_effect(character, elapsed_minutes)`; all chance-based drift becomes per-minute hazards via one closed form (`1−(1−p)^t`, cadence-independent by construction). Infection is **restored from its 5× drift** to documented pacing. The treated-bleeding `int()` truncation (treated ≈ stopped) is preserved deliberately for equivalence and flagged for separate retuning. `CONDITION_INTERVALS` and friends deleted. `last_processed` persists everywhere; legacy saves default to "now" — no retroactive billing.

**Before/after timing** (user-requested, identical kit: full medical pass, bleeding+pain+infection per character):

| | before | after |
|---|---|---|
| tick-all N=1000 | 163.7ms | 168.2ms (+2.7%, noise) |
| 10 passes N=1000 | 2,272ms | 2,289ms (+0.7%) |

The kit caught one real regression pre-ship: the heal-elapsed marker first landed on `db` — a persisted write per character per tick, **4.5× cost at N=1000** — and moved to `ndb`, which is also semantically correct (reload resetting the marker is the downtime cap's intent). The doctrine works.

**Rollback anchor:** tag `pre-cadence-refactor` (= `1a9cb27`, pushed). `git reset --hard pre-cadence-refactor` + live reset. Data-safe in both directions — old code ignores the new persisted fields, new code defaults them.

Test plan: 12 new contract tests per spec §9 (hazard math, equivalence, 6×10s ≡ 1×60s, downtime cap + no-rebilling, infection restoration, environmental scaling, persistence round-trips). Full `world.tests` **2,396/2,396**. Live reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)