### PR TITLE
Cybernetics M1: spec-carrying organ items

### DIFF
--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -787,12 +787,30 @@ def _resolve_install(actor, target, *, organ_item, location: str,
         )
         return
 
-    # Success / partial: organ installs.  Living target: restore HP and
-    # attach any organ-bound conditions from the harvested item to the
-    # corresponding organ on the recipient.
+    # Success / partial: organ installs.  Living target: the slot's
+    # organ is rebuilt or restored, and any organ-bound conditions
+    # from the harvested item attach to it.
     state = getattr(target, "medical_state", None)
     if state is not None:
-        organ = state.organs.get(organ_item.db.organ_name)
+        organ_name = organ_item.db.organ_name
+        organ = state.organs.get(organ_name)
+
+        # Spec-carrying install (#526 M1): when the item carries an
+        # organ spec, the item IS the organ — rebuild the slot with
+        # the item's nature.  Same canonical name (capacity tables
+        # key by name; theming lives in prose), new spec: a
+        # cybernetic heart installs into the "heart" slot as
+        # inorganic chrome.  Items without a spec (legacy harvests,
+        # plain biological organs) keep the HP-restore behavior on
+        # the existing slot organ.
+        from evennia.utils.dbserialize import deserialize
+        item_spec = deserialize(getattr(organ_item.db, "organ_spec", None) or {})
+        if item_spec:
+            from world.medical.core import Organ
+            organ = Organ(organ_name, organ_data=dict(item_spec))
+            organ.medical_state = state
+            state.organs[organ_name] = organ
+
         if organ is not None:
             # Reset HP based on harvested condition.
             condition_hp = {
@@ -1714,6 +1732,17 @@ def _configure_harvested_item(item, *, organ_name: str, condition: str,
     # gate cross-species installs.  Legacy items pre-dating this
     # field fall back to ``[source_species]`` at picker time.
     item.db.compatible_species = [species]
+
+    # Spec-carrying harvest (#526 M1): the organ's spec dict travels
+    # with the item, so cyber organs and ability modules survive
+    # extraction and reinstall as what they ARE — not as whatever
+    # the destination slot's species default happens to be.  Legacy
+    # snapshots without "data" produce no spec; install falls back
+    # to its HP-restore behavior.
+    spec = organ_data.get("data") if hasattr(organ_data, "get") else None
+    if spec and hasattr(spec, "get"):
+        from evennia.utils.dbserialize import deserialize
+        item.db.organ_spec = deserialize(spec)
 
     stage_getter = getattr(source, "get_decay_stage", None)
     if callable(stage_getter):

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -1983,6 +1983,32 @@ CYBERNETIC_TAIL = {
     ],
 }
 
+# Cybernetic Heart - first spec-carrying replacement organ (#526 M1)
+# Installs into the canonical "heart" slot via the standard
+# replacement path (incise chest -> install -> suture).  Same organ
+# NAME so the blood_pumping capacity wiring is untouched; the SPEC
+# makes it chrome — inorganic (no bleed, no sepsis), sturdier than
+# meat.
+CYBERNETIC_HEART = {
+    "key": "cybernetic heart",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["cyber heart", "pump unit"],
+    "desc": "A fist-sized cardiac replacement unit, its impeller housing machined from surgical alloy and its mounting collar ringed with vascular couplers. It does one thing, forever, without being asked.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("organ_name", "heart"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "chest", "max_hp": 20, "hit_weight": "uncommon",
+            "vital": True, "capacity": "blood_pumping",
+            "contribution": "total",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True,
+        }),
+    ],
+}
+
 # Shotgun Arm - first replacement augment + integrated weapon (#516)
 SHOTGUN_ARM = {
     "key": "shotgun arm",

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -529,6 +529,110 @@ class TestAnatomyIsTheTruth(TestCase):
         self.assertLess(severed, healthy)
 
 
+CYBER_HEART_SPEC = {
+    "container": "chest", "max_hp": 20, "hit_weight": "uncommon",
+    "vital": True, "capacity": "blood_pumping", "contribution": "total",
+    "inorganic": True,
+}
+
+
+def _organ_item(organ_name="heart", organ_spec=None, condition="pristine"):
+    """Stub mirroring a harvested/cyber organ item (#526 M1)."""
+    item = SimpleNamespace()
+    item.key = f"cybernetic {organ_name}"
+    item.deleted = False
+
+    def _delete():
+        item.deleted = True
+    item.delete = _delete
+    item.db = SimpleNamespace(
+        organ_name=organ_name,
+        condition=condition,
+        organ_conditions=[],
+        organ_spec=organ_spec,
+        compatible_species=["human"],
+    )
+    item.get_display_name = lambda looker=None: item.key
+    return item
+
+
+class TestSpecCarryingOrgans(TestCase):
+    """#526 M1: the item IS the organ — specs travel with harvested
+    items and rebuild the slot on install (same canonical name, new
+    nature)."""
+
+    def _install(self, target, item, outcome="success"):
+        from world.medical.procedures import _resolve_install
+
+        actor = _surgeon()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": outcome},
+        ):
+            _resolve_install(
+                actor, target, organ_item=item, location="chest",
+            )
+        return actor
+
+    def test_spec_item_rebuilds_the_slot(self):
+        """Installing a cybernetic heart replaces the flesh heart's
+        NATURE while keeping the canonical name — capacity wiring
+        untouched, organ now chrome."""
+        target = _patient()
+        open_incision(target, "chest")
+        self._install(target, _organ_item(organ_spec=dict(CYBER_HEART_SPEC)))
+
+        heart = target.medical_state.organs["heart"]
+        self.assertTrue(heart.data.get("inorganic"))
+        self.assertEqual(heart.max_hp, 20)
+        self.assertEqual(heart.current_hp, 20)  # pristine
+        self.assertEqual(heart.container, "chest")
+        self.assertIs(heart.medical_state, target.medical_state)
+
+    def test_damaged_spec_item_installs_damaged(self):
+        target = _patient()
+        open_incision(target, "chest")
+        self._install(
+            target,
+            _organ_item(organ_spec=dict(CYBER_HEART_SPEC), condition="damaged"),
+        )
+        heart = target.medical_state.organs["heart"]
+        self.assertEqual(heart.current_hp, 12)  # 60% of 20
+        self.assertEqual(heart.wound_stage, "fresh")
+
+    def test_legacy_item_keeps_restore_behavior(self):
+        """No spec = plain biological organ: the existing slot organ
+        is restored, its nature unchanged."""
+        target = _patient()
+        open_incision(target, "chest")
+        original = target.medical_state.organs["heart"]
+        original.current_hp = 3
+        self._install(target, _organ_item(organ_spec=None))
+
+        heart = target.medical_state.organs["heart"]
+        self.assertIs(heart, original)
+        self.assertEqual(heart.current_hp, heart.max_hp)
+        self.assertFalse(heart.data.get("inorganic"))
+
+    def test_harvest_writes_the_spec_onto_the_item(self):
+        """The other half of the round trip: extraction carries the
+        organ's spec so chrome reinstalls as chrome."""
+        from world.medical.procedures import _configure_harvested_item
+
+        target = _patient()
+        cyber = Organ("heart", organ_data=dict(CYBER_HEART_SPEC))
+        cyber.medical_state = target.medical_state
+        target.medical_state.organs["heart"] = cyber
+
+        item = SimpleNamespace(db=SimpleNamespace())
+        _configure_harvested_item(
+            item, organ_name="heart", condition="pristine",
+            source=target, organ_data=cyber.to_dict(),
+        )
+        self.assertTrue(item.db.organ_spec.get("inorganic"))
+        self.assertEqual(item.db.organ_spec.get("max_hp"), 20)
+
+
 class TestSeveredCyberProse(TestCase):
     def test_inorganic_parts_get_chrome_prose(self):
         from world.anatomy.severed_parts import get_severed_part_description


### PR DESCRIPTION
First phase of #526 (spec §7): **the item IS the organ.**

- **Harvest carries the spec out**: `organ_spec` written onto harvested items from the organ's data dict — chrome extracts as chrome, modules will extract as modules. Legacy data degrades gracefully.
- **Install rebuilds from the spec**: the replacement path replaces the slot organ's *nature* while keeping the canonical name (capacity wiring untouched). Condition fidelity maps onto the new spec's HP ceiling. Spec-less biological items keep today's HP-restore behavior, pinned.
- **`CYBERNETIC_HEART`** exemplar — the low-impact replacement-organ tier, installed via the ordinary surgery loop, inorganic (no bleed/sepsis per #523), spawn-verified.

Tests: +4 (rebuild, damaged-condition mapping, legacy behavior, harvest spec carry). Suite: **2,477 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)