### PR TITLE
Solve bleeding: layered brakes, clot cap, rename, stale-rate fix

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -241,7 +241,7 @@ class ConsumptionCommand(Command):
             try:
                 # Check for low blood level or bleeding conditions
                 blood_level = getattr(target.medical_state, 'blood_level', 100)
-                has_bleeding = any(condition.condition_type == "minor_bleeding" 
+                has_bleeding = any(condition.condition_type == "bleeding" 
                                  for condition in getattr(target.medical_state, 'conditions', []))
                 return blood_level < 100 or has_bleeding
             except Exception:
@@ -251,7 +251,7 @@ class ConsumptionCommand(Command):
             # Check if character has bleeding conditions that bandages can treat
             try:
                 # Check for bleeding conditions (bandages help with external bleeding)
-                has_bleeding = any(condition.condition_type == "minor_bleeding" 
+                has_bleeding = any(condition.condition_type == "bleeding" 
                                  for condition in getattr(target.medical_state, 'conditions', []))
                 return has_bleeding
             except Exception:

--- a/specs/CONDITION_CADENCE_SPEC.md
+++ b/specs/CONDITION_CADENCE_SPEC.md
@@ -163,7 +163,7 @@ running 5× off its design:
 
 | Constant / behavior | Today (per 60s tick) | Per-minute | Note |
 |---|---|---|---|
-| `BLOOD_LOSS_PER_SEVERITY` | 0.5–2.5% per tick | same, per minute | 1:1 — authored for 60s |
+| `BLOOD_LOSS_PER_SEVERITY` | 0.5–2.5% per tick | same, per minute | 1:1 — authored for 60s.  #507 then made the rate derive from *current* severity (stale-rate fix) and replaced the treated-path truncation with the layered-brakes model: bandage slows to 30%, dressing stops, clotting only at severity ≤5 |
 | Bleeding natural clotting (severity −1 chance) | per tick | same hazard per minute | 1:1 |
 | Pain decay | 1 severity per tick | 1 per minute | 1:1 |
 | Infection: treated improvement | 12% per tick (authored: "12% per 12s tick") | **restored**: `1−(1−0.12)⁵ ≈ 47%` per minute | the 5× drift fix |

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -906,6 +906,6 @@ DIAGNOSE_CACHE_TTL_SECONDS = 300
 # These layer on top of the per-organ wound rolls — separate roll
 # per condition.
 DIAGNOSE_CONDITION_DCS = {
-    "minor_bleeding": 1,    # active bleeding is obvious
+    "bleeding": 1,          # active bleeding is obvious
     "infection":      6,    # early infection requires palpation
 }

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -14,6 +14,9 @@ from .constants import (
     BLEEDING_DAMAGE_THRESHOLDS,
     CONDITION_TRIGGERS,
     BLEEDING_CLOT_HAZARD_PER_MINUTE,
+    BLEEDING_TREATED_MULTIPLIER,
+    BLEEDING_SELF_CLOT_MAX_SEVERITY,
+    BLEEDING_SEVERITY_LABELS,
     PAIN_DECAY_HAZARD_PER_MINUTE,
     INFECTION_IMPROVE_HAZARD_PER_MINUTE,
     INFECTION_WORSEN_HAZARD_PER_MINUTE,
@@ -193,11 +196,28 @@ class MedicalCondition:
 
 
 class BleedingCondition(MedicalCondition):
-    """Bleeding condition that causes blood loss over time."""
-    
+    """Bleeding: blood loss over time, severity-tiered (#507).
+
+    The "layered brakes" model:
+    - **bandage** (``apply_treatment``) — reduces severity and slows
+      the residual loss to ``BLEEDING_TREATED_MULTIPLIER``; buying
+      time, not a fix
+    - **wound-care dressing** (stabilization, PR-B) — full stop at
+      the location, plus healing
+    - **natural clotting** — only severity ≤
+      ``BLEEDING_SELF_CLOT_MAX_SEVERITY`` self-resolves (doubled
+      hazard when bandaged); arterial-tier wounds bleed until
+      someone intervenes
+
+    The blood-loss rate derives from *current* severity at tick
+    time — never stored — so clotting/treatment lowering severity
+    lowers the rate with it (the stale-rate bug class).
+    condition_type is "bleeding"; legacy saves with "minor_bleeding"
+    load transparently.
+    """
+
     def __init__(self, severity, location=None):
-        super().__init__("minor_bleeding", severity, location, tick_interval=60)
-        self.blood_loss_rate = BLOOD_LOSS_PER_SEVERITY.get(severity, 1)
+        super().__init__("bleeding", severity, location, tick_interval=60)
         
     def tick_effect(self, character, elapsed_minutes=1.0):
         """Apply ``elapsed_minutes`` of blood loss; chance to clot."""
@@ -218,14 +238,11 @@ class BleedingCondition(MedicalCondition):
         if self._location_stabilized(medical_state):
             return
 
-        # Per-minute blood loss x elapsed.  NOTE: the treated path
-        # keeps the historical int() truncation deliberately — at
-        # common severities int(rate * 0.3) is 0, i.e. "treated"
-        # currently means *stopped*.  Preserved for equivalence
-        # (#501 §5); retune as a separate balance decision.
-        rate_per_minute = self.blood_loss_rate
-        if self.treated:
-            rate_per_minute = int(rate_per_minute * 0.3)
+        # Per-minute blood loss x elapsed, derived from CURRENT
+        # severity (#507: never the stale stored rate).  Bandaged
+        # wounds leak at the treated multiplier — slowed, not
+        # stopped; the full stop is the stabilization channel.
+        rate_per_minute = self.get_blood_loss_rate()
         blood_loss = rate_per_minute * elapsed_minutes
 
         if blood_loss > 0:
@@ -233,10 +250,17 @@ class BleedingCondition(MedicalCondition):
             medical_state.blood_level = max(0, medical_state.blood_level - blood_loss)
             splattercast.msg(f"BLOOD_LOSS: {character.key} loses {blood_loss:.2f} blood ({old_blood:.1f} -> {medical_state.blood_level:.1f})")
 
-        # Natural clotting — per-minute hazard sampled over elapsed.
-        if not self.treated and hazard_fires(BLEEDING_CLOT_HAZARD_PER_MINUTE, elapsed_minutes):
-            self.severity = max(0, self.severity - 1)
-            splattercast.msg(f"BLEEDING_HEAL: {character.key} bleeding severity reduced to {self.severity}")
+        # Natural clotting — only wounds that plausibly clot (#507):
+        # severity ≤ the self-clot cap.  Bandaging promotes clotting
+        # (doubled hazard), which also gives treated wounds an
+        # endpoint instead of a permanent slow leak.
+        if self.severity <= BLEEDING_SELF_CLOT_MAX_SEVERITY:
+            clot_hazard = BLEEDING_CLOT_HAZARD_PER_MINUTE
+            if self.treated:
+                clot_hazard *= 2
+            if hazard_fires(clot_hazard, elapsed_minutes):
+                self.severity = max(0, self.severity - 1)
+                splattercast.msg(f"BLEEDING_HEAL: {character.key} bleeding severity reduced to {self.severity}")
 
     def _location_stabilized(self, medical_state) -> bool:
         """True when any damaged organ at this condition's location is
@@ -279,11 +303,15 @@ class BleedingCondition(MedicalCondition):
         return max(1, self.severity // 2)  # Half severity as pain
         
     def get_blood_loss_rate(self):
-        """Return blood loss rate per tick."""
-        blood_loss = self.blood_loss_rate
+        """Per-minute blood loss, derived from current severity.
+
+        Bandaged wounds run at the treated multiplier — slowed, not
+        stopped (#507 layered brakes).
+        """
+        rate = BLOOD_LOSS_PER_SEVERITY.get(self.severity, 0.0)
         if self.treated:
-            blood_loss = int(blood_loss * 0.3)  # Treated bleeding loses less blood
-        return blood_loss
+            rate = rate * BLEEDING_TREATED_MULTIPLIER
+        return rate
         
     def apply_treatment(self, treatment_quality="adequate"):
         """Apply medical treatment to bleeding."""
@@ -294,15 +322,16 @@ class BleedingCondition(MedicalCondition):
         severity_reduction = max(1, int(self.severity * effectiveness))
         
         self.severity = max(0, self.severity - severity_reduction)
+        # Residual loss slows via the treated multiplier in
+        # get_blood_loss_rate (derived live) — no stored rate to
+        # mutate (#507).
         
-        # Reduce blood loss rate for treated bleeding
-        self.blood_loss_rate = max(1, int(self.blood_loss_rate * 0.3))
-        
-    def to_dict(self):
-        """Serialize bleeding condition for persistence."""
-        data = super().to_dict()
-        data["blood_loss_rate"] = self.blood_loss_rate
-        return data
+    @property
+    def display_name(self):
+        """Severity-tiered label — "arterial bleeding", not "minor"."""
+        return BLEEDING_SEVERITY_LABELS.get(
+            max(1, min(10, self.severity)), "bleeding",
+        )
         
     @classmethod
     def from_dict(cls, data):
@@ -315,7 +344,8 @@ class BleedingCondition(MedicalCondition):
         condition.tick_interval = data.get("tick_interval", 60)
         condition.requires_ticker = data.get("requires_ticker", True)
         condition.treated = data.get("treated", False)
-        condition.blood_loss_rate = data.get("blood_loss_rate", condition.blood_loss_rate)
+        # Legacy "blood_loss_rate" in old saves is ignored — the rate
+        # derives from severity now (#507).
         condition.last_processed = data.get("last_processed", clock_now())
         return condition
 
@@ -716,7 +746,7 @@ def deserialize_condition(condition_dict):
         class so the data round-trips without crashing.
     """
     condition_type = condition_dict.get("condition_type", "unknown")
-    if condition_type == "minor_bleeding":
+    if condition_type in ("bleeding", "minor_bleeding"):  # legacy alias
         return BleedingCondition.from_dict(condition_dict)
     if condition_type == "pain":
         return PainCondition.from_dict(condition_dict)

--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -173,7 +173,10 @@ ELAPSED_CAP_MINUTES = 2.0
 # Per-minute hazards for chance-based condition drift (spec §4.4).
 # Authored per minute; sampled at any cadence via
 # 1 - (1 - p) ** elapsed_minutes.
-BLEEDING_CLOT_HAZARD_PER_MINUTE = 0.10      # untreated natural clotting
+BLEEDING_CLOT_HAZARD_PER_MINUTE = 0.10      # natural clotting (severity
+                                            # ≤ the self-clot cap below;
+                                            # doubled when bandaged —
+                                            # treatment promotes clotting)
 PAIN_DECAY_HAZARD_PER_MINUTE = 0.20         # pain fading one severity
 INFECTION_IMPROVE_HAZARD_PER_MINUTE = 0.07  # treated: ~"improves every
                                             # ~5 minutes" per the
@@ -182,6 +185,23 @@ INFECTION_IMPROVE_HAZARD_PER_MINUTE = 0.07  # treated: ~"improves every
 INFECTION_WORSEN_HAZARD_PER_MINUTE = 0.05   # untreated, x environmental
                                             # modifier: the documented
                                             # "~20min progression"
+# Bleeding model (#507, "layered brakes"):
+# - bandage (apply_treatment): reduces severity AND slows residual
+#   loss to BLEEDING_TREATED_MULTIPLIER — buys time, doesn't stop it
+# - wound-care dressing (stabilization, PR-B): full stop + healing
+# - natural clotting: only severity ≤ BLEEDING_SELF_CLOT_MAX_SEVERITY
+#   self-resolves; critical/arterial (6+) bleeds until intervention
+BLEEDING_TREATED_MULTIPLIER = 0.3
+BLEEDING_SELF_CLOT_MAX_SEVERITY = 5
+
+#: Display labels per bleeding severity (diagnose etc.).
+BLEEDING_SEVERITY_LABELS = {
+    1: "minor bleeding", 2: "light bleeding", 3: "moderate bleeding",
+    4: "heavy bleeding", 5: "severe bleeding", 6: "critical bleeding",
+    7: "arterial bleeding", 8: "massive bleeding",
+    9: "catastrophic bleeding", 10: "fatal bleeding",
+}
+
 CONSCIOUSNESS_RECOVERY_HAZARD_PER_MINUTE = {
     "knockout": 0.25,
     "sedative": 0.15,

--- a/world/medical/diagnose.py
+++ b/world/medical/diagnose.py
@@ -117,7 +117,7 @@ def classify_condition_rung(patient) -> str:
     conditions = list(getattr(state, "conditions", []) or [])
     bleeders = [
         c for c in conditions
-        if getattr(c, "condition_type", None) == "minor_bleeding"
+        if getattr(c, "condition_type", None) == "bleeding"
     ]
 
     # Moribund — actively dying.
@@ -266,7 +266,7 @@ def clinical_phrase(organ) -> str:
 
 
 _CONDITION_PHRASE = {
-    "minor_bleeding": "active haemorrhage from the {region}",
+    "bleeding": "active haemorrhage from the {region}",
     "infection":      "septic focus at the {region}",
 }
 

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -186,7 +186,7 @@ class MedicalScript(DefaultScript):
                         condition.process(self.obj)
                         
                         # Track bleeding severity for consolidated messaging
-                        if condition.condition_type == "minor_bleeding":
+                        if condition.condition_type == "bleeding":
                             total_bleeding_severity += condition.severity
                         
                         # Track pain severity for consolidated messaging

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -787,7 +787,7 @@ def apply_medical_effects(item, user, target, **kwargs):
         
         # Reduce bleeding (check for minor_bleeding condition type)
         bleeding_conditions = [c for c in medical_state.conditions 
-                             if hasattr(c, 'condition_type') and c.condition_type == "minor_bleeding"]
+                             if hasattr(c, 'condition_type') and c.condition_type == "bleeding"]
         for condition in bleeding_conditions[:2]:  # Reduce up to 2 bleeding conditions
             condition.severity = max(0, condition.severity - 3)
             if condition.severity <= 0:
@@ -809,7 +809,7 @@ def apply_medical_effects(item, user, target, **kwargs):
     elif medical_type == "wound_care":
         # Bandaging effects
         bleeding_conditions = [c for c in medical_state.conditions 
-                             if hasattr(c, 'condition_type') and c.condition_type == "minor_bleeding"]
+                             if hasattr(c, 'condition_type') and c.condition_type == "bleeding"]
         for condition in bleeding_conditions[:1]:  # Stop one source of bleeding
             condition.severity = max(0, condition.severity - 2)
             if condition.severity <= 0:

--- a/world/tests/test_condition_cadence.py
+++ b/world/tests/test_condition_cadence.py
@@ -96,17 +96,10 @@ class TestBleedingEquivalence(TestCase):
 
         self.assertAlmostEqual(state_a.blood_level, state_b.blood_level)
 
-    def test_treated_truncation_preserved(self):
-        """Historical behavior kept deliberately: treated bleeding at
-        common severities loses zero blood (int truncation)."""
-        target, state = _patient()
-        condition = BleedingCondition(3, "chest")
-        condition.treated = True
-        state.add_condition(condition)
-        condition.last_processed = 1000.0
-        with patch("world.medical.conditions.random.random", return_value=0.99):
-            condition.process(target, current=1060.0)
-        self.assertEqual(state.blood_level, 100.0)
+    # NOTE: the Phase-1 "treated truncation preserved" equivalence
+    # test was superseded by the #507 design decision: treated now
+    # means SLOWED (layered brakes), pinned by
+    # TestBleedingModel.test_bandaged_wound_slows_to_thirty_percent.
 
 
 class TestDowntimeCap(TestCase):
@@ -174,3 +167,73 @@ class TestPersistence(TestCase):
         before = __import__("time").time()
         restored = deserialize_condition(data)
         self.assertGreaterEqual(restored.last_processed, before - 1)
+
+
+# ---------------------------------------------------------------------
+# Bleeding model (#507): layered brakes, clot cap, live-derived rate
+# ---------------------------------------------------------------------
+
+
+class TestBleedingModel(TestCase):
+    def test_bandaged_wound_slows_to_thirty_percent(self):
+        """Layered brakes: treated = slowed, not stopped."""
+        target, state = _patient()
+        condition = BleedingCondition(4, "chest")  # 2.0/min
+        condition.treated = True
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        with patch("world.medical.conditions.random.random", return_value=0.99):
+            condition.process(target, current=1060.0)
+        self.assertAlmostEqual(state.blood_level, 100.0 - 2.0 * 0.3)
+
+    def test_arterial_bleeding_never_self_clots(self):
+        """Severity 6+ has no natural resolution — intervention or
+        death."""
+        target, state = _patient()
+        condition = BleedingCondition(7, "chest")
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        # Roll that would always fire a hazard — but no hazard exists.
+        with patch("world.medical.conditions.random.random", return_value=0.0):
+            condition.process(target, current=1060.0)
+        self.assertEqual(condition.severity, 7)
+
+    def test_moderate_bleeding_can_clot(self):
+        target, state = _patient()
+        condition = BleedingCondition(5, "chest")
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        with patch("world.medical.conditions.random.random", return_value=0.0):
+            condition.process(target, current=1060.0)
+        self.assertEqual(condition.severity, 4)
+
+    def test_treated_wounds_clot_faster_and_resolve(self):
+        """Bandaging doubles the clot hazard — slowed wounds have an
+        endpoint, not a permanent leak."""
+        target, state = _patient()
+        condition = BleedingCondition(2, "chest")
+        condition.treated = True
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        # 0.19 < 1-(1-0.20)^1 → fires only with the doubled hazard.
+        with patch("world.medical.conditions.random.random", return_value=0.19):
+            condition.process(target, current=1060.0)
+        self.assertEqual(condition.severity, 1)
+
+    def test_rate_follows_severity_not_creation(self):
+        """The stale-rate bug: a clotted-down wound bleeds at its
+        CURRENT severity's rate."""
+        condition = BleedingCondition(5, "chest")  # created at 3.0/min
+        condition.severity = 1
+        self.assertAlmostEqual(condition.get_blood_loss_rate(), 0.5)
+
+    def test_rename_with_legacy_alias(self):
+        condition = BleedingCondition(9, "chest")
+        self.assertEqual(condition.condition_type, "bleeding")
+        self.assertEqual(condition.display_name, "catastrophic bleeding")
+        # Legacy persisted saves load transparently.
+        data = condition.to_dict()
+        data["condition_type"] = "minor_bleeding"
+        restored = deserialize_condition(data)
+        self.assertEqual(restored.condition_type, "bleeding")
+        self.assertEqual(restored.severity, 9)

--- a/world/tests/test_condition_creation.py
+++ b/world/tests/test_condition_creation.py
@@ -59,4 +59,4 @@ class TestBaselineConditions(TestCase):
     @patch("world.medical.conditions.random.randint", return_value=100)
     def test_heavy_damage_produces_bleeding(self, _r):
         conditions = create_condition_from_damage(10, "cut", "left_arm")
-        self.assertIn("minor_bleeding", _types(conditions))
+        self.assertIn("bleeding", _types(conditions))

--- a/world/tests/test_diagnose.py
+++ b/world/tests/test_diagnose.py
@@ -113,14 +113,14 @@ class TestClassifyConditionRung(TestCase):
 
     def test_single_bleeder_serious(self):
         patient = _FakePatient(state=_FakeState(conditions=[
-            _FakeCondition(condition_type="minor_bleeding"),
+            _FakeCondition(condition_type="bleeding"),
         ]))
         self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_SERIOUS)
 
     def test_two_bleeders_critical(self):
         patient = _FakePatient(state=_FakeState(conditions=[
-            _FakeCondition(condition_type="minor_bleeding"),
-            _FakeCondition(condition_type="minor_bleeding"),
+            _FakeCondition(condition_type="bleeding"),
+            _FakeCondition(condition_type="bleeding"),
         ]))
         self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_CRITICAL)
 
@@ -130,9 +130,9 @@ class TestClassifyConditionRung(TestCase):
 
     def test_three_bleeders_moribund(self):
         patient = _FakePatient(state=_FakeState(conditions=[
-            _FakeCondition(condition_type="minor_bleeding"),
-            _FakeCondition(condition_type="minor_bleeding"),
-            _FakeCondition(condition_type="minor_bleeding"),
+            _FakeCondition(condition_type="bleeding"),
+            _FakeCondition(condition_type="bleeding"),
+            _FakeCondition(condition_type="bleeding"),
         ]))
         self.assertEqual(dx.classify_condition_rung(patient), dx.RUNG_MORIBUND)
 
@@ -453,7 +453,7 @@ class TestConditionRendering(TestCase):
     def test_bleeding_condition_renders_clinically(self):
         patient = _FakePatient(state=_FakeState(
             conditions=[_FakeCondition(
-                condition_type="minor_bleeding", location="chest",
+                condition_type="bleeding", location="chest",
             )],
         ))
         physician = _FakePhysician()


### PR DESCRIPTION
Closes #507. Design decisions per discussion:

**Layered brakes** — each tool distinct: bandage = severity reduction + residual loss slowed to **30%** (the original intent, un-truncated — "treated" no longer secretly means "stopped"); wound-care dressing = full stop + healing (unchanged); natural clotting **only at severity ≤5** — critical/arterial wounds (6+) never self-resolve: untreated means dead in 8–21 minutes, medics matter. Bandaging doubles the clot hazard so slowed wounds resolve instead of leaking forever.

**Stale-rate fix** — `blood_loss_rate` was frozen at creation: a severity-5 wound clotted down to 1 kept bleeding at 3.0/min. Now derived live from current severity.

**Rename** — `minor_bleeding` → `bleeding` (severity-9 arterial spray is no longer "minor"); legacy saves load via a deserialize alias; `display_name` exposes the tier ("catastrophic bleeding").

The Phase-1 truncation-equivalence test is explicitly superseded by this design decision, noted in place. 6 new model tests. Full `world.tests` 2,401/2,401. Live reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)