### PR TITLE
Severed cybernetic limbs reattach whole

### DIFF
--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -524,6 +524,13 @@ class CmdInstall(Command):
             )
             return
 
+        # Severed cybernetic limbs (#526 follow-up) reattach whole —
+        # an Appendage whose snapshot carries inorganic anatomy.
+        from world.medical.procedures import is_cybernetic_limb
+        if is_cybernetic_limb(organ_item):
+            self._install_limb(caller, organ_item, target_phrase)
+            return
+
         organ_name = getattr(organ_item.db, "organ_name", None)
         if not organ_name:
             caller.msg(
@@ -847,6 +854,95 @@ class CmdInstall(Command):
             f"You begin seating the {organ_item.key} into the "
             f"hardpoint at {target.get_display_name(caller)}'s "
             f"{container.replace('_', ' ')}..."
+        )
+
+    def _install_limb(self, caller, organ_item, target_phrase):
+        """Stage a severed-cybernetic-limb reattachment (#526
+        follow-up): bolt the whole limb back on over a stump.
+
+        Pre-dispatch gates: living target, the target has a stump at
+        every one of the limb's containers (amputate first — looted
+        chrome bolts onto any compatible body), and an open incision
+        at the cut point.  The resolver re-checks all of these.
+        """
+        from world.medical.procedures import get_organ_snapshot
+
+        target = _resolve_target(caller, target_phrase)
+        if target is None:
+            return
+        if not _is_body_container(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} isn't something "
+                f"you can reattach a limb to."
+            )
+            return
+        state = getattr(target, "medical_state", None)
+        if state is None or not getattr(state, "organs", None):
+            caller.msg(
+                f"The {organ_item.key} needs a living body to "
+                f"reattach to."
+            )
+            return
+
+        snapshot = get_organ_snapshot(organ_item)
+        organs_data = (snapshot or {}).get("organs") or {}
+        declared = {
+            d.get("container") for d in organs_data.values()
+            if hasattr(d, "get") and d.get("container")
+        }
+        target_containers = {
+            getattr(o, "container", None) for o in state.organs.values()
+        }
+        missing = declared - target_containers
+        if missing:
+            nice = ", ".join(sorted(c.replace("_", " ") for c in missing))
+            caller.msg(
+                f"{target.get_display_name(caller)} has nowhere to "
+                f"attach the {organ_item.key} — no {nice}."
+            )
+            return
+        living = [
+            o for o in state.organs.values()
+            if getattr(o, "container", None) in declared and o.current_hp > 0
+        ]
+        if living:
+            container = living[0].container
+            caller.msg(
+                f"{target.get_display_name(caller)} still has a living "
+                f"{container.replace('_', ' ')} — amputate before "
+                f"reattaching the {organ_item.key}."
+            )
+            return
+
+        # Anchor = the limb's cut point (its severed location).
+        anchor = getattr(organ_item.db, "location_name", None)
+        if anchor not in declared:
+            anchor = sorted(declared)[0] if declared else None
+        if not anchor or not has_incision(target, anchor):
+            anchor_disp = (anchor or "the stump").replace("_", " ")
+            caller.msg(
+                f"The {organ_item.key} bolts on at the {anchor_disp}, "
+                f"and {target.get_display_name(caller)}'s {anchor_disp} "
+                f"isn't open. Try ``incise {target_phrase} at "
+                f"{anchor_disp}``."
+            )
+            return
+
+        if _reject_if_busy(caller, target):
+            return
+        kit = _find_surgical_kit(caller)
+        if kit is None:
+            caller.msg("You need a surgical kit to reattach a limb.")
+            return
+
+        start_procedure(
+            target, verb="install_limb", actor=caller,
+            organ_item=organ_item, location=anchor,
+        )
+        caller.msg(
+            f"You begin reattaching the {organ_item.key} to "
+            f"{target.get_display_name(caller)}'s "
+            f"{anchor.replace('_', ' ')}..."
         )
 
 

--- a/world/medical/charts.py
+++ b/world/medical/charts.py
@@ -513,6 +513,11 @@ def commence_chart(target, actor) -> Optional[dict]:
             # Module seats at the recorded hardpoint container; the
             # resolver re-finds the slot and re-checks the gates.
             verb = "install_module"
