### PR TITLE
Chrome: cyber eyes / ears / legs restore sight / hearing / moving

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2268,6 +2268,156 @@ SHOTGUN_ARM_GUN = {
     ],
 }
 
+# ===================================================================
+# Sensory + locomotion chrome (CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC)
+# ===================================================================
+# These restore a performance capacity the SAME way CYBER_ARM restores
+# manipulation and CYBER_JAW restores talking: a capacity-bearing
+# replacement organ at the CANONICAL organ name, so
+# ``calculate_body_capacity`` counts it and every consumer (combat
+# aim/dodge, identity recognition, perception render) sees the sense
+# restored — no special-case override needed.  Eyes/ears are head
+# sub-organs, so they use the single-organ (``organ_name``) path like
+# CYBER_JAW (replace the destroyed flesh organ in its slot — the rest
+# of the head stays put).  Legs span limb containers, so they use the
+# side-agnostic ``augment_organs`` chassis path like CYBER_ARM.
+
+# --- Optical implants → sight (combat aim, visual recognition, LOOK) ---
+CYBER_LEFT_EYE = {
+    "key": "cybernetic left eye",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["cyber left eye", "left optic", "left ocular unit"],
+    "desc": "A spherical optical replacement unit nested in protective foam — a machined alloy housing, a cluster lens of layered apertures, and a fan of micro-couplers trailing from the back like an optic nerve rendered in ribbon cable. The iris ring glows a faint standby amber. Mounts in a left socket; surgical installation required.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("organ_name", "left_eye"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "head", "display_location": "left_eye",
+            "max_hp": 10, "hit_weight": "rare",
+            "capacity": "sight", "contribution": "major",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True, "prosthetic_frame": True,
+        }),
+    ],
+}
+
+CYBER_RIGHT_EYE = {
+    "key": "cybernetic right eye",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["cyber right eye", "right optic", "right ocular unit"],
+    "desc": "A spherical optical replacement unit nested in protective foam — a machined alloy housing, a cluster lens of layered apertures, and a fan of micro-couplers trailing from the back like an optic nerve rendered in ribbon cable. The iris ring glows a faint standby amber. Mounts in a right socket; surgical installation required.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("organ_name", "right_eye"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "head", "display_location": "right_eye",
+            "max_hp": 10, "hit_weight": "rare",
+            "capacity": "sight", "contribution": "major",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True, "prosthetic_frame": True,
+        }),
+    ],
+}
+
+# --- Cochlear implants → hearing (voice discernment, LOOK auditory) ---
+CYBER_LEFT_EAR = {
+    "key": "cybernetic left ear",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["cyber left ear", "left cochlear unit"],
+    "desc": "A cochlear replacement unit — a coiled alloy snail-shell of transducers feeding a slim pickup membrane, the whole assembly small enough to seat in a temporal bone. A standby LED winks at the base of the coupler. Mounts on the left; surgical installation required.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("organ_name", "left_ear"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "head", "display_location": "left_ear",
+            "max_hp": 12, "hit_weight": "rare",
+            "capacity": "hearing", "contribution": "major",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True, "prosthetic_frame": True,
+        }),
+    ],
+}
+
+CYBER_RIGHT_EAR = {
+    "key": "cybernetic right ear",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["cyber right ear", "right cochlear unit"],
+    "desc": "A cochlear replacement unit — a coiled alloy snail-shell of transducers feeding a slim pickup membrane, the whole assembly small enough to seat in a temporal bone. A standby LED winks at the base of the coupler. Mounts on the right; surgical installation required.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("organ_name", "right_ear"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "head", "display_location": "right_ear",
+            "max_hp": 12, "hit_weight": "rare",
+            "capacity": "hearing", "contribution": "major",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True, "prosthetic_frame": True,
+        }),
+    ],
+}
+
+# --- Cybernetic leg → moving (dodge, flee, movement) ---
+# Side-agnostic chassis like CYBER_ARM: one prototype mounts left OR
+# right, the surgeon names the side, and the canonical bone names
+# ({side}_femur etc.) keep the `moving` capacity wiring intact.
+CYBER_LEG = {
+    "key": "cybernetic leg",
+    "typeclass": "typeclasses.items.Item",
+    "aliases": ["cyber leg", "prosthetic leg", "leg unit"],
+    "desc": "A full leg replacement unit in its transport cradle, hip coupling to footplate, ambidextrous mounting hardware along the seam. The shin housing is a column of linear actuators behind impact plating; the foot is a sprung alloy plate built to take a landing. Mounts over an amputated leg, either side; surgical installation required.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("augment_organs", {
+            "{side}_femur": {
+                "container": "{side}_thigh", "max_hp": 40,
+                "hit_weight": "common", "capacity": "moving",
+                "contribution": "major", "can_be_destroyed": True,
+                "fracture_vulnerable": True,
+                "bone_type": "actuator_column", "inorganic": True,
+                "prosthetic_frame": True,
+            },
+            "{side}_tibia": {
+                "container": "{side}_shin", "max_hp": 32,
+                "hit_weight": "common", "capacity": "moving",
+                "contribution": "major", "can_be_destroyed": True,
+                "fracture_vulnerable": True,
+                "bone_type": "actuator_column", "inorganic": True,
+                "prosthetic_frame": True,
+            },
+            "{side}_metatarsals": {
+                "container": "{side}_foot", "max_hp": 18,
+                "hit_weight": "uncommon", "capacity": "moving",
+                "contribution": "minor", "can_be_destroyed": True,
+                "fracture_vulnerable": True,
+                "bone_type": "actuator_lattice", "inorganic": True,
+                "prosthetic_frame": True,
+            },
+        }),
+        ("augment_container", "{side}_thigh"),
+        ("augment_anchor", "{side}_thigh"),
+        ("augment_longdesc", [
+            {
+                "key": "{side}_thigh",
+                "default_desc": "{Their} {side} leg is a full cybernetic replacement, a column of linear actuators behind matte impact plating, an access seam running the length of the shin.",
+            },
+            {
+                "key": "{side}_foot",
+                "default_desc": "{Their} {side} foot is a sprung alloy plate, the underside scuffed to bare metal where it takes the ground.",
+                "display_after": "{side}_thigh",
+            },
+        ]),
+        ("compatible_species", ["human"]),
+    ],
+}
+
 # Surgical Kit - Advanced multi-use medical tools
 SURGICAL_KIT = {
     "key": "surgical kit",

--- a/world/tests/test_capacity_chrome.py
+++ b/world/tests/test_capacity_chrome.py
@@ -1,0 +1,150 @@
+"""
+Tests that sensory / locomotion chrome restores its capacity consumer
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC — augment wiring).
+
+The chrome prototypes (CYBER_LEFT_EYE / CYBER_RIGHT_EYE / CYBER_LEFT_EAR /
+CYBER_RIGHT_EAR / CYBER_LEG) restore a performance capacity by being
+capacity-bearing replacement organs at the canonical organ names — so
+``calculate_body_capacity`` counts them and every consumer sees the sense /
+locomotion restored, with no special-case override. These tests drive the
+actual prototype specs through a real human ``MedicalState`` and assert the
+consumer factors recover.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_capacity_chrome
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.core import MedicalState, Organ
+from world.combat.capacity import sight_hit_factor, moving_dodge_factor
+from world.voice import can_see, can_hear
+from world.prototypes import (
+    CYBER_LEFT_EYE,
+    CYBER_RIGHT_EYE,
+    CYBER_LEFT_EAR,
+    CYBER_RIGHT_EAR,
+    CYBER_LEG,
+)
+
+
+def _organ_spec(prototype):
+    """Pull the single-organ ``organ_spec`` dict off a prototype."""
+    return dict(prototype["attrs"])["organ_spec"]
+
+
+def _augment_organs(prototype, side):
+    """Resolve a side-agnostic augment's ``{side}`` organ specs."""
+    raw = dict(prototype["attrs"])["augment_organs"]
+    out = {}
+    for name, spec in raw.items():
+        rn = name.replace("{side}", side)
+        rs = {k: (v.replace("{side}", side) if isinstance(v, str) else v)
+              for k, v in spec.items()}
+        out[rn] = rs
+    return out
+
+
+class _Patient:
+    """A character whose ``medical_state`` the consumers read."""
+    def __init__(self):
+        self.db = SimpleNamespace(species="human")
+
+    def attach(self):
+        self.medical_state = MedicalState(character=self)
+        return self.medical_state
+
+
+def _install(state, organ_name, spec):
+    state.organs[organ_name] = Organ(organ_name, organ_data=dict(spec))
+    state._cache_dirty = True
+
+
+def _destroy(state, *organ_names):
+    for name in organ_names:
+        if name in state.organs:
+            state.organs[name].current_hp = 0
+    state._cache_dirty = True
+
+
+class CyberEyeRestoresSight(TestCase):
+    def test_blind_then_chromed(self):
+        p = _Patient()
+        state = p.attach()
+        self.assertTrue(can_see(p))
+        self.assertAlmostEqual(sight_hit_factor(p, is_ranged=True), 1.0)
+
+        # Both flesh eyes destroyed → blind, aim collapses.
+        _destroy(state, "left_eye", "right_eye")
+        self.assertFalse(can_see(p))
+        self.assertLess(sight_hit_factor(p, is_ranged=True), 0.1)
+
+        # Install chrome optics at the canonical eye slots.
+        _install(state, "left_eye", _organ_spec(CYBER_LEFT_EYE))
+        _install(state, "right_eye", _organ_spec(CYBER_RIGHT_EYE))
+        self.assertTrue(can_see(p))
+        self.assertAlmostEqual(sight_hit_factor(p, is_ranged=True), 1.0)
+
+    def test_single_optic_restores_one_eye(self):
+        p = _Patient()
+        state = p.attach()
+        _destroy(state, "left_eye", "right_eye")
+        _install(state, "left_eye", _organ_spec(CYBER_LEFT_EYE))
+        # One working eye is enough to see (perception threshold) even if
+        # depth perception (ranged aim) is still imperfect.
+        self.assertTrue(can_see(p))
+
+
+class CyberEarRestoresHearing(TestCase):
+    def test_deaf_then_chromed(self):
+        p = _Patient()
+        state = p.attach()
+        self.assertTrue(can_hear(p))
+
+        _destroy(state, "left_ear", "right_ear")
+        self.assertFalse(can_hear(p))
+
+        _install(state, "left_ear", _organ_spec(CYBER_LEFT_EAR))
+        _install(state, "right_ear", _organ_spec(CYBER_RIGHT_EAR))
+        self.assertTrue(can_hear(p))
+
+
+class CyberLegRestoresMoving(TestCase):
+    def test_wrecked_leg_then_chromed(self):
+        p = _Patient()
+        state = p.attach()
+        self.assertAlmostEqual(moving_dodge_factor(p), 1.0)
+
+        # Destroy the left leg's locomotion organs → dodge degrades.
+        _destroy(state, "left_femur", "left_tibia", "left_metatarsals")
+        self.assertLess(moving_dodge_factor(p), 1.0)
+        wrecked = moving_dodge_factor(p)
+
+        # Install the cybernetic leg (left side) — actuators at the canonical
+        # bone names restore the moving capacity.
+        for name, spec in _augment_organs(CYBER_LEG, "left").items():
+            _install(state, name, spec)
+        self.assertGreater(moving_dodge_factor(p), wrecked)
+        self.assertAlmostEqual(moving_dodge_factor(p), 1.0)
+
+
+class ChromePrototypeShape(TestCase):
+    """Guard the capacity wiring the consumers depend on."""
+
+    def test_eyes_declare_sight(self):
+        for proto in (CYBER_LEFT_EYE, CYBER_RIGHT_EYE):
+            self.assertEqual(_organ_spec(proto)["capacity"], "sight")
+
+    def test_ears_declare_hearing(self):
+        for proto in (CYBER_LEFT_EAR, CYBER_RIGHT_EAR):
+            self.assertEqual(_organ_spec(proto)["capacity"], "hearing")
+
+    def test_leg_organs_use_canonical_bone_names(self):
+        organs = _augment_organs(CYBER_LEG, "right")
+        for name in ("right_femur", "right_tibia", "right_metatarsals"):
+            self.assertIn(name, organs)
+            self.assertEqual(organs[name]["capacity"], "moving")


### PR DESCRIPTION
Make the sensory + locomotion chrome real, completing the capacity-consumer
loop. These restore a performance capacity the SAME way CYBER_ARM restores
manipulation and CYBER_JAW restores talking — capacity-bearing replacement
organs at the canonical organ names, so calculate_body_capacity counts them
and every consumer (combat aim/dodge, identity recognition, perception
render) sees the sense/locomotion restored. No special-case override needed.

- CYBER_LEFT_EYE / CYBER_RIGHT_EYE: single-organ (organ_name) replacements
  like CYBER_JAW (head sub-organ; replace the destroyed flesh eye in its
  slot). capacity sight.
- CYBER_LEFT_EAR / CYBER_RIGHT_EAR: single-organ replacements. capacity
  hearing.
- CYBER_LEG: side-agnostic augment_organs chassis like CYBER_ARM
  ({side}_femur / {side}_tibia / {side}_metatarsals — canonical bone names
  keep the moving wiring intact). capacity moving.

All install through the existing surgical flow unchanged (single-organ path
for eyes/ears, augment-chassis path for the leg).

Tests: world/tests/test_capacity_chrome.py drives the actual prototype specs
through a real human MedicalState — blind/deafen/cripple, install chrome,
assert sight_hit_factor / can_see / can_hear / moving_dodge_factor recover.

The voice modulator (sets voice_modulator_active, a flag not a capacity
organ) is a separate mechanism, landing next.

Closes #597

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
