### PR TITLE
JAWZ: flesh-mount cyber teeth

### DIFF
--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -772,17 +772,25 @@ class CmdInstall(Command):
             new_ability_names = set(
                 ((organ_item.db.organ_spec or {}).get("abilities") or {})
             )
+            flesh_organ = getattr(organ_item.db, "flesh_organ", None)
             for container in declared:
                 if side_or_location:
                     side = side_or_location.split("_")[0]
                     if not container.startswith(side):
                         continue
-                host = next(
-                    (o for o in state.organs.values()
-                     if getattr(o, "container", None) == container
-                     and o.current_hp > 0),
-                    None,
-                )
+                # Specific named host (JAWZ → jaw) or first living
+                # organ at the container (NAILZ → the lone hand organ).
+                if flesh_organ:
+                    host = state.organs.get(flesh_organ)
+                    if host is not None and host.current_hp <= 0:
+                        host = None
+                else:
+                    host = next(
+                        (o for o in state.organs.values()
+                         if getattr(o, "container", None) == container
+                         and o.current_hp > 0),
+                        None,
+                    )
                 if host is None:
                     continue
                 if new_ability_names & set(host.data.get("abilities") or {}):

--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -1631,12 +1631,21 @@ def _resolve_install_module(actor, target, *, organ_item, location: str,
                 target, outcome=f"{organ_item.key} can't mount at {location}",
             )
             return
-        host = next(
-            (o for o in state.organs.values()
-             if getattr(o, "container", None) == location
-             and o.current_hp > 0),
-            None,
-        )
+        # A module may name a SPECIFIC host organ (JAWZ → the jaw) for
+        # multi-organ containers; otherwise it takes the first living
+        # organ at the location (NAILZ → the lone hand organ).
+        flesh_organ = getattr(item_db, "flesh_organ", None)
+        if flesh_organ:
+            host = state.organs.get(flesh_organ)
+            if host is not None and host.current_hp <= 0:
+                host = None
+        else:
+            host = next(
+                (o for o in state.organs.values()
+                 if getattr(o, "container", None) == location
+                 and o.current_hp > 0),
+                None,
+            )
         if host is None:
             actor.msg(
                 f"Nothing living at {target.get_display_name(actor)}'s "

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2156,6 +2156,57 @@ NAILZ_CLAWS = {
     ],
 }
 
+# JAWZ - flesh-mount natural weapon, implanted into the jaw (#525/M4).
+# Like NAILZ but targets a SPECIFIC host organ (the jaw) since the
+# head container holds many organs.  /jawz bares the fangs; active
+# fangs take combat precedence over a held weapon (you bit them).
+JAWZ = {
+    "key": "Jawz",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["jawz", "fang implants", "teeth implants"],
+    "desc": "A surgical case of paired titanium-alloy fangs and their gum-line actuators, machined to seat over a living mandible. The lid carries a worn sticker — a grinning chrome skull — and a warranty void the moment it leaves the shop. Installation requires a surgeon.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("module_type", "jawz"),
+        ("module_mount", "flesh"),
+        ("flesh_containers", ["head"]),
+        ("flesh_organ", "jaw"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "module_type": "jawz",
+            "abilities": {
+                "jawz": {
+                    "type": "natural_weapon",
+                    "weapon_prototype": "JAWZ_FANGS",
+                    "deploy_msg": "Your gums ache and split — alloy fangs slide down over your teeth with an oily click, and your jaw sets a little wider to hold them.",
+                    "retract_msg": "The fangs retract into your gum line with a wet snick; your smile is almost normal again.",
+                    "deployed_longdesc": "Alloy fangs jut from {their} gum line, too long and too sharp for the mouth that holds them.",
+                    "deploy_room": "{actor}'s jaw flexes and a row of alloy fangs slides down over their teeth, catching the light.",
+                    "retract_room": "{actor}'s fangs retract into their gum line with a wet click.",
+                },
+            },
+        }),
+    ],
+}
+
+# The fangs Jawz bares (#525).  Never held — they ARE the bite;
+# combat reads them via natural-weapon precedence.
+JAWZ_FANGS = {
+    "prototype_parent": "MELEE_WEAPON_BASE",
+    "key": "alloy fangs",
+    "aliases": ["fangs", "jawz fangs", "teeth"],
+    "desc": "Paired rows of titanium-alloy fangs, extended and locked. They were not designed with kissing in mind.",
+    "damage": 8,
+    "locks": "get:false();drop:false();give:false()",
+    "attrs": [
+        ("weapon_type", "cybernetic_teeth"),
+        ("damage_type", "stab"),
+        ("hands_required", 0),
+        ("integrated", True),
+    ],
+}
+
 # The integrated weapon the shotgun arm deploys (#516).  Spawned
 # lazily on first /shotgun; locked + flagged integrated by the
 # ability layer regardless of what's declared here.

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -804,6 +804,37 @@ class TestFleshMountModules(TestCase):
             )
         return actor
 
