### PR TITLE
Abilities require a functional organ

### DIFF
--- a/world/medical/augments.py
+++ b/world/medical/augments.py
@@ -34,14 +34,16 @@ CYBERWARE_COMMAND_PREFIX = "/"
 
 def iter_abilities(character):
     """Yield ``(organ, ability_name, spec)`` for every ability on the
-    character's body.  Severed organs are skipped — the hardware left
-    with the limb."""
+    character's body.  Abilities require a FUNCTIONAL organ: severed
+    limbs took their hardware with them, harvested-out modules left a
+    dead slot, and a destroyed hardpoint is so much shrapnel — all of
+    those are 0-HP tombstones and power nothing."""
     state = getattr(character, "medical_state", None)
     organs = getattr(state, "organs", None) if state else None
     if not organs:
         return
     for organ in organs.values():
-        if getattr(organ, "wound_stage", None) == "severed":
+        if getattr(organ, "current_hp", 0) <= 0:
             continue
         data = getattr(organ, "data", None)
         abilities = data.get("abilities") if data else None

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -78,9 +78,18 @@ class TestAbilityLayer(EvenniaTest):
 
     def test_severed_organ_loses_the_ability(self):
         self.organ.wound_stage = "severed"
+        self.organ.current_hp = 0
         organ, spec = find_ability(self.char, "shotgun")
         self.assertIsNone(organ)
         self.assertIn("no cyberware", toggle_ability(self.char, "shotgun"))
+
+    def test_dead_organ_powers_nothing(self):
+        """Abilities require a FUNCTIONAL organ (#526 playtest fix):
+        a harvested-out or destroyed slot at 0 HP is a tombstone, not
+        a power source — /shotgun on it must find nothing."""
+        self.organ.current_hp = 0  # destroyed in place / harvested out
+        organ, spec = find_ability(self.char, "shotgun")
+        self.assertIsNone(organ)
 
     def test_unknown_ability_lists_what_you_have(self):
         msg = toggle_ability(self.char, "lasereyes")


### PR DESCRIPTION
Found while live-proving the "harvest a module without taking the arm off" loop (which works end to end — operate listing, arm-open-not-off incision gate, module provenance, deployed-hardware sweep). The one bug: harvest tombstones the slot at 0 HP, but `iter_abilities` only skipped `severed` — the extracted module's ability still resolved.

New rule: **abilities require a functional organ** — severed, harvested-out, and destroyed-in-place tombstones all power nothing; damaged-but-alive keeps working. Combat bonus: shooting out a hardpoint now disables the weapon in it.

Tests: +1. Suite: **2,491 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)