### PR TITLE
Voice: voice memory + recognition — the recognition_memory parallel (2b)

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -2161,6 +2161,16 @@ class CmdRemember(Command):
         memory[apparent_uid] = entry
         caller.recognition_memory = memory
 
+        # Voice recognition (CAPACITY_CONSUMERS spec §4.2): remembering a
+        # speaker you can see also teaches you their voice — you are co-located,
+        # so you hear them. Skipped when their voice is currently garbled (a
+        # wrecked `talking` capacity — you can't learn a voice that's broken
+        # right now). The full listener-deafness gate lands with the resolution
+        # chain (2c); the speaker-garble gate is correct now.
+        from world.voice import remember_voice, is_voice_garbled
+        if not is_voice_garbled(target):
+            remember_voice(caller, target, name)
+
         # Provide feedback using the newly assigned name
         if old_name and old_name != name:
             caller.msg(
@@ -2403,6 +2413,12 @@ class CmdForget(Command):
 
         memory[apparent_uid]["assigned_name"] = ""
         caller.recognition_memory = memory
+
+        # Forget their voice too (CAPACITY_CONSUMERS spec §4.2) — the visible
+        # and audible channels are forgotten together when you forget a present
+        # target. A modulated voice keys to its own entry and is untouched.
+        from world.voice import forget_voice
+        forget_voice(caller, target)
 
         # Drop stale pierce-cache verdicts for this sleeve so the next
         # look re-evaluates against the now-nameless memory.  Prefer

--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -361,9 +361,15 @@ is the content lift) → per-effector resolver (manipulation/moving).
      set/view/list/clear). `say` renders flavour: garble always, otherwise the
      §4.6 "can-see → sporadic sprinkle" branch (the only branch reachable until
      2c). Tests: `world/tests/test_voice_identity.py`.
-   - **2b — voice memory + recognition** (the apparent-UID/`recognition_memory`
-     parallel): a `get_voice_signature`/voice-UID and per-listener voice memory
-     so a known voice attributes a speaker. *Not built.*
+   - **2b ✅ SHIPPED — voice memory + recognition.** The apparent-UID /
+     `recognition_memory` parallel in `world/voice.py`: `get_voice_signature`
+     (salted on `sleeve_uid`, so everyone has a stable recognisable voice + a
+     `voice_modulator_active` slot that, like a mask, changes the UID),
+     `get_apparent_voice_uid`, and a `voice_memory` AttributeProperty on the
+     Character with `remember_voice`/`forget_voice`/`get_assigned_voice_name`.
+     `remember <target>`/`forget <target>` now teach/clear the voice alongside
+     the face (skipping garbled speakers). Tests in `test_voice_identity.py`.
+     *Not yet consumed by display* — that's 2c.
    - **2c — the resolution chain** (§4.5) in `get_display_name`/`say`: see→hear→
      neither, gated on the listener's `sight`/`hearing`; unlocks unseen
      speakers and the full §4.6 heuristic (mandatory disambiguation). *Not built.*

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -99,6 +99,11 @@ class Character(
     hair_style = AttributeProperty(None, category="identity")
     sdesc_keyword = AttributeProperty(None, category="identity")
     recognition_memory = AttributeProperty({}, category="identity", autocreate=True)
+    # Voice recognition — the auditory parallel to recognition_memory, keyed by
+    # voice UID (CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §4.2). Populated when you
+    # remember an audible speaker; read by the resolution chain to attribute a
+    # known voice you can't see.
+    voice_memory = AttributeProperty({}, category="identity", autocreate=True)
     species = AttributeProperty("human", category="identity")
 
     # Shop System Attributes

--- a/world/tests/test_voice_identity.py
+++ b/world/tests/test_voice_identity.py
@@ -17,21 +17,27 @@ from world.voice import (
     DEFAULT_VOICE_DESCRIPTIONS,
     DEFAULT_VOICE_ENDINGS,
     VOICE_GARBLE_THRESHOLD,
+    forget_voice,
     garbled_voice_phrase,
+    get_apparent_voice_uid,
+    get_assigned_voice_name,
     get_voice_descriptions,
     get_voice_endings,
+    get_voice_signature,
     has_voice_signature,
     is_valid_voice_description,
     is_valid_voice_ending,
     is_voice_garbled,
+    remember_voice,
     voice_phrase,
 )
 
 
 class _FakeDB:
-    def __init__(self, description=None, ending=None):
+    def __init__(self, description=None, ending=None, modulated=False):
         self.voice_description = description
         self.voice_ending = ending
+        self.voice_modulator_active = modulated
 
 
 class _FakeMedicalState:
@@ -46,9 +52,11 @@ class _FakeMedicalState:
 
 class _FakeChar:
     def __init__(self, description=None, ending=None, talking=1.0,
-                 medical=True):
-        self.db = _FakeDB(description, ending)
+                 medical=True, sleeve_uid="sleeve-1", modulated=False):
+        self.db = _FakeDB(description, ending, modulated)
         self.medical_state = _FakeMedicalState(talking) if medical else None
