### PR TITLE
Only weapons dominate the sdesc; held junk yields to garments

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -923,9 +923,25 @@ class Character(
                 return format_wielded_feature(natural.key)
         except Exception:
             pass
+        # Only an actual weapon or explosive carries enough weight to
+        # dominate the sdesc — a cigarette, lighter, or tool in hand
+        # falls through to the predominant garment (#516 review).
+        # "Weapon" is the ("weapon", "type") tag, not db.weapon_type
+        # (which defaults to "melee" on every item — the #520/#522
+        # lesson).
         hands = self.hands or {}
         for _hand, item in hands.items():
-            if item is not None:
+            if item is None:
+                continue
+            tags = getattr(item, "tags", None)
+            is_weapon = tags is not None and tags.has("weapon", category="type")
+            if not is_weapon:
+                try:
+                    from world.combat.throwing import is_explosive
+                    is_weapon = bool(is_explosive(item))
+                except Exception:
+                    is_weapon = False
+            if is_weapon:
                 return format_wielded_feature(item.key)
 
         # 2. Outermost clothing item (pick the first location with coverage).

--- a/world/tests/test_character_identity.py
+++ b/world/tests/test_character_identity.py
@@ -33,7 +33,7 @@ from world.tests._identity_helpers import (
 # ===================================================================
 
 
-def _make_item(key="Kitchen Knife", coverage=None):
+def _make_item(key="Kitchen Knife", coverage=None, weapon=False):
     """Return a minimal mock item with a ``.key`` and disguise defaults.
 
     Disguise-related attributes are pinned to falsy defaults so the
@@ -56,6 +56,12 @@ def _make_item(key="Kitchen Knife", coverage=None):
     item.worn_sdesc_short = ""
     item.coverage = list(coverage) if coverage else []
     item.disguise_silent_feature = False
+    # Weapon discrimination for the distinguishing-feature chain
+    # (#516 review): only actual weapons / explosives dominate the
+    # sdesc.  MagicMock would make ``tags.has`` and ``db.is_explosive``
+    # auto-truthy, so pin both explicitly.
+    item.tags.has.return_value = bool(weapon)
+    item.db.is_explosive = False
     return item
 
 
@@ -138,7 +144,7 @@ class TestDistinguishingFeature(TestCase):
 
     def test_wielded_weapon_wins(self):
         """Wielded weapon outranks clothing and hair."""
-        knife = _make_item("Kitchen Knife")
+        knife = _make_item("Kitchen Knife", weapon=True)
         trenchcoat = _make_item("Black Trenchcoat")
         char = _make_character(
             hands={"left": None, "right": knife},
@@ -159,6 +165,31 @@ class TestDistinguishingFeature(TestCase):
         )
         result = char.get_distinguishing_feature()
         self.assertEqual(result, "in a Black Trenchcoat")
+
+    def test_non_weapon_in_hand_falls_through_to_garment(self):
+        """#516 review: a cigarette / lighter / tool in hand carries
+        no sdesc weight — the predominant garment wins instead."""
+        cigarette = _make_item("cigarette")  # weapon=False
+        coat = _make_item("Armored Jacket")
+        char = _make_character(
+            hands={"left": None, "right": cigarette},
+            worn_items={"chest": [coat]},
+        )
+        result = char.get_distinguishing_feature()
+        self.assertEqual(result, "in an Armored Jacket")
+
+    def test_non_weapon_in_hand_falls_through_to_hair(self):
+        """With nothing worn, a non-weapon held item still doesn't
+        dominate — hair is the next fallback."""
+        pack = _make_item("pack of cigarettes")  # weapon=False
+        char = _make_character(
+            hands={"left": None, "right": pack},
+            hair_color="black",
+            hair_style="slicked",
+        )
+        result = char.get_distinguishing_feature()
+        self.assertIn("hair", result.lower() + result)
+        self.assertNotIn("cigarettes", result)
 
     def test_hair_when_no_weapon_or_clothing(self):
         """Hair feature used when no weapon or clothing."""
@@ -189,15 +220,15 @@ class TestDistinguishingFeature(TestCase):
 
     def test_left_hand_wielded(self):
         """Left-hand weapon detected."""
-        sword = _make_item("Katana")
+        sword = _make_item("Katana", weapon=True)
         char = _make_character(hands={"left": sword, "right": None})
         result = char.get_distinguishing_feature()
         self.assertEqual(result, "wielding a Katana")
 
     def test_both_hands_wielded_picks_first(self):
         """When both hands hold items, one is chosen (deterministic)."""
-        knife = _make_item("Kitchen Knife")
-        pistol = _make_item("Pistol")
+        knife = _make_item("Kitchen Knife", weapon=True)
+        pistol = _make_item("Pistol", weapon=True)
         char = _make_character(hands={"left": knife, "right": pistol})
         result = char.get_distinguishing_feature()
         # Dict iteration order in Python 3.7+ is insertion order
@@ -216,7 +247,7 @@ class TestDistinguishingFeature(TestCase):
 
     def test_article_an_for_vowel_item(self):
         """Items starting with a vowel get 'an' article."""
-        axe = _make_item("Axe")
+        axe = _make_item("Axe", weapon=True)
         char = _make_character(hands={"left": None, "right": axe})
         result = char.get_distinguishing_feature()
         self.assertEqual(result, "wielding an Axe")
@@ -361,7 +392,7 @@ class TestGetSdesc(TestCase):
 
     def test_full_sdesc_with_feature(self):
         """Height + build + keyword + feature produces full sdesc."""
-        knife = _make_item("Kitchen Knife")
+        knife = _make_item("Kitchen Knife", weapon=True)
         char = _make_character(
             height="tall",
             build="lean",
@@ -502,7 +533,7 @@ class TestGetDisplayName(TestCase):
 
     def test_stranger_with_feature(self):
         """Stranger sdesc includes distinguishing feature."""
-        knife = _make_item("Kitchen Knife")
+        knife = _make_item("Kitchen Knife", weapon=True)
         target = _make_character(
             key="Jorge Jackson",
             height="tall",


### PR DESCRIPTION
Playtest: a pack of cigarettes in hand read with full weapon weight in the sdesc. `get_distinguishing_feature`'s priority-1 slot ("Wielded weapon or explosive" per its docstring) returned the first held item of *any* kind.

Now only actual weapons (the `("weapon", "type")` tag — not `db.weapon_type`, which defaults to `"melee"` on everything) and explosives dominate. Cigarettes / lighters / tools fall through to the predominant garment, then hair. Deployed cyber weapons still dominate (their items carry the weapon tag).

Tests: +2; existing weapon-holding identity tests flag their items as weapons (the MagicMock mocks were auto-truthy). Suite: **2,511 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)