### PR TITLE
Voice: voice-signature foundation + @voice + speech flavour (layer 2a)

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1697,6 +1697,134 @@ def _process_longdesc_entry(caller, raw_string, **kwargs):
     return "node_describe_list"
 
 
+class CmdVoice(Command):
+    """
+    Set how your character's voice sounds when they speak.
+
+    Your voice is a second identity — others can come to recognise you by it
+    even when they can't see you. It has two parts, both chosen from a curated
+    vocabulary (like your sdesc keyword):
+
+      |wdescription|n  - the colour/timbre, e.g. |wgravelly|n, |wsilken|n, |whusky|n
+      |wending|n       - the delivery, e.g. |wdrawl|n, |wrasp|n, |wlilt|n, |wpurr|n
+
+    Together they render in speech as, for example:
+      Robert says, |x*speaking Common, in a gravelly drawl*|n "Call me Bob."
+
+    Usage:
+      @voice                          - Show your current voice
+      @voice description <word>       - Set the colour of your voice
+      @voice ending <word>            - Set the delivery of your voice
+      @voice list                     - List the available words
+      @voice clear                    - Clear your voice flavour
+
+    Examples:
+      @voice description gravelly
+      @voice ending drawl
+    """
+
+    key = "@voice"
+    aliases = ["voice"]
+    locks = "cmd:all()"
+    help_category = "Social"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+
+        if not args:
+            self._show_current(caller)
+            return
+
+        lower = args.lower()
+        if lower == "list":
+            self._show_list(caller)
+            return
+        if lower in ("clear", "none", "reset"):
+            caller.attributes.remove("voice_description")
+            caller.attributes.remove("voice_ending")
+            caller.msg("Cleared your voice flavour.")
+            return
+
+        parts = args.split(None, 1)
+        slot = parts[0].lower()
+        word = parts[1].strip().lower() if len(parts) > 1 else ""
+
+        if slot in ("description", "desc", "colour", "color"):
+            self._set_description(caller, word)
+        elif slot in ("ending", "end", "delivery"):
+            self._set_ending(caller, word)
+        else:
+            caller.msg(
+                "Usage: |w@voice description <word>|n or "
+                "|w@voice ending <word>|n. See |w@voice list|n."
+            )
+
+    def _set_description(self, caller, word):
+        from world.voice import is_valid_voice_description
+        if not word:
+            caller.msg("Usage: |w@voice description <word>|n")
+            return
+        if not is_valid_voice_description(word):
+            caller.msg(
+                f"|r'{word}' is not an available voice description.|n "
+                f"See |w@voice list|n."
+            )
+            return
+        caller.db.voice_description = word
+        self._preview(caller, f"Voice description set to |w{word}|n.")
+
+    def _set_ending(self, caller, word):
+        from world.voice import is_valid_voice_ending
+        if not word:
+            caller.msg("Usage: |w@voice ending <word>|n")
+            return
+        if not is_valid_voice_ending(word):
+            caller.msg(
+                f"|r'{word}' is not an available voice ending.|n "
+                f"See |w@voice list|n."
+            )
+            return
+        caller.db.voice_ending = word
+        self._preview(caller, f"Voice ending set to |w{word}|n.")
+
+    def _preview(self, caller, header):
+        from world.voice import voice_phrase
+        caller.msg(header)
+        phrase = voice_phrase(caller)
+        if phrase:
+            caller.msg(f'You now sound like: |x*{phrase}*|n')
+
+    def _show_current(self, caller):
+        from world.voice import (
+            get_voice_description, get_voice_ending, voice_phrase,
+        )
+        desc = get_voice_description(caller)
+        ending = get_voice_ending(caller)
+        if not (desc or ending):
+            caller.msg(
+                "You have set no voice flavour. Your voice is unremarkable. "
+                "Use |w@voice description <word>|n and |w@voice ending <word>|n."
+            )
+            return
+        caller.msg(
+            f"Voice description: |w{desc or '(unset)'}|n   "
+            f"ending: |w{ending or '(unset)'}|n"
+        )
+        phrase = voice_phrase(caller)
+        if phrase:
+            caller.msg(f'You sound like: |x*{phrase}*|n')
+
+    def _show_list(self, caller):
+        from world.voice import get_voice_descriptions, get_voice_endings
+        descs = ", ".join(sorted(get_voice_descriptions()))
+        endings = ", ".join(sorted(get_voice_endings()))
+        caller.msg(
+            f"|wVoice descriptions|n (the colour):\n  {descs}\n\n"
+            f"|wVoice endings|n (the delivery):\n  {endings}"
+        )
+
+
 class CmdSkintone(Command):
     """
     Set your character's skintone for longdesc display coloring.

--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -20,8 +20,15 @@ from world.emote import (
     tokenize_dot_pose,
     tokenize_emote,
 )
+from random import random
+
 from world.grammar import capitalize_first
 from world.identity_utils import msg_room_identity
+from world.voice import (
+    garbled_voice_phrase,
+    voice_phrase,
+    VOICE_FLAVOR_SPRINKLE_CHANCE,
+)
 
 
 class CmdSay(Command):
@@ -57,6 +64,20 @@ class CmdSay(Command):
         # Actor sees their own message
         caller.msg(f'You say, "{speech}"')
 
+        # Voice flavour (CAPACITY_CONSUMERS spec §4). A garbled voice (wrecked
+        # `talking` capacity) always renders — a ruined voice is conspicuous;
+        # otherwise the speaker is visible to the room, so flavour is a
+        # sporadic, low-frequency sprinkle (§4.6 can-see branch) rolled once
+        # per utterance for a consistent reading. The full sight/hearing
+        # resolution chain (unseen speakers → mandatory attribution) is a
+        # later slice.
+        flavor = garbled_voice_phrase(caller)
+        if flavor is None:
+            phrase = voice_phrase(caller)
+            if phrase and random() < VOICE_FLAVOR_SPRINKLE_CHANCE:
+                flavor = phrase
+        say_verb = f"says, |x*{flavor}*|n" if flavor else "says,"
+
         # Each observer sees per-observer speaker attribution
         for observer in location.contents:
             if observer is caller:
@@ -65,7 +86,7 @@ class CmdSay(Command):
                 continue
             speaker_name = caller.get_display_name(observer)
             observer.msg(
-                text=f'{capitalize_first(speaker_name)} says, "{speech}"',
+                text=f'{capitalize_first(speaker_name)} {say_verb} "{speech}"',
                 type="say",
                 from_obj=caller,
             )

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -37,7 +37,7 @@ from commands.CmdExplosives import (
     CmdClearDetonator,
 )
 from commands.CmdGraffiti import CmdGraffiti, CmdPress
-from commands.CmdCharacter import CmdDescribe, CmdSkintone
+from commands.CmdCharacter import CmdDescribe, CmdSkintone, CmdVoice
 from commands.CmdCharacter import CmdRemember, CmdForget, CmdRecall, CmdMemory
 from commands.CmdCommunication import CmdSay, CmdWhisper, CmdEmote, CmdDotPose
 from commands.forensics import CmdAutopsy, CmdSever
@@ -182,6 +182,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         # Add unified describe command (short desc + keyword + longdesc).
         # Replaces @longdesc, @shortdesc, and Evennia's default setdesc.
         self.add(CmdDescribe())
+        self.add(CmdVoice())
         # Remove Evennia's default setdesc; the Short Description menu option
         # and `describe short <text>` now own the main description.
         self.remove(CmdSetDesc())

--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -353,6 +353,20 @@ is the content lift) → per-effector resolver (manipulation/moving).
    `world/tests/test_combat_capacity_sight.py`.
 2. **Identity / voice** — `@voice` + voice signature + the resolution chain +
    rendering heuristic; gates visual recognition on `sight`, voice on `hearing`.
+   - **2a ✅ SHIPPED — voice signature foundation.** `world/voice.py`: curated
+     description+ending vocabulary (config-overridable), composer
+     (`voice_phrase`), and the **`talking`-capacity garble gate** (§4.7 — first
+     consumer of the otherwise-blocked `talking` capacity: wrecked jaw →
+     `garbled_voice_phrase`). `@voice` command (`commands/CmdCharacter.py`,
+     set/view/list/clear). `say` renders flavour: garble always, otherwise the
+     §4.6 "can-see → sporadic sprinkle" branch (the only branch reachable until
+     2c). Tests: `world/tests/test_voice_identity.py`.
+   - **2b — voice memory + recognition** (the apparent-UID/`recognition_memory`
+     parallel): a `get_voice_signature`/voice-UID and per-listener voice memory
+     so a known voice attributes a speaker. *Not built.*
+   - **2c — the resolution chain** (§4.5) in `get_display_name`/`say`: see→hear→
+     neither, gated on the listener's `sight`/`hearing`; unlocks unseen
+     speakers and the full §4.6 heuristic (mandatory disambiguation). *Not built.*
 3. **Perception render** — capacities gate LOOK sensory categories + compensatory
    enrichment.
 4. **Per-effector resolver** — `manipulation`/`moving` (and the multi-appendage

--- a/world/tests/test_voice_identity.py
+++ b/world/tests/test_voice_identity.py
@@ -1,0 +1,146 @@
+"""
+Tests for the voice-identity foundation
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §4, build slice 2a).
+
+Covers the curated vocabulary + validation, the composed speech-flavour
+phrase across signature states, and the ``talking``-capacity garble gate
+(§4.7) — the first consumer of the otherwise-blocked ``talking`` capacity.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_voice_identity
+"""
+
+from unittest import TestCase
+
+from world.voice import (
+    DEFAULT_VOICE_DESCRIPTIONS,
+    DEFAULT_VOICE_ENDINGS,
+    VOICE_GARBLE_THRESHOLD,
+    garbled_voice_phrase,
+    get_voice_descriptions,
+    get_voice_endings,
+    has_voice_signature,
+    is_valid_voice_description,
+    is_valid_voice_ending,
+    is_voice_garbled,
+    voice_phrase,
+)
+
+
+class _FakeDB:
+    def __init__(self, description=None, ending=None):
+        self.voice_description = description
+        self.voice_ending = ending
+
+
+class _FakeMedicalState:
+    def __init__(self, talking=1.0):
+        self._talking = talking
+
+    def calculate_body_capacity(self, name):
+        if name == "talking":
+            return self._talking
+        return 1.0
+
+
+class _FakeChar:
+    def __init__(self, description=None, ending=None, talking=1.0,
+                 medical=True):
+        self.db = _FakeDB(description, ending)
+        self.medical_state = _FakeMedicalState(talking) if medical else None
+
+
+class VocabularyTests(TestCase):
+    def test_defaults_are_nonempty_and_lowercase(self):
+        self.assertTrue(DEFAULT_VOICE_DESCRIPTIONS)
+        self.assertTrue(DEFAULT_VOICE_ENDINGS)
+        for word in (*DEFAULT_VOICE_DESCRIPTIONS, *DEFAULT_VOICE_ENDINGS):
+            self.assertEqual(word, word.lower())
+
+    def test_getters_return_defaults_without_config(self):
+        self.assertEqual(get_voice_descriptions(), DEFAULT_VOICE_DESCRIPTIONS)
+        self.assertEqual(get_voice_endings(), DEFAULT_VOICE_ENDINGS)
+
+    def test_validation_accepts_known_words(self):
+        self.assertTrue(is_valid_voice_description("gravelly"))
+        self.assertTrue(is_valid_voice_ending("drawl"))
+
+    def test_validation_is_case_insensitive(self):
+        self.assertTrue(is_valid_voice_description("GRAVELLY"))
+        self.assertTrue(is_valid_voice_ending("  Drawl "))
+
+    def test_validation_rejects_unknown_and_empty(self):
+        self.assertFalse(is_valid_voice_description("xyzzy"))
+        self.assertFalse(is_valid_voice_ending("xyzzy"))
+        self.assertFalse(is_valid_voice_description(""))
+        self.assertFalse(is_valid_voice_ending(""))
+
+
+class SignatureCompositionTests(TestCase):
+    def test_both_slots_compose_full_phrase(self):
+        char = _FakeChar("gravelly", "drawl")
+        self.assertEqual(
+            voice_phrase(char), "speaking Common, in a gravelly drawl"
+        )
+
+    def test_description_only(self):
+        char = _FakeChar("silken", None)
+        self.assertEqual(
+            voice_phrase(char), "speaking Common, in a silken voice"
+        )
+
+    def test_ending_only(self):
+        char = _FakeChar(None, "rasp")
+        self.assertEqual(voice_phrase(char), "speaking Common, in a rasp")
+
+    def test_no_signature_returns_none(self):
+        self.assertIsNone(voice_phrase(_FakeChar()))
+
+    def test_language_slot_is_parameterised(self):
+        char = _FakeChar("husky", "purr")
+        self.assertIn("speaking Streetcant", voice_phrase(char, "Streetcant"))
+
+    def test_has_voice_signature(self):
+        self.assertTrue(has_voice_signature(_FakeChar("gravelly", None)))
+        self.assertTrue(has_voice_signature(_FakeChar(None, "drawl")))
+        self.assertFalse(has_voice_signature(_FakeChar()))
+
+
+class TalkingGarbleGateTests(TestCase):
+    def test_healthy_talking_not_garbled(self):
+        self.assertFalse(is_voice_garbled(_FakeChar(talking=1.0)))
+        self.assertIsNone(garbled_voice_phrase(_FakeChar(talking=1.0)))
+
+    def test_wrecked_talking_garbles(self):
+        char = _FakeChar("gravelly", "drawl", talking=0.1)
+        self.assertTrue(is_voice_garbled(char))
+        self.assertEqual(
+            garbled_voice_phrase(char),
+            "speaking Common, in a slurred, broken voice",
+        )
+
+    def test_threshold_boundary(self):
+        # Exactly at threshold is NOT garbled (strict less-than).
+        self.assertFalse(is_voice_garbled(_FakeChar(talking=VOICE_GARBLE_THRESHOLD)))
+        self.assertTrue(
+            is_voice_garbled(_FakeChar(talking=VOICE_GARBLE_THRESHOLD - 0.01))
+        )
+
+    def test_no_medical_model_fails_open(self):
+        # No medical state => no garble (mobs, stubs).
+        char = _FakeChar("gravelly", "drawl", medical=False)
+        self.assertFalse(is_voice_garbled(char))
+        self.assertIsNone(garbled_voice_phrase(char))
+
+
+class CommandRegistrationTests(TestCase):
+    """@voice is wired into the live character cmdset (runs under the evennia
+    test harness, which bootstraps the command framework)."""
+
+    def test_voice_command_registered(self):
+        from commands.default_cmdsets import CharacterCmdSet
+        cs = CharacterCmdSet()
+        cs.at_cmdset_creation()
+        keys = {c.key for c in cs.commands}
+        self.assertIn("@voice", keys)

--- a/world/voice.py
+++ b/world/voice.py
@@ -1,0 +1,174 @@
+"""
+Voice identity — the parallel-to-visual identity axis
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §4).
+
+The visual identity stack (``world/identity.py``) answers *"who do I see?"* via
+sdesc → apparent-UID → recognition memory. Voice is the same machine on a second
+axis — *"who do I hear?"* — so a known voice attributes a speaker even when the
+listener can't see them (blind, dark, around a corner).
+
+This module is the **data + composition** layer (slice 2a):
+
+* A **curated vocabulary** (bounded, like visual keywords — not free text) for
+  the two voice slots a player sets: a **description** (the colour/timbre:
+  "gravelly", "silken") and an **ending** (the delivery cap: "drawl", "rasp").
+* Read/compose helpers that turn that pair into the speech-flavour phrase
+  rendered in ``say`` (``*speaking Common, in a gravelly drawl*``).
+* The **talking** capacity gate (§4.7): a wrecked jaw/tongue garbles voice
+  production, so a low-``talking`` speaker has no usable signature — their
+  voice renders as broken regardless of what they set. This is the first
+  consumer of the ``talking`` capacity (otherwise blocked on the social system).
+
+Voice *recognition* (the memory/UID parallel) and the sight/hearing resolution
+chain are later slices (2b/2c); this layer is their prerequisite — you cannot
+recognise a voice that does not yet exist.
+
+Vocabularies are illustrative/tunable (spec §11) and config-overridable, exactly
+like the visual-keyword sets.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --------------------------------------------------------------------------
+# Curated vocabulary
+# --------------------------------------------------------------------------
+# The colour of the voice — timbre / texture / register. A single curated word
+# (a future slice may add a second register slot; the example "gravelly baritone
+# drawl" folds register into description for now).
+DEFAULT_VOICE_DESCRIPTIONS = frozenset({
+    "gravelly", "smoky", "silken", "gritty", "honeyed", "nasal", "breathy",
+    "resonant", "raspy", "velvety", "brassy", "reedy", "hoarse", "mellow",
+    "clipped", "booming", "husky", "flinty", "icy", "warm", "sandy", "wiry",
+})
+
+# The delivery cap — manner / cadence. Rendered as "in a <description> <ending>".
+DEFAULT_VOICE_ENDINGS = frozenset({
+    "drawl", "rasp", "lilt", "growl", "purr", "murmur", "snarl", "croon",
+    "monotone", "burr", "twang", "cadence", "hum", "baritone", "tenor", "alto",
+    "warble", "hiss",
+})
+
+# Below this ``talking`` capacity the speaker's voice is garbled — no usable
+# signature (§4.7). Tunable.
+VOICE_GARBLE_THRESHOLD = 0.35
+
+# How often a *visible* speaker's voice flavour is sprinkled into their speech.
+# The §4.6 rendering heuristic's "can see the speaker → sporadic, low-frequency
+# flavour" branch — the only branch reachable until the sight/hearing resolution
+# chain (slice 2c) can produce unseen speakers. Keeps voices alive for everyone
+# without spamming. Garble bypasses this and always renders. Tunable.
+VOICE_FLAVOR_SPRINKLE_CHANCE = 0.25
+
+
+def _read_conf_set(conf_key: str, default: frozenset[str]) -> frozenset[str]:
+    """Return a config-overridable vocabulary set, falling back to *default*.
+
+    Mirrors ``world.identity._read_keyword_set`` — server config may extend or
+    replace the starter vocabulary without a code change.
+    """
+    try:
+        from django.conf import settings
+        value = getattr(settings, conf_key, None)
+    except Exception:
+        value = None
+    if not value:
+        return default
+    return frozenset(str(v).strip().lower() for v in value if str(v).strip())
+
+
+def get_voice_descriptions() -> frozenset[str]:
+    """The approved vocal-description vocabulary."""
+    return _read_conf_set("VOICE_DESCRIPTIONS", DEFAULT_VOICE_DESCRIPTIONS)
+
+
+def get_voice_endings() -> frozenset[str]:
+    """The approved voice-ending vocabulary."""
+    return _read_conf_set("VOICE_ENDINGS", DEFAULT_VOICE_ENDINGS)
+
+
+def is_valid_voice_description(word: str) -> bool:
+    return bool(word) and word.strip().lower() in get_voice_descriptions()
+
+
+def is_valid_voice_ending(word: str) -> bool:
+    return bool(word) and word.strip().lower() in get_voice_endings()
+
+
+# --------------------------------------------------------------------------
+# Stored signature accessors
+# --------------------------------------------------------------------------
+def get_voice_description(char: Any) -> str | None:
+    db = getattr(char, "db", None)
+    return getattr(db, "voice_description", None) if db is not None else None
+
+
+def get_voice_ending(char: Any) -> str | None:
+    db = getattr(char, "db", None)
+    return getattr(db, "voice_ending", None) if db is not None else None
+
+
+def has_voice_signature(char: Any) -> bool:
+    """True if the character has set any voice flavour at all."""
+    return bool(get_voice_description(char) or get_voice_ending(char))
+
+
+# --------------------------------------------------------------------------
+# The talking-capacity gate (§4.7)
+# --------------------------------------------------------------------------
+def _read_talking_capacity(char: Any) -> float | None:
+    """Raw ``talking`` capacity (0.0–1.0), or ``None`` if unreadable.
+
+    ``None`` → fail open (no medical model means no garble).
+    """
+    state = getattr(char, "medical_state", None)
+    calc = getattr(state, "calculate_body_capacity", None)
+    if not callable(calc):
+        return None
+    try:
+        return calc("talking")
+    except Exception:
+        return None
+
+
+def is_voice_garbled(char: Any) -> bool:
+    """True when a wrecked ``talking`` capacity ruins voice production."""
+    talking = _read_talking_capacity(char)
+    if talking is None:
+        return False
+    return talking < VOICE_GARBLE_THRESHOLD
+
+
+# --------------------------------------------------------------------------
+# Composition (what ``say`` renders)
+# --------------------------------------------------------------------------
+def garbled_voice_phrase(char: Any, language: str = "Common") -> str | None:
+    """The flavour phrase for a speaker whose voice is garbled, else ``None``.
+
+    Garble always renders (a ruined voice is conspicuous every time) — the
+    caller does not sprinkle it.
+    """
+    if not is_voice_garbled(char):
+        return None
+    return f"speaking {language}, in a slurred, broken voice"
+
+
+def voice_phrase(char: Any, language: str = "Common") -> str | None:
+    """The descriptive voice-flavour phrase from the speaker's signature.
+
+    Returns ``None`` when the speaker has set no voice flavour (graceful — no
+    empty ``*speaking Common*`` noise). Ignores the talking gate; callers check
+    :func:`garbled_voice_phrase` first.
+    """
+    desc = get_voice_description(char)
+    ending = get_voice_ending(char)
+    if desc and ending:
+        body = f"in a {desc} {ending}"
+    elif desc:
+        body = f"in a {desc} voice"
+    elif ending:
+        body = f"in a {ending}"
+    else:
+        return None
+    return f"speaking {language}, {body}"


