### PR TITLE
Show deployed cyber weapons in the look held line (#516 follow-up)

### DIFF
--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -665,28 +665,27 @@ class AppearanceMixin:
         # here made this section permanently render "holding
         # nothing" (issue #460).
         hands = self.hands or {}
-        # Integrated cyberware (#516) is excluded from the held list:
-        # a deployed arm-gun is part of the body, represented in the
-        # longdesc and dominating the sdesc — not "held".
+        # Normal held items: integrated cyberware (#516) is excluded —
+        # a deployed arm-gun isn't "held", it IS the limb, and renders
+        # on its own line below.
         wielded_items = [
             item for item in hands.values()
             if item is not None and not getattr(item.db, "integrated", False)
         ]
-        # Whether a deployed cyber weapon (integrated in a slot OR an
-        # active natural weapon like claws) is present — used to
-        # suppress the misleading "holding nothing" line, since the
-        # sdesc shows them armed.
-        has_deployed_chrome = any(
-            getattr(item.db, "integrated", False) for item in hands.values()
-            if item is not None
-        )
-        if not has_deployed_chrome:
-            try:
-                from world.medical.augments import get_active_natural_weapon
-                has_deployed_chrome = get_active_natural_weapon(self) is not None
-            except Exception:
-                pass
-
+        # Deployed integrated weapons, paired with the hand they have
+        # become.  These read as the body for onlookers ("Chrome's
+        # shotgun module is their right hand"), the third-person mirror
+        # of the first-person ``inv`` frame ("... is your right hand").
+        integrated_weapons = [
+            (hand, item) for hand, item in hands.items()
+            if item is not None and getattr(item.db, "integrated", False)
+        ]
+        # A natural weapon (claws/jaws) lives off-grid — never in a hand
+        # slot — so it never surfaces in this section.  Its visibility is
+        # handled by the sdesc and (later) the cyberware status/extend
+        # commands.  Crucially, it does NOT suppress "holding nothing":
+        # claws aren't *held*, so empty hands genuinely hold nothing even
+        # while the claws are out (the sdesc still shows them armed).
         if wielded_items:
             wielded_names = [obj.get_display_name(looker) for obj in wielded_items]
             if len(wielded_names) == 1:
@@ -708,10 +707,17 @@ class AppearanceMixin:
                     f"{wielded_with_articles[-1]}."
                 )
             parts.append(wielded_text)
-        elif not has_deployed_chrome:
-            # Show explicitly when hands are empty — but not when a
-            # deployed cyber weapon fills them (the sdesc already
-            # shows them armed; "holding nothing" would contradict).
+
+        if integrated_weapons:
+            parts.append(
+                self._format_integrated_weapon_line(integrated_weapons, looker)
+            )
+
+        # Show "holding nothing" whenever the hands themselves are empty.
+        # An integrated weapon HAS become a hand (line above), so it
+        # suppresses this; a natural weapon (claws/jaws) has not, so the
+        # hands still read empty even while it is deployed.
+        if not wielded_items and not integrated_weapons:
             parts.append(f"{self.get_display_name(looker)} is holding nothing.")
 
         # 4. Staff-only comprehensive inventory (with explicit admin messaging)
@@ -729,6 +735,45 @@ class AppearanceMixin:
 
         # Join all parts with appropriate spacing (blank lines between sections)
         return '\n\n'.join(parts)
