### PR TITLE
Chrome severance prose: cyber limbs shear, they don't bleed

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -2484,7 +2484,13 @@ def apply_sever_to_character(character, container, *, injury_type="cut"):
     try:
         from world.combat.messages.severance import get_severance_message
         from world.identity_utils import msg_room_identity
+        from world.medical.procedures import is_cybernetic_limb
 
+        # A severed prosthetic limb narrates as sheared hardware, not
+        # bleeding meat — keyed on the same prosthetic_frame marker that
+        # governs reattachment (#525).  A flesh limb with cyberware in it
+        # is still flesh: no frame, so it bleeds.
+        material = "chrome" if is_cybernetic_limb(appendage) else "flesh"
         msgs = get_severance_message(
             location=container,
             injury_type=injury_type,
@@ -2492,6 +2498,7 @@ def apply_sever_to_character(character, container, *, injury_type="cut"):
             target=character,
             item=weapon,
             severity="grievous",
+            material=material,
             hit_location=container,
         )
         if attacker is not None:

--- a/world/combat/messages/severance/__init__.py
+++ b/world/combat/messages/severance/__init__.py
@@ -107,15 +107,15 @@ class _PassThrough(dict):
         return f"{{{key}}}"
 
 
-def _select_template(
-    location: str, injury_type: str, severity: str
+def _pick_variant(
+    module_name: str, injury_type: str, severity: str, attr: str
 ) -> dict | None:
-    """Load the MESSAGES dict and pick a random variant.
+    """Load ``attr`` (``MESSAGES`` / ``CHROME_MESSAGES``) off the
+    location module and pick a random variant.
 
     Returns ``None`` if any lookup step fails — callers fall through to
-    a generic fallback template.
+    the next bank or the generic template.
     """
-    module_name = _resolve_module_name(location)
     try:
         module = importlib.import_module(
             f"world.combat.messages.severance.{module_name}"
@@ -123,7 +123,7 @@ def _select_template(
     except ModuleNotFoundError:
         return None
 
-    messages = getattr(module, "MESSAGES", {})
+    messages = getattr(module, attr, {})
     by_injury = messages.get(injury_type)
     if not isinstance(by_injury, dict):
         return None
@@ -136,6 +136,32 @@ def _select_template(
 
     valid = [v for v in variants if isinstance(v, dict)]
     return random.choice(valid) if valid else None
+
+
+def _select_template(
+    location: str, injury_type: str, severity: str, material: str = "flesh"
+) -> dict | None:
+    """Pick a variant for one (location, injury, severity, material).
+
+    Flesh severances read the location module's ``MESSAGES``.  Chrome
+    severances read its ``CHROME_MESSAGES``; a location with no chrome
+    bank yet falls back to the generic ``cybernetic`` module so any
+    prosthetic limb still narrates as hardware, never meat.  Returns
+    ``None`` if every bank is empty — callers fall through to the
+    generic (blood-free) fallback template.
+    """
+    module_name = _resolve_module_name(location)
+    if material == "chrome":
+        chosen = _pick_variant(
+            module_name, injury_type, severity, "CHROME_MESSAGES"
+        )
+        if chosen is not None:
+            return chosen
+        # Generic chrome prose — works at any location via {hit_location}.
+        return _pick_variant(
+            "cybernetic", injury_type, severity, "MESSAGES"
+        )
+    return _pick_variant(module_name, injury_type, severity, "MESSAGES")
 
 
 def _fallback_template(location: str) -> dict:
@@ -163,6 +189,7 @@ def get_severance_message(
     target=None,
     item=None,
     severity: str = "grievous",
+    material: str = "flesh",
     **kwargs,
 ) -> dict:
     """Render a severance message set for one body location.
@@ -184,6 +211,10 @@ def get_severance_message(
         severity: ``"grievous"`` (default, dramatic / brutal) or
             ``"minor"`` (clean / surgical). Falls back to the other
             severity if the chosen cell is empty.
+        material: ``"flesh"`` (default) or ``"chrome"``.  Chrome routes
+            to the location's ``CHROME_MESSAGES`` bank (then the generic
+            ``cybernetic`` module) so a severed prosthetic limb narrates
+            as sheared hardware, not bleeding meat.
         **kwargs: Extra format substitutions (``hit_location`` is the
             common one — defaults to the canonical location key with
             underscores replaced by spaces).
@@ -198,7 +229,7 @@ def get_severance_message(
     if severity not in _VALID_SEVERITIES:
         severity = "grievous"
 
-    chosen = _select_template(location, injury_type, severity) or _fallback_template(location)
+    chosen = _select_template(location, injury_type, severity, material) or _fallback_template(location)
 
     # Identity-aware names.
     attacker_sees_target = (

--- a/world/combat/messages/severance/arms.py
+++ b/world/combat/messages/severance/arms.py
@@ -146,3 +146,72 @@ MESSAGES = {
         ],
     },
 }
+
+
+# Chrome bank (#525): a CYBER_ARM sheared at the shoulder mount.  No
+# blood — sheared actuator column, snapped cable looms, dead alloy.
+CHROME_MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade shears through {target_name}'s {hit_location} at the shoulder mount. The chrome limb drops dead-weight, cable looms whipping loose, and clangs off the floor.",
+                "victim_msg": "{attacker_name}'s blade shears through your {hit_location} at the shoulder mount. The arm goes dead and drops away, cables snapping loose.",
+                "observer_msg": "{attacker_name}'s blade shears through {target_name}'s {hit_location} at the shoulder mount. The chrome limb drops dead-weight, cable looms whipping loose, and clangs off the floor.",
+            },
+            {
+                "attacker_msg": "The edge bites into the actuator column with a shriek. {target_name}'s {hit_location} tears off at the shoulder, sparks fizzing from the stripped coupling.",
+                "victim_msg": "The edge bites into your {hit_location} actuator column with a shriek. The arm tears off at the shoulder, sparks fizzing from the stripped coupling.",
+                "observer_msg": "The edge bites into the actuator column with a shriek. {target_name}'s {hit_location} tears off at the shoulder, sparks fizzing from the stripped coupling.",
+            },
+            {
+                "attacker_msg": "You take {target_name}'s {hit_location} off at the shoulder seam and the dead chrome goes one way while the body lurches the other, balance lost to the missing weight.",
+                "victim_msg": "{attacker_name} takes your {hit_location} off at the shoulder seam. The dead chrome goes one way while your body lurches the other.",
+                "observer_msg": "{attacker_name} takes {target_name}'s {hit_location} off at the shoulder seam and the dead chrome goes one way while the body lurches the other, balance lost to the missing weight.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A clean stroke parts {target_name}'s {hit_location} at the shoulder coupling. The arm detaches almost gently, hardware gone dark.",
+                "victim_msg": "{attacker_name}'s clean stroke parts your {hit_location} at the shoulder coupling. The arm detaches almost gently, hardware gone dark.",
+                "observer_msg": "A clean stroke parts {target_name}'s {hit_location} at the shoulder coupling. The arm detaches almost gently, hardware gone dark.",
+            },
+            {
+                "attacker_msg": "Your blade slips through the shoulder joint and {target_name}'s {hit_location} drops free, neat as a part pulled for service.",
+                "victim_msg": "{attacker_name}'s blade slips through the joint and your {hit_location} drops free, neat as a part pulled for service.",
+                "observer_msg": "{attacker_name}'s blade slips through the shoulder joint and {target_name}'s {hit_location} drops free, neat as a part pulled for service.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point into {target_name}'s shoulder junction and twist; the {hit_location} coupling lets go and the dead arm sags off its mounts.",
+                "victim_msg": "{attacker_name} drives the point into your shoulder junction and twists. The {hit_location} coupling lets go and the dead arm sags off its mounts.",
+                "observer_msg": "{attacker_name} drives the point into {target_name}'s shoulder junction and twists; the {hit_location} coupling lets go and the dead arm sags off its mounts.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "Your point finds the gap between shoulder plates and {target_name}'s {hit_location} pops loose, sliding off its frame.",
+                "victim_msg": "{attacker_name}'s point finds the gap between your shoulder plates and your {hit_location} pops loose, sliding off its frame.",
+                "observer_msg": "{attacker_name}'s point finds the gap between shoulder plates and {target_name}'s {hit_location} pops loose, sliding off its frame.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "You saw the edge through the shoulder until the last cable parts. {target_name}'s {hit_location} swings free on a thread of wire, then falls, sparking.",
+                "victim_msg": "{attacker_name} saws the edge through your shoulder until the last cable parts. Your {hit_location} swings free on a thread of wire, then falls, sparking.",
+                "observer_msg": "{attacker_name} saws the edge through the shoulder until the last cable parts. {target_name}'s {hit_location} swings free on a thread of wire, then falls, sparking.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A short, tearing stroke severs the {hit_location} cable bundle at the shoulder and the dead arm sags away.",
+                "victim_msg": "{attacker_name}'s tearing stroke severs your {hit_location} cable bundle at the shoulder and the dead arm sags away.",
+                "observer_msg": "A short, tearing stroke severs {target_name}'s {hit_location} cable bundle at the shoulder and the dead arm sags away.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/cybernetic.py
+++ b/world/combat/messages/severance/cybernetic.py
@@ -1,0 +1,91 @@
+"""Generic chrome-limb severance templates (#525).
+
+The catch-all bank for any PROSTHETIC limb whose location hasn't been
+given a bespoke ``CHROME_MESSAGES`` cell yet.  Selected when
+``get_severance_message(..., material="chrome")`` finds no per-location
+chrome prose; ``{hit_location}`` fills in whichever part came off.
+
+Chrome doesn't bleed — it shears.  Prose here trades the spray of red
+for sheared actuators, snapped cable looms, a hiss of coolant, and the
+dead-weight clatter of alloy hitting the floor.  Per-location modules
+(``arms``, ``hands``, ``tail``, ...) override with limb-specific
+hardware; this is the floor everything falls back to.
+
+See ``world/combat/messages/severance/__init__.py`` for the loader.
+"""
+
+MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your edge shears clean through the {hit_location} coupling. {target_name}'s limb drops dead-weight, cable looms whipping loose, and clatters to the floor in a hiss of coolant.",
+                "victim_msg": "{attacker_name}'s edge shears through your {hit_location} coupling. The limb goes dead and drops away, cables snapping loose with a hiss of coolant.",
+                "observer_msg": "{attacker_name}'s edge shears through {target_name}'s {hit_location} coupling. The limb drops dead-weight, cable looms whipping loose, and clatters to the floor in a hiss of coolant.",
+            },
+            {
+                "attacker_msg": "Alloy parts with a shriek under your blade. {target_name}'s {hit_location} tears free, sparks fizzing from the stub where the servos used to run.",
+                "victim_msg": "Your {hit_location} parts with a shriek of metal. It tears free and falls, sparks fizzing from the stub.",
+                "observer_msg": "Alloy parts with a shriek under {attacker_name}'s blade. {target_name}'s {hit_location} tears free, sparks fizzing from the stub where the servos used to run.",
+            },
+            {
+                "attacker_msg": "The cut finds the seam in the chassis and {target_name}'s {hit_location} comes away whole, a length of dead chrome trailing severed hydraulic line.",
+                "victim_msg": "{attacker_name}'s cut finds the seam in the chassis. Your {hit_location} comes away whole, dead chrome trailing severed hydraulic line.",
+                "observer_msg": "{attacker_name}'s cut finds the seam in the chassis and {target_name}'s {hit_location} comes away whole, a length of dead chrome trailing severed hydraulic line.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A single clean stroke parts the {hit_location} mounting bolts. {target_name}'s limb detaches almost gently, hardware gone dark.",
+                "victim_msg": "{attacker_name}'s clean stroke parts your {hit_location} mounting. The limb detaches almost gently, hardware gone dark.",
+                "observer_msg": "A single clean stroke parts {target_name}'s {hit_location} mounting bolts. The limb detaches almost gently, hardware gone dark.",
+            },
+            {
+                "attacker_msg": "Your blade slips through the actuator joint and {target_name}'s {hit_location} drops free, neat as a part pulled for service.",
+                "victim_msg": "{attacker_name}'s blade slips through the joint and your {hit_location} drops free, neat as a part pulled for service.",
+                "observer_msg": "{attacker_name}'s blade slips through the actuator joint and {target_name}'s {hit_location} drops free, neat as a part pulled for service.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point into the {hit_location} junction and twist; the coupling lets go and the limb sags off its mounts, dead and heavy.",
+                "victim_msg": "{attacker_name} drives the point into your {hit_location} junction and twists. The coupling lets go and the limb sags off its mounts, dead and heavy.",
+                "observer_msg": "{attacker_name} drives the point into {target_name}'s {hit_location} junction and twists; the coupling lets go and the limb sags off its mounts, dead and heavy.",
+            },
+            {
+                "attacker_msg": "The thrust punches clean through the chassis seam. {target_name}'s {hit_location} shudders, servos screaming, then drops in a spray of sparks.",
+                "victim_msg": "The thrust punches through your {hit_location} seam. The limb shudders, servos screaming, then drops in a spray of sparks.",
+                "observer_msg": "{attacker_name}'s thrust punches clean through the chassis seam. {target_name}'s {hit_location} shudders, servos screaming, then drops in a spray of sparks.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "Your point finds the gap between plates and the {hit_location} coupling pops loose; the limb slides off its frame and clatters down.",
+                "victim_msg": "{attacker_name}'s point finds the gap and your {hit_location} coupling pops loose; the limb slides off its frame and clatters down.",
+                "observer_msg": "{attacker_name}'s point finds the gap between plates and {target_name}'s {hit_location} coupling pops loose; the limb slides off its frame and clatters down.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "You saw the edge back and forth until the last cable parts. {target_name}'s {hit_location} swings free on a thread of wire, then falls, sparking.",
+                "victim_msg": "{attacker_name} saws the edge back and forth until the last cable parts. Your {hit_location} swings free on a thread of wire, then falls, sparking.",
+                "observer_msg": "{attacker_name} saws the edge back and forth until the last cable parts. {target_name}'s {hit_location} swings free on a thread of wire, then falls, sparking.",
+            },
+            {
+                "attacker_msg": "The ragged cut tears the chassis open and chews through the wiring. {target_name}'s {hit_location} comes off in a grind of stripped alloy.",
+                "victim_msg": "The ragged cut tears your {hit_location} chassis open and chews through the wiring. It comes off in a grind of stripped alloy.",
+                "observer_msg": "{attacker_name}'s ragged cut tears the chassis open and chews through the wiring. {target_name}'s {hit_location} comes off in a grind of stripped alloy.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A short, tearing stroke severs the {hit_location} cable bundle and the limb sags away, dark and inert.",
+                "victim_msg": "{attacker_name}'s tearing stroke severs your {hit_location} cable bundle and the limb sags away, dark and inert.",
+                "observer_msg": "A short, tearing stroke severs {target_name}'s {hit_location} cable bundle and the limb sags away, dark and inert.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/hands.py
+++ b/world/combat/messages/severance/hands.py
@@ -146,3 +146,62 @@ MESSAGES = {
         ],
     },
 }
