### PR TITLE
Operate menu installs augments; unify species gate on compatible_species

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -510,12 +510,20 @@ def _list_organs(target):
 
 def _list_donor_organs(caller):
     """Return ``(item, organ_name)`` pairs — Organ items in the
-    caller's inventory that came from a harvest and can be installed."""
+    caller's inventory that came from a harvest, plus augment items
+    (ANATOMY_AUGMENTS_SPEC §3.3) that carry their own anatomy and
+    install via the same menu."""
     out = []
     for obj in (getattr(caller, "contents", None) or ()):
-        organ_name = getattr(getattr(obj, "db", None), "organ_name", None)
+        obj_db = getattr(obj, "db", None)
+        organ_name = getattr(obj_db, "organ_name", None)
         if organ_name:
             out.append((obj, organ_name))
+            continue
+        augment = getattr(obj_db, "augment_organs", None)
+        if augment:
+            label = getattr(obj_db, "augment_container", None) or obj.key
+            out.append((obj, label))
     return out
 
 
@@ -940,6 +948,44 @@ def _process_install_donor(caller, raw_string, **kwargs):
     # read its compatibility / placement attrs (db.organ_name,
     # db.compatible_species, db.target_container, db.target_display_locations).
     caller.ndb._operate_install_donor_item = item
+
+    # Augment items (ANATOMY_AUGMENTS_SPEC §3.3) carry their own
+    # placement — the mount point is the item's anchor, so there is
+    # no location to pick.  Species-gate here for early feedback
+    # (the resolver re-checks at execution).
+    item_db = getattr(item, "db", None)
+    if getattr(item_db, "augment_organs", None):
+        target = caller.ndb._operate_target
+        target_species = (
+            getattr(getattr(target, "db", None), "species", None) or "human"
+        )
+        compat = [
+            s.lower() for s in (
+                getattr(item_db, "compatible_species", None)
+                or getattr(item_db, "species_compat", None) or []
+            )
+        ]
+        if target_species.lower() not in compat:
+            caller.msg(
+                f"|r{item.key}'s mounting hardware isn't rated for "
+                f"{target_species} anatomy.|n"
+            )
+            return "node_top"
+        anchor = (
+            getattr(item_db, "augment_anchor", None)
+            or getattr(item_db, "augment_container", None)
+        )
+        _add_step_to_chart(
+            caller, "install",
+            {"organ_item_key": item.key, "location": anchor},
+        )
+        caller.msg(
+            f"{item.key} mounts at the {anchor.replace('_', ' ')} — "
+            f"the {anchor.replace('_', ' ')} must be open when this "
+            f"step runs (add an incise step first if it isn't)."
+        )
+        return "node_top"
+
     # Now ask for the install location.
     return "node_install_location"
 

--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -586,8 +586,13 @@ class CmdInstall(Command):
             return
 
         species = getattr(target.db, "species", None) or "human"
+        # ``compatible_species`` is the established cyberware gate;
+        # ``species_compat`` accepted for pre-unification items.
         compat = [
-            s.lower() for s in (organ_item.db.species_compat or [])
+            s.lower() for s in (
+                organ_item.db.compatible_species
+                or organ_item.db.species_compat or []
+            )
         ]
         if species.lower() not in compat:
             caller.msg(

--- a/specs/ANATOMY_AUGMENTS_SPEC.md
+++ b/specs/ANATOMY_AUGMENTS_SPEC.md
@@ -108,13 +108,22 @@ Augment items declare (as attrs):
   from there
 * `augment_longdesc` — `{key, default_desc, display_after}` for the
   rendering surface
-* `species_compat` — `["human"]`
+* `compatible_species` — `["human"]` (the established cyberware /
+  harvest-provenance species gate; one field everywhere)
 
 `CmdInstall` grows an augment branch: species check → incision at
 the **anchor** (the slot doesn't exist yet; you cut where it goes) →
 create the organ(s) with `organ_data` from the item → add the
 longdesc key → persist.  Repeat-install while present is rejected
 ("already has a tail").
+
+The operate menu reaches the same resolver: augment items list
+alongside donor organs in the install picker, picking one records
+the chart step at the item's anchor with no location prompt (the
+item knows where it mounts), and the chart runner routes execution
+to the augment resolver — with the species and incision gates
+re-checked there, since chart commencement bypasses the command's
+pre-dispatch gates.
 
 ### 3.4 · Prehensile grasping
 
@@ -158,7 +167,7 @@ container `"tail"` (`"tail"` is already in `LIMB_CONTAINERS` —
 tourniquets gate correctly with zero changes), bone-typed, modest
 HP, common hit weight, `severable_container`, `grasping`; anchor
 `"back"` (the mount bolts to the base of the spine — you incise
-where it attaches); `species_compat ["human"]`.  Future biotech
+where it attaches); `compatible_species ["human"]`.  Future biotech
 variants are new prototype text over the same attrs.
 
 ## 5 · Phases

--- a/world/medical/charts.py
+++ b/world/medical/charts.py
@@ -489,6 +489,22 @@ def commence_chart(target, actor) -> Optional[dict]:
         save_chart(target, chart)
         return commence_chart(target, actor)
 
+    # Augment items route to their own resolver (ANATOMY_AUGMENTS_SPEC
+    # §3.3): the chart vocabulary stays "install", the execution
+    # differs.  The mount point is authoritative from the item — the
+    # anchor overrides whatever location the chart recorded, so a
+    # stale or hand-authored step still cuts in the right place.
+    if verb == "install":
+        item_db = getattr(resolved_args.get("organ_item"), "db", None)
+        if getattr(item_db, "augment_organs", None):
+            verb = "install_augment"
+            anchor = (
+                getattr(item_db, "augment_anchor", None)
+                or getattr(item_db, "augment_container", None)
+            )
+            if anchor:
+                resolved_args["location"] = anchor
+
     step["status"] = RUNNING
     chart["status"] = IN_PROGRESS
     save_chart(target, chart)

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -1250,6 +1250,31 @@ def _resolve_install_augment(actor, target, *, organ_item, location: str,
         actor.msg(f"The {organ_item.key} has nothing installable in it.")
         return
 
+    # Species gate — re-checked here because chart-commenced installs
+    # bypass CmdInstall's pre-dispatch gates.  ``compatible_species``
+    # is the established cyberware convention; ``species_compat`` is
+    # accepted for items spawned before the unification.
+    target_species = (
+        getattr(getattr(target, "db", None), "species", None) or "human"
+    )
+    compat = [
+        s.lower() for s in (
+            getattr(item_db, "compatible_species", None)
+            or getattr(item_db, "species_compat", None) or []
+        )
+    ]
+    if target_species.lower() not in compat:
+        actor.msg(
+            f"The {organ_item.key}'s mounting hardware isn't rated "
+            f"for {target_species} anatomy."
+        )
+        from world.medical.charts import mark_running_step_failed
+        mark_running_step_failed(
+            target,
+            outcome=f"species mismatch — {target_species} not supported",
+        )
+        return
+
     # Access gate — symmetric to install's chart-bypass check: the
     # anchor must still be open when the procedure resolves.
     if not has_incision(target, location):

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -1975,7 +1975,10 @@ CYBERNETIC_TAIL = {
             "default_desc": "A segmented cybernetic tail sways at the base of the spine, alloy vertebrae clicking softly when it moves.",
             "display_after": "back",
         }),
-        ("species_compat", ["human"]),
+        # The established cyberware species gate (the same field
+        # harvest provenance sets) — synth expansion is editing this
+        # list, no code.
+        ("compatible_species", ["human"]),
     ],
 }
 

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -76,7 +76,7 @@ def _surgeon():
     return actor
 
 
-def _tail_item():
+def _tail_item(**db_overrides):
     item = SimpleNamespace()
     item.key = "cybernetic tail"
     item.deleted = False
@@ -84,7 +84,7 @@ def _tail_item():
     def _delete():
         item.deleted = True
     item.delete = _delete
-    item.db = SimpleNamespace(
+    db_attrs = dict(
         augment_organs={"cybernetic_tailbone": dict(TAIL_ORGAN_SPEC)},
         augment_container="tail",
         augment_anchor="back",
@@ -93,15 +93,17 @@ def _tail_item():
             "default_desc": "A cybernetic tail.",
             "display_after": "back",
         },
-        species_compat=["human"],
+        compatible_species=["human"],
     )
+    db_attrs.update(db_overrides)
+    item.db = SimpleNamespace(**db_attrs)
     return item
 
 
 class TestInstallAugmentResolver(TestCase):
-    def _install(self, target, outcome="success"):
+    def _install(self, target, outcome="success", item=None):
         actor = _surgeon()
-        item = _tail_item()
+        item = item if item is not None else _tail_item()
         with patch(
             "world.medical.procedures.roll_procedure",
             return_value={"outcome": outcome},
@@ -179,6 +181,44 @@ class TestInstallAugmentResolver(TestCase):
             if getattr(c, "condition_type", "") == "infection"
         ]
         self.assertTrue(infections)
+
+    def test_species_gate_blocks_in_resolver(self):
+        """Chart-commenced installs bypass CmdInstall's gates — the
+        resolver re-checks species itself."""
+        target = _patient(species="rat")
+        open_incision(target, "back")
+        actor, item = self._install(target)
+        self.assertNotIn("cybernetic_tailbone", target.medical_state.organs)
+        self.assertFalse(item.deleted)
+        self.assertTrue(any("isn't rated" in m for m in actor.messages))
+
+    def test_legacy_species_compat_field_accepted(self):
+        """Items spawned before the compatible_species unification
+        carry species_compat — still honored."""
+        target = _patient()
+        open_incision(target, "back")
+        item = _tail_item(compatible_species=None, species_compat=["human"])
+        self._install(target, item=item)
+        self.assertIn("cybernetic_tailbone", target.medical_state.organs)
+
+
+class TestOperateMenuDonorListing(TestCase):
+    def test_augment_items_list_as_donors(self):
+        """The operate install picker shows augment items alongside
+        harvested organs — the bug where the tail never appeared."""
+        from commands.CmdOperate import _list_donor_organs
+
+        heart = SimpleNamespace(
+            key="donor heart", db=SimpleNamespace(organ_name="heart"),
+        )
+        tail = _tail_item()
+        plain = SimpleNamespace(key="brick", db=SimpleNamespace())
+        caller = SimpleNamespace(contents=[heart, tail, plain])
+        donors = _list_donor_organs(caller)
+        items = [item for item, _label in donors]
+        self.assertIn(heart, items)
+        self.assertIn(tail, items)
+        self.assertNotIn(plain, items)
 
 
 class TestSeverableOverlay(TestCase):


### PR DESCRIPTION
Playtest bug: the cybernetic tail never appeared in the operate menu's donor picker — `_list_donor_organs` filters on `db.organ_name` (harvest provenance), which augment items don't carry. CmdInstall worked; the chart path didn't.

## Fix
- **Donor picker** lists augment items alongside harvested organs.
- **No location prompt for augments** — the item knows where it mounts. Picking one species-gates immediately, records the chart step at the item's anchor, and reminds the surgeon the anchor must be open when the step runs.
- **Chart runner** routes install steps whose item carries `augment_organs` to the `install_augment` resolver, with the item's anchor overriding the recorded location.
- **Resolver re-checks species** — chart commencement bypasses CmdInstall's pre-dispatch gates, so the gate lives at execution too (symmetric to the existing incision re-check). Failures mark the running chart step FAILED.

## Naming unification
Phase 2 introduced `species_compat`; the operate menu's cyberware path had already established `compatible_species` (the field harvest provenance sets). One concept, one field now: prototype and spec use `compatible_species`, gates read it first and accept `species_compat` for items spawned in the pre-unification window.

## Tests
+3 (donor listing, resolver species gate, legacy fallback). Suite: **2,439 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)