### PR TITLE
Augment abilities Phase 1: the cyberware toggle layer

### DIFF
--- a/commands/CmdCyberware.py
+++ b/commands/CmdCyberware.py
@@ -1,0 +1,53 @@
+"""The cyberware dispatcher (AUGMENT_ABILITIES_SPEC §3.1, #516).
+
+One command, keyed on :data:`CYBERWARE_COMMAND_PREFIX`.  Evennia's
+parser matches command keys as prefixes, so ``/shotgun`` resolves to
+this command with ``args = "shotgun"`` — no per-weapon commands, no
+dynamic cmdsets.  Swapping the prefix (``/`` → ``=``) is a one-line
+change in ``world.medical.augments``.
+"""
+
+from __future__ import annotations
+
+from evennia import Command
+
+from world.medical.augments import (
+    CYBERWARE_COMMAND_PREFIX,
+    list_abilities,
+    toggle_ability,
+)
+
+
+class CmdCyberware(Command):
+    """Command your installed cyberware.
+
+    Usage:
+        /            - list your installed cyberware and its state
+        /<ability>   - toggle that ability (deploy / retract)
+
+    Examples:
+        /shotgun     - deploy or retract the arm-mounted shotgun
+
+    Deploying an integrated weapon transforms the hand it lives in —
+    anything that hand was holding drops to the ground, and the hand
+    can't hold anything until the weapon is retracted.  Integrated
+    weapons can't be dropped, given away, or disarmed; they are
+    bolted to your skeleton.
+
+    Abilities come from installed augments and leave with them — a
+    severed gun arm takes the gun.
+    """
+
+    key = CYBERWARE_COMMAND_PREFIX
+    locks = "cmd:all()"
+    help_category = "Cyberware"
+    # Accept args glued directly to the key ("/shotgun"), no space.
+    arg_regex = r"(?s).*"
+
+    def func(self):
+        caller = self.caller
+        name = (self.args or "").strip().lower()
+        if not name:
+            caller.msg(list_abilities(caller))
+            return
+        caller.msg(toggle_ability(caller, name))

--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -841,9 +841,19 @@ class CmdWrest(Command):
         target_hand, target_object = self._find_object_in_target_hands(target)
         if not target_object:
             caller.msg(MSG_WREST_OBJECT_NOT_IN_HANDS.format(
-                target=target.get_display_name(caller), 
+                target=target.get_display_name(caller),
                 object=self.object_name
             ))
+            return
+
+        # 4b. Integrated cyberware (#516) is bolted to the skeleton —
+        # there is nothing to wrest, even from the unconscious.
+        if target_object.db.integrated:
+            caller.msg(
+                f"{target_object.get_display_name(caller)} is part of "
+                f"{target.get_display_name(caller)}'s body — you can't "
+                f"wrest it loose."
+            )
             return
 
         # 5. Check if target is grappled (for disadvantage)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -287,6 +287,12 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         from commands.CmdOperate import CmdOperate
         self.add(CmdOperate())
 
