### PR TITLE
@heal and @resetmedical learn the anatomy-truth standard

### DIFF
--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -154,26 +154,17 @@ class CmdHeal(Command):
                     caller.msg(f"|g{target.key} has no medical conditions.|n")
                 continue
             
-            # Full heal without condition type - complete medical restoration
+            # Full heal without condition type - complete medical
+            # restoration of PRESENT anatomy (#526 review: severed
+            # tombstones stay severed — @heal doesn't regrow limbs or
+            # resurrect harvested-out modules; full_heal owns the
+            # standard).
             if amount is None and condition_type is None:
-                # Clear all conditions
-                medical_state.conditions.clear()
-                
+                organs_healed = medical_state.full_heal()
+
                 # Stop medical script since no conditions remain
                 from world.medical.script import stop_medical_script
                 stop_medical_script(target)
-                
-                # Restore all organs to full health
-                organs_healed = 0
-                for organ in medical_state.organs.values():
-                    if organ.current_hp < organ.max_hp:
-                        organ.current_hp = organ.max_hp
-                        organs_healed += 1
-                
-                # Restore vital signs
-                medical_state.blood_level = 100.0
-                medical_state.pain_level = 0.0
-                medical_state.consciousness = 1.0  # Consciousness is stored as 0.0-1.0, displayed as percentage
                 
                 # Clear any death or unconsciousness placement descriptions
                 if hasattr(target, 'override_place'):
@@ -354,22 +345,15 @@ class CmdTestDeath(Command):
             # Character is dead, revive them using heal command logic
             if hasattr(target, 'medical_state') and target.medical_state:
                 medical_state = target.medical_state
-                
-                # Clear all conditions (including consciousness suppression)
-                medical_state.conditions.clear()
-                
+
+                # Full restoration of PRESENT anatomy (#526 review —
+                # severed tombstones stay severed; full_heal owns
+                # the standard).
+                medical_state.full_heal()
+
                 # Stop medical script since no conditions remain
                 from world.medical.script import stop_medical_script
                 stop_medical_script(target)
-                
-                # Restore all organs to full health
-                for organ in medical_state.organs.values():
-                    organ.current_hp = organ.max_hp
-                
-                # Restore vital signs
-                medical_state.blood_level = 100.0
-                medical_state.pain_level = 0.0
-                medical_state.consciousness = 1.0
                 
                 # Clear placement descriptions and processing flags
                 if hasattr(target, 'override_place'):
@@ -841,21 +825,22 @@ class CmdResetMedical(Command):
             from typeclasses.characters import Character
             characters = Character.objects.all()
             count = 0
-            
+            preserved_total = 0
+
             for char in characters:
-                if hasattr(char, '_medical_state'):
-                    delattr(char, '_medical_state')
-                if char.db.medical_state:
-                    del char.db.medical_state
+                preserved_total += _reset_medical_preserving_augments(char)
                 count += 1
-                
-            caller.msg(f"|gReset medical states for {count} characters.|n")
-            caller.msg("|yCharacters will get current medical structure on next access.|n")
-            
+
+            caller.msg(
+                f"|gReset medical states for {count} characters "
+                f"({preserved_total} augment organs preserved).|n"
+            )
+            caller.msg("|yFlesh rebuilt from the current structure; installed cyberware carried over.|n")
+
         elif args.lower() == "all":
             caller.msg("|yWarning: This will reset ALL character medical states!|n")
             caller.msg("|yUse '@resetmedical confirm all' to proceed.|n")
-            
+
         else:
             # Reset specific character
             target = resolve_admin_target(caller, args)
@@ -863,13 +848,59 @@ class CmdResetMedical(Command):
                 caller.msg(f"|rCould not find '{args}'.|n")
                 return
 
-            if hasattr(target, '_medical_state'):
-                delattr(target, '_medical_state')
-            if target.db.medical_state:
-                del target.db.medical_state
-                
-            caller.msg(f"|gReset medical state for {target.get_display_name(caller)}.|n")
-            caller.msg("|yThey will get current medical structure on next access.|n")
+            preserved = _reset_medical_preserving_augments(target)
+
+            caller.msg(
+                f"|gReset medical state for "
+                f"{target.get_display_name(caller)} "
+                f"({preserved} augment organs preserved).|n"
+            )
+            caller.msg("|yFlesh rebuilt from the current structure; installed cyberware carried over.|n")
+
+
+def _reset_medical_preserving_augments(char) -> int:
+    """Rebuild ``char``'s medical state from the current species
+    structure while carrying installed augments over (#526 review).
+
+    Pre-#526 this command nuked the state wholesale — which, with
+    per-character anatomy, erased every installed arm, tail, heart,
+    and module while orphaning their longdesc keys and parked
+    weapon items.  Augment organs (``is_augment_organ``) now survive
+    the rebuild; flesh resets to factory exactly as before.
+
+    Returns the number of organs preserved.
+    """
+    from world.anatomy import get_species_organs
+    from world.medical.core import is_augment_organ
+
+    species = getattr(getattr(char, "db", None), "species", None)
+    species_table = get_species_organs(species)
+
+    preserved = []
+    try:
+        old_state = char.medical_state
+    except AttributeError:
+        old_state = None
+    if old_state is not None and getattr(old_state, "organs", None):
+        preserved = [
+            organ for organ in old_state.organs.values()
+            if is_augment_organ(organ, species_table)
+        ]
+
+    if hasattr(char, '_medical_state'):
+        delattr(char, '_medical_state')
+    if char.db.medical_state:
+        del char.db.medical_state
+
+    if preserved:
+        new_state = char.medical_state  # property rebuilds from species
+        for organ in preserved:
+            organ.medical_state = new_state
+            new_state.organs[organ.name] = organ
+        save = getattr(char, "save_medical_state", None)
+        if callable(save):
+            save()
+    return len(preserved)
 
 
 class CmdMedicalAudit(Command):

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -565,6 +565,26 @@ class Organ:
         return organ
 
 
