### PR TITLE
Derive corpse headlessness from anatomy, not the head_severed flag

### DIFF
--- a/typeclasses/corpse.py
+++ b/typeclasses/corpse.py
@@ -176,33 +176,37 @@ class Corpse(IdentityBearerMixin, Item):
         """True when this corpse has lost its head — the dominant
         unaided-recognition cue (PR #208).
 
-        Derived from the DURABLE severance record
-        (``'head' in severed_locations``) in addition to the legacy
-        ``head_severed`` boolean.  The two are set by different paths and
-        can drift apart: the living-decapitation propagation in
-        :meth:`death_progression.DeathProgressionScript._create_corpse_from_character`
-        only flips ``head_severed`` when the transient
-        ``decapitation_pending`` handshake survives to corpse-build time.
-        A reload mid-progression (or an NPC corpse path that skips that
-        block) strands ``head_severed=False`` while ``severed_locations``
-        still records the head came off — the live bug where a
-        decapitated rat carcass kept rendering its name (#2696:
-        ``severed_locations=['head']`` but ``head_severed=False``).
-        Reading ``severed_locations`` here makes anonymisation robust to
-        that drift and self-heals already-stranded corpses on deploy.
+        Derived from the corpse's ACTUAL ANATOMY, not a stored flag.
+        ``head_severed`` and ``severed_locations`` are written by the
+        living-decapitation propagation in
+        :meth:`death_progression.DeathProgressionScript._create_corpse_from_character`,
+        which is gated on the transient ``decapitation_pending``
+        handshake surviving to corpse-build time — a reload mid-
+        progression or an NPC corpse path leaves them unset even though
+        the head is plainly gone.  Live carcasses #2696 and #2497 were
+        stranded two different ways (one with ``severed_locations=['head']``
+        + ``head_severed=False``, the other with both empty), which is
+        why reading those flags is a band-aid.
+
+        :func:`world.medical.severance.compute_severed_containers` reads
+        the AUTHORITATIVE record instead — severed organ tombstones on a
+        living body, ``wounds_at_death`` stumps on a corpse — both
+        populated by the *ungated* wound / medical-snapshot path at
+        death, never the ``decapitation_pending`` handshake.  So
+        headlessness cannot desync from the anatomy, and every
+        already-stranded corpse self-heals the moment it is looked at.
         """
