### PR TITLE
Deployed cyber weapons read as body, not held items

### DIFF
--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -255,7 +255,19 @@ class CmdInventory(Command):
         for hand, item in hands.items():
             display = hand.replace("_", " ")
             if item:
-                lines.append(f"A {item.get_display_name(caller)} is held in your {display}.")
+                # Integrated cyberware (#516) isn't held — it IS the
+                # hand.  "A shotgun module is your right hand" reads
+                # truer than "held in your right hand".
+                if getattr(item.db, "integrated", False):
+                    lines.append(
+                        f"A {item.get_display_name(caller)} is your "
+                        f"{display}."
+                    )
+                else:
+                    lines.append(
+                        f"A {item.get_display_name(caller)} is held in "
+                        f"your {display}."
+                    )
             else:
                 lines.append(f"Nothing is in your {display}.")
 

--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -690,7 +690,27 @@ class AppearanceMixin:
         # here made this section permanently render "holding
         # nothing" (issue #460).
         hands = self.hands or {}
-        wielded_items = [item for item in hands.values() if item is not None]
+        # Integrated cyberware (#516) is excluded from the held list:
+        # a deployed arm-gun is part of the body, represented in the
+        # longdesc and dominating the sdesc — not "held".
+        wielded_items = [
+            item for item in hands.values()
+            if item is not None and not getattr(item.db, "integrated", False)
+        ]
+        # Whether a deployed cyber weapon (integrated in a slot OR an
+        # active natural weapon like claws) is present — used to
+        # suppress the misleading "holding nothing" line, since the
+        # sdesc shows them armed.
+        has_deployed_chrome = any(
+            getattr(item.db, "integrated", False) for item in hands.values()
+            if item is not None
+        )
+        if not has_deployed_chrome:
+            try:
+                from world.medical.augments import get_active_natural_weapon
+                has_deployed_chrome = get_active_natural_weapon(self) is not None
+            except Exception:
+                pass
 
         if wielded_items:
             wielded_names = [obj.get_display_name(looker) for obj in wielded_items]
@@ -713,8 +733,10 @@ class AppearanceMixin:
                     f"{wielded_with_articles[-1]}."
                 )
             parts.append(wielded_text)
-        else:
-            # Show explicitly when hands are empty
+        elif not has_deployed_chrome:
+            # Show explicitly when hands are empty — but not when a
+            # deployed cyber weapon fills them (the sdesc already
+            # shows them armed; "holding nothing" would contradict).
             parts.append(f"{self.get_display_name(looker)} is holding nothing.")
 
         # 4. Staff-only comprehensive inventory (with explicit admin messaging)

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -911,7 +911,18 @@ class Character(
             format_wielded_feature,
         )
 
-        # 1. Wielded weapon / explosive
+        # 1. Wielded weapon / explosive.  A deployed cyber weapon
+        # dominates the sdesc with normal weapon weight (#516 review):
+        # integrated weapons already sit in ``hands`` (held-is-
+        # wielded); active natural weapons (claws) live off-grid, so
+        # check them explicitly first.
+        try:
+            from world.medical.augments import get_active_natural_weapon
+            natural = get_active_natural_weapon(self)
+            if natural is not None:
+                return format_wielded_feature(natural.key)
+        except Exception:
+            pass
         hands = self.hands or {}
         for _hand, item in hands.items():
             if item is not None:

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -356,3 +356,77 @@ class TestSeveranceDropsHeldItems(EvenniaTest):
         self.assertIsNone(
             getattr(char.ndb, "_sever_dropped_items", None)
         )
+
+
+class TestDeployedWeaponDisplay(EvenniaTest):
+    """#516 review (items 1+4): a deployed cyber weapon is not 'held'
+    — it reads as part of the hand in self-inventory, is excluded
+    from the look-at-others held list, and dominates the sdesc."""
+
+    def setUp(self):
+        super().setUp()
+        self.char = create_object(Character, key="Chrome", location=self.room1)
+        # Give them an sdesc so get_distinguishing_feature engages.
+        self.char.db.height = "average"
+        self.char.db.build = "wiry"
+        organ = Organ("cybernetic_humerus", organ_data={
+            "container": "right_arm", "max_hp": 30,
+            "abilities": {"shotgun": {
+                "type": "integrated_weapon", "slot": "right_hand",
+                "weapon_prototype": "SHOTGUN_ARM_GUN",
+            }},
+        })
+        organ.medical_state = self.char.medical_state
+        self.char.medical_state.organs["cybernetic_humerus"] = organ
+        self.organ = organ
+        self.gun = create_object(
+            "typeclasses.items.Item", key="shotgun module", location=None,
+        )
+        self.gun.db.integrated = True
+        self.gun.tags.add("weapon", category="type")
+        organ.ability_state = {"shotgun": {"weapon_dbref": self.gun.dbref}}
+
+    def test_self_inventory_says_is_your_hand(self):
+        from commands.CmdInventory import CmdInventory
+
+        toggle_ability(self.char, "shotgun")
+        captured = []
+        self.char.msg = lambda text=None, **kw: captured.append(text or "")
+        cmd = CmdInventory()
+        cmd.caller = self.char
+        cmd.args = ""
+        cmd.obj = self.char
+        cmd.func()
+        output = "\n".join(captured).lower()
+        self.assertIn("shotgun module is your", output)
+        self.assertNotIn("shotgun module is held in", output)
+
+    def test_look_excludes_integrated_from_held(self):
+        toggle_ability(self.char, "shotgun")
+        looker = create_object(Character, key="Witness", location=self.room1)
+        appearance = self.char.return_appearance(looker)
+        self.assertNotIn("holding a shotgun module", appearance)
+        self.assertNotIn("holding nothing", appearance)
+
+    def test_integrated_dominates_sdesc(self):
+        toggle_ability(self.char, "shotgun")
+        feature = self.char.get_distinguishing_feature()
+        self.assertIn("shotgun module", feature)
+
+    def test_natural_weapon_dominates_sdesc(self):
+        claws_organ = Organ("left_metacarpals", organ_data={
+            "container": "left_hand", "max_hp": 15,
+            "abilities": {"nailz": {
+                "type": "natural_weapon", "weapon_prototype": "NAILZ_CLAWS",
+            }},
+        })
+        claws_organ.medical_state = self.char.medical_state
+        self.char.medical_state.organs["left_metacarpals"] = claws_organ
+        claws = create_object(
+            "typeclasses.items.Item", key="monofilament claws", location=None,
+        )
+        claws.db.integrated = True
+        claws_organ.ability_state = {"nailz": {"weapon_dbref": claws.dbref}}
+        toggle_ability(self.char, "nailz")
+        feature = self.char.get_distinguishing_feature()
+        self.assertIn("claws", feature.lower())


### PR DESCRIPTION
Display housekeeping (items 1 + 4 of the playtest list):

- **Self-inventory**: integrated weapon → "A shotgun module is your right hand" (not "held in").
- **Look at others**: integrated weapons excluded from the held list; "holding nothing" suppressed when a deployed cyber weapon fills the hands.
- **Sdesc**: deployed cyber weapons dominate the distinguishing feature with weapon weight — integrated already did (held-is-wielded), active natural weapons (claws) now checked explicitly.

A deployed shotgun arm is now represented consistently: arm in the longdesc, "wielding a shotgun module" in the sdesc, absent from the held list. (Longdesc module-expansion + chrome rendering is the next PR.)

Tests: +4. Suite: **2,504 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)