+def is_augment_organ(organ, species_organs) -> bool:
+    """Whether ``organ`` is installed hardware rather than factory
+    anatomy (#526 review — the @resetmedical preservation predicate).
+
+    True when the organ has no species-table entry (the tail, a
+    hardpoint) OR its spec carries augment markers: ``inorganic``
+    (canonical-name chrome like a cyber humerus or heart),
+    ``abilities`` (a flesh-mounted Nailz host), ``hardpoint`` /
+    ``module_type`` (chassis slots and seated modules).
+    """
+    data = getattr(organ, "data", None) or {}
+    return bool(
+        organ.name not in (species_organs or {})
+        or data.get("inorganic")
+        or data.get("abilities")
+        or data.get("hardpoint")
+        or data.get("module_type")
+    )
+
+
 class MedicalState:
     """
     Manages the complete medical state of a character.
@@ -666,6 +686,42 @@ class MedicalState:
         """
         return self.organs.get(organ_name)
         
+    def full_heal(self):
+        """Complete medical restoration of PRESENT anatomy (#526
+        review — the @heal/@revive backend).
+
+        The anatomy-truth standard applies: severed tombstones are
+        absence records, not injuries — healing does not regrow
+        limbs or resurrect harvested-out modules (which would
+        duplicate their abilities).  Destroyed-in-place organs ARE
+        still attached and restore fully, wound bookkeeping cleared.
+        Cyberware toggle state survives: a deployed gun is not an
+        injury.
+
+        Returns the number of organs that needed healing.
+        """
+        healed = 0
+        for organ in self.organs.values():
+            if organ.wound_stage == "severed":
+                continue
+            if organ.current_hp < organ.max_hp:
+                healed += 1
+            organ.current_hp = organ.max_hp
+            organ.wound_stage = None
+            organ.injury_type = None
+            organ.wound_timestamp = None
+            organ.stabilized = False
+            organ.dressing_rate = 0
+            organ.dressing_progress = 0.0
+            organ.tourniqueted = False
+        self.conditions.clear()
+        self.blood_level = 100.0
+        self.pain_level = 0.0
+        self.consciousness = 1.0
+        self._cached_is_dead = None
+        self._cache_dirty = True
+        return healed
+
     def location_severable_by_organ(self, location):
         """True when any organ at ``location`` flags
         ``severable_container`` in its spec (ANATOMY_AUGMENTS_SPEC

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -964,6 +964,94 @@ class TestSpecCarryingOrgans(TestCase):
         self.assertEqual(item.db.organ_spec.get("max_hp"), 20)
 
 
+class TestFullHealStandard(TestCase):
+    """#526 review: @heal restores PRESENT anatomy — tombstones are
+    absence records, not injuries."""
+
+    def test_severed_tombstones_stay_severed(self):
+        target = _patient()
+        _sever_right_arm(target)
+        target.medical_state.full_heal()
+        stump = target.medical_state.organs["right_humerus"]
+        self.assertEqual(stump.current_hp, 0)
+        self.assertEqual(stump.wound_stage, "severed")
+
+    def test_harvested_module_does_not_resurrect(self):
+        """The duplication exploit: harvest the module (item in
+        hand), @heal the patient, ability returns.  Must not."""
+        from world.medical.augments import find_ability
+
+        target = _patient()
+        spec = dict(SHOTGUN_MODULE_SPEC)
+        spec["container"] = "left_arm"
+        organ = Organ("left_forearm_hardpoint", organ_data=spec)
+        organ.current_hp = 0
+        organ.wound_stage = "severed"  # harvest tombstone
+        organ.medical_state = target.medical_state
+        target.medical_state.organs["left_forearm_hardpoint"] = organ
+
+        target.medical_state.full_heal()
+        self.assertEqual(organ.current_hp, 0)
+        found, _spec = find_ability(target, "shotgun")
+        self.assertIsNone(found)
+
+    def test_destroyed_in_place_restores_clean(self):
+        target = _patient()
+        heart = target.medical_state.organs["heart"]
+        heart.current_hp = 0
+        heart.wound_stage = "destroyed"
+        heart.injury_type = "bullet"
+        heart.stabilized = True
+        heart.tourniqueted = True
+        healed = target.medical_state.full_heal()
+        self.assertGreaterEqual(healed, 1)
+        self.assertEqual(heart.current_hp, heart.max_hp)
+        self.assertIsNone(heart.wound_stage)
+        self.assertIsNone(heart.injury_type)
+        self.assertFalse(heart.stabilized)
+        self.assertFalse(heart.tourniqueted)
+
+    def test_vitals_and_conditions_reset(self):
+        from world.medical.conditions import BleedingCondition, MedicalCondition
+
+        target = _patient()
+        state = target.medical_state
+        with patch.object(
+            MedicalCondition, "start_condition", lambda self, ch: None,
+        ):
+            state.add_condition(BleedingCondition(4, "chest"))
+        state.blood_level = 40.0
+        state.pain_level = 12.0
+        state.full_heal()
+        self.assertEqual(state.conditions, [])
+        self.assertEqual(state.blood_level, 100.0)
+        self.assertEqual(state.pain_level, 0.0)
+
+
+class TestAugmentOrganPredicate(TestCase):
+    """#526 review: the @resetmedical preservation rule."""
+
+    def test_predicate_classifies_the_templates(self):
+        from world.anatomy import get_species_organs
+        from world.medical.core import is_augment_organ
+
+        table = get_species_organs(None)
+        # New-container anatomy: no table entry.
+        tail = Organ("cybernetic_tailbone", organ_data=dict(TAIL_ORGAN_SPEC))
+        self.assertTrue(is_augment_organ(tail, table))
+        # Canonical-name chrome: table entry, inorganic spec.
+        cyber_heart = Organ("heart", organ_data=dict(CYBER_HEART_SPEC))
+        self.assertTrue(is_augment_organ(cyber_heart, table))
+        # Flesh-mounted module host: flesh spec + abilities.
+        host_spec = dict(get_species_organs(None)["left_metacarpals"])
+        host_spec["abilities"] = {"nailz": {"type": "natural_weapon"}}
+        host = Organ("left_metacarpals", organ_data=host_spec)
+        self.assertTrue(is_augment_organ(host, table))
+        # Factory flesh: not an augment.
+        flesh = _patient().medical_state.organs["heart"]
+        self.assertFalse(is_augment_organ(flesh, table))
+
+
 class TestSeveredCyberProse(TestCase):
     def test_inorganic_parts_get_chrome_prose(self):
         from world.anatomy.severed_parts import get_severed_part_description

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -195,6 +195,29 @@ class TestAbilityLayer(EvenniaTest):
         # Retracted: the held knife serves again.
         self.assertIs(get_wielded_weapon(self.char), knife)
 
