### PR TITLE
Reconcile specs after the cyberware arc (#511-#551)

### DIFF
--- a/specs/ANATOMY_AUGMENTS_SPEC.md
+++ b/specs/ANATOMY_AUGMENTS_SPEC.md
@@ -192,6 +192,15 @@ from the graft).  Severed inorganic parts get cybernetic part prose
 and a `"cybernetic <part>"` name instead of flesh ("muscle firm…
 cartilage").
 
+The **severance moment** is forked too (#551): a prosthetic limb's
+detachment narrates as sheared hardware, not bleeding meat.
+`get_severance_message(..., material="chrome")` routes to a
+per-location `CHROME_MESSAGES` bank (then a generic `cybernetic`
+fallback module).  The fork keys on `is_cybernetic_limb` — the same
+`prosthetic_frame` marker as reattachment (§3.10) — so a flesh limb
+with cyberware implanted in it still bleeds.  See
+`AUGMENT_ABILITIES_SPEC` §8.
+
 ### 3.9 · Heal & reset
 
 `MedicalState.full_heal()` (the `@heal` / revive backend) restores

--- a/specs/AUGMENT_ABILITIES_SPEC.md
+++ b/specs/AUGMENT_ABILITIES_SPEC.md
@@ -181,7 +181,9 @@ as a hand until you `/shotgun`.
 
 Settled 2026-06-13 after the shotgun arm shipped: **chassis +
 module is the standard**; future cybernetics are data over these
-four templates, never bespoke systems.
+five templates, never bespoke systems.  (Originally framed as four;
+the #549 sharpening split "ability module" into a hardpoint module
+and a distinct flesh-implant tier — see 4 and 5 below.)
 
 1. **Replacement organ** (cyber heart / eye / kidney — the
    low-impact tier).  An organ item carrying its own spec installs
@@ -199,17 +201,31 @@ four templates, never bespoke systems.
    the item's organ/longdesc/anchor templates resolve `{side}`.
    A chassis declares empty **hardpoint** organ slots and stamps
    `prosthetic_frame` on its frame organs (§9).  **Shipped** (M2/M3).
-4. **Ability module** (shotgun, claws/Nailz, teeth/Jawz): an organ
-   item carrying spec + ability that installs INTO anatomy — a
-   chassis hardpoint, or **compatible flesh anatomy** (Nailz into a
-   flesh hand, Jawz into a flesh jaw; some modules are
-   chrome-or-meat agnostic by declaration).  The module inherits
-   its side/slot from where it's mounted; its ability "just does
-   its thing" from there.  **Harvest is the recovery verb**: a
-   module comes out of a severed limb or corpse as the organ item
-   it is.  **Shipped** (M3 hardpoint + M4 flesh-mount):
-   `SHOTGUN_MODULE` (forearm hardpoint), `NAILZ` (flesh-mount
-   natural weapon).
+4. **Ability module** (shotgun, teeth/Jawz): an organ item carrying
+   spec + ability that seats into a chassis **hardpoint**, inheriting
+   its side/slot from the mount; its ability "just does its thing"
+   from there.  **A module needs a hardpoint — that is the line**
+   (sharpened #549; supersedes the earlier "hardpoint OR compatible
+   flesh" framing).  **Harvest is the recovery verb**: a module comes
+   out of a severed limb or corpse as the organ item it is.
+   **Shipped** (M3): `SHOTGUN_MODULE` (a `CYBER_ARM` forearm
+   hardpoint); `JAWZ` (a `CYBER_JAW` jaw hardpoint, #550).
+   `CYBER_JAW` is the first **replacement organ that is itself a
+   chassis** — it rebuilds the jaw slot (keeping talk/eat) *and*
+   carries a `jaw` hardpoint for the bite module.  It installs via the
+   replacement path (template 1), is surface-accessible (no cavity
+   incision), then the module seats into its hardpoint.
+
+5. **Flesh implant** (Nailz): the sibling tier, **not a module** —
+   an ability grafted directly into LIVING anatomy (carbide claws
+   into a flesh hand), no hardpoint, no chassis.  The host stays
+   flesh and still bleeds; it has no `prosthetic_frame`, so it
+   necroses and the limb doesn't reattach (the implant harvests out
+   separately).  `module_mount: "flesh"` in code, but conceptually
+   it's the implant tier, distinct from a hardpoint module.
+   **Shipped** (M4): `NAILZ` + `NAILZ_CLAWS` — carbide claw body
+   honed to a **monofilament edge** (the edge is the wire, not the
+   claw; corrected #549).
 
 The fused `SHOTGUN_ARM` was retired in favor of `CYBER_ARM`
 (side-agnostic chassis, forearm hardpoint) + `SHOTGUN_MODULE`.
@@ -253,11 +269,23 @@ snapshot over a stump (amputate first — any compatible body, so
 scavenged chrome bolts on), restores the carried longdesc, and
 consumes the appendage.
 
+**Severance narrative (chrome, #551).** The moment a prosthetic limb
+comes off narrates as sheared hardware, not bleeding meat.
+`get_severance_message(..., material="chrome")` reads a per-location
+`CHROME_MESSAGES` bank (arms / hands / tail today), falling back to a
+generic `cybernetic` module, then a blood-free generic template.  The
+one fork lives in `apply_sever_to_character`, keyed on
+`is_cybernetic_limb(appendage)` — the same `prosthetic_frame` marker
+as reattachment above — so a flesh limb with cyberware in it still
+bleeds.  The head/decapitation beat stays flesh (no cyber skull
+exists).  Prose: sheared actuators, snapped cable looms, a coolant
+hiss, dead-weight alloy clatter.
+
 ## 9 · Chrome rendering
 
-Inorganic body locations render in a light steel grey
-(`CHROME_DEFAULT_COLOR`, `world/combat/constants.py`) rather than
-the wearer's skintone — chrome is not flesh.  Coating items will
+Inorganic body locations render in a dark steel grey
+(`CHROME_DEFAULT_COLOR` = `|=l`, `world/combat/constants.py`) rather
+than the wearer's skintone — chrome is not flesh.  Coating items will
 override this per augment when they exist; until then it is the
 bare-metal default.  Limb longdesc is side-aware via the `{side}`
 token (resolved at install), and a deployed integrated weapon

--- a/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
+++ b/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
@@ -49,7 +49,12 @@ alias kept).  Blood-loss rate derives from **current** severity
 The character's `organs` dict is the single source of present
 anatomy (no auto-create; severed organs persist as 0-HP tombstones).
 `inorganic` organs take **pain-only** damage (no bleed / infection).
-Heal and `@resetmedical` are chrome-aware.  Full design:
+Severing a prosthetic limb narrates as sheared hardware, not bleeding
+meat — `get_severance_message(..., material="chrome")`, keyed on the
+`prosthetic_frame` marker (#551).  Heal and `@resetmedical` are
+chrome-aware.  Cybernetics follow the chassis+module standard (five
+templates: replacement organ, anatomy augment, limb chassis,
+hardpoint module, flesh implant).  Full design:
 `ANATOMY_AUGMENTS_SPEC` + `AUGMENT_ABILITIES_SPEC`.
 
 ## Implementation Status

--- a/specs/LONGDESC_SYSTEM_SPEC.md
+++ b/specs/LONGDESC_SYSTEM_SPEC.md
@@ -518,11 +518,37 @@ longdesc = AttributeProperty(
 - Permanent modifications (scars, prosthetics)
 - Medical condition visibility
 
-#### Cybernetic/Modification System
-- Cybernetic implants as location overrides
+#### Chrome / Inorganic Rendering ✅ **SHIPPED** (anatomy-augments + cyberware arc, #511–#551)
+Cybernetic limbs/organs are no longer a future overlay — they render
+through a live inorganic layer in `typeclasses/appearance_mixin.py`:
+
+- **Inorganic location detection** — `_location_is_inorganic(location)`
+  reads the per-character organ snapshot for an `inorganic`/
+  `prosthetic_frame` organ at the location; chrome locations render in
+  `CHROME_DEFAULT_COLOR` (`|=l`, dark steel grey — `world/combat/constants.py`)
+  instead of skin tone.
+- **Side-aware chassis longdesc** — `{side}` tokens in a chassis
+  prototype's `augment_longdesc` resolve at install (a left/right cyber
+  arm reads correctly), alongside the existing `{Their}` pronoun flex.
+- **Deployed-module expansion** — `_deployed_module_longdesc(location)`
+  appends an active module's `deployed_longdesc` (the shotgun arm, the
+  Nailz claws) after the base body line.
+- **Deployed hand-slot override** — `_deployed_slot_prose(location)`
+  replaces a *consumed* hand's longdesc when an integrated weapon folds
+  the hand away (`/shotgun` shows the firing socket, not a hand).
+- **Stored-at-install policy** — chrome longdesc prose is captured when
+  the chassis is installed, not re-rendered each look (a settled design
+  call: old installs keep stale prose until re-install; acceptable
+  pre-production).
+
+Tattoos / piercings / scar overlays remain future (see Modification
+System below).
+
+#### Tattoo / Piercing / Scar Modification System (Future)
 - Tattoo system integration
 - Body modification descriptions
 - Enhancement visibility rules
+- Scar overlays (medical `can_scar` hook exists; rendering not wired)
 
 #### Equipment Integration
 - Worn equipment affects appearance
@@ -574,7 +600,7 @@ longdesc = AttributeProperty(
 1. **Clothing System** ✅ **COMPLETED**: Coverage-based visibility using shared location constants with dynamic styling
 2. **Equipment System** 🔄 **READY**: Worn item integration architecture prepared  
 3. **Injury System** 🔄 **READY**: Medical condition display hooks established
-4. **Modification System** 🔄 **READY**: Cybernetics, tattoos, piercings integration points prepared
+4. **Modification System** ◐ **PARTIAL**: Chrome/inorganic cybernetic rendering shipped (#511–#551 — see "Chrome / Inorganic Rendering" above); tattoos/piercings/scars still prepared-not-wired
 5. **Pronoun System** ✅ **COMPLETED**: Dynamic pronoun integration with $pron() support
 6. **Tailor System** 🔄 **READY**: Custom fitting commands for unique anatomies architecture prepared
 

--- a/specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md
+++ b/specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md
@@ -41,6 +41,21 @@ a substrate consumer for things like `incapacitation_threshold`,
 `paralysis_if_destroyed`, or `total_loss_penalty`. Those substrate phases
 remain the right next focus for an audit-aligned arc.
 
+**The anatomy-augments + cyberware arc (#511–#551) is likewise orthogonal
+to the substrate gaps.** Chassis+module cyberware, spec-carrying
+replacement organs, inorganic damage (pain-only), reattachment, and
+chrome severance prose all read / mutate organ HP, `wound_stage`,
+`inorganic`, and `abilities` — but none introduces or resolves a consumer
+for `incapacitation_threshold`, `paralysis_if_destroyed`, or
+`total_loss_penalty`. The substrate phases are unchanged by it. One
+*genuine new wrinkle* the arc exposed, though: augment organs can **add**
+anatomy and capacities a species table never declared (the cyber tail).
+The substrate plan (Phases 7–9) assumes the static species table is the
+full capacity set; **per-character capacity extension** is an
+un-catalogued substrate concern to fold into movement-policing /
+senses / equipment-handling whenever those are scoped. Tracked in
+`MEDICAL_SUBSTRATE_READINESS.md`.
+
 The audit's Core Insight ("schema without consumers") still stands and
 sequences correctly: build substrate before wiring schema to it.
 

--- a/specs/MEDICAL_SUBSTRATE_READINESS.md
+++ b/specs/MEDICAL_SUBSTRATE_READINESS.md
@@ -40,6 +40,44 @@ The audit itself is the planning artifact and lifecycle: this is the at-a-glance
 | `fracture_vulnerable` | 2 files | Bone-fracture condition spawn path (`world/medical/utils.py`, `commands/CmdConsumption.py`) | — (live) | **Live** — load-bearing |
 | `bone_type` | 3 files | Bone-fracture and severance routing (`world/medical/utils.py`, `world/medical/core.py`, `commands/CmdConsumption.py`) | — (live) | **Live** — load-bearing |
 
+> **Read-count caveat (2026-06-14):** the "Reads (current)" column above was
+> last validated June 2026 and is stale — re-run the grep-counts before
+> relying on a specific number. The flags are correctly *classified*
+> (vestigial / gap / live); only the integer counts drift.
+
+---
+
+## Flags from the augment / cyberware arc (#511–#551)
+
+These organ-spec flags landed with the anatomy-augments and cyberware
+chassis+module work and are **already consumed by runtime** — they are
+live and load-bearing, not substrate-gaps. Catalogued here because the
+"Adding a new flag" checklist below requires a row per flag, and the
+arc shipped before this index was updated (the flag-debt symptom this
+doc exists to catch, turned on the doc itself).
+
+| Flag (declaration site) | Intended consumer | Status |
+|---|---|---|
+| `inorganic` (organ spec) | Damage model — chrome takes pain only, no bleed/infection (`Organ.take_damage`); chrome rendering (`appearance_mixin`); chrome severance prose (`get_severance_message`) | **Live** — load-bearing |
+| `prosthetic_frame` (chassis organs) | `is_cybernetic_limb` — reattachment eligibility + chrome severance routing | **Live** — load-bearing |
+| `hardpoint` (chassis slot organ) | `find_hardpoint` — module seating (`world/medical/procedures.py`) | **Live** — load-bearing |
+| `module_type` (module item / hardpoint) | Install dispatch + hardpoint match + harvest provenance | **Live** — load-bearing |
+| `abilities` (organ spec) | Ability layer — `find_ability`, `iter_abilities`, toggle dispatcher | **Live** — load-bearing |
+| `flesh_organ` (flesh-mount module) | Names the specific host organ in a multi-organ container (Jawz→jaw) | **Live** — load-bearing |
+| `can_be_harvested` / `can_be_replaced` | Harvest / install gates (operate menu + resolvers) | **Live** — load-bearing |
+| `capacities` (list) + `*_contribution` | Per-character capacity math for replacement/augment organs (`calculate_body_capacity`) | **Live** — load-bearing |
+| `grasping` (organ spec) | Prehensile `hands` overlay — extra held slot from a grasping container | **Live** — load-bearing |
+| `severable_container` (augment organ) | Severable-overlay + operate-menu sever listing | **Live** — load-bearing |
+| `display_location` / `hit_weight` | Surface-access incision gate + hit-distribution weighting (pre-arc, never catalogued) | **Live** — load-bearing |
+
+**Capacity-extension note:** augment organs can *add* anatomy and
+capacities a species table never declared (the cyber tail; a future
+Doc-Ock rig). The substrate phases below (movement policing, senses,
+equipment-handling) assume the static species table is the full
+capacity set — per-character capacity *extension* is an un-catalogued
+wrinkle to fold in when those substrates are scoped. See
+`MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md`.
+
 ---
 
 ## Substrate → Phases the Audit Sequences


### PR DESCRIPTION
Spec-drift audit + reconciliation across the intertwined medical / forensics / identity / rendering specs after the anatomy-augments + cyberware arc (#511–#551).

**Throughline:** the arc's drift landed in the **rendering** and **flag-ledger** docs — not the identity or medical-*model* docs. The identity model anticipated cyberware (forensic-chain rule subsumes prosthetics) and the death-model held; the longdesc spec and the substrate-readiness ledger fell behind.

## Changes
- **`MEDICAL_SUBSTRATE_READINESS`** — new table cataloguing the ~12 live organ-spec flags the arc introduced (`inorganic`, `prosthetic_frame`, `hardpoint`, `module_type`, `abilities`, `flesh_organ`, `capacities`, `grasping`, …), consumed-but-uncatalogued; stale-count caveat; per-character capacity-extension note.
- **`LONGDESC_SYSTEM_SPEC`** — retired the "future Modification System" stub; documented the **shipped** chrome/inorganic rendering layer.
- **`AUGMENT_ABILITIES`** — §7 rewritten for the #549 split (hardpoint module vs flesh implant), CYBER_JAW/JAWZ + NAILZ-carbide exemplars, four→five templates; §8 chrome-severance section (#551); §9 colour corrected to `\|=l`.
- **`ANATOMY_AUGMENTS`** — §3.8 chrome severance-moment cross-ref.
- **`HEALTH_AND_SUBSTANCE`** — cyberware summary names chrome severance + the five-template standard.
- **`MEDICAL_COMBAT_AUDIT`** — true-up paragraph (arc orthogonal to substrate gaps) + capacity-extension design note.

`IDENTITY_RECOGNITION` audited and found **clean** — no edits needed.

Docs only; no code, no live impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)