+        else:
+            # Severed cybernetic limb (#526 follow-up): reattach whole.
+            from world.medical.procedures import is_cybernetic_limb
+            if is_cybernetic_limb(resolved_args.get("organ_item")):
+                verb = "install_limb"
 
     step["status"] = RUNNING
     chart["status"] = IN_PROGRESS

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -82,6 +82,9 @@ PROCEDURE_DURATIONS = {
     # Module seating (#526 M3) — quicker than a graft: the chassis
     # did the hard integration work already.
     "install_module": 9,
+    # Limb reattachment (#526 follow-up): bolting a severed cyber
+    # limb back on is full-graft work, like the original mount.
+    "install_limb": 18,
     "suture":   9,
     "amputate": 12,
     # Autopsy is the deliberate counterpart to the cursory ``inspect``
@@ -1784,6 +1787,196 @@ def _resolve_install_module(actor, target, *, organ_item, location: str,
         _log_guarded_failure("install_module_item_delete", organ_item, exc)
 
 
+def is_cybernetic_limb(appendage) -> bool:
+    """True when ``appendage`` is a severed CYBERNETIC limb (#526
+    follow-up): an organ-snapshot-bearing part with at least one
+    inorganic organ.  Flesh limbs don't reattach (necrosis); chrome
+    bolts back on."""
+    snapshot = get_organ_snapshot(appendage)
+    organs = (snapshot or {}).get("organs") or {}
+    for entry in organs.values():
+        if not hasattr(entry, "get"):
+            continue
+        data = entry.get("data")
+        if data and hasattr(data, "get") and data.get("inorganic"):
+            return True
+    return False
+
+
+def _resolve_install_limb(actor, target, *, organ_item, location: str,
+                          **_) -> None:
+    """Reattach a severed cybernetic limb (#526 follow-up, user
+    decision 2026-06-13).
+
+    The whole limb goes back on — chassis plus whatever module is
+    still seated, at its current HP / condition.  A bare chassis
+    (module already harvested out) reattaches fine.  Looted chrome:
+    any compatible body, gated by the target having a stump at every
+    one of the limb's containers (you amputate first, then bolt the
+    scavenged arm on).  Deployed weapons don't survive the cut, so
+    modules come back retracted.
+    """
+    from world.identity_utils import msg_room_identity
+    from world.medical.charts import mark_running_step_failed
+    from world.medical.core import Organ
+
+    snapshot = get_organ_snapshot(organ_item)
+    organs_data = (snapshot or {}).get("organs") or {}
+    if not organs_data:
+        actor.msg(f"The {organ_item.key} has no anatomy to reattach.")
+        return
+
+    state = getattr(target, "medical_state", None)
+    if state is None or not getattr(state, "organs", None):
+        actor.msg(
+            f"The {organ_item.key} needs a living body to reattach to."
+        )
+        return
+
+    declared = {
+        d.get("container") for d in organs_data.values()
+        if hasattr(d, "get") and d.get("container")
+    }
+
+    # Container fit (the "compatible body" gate): the target must
+    # have every one of the limb's containers as a real slot —
+    # represented by a stump / wreckage organ from a prior
+    # amputation.  No slot = nowhere to bolt it.
+    target_containers = {
+        getattr(o, "container", None) for o in state.organs.values()
+    }
+    missing = declared - target_containers
+    if missing:
+        nice = ", ".join(sorted(c.replace("_", " ") for c in missing))
+        actor.msg(
+            f"{target.get_display_name(actor)} has nowhere to attach "
+            f"the {organ_item.key} — no {nice} to bolt it to."
+        )
+        mark_running_step_failed(
+            target, outcome=f"no host containers: {sorted(missing)}",
+        )
+        return
+
+    # Living-anatomy gate: every container must be a stump or
+    # wreckage, never living flesh/chrome.  Amputate first.
+    living = [
+        o for o in state.organs.values()
+        if getattr(o, "container", None) in declared and o.current_hp > 0
+    ]
+    if living:
+        container = living[0].container
+        actor.msg(
+            f"{target.get_display_name(actor)} still has a living "
+            f"{container.replace('_', ' ')} — amputate before "
+            f"reattaching the {organ_item.key}."
+        )
+        mark_running_step_failed(
+            target, outcome=f"living anatomy at {container}",
+        )
+        return
+
+    if not has_incision(target, location):
+        actor.msg(
+            f"You line the {organ_item.key} up against the stump, but "
+            f"{target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')} isn't open."
+        )
+        mark_running_step_failed(
+            target, outcome=f"no incision at {location} — reattach blocked",
+        )
+        return
+
+    result = roll_procedure(actor, target)
+    outcome = result["outcome"]
+    if outcome == "failure":
+        seed_infection(target, location)
+        seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["install"])
+        actor.msg(
+            f"The graft won't take. The {organ_item.key} stays loose "
+            f"in your hands."
+        )
+        return
+
+    # Success / partial: rebuild every organ from the appendage's
+    # snapshot at its container, replacing any stump/wreckage there.
+    for container in declared:
+        for oname in [
+            n for n, o in state.organs.items()
+            if getattr(o, "container", None) == container
+        ]:
+            del state.organs[oname]
+
+    for name, odata in organs_data.items():
+        spec = odata.get("data") if hasattr(odata, "get") else None
+        spec = dict(spec) if spec and hasattr(spec, "get") else {}
+        organ = Organ(name, organ_data=spec or None)
+        organ.max_hp = odata.get("max_hp", organ.max_hp)
+        organ.current_hp = odata.get("current_hp", organ.max_hp)
+        organ.wound_stage = odata.get("wound_stage")
+        # Modules come back retracted — the deployed weapon item did
+        # not survive the severance.  Clean up the orphaned weapon if
+        # it's still floating, then reset the toggle state.
+        raw_ability = odata.get("ability_state") or {}
+        reset_state = {}
+        for ability_name, astate in raw_ability.items():
+            if hasattr(astate, "get"):
+                dbref = astate.get("weapon_dbref")
+                if dbref:
+                    try:
+                        from evennia.utils.search import search_object
+                        for found in search_object(dbref):
+                            found.delete()
+                    except Exception:
+                        pass
+                reset_state[ability_name] = {"deployed": False}
+        organ.ability_state = reset_state
+        organ.medical_state = state
+        state.organs[name] = organ
+
+    # Restore the limb's longdesc prose (carried on the appendage at
+    # sever time — apply_living_sever_overlay).
+    carried = getattr(organ_item.db, "longdesc_data", None) or {}
+    if carried:
+        ld = dict(target.longdesc or {})
+        for loc, text in carried.items():
+            ld[loc] = text
+        target.longdesc = ld
+
+    seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["install"])
+    if outcome == "partial":
+        seed_infection(target, location)
+        actor.msg(
+            f"You bolt the {organ_item.key} back on — but the graft "
+            f"is sloppy. Time will tell."
+        )
+    else:
+        actor.msg(
+            f"You reattach the {organ_item.key} to "
+            f"{target.get_display_name(actor)}'s "
+            f"{location.replace('_', ' ')}."
+        )
+
+    save = getattr(target, "save_medical_state", None)
+    if callable(save):
+        save()
+
+    if actor.location is not None:
+        msg_room_identity(
+            location=actor.location,
+            template=(
+                f"{{actor}} reattaches a {organ_item.key} to "
+                f"{{patient}}'s {location.replace('_', ' ')}."
+            ),
+            char_refs={"actor": actor, "patient": target},
+            exclude=[actor, target] if target is not actor else [actor],
+        )
+
+    try:
+        organ_item.delete()
+    except Exception as exc:
+        _log_guarded_failure("install_limb_item_delete", organ_item, exc)
+
+
 # Mapping consumed by ``_resolve_procedure_callback``.
 _VERB_RESOLVERS = {
     "incise":   _resolve_incise,
@@ -1791,6 +1984,7 @@ _VERB_RESOLVERS = {
     "install":  _resolve_install,
     "install_augment": _resolve_install_augment,
     "install_module": _resolve_install_module,
+    "install_limb": _resolve_install_limb,
     "suture":   _resolve_suture,
     "amputate": _resolve_amputate,
     "autopsy":  _resolve_autopsy,

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -1052,6 +1052,140 @@ class TestAugmentOrganPredicate(TestCase):
         self.assertFalse(is_augment_organ(flesh, table))
 
 
+def _severed_cyber_arm(deployed=False):
+    """Stub Appendage carrying a severed cyber-arm snapshot (#526
+    reattach)."""
+    item = SimpleNamespace()
+    item.key = "cybernetic right arm"
+    item.deleted = False
+
+    def _delete():
+        item.deleted = True
+    item.delete = _delete
+    snapshot = {"organs": {
+        "right_humerus": {
+            "container": "right_arm", "current_hp": 30, "max_hp": 30,
+            "wound_stage": "severed",
+            "data": {"container": "right_arm", "max_hp": 30, "inorganic": True},
+        },
+        "right_metacarpals": {
+            "container": "right_hand", "current_hp": 18, "max_hp": 18,
+            "wound_stage": "severed",
+            "data": {"container": "right_hand", "max_hp": 18,
+                     "inorganic": True, "grasping": True},
+        },
+        "right_forearm_hardpoint": {
+            "container": "right_arm", "current_hp": 12, "max_hp": 12,
+            "wound_stage": "severed",
+            "ability_state": {"shotgun": {"deployed": deployed,
+                                          "weapon_dbref": None}},
+            "data": {"container": "right_arm", "inorganic": True,
+                     "hardpoint": "forearm",
+                     "abilities": {"shotgun": {
+                         "type": "integrated_weapon",
+                         "slot": "right_hand", "weapon_prototype": "X"}}},
+        },
+    }}
+    item.get_medical_snapshot = lambda: snapshot
+    item.db = SimpleNamespace(
+        location_name="right_arm",
+        longdesc_data={
+            "right_arm": "A full cybernetic right arm.",
+            "right_hand": "An articulated alloy right hand.",
+        },
+    )
+    item.get_display_name = lambda looker=None: item.key
+    return item
+
+
+class TestLimbReattach(TestCase):
+    """#526 follow-up (user decision 2026-06-13): a severed cyber
+    limb reattaches whole — chassis + seated module, over a stump,
+    onto any compatible body."""
+
+    def _amputee(self):
+        target = _patient()
+        for o in target.medical_state.organs.values():
+            if o.container in ("right_arm", "right_hand"):
+                o.current_hp = 0
+                o.wound_stage = "severed"
+        target.longdesc = {"head": None}
+        return target
+
+    def _reattach(self, target, item, outcome="success"):
+        from world.medical.procedures import _resolve_install_limb
+        actor = _surgeon()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": outcome},
+        ):
+            _resolve_install_limb(
+                actor, target, organ_item=item, location="right_arm",
+            )
+        return actor
+
+    def test_is_cybernetic_limb_detects(self):
+        from world.medical.procedures import is_cybernetic_limb
+        self.assertTrue(is_cybernetic_limb(_severed_cyber_arm()))
+
+    def test_reattach_rebuilds_the_limb(self):
+        from world.medical.augments import find_ability
+
+        target = self._amputee()
+        open_incision(target, "right_arm")
+        item = _severed_cyber_arm()
+        self._reattach(target, item)
+
+        organs = target.medical_state.organs
+        self.assertEqual(organs["right_humerus"].current_hp, 30)
+        self.assertTrue(organs["right_humerus"].data.get("inorganic"))
+        self.assertIn("right_forearm_hardpoint", organs)
+        found, _spec = find_ability(target, "shotgun")
+        self.assertIsNotNone(found)
+        self.assertEqual(
+            target.longdesc["right_arm"], "A full cybernetic right arm.",
+        )
+        self.assertTrue(item.deleted)
+
+    def test_reattach_comes_back_retracted(self):
+        target = self._amputee()
+        open_incision(target, "right_arm")
+        item = _severed_cyber_arm(deployed=True)
+        self._reattach(target, item)
+        hp = target.medical_state.organs["right_forearm_hardpoint"]
+        self.assertFalse(hp.ability_state["shotgun"]["deployed"])
+
+    def test_bare_chassis_reattaches(self):
+        """No module seated — the chassis still goes back on."""
+        target = self._amputee()
+        open_incision(target, "right_arm")
+        item = _severed_cyber_arm()
+        # Strip the module from the snapshot.
+        del item.get_medical_snapshot()["organs"]["right_forearm_hardpoint"]
+        self._reattach(target, item)
+        self.assertIn("right_humerus", target.medical_state.organs)
+        self.assertNotIn(
+            "right_forearm_hardpoint", target.medical_state.organs,
+        )
+        self.assertTrue(item.deleted)
+
+    def test_living_arm_blocks_reattach(self):
+        target = _patient()
+        target.longdesc = {"head": None}
+        open_incision(target, "right_arm")
+        item = _severed_cyber_arm()
+        actor = self._reattach(target, item)
+        self.assertFalse(item.deleted)
+        self.assertTrue(any("living" in m for m in actor.messages))
+
+    def test_reattach_needs_incision(self):
+        target = self._amputee()
+        item = _severed_cyber_arm()
+        actor = self._reattach(target, item)
+        self.assertFalse(item.deleted)
+        self.assertTrue(any("isn't open" in m for m in actor.messages))
+
+
 class TestSeveredCyberProse(TestCase):
     def test_inorganic_parts_get_chrome_prose(self):
         from world.anatomy.severed_parts import get_severed_part_description


### PR DESCRIPTION
Playtest: an amputated cyber arm couldn't be re-installed. The severed `Appendage` carries its organs in a snapshot but no install-routing data, so `CmdInstall` didn't recognize it — the long-anticipated "Phase 3.2 cybernetics can re-attach" feature was never built.

**User decision (2026-06-13):** reattach the whole limb OR strip just the module (harvest, already worked); bare chassis reattaches even without a module; any compatible body (looted chrome).

- `is_cybernetic_limb()` identifies a severed Appendage with inorganic anatomy (flesh doesn't reattach — necrosis).
- `install_limb` resolver rebuilds every organ from the appendage snapshot at its container, restores the carried longdesc, resets modules to retracted (the deployed weapon item didn't survive the cut; orphan cleaned up), consumes the appendage.
- Gates (command + resolver): living target, a stump/wreckage at every container (amputate first), open incision at the cut point. CmdInstall + chart runner both route in.

Verified live on the real playtest severed arm: chassis, hardpoint, shotgun ability, and side-aware longdesc all restored.

Tests: +6. Suite: **2,519 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)