+
+
+# Chrome bank (#525): a CYBER_ARM's hand sheared at the wrist coupling.
+# No blood — snapped finger servos, dead manipulator actuators.
+CHROME_MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your edge shears through {target_name}'s {hit_location} at the wrist coupling. The chrome hand drops, finger servos still ticking, and clatters across the floor.",
+                "victim_msg": "{attacker_name}'s edge shears through your {hit_location} at the wrist coupling. The hand drops, finger servos still ticking, and clatters away.",
+                "observer_msg": "{attacker_name}'s edge shears through {target_name}'s {hit_location} at the wrist coupling. The chrome hand drops, finger servos still ticking, and clatters across the floor.",
+            },
+            {
+                "attacker_msg": "Alloy parts with a shriek and {target_name}'s {hit_location} tears off at the wrist, the severed manipulator cables sparking once and going dead.",
+                "victim_msg": "Alloy parts with a shriek and your {hit_location} tears off at the wrist, the manipulator cables sparking once and going dead.",
+                "observer_msg": "Alloy parts with a shriek and {target_name}'s {hit_location} tears off at the wrist, the severed manipulator cables sparking once and going dead.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A clean stroke parts the wrist coupling and {target_name}'s {hit_location} drops free, fingers frozen mid-curl.",
+                "victim_msg": "{attacker_name}'s clean stroke parts your wrist coupling and your {hit_location} drops free, fingers frozen mid-curl.",
+                "observer_msg": "A clean stroke parts the wrist coupling and {target_name}'s {hit_location} drops free, fingers frozen mid-curl.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You punch the point through {target_name}'s wrist seam and the {hit_location} sags off its mount, dead alloy and trailing wire.",
+                "victim_msg": "{attacker_name} punches the point through your wrist seam and your {hit_location} sags off its mount, dead alloy and trailing wire.",
+                "observer_msg": "{attacker_name} punches the point through {target_name}'s wrist seam and the {hit_location} sags off its mount, dead alloy and trailing wire.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "Your point finds the wrist gap and {target_name}'s {hit_location} pops loose, sliding off its coupling.",
+                "victim_msg": "{attacker_name}'s point finds your wrist gap and your {hit_location} pops loose, sliding off its coupling.",
+                "observer_msg": "{attacker_name}'s point finds the wrist gap and {target_name}'s {hit_location} pops loose, sliding off its coupling.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "You saw through the wrist until the cable bundle parts; {target_name}'s {hit_location} swings free on a thread of wire and falls, sparking.",
+                "victim_msg": "{attacker_name} saws through your wrist until the cable bundle parts; your {hit_location} swings free on a thread of wire and falls, sparking.",
+                "observer_msg": "{attacker_name} saws through the wrist until the cable bundle parts; {target_name}'s {hit_location} swings free on a thread of wire and falls, sparking.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A short, tearing stroke severs the {hit_location} cable bundle and the dead hand drops away.",
+                "victim_msg": "{attacker_name}'s tearing stroke severs your {hit_location} cable bundle and the dead hand drops away.",
+                "observer_msg": "A short, tearing stroke severs {target_name}'s {hit_location} cable bundle and the dead hand drops away.",
+            },
+        ],
+    },
+}

