### PR TITLE
Cybernetics M2+M3: side-agnostic chassis + hardpoint modules

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -516,14 +516,23 @@ def _list_donor_organs(caller):
     out = []
     for obj in (getattr(caller, "contents", None) or ()):
         obj_db = getattr(obj, "db", None)
-        organ_name = getattr(obj_db, "organ_name", None)
-        if organ_name:
-            out.append((obj, organ_name))
-            continue
         augment = getattr(obj_db, "augment_organs", None)
         if augment:
             label = getattr(obj_db, "augment_container", None) or obj.key
             out.append((obj, label))
+            continue
+        # Ability modules (#526 M3) — checked before organ_name:
+        # harvested modules carry both, and the module route wins.
+        module_type = (
+            getattr(obj_db, "module_type", None)
+            or (getattr(obj_db, "organ_spec", None) or {}).get("module_type")
+        )
+        if module_type:
+            out.append((obj, f"{module_type} module"))
+            continue
+        organ_name = getattr(obj_db, "organ_name", None)
+        if organ_name:
+            out.append((obj, organ_name))
     return out
 
 
@@ -579,6 +588,28 @@ def _list_install_locations(target, donor_item):
             compatible = [source_species]
     if compatible and target_species not in compatible:
         return []
+
+    # Ability modules (#526 M3): the install locations are the
+    # target's FREE matching hardpoint containers.
+    module_type = (
+        getattr(donor_db, "module_type", None)
+        or (getattr(donor_db, "organ_spec", None) or {}).get("module_type")
+    )
+    if module_type:
+        state = getattr(target, "medical_state", None)
+        organs = getattr(state, "organs", {}) if state is not None else {}
+        out = []
+        for organ in organs.values():
+            data = getattr(organ, "data", None)
+            if not data or data.get("hardpoint") != module_type:
+                continue
+            occupied = bool(data.get("abilities")) and organ.current_hp > 0
+            container = getattr(organ, "container", None)
+            if container:
+                out.append((container, "occupied" if occupied else "empty"))
+        # The picker may only offer free slots — occupied ones show
+        # for context but the command/resolver gates refuse them.
+        return [entry for entry in out if entry[1] == "empty"]
 
     target_displays = getattr(donor_db, "target_display_locations", None)
     target_container = getattr(donor_db, "target_container", None)
@@ -971,10 +1002,13 @@ def _process_install_donor(caller, raw_string, **kwargs):
                 f"{target_species} anatomy.|n"
             )
             return "node_top"
-        anchor = (
-            getattr(item_db, "augment_anchor", None)
-            or getattr(item_db, "augment_container", None)
-        )
+        # Side-agnostic chassis (#526 M2): the surgeon picks the
+        # side before the step is recorded.
+        from world.medical.procedures import resolve_augment_declaration
+        declaration = resolve_augment_declaration(item_db)
+        if declaration["side_agnostic"]:
+            return "node_install_side"
+        anchor = declaration["anchor"] or declaration["container"]
         _add_step_to_chart(
             caller, "install",
             {"organ_item_key": item.key, "location": anchor},
@@ -988,6 +1022,49 @@ def _process_install_donor(caller, raw_string, **kwargs):
 
     # Now ask for the install location.
     return "node_install_location"
+
+
+def _node_install_side(caller, raw_string, **kwargs):
+    """Side picker for side-agnostic chassis (#526 M2)."""
+    donor_key = getattr(caller.ndb, "_operate_install_donor", "?")
+    text = (
+        f"\n|wInstall {donor_key} — pick the side|n\n\n"
+        f"{donor_key} mounts on either side:\n\n"
+        "  1. left\n"
+        "  2. right\n\n"
+        "  x. Cancel\n\n"
+        "|wWhich side?|n"
+    )
+    options = ({"key": "_default", "goto": _process_install_side},)
+    return text, options
+
+
+def _process_install_side(caller, raw_string, **kwargs):
+    raw = (raw_string or "").strip().lower()
+    if raw in ("x", "exit", "cancel"):
+        return "node_top"
+    side = {"1": "left", "2": "right"}.get(raw, raw)
+    if side not in ("left", "right"):
+        caller.msg("|rPick left or right.|n")
+        return None
+    donor_item = getattr(caller.ndb, "_operate_install_donor_item", None)
+    donor_key = getattr(caller.ndb, "_operate_install_donor", None)
+    if donor_item is None or not donor_key:
+        caller.msg("|rDonor selection lost; please retry from the top.|n")
+        return "node_top"
+    from world.medical.procedures import resolve_augment_declaration
+    declaration = resolve_augment_declaration(donor_item.db, side=side)
+    anchor = declaration["anchor"] or declaration["container"]
+    _add_step_to_chart(
+        caller, "install",
+        {"organ_item_key": donor_key, "location": anchor, "side": side},
+    )
+    caller.msg(
+        f"{donor_key} mounts at the {anchor.replace('_', ' ')} — it "
+        f"must be open when this step runs (add an incise step first "
+        f"if it isn't)."
+    )
+    return "node_top"
 
 
 def _node_install_location(caller, raw_string, **kwargs):
@@ -1525,6 +1602,7 @@ class CmdOperate(Command):
                 "node_harvest_organ":    _node_harvest_organ,
                 "node_install_organ":    _node_install_organ,
                 "node_install_location": _node_install_location,
+                "node_install_side":     _node_install_side,
                 "node_suture_location":  _node_suture_location,
                 "node_amputate_location":_node_amputate_location,
                 "node_edit_chart":       _node_edit_chart,

--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -479,12 +479,23 @@ class CmdInstall(Command):
         caller = self.caller
         raw = (self.args or "").strip()
         if " in " not in raw:
-            caller.msg("Usage: install <organ> in <target>")
+            caller.msg("Usage: install <organ> in <target> [at <side/location>]")
             return
 
         item_phrase, _, target_phrase = raw.partition(" in ")
         item_phrase = item_phrase.strip()
         target_phrase = target_phrase.strip()
+
+        # Optional side / location suffix (#526 M2/M3):
+        # ``install cyber arm in bob at left`` (side-agnostic chassis)
+        # ``install shotgun module in bob at left arm`` (hardpoint pick)
+        side_or_location = None
+        if " at " in target_phrase:
+            target_phrase, _, side_or_location = target_phrase.partition(" at ")
+            target_phrase = target_phrase.strip()
+            side_or_location = (
+                side_or_location.strip().lower().replace(" ", "_")
+            )
 
         organ_item = caller.search(item_phrase, location=caller)
         if organ_item is None:
@@ -494,7 +505,23 @@ class CmdInstall(Command):
         # anatomy and CREATE their slot instead of requiring one —
         # they branch before the harvested-organ gate.
         if getattr(organ_item.db, "augment_organs", None):
-            self._install_augment(caller, organ_item, target_phrase)
+            self._install_augment(
+                caller, organ_item, target_phrase,
+                side=side_or_location,
+            )
+            return
+
+        # Ability modules (#526 M3) seat into chassis hardpoints —
+        # placement comes from the slot, not the organ name.
+        module_type = (
+            getattr(organ_item.db, "module_type", None)
+            or (getattr(organ_item.db, "organ_spec", None) or {}).get("module_type")
+        )
+        if module_type:
+            self._install_module(
+                caller, organ_item, target_phrase, module_type,
+                side_or_location=side_or_location,
+            )
             return
 
         organ_name = getattr(organ_item.db, "organ_name", None)
@@ -555,7 +582,8 @@ class CmdInstall(Command):
             f"{target.get_display_name(caller)}..."
         )
 
