### PR TITLE
Spec drift sweep: anatomy substrate, identity weapon-feature, health notice

### DIFF
--- a/specs/ANATOMY_AUGMENTS_SPEC.md
+++ b/specs/ANATOMY_AUGMENTS_SPEC.md
@@ -133,6 +133,15 @@ with the species grasping set, minus severed — the existing
 severance subtraction then handles "severed tail drops what it
 held" with no new code.
 
+**Grasping requires functional anatomy** (shipped, post-Phase 2):
+a hand slot only grips when it has a living organ at its container.
+Chain severance suppresses a downstream wound (one wound at the cut
+point), so the wound-derived severed set alone missed a hand
+attached to a severed arm — it kept holding things.  The `hands`
+property now also drops any container whose organs are all
+tombstoned (severed / harvested / pulped).  A crushed-but-attached
+hand can't grip either.
+
 ### 3.5 · Severance
 
 A container is severable when it's in the species severable set
@@ -148,6 +157,62 @@ The longdesc renderer appends per-character locations missing from
 the species display order after their `display_after` hint (or at
 the end of their region).  Wound rendering follows
 `display_location` as it already does.
+
+**Chrome rendering** (shipped): a body location whose organs are
+`inorganic` renders in a light steel grey (`CHROME_DEFAULT_COLOR`)
+instead of the wearer's skintone — chrome is not flesh.  Limb
+longdesc is side-aware via the `{side}` token (resolved at install).
+A deployed integrated weapon expands the limb's longdesc and
+replaces the consumed hand's — see `AUGMENT_ABILITIES_SPEC` §9.
+
+### 3.7 · The body is the single truth (the anatomy-truth standard)
+
+The character's `organs` dict is the **only** source of present
+anatomy; nothing auto-creates.  `get_organ` returns existing-or-
+`None` — never lazily creates from the species table (the old
+behavior was a zombie-organ factory: capacity math iterating
+species lists by name resurrected install-deleted flesh organs at
+full HP).  Absence is meaningful.
+
+Severed organs persist as **0-HP `"severed"` tombstones** — they
+ARE the stump, and they are load-bearing: wound rendering, the
+`hands` functional gate (§3.4), capacity loss, and the re-augment
+"stump or wreckage" gate all read them.  Augment / reattach installs
+clear tombstones at their containers when new anatomy takes the
+slot.  Capacity math skips absent organs — a mounted replacement
+implicitly restores capacity; a bare stump keeps dragging it down
+via its tombstone.
+
+### 3.8 · Inorganic organs
+
+An organ spec flag `"inorganic": true` marks chrome.  Damage to an
+inorganic organ yields **pain only** — no bleeding, no infection
+(chrome doesn't hemorrhage or go septic; pain is neural feedback
+from the graft).  Severed inorganic parts get cybernetic part prose
+and a `"cybernetic <part>"` name instead of flesh ("muscle firm…
+cartilage").
+
+### 3.9 · Heal & reset
+
+`MedicalState.full_heal()` (the `@heal` / revive backend) restores
+**present anatomy only** — tombstones are absence records, not
+injuries, so healing never regrows a severed limb or resurrects a
+harvested-out module (which would duplicate its ability).  It
+preserves cyberware toggle state (a deployed gun is not an injury).
+`@resetmedical` rebuilds flesh from the current species table but
+**preserves installed augments** via `is_augment_organ()` (no
+species-table entry, or `inorganic` / `abilities` / `hardpoint` /
+`module_type` markers) — a wholesale nuke would erase every
+installed limb, tail, heart, and module.
+
+### 3.10 · Reattachment & the prosthetic frame
+
+Reattaching a whole severed limb is gated on an explicit
+`"prosthetic_frame": true` marker stamped on a chassis's frame
+organs at install — never inferred from organ content.  Flesh never
+reattaches (necrosis), even with cyberware implanted in it; only a
+prosthetic frame bolts back on.  Full mechanics in
+`AUGMENT_ABILITIES_SPEC` §8.
 
 ## 4 · The cybernetic tail (first consumer)
 
@@ -172,13 +237,18 @@ variants are new prototype text over the same attrs.
 
 ## 5 · Phases
 
-* **Phase 1 — substrate refactor** (one PR): organ-spec round-trip
-  + per-character location→organ resolution + equivalence tests +
-  the rat-tail fix + hit-resolution benchmark.  Pure refactor; no
-  behavior change for humans.
-* **Phase 2 — augment install** (one PR): `CmdInstall` augment
+* **Phase 1 — substrate refactor** — **shipped**: organ-spec
+  round-trip + per-character location→organ resolution + the
+  rat-tail fix + hit-resolution benchmark.
+* **Phase 2 — augment install** — **shipped**: `CmdInstall` augment
   branch, longdesc insertion, severable/grasping overlays,
-  prehensile `hands` merge, the tail prototype, full test suite.
+  prehensile `hands` merge, the tail prototype.
+* **Post-Phase-2 standards** — **shipped** (§3.4, §3.6–3.10):
+  functional-anatomy grasping, chrome rendering, the anatomy-truth
+  tombstone standard, inorganic-organ behavior, chrome-aware heal /
+  reset, and the prosthetic-frame reattachment gate.  The
+  chassis+module cyberware standard built on this substrate lives in
+  `AUGMENT_ABILITIES_SPEC` §7.
 * **Phase 3 — future, parked**: capacity contributions (waits on
   capacity consumers), synth compatibility (item-data edit),
   biotech theming, implant-specific organ-bound conditions

--- a/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
+++ b/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
@@ -1,5 +1,23 @@
 # Health and Substance System Specification
 
+> **⚠️ Drift notice (2026-06-13).** This document predates several
+> shipped systems and is stale in places. Authoritative sources for
+> the current behavior:
+> * **Bleeding model** — layered brakes (bandage roll → `treated`
+>   30% residual flow + doubled clot hazard; wound-care dressing =
+>   full stop; **tourniquets** = limb-only instant hold; natural
+>   clotting only at severity ≤ 5; arterial 6+ needs intervention).
+>   The condition was renamed `minor_bleeding` → **`bleeding`**
+>   (legacy deserialize alias kept). See `CONDITION_CADENCE_SPEC` §5
+>   and `world/medical/conditions.py`.
+> * **Condition cadence** (per-minute rates, downtime cap, clock
+>   seam) — `CONDITION_CADENCE_SPEC`.
+> * **Per-character anatomy, augments, cyberware** —
+>   `ANATOMY_AUGMENTS_SPEC` and `AUGMENT_ABILITIES_SPEC` (incl. the
+>   anatomy-truth tombstone standard, `inorganic` organs = pain-only
+>   damage, chrome-aware heal/reset).
+> A full reconciliation of this spec is tracked as its own pass.
+
 ## Implementation Status
 
 ### ✅ COMPLETED PHASES

--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -33,7 +33,7 @@ What strangers see instead of a name. Composed from observable physical traits:
 
 - **Physical descriptor** — auto-derived from height × build (immutable without a new sleeve)
 - **Keyword** — player-selected via `describe keyword`, gender-gated
-- **Distinguishing feature** — auto-derived from visible state: clothing > hair > nothing
+- **Distinguishing feature** — auto-derived from visible state: wielded weapon / explosive > clothing > hair > nothing
 
 Skintone is deliberately excluded from the sdesc. It appears only in the longdesc when someone `look`s at the character directly.
 
@@ -148,7 +148,15 @@ person, kid, urchin, human, citizen, elder, fossil, fleshbag, denizen, neut, sna
 
 The distinguishing feature is the final clause of the sdesc. It is **always auto-derived** from the character's actual visible state — players cannot set it directly. This ensures the sdesc is always truthful to what observers can actually see.
 
-**Priority order:** clothing > hair > nothing
+**Priority order:** wielded weapon / explosive > clothing > hair > nothing
+
+#### Weapon-based Feature
+
+A held **weapon or explosive** outranks clothing and hair — what someone is brandishing is the most salient thing about them. "Weapon" means an item carrying the `("weapon", "type")` tag (the weapon-base prototypes), **not** `db.weapon_type` (which defaults to `"melee"` on every item — so a cigarette, lighter, or tool in hand does NOT dominate; it falls through to the garment). Explosives (`db.is_explosive`) also dominate.
+
+Format: `"wielding {article} {weapon}"` — e.g., `"wielding a kitchen knife"`.
+
+**Deployed cyberweapons dominate too.** An integrated weapon (arm-shotgun) sits in the `hands` dict while deployed, so it's picked here naturally; an active natural weapon (claws) lives off-grid and is checked explicitly via `get_active_natural_weapon`. Either way a deployed cyber weapon carries normal weapon weight in the sdesc while staying out of the "holding" list (it's part of the body — see `AUGMENT_ABILITIES_SPEC`).
 
 #### Clothing-based Feature
 


### PR DESCRIPTION
Follow-up to #541. A broader spec audit found three more drifted docs:

- **ANATOMY_AUGMENTS_SPEC**: phases marked shipped + new sections (§3.4 functional grasping, §3.6 chrome rendering, §3.7 anatomy-truth tombstones, §3.8 inorganic organs, §3.9 heal/reset, §3.10 prosthetic-frame reattach) — the standards that shipped on top of the substrate this session.
- **IDENTITY_RECOGNITION_SPEC**: the feature priority never documented wielded weapon (said "clothing > hair"); now correct, with the weapon-tag discriminator and deployed-cyberweapon rule (#535/#537).
- **HEALTH_AND_SUBSTANCE_SYSTEM_SPEC**: deeper older drift (pre-#508 `minor_bleeding`, no tourniquet model) — added a drift-notice banner pointing to authoritative sources; full reconciliation tracked separately.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)