+    def test_jawz_targets_the_jaw_not_the_brain(self):
+        """flesh_organ targeting (#525): a multi-organ container (head)
+        requires naming the specific host, or the implant would land
+        in whatever organ comes first (the brain)."""
+        from world.medical.augments import find_ability
+
+        target = _patient()
+        open_incision(target, "head")
+        jawz = SimpleNamespace()
+        jawz.key = "Jawz"
+        jawz.deleted = False
+        jawz.delete = lambda: setattr(jawz, "deleted", True)
+        jawz.get_display_name = lambda looker=None: "Jawz"
+        jawz.db = SimpleNamespace(
+            module_type="jawz", module_mount="flesh",
+            flesh_containers=["head"], flesh_organ="jaw",
+            condition="pristine", organ_conditions=[],
+            organ_spec={"module_type": "jawz", "abilities": {
+                "jawz": {"type": "natural_weapon",
+                         "weapon_prototype": "JAWZ_FANGS"}}},
+            compatible_species=["human"],
+        )
+        self._install(target, jawz, location="head")
+
+        organs = target.medical_state.organs
+        self.assertIn("jawz", organs["jaw"].data.get("abilities", {}))
+        self.assertNotIn("jawz", organs["brain"].data.get("abilities", {}))
+        self.assertTrue(jawz.deleted)
+        found, _spec = find_ability(target, "jawz")
+        self.assertIs(found, organs["jaw"])
+
     def test_implants_into_living_flesh(self):
         from world.medical.augments import find_ability
 
@@ -1270,6 +1301,35 @@ class TestCyberneticShotgunMessages(TestCase):
             "attacker_name": "A", "target_name": "B",
             "item_name": "gun", "item": "gun",
             "hit_location": "chest", "damage": 20, "phase": "x",
+        }
+        for phase, variants in MESSAGES.items():
+            for variant in variants:
+                for key in ("attacker_msg", "victim_msg", "observer_msg"):
+                    variant[key].format(**kwargs)
+
+
+class TestCyberneticTeethMessages(TestCase):
+    """Jawz bite message set (#525)."""
+
+    def test_message_set_loads_for_every_phase(self):
+        from world.combat.messages import get_combat_message
+        from world.combat.messages.cybernetic_teeth import MESSAGES
+
+        for phase in ("initiate", "hit", "miss", "kill"):
+            self.assertGreaterEqual(len(MESSAGES[phase]), 12)
+            result = get_combat_message(
+                "cybernetic_teeth", phase, hit_location="arm",
+            )
+            self.assertNotIn("Error", result["attacker_msg"])
+            self.assertNotIn(f"You {phase}", result["attacker_msg"])
+
+    def test_every_variant_formats_cleanly(self):
+        from world.combat.messages.cybernetic_teeth import MESSAGES
+
+        kwargs = {
+            "attacker_name": "A", "target_name": "B",
+            "item_name": "fangs", "item": "fangs",
+            "hit_location": "arm", "phase": "x",
         }
         for phase, variants in MESSAGES.items():
             for variant in variants:


### PR DESCRIPTION
The second flesh-mount natural weapon (finishing the cyberware arc, with #525 to follow). Jawz implants alloy fangs into the jaw; `/jawz` bares them; active fangs take combat precedence over a held weapon.

**Generalizes flesh-mount targeting.** A module may name a specific host organ via `flesh_organ`. NAILZ took the lone organ at its container (the hand); the jaw shares `head` with the brain/eyes, so first-at-container would've implanted into the brain. The resolver and operate candidate scan now honor `flesh_organ` (jaw), falling back to first-at-container when unset.

Prototypes: `JAWZ` + `JAWZ_FANGS` (`cybernetic_teeth`, stab, integrated). New `cybernetic_teeth` message set — bite voice, 15 variants/phase, every variant format-tested.

Verified live: Jawz seats in the jaw (brain untouched), ability resolves, all phases load. Tests: +3. Suite: **2,525 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)