### PR TITLE
Fix operate-menu install for surface organs (jaw/eyes/ears/nose/tongue)

### DIFF
--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -763,18 +763,32 @@ def _resolve_install(actor, target, *, organ_item, location: str,
                          "organ_name", None) or organ_item.key
     slot = snapshot_organs.get(organ_name)
     if slot is not None and hasattr(slot, "get"):
-        slot_display = slot.get("display_location") or location
-        if slot_display == location and not has_incision(target, location):
+        # Surface-accessibility is a property of the ORGAN (its
+        # container vs display_location), NOT of whatever ``location``
+        # the caller happened to pass.  Mirrors ``_incision_required``:
+        # an organ whose display_location differs from its container
+        # (jaw/eyes/ears/nose/tongue — all surface at "face" etc.) sits
+        # on the outside and installs without a cavity incision; one
+        # whose display falls back to its container lives inside and
+        # needs it opened.  The incisable unit is always the CONTAINER —
+        # the operate menu only ever opens containers, never display
+        # surfaces.  (Bug fixed: the install picker passes the jaw's
+        # display_location "face" as the location, so the old
+        # ``slot_display == location`` test demanded a "face" incision
+        # that the menu can't make — install dead-ended.)
+        container = slot.get("container") or location
+        slot_display = slot.get("display_location") or container
+        if slot_display == container and not has_incision(target, container):
             actor.msg(
                 f"You try to slot the {organ_item.key} in but "
                 f"{target.get_display_name(actor)}'s "
-                f"{location.replace('_', ' ')} isn't open."
+                f"{container.replace('_', ' ')} isn't open."
             )
             from world.medical.charts import mark_running_step_failed
             mark_running_step_failed(
                 target,
                 outcome=(
-                    f"no incision at {location.replace('_', ' ')} — "
+                    f"no incision at {container.replace('_', ' ')} — "
                     f"install blocked"
                 ),
             )

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -858,6 +858,21 @@ class TestCyberJawHardpoint(TestCase):
         # No ability yet — the hardpoint is empty.
         self.assertFalse(jaw.data.get("abilities"))
 
+    def test_cyber_jaw_installs_at_face_display_location(self):
+        """Regression (operate-menu bug): the install picker passes the
+        jaw's *display_location* ("face"), not its container ("head"),
+        as the procedure location.  Surface-accessibility must be judged
+        from the organ itself, so installing at "face" needs NO incision
+        — the old gate wrongly demanded a face incision the menu can't
+        open, dead-ending the install."""
+        target = _patient()
+        self._install_jaw(target, self._cyber_jaw_item(), location="face")
+
+        jaw = target.medical_state.organs["jaw"]
+        self.assertTrue(jaw.data.get("inorganic"))
+        self.assertTrue(jaw.data.get("prosthetic_frame"))
+        self.assertEqual(jaw.data.get("hardpoint"), "jaw")
+
     def test_jawz_seats_into_cyber_jaw_hardpoint(self):
         """The module: with a cyber jaw in place, Jawz seats into the
         jaw hardpoint, adding the bite while keeping talk/eat."""


### PR DESCRIPTION
## The bug

Installing a **cybernetic jaw** through the **operate menu** dead-ends: it offers the install at *"face"*, then refuses because *"the face isn't open"* — but the menu's incise picker only ever opens **containers** (head/chest/…), never display surfaces like "face", so the required incision can never be made.

## Root cause

The install picker (`_list_install_locations`, biological path) returns a surface organ's **`display_location`** ("face") as the install slot, not its **`container`** ("head"). `_resolve_install`'s incision gate then compared the slot's `display_location` to that passed location — when they matched (`"face" == "face"`), it demanded an incision at "face".

The raw `install <organ> in <patient>` command was unaffected because it passes the **container** (`"head"`), so the gate correctly skipped the incision (surface-accessible). That's also why tests stayed green — they drove `_resolve_install` with `location="head"`, never the menu's display-location path.

## Fix

Judge surface-accessibility from the **organ itself** (container vs `display_location`, mirroring `_incision_required`) and check the incision at the **container**, independent of whatever `location` the caller passed:

- Surface organs (display ≠ container — jaw, eyes, ears, nose, tongue) install with **no** cavity incision.
- Internal organs still require their container opened.

One change fixes the whole surface-organ family on **both** the menu and command paths.

## Tests

- New regression `test_cyber_jaw_installs_at_face_display_location` — installs the cyber jaw at the display location `"face"` (the menu path) and asserts success with no incision. Fails before the fix, passes after.
- `test_anatomy_augments` + `test_surgical_procedures`: 130 OK (internal-organ installs still require incision).
- Full `world` suite: **2,538 OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)