-    def _install_augment(self, caller, organ_item, target_phrase):
+    def _install_augment(self, caller, organ_item, target_phrase,
+                         side=None):
         """Stage an augment install (ANATOMY_AUGMENTS_SPEC §3.3).
 
         Pre-dispatch gates: living target, species compatibility
@@ -563,7 +591,28 @@ class CmdInstall(Command):
         edit), no healthy anatomy already at the augment container,
         and an open incision at the **anchor** (the slot doesn't
         exist yet; you cut where the hardware mounts).
+
+        ``side`` resolves side-agnostic chassis (#526 M2): one
+        CYBER_ARM prototype mounts left or right; the surgeon names
+        the side (``install cyber arm in bob at left``).
         """
+        # Normalize side input ("left arm" → "left").
+        if side:
+            side = side.split("_")[0]
+            if side not in ("left", "right"):
+                caller.msg("Side must be left or right.")
+                return
+
+        from world.medical.procedures import resolve_augment_declaration
+        declaration = resolve_augment_declaration(organ_item.db, side=side)
+        if declaration["side_agnostic"] and not side:
+            caller.msg(
+                f"The {organ_item.key} mounts on either side — name "
+                f"one: ``install {organ_item.key} in {target_phrase} "
+                f"at left`` (or right)."
+            )
+            return
+
         target = _resolve_target(caller, target_phrase)
         if target is None:
             return
@@ -608,8 +657,8 @@ class CmdInstall(Command):
         # mount (user decision 2026-06-13: sever and amputate are one
         # path, and the install surgery clears ruined remains the
         # same way it clears severed remnants).
-        augment_container = organ_item.db.augment_container
-        augment_organs = organ_item.db.augment_organs or {}
+        augment_container = declaration["container"]
+        augment_organs = declaration["organs"]
         declared = {
             spec.get("container")
             for spec in augment_organs.values()
@@ -630,7 +679,7 @@ class CmdInstall(Command):
             )
             return
 