-        if self.db.head_severed:
-            return True
-        return "head" in (self.db.severed_locations or ())
+        from world.medical.severance import compute_severed_containers
+        return "head" in compute_severed_containers(self)
 
     def get_display_name(self, looker, **kwargs):
         """Decay-stage fallback when the head has been severed.
 
         PR #208: a headless corpse loses the face — the dominant
         unaided-recognition cue.  When the corpse is headless (see
-        :meth:`_is_headless` — ``head_severed`` OR the head recorded in
-        ``severed_locations``) we short-circuit to the bare decay-stage
-        name,
+        :meth:`_is_headless`, which derives from the corpse's actual
+        severance record rather than a stored flag) we short-circuit to
+        the bare decay-stage name,
         suppressing both natural recognition (Pass 1 in the mixin —
         live degraded-UID lookup) and the forensic-recovery Intellect
         roll (Pass 2).  Investigators must use the explicit

--- a/world/tests/test_corpse_decay_recognition.py
+++ b/world/tests/test_corpse_decay_recognition.py
@@ -91,13 +91,17 @@ class _FakeDecayCorpse:
         self.db.apparent_uid_at_death = None
         self.db.signature_at_death = None
         self.db.forensic_recognition_cache = None
-        # PR #208: default to head-intact; tests that exercise the
-        # head-severed look-suppression flip this to True.
+        # PR #208: head-intact by default.  ``_is_headless`` derives
+        # headlessness from the AUTHORITATIVE severance record, so the
+        # head-suppression tests give the corpse an actual severed-head
+        # stump in ``wounds_at_death`` (what ``compute_severed_containers``
+        # reads for a corpse) rather than flipping a flag.  The legacy
+        # ``head_severed`` / ``severed_locations`` fields are kept as
+        # head-intact defaults purely so other surfaces that still read
+        # them on a fake don't trip.
         self.db.head_severed = False
-        # Durable severance record — the corpse-build bug strands
-        # ``head_severed`` False while this still records the head came
-        # off, so ``_is_headless`` also reads here.
         self.db.severed_locations = []
+        self.db.wounds_at_death = []
         self.contents = list(contents or [])
         self.ndb = type("_NDB", (), {})()
         self._stage = stage
@@ -518,7 +522,7 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_blocks_natural_recognition_fresh(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="fresh")
-        corpse.db.head_severed = True
+        corpse.db.wounds_at_death = [{"injury_type": "severed", "location": "head"}]
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -527,17 +531,22 @@ class TestHeadSeveredSuppression(TestCase):
             corpse.get_display_name(observer), "human corpse",
         )
 
-    def test_severed_locations_head_anonymizes_without_flag(self):
-        """Regression (live carcass #2696): the corpse-build handshake
-        can strand ``head_severed=False`` while ``severed_locations``
-        still records the head came off (the living-decapitation
-        propagation skipped by a reload mid-progression / an NPC corpse
-        path).  ``_is_headless`` reads the durable list too, so such a
-        corpse still anonymises — and shipping it self-heals the
-        already-stranded corpses on deploy."""
+    def test_severed_head_wound_anonymizes_despite_stale_flags(self):
+        """Regression (live carcasses #2696 + #2497): the corpse-build
+        ``decapitation_pending`` handshake can strand BOTH ``head_severed``
+        and ``severed_locations`` unset even though the head is gone (a
+        reload mid death-progression, or an NPC corpse path that skips
+        that block).  Headlessness must derive from the AUTHORITATIVE
+        record — the severed-head stump in ``wounds_at_death`` — so the
+        corpse still anonymises with both legacy flags stale, and every
+        already-stranded corpse self-heals on the next look."""
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="fresh")
+        # The exact stranded shape from live carcass #2497.
         corpse.db.head_severed = False
-        corpse.db.severed_locations = ["head"]
+        corpse.db.severed_locations = []
+        corpse.db.wounds_at_death = [
+            {"injury_type": "severed", "location": "head"},
+        ]
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -548,7 +557,7 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_blocks_natural_recognition_early(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="early")
-        corpse.db.head_severed = True
+        corpse.db.wounds_at_death = [{"injury_type": "severed", "location": "head"}]
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -559,7 +568,7 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_blocks_forensic_recovery_at_moderate(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
-        corpse.db.head_severed = True
+        corpse.db.wounds_at_death = [{"injury_type": "severed", "location": "head"}]
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -576,7 +585,7 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_blocks_forensic_recovery_at_advanced(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="advanced")
-        corpse.db.head_severed = True
+        corpse.db.wounds_at_death = [{"injury_type": "severed", "location": "head"}]
         fresh_uid = get_apparent_uid(corpse)
         observer = _FakeObserver(
             memory={fresh_uid: {"assigned_name": "Jorge"}},
@@ -603,14 +612,14 @@ class TestHeadSeveredSuppression(TestCase):
 
     def test_headless_none_looker_still_returns_decay_name(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="moderate")
-        corpse.db.head_severed = True
+        corpse.db.wounds_at_death = [{"injury_type": "severed", "location": "head"}]
         self.assertEqual(
             corpse.get_display_name(None), "rotting corpse",
         )
 
     def test_headless_skeletal_still_returns_decay_name(self):
         corpse = _FakeDecayCorpse(sleeve_uid="uid-jorge", stage="skeletal")
-        corpse.db.head_severed = True
+        corpse.db.wounds_at_death = [{"injury_type": "severed", "location": "head"}]
         self.assertEqual(
             corpse.get_display_name(None), "skeletal remains",
         )


### PR DESCRIPTION
## Why (follow-up to #558)

#558 was a band-aid. It read `head_severed` **OR** `'head' in severed_locations` — but **both** are written only by the living-decapitation propagation in `_create_corpse_from_character`, gated on the transient `decapitation_pending` handshake surviving to corpse-build time. A reload mid death-progression (or an NPC corpse path that skips that block) strands them.

Live inspection found **two** stranded carcasses drifted *different* ways:
- `#2696` — `severed_locations=['head']`, `head_severed=False`
- `#2497` — **both** empty

#558 only caught `#2696`. `#2497` was still rendering as decapitated-but-named.

## The fix

The authoritative, **ungated** record is the severance state itself: severed organ tombstones on a living body, `wounds_at_death` stumps on a corpse — both populated by the normal wound/medical-snapshot path at death, never the handshake.

`Corpse._is_headless` now derives from `compute_severed_containers` (`'head' in` the severed set). Headlessness can't desync from the anatomy, and **every already-stranded corpse self-heals on the next look** — verified live: both `#2696` and `#2497` carry a severed-head stump in `wounds_at_death`.

`_is_headless` is the **only** runtime reader of `db.head_severed` anywhere (confirmed by grep), so the writers are left intact but the flag is no longer load-bearing for display.

## Tests

- Suppression tests now drive the authoritative record (severed-head stump in `wounds_at_death`) instead of flipping a flag.
- Regression test reproduces the harder `#2497` shape (both legacy flags stale → still anonymizes).
- Full `world` suite: **2,539 OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)