### PR TITLE
Combat: wire sight capacity into hit math (capacity-consumer layer 1)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -345,7 +345,12 @@ is the content lift) → per-effector resolver (manipulation/moving).
 ## 9 · Build sequencing (layered)
 
 1. **Combat consumers** (`sight`→ranged/melee) — proves multiplicative +
-   suppressible-effect pattern on a whole-body capacity.
+   suppressible-effect pattern on a whole-body capacity. **✅ SHIPPED** —
+   `world/combat/capacity.py` `sight_hit_factor()` multiplies the attacker's
+   motorics term in `world/combat/attack.py` `process_attack`; piecewise curves
+   (ranged steep, melee light), `sight_override` condition suppresses the
+   penalty (the chrome seam — augment not built yet). Tests:
+   `world/tests/test_combat_capacity_sight.py`.
 2. **Identity / voice** — `@voice` + voice signature + the resolution chain +
    rendering heuristic; gates visual recognition on `sight`, voice on `hearing`.
 3. **Perception render** — capacities gate LOOK sensory categories + compensatory

--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -14,6 +14,7 @@ from random import randint
 from .debug import get_splattercast
 
 from world.combat.messages import get_combat_message
+from world.combat.capacity import sight_hit_factor
 from world.medical.utils import select_hit_location, select_target_organ
 
 from .constants import (
@@ -390,8 +391,22 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
     attacker_skill = get_numeric_stat(attacker, "motorics", 1)
     target_skill = get_numeric_stat(target, "motorics", 1)
 
+    # Sight capacity consumes the attacker's aim (CAPACITY_CONSUMERS spec §3,
+    # §9 layer 1).  Multiplicative on the motorics skill term: ranged falls off
+    # steeply (depth perception), melee only when fully blind.  A sight-override
+    # condition (chrome sense-enhancer) suppresses the penalty.  Whole-body
+    # capacity, so no per-effector resolver needed.
+    sight_factor = sight_hit_factor(attacker, is_ranged_attack)
+    effective_skill = attacker_skill * sight_factor
+    if sight_factor < 1.0:
+        splattercast.msg(
+            f"ATTACK_SIGHT: {attacker.key} sight factor {sight_factor:.2f} "
+            f"({'ranged' if is_ranged_attack else 'melee'}) — motorics "
+            f"{attacker_skill} -> {effective_skill:.1f}"
+        )
+
     # Roll for attack
-    attacker_roll = randint(1, 20) + attacker_skill
+    attacker_roll = randint(1, 20) + effective_skill
     target_roll = randint(1, 20) + target_skill
 
     # Check for charge bonus

--- a/world/combat/capacity.py
+++ b/world/combat/capacity.py
@@ -1,0 +1,120 @@
+"""
+Combat capacity consumers (CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §9 layer 1).
+
+Body capacities (``world/medical/core.py`` ``calculate_body_capacity``) are
+computed from organ health but, historically, only the *lethal* ones gated
+anything.  This module is the first **consumer** of a performance capacity:
+``sight`` multiplies a character's combat hit math.
+
+The model (spec §1, decided):
+
+* **Multiplicative** — the capacity scales the GRIM-derived result, it does
+  not add/subtract a flat modifier.  Here that means the attacker's motorics
+  skill term is multiplied by a 0.0–1.0 factor before it joins the d20.
+* **Hybrid curve** — graduated falloff with redundancy protection: losing one
+  of a redundant pair (one eye) costs little; losing the whole capacity (blind)
+  falls off a cliff.  Encoded as a transparent piecewise-linear curve through
+  the anchor points the spec calls out, so it is trivially tunable.
+* **Suppressible named-effect** — a condition (the integration seam for chrome
+  / biotech, e.g. a cyber sense-enhancer or a "blindsight" effect) can suppress
+  the penalty entirely, restoring the capacity to full.  Riding the condition
+  system means one augment is coherent across every consumer at once.
+
+``sight`` is whole-body (you do not *wield* eyes), so it is the clean first
+slice and dodges the per-effector resolver (spec §6) that manipulation/moving
+will need.
+
+Fail-open: anything without a readable medical state (many mobs, test stubs)
+takes no penalty.  Absence of the medical model must never blind a combatant.
+"""
+
+from __future__ import annotations
+
+# The condition_type that, when present on a combatant, suppresses the sight
+# penalty and treats sight as fully present (spec §3 augment hook).  Nothing
+# adds this condition yet — the cyber sense-enhancer augment is a later layer —
+# but the consumer honours the seam now so the augment is pure content when it
+# lands.
+SIGHT_OVERRIDE_CONDITION = "sight_override"
+
+# Piecewise-linear curves mapping raw ``sight`` capacity (0.0–1.0) to a hit
+# multiplier.  Anchors are (raw_capacity, factor), ascending by capacity.
+# Magnitudes are illustrative/tunable (spec §11) — the *shape* is the contract.
+#
+# Ranged (the big one): steep falloff with redundancy protection.  Two eyes =
+# no penalty; one eye ≈ 0.65 (depth perception gone, but you can still aim);
+# blind ≈ a near-useless 0.05 floor (point-blank-or-nothing).
+SIGHT_CURVE_RANGED = ((0.0, 0.05), (0.5, 0.65), (1.0, 1.0))
+
+# Melee (light): you can grab and swing by feel.  One eye costs nothing; only
+# full blindness imposes a modest penalty.
+SIGHT_CURVE_MELEE = ((0.0, 0.70), (0.5, 1.0), (1.0, 1.0))
+
+
+def _piecewise(raw: float, anchors) -> float:
+    """Linear-interpolate *raw* (clamped 0–1) through ascending *anchors*."""
+    raw = max(0.0, min(1.0, raw))
+    lo_x, lo_y = anchors[0]
+    if raw <= lo_x:
+        return lo_y
+    for hi_x, hi_y in anchors[1:]:
+        if raw <= hi_x:
+            span = hi_x - lo_x
+            if span <= 0:
+                return hi_y
+            t = (raw - lo_x) / span
+            return lo_y + t * (hi_y - lo_y)
+        lo_x, lo_y = hi_x, hi_y
+    return anchors[-1][1]
+
+
+def _read_sight_capacity(character):
+    """Return raw ``sight`` capacity (0.0–1.0), or ``None`` if unreadable.
+
+    ``None`` signals "no medical model" — the caller fails open.
+    """
+    state = getattr(character, "medical_state", None)
+    if state is None:
+        return None
+    calc = getattr(state, "calculate_body_capacity", None)
+    if not callable(calc):
+        return None
+    try:
+        return calc("sight")
+    except Exception:
+        return None
+
+
+def _has_sight_override(character) -> bool:
+    """True if a condition suppresses the sight penalty (chrome/biotech seam)."""
+    state = getattr(character, "medical_state", None)
+    getter = getattr(state, "get_conditions_by_type", None)
+    if not callable(getter):
+        return False
+    try:
+        return bool(getter(SIGHT_OVERRIDE_CONDITION))
+    except Exception:
+        return False
+
+
+def sight_hit_factor(character, is_ranged: bool) -> float:
+    """Multiplier applied to *character*'s motorics skill term when attacking.
+
+    Args:
+        character: the attacker.
+        is_ranged: True for ranged attacks (steep curve), False for melee
+            (light curve — sight only matters when fully blind).
+
+    Returns:
+        A factor in ``[0.0, 1.0]``.  ``1.0`` means no sight penalty (full
+        sight, no medical model, or an active suppressor).
+    """
+    if _has_sight_override(character):
+        return 1.0
+
+    raw = _read_sight_capacity(character)
+    if raw is None:
+        return 1.0  # fail-open: no medical model, no penalty
+
+    curve = SIGHT_CURVE_RANGED if is_ranged else SIGHT_CURVE_MELEE
+    return _piecewise(raw, curve)

--- a/world/tests/test_combat_capacity_sight.py
+++ b/world/tests/test_combat_capacity_sight.py
@@ -1,0 +1,135 @@
+"""
+Tests for the sight combat-capacity consumer
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §9 layer 1).
+
+``world/combat/capacity.py`` turns the previously-inert ``sight`` body
+capacity into a multiplier on combat aim.  These tests pin the curve's
+contract (anchor points + shape), the chrome/biotech suppression seam, and
+the fail-open guarantee — without standing up a full combat handler.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_combat_capacity_sight
+"""
+
+from unittest import TestCase
+
+from world.combat.capacity import (
+    SIGHT_OVERRIDE_CONDITION,
+    sight_hit_factor,
+    _piecewise,
+    SIGHT_CURVE_RANGED,
+    SIGHT_CURVE_MELEE,
+)
+
+
+class _FakeMedicalState:
+    """Minimal stand-in for ``MedicalState`` exposing only what the
+    capacity consumer reads."""
+
+    def __init__(self, sight=1.0, override_conditions=0):
+        self._sight = sight
+        self._overrides = override_conditions
+
+    def calculate_body_capacity(self, name):
+        if name == "sight":
+            return self._sight
+        return 1.0
+
+    def get_conditions_by_type(self, condition_type):
+        if condition_type == SIGHT_OVERRIDE_CONDITION:
+            return [object()] * self._overrides
+        return []
+
+
+class _FakeChar:
+    def __init__(self, medical_state=None):
+        self.key = "Tester"
+        self.medical_state = medical_state
+
+
+class PiecewiseCurveTests(TestCase):
+    """The interpolation primitive itself."""
+
+    def test_hits_exact_anchor_values(self):
+        for raw, expected in SIGHT_CURVE_RANGED:
+            self.assertAlmostEqual(_piecewise(raw, SIGHT_CURVE_RANGED), expected)
+
+    def test_interpolates_between_anchors(self):
+        # Midway between (0.5, 0.65) and (1.0, 1.0) -> 0.825
+        self.assertAlmostEqual(_piecewise(0.75, SIGHT_CURVE_RANGED), 0.825)
+
+    def test_clamps_out_of_range(self):
+        self.assertAlmostEqual(_piecewise(-5.0, SIGHT_CURVE_RANGED), 0.05)
+        self.assertAlmostEqual(_piecewise(5.0, SIGHT_CURVE_RANGED), 1.0)
+
+
+class RangedSightTests(TestCase):
+    def _factor(self, sight):
+        char = _FakeChar(_FakeMedicalState(sight=sight))
+        return sight_hit_factor(char, is_ranged=True)
+
+    def test_two_eyes_no_penalty(self):
+        self.assertAlmostEqual(self._factor(1.0), 1.0)
+
+    def test_one_eye_redundancy_protected(self):
+        # One eye (0.5) keeps you above the linear 0.5 — depth perception
+        # gone but still combat-capable.
+        self.assertAlmostEqual(self._factor(0.5), 0.65)
+        self.assertGreater(self._factor(0.5), 0.5)
+
+    def test_blind_is_near_useless(self):
+        self.assertAlmostEqual(self._factor(0.0), 0.05)
+
+    def test_monotonic_non_decreasing(self):
+        prev = -1.0
+        for raw in (0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0):
+            cur = self._factor(raw)
+            self.assertGreaterEqual(cur, prev)
+            prev = cur
+
+
+class MeleeSightTests(TestCase):
+    def _factor(self, sight):
+        char = _FakeChar(_FakeMedicalState(sight=sight))
+        return sight_hit_factor(char, is_ranged=False)
+
+    def test_two_eyes_no_penalty(self):
+        self.assertAlmostEqual(self._factor(1.0), 1.0)
+
+    def test_one_eye_costs_nothing_in_melee(self):
+        self.assertAlmostEqual(self._factor(0.5), 1.0)
+
+    def test_blind_modest_penalty_only(self):
+        # You can still grab and swing by feel.
+        self.assertAlmostEqual(self._factor(0.0), 0.70)
+
+    def test_melee_never_below_ranged_at_same_sight(self):
+        for raw in (0.0, 0.25, 0.5):
+            char = _FakeChar(_FakeMedicalState(sight=raw))
+            melee = sight_hit_factor(char, is_ranged=False)
+            ranged = sight_hit_factor(char, is_ranged=True)
+            self.assertGreaterEqual(melee, ranged)
+
+
+class SuppressionAndFailOpenTests(TestCase):
+    def test_override_condition_nulls_penalty(self):
+        # Blind, but a chrome sense-enhancer (override condition) restores aim.
+        char = _FakeChar(_FakeMedicalState(sight=0.0, override_conditions=1))
+        self.assertAlmostEqual(sight_hit_factor(char, is_ranged=True), 1.0)
+        self.assertAlmostEqual(sight_hit_factor(char, is_ranged=False), 1.0)
+
+    def test_no_medical_state_fails_open(self):
+        char = _FakeChar(medical_state=None)
+        self.assertAlmostEqual(sight_hit_factor(char, is_ranged=True), 1.0)
+
+    def test_unreadable_capacity_fails_open(self):
+        class _Broken:
+            def calculate_body_capacity(self, name):
+                raise RuntimeError("boom")
+
+            def get_conditions_by_type(self, ct):
+                return []
+
+        char = _FakeChar(_Broken())
+        self.assertAlmostEqual(sight_hit_factor(char, is_ranged=True), 1.0)


### PR DESCRIPTION
First consumer of a performance body capacity
(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §9 layer 1). The previously-inert
`sight` capacity now multiplies the attacker's motorics skill term in
`process_attack`:

- world/combat/capacity.py: `sight_hit_factor(character, is_ranged)` reads
  `calculate_body_capacity("sight")` and maps it through a transparent
  piecewise-linear curve. Ranged is steep with redundancy protection (two
  eyes 1.0, one eye ~0.65, blind ~0.05); melee is light (one eye costs
  nothing, blind ~0.70 — you can still grab and swing).
- A `sight_override` condition suppresses the penalty entirely — the
  chrome/biotech integration seam (cyber sense-enhancer); nothing adds it
  yet, the consumer just honours it so the augment is pure content later.
- Fail-open: no readable medical state (many mobs, stubs) = no penalty.

Multiplicative, suppressible-effect, whole-body — proves the model the
remaining capacities (manipulation/moving via the §6 resolver) will reuse.

Tests: world/tests/test_combat_capacity_sight.py (14 cases: curve anchors,
interpolation, ranged/melee shape, monotonicity, suppression, fail-open).

Closes #581

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
