### PR TITLE
Combat: moving capacity -> dodge (layer 4a, defensive half)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -408,6 +408,18 @@ is the content lift) → per-effector resolver (manipulation/moving).
    layer stays whole for now; gating the additive pools is the buildable slice.
 4. **Per-effector resolver** — `manipulation`/`moving` (and the multi-appendage
    future).
+   - **4a ✅ SHIPPED — `moving` → dodge (defensive half).** `world/combat/
+     capacity.py` `moving_dodge_factor` multiplies the *target's* motorics in
+     `attack.py` (dodge = motorics × moving). Whole-body, species-normalized
+     (§6.2 — you don't pick a leg); hard floor at the table's 0.15
+     incapacitation_threshold collapses evasion to a flail; `moving_override`
+     chrome-legs seam. Tests in `test_combat_capacity_sight.py`.
+   - **4b — `manipulation` → hit (per-effector, offensive half).** The intricate
+     part (§6.1 Q1): per-*gripping-hand* manipulation, not body-wide — a
+     one-armed shooter fights at full accuracy. Needs the weapon→hand→limb-chain
+     organ traversal (invert `limb_downstream_chain`, scope a capacity to those
+     organs) + 2H under-grip blend. Breadth meta-bonuses (Q2: initiative/disarm-
+     resist/loadout) remain a future combat revision. *Not built.*
 
 Each layer ships standalone value. The five-senses *description model* (§5) is
 the one piece worth pinning early so earlier layers don't contradict it.

--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -14,7 +14,7 @@ from random import randint
 from .debug import get_splattercast
 
 from world.combat.messages import get_combat_message
-from world.combat.capacity import sight_hit_factor
+from world.combat.capacity import sight_hit_factor, moving_dodge_factor
 from world.medical.utils import select_hit_location, select_target_organ
 
 from .constants import (
@@ -405,9 +405,21 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
             f"{attacker_skill} -> {effective_skill:.1f}"
         )
 
+    # Moving capacity consumes the target's dodge (CAPACITY_CONSUMERS spec §6.2,
+    # §9 layer 4 — defensive half).  Whole-body, species-normalized; a hard floor
+    # at the incapacitation threshold means wrecked legs collapse evasion to a
+    # flail.  A moving-override condition (cyber legs) suppresses the penalty.
+    moving_factor = moving_dodge_factor(target)
+    effective_dodge = target_skill * moving_factor
+    if moving_factor < 1.0:
+        splattercast.msg(
+            f"DODGE_MOVING: {target.key} moving factor {moving_factor:.2f} — "
+            f"motorics {target_skill} -> {effective_dodge:.1f}"
+        )
+
     # Roll for attack
     attacker_roll = randint(1, 20) + effective_skill
-    target_roll = randint(1, 20) + target_skill
+    target_roll = randint(1, 20) + effective_dodge
 
     # Check for charge bonus
     has_attr = hasattr(attacker.ndb, NDB_CHARGE_BONUS)

--- a/world/combat/capacity.py
+++ b/world/combat/capacity.py
@@ -68,8 +68,8 @@ def _piecewise(raw: float, anchors) -> float:
     return anchors[-1][1]
 
 
-def _read_sight_capacity(character):
-    """Return raw ``sight`` capacity (0.0–1.0), or ``None`` if unreadable.
+def _read_capacity(character, name: str):
+    """Return raw body capacity *name* (0.0–1.0), or ``None`` if unreadable.
 
     ``None`` signals "no medical model" — the caller fails open.
     """
@@ -80,19 +80,19 @@ def _read_sight_capacity(character):
     if not callable(calc):
         return None
     try:
-        return calc("sight")
+        return calc(name)
     except Exception:
         return None
 
 
-def _has_sight_override(character) -> bool:
-    """True if a condition suppresses the sight penalty (chrome/biotech seam)."""
+def _has_override(character, condition_type: str) -> bool:
+    """True if a condition suppresses a capacity penalty (chrome/biotech seam)."""
     state = getattr(character, "medical_state", None)
     getter = getattr(state, "get_conditions_by_type", None)
     if not callable(getter):
         return False
     try:
-        return bool(getter(SIGHT_OVERRIDE_CONDITION))
+        return bool(getter(condition_type))
     except Exception:
         return False
 
@@ -109,12 +109,47 @@ def sight_hit_factor(character, is_ranged: bool) -> float:
         A factor in ``[0.0, 1.0]``.  ``1.0`` means no sight penalty (full
         sight, no medical model, or an active suppressor).
     """
-    if _has_sight_override(character):
+    if _has_override(character, SIGHT_OVERRIDE_CONDITION):
         return 1.0
 
-    raw = _read_sight_capacity(character)
+    raw = _read_capacity(character, "sight")
     if raw is None:
         return 1.0  # fail-open: no medical model, no penalty
 
     curve = SIGHT_CURVE_RANGED if is_ranged else SIGHT_CURVE_MELEE
     return _piecewise(raw, curve)
+
+
+# --------------------------------------------------------------------------
+# Moving → dodge (CAPACITY_CONSUMERS spec §6.2/§6.3 — defensive half)
+# --------------------------------------------------------------------------
+# Unlike manipulation, ``moving`` is whole-body and already species-normalized
+# (``calculate_body_capacity`` weights leg organs per anatomy: a human losing
+# one of two legs ≫ a rat losing one of four). It drives the defensive side of
+# the combat stack — dodge/evasion = motorics × moving.
+#
+# Hard floor at the species table's 0.15 incapacitation_threshold: below it you
+# can't locomote (drag yourself), so evasion collapses to a flail. Graceful
+# above. Magnitudes tunable (spec §11).
+MOVING_INCAPACITATION_THRESHOLD = 0.15
+MOVING_CURVE_DODGE = ((0.0, 0.10), (0.15, 0.25), (1.0, 1.0))
+
+# The chrome-legs seam — a cyber locomotion augment suppresses the dodge
+# penalty. Nothing sets it yet; honoured now so the augment is pure content.
+MOVING_OVERRIDE_CONDITION = "moving_override"
+
+
+def moving_dodge_factor(character) -> float:
+    """Multiplier applied to *character*'s motorics when dodging/evading.
+
+    Returns a factor in ``[0.0, 1.0]``; ``1.0`` means no penalty (full
+    locomotion, no medical model, or an active suppressor).
+    """
+    if _has_override(character, MOVING_OVERRIDE_CONDITION):
+        return 1.0
+
+    raw = _read_capacity(character, "moving")
+    if raw is None:
+        return 1.0  # fail-open
+
+    return _piecewise(raw, MOVING_CURVE_DODGE)

--- a/world/tests/test_combat_capacity_sight.py
+++ b/world/tests/test_combat_capacity_sight.py
@@ -16,7 +16,9 @@ from unittest import TestCase
 
 from world.combat.capacity import (
     SIGHT_OVERRIDE_CONDITION,
+    MOVING_OVERRIDE_CONDITION,
     sight_hit_factor,
+    moving_dodge_factor,
     _piecewise,
     SIGHT_CURVE_RANGED,
     SIGHT_CURVE_MELEE,
@@ -133,3 +135,49 @@ class SuppressionAndFailOpenTests(TestCase):
 
         char = _FakeChar(_Broken())
         self.assertAlmostEqual(sight_hit_factor(char, is_ranged=True), 1.0)
+
+
+class _MovingMedicalState:
+    def __init__(self, moving=1.0, override_conditions=0):
+        self._moving = moving
+        self._overrides = override_conditions
+
+    def calculate_body_capacity(self, name):
+        return self._moving if name == "moving" else 1.0
+
+    def get_conditions_by_type(self, condition_type):
+        if condition_type == MOVING_OVERRIDE_CONDITION:
+            return [object()] * self._overrides
+        return []
+
+
+class MovingDodgeTests(TestCase):
+    def _factor(self, moving):
+        return moving_dodge_factor(_FakeChar(_MovingMedicalState(moving=moving)))
+
+    def test_full_locomotion_no_penalty(self):
+        self.assertAlmostEqual(self._factor(1.0), 1.0)
+
+    def test_healthy_partial_loss_scales(self):
+        # A clear penalty below full, but still mobile.
+        self.assertLess(self._factor(0.5), 1.0)
+        self.assertGreater(self._factor(0.5), 0.25)
+
+    def test_incapacitation_floor_collapses_dodge(self):
+        # At/below the 0.15 threshold, evasion is a flail.
+        self.assertAlmostEqual(self._factor(0.15), 0.25)
+        self.assertAlmostEqual(self._factor(0.0), 0.10)
+
+    def test_monotonic_non_decreasing(self):
+        prev = -1.0
+        for raw in (0.0, 0.15, 0.3, 0.6, 1.0):
+            cur = self._factor(raw)
+            self.assertGreaterEqual(cur, prev)
+            prev = cur
+
+    def test_override_condition_nulls_penalty(self):
+        char = _FakeChar(_MovingMedicalState(moving=0.0, override_conditions=1))
+        self.assertAlmostEqual(moving_dodge_factor(char), 1.0)
+
+    def test_no_medical_state_fails_open(self):
+        self.assertAlmostEqual(moving_dodge_factor(_FakeChar(None)), 1.0)


### PR DESCRIPTION
The defensive half of the §6.3 combat capacity stack (CAPACITY_CONSUMERS
spec §6.2): dodge = motorics × moving.

- world/combat/capacity.py: moving_dodge_factor multiplies the TARGET's
  motorics term in attack.py. `moving` is whole-body and already species-
  normalized (a human losing 1 of 2 legs >> a rat losing 1 of 4 — §6.2,
  you don't pick a leg). Hard floor at the table's 0.15 incapacitation
  threshold collapses evasion to a flail; graceful above. `moving_override`
  is the chrome-legs seam. Fail-open with no medical model. The sight read
  helpers are generalised to _read_capacity / _has_override.

Offensive half (manipulation -> hit, per-gripping-hand, §6.1 Q1) lands
next as 4b.

Tests: world/tests/test_combat_capacity_sight.py (MovingDodgeTests).
54-test combat sweep green.

Closes #593

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