+        # Cyberware dispatcher (#516): ``/<ability>`` toggles
+        # installed augment abilities.  One command keyed on the
+        # prefix constant — see ``world/medical/augments.py``.
+        from commands.CmdCyberware import CmdCyberware
+        self.add(CmdCyberware())
+
 class AccountCmdSet(default_cmds.AccountCmdSet):
     """
     This is the cmdset available to the Account at all times. It is

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -2378,6 +2378,21 @@ def apply_sever_to_character(character, container, *, injury_type="cut"):
 
     detach_items_to_appendage(character, appendage, chain)
 
+    # Integrated cyberware hardware travels with the limb (#516).
+    # Deployed weapons already moved (they sat in held_items); this
+    # covers retracted hardware folded inside the severed arm.
+    try:
+        from world.medical.augments import carry_hardware_to_appendage
+        carry_hardware_to_appendage(character, chain, appendage)
+    except Exception:
+        # Deliberate (#469): hardware bookkeeping must never block
+        # the severance itself.  Audit-logged for investigation.
+        from world.combat.debug import get_splattercast
+        get_splattercast().msg(
+            f"SEVER_HARDWARE_CARRY_ERROR: "
+            f"{getattr(character, 'key', '?')} at {container}"
+        )
+
     # Severance narrative — issue #332. Replaces the previous inline
     # template with a library lookup so each (location, injury_type,
     # severity) cell gets variant prose. Falls back gracefully to the

--- a/world/combat/actions.py
+++ b/world/combat/actions.py
@@ -97,16 +97,18 @@ def resolve_disarm(handler, char, entry):
         )
         return
 
-    # Find weapon to disarm (prioritize weapons, then any held item)
+    # Find weapon to disarm (prioritize weapons, then any held item).
+    # Integrated cyberware (#516) is bolted to the skeleton — you
+    # can't knock an arm-gun out of someone's hand.
     weapon_hand = None
     for hand, item in hands.items():
-        if item and item.db.weapon_type:
+        if item and item.db.weapon_type and not item.db.integrated:
             weapon_hand = hand
             break
 
     if not weapon_hand:
         for hand, item in hands.items():
-            if item:
+            if item and not item.db.integrated:
                 weapon_hand = hand
                 break
 

--- a/world/medical/augments.py
+++ b/world/medical/augments.py
@@ -1,0 +1,290 @@
+"""Toggled cyberware abilities (AUGMENT_ABILITIES_SPEC, issue #516).
+
+Abilities live on organs: an augment item's organ spec carries an
+``abilities`` dict (see spec §2), which the anatomy substrate
+persists and severs with the organ.  Installed means the ability
+exists; severed means it's gone — no registry.
+
+The single dispatcher command (``commands.CmdCyberware``) parses
+``/<ability>`` and calls :func:`toggle_ability` here.  The prefix
+lives in :data:`CYBERWARE_COMMAND_PREFIX` — swapping ``/`` for ``=``
+later is this one constant.
+
+The integrated_weapon type exploits held-is-wielded: deploying
+moves a locked weapon item INTO the hand slot, which simultaneously
+makes the hand unusable for holding and makes the weapon the active
+combat weapon (``get_wielded_weapon`` reads hands).  Retracting
+parks the item off-grid (``location = None`` — it is folded inside
+your arm, not in your backpack).
+"""
+
+from __future__ import annotations
+
+
+#: The cyberware command prefix.  ``/shotgun`` toggles the shotgun
+#: ability.  May become ``=`` or anything else — change it HERE ONLY
+#: (the dispatcher keys itself on this constant).
+CYBERWARE_COMMAND_PREFIX = "/"
+
+
+# ---------------------------------------------------------------------
+# Ability lookup
+# ---------------------------------------------------------------------
+
+
+def iter_abilities(character):
+    """Yield ``(organ, ability_name, spec)`` for every ability on the
+    character's body.  Severed organs are skipped — the hardware left
+    with the limb."""
+    state = getattr(character, "medical_state", None)
+    organs = getattr(state, "organs", None) if state else None
+    if not organs:
+        return
+    for organ in organs.values():
+        if getattr(organ, "wound_stage", None) == "severed":
+            continue
+        data = getattr(organ, "data", None)
+        abilities = data.get("abilities") if data else None
+        if not abilities:
+            continue
+        for name, spec in abilities.items():
+            yield organ, name, spec
+
+
+def find_ability(character, name):
+    """Return ``(organ, spec)`` for the named ability, or
+    ``(None, None)``."""
+    wanted = (name or "").strip().lower()
+    for organ, ability_name, spec in iter_abilities(character):
+        if ability_name.lower() == wanted:
+            return organ, spec
+    return None, None
+
+
+# ---------------------------------------------------------------------
+# Toggle dispatch
+# ---------------------------------------------------------------------
+
+
+def toggle_ability(character, name) -> str:
+    """Toggle the named ability.  Returns the message for the caller
+    (room messages are broadcast inside).  All gates live here so the
+    dispatcher command stays a thin parser."""
+    organ, spec = find_ability(character, name)
+    if organ is None:
+        available = sorted(
+            ability for _o, ability, _s in iter_abilities(character)
+        )
+        if available:
+            listing = ", ".join(
+                f"{CYBERWARE_COMMAND_PREFIX}{a}" for a in available
+            )
+            return f"No such cyberware. You have: {listing}"
+        return "You have no cyberware to command."
+
+    # Body gates: the dead and the unconscious don't toggle hardware.
+    state = getattr(character, "medical_state", None)
+    if state is not None and callable(getattr(state, "is_dead", None)) and state.is_dead():
+        return "You are dead."
+    if callable(getattr(character, "is_unconscious", None)) and character.is_unconscious():
+        return "You are unconscious."
+
+    ability_type = spec.get("type")
+    if ability_type == "integrated_weapon":
+        return _toggle_integrated_weapon(character, organ, name, spec)
+    return f"{name} doesn't respond. (unknown ability type {ability_type!r})"
+
+
+def list_abilities(character) -> str:
+    """The bare-prefix listing: every installed ability + state."""
+    lines = []
+    for organ, name, spec in iter_abilities(character):
+        ability_state = _ability_state(organ, name)
+        deployed = ability_state.get("deployed", False)
+        tag = "deployed" if deployed else "retracted"
+        lines.append(f"  {CYBERWARE_COMMAND_PREFIX}{name} — {tag}")
+    if not lines:
+        return "You have no cyberware to command."
+    return "Installed cyberware:\n" + "\n".join(lines)
+
+
+# ---------------------------------------------------------------------
+# integrated_weapon
+# ---------------------------------------------------------------------
+
+
+def _ability_state(organ, name) -> dict:
+    """Runtime state bucket for one ability on one organ.  Lives on
+    ``organ.ability_state`` (persisted alongside stabilized /
+    tourniqueted)."""
+    store = getattr(organ, "ability_state", None)
+    if store is None:
+        store = {}
+        organ.ability_state = store
+    return store.setdefault(name, {})
+
+
+def _toggle_integrated_weapon(character, organ, name, spec) -> str:
+    from world.identity_utils import msg_room_identity
+
+    state = _ability_state(organ, name)
+    slot = spec.get("slot")
+    if not slot:
+        return f"{name} has no slot configured — report this."
+
+    if not state.get("deployed"):
+        # ── Deploy ────────────────────────────────────────────────
+        hands = getattr(character, "hands", None) or {}
+        if slot not in hands:
+            # Slot anatomy gone (severed hand on a surviving arm
+            # organ, or species drift) — nothing to transform.
+            return (
+                f"Your {slot.replace('_', ' ')} isn't there to "
+                f"transform."
+            )
+
+        weapon = _get_or_spawn_weapon(character, state, spec)
+        if weapon is None:
+            return f"{name} grinds and fails — no weapon hardware found."
+
+        # Auto-drop whatever the hand held (settled decision: the
+        # hand transforms regardless; the knife clatters down).
+        held = hands.get(slot)
+        if held is not None and character.location is not None:
+            held.move_to(character.location, quiet=True)
+            character.msg(
+                f"Your {slot.replace('_', ' ')} splits open — "
+                f"{held.get_display_name(character)} clatters to the "
+                f"ground."
+            )
+            msg_room_identity(
+                location=character.location,
+                template=(
+                    f"{{actor}} drops {held.key} as their "
+                    f"{slot.replace('_', ' ')} reconfigures."
+                ),
+                char_refs={"actor": character},
+                exclude=[character],
+            )
+
+        weapon.location = character
+        character.hands = {slot: weapon}
+        state["deployed"] = True
+        _persist(character)
+
+        deploy_msg = spec.get("deploy_msg") or (
+            f"Servos whine — the {weapon.key} deploys from your "
+            f"{slot.replace('_', ' ')}."
+        )
+        if character.location is not None:
+            msg_room_identity(
+                location=character.location,
+                template=spec.get("deploy_room") or (
+                    f"{{actor}}'s {slot.replace('_', ' ')} "
+                    f"reconfigures into a {weapon.key} with a snap of "
+                    f"locking servos."
+                ),
+                char_refs={"actor": character},
+                exclude=[character],
+            )
+        return deploy_msg
+
+    # ── Retract ───────────────────────────────────────────────────
+    weapon = _find_weapon(state)
+    if weapon is not None and weapon.location is character:
+        character.hands = {slot: None}
+        weapon.location = None  # folded back inside the arm
+    state["deployed"] = False
+    _persist(character)
+
+    retract_msg = spec.get("retract_msg") or (
+        f"The hardware folds away — your {slot.replace('_', ' ')} "
+        f"is a hand again."
+    )
+    if character.location is not None:
+        msg_room_identity(
+            location=character.location,
+            template=spec.get("retract_room") or (
+                f"{{actor}}'s weapon hardware folds back into their "
+                f"{slot.replace('_', ' ')}."
+            ),
+            char_refs={"actor": character},
+            exclude=[character],
+        )
+    return retract_msg
+
+
+def _find_weapon(state):
+    """Resolve the ability's weapon item from its recorded dbref."""
+    dbref = state.get("weapon_dbref")
+    if not dbref:
+        return None
+    from evennia.utils.search import search_object
+    found = search_object(dbref)
+    return found[0] if found else None
+
+
+def _get_or_spawn_weapon(character, state, spec):
+    """The ability's weapon item — lazily spawned on first deploy,
+    then reused for the life of the augment.  Locked and flagged
+    integrated regardless of what the prototype declares
+    (belt-and-suspenders: this item must never leave the body by any
+    path but severance)."""
+    weapon = _find_weapon(state)
+    if weapon is not None:
+        return weapon
+
+    prototype = spec.get("weapon_prototype")
+    if not prototype:
+        return None
+    try:
+        from evennia.prototypes.spawner import spawn
+        spawned = spawn(prototype)
+    except Exception:
+        return None
+    if not spawned:
+        return None
+    weapon = spawned[0]
+    weapon.locks.add("get:false();drop:false();give:false()")
+    weapon.db.integrated = True
+    state["weapon_dbref"] = weapon.dbref
+    return weapon
+
+
+def _persist(character):
+    save = getattr(character, "save_medical_state", None)
+    if callable(save):
+        save()
+
+
+# ---------------------------------------------------------------------
+# Severance integration
+# ---------------------------------------------------------------------
+
+
+def carry_hardware_to_appendage(character, chain, appendage) -> None:
+    """Move integrated hardware whose organ just severed onto the
+    severed appendage (spec decision 7: the limb takes its gear).
+
+    Deployed weapons travel automatically (they sit in ``held_items``
+    and ``detach_items_to_appendage`` already moved them); this hook
+    covers the RETRACTED case — the item parked at ``location=None``,
+    folded inside the arm that just hit the floor.  Idempotent for
+    the deployed case.
+    """
+    state = getattr(character, "medical_state", None)
+    organs = getattr(state, "organs", None) if state else None
+    if not organs:
+        return
+    chain_set = set(chain)
+    for organ in organs.values():
+        if getattr(organ, "container", None) not in chain_set:
+            continue
+        store = getattr(organ, "ability_state", None) or {}
+        for name, ability_state in store.items():
+            if not isinstance(ability_state, dict):
+                continue
+            weapon = _find_weapon(ability_state)
+            if weapon is not None and weapon.location is not appendage:
+                weapon.location = appendage
+            ability_state["deployed"] = False

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -136,6 +136,13 @@ class Organ:
         # (tourniquets can't stay on forever) is the noted future
         # hook — the elapsed-time machinery makes it cheap to add.
         self.tourniqueted = False
+
+        # Cyberware ability runtime state (AUGMENT_ABILITIES_SPEC §2,
+        # #516): {ability_name: {"deployed": bool, "weapon_dbref": str}}.
+        # The ability DECLARATION lives in self.data["abilities"]
+        # (round-trips with the spec); this is the toggle state,
+        # persisted like stabilized / tourniqueted.
+        self.ability_state = {}
         
     @property
     def current_hp(self):
@@ -491,6 +498,7 @@ class Organ:
             "dressing_rate": self.dressing_rate,
             "dressing_progress": getattr(self, "dressing_progress", 0.0),
             "tourniqueted": getattr(self, "tourniqueted", False),
+            "ability_state": getattr(self, "ability_state", {}) or {},
         }
         
     @classmethod
