### PR TITLE
Anatomy substrate Phase 1: per-character organ resolution + spec round-trip

### DIFF
--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -462,9 +462,16 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
             (attacker_motorics * 0.7) + (attacker_intellect * 0.3)
         )
 
-        # Select specific target organ within the hit location
+        # Select specific target organ within the hit location —
+        # resolved from the target's actual body so augments and
+        # non-human anatomy are hittable (ANATOMY_AUGMENTS_SPEC §3.2).
+        try:
+            target_medical_state = target.medical_state
+        except AttributeError:
+            target_medical_state = None
         target_organ = select_target_organ(
-            hit_location, precision_roll, precision_skill
+            hit_location, precision_roll, precision_skill,
+            medical_state=target_medical_state,
         )
 
         # Debug output for precision targeting

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -465,6 +465,12 @@ class Organ:
         """
         return {
             "name": self.name,
+            # The organ's spec dict (ANATOMY_AUGMENTS_SPEC §3.1).
+            # Species-table organs could re-derive this at load, but
+            # augment organs (cybernetic tail) have no table entry —
+            # an organ that can't survive a save/load round trip is
+            # a bug, so every organ carries its spec.
+            "data": self.data,
             "current_hp": self.current_hp,
             "max_hp": self.max_hp,
             # Organ-bound conditions (#307 three-tier model: body /
@@ -498,7 +504,11 @@ class Organ:
         Returns:
             Organ: Restored organ instance
         """
-        organ = cls(data["name"])
+        # Snapshots carry the organ's spec dict (ANATOMY_AUGMENTS_SPEC
+        # §3.1) so non-species organs (augments) restore container /
+        # hit_weight / flags intact.  Legacy snapshots without it fall
+        # back to the species-table lookup, exactly as before.
+        organ = cls(data["name"], organ_data=data.get("data") or None)
         organ.current_hp = data.get("current_hp", organ.max_hp)
         organ.max_hp = data.get("max_hp", organ.max_hp)
         # Restore organ-bound conditions through the proper factory

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -9,16 +9,29 @@ from .constants import ORGANS, HIT_WEIGHTS
 from .core import MedicalState
 
 
-def get_organ_by_body_location(location):
+def get_organ_by_body_location(location, medical_state=None):
     """
     Get all organs that are contained within a specific body location.
-    
+
+    Per ANATOMY_AUGMENTS_SPEC §3.2 the character's actual organs are
+    the runtime truth: when a ``medical_state`` is in hand, resolution
+    reads its live organ instances — which is what makes augment
+    anatomy (and non-human species) hittable at all.  The static
+    human-table scan remains only as the no-character fallback.
+
     Args:
         location (str): Body location (e.g., "chest", "head", "left_arm")
-        
+        medical_state: The target's MedicalState, when available.
+
     Returns:
         list: List of organ names in that location
     """
+    if medical_state is not None and getattr(medical_state, "organs", None):
+        return [
+            organ_name
+            for organ_name, organ in medical_state.organs.items()
+            if getattr(organ, "container", None) == location
+        ]
     organs_in_location = []
     for organ_name, organ_data in ORGANS.items():
         if organ_data.get("container") == location:
@@ -26,25 +39,35 @@ def get_organ_by_body_location(location):
     return organs_in_location
 
 
-def calculate_hit_weights_for_location(location):
+def _hit_weight_category(organ_name, medical_state=None):
+    """Hit-weight category for an organ — live instance first, static
+    table fallback (ANATOMY_AUGMENTS_SPEC §3.2)."""
+    if medical_state is not None and getattr(medical_state, "organs", None):
+        organ = medical_state.organs.get(organ_name)
+        if organ is not None:
+            return getattr(organ, "hit_weight", "common") or "common"
+    return ORGANS.get(organ_name, {}).get("hit_weight", "common")
+
+
+def calculate_hit_weights_for_location(location, medical_state=None):
     """
     Calculate hit weights for all organs in a body location.
-    
+
     Args:
         location (str): Body location
-        
+        medical_state: The target's MedicalState, when available.
+
     Returns:
         dict: {organ_name: hit_weight_value} mapping
     """
