### PR TITLE
Integrated cyberware survives the full inventory verb surface

### DIFF
--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -319,7 +319,16 @@ class CmdDrop(Command):
         if not obj:
             caller.msg("You aren't carrying or holding that.")
             return
-        
+
+        # Integrated cyberware (#516) is bolted to your skeleton —
+        # it leaves the body by severance or surgery, not gravity.
+        if obj.db.integrated:
+            caller.msg(
+                f"{obj.get_display_name(caller)} is part of your "
+                f"body — retract it instead."
+            )
+            return
+
         # Check if item is currently worn
         if hasattr(caller, 'is_item_worn') and caller.is_item_worn(obj):
             caller.msg("You can't drop something you're wearing. Remove it first.")
@@ -717,6 +726,15 @@ class CmdGive(Command):
 
         if not item:
             caller.msg(f"You aren't carrying or holding '{self.item_name}'.")
+            return
+
+        # Integrated cyberware (#516) can't change owners by
+        # generosity — it's bolted to your skeleton.
+        if item.db.integrated:
+            caller.msg(
+                f"{item.get_display_name(caller)} is part of your "
+                f"body — you can't give it away."
+            )
             return
 
         # If giving from inventory, need to wield it first

--- a/commands/CmdThrow.py
+++ b/commands/CmdThrow.py
@@ -223,6 +223,15 @@ class CmdThrow(Command):
                 self.caller.msg(MSG_THROW_OBJECT_NOT_FOUND.format(object=self.object_name))
                 return None
 
