### PR TITLE
Combat: per-hand manipulation resolver -> hit (layer 4b, offensive half)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -407,19 +407,30 @@ is the content lift) → per-effector resolver (manipulation/moving).
    accepted):** base single-blob room-desc sense decomposition — the visual
    layer stays whole for now; gating the additive pools is the buildable slice.
 4. **Per-effector resolver** — `manipulation`/`moving` (and the multi-appendage
-   future).
+   future). **✅ CORE SHIPPED (4a/4b).** Deferred: Q2 breadth meta-bonuses
+   (surplus-appendage initiative / disarm-resist / loadout) — a future combat
+   revision.
    - **4a ✅ SHIPPED — `moving` → dodge (defensive half).** `world/combat/
      capacity.py` `moving_dodge_factor` multiplies the *target's* motorics in
      `attack.py` (dodge = motorics × moving). Whole-body, species-normalized
      (§6.2 — you don't pick a leg); hard floor at the table's 0.15
      incapacitation_threshold collapses evasion to a flail; `moving_override`
      chrome-legs seam. Tests in `test_combat_capacity_sight.py`.
-   - **4b — `manipulation` → hit (per-effector, offensive half).** The intricate
-     part (§6.1 Q1): per-*gripping-hand* manipulation, not body-wide — a
-     one-armed shooter fights at full accuracy. Needs the weapon→hand→limb-chain
-     organ traversal (invert `limb_downstream_chain`, scope a capacity to those
-     organs) + 2H under-grip blend. Breadth meta-bonuses (Q2: initiative/disarm-
-     resist/loadout) remain a future combat revision. *Not built.*
+   - **4b ✅ SHIPPED — `manipulation` → hit (per-effector, offensive half).**
+     `MedicalState.calculate_capacity_scoped(capacity, containers)` computes a
+     capacity from only one limb's organs (the contribution math is extracted
+     into `_resolve_capacity_contribution`, shared with the body-wide method).
+     `world/combat/capacity.py` `manipulation_hit_factor(attacker, weapon)` finds
+     the gripping slot(s) from `attacker.hands`, inverts `limb_downstream_chain`
+     to the hand's limb organs, and scopes manipulation there — so a one-armed
+     shooter with a good hand fights at **full** accuracy (Q1 isolation, tested).
+     Two-handed grips take the weaker hand (`min`; exact blend TBD §10);
+     unarmed/natural-weapon falls back to body-wide; `manipulation_override`
+     chrome-arm seam. Multiplied into the attacker's motorics in `attack.py`,
+     completing the stack (ranged: motorics × sight × manipulation; melee:
+     motorics × manipulation × light-sight; dodge: motorics × moving). Breadth
+     meta-bonuses (Q2: initiative/disarm-resist/loadout) remain a future combat
+     revision. Tests: `test_combat_manipulation_resolver.py`.
 
 Each layer ships standalone value. The five-senses *description model* (§5) is
 the one piece worth pinning early so earlier layers don't contradict it.

--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -14,7 +14,9 @@ from random import randint
 from .debug import get_splattercast
 
 from world.combat.messages import get_combat_message
