### PR TITLE
Sever/install review: chrome doesn't bleed, wreckage admits the mount

### DIFF
--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -603,8 +603,11 @@ class CmdInstall(Command):
 
         # Multi-container gate (spec §3.5): a replacement augment
         # (the shotgun arm spans right_arm + right_hand) declares
-        # organs at several containers — every one of them must be
-        # vacant or a severed stump.  Amputate first, then mount.
+        # organs at several containers — every one must be free of
+        # LIVING anatomy.  Stumps and pulped wreckage both admit the
+        # mount (user decision 2026-06-13: sever and amputate are one
+        # path, and the install surgery clears ruined remains the
+        # same way it clears severed remnants).
         augment_container = organ_item.db.augment_container
         augment_organs = organ_item.db.augment_organs or {}
         declared = {
@@ -615,15 +618,15 @@ class CmdInstall(Command):
         blocking = [
             organ for organ in state.organs.values()
             if getattr(organ, "container", None) in declared
-            and organ.wound_stage != "severed"
+            and organ.current_hp > 0
         ]
         if blocking:
             container = blocking[0].container
             caller.msg(
-                f"{target.get_display_name(caller)} already has a "
-                f"{container.replace('_', ' ')} — the "
-                f"{organ_item.key} mounts over a stump, not living "
-                f"anatomy."
+                f"{target.get_display_name(caller)} still has a "
+                f"living {container.replace('_', ' ')} — the "
+                f"{organ_item.key} mounts over a stump or wreckage, "
+                f"not living anatomy."
             )
             return
 

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1225,7 +1225,16 @@ class Appendage(Item):
         # look output explicitly surfaces the freshness state.  The
         # tagline travels in ``db.desc`` so the dynamic wound /
         # longdesc composition below still rides on top cleanly.
-        prose = get_severed_part_description(species, location_name, condition)
+        # Cyber-aware prose (#516 follow-up): a severed augment limb
+        # is chrome, not meat.  Snapshot organ dicts carry their spec
+        # under "data" since the anatomy substrate.
+        snapshot = corpse.get_medical_snapshot() if hasattr(corpse, "get_medical_snapshot") else {}
+        inorganic = _chain_organs_inorganic_snapshot(snapshot, chain)
+        if inorganic and species in (self.key or ""):
+            self.key = self.key.replace(species, "cybernetic", 1)
+        prose = get_severed_part_description(
+            species, location_name, condition, inorganic=inorganic,
+        )
         composed = prepend_condition_to_desc(condition, prose)
         if composed:
             self.db.desc = composed
@@ -1327,7 +1336,14 @@ class Appendage(Item):
         else:
             self.key = get_species_part_name(species, location_name, "fresh")
 
-        prose = get_severed_part_description(species, location_name, condition)
+        # Cyber-aware prose (#516 follow-up): a severed augment limb
+        # is chrome, not meat.  Read live off the still-intact body.
+        inorganic = _chain_organs_inorganic_live(character, chain)
+        if inorganic and species in (self.key or ""):
+            self.key = self.key.replace(species, "cybernetic", 1)
+        prose = get_severed_part_description(
+            species, location_name, condition, inorganic=inorganic,
+        )
         composed = prepend_condition_to_desc(condition, prose)
         if composed:
             self.db.desc = composed
@@ -1659,6 +1675,42 @@ def apply_organ_snapshot_overlay(appendage, *, source_snapshot,
             name for name in (source_removed_organs or ())
             if name in trimmed
         ]
+
+
+def _chain_organs_inorganic_live(character, chain):
+    """True when the organs at the severed chain's containers are
+    augment chrome (any flags ``inorganic`` — #516 follow-up).  Read
+    off the living body BEFORE the sever mutates it."""
+    state = getattr(character, "medical_state", None)
+    organs = getattr(state, "organs", None) if state else None
+    if not organs:
+        return False
+    chain_set = set(chain or ())
+    for organ in organs.values():
+        if getattr(organ, "container", None) not in chain_set:
+            continue
+        data = getattr(organ, "data", None)
+        if data and data.get("inorganic"):
+            return True
+    return False
+
+
+def _chain_organs_inorganic_snapshot(snapshot, chain):
+    """Snapshot-dict twin of :func:`_chain_organs_inorganic_live` for
+    the corpse path.  Organ dicts carry their spec under ``"data"``
+    since the anatomy substrate; legacy snapshots without it read as
+    flesh."""
+    organs = (snapshot or {}).get("organs") or {}
+    chain_set = set(chain or ())
+    for entry in organs.values():
+        if not hasattr(entry, "get"):
+            continue
+        if entry.get("container") not in chain_set:
+            continue
+        data = entry.get("data")
+        if data and hasattr(data, "get") and data.get("inorganic"):
+            return True
+    return False
 
 
 def apply_sever_to_corpse(corpse, location_arg, *, head_locations=None):

--- a/world/anatomy/severed_parts.py
+++ b/world/anatomy/severed_parts.py
@@ -367,7 +367,31 @@ SEVERED_PART_DESCRIPTIONS.setdefault("rat", {
 })
 
 
-def get_severed_part_description(species, location, condition):
+#: Severed cybernetic parts (#516 follow-up).  Augment anatomy is
+#: chrome, not meat — a severed gun arm must not describe "muscle
+#: firm" and "cartilage".  Keyed by location with a ``None`` generic
+#: fallback whose ``{part}`` formats to the location name.  Used
+#: whenever the severed chain's organs are flagged ``inorganic``.
+CYBERNETIC_PART_DESCRIPTIONS = {
+    None: {
+        "pristine": (
+            "A severed cybernetic {part}, composite plating intact "
+            "and torn power couplings trailing from the mount-end, "
+            "still beaded with sealant gel."
+        ),
+        "damaged": (
+            "A scuffed cybernetic {part}, its plating dented and the "
+            "mount-end couplings frayed dark where they tore."
+        ),
+        "putrid": (
+            "A grime-caked cybernetic {part}, servos locked stiff and "
+            "the flesh-interface ring at the mount gone soft and foul."
+        ),
+    },
+}
+
+
+def get_severed_part_description(species, location, condition, inorganic=False):
     """Return condition-keyed prose for a severed body part.
 
     Args:
@@ -384,7 +408,21 @@ def get_severed_part_description(species, location, condition):
         isn't registered.  Callers should treat empty as "no default
         desc available, fall back to whatever Evennia does next"
         rather than asserting.
+
+    When ``inorganic`` is True (the severed chain's organs are
+    augment chrome), the cybernetic table answers first — location-
+    specific entry, then the generic ``{part}`` template — before
+    falling through to the species flesh prose.
     """
+    if inorganic:
+        cyber_table = (
+            CYBERNETIC_PART_DESCRIPTIONS.get(location)
+            or CYBERNETIC_PART_DESCRIPTIONS.get(None, {})
+        )
+        prose = cyber_table.get(condition, "")
+        if prose:
+            return prose.format(part=(location or "limb").replace("_", " "))
+
     species_table = SEVERED_PART_DESCRIPTIONS.get(species)
     if species_table is None:
         species_table = SEVERED_PART_DESCRIPTIONS.get("human", {})

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -913,13 +913,23 @@ class MedicalState:
         """
         organ = self.get_organ(organ_name)
         was_destroyed = organ.take_damage(damage_amount, injury_type)
-        
+
         # Create medical conditions based on damage type and amount (Phase 2.6)
         if damage_amount > 0:
             new_conditions = self._create_conditions_from_damage(
                 damage_amount, injury_type, organ.container
             )
-            
+
+            # Inorganic organs (#516 follow-up, user decision
+            # 2026-06-13): chrome doesn't bleed and doesn't go
+            # septic — a shot-up gun arm loses function, not blood.
+            # Pain stays: neural feedback from the damaged graft.
+            if organ.data.get("inorganic"):
+                new_conditions = [
+                    c for c in new_conditions
+                    if getattr(c, "condition_type", "") == "pain"
+                ]
+
             # Add and start new conditions
             for condition in new_conditions:
                 self.add_condition(condition)

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -1331,6 +1331,29 @@ def _resolve_install_augment(actor, target, *, organ_item, location: str,
     } - {None}
     declared_containers.add(augment_container)
 
+    # Living-anatomy gate, re-checked at resolution (chart-commenced
+    # installs bypass CmdInstall's pre-dispatch gates — same pattern
+    # as the species and incision re-checks above).  Stumps and
+    # wreckage admit the mount; a living limb does not.
+    living = [
+        organ for organ in state.organs.values()
+        if getattr(organ, "container", None) in declared_containers
+        and organ.current_hp > 0
+    ]
+    if living:
+        container = living[0].container
+        actor.msg(
+            f"{target.get_display_name(actor)} still has a living "
+            f"{container.replace('_', ' ')} — the {organ_item.key} "
+            f"mounts over a stump or wreckage, not living anatomy."
+        )
+        from world.medical.charts import mark_running_step_failed
+        mark_running_step_failed(
+            target,
+            outcome=f"living anatomy at {container} — augment blocked",
+        )
+        return
+
     for organ_name in [
         name for name, organ in state.organs.items()
         if getattr(organ, "container", None) in declared_containers
@@ -1358,6 +1381,10 @@ def _resolve_install_augment(actor, target, *, organ_item, location: str,
             continue
         longdesc_key = entry.get("key") or augment_container
         if longdesc_key in longdescs:
+            # Mounting over destroyed-in-place anatomy: the key
+            # survived (only severance removes it) but the limb it
+            # described is gone — the augment's prose replaces it.
+            longdescs[longdesc_key] = entry.get("default_desc")
             continue
         new_longdescs = {}
         display_after = entry.get("display_after")

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -1966,6 +1966,7 @@ CYBERNETIC_TAIL = {
                 "fracture_vulnerable": True, "bone_type": "actuator_column",
                 "severable_container": True,
                 "grasping": True,
+                "inorganic": True,
             },
         }),
         ("augment_container", "tail"),
@@ -2000,6 +2001,7 @@ SHOTGUN_ARM = {
                 "hit_weight": "common", "can_be_destroyed": True,
                 "fracture_vulnerable": True,
                 "bone_type": "actuator_column",
+                "inorganic": True,
                 "abilities": {
                     "shotgun": {
                         "type": "integrated_weapon",
@@ -2018,6 +2020,7 @@ SHOTGUN_ARM = {
                 "fracture_vulnerable": True,
                 "bone_type": "actuator_lattice",
                 "grasping": True,
+                "inorganic": True,
             },
         }),
         ("augment_container", "right_arm"),

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -369,28 +369,140 @@ class TestReplacementAugmentInstall(TestCase):
 
 
 class TestReplacementAugmentGate(TestCase):
-    def test_living_anatomy_blocks_install(self):
-        """The command gate: you amputate first, then mount.  Tested
-        at the helper level the command branch uses."""
-        target = _patient()
-        item = _arm_item()
+    """Living anatomy blocks; stumps AND wreckage admit (user
+    decision 2026-06-13: sever and amputate are one path, and the
+    install surgery clears mangled remains the same way).  The gate
+    is HP-based — tested at the helper level the command branch and
+    resolver both use."""
+
+    def _blocking(self, target, item):
         declared = {
             spec["container"]
             for spec in item.db.augment_organs.values()
         }
-        blocking = [
+        return [
             organ for organ in target.medical_state.organs.values()
-            if organ.container in declared
-            and organ.wound_stage != "severed"
+            if organ.container in declared and organ.current_hp > 0
         ]
-        self.assertTrue(blocking)  # healthy arm blocks
+
+    def test_living_anatomy_blocks_install(self):
+        target = _patient()
+        self.assertTrue(self._blocking(target, _arm_item()))
+
+    def test_severed_stump_admits(self):
+        target = _patient()
         _sever_right_arm(target)
-        blocking = [
-            organ for organ in target.medical_state.organs.values()
-            if organ.container in declared
-            and organ.wound_stage != "severed"
+        self.assertFalse(self._blocking(target, _arm_item()))
+
+    def test_destroyed_wreckage_admits(self):
+        """Pulped-in-place (blunt/bullet — destroyed, not severed)
+        is anatomy to clear, not anatomy that blocks."""
+        target = _patient()
+        for organ in target.medical_state.organs.values():
+            if organ.container in ("right_arm", "right_hand"):
+                organ.current_hp = 0
+                organ.wound_stage = "destroyed"
+        self.assertFalse(self._blocking(target, _arm_item()))
+
+    def test_resolver_recheck_blocks_living_anatomy(self):
+        """Chart-commenced installs bypass the command gate — the
+        resolver re-checks and marks the step failed."""
+        target = _patient()
+        target.longdesc = {"head": None, "right_arm": None}
+        open_incision(target, "right_arm")
+        actor = _surgeon()
+        item = _arm_item()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": "success"},
+        ):
+            _resolve_install_augment(
+                actor, target, organ_item=item, location="right_arm",
+            )
+        self.assertNotIn("cybernetic_humerus", target.medical_state.organs)
+        self.assertFalse(item.deleted)
+        self.assertTrue(any("living" in m for m in actor.messages))
+
+    def test_install_over_wreckage_replaces_longdesc(self):
+        """Destroyed-in-place limbs keep their longdesc key (only
+        severance removes it) — the mount overwrites the dead flesh
+        prose with the augment's."""
+        target = _patient()
+        target.longdesc = {
+            "head": None, "right_arm": "A scarred but mighty arm.",
+            "right_hand": None,
+        }
+        for organ in target.medical_state.organs.values():
+            if organ.container in ("right_arm", "right_hand"):
+                organ.current_hp = 0
+                organ.wound_stage = "destroyed"
+        open_incision(target, "right_arm")
+        actor = _surgeon()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": "success"},
+        ):
+            _resolve_install_augment(
+                actor, target, organ_item=_arm_item(), location="right_arm",
+            )
+        self.assertIn("cybernetic_humerus", target.medical_state.organs)
+        self.assertEqual(target.longdesc["right_arm"], "A cyber arm.")
+        self.assertEqual(target.longdesc["right_hand"], "A cyber hand.")
+
+
+class TestInorganicConditions(TestCase):
+    """Chrome doesn't bleed and doesn't go septic; pain stays as
+    neural feedback (user decision 2026-06-13)."""
+
+    def _damaged(self, inorganic):
+        from world.medical.conditions import MedicalCondition
+
+        target = _patient()
+        spec = dict(TAIL_ORGAN_SPEC)
+        spec["inorganic"] = inorganic
+        organ = Organ("cybernetic_tailbone", organ_data=spec)
+        organ.medical_state = target.medical_state
+        target.medical_state.organs["cybernetic_tailbone"] = organ
+        # Script lifecycle isn't under test — the stub has no
+        # Evennia scripts handler.
+        with patch.object(
+            MedicalCondition, "start_condition", lambda self, ch: None,
+        ):
+            target.medical_state.take_organ_damage(
+                "cybernetic_tailbone", 12, "bullet",
+            )
+        return [
+            getattr(c, "condition_type", "")
+            for c in target.medical_state.conditions
         ]