### PR DESCRIPTION
First slice of capacity-consumer layer 2 (identity/voice,
CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §4) — the voice-identity foundation
the recognition/resolution-chain slices build on.

- world/voice.py: curated, config-overridable description+ending vocabulary
  (the colour: gravelly/silken; the delivery: drawl/rasp); `voice_phrase()`
  composes the speech-flavour phrase; the `talking`-capacity garble gate
  (§4.7) is the first consumer of the otherwise-blocked `talking` capacity —
  a wrecked jaw/tongue yields no usable signature and renders as a broken
  voice. Fails open with no medical model.
- @voice command (commands/CmdCharacter.py): set/view/list/clear, curated
  validation mirroring `describe keyword`. Registered in CharacterCmdSet.
- say rendering (commands/CmdCommunication.py): a garbled voice always
  renders; otherwise voice flavour is a sporadic, low-frequency sprinkle —
  the §4.6 "can see the speaker" branch, the only branch reachable until the
  sight/hearing resolution chain (2c) can produce unseen speakers. No spam.

Deferred: 2b voice memory + recognition (apparent-UID/recognition_memory
parallel), 2c the resolution chain (see -> hear -> neither) + full heuristic.

Tests: world/tests/test_voice_identity.py (16 cases: vocab validation,
composition across signature states, talking garble gate + boundary +
fail-open, and @voice cmdset registration under the evennia harness).

Closes #583

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
