### PR TITLE
Reattach keys on a prosthetic-frame marker; operate can author it

### DIFF
--- a/commands/CmdOperate.py
+++ b/commands/CmdOperate.py
@@ -530,6 +530,13 @@ def _list_donor_organs(caller):
         if module_type:
             out.append((obj, f"{module_type} module"))
             continue
+        # Severed cybernetic limbs (#526 follow-up) reattach whole —
+        # listed so surgeons can author a reattach step from the
+        # chart, parity with the ``install`` command.
+        from world.medical.procedures import is_cybernetic_limb
+        if is_cybernetic_limb(obj):
+            out.append((obj, obj.key))
+            continue
         organ_name = getattr(obj_db, "organ_name", None)
         if organ_name:
             out.append((obj, organ_name))
@@ -1017,6 +1024,36 @@ def _process_install_donor(caller, raw_string, **kwargs):
             f"{item.key} mounts at the {anchor.replace('_', ' ')} — "
             f"the {anchor.replace('_', ' ')} must be open when this "
             f"step runs (add an incise step first if it isn't)."
+        )
+        return "node_top"
+
+    # Severed cybernetic limbs (#526 follow-up) reattach at their cut
+    # point — no location to pick.  The chart runner routes the step
+    # to install_limb; the resolver re-checks the stump + incision.
+    from world.medical.procedures import (
+        get_organ_snapshot, is_cybernetic_limb,
+    )
+    if is_cybernetic_limb(item):
+        anchor = getattr(item_db, "location_name", None)
+        if not anchor:
+            snap = get_organ_snapshot(item)
+            conts = {
+                d.get("container")
+                for d in (snap.get("organs") or {}).values()
+                if hasattr(d, "get") and d.get("container")
+            }
+            anchor = sorted(conts)[0] if conts else None
+        if not anchor:
+            caller.msg("|rThat limb has no attachment point.|n")
+            return "node_top"
+        _add_step_to_chart(
+            caller, "install",
+            {"organ_item_key": item.key, "location": anchor},
+        )
+        caller.msg(
+            f"{item.key} reattaches at the {anchor.replace('_', ' ')} "
+            f"— the stump must be amputated and open when this step "
+            f"runs (add an incise step first if needed)."
         )
         return "node_top"
 

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -1788,17 +1788,26 @@ def _resolve_install_module(actor, target, *, organ_item, location: str,
 
 
 def is_cybernetic_limb(appendage) -> bool:
-    """True when ``appendage`` is a severed CYBERNETIC limb (#526
-    follow-up): an organ-snapshot-bearing part with at least one
-    inorganic organ.  Flesh limbs don't reattach (necrosis); chrome
-    bolts back on."""
+    """True when ``appendage`` is a severed PROSTHETIC limb that
+    reattaches (#526 follow-up; criteria settled with user
+    2026-06-13).
+
+    Reattachability is a property of the limb's FRAME, marked
+    explicitly when the prosthetic chassis is installed
+    (``prosthetic_frame`` on the chassis organs) — NOT inferred from
+    counting inorganic organs.  A flesh limb is flesh even with
+    cyberware implanted in it (Nailz on a flesh hand, a cyber
+    sub-organ in an otherwise-flesh limb): no prosthetic frame, so it
+    necroses and does not reattach.  Its implants / harvestable
+    organs still pull and reinstall separately.
+    """
     snapshot = get_organ_snapshot(appendage)
     organs = (snapshot or {}).get("organs") or {}
     for entry in organs.values():
         if not hasattr(entry, "get"):
             continue
         data = entry.get("data")
-        if data and hasattr(data, "get") and data.get("inorganic"):
+        if data and hasattr(data, "get") and data.get("prosthetic_frame"):
             return True
     return False
 

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2029,6 +2029,7 @@ CYBER_ARM = {
                 "contribution": "major", "can_be_destroyed": True,
                 "fracture_vulnerable": True,
                 "bone_type": "actuator_column", "inorganic": True,
+                "prosthetic_frame": True,
             },
             "{side}_metacarpals": {
                 "container": "{side}_hand", "max_hp": 18,
@@ -2036,11 +2037,12 @@ CYBER_ARM = {
                 "contribution": "moderate", "can_be_destroyed": True,
                 "fracture_vulnerable": True,
                 "bone_type": "actuator_lattice", "inorganic": True,
+                "prosthetic_frame": True,
             },
             "{side}_forearm_hardpoint": {
                 "container": "{side}_arm", "max_hp": 10,
                 "hit_weight": "rare", "inorganic": True,
-                "hardpoint": "forearm",
+                "hardpoint": "forearm", "prosthetic_frame": True,
             },
         }),
         ("augment_container", "{side}_arm"),