-        self.assertFalse(blocking)  # stump admits the mount
+
+    def test_inorganic_organ_damage_yields_pain_only(self):
+        types = self._damaged(inorganic=True)
+        self.assertNotIn("bleeding", types)
+        self.assertNotIn("infection", types)
+        self.assertIn("pain", types)
+
+    def test_organic_organ_damage_still_bleeds(self):
+        types = self._damaged(inorganic=False)
+        self.assertIn("bleeding", types)
+
+
+class TestSeveredCyberProse(TestCase):
+    def test_inorganic_parts_get_chrome_prose(self):
+        from world.anatomy.severed_parts import get_severed_part_description
+
+        for condition in ("pristine", "damaged", "putrid"):
+            prose = get_severed_part_description(
+                "human", "right_arm", condition, inorganic=True,
+            )
+            self.assertIn("cybernetic", prose.lower())
+            self.assertNotIn("muscle", prose.lower())
+
+    def test_flesh_parts_unchanged(self):
+        from world.anatomy.severed_parts import get_severed_part_description
+
+        prose = get_severed_part_description("human", "right_arm", "pristine")
+        self.assertIn("muscle", prose.lower())
 
 
 class TestCyberneticShotgunMessages(TestCase):


### PR DESCRIPTION
User-requested review of amputation/severance vs augment install, verified by live round-trip simulation (sever flesh arm → mount gun arm → deploy → sever cyber arm). Sever and surgical amputate confirmed identical — one code path. The round trip itself is sound: stump state fully heals on install, the stump's open incision legitimately satisfies the mount's anchor gate, and severed cyber arms carry their hardware and organs.

## Fixed
1. **Chrome bled and went septic.** Condition creation had zero organ awareness. New `inorganic` organ-spec flag: damage to cyber organs yields **pain only** (neural feedback — user decision); bleeding/infection filtered. Tail + arm prototypes flagged.
2. **Wreckage blocked the mount.** Per user ruling (installing addresses the mangled limb), the already-has gate is now HP-based — living anatomy blocks, stumps *and* pulped-in-place limbs admit. Re-checked in the resolver (chart path bypasses command gates), and the destroyed limb's surviving longdesc prose is overwritten by the augment's.
3. **Severed cyber arms read as flesh** ("muscle firm... cartilage", keyed "human right arm"). Severed-part prose and naming are now inorganic-aware on both the living-sever and corpse paths — "cybernetic right arm" with chrome prose.

## Noted, deliberately unfixed
Severance-moment narrative still flesh-flavored for chrome (message-library content pass); the gun stays entombed in a severed arm pending a salvage mechanic.

Tests: +8 (inorganic conditions both ways, HP gate ladder incl. wreckage, resolver re-check, longdesc overwrite, chrome/flesh prose split). Suite: **2,469 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)