### PR TITLE
Reorganize specs/: shipped at top level, the rest into folders

### DIFF
--- a/specs/COMBAT_SYSTEM.md
+++ b/specs/COMBAT_SYSTEM.md
@@ -1,5 +1,7 @@
 # G.R.I.M. Combat System Documentation
 
+> **Status:** ✅ Shipped — high-level overview of the running combat system. NOTE: some features described below are aspirational and NOT implemented — skill progression, reputation, ammunition tracking, weapon durability, and formation fighting. Treat the combat code and COMBAT_REFACTOR (roadmap) as current truth where they disagree.
+
 ## Overview
 
 The **G.R.I.M. Combat System** is a roleplay-focused, turn-based combat engine that emphasizes both violent and non-violent conflict resolution. It's built around four core character attributes and supports complex tactical scenarios while maintaining narrative focus.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,70 +1,85 @@
 # specs/
 
-Design specifications for game systems and features. 44 spec files covering combat, commands, UI, medical, identity, communication, and integrations.
+Design specifications for **shipped** game systems — the index below
+describes how the game works today. Each entry is a running system
+(deferred sub-features are noted inline within each spec).
 
-## Core Systems
+Specs that are **not** shipped live in subfolders and are kept out of this
+index:
+
+- **`proposals/`** — 📋 designed, nothing built yet.
+- **`roadmaps/`** — 🛣 forward build-plans layered on live systems (partial).
+- **`archive/`** — 🗄 task complete or superseded; kept for context only.
+
+Every spec in those folders carries a `> **Status:**` banner at the top.
+
+---
+
+## Combat
 
 | Spec | Description |
 |------|-------------|
-| `COMBAT_SYSTEM.md` | Overall combat system design |
-| `COMBAT_REFACTOR_SPEC.md` | Combat module decomposition plan |
+| `COMBAT_SYSTEM.md` | High-level overview of the combat system (some listed features are aspirational — see banner) |
 | `COMBAT_AUDIT_LOGGING_SPEC.md` | Single-sink combat/medical diagnostics: always-on audit file + gated Splattercast channel (`world/combat/debug.py`) |
