### PR TITLE
Rename audit specs to roadmaps (forward plans, not history)

### DIFF
--- a/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
+++ b/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
@@ -331,7 +331,7 @@ class DeathProgressionScript(DefaultScript):
     def _check_medical_revival_conditions(self, character):
         """Check if medical treatment has resolved fatal conditions"""
         # Brain death blocks revival — tracked as Phase 2 of the
-        # MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC remediation plan.
+        # MEDICAL_SUBSTRATE_ROADMAP remediation plan.
         # Below is the intended shape; the live code in
         # typeclasses/death_progression.py:_check_medical_revival_conditions
         # currently only calls medical_state.is_dead() and will gain

--- a/specs/MEDICAL_SUBSTRATE_READINESS.md
+++ b/specs/MEDICAL_SUBSTRATE_READINESS.md
@@ -1,6 +1,6 @@
 # Medical Substrate Readiness Index
 
-This document is the load-bearing artifact spun out of Phase 1 of `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md`. Its purpose is captured in that spec's Core Insight:
+This document is the load-bearing artifact spun out of Phase 1 of `MEDICAL_SUBSTRATE_ROADMAP.md`. Its purpose is captured in that spec's Core Insight:
 
 > The medical system has a top-down anatomical schema whose bottom-up consumer systems were never built. Each declarative flag advertises a consumer system that hasn't been written yet. Deleting them would be deleting design documentation. The right work is *building the substrates*.
 
@@ -76,7 +76,7 @@ Doc-Ock rig). The substrate phases below (movement policing, senses,
 equipment-handling) assume the static species table is the full
 capacity set — per-character capacity *extension* is an un-catalogued
 wrinkle to fold in when those substrates are scoped. See
-`MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md`.
+`MEDICAL_SUBSTRATE_ROADMAP.md`.
 
 ---
 
@@ -102,13 +102,13 @@ Phases 4 (Vestigial-Flag Deletion) and 5 (`LETHAL_CAPACITY_NAMES` Split) don't d
 2. If existing runtime: wire it on the same PR. Don't add unconsumed declarative state.
 3. If future substrate: add a row to the table above with the substrate name and audit phase that will wire it. **An unconsumed flag without a row here is the symptom the audit catalogues** — that's how flag-debt accumulates.
 
-When the audit's Phases 4–13 land, prune rows here and remove the flag-debt in `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md`'s "Drift Quick Reference" headline list.
+When the audit's Phases 4–13 land, prune rows here and remove the flag-debt in `MEDICAL_SUBSTRATE_ROADMAP.md`'s "Drift Quick Reference" headline list.
 
 ---
 
 ## See Also
 
-- `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md` — full audit catalogue, remediation phases, sequencing
+- `MEDICAL_SUBSTRATE_ROADMAP.md` — full audit catalogue, remediation phases, sequencing
 - `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` — the canonical health/medical spec; "Spinal Anatomy, Decapitation & Combat Severance" section is the canonical reference for how death wiring crosses the schema boundary
 - `world/medical/constants.py` — `LETHAL_CAPACITY_NAMES`, `BODY_CAPACITIES`, `CONSCIOUSNESS_UNCONSCIOUS_THRESHOLD`, `BLOOD_LOSS_DEATH_THRESHOLD`
 - `world/medical/core.py` — `MedicalState.is_dead`, `is_unconscious`, `calculate_body_capacity`

--- a/specs/MEDICAL_SUBSTRATE_ROADMAP.md
+++ b/specs/MEDICAL_SUBSTRATE_ROADMAP.md
@@ -1,15 +1,25 @@
-# Medical & Combat Audit and Remediation Spec
+# Medical Substrate Roadmap
+
+> Renamed from `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC` (2026-06-14).
+> This is a **forward roadmap**, not a historical audit — the findings
+> below seeded a phased plan for building the medical/combat substrate
+> consumers, and most phases are still ahead. The at-a-glance flag map
+> lives in `MEDICAL_SUBSTRATE_READINESS.md`.
 
 ## Overview
 
-End-to-end audit of the medical and combat systems, the death-progression
-pipeline, and the tertiary systems they depend on (wounds, conditions, armor,
-corpse, hit selection). This spec catalogues every drift, dead metadata flag,
-and documented-but-unimplemented feature found in that audit, and lays out a
-prioritised remediation plan with discrete phases.
+Started as an end-to-end audit of the medical and combat systems, the
+death-progression pipeline, and the tertiary systems they depend on
+(wounds, conditions, armor, corpse, hit selection). It catalogued every
+drift, dead metadata flag, and documented-but-unimplemented feature found,
+and laid out a prioritised remediation plan with discrete phases. That
+remediation plan — building the substrate consumers the schema advertises —
+is the live content; the audit catalogue is its rationale.
 