+        self.sleeve_uid = sleeve_uid
+        self.voice_memory = {}
 
 
 class VocabularyTests(TestCase):
@@ -132,6 +140,67 @@ class TalkingGarbleGateTests(TestCase):
         char = _FakeChar("gravelly", "drawl", medical=False)
         self.assertFalse(is_voice_garbled(char))
         self.assertIsNone(garbled_voice_phrase(char))
+
+
+class VoiceRecognitionTests(TestCase):
+    """The voice apparent-UID / voice-memory parallel (§4.2)."""
+
+    def test_uid_is_stable_and_deterministic(self):
+        a = _FakeChar("gravelly", "drawl", sleeve_uid="s1")
+        b = _FakeChar("gravelly", "drawl", sleeve_uid="s1")
+        self.assertEqual(get_apparent_voice_uid(a), get_apparent_voice_uid(b))
+        self.assertEqual(len(get_apparent_voice_uid(a)), 16)
+
+    def test_uid_salted_on_sleeve_even_without_flavour(self):
+        # Everyone has a recognisable voice UID via sleeve_uid; flavour is
+        # presentation, not identity.
+        a = _FakeChar(sleeve_uid="s1")
+        b = _FakeChar(sleeve_uid="s2")
+        self.assertIsNotNone(get_apparent_voice_uid(a))
+        self.assertNotEqual(get_apparent_voice_uid(a), get_apparent_voice_uid(b))
+
+    def test_no_sleeve_uid_means_no_uid(self):
+        self.assertIsNone(get_apparent_voice_uid(_FakeChar(sleeve_uid=None)))
+
+    def test_modulator_changes_uid(self):
+        bare = _FakeChar("gravelly", "drawl", sleeve_uid="s1", modulated=False)
+        masked = _FakeChar("gravelly", "drawl", sleeve_uid="s1", modulated=True)
+        self.assertNotEqual(
+            get_apparent_voice_uid(bare), get_apparent_voice_uid(masked)
+        )
+
+    def test_signature_shape(self):
+        char = _FakeChar("gravelly", "drawl", sleeve_uid="s1")
+        self.assertEqual(
+            get_voice_signature(char), ("s1", "gravelly", "drawl", False)
+        )
+
+    def test_remember_and_resolve(self):
+        observer = _FakeChar(sleeve_uid="obs")
+        speaker = _FakeChar("gravelly", "drawl", sleeve_uid="spk")
+        self.assertIsNone(get_assigned_voice_name(observer, speaker))
+        self.assertTrue(remember_voice(observer, speaker, "Bob"))
+        self.assertEqual(get_assigned_voice_name(observer, speaker), "Bob")
+
+    def test_remembered_voice_not_recognised_through_modulator(self):
+        observer = _FakeChar(sleeve_uid="obs")
+        speaker = _FakeChar("gravelly", "drawl", sleeve_uid="spk")
+        remember_voice(observer, speaker, "Bob")
+        # Same person switches on a modulator → unknown voice.
+        speaker.db.voice_modulator_active = True
+        self.assertIsNone(get_assigned_voice_name(observer, speaker))
+
+    def test_cannot_remember_voiceless_target(self):
+        observer = _FakeChar(sleeve_uid="obs")
+        no_sleeve = _FakeChar(sleeve_uid=None)
+        self.assertFalse(remember_voice(observer, no_sleeve, "Ghost"))
+
+    def test_forget_voice(self):
+        observer = _FakeChar(sleeve_uid="obs")
+        speaker = _FakeChar("gravelly", "drawl", sleeve_uid="spk")
+        remember_voice(observer, speaker, "Bob")
+        self.assertTrue(forget_voice(observer, speaker))
+        self.assertIsNone(get_assigned_voice_name(observer, speaker))
 
 
 class CommandRegistrationTests(TestCase):

