### PR TITLE
Cybernetics M4: flesh-mount modules + natural weapons

### DIFF
--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -745,28 +745,71 @@ class CmdInstall(Command):
             )
             return
 
-        # Collect free hardpoints, optionally filtered by side.
+        # Collect candidate mount containers, optionally filtered by
+        # side.  Hardpoint modules want a free chassis slot; flesh
+        # modules (#526 M4 — Nailz/Jawz class) want LIVING anatomy
+        # at one of their declared containers.
+        mount_mode = (
+            getattr(organ_item.db, "module_mount", None) or "hardpoint"
+        )
         candidates = []
-        for organ_name, organ in state.organs.items():
-            data = getattr(organ, "data", None)
-            if not data or data.get("hardpoint") != module_type:
-                continue
-            if bool(data.get("abilities")) and organ.current_hp > 0:
-                continue  # occupied
-            container = getattr(organ, "container", None) or ""
-            if side_or_location:
-                side = side_or_location.split("_")[0]
-                if not container.startswith(side):
+        if mount_mode == "flesh":
+            declared = []
+            for raw in (organ_item.db.flesh_containers or []):
+                if "{side}" in raw:
+                    declared.extend(
+                        raw.replace("{side}", s) for s in ("left", "right")
+                    )
+                else:
+                    declared.append(raw)
+            new_ability_names = set(
+                ((organ_item.db.organ_spec or {}).get("abilities") or {})
+            )
+            for container in declared:
+                if side_or_location:
+                    side = side_or_location.split("_")[0]
+                    if not container.startswith(side):
+                        continue
+                host = next(
+                    (o for o in state.organs.values()
+                     if getattr(o, "container", None) == container
+                     and o.current_hp > 0),
+                    None,
+                )
+                if host is None:
                     continue
-            candidates.append((organ_name, container))
+                if new_ability_names & set(host.data.get("abilities") or {}):
+                    continue  # already carries this hardware
+                candidates.append((container, container))
+        else:
+            for organ_name, organ in state.organs.items():
+                data = getattr(organ, "data", None)
+                if not data or data.get("hardpoint") != module_type:
+                    continue
+                if bool(data.get("abilities")) and organ.current_hp > 0:
+                    continue  # occupied
+                container = getattr(organ, "container", None) or ""
+                if side_or_location:
+                    side = side_or_location.split("_")[0]
+                    if not container.startswith(side):
+                        continue
+                candidates.append((organ_name, container))
 
         if not candidates:
