### PR TITLE
Deploying a hand-slot weapon replaces the hand's longdesc too

### DIFF
--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -778,13 +778,45 @@ class AppearanceMixin:
                     out.append(prose)
         return " ".join(out)
 
+    def _deployed_slot_prose(self, location):
+        """Replacement prose for a hand whose slot a deployed weapon
+        has consumed (#516 review follow-up): when /shotgun fills the
+        hand, the hand isn't a hand anymore — its longdesc is
+        REPLACED by the ability's ``deployed_longdesc_slot``, not just
+        appended to.  An ability's ``slot`` (resolved to a real
+        container at install) names which location it consumes.
+        Returns the prose, or ``""`` when nothing is deployed here.
+        """
+        state = getattr(self, "medical_state", None)
+        organs = getattr(state, "organs", None) if state else None
+        if not organs:
+            return ""
+        for organ in organs.values():
+            data = getattr(organ, "data", None) or {}
+            abilities = data.get("abilities") or {}
+            store = getattr(organ, "ability_state", None) or {}
+            for name, spec in abilities.items():
+                if spec.get("slot") != location:
+                    continue
+                if not (store.get(name) or {}).get("deployed"):
+                    continue
+                prose = spec.get("deployed_longdesc_slot")
+                if prose:
+                    return prose
+        return ""
+
     def _render_body_longdesc(self, location, text, looker):
         """Process one location's longdesc: flesh gets tokens +
         skintone; chrome (#516 review) gets gunmetal + any deployed-
         module expansion instead.  Wounds append either way."""
         is_chrome = self._location_is_inorganic(location)
+        # A hand whose slot a deployed weapon has taken renders the
+        # weapon's slot prose INSTEAD of its baseline hand text — the
+        # hand has folded away.
+        slot_override = self._deployed_slot_prose(location) if is_chrome else ""
+        base_text = slot_override or text
         processed = self._process_description_variables(
-            text, looker,
+            base_text, looker,
             force_third_person=True, apply_skintone=not is_chrome,
             side=self._side_from_location(location),
         )

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2086,6 +2086,7 @@ SHOTGUN_MODULE = {
                     "deploy_msg": "Your {side} forearm splits along its seam and the shotgun rotates up into place — the hand folds back and away, and the barrel is just *there*, like it always was.",
                     "retract_msg": "The shotgun swings down and folds along the actuator column; plating closes over it and your fingers flex, a hand again.",
                     "deployed_longdesc": "The forearm housing has split open along its seam, a stub shotgun barrel deployed and locked where the hand should be.",
+                    "deployed_longdesc_slot": "Where the {side} hand should be, the wrist tapers into a seamless firing socket — the hand has folded back and stowed along the forearm.",
                     "deploy_room": "{actor}'s forearm splits open with a snap of locking servos — a shotgun barrel rotates up out of the housing where their hand used to be.",
                     "retract_room": "{actor}'s arm-shotgun folds away into the forearm housing; plating seals and their hand reassembles, fingers flexing.",
                 },

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -491,3 +491,42 @@ class TestChromeLongdesc(EvenniaTest):
             "left_arm", self.char.longdesc["left_arm"], self.char,
         )
         self.assertNotIn("shotgun barrel juts", rendered)
+
+    def _add_chrome_hand(self):
+        hand = Organ("cybernetic_metacarpals", organ_data={
+            "container": "left_hand", "max_hp": 18, "inorganic": True,
+        })
+        hand.medical_state = self.char.medical_state
+        self.char.medical_state.organs["cybernetic_metacarpals"] = hand
+        ld = dict(self.char.longdesc or {})
+        ld["left_hand"] = (
+            "An articulated alloy left hand, five-fingered and precise."
+        )
+        self.char.longdesc = ld
+        self.organ.data["abilities"]["shotgun"]["deployed_longdesc_slot"] = (
+            "Where the left hand should be, the wrist tapers into a "
+            "seamless firing socket."
+        )
+
+    def test_deployed_weapon_replaces_the_hand_longdesc(self):
+        """The /shotgun follow-up: deploying folds the hand away, so
+        the hand's longdesc is REPLACED (not appended) by the slot
+        prose."""
+        self._add_chrome_hand()
+        self.organ.ability_state = {
+            "shotgun": {"deployed": True, "weapon_dbref": "#1"},
+        }
+        rendered = self.char._render_body_longdesc(
+            "left_hand", self.char.longdesc["left_hand"], self.char,
+        )
+        self.assertIn("firing socket", rendered)
+        self.assertNotIn("five-fingered", rendered)  # baseline replaced
+
+    def test_retracted_weapon_restores_the_hand_longdesc(self):
+        self._add_chrome_hand()
+        self.organ.ability_state = {"shotgun": {"deployed": False}}
+        rendered = self.char._render_body_longdesc(
+            "left_hand", self.char.longdesc["left_hand"], self.char,
+        )
+        self.assertIn("five-fingered", rendered)
+        self.assertNotIn("firing socket", rendered)


### PR DESCRIPTION
Missed-requirement follow-up: `/shotgun` expanded the forearm longdesc but the hand still read "five-fingered and precise" — even though it's folded away to make room for the barrel.

An integrated weapon already declares its consumed slot (`slot: "{side}_hand"`). New `deployed_longdesc_slot` prose **replaces** the hand's longdesc while deployed ("Where the left hand should be, the wrist tapers into a seamless firing socket — the hand has folded back..."); retract restores it.

`_deployed_slot_prose` matches an ability by its consumed slot; `_render_body_longdesc` uses it as the base-text override for chrome locations. Natural weapons (claws) unaffected — no slot, and they extend *from* the fingers rather than folding them away. Verified end-to-end on a real CYBER_ARM + SHOTGUN_MODULE install.

Tests: +2. Suite: **2,513 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)