+    def test_resetmedical_preserves_chrome(self):
+        """#526 review: @resetmedical rebuilds flesh from the current
+        species table but carries installed augments over instead of
+        erasing them."""
+        from commands.CmdAdmin import _reset_medical_preserving_augments
+
+        # The gun-arm organ from setUp is an augment (abilities).
+        # Wound the flesh heart so we can see it factory-reset.
+        self.char.medical_state.organs["heart"].current_hp = 3
+        preserved = _reset_medical_preserving_augments(self.char)
+        self.assertGreaterEqual(preserved, 1)
+        state = self.char.medical_state
+        self.assertIn("cybernetic_humerus", state.organs)
+        self.assertIn(
+            "shotgun",
+            state.organs["cybernetic_humerus"].data.get("abilities", {}),
+        )
+        # Flesh rebuilt at factory.
+        self.assertEqual(
+            state.organs["heart"].current_hp,
+            state.organs["heart"].max_hp,
+        )
+
     def test_no_inline_weapon_picks_outside_the_resolver(self):
         """Doctrine pin (#516 playtest): combat code must resolve
         weapons through get_wielded_weapon, never the inline


### PR DESCRIPTION
Review prompted by playtest question — and no, the admin tools did not "just work" with chrome:

1. **@heal resurrected tombstones.** Every organ went to max HP, including severed stumps (desynced half-regrown limbs) and harvested-out module slots — **a duplication exploit**: harvest the module item, @heal the patient, the ability returns, repeat. Wound bookkeeping also never cleared. Fix: `MedicalState.full_heal()` owns the standard — present anatomy only, bookkeeping cleared, toggle state preserved. Both @heal and the @revive copy call it.

2. **@resetmedical erased chrome.** The wholesale state nuke now preserves augments via `is_augment_organ()` (covers all four §7 templates: new-container anatomy, canonical-name inorganic chrome, ability-carrying flesh hosts, module markers). Flesh factory-resets exactly as before.

Tests: +6, including the duplication exploit pinned shut and a real-character reset round-trip. Suite: **2,497 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)