### PR TITLE
Spec hygiene fixes from the full-folder read

### DIFF
--- a/specs/CLOTHING_SYSTEM_SPEC.md
+++ b/specs/CLOTHING_SYSTEM_SPEC.md
@@ -4,7 +4,7 @@
 
 **Design Phase**: Comprehensive specification completed with dynamic styling system  
 **Implementation Status**: Core functionality implemented and tested - ready for advanced features  
-**Documentation Status**: Complete specification with corrected FuncParser understanding  
+**Documentation Status**: Complete. Pronoun handling is the grammar engine's `{their}`/`{they}` brace tokens — `$pron()` was found not to work in prototypes (see §Enhanced Features).  
 **Testing Status**: Basic clothing system verified working in game environment
 
 ## Overview
@@ -19,7 +19,7 @@ The Clothing System extends the longdesc foundation to provide wearable items th
 4. **Shared Location Constants**: Uses the same body location system as longdesc for consistency
 5. **Appearance Integration**: Seamlessly integrates with existing character appearance system
 6. **Roleplay Enhancement**: Style commands provide intuitive roleplay interactions with meaningful feedback
-7. **Pronoun Integration**: All clothing descriptions use Evennia's `$pron()` system for perspective handling
+7. **Pronoun Integration**: Clothing descriptions use the grammar engine's `{their}`/`{they}` brace tokens for perspective handling — **not** Evennia's `$pron()` (which doesn't work in prototypes; see §Enhanced Features and `GRAMMAR_ENGINE_SPEC.md`)
 8. **Color Immersion**: ANSI color integration for enhanced visual immersion and atmospheric descriptions
 
 ## Integration with Longdesc System
@@ -55,7 +55,7 @@ class Item(DefaultObject):
     
     # Clothing-specific description that appears when worn (base state)
     # Empty string = not clothing, populated = worn description
-    # USES $pron() for perspective-aware descriptions
+    # USES {their}/{they} brace tokens for perspective-aware descriptions
     worn_desc = AttributeProperty("", autocreate=True)
     
     # ANSI color definition for this item
@@ -138,13 +138,13 @@ COLOR_DEFINITIONS = {
 
 # Example colored clothing prototypes
 DEVELOPER_HOODIE = {
-    "worn_desc": "A menacing {color}black|n developer hoodie that clings to $pron(their) frame like digital shadow incarnate, command-line text pulsing ominously across $pron(their) chest",
+    "worn_desc": "A menacing {color}black|n developer hoodie that clings to {their} frame like digital shadow incarnate, command-line text pulsing ominously across {their} chest",
     "color": "black",
     "material": "cotton",
 }
 
 BLUE_JEANS = {
-    "worn_desc": "Battle-tested {color}denim|n jeans that cling to $pron(their) form with urban authority, $pron(their) faded indigo surface scarred by countless encounters", 
+    "worn_desc": "Battle-tested {color}denim|n jeans that cling to {their} form with urban authority, {their} faded indigo surface scarred by countless encounters", 
     "color": "blue",
     "material": "denim",
 }
@@ -167,7 +167,7 @@ def get_colored_description(self):
 
 # Example usage in prototypes:
 RAINBOW_SOCKS = {
-    "worn_desc": "Wildly vibrant rainbow socks that shimmer with {color}prismatic brilliance|n across $pron(their) feet",
+    "worn_desc": "Wildly vibrant rainbow socks that shimmer with {color}prismatic brilliance|n across {their} feet",
     "color": "bright_magenta",
     "material": "synthetic",
 }
@@ -675,7 +675,7 @@ def _build_clothing_coverage_map(self):
     return coverage
 
 def return_appearance(self, looker, **kwargs):
-    """Enhanced appearance integrating clothing with existing formatting and $pron() system."""
+    """Enhanced appearance integrating clothing with existing formatting and the {their}/{they} brace-token system."""
     # Get base header (name, description, etc.)
     string = self._get_appearance_header(looker, **kwargs)
     
@@ -683,7 +683,7 @@ def return_appearance(self, looker, **kwargs):
     body_descriptions = self._get_visible_body_descriptions(looker)
     
     if body_descriptions:
-        # Feed into existing paragraph formatting system with $pron() processing
+        # Feed into existing paragraph formatting system with brace-token processing
         formatted_body = self._format_longdescs_with_paragraphs(body_descriptions, looker)
         string += f"\n{formatted_body}"
     
@@ -697,7 +697,7 @@ def _get_visible_body_descriptions(self, looker=None):
     
     for location in LONGDESC_LOCATIONS:
         if location in coverage_map:
-            # Location covered by clothing - use current worn_desc with $pron() processing
+            # Location covered by clothing - use current worn_desc with brace-token processing
             clothing_item = coverage_map[location]
             desc = clothing_item.get_current_worn_desc_with_perspective(looker, from_obj=self)
             if desc:
@@ -706,7 +706,7 @@ def _get_visible_body_descriptions(self, looker=None):
             # Location not covered - use character's longdesc
             desc = self.longdescs.get(location)
             if desc:
-                # Process longdescs through $pron() system too for consistency
+                # Process longdescs through the brace-token system too for consistency
                 processed_desc = self._process_description_pronouns(desc, looker)
                 descriptions.append(processed_desc)
     
@@ -718,14 +718,14 @@ def _get_visible_body_descriptions(self, looker=None):
 ### Pronoun and Color Processing
 ```python
 def get_current_worn_desc_with_perspective(self, looker=None, from_obj=None):
-    """Get current worn description with $pron() and color processing"""
+    """Get current worn description with brace-token and color processing"""
     # Get base description (considering current style state)
     desc = self.get_current_worn_desc()
     
     # Process color placeholders
     desc = self._process_color_codes(desc)
     
-    # Process $pron() tags with perspective
+    # Process {their}/{they} brace tokens with perspective
     if looker and from_obj:
         from evennia.utils.funcparser import FuncParser
         parser = FuncParser(desc)
@@ -911,7 +911,7 @@ The shirt doesn't have a zipper.
 
 ## Enhanced Prototype Examples
 
-### Developer Hoodie with $pron() and Color Integration
+### Developer Hoodie with brace-token and Color Integration
 ```python
 DEVELOPER_HOODIE = {
     "prototype_key": "DEVELOPER_HOODIE",
@@ -1071,5 +1071,5 @@ COMBAT_BOOTS = {
 
 ---
 
-**Document Status**: Enhanced with `$pron()` integration, streamlined single-color system, and material attribute for future extensibility
+**Document Status**: Enhanced with `{their}`/`{they}` brace-token integration, streamlined single-color system, and material attribute for future extensibility
 **Next Steps**: Implement Phase 2 color & material system enhancements in codebase

--- a/specs/DISCOURSE_INTEGRATION.md
+++ b/specs/DISCOURSE_INTEGRATION.md
@@ -130,19 +130,21 @@ enable local logins = false          # Force SSO only
 
 ### 3.2 Set Color Values
 
-Use these values (matching your game's `custom.css`):
+Use these values (matching the live site palette in `STYLING_SPEC.md` /
+`custom.css` — the muted jade-green "Blade Runner" scheme, **not** the
+old blue accent):
 
 ```
-Primary (text):           #ffffff
+Primary (text):           #e0e0e0
 Secondary (background):   #1a1a1a
-Tertiary (accent):        #6fa8dc
-Quaternary (borders):     #3a3a3a
+Tertiary (accent):        #5fd38d   (muted jade green)
+Quaternary (borders):     #404040
 Header Background:        #1a1a1a
-Header Primary:           #ffffff
-Highlight (selected):     #5a8fc7
-Danger (errors):          #dc6f6f
-Success (confirmations):  #6fdc7a
-Love (likes):             #dc6fa8
+Header Primary:           #e0e0e0
+Highlight (selected):     #4a9d6d   (dimmed jade)
+Danger (errors):          #e85555
+Success (confirmations):  #5fd38d
+Love (likes):             #e6c547
 ```
 
 ### 3.3 Apply to Theme

--- a/specs/FORUM_INTEGRATION_GUIDE.md
+++ b/specs/FORUM_INTEGRATION_GUIDE.md
@@ -42,13 +42,12 @@ The following files support forum integration but are **non-invasive**:
 
 ### Discourse Side (Forum)
 
-If you set up a Discourse forum, these specs provide complete theme configuration:
-
-**Consolidated Specs**:
-- `DISCOURSE_COLOR_PALETTE.md` - Color scheme matching your game
-- `DISCOURSE_DARK_THEME_CSS.md` - CSS for header integration
-- `DISCOURSE_THEME_CODE_FIXED.md` - JavaScript for iframe embedding
-- `CACHING_AND_PRECONNECT_SETUP.md` - Performance optimizations
+If you set up a Discourse forum, the complete theme configuration —
+color scheme, header-integration CSS, iframe-embedding JavaScript, and
+caching/preconnect setup — lives in **`DISCOURSE_INTEGRATION.md`**
+(steps 3–9). (The previously-separate `DISCOURSE_COLOR_PALETTE.md` /
+`DISCOURSE_DARK_THEME_CSS.md` / `DISCOURSE_THEME_CODE_FIXED.md` /
+`CACHING_AND_PRECONNECT_SETUP.md` files were consolidated into it.)
 
 ---
 

--- a/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
+++ b/specs/HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md
@@ -2788,7 +2788,9 @@ HIT_LOCATION_DIFFICULTY = {
 3. ~~Define location difficulty constants and organ targeting weights~~ → Implemented with success margin thresholds and precision-based organ weights
 4. ~~Update combat handler to use smart location targeting~~ → Fully integrated two-stage targeting system
 
-**Phase 3.2: Armor Protection Layer** - 🔲 PLANNED 
+**Phase 3.2: Armor Protection Layer** - ✅ SHIPPED — armor moved to its
+own system; see `MODULAR_ARMOR_SYSTEM_SPEC.md` (stacking, plate carriers,
+tactical targeting). The sketch below is superseded historical intent.
 1. Extend `typeclasses/items.py` with armor properties:
    ```python
    # Add to clothing items

--- a/specs/WEBCLIENT_SCREEN_SIZE_DETECTION_SPEC.md
+++ b/specs/WEBCLIENT_SCREEN_SIZE_DETECTION_SPEC.md
@@ -3,9 +3,10 @@
 ## Document Information
 
 **Version:** 1.0  
-**Date:** 2025-01-XX  
-**Status:** Draft - Awaiting Review  
-**Author:** AI Agent  
+**Date:** 2025-01  
+**Status:** ✅ Implemented — the webclient size-detection plugin ships in
+`web/static/webclient/js/gel.js`; the §Implementation Plan checklist
+below is delivered. (Header corrected 2026-06-14 — was stale "Draft".)  
 **Related Systems:** G.R.I.M. Combat System, Evennia Webclient  
 
 ---

--- a/specs/WEB_CHARACTER_CREATION_ALIGNMENT.md
+++ b/specs/WEB_CHARACTER_CREATION_ALIGNMENT.md
@@ -72,9 +72,10 @@ char.db.archived = False
 > **Status: Form COMPLETE.** Phases 1–4 were built incrementally and are now
 > live. The shipped `CharacterForm` in `web/website/forms.py` includes the split
 > name fields (`first_name`, `last_name`), `sex`, all four GRIM stats, and the
-> full 300-point + name-uniqueness validation. Phase 5 (respawn interface)
-> remains optional/future. The per-phase breakdown is retained below as the
-> historical implementation plan.
+> full 300-point + name-uniqueness validation. The respawn interface
+> (templates + flash clone) also **shipped and is deployed to production**
+> — see `WEB_RESPAWN_CHARACTER_CREATION_SPEC.md`. The per-phase breakdown
+> is retained below as the historical implementation plan.
 
 ### Phase 1: Minimal Form (COMPLETE)
 


### PR DESCRIPTION
Six small doc-accuracy fixes surfaced by reading every spec end-to-end (the verification pass after the audit #552 / renames #553 / reorg #554). No structure changes — every classification held; these are just stale-text corrections.

- **`CLOTHING`** — resolve the internal `$pron()` contradiction (the doc both claimed and denied using it). Reality is the grammar engine's `{their}`/`{they}` brace tokens. Fixed the Core-Principles claim, doc-status line, prototype example strings, and the method-section "uses `$pron()`" mentions; kept the "`$pron()` doesn't work in prototypes" notes.
- **`FORUM`** — the four "Consolidated Specs" it referenced don't exist; that content lives in `DISCOURSE_INTEGRATION.md`. Point there.
- **`DISCOURSE`** — color palette was stale (blue accent) → aligned to the live jade-green scheme in `STYLING_SPEC`.
- **`WEBCLIENT`** — header said "Draft – Awaiting Review" but the plugin ships in `gel.js`; marked implemented.
- **`HEALTH`** — Phase 3.2 armor said "PLANNED" but armor shipped under `MODULAR_ARMOR`; marked shipped/superseded.
- **`WEB_CHAR`** — said web respawn was "future" but it's deployed (`WEB_RESPAWN`); corrected.

(The seventh finding — that chargen allocates a 300-point GRIM distribution, so only NPCs default to stat `1` — was a correction to working notes, not a spec error, so it's not in this PR.)

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)