### PR TITLE
Anonymize decapitated corpses via severed_locations, not just head_severed

### DIFF
--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -172,12 +172,37 @@ class Corpse(IdentityBearerMixin, Item):
         species = self.db.species or "human"
         return get_species_corpse_name(species, stage)
 
+    def _is_headless(self):
+        """True when this corpse has lost its head — the dominant
+        unaided-recognition cue (PR #208).
+
+        Derived from the DURABLE severance record
+        (``'head' in severed_locations``) in addition to the legacy
+        ``head_severed`` boolean.  The two are set by different paths and
+        can drift apart: the living-decapitation propagation in
+        :meth:`death_progression.DeathProgressionScript._create_corpse_from_character`
+        only flips ``head_severed`` when the transient
+        ``decapitation_pending`` handshake survives to corpse-build time.
+        A reload mid-progression (or an NPC corpse path that skips that
+        block) strands ``head_severed=False`` while ``severed_locations``
+        still records the head came off — the live bug where a
+        decapitated rat carcass kept rendering its name (#2696:
+        ``severed_locations=['head']`` but ``head_severed=False``).
+        Reading ``severed_locations`` here makes anonymisation robust to
+        that drift and self-heals already-stranded corpses on deploy.
+        """
+        if self.db.head_severed:
+            return True
+        return "head" in (self.db.severed_locations or ())
+
     def get_display_name(self, looker, **kwargs):
         """Decay-stage fallback when the head has been severed.
 
         PR #208: a headless corpse loses the face — the dominant
-        unaided-recognition cue.  When ``self.db.head_severed`` is
-        ``True`` we short-circuit to the bare decay-stage name,
+        unaided-recognition cue.  When the corpse is headless (see
+        :meth:`_is_headless` — ``head_severed`` OR the head recorded in
+        ``severed_locations``) we short-circuit to the bare decay-stage
+        name,
         suppressing both natural recognition (Pass 1 in the mixin —
         live degraded-UID lookup) and the forensic-recovery Intellect
         roll (Pass 2).  Investigators must use the explicit
@@ -198,7 +223,7 @@ class Corpse(IdentityBearerMixin, Item):
         :class:`world.tests.test_corpse_decay_recognition._FakeDecayCorpse`)
         still resolve the recognition pipeline correctly.
         """
-        if self.db.head_severed:
+        if self._is_headless():
             return self._decay_display_name()
         return IdentityBearerMixin.get_display_name(self, looker, **kwargs)
 

--- a/world/tests/test_corpse_decay_recognition.py
+++ b/world/tests/test_corpse_decay_recognition.py
@@ -66,6 +66,7 @@ class _FakeDecayCorpse:
 
     # Bind production methods so tests exercise the real implementation.
     get_display_name = Corpse.get_display_name
+    _is_headless = Corpse._is_headless
     _attempt_forensic_recognition = Corpse._attempt_forensic_recognition
     _FORENSIC_RECOGNITION_DC = Corpse._FORENSIC_RECOGNITION_DC
 
@@ -93,6 +94,10 @@ class _FakeDecayCorpse:
         # PR #208: default to head-intact; tests that exercise the
         # head-severed look-suppression flip this to True.
         self.db.head_severed = False
+        # Durable severance record — the corpse-build bug strands
+        # ``head_severed`` False while this still records the head came
+        # off, so ``_is_headless`` also reads here.
+        self.db.severed_locations = []
         self.contents = list(contents or [])
         self.ndb = type("_NDB", (), {})()
         self._stage = stage
@@ -514,6 +519,25 @@ class TestHeadSeveredSuppression(TestCase):
     def test_headless_blocks_natural_recognition_fresh(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="fresh")
         corpse.db.head_severed = True
+        fresh_uid = get_apparent_uid(corpse)
+        observer = _FakeObserver(
+            memory={fresh_uid: {"assigned_name": "Jorge"}},
+        )
+        self.assertEqual(
+            corpse.get_display_name(observer), "human corpse",
+        )
+
+    def test_severed_locations_head_anonymizes_without_flag(self):
+        """Regression (live carcass #2696): the corpse-build handshake
+        can strand ``head_severed=False`` while ``severed_locations``
+        still records the head came off (the living-decapitation
+        propagation skipped by a reload mid-progression / an NPC corpse
+        path).  ``_is_headless`` reads the durable list too, so such a
+        corpse still anonymises — and shipping it self-heals the
+        already-stranded corpses on deploy."""
+        corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="fresh")
+        corpse.db.head_severed = False
+        corpse.db.severed_locations = ["head"]
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},


### PR DESCRIPTION
## The bug

A decapitated corpse is supposed to lose its name (PR #208), but the rat carcass **"Scooby Doo" kept rendering its identity** after decapitation.

Live read-only inspection of the running server found the carcass (`#2696`) with:
- `severed_locations = ['head']` — the corpse knows the head came off
- `head_severed = False` — but the boolean that gates identity suppression was never flipped

`Corpse.get_display_name` checks *only* `head_severed` (corpse.py:201), so it sailed past anonymization. A correctly-anonymized decap (`#2489`) had **both** set.

## Root cause

`head_severed` and `severed_locations` are set by different paths, and only one is durable:
- `severed_locations` rides the death snapshot — robust.
- `head_severed` is set by either a post-mortem head sever (`apply_sever_to_corpse`) **or** the living-decapitation propagation in `_create_corpse_from_character`, which is **gated on the transient `decapitation_pending` handshake** surviving to corpse-build time (death_progression.py:721). A reload mid-progression — or an NPC corpse path that skips that block — strands `head_severed=False` while the head is clearly off.

## Fix

`get_display_name` now derives "headless" from a new `_is_headless` helper: `head_severed` **OR** `'head' in severed_locations`. This:
- makes anonymization robust to the drift, and
- **self-heals already-stranded corpses** (like `#2696`) the instant it ships — no data migration.

## Tests

- New regression `test_severed_locations_head_anonymizes_without_flag` reproduces `#2696` exactly (`severed_locations=['head']`, `head_severed=False` → still anonymizes).
- Corpse/decap recognition suites: 110 OK.
- Full `world` suite: **2,539 OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)