### PR TITLE
Bandages roll, tourniquets hold: complete the layered-brakes bleeding model

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -154,7 +154,7 @@ class ConsumptionCommand(Command):
         if hasattr(target, 'is_unconscious') and target.is_unconscious():
             # Some procedures can be done on unconscious patients
             medical_type = get_medical_type(item)
-            if medical_type not in ["blood_restoration", "surgical_treatment", "wound_care", "antiseptic", "fracture_treatment", "organ_repair"]:
+            if medical_type not in ["blood_restoration", "surgical_treatment", "wound_care", "antiseptic", "fracture_treatment", "organ_repair", "tourniquet"]:
                 errors.append(f"{target.get_display_name(user)} is unconscious and cannot cooperate.")
                 
         return errors
@@ -453,6 +453,60 @@ class CmdApply(ConsumptionCommand):
         errors = self.check_medical_requirements(item, caller, target)
         if errors:
             caller.msg(errors[0])
+            return
+
+        # #509: tourniquets are limb-only instant bleeding holds.
+        # They require a named location — there is no "worst wound"
+        # fallback because the limb gate is the whole point.
+        if medical_type == "tourniquet":
+            if not location:
+                caller.msg(
+                    "Tourniquets go on a specific limb: "
+                    "apply tourniquet to <target>'s <limb>."
+                )
+                return
+            from world.medical.treatments import apply_tourniquet
+            tourniquet_location = location
+            # Resolve location → container if the player named an organ.
+            try:
+                state = target.medical_state
+            except AttributeError:
+                state = None
+            if state is not None and hasattr(state, "organs"):
+                organ = state.organs.get(location)
+                if organ is not None:
+                    tourniquet_location = organ.container
+            outcome = apply_tourniquet(
+                actor=caller, target=target, item=item,
+                location=tourniquet_location,
+            )
+            if outcome["applied"]:
+                use_item(item)
+                if is_self:
+                    msg_room_identity(
+                        location=caller.location,
+                        template=(
+                            f"{{actor}} cinches a tourniquet around their "
+                            f"{tourniquet_location.replace('_', ' ')}."
+                        ),
+                        char_refs={"actor": caller},
+                        exclude=[caller],
+                    )
+                else:
+                    msg_room_identity(
+                        location=caller.location,
+                        template=(
+                            f"{{actor}} cinches a tourniquet around "
+                            f"{{target}}'s "
+                            f"{tourniquet_location.replace('_', ' ')}."
+                        ),
+                        char_refs={"actor": caller, "target": target},
+                        exclude=[caller, target],
+                    )
+            for line in outcome["messages"]:
+                caller.msg(line)
+                if not is_self:
+                    target.msg(line)
             return
 
         # PR-B (#307): wound_care items applied with location precision

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -238,6 +238,13 @@ class BleedingCondition(MedicalCondition):
         if self._location_stabilized(medical_state):
             return
 
+        # Tourniquet (#509): an applied tourniquet holds the limb
+        # completely — no loss, no severity drift, no clotting
+        # progress (flow is stopped; nothing to clot).  It is NOT a
+        # fix: remove it untreated and this picks right back up.
+        if self._location_tourniqueted(medical_state):
+            return
+
         # Per-minute blood loss x elapsed, derived from CURRENT
         # severity (#507: never the stale stored rate).  Bandaged
         # wounds leak at the treated multiplier — slowed, not
@@ -261,6 +268,23 @@ class BleedingCondition(MedicalCondition):
             if hazard_fires(clot_hazard, elapsed_minutes):
                 self.severity = max(0, self.severity - 1)
                 splattercast.msg(f"BLEEDING_HEAL: {character.key} bleeding severity reduced to {self.severity}")
