### PR TITLE
Nailz: bilateral + Molly Millions finger-blades

### DIFF
--- a/world/medical/procedures.py
+++ b/world/medical/procedures.py
@@ -1694,16 +1694,47 @@ def _resolve_install_module(actor, target, *, organ_item, location: str,
             )
             return
 
-        # Implant: merge the ability into the host organ's spec —
-        # deep-copied dict swap so the organ never shares storage
-        # with the soon-deleted item and the species table is never
-        # mutated.
-        host_data = dict(host.data)
-        merged = dict(host_data.get("abilities") or {})
-        merged.update(new_abilities)
-        host_data["abilities"] = merged
-        host_data["module_type"] = module_type
-        host.data = host_data
+        # Implant: seat the ability into the living host at EVERY listed
+        # flesh container, not just the install site.  Nailz is bilateral
+        # — five carbide blades per hand, both hands — so one tray claws
+        # both; lose a hand and the other keeps its blades.  Single-
+        # container modules (the common case) seat into their one host.
+        # Hosts already carrying the ability, or with no living organ,
+        # are skipped.  Deep-copied dict swaps so the organ never shares
+        # storage with the soon-deleted item and the species table is
+        # never mutated.
+        seated_locations = []
+        for container in flesh_containers:
+            if flesh_organ:
+                h = state.organs.get(flesh_organ)
+                if h is not None and h.current_hp <= 0:
+                    h = None
+            else:
+                h = next(
+                    (o for o in state.organs.values()
+                     if getattr(o, "container", None) == container
+                     and o.current_hp > 0),
+                    None,
+                )
+            if h is None:
+                continue
+            if any(name in (h.data.get("abilities") or {})
+                   for name in new_abilities):
+                continue
+            h_data = dict(h.data)
+            merged = dict(h_data.get("abilities") or {})
+            merged.update(new_abilities)
+            h_data["abilities"] = merged
+            h_data["module_type"] = module_type
+            h.data = h_data
+            seated_locations.append(container)
+
+        if len(seated_locations) > 1:
+            where = "both hands"
+        elif seated_locations:
+            where = seated_locations[0].replace("_", " ")
+        else:
+            where = location.replace("_", " ")
 
         seed_pain(target, location, CONSCIOUS_PAIN_SEVERITY["install"])
         if outcome == "partial":
