### PR TITLE
Cadence Phase 2: script hygiene

### DIFF
--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -88,6 +88,15 @@ class DeathProgressionScript(DefaultScript):
     
     Attached to a character who is dying but not yet permanently dead.
     Provides a window for medical intervention and creates dramatic tension.
+
+    Lifecycle (#501 §6.2):
+    - CREATED by start_death_progression() when a character crosses
+      the death threshold (idempotent — returns existing script).
+    - TERMINATES via medical revival, via completion (corpse +
+      transition), or self-cleanup on an invalid character.
+    - SURVIVES reload (persistent Script); progression math is
+      already wall-clock (db.start_time), so a reload doesn't skew
+      the revival window.  at_start re-asserts the check interval.
     """
     
     def at_msg_send(self, text=None, to_obj=None, **kwargs):
@@ -143,11 +152,17 @@ class DeathProgressionScript(DefaultScript):
         )
         
     def at_start(self):
-        """Called when script starts."""
+        """Called when script starts.
+
+        Re-asserts the check interval from constants (#501 Phase 2:
+        persisted scripts never trust persisted config).
+        """
         character = self.obj
         if not character:
             self.stop()
             return
+        if self.interval != DEATH_PROGRESSION_CHECK_INTERVAL:
+            self.restart(interval=DEATH_PROGRESSION_CHECK_INTERVAL)
             
         # Log start of death progression with configurable duration
         splattercast = get_splattercast()

--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -150,7 +150,15 @@ def get_or_create_combat(location):
 class CombatHandler(DefaultScript):
     """
     Script that manages turn-based combat for all combatants in a location.
-    
+
+    Lifecycle (#501 §6.2):
+    - CREATED by get_or_create_combat() on the room when combat
+      begins (one handler per location).
+    - TERMINATES via its own cleanup when no combatants remain
+      (stop+delete, or merge into another room's handler).
+    - SURVIVES reload (persistent Script) — combatant state lives in
+      db.combatants and re-validates each round.
+
     This is the central orchestrator of combat encounters, handling:
     - Combat state management and lifecycle
     - Turn-based initiative and action resolution

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -96,8 +96,30 @@ class MedicalScript(DefaultScript):
     - Automatically starts when first condition is added
     - Automatically stops when no conditions remain
     - Provides centralized medical condition management
+
+    Lifecycle (#501 §6.2):
+    - CREATED by start_medical_script() when a condition lands or a
+      dressing needs ticking (idempotent — returns existing script).
+    - TERMINATES itself when no conditions remain and no dressed
+      organ has healing work; also stop+delete on critical tick
+      error (prevents per-tick retry storms).
+    - SURVIVES reload (persistent Script); at_start re-asserts the
+      interval from constants so persisted config can't go stale.
+      Conditions apply capped elapsed time via process(), so the
+      reload gap itself is billed at most one extra sampling window.
     """
     
+    def at_start(self):
+        """Re-assert config on every (re)start (#501 Phase 2).
+
+        Persisted scripts must never trust persisted config: this is
+        what left pre-#465 scripts ticking at a stale 12s for their
+        whole lifetime.  Re-reading the constant here means interval
+        changes propagate to every live script on the next reload.
+        """
+        if self.interval != MEDICAL_TICK_INTERVAL:
+            self.restart(interval=MEDICAL_TICK_INTERVAL)
+
     def at_script_creation(self):
         """Called when script is first created."""
         self.key = "medical_script"  # Use consistent key for searching


### PR DESCRIPTION
Closes #501 (Phases 1+2 done; Phase 3 parked per spec until tactical-tier content exists).

Spec §6 delivered: `at_start` interval re-assertion on MedicalScript and DeathProgressionScript (persisted scripts never trust persisted config — kills the stale-12s class of bug permanently), lifecycle contracts documented on all three long-lived scripts, and the grenade-fuse reload hazard filed with its fix shape (persist the detonation deadline, sweep at server start).

Full `world.tests` 2,396/2,396. Live reloaded — which also exercised the new at_start path on every live script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)