### PR TITLE
Severed flesh limbs decay over time (lift the clock to Appendage)

### DIFF
--- a/specs/IDENTITY_RECOGNITION_SPEC.md
+++ b/specs/IDENTITY_RECOGNITION_SPEC.md
@@ -2002,7 +2002,9 @@ forensic-chain fields as `Organ` (`source_signature`,
 
 The display key is rendered via
 `get_species_part_name(species, location, decay_stage)` at spawn
-time by `configure_from_sever` (PR #202 / PR-G).  Fresh / early
+time by `configure_from_sever` (PR #202 / PR-G) and **then advances
+with decay** — see "Severed-Part Decay & Preservation" below; the
+key is no longer frozen at the sever-moment tier.  Fresh / early
 decay produces `"{species} {location}"` (e.g. `human left arm`);
 moderate / advanced drops to `"rotting {location}"`; the skeletal
 tier reads `"skeletal {location}"` — limbs *can* skeletonize, so
@@ -2012,6 +2014,71 @@ tissue dries rather than skeletonizes — see issue #212).  The
 freshness `condition` (`pristine` / `damaged` / `putrid`) is
 conveyed via `db.desc` (PR #204) and surfaces at `look` time, not
 in the key.
+
+### Severed-Part Decay & Preservation
+
+A severed part keeps decaying after it leaves the body. The model has
+three categories, only one of which is fully built today.
+
+#### Flesh limbs — free-running decay ✅ (Shipped)
+
+`Appendage` carries the same decay clock as `Corpse` / `SeveredHead`
+(the clock was lifted *down* from `SeveredHead` to the `Appendage` base
+so every severed part shares it):
+
+| Field / method | Behavior |
+|---|---|
+| `db.creation_time` | Corpse-sever copies `corpse.db.creation_time` (the limb ages with its source corpse); living-sever stamps `time.time()` (cut fresh, decays from now). |
+| `_DECAY_STAGES` | `fresh(<1h) → early(<1d) → moderate(<3d) → advanced(<1wk) → skeletal`. Identical ladder to the corpse. |
+| `get_decay_stage()` | Live tier from `creation_time`. |
+| `_refresh_decay_key_if_changed()` | Advances `self.key` to the current tier's species-aware name (`get_species_part_name` / compound `get_species_severed_chain_name`). |
+
+The key advances on the **same lifecycle hook the corpse uses** —
+`Room._check_corpse_decay`, fired on character entry — keeping `look` a
+pure read. Targeting survives the rename without alias churn because the
+**location words are invariant across tiers** (`human left arm` →
+`rotting left arm` → `skeletal left arm` all contain `left arm`), so
+substring matching still resolves.
+
+**Skeletal is terminal.** Bones persist on a scale we don't simulate, so
+there's no tier past skeletal. **Limb cleanup is deliberately deferred**
+(the room hook refreshes severed-part keys but, unlike corpses, does not
+`check_complete_decay()` them) — a fully-decayed flesh limb becomes a
+persistent bone.
+
+#### Cyberware limbs — frozen (preservation-gated, future)
+
+A severed *cybernetic* limb does **not** free-run decay:
+`_refresh_decay_key_if_changed()` skips any part for which
+`is_cybernetic_limb(self)` is true. Chrome doesn't rot. Its degradation
+instead rides the preservation model below — specialized tech that
+requires protection and, like a harvested organ, has a viability window.
+
+#### Organs + cyberware — viability via preservation (future, blocked)
+
+Harvested **organs and cyberware** behave identically for viability:
+they degrade only while **unprotected**, not on a free-running clock.
+This is blocked on a **refrigeration / cold-storage mechanic** that does
+not exist yet — without it there is no signal to discern protected from
+unprotected, and a naive rot-timer would make every harvested organ
+useless in minutes.
+
+Intended model when built:
+
+- A cold-storage container (or location) **pauses** the viability clock.
+- Implementation: **timestamp cold-storage entry and exit**, then accrue
+  the *unprotected* duration against the item; decay tier derives from
+  accumulated unprotected time rather than wall-clock age.
+- **Utilization viability** is the gate that consumes this: transplant
+  (organs), reinstall (cyberware), and limb **reattachment** all check
+  freshness. Reattaching a severed limb is *uncommon but sometimes
+  viable* — a fresh/early limb may graft; beyond that it has necrosed
+  and is refused. (For flesh limbs this gate is **future** — the shipped
+  flesh-limb decay above is cosmetic only; it does not yet block
+  reattachment.)
+
+This belongs to the medical substrate; see
+`HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md` for the organ/harvest detail.
 
 ### Harvest interaction
 

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -1151,6 +1151,82 @@ class Appendage(Item):
         # cluster.  Read by ``return_appearance`` (forensic prose)
         # and the third-party ``undress`` verb.
         self.db.worn_items = {}
+        # Decay clock — a severed limb keeps rotting after it leaves the
+        # body, exactly like the corpse and severed head.  ``creation_time``
+        # is set by the configure paths (corpse-sever copies the source
+        # corpse's clock so the limb ages with it; living-sever stamps
+        # "now").  Defaults to object-creation time so a bare Appendage
+        # spawned outside the configure paths still renders sanely.
+        # ``get_decay_stage`` reads this against ``_DECAY_STAGES``.
+        import time as _time
+        self.db.creation_time = _time.time()
+
+    # Decay tier thresholds, in seconds since ``creation_time`` — the
+    # same ladder the corpse and severed head use (CORPSE_DECAY_*).  A
+    # severed limb ages through these tiers after it leaves the body;
+    # ``skeletal`` is terminal (bones persist on a scale we don't
+    # simulate, and limb cleanup is deliberately deferred).
+    _DECAY_STAGES = (
+        ("fresh", 3600),
+        ("early", 86400),
+        ("moderate", 259200),
+        ("advanced", 604800),
+    )
+
+    def get_decay_stage(self):
+        """Return the current decay tier; mirrors Corpse / SeveredHead."""
+        import time
+        elapsed = time.time() - (self.db.creation_time or time.time())
+        for stage, threshold in self._DECAY_STAGES:
+            if elapsed < threshold:
+                return stage
+        return "skeletal"
+
+    def _current_decay_key(self):
+        """Compose the species-aware part name at the CURRENT decay tier.
+
+        Mirrors the naming in :meth:`configure_from_sever` — compound
+        chain name when the limb carries downstream parts (thigh+shin+
+        foot → "rotting left leg"), single-part name otherwise — but
+        read live against :meth:`get_decay_stage` so the key advances as
+        the limb rots.
+        """
+        from world.anatomy import (
+            get_species_part_name,
+            get_species_severed_chain_name,
+        )
+        species = self.db.source_species or "human"
+        location = self.db.location_name or ""
+        stage = self.get_decay_stage()
+        chain = self.db.chain or (location,)
+        if len(chain) > 1:
+            return get_species_severed_chain_name(species, location, stage)
+        return get_species_part_name(species, location, stage)
+
+    def _refresh_decay_key_if_changed(self):
+        """Advance ``self.key`` to the current decay tier's name.
+
+        Lifecycle hook, called from
+        :meth:`typeclasses.rooms.Room._check_corpse_decay` on character
+        entry (NOT from ``look`` — look stays pure), the same contract
+        the corpse uses (issue #230).  Targeting survives the change
+        without alias churn: the location words ("left arm") stay in the
+        key at every tier, so substring matching still resolves.
+
+        Skips CYBERNETIC limbs: chrome doesn't rot, so a severed cyber
+        limb keeps its frozen name.  Its degradation rides the future
+        preservation / refrigeration model (viability accrues only while
+        unprotected), not this free-running organic clock.
+        """
+        try:
+            from world.medical.procedures import is_cybernetic_limb
+            if is_cybernetic_limb(self):
+                return
+        except Exception:
+            pass
+        new_key = self._current_decay_key()
+        if new_key and new_key != self.key:
+            self.key = new_key
 
     def configure_from_sever(self, *, location_name, condition, corpse):
         """Populate forensic-chain fields immediately after spawn.
@@ -1208,6 +1284,15 @@ class Appendage(Item):
             decay_stage = corpse.get_decay_stage()
         else:
             decay_stage = "fresh"
+        # Decay clock: the limb ages with its source corpse — copy the
+        # corpse's ``creation_time`` so a limb cut off a moderate-decay
+        # corpse is itself moderate-decay (exactly like the severed
+        # head).  ``db.chain`` (set below) lets the lazy key-refresh
+        # re-derive the compound vs single name at later tiers.
+        import time as _time
+        self.db.creation_time = (
+            getattr(corpse.db, "creation_time", None) or _time.time()
+        )
         # Compound name when the chain has downstream parts (#339).
         if len(chain) > 1:
             self.key = get_species_severed_chain_name(
@@ -1306,6 +1391,11 @@ class Appendage(Item):
         self.db.location_name = location_name
         self.db.chain = chain  # Preserve for downstream consumers.
         self.db.condition = condition
+        # Decay clock: a limb cut from the living starts its rot now
+        # (no source corpse to inherit a clock from).  The lazy
+        # key-refresh advances the name from "fresh" through the tiers.
+        import time as _time
+        self.db.creation_time = _time.time()
         # No source corpse exists for a living sever.
         self.db.source_corpse_dbref = None
 
@@ -2765,17 +2855,9 @@ class SeveredHead(IdentityBearerMixin, Appendage):
     # ------------------------------------------------------------------
     # IdentityBearerMixin contract — decay surface
     # ------------------------------------------------------------------
-
-    # Decay tier thresholds, in seconds since ``creation_time``.  Same
-    # ladder the corpse uses (see ``world/combat/constants.py``
-    # ``CORPSE_DECAY_*``).  Copied locally so we don't need a Corpse
-    # instance to consult.
-    _DECAY_STAGES = (
-        ("fresh", 3600),
-        ("early", 86400),
-        ("moderate", 259200),
-        ("advanced", 604800),
-    )
+    # ``_DECAY_STAGES`` + ``get_decay_stage`` are inherited from
+    # :class:`Appendage` (the decay clock now lives on the base severed-
+    # part class so flesh limbs age too — issue: severed-limb decay).
 
     @property
     def sleeve_uid(self):
@@ -2794,15 +2876,6 @@ class SeveredHead(IdentityBearerMixin, Appendage):
         essential-items axis collapses to an empty tuple naturally.
         """
         return self.db.sleeve_uid
-
-    def get_decay_stage(self):
-        """Return the current decay tier; mirrors Corpse semantics."""
-        import time
-        elapsed = time.time() - (self.db.creation_time or time.time())
-        for stage, threshold in self._DECAY_STAGES:
-            if elapsed < threshold:
-                return stage
-        return "skeletal"
 
     def _decay_display_name(self):
         """Fallback display when no recognition memory matches.

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -118,7 +118,20 @@ class Room(ObjectParent, DefaultRoom):
                 # runs on room entry — a broken corpse must never block
                 # a character walking into the room.
                 pass
-    
+
+        # Severed-part decay: a severed limb keeps rotting after it
+        # leaves the body, so advance its key to the current tier on the
+        # same character-entry lifecycle the corpse uses.  Refresh-only —
+        # limb cleanup is deliberately deferred (no check_complete_decay).
+        # Catches SeveredHead too (an Appendage subclass); harmless, since
+        # its display is recognition-driven and the key stays consistent.
+        from typeclasses.items import Appendage
+        for part in [o for o in self.contents if isinstance(o, Appendage)]:
+            try:
+                part._refresh_decay_key_if_changed()
+            except Exception:
+                pass
+
     # Override the appearance template to use our custom footer for exits
     # and custom things display to handle @integrate objects
     # This avoids duplicate display issues with exits while letting Evennia handle characters

--- a/world/tests/test_severed_part_descriptions.py
+++ b/world/tests/test_severed_part_descriptions.py
@@ -209,3 +209,79 @@ class TestAppendageConfigureFromSeverPopulatesDesc(TestCase):
         )
         self.assertEqual(app.db.original_gender, "male")
         self.assertEqual(app.db.original_character_name, "Jdoe")
+
+
+class TestAppendageDecay(TestCase):
+    """Severed limbs decay after they leave the body — the decay clock
+    now lives on the ``Appendage`` base (lifted from ``SeveredHead``), so
+    flesh limbs advance through the tiers instead of staying frozen at
+    their sever-moment name.  Cyber limbs stay frozen: chrome doesn't
+    rot, and its degradation rides the future preservation model.
+    """
+
+    def _fake_limb(self, *, location_name="left_arm", chain=None,
+                   creation_time=None, species="human"):
+        import time
+        from typeclasses.items import Appendage
+
+        class _DB:
+            pass
+
+        limb = type("FakeLimb", (), {})()
+        limb.db = _DB()
+        limb.db.location_name = location_name
+        limb.db.chain = chain or [location_name]
+        limb.db.source_species = species
+        limb.db.creation_time = (
+            creation_time if creation_time is not None else time.time()
+        )
+        limb.key = ""
+        limb._DECAY_STAGES = Appendage._DECAY_STAGES
+        for name in ("get_decay_stage", "_current_decay_key",
+                     "_refresh_decay_key_if_changed"):
+            setattr(limb, name, getattr(Appendage, name).__get__(limb))
+        return limb
+
+    def test_stage_advances_with_age(self):
+        import time
+        limb = self._fake_limb(creation_time=time.time())
+        self.assertEqual(limb.get_decay_stage(), "fresh")
+        # Backdate the clock past the advanced threshold → terminal skeletal.
+        limb.db.creation_time = time.time() - 700000
+        self.assertEqual(limb.get_decay_stage(), "skeletal")
+
+    def test_refresh_advances_key_to_current_tier(self):
+        import time
+        limb = self._fake_limb(creation_time=time.time())
+        limb._refresh_decay_key_if_changed()
+        fresh_key = limb.key
+        self.assertIn("left arm", fresh_key.lower())
+        # Age to skeletal and refresh — the key advances, location words stay.
+        limb.db.creation_time = time.time() - 700000
+        limb._refresh_decay_key_if_changed()
+        self.assertNotEqual(limb.key, fresh_key)
+        self.assertIn("left arm", limb.key.lower())
+        self.assertIn("skeletal", limb.key.lower())
+
+    def test_compound_chain_decays_as_one_name(self):
+        import time
+        limb = self._fake_limb(
+            location_name="left_thigh",
+            chain=["left_thigh", "left_shin", "left_foot"],
+            creation_time=time.time() - 700000,
+        )
+        limb._refresh_decay_key_if_changed()
+        # Compound leg name, not the bare thigh.
+        self.assertIn("left leg", limb.key.lower())
+
+    def test_cyber_limb_does_not_decay(self):
+        import time
+        from unittest.mock import patch
+        limb = self._fake_limb(creation_time=time.time() - 700000)
+        limb.key = "cybernetic left arm"
+        with patch(
+            "world.medical.procedures.is_cybernetic_limb", return_value=True,
+        ):
+            limb._refresh_decay_key_if_changed()
+        # Chrome doesn't rot — frozen name preserved.
+        self.assertEqual(limb.key, "cybernetic left arm")


### PR DESCRIPTION
## Why

Severed limbs (arms/legs/hands/tail) were **frozen** at their sever-moment name forever — a limb hacked off a fresh corpse stayed "pristine left arm" a week later. Only the corpse and severed head decayed: the decay clock lived on `SeveredHead`, but the base `Appendage` never got it.

## Fix — lift the head's proven pattern down to the base class

`Appendage` now carries the decay clock (`creation_time` + `_DECAY_STAGES` + `get_decay_stage` + `_refresh_decay_key_if_changed`):

- **Both sever paths set the clock** — corpse-sever copies `corpse.creation_time` (the limb ages with its source corpse); living-sever stamps "now".
- **Key advances on the corpse's existing lifecycle hook** (`Room._check_corpse_decay`, on character entry) — `look` stays a pure read.
- **Targeting survives** the rename without alias churn: the location words are invariant across tiers (`human left arm` → `rotting left arm` → `skeletal left arm` all contain `left arm`).
- `SeveredHead` now **inherits** the clock (its duplicate `_DECAY_STAGES`/`get_decay_stage` removed).
- **Skeletal is terminal** and **limb cleanup is deferred** — the hook refreshes keys but doesn't `check_complete_decay()` limbs.

## Scope decisions (discussed)

- **Cyber limbs exempt** — `_refresh_decay_key_if_changed` skips `is_cybernetic_limb`. Chrome doesn't rot.
- **Organs + cyberware viability** = degrade only while *unprotected*; blocked on a future refrigeration mechanic (timestamp cold-storage entry/exit, accrue unprotected time). Reattach/transplant/reinstall viability rides that same future work — this PR's flesh-limb decay is **cosmetic only**.

## Spec

`IDENTITY_RECOGNITION_SPEC.md` → new **"Severed-Part Decay & Preservation"** section documents flesh-limb decay (shipped), the cyberware/organ preservation model (future, blocked), and the viability gate.

## Tests

- New `TestAppendageDecay` (4): stage advances with age, key advances to current tier, compound chain decays as one name, cyber limb stays frozen.
- Severed-part/head/corpse suites: 105 OK.
- Full `world` suite: **2,543 OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)