@@ -539,6 +547,13 @@ class Organ:
             organ.tourniqueted = bool(data.get("tourniqueted", False))
         except (TypeError, ValueError):
             organ.dressing_rate = 0
+        # Cyberware toggle state (#516) — plain-dict copy so the
+        # restored organ never shares storage with the snapshot.
+        raw_ability_state = data.get("ability_state") or {}
+        organ.ability_state = {
+            str(name): dict(entry) if hasattr(entry, "keys") else {}
+            for name, entry in raw_ability_state.items()
+        }
         # Issue #346: persisted organs may predate ``display_location`` —
         # the ``cls(data["name"])`` constructor already seeded it from
         # the ORGANS spec, so only override when the snapshot carries

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -1,0 +1,150 @@
+"""Phase 1 test contract for AUGMENT_ABILITIES_SPEC (issue #516).
+
+Pins the toggled-cyberware ability layer:
+
+* ability lookup reads organs (severed organs drop out);
+* integrated_weapon deploy fills the hand slot with the weapon item
+  (held-is-wielded: combat resolution follows for free) and
+  auto-drops whatever the hand held;
+* retract restores the empty hand and parks the weapon off-grid;
+* ability_state round-trips with the organ;
+* severance carries retracted hardware onto the appendage.
+
+Run via::
+
+    evennia test --settings settings.py world.tests.test_augment_abilities
+"""
+
+from __future__ import annotations
+
+from evennia import create_object
+from evennia.utils.test_resources import EvenniaTest
+
+from typeclasses.characters import Character
+from world.medical.augments import (
+    CYBERWARE_COMMAND_PREFIX,
+    carry_hardware_to_appendage,
+    find_ability,
+    list_abilities,
+    toggle_ability,
+)
+from world.medical.core import Organ
+
+
+def _gun_arm_organ(state, deployed_weapon_dbref=None):
+    """A cybernetic arm organ carrying the shotgun ability — the
+    spec shape the SHOTGUN_ARM item will declare.  Built with a
+    bespoke organ_data copy (never mutate species-table specs)."""
+    organ = Organ("cybernetic_humerus", organ_data={
+        "container": "right_arm", "max_hp": 30, "hit_weight": "common",
+        "bone_type": "actuator_column",
+        "abilities": {
+            "shotgun": {
+                "type": "integrated_weapon",
+                "slot": "right_hand",
+                "weapon_prototype": "SHOTGUN_ARM_GUN",
+            },
+        },
+    })
+    organ.medical_state = state
+    state.organs["cybernetic_humerus"] = organ
+    if deployed_weapon_dbref:
+        organ.ability_state = {
+            "shotgun": {"weapon_dbref": deployed_weapon_dbref},
+        }
+    return organ
+
+
+class TestAbilityLayer(EvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.char = create_object(Character, key="Chrome", location=self.room1)
+        self.organ = _gun_arm_organ(self.char.medical_state)
+        # Pre-seed the integrated weapon so tests don't depend on the
+        # Phase 2 prototype.
+        self.gun = create_object(
+            "typeclasses.items.Item", key="arm shotgun", location=None,
+        )
+        self.gun.db.integrated = True
+        self.gun.locks.add("get:false();drop:false();give:false()")
+        self.organ.ability_state = {
+            "shotgun": {"weapon_dbref": self.gun.dbref},
+        }
+
+    def test_find_ability_reads_organs(self):
+        organ, spec = find_ability(self.char, "shotgun")
+        self.assertIs(organ, self.organ)
+        self.assertEqual(spec["slot"], "right_hand")
+
+    def test_severed_organ_loses_the_ability(self):
+        self.organ.wound_stage = "severed"
+        organ, spec = find_ability(self.char, "shotgun")
+        self.assertIsNone(organ)
+        self.assertIn("no cyberware", toggle_ability(self.char, "shotgun"))
+
+    def test_unknown_ability_lists_what_you_have(self):
+        msg = toggle_ability(self.char, "lasereyes")
+        self.assertIn(f"{CYBERWARE_COMMAND_PREFIX}shotgun", msg)
+
+    def test_deploy_fills_the_slot(self):
+        toggle_ability(self.char, "shotgun")
+        self.assertIs(self.char.hands["right_hand"], self.gun)
+        self.assertIs(self.gun.location, self.char)
+        self.assertTrue(
+            self.organ.ability_state["shotgun"]["deployed"]
+        )
+        # Held-is-wielded: combat resolves the deployed gun.
+        from world.combat.utils import get_wielded_weapon
+        self.assertIs(get_wielded_weapon(self.char), self.gun)
+
+    def test_deploy_auto_drops_held_item(self):
+        knife = create_object(
+            "typeclasses.items.Item", key="knife", location=self.char,
+        )
+        self.char.hands = {"right_hand": knife}
+        toggle_ability(self.char, "shotgun")
+        self.assertIs(knife.location, self.room1)
+        self.assertIs(self.char.hands["right_hand"], self.gun)
+
+    def test_retract_restores_the_hand(self):
+        toggle_ability(self.char, "shotgun")
+        toggle_ability(self.char, "shotgun")
+        self.assertIsNone(self.char.hands["right_hand"])
+        self.assertIsNone(self.gun.location)
+        self.assertFalse(
+            self.organ.ability_state["shotgun"]["deployed"]
+        )
+
+    def test_listing_shows_state(self):
+        self.assertIn("retracted", list_abilities(self.char))
+        toggle_ability(self.char, "shotgun")
+        self.assertIn("deployed", list_abilities(self.char))
+
+    def test_ability_state_round_trips(self):
+        toggle_ability(self.char, "shotgun")
+        restored = Organ.from_dict(self.organ.to_dict())
+        self.assertTrue(restored.ability_state["shotgun"]["deployed"])
+        self.assertEqual(
+            restored.ability_state["shotgun"]["weapon_dbref"],
+            self.gun.dbref,
+        )
+        self.assertIn("abilities", restored.data)
+
+    def test_severance_carries_retracted_hardware(self):
+        """Retracted = folded inside the arm; the severed arm takes
+        it (spec decision 7)."""
+        appendage = create_object(
+            "typeclasses.items.Item", key="severed arm", location=self.room1,
+        )
+        carry_hardware_to_appendage(
+            self.char, ("right_arm", "right_hand"), appendage,
+        )
+        self.assertIs(self.gun.location, appendage)
+        self.assertFalse(
+            self.organ.ability_state["shotgun"].get("deployed", False)
+        )
+
+    def test_integrated_weapon_refuses_drop(self):
+        toggle_ability(self.char, "shotgun")
+        self.assertFalse(self.gun.access(self.char, "drop"))
+        self.assertFalse(self.gun.access(self.char, "get"))


### PR DESCRIPTION
Phase 1 of #516 (`specs/AUGMENT_ABILITIES_SPEC.md` §3.1–3.3) — the layer the shotgun arm (Phase 2) plugs into.

## What ships
- **`CmdCyberware` dispatcher** keyed on `CYBERWARE_COMMAND_PREFIX` (`/`): `/shotgun` toggles, bare `/` lists installed abilities with state. The future `=` swap is one constant.
- **`integrated_weapon` toggle**: deploy lazily spawns the weapon item (locked + `db.integrated`), **auto-drops whatever the hand held** (settled decision), and moves the gun into the hand slot — held-is-wielded makes it the active combat weapon with zero combat changes. Retract parks it at `location=None` (folded inside the arm).
- **Theft-proof**: combat disarm skips integrated items; wrest refuses them.
- **Severance carries the hardware**: deployed guns travel with the held-items detach; a new hook moves retracted hardware onto the appendage. Severed organs lose their abilities (lookup skips them).
- **Persistence**: `organ.ability_state` round-trips beside `stabilized`/`tourniqueted`.

## Tests
+10 in `test_augment_abilities.py` (EvenniaTest, real Characters): lookup + severed dropout, deploy fills slot + combat resolution, auto-drop, retract, listing, round-trip, severance carry, lock access checks. Suite: **2,449 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)