### PR TITLE
Combat weapon resolution prefers actual weapons over held junk

### DIFF
--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -104,16 +104,28 @@ from .proximity import clear_all_proximity as clear_character_proximity  # noqa:
 
 def get_wielded_weapon(character):
     """
-    Get the first weapon found in character's hands.
-    
+    Get the weapon the character fights with.
+
+    Actual weapons (items carrying ``db.weapon_type``) take priority
+    over other held items — a deployed arm-shotgun beats the
+    cigarette in the off hand (#516 playtest fix; previously this
+    returned the FIRST held item of any kind, so hand order decided
+    whether you shot or brandished your smoke).  With no real weapon
+    in hand, the first held item still serves — brawling with a
+    bottle works as before.
+
     Args:
         character: The character to check
-        
+
     Returns:
         The weapon object, or None if no weapon is wielded
     """
     hands = getattr(character, "hands", {})
-    return next((item for hand, item in hands.items() if item), None)
+    held = [item for item in hands.values() if item]
+    for item in held:
+        if getattr(getattr(item, "db", None), "weapon_type", None):
+            return item
+    return held[0] if held else None
 
 
 def is_wielding_ranged_weapon(character):

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -148,3 +148,22 @@ class TestAbilityLayer(EvenniaTest):
         toggle_ability(self.char, "shotgun")
         self.assertFalse(self.gun.access(self.char, "drop"))
         self.assertFalse(self.gun.access(self.char, "get"))
+
+    def test_deployed_gun_beats_offhand_junk(self):
+        """The Laszlo bug: combat must resolve the deployed shotgun,
+        not the cigarette in the other hand — weapons (weapon_type)
+        take priority over other held items regardless of hand
+        order."""
+        from world.combat.utils import get_wielded_weapon
+
+        self.gun.db.weapon_type = "cybernetic_shotgun"
+        cigarette = create_object(
+            "typeclasses.items.Item", key="cigarette", location=self.char,
+        )
+        self.char.hands = {"left_hand": cigarette}
+        toggle_ability(self.char, "shotgun")
+        self.assertIs(get_wielded_weapon(self.char), self.gun)
+        # Retracted, the cigarette is all that's held — brawl-with-
+        # whatever behavior is preserved.
+        toggle_ability(self.char, "shotgun")
+        self.assertIs(get_wielded_weapon(self.char), cigarette)


### PR DESCRIPTION
Playtest bug from the shotgun arm: with a cigarette in one hand and the deployed arm-shotgun in the other, combat referenced **the cigarette**.

`get_wielded_weapon` returned the first held item of any kind — its docstring claimed "first weapon," but hand-dict iteration order decided whether you shot or brandished your smoke.

Fix mirrors `resolve_disarm`'s existing prioritization: items carrying `db.weapon_type` win over other held items regardless of hand order; with no real weapon held, the first item still serves (brawling with a bottle unchanged). All call sites benefit — attack resolution, threat assessment, forensic weapon attribution.

Pinned both ways in `test_augment_abilities`: deployed gun beats off-hand cigarette; retracted, the cigarette serves again. Suite: **2,456 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)