--- a/world/voice.py
+++ b/world/voice.py
@@ -29,7 +29,12 @@ like the visual-keyword sets.
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
+
+# Voice-UID digest size — matches the visual Apparent-UID convention
+# (``world.identity._APPARENT_UID_DIGEST_BYTES``) so the two axes read alike.
+_VOICE_UID_DIGEST_BYTES = 8
 
 # --------------------------------------------------------------------------
 # Curated vocabulary
@@ -127,9 +132,14 @@ def _read_talking_capacity(char: Any) -> float | None:
     if not callable(calc):
         return None
     try:
-        return calc("talking")
+        value = calc("talking")
     except Exception:
         return None
+    # Only a real number gates garble; anything else (e.g. a test mock) fails
+    # open, mirroring ``world.combat.dice.get_character_stat``.
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    return value
 
 
 def is_voice_garbled(char: Any) -> bool:
@@ -172,3 +182,125 @@ def voice_phrase(char: Any, language: str = "Common") -> str | None:
     else:
         return None
     return f"speaking {language}, {body}"
+
+
+# --------------------------------------------------------------------------
+# Voice recognition — the apparent-UID / recognition-memory parallel (§4.2)
+# --------------------------------------------------------------------------
+# Voice recognition is the visual recognition machine on a second axis. The
+# signature is salted on the speaker's real ``sleeve_uid`` (so everyone has a
+# stable, recognisable voice even before they curate flavour — the description /
+# ending are presentation, exactly as the visual sdesc keyword is) plus the
+# presentation slots and the modulator state. A voice modulator changes the UID,
+# defeating recognition the way a mask defeats the visual channel.
+#
+# Garble (a wrecked ``talking`` capacity) is NOT a signature input — it does not
+# change *who* the voice belongs to, it transiently prevents production. The
+# resolution chain (slice 2c) skips the voice channel for a currently-garbled
+# speaker; the stored UID stays stable across the injury.
+
+def is_voice_modulated(char: Any) -> bool:
+    """True if a voice modulator is masking this character's voice.
+
+    The cyber-disguise parallel to a visual mask (§4.2). No augment sets this
+    yet; the flag is honoured now so the modulator is pure content later.
+    """
+    db = getattr(char, "db", None)
+    return bool(getattr(db, "voice_modulator_active", False)) if db is not None else False
+
+
+def get_voice_signature(char: Any) -> tuple:
+    """The voice signature tuple — input to :func:`get_apparent_voice_uid`.
+
+    Mirrors ``world.identity.get_identity_signature``: real ``sleeve_uid`` as a
+    per-character salt, plus the curated presentation slots and modulator state.
+
+    Returns:
+        ``(sleeve_uid, voice_description, voice_ending, modulator_active)``.
+    """
+    return (
+        getattr(char, "sleeve_uid", None),
+        get_voice_description(char),
+        get_voice_ending(char),
+        is_voice_modulated(char),
+    )
+
+
+def get_apparent_voice_uid(char: Any) -> str | None:
+    """Deterministic voice UID for a character's current voice presentation.
+
+    ``None`` when there is no real ``sleeve_uid`` (pre-chargen shell) — callers
+    MUST treat ``None`` as "no voice recognition possible", exactly as the
+    visual pipeline treats a ``None`` Apparent UID.
+    """
+    signature = get_voice_signature(char)
+    if signature[0] is None:
+        return None
+    signature_bytes = repr(signature).encode("utf-8")
+    return hashlib.blake2b(
+        signature_bytes, digest_size=_VOICE_UID_DIGEST_BYTES
+    ).hexdigest()
+
+
+def get_assigned_voice_name(observer: Any, target: Any) -> str | None:
+    """Return *observer*'s assigned name for *target*'s current voice.
+
+    Resolves *target*'s current voice UID and looks up the matching
+    ``voice_memory`` entry on *observer*. The voice parallel to
+    ``world.identity.get_assigned_name``. Returns the non-empty assigned name,
+    or ``None`` when the observer has not named this voice (including when the
+    target has no voice UID, or the voice is modulated into an unknown UID).
+    """
+    voice_uid = get_apparent_voice_uid(target)
+    if voice_uid is None:
+        return None
+    memory = getattr(observer, "voice_memory", None)
+    if not memory or voice_uid not in memory:
+        return None
+    assigned = memory[voice_uid].get("assigned_name") or ""
+    return assigned or None
+
+
+def remember_voice(observer: Any, target: Any, name: str) -> bool:
+    """Record *name* for *target*'s current voice in *observer*'s voice memory.
+
+    The voice parallel to the recognition-memory writer in ``CmdRemember``.
+    Keyed on the target's current voice UID, so a modulated voice gets its own
+    entry (you can know someone's real voice and not their disguised one).
+
+    Returns ``True`` if an entry was written, ``False`` when the target has no
+    usable voice UID (nothing to remember).
+    """
+    voice_uid = get_apparent_voice_uid(target)
+    if voice_uid is None:
+        return False
+
+    memory = getattr(observer, "voice_memory", None)
+    if memory is None:
+        memory = {}
+
+    entry = memory.get(voice_uid, {})
+    entry["assigned_name"] = name
+    entry["voice_phrase_at_encounter"] = voice_phrase(target)
+    entry["real_sleeve_uid"] = getattr(target, "sleeve_uid", None)
+    memory[voice_uid] = entry
+    # Reassign through the attribute so the AttributeProperty persists the
+    # mutated dict (mirrors how CmdRemember writes recognition_memory).
+    observer.voice_memory = memory
+    return True
+
+
+def forget_voice(observer: Any, target: Any) -> bool:
+    """Clear *observer*'s assigned name for *target*'s current voice.
+
+    Returns ``True`` if an entry was cleared, ``False`` otherwise.
+    """
+    voice_uid = get_apparent_voice_uid(target)
+    if voice_uid is None:
+        return False
+    memory = getattr(observer, "voice_memory", None)
+    if not memory or voice_uid not in memory:
+        return False
+    memory[voice_uid]["assigned_name"] = ""
+    observer.voice_memory = memory
+    return True