-from world.combat.capacity import sight_hit_factor, moving_dodge_factor
+from world.combat.capacity import (
+    sight_hit_factor, moving_dodge_factor, manipulation_hit_factor,
+)
 from world.medical.utils import select_hit_location, select_target_organ
 
 from .constants import (
@@ -397,10 +399,17 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
     # condition (chrome sense-enhancer) suppresses the penalty.  Whole-body
     # capacity, so no per-effector resolver needed.
     sight_factor = sight_hit_factor(attacker, is_ranged_attack)
-    effective_skill = attacker_skill * sight_factor
-    if sight_factor < 1.0:
+    # Manipulation consumes the attacker's aim too (CAPACITY_CONSUMERS spec §6.1,
+    # §9 layer 4b — offensive half).  Per-gripping-hand, NOT body-wide: a
+    # one-armed shooter with a good hand fights at full accuracy.  Completes the
+    # combat stack — ranged: motorics × sight × manipulation(trigger hand);
+    # melee: motorics × manipulation(wield hand) × light-sight.
+    manip_factor = manipulation_hit_factor(attacker, weapon)
+    effective_skill = attacker_skill * sight_factor * manip_factor
+    if sight_factor < 1.0 or manip_factor < 1.0:
         splattercast.msg(
-            f"ATTACK_SIGHT: {attacker.key} sight factor {sight_factor:.2f} "
+            f"ATTACK_CAPACITY: {attacker.key} sight {sight_factor:.2f} × "
+            f"manip {manip_factor:.2f} "
             f"({'ranged' if is_ranged_attack else 'melee'}) — motorics "
             f"{attacker_skill} -> {effective_skill:.1f}"
         )

--- a/world/combat/capacity.py
+++ b/world/combat/capacity.py
@@ -153,3 +153,78 @@ def moving_dodge_factor(character) -> float:
         return 1.0  # fail-open
 
     return _piecewise(raw, MOVING_CURVE_DODGE)
+
+
+# --------------------------------------------------------------------------
+# Manipulation → hit (CAPACITY_CONSUMERS spec §6.1/§6.3 — offensive half)
+# --------------------------------------------------------------------------
+# Unlike sight/moving, manipulation is NOT body-wide: weapon handling depends on
+# the *specific hand(s) gripping the weapon*, not a body average (§6.1 Q1). A
+# one-armed character with a pistol in their good hand fights at FULL accuracy —
+# the missing arm is irrelevant to that weapon. So we scope the capacity to the
+# gripping hand's limb chain via MedicalState.calculate_capacity_scoped.
+#
+# Breadth from surplus arms (Q2: initiative / disarm-resist / loadout) is a
+# separate output and a future combat revision — not modelled here.
+MANIPULATION_CURVE = ((0.0, 0.20), (0.5, 0.65), (1.0, 1.0))
+MANIPULATION_OVERRIDE_CONDITION = "manipulation_override"
+
+
+def _gripping_slots(attacker, weapon):
+    """The grasping slots currently holding *weapon* (e.g. ``["left_hand"]``)."""
+    hands = getattr(attacker, "hands", None) or {}
+    try:
+        return [slot for slot, item in hands.items() if item is weapon]
+    except Exception:
+        return []
+
+
+def _limb_ancestors(attacker, slot):
+    """Containers whose organs power *slot* — the slot + its upstream chain.
+
+    Inverts the species ``limb_downstream_chain``: every container whose
+    downstream set includes *slot* (e.g. ``left_hand`` → ``{left_arm,
+    left_hand}``), so both the hand bones and the arm bones count.
+    """
+    species = getattr(getattr(attacker, "db", None), "species", None)
+    try:
+        from world.anatomy import get_species_limb_downstream_chain
+        chain = get_species_limb_downstream_chain(species) or {}
+    except Exception:
+        chain = {}
+    ancestors = {c for c, downstream in chain.items() if slot in downstream}
+    ancestors.add(slot)  # a grasping container may itself hold organs (e.g. tail)
+    return ancestors
+
+
+def manipulation_hit_factor(attacker, weapon) -> float:
+    """Multiplier on *attacker*'s motorics from the hand(s) gripping *weapon*.
+
+    Per-effector (§6.1): scoped to the gripping hand's limb chain, not body-wide.
+    When two hands grip one weapon, the weaker hand drags it (``min`` for now;
+    exact min-vs-blend is TBD, spec §10). Falls back to body-wide manipulation
+    for unarmed / natural-weapon / undeterminable grips. Fail-open to ``1.0``.
+    """
+    if _has_override(attacker, MANIPULATION_OVERRIDE_CONDITION):
+        return 1.0
+
+    state = getattr(attacker, "medical_state", None)
+    scoped = getattr(state, "calculate_capacity_scoped", None)
+
+    gripping = _gripping_slots(attacker, weapon) if weapon is not None else []
+    if not gripping or not callable(scoped):
+        # Unarmed, natural weapon, or no scoped model — body-wide manipulation.
+        raw = _read_capacity(attacker, "manipulation")
+        if raw is None:
+            return 1.0
+        return _piecewise(raw, MANIPULATION_CURVE)
+
+    caps = []
+    for slot in gripping:
+        try:
+            caps.append(scoped("manipulation", _limb_ancestors(attacker, slot)))
+        except Exception:
+            return 1.0  # fail-open on any anatomy lookup failure
+    if not caps:
+        return 1.0
+    return _piecewise(min(caps), MANIPULATION_CURVE)

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -809,52 +809,107 @@ class MedicalState:
                 # taking the flesh organ out of the equation.
                 continue
             organ_functionality = organ.get_functionality_percentage()
-            
-            # Get contribution level - check for organ-specific contributions first
-            contribution_value = None
-            
-            # Check for organ-specific contributions (e.g., liver_contribution, stomach_contribution)
-            organ_contribution_key = f"{organ_name}_contribution"
-            if organ_contribution_key in capacity_data:
-                contribution_value = capacity_data[organ_contribution_key]
-            else:
-                # Check for bone-specific contributions (e.g., femur_contribution, humerus_contribution)
-                bone_type = organ_name.split('_')[-1]  # Get bone name (femur, humerus, etc.)
-                if bone_type in ['femur', 'tibia', 'humerus']:
-                    bone_contribution_key = f"{bone_type}_contribution"
-                elif 'metacarpals' in organ_name:
-                    bone_contribution_key = "metacarpal_contribution"
-                elif 'metatarsals' in organ_name:
-                    bone_contribution_key = "metatarsal_contribution"
-                else:
-                    bone_contribution_key = None
-                    
-                if bone_contribution_key and bone_contribution_key in capacity_data:
-                    contribution_value = capacity_data[bone_contribution_key]
-                else:
-                    # Fall back to organ's defined contribution or generic lookup
-                    contribution_key = organ.data.get(f"{capacity_name}_contribution", organ.contribution)
-                    if isinstance(contribution_key, str):
-                        contribution_value = CONTRIBUTION_VALUES.get(contribution_key, 0.05)
-                    else:
-                        contribution_value = float(contribution_key)
-                
+            contribution_value = self._resolve_capacity_contribution(
+                organ_name, organ, capacity_data, capacity_name
+            )
+
             # Add to totals
             total_capacity += organ_functionality * contribution_value
             max_possible_capacity += contribution_value
-            
+
         # Normalize to 0.0-1.0 range based on maximum possible capacity
         if max_possible_capacity > 0:
             capacity_level = total_capacity / max_possible_capacity
         else:
             capacity_level = 1.0
-            
+
         # Clamp to valid range
         capacity_level = max(0.0, min(1.0, capacity_level))
-        
+
         # Cache the result
         self._capacity_cache[capacity_name] = capacity_level
         return capacity_level
+
+    def _resolve_capacity_contribution(
+        self, organ_name, organ, capacity_data, capacity_name
+    ):
+        """Return one organ's contribution weight toward *capacity_name*.
+
+        Extracted from :meth:`calculate_body_capacity` so the per-effector
+        scoped resolver (:meth:`calculate_capacity_scoped`) shares the exact
+        same contribution rules (CAPACITY_CONSUMERS spec §6.1).
+        """
+        # Organ-specific contributions (e.g. liver_contribution).
+        organ_contribution_key = f"{organ_name}_contribution"
+        if organ_contribution_key in capacity_data:
+            return capacity_data[organ_contribution_key]
+
+        # Bone-type contributions (e.g. humerus_contribution, metacarpal_*).
+        bone_type = organ_name.split('_')[-1]
+        if bone_type in ['femur', 'tibia', 'humerus']:
+            bone_contribution_key = f"{bone_type}_contribution"
+        elif 'metacarpals' in organ_name:
+            bone_contribution_key = "metacarpal_contribution"
+        elif 'metatarsals' in organ_name:
+            bone_contribution_key = "metatarsal_contribution"
+        else:
+            bone_contribution_key = None
+
+        if bone_contribution_key and bone_contribution_key in capacity_data:
+            return capacity_data[bone_contribution_key]
+
+        # Fall back to the organ's own declared contribution.
+        contribution_key = organ.data.get(
+            f"{capacity_name}_contribution", organ.contribution
+        )
+        if isinstance(contribution_key, str):
+            return CONTRIBUTION_VALUES.get(contribution_key, 0.05)
+        return float(contribution_key)
+
+    def calculate_capacity_scoped(self, capacity_name, containers):
+        """Capacity computed from only the organs in *containers* (uncached).
+
+        The per-effector resolver (CAPACITY_CONSUMERS spec §6.1): instead of the
+        body-wide average, scope a capacity to a specific limb — e.g. the
+        ``manipulation`` of the one hand actually gripping a weapon, so a
+        one-armed character shoots at full accuracy with their good hand.
+
+        Args:
+            capacity_name (str): capacity to compute (e.g. ``"manipulation"``).
+            containers (set[str]): container/location names whose organs count
+                (e.g. ``{"left_arm", "left_hand"}`` for the left gripping hand).
+
+        Returns:
+            float: 0.0–1.0. Returns 1.0 (no penalty) when no in-scope organs
+            define the capacity — fail open.
+        """
+        from world.anatomy import get_species_body_capacities
+        species = None
+        if self.character is not None:
+            species = getattr(self.character.db, "species", None)
+        capacity_data = get_species_body_capacities(species).get(capacity_name, {})
+        capacity_organs = capacity_data.get("organs", [])
+        if not capacity_organs:
+            return 1.0
+
+        containers = set(containers or ())
+        total = 0.0
+        max_possible = 0.0
+        for organ_name in capacity_organs:
+            organ = self.organs.get(organ_name)
+            if organ is None:
+                continue
+            if organ.data.get("container") not in containers:
+                continue
+            contribution = self._resolve_capacity_contribution(
+                organ_name, organ, capacity_data, capacity_name
+            )
+            total += organ.get_functionality_percentage() * contribution
+            max_possible += contribution
+
+        if max_possible <= 0:
+            return 1.0  # no in-scope organs define this capacity — fail open
+        return max(0.0, min(1.0, total / max_possible))
         
     def is_unconscious(self):
         """Return True when the character is currently unconscious.

--- a/world/tests/test_combat_manipulation_resolver.py
+++ b/world/tests/test_combat_manipulation_resolver.py
@@ -1,0 +1,164 @@
+"""
+Tests for the per-effector manipulation resolver
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §6.1, build layer 4b).
+
+The defining property (§6.1 Q1): weapon handling scopes to the *specific
+gripping hand*, not the body-wide average — a one-armed character with a
+pistol in their good hand fights at FULL accuracy. These tests pin that
+isolation on a real human ``MedicalState`` plus the resolver's blend /
+fallback / override / fail-open behaviour.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_combat_manipulation_resolver
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.core import MedicalState
+from world.combat.capacity import (
+    MANIPULATION_CURVE,
+    MANIPULATION_OVERRIDE_CONDITION,
+    manipulation_hit_factor,
+    _piecewise,
+)
+
+
+class _Human:
+    def __init__(self):
+        self.db = SimpleNamespace(species="human")
+
+
+def _human_state():
+    return MedicalState(character=_Human())
+
+
+def _attacker(hands, state):
+    """A combat actor exposing what the resolver reads."""
+    return SimpleNamespace(hands=hands, db=SimpleNamespace(species="human"),
+                           medical_state=state)
+
+
+# ----------------------------------------------------------------------
+# calculate_capacity_scoped — the scoped-anatomy primitive
+# ----------------------------------------------------------------------
+class ScopedCapacityTests(TestCase):
+    def test_intact_left_hand_scope_full(self):
+        state = _human_state()
+        self.assertAlmostEqual(
+            state.calculate_capacity_scoped("manipulation", {"left_arm", "left_hand"}),
+            1.0,
+        )
+
+    def test_left_arm_damage_scoped_to_left_only(self):
+        state = _human_state()
+        state.organs["left_humerus"].current_hp = 0
+        state._cache_dirty = True
+        left = state.calculate_capacity_scoped(
+            "manipulation", {"left_arm", "left_hand"}
+        )
+        right = state.calculate_capacity_scoped(
+            "manipulation", {"right_arm", "right_hand"}
+        )
+        # The wrecked left humerus drags the LEFT scope down...
+        self.assertLess(left, 1.0)
+        # ...but the RIGHT hand is untouched (the Q1 isolation property).
+        self.assertAlmostEqual(right, 1.0)
+
+    def test_empty_scope_fails_open(self):
+        state = _human_state()
+        self.assertAlmostEqual(
+            state.calculate_capacity_scoped("manipulation", set()), 1.0
+        )
+
+
+# ----------------------------------------------------------------------
+# manipulation_hit_factor — the combat consumer
+# ----------------------------------------------------------------------
+class ManipulationHitFactorTests(TestCase):
+    def test_full_hand_full_factor(self):
+        state = _human_state()
+        weapon = object()
+        attacker = _attacker({"left_hand": weapon}, state)
+        self.assertAlmostEqual(manipulation_hit_factor(attacker, weapon), 1.0)
+
+    def test_good_hand_unaffected_by_other_arm_loss(self):
+        # The headline Q1 case: pistol in the right hand, left arm destroyed —
+        # full accuracy, the missing arm is irrelevant to this weapon.
+        state = _human_state()
+        state.organs["left_humerus"].current_hp = 0
+        state.organs["left_metacarpals"].current_hp = 0
+        state._cache_dirty = True
+        weapon = object()
+        attacker = _attacker({"right_hand": weapon}, state)
+        self.assertAlmostEqual(manipulation_hit_factor(attacker, weapon), 1.0)
+
+    def test_damaged_gripping_hand_reduces_factor(self):
+        state = _human_state()
+        state.organs["right_humerus"].current_hp = 0
+        state._cache_dirty = True
+        weapon = object()
+        attacker = _attacker({"right_hand": weapon}, state)
+        self.assertLess(manipulation_hit_factor(attacker, weapon), 1.0)
+
+    def test_two_handed_weaker_hand_drags(self):
+        # Weapon gripped in both hands; one arm wrecked → the weaker hand
+        # sets the handling (min blend).
+        state = _human_state()
+        state.organs["left_humerus"].current_hp = 0
+        state._cache_dirty = True
+        weapon = object()
+        both = _attacker({"left_hand": weapon, "right_hand": weapon}, state)
+        one_good = _attacker({"right_hand": weapon}, _human_state())
+        self.assertLess(
+            manipulation_hit_factor(both, weapon),
+            manipulation_hit_factor(one_good, weapon),
+        )
+
+    def test_unarmed_falls_back_to_body_wide(self):
+        # No weapon → body-wide manipulation (still full when intact).
+        state = _human_state()
+        attacker = _attacker({}, state)
+        self.assertAlmostEqual(manipulation_hit_factor(attacker, None), 1.0)
+
+
+class ManipulationOverrideAndFailOpenTests(TestCase):
+    class _Stub:
+        def __init__(self, overrides=0, scoped=0.0):
+            self._overrides = overrides
+            self._scoped = scoped
+
+        def calculate_capacity_scoped(self, name, containers):
+            return self._scoped
+
+        def calculate_body_capacity(self, name):
+            return self._scoped
+
+        def get_conditions_by_type(self, ct):
+            if ct == MANIPULATION_OVERRIDE_CONDITION:
+                return [object()] * self._overrides
+            return []
+
+    def test_override_condition_nulls_penalty(self):
+        weapon = object()
+        state = self._Stub(overrides=1, scoped=0.0)
+        attacker = _attacker({"right_hand": weapon}, state)
+        self.assertAlmostEqual(manipulation_hit_factor(attacker, weapon), 1.0)
+
+    def test_no_medical_model_fails_open(self):
+        weapon = object()
+        attacker = SimpleNamespace(
+            hands={"right_hand": weapon},
+            db=SimpleNamespace(species="human"),
+            medical_state=None,
+        )
+        self.assertAlmostEqual(manipulation_hit_factor(attacker, weapon), 1.0)
+
+    def test_curve_anchor_sanity(self):
+        # Guard the curve contract the factor relies on.
+        self.assertAlmostEqual(_piecewise(1.0, MANIPULATION_CURVE), 1.0)
+        self.assertAlmostEqual(_piecewise(0.5, MANIPULATION_CURVE), 0.65)
+        self.assertAlmostEqual(_piecewise(0.0, MANIPULATION_CURVE), 0.20)


