### PR TITLE
/system: detect augments via is_augment_organ (fixes missing cybernetic tail)

### DIFF
--- a/world/medical/cyberware_status.py
+++ b/world/medical/cyberware_status.py
@@ -40,19 +40,42 @@ def _label_box(label: str) -> tuple[str, str, str]:
     return f"╔{'═' * _BOX_W}╗", f"║{text}║", f"╚{'═' * _BOX_W}╝"
 
 
-def _cyber_organs(character):
-    """Return ``(name, organ, data)`` for every cyber-relevant organ:
-    chrome (``inorganic`` / ``prosthetic_frame``) or any organ carrying
-    an ability (catches flesh-mount modules like Nailz)."""
+def _species_organs(character) -> dict:
+    """The character's species anatomy table — the baseline the augment
+    predicate measures against."""
+    from world.anatomy import get_species_organs
+
+    species = getattr(getattr(character, "db", None), "species", None) or "human"
+    try:
+        return get_species_organs(species) or {}
+    except Exception:
+        return {}
+
+
+def _cyber_organs(character, species_organs):
+    """Return ``(name, organ, data)`` for every FUNCTIONAL augment organ,
+    via the canonical :func:`world.medical.core.is_augment_organ`
+    predicate (the one ``@resetmedical`` preserves on).
+
+    Using that predicate — rather than a hand-rolled
+    ``inorganic``/``abilities`` check — is what lets the readout catch
+    augment-added limbs like the cybernetic tail: it's recognised by
+    being absent from the species table, so a stale install missing the
+    ``inorganic`` flag still shows (#569).  0-HP tombstones (severed /
+    destroyed) power nothing and are skipped, matching ``iter_abilities``.
+    """
+    from world.medical.core import is_augment_organ
+
     state = getattr(character, "medical_state", None)
     organs = getattr(state, "organs", None) if state else None
     out = []
     if not organs:
         return out
     for name, organ in organs.items():
-        data = getattr(organ, "data", None) or {}
-        if data.get("inorganic") or data.get("prosthetic_frame") or data.get("abilities"):
-            out.append((name, organ, data))
+        if getattr(organ, "current_hp", 0) <= 0:
+            continue
+        if is_augment_organ(organ, species_organs):
+            out.append((name, organ, getattr(organ, "data", None) or {}))
     return out
 
 
@@ -81,18 +104,25 @@ def _ability_lines(organ, data) -> list[str]:
 
 
 def render_system(character) -> str:
-    cyber = _cyber_organs(character)
+    species_organs = _species_organs(character)
+    cyber = _cyber_organs(character, species_organs)
     if not cyber:
         return (
             "Self-diagnostic: your wetware is all meat. "
             "No cybernetics installed."
         )
 
-    chrome = [(n, o, d) for n, o, d in cyber
-              if d.get("inorganic") or d.get("prosthetic_frame")]
-    flesh_mods = [(n, o, d) for n, o, d in cyber
-                  if not (d.get("inorganic") or d.get("prosthetic_frame"))
-                  and d.get("abilities")]
+    # Flesh-mount = NATIVE anatomy (in the species table) carrying an
+    # ability but not itself chrome (Nailz in a flesh hand).  Everything
+    # else augment is chrome / an augment limb — including a flag-less
+    # stale tail, which lands here by being absent from the species table.
+    chrome, flesh_mods = [], []
+    for name, organ, data in cyber:
+        native = name in species_organs
+        if native and data.get("abilities") and not data.get("inorganic"):
+            flesh_mods.append((name, organ, data))
+        else:
+            chrome.append((name, organ, data))
 
     # --- Chrome devices: group limb organs by container, head/torso by name.
     groups: dict = {}

--- a/world/tests/test_cyberware_status.py
+++ b/world/tests/test_cyberware_status.py
@@ -22,6 +22,9 @@ def _organ(container, hp, mx, data, astate=None):
 
 
 def _char(organs):
+    # is_augment_organ reads organ.name; mirror the dict key onto it.
+    for name, organ in organs.items():
+        organ.name = name
     return NS(medical_state=NS(organs=organs))
 
 
@@ -44,6 +47,16 @@ _RAZORBOY = {
         {"jawz": {"deployed": False}}),
     "left_eye": _organ(
         "head", 6, 14, {"inorganic": True, "prosthetic_frame": True}),
+}
+
+# Stale cybernetic tail (#569): an augment limb whose runtime data is
+# missing the ``inorganic`` flag (installed before the prototype had it).
+# It must still show — recognised by being absent from the species table.
+_STALE_TAIL = {
+    "cybernetic_tailbone": _organ(
+        "tail", 25, 25,
+        {"bone_type": "actuator_column", "grasping": True,
+         "severable_container": True}),
 }
 
 # Razorgirl: flesh body, Nailz both hands (deployed).
@@ -91,6 +104,14 @@ class TestCyberwareSystemReadout(TestCase):
         self.assertIn("degraded", out)
         # Prose-only — no raw HP numbers.
         self.assertNotIn("6/14", out)
+
+    def test_stale_cyber_tail_still_shows(self):
+        """#569: an augment limb (the tail) missing the ``inorganic``
+        flag still lists — detected by being absent from the species
+        table, via the canonical is_augment_organ predicate."""
+        out = render_system(_char(_STALE_TAIL))
+        self.assertIn("cybernetic tail", out)
+        self.assertNotIn("No cybernetics installed", out)
 
     def test_nailz_flesh_mount_groups_both_hands(self):
         out = render_system(_char(_RAZORGIRL))


### PR DESCRIPTION
Closes #569.

`/system` didn't list the cybernetic tail. The readout rolled its own cyberware filter (`inorganic` / `prosthetic_frame` / `abilities`), but the tail organ on existing characters is missing the `inorganic` flag — installed before the CYBERNETIC_TAIL prototype gained it (verified live on Laszlo #2017).

## Fix
Detect with the canonical `world.medical.core.is_augment_organ` predicate — the same one `@resetmedical` preserves on — which recognises the tail by being **absent from the species table**, so a stale install with no `inorganic` flag still shows. The chrome-vs-flesh-mount split now keys on species-table membership (native organ + ability = flesh-mount like Nailz; everything else augment = chrome), so a flag-less augment limb renders as chrome rather than vanishing. 0-HP tombstones are skipped (matches `iter_abilities`).

## Tests
- `test_stale_cyber_tail_still_shows` — a tail organ with no `inorganic` flag still lists.
- Full `world` suite: **2,554 OK**.

## Flagged separately (not this PR)
The same stale data means the tail also lacks `prosthetic_frame`, so it won't chrome-shear on severance or reattach as a cyber limb — and the prototype itself never set it. Follow-up = prototype + possible migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)