+
+    def _location_tourniqueted(self, medical_state) -> bool:
+        """True when any organ at this location carries an applied
+        tourniquet flag (#509).  Limb-only by application rules; the
+        flag lives organ-level like ``stabilized``."""
+        if self.location is None:
+            return False
+        organs = getattr(medical_state, "organs", None)
+        if not organs:
+            return False
+        for organ in organs.values():
+            container = getattr(organ, "container", None)
+            if self.location != container:
+                continue
+            if getattr(organ, "tourniqueted", False):
+                return True
+        return False
 
     def _location_stabilized(self, medical_state) -> bool:
         """True when any damaged organ at this condition's location is

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -127,6 +127,15 @@ class Organ:
         # Fractional HP progress toward the next whole point of
         # dressed healing (#501) — persisted with the organ.
         self.dressing_progress = 0.0
+
+        # Tourniquet flag (#509).  Limb-only by application rules:
+        # while True, bleeding at this organ's container is held
+        # completely (no loss, no clotting) — but nothing heals and
+        # removal without treatment resumes the bleed.  Cleared by
+        # proper wound treatment at the location.  Ischemia cost
+        # (tourniquets can't stay on forever) is the noted future
+        # hook — the elapsed-time machinery makes it cheap to add.
+        self.tourniqueted = False
         
     @property
     def current_hp(self):
@@ -475,6 +484,7 @@ class Organ:
             "stabilized": self.stabilized,
             "dressing_rate": self.dressing_rate,
             "dressing_progress": getattr(self, "dressing_progress", 0.0),
+            "tourniqueted": getattr(self, "tourniqueted", False),
         }
         
     @classmethod
@@ -516,6 +526,7 @@ class Organ:
         try:
             organ.dressing_rate = int(data.get("dressing_rate", 0) or 0)
             organ.dressing_progress = float(data.get("dressing_progress", 0.0) or 0.0)
+            organ.tourniqueted = bool(data.get("tourniqueted", False))
         except (TypeError, ValueError):
             organ.dressing_rate = 0
         # Issue #346: persisted organs may predate ``display_location`` —

--- a/world/medical/treatments.py
+++ b/world/medical/treatments.py
@@ -208,6 +208,95 @@ def _conditions_at_location(
 # ---------------------------------------------------------------------
 
 
+LIMB_CONTAINERS = {
+    "left_arm", "right_arm", "left_hand", "right_hand",
+    "left_thigh", "right_thigh", "left_shin", "right_shin",
+    "left_foot", "right_foot", "tail", "left_wing", "right_wing",
+}
+
+
+def is_tourniquetable_location(location: str) -> bool:
+    """Limbs only (#509) — you cannot tourniquet a chest or a neck.
+
+    Torso/head arterial bleeding is dressing-or-die by design.
+    Numbered appendages (tentacles etc.) count as limbs, matching
+    ``Organ._is_limb_container``.
+    """
+    if location in LIMB_CONTAINERS:
+        return True
+    return "tentacle_" in location or "_leg_" in location or "_arm_" in location
+
+
+def apply_tourniquet(actor, target, item, location: str) -> dict:
+    """Apply a tourniquet at a limb location (#509).
+
+    Instant full hold of bleeding at the limb, ANY severity — the
+    field answer to arterial limb wounds.  Not a fix: nothing heals
+    under it, and bleeding resumes if it's removed before proper
+    treatment.  Proper wound care at the location clears the flag
+    (the surgeon takes it off as part of doing the job).
+
+    Returns {"applied": bool, "messages": [str, ...]}.
+    """
+    if not is_tourniquetable_location(location):
+        return {
+            "applied": False,
+            "messages": [
+                f"You can't tourniquet a {location.replace('_', ' ')} — "
+                f"that needs pressure dressing or a surgeon."
+            ],
+        }
+    state = getattr(target, "medical_state", None)
+    organs = getattr(state, "organs", None) if state else None
+    if not organs:
+        return {"applied": False, "messages": ["Nothing there to bind."]}
+
+    marked = False
+    for organ in organs.values():
+        if getattr(organ, "container", None) == location:
+            organ.tourniqueted = True
+            marked = True
+    if not marked:
+        return {
+            "applied": False,
+            "messages": [f"No {location.replace('_', ' ')} to bind."],
+        }
+    save = getattr(target, "save_medical_state", None)
+    if callable(save):
+        save()
+    return {
+        "applied": True,
+        "messages": [
+            f"The tourniquet bites down above the "
+            f"{location.replace('_', ' ')} — the bleeding there stops "
+            f"cold.  It is not a fix: get them to proper care."
+        ],
+    }
+
+
+def clear_tourniquet(target, location: str) -> bool:
+    """Remove the tourniquet flag at ``location`` (#509).
+
+    Called by proper wound treatment at the location, or by an
+    explicit removal.  Returns True if anything was cleared —
+    callers should warn that untreated bleeding resumes.
+    """
+    state = getattr(target, "medical_state", None)
+    organs = getattr(state, "organs", None) if state else None
+    if not organs:
+        return False
+    cleared = False
+    for organ in organs.values():
+        if getattr(organ, "container", None) == location and getattr(organ, "tourniqueted", False):
+            organ.tourniqueted = False
+            cleared = True
+    if cleared:
+        save = getattr(target, "save_medical_state", None)
+        if callable(save):
+            save()
+    return cleared
+
+
 def apply_wound_care(actor, target, item, location: str) -> dict:
     """Apply a wound_care item at ``location`` on ``target``.
 
@@ -295,6 +384,9 @@ def apply_wound_care(actor, target, item, location: str) -> dict:
     wound_healing_rating = int(effectiveness.get("wound_healing", 0) or 0)
     for organ in wounded_organs:
         organ.stabilized = True
+        # Proper care supersedes the field tourniquet (#509): the
+        # dressing holds the wound, so the band comes off with it.
+        organ.tourniqueted = False
         organ.dressing_rate = wound_healing_rating
     result["stabilized"] = True
     result["messages"].append(

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -807,15 +807,42 @@ def apply_medical_effects(item, user, target, **kwargs):
         result_msg = "Painkiller administered. Pain significantly reduced."
         
     elif medical_type == "wound_care":
-        # Bandaging effects
+        # Roll-based bandaging (#509 — completes the #508 layered
+        # brakes, which previously had no caller).  One bleeding
+        # source per application:
+        #   success          -> wound closed outright ("sutured for
+        #                       all intents") on modest wounds;
+        #                       heavy wounds take a big severity cut
+        #   partial_success  -> severity -2
+        #   failure          -> severity -1 (you did *something*)
+        # Any contact sets `treated`: residual flow slows to the
+        # treated multiplier and the clot hazard doubles.
         bleeding_conditions = [c for c in medical_state.conditions 
                              if hasattr(c, 'condition_type') and c.condition_type == "bleeding"]
-        for condition in bleeding_conditions[:1]:  # Stop one source of bleeding
-            condition.severity = max(0, condition.severity - 2)
+        result_msg = "Wounds bandaged."
+        for condition in bleeding_conditions[:1]:
+            outcome = calculate_treatment_success(
+                item, user, target, "bleeding",
+            )["success_level"]
+            if outcome == "success":
+                # Closes modest wounds (≤4) outright; heavier wounds
+                # take a -4 cut — a field bandage can't shut an
+                # artery, only shrink the problem.
+                reduction = condition.severity if condition.severity <= 4 else 4
+                if condition.severity <= 4:
+                    result_msg = "Expert bandaging — the bleeding is closed off."
+                else:
+                    result_msg = "Expert bandaging — the bleeding eases dramatically."
+            elif outcome == "partial_success":
+                reduction = 2
+                result_msg = "Wounds properly bandaged. Bleeding controlled."
+            else:
+                reduction = 1
+                result_msg = "Clumsy bandaging — the bleeding slows, barely."
+            condition.severity = max(0, condition.severity - reduction)
+            condition.treated = True
             if condition.severity <= 0:
                 medical_state.conditions.remove(condition)
-        
-        result_msg = "Wounds properly bandaged. Bleeding controlled."
         
     elif medical_type == "fracture_treatment":
         # Splint treatment - heal damaged bones only (excludes destroyed bones)

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -1931,6 +1931,22 @@ SPLINT = {
     ],
 }
 
+# Tourniquet - Reusable limb bleeding control (#509)
+TOURNIQUET = {
+    "key": "tourniquet",
+    "typeclass": "typeclasses.items.Item",
+    "aliases": ["tq", "strap"],
+    "desc": "A windlass-and-strap tourniquet for clamping off catastrophic limb bleeding. Stops any bleed it can reach cold — but nothing heals under it, and the wound reopens the moment it comes off without proper treatment. Limbs only.",
+    "tags": [("medical_item", "item_type"), ("apply", "delivery_method")],
+    "attrs": [
+        ("medical_type", "tourniquet"),
+        ("uses_left", 1),
+        ("max_uses", 1),
+        ("stat_requirement", 0),
+        ("application_time", 1),
+    ],
+}
+
 # Surgical Kit - Advanced multi-use medical tools
 SURGICAL_KIT = {
     "key": "surgical kit",

--- a/world/tests/test_condition_cadence.py
+++ b/world/tests/test_condition_cadence.py
@@ -237,3 +237,177 @@ class TestBleedingModel(TestCase):
         restored = deserialize_condition(data)
         self.assertEqual(restored.condition_type, "bleeding")
         self.assertEqual(restored.severity, 9)
+
+
+# ---------------------------------------------------------------------
+# Bandage roll + tourniquets (#509)
+# ---------------------------------------------------------------------
+
+
+class _FakeAttrs:
+    """Dict-backed stand-in for Evennia's AttributeHandler."""
+
+    def __init__(self, data):
+        self._d = dict(data)
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def add(self, key, value):
+        self._d[key] = value
+
+
+class TestBandageRoll(TestCase):
+    """#509: bandaging routes through the treatment roll and engages
+    the #508 layered brakes (which previously had no caller)."""
+
+    def _bandage(self, severity, success_level):
+        from world.medical.utils import apply_medical_effects
+
+        target, state = _patient()
+        # The post-treatment revival check walks target.scripts.
+        target.scripts = SimpleNamespace(get=lambda *a, **kw: [])
+        condition = BleedingCondition(severity, "left_arm")
+        state.add_condition(condition)
+        item = SimpleNamespace(
+            attributes=_FakeAttrs({"medical_type": "wound_care"}),
+            key="test bandage",
+        )
+        user = SimpleNamespace(intellect=3, key="medic")
+        with patch(
+            "world.medical.utils.calculate_treatment_success",
+            return_value={"success_level": success_level},
+        ):
+            apply_medical_effects(item, user, target)
+        return state, condition
+
+    def test_success_sutures_modest_wound_shut(self):
+        """'Sutured for all intents and purposes': severity ≤4 closes
+        outright and the condition is removed."""
+        state, condition = self._bandage(4, "success")
+        self.assertEqual(condition.severity, 0)
+        self.assertNotIn(condition, state.conditions)
+
+    def test_success_cannot_close_an_artery(self):
+        """Heavy wounds (5+) take the -4 cut but stay open — a field
+        bandage shrinks the problem, it doesn't shut an artery."""
+        state, condition = self._bandage(8, "success")
+        self.assertEqual(condition.severity, 4)
+        self.assertTrue(condition.treated)
+        self.assertIn(condition, state.conditions)
+
+    def test_partial_success_reduces_two_and_treats(self):
+        state, condition = self._bandage(5, "partial_success")
+        self.assertEqual(condition.severity, 3)
+        self.assertTrue(condition.treated)
+
+    def test_failure_still_engages_the_brakes(self):
+        """Even clumsy bandaging slows the wound: -1 severity and the
+        treated flag (30% flow, doubled clot hazard) both land."""
+        state, condition = self._bandage(5, "failure")
+        self.assertEqual(condition.severity, 4)
+        self.assertTrue(condition.treated)
+
+
+class TestTourniquets(TestCase):
+    """#509: limb-only instant full hold; not a fix."""
+
+    def test_limb_gate(self):
+        from world.medical.treatments import is_tourniquetable_location
+
+        self.assertTrue(is_tourniquetable_location("left_arm"))
+        self.assertTrue(is_tourniquetable_location("right_shin"))
+        self.assertTrue(is_tourniquetable_location("tentacle_3"))
+        self.assertFalse(is_tourniquetable_location("chest"))
+        self.assertFalse(is_tourniquetable_location("neck"))
+        self.assertFalse(is_tourniquetable_location("head"))
+
+    def test_cannot_tourniquet_torso(self):
+        from world.medical.treatments import apply_tourniquet
+
+        target, state = _patient()
+        outcome = apply_tourniquet(None, target, None, "chest")
+        self.assertFalse(outcome["applied"])
+
+    def test_holds_arterial_bleeding_completely(self):
+        """The design point: a tourniquet stops ANY severity at a
+        limb — the bleed that nothing else can touch in the field."""
+        from world.medical.treatments import apply_tourniquet
+
+        target, state = _patient()
+        condition = BleedingCondition(7, "left_arm")
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        outcome = apply_tourniquet(None, target, None, "left_arm")
+        self.assertTrue(outcome["applied"])
+        with patch("world.medical.conditions.random.random", return_value=0.99):
+            condition.process(target, current=1060.0)
+        self.assertEqual(state.blood_level, 100.0)
+        self.assertEqual(condition.severity, 7)
+
+    def test_no_clotting_under_a_tourniquet(self):
+        """Flow is stopped, so nothing clots — severity is frozen,
+        not improving.  Remove it untreated and the wound is exactly
+        as bad as it was."""
+        from world.medical.treatments import apply_tourniquet
+
+        target, state = _patient()
+        condition = BleedingCondition(3, "left_arm")
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        apply_tourniquet(None, target, None, "left_arm")
+        # Roll 0.0 would clot a severity-3 wound — but not under the band.
+        with patch("world.medical.conditions.random.random", return_value=0.0):
+            condition.process(target, current=1060.0)
+        self.assertEqual(condition.severity, 3)
+        self.assertEqual(state.blood_level, 100.0)
+
+    def test_removal_resumes_bleeding(self):
+        from world.medical.treatments import apply_tourniquet, clear_tourniquet
+
+        target, state = _patient()
+        condition = BleedingCondition(4, "left_arm")  # 2.0/min
+        state.add_condition(condition)
+        condition.last_processed = 1000.0
+        apply_tourniquet(None, target, None, "left_arm")
+        with patch("world.medical.conditions.random.random", return_value=0.99):
+            condition.process(target, current=1060.0)
+            self.assertEqual(state.blood_level, 100.0)
+            self.assertTrue(clear_tourniquet(target, "left_arm"))
+            condition.process(target, current=1120.0)
+        self.assertAlmostEqual(state.blood_level, 100.0 - 2.0)
+
+    def test_dressing_supersedes_tourniquet(self):
+        """Proper wound care at the location clears the band — the
+        dressing holds the wound, so the tourniquet comes off."""
+        from world.medical.treatments import apply_wound_care
+
+        target, state = _patient()
+        organ = next(
+            o for o in state.organs.values() if o.container == "left_arm"
+        )
+        organ.current_hp = organ.max_hp - 5
+        organ.tourniqueted = True
+        actor = SimpleNamespace(intellect=3, motorics=3, key="medic")
+        item = SimpleNamespace(
+            attributes=_FakeAttrs({"effectiveness": {}, "uses_left": 2}),
+            key="dressing",
+        )
+        outcome = apply_wound_care(
+            actor=actor, target=target, item=item, location="left_arm",
+        )
+        self.assertTrue(outcome["stabilized"])
+        self.assertFalse(organ.tourniqueted)
+        self.assertTrue(organ.stabilized)
+
+    def test_tourniquet_flag_round_trips(self):
+        from world.medical.core import Organ
+
+        organ = Organ("left_humerus")
+        organ.tourniqueted = True
+        restored = Organ.from_dict(organ.to_dict())
+        self.assertTrue(restored.tourniqueted)
+        # Legacy snapshots without the field default to False.
+        data = organ.to_dict()
+        del data["tourniqueted"]
+        self.assertFalse(Organ.from_dict(data).tourniqueted)


### PR DESCRIPTION
Closes #509.

## The gap
The #508 layered brakes (treated wounds slow to 30% flow with doubled clot hazard) shipped with **no caller** — nothing in the treatment surface ever set `treated`. CmdBandage's path did a flat severity −2 with no roll.

## Bandages — roll-based, engage the brakes
`apply_medical_effects` wound_care branch now rolls via `calculate_treatment_success`:

| Outcome | Effect |
|---|---|
| success | wound ≤4 closes outright ("sutured for all intents and purposes"); 5+ takes −4 — a field bandage can't shut an artery |
| partial | severity −2 |
| failure | severity −1 |

Every outcome sets `treated` — even clumsy bandaging slows residual flow to the treated multiplier and doubles the clot hazard.

## Tourniquets — limb-only instant hold
New `medical_type: "tourniquet"` + `TOURNIQUET` prototype, routed through CmdApply with a required limb location (`apply tourniquet to Alice's left arm`):

- **Full hold at any severity** — no blood loss, no severity drift, no clotting progress (flow is stopped; nothing to clot)
- **Not a fix** — nothing heals under it; `clear_tourniquet` resumes the bleed exactly where it was
- **Limb gate** — torso/head/neck arterial bleeding stays dressing-or-die by design; numbered appendages (tentacles, multi-legs) count as limbs, matching `Organ._is_limb_container`
- Proper wound-care dressing at the location clears the band (the medic takes it off as part of doing the job)
- Flag persists organ-level alongside `stabilized`; legacy snapshots default to off
- Usable on unconscious patients (the prime use case)

Explicit removal command and the ischemia clock (tourniquets can't stay on forever) are noted future hooks — the elapsed-time machinery makes the latter cheap to add when we want it.

## Tests
+11 in the cadence contract file (`TestBandageRoll`, `TestTourniquets`): roll outcome ladder, limb gate, arterial hold, no-clot-under-band, removal resume, dressing supersession, persistence round-trip. Suite: **2,412 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)