@@ -2076,7 +2078,7 @@ SHOTGUN_MODULE = {
         ("compatible_species", ["human"]),
         ("organ_spec", {
             "container": "{side}_arm", "max_hp": 12, "hit_weight": "rare",
-            "inorganic": True,
+            "inorganic": True, "prosthetic_frame": True,
             "hardpoint": "forearm", "module_type": "forearm",
             "abilities": {
                 "shotgun": {

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -1066,13 +1066,15 @@ def _severed_cyber_arm(deployed=False):
         "right_humerus": {
             "container": "right_arm", "current_hp": 30, "max_hp": 30,
             "wound_stage": "severed",
-            "data": {"container": "right_arm", "max_hp": 30, "inorganic": True},
+            "data": {"container": "right_arm", "max_hp": 30,
+                     "inorganic": True, "prosthetic_frame": True},
         },
         "right_metacarpals": {
             "container": "right_hand", "current_hp": 18, "max_hp": 18,
             "wound_stage": "severed",
             "data": {"container": "right_hand", "max_hp": 18,
-                     "inorganic": True, "grasping": True},
+                     "inorganic": True, "prosthetic_frame": True,
+                     "grasping": True},
         },
         "right_forearm_hardpoint": {
             "container": "right_arm", "current_hp": 12, "max_hp": 12,
@@ -1080,7 +1082,7 @@ def _severed_cyber_arm(deployed=False):
             "ability_state": {"shotgun": {"deployed": deployed,
                                           "weapon_dbref": None}},
             "data": {"container": "right_arm", "inorganic": True,
-                     "hardpoint": "forearm",
+                     "prosthetic_frame": True, "hardpoint": "forearm",
                      "abilities": {"shotgun": {
                          "type": "integrated_weapon",
                          "slot": "right_hand", "weapon_prototype": "X"}}},
@@ -1184,6 +1186,45 @@ class TestLimbReattach(TestCase):
         actor = self._reattach(target, item)
         self.assertFalse(item.deleted)
         self.assertTrue(any("isn't open" in m for m in actor.messages))
+
+    def test_reattach_keys_on_frame_not_inorganic(self):
+        """The frame marker is the discriminator, not organ content:
+        strip ``prosthetic_frame`` (leaving the chrome) and the limb
+        no longer reattaches."""
+        from world.medical.procedures import is_cybernetic_limb
+        item = _severed_cyber_arm()
+        for d in item.get_medical_snapshot()["organs"].values():
+            d["data"].pop("prosthetic_frame", None)
+        self.assertFalse(is_cybernetic_limb(item))
+
+    def test_flesh_hand_with_cyberware_not_reattachable(self):
+        """The user's case: a flesh hand with cyberware implanted in
+        it (Nailz) is still flesh — no prosthetic frame, so it
+        necroses and doesn't reattach.  The cyberware harvests out
+        separately."""
+        from world.medical.procedures import is_cybernetic_limb
+
+        item = SimpleNamespace()
+        snap = {"organs": {
+            "left_metacarpals": {
+                "container": "left_hand", "current_hp": 0,
+                # Flesh organ carrying an implanted ability — and even
+                # a stray inorganic sub-part — but NO prosthetic frame.
+                "data": {"container": "left_hand", "inorganic": True,
+                         "abilities": {"nailz": {"type": "natural_weapon"}}},
+            },
+        }}
+        item.get_medical_snapshot = lambda: snap
+        item.db = SimpleNamespace(location_name="left_hand")
+        self.assertFalse(is_cybernetic_limb(item))
+
+    def test_operate_lists_cyber_limb_as_donor(self):
+        from commands.CmdOperate import _list_donor_organs
+
+        limb = _severed_cyber_arm()
+        caller = SimpleNamespace(contents=[limb])
+        donors = _list_donor_organs(caller)
+        self.assertTrue(any(it is limb for it, _label in donors))
 
 
 class TestSeveredCyberProse(TestCase):


### PR DESCRIPTION
Two fixes from the design discussion:

**1. Criteria corrected to a frame marker.** "Any inorganic organ" (and my interim "all inorganic" guess) used the wrong axis — a limb can be flesh and chrome at once. Per the settled model, reattachability is a property of the limb's **frame**, marked explicitly at chassis install (`prosthetic_frame` on the chassis organs), never inferred from organ content. A flesh hand with cyberware implanted in it is still flesh: no frame → necroses → doesn't reattach; its implants harvest out separately. `CYBER_ARM` chassis organs + the hardpoint `SHOTGUN_MODULE` carry the flag; flesh-mount `NAILZ` does not.

**2. Operate parity (the requested fix).** Severed cyber limbs now appear in the operate donor picker; authoring one records a reattach step at the limb's cut point (no location/side prompt). The chart runner already routed `install_limb`, so reattach now works through both the `install` command and the chart flow.

Verified live: a freshly installed `CYBER_ARM` carries the frame flag through severance and detects as reattachable; a flesh arm doesn't. Tests on the frame model incl. the flesh-hand-with-cyberware case. Suite: **2,522 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)