-            caller.msg(
-                f"No free {module_type.replace('_', ' ')} hardpoint "
-                f"on {target.get_display_name(caller)} — the "
-                f"{organ_item.key} needs a chassis slot (and an "
-                f"unoccupied one)."
-            )
+            if mount_mode == "flesh":
+                caller.msg(
+                    f"Nowhere on {target.get_display_name(caller)} "
+                    f"for the {organ_item.key} — it needs living "
+                    f"anatomy at a compatible location, without that "
+                    f"hardware already in it."
+                )
+            else:
+                caller.msg(
+                    f"No free {module_type.replace('_', ' ')} hardpoint "
+                    f"on {target.get_display_name(caller)} — the "
+                    f"{organ_item.key} needs a chassis slot (and an "
+                    f"unoccupied one)."
+                )
             return
         if len({c for _n, c in candidates}) > 1:
             sides = ", ".join(sorted(c.replace("_", " ") for _n, c in candidates))

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -123,6 +123,18 @@ def get_wielded_weapon(character):
     Returns:
         The weapon object, or None if no weapon is wielded
     """
+    # Active natural cyberweapons win outright (#526 M4, settled
+    # decision 2026-06-12): claws out means you fight with claws,
+    # knife in hand or not.  Toggle them off to use the knife.
+    try:
+        from world.medical.augments import get_active_natural_weapon
+        natural = get_active_natural_weapon(character)
+        if natural is not None:
+            return natural
+    except Exception:
+        # Test stubs without a medical state fall through to hands.
+        pass
+
     hands = getattr(character, "hands", {})
     held = [item for item in hands.values() if item]
     for item in held:

--- a/world/medical/augments.py
+++ b/world/medical/augments.py
@@ -92,6 +92,8 @@ def toggle_ability(character, name) -> str:
     ability_type = spec.get("type")
     if ability_type == "integrated_weapon":
         return _toggle_integrated_weapon(character, organ, name, spec)
+    if ability_type == "natural_weapon":
+        return _toggle_natural_weapon(character, organ, name, spec)
     return f"{name} doesn't respond. (unknown ability type {ability_type!r})"
 
 
@@ -238,6 +240,77 @@ def _toggle_integrated_weapon(character, organ, name, spec) -> str:
             exclude=[character],
         )
     return retract_msg
+
+
+def _toggle_natural_weapon(character, organ, name, spec) -> str:
+    """Toggle a natural cyberweapon (#526 M4 — the claws family).
+
+    Unlike integrated weapons, natural weapons never touch the hand
+    slots: the claws ARE the hand.  The weapon item lives off-grid
+    permanently; combat resolution reads it via the precedence rule
+    (active natural cyberweapon > held weapon > fists — settled
+    decision 2026-06-12: claws out means you fight with claws,
+    knife in hand or not).
+    """
+    from world.identity_utils import msg_room_identity
+
+    state = _ability_state(organ, name)
+    if not state.get("deployed"):
+        weapon = _get_or_spawn_weapon(character, state, spec)
+        if weapon is None:
+            return f"{name} grinds and fails — no hardware found."
+        state["deployed"] = True
+        _persist(character)
+        msg = spec.get("deploy_msg") or (
+            f"The {weapon.key} extend with a wet metallic whisper."
+        )
+        if character.location is not None:
+            msg_room_identity(
+                location=character.location,
+                template=spec.get("deploy_room") or (
+                    f"{{actor}}'s {weapon.key} slide out, catching "
+                    f"the light."
+                ),
+                char_refs={"actor": character},
+                exclude=[character],
+            )
+        return msg
+
+    state["deployed"] = False
+    _persist(character)
+    weapon = _find_weapon(state)
+    weapon_name = weapon.key if weapon else name
+    msg = spec.get("retract_msg") or (
+        f"The {weapon_name} retract, gone like they were never there."
+    )
+    if character.location is not None:
+        msg_room_identity(
+            location=character.location,
+            template=spec.get("retract_room") or (
+                f"{{actor}}'s {weapon_name} slide away out of sight."
+            ),
+            char_refs={"actor": character},
+            exclude=[character],
+        )
+    return msg
+
+
+def get_active_natural_weapon(character):
+    """The deployed natural cyberweapon's item, or ``None`` (#526
+    M4).  Consumed by combat's weapon resolution: active natural
+    cyberweapons take precedence over held weapons (settled decision
+    2026-06-12).  Severed organs drop out via :func:`iter_abilities`.
+    """
+    for organ, name, spec in iter_abilities(character):
+        if spec.get("type") != "natural_weapon":
+            continue
+        store = getattr(organ, "ability_state", None) or {}
+        if not (store.get(name) or {}).get("deployed"):
+            continue
+        weapon = _find_weapon(store.get(name) or {})
+        if weapon is not None:
+            return weapon
+    return None
 
 
 def _find_weapon(state):

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -1604,6 +1604,113 @@ def _resolve_install_module(actor, target, *, organ_item, location: str,
         )
         return
 
+    # The module inherits its side from its mount's container
+    # ("left_arm" → "left") — one prototype serves either side.
+    side = location.split("_")[0] if "_" in location else ""
+    spec = _format_side(dict(module_spec), side) if side in ("left", "right") else dict(module_spec)
+
+    # Mount mode (#526 M4): "hardpoint" (default — chassis slot) or
+    # "flesh" (Nailz/Jawz class — the ability implants into LIVING
+    # anatomy at a declared container; flesh stays flesh, still
+    # bleeds, now has claws in it; a cyber hand stays chrome).
+    mount_mode = getattr(item_db, "module_mount", None) or "hardpoint"
+    if mount_mode == "flesh":
+        flesh_containers = [
+            _format_side(c, side) if side in ("left", "right") else c
+            for c in (getattr(item_db, "flesh_containers", None) or [])
+        ]
+        if location not in flesh_containers:
+            actor.msg(
+                f"The {organ_item.key} doesn't mount at "
+                f"{location.replace('_', ' ')}."
+            )
+            mark_running_step_failed(
+                target, outcome=f"{organ_item.key} can't mount at {location}",
+            )
+            return
+        host = next(
+            (o for o in state.organs.values()
+             if getattr(o, "container", None) == location
+             and o.current_hp > 0),
+            None,
+        )
+        if host is None:
+            actor.msg(
+                f"Nothing living at {target.get_display_name(actor)}'s "
+                f"{location.replace('_', ' ')} to implant the "
+                f"{organ_item.key} into."
+            )
+            mark_running_step_failed(
+                target, outcome=f"no living host anatomy at {location}",
+            )
+            return
+        new_abilities = spec.get("abilities") or {}
+        existing = host.data.get("abilities") or {}
+        if any(name in existing for name in new_abilities):
+            actor.msg(
+                f"{target.get_display_name(actor)}'s "
+                f"{location.replace('_', ' ')} already carries that "
+                f"hardware."
+            )
+            mark_running_step_failed(
+                target, outcome=f"duplicate module at {location}",
+            )
+            return
+
+        result = roll_procedure(actor, target)
+        outcome = result["outcome"]
+        if outcome == "failure":
+            seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["install"])
+            seed_infection(target, location)
+            actor.msg(
+                f"The implant bed won't take. The {organ_item.key} "
+                f"stays loose in your hands."
+            )
+            return
+
+        # Implant: merge the ability into the host organ's spec —
+        # deep-copied dict swap so the organ never shares storage
+        # with the soon-deleted item and the species table is never
+        # mutated.
+        host_data = dict(host.data)
+        merged = dict(host_data.get("abilities") or {})
+        merged.update(new_abilities)
+        host_data["abilities"] = merged
+        host_data["module_type"] = module_type
+        host.data = host_data
+
+        seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["install"])
+        if outcome == "partial":
+            seed_infection(target, location)
+            actor.msg(
+                f"You implant the {organ_item.key} — but the bed is "
+                f"inflamed. Time will tell."
+            )
+        else:
+            actor.msg(
+                f"You implant the {organ_item.key} into "
+                f"{target.get_display_name(actor)}'s "
+                f"{location.replace('_', ' ')}."
+            )
+        save = getattr(target, "save_medical_state", None)
+        if callable(save):
+            save()
+        if actor.location is not None:
+            msg_room_identity(
+                location=actor.location,
+                template=(
+                    f"{{actor}} implants a {organ_item.key} into "
+                    f"{{patient}}'s {location.replace('_', ' ')}."
+                ),
+                char_refs={"actor": actor, "patient": target},
+                exclude=[actor, target] if target is not actor else [actor],
+            )
+        try:
+            organ_item.delete()
+        except Exception as exc:
+            _log_guarded_failure("install_module_item_delete", organ_item, exc)
+        return
+
     hardpoint_name, hardpoint = find_hardpoint(
         state, module_type, container=location,
     )
@@ -1628,11 +1735,6 @@ def _resolve_install_module(actor, target, *, organ_item, location: str,
             f"stays loose in your hands."
         )
         return
-
-    # The module inherits its side from the hardpoint's container
-    # ("left_arm" → "left") — one prototype serves either arm.
-    side = location.split("_")[0] if "_" in location else ""
-    spec = _format_side(dict(module_spec), side) if side in ("left", "right") else dict(module_spec)
 
     from world.medical.core import Organ
     organ = Organ(hardpoint_name, organ_data=spec)

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2093,6 +2093,57 @@ SHOTGUN_MODULE = {
     ],
 }
 
+# Nailz - flesh-mount natural weapon module (#526 M4)
+# Implants into LIVING anatomy at either hand (flesh or chrome) —
+# the host stays what it is; it just has claws in it now.  /nailz
+# extends them; active claws take combat precedence over anything
+# held (settled decision 2026-06-12).
+NAILZ = {
+    "key": "Nailz",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["nailz", "claw implants", "nail implants"],
+    "desc": "A sealed clinical tray of ten curved monofilament claws and their spring housings, sized for implantation along the fingers of one hand. The marketing name is etched on the tray lid in a typeface that has seen some court dates. Installation requires a surgeon; regret is sold separately.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("module_type", "nailz"),
+        ("module_mount", "flesh"),
+        ("flesh_containers", ["{side}_hand"]),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "module_type": "nailz",
+            "abilities": {
+                "nailz": {
+                    "type": "natural_weapon",
+                    "weapon_prototype": "NAILZ_CLAWS",
+                    "deploy_msg": "Your knuckles ache, then part — ten monofilament claws slide out along your fingers with a sound like scissors closing.",
+                    "retract_msg": "The claws fold back under your skin; your hand is just a hand again, mostly.",
+                    "deploy_room": "{actor} flexes a hand and monofilament claws slide out along their fingers, catching the light.",
+                    "retract_room": "{actor}'s claws fold away under the skin of their hand.",
+                },
+            },
+        }),
+    ],
+}
+
+# The claw weapon Nailz extends (#526 M4).  Never held — the claws
+# ARE the hand; combat resolution reads it via natural-weapon
+# precedence.  Reuses the tiger_claws message set.
+NAILZ_CLAWS = {
+    "prototype_parent": "MELEE_WEAPON_BASE",
+    "key": "monofilament claws",
+    "aliases": ["claws", "nailz claws"],
+    "desc": "Ten curved monofilament claws, extended from their knuckle housings. They are not for opening letters.",
+    "damage": 9,
+    "locks": "get:false();drop:false();give:false()",
+    "attrs": [
+        ("weapon_type", "tiger_claws"),
+        ("damage_type", "cut"),
+        ("hands_required", 1),
+        ("integrated", True),
+    ],
+}
+
 # The integrated weapon the shotgun arm deploys (#516).  Spawned
 # lazily on first /shotgun; locked + flagged integrated by the
 # ability layer regardless of what's declared here.

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -758,6 +758,108 @@ class TestModuleInstall(TestCase):
         self.assertIn("abilities", item.db.organ_spec)
 
 
+def _nailz_item():
+    item = SimpleNamespace()
+    item.key = "Nailz"
+    item.deleted = False
+
+    def _delete():
+        item.deleted = True
+    item.delete = _delete
+    item.db = SimpleNamespace(
+        module_type="nailz",
+        module_mount="flesh",
+        flesh_containers=["{side}_hand"],
+        condition="pristine",
+        organ_conditions=[],
+        organ_spec={
+            "module_type": "nailz",
+            "abilities": {
+                "nailz": {
+                    "type": "natural_weapon",
+                    "weapon_prototype": "NAILZ_CLAWS",
+                },
+            },
+        },
+        compatible_species=["human"],
+    )
+    item.get_display_name = lambda looker=None: item.key
+    return item
+
+
+class TestFleshMountModules(TestCase):
+    """#526 M4: the Nailz/Jawz class — abilities implant into LIVING
+    anatomy; the host stays what it is (flesh still bleeds)."""
+
+    def _install(self, target, item, location="left_hand", outcome="success"):
+        from world.medical.procedures import _resolve_install_module
+
+        actor = _surgeon()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": outcome},
+        ):
+            _resolve_install_module(
+                actor, target, organ_item=item, location=location,
+            )
+        return actor
+
+    def test_implants_into_living_flesh(self):
+        from world.medical.augments import find_ability
+
+        target = _patient()
+        open_incision(target, "left_hand")
+        item = _nailz_item()
+        self._install(target, item)
+
+        host = target.medical_state.organs["left_metacarpals"]
+        self.assertIn("nailz", host.data.get("abilities", {}))
+        # The host stays flesh — it still bleeds.
+        self.assertFalse(host.data.get("inorganic"))
+        organ, spec = find_ability(target, "nailz")
+        self.assertIs(organ, host)
+        self.assertEqual(spec["type"], "natural_weapon")
+        self.assertTrue(item.deleted)
+        # The species table was never mutated: a second character's
+        # metacarpals carry no claws.
+        other = _patient()
+        self.assertNotIn(
+            "nailz",
+            other.medical_state.organs["left_metacarpals"].data.get(
+                "abilities", {},
+            ),
+        )
+
+    def test_duplicate_implant_rejects(self):
+        target = _patient()
+        open_incision(target, "left_hand")
+        self._install(target, _nailz_item())
+        second = _nailz_item()
+        actor = self._install(target, second)
+        self.assertFalse(second.deleted)
+        self.assertTrue(any("already carries" in m for m in actor.messages))
+
+    def test_dead_anatomy_rejects(self):
+        target = _patient()
+        for organ in target.medical_state.organs.values():
+            if organ.container == "left_hand":
+                organ.current_hp = 0
+                organ.wound_stage = "destroyed"
+        open_incision(target, "left_hand")
+        item = _nailz_item()
+        actor = self._install(target, item)
+        self.assertFalse(item.deleted)
+        self.assertTrue(any("Nothing living" in m for m in actor.messages))
+
+    def test_undeclared_container_rejects(self):
+        target = _patient()
+        open_incision(target, "chest")
+        item = _nailz_item()
+        actor = self._install(target, item, location="chest")
+        self.assertFalse(item.deleted)
+        self.assertTrue(any("doesn't mount" in m for m in actor.messages))
+
+
 CYBER_HEART_SPEC = {
     "container": "chest", "max_hp": 20, "hit_weight": "uncommon",
     "vital": True, "capacity": "blood_pumping", "contribution": "total",

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -144,6 +144,48 @@ class TestAbilityLayer(EvenniaTest):
             self.organ.ability_state["shotgun"].get("deployed", False)
         )
 
+    def test_natural_weapon_toggle_and_precedence(self):
+        """#526 M4: claws never touch the hand slots, and active
+        claws beat anything held (settled decision 2026-06-12)."""
+        from world.combat.utils import get_wielded_weapon
+
+        claws_organ = Organ("left_metacarpals_clawed", organ_data={
+            "container": "left_hand", "max_hp": 15,
+            "abilities": {
+                "nailz": {
+                    "type": "natural_weapon",
+                    "weapon_prototype": "NAILZ_CLAWS",
+                },
+            },
+        })
+        claws_organ.medical_state = self.char.medical_state
+        self.char.medical_state.organs["left_metacarpals_clawed"] = claws_organ
+        claws = create_object(
+            "typeclasses.items.Item", key="monofilament claws",
+            location=None,
+        )
+        claws.db.integrated = True
+        claws_organ.ability_state = {
+            "nailz": {"weapon_dbref": claws.dbref},
+        }
+        # A held, weapon-tagged knife to lose the precedence fight.
+        knife = create_object(
+            "typeclasses.items.Item", key="knife", location=self.char,
+        )
+        knife.tags.add("weapon", category="type")
+        self.char.hands = {"left_hand": knife}
+
+        toggle_ability(self.char, "nailz")
+        # Claws deployed: never in hands, still off-grid, but they
+        # ARE the combat weapon.
+        self.assertIsNone(claws.location)
+        self.assertNotIn(claws, self.char.hands.values())
+        self.assertIs(get_wielded_weapon(self.char), claws)
+
+        toggle_ability(self.char, "nailz")
+        # Retracted: the held knife serves again.
+        self.assertIs(get_wielded_weapon(self.char), knife)
+
     def test_no_inline_weapon_picks_outside_the_resolver(self):
         """Doctrine pin (#516 playtest): combat code must resolve
         weapons through get_wielded_weapon, never the inline


### PR DESCRIPTION
Final phase of #526, closing it.

## natural_weapon (ability-layer Phase 3, as designed)
Toggled cyberweapons that never touch hand slots — the claws ARE the hand. The weapon item lives off-grid permanently, and `get_wielded_weapon` gains the settled precedence rule: **active natural cyberweapon > held weapon > fists**. Toggle claws off to use the knife.

## Flesh-mount modules (the Nailz/Jawz class)
`module_mount: "flesh"` implants the ability into **living** anatomy at a declared container. The host organ keeps its nature — flesh stays flesh and still bleeds; a cyber hand stays chrome. Living-host, duplicate-hardware, and undeclared-container gates; side disambiguation as with hardpoints; recovery via harvesting the host organ (the ability rides its spec).

## Exemplars
`NAILZ` (either hand, `/nailz`) + `NAILZ_CLAWS` (tiger_claws message set, integrated locks). Spawn-verified.

Tests: +5 (implant + species-table isolation, duplicate/dead/undeclared gates, toggle + precedence both ways). Suite: **2,490 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)