### PR TITLE
Chrome longdesc: side-aware, gunmetal, module-expanding

### DIFF
--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -170,23 +170,11 @@ class AppearanceMixin:
                 # is the sole description.
                 if (location in longdescs and longdescs[location]
                         and location not in destroyed_locs):
-                    # Longdesc should have skintone applied
-                    processed_desc = self._process_description_variables(
-                        longdescs[location], looker,
-                        force_third_person=True, apply_skintone=True,
-                        side=self._side_from_location(location),
+                    # Chrome-aware render: flesh → skintone, inorganic
+                    # → gunmetal + deployed-module expansion (#516).
+                    processed_desc = self._render_body_longdesc(
+                        location, longdescs[location], looker
                     )
-
-                    # Add wounds to this location if any exist
-                    try:
-                        from world.medical.wounds import append_wounds_to_longdesc
-                        processed_desc = append_wounds_to_longdesc(
-                            processed_desc, self, location, looker
-                        )
-                    except ImportError:
-                        # Wound system not available, continue without wounds
-                        pass
-
                     descriptions.append((location, processed_desc))
                 else:
                     # No longdesc for this location, but check for standalone wounds
@@ -230,26 +218,13 @@ class AppearanceMixin:
                             descriptions.append((location, desc))
                             added_clothing_items.add(clothing_item)
                 elif location in longdescs and longdescs[location]:
-                    # Extended location with longdesc - apply template variable
-                    # processing and skintone. Same side-aware singular
-                    # flex treatment as the standard-anatomy branch
-                    # above (#341).
-                    processed_desc = self._process_description_variables(
-                        longdescs[location], looker,
-                        force_third_person=True, apply_skintone=True,
-                        side=self._side_from_location(location),
+                    # Extended location with longdesc — chrome-aware
+                    # render (skintone for flesh, gunmetal + deployed-
+                    # module expansion for inorganic; #341 side flex
+                    # and wound-append handled inside the helper).
+                    processed_desc = self._render_body_longdesc(
+                        location, longdescs[location], looker
                     )
-
-                    # Add wounds to this extended location if any exist
-                    try:
-                        from world.medical.wounds import append_wounds_to_longdesc
-                        processed_desc = append_wounds_to_longdesc(
-                            processed_desc, self, location, looker
-                        )
-                    except ImportError:
-                        # Wound system not available, continue without wounds
-                        pass
-
                     descriptions.append((location, processed_desc))
                 else:
                     # No longdesc for extended location, but check for
@@ -754,6 +729,78 @@ class AppearanceMixin:
 
         # Join all parts with appropriate spacing (blank lines between sections)
         return '\n\n'.join(parts)
+
+    def _location_is_inorganic(self, location):
+        """True when ``location`` is cybernetic chrome (#516 review).
+
+        Reads the medical organs at the container: any organ flagged
+        ``inorganic`` makes the whole location render as metal rather
+        than flesh (no skintone; gunmetal wrap).  Matches by container
+        or display_location so surface keys line up with bulk organs.
+        """
+        state = getattr(self, "medical_state", None)
+        organs = getattr(state, "organs", None) if state else None
+        if not organs:
+            return False
+        for organ in organs.values():
+            if location not in (
+                getattr(organ, "container", None),
+                getattr(organ, "display_location", None),
+            ):
+                continue
+            data = getattr(organ, "data", None)
+            if data and data.get("inorganic"):
+                return True
+        return False
+
+    def _deployed_module_longdesc(self, location):
+        """Prose for any deployed ability module at ``location``
+        (#516 review item 4): the chrome arm's baseline longdesc
+        expands when a weapon is out.  Returns the joined
+        ``deployed_longdesc`` strings, or ``""``.
+        """
+        state = getattr(self, "medical_state", None)
+        organs = getattr(state, "organs", None) if state else None
+        if not organs:
+            return ""
+        out = []
+        for organ in organs.values():
+            if getattr(organ, "container", None) != location:
+                continue
+            data = getattr(organ, "data", None) or {}
+            abilities = data.get("abilities") or {}
+            store = getattr(organ, "ability_state", None) or {}
+            for name, spec in abilities.items():
+                if not (store.get(name) or {}).get("deployed"):
+                    continue
+                prose = spec.get("deployed_longdesc")
+                if prose:
+                    out.append(prose)
+        return " ".join(out)
+
+    def _render_body_longdesc(self, location, text, looker):
+        """Process one location's longdesc: flesh gets tokens +
+        skintone; chrome (#516 review) gets gunmetal + any deployed-
+        module expansion instead.  Wounds append either way."""
+        is_chrome = self._location_is_inorganic(location)
+        processed = self._process_description_variables(
+            text, looker,
+            force_third_person=True, apply_skintone=not is_chrome,
+            side=self._side_from_location(location),
+        )
+        if is_chrome:
+            from world.combat.constants import CHROME_DEFAULT_COLOR
+            deployed = self._deployed_module_longdesc(location)
+            body = f"{processed} {deployed}" if deployed else processed
+            processed = f"{CHROME_DEFAULT_COLOR}{body}|n"
+        try:
+            from world.medical.wounds import append_wounds_to_longdesc
+            processed = append_wounds_to_longdesc(
+                processed, self, location, looker
+            )
+        except ImportError:
+            pass
+        return processed
 
     @staticmethod
     def _side_from_location(location):

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -216,6 +216,12 @@ SKINTONE_PALETTE = {
 # Valid skintone names for validation
 VALID_SKINTONES = set(SKINTONE_PALETTE.keys())
 
+# Raw cybernetic chrome (#516 review).  Inorganic body locations
+# render in gunmetal grey instead of the wearer's skintone — chrome
+# is not flesh.  When coating items arrive they'll override this per
+# augment; until then this is the bare-metal default.
+CHROME_DEFAULT_COLOR = "|x"  # gunmetal / bright-black
+
 # ===================================================================
 # CHANNELS & LOGGING
 # ===================================================================

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2048,11 +2048,11 @@ CYBER_ARM = {
         ("augment_longdesc", [
             {
                 "key": "{side}_arm",
-                "default_desc": "A full cybernetic arm, matte composite plating over an actuator column, an access panel seam running the length of the forearm.",
+                "default_desc": "A full cybernetic {side} arm, matte composite plating over an actuator column, an access panel seam running the length of the forearm.",
             },
             {
                 "key": "{side}_hand",
-                "default_desc": "An articulated alloy hand, five-fingered and precise, the knuckle plating worn smooth.",
+                "default_desc": "An articulated alloy {side} hand, five-fingered and precise, the knuckle plating worn smooth.",
                 "display_after": "{side}_arm",
             },
         ]),
@@ -2085,6 +2085,7 @@ SHOTGUN_MODULE = {
                     "weapon_prototype": "SHOTGUN_ARM_GUN",
                     "deploy_msg": "Your {side} forearm splits along its seam and the shotgun rotates up into place — the hand folds back and away, and the barrel is just *there*, like it always was.",
                     "retract_msg": "The shotgun swings down and folds along the actuator column; plating closes over it and your fingers flex, a hand again.",
+                    "deployed_longdesc": "The forearm housing has split open along its seam, a stub shotgun barrel deployed and locked where the hand should be.",
                     "deploy_room": "{actor}'s forearm splits open with a snap of locking servos — a shotgun barrel rotates up out of the housing where their hand used to be.",
                     "retract_room": "{actor}'s arm-shotgun folds away into the forearm housing; plating seals and their hand reassembles, fingers flexing.",
                 },
@@ -2118,6 +2119,7 @@ NAILZ = {
                     "weapon_prototype": "NAILZ_CLAWS",
                     "deploy_msg": "Your knuckles ache, then part — ten monofilament claws slide out along your fingers with a sound like scissors closing.",
                     "retract_msg": "The claws fold back under your skin; your hand is just a hand again, mostly.",
+                    "deployed_longdesc": "Ten monofilament claws stand extended from the fingertips, catching the light.",
                     "deploy_room": "{actor} flexes a hand and monofilament claws slide out along their fingers, catching the light.",
                     "retract_room": "{actor}'s claws fold away under the skin of their hand.",
                 },

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -430,3 +430,64 @@ class TestDeployedWeaponDisplay(EvenniaTest):
         toggle_ability(self.char, "nailz")
         feature = self.char.get_distinguishing_feature()
         self.assertIn("claws", feature.lower())
+
+
+class TestChromeLongdesc(EvenniaTest):
+    """#516 review (item 2 + item 4-longdesc): chrome renders gunmetal
+    (not skintone), and a deployed module expands the limb's longdesc."""
+
+    def setUp(self):
+        super().setUp()
+        self.char = create_object(Character, key="Chrome", location=self.room1)
+        self.char.db.skintone = "tan"
+        organ = Organ("cybernetic_humerus", organ_data={
+            "container": "left_arm", "max_hp": 30, "inorganic": True,
+            "abilities": {"shotgun": {
+                "type": "integrated_weapon", "slot": "left_hand",
+                "weapon_prototype": "X",
+                "deployed_longdesc": "A stub shotgun barrel juts where the hand should be.",
+            }},
+        })
+        organ.medical_state = self.char.medical_state
+        self.char.medical_state.organs["cybernetic_humerus"] = organ
+        self.organ = organ
+        ld = dict(self.char.longdesc or {})
+        ld["left_arm"] = "A full cybernetic left arm."
+        self.char.longdesc = ld
+
+    def test_inorganic_location_detected(self):
+        self.assertTrue(self.char._location_is_inorganic("left_arm"))
+        self.assertFalse(self.char._location_is_inorganic("chest"))
+
+    def test_chrome_renders_gunmetal_not_skintone(self):
+        from world.combat.constants import (
+            CHROME_DEFAULT_COLOR, SKINTONE_PALETTE,
+        )
+        rendered = self.char._render_body_longdesc(
+            "left_arm", self.char.longdesc["left_arm"], self.char,
+        )
+        self.assertIn(CHROME_DEFAULT_COLOR, rendered)
+        self.assertNotIn(SKINTONE_PALETTE["tan"], rendered)
+
+    def test_flesh_still_skintoned(self):
+        from world.combat.constants import SKINTONE_PALETTE
+        rendered = self.char._render_body_longdesc(
+            "chest", "A broad chest.", self.char,
+        )
+        self.assertIn(SKINTONE_PALETTE["tan"], rendered)
+
+    def test_deployed_module_expands_longdesc(self):
+        self.organ.ability_state = {
+            "shotgun": {"deployed": True, "weapon_dbref": "#1"},
+        }
+        rendered = self.char._render_body_longdesc(
+            "left_arm", self.char.longdesc["left_arm"], self.char,
+        )
+        self.assertIn("shotgun barrel juts", rendered)
+
+    def test_retracted_module_does_not_expand(self):
+        self.organ.ability_state = {"shotgun": {"deployed": False}}
+        rendered = self.char._render_body_longdesc(
+            "left_arm", self.char.longdesc["left_arm"], self.char,
+        )
+        self.assertNotIn("shotgun barrel juts", rendered)


### PR DESCRIPTION
Final display housekeeping piece (item 2 + item 4-longdesc):

- **Side-aware**: `CYBER_ARM` longdesc uses `{side}` — the M2 install resolver fills it, so a left install reads "A full cybernetic left arm". Any prosthetic gets side declaration by using the token.
- **Gunmetal, not skintone**: inorganic body locations render in `CHROME_DEFAULT_COLOR` (`|x`, your gunmetal pick) instead of the wearer's skintone. Coatings will override per-augment later.
- **Deployed-module expansion**: a limb's longdesc grows the module's `deployed_longdesc` when the weapon is out and reverts on retract. `SHOTGUN_MODULE` + `NAILZ` declare it.

New helpers `_location_is_inorganic` / `_deployed_module_longdesc`; both longdesc render branches de-duplicated through one `_render_body_longdesc`. Verified `{side}` resolves end-to-end on the real prototype.

With #535 this completes the deployed-weapon trio: arm in the (chrome, expanding) longdesc, weapon in the sdesc, absent from the held list.

Tests: +5. Suite: **2,509 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)