### PR TITLE
Cybernetic arm longdesc reads as character prose, not a bare label

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2047,14 +2047,21 @@ CYBER_ARM = {
         }),
         ("augment_container", "{side}_arm"),
         ("augment_anchor", "{side}_arm"),
+        # Templated longdesc prose (#516 review): reads as part of the
+        # character, not a bare label.  `{Their}` flexes His/Her/Their
+        # by the wearer's gender at render; the verb agrees with the
+        # part ("arm is", "hand is"), sidestepping person-number verb
+        # agreement.  `{side}` is the install-resolved literal
+        # ("right"/"left") — NOT the `{arm}`/`{hand}` body-noun flex,
+        # which pluralizes wrong for singular-they ("a cybernetic arms").
         ("augment_longdesc", [
             {
                 "key": "{side}_arm",
-                "default_desc": "A full cybernetic {side} arm, matte composite plating over an actuator column, an access panel seam running the length of the forearm.",
+                "default_desc": "{Their} {side} arm is a full cybernetic replacement, matte composite plating over an actuator column, an access panel seam running the length of the forearm.",
             },
             {
                 "key": "{side}_hand",
-                "default_desc": "An articulated alloy {side} hand, five-fingered and precise, the knuckle plating worn smooth.",
+                "default_desc": "{Their} {side} hand is articulated alloy, five-fingered and precise, the knuckle plating worn smooth.",
                 "display_after": "{side}_arm",
             },
         ]),


### PR DESCRIPTION
Playtest: the cyber arm/hand longdesc was a noun fragment ("A full cybernetic right arm, matte composite plating...") instead of flowing character prose. Rewrote both entries parallel to the flesh convention:

> {Their} {side} arm is a full cybernetic replacement, matte composite plating over an actuator column, an access panel seam running the length of the forearm.
> {Their} {side} hand is articulated alloy, five-fingered and precise, the knuckle plating worn smooth.

`{Their}` flexes His/Her/Their by gender; the verb agrees with the **part** ("arm is"), deliberately sidestepping person-number verb agreement. (A `{They} {have}` construction breaks in a single-location longdesc — the one `number` param drives both body-noun flex *and* subject-verb agreement, which conflict for a they-character. `{side}` stays the install-resolved literal, not the body-noun flex that pluralizes to "a cybernetic arms".)

Verified live across male/female/they. Suite: **2,522 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)