### PR TITLE
Jawz/Nailz rework: CYBER_JAW chassis + Jawz hardpoint module

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2109,11 +2109,16 @@ SHOTGUN_MODULE = {
 # the host stays what it is; it just has claws in it now.  /nailz
 # extends them; active claws take combat precedence over anything
 # held (settled decision 2026-06-12).
+# NAILZ — flesh IMPLANT (not a module): carbide claws grafted into a
+# living hand, no chassis required.  The clean counterexample to the
+# hardpoint modules.  Material note (#525 review): the claws are
+# carbide (a rigid blade material); "monofilament" is a wire/whip and
+# belongs on the cutting EDGE, not the claw body.
 NAILZ = {
     "key": "Nailz",
     "typeclass": "typeclasses.items.Organ",
     "aliases": ["nailz", "claw implants", "nail implants"],
-    "desc": "A sealed clinical tray of ten curved monofilament claws and their spring housings, sized for implantation along the fingers of one hand. The marketing name is etched on the tray lid in a typeface that has seen some court dates. Installation requires a surgeon; regret is sold separately.",
+    "desc": "A sealed clinical tray of ten curved carbide claws and their spring housings, each blade honed to a monofilament edge, sized for implantation along the fingers of one hand. The marketing name is etched on the tray lid in a typeface that has seen some court dates. Installation requires a surgeon; regret is sold separately.",
     "tags": [("medical_item", "item_type"), ("augment", "item_type")],
     "attrs": [
         ("module_type", "nailz"),
@@ -2127,10 +2132,10 @@ NAILZ = {
                 "nailz": {
                     "type": "natural_weapon",
                     "weapon_prototype": "NAILZ_CLAWS",
-                    "deploy_msg": "Your knuckles ache, then part — ten monofilament claws slide out along your fingers with a sound like scissors closing.",
+                    "deploy_msg": "Your knuckles ache, then part — ten carbide claws slide out along your fingers with a sound like scissors closing.",
                     "retract_msg": "The claws fold back under your skin; your hand is just a hand again, mostly.",
-                    "deployed_longdesc": "Ten monofilament claws stand extended from the fingertips, catching the light.",
-                    "deploy_room": "{actor} flexes a hand and monofilament claws slide out along their fingers, catching the light.",
+                    "deployed_longdesc": "Ten carbide claws stand extended from the fingertips, monofilament edges catching the light.",
+                    "deploy_room": "{actor} flexes a hand and carbide claws slide out along their fingers, catching the light.",
                     "retract_room": "{actor}'s claws fold away under the skin of their hand.",
                 },
             },
@@ -2143,9 +2148,9 @@ NAILZ = {
 # precedence.  Reuses the tiger_claws message set.
 NAILZ_CLAWS = {
     "prototype_parent": "MELEE_WEAPON_BASE",
-    "key": "monofilament claws",
-    "aliases": ["claws", "nailz claws"],
-    "desc": "Ten curved monofilament claws, extended from their knuckle housings. They are not for opening letters.",
+    "key": "carbide claws",
+    "aliases": ["claws", "nailz claws", "carbide claws"],
+    "desc": "Ten curved carbide claws, extended from their knuckle housings, each honed to a monofilament edge. They are not for opening letters.",
     "damage": 9,
     "locks": "get:false();drop:false();give:false()",
     "attrs": [
@@ -2156,30 +2161,63 @@ NAILZ_CLAWS = {
     ],
 }
 
-# JAWZ - flesh-mount natural weapon, implanted into the jaw (#525/M4).
-# Like NAILZ but targets a SPECIFIC host organ (the jaw) since the
-# head container holds many organs.  /jawz bares the fangs; active
-# fangs take combat precedence over a held weapon (you bit them).
-JAWZ = {
-    "key": "Jawz",
+# CYBER_JAW — prosthetic-jaw chassis (#525 review).  Replaces the
+# flesh jaw with a chrome one (keeps talking/eating) and carries a
+# "jaw" HARDPOINT for a Jawz-class module.  Installs via the
+# replacement-organ path (same canonical name "jaw").  A MODULE needs
+# a hardpoint, so a cyber jaw is the prerequisite for Jawz.
+CYBER_JAW = {
+    "key": "cybernetic jaw",
     "typeclass": "typeclasses.items.Organ",
-    "aliases": ["jawz", "fang implants", "teeth implants"],
-    "desc": "A surgical case of paired titanium-alloy fangs and their gum-line actuators, machined to seat over a living mandible. The lid carries a worn sticker — a grinning chrome skull — and a warranty void the moment it leaves the shop. Installation requires a surgeon.",
+    "aliases": ["cyber jaw", "prosthetic jaw", "jaw unit"],
+    "desc": "A full cybernetic mandible — articulated alloy and a composite chin plate, the gum line machined with an empty hardpoint behind a slide cover. It eats, it talks, and it's waiting for something to put in the slot. Surgical installation required.",
     "tags": [("medical_item", "item_type"), ("augment", "item_type")],
     "attrs": [
-        ("module_type", "jawz"),
-        ("module_mount", "flesh"),
-        ("flesh_containers", ["head"]),
-        ("flesh_organ", "jaw"),
+        ("organ_name", "jaw"),
         ("condition", "pristine"),
         ("compatible_species", ["human"]),
         ("organ_spec", {
-            "module_type": "jawz",
+            "container": "head", "display_location": "face",
+            "max_hp": 14, "hit_weight": "rare",
+            "capacities": ["talking", "eating"],
+            "talking_contribution": "major",
+            "eating_contribution": "moderate",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True, "prosthetic_frame": True,
+            "hardpoint": "jaw",
+        }),
+    ],
+}
+
+# JAWZ — hardpoint module (#525 review): seats into a CYBER_JAW's jaw
+# hardpoint (module = hardpoint hardware; you need the cyber jaw
+# first).  Rebuilds the jaw organ to keep its talking/eating function
+# while adding the bite.  /jawz bares the fangs; active fangs take
+# combat precedence over a held weapon (you bit them).
+JAWZ = {
+    "key": "Jawz",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["jawz", "fang module", "teeth module"],
+    "desc": "A surgical case of paired titanium-alloy fangs and their gum-line actuators, machined to seat into a cybernetic jaw's hardpoint. The lid carries a worn sticker — a grinning chrome skull — and a warranty void the moment it leaves the shop. Needs a cyber jaw to mount into; installation requires a surgeon.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("module_type", "jaw"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "head", "display_location": "face",
+            "max_hp": 14, "hit_weight": "rare",
+            "capacities": ["talking", "eating"],
+            "talking_contribution": "major",
+            "eating_contribution": "moderate",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True, "prosthetic_frame": True,
+            "hardpoint": "jaw", "module_type": "jaw",
             "abilities": {
                 "jawz": {
                     "type": "natural_weapon",
                     "weapon_prototype": "JAWZ_FANGS",
-                    "deploy_msg": "Your gums ache and split — alloy fangs slide down over your teeth with an oily click, and your jaw sets a little wider to hold them.",
+                    "deploy_msg": "Your gums split along their seam — alloy fangs slide down over your teeth with an oily click, and your jaw sets a little wider to hold them.",
                     "retract_msg": "The fangs retract into your gum line with a wet snick; your smile is almost normal again.",
                     "deployed_longdesc": "Alloy fangs jut from {their} gum line, too long and too sharp for the mouth that holds them.",
                     "deploy_room": "{actor}'s jaw flexes and a row of alloy fangs slides down over their teeth, catching the light.",

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -758,6 +758,143 @@ class TestModuleInstall(TestCase):
         self.assertIn("abilities", item.db.organ_spec)
 
 
+CYBER_JAW_SPEC = {
+    "container": "head", "display_location": "face",
+    "max_hp": 14, "hit_weight": "rare",
+    "capacities": ["talking", "eating"],
+    "talking_contribution": "major",
+    "eating_contribution": "moderate",
+    "can_be_harvested": True, "can_be_replaced": True,
+    "inorganic": True, "prosthetic_frame": True,
+    "hardpoint": "jaw",
+}
+
+JAWZ_MODULE_SPEC = dict(
+    CYBER_JAW_SPEC,
+    module_type="jaw",
+    abilities={
+        "jawz": {
+            "type": "natural_weapon",
+            "weapon_prototype": "JAWZ_FANGS",
+        },
+    },
+)
+
+
+def _jawz_item():
+    item = SimpleNamespace()
+    item.key = "Jawz"
+    item.deleted = False
+
+    def _delete():
+        item.deleted = True
+    item.delete = _delete
+    item.db = SimpleNamespace(
+        module_type="jaw",
+        condition="pristine",
+        organ_conditions=[],
+        organ_spec={k: (dict(v) if isinstance(v, dict) else v)
+                    for k, v in JAWZ_MODULE_SPEC.items()},
+        compatible_species=["human"],
+    )
+    item.get_display_name = lambda looker=None: item.key
+    return item
+
+
+class TestCyberJawHardpoint(TestCase):
+    """#525 review: Jawz is a hardpoint module, not a flesh implant.
+    The line is drawn — a MODULE needs a chassis hardpoint, so a
+    cybernetic jaw (CYBER_JAW) is the prerequisite.  The cyber jaw
+    replaces the flesh jaw via the spec-carrying organ path and
+    carries a ``jaw`` hardpoint; Jawz seats into it."""
+
+    def _install_jaw(self, target, item, location="head", outcome="success"):
+        from world.medical.procedures import _resolve_install
+
+        actor = _surgeon()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": outcome},
+        ):
+            _resolve_install(
+                actor, target, organ_item=item, location=location,
+            )
+        return actor
+
+    def _install_module(self, target, item, location="head",
+                        outcome="success"):
+        from world.medical.procedures import _resolve_install_module
+
+        actor = _surgeon()
+        with patch(
+            "world.medical.procedures.roll_procedure",
+            return_value={"outcome": outcome},
+        ):
+            _resolve_install_module(
+                actor, target, organ_item=item, location=location,
+            )
+        return actor
+
+    def _cyber_jaw_item(self):
+        return _organ_item(
+            organ_name="jaw", organ_spec=dict(CYBER_JAW_SPEC),
+        )
+
+    def test_cyber_jaw_replaces_flesh_jaw(self):
+        """The chassis: a cyber jaw rebuilds the jaw slot as chrome,
+        keeps talking/eating, and exposes a jaw hardpoint.  The jaw
+        is surface-accessible (its display_location is its own face),
+        so no cavity incision is required."""
+        target = _patient()
+        self._install_jaw(target, self._cyber_jaw_item())
+
+        jaw = target.medical_state.organs["jaw"]
+        self.assertTrue(jaw.data.get("inorganic"))
+        self.assertTrue(jaw.data.get("prosthetic_frame"))
+        self.assertEqual(jaw.data.get("hardpoint"), "jaw")
+        self.assertEqual(jaw.max_hp, 14)
+        self.assertIn("talking", jaw.data.get("capacities", []))
+        self.assertIn("eating", jaw.data.get("capacities", []))
+        # No ability yet — the hardpoint is empty.
+        self.assertFalse(jaw.data.get("abilities"))
+
+    def test_jawz_seats_into_cyber_jaw_hardpoint(self):
+        """The module: with a cyber jaw in place, Jawz seats into the
+        jaw hardpoint, adding the bite while keeping talk/eat."""
+        from world.medical.augments import find_ability
+
+        target = _patient()
+        self._install_jaw(target, self._cyber_jaw_item())
+        open_incision(target, "head")
+        item = _jawz_item()
+        self._install_module(target, item)
+
+        jaw = target.medical_state.organs["jaw"]
+        self.assertIn("jawz", jaw.data.get("abilities", {}))
+        # Chassis function preserved.
+        self.assertTrue(jaw.data.get("inorganic"))
+        self.assertIn("talking", jaw.data.get("capacities", []))
+        self.assertIn("eating", jaw.data.get("capacities", []))
+        found, spec = find_ability(target, "jawz")
+        self.assertIs(found, jaw)
+        self.assertEqual(spec["type"], "natural_weapon")
+        self.assertEqual(spec["weapon_prototype"], "JAWZ_FANGS")
+        self.assertTrue(item.deleted)
+
+    def test_jawz_without_cyber_jaw_rejects(self):
+        """The gate: a flesh jaw has no hardpoint — Jawz can't seat,
+        and the message names the missing hardpoint."""
+        target = _patient()
+        open_incision(target, "head")
+        item = _jawz_item()
+        actor = self._install_module(target, item)
+        self.assertFalse(item.deleted)
+        self.assertTrue(any("hardpoint" in m for m in actor.messages))
+        # Flesh jaw untouched — no bite grafted onto living anatomy.
+        jaw = target.medical_state.organs["jaw"]
+        self.assertNotIn("jawz", jaw.data.get("abilities", {}) or {})
+
+
 def _nailz_item():
     item = SimpleNamespace()
     item.key = "Nailz"
@@ -804,35 +941,35 @@ class TestFleshMountModules(TestCase):
             )
         return actor
 
-    def test_jawz_targets_the_jaw_not_the_brain(self):
-        """flesh_organ targeting (#525): a multi-organ container (head)
+    def test_flesh_organ_targets_named_host_not_first(self):
+        """flesh_organ targeting: a multi-organ container (head)
         requires naming the specific host, or the implant would land
         in whatever organ comes first (the brain)."""
         from world.medical.augments import find_ability
 
         target = _patient()
         open_incision(target, "head")
-        jawz = SimpleNamespace()
-        jawz.key = "Jawz"
-        jawz.deleted = False
-        jawz.delete = lambda: setattr(jawz, "deleted", True)
-        jawz.get_display_name = lambda looker=None: "Jawz"
-        jawz.db = SimpleNamespace(
-            module_type="jawz", module_mount="flesh",
+        implant = SimpleNamespace()
+        implant.key = "test implant"
+        implant.deleted = False
+        implant.delete = lambda: setattr(implant, "deleted", True)
+        implant.get_display_name = lambda looker=None: "test implant"
+        implant.db = SimpleNamespace(
+            module_type="testmod", module_mount="flesh",
             flesh_containers=["head"], flesh_organ="jaw",
             condition="pristine", organ_conditions=[],
-            organ_spec={"module_type": "jawz", "abilities": {
-                "jawz": {"type": "natural_weapon",
-                         "weapon_prototype": "JAWZ_FANGS"}}},
+            organ_spec={"module_type": "testmod", "abilities": {
+                "testmod": {"type": "natural_weapon",
+                            "weapon_prototype": "JAWZ_FANGS"}}},
             compatible_species=["human"],
         )
-        self._install(target, jawz, location="head")
+        self._install(target, implant, location="head")
 
         organs = target.medical_state.organs
-        self.assertIn("jawz", organs["jaw"].data.get("abilities", {}))
-        self.assertNotIn("jawz", organs["brain"].data.get("abilities", {}))
-        self.assertTrue(jawz.deleted)
-        found, _spec = find_ability(target, "jawz")
+        self.assertIn("testmod", organs["jaw"].data.get("abilities", {}))
+        self.assertNotIn("testmod", organs["brain"].data.get("abilities", {}))
+        self.assertTrue(implant.deleted)
+        found, _spec = find_ability(target, "testmod")
         self.assertIs(found, organs["jaw"])
 
     def test_implants_into_living_flesh(self):
@@ -889,6 +1026,22 @@ class TestFleshMountModules(TestCase):
         actor = self._install(target, item, location="chest")
         self.assertFalse(item.deleted)
         self.assertTrue(any("doesn't mount" in m for m in actor.messages))
+
+
+class TestNailzMaterial(TestCase):
+    """#525 review: claws are carbide with a monofilament EDGE — a
+    monofilament whip/wire isn't a claw body.  Pins the material so
+    the prose doesn't drift back to 'monofilament claws'."""
+
+    def test_nailz_prototypes_are_carbide(self):
+        from world import prototypes
+
+        for proto in (prototypes.NAILZ, prototypes.NAILZ_CLAWS):
+            desc = proto["desc"].lower()
+            self.assertIn("carbide", desc)
+            self.assertNotIn("monofilament claw", desc)
+        # The edge — not the body — is the monofilament part.
+        self.assertIn("monofilament edge", prototypes.NAILZ["desc"].lower())
 
 
 CYBER_HEART_SPEC = {


### PR DESCRIPTION
Closes #549.

## What
Draws the chassis/module line for the bite-and-claw augments. A MODULE needs a hardpoint.

- **CYBER_JAW** — prosthetic-jaw chassis. Replaces the flesh jaw via the spec-carrying organ path (#526 M1), keeps talking/eating, renders chrome, exposes a `jaw` hardpoint. Surface-accessible, so it installs without a cavity incision (`install cyber jaw in <target>`).
- **JAWZ** — converted from a flesh implant to a hardpoint module. Seats into the cyber jaw's `jaw` hardpoint, rebuilding the jaw to keep talk/eat while adding the `/jawz` bite. No cyber jaw → no hardpoint → refused. Flow: `install cyber jaw → incise head → install jawz`.
- **NAILZ** — stays a flesh IMPLANT (carbide claws in a living hand).
- **Material fix** — monofilament is a wire/whip, not a claw body. Nailz claws are now **carbide with a monofilament edge** (prose only).

## Tests
- `TestCyberJawHardpoint`: chassis replaces flesh jaw (inorganic + prosthetic_frame + `jaw` hardpoint, talk/eat preserved); Jawz seats; Jawz without a cyber jaw rejected.
- `TestNailzMaterial`: pins carbide-body / monofilament-edge wording.
- Removed obsolete `test_jawz_targets_the_jaw_not_the_brain`; kept generic `flesh_organ` targeting under a neutral name.

Full world suite green (2529).

🤖 Generated with [Claude Code](https://claude.com/claude-code)