### PR TITLE
Voice: the resolution chain — see->hear->neither, gated on capacities (2c)

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -25,7 +25,9 @@ from random import random
 from world.grammar import capitalize_first
 from world.identity_utils import msg_room_identity
 from world.voice import (
+    can_see,
     garbled_voice_phrase,
+    resolve_speaker_attribution,
     voice_phrase,
     VOICE_FLAVOR_SPRINKLE_CHANCE,
 )
@@ -64,29 +66,34 @@ class CmdSay(Command):
         # Actor sees their own message
         caller.msg(f'You say, "{speech}"')
 
-        # Voice flavour (CAPACITY_CONSUMERS spec §4). A garbled voice (wrecked
-        # `talking` capacity) always renders — a ruined voice is conspicuous;
-        # otherwise the speaker is visible to the room, so flavour is a
-        # sporadic, low-frequency sprinkle (§4.6 can-see branch) rolled once
-        # per utterance for a consistent reading. The full sight/hearing
-        # resolution chain (unseen speakers → mandatory attribution) is a
-        # later slice.
-        flavor = garbled_voice_phrase(caller)
-        if flavor is None:
+        # Voice flavour for observers who can SEE the speaker (CAPACITY_CONSUMERS
+        # spec §4.6 can-see branch): a garbled voice always renders — a ruined
+        # voice is conspicuous — otherwise a sporadic, low-frequency sprinkle,
+        # rolled once per utterance for a consistent reading.
+        visible_flavor = garbled_voice_phrase(caller)
+        if visible_flavor is None:
             phrase = voice_phrase(caller)
             if phrase and random() < VOICE_FLAVOR_SPRINKLE_CHANCE:
-                flavor = phrase
-        say_verb = f"says, |x*{flavor}*|n" if flavor else "says,"
+                visible_flavor = phrase
+        visible_verb = f"says, |x*{visible_flavor}*|n" if visible_flavor else "says,"
 
-        # Each observer sees per-observer speaker attribution
+        # Each observer's attribution resolves per the sight/hearing chain
+        # (§4.5): see → display name; can't-see-but-hear → voice discernment
+        # (name or "someone"); neither → "someone". Voice flavour only attaches
+        # on the can-see branch; an unseen, undiscerned voice is not described.
         for observer in location.contents:
             if observer is caller:
                 continue
             if not hasattr(observer, "msg"):
                 continue
-            speaker_name = caller.get_display_name(observer)
+            if can_see(observer):
+                speaker_name = caller.get_display_name(observer)
+                verb = visible_verb
+            else:
+                speaker_name = resolve_speaker_attribution(caller, observer)
+                verb = "says,"
             observer.msg(
-                text=f'{capitalize_first(speaker_name)} {say_verb} "{speech}"',
+                text=f'{capitalize_first(speaker_name)} {verb} "{speech}"',
                 type="say",
                 from_obj=caller,
             )

--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -353,6 +353,8 @@ is the content lift) → per-effector resolver (manipulation/moving).
    `world/tests/test_combat_capacity_sight.py`.
 2. **Identity / voice** — `@voice` + voice signature + the resolution chain +
    rendering heuristic; gates visual recognition on `sight`, voice on `hearing`.
+   **✅ CORE SHIPPED (2a/2b/2c).** Deferred: voice-descriptor-as-identity +
+   §4.6 multi-voice disambiguation; deaf audio suppression.
    - **2a ✅ SHIPPED — voice signature foundation.** `world/voice.py`: curated
      description+ending vocabulary (config-overridable), composer
      (`voice_phrase`), and the **`talking`-capacity garble gate** (§4.7 — first
@@ -370,9 +372,21 @@ is the content lift) → per-effector resolver (manipulation/moving).
      `remember <target>`/`forget <target>` now teach/clear the voice alongside
      the face (skipping garbled speakers). Tests in `test_voice_identity.py`.
      *Not yet consumed by display* — that's 2c.