+        # Integrated cyberware (#516) is bolted to your skeleton —
+        # throwing your own arm-gun is not the move it sounds like.
+        if obj.db.integrated:
+            self.caller.msg(
+                f"{obj.get_display_name(self.caller)} is part of your "
+                f"body — you can't throw it."
+            )
+            return None
+
         # Check for special grenade validation
         if is_explosive(obj):
             if not self.validate_grenade_throw(obj):

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1701,6 +1701,16 @@ class Character(
         if item.location != self:
             return "You're not carrying that item."
 
+        # Integrated cyberware (#516) never takes the wield path —
+        # it deploys into its own slot via /<ability>.  Without this
+        # gate a freed integrated weapon could be wielded into the
+        # WRONG hand, desyncing the toggle state.
+        if item.db.integrated:
+            return (
+                f"{item.get_display_name(self)} is part of your body — "
+                f"it deploys and retracts, it doesn't wield."
+            )
+
         # Check if item is currently worn
         if hasattr(self, 'is_item_worn') and self.is_item_worn(item):
             return "You can't wield something you're wearing. Remove it first."
@@ -1728,6 +1738,15 @@ class Character(
         item = current[canonical]
         if not item:
             return f"You're not holding anything in your {display}."
+
+        # Integrated cyberware (#516): the deployed arm-gun is not
+        # held, it IS the hand.  unwield and freehands both route
+        # through here — refusing here closes both paths.
+        if item.db.integrated:
+            return (
+                f"{item.get_display_name(self)} is part of your "
+                f"{display} — retract it instead."
+            )
 
         item.move_to(self, quiet=True)
         held = dict(self.held_items or {})

--- a/world/combat/actions.py
+++ b/world/combat/actions.py
@@ -98,11 +98,14 @@ def resolve_disarm(handler, char, entry):
         return
 
     # Find weapon to disarm (prioritize weapons, then any held item).
+    # "Weapon" = the ("weapon", "type") tag — db.weapon_type can't
+    # discriminate because every item defaults to "melee".
     # Integrated cyberware (#516) is bolted to the skeleton — you
     # can't knock an arm-gun out of someone's hand.
     weapon_hand = None
     for hand, item in hands.items():
-        if item and item.db.weapon_type and not item.db.integrated:
+        if (item and not item.db.integrated
+                and item.tags.has("weapon", category="type")):
             weapon_hand = hand
             break
 

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -106,13 +106,16 @@ def get_wielded_weapon(character):
     """
     Get the weapon the character fights with.
 
-    Actual weapons (items carrying ``db.weapon_type``) take priority
-    over other held items — a deployed arm-shotgun beats the
-    cigarette in the off hand (#516 playtest fix; previously this
-    returned the FIRST held item of any kind, so hand order decided
-    whether you shot or brandished your smoke).  With no real weapon
-    in hand, the first held item still serves — brawling with a
-    bottle works as before.
+    Actual weapons take priority over other held items — a deployed
+    arm-shotgun beats the cigarette in the off hand (#516 playtest
+    fix; previously this returned the FIRST held item of any kind,
+    so hand order decided whether you shot or brandished your
+    smoke).  "Actual weapon" means the ``("weapon", "type")`` tag
+    from the weapon base prototypes — ``db.weapon_type`` is useless
+    as a discriminator because EVERY item defaults to ``"melee"``
+    at creation (the brawl-with-anything design).  With no real
+    weapon in hand, the first held item still serves — brawling
+    with a bottle works as before.
 
     Args:
         character: The character to check
@@ -123,7 +126,8 @@ def get_wielded_weapon(character):
     hands = getattr(character, "hands", {})
     held = [item for item in hands.values() if item]
     for item in held:
-        if getattr(getattr(item, "db", None), "weapon_type", None):
+        tags = getattr(item, "tags", None)
+        if tags is not None and tags.has("weapon", category="type"):
             return item
     return held[0] if held else None
 

--- a/world/medical/augments.py
+++ b/world/medical/augments.py
@@ -149,7 +149,11 @@ def _toggle_integrated_weapon(character, organ, name, spec) -> str:
 
         # Auto-drop whatever the hand held (settled decision: the
         # hand transforms regardless; the knife clatters down).
+        # Never the weapon itself — a state desync that left the gun
+        # seated must not hurl the integrated gun to the floor.
         held = hands.get(slot)
+        if held == weapon:
+            held = None
         if held is not None and character.location is not None:
             held.move_to(character.location, quiet=True)
             character.msg(
@@ -166,6 +170,17 @@ def _toggle_integrated_weapon(character, organ, name, spec) -> str:
                 char_refs={"actor": character},
                 exclude=[character],
             )
+
+        # Self-healing seat (#516 playtest): if the weapon is somehow
+        # referenced from another slot (legacy state from before the
+        # inventory-verb guards), clear those references first so the
+        # gun exists in exactly one place — its spec slot.
+        held = dict(character.held_items or {})
+        stale = [k for k, v in held.items() if v == weapon and k != slot]
+        if stale:
+            for k in stale:
+                held[k] = None
+            character.held_items = held
 
         weapon.location = character
         character.hands = {slot: weapon}
@@ -191,9 +206,20 @@ def _toggle_integrated_weapon(character, organ, name, spec) -> str:
 
     # ── Retract ───────────────────────────────────────────────────
     weapon = _find_weapon(state)
-    if weapon is not None and weapon.location is character:
-        character.hands = {slot: None}
-        weapon.location = None  # folded back inside the arm
+    if weapon is not None:
+        # Clear the slot the weapon is ACTUALLY in — scanned, not
+        # assumed — so a gun displaced into the wrong slot by legacy
+        # state still retracts cleanly instead of leaving a ghost.
+        held = dict(character.held_items or {})
+        cleared = False
+        for k, v in held.items():
+            if v == weapon:
+                held[k] = None
+                cleared = True
+        if cleared:
+            character.held_items = held
+        if weapon.location == character:
+            weapon.location = None  # folded back inside the arm
     state["deployed"] = False
     _persist(character)
 

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -149,6 +149,50 @@ class TestAbilityLayer(EvenniaTest):
         self.assertFalse(self.gun.access(self.char, "drop"))
         self.assertFalse(self.gun.access(self.char, "get"))
 
+    def test_unwield_refuses_integrated(self):
+        """The freehands bug: unwield and freehands both route
+        through unwield_item — the deployed gun is not held, it IS
+        the hand."""
+        toggle_ability(self.char, "shotgun")
+        result = self.char.unwield_item("right_hand")
+        self.assertIn("retract it instead", result)
+        # Still seated.
+        self.assertIs(self.char.hands["right_hand"], self.gun)
+
+    def test_wield_refuses_integrated(self):
+        """A freed integrated weapon must never be wieldable into an
+        arbitrary hand — that's how the gun ended up in the wrong
+        slot."""
+        self.gun.location = self.char  # simulate the freed state
+        result = self.char.wield_item(self.gun, "left_hand")
+        self.assertIn("doesn't wield", result)
+        self.assertIsNone(self.char.hands["left_hand"])
+
+    def test_retract_clears_the_actual_slot(self):
+        """Legacy desync (the Laszlo state): gun displaced into the
+        WRONG slot — retract scans for where it really is instead of
+        trusting the spec slot."""
+        self.gun.location = self.char
+        self.char.held_items = {"left_hand": self.gun}
+        self.organ.ability_state["shotgun"]["deployed"] = True
+        toggle_ability(self.char, "shotgun")  # retract
+        self.assertIsNone(self.char.hands["left_hand"])
+        self.assertIsNone(self.char.hands["right_hand"])
+        self.assertIsNone(self.gun.location)
+
+    def test_deploy_reseats_from_wrong_slot(self):
+        """Deploying over the same legacy desync clears the stale
+        reference and seats the gun in its spec slot — exactly one
+        place, the right one."""
+        self.gun.location = self.char
+        self.char.held_items = {"left_hand": self.gun}
+        toggle_ability(self.char, "shotgun")  # deploy
+        self.assertIs(self.char.hands["right_hand"], self.gun)
+        self.assertIsNone(self.char.hands["left_hand"])
+        # And the desync auto-drop guard: the gun itself was never
+        # "dropped" to the room.
+        self.assertIs(self.gun.location, self.char)
+
     def test_deployed_gun_beats_offhand_junk(self):
         """The Laszlo bug: combat must resolve the deployed shotgun,
         not the cigarette in the other hand — weapons (weapon_type)
@@ -157,6 +201,10 @@ class TestAbilityLayer(EvenniaTest):
         from world.combat.utils import get_wielded_weapon
 
         self.gun.db.weapon_type = "cybernetic_shotgun"
+        # The real discriminator: every Item defaults weapon_type to
+        # "melee" (the cigarette included), so weapons are known by
+        # the ("weapon", "type") tag the base prototypes carry.
+        self.gun.tags.add("weapon", category="type")
         cigarette = create_object(
             "typeclasses.items.Item", key="cigarette", location=self.char,
         )


### PR DESCRIPTION
Full audit from the playtest reports (freehands unwielding the arm-gun; combat still resolving the cigarette). Two root causes, both fixed:

## 1. Inventory verbs bypass locks entirely
The `get/drop/give` locks only protect default Evennia paths — **every custom verb mutates hands/locations directly.** `freehands` pulled the deployed gun to inventory; `wield` then seated it in the wrong hand, desyncing the toggle.

Guards added at the choke points: `wield_item` (integrated never wields), `unwield_item` (closes unwield **and** freehands), CmdDrop, CmdGive, CmdThrow, plus disarm/wrest from #518/#520. All refuse with body-part flavor.

## 2. `db.weapon_type` can't identify weapons
Every Item defaults to `weapon_type="melee"` at creation (brawl-with-anything design) — so #520's priority matched the cigarette too, and set-ordered hand iteration picked the winner. Real weapons carry the `("weapon", "type")` tag from the weapon base prototypes; `get_wielded_weapon` and disarm's priority now use it. Melee-default junk still serves when it's all you hold.

## Self-healing toggle
Deploy clears stale held references (and never auto-drops the weapon itself on desync); retract clears the slot the gun is *actually* in, scanned not assumed. Laszlo's gun-in-the-left-hand state heals on his next `/shotgun`.

## Tests
+5: wield/unwield refusals, wrong-slot retract and reseat, tag-based resolution pinned. Suite: **2,460 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)