### PR TITLE
Cyber tail: add prosthetic_frame so it shears and reattaches

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -1967,6 +1967,11 @@ CYBERNETIC_TAIL = {
                 "severable_container": True,
                 "grasping": True,
                 "inorganic": True,
+                # Prosthetic-frame marker (#527/#539 standard): a severed
+                # cyber tail chrome-shears (not bleeds) and reattaches
+                # whole, like every other cyber limb.  Predated the
+                # standard and was missing it (#571).
+                "prosthetic_frame": True,
             },
         }),
         ("augment_container", "tail"),

--- a/world/tests/test_anatomy_augments.py
+++ b/world/tests/test_anatomy_augments.py
@@ -1097,6 +1097,36 @@ class TestNailzMaterial(TestCase):
         self.assertEqual(set(containers), {"left_hand", "right_hand"})
 
 
+class TestCyberTailFlags(TestCase):
+    """#571: the cyber tail is a chrome limb — its organ must carry both
+    ``inorganic`` (chrome rendering / pain-only damage) and
+    ``prosthetic_frame`` (chrome severance + whole-limb reattach, via
+    is_cybernetic_limb).  The prototype predated the #527/#539 standard
+    and was missing the frame marker."""
+
+    def test_tail_organ_is_chrome_and_framed(self):
+        from world import prototypes
+
+        spec = dict(prototypes.CYBERNETIC_TAIL["attrs"])
+        tailbone = spec["augment_organs"]["cybernetic_tailbone"]
+        self.assertTrue(tailbone.get("inorganic"))
+        self.assertTrue(tailbone.get("prosthetic_frame"))
+
+    def test_framed_tail_reads_as_cybernetic_limb(self):
+        """A severed tail whose organ carries the frame marker is
+        recognised by is_cybernetic_limb (the chrome-severance +
+        reattach gate)."""
+        from world.medical.procedures import is_cybernetic_limb
+
+        snapshot = {"organs": {"cybernetic_tailbone": {
+            "data": {"container": "tail", "prosthetic_frame": True}}}}
+        appendage = SimpleNamespace(
+            get_medical_snapshot=lambda: snapshot,
+            medical_state=None,
+        )
+        self.assertTrue(is_cybernetic_limb(appendage))
+
+
 CYBER_HEART_SPEC = {
     "container": "chest", "max_hp": 20, "hit_weight": "uncommon",
     "vital": True, "capacity": "blood_pumping", "contribution": "total",


### PR DESCRIPTION
Closes #571. Follow-up to #570 (which fixed the `/system` display; this fixes the underlying flags).

The `CYBERNETIC_TAIL` prototype's `cybernetic_tailbone` set `inorganic` but never `prosthetic_frame` — it predated the #527/#539 chrome standard. So a severed cyber tail **bled** (flesh severance) instead of chrome-shearing, and **necrosed** instead of reattaching whole, because both routes gate on `is_cybernetic_limb` (which checks `prosthetic_frame`).

## Fix
Add `prosthetic_frame: True` to the tailbone spec. Fresh tails now chrome-shear and reattach like every other cyber limb.

## Tests
- Prototype carries both `inorganic` + `prosthetic_frame`.
- A framed severed tail reads as a cybernetic limb (`is_cybernetic_limb`).
- Full `world` suite: **2,556 OK**.

## Stale data
Existing `cybernetic_tailbone` organs (e.g. Laszlo #2017) are missing the flags entirely — repaired by a one-time backfill run on the live server (idempotent), not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)