-        anchor = organ_item.db.augment_anchor or augment_container
+        anchor = declaration["anchor"] or augment_container
         if not has_incision(target, anchor):
             caller.msg(
                 f"The {organ_item.key} mounts at the "
@@ -652,12 +701,109 @@ class CmdInstall(Command):
 
         start_procedure(
             target, verb="install_augment", actor=caller,
-            organ_item=organ_item, location=anchor,
+            organ_item=organ_item, location=anchor, side=side,
         )
         caller.msg(
             f"You begin mounting the {organ_item.key} at "
             f"{target.get_display_name(caller)}'s "
             f"{anchor.replace('_', ' ')}..."
+        )
+
+    def _install_module(self, caller, organ_item, target_phrase,
+                        module_type, side_or_location=None):
+        """Stage an ability-module install (#526 M3): the module
+        seats into a free chassis hardpoint.  With hardpoints on
+        both sides, the surgeon names one (``at left`` /
+        ``at left arm``)."""
+        from world.medical.procedures import find_hardpoint
+
+        target = _resolve_target(caller, target_phrase)
+        if target is None:
+            return
+        if not _is_body_container(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} isn't something "
+                f"you can install a module into."
+            )
+            return
+        state = getattr(target, "medical_state", None)
+        if state is None or not getattr(state, "organs", None):
+            caller.msg(
+                f"The {organ_item.key} needs a living body to "
+                f"integrate with."
+            )
+            return
+
+        species = getattr(target.db, "species", None) or "human"
+        compat = [
+            s.lower() for s in (organ_item.db.compatible_species or [])
+        ]
+        if compat and species.lower() not in compat:
+            caller.msg(
+                f"The {organ_item.key} isn't rated for {species} "
+                f"anatomy."
+            )
+            return
+
+        # Collect free hardpoints, optionally filtered by side.
+        candidates = []
+        for organ_name, organ in state.organs.items():
+            data = getattr(organ, "data", None)
+            if not data or data.get("hardpoint") != module_type:
+                continue
+            if bool(data.get("abilities")) and organ.current_hp > 0:
+                continue  # occupied
+            container = getattr(organ, "container", None) or ""
+            if side_or_location:
+                side = side_or_location.split("_")[0]
+                if not container.startswith(side):
+                    continue
+            candidates.append((organ_name, container))
+
+        if not candidates:
+            caller.msg(
+                f"No free {module_type.replace('_', ' ')} hardpoint "
+                f"on {target.get_display_name(caller)} — the "
+                f"{organ_item.key} needs a chassis slot (and an "
+                f"unoccupied one)."
+            )
+            return
+        if len({c for _n, c in candidates}) > 1:
+            sides = ", ".join(sorted(c.replace("_", " ") for _n, c in candidates))
+            caller.msg(
+                f"{target.get_display_name(caller)} has free "
+                f"hardpoints at: {sides}.  Name one — ``install "
+                f"{organ_item.key} in {target_phrase} at left`` (or "
+                f"right)."
+            )
+            return
+
+        container = candidates[0][1]
+        if not has_incision(target, container):
+            caller.msg(
+                f"The hardpoint sits inside "
+                f"{target.get_display_name(caller)}'s "
+                f"{container.replace('_', ' ')} — it isn't open. "
+                f"Try ``incise {target_phrase} at "
+                f"{container.replace('_', ' ')}``."
+            )
+            return
+
+        if _reject_if_busy(caller, target):
+            return
+        kit = _find_surgical_kit(caller)
+        if kit is None:
+            caller.msg("You need a surgical kit to seat a module.")
+            return
+
+        start_procedure(
+            target, verb="install_module", actor=caller,
+            organ_item=organ_item, location=container,
+        )
+        caller.msg(
+            f"You begin seating the {organ_item.key} into the "
+            f"hardpoint at {target.get_display_name(caller)}'s "
+            f"{container.replace('_', ' ')}..."
         )
 
 

--- a/world/medical/augments.py
+++ b/world/medical/augments.py
@@ -288,6 +288,34 @@ def _persist(character):
 # ---------------------------------------------------------------------
 
 
