### PR TITLE
All combat paths resolve weapons through get_wielded_weapon

### DIFF
--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -71,7 +71,7 @@ class CmdAttack(Command):
 
         # --- WEAPON IDENTIFICATION (early) ---
         hands = getattr(caller, "hands", {})
-        weapon_obj = next((item for hand, item in hands.items() if item), None)
+        weapon_obj = get_wielded_weapon(caller)
         
         # Debug weapon detection
         splattercast.msg(f"WEAPON_DETECT: {caller.key} hands={hands}, weapon_obj={weapon_obj.key if weapon_obj else 'None'}")
@@ -537,7 +537,7 @@ class CmdStop(Command):
                 
                 # Get weapon name for better messaging
                 hands = getattr(caller, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                weapon = get_wielded_weapon(caller)
                 weapon_name = weapon.key if weapon else "weapon"
                 
                 caller.msg(f"You stop aiming at {get_display_name_safe(aiming_target, caller)} and lower your {weapon_name}.")
@@ -553,7 +553,7 @@ class CmdStop(Command):
                 
                 # Get weapon name for better messaging
                 hands = getattr(caller, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                weapon = get_wielded_weapon(caller)
                 weapon_name = weapon.key if weapon else "weapon"
                 
                 # Try to get the actual exit name from the direction

--- a/commands/combat/movement.py
+++ b/commands/combat/movement.py
@@ -37,7 +37,7 @@ from commands.combat.jump import CmdJump, apply_gravity_to_items  # noqa: F401
 from commands._identity_targeting import resolve_character_in_rooms
 from world.combat.utils import (
     get_highest_opponent_stat, get_numeric_stat, filter_valid_opponents,
-    standard_roll, clear_aim_state,
+    standard_roll, clear_aim_state, get_wielded_weapon,
 )
 from world.identity_utils import msg_room_identity
 
@@ -129,7 +129,7 @@ class CmdFlee(Command):
                             other_entry = next((e for e in other_h.db.combatants if e["char"] == char_in_dest), None)
                             if other_entry and other_h.get_target_obj(other_entry) == caller:
                                 other_hands = getattr(char_in_dest, "hands", {})
-                                other_weapon_obj = next((item for hand, item in other_hands.items() if item), None)
+                                other_weapon_obj = get_wielded_weapon(char_in_dest)
                                 other_is_ranged = other_weapon_obj and other_weapon_obj.db.is_ranged
                                 if other_is_ranged:
                                     is_this_exit_safe_from_ranged_targeters = False
@@ -338,7 +338,7 @@ class CmdFlee(Command):
                             other_entry = next((e for e in (other_handler.db.combatants or []) if e["char"] == char_in_dest), None)
                             if other_entry and original_handler_at_flee_start.get_target_obj(other_entry) == caller:
                                 other_hands = getattr(char_in_dest, "hands", {})
-                                other_weapon = next((item for hand, item in other_hands.items() if item), None)
+                                other_weapon = get_wielded_weapon(char_in_dest)
                                 if other_weapon and other_weapon.db.is_ranged:
                                     is_safe = False
                                     break

--- a/commands/combat/special_actions.py
+++ b/commands/combat/special_actions.py
@@ -35,7 +35,10 @@ from world.combat.constants import (
     COMBAT_ACTION_GRAPPLE_TAKEOVER,
     COMBAT_ACTION_ESCAPE_GRAPPLE, COMBAT_ACTION_RELEASE_GRAPPLE,
 )
-from world.combat.utils import log_combat_action, initialize_proximity_ndb, get_display_name_safe
+from world.combat.utils import (
+    log_combat_action, initialize_proximity_ndb, get_display_name_safe,
+    get_wielded_weapon,
+)
 from world.grammar import capitalize_first
 from world.identity_utils import msg_room_identity
 from commands._identity_targeting import resolve_character_target
@@ -385,7 +388,7 @@ class CmdAim(Command):
                 
                 # Get weapon name for better messaging
                 hands = getattr(caller, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                weapon = get_wielded_weapon(caller)
                 weapon_name = weapon.key if weapon else "weapon"
                 
                 caller.msg(f"You stop aiming at {get_display_name_safe(current_target, caller)} and lower your {weapon_name}.")
@@ -402,7 +405,7 @@ class CmdAim(Command):
                 
                 # Get weapon name for better messaging
                 hands = getattr(caller, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                weapon = get_wielded_weapon(caller)
                 weapon_name = weapon.key if weapon else "weapon"
                 
                 # Try to get the actual exit name from the direction
@@ -493,7 +496,7 @@ class CmdAim(Command):
                 
                 # Check if caller has a ranged weapon for direction aiming
                 hands = getattr(caller, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                weapon = get_wielded_weapon(caller)
                 
                 is_ranged_weapon = False
                 if weapon:
@@ -522,7 +525,7 @@ class CmdAim(Command):
                 
                 # Get held weapon for better messaging
                 hands = getattr(caller, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                weapon = get_wielded_weapon(caller)
                 weapon_name = weapon.key if weapon else "weapon"
                 
                 # Use the exit's actual name instead of hardcoded direction mapping
@@ -589,7 +592,7 @@ class CmdAim(Command):
 
             # Check if caller has a ranged weapon
             hands = getattr(caller, "hands", {})
-            weapon = next((item for hand, item in hands.items() if item), None)
+            weapon = get_wielded_weapon(caller)
             
             is_ranged_weapon = False
             if weapon:
@@ -606,7 +609,7 @@ class CmdAim(Command):
 
             # Send messages - get weapon name for better messaging
             hands = getattr(caller, "hands", {})
-            weapon = next((item for hand, item in hands.items() if item), None)
+            weapon = get_wielded_weapon(caller)
             weapon_name = weapon.key if weapon else "weapon"
             
             caller.msg(f"You raise your {weapon_name}, taking careful aim at {get_display_name_safe(target, caller)}.")
@@ -646,7 +649,7 @@ class CmdAim(Command):
                 splattercast.msg(f"AIM_DEBUG: Direction '{direction}' is valid, proceeding with aiming")
                 # Check if caller has a ranged weapon for direction aiming
                 hands = getattr(caller, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                weapon = get_wielded_weapon(caller)
                 
                 is_ranged_weapon = False
                 if weapon:
@@ -675,7 +678,7 @@ class CmdAim(Command):
                 
                 # Get held weapon for better messaging
                 hands = getattr(caller, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                weapon = get_wielded_weapon(caller)
                 weapon_name = weapon.key if weapon else "weapon"
                 
                 # For this path, we don't have a target object since it's a fallback direction aim

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -144,7 +144,8 @@ class Exit(DefaultExit):
                 
                 # Get weapon name for better messaging
                 hands = getattr(traversing_object, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                from world.combat.utils import get_wielded_weapon
+                weapon = get_wielded_weapon(traversing_object)
                 weapon_name = weapon.key if weapon else "weapon"
                 
                 traversing_object.msg(f"You stop aiming at {old_aim_target.get_display_name(traversing_object)} and lower your {weapon_name} as you move.")
@@ -160,7 +161,8 @@ class Exit(DefaultExit):
                 
                 # Get weapon name for better messaging
                 hands = getattr(traversing_object, "hands", {})
-                weapon = next((item for hand, item in hands.items() if item), None)
+                from world.combat.utils import get_wielded_weapon
+                weapon = get_wielded_weapon(traversing_object)
                 weapon_name = weapon.key if weapon else "weapon"
                 
                 # Try to get the actual exit name from the direction

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -144,6 +144,29 @@ class TestAbilityLayer(EvenniaTest):
             self.organ.ability_state["shotgun"].get("deployed", False)
         )
 
+    def test_no_inline_weapon_picks_outside_the_resolver(self):
+        """Doctrine pin (#516 playtest): combat code must resolve
+        weapons through get_wielded_weapon, never the inline
+        first-held-item idiom — that idiom is how the engagement
+        message brandished a zippo while the hit fired the arm-gun.
+        """
+        import pathlib
+
+        root = pathlib.Path(__file__).resolve().parents[2]
+        idiom = "next((item for hand, item in"
+        offenders = []
+        for sub in ("commands", "world", "typeclasses"):
+            for path in (root / sub).rglob("*.py"):
+                if "tests" in path.parts:
+                    continue
+                if idiom in path.read_text(encoding="utf-8"):
+                    offenders.append(str(path.relative_to(root)))
+        self.assertEqual(
+            offenders, [],
+            "inline weapon picks found — use get_wielded_weapon: "
+            f"{offenders}",
+        )
+
     def test_integrated_weapon_refuses_drop(self):
         toggle_ability(self.char, "shotgun")
         self.assertFalse(self.gun.access(self.char, "drop"))


### PR DESCRIPTION
Playtest: attacks fired the `cybernetic_shotgun` message set, but combat **initiation** said "zippo lighter glinting menacingly."

Root cause: **fifteen** inline copies of the first-held-item idiom scattered across `core_actions` (attack initiation, stop-aiming), `special_actions` (aim messaging + ranged checks, 8 sites), `movement` (flee ranged-threat safety — silently missing a deployed gun in the off hand when judging exit safety), and `exits` (aim-clear messaging). All predate `get_wielded_weapon` and none received the #520/#521 tag-priority fixes.

All fifteen now route through `get_wielded_weapon`, and a doctrine test scans the codebase for the idiom so it can't creep back — weapon resolution has exactly one home.

Suite: **2,461 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)