+
+    def _format_integrated_weapon_line(self, integrated_weapons, looker):
+        """Render deployed integrated cyber weapons as the limbs they
+        have become — the third-person mirror of the ``inv`` "... is
+        your right hand" frame (#516 follow-up).  Multiple deployed
+        weapons join into one sentence, like the held-items list::
+
+            "Chrome's shotgun module is their right hand."
+            "Chrome's shotgun module is their right hand and their
+             plasma cutter is their left hand."
+
+        Args:
+            integrated_weapons: list of ``(hand_key, item)`` pairs.
+            looker (Character): who is looking.
+        """
+        gender_mapping = {
+            'male': 'male', 'female': 'female',
+            'neutral': 'plural', 'nonbinary': 'plural', 'other': 'plural',
+        }
+        character_gender = gender_mapping.get(self.gender, 'plural')
+        possessive = self._get_pronoun('possessive', character_gender)
+        name_possessive = f"{self.get_display_name(looker)}'s"
+
+        clauses = []
+        for index, (hand, item) in enumerate(integrated_weapons):
+            # First clause names the character; later clauses use the
+            # pronoun ("Chrome's shotgun ... and their cutter ...").
+            owner = name_possessive if index == 0 else possessive
+            weapon = item.get_display_name(looker)
+            hand_label = hand.replace("_", " ")
+            clauses.append(f"{owner} {weapon} is {possessive} {hand_label}")
+
+        if len(clauses) == 1:
+            sentence = clauses[0]
+        elif len(clauses) == 2:
+            sentence = f"{clauses[0]} and {clauses[1]}"
+        else:
+            sentence = f"{', '.join(clauses[:-1])}, and {clauses[-1]}"
+        return f"{sentence}."
 
     def _location_is_inorganic(self, location):
         """True when ``location`` is cybernetic chrome (#516 review).

--- a/world/tests/test_augment_abilities.py
+++ b/world/tests/test_augment_abilities.py
@@ -408,10 +408,41 @@ class TestDeployedWeaponDisplay(EvenniaTest):
         self.assertNotIn("holding a shotgun module", appearance)
         self.assertNotIn("holding nothing", appearance)
 
+    def test_look_shows_integrated_as_hand(self):
+        """An onlooker sees the deployed weapon AS the hand — the
+        third-person mirror of the ``inv`` "is your right hand" line."""
+        toggle_ability(self.char, "shotgun")
+        looker = create_object(Character, key="Witness", location=self.room1)
+        appearance = self.char.return_appearance(looker).lower()
+        self.assertIn("shotgun module is", appearance)
+        self.assertIn("right hand", appearance)
+
     def test_integrated_dominates_sdesc(self):
         toggle_ability(self.char, "shotgun")
         feature = self.char.get_distinguishing_feature()
         self.assertIn("shotgun module", feature)
+
+    def test_natural_weapon_leaves_hands_empty(self):
+        """Claws live off-grid: they don't fill a hand, so empty hands
+        still read "holding nothing" while the claws are out (the sdesc
+        carries the armed signal)."""
+        claws_organ = Organ("left_metacarpals", organ_data={
+            "container": "left_hand", "max_hp": 15,
+            "abilities": {"nailz": {
+                "type": "natural_weapon", "weapon_prototype": "NAILZ_CLAWS",
+            }},
+        })
+        claws_organ.medical_state = self.char.medical_state
+        self.char.medical_state.organs["left_metacarpals"] = claws_organ
+        claws = create_object(
+            "typeclasses.items.Item", key="monofilament claws", location=None,
+        )
+        claws.db.integrated = True
+        claws_organ.ability_state = {"nailz": {"weapon_dbref": claws.dbref}}
+        toggle_ability(self.char, "nailz")
+        looker = create_object(Character, key="Witness", location=self.room1)
+        appearance = self.char.return_appearance(looker).lower()
+        self.assertIn("holding nothing", appearance)
 
     def test_natural_weapon_dominates_sdesc(self):
         claws_organ = Organ("left_metacarpals", organ_data={


### PR DESCRIPTION
## What

When an onlooker `look`s at someone with a **deployed integrated cyber weapon** (e.g. the shotgun arm), they now see it as the limb it has become — the third-person mirror of the `inv` line *"... is your right hand"*:

> Chrome's shotgun module is their right hand.

Multiple deployed weapons join into one sentence, like the held-items list:

> Chrome's shotgun module is their right hand and their plasma cutter is their left hand.

## Why

Previously the held line went **silent** for deployed weapons: the integrated weapon was excluded from the "is holding..." list (#535) and "holding nothing" was suppressed, so an onlooker saw nothing where held items normally display.

## Natural weapons (claws / jaws)

Nailz/Jawz are `natural_weapon` mounts that live off-grid and never fill a hand slot, so:
- they are **not** listed in this held line, and
- they **no longer suppress** "holding nothing" — empty hands genuinely hold nothing while claws are out. The sdesc still carries the armed signal; full status surfacing lands later with the cyberware extend/retract commands.

## Tests
- `test_look_shows_integrated_as_hand` — integrated weapon renders the "is their right hand" line.
- `test_natural_weapon_leaves_hands_empty` — claws out + empty hands still reads "holding nothing".
- Existing `test_look_excludes_integrated_from_held` still holds (no "holding a shotgun module", no "holding nothing" when integrated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)