### PR TITLE
Voice: deaf audio gating for say / poses / whisper (layer 2d)

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -25,6 +25,7 @@ from random import random
 from world.grammar import capitalize_first
 from world.identity_utils import msg_room_identity
 from world.voice import (
+    can_hear,
     can_see,
     garbled_voice_phrase,
     resolve_speaker_attribution,
@@ -77,26 +78,36 @@ class CmdSay(Command):
                 visible_flavor = phrase
         visible_verb = f"says, |x*{visible_flavor}*|n" if visible_flavor else "says,"
 
-        # Each observer's attribution resolves per the sight/hearing chain
-        # (§4.5): see → display name; can't-see-but-hear → voice discernment
-        # (name or "someone"); neither → "someone". Voice flavour only attaches
-        # on the can-see branch; an unseen, undiscerned voice is not described.
+        # Each observer's perception resolves per the sight/hearing chain
+        # (§4.5). Hearing gates the *content* (the words); sight + the voice
+        # channel gate the *attribution* (who):
+        #   - can hear → the words, attributed by sight (name + flavour) or by
+        #     voice discernment (name / "someone").
+        #   - deaf but can see → they watch the speaker mouth something but
+        #     can't make it out (no content).
+        #   - deaf and blind → no channel at all; the utterance is suppressed.
         for observer in location.contents:
             if observer is caller:
                 continue
             if not hasattr(observer, "msg"):
                 continue
-            if can_see(observer):
-                speaker_name = caller.get_display_name(observer)
-                verb = visible_verb
+
+            heard = can_hear(observer)
+            seen = can_see(observer)
+            if not heard and not seen:
+                continue  # no channel — suppress entirely
+
+            speaker_name = resolve_speaker_attribution(caller, observer)
+            if heard:
+                verb = visible_verb if seen else "says,"
+                text = f'{capitalize_first(speaker_name)} {verb} "{speech}"'
             else:
-                speaker_name = resolve_speaker_attribution(caller, observer)
-                verb = "says,"
-            observer.msg(
-                text=f'{capitalize_first(speaker_name)} {verb} "{speech}"',
-                type="say",
-                from_obj=caller,
-            )
+                # Deaf but watching: speech is visible, content is not.
+                text = (
+                    f"{capitalize_first(speaker_name)} says something "
+                    f"you can't make out."
+                )
+            observer.msg(text=text, type="say", from_obj=caller)
 
 
 class CmdWhisper(Command):
@@ -143,16 +154,21 @@ class CmdWhisper(Command):
         target_name_for_actor = target.get_display_name(caller)
         caller.msg(f'You whisper to {target_name_for_actor}, "{speech}"')
 
-        # Target hears the full message
-        speaker_name_for_target = caller.get_display_name(target)
-        target.msg(
-            text=(
-                f'{capitalize_first(speaker_name_for_target)}'
-                f' whispers to you, "{speech}"'
-            ),
-            type="whisper",
-            from_obj=caller,
+        # Target hears the full message — unless deaf, in which case they feel
+        # the lean-in but can't make out the words (CAPACITY_CONSUMERS §4).
+        speaker_name_for_target = capitalize_first(
+            caller.get_display_name(target)
         )
+        if can_hear(target):
+            target_text = (
+                f'{speaker_name_for_target} whispers to you, "{speech}"'
+            )
+        else:
+            target_text = (
+                f"{speaker_name_for_target} leans in to whisper, but you "
+                f"can't make out a word of it."
+            )
+        target.msg(text=target_text, type="whisper", from_obj=caller)
 
         # Room observers see that a whisper occurred, but NOT the content
         for observer in location.contents:

--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -353,8 +353,16 @@ is the content lift) → per-effector resolver (manipulation/moving).
    `world/tests/test_combat_capacity_sight.py`.
 2. **Identity / voice** — `@voice` + voice signature + the resolution chain +
    rendering heuristic; gates visual recognition on `sight`, voice on `hearing`.
-   **✅ CORE SHIPPED (2a/2b/2c).** Deferred: voice-descriptor-as-identity +
-   §4.6 multi-voice disambiguation; deaf audio suppression.
+   **✅ CORE SHIPPED (2a/2b/2c/2d).** Deferred: voice-descriptor-as-identity +
+   §4.6 multi-voice disambiguation.
+   - **2d ✅ SHIPPED — deaf audio gating.** Hearing gates speech *content*, not
+     just attribution. `say`: a deaf+sighted listener sees "{name} says
+     something you can't make out"; deaf+blind is suppressed entirely.
+     Poses/emotes: `world/emote.py` `process_speech` redacts quoted speech to
+     `"..."` for a deaf observer (both `render_dot_pose` and the traditional
+     `render_emote` now route through it); the visible action still shows
+     (visual gating is layer 3). Whisper to a deaf target is redacted too. The
+     speaker always reads their own words. Tests in `test_emote.py`.
    - **2a ✅ SHIPPED — voice signature foundation.** `world/voice.py`: curated
      description+ending vocabulary (config-overridable), composer
      (`voice_phrase`), and the **`talking`-capacity garble gate** (§4.7 — first

--- a/world/emote.py
+++ b/world/emote.py
@@ -92,9 +92,11 @@ def process_speech(
 ) -> str:
     """Process speech content for a specific observer.
 
-    Default implementation returns text unchanged, wrapped in quotes.
-    Future language system overrides this to apply comprehension
-    filtering based on speaker's language and observer's skills.
+    Wraps speech in quotes. A deaf observer (one who cannot hear the speaker)
+    perceives that speech occurred but not its content — the quoted words are
+    redacted to ``"..."`` (CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §4: hearing
+    gates the auditory channel). The speaker always hears their own words.
+    Future language system layers further comprehension filtering here.
 
     Args:
         text: Raw speech content.
@@ -103,8 +105,12 @@ def process_speech(
         language: Language identifier or ``None`` for common/default.
 
     Returns:
-        Rendered speech string including quotes.
+        Rendered speech string including quotes (redacted when unheard).
     """
+    if observer is not speaker:
+        from world.voice import can_hear
+        if not can_hear(observer):
+            return '"..."'
     return f'"{text}"'
 
 
@@ -998,7 +1004,11 @@ def render_emote_for_observer(
         if isinstance(token, TextToken):
             parts.append(token.text)
         elif isinstance(token, SpeechToken):
-            parts.append(f'"{token.text}"')
+            parts.append(
+                process_speech(
+                    token.text, token.speaker, observer, token.language
+                )
+            )
         elif isinstance(token, CharRefToken):
             display_name = token.character.get_display_name(observer)
             parts.append(display_name)

--- a/world/tests/test_emote.py
+++ b/world/tests/test_emote.py
@@ -28,6 +28,7 @@ from world.emote import (
     _should_conjugate,
     _split_speech_segments,
     build_char_candidates,
+    process_speech,
     render_dot_pose,
     render_emote,
     render_emote_for_observer,
@@ -130,6 +131,60 @@ def _make_room(contents):
 # ===================================================================
 # Tests: Speech Splitting
 # ===================================================================
+
+
+class _MedState:
+    def __init__(self, hearing):
+        self._hearing = hearing
+
+    def calculate_body_capacity(self, name):
+        return self._hearing if name == "hearing" else 1.0
+
+    def get_conditions_by_type(self, condition_type):
+        return []
+
+
+class _Listener:
+    def __init__(self, hearing=1.0, medical=True):
+        self.medical_state = _MedState(hearing) if medical else None
+
+
+class TestProcessSpeechDeaf(TestCase):
+    """process_speech redacts quoted content for a deaf observer (§4)."""
+
+    def setUp(self):
+        self.speaker = object()  # identity-only; not the observer
+
+    def test_hearing_observer_gets_words(self):
+        observer = _Listener(hearing=1.0)
+        self.assertEqual(
+            process_speech("you're late", self.speaker, observer), '"you\'re late"'
+        )
+
+    def test_deaf_observer_content_redacted(self):
+        observer = _Listener(hearing=0.0)
+        self.assertEqual(
+            process_speech("you're late", self.speaker, observer), '"..."'
+        )
+
+    def test_one_ear_still_hears(self):
+        observer = _Listener(hearing=0.5)
+        self.assertEqual(
+            process_speech("hi", self.speaker, observer), '"hi"'
+        )
+
+    def test_speaker_always_hears_self(self):
+        # Even a deaf speaker reads back their own quoted words.
+        deaf_speaker = _Listener(hearing=0.0)
+        self.assertEqual(
+            process_speech("my words", deaf_speaker, deaf_speaker), '"my words"'
+        )
+
+    def test_no_medical_model_fails_open(self):
+        observer = _Listener(medical=False)
+        self.assertEqual(
+            process_speech("hi", self.speaker, observer), '"hi"'
+        )
 
 
 class TestSplitSpeechSegments(TestCase):


### PR DESCRIPTION
Hearing gates speech CONTENT, not just attribution (CAPACITY_CONSUMERS spec
§4). Before this a deaf player still received the full spoken words.

- say (commands/CmdCommunication.py): deaf + sighted -> "{name} says
  something you can't make out" (they watch the speaker mouth words);
  deaf + blind -> suppressed entirely (no perception channel).
- poses/emotes (world/emote.py): process_speech redacts quoted speech to
  "..." for a deaf observer. Both render_dot_pose and the traditional
  render_emote now route quotes through process_speech (the emote path
  previously inlined them). The visible action still shows — visual gating
  is layer 3.
- whisper: a deaf target feels the lean-in but can't make out the words.
- The speaker always reads their own words back.

Answers the deaf-perception design question for say + quotes in poses.

Tests: world/tests/test_emote.py (TestProcessSpeechDeaf). 203-test
emote + communication + voice sweep green.

Closes #589

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