-| `COMBAT_MESSAGE_FORMAT_SPEC.md` | Combat messaging and template system |
-| `PROXIMITY_SYSTEM_SPEC.md` | Tactical positioning mechanics |
-| `GRAPPLE_SYSTEM_SPEC.md` | Grappling and restraint mechanics |
-| `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` | Medical/trauma system design; canonical source of truth for anatomy (spinal organs, neck integrity) and death/decapitation conditions |
-| `MEDICAL_SUBSTRATE_ROADMAP.md` | **Roadmap** (formerly `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC`) — phased plan for building the medical/combat substrate consumers the schema advertises. Phase 1 done; 2–13 ahead. Paired with `MEDICAL_SUBSTRATE_READINESS.md`. |
-| `CONDITION_CADENCE_SPEC.md` | Elapsed-time condition rates: per-minute rates, ticks as sampling, downtime cap, script hygiene doctrine (#501) |
-| `MEDICAL_SUBSTRATE_READINESS.md` | Index of unconsumed declarative flags in the medical schema → intended consumer system → audit phase. Use when adding new flags or wiring substrates. |
-| `STORAGE_PATTERNS_ROADMAP.md` | **Roadmap** (formerly `STORAGE_PATTERNS_AUDIT_AND_REMEDIATION_SPEC`) — survey of storage/persistence patterns + a drafted, not-yet-executed remediation plan. |
-| `CLOTHING_SYSTEM_SPEC.md` | Clothing and layering system |
-| `MODULAR_ARMOR_SYSTEM_SPEC.md` | Armor coverage and damage reduction |
-| `SHOP_SYSTEM_SPEC.md` | Shop pricing and inventory |
-| `TIME_SYSTEM_SPEC.md` | In-game time and day/night cycle |
-| `WORLD_STATE_INTELLIGENCE_SYSTEM_SPEC.md` | Zone-level world simulation (design phase) |
-| `IDENTITY_RECOGNITION_SPEC.md` | Sleeve-based identity, recognition memory, and assigned names |
-| `EMOTE_POSE_SPEC.md` | Emote, pose, and communication system with identity integration |
+| `COMBAT_MESSAGE_FORMAT_SPEC.md` | Three-perspective combat messaging format |
+| `GRAPPLE_SYSTEM_SPEC.md` | Grappling, restraint, human-shield mechanics |
+
+## Medical, Anatomy & Body
+
+| Spec | Description |
+|------|-------------|
+| `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` | Canonical medical/trauma system: anatomy, organs, death/decapitation, substances |
+| `CONDITION_CADENCE_SPEC.md` | Elapsed-time condition rates: per-minute rates, ticks as sampling, downtime cap (#501) |
+| `ANATOMY_AUGMENTS_SPEC.md` | Per-character anatomy; augment install; the cybernetic tail; inorganic organs |
+| `AUGMENT_ABILITIES_SPEC.md` | Toggleable cyberware; the chassis+module standard; reattachment; chrome severance |
+| `SPECIES_AUTHORING.md` | How to add a species so combat/severance/medical/longdesc behave without renderer changes |
+| `SUBSTANCES_AND_DELIVERY_SPEC.md` | Item → substance → delivery model; registry, tolerance/addiction |
+
+## Identity, Communication & Appearance
+
+| Spec | Description |
+|------|-------------|
+| `IDENTITY_RECOGNITION_SPEC.md` | Sleeve-based identity, recognition memory, personas, disguise piercing |
+| `EMOTE_POSE_SPEC.md` | Emote, pose, say/whisper with per-observer identity rendering |
+| `LONGDESC_SYSTEM_SPEC.md` | Per-location body descriptions; pair-collapse; chrome rendering |
+| `GRAMMAR_ENGINE_SPEC.md` | Pronoun/conjugation/article engine (`{they}`/`{their}` tokens) |
+| `DEATH_CURTAIN_SPEC.md` | Narrative death animation + death-progression timer |
+
+## Items, Equipment & World
+
+| Spec | Description |
+|------|-------------|
+| `CLOTHING_SYSTEM_SPEC.md` | Clothing, coverage-based visibility, layering, dynamic styling |
+| `MODULAR_ARMOR_SYSTEM_SPEC.md` | Armor stacking, plate carriers, tactical targeting |
+| `SHOP_SYSTEM_SPEC.md` | Container-based shops, pricing, inventory (Phase 2 deferred — #302) |
+| `GRAFFITI_SYSTEM_SPEC.md` | Spray-paint / solvent environmental writing |
 
 ## Commands
 
 | Spec | Description |
 |------|-------------|
-| `JUMP_COMMAND_SPEC.md` | Inter-room jumping |
+| `LOOK_COMMAND_SPEC.md` | Enhanced, combat-aware look |
 | `THROW_COMMAND_SPEC.md` | Cross-room projectile throwing |
-| `WREST_COMMAND_SPEC.md` | Taking items by force |
+| `WREST_COMMAND_SPEC.md` | Taking held items by force (non-combat) |
+| `JUMP_COMMAND_SPEC.md` | Inter-room jumping |
 | `BUG_COMMAND_SPEC.md` | In-game bug reporting |
-| `LOOK_COMMAND_SPEC.md` | Enhanced look command |
-| `GRAFFITI_SYSTEM_SPEC.md` | Environmental writing |
 | `REMOTE_DETONATOR_SPEC.md` | Remote explosive detonation |
 | `STICKY_GRENADE_SPEC.md` | Sticky grenade mechanics |
 
-## Character & Display
+## Patterns, Web & UI
 
 | Spec | Description |
 |------|-------------|
-| `DESCRIPTIVE_STAT_SYSTEM_SPEC.md` | G.R.I.M. stat descriptors |
-| `LONGDESC_SYSTEM_SPEC.md` | Character appearance generation |
-| `GRAMMAR_ENGINE_SPEC.md` | Pronoun/conjugation/article grammar engine (`{they}`/`{their}` tokens) |
-| `DEATH_CURTAIN_SPEC.md` | Narrative death experience |
-| `PRONOUN_DEEP_DIVE_IMPLEMENTATION_SPEC.md` | Pronoun system internals |
-| `ORDINAL_NUMBERS_SPEC.md` | Ordinal number object display |
-| `WEAPON_MESSAGE_CONVERSION_SPEC.md` | Weapon message migration plan |
-| `EVMENU_PATTERNS_SPEC.md` | EvMenu usage patterns |
-
-## Web & UI
-
-| Spec | Description |
-|------|-------------|
-| `STYLING_SPEC.md` | Web client styling |
-| `WEBCLIENT_SCREEN_SIZE_DETECTION_SPEC.md` | Responsive client layout |
-| `WEB_CHARACTER_CREATION_ALIGNMENT.md` | Web/game character creation parity |
+| `EVMENU_PATTERNS_SPEC.md` | EvMenu text-input / multi-source-picker patterns |
+| `STYLING_SPEC.md` | Web client / terminal-brutalist styling |
+| `WEBCLIENT_SCREEN_SIZE_DETECTION_SPEC.md` | Responsive client layout / screen-width detection |
+| `WEB_CHARACTER_CREATION_ALIGNMENT.md` | Web/game character-creation parity |
 | `WEB_RESPAWN_CHARACTER_CREATION_SPEC.md` | Web respawn flow |
-| `GMCP_PACKAGES_SPEC.md` | GMCP protocol packages |
-| `TURNSTILE_INTEGRATION_SPEC.md` | Cloudflare Turnstile captcha |
+| `TURNSTILE_INTEGRATION_SPEC.md` | Cloudflare Turnstile captcha on registration |
 
 ## Forum Integration (Optional)
 
-These only apply if running a Discourse forum alongside the game:
+Only applies if running a Discourse forum alongside the game:
 
 | Spec | Description |
 |------|-------------|

--- a/specs/archive/ORDINAL_NUMBERS_SPEC.md
+++ b/specs/archive/ORDINAL_NUMBERS_SPEC.md
@@ -1,5 +1,7 @@
 # Ordinal Number Support - Implementation Complete
 
+> **Status:** 🗄 Historical — completion record of a shipped feature (natural-language ordinal multimatch). Kept for context.
+
 ## Overview
 Successfully implemented natural language ordinal number support for multimatch disambiguation in Evennia commands. Players can now use intuitive commands like "get 1st mushroom" instead of "get mushroom-1".
 

--- a/specs/archive/PRONOUN_DEEP_DIVE_IMPLEMENTATION_SPEC.md
+++ b/specs/archive/PRONOUN_DEEP_DIVE_IMPLEMENTATION_SPEC.md
@@ -1,5 +1,7 @@
 # Pronoun System Deep Dive: Clothing & Longdesc Integration
 
+> **Status:** 🗄 Superseded — the $pron()/FuncParser design here was never built; perspective pronouns shipped via the grammar engine + brace tokens (see GRAMMAR_ENGINE_SPEC, LONGDESC_SYSTEM_SPEC, EMOTE_POSE_SPEC). Kept for historical design context.
+
 > **STATUS: SUPERSEDED / HISTORICAL.** The `$pron()`/FuncParser design proposed here was not implemented. Perspective-aware pronouns shipped via the grammar engine and `{their}`/`{they}` brace tokens instead. See `GRAMMAR_ENGINE_SPEC.md` and `LONGDESC_SYSTEM_SPEC.md` for the actual implementation. Retained for historical design context.
 
 ## Overview

--- a/specs/archive/WEAPON_MESSAGE_CONVERSION_SPEC.md
+++ b/specs/archive/WEAPON_MESSAGE_CONVERSION_SPEC.md
@@ -1,5 +1,7 @@
 # Weapon Message Conversion Specification
 
+> **Status:** 🗄 Historical — a one-time migration how-to; the conversion is complete (~80 files). Superseded as the format reference by COMBAT_MESSAGE_FORMAT_SPEC.
+
 ## Overview
 This specification defines the process for converting weapon message files from the old single-perspective format to the new multi-perspective format in the Evennia combat system.
 

--- a/specs/proposals/DESCRIPTIVE_STAT_SYSTEM_SPEC.md
+++ b/specs/proposals/DESCRIPTIVE_STAT_SYSTEM_SPEC.md
@@ -1,5 +1,7 @@
 # Descriptive Stat System Specification
 
+> **Status:** 📋 Proposal — not implemented. The four G.R.I.M. stats exist on the Character, but the A–Z descriptor display layer and any skill system described below are unbuilt.
+
 ## Overview
 
 The G.R.I.M. (Grit, Resonance, Intellect, Motorics) system will be enhanced with descriptive words that replace raw numerical displays for players. Each stat will have 26 alphabetical descriptive tiers (A-Z) representing power levels from 0-150, with each tier covering a 6-point range.

--- a/specs/proposals/GMCP_PACKAGES_SPEC.md
+++ b/specs/proposals/GMCP_PACKAGES_SPEC.md
@@ -1,5 +1,7 @@
 # GMCP Packages Specification
 
+> **Status:** 📋 Proposal — not implemented (tracking #305). The game advertises GMCP in MSSP but sends no custom packages yet.
+
 ## Overview
 
 This spec defines the Generic MUD Communication Protocol (GMCP) packages

--- a/specs/proposals/PROXIMITY_SYSTEM_SPEC.md
+++ b/specs/proposals/PROXIMITY_SYSTEM_SPEC.md
@@ -1,5 +1,7 @@
 # Proximity System Architecture Specification
 
+> **Status:** 📋 Proposal — the live dual-proximity system it documents is accurate; the Option-A unification it proposes is NOT implemented.
+
 ## Overview
 The G.R.I.M. Combat System currently operates with dual proximity systems that evolved to handle different use cases. This document outlines the current architecture, identifies the challenges, and proposes a unification strategy.
 

--- a/specs/proposals/TIME_SYSTEM_SPEC.md
+++ b/specs/proposals/TIME_SYSTEM_SPEC.md
@@ -1,5 +1,7 @@
 # Time System Specification
 
+> **Status:** 📋 Proposal — not implemented (tracking #301). The TST real-time clock is the future-clock seam the cadence system already references; current TIME_FACTOR is unchanged.
+
 ## Overview
 
 The Gelatinous Monster universe operates on Terran Standard Time (TST) - Earth's UTC calendar system maintained across all human settlements and installations. This specification outlines the practical, technical, and cultural reasons for this temporal standardization in a spacefaring civilization.

--- a/specs/proposals/WORLD_STATE_INTELLIGENCE_SYSTEM_SPEC.md
+++ b/specs/proposals/WORLD_STATE_INTELLIGENCE_SYSTEM_SPEC.md
@@ -1,6 +1,6 @@
 # World State Intelligence System (WSIS) Specification
 
-> **Status:** Design phase -- no implementation yet.
+> **Status:** 📋 Proposal — not implemented (tracking #303). Depends on faction / infrastructure / economy systems that are themselves unbuilt.
 >
 > This spec defines a world simulation layer and player-facing intelligence interface
 > for tracking colony-wide state across multiple dimensions (security, infrastructure,

--- a/specs/roadmaps/COMBAT_REFACTOR_SPEC.md
+++ b/specs/roadmaps/COMBAT_REFACTOR_SPEC.md
@@ -1,5 +1,7 @@
 # Combat System Refactor Specification
 
+> **Status:** 🛣 Roadmap (partial) — dice.py/debug.py/actions.py were split out; several proposed modules and the size-reduction targets are NOT done. The diagnostics-routing section is superseded by COMBAT_AUDIT_LOGGING_SPEC.
+
 ## Overview
 
 This specification outlines a systematic refactor of the combat module to address technical debt accumulated through incremental LLM development. The refactor will transform both the monolithic `handler.py` (originally 1,470 lines; currently ~1,077) and the oversized `utils.py` (originally 1,007 lines; currently ~1,047) into a maintainable, modular system. **Status:** partially delivered — `dice.py`, `debug.py`, and `actions.py` were split out, but several proposed modules below were never created and the size-reduction targets have not yet been met.

--- a/specs/roadmaps/MEDICAL_SUBSTRATE_READINESS.md
+++ b/specs/roadmaps/MEDICAL_SUBSTRATE_READINESS.md
@@ -1,5 +1,7 @@
 # Medical Substrate Readiness Index
 
+> **Status:** 🛣 Roadmap reference — the flag→consumer ledger paired with MEDICAL_SUBSTRATE_ROADMAP. Describes live anatomy flags + which (mostly unbuilt) substrate will consume each.
+
 This document is the load-bearing artifact spun out of Phase 1 of `MEDICAL_SUBSTRATE_ROADMAP.md`. Its purpose is captured in that spec's Core Insight:
 
 > The medical system has a top-down anatomical schema whose bottom-up consumer systems were never built. Each declarative flag advertises a consumer system that hasn't been written yet. Deleting them would be deleting design documentation. The right work is *building the substrates*.

--- a/specs/roadmaps/MEDICAL_SUBSTRATE_ROADMAP.md
+++ b/specs/roadmaps/MEDICAL_SUBSTRATE_ROADMAP.md
@@ -1,5 +1,7 @@
 # Medical Substrate Roadmap
 
+> **Status:** 🛣 Roadmap — Phase 1 shipped; Phases 2–13 ahead. The plan for building the medical/combat substrate consumers the schema advertises.
+
 > Renamed from `MEDICAL_COMBAT_AUDIT_AND_REMEDIATION_SPEC` (2026-06-14).
 > This is a **forward roadmap**, not a historical audit — the findings
 > below seeded a phased plan for building the medical/combat substrate
@@ -21,6 +23,77 @@ Implementation Progress true-up below). Origin: audit pass after the
 pelvis-in-groin fix (issue #325) surfaced broader questions about the
 death model and dead metadata.
 
+## Roadmap at a glance
+
+**Status key:** ✅ complete · ⏳ pending · ⛔ blocked (needs a substrate
+first) · 💬 needs analysis / discussion before it can be scoped.
+
+The core insight sequences the whole plan: **build the substrate before
+wiring schema to it.** Standalone phases ship anytime; substrate phases
+(Sprint 2) gate the wiring phases (Sprint 3).
+
+```mermaid
+graph LR
+    P1["✅ P1 · Documentation"]:::done
+
+    subgraph S1["Sprint 1 · standalone — ship anytime ⏳"]
+        P2["P2 · Brain death blocks revival"]
+        P3["P3 · Failure-mode surfacing"]
+        P4["P4 · Vestigial-flag deletion"]
+        P5["P5 · LETHAL_CAPACITY split"]
+    end
+
+    subgraph S2["Sprint 2 · substrates — build first ⏳"]
+        P6["P6 · Chronic conditions"]
+        P7["P7 · Movement policing"]
+        P8["P8 · Senses"]
+        P9["P9 · Equipment-handling"]
+    end
+
+    subgraph S3["Sprint 3 · wiring — blocked on substrates ⛔"]
+        P10["P10 · Functional incapacitation"]
+        P11["P11 · Paralysis"]
+        P12["P12 · Kidney death (RenalFailure)"]
+        P13["P13 · Final flag audit"]
+    end
+
+    P6 --> P12
+    P7 --> P10
+    P7 --> P11
+    P8 --> P10
+    P9 --> P10
+    P10 --> P13
+    P11 --> P13
+    P12 --> P13
+
+    classDef done fill:#1b5e20,color:#fff,stroke:#0d3311;
+```
+
+### Status dashboard
+
+| Bucket | Phases | Notes |
+|---|---|---|
+| ✅ **Complete** | Phase 1 | Documentation & architectural clarification (the substrate-vs-runtime split, this roadmap, the readiness ledger). |
+| ⏳ **Pending — standalone** | Phases 2–5 | No substrate dependency; each a half-to-full-day session. Phase 4/5 also unblock the flag cleanup. |
+| ⏳ **Pending — substrate** | Phases 6–9 | The main build effort; each a real spec + PR. They gate Sprint 3. |
+| ⛔ **Blocked — wiring** | Phases 10–13 | Wait on their substrate (10←7/8/9, 11←7, 12←6, 13←all). |
+
+### 💬 Needs analysis / discussion (not yet a phase)
+
+- **Skill / stat model** — *upstream of this entire roadmap's tuning.*
+  Every medical roll (`roll_procedure`, `calculate_treatment_success`)
+  and forensic check is a placeholder formula on G.R.I.M. stats that all
+  default to `1`. Difficulty/effectiveness balance can't be tuned, and
+  capacity→roll penalties (the point of Sprints 2–3) have no real roll to
+  modify, until the skill/stat design is decided. **Design decision owed.**
+- **Per-character capacity extension** — augment organs can *add* anatomy
+  and capacities a species table never declared (the cyber tail). Sprints
+  2–3 assume the static species table is the full capacity set; extension
+  is an un-catalogued substrate concern. See `MEDICAL_SUBSTRATE_READINESS.md`.
+- **Social-interaction substrate** — `talking` total-loss effects
+  (`cannot_negotiate`, …) have no audit phase: open design, depends on a
+  trade/negotiation system that doesn't exist yet.
+
 ## Implementation Progress (June 2026 true-up)
 
 This spec is a planning artifact; as phases land, their content gets
@@ -30,7 +103,7 @@ work:
 
 | Phase | Status | Notes |
 |---|---|---|
-| Phase 1 — Documentation & Architectural Clarification | **✅ Complete** | All four tasks shipped. Task 1: `LETHAL_CAPACITY_NAMES` comment in `world/medical/constants.py` now explicitly documents the union role. Task 2: `MedicalState.is_dead` / `is_unconscious` / `calculate_body_capacity` docstrings spell out the substrate-vs-runtime split and cross-reference the audit's phase numbers. Task 3: HEALTH spec's brain-death `# NEXT:` pseudo-code now explicitly points at audit Phase 2 instead of reading as an open design note. Task 4: `specs/MEDICAL_SUBSTRATE_READINESS.md` index lists every unconsumed flag with its intended consumer system and audit phase. |
+| Phase 1 — Documentation & Architectural Clarification | **✅ Complete** | All four tasks shipped. Task 1: `LETHAL_CAPACITY_NAMES` comment in `world/medical/constants.py` now explicitly documents the union role. Task 2: `MedicalState.is_dead` / `is_unconscious` / `calculate_body_capacity` docstrings spell out the substrate-vs-runtime split and cross-reference the audit's phase numbers. Task 3: HEALTH spec's brain-death `# NEXT:` pseudo-code now explicitly points at audit Phase 2 instead of reading as an open design note. Task 4: `specs/roadmaps/MEDICAL_SUBSTRATE_READINESS.md` index lists every unconsumed flag with its intended consumer system and audit phase. |
 | Phase 2 — Brain Death Blocks Revival | Not started | `_check_medical_revival_conditions` still gates only on `is_dead()`. |
 | Phase 3 — Failure-Mode Surfacing | Not started | Empty-distribution / unbacked-container warnings not wired. |
 | Phase 4 — Vestigial-Flag Deletion | Not started | All flags listed under "Vestigial (delete)" still present. |
@@ -333,7 +406,7 @@ Tasks:
      capacity.
 3. Reframe `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md`'s `# NEXT:` brain-death
    pseudo-code: point it at Phase 2 of this spec.
-4. Add a `specs/MEDICAL_SUBSTRATE_READINESS.md` index that documents
+4. Add a `specs/roadmaps/MEDICAL_SUBSTRATE_READINESS.md` index that documents
    each declarative flag, its intended consumer system, and the phase
    that will wire it.
 

--- a/specs/roadmaps/STORAGE_PATTERNS_ROADMAP.md
+++ b/specs/roadmaps/STORAGE_PATTERNS_ROADMAP.md
@@ -1,5 +1,7 @@
 # Storage Patterns Roadmap
 
+> **Status:** 🛣 Roadmap — survey complete; the §5 remediation plan is drafted, not executed.
+
 > Renamed from `STORAGE_PATTERNS_AUDIT_AND_REMEDIATION_SPEC` (2026-06-14).
 > A **forward roadmap**: the survey is done, the §5 remediation plan is
 > drafted and not yet executed.

--- a/world/combat/messages/severance/__init__.py
+++ b/world/combat/messages/severance/__init__.py
@@ -35,7 +35,7 @@ Example::
         exclude=[attacker, target],
     )
 
-See ``specs/MEDICAL_SUBSTRATE_ROADMAP.md`` and issue #332
+See ``specs/roadmaps/MEDICAL_SUBSTRATE_ROADMAP.md`` and issue #332
 for the broader design context.
 """
 


### PR DESCRIPTION
Follow-up to the spec-drift audit (#552/#553). The flat `specs/` folder mixed running systems with unbuilt proposals, partial roadmaps, and superseded docs — you couldn't tell vision from reality without opening each file.

## Structure
- **`specs/`** (top level) = shipped systems only; the README indexes just these.
- **`specs/proposals/`** = designed, nothing built — `WORLD_STATE_INTELLIGENCE`, `GMCP_PACKAGES`, `TIME_SYSTEM`, `PROXIMITY` (unification unbuilt), `DESCRIPTIVE_STAT_SYSTEM`.
- **`specs/roadmaps/`** = forward build-plans on live systems — `MEDICAL_SUBSTRATE_ROADMAP` + `MEDICAL_SUBSTRATE_READINESS`, `STORAGE_PATTERNS_ROADMAP`, `COMBAT_REFACTOR`.
- **`specs/archive/`** = task complete / superseded — `PRONOUN_DEEP_DIVE`, `WEAPON_MESSAGE_CONVERSION`, `ORDINAL_NUMBERS`.

## Consistency
- Every foldered spec carries a `> **Status:**` banner (📋 proposal · 🛣 roadmap · 🗄 archive).
- `COMBAT_SYSTEM` stays top-level as a shipped overview but gains a banner flagging its aspirational features (skill progression, reputation, ammo, durability) as **not** implemented.
- README rewritten: shipped-only, grouped by domain, pointer to subfolders. Added four shipped specs that were never indexed (`ANATOMY_AUGMENTS`, `AUGMENT_ABILITIES`, `SPECIES_AUTHORING`, `SUBSTANCES_AND_DELIVERY`).

Fixed the three path-style cross-refs broken by the moves. No empty specs or placeholder issues created — specs stay ephemeral until implementation.

Docs only (one docstring touched; parses clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)