--- a/world/combat/messages/severance/tail.py
+++ b/world/combat/messages/severance/tail.py
@@ -75,3 +75,63 @@ MESSAGES = {
         ],
     },
 }
+
+
+# Chrome bank (#525): the human CYBERNETIC_TAIL sheared at the spine
+# mount.  Rats keep the organic MESSAGES above; the human tail is
+# chrome-only, so its severance is a counterweight actuator going dead.
+CHROME_MESSAGES = {
+    "cut": {
+        "grievous": [
+            {
+                "attacker_msg": "Your blade catches {target_name}'s {hit_location} at the spine mount and the chrome length whips loose, counterweight actuator dead, ringing off the floor.",
+                "victim_msg": "{attacker_name}'s blade catches your {hit_location} at the spine mount. The chrome length whips loose, the counterweight gone dead, and rings off the floor.",
+                "observer_msg": "{attacker_name}'s blade catches {target_name}'s {hit_location} at the spine mount and the chrome length whips loose, counterweight actuator dead, ringing off the floor.",
+            },
+            {
+                "attacker_msg": "The cut shears the {hit_location} off at the base coupling. {target_name}'s body lurches as the dead counterweight clatters away in a fizz of sparks.",
+                "victim_msg": "{attacker_name}'s cut shears your {hit_location} off at the base coupling. Your body lurches as the dead counterweight clatters away in a fizz of sparks.",
+                "observer_msg": "The cut shears the {hit_location} off at the base coupling. {target_name}'s body lurches as the dead counterweight clatters away in a fizz of sparks.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A clean stroke parts the {hit_location} at the spine coupling and the dead chrome length drops away, neat as a part pulled for service.",
+                "victim_msg": "{attacker_name}'s clean stroke parts your {hit_location} at the spine coupling and the dead chrome length drops away.",
+                "observer_msg": "A clean stroke parts {target_name}'s {hit_location} at the spine coupling and the dead chrome length drops away, neat as a part pulled for service.",
+            },
+        ],
+    },
+    "stab": {
+        "grievous": [
+            {
+                "attacker_msg": "You drive the point into the {hit_location} base junction and twist; the coupling lets go and the dead chrome length sags off the spine mount.",
+                "victim_msg": "{attacker_name} drives the point into your {hit_location} base junction and twists. The coupling lets go and the dead chrome length sags off the spine mount.",
+                "observer_msg": "{attacker_name} drives the point into {target_name}'s {hit_location} base junction and twists; the coupling lets go and the dead chrome length sags off the spine mount.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "Your point finds the gap at the base and {target_name}'s {hit_location} pops loose from the spine mount, sliding free.",
+                "victim_msg": "{attacker_name}'s point finds the gap at your base and your {hit_location} pops loose from the spine mount, sliding free.",
+                "observer_msg": "{attacker_name}'s point finds the gap at the base and {target_name}'s {hit_location} pops loose from the spine mount, sliding free.",
+            },
+        ],
+    },
+    "laceration": {
+        "grievous": [
+            {
+                "attacker_msg": "You saw through the base until the last cable parts; {target_name}'s {hit_location} swings free on a thread of wire and falls, sparking.",
+                "victim_msg": "{attacker_name} saws through your base until the last cable parts; your {hit_location} swings free on a thread of wire and falls, sparking.",
+                "observer_msg": "{attacker_name} saws through the base until the last cable parts; {target_name}'s {hit_location} swings free on a thread of wire and falls, sparking.",
+            },
+        ],
+        "minor": [
+            {
+                "attacker_msg": "A short, tearing stroke severs the {hit_location} cable bundle at the base and the dead chrome length sags away.",
+                "victim_msg": "{attacker_name}'s tearing stroke severs your {hit_location} cable bundle at the base and the dead chrome length sags away.",
+                "observer_msg": "A short, tearing stroke severs {target_name}'s {hit_location} cable bundle at the base and the dead chrome length sags away.",
+            },
+        ],
+    },
+}