### PR DESCRIPTION
The offensive half of the §6.3 combat stack and the most intricate slice
(CAPACITY_CONSUMERS spec §6.1 Q1): weapon handling scopes to the specific
gripping hand, not body-wide — a one-armed shooter with a good hand fights
at FULL accuracy.

- MedicalState.calculate_capacity_scoped(capacity, containers) (uncached)
  computes a capacity from only the organs in the given containers. The
  per-organ contribution math is extracted into _resolve_capacity_contribution,
  shared with the body-wide calculate_body_capacity (behaviour-preserving).
- world/combat/capacity.py manipulation_hit_factor(attacker, weapon): finds
  the gripping slot(s) from attacker.hands, inverts limb_downstream_chain to
  the hand's limb organs (left_hand -> {left_arm, left_hand}), scopes
  manipulation there. Two-handed grips take the weaker hand (min; exact blend
  TBD §10); unarmed/natural-weapon falls back to body-wide;
  manipulation_override is the chrome-arm seam; fail-open throughout.
- Multiplied into the attacker's motorics in attack.py, completing the stack:
  ranged = motorics × sight × manipulation; melee = motorics × manipulation ×
  light-sight; dodge = motorics × moving.

Q2 breadth meta-bonuses (surplus-appendage initiative / disarm-resist /
loadout) remain a future combat revision.

Tests: world/tests/test_combat_manipulation_resolver.py (the Q1 isolation
property + blend / fallback / override / fail-open). 265-test medical +
combat sweep green.

Closes #595

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