-Status: **proposal**. Author: audit pass after the pelvis-in-groin fix
-(issue #325) surfaced broader questions about death model and dead metadata.
+Status: **active roadmap** (Phase 1 complete; 2–13 ahead — see the
+Implementation Progress true-up below). Origin: audit pass after the
+pelvis-in-groin fix (issue #325) surfaced broader questions about the
+death model and dead metadata.
 
 ## Implementation Progress (June 2026 true-up)
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -13,9 +13,10 @@ Design specifications for game systems and features. 44 spec files covering comb
 | `PROXIMITY_SYSTEM_SPEC.md` | Tactical positioning mechanics |
 | `GRAPPLE_SYSTEM_SPEC.md` | Grappling and restraint mechanics |
 | `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` | Medical/trauma system design; canonical source of truth for anatomy (spinal organs, neck integrity) and death/decapitation conditions |
-| `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md` | **Planning artifact** — end-to-end audit of medical/combat/death systems and a phased remediation plan. Content gets absorbed into canonical specs as each phase lands, then this document retires. |
+| `MEDICAL_SUBSTRATE_ROADMAP.md` | **Roadmap** (formerly `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC`) — phased plan for building the medical/combat substrate consumers the schema advertises. Phase 1 done; 2–13 ahead. Paired with `MEDICAL_SUBSTRATE_READINESS.md`. |
 | `CONDITION_CADENCE_SPEC.md` | Elapsed-time condition rates: per-minute rates, ticks as sampling, downtime cap, script hygiene doctrine (#501) |
 | `MEDICAL_SUBSTRATE_READINESS.md` | Index of unconsumed declarative flags in the medical schema → intended consumer system → audit phase. Use when adding new flags or wiring substrates. |
+| `STORAGE_PATTERNS_ROADMAP.md` | **Roadmap** (formerly `STORAGE_PATTERNS_AUDIT_AND_REMEDIATION_SPEC`) — survey of storage/persistence patterns + a drafted, not-yet-executed remediation plan. |
 | `CLOTHING_SYSTEM_SPEC.md` | Clothing and layering system |
 | `MODULAR_ARMOR_SYSTEM_SPEC.md` | Armor coverage and damage reduction |
 | `SHOP_SYSTEM_SPEC.md` | Shop pricing and inventory |

--- a/specs/STORAGE_PATTERNS_ROADMAP.md
+++ b/specs/STORAGE_PATTERNS_ROADMAP.md
@@ -1,6 +1,10 @@
-# Storage Patterns: Audit and Remediation Spec
+# Storage Patterns Roadmap
 
-**Status**: Audit complete · remediation roadmap drafted · no code
+> Renamed from `STORAGE_PATTERNS_AUDIT_AND_REMEDIATION_SPEC` (2026-06-14).
+> A **forward roadmap**: the survey is done, the §5 remediation plan is
+> drafted and not yet executed.
+
+**Status**: Survey complete · remediation roadmap drafted · no code
 changes yet.
 
 ## 0 · The architectural principle

--- a/world/combat/messages/severance/__init__.py
+++ b/world/combat/messages/severance/__init__.py
@@ -35,7 +35,7 @@ Example::
         exclude=[attacker, target],
     )
 
-See ``specs/MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md`` and issue #332
+See ``specs/MEDICAL_SUBSTRATE_ROADMAP.md`` and issue #332
 for the broader design context.
 """
 


### PR DESCRIPTION
Follow-up to #552. The two "audit" specs are misnamed: they're unexecuted **forward roadmaps**, not historical audits. The medical one still has Phases 2–13 ahead and four live dependents (the readiness ledger is spun out of it); the storage one carries a drafted-but-unrun §5 remediation plan. PR history preserves completed work — it can't preserve a *plan*. So rename rather than scrub.

- `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC.md` → `MEDICAL_SUBSTRATE_ROADMAP.md`
- `STORAGE_PATTERNS_AUDIT_AND_REMEDIATION_SPEC.md` → `STORAGE_PATTERNS_ROADMAP.md`

Updated titles + intros (audit → active-roadmap framing), all inbound cross-refs (`MEDICAL_SUBSTRATE_READINESS`, `HEALTH_AND_SUBSTANCE`, `README`, and a `severance/__init__.py` docstring), and indexed the storage roadmap in the README (it was never listed). Only non-doc change is a docstring "See spec" reference — parses clean, no runtime effect.

**Follow-up (next PR):** consolidate these into proper roadmap docs with mermaid phase diagrams and complete / pending / needs-discussion status markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)