--- a/world/tests/test_severance_messages.py
+++ b/world/tests/test_severance_messages.py
@@ -253,3 +253,96 @@ class FallbackTests(TestCase):
         self.assertIn("attacker_msg", msgs)
         self.assertIn("victim_msg", msgs)
         self.assertIn("observer_msg", msgs)
+
+
+# =====================================================================
+# Chrome severances (#525) — prosthetic limbs shear, they don't bleed
+# =====================================================================
+
+
+# Words that mark FLESH severance prose. Chrome output must never use
+# them — the whole point of material="chrome" is to swap meat for
+# hardware.
+_BLOOD_WORDS = ("blood", "socket", "spray of red", "gore", "flesh")
+
+
+def _is_bloodless(text: str) -> bool:
+    low = text.lower()
+    return not any(w in low for w in _BLOOD_WORDS)
+
+
+class ChromeSeveranceTests(TestCase):
+    """material="chrome" routes to the per-location CHROME_MESSAGES bank
+    (then the generic ``cybernetic`` module), never the flesh prose."""
+
+    def _all_msgs(self, location, draws=20, **kw):
+        a, t = _FakeChar("Vasquez"), _FakeChar("Maria")
+        out = []
+        for _ in range(draws):
+            m = get_severance_message(
+                location, "cut", a, t, _FakeItem("monoblade"),
+                material="chrome", hit_location=location, **kw,
+            )
+            out.extend(
+                m[k] for k in ("attacker_msg", "victim_msg", "observer_msg")
+            )
+        return out
+
+    def test_flesh_is_the_default(self):
+        # No material arg → flesh path; the signature default holds.
+        a, t = _FakeChar("A"), _FakeChar("B")
+        msgs = get_severance_message("left_arm", "cut", a, t)
+        self.assertIn("attacker_msg", msgs)
+
+    def test_per_location_chrome_is_bloodless(self):
+        # arms / hands / tail carry bespoke CHROME_MESSAGES banks.
+        for loc in ("left_arm", "left_hand", "tail"):
+            with self.subTest(location=loc):
+                for text in self._all_msgs(loc):
+                    self.assertTrue(
+                        _is_bloodless(text),
+                        f"chrome {loc} leaked flesh prose: {text!r}",
+                    )
+
+    def test_chrome_reads_as_hardware(self):
+        # Over many draws, chrome arm prose names hardware, not anatomy.
+        joined = " ".join(self._all_msgs("left_arm")).lower()
+        self.assertTrue(
+            any(w in joined for w in
+                ("coupling", "actuator", "cable", "alloy", "servo", "chrome")),
+            "chrome arm prose names no hardware",
+        )
+
+    def test_chromeless_location_falls_back_to_generic(self):
+        # thighs has no CHROME_MESSAGES bank yet → generic cybernetic
+        # module, still bloodless hardware prose (never the flesh cell).
+        for text in self._all_msgs("left_thigh"):
+            self.assertTrue(
+                _is_bloodless(text),
+                f"generic chrome fallback leaked flesh prose: {text!r}",
+            )
+
+    def test_generic_module_covers_every_cell(self):
+        # The fallback floor must be complete: every injury × severity
+        # populated so any chrome limb has prose to land on.
+        import importlib
+        mod = importlib.import_module(
+            "world.combat.messages.severance.cybernetic"
+        )
+        for itype in ("cut", "stab", "laceration"):
+            for sev in ("grievous", "minor"):
+                cell = mod.MESSAGES.get(itype, {}).get(sev, [])
+                with self.subTest(injury=itype, severity=sev):
+                    self.assertGreaterEqual(len(cell), 1)
+                    for variant in cell:
+                        for key in ("attacker_msg", "victim_msg",
+                                    "observer_msg"):
+                            self.assertIn(key, variant)
+
+    def test_chrome_still_color_wrapped(self):
+        a, t = _FakeChar("A"), _FakeChar("B")
+        msgs = get_severance_message(
+            "left_arm", "cut", a, t, material="chrome",
+        )
+        self.assertTrue(msgs["attacker_msg"].startswith("|r"))
+        self.assertTrue(msgs["attacker_msg"].endswith("|n"))