@@ -1715,8 +1746,7 @@ def _resolve_install_module(actor, target, *, organ_item, location: str,
         else:
             actor.msg(
                 f"You implant the {organ_item.key} into "
-                f"{target.get_display_name(actor)}'s "
-                f"{location.replace('_', ' ')}."
+                f"{target.get_display_name(actor)}'s {where}."
             )
         save = getattr(target, "save_medical_state", None)
         if callable(save):
@@ -1726,7 +1756,7 @@ def _resolve_install_module(actor, target, *, organ_item, location: str,
                 location=actor.location,
                 template=(
                     f"{{actor}} implants a {organ_item.key} into "
-                    f"{{patient}}'s {location.replace('_', ' ')}."
+                    f"{{patient}}'s {where}."
                 ),
                 char_refs={"actor": actor, "patient": target},
                 exclude=[actor, target] if target is not actor else [actor],

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2118,12 +2118,12 @@ NAILZ = {
     "key": "Nailz",
     "typeclass": "typeclasses.items.Organ",
     "aliases": ["nailz", "claw implants", "nail implants"],
-    "desc": "A sealed clinical tray of ten curved carbide claws and their spring housings, each blade honed to a monofilament edge, sized for implantation along the fingers of one hand. The marketing name is etched on the tray lid in a typeface that has seen some court dates. Installation requires a surgeon; regret is sold separately.",
+    "desc": "A sealed clinical tray of ten slender carbide blades and their spring housings, each scalpel honed to a monofilament edge and sized to seat beneath a fingernail — five per hand, both hands. The marketing name is etched on the tray lid in a typeface that has seen some court dates. Installation requires a surgeon; regret is sold separately.",
     "tags": [("medical_item", "item_type"), ("augment", "item_type")],
     "attrs": [
         ("module_type", "nailz"),
         ("module_mount", "flesh"),
-        ("flesh_containers", ["{side}_hand"]),
+        ("flesh_containers", ["left_hand", "right_hand"]),
         ("condition", "pristine"),
         ("compatible_species", ["human"]),
         ("organ_spec", {
@@ -2132,11 +2132,11 @@ NAILZ = {
                 "nailz": {
                     "type": "natural_weapon",
                     "weapon_prototype": "NAILZ_CLAWS",
-                    "deploy_msg": "Your knuckles ache, then part — ten carbide claws slide out along your fingers with a sound like scissors closing.",
-                    "retract_msg": "The claws fold back under your skin; your hand is just a hand again, mostly.",
-                    "deployed_longdesc": "Ten carbide claws stand extended from the fingertips, monofilament edges catching the light.",
-                    "deploy_room": "{actor} flexes a hand and carbide claws slide out along their fingers, catching the light.",
-                    "retract_room": "{actor}'s claws fold away under the skin of their hand.",
+                    "deploy_msg": "Your nails lift and part — ten carbide blades slide out from beneath them, four centimetres of monofilament edge sheathing your fingertips with a sound like scissors closing.",
+                    "retract_msg": "The blades withdraw beneath your nails; your hands are just hands again, mostly.",
+                    "deployed_longdesc": "Slender carbide blades jut from beneath {their} fingernails, monofilament edges catching the light.",
+                    "deploy_room": "{actor}'s fingernails lift and carbide blades slide out from beneath them, catching the light.",
+                    "retract_room": "{actor}'s finger-blades withdraw beneath their nails.",
                 },
             },
         }),
@@ -2148,9 +2148,9 @@ NAILZ = {
 # precedence.  Reuses the tiger_claws message set.
 NAILZ_CLAWS = {
     "prototype_parent": "MELEE_WEAPON_BASE",
-    "key": "carbide claws",
-    "aliases": ["claws", "nailz claws", "carbide claws"],
-    "desc": "Ten curved carbide claws, extended from their knuckle housings, each honed to a monofilament edge. They are not for opening letters.",
+    "key": "carbide blades",
+    "aliases": ["blades", "nailz", "nailz blades", "finger-blades"],
+    "desc": "Ten slender carbide blades, extended from beneath the fingernails, each four centimetres of monofilament edge. They are not for opening letters.",
     "damage": 9,
     "locks": "get:false();drop:false();give:false()",
     "attrs": [

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -921,7 +921,7 @@ def _nailz_item():
     item.db = SimpleNamespace(
         module_type="nailz",
         module_mount="flesh",
-        flesh_containers=["{side}_hand"],
+        flesh_containers=["left_hand", "right_hand"],
         condition="pristine",
         organ_conditions=[],
         organ_spec={
@@ -1003,6 +1003,23 @@ class TestFleshMountModules(TestCase):
         self.assertIs(organ, host)
         self.assertEqual(spec["type"], "natural_weapon")
         self.assertTrue(item.deleted)
+
+    def test_nailz_is_bilateral(self):
+        """One Nailz tray claws BOTH hands (#565): five carbide blades
+        per hand, both hands.  A single install seats the ability into
+        every living host in ``flesh_containers``, not just the site —
+        so losing one hand leaves the other's blades intact."""
+        target = _patient()
+        open_incision(target, "left_hand")
+        item = _nailz_item()
+        actor = self._install(target, item)
+        for organ_name in ("left_metacarpals", "right_metacarpals"):
+            host = target.medical_state.organs[organ_name]
+            self.assertIn(
+                "nailz", host.data.get("abilities", {}),
+                f"{organ_name} should carry the blades",
+            )
+        self.assertTrue(any("both hands" in m for m in actor.messages))
         # The species table was never mutated: a second character's
         # metacarpals carry no claws.
         other = _patient()
@@ -1057,6 +1074,27 @@ class TestNailzMaterial(TestCase):
             self.assertNotIn("monofilament claw", desc)
         # The edge — not the body — is the monofilament part.
         self.assertIn("monofilament edge", prototypes.NAILZ["desc"].lower())
+
+    def test_nailz_is_molly_not_wolverine(self):
+        """#565: blades seat beneath the fingernails (Molly Millions),
+        not from knuckle housings (wolverine).  Pins the flavor."""
+        from world import prototypes
+
+        weapon_desc = prototypes.NAILZ_CLAWS["desc"].lower()
+        self.assertIn("beneath the fingernails", weapon_desc)
+        self.assertNotIn("knuckle", weapon_desc)
+        deploy = prototypes.NAILZ["attrs"]
+        spec = dict(deploy)["organ_spec"]
+        deploy_msg = spec["abilities"]["nailz"]["deploy_msg"].lower()
+        self.assertNotIn("knuckle", deploy_msg)
+
+    def test_nailz_prototype_is_bilateral(self):
+        """#565: one tray claws both hands — flesh_containers names
+        both, so a single install seats blades in each."""
+        from world import prototypes
+
+        containers = dict(prototypes.NAILZ["attrs"])["flesh_containers"]
+        self.assertEqual(set(containers), {"left_hand", "right_hand"})
 
 
 CYBER_HEART_SPEC = {


### PR DESCRIPTION
Closes #565.

## 1. Both hands
`flesh_containers` was `["{side}_hand"]` — one hand. Now `["left_hand", "right_hand"]`, and the flesh-mount install seats the ability into the living host at **every** listed container, not just the install site. One tray = ten blades = five per hand, both hands; lose a hand and the other keeps its blades. Single-container flesh modules are unaffected.

## 2. Molly Millions, not Wolverine
Reworded `NAILZ` / `NAILZ_CLAWS` prose: carbide scalpel-blades that slide out from **beneath the fingernails**, not claws from knuckle housings. The `tiger_claws` combat message bank was already blade-flavored ("metal tips where your fingers end") and is left as-is.

## Tests
- `test_nailz_is_bilateral` — both metacarpals carry the ability + "both hands" message.
- `test_nailz_is_molly_not_wolverine` — fingernails, not knuckles.
- `test_nailz_prototype_is_bilateral`.
- Full `world` suite: **2,546 OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)