### PR DESCRIPTION
Second slice of capacity-consumer layer 2 (CAPACITY_CONSUMERS spec §4.2):
the voice recognition machine, mirroring the visual apparent-UID /
recognition_memory pipeline so a known voice can attribute a speaker.

- world/voice.py: get_voice_signature (salted on sleeve_uid so everyone has
  a stable, recognisable voice — flavour is presentation, not identity —
  plus a voice_modulator_active slot that, like a mask, changes the UID and
  defeats recognition); get_apparent_voice_uid (blake2b, matches the visual
  16-hex convention); get_assigned_voice_name / remember_voice / forget_voice.
  _read_talking_capacity hardened to require a real number (fail open on a
  non-numeric, e.g. a test mock).
- typeclasses/characters.py: voice_memory AttributeProperty, mirroring
  recognition_memory.
- remember <target> / forget <target> (CmdCharacter.py) teach/clear the voice
  alongside the face — you are co-located, so you hear them — skipped when the
  speaker's voice is currently garbled (wrecked `talking`). Garble is a
  resolution-time gate, not a signature input; the stored UID stays stable.

Not yet consumed by display — the see -> hear -> neither resolution chain is
slice 2c.

Tests: world/tests/test_voice_identity.py (+9 recognition cases). Full
596-test identity + voice + combat sweep green.

Closes #585

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