### PR DESCRIPTION
Closes #525 (the severance-moment half).

## What
The severance-moment broadcast still narrated cyber limbs as bleeding meat. This forks it on **material**.

- `get_severance_message(..., material="flesh"|"chrome")`. Chrome reads a location's new **`CHROME_MESSAGES`** bank, falling back to a generic **`cybernetic`** module (works anywhere via `{hit_location}`), then the existing blood-free generic template. The flesh path is untouched — `MESSAGES` unchanged in all 12 location modules.
- **`apply_sever_to_character`** (the one path both combat and chart-amputation use) passes `material="chrome"` when `is_cybernetic_limb(appendage)` — the same `prosthetic_frame` marker that governs reattachment. A flesh limb with cyberware implanted in it has no frame, so it still bleeds.
- **Content:** generic `cybernetic.py` (all six injury × severity cells) + bespoke `CHROME_MESSAGES` for the locations cyber limbs exist at today — **arms, hands, and the human cyber tail**. `tail.py` keeps its organic *rat* `MESSAGES`; the human tail is chrome-only, so the same location carries both banks. Other locations fall back to the generic module until a chassis ships for them.

The head/decapitation beat stays flesh (no cyber skull exists). Prose trades the spray of red for sheared actuators, snapped cable looms, a coolant hiss, and the dead-weight clatter of alloy.

## Scope note
#525 also mentioned wounds/stumps, but #523/#532/#536 already made the standing-body rendering chrome-aware (severed-part prose, chrome longdesc, "Severed" medinfo). The severance **moment** was the real remaining gap; that's what this closes.

## Tests
`ChromeSeveranceTests`: chrome routing, flesh-default, generic fallback for chromeless locations, hardware vocabulary, a no-blood-words guard, generic-module completeness, colour wrap. Full world suite green (2535).

🤖 Generated with [Claude Code](https://claude.com/claude-code)