-    organs = get_organ_by_body_location(location)
+    organs = get_organ_by_body_location(location, medical_state)
     hit_weights = {}
-    
+
     for organ_name in organs:
-        organ_data = ORGANS.get(organ_name, {})
-        weight_category = organ_data.get("hit_weight", "common")
+        weight_category = _hit_weight_category(organ_name, medical_state)
         weight_value = HIT_WEIGHTS.get(weight_category, HIT_WEIGHTS["common"])
         hit_weights[organ_name] = weight_value
-        
+
     return hit_weights
 
 
@@ -119,10 +142,17 @@ def select_hit_location(character, success_margin=0, attacker=None):
     available_locations = list(character.longdesc.keys())
     if not available_locations:
         return "chest"
-    
+
+    # The character's own organs drive the weights (ANATOMY_AUGMENTS
+    # §3.2); fall back to the static table when no medical state.
+    try:
+        target_medical_state = character.medical_state
+    except AttributeError:
+        target_medical_state = None
+
     # Calculate total hit weights for each body location
     location_weights = {}
-    
+
     # Calculate targeting parameters based on attacker's abilities
     if attacker:
         from world.combat.utils import get_character_stat
@@ -175,12 +205,11 @@ def select_hit_location(character, success_margin=0, attacker=None):
     
     for location in available_locations:
         # Get all organs in this location and sum their hit weights
-        organs = get_organ_by_body_location(location)
+        organs = get_organ_by_body_location(location, target_medical_state)
         total_weight = 0
-        
+
         for organ_name in organs:
-            organ_data = ORGANS.get(organ_name, {})
-            weight_category = organ_data.get("hit_weight", "common")
+            weight_category = _hit_weight_category(organ_name, target_medical_state)
             weight_value = HIT_WEIGHTS.get(weight_category, HIT_WEIGHTS["common"])
             total_weight += weight_value
             
@@ -306,32 +335,34 @@ def _get_location_armor_coverage(character, location):
     return total_armor
 
 
-def select_target_organ(location, precision_roll=0, attacker_skill=1):
+def select_target_organ(location, precision_roll=0, attacker_skill=1, medical_state=None):
     """
     Select a specific organ within a body location based on precision.
     Higher precision rolls are more likely to hit rare/vital organs.
-    
+
     Args:
         location (str): Body location that was hit
         precision_roll (int): d20 roll for precision targeting
         attacker_skill (int): Attacker's skill for precision calculation
-        
+        medical_state: The target's MedicalState, when available —
+            resolves organs from the actual body (augments, species)
+            per ANATOMY_AUGMENTS_SPEC §3.2.
+
     Returns:
         str: Selected organ name, or None if no organs in location
     """
     import random
-    
-    organs = get_organ_by_body_location(location)
+
+    organs = get_organ_by_body_location(location, medical_state)
     if not organs:
         return None
-        
+
     # Calculate precision-based organ weights
     organ_weights = {}
     precision_total = precision_roll + attacker_skill
-    
+
     for organ_name in organs:
-        organ_data = ORGANS.get(organ_name, {})
-        hit_weight_category = organ_data.get("hit_weight", "common")
+        hit_weight_category = _hit_weight_category(organ_name, medical_state)
         base_weight = HIT_WEIGHTS.get(hit_weight_category, HIT_WEIGHTS["common"])
         
         # Precision affects targeting of rare organs