-   - **2c — the resolution chain** (§4.5) in `get_display_name`/`say`: see→hear→
-     neither, gated on the listener's `sight`/`hearing`; unlocks unseen
-     speakers and the full §4.6 heuristic (mandatory disambiguation). *Not built.*
+   - **2c ✅ SHIPPED — the resolution chain.** `resolve_speaker_attribution`
+     (`world/voice.py`) gates speech attribution on the *listener's* capacities:
+     **can-see → display name; can't-see-but-hear → voice discernment; neither →
+     "someone."** `can_see`/`can_hear` read `sight`/`hearing` (override-condition
+     seams for chrome eyes/ears). **Discerning a voice is always a determination**
+     mirroring disguise piercing: `attempt_voice_discern` runs opposed
+     Intellect-vs-Resonance, familiarity buff, modulator penalty, **weighted by
+     the listener's `hearing` capacity** (the consumer — `hearing` finally lands),
+     cached per presentation; forget invalidates it. **Decided simplification:**
+     an unrecognised/undiscerned voice is *not* attributed (no descriptor) — it
+     renders as "someone"; the voice-descriptor-as-identity ("a gravelly drawl
+     says…") and the §4.6 multi-voice disambiguation are **deferred**. Wired into
+     `say` (per-observer; 2a flavour now confined to the can-see branch). Tests in
+     `test_voice_identity.py`. **Headline payoff live: a blind listener recognises
+     a known voice; a stranger's stays "someone."**
 3. **Perception render** — capacities gate LOOK sensory categories + compensatory
    enrichment.
 4. **Per-effector resolver** — `manipulation`/`moving` (and the multi-appendage

--- a/world/tests/test_voice_identity.py
+++ b/world/tests/test_voice_identity.py
@@ -16,7 +16,11 @@ from unittest import TestCase
 from world.voice import (
     DEFAULT_VOICE_DESCRIPTIONS,
     DEFAULT_VOICE_ENDINGS,
+    GENERIC_UNSEEN_SPEAKER,
     VOICE_GARBLE_THRESHOLD,
+    attempt_voice_discern,
+    can_hear,
+    can_see,
     forget_voice,
     garbled_voice_phrase,
     get_apparent_voice_uid,
@@ -29,6 +33,7 @@ from world.voice import (
     is_valid_voice_ending,
     is_voice_garbled,
     remember_voice,
+    resolve_speaker_attribution,
     voice_phrase,
 )
 
@@ -38,25 +43,42 @@ class _FakeDB:
         self.voice_description = description
         self.voice_ending = ending
         self.voice_modulator_active = modulated
+        # Evennia's db handler returns None for unset attributes; the discern
+        # cache relies on that.
+        self.voice_discern_cache = None
 
 
 class _FakeMedicalState:
-    def __init__(self, talking=1.0):
-        self._talking = talking
+    def __init__(self, talking=1.0, sight=1.0, hearing=1.0, conditions=None):
+        self._caps = {"talking": talking, "sight": sight, "hearing": hearing}
+        self._conditions = conditions or {}
 
     def calculate_body_capacity(self, name):
-        if name == "talking":
-            return self._talking
-        return 1.0
+        return self._caps.get(name, 1.0)
+
+    def get_conditions_by_type(self, condition_type):
+        return [object()] * self._conditions.get(condition_type, 0)
 
 
 class _FakeChar:
     def __init__(self, description=None, ending=None, talking=1.0,
-                 medical=True, sleeve_uid="sleeve-1", modulated=False):
+                 medical=True, sleeve_uid="sleeve-1", modulated=False,
+                 sight=1.0, hearing=1.0, intellect=10, resonance=10,
+                 dbref="#1", conditions=None, key="Speaker"):
         self.db = _FakeDB(description, ending, modulated)
-        self.medical_state = _FakeMedicalState(talking) if medical else None
+        self.medical_state = (
+            _FakeMedicalState(talking, sight, hearing, conditions)
+            if medical else None
+        )
         self.sleeve_uid = sleeve_uid
         self.voice_memory = {}
+        self.intellect = intellect
+        self.resonance = resonance
+        self.dbref = dbref
+        self.key = key
+
+    def get_display_name(self, looker=None, **kwargs):
+        return self.key
 
 
 class VocabularyTests(TestCase):
@@ -201,6 +223,146 @@ class VoiceRecognitionTests(TestCase):
         remember_voice(observer, speaker, "Bob")
         self.assertTrue(forget_voice(observer, speaker))
         self.assertIsNone(get_assigned_voice_name(observer, speaker))
+
+
+class PerceptionTests(TestCase):
+    """can_see / can_hear capacity thresholds + override seams (§4.5)."""
+
+    def test_full_senses(self):
+        char = _FakeChar(sight=1.0, hearing=1.0)
+        self.assertTrue(can_see(char))
+        self.assertTrue(can_hear(char))
+
+    def test_one_eye_one_ear_still_perceive(self):
+        char = _FakeChar(sight=0.5, hearing=0.5)
+        self.assertTrue(can_see(char))
+        self.assertTrue(can_hear(char))
+
+    def test_blind_and_deaf(self):
+        char = _FakeChar(sight=0.0, hearing=0.0)
+        self.assertFalse(can_see(char))
+        self.assertFalse(can_hear(char))
+
+    def test_override_conditions_restore_senses(self):
+        from world.voice import (
+            SIGHT_OVERRIDE_CONDITION, HEARING_OVERRIDE_CONDITION,
+        )
+        char = _FakeChar(
+            sight=0.0, hearing=0.0,
+            conditions={SIGHT_OVERRIDE_CONDITION: 1, HEARING_OVERRIDE_CONDITION: 1},
+        )
+        self.assertTrue(can_see(char))
+        self.assertTrue(can_hear(char))
+
+    def test_no_medical_model_fails_open(self):
+        char = _FakeChar(medical=False)
+        self.assertTrue(can_see(char))
+        self.assertTrue(can_hear(char))
+
+
+class VoiceDiscernmentTests(TestCase):
+    """The discernment determination (mirrors disguise piercing, §4.5)."""
+
+    def _observer(self, **kw):
+        kw.setdefault("dbref", "#100")
+        kw.setdefault("key", "Listener")
+        return _FakeChar(**kw)
+
+    def test_unknown_voice_not_discerned(self):
+        observer = self._observer()
+        speaker = _FakeChar(sleeve_uid="spk", dbref="#1")
+        self.assertIsNone(attempt_voice_discern(observer, speaker))
+
+    def test_garbled_speaker_not_discerned(self):
+        observer = self._observer(intellect=1000)
+        speaker = _FakeChar(sleeve_uid="spk", dbref="#1", resonance=1, talking=0.0)
+        remember_voice(observer, speaker, "Bob")
+        self.assertIsNone(attempt_voice_discern(observer, speaker))
+
+    def test_no_sleeve_not_discerned(self):
+        observer = self._observer()
+        speaker = _FakeChar(sleeve_uid=None, dbref="#1")
+        self.assertIsNone(attempt_voice_discern(observer, speaker))
+
+    def test_strong_observer_discerns_known_voice(self):
+        # Overwhelming intellect vs minimal resonance + familiarity → success
+        # is deterministic (obs_roll>=1, +fam, vs tgt_roll==1).
+        observer = self._observer(intellect=1000, hearing=1.0)
+        speaker = _FakeChar(sleeve_uid="spk", dbref="#1", resonance=1)
+        remember_voice(observer, speaker, "Bob")
+        self.assertEqual(attempt_voice_discern(observer, speaker), "Bob")
+
+    def test_hearing_capacity_gates_discernment(self):
+        # Same overwhelming setup, but near-zero hearing collapses the
+        # observer's side below the target's floor → deterministic failure.
+        speaker = _FakeChar(sleeve_uid="spk", dbref="#1", resonance=1)
+        deaf = self._observer(intellect=1000, hearing=0.0001, dbref="#101")
+        remember_voice(deaf, speaker, "Bob")
+        self.assertIsNone(attempt_voice_discern(deaf, speaker))
+
+    def test_verdict_is_cached(self):
+        observer = self._observer()
+        speaker = _FakeChar(sleeve_uid="spk", dbref="#1", resonance=1)
+        remember_voice(observer, speaker, "Bob")
+        # Pre-seed a True verdict; the cached value is honoured (no re-roll).
+        voice_uid = get_apparent_voice_uid(speaker)
+        observer.db.voice_discern_cache = {("#1", voice_uid): True}
+        self.assertEqual(attempt_voice_discern(observer, speaker), "Bob")
+        # Flip the cached verdict → None, proving the cache is read.
+        observer.db.voice_discern_cache = {("#1", voice_uid): False}
+        self.assertIsNone(attempt_voice_discern(observer, speaker))
+
+    def test_forget_clears_discern_cache(self):
+        observer = self._observer(intellect=1000)
+        speaker = _FakeChar(sleeve_uid="spk", dbref="#1", resonance=1)
+        remember_voice(observer, speaker, "Bob")
+        attempt_voice_discern(observer, speaker)  # populate cache
+        self.assertTrue(observer.db.voice_discern_cache)
+        forget_voice(observer, speaker)
+        self.assertFalse(observer.db.voice_discern_cache)
+
+
+class ResolutionChainTests(TestCase):
+    """resolve_speaker_attribution: see -> hear -> neither (§4.5)."""
+
+    def test_self_returns_own_key(self):
+        char = _FakeChar(key="Me")
+        self.assertEqual(resolve_speaker_attribution(char, char), "Me")
+
+    def test_sighted_observer_uses_display_name(self):
+        speaker = _FakeChar(key="Bob")
+        observer = _FakeChar(sight=1.0, dbref="#100", key="Listener")
+        self.assertEqual(resolve_speaker_attribution(speaker, observer), "Bob")
+
+    def test_blind_hearing_discerns_known_voice(self):
+        speaker = _FakeChar(key="Bob", sleeve_uid="spk", dbref="#1", resonance=1)
+        observer = _FakeChar(
+            sight=0.0, hearing=1.0, intellect=1000, dbref="#100", key="Listener"
+        )
+        remember_voice(observer, speaker, "Bob-voice")
+        self.assertEqual(
+            resolve_speaker_attribution(speaker, observer), "Bob-voice"
+        )
+
+    def test_blind_hearing_unknown_voice_is_generic(self):
+        speaker = _FakeChar(key="Bob", sleeve_uid="spk", dbref="#1")
+        observer = _FakeChar(sight=0.0, hearing=1.0, dbref="#100")
+        self.assertEqual(
+            resolve_speaker_attribution(speaker, observer),
+            GENERIC_UNSEEN_SPEAKER,
+        )
+
+    def test_blind_and_deaf_is_generic(self):
+        speaker = _FakeChar(key="Bob", sleeve_uid="spk", dbref="#1", resonance=1)
+        observer = _FakeChar(
+            sight=0.0, hearing=0.0, intellect=1000, dbref="#100"
+        )
+        remember_voice(observer, speaker, "Bob-voice")
+        # Even with the voice remembered, no hearing → generic.
+        self.assertEqual(
+            resolve_speaker_attribution(speaker, observer),
+            GENERIC_UNSEEN_SPEAKER,
+        )
 
 
 class CommandRegistrationTests(TestCase):

--- a/world/voice.py
+++ b/world/voice.py
@@ -120,34 +120,93 @@ def has_voice_signature(char: Any) -> bool:
 
 
 # --------------------------------------------------------------------------
-# The talking-capacity gate (§4.7)
+# Capacity reads
 # --------------------------------------------------------------------------
-def _read_talking_capacity(char: Any) -> float | None:
-    """Raw ``talking`` capacity (0.0–1.0), or ``None`` if unreadable.
+def _read_capacity(char: Any, name: str) -> float | None:
+    """Raw body capacity *name* (0.0–1.0) for *char*, or ``None`` if unreadable.
 
-    ``None`` → fail open (no medical model means no garble).
+    ``None`` signals "no medical model" — callers fail open. Only a real number
+    is returned; anything else (e.g. a test mock) yields ``None``, mirroring
+    ``world.combat.dice.get_character_stat``.
     """
     state = getattr(char, "medical_state", None)
     calc = getattr(state, "calculate_body_capacity", None)
     if not callable(calc):
         return None
     try:
-        value = calc("talking")
+        value = calc(name)
     except Exception:
         return None
-    # Only a real number gates garble; anything else (e.g. a test mock) fails
-    # open, mirroring ``world.combat.dice.get_character_stat``.
     if not isinstance(value, (int, float)) or isinstance(value, bool):
         return None
     return value
 
 
+def _has_condition(char: Any, condition_type: str) -> bool:
+    """True if *char* carries an active condition of *condition_type*."""
+    state = getattr(char, "medical_state", None)
+    getter = getattr(state, "get_conditions_by_type", None)
+    if not callable(getter):
+        return False
+    try:
+        return bool(getter(condition_type))
+    except Exception:
+        return False
+
+
+# --------------------------------------------------------------------------
+# The talking-capacity gate (§4.7)
+# --------------------------------------------------------------------------
 def is_voice_garbled(char: Any) -> bool:
     """True when a wrecked ``talking`` capacity ruins voice production."""
-    talking = _read_talking_capacity(char)
+    talking = _read_capacity(char, "talking")
     if talking is None:
         return False
     return talking < VOICE_GARBLE_THRESHOLD
+
+
+# --------------------------------------------------------------------------
+# Perception primitives — can the observer see / hear the speaker (§4.5)
+# --------------------------------------------------------------------------
+# Below these capacities the observer has effectively lost the sense (blind /
+# deaf). One eye / one ear (0.5) still perceives; total loss (0.0) does not.
+# These live here for the resolution chain; layer 3 (perception render) may
+# promote them to a shared perception module. Tunable.
+SIGHT_PERCEPTION_THRESHOLD = 0.15
+HEARING_PERCEPTION_THRESHOLD = 0.15
+
+# Condition seams that restore a lost sense (chrome eyes / cyber ears). Reuse
+# the combat sight-override constant so one augment is coherent everywhere.
+from world.combat.capacity import SIGHT_OVERRIDE_CONDITION  # noqa: E402
+HEARING_OVERRIDE_CONDITION = "hearing_override"
+
+
+def can_see(char: Any) -> bool:
+    """True if *char* can see (enough ``sight`` to visually identify others).
+
+    Fails open with no medical model. A sight-override condition (chrome eyes)
+    restores sight regardless of organ state.
+    """
+    if _has_condition(char, SIGHT_OVERRIDE_CONDITION):
+        return True
+    sight = _read_capacity(char, "sight")
+    if sight is None:
+        return True
+    return sight >= SIGHT_PERCEPTION_THRESHOLD
+
+
+def can_hear(char: Any) -> bool:
+    """True if *char* can hear (enough ``hearing`` to receive a voice).
+
+    Fails open with no medical model. A hearing-override condition (cyber ears)
+    restores hearing regardless of organ state.
+    """
+    if _has_condition(char, HEARING_OVERRIDE_CONDITION):
+        return True
+    hearing = _read_capacity(char, "hearing")
+    if hearing is None:
+        return True
+    return hearing >= HEARING_PERCEPTION_THRESHOLD
 
 
 # --------------------------------------------------------------------------
@@ -283,6 +342,9 @@ def remember_voice(observer: Any, target: Any, name: str) -> bool:
     entry["assigned_name"] = name
     entry["voice_phrase_at_encounter"] = voice_phrase(target)
     entry["real_sleeve_uid"] = getattr(target, "sleeve_uid", None)
+    # Familiarity: how many times this voice has been remembered, feeding the
+    # discernment determination (mirrors recognition ``times_seen``).
+    entry["times_heard"] = int(entry.get("times_heard", 0) or 0) + 1
     memory[voice_uid] = entry
     # Reassign through the attribute so the AttributeProperty persists the
     # mutated dict (mirrors how CmdRemember writes recognition_memory).
@@ -303,4 +365,173 @@ def forget_voice(observer: Any, target: Any) -> bool:
         return False
     memory[voice_uid]["assigned_name"] = ""
     observer.voice_memory = memory
+    invalidate_voice_discern_cache_for_sleeve(
+        observer, getattr(target, "sleeve_uid", None)
+    )
     return True
+
+
+def find_voice_entries_by_real_sleeve_uid(observer, real_sleeve_uid):
+    """All *observer* voice-memory ``(voice_uid, entry)`` for a given sleeve.
+
+    Voice parallel to ``world.identity.find_entries_by_real_sleeve_uid`` — lets
+    discernment find "have I named this person's voice under *any* presentation?"
+    (e.g. their natural voice, when they are now modulated).
+    """
+    if not real_sleeve_uid:
+        return []
+    memory = getattr(observer, "voice_memory", None) or {}
+    return [
+        (uid, entry)
+        for uid, entry in memory.items()
+        if entry.get("real_sleeve_uid") == real_sleeve_uid
+    ]
+
+
+# --------------------------------------------------------------------------
+# Voice discernment — the determination (mirrors disguise piercing, §4.5)
+# --------------------------------------------------------------------------
+# Discerning a voice is ALWAYS a determination, never a free lookup: a face you
+# can stare at, a voice you must place, and audio-only is an inherently less
+# certain channel. The mechanic mirrors ``world.identity.attempt_disguise_pierce``
+# exactly — opposed Intellect (observer) vs Resonance (target), familiarity
+# buff, a "disguise" penalty (here the voice modulator), permanently cached per
+# presentation so one determination sticks (no per-utterance flicker). What
+# voice adds is the ``hearing`` capacity multiplier on the observer's side — the
+# consumer that makes this layer earn its name (deaf cannot discern, one ear is
+# impaired). Magnitudes mirror the visual side and are tunable (spec §11).
+
+VOICE_DISCERN_FAMILIARITY_CAP = 5
+VOICE_DISCERN_MODULATION_PENALTY = 3
+
+#: What an unseen, undiscerned speaker is rendered as. The voice descriptor as a
+#: stand-in identity ("a gravelly drawl says…") is deferred — for now an
+#: unrecognised voice simply isn't attributed (decided).
+GENERIC_UNSEEN_SPEAKER = "someone"
+
+
+def attempt_voice_discern(observer: Any, target: Any) -> str | None:
+    """Resolve (and cache) whether *observer* places *target*'s voice by name.
+
+    Returns the assigned voice name on success, ``None`` otherwise (never
+    heard/named this voice, garbled production, failed determination). The
+    caller renders ``None`` as :data:`GENERIC_UNSEEN_SPEAKER`.
+    """
+    if observer is target:
+        return None
+    # A garbled voice carries no usable signature to place.
+    if is_voice_garbled(target):
+        return None
+
+    voice_uid = get_apparent_voice_uid(target)
+    real_sleeve = getattr(target, "sleeve_uid", None)
+    if voice_uid is None or not real_sleeve:
+        return None
+
+    # Have we named this person's voice under any presentation?
+    named = [
+        (uid, entry)
+        for uid, entry in find_voice_entries_by_real_sleeve_uid(observer, real_sleeve)
+        if (entry.get("assigned_name") or "")
+    ]
+    if not named:
+        return None
+    # Prefer the entry for the *current* voice presentation; otherwise any named
+    # presentation (you know their natural voice, they are modulated now).
+    bare_entry = next(
+        (entry for uid, entry in named if uid == voice_uid), named[0][1]
+    )
+    assigned_name = bare_entry["assigned_name"]
+
+    observer_dbref = getattr(observer, "dbref", None)
+    target_dbref = getattr(target, "dbref", None)
+    cacheable = (
+        observer_dbref is not None
+        and target_dbref is not None
+        and bool(voice_uid)
+    )
+    if cacheable:
+        cache = observer.db.voice_discern_cache
+        if cache is None:
+            cache = {}
+        key = (target_dbref, voice_uid)
+        if key in cache:
+            return assigned_name if cache[key] else None
+    else:
+        cache = None
+        key = None
+
+    from world.combat.dice import opposed_roll
+
+    obs_roll, tgt_roll, _ = opposed_roll(
+        observer, target, "intellect", "resonance"
+    )
+    familiarity = min(
+        int(bare_entry.get("times_heard", 0) or 0),
+        VOICE_DISCERN_FAMILIARITY_CAP,
+    )
+    penalty = VOICE_DISCERN_MODULATION_PENALTY if is_voice_modulated(target) else 0
+    # Hearing weights the observer's side — the capacity consumer. Fail open
+    # (full hearing) with no medical model.
+    hearing = _read_capacity(observer, "hearing")
+    if hearing is None:
+        hearing = 1.0
+    success = (obs_roll + familiarity) * hearing > (tgt_roll + penalty)
+
+    if cacheable:
+        cache[key] = success
+        observer.db.voice_discern_cache = cache
+
+    return assigned_name if success else None
+
+
+def invalidate_voice_discern_cache_for_sleeve(observer, real_sleeve_uid):
+    """Drop cached voice-discern verdicts for every presentation of a sleeve.
+
+    Voice parallel to ``world.identity.invalidate_pierce_cache_for_sleeve`` —
+    called on forget so the cognitive act of forgetting a person also discards
+    every cached discernment for any voice presentation they have used.
+    """
+    if not real_sleeve_uid:
+        return 0
+    db = getattr(observer, "db", None)
+    cache = getattr(db, "voice_discern_cache", None) if db is not None else None
+    if not cache:
+        return 0
+    uids = {
+        uid for uid, _ in find_voice_entries_by_real_sleeve_uid(observer, real_sleeve_uid)
+    }
+    if not uids:
+        return 0
+    removed = 0
+    for key in list(cache.keys()):
+        # key == (target_dbref, voice_uid)
+        if isinstance(key, tuple) and len(key) == 2 and key[1] in uids:
+            del cache[key]
+            removed += 1
+    if removed:
+        observer.db.voice_discern_cache = cache
+    return removed
+
+
+# --------------------------------------------------------------------------
+# The resolution chain — who said it, per listener (§4.5)
+# --------------------------------------------------------------------------
+def resolve_speaker_attribution(speaker: Any, observer: Any) -> str:
+    """How *observer* hears *speaker* attributed in speech.
+
+    The see → hear → neither chain, gated on the *observer's* capacities:
+
+    1. **Can see** → the normal visual display name (recognition / disguise
+       pierce / sdesc) — unchanged from the sighted path.
+    2. **Can't see, can hear** → the voice discernment determination: the
+       assigned voice name on success, else :data:`GENERIC_UNSEEN_SPEAKER`.
+    3. **Neither** (blind + deaf) → :data:`GENERIC_UNSEEN_SPEAKER`.
+    """
+    if observer is speaker:
+        return getattr(speaker, "key", GENERIC_UNSEEN_SPEAKER)
+    if can_see(observer):
+        return speaker.get_display_name(observer)
+    if can_hear(observer):
+        return attempt_voice_discern(observer, speaker) or GENERIC_UNSEEN_SPEAKER
+    return GENERIC_UNSEEN_SPEAKER


### PR DESCRIPTION
Third slice of capacity-consumer layer 2 (CAPACITY_CONSUMERS spec §4.5),
the headline payoff: a blind listener recognises a known voice.

- resolve_speaker_attribution(speaker, observer) gates speech attribution on
  the LISTENER's capacities: can-see -> visual display name; can't-see-but-
  hear -> voice discernment; neither -> "someone".
- can_see / can_hear read sight / hearing capacities with override-condition
  seams (chrome eyes / cyber ears). `hearing` finally consumes here.
- attempt_voice_discern: discerning a voice is ALWAYS a determination (a face
  you stare at; a voice you must place), mirroring attempt_disguise_pierce —
  opposed Intellect-vs-Resonance, familiarity buff (times_heard), voice-
  modulator penalty, WEIGHTED BY the listener's hearing capacity, permanently
  cached per presentation (no per-utterance flicker); forget invalidates it.
  A garbled or modulated voice resists.
- Decided simplification: an unrecognised voice is NOT attributed (no
  descriptor) — it renders as "someone". The voice-descriptor-as-identity
  ("a gravelly drawl says...") and the §4.6 multi-voice disambiguation are
  deferred.
- Wired into `say` per-observer; 2a's flavour sprinkle is now confined to the
  can-see branch. remember_voice tracks times_heard for familiarity; the
  talking capacity read is generalised to _read_capacity.

Tests: world/tests/test_voice_identity.py (42 total; +17 perception /
discernment / resolution-chain). 239-test voice+combat+identity sweep green.

Closes #587

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
