### PR TITLE
Grasping slots require functional anatomy

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1583,6 +1583,28 @@ class Character(
             self._get_severed_locations()
             if hasattr(self, "_get_severed_locations") else set()
         )
+
+        # Functional-anatomy gate (#526 review): a grasping slot
+        # needs LIVING organs at its container.  The severed-set
+        # subtraction alone misses chain severances — the cut-point
+        # wound filter suppresses downstream wounds, so a hand
+        # attached to a severed arm never appeared "severed" and
+        # kept holding items.  Organ truth closes it: all organs at
+        # the container tombstoned (severed, harvested, or pulped
+        # in place) = no grip.  Characters without organ data at a
+        # location keep the legacy severed-set behavior.
+        if medical_state is not None:
+            organs = getattr(medical_state, "organs", {}) or {}
+            for location in list(grasping):
+                at_location = [
+                    o for o in organs.values()
+                    if getattr(o, "container", None) == location
+                ]
+                if at_location and not any(
+                        getattr(o, "current_hp", 1) > 0
+                        for o in at_location):
+                    severed = set(severed) | {location}
+
         held = self.held_items or {}
         return {
             location: held.get(location)

--- a/world/tests/test_dynamic_hands.py
+++ b/world/tests/test_dynamic_hands.py
@@ -152,6 +152,23 @@ class _HandsViewStub:
                         grasping.add(container)
 
         severed = self._get_severed_locations()
+
+        # Functional-anatomy gate (#526 review) — mirror of the real
+        # property: all organs at a grasping container tombstoned =
+        # no grip, even when the severed set missed it (chain
+        # severance suppresses downstream wounds).
+        if medical_state is not None:
+            organs = getattr(medical_state, "organs", {}) or {}
+            for location in list(grasping):
+                at_location = [
+                    o for o in organs.values()
+                    if getattr(o, "container", None) == location
+                ]
+                if at_location and not any(
+                        getattr(o, "current_hp", 1) > 0
+                        for o in at_location):
+                    severed = set(severed) | {location}
+
         held = self.held_items or {}
         return {
             location: held.get(location)
@@ -198,6 +215,27 @@ class HandsViewAgainstAnatomy(TestCase):
             set(char.hands), {"left_hand", "right_hand", "tail"},
         )
         self.assertIsNone(char.hands["tail"])
+
+    def test_chain_severed_hand_drops_out(self):
+        """The Laszlo finding (#526 review): severing the ARM
+        suppresses the hand's own wounds (cut-point filter), so the
+        severed set misses the hand — the organ-truth gate must
+        still remove the slot.  No holding cigarettes in a hand
+        attached to nothing."""
+        dead_hand_organ = SimpleNamespace(
+            data={}, container="right_hand", current_hp=0,
+        )
+        live_hand_organ = SimpleNamespace(
+            data={}, container="left_hand", current_hp=15,
+        )
+        state = SimpleNamespace(organs={
+            "right_metacarpals": dead_hand_organ,
+            "left_metacarpals": live_hand_organ,
+        })
+        char = _HandsViewStub(species="human", medical_state=state)
+        view = char.hands
+        self.assertNotIn("right_hand", view)
+        self.assertIn("left_hand", view)
 
     def test_severed_tail_drops_out_of_view(self):
         """The existing severance subtraction covers the augment slot


### PR DESCRIPTION
Playtest diagnosis: Laszlo held a cigarette pack in a right hand attached to nothing. Chain severance suppresses downstream wounds (one wound at the cut point — correct for rendering), so `_get_severed_locations` never listed the hand and the slot survived its own amputation.

Fix: the hands property gates on **living organs at the container** — all tombstoned (severed/harvested/pulped) means no grip. Bonus correctness: a crushed-but-attached hand can't hold things either. Legacy severed-set behavior preserved where organ data is absent.

Tests: +1. Suite: **2,498 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)