@@ -393,10 +424,10 @@ def distribute_damage_to_organs(location, total_damage, medical_state, injury_ty
     Returns:
         dict: {organ_name: damage_amount} mapping
     """
-    organs = get_organ_by_body_location(location)
+    organs = get_organ_by_body_location(location, medical_state)
     if not organs:
         return {}
-    
+
     # Filter out destroyed organs - can't damage what's already destroyed
     functional_organs = []
     for organ_name in organs:
@@ -418,7 +449,7 @@ def distribute_damage_to_organs(location, total_damage, medical_state, injury_ty
         # Fall back to proportional distribution among functional organs
         pass
         
-    hit_weights = calculate_hit_weights_for_location(location)
+    hit_weights = calculate_hit_weights_for_location(location, medical_state)
     # Recalculate total weight using only functional organs
     total_weight = sum(hit_weights.get(organ_name, 0) for organ_name in functional_organs)
     
@@ -473,7 +504,7 @@ def apply_anatomical_damage(character, damage_amount, location, injury_type="gen
     
     # Check if all organs in this location are destroyed (potential limb loss)
     if not damage_distribution:
-        organs_in_location = get_organ_by_body_location(location)
+        organs_in_location = get_organ_by_body_location(location, medical_state)
         if organs_in_location:
             # All organs destroyed - this represents total destruction of body part
             return {

--- a/world/tests/test_anatomy_substrate.py
+++ b/world/tests/test_anatomy_substrate.py
@@ -1,0 +1,173 @@
+"""Phase 1 test contract for ANATOMY_AUGMENTS_SPEC (issue #511).
+
+Pins the per-character anatomy substrate:
+
+* equivalence — for a default human, body-driven location→organ
+  resolution matches the static-table answers exactly;
+* the rat fix — a hit at a rat's tail resolves the rat's tail
+  organs and applies damage (previously a silent no-op against
+  the human table);
+* spec round-trip — an organ whose spec is NOT in any species
+  table (an augment) survives ``to_dict``/``from_dict`` with
+  container, hit weight, and flags intact;
+* legacy fallback — snapshots predating the spec field still
+  restore via the species-table lookup.
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_anatomy_substrate
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.core import MedicalState, Organ
+from world.medical.utils import (
+    calculate_hit_weights_for_location,
+    distribute_damage_to_organs,
+    get_organ_by_body_location,
+    select_target_organ,
+)
+
+
+def _human_state():
+    return MedicalState(character=None)
+
+
+def _rat_state():
+    rat = SimpleNamespace(db=SimpleNamespace(species="rat"), key="test-rat")
+    return MedicalState(character=rat)
+
+
+# A spec no species table carries — the augment shape (the
+# cybernetic tail's organ, in miniature).
+AUGMENT_SPEC = {
+    "container": "tail",
+    "max_hp": 20,
+    "hit_weight": "common",
+    "severable_container": True,
+    "grasping": True,
+}
+
+
+class TestHumanEquivalence(TestCase):
+    """Body-driven resolution must not change human combat at all."""
+
+    def test_organ_resolution_matches_static_table(self):
+        state = _human_state()
+        locations = {o.container for o in state.organs.values()}
+        for location in locations:
+            self.assertEqual(
+                sorted(get_organ_by_body_location(location, state)),
+                sorted(get_organ_by_body_location(location)),
+                f"divergence at {location}",
+            )
+
+    def test_hit_weights_match_static_table(self):
+        state = _human_state()
+        locations = {o.container for o in state.organs.values()}
+        for location in locations:
+            self.assertEqual(
+                calculate_hit_weights_for_location(location, state),
+                calculate_hit_weights_for_location(location),
+                f"divergence at {location}",
+            )
+
+
+class TestRatResolution(TestCase):
+    """The pre-existing species bug, pinned: rats resolve from their
+    own body, not the human table."""
+
+    def test_rat_tail_resolves_rat_organs(self):
+        state = _rat_state()
+        self.assertEqual(
+            get_organ_by_body_location("tail", state), ["tail_vertebrae"]
+        )
+        # The bug being fixed: the static human table has no tail.
+        self.assertEqual(get_organ_by_body_location("tail"), [])
+
+    def test_rat_tail_takes_damage(self):
+        state = _rat_state()
+        distribution = distribute_damage_to_organs("tail", 4, state)
+        self.assertEqual(distribution, {"tail_vertebrae": 4})
+
+    def test_rat_tail_organ_targetable(self):
+        state = _rat_state()
+        organ = select_target_organ(
+            "tail", precision_roll=10, attacker_skill=5, medical_state=state
+        )
+        self.assertEqual(organ, "tail_vertebrae")
+
+
+class TestAugmentResolution(TestCase):
+    """An organ added beyond the species table is hittable — the
+    substrate guarantee the cybernetic tail rides on."""
+
+    def _human_with_tail(self):
+        state = _human_state()
+        organ = Organ("cybernetic_tail", organ_data=dict(AUGMENT_SPEC))
+        organ.medical_state = state
+        state.organs["cybernetic_tail"] = organ
+        return state
+
+    def test_augment_organ_resolves_at_its_container(self):
+        state = self._human_with_tail()
+        self.assertEqual(
+            get_organ_by_body_location("tail", state), ["cybernetic_tail"]
+        )
+
+    def test_augment_organ_takes_damage(self):
+        state = self._human_with_tail()
+        distribution = distribute_damage_to_organs("tail", 6, state)
+        self.assertEqual(distribution, {"cybernetic_tail": 6})
+
+    def test_human_locations_unaffected_by_augment(self):
+        state = self._human_with_tail()
+        self.assertEqual(
+            sorted(get_organ_by_body_location("chest", state)),
+            sorted(get_organ_by_body_location("chest")),
+        )
+
+
+class TestOrganSpecRoundTrip(TestCase):
+    def test_augment_spec_survives_persistence(self):
+        organ = Organ("cybernetic_tail", organ_data=dict(AUGMENT_SPEC))
+        organ.current_hp = 12
+        restored = Organ.from_dict(organ.to_dict())
+        self.assertEqual(restored.container, "tail")
+        self.assertEqual(restored.hit_weight, "common")
+        self.assertEqual(restored.max_hp, 20)
+        self.assertEqual(restored.current_hp, 12)
+        self.assertTrue(restored.data.get("grasping"))
+        self.assertTrue(restored.data.get("severable_container"))
+
+    def test_species_organ_spec_round_trips(self):
+        """Every organ carries its spec now — a rat organ restored
+        outside its species context keeps the right container
+        (previously this looked up the HUMAN table and got
+        'unknown')."""
+        rat_state = _rat_state()
+        organ = rat_state.organs["tail_vertebrae"]
+        restored = Organ.from_dict(organ.to_dict())
+        self.assertEqual(restored.container, "tail")
+
+    def test_legacy_snapshot_falls_back_to_species_table(self):
+        organ = Organ("left_humerus")
+        data = organ.to_dict()
+        del data["data"]
+        restored = Organ.from_dict(data)
+        self.assertEqual(restored.container, "left_arm")
+
+    def test_full_state_round_trip_with_augment(self):
+        state = _human_state()
+        augment = Organ("cybernetic_tail", organ_data=dict(AUGMENT_SPEC))
+        augment.medical_state = state
+        state.organs["cybernetic_tail"] = augment
+        restored = MedicalState.from_dict(state.to_dict())
+        self.assertIn("cybernetic_tail", restored.organs)
+        self.assertEqual(restored.organs["cybernetic_tail"].container, "tail")
+        self.assertEqual(
+            get_organ_by_body_location("tail", restored), ["cybernetic_tail"]
+        )


### PR DESCRIPTION
Phase 1 of #511 (`specs/ANATOMY_AUGMENTS_SPEC.md` §3.1–3.2). Pure substrate — no behavior change for humans, pinned by equivalence tests.

## What changes
- **Location→organ resolution reads the body**: `get_organ_by_body_location` / `select_target_organ` / `calculate_hit_weights_for_location` / damage distribution take an optional `medical_state` and resolve from the character's live organs; the static `ORGANS` scan is now only the no-character fallback. `attack.py` passes the target's state.
- **Organ specs round-trip**: `Organ.to_dict` carries the spec dict; `from_dict` uses it as the `organ_data` override. Legacy snapshots fall back to the species lookup exactly as before.

## Live bugs fixed (both pinned in tests)
1. A hit at a **rat's tail silently no-opped** — combat resolved organs from the static human table, which has no tail.
2. **Restored rat organs got human-table lookups** (`Organ.from_dict` never knew the species) — container `"unknown"` after a save/load.

## Benchmark (per the hot-path rule)
Isolated hit pipeline (select location + organ + distribute, N=20k, stub human): **50.0µs → 57.8µs per attack** (+7.8µs). Per-attack path, zero DB writes — accepted. Harness not committed.

## Tests
+12 in `world/tests/test_anatomy_substrate.py`: human equivalence across all locations, the rat fixes, augment-organ resolution/damage, spec round-trip + legacy fallback, full-state round trip with an augment organ. Suite: **2,424 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)