+def park_organ_hardware(character, organ) -> None:
+    """Retract and park one organ's ability hardware (#526 M3).
+
+    Called when the organ is being removed from the body (module or
+    organ harvest): any deployed weapon comes out of the hands and
+    off the grid so it travels with the harvested item's spec rather
+    than being orphaned — locked, undroppable, unretractable — in
+    the hand of a body that no longer has the ability.
+    """
+    store = getattr(organ, "ability_state", None) or {}
+    held = dict(getattr(character, "held_items", None) or {})
+    held_changed = False
+    for name, ability_state in store.items():
+        if not isinstance(ability_state, dict):
+            continue
+        weapon = _find_weapon(ability_state)
+        if weapon is not None:
+            for slot, item in held.items():
+                if item == weapon:
+                    held[slot] = None
+                    held_changed = True
+            if weapon.location == character:
+                weapon.location = None
+        ability_state["deployed"] = False
+    if held_changed:
+        character.held_items = held
+
+
 def carry_hardware_to_appendage(character, chain, appendage) -> None:
     """Move integrated hardware whose organ just severed onto the
     severed appendage (spec decision 7: the limb takes its gear).

--- a/world/medical/charts.py
+++ b/world/medical/charts.py
@@ -489,21 +489,30 @@ def commence_chart(target, actor) -> Optional[dict]:
         save_chart(target, chart)
         return commence_chart(target, actor)
 
-    # Augment items route to their own resolver (ANATOMY_AUGMENTS_SPEC
-    # §3.3): the chart vocabulary stays "install", the execution
-    # differs.  The mount point is authoritative from the item — the
-    # anchor overrides whatever location the chart recorded, so a
-    # stale or hand-authored step still cuts in the right place.
+    # Augment and module items route to their own resolvers (#516,
+    # #526 M3): the chart vocabulary stays "install", the execution
+    # differs.  For augments the mount point is authoritative from
+    # the item — the anchor overrides whatever location the chart
+    # recorded (side-resolved for side-agnostic chassis, #526 M2).
     if verb == "install":
         item_db = getattr(resolved_args.get("organ_item"), "db", None)
         if getattr(item_db, "augment_organs", None):
             verb = "install_augment"
-            anchor = (
-                getattr(item_db, "augment_anchor", None)
-                or getattr(item_db, "augment_container", None)
-            )
-            if anchor:
+            side = (args or {}).get("side")
+            from world.medical.procedures import resolve_augment_declaration
+            declaration = resolve_augment_declaration(item_db, side=side)
+            anchor = declaration["anchor"] or declaration["container"]
+            if anchor and "{side}" not in str(anchor):
                 resolved_args["location"] = anchor
+            if side:
+                resolved_args["side"] = side
+        elif (
+            getattr(item_db, "module_type", None)
+            or (getattr(item_db, "organ_spec", None) or {}).get("module_type")
+        ):
+            # Module seats at the recorded hardpoint container; the
+            # resolver re-finds the slot and re-checks the gates.
+            verb = "install_module"
 
     step["status"] = RUNNING
     chart["status"] = IN_PROGRESS

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -79,6 +79,9 @@ PROCEDURE_DURATIONS = {
     # Augment installs (ANATOMY_AUGMENTS_SPEC §3.3) — mounting new
     # anatomy is the same order of work as grafting an organ.
     "install_augment": 18,
+    # Module seating (#526 M3) — quicker than a graft: the chassis
+    # did the hard integration work already.
+    "install_module": 9,
     "suture":   9,
     "amputate": 12,
     # Autopsy is the deliberate counterpart to the cursory ``inspect``
@@ -1246,7 +1249,53 @@ def _resolve_autopsy(actor, target, **_) -> None:
     _store_result(full_report)
 
 
+def _format_side(value, side):
+    """Recursively resolve ``{side}`` placeholders in an augment
+    declaration (#526 M2).  Strings format; dicts format both keys
+    and values; lists/tuples map.  Non-templated data passes
+    through untouched."""
+    if isinstance(value, str):
+        return value.replace("{side}", side) if "{side}" in value else value
+    if hasattr(value, "items"):
+        return {
+            _format_side(k, side): _format_side(v, side)
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_format_side(v, side) for v in value]
+    return value
+
+
+def resolve_augment_declaration(item_db, side=None) -> dict:
+    """Return the item's augment declaration as plain data, with
+    ``{side}`` templates resolved (#526 M2 — side-agnostic chassis:
+    one CYBER_ARM prototype mounts left or right; the surgeon names
+    the side and everything resolves from it).
+
+    Returns ``{"organs", "container", "anchor", "longdesc",
+    "side_agnostic"}``.  ``side_agnostic`` is True when the raw
+    declaration contains ``{side}`` templates — callers must supply
+    ``side`` before gating or installing such items.
+    """
+    from evennia.utils.dbserialize import deserialize
+
+    raw = {
+        "organs": deserialize(getattr(item_db, "augment_organs", None) or {}),
+        "container": getattr(item_db, "augment_container", None),
+        "anchor": getattr(item_db, "augment_anchor", None),
+        "longdesc": deserialize(getattr(item_db, "augment_longdesc", None) or {}),
+    }
+    side_agnostic = "{side}" in str(raw["container"] or "") or any(
+        "{side}" in name for name in raw["organs"]
+    )
+    if side_agnostic and side:
+        raw = {key: _format_side(value, side) for key, value in raw.items()}
+    raw["side_agnostic"] = side_agnostic
+    return raw
+
+
 def _resolve_install_augment(actor, target, *, organ_item, location: str,
+                             side: str = None,
                              **_) -> None:
     """Resolve an augment install (ANATOMY_AUGMENTS_SPEC §3.3):
     create the item's declared anatomy on ``target``.
@@ -1255,15 +1304,26 @@ def _resolve_install_augment(actor, target, *, organ_item, location: str,
     opened — e.g. ``"back"`` for the tail); the new anatomy grows at
     the item's ``augment_container``.  Handles re-augmentation: any
     severed remnants at the augment container are replaced wholesale
-    by the fresh hardware.
+    by the fresh hardware.  ``side`` resolves a side-agnostic
+    chassis's ``{side}`` templates (#526 M2).
     """
-    from evennia.utils.dbserialize import deserialize
     from world.identity_utils import msg_room_identity
 
     item_db = getattr(organ_item, "db", None)
-    augment_organs = deserialize(getattr(item_db, "augment_organs", None) or {})
-    augment_container = getattr(item_db, "augment_container", None)
-    augment_longdesc = deserialize(getattr(item_db, "augment_longdesc", None) or {})
+    declaration = resolve_augment_declaration(item_db, side=side)
+    if declaration["side_agnostic"] and not side:
+        actor.msg(
+            f"The {organ_item.key} mounts on either side — name one "
+            f"(left or right)."
+        )
+        from world.medical.charts import mark_running_step_failed
+        mark_running_step_failed(
+            target, outcome="side-agnostic augment without a side",
+        )
+        return
+    augment_organs = declaration["organs"]
+    augment_container = declaration["container"]
+    augment_longdesc = declaration["longdesc"]
     if not augment_organs or not augment_container:
         actor.msg(f"The {organ_item.key} has nothing installable in it.")
         return
@@ -1464,12 +1524,171 @@ def _resolve_install_augment(actor, target, *, organ_item, location: str,
         _log_guarded_failure("install_augment_item_delete", organ_item, exc)
 
 
+def find_hardpoint(state, module_type: str, container: str = None):
+    """Return ``(organ_name, organ)`` for a hardpoint slot matching
+    ``module_type`` (#526 M3), optionally restricted to one
+    container.  Occupied hardpoints (a live module with abilities)
+    don't match — harvest the current module first.  Tombstoned
+    hardpoints (module harvested out) DO match: the module install
+    rebuilds the slot organ wholesale."""
+    organs = getattr(state, "organs", None) or {}
+    for organ_name, organ in organs.items():
+        data = getattr(organ, "data", None)
+        if not data or data.get("hardpoint") != module_type:
+            continue
+        if container and getattr(organ, "container", None) != container:
+            continue
+        occupied = bool(data.get("abilities")) and organ.current_hp > 0
+        if occupied:
+            continue
+        return organ_name, organ
+    return None, None
+
+
+def _resolve_install_module(actor, target, *, organ_item, location: str,
+                            **_) -> None:
+    """Resolve an ability-module install (#526 M3): rebuild the
+    hardpoint organ at ``location`` with the module's spec.  The
+    side resolves from the hardpoint's container, so one module
+    prototype serves either arm — it inherits its side from where
+    it's mounted."""
+    from evennia.utils.dbserialize import deserialize
+    from world.identity_utils import msg_room_identity
+    from world.medical.charts import mark_running_step_failed
+
+    item_db = getattr(organ_item, "db", None)
+    module_spec = deserialize(getattr(item_db, "organ_spec", None) or {})
+    module_type = (
+        getattr(item_db, "module_type", None)
+        or module_spec.get("module_type")
+    )
+    if not module_spec or not module_type:
+        actor.msg(f"The {organ_item.key} has no module hardware in it.")
+        return
+
+    state = getattr(target, "medical_state", None)
+    if state is None or not getattr(state, "organs", None):
+        actor.msg(
+            f"The {organ_item.key} needs a living body to integrate with."
+        )
+        return
+
+    # Species gate — chart-commenced installs bypass command gates.
+    target_species = (
+        getattr(getattr(target, "db", None), "species", None) or "human"
+    )
+    compat = [
+        s.lower() for s in (
+            getattr(item_db, "compatible_species", None) or []
+        )
+    ]
+    if compat and target_species.lower() not in compat:
+        actor.msg(
+            f"The {organ_item.key} isn't rated for {target_species} "
+            f"anatomy."
+        )
+        mark_running_step_failed(
+            target, outcome=f"species mismatch — {target_species}",
+        )
+        return
+
+    if not has_incision(target, location):
+        actor.msg(
+            f"You line up the {organ_item.key} but "
+            f"{target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')} isn't open."
+        )
+        mark_running_step_failed(
+            target,
+            outcome=f"no incision at {location} — module install blocked",
+        )
+        return
+
+    hardpoint_name, hardpoint = find_hardpoint(
+        state, module_type, container=location,
+    )
+    if hardpoint is None:
+        actor.msg(
+            f"No free {module_type.replace('_', ' ')} hardpoint at "
+            f"{target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')} — the {organ_item.key} "
+            f"needs a chassis slot to seat in."
+        )
+        mark_running_step_failed(
+            target, outcome=f"no free {module_type} hardpoint at {location}",
+        )
+        return
+
+    result = roll_procedure(actor, target)
+    outcome = result["outcome"]
+    if outcome == "failure":
+        seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["install"])
+        actor.msg(
+            f"The {organ_item.key} won't seat in the hardpoint. It "
+            f"stays loose in your hands."
+        )
+        return
+
+    # The module inherits its side from the hardpoint's container
+    # ("left_arm" → "left") — one prototype serves either arm.
+    side = location.split("_")[0] if "_" in location else ""
+    spec = _format_side(dict(module_spec), side) if side in ("left", "right") else dict(module_spec)
+
+    from world.medical.core import Organ
+    organ = Organ(hardpoint_name, organ_data=spec)
+    organ.medical_state = state
+    state.organs[hardpoint_name] = organ
+    condition_hp = {
+        "pristine": organ.max_hp,
+        "damaged": int(organ.max_hp * 0.6),
+        "putrid": int(organ.max_hp * 0.3),
+    }
+    organ.current_hp = condition_hp.get(
+        getattr(item_db, "condition", None) or "pristine", organ.max_hp,
+    )
+
+    seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["install"])
+    if outcome == "partial":
+        seed_infection(target, location)
+        actor.msg(
+            f"You seat the {organ_item.key} — but the coupling is "
+            f"sloppy. Time will tell."
+        )
+    else:
+        actor.msg(
+            f"You seat the {organ_item.key} in the hardpoint at "
+            f"{target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')}."
+        )
+
+    save = getattr(target, "save_medical_state", None)
+    if callable(save):
+        save()
+
+    if actor.location is not None:
+        msg_room_identity(
+            location=actor.location,
+            template=(
+                f"{{actor}} seats a {organ_item.key} into "
+                f"{{patient}}'s {location.replace('_', ' ')}."
+            ),
+            char_refs={"actor": actor, "patient": target},
+            exclude=[actor, target] if target is not actor else [actor],
+        )
+
+    try:
+        organ_item.delete()
+    except Exception as exc:
+        _log_guarded_failure("install_module_item_delete", organ_item, exc)
+
+
 # Mapping consumed by ``_resolve_procedure_callback``.
 _VERB_RESOLVERS = {
     "incise":   _resolve_incise,
     "harvest":  _resolve_harvest,
     "install":  _resolve_install,
     "install_augment": _resolve_install_augment,
+    "install_module": _resolve_install_module,
     "suture":   _resolve_suture,
     "amputate": _resolve_amputate,
     "autopsy":  _resolve_autopsy,
@@ -1617,6 +1836,19 @@ def _mark_organ_removed(target, organ_name: str) -> None:
 
     state = getattr(target, "medical_state", None)
     if state is not None and hasattr(state, "organs"):
+        # Hardware sweep (#526 M3): removing an organ whose ability
+        # has a DEPLOYED weapon must park the hardware first —
+        # otherwise the locked gun is orphaned in the hand with its
+        # ability gone and no way to retract it.  Guarded: hardware
+        # bookkeeping never blocks the extraction.
+        try:
+            organ_for_sweep = state.organs.get(organ_name)
+            if organ_for_sweep is not None and getattr(
+                    organ_for_sweep, "ability_state", None):
+                from world.medical.augments import park_organ_hardware
+                park_organ_hardware(target, organ_for_sweep)
+        except Exception as exc:
+            _log_guarded_failure("organ_removed_hardware_sweep", target, exc)
         organ = state.organs.get(organ_name)
         if organ is not None:
             organ.current_hp = 0
@@ -1743,6 +1975,11 @@ def _configure_harvested_item(item, *, organ_name: str, condition: str,
     if spec and hasattr(spec, "get"):
         from evennia.utils.dbserialize import deserialize
         item.db.organ_spec = deserialize(spec)
+        # Module provenance (#526 M3): a harvested module routes back
+        # through the module-install branch, not the by-name path —
+        # it seats into any matching hardpoint, either side.
+        if spec.get("module_type"):
+            item.db.module_type = spec.get("module_type")
 
     stage_getter = getattr(source, "get_decay_stage", None)
     if callable(stage_getter):

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2009,60 +2009,87 @@ CYBERNETIC_HEART = {
     ],
 }
 
-# Shotgun Arm - first replacement augment + integrated weapon (#516)
-SHOTGUN_ARM = {
-    "key": "shotgun arm",
+# Cybernetic Arm - side-agnostic limb chassis (#526 M2/M3)
+# One prototype mounts left OR right: the surgeon names the side and
+# every {side} template resolves from it.  Organs keep CANONICAL
+# names ({side}_humerus etc.) so capacity wiring survives — the SPEC
+# makes them chrome.  The forearm hardpoint is an empty module slot:
+# weapons/tools seat into it via `install <module> in <target>`.
+CYBER_ARM = {
+    "key": "cybernetic arm",
     "typeclass": "typeclasses.items.Item",
-    "aliases": ["gun arm", "arm unit"],
-    "desc": "A full right-arm replacement unit in its transport cradle, shoulder coupling to fingertips. The forearm housing is noticeably thicker than the muscle it imitates — inside it, folded along the actuator column, sits an integrated combat shotgun. The hand is five-fingered, dexterous, and honest until it isn't. Mounts over an amputated right arm; surgical installation required.",
+    "aliases": ["cyber arm", "prosthetic arm", "arm unit"],
+    "desc": "A full arm replacement unit in its transport cradle, shoulder coupling to fingertips, ambidextrous mounting hardware along the seam. The forearm housing carries an empty modular hardpoint behind an access panel — the chassis is honest work; what goes in the slot is the owner's business. Mounts over an amputated arm, either side; surgical installation required.",
     "tags": [("medical_item", "item_type"), ("augment", "item_type")],
     "attrs": [
-        # Replacement anatomy (spec §3.5): mirrors the flesh arm's
-        # organ architecture — bone-typed, splintable, same
-        # containers, same chain severance.  The shotgun ability
-        # lives on the humerus actuator; the hand grasps.
         ("augment_organs", {
-            "cybernetic_humerus": {
-                "container": "right_arm", "max_hp": 30,
-                "hit_weight": "common", "can_be_destroyed": True,
+            "{side}_humerus": {
+                "container": "{side}_arm", "max_hp": 30,
+                "hit_weight": "common", "capacity": "manipulation",
+                "contribution": "major", "can_be_destroyed": True,
                 "fracture_vulnerable": True,
-                "bone_type": "actuator_column",
-                "inorganic": True,
-                "abilities": {
-                    "shotgun": {
-                        "type": "integrated_weapon",
-                        "slot": "right_hand",
-                        "weapon_prototype": "SHOTGUN_ARM_GUN",
-                        "deploy_msg": "Your right forearm splits along its seam and the shotgun rotates up into place — the hand folds back and away, and the barrel is just *there*, like it always was.",
-                        "retract_msg": "The shotgun swings down and folds along the actuator column; plating closes over it and your fingers flex, a hand again.",
-                        "deploy_room": "{actor}'s right forearm splits open with a snap of locking servos — a shotgun barrel rotates up out of the housing where their hand used to be.",
-                        "retract_room": "{actor}'s arm-shotgun folds away into the forearm housing; plating seals and their hand reassembles, fingers flexing.",
-                    },
-                },
+                "bone_type": "actuator_column", "inorganic": True,
             },
-            "cybernetic_metacarpals": {
-                "container": "right_hand", "max_hp": 18,
-                "hit_weight": "uncommon", "can_be_destroyed": True,
+            "{side}_metacarpals": {
+                "container": "{side}_hand", "max_hp": 18,
+                "hit_weight": "uncommon", "capacity": "manipulation",
+                "contribution": "moderate", "can_be_destroyed": True,
                 "fracture_vulnerable": True,
-                "bone_type": "actuator_lattice",
-                "grasping": True,
-                "inorganic": True,
+                "bone_type": "actuator_lattice", "inorganic": True,
+            },
+            "{side}_forearm_hardpoint": {
+                "container": "{side}_arm", "max_hp": 10,
+                "hit_weight": "rare", "inorganic": True,
+                "hardpoint": "forearm",
             },
         }),
-        ("augment_container", "right_arm"),
-        ("augment_anchor", "right_arm"),
+        ("augment_container", "{side}_arm"),
+        ("augment_anchor", "{side}_arm"),
         ("augment_longdesc", [
             {
-                "key": "right_arm",
-                "default_desc": "A full cybernetic right arm, matte composite plating over an actuator column, the forearm housing a shade too thick for what a forearm needs to be.",
+                "key": "{side}_arm",
+                "default_desc": "A full cybernetic arm, matte composite plating over an actuator column, an access panel seam running the length of the forearm.",
             },
             {
-                "key": "right_hand",
-                "default_desc": "An articulated alloy right hand, five-fingered and precise, the knuckle plating worn smooth.",
-                "display_after": "right_arm",
+                "key": "{side}_hand",
+                "default_desc": "An articulated alloy hand, five-fingered and precise, the knuckle plating worn smooth.",
+                "display_after": "{side}_arm",
             },
         ]),
         ("compatible_species", ["human"]),
+    ],
+}
+
+# Shotgun Module - forearm hardpoint weapon (#526 M3)
+# Seats into any free forearm hardpoint, either side — it inherits
+# its side from the slot.  Harvest recovers it from a limb or corpse
+# as this same item.
+SHOTGUN_MODULE = {
+    "key": "shotgun module",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["arm shotgun module", "weapon module"],
+    "desc": "A combat shotgun folded into a forearm-hardpoint form factor: barrel shroud, feed system, and deployment servos packed into a unit the size of a forearm bone. The coupling collar is standard chassis gauge. It wants a slot.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("module_type", "forearm"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "{side}_arm", "max_hp": 12, "hit_weight": "rare",
+            "inorganic": True,
+            "hardpoint": "forearm", "module_type": "forearm",
+            "abilities": {
+                "shotgun": {
+                    "type": "integrated_weapon",
+                    "slot": "{side}_hand",
+                    "weapon_prototype": "SHOTGUN_ARM_GUN",
+                    "deploy_msg": "Your {side} forearm splits along its seam and the shotgun rotates up into place — the hand folds back and away, and the barrel is just *there*, like it always was.",
+                    "retract_msg": "The shotgun swings down and folds along the actuator column; plating closes over it and your fingers flex, a hand again.",
+                    "deploy_room": "{actor}'s forearm splits open with a snap of locking servos — a shotgun barrel rotates up out of the housing where their hand used to be.",
+                    "retract_room": "{actor}'s arm-shotgun folds away into the forearm housing; plating seals and their hand reassembles, fingers flexing.",
+                },
+            },
+        }),
     ],
 }
 

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -529,6 +529,235 @@ class TestAnatomyIsTheTruth(TestCase):
         self.assertLess(severed, healthy)
 
 
+SIDED_ARM_ORGANS = {
+    "{side}_humerus": {
+        "container": "{side}_arm", "max_hp": 30, "hit_weight": "common",
+        "capacity": "manipulation", "contribution": "major",
+        "bone_type": "actuator_column", "inorganic": True,
+    },
+    "{side}_forearm_hardpoint": {
+        "container": "{side}_arm", "max_hp": 10, "hit_weight": "rare",
+        "inorganic": True, "hardpoint": "forearm",
+    },
+}
+
+SHOTGUN_MODULE_SPEC = {
+    "container": "{side}_arm", "max_hp": 12, "hit_weight": "rare",
+    "inorganic": True, "hardpoint": "forearm", "module_type": "forearm",
+    "abilities": {
+        "shotgun": {
+            "type": "integrated_weapon",
+            "slot": "{side}_hand",
+            "weapon_prototype": "SHOTGUN_ARM_GUN",
+        },
+    },
+}
+
+
+def _sided_arm_item():
+    """Stub mirroring the CYBER_ARM prototype's side-agnostic shape."""
+    item = SimpleNamespace()
+    item.key = "cybernetic arm"
+    item.deleted = False
+
+    def _delete():
+        item.deleted = True
+    item.delete = _delete
+    item.db = SimpleNamespace(
+        augment_organs={k: dict(v) for k, v in SIDED_ARM_ORGANS.items()},
+        augment_container="{side}_arm",
+        augment_anchor="{side}_arm",
+        augment_longdesc=[
+            {"key": "{side}_arm", "default_desc": "A cyber arm."},
+        ],
+        compatible_species=["human"],
+    )
+    return item
+
+
+def _module_item():
+    item = SimpleNamespace()
+    item.key = "shotgun module"
+    item.deleted = False
+
+    def _delete():
+        item.deleted = True
+    item.delete = _delete
+    item.db = SimpleNamespace(
+        module_type="forearm",
+        condition="pristine",
+        organ_conditions=[],
+        organ_spec=dict(SHOTGUN_MODULE_SPEC),
+        compatible_species=["human"],
+    )
+    item.get_display_name = lambda looker=None: item.key
+    return item
+
+
+class TestSideAgnosticChassis(TestCase):
+    """#526 M2: one CYBER_ARM mounts left or right — the surgeon
+    names the side and the {side} templates resolve from it."""
+
+    def test_declaration_resolves_side(self):
+        from world.medical.procedures import resolve_augment_declaration
+
+        declaration = resolve_augment_declaration(
+            _sided_arm_item().db, side="left",
+        )
+        self.assertTrue(declaration["side_agnostic"])
+        self.assertEqual(declaration["container"], "left_arm")
+        self.assertEqual(declaration["anchor"], "left_arm")
+        self.assertIn("left_humerus", declaration["organs"])
+        self.assertEqual(
+            declaration["organs"]["left_humerus"]["container"], "left_arm",
+        )
+        self.assertEqual(declaration["longdesc"][0]["key"], "left_arm")
+
+    def test_declaration_without_side_keeps_templates(self):
+        from world.medical.procedures import resolve_augment_declaration
+
+        declaration = resolve_augment_declaration(_sided_arm_item().db)
+        self.assertTrue(declaration["side_agnostic"])
+        self.assertIn("{side}_humerus", declaration["organs"])
+
+    def test_install_resolves_left(self):
+        target = _patient()
+        target.longdesc = {"head": None, "back": None}
+        for organ in target.medical_state.organs.values():
+            if organ.container in ("left_arm", "left_hand"):
+                organ.current_hp = 0
+                organ.wound_stage = "severed"
+        open_incision(target, "left_arm")
+        actor = _surgeon()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": "success"},
+        ):
+            _resolve_install_augment(
+                actor, target, organ_item=_sided_arm_item(),
+                location="left_arm", side="left",
+            )
+        organs = target.medical_state.organs
+        self.assertIn("left_humerus", organs)
+        self.assertTrue(organs["left_humerus"].data.get("inorganic"))
+        self.assertIn("left_forearm_hardpoint", organs)
+        self.assertIn("left_arm", target.longdesc)
+        # The RIGHT side is untouched flesh.
+        self.assertFalse(organs["right_humerus"].data.get("inorganic"))
+
+    def test_install_without_side_blocks(self):
+        target = _patient()
+        open_incision(target, "left_arm")
+        actor = _surgeon()
+        item = _sided_arm_item()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": "success"},
+        ):
+            _resolve_install_augment(
+                actor, target, organ_item=item, location="left_arm",
+            )
+        self.assertFalse(item.deleted)
+        self.assertTrue(any("either side" in m for m in actor.messages))
+
+
+class TestModuleInstall(TestCase):
+    """#526 M3: modules seat into chassis hardpoints and inherit
+    their side from the slot."""
+
+    def _chassis_patient(self, side="left"):
+        target = _patient()
+        spec = {
+            "container": f"{side}_arm", "max_hp": 10, "hit_weight": "rare",
+            "inorganic": True, "hardpoint": "forearm",
+        }
+        organ = Organ(f"{side}_forearm_hardpoint", organ_data=spec)
+        organ.medical_state = target.medical_state
+        target.medical_state.organs[f"{side}_forearm_hardpoint"] = organ
+        return target
+
+    def _install(self, target, item, location="left_arm", outcome="success"):
+        from world.medical.procedures import _resolve_install_module
+
+        actor = _surgeon()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": outcome},
+        ):
+            _resolve_install_module(
+                actor, target, organ_item=item, location=location,
+            )
+        return actor
+
+    def test_module_seats_and_inherits_side(self):
+        from world.medical.augments import find_ability
+
+        target = self._chassis_patient("left")
+        open_incision(target, "left_arm")
+        item = _module_item()
+        self._install(target, item)
+
+        organ = target.medical_state.organs["left_forearm_hardpoint"]
+        self.assertIn("shotgun", organ.data.get("abilities", {}))
+        # Side inherited from the slot: the ability deploys into the
+        # LEFT hand.
+        found, spec = find_ability(target, "shotgun")
+        self.assertIs(found, organ)
+        self.assertEqual(spec["slot"], "left_hand")
+        self.assertTrue(item.deleted)
+
+    def test_occupied_hardpoint_rejects(self):
+        target = self._chassis_patient("left")
+        # Occupy it with a live module.
+        occupied_spec = dict(SHOTGUN_MODULE_SPEC)
+        occupied_spec["container"] = "left_arm"
+        organ = Organ("left_forearm_hardpoint", organ_data=occupied_spec)
+        organ.medical_state = target.medical_state
+        target.medical_state.organs["left_forearm_hardpoint"] = organ
+        open_incision(target, "left_arm")
+        item = _module_item()
+        actor = self._install(target, item)
+        self.assertFalse(item.deleted)
+        self.assertTrue(any("hardpoint" in m for m in actor.messages))
+
+    def test_harvested_out_hardpoint_accepts_again(self):
+        """Module harvest tombstones the slot (hp 0 severed) — a new
+        module rebuilds over it."""
+        target = self._chassis_patient("left")
+        occupied_spec = dict(SHOTGUN_MODULE_SPEC)
+        occupied_spec["container"] = "left_arm"
+        organ = Organ("left_forearm_hardpoint", organ_data=occupied_spec)
+        organ.current_hp = 0
+        organ.wound_stage = "severed"
+        organ.medical_state = target.medical_state
+        target.medical_state.organs["left_forearm_hardpoint"] = organ
+        open_incision(target, "left_arm")
+        item = _module_item()
+        self._install(target, item)
+        rebuilt = target.medical_state.organs["left_forearm_hardpoint"]
+        self.assertEqual(rebuilt.current_hp, rebuilt.max_hp)
+        self.assertIn("shotgun", rebuilt.data.get("abilities", {}))
+
+    def test_harvest_carries_module_provenance(self):
+        from world.medical.procedures import _configure_harvested_item
+
+        target = self._chassis_patient("left")
+        occupied_spec = dict(SHOTGUN_MODULE_SPEC)
+        occupied_spec = {
+            k: (v.replace("{side}", "left") if isinstance(v, str) else v)
+            for k, v in occupied_spec.items()
+        }
+        organ = Organ("left_forearm_hardpoint", organ_data=occupied_spec)
+        item = SimpleNamespace(db=SimpleNamespace())
+        _configure_harvested_item(
+            item, organ_name="left_forearm_hardpoint",
+            condition="pristine", source=target,
+            organ_data=organ.to_dict(),
+        )
+        self.assertEqual(item.db.module_type, "forearm")
+        self.assertIn("abilities", item.db.organ_spec)
+
+
 CYBER_HEART_SPEC = {
     "container": "chest", "max_hp": 20, "hit_weight": "uncommon",
     "vital": True, "capacity": "blood_pumping", "contribution": "total",


### PR DESCRIPTION
Phases M2+M3 of #526 — the chassis+module standard.

## M2 — one arm, either side
Augment declarations template `{side}` through organ names, specs, containers, anchor, and longdesc. `resolve_augment_declaration()` is the single seam used by CmdInstall (`install cyber arm in bob at left`), the operate menu (new side-picker node), the chart runner, and the resolver — sideless installs of side-agnostic items refuse everywhere. Chassis organs keep **canonical names** (`{side}_humerus`) so capacity wiring survives; the spec makes them chrome.

## M3 — modules seat into hardpoints
`CYBER_ARM` ships with an empty forearm hardpoint organ. `SHOTGUN_MODULE` is a spec-carrying organ item that seats into any free matching hardpoint and **inherits its side from the slot** — the shotgun deploys into whichever hand that arm owns. Occupied hardpoints refuse (harvest the current module first); tombstoned slots rebuild. Harvest writes module provenance, closing the recovery loop: sever an arm, pull the module, seat it in another chassis, either side.

Also closes the stuck-gun hazard: organ removal sweeps ability hardware so a deployed weapon never orphans locked in a hand whose ability is gone.

`SHOTGUN_ARM` retires in favor of the pair (existing fused installs keep working — same ability machinery). Tests: +8. Suite: **2,485 green**. Both prototypes spawn-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)