### PR TITLE
The organs dict is the truth: kill the zombie-organ factory

### DIFF
--- a/commands/CmdMedical.py
+++ b/commands/CmdMedical.py
@@ -256,6 +256,10 @@ class CmdMedicalInfo(Command):
                 status = "|yDamaged|n"
             elif organ.current_hp > 0:
                 status = "|rSeverely Damaged|n"
+            elif organ.wound_stage == "severed":
+                # The 0-HP tombstone of a severed limb is the stump
+                # record, not in-place destruction (#516 review).
+                status = "|xSevered|n"
             else:
                 status = "|RDestroyed|n"
                 

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -646,21 +646,25 @@ class MedicalState:
         self._cache_dirty = True
 
     def get_organ(self, organ_name):
-        """Get organ by name, creating if it doesn't exist.
+        """Get organ by name, or ``None`` when the body doesn't have it.
 
-        Species-aware (issue #356 Phase 1) — lazily-created organs
-        consult the owning character's species so the spec lookup
-        targets the right table.  Sets the parent back-reference
-        (#307) on newly-created organs.
+        NEVER creates (#516 sever/install review).  Per-character
+        anatomy makes absence meaningful: an organ deleted by an
+        augment install, or never present, must STAY absent.  The
+        old auto-create behavior was a zombie-organ factory — any
+        name lookup (capacity math iterating species tables, medinfo)
+        silently resurrected deleted anatomy at full HP, so a
+        character with a cybernetic arm grew phantom flesh bones the
+        moment anyone computed their capacities.
+
+        The standard: the organs dict is the single truth of present
+        anatomy.  Severed organs remain as 0-HP ``wound_stage
+        "severed"`` tombstones (they ARE the stump — wound rendering,
+        hands subtraction, and the re-augment gate all read them);
+        augment installs clear tombstones at their containers when
+        new anatomy takes the slot.
         """
-        if organ_name not in self.organs:
-            species = None
-            if self.character is not None:
-                species = getattr(self.character.db, "species", None)
-            organ = Organ(organ_name, species=species)
-            organ.medical_state = self
-            self.organs[organ_name] = organ
-        return self.organs[organ_name]
+        return self.organs.get(organ_name)
         
     def location_severable_by_organ(self, location):
         """True when any organ at ``location`` flags
@@ -739,7 +743,15 @@ class MedicalState:
         max_possible_capacity = 0.0
         
         for organ_name in capacity_organs:
-            organ = self.get_organ(organ_name)
+            organ = self.organs.get(organ_name)
+            if organ is None:
+                # Absent anatomy (#516 review): organ deleted by an
+                # augment install or never present — it contributes
+                # nothing and counts toward nothing.  Severed limbs
+                # still reduce capacity via their 0-HP tombstones;
+                # a mounted replacement implicitly restores it by
+                # taking the flesh organ out of the equation.
+                continue
             organ_functionality = organ.get_functionality_percentage()
             
             # Get contribution level - check for organ-specific contributions first
@@ -911,7 +923,11 @@ class MedicalState:
         Returns:
             bool: True if organ was destroyed
         """
-        organ = self.get_organ(organ_name)
+        organ = self.organs.get(organ_name)
+        if organ is None:
+            # Absent anatomy can't be damaged (#516 review — no
+            # auto-create; see get_organ).
+            return False
         was_destroyed = organ.take_damage(damage_amount, injury_type)
 
         # Create medical conditions based on damage type and amount (Phase 2.6)

--- a/world/medical/utils.py
+++ b/world/medical/utils.py
@@ -432,7 +432,7 @@ def distribute_damage_to_organs(location, total_damage, medical_state, injury_ty
     functional_organs = []
     for organ_name in organs:
         organ = medical_state.get_organ(organ_name)
-        if not organ.is_destroyed():
+        if organ is not None and not organ.is_destroyed():
             functional_organs.append(organ_name)
     
     # If all organs in this location are destroyed, no damage can be applied

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -487,6 +487,48 @@ class TestInorganicConditions(TestCase):
         self.assertIn("bleeding", types)
 
 
+class TestAnatomyIsTheTruth(TestCase):
+    """The #516-review standard: the organs dict is the single truth
+    of present anatomy — nothing auto-creates.  The old get_organ
+    auto-create was a zombie-organ factory: capacity math iterating
+    species tables by name resurrected install-deleted flesh organs
+    at full HP."""
+
+    def test_get_organ_never_creates(self):
+        state = _patient().medical_state
+        del state.organs["right_humerus"]
+        self.assertIsNone(state.get_organ("right_humerus"))
+        self.assertNotIn("right_humerus", state.organs)
+
+    def test_capacity_math_does_not_resurrect(self):
+        """The exact bug: medinfo capacities after a gun-arm install
+        re-created the deleted flesh arm."""
+        state = _patient().medical_state
+        del state.organs["right_humerus"]
+        state._cache_dirty = True
+        state.calculate_body_capacity("manipulation")
+        self.assertNotIn("right_humerus", state.organs)
+
+    def test_damage_to_absent_organ_is_a_noop(self):
+        state = _patient().medical_state
+        del state.organs["right_humerus"]
+        result = state.take_organ_damage("right_humerus", 10, "cut")
+        self.assertFalse(result)
+        self.assertNotIn("right_humerus", state.organs)
+
+    def test_severed_tombstones_still_reduce_capacity(self):
+        """Tombstones are load-bearing: a severed (not replaced) arm
+        keeps dragging manipulation down via its 0-HP record."""
+        target = _patient()
+        state = target.medical_state
+        state._cache_dirty = True
+        healthy = state.calculate_body_capacity("manipulation")
+        _sever_right_arm(target)
+        state._cache_dirty = True
+        severed = state.calculate_body_capacity("manipulation")
+        self.assertLess(severed, healthy)
+
+
 class TestSeveredCyberProse(TestCase):
     def test_inorganic_parts_get_chrome_prose(self):
         from world.anatomy.severed_parts import get_severed_part_description

--- a/world/tests/test_organ_condition_modifiers.py
+++ b/world/tests/test_organ_condition_modifiers.py
@@ -146,12 +146,17 @@ class OrganBackRefWired(TestCase):
             with self.subTest(organ=name):
                 self.assertIs(organ.medical_state, state)
 
-    def test_lazy_get_organ_sets_back_ref(self):
+    def test_get_organ_does_not_resurrect(self):
+        """SUPERSEDED behavior (#516 sever/install review): get_organ
+        no longer lazily creates.  Per-character anatomy makes
+        absence meaningful — auto-create was a zombie-organ factory
+        that resurrected install-deleted organs.  Absent stays
+        absent; the back-ref contract is covered by the init path
+        above and the augment install path."""
         state = MedicalState(_human_character())
-        # Drop an organ then re-fetch via get_organ.
         del state.organs["heart"]
-        heart = state.get_organ("heart")
-        self.assertIs(heart.medical_state, state)
+        self.assertIsNone(state.get_organ("heart"))
+        self.assertNotIn("heart", state.organs)
 
 
 class OrganScanFiltersConditionsByLocation(TestCase):


### PR DESCRIPTION
Part 2 of the sever/install review (playtest: medinfo showed install-deleted flesh organs back as "destroyed").

**Root cause:** `MedicalState.get_organ` auto-created any organ it was asked about. Capacity math iterates species organ lists by name, so running `medinfo` after a gun-arm install **resurrected the deleted flesh arm at full HP** — phantom anatomy inflating capacities — and the next severance tombstoned the zombies alongside the cyber organs.

**The standard, now codified:**
- The organs dict is the single truth of present anatomy; nothing auto-creates.
- Severed organs remain as 0-HP `severed` tombstones — they ARE the stump (wound rendering, hands subtraction, capacity loss, the re-augment gate all read them).
- Augment installs clear tombstones at their containers (#523).

`get_organ` returns existing-or-None; capacity math skips absent organs (a mounted replacement implicitly restores capacity; a bare stump keeps dragging it down); damage to absent anatomy no-ops; `medinfo` labels tombstones "Severed" rather than "Destroyed". One legacy test pinning lazy-create superseded in place.

Existing damaged characters self-heal: the next augment install over the affected containers clears all tombstones there.

Tests: +4. Suite: **2,473 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)