### PR TITLE
Chrome: voice modulator augment (the audio disguise)

### DIFF
--- a/world/medical/augments.py
+++ b/world/medical/augments.py
@@ -96,6 +96,8 @@ def toggle_ability(character, name) -> str:
         return _toggle_integrated_weapon(character, organ, name, spec)
     if ability_type == "natural_weapon":
         return _toggle_natural_weapon(character, organ, name, spec)
+    if ability_type == "voice_modulator":
+        return _toggle_voice_modulator(character, organ, name, spec)
     return f"{name} doesn't respond. (unknown ability type {ability_type!r})"
 
 
@@ -295,6 +297,34 @@ def _toggle_natural_weapon(character, organ, name, spec) -> str:
             exclude=[character],
         )
     return msg
+
+
+def _toggle_voice_modulator(character, organ, name, spec) -> str:
+    """Toggle a voice modulator (CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §4.2).
+
+    The voice-disguise parallel to a worn mask: while engaged it sets
+    ``character.db.voice_modulator_active``, which shifts the voice signature
+    to a different UID (``world.voice.get_voice_signature``) so listeners no
+    longer recognise the voice (and the discernment determination re-rolls
+    against the new presentation). Covert by design — engaging it draws no room
+    message; only the change in voice when the wearer next speaks is observable.
+    """
+    state = _ability_state(organ, name)
+    if not state.get("deployed"):
+        state["deployed"] = True
+        character.db.voice_modulator_active = True
+        _persist(character)
+        return spec.get("deploy_msg") or (
+            "Your voice modulator hums to life — your next words will carry "
+            "a stranger's timbre."
+        )
+
+    state["deployed"] = False
+    character.db.voice_modulator_active = False
+    _persist(character)
+    return spec.get("retract_msg") or (
+        "Your voice modulator powers down — your own voice returns."
+    )
 
 
 def get_active_natural_weapon(character):

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2418,6 +2418,43 @@ CYBER_LEG = {
     ],
 }
 
+# --- Voice modulator → voice disguise (the audio parallel to a mask) ---
+# A jaw-hardpoint module (JAWZ pattern): seats into a CYBER_JAW's slot,
+# rebuilds the jaw so talking/eating survive, and adds a toggleable
+# `modulate` ability.  Engaging it sets `voice_modulator_active`, which
+# shifts the voice signature to a different UID so listeners no longer
+# recognise the voice (CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §4.2).
+# Needs a cyber jaw to mount into; installation requires a surgeon.
+VOICE_MODULATOR = {
+    "key": "voice modulator",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["voice mod", "vox modulator", "modulator module"],
+    "desc": "A flat module the size of a guitar pick, machined to seat into a cybernetic jaw's hardpoint. A lattice of resonator films and a DSP die hide under a perforated cover; the coupling collar is standard jaw gauge. Engaged, it re-synthesises every word in a voice that isn't yours. Needs a cyber jaw to mount into; installation requires a surgeon.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("module_type", "jaw"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "head", "display_location": "face",
+            "max_hp": 14, "hit_weight": "rare",
+            "capacities": ["talking", "eating"],
+            "talking_contribution": "major",
+            "eating_contribution": "moderate",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True, "prosthetic_frame": True,
+            "hardpoint": "jaw", "module_type": "jaw",
+            "abilities": {
+                "modulate": {
+                    "type": "voice_modulator",
+                    "deploy_msg": "The modulator hums against your jaw — your next words will leave your mouth in a stranger's voice.",
+                    "retract_msg": "The modulator powers down with a faint click; your own voice settles back into your throat.",
+                },
+            },
+        }),
+    ],
+}
+
 # Surgical Kit - Advanced multi-use medical tools
 SURGICAL_KIT = {
     "key": "surgical kit",

--- a/world/tests/test_voice_modulator.py
+++ b/world/tests/test_voice_modulator.py
@@ -1,0 +1,82 @@
+"""
+Tests for the voice-modulator augment ability
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §4.2).
+
+The modulator is the audio parallel to a worn mask: toggling it sets
+``voice_modulator_active``, which shifts the voice signature to a different
+UID so listeners no longer recognise the voice. These tests drive the
+``voice_modulator`` ability handler and confirm the recognition effect.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_voice_modulator
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.augments import _toggle_voice_modulator
+from world.voice import (
+    get_apparent_voice_uid,
+    get_assigned_voice_name,
+    is_voice_modulated,
+    remember_voice,
+)
+
+
+class _Organ:
+    def __init__(self):
+        self.ability_state = {}
+
+
+class _Char:
+    def __init__(self, sleeve_uid="s1"):
+        self.db = SimpleNamespace(voice_modulator_active=False)
+        self.sleeve_uid = sleeve_uid
+        self.voice_memory = {}
+
+
+class VoiceModulatorToggleTests(TestCase):
+    def test_toggle_sets_and_clears_flag(self):
+        char, organ = _Char(), _Organ()
+        self.assertFalse(is_voice_modulated(char))
+
+        _toggle_voice_modulator(char, organ, "modulate", {})
+        self.assertTrue(char.db.voice_modulator_active)
+        self.assertTrue(is_voice_modulated(char))
+        self.assertTrue(organ.ability_state["modulate"]["deployed"])
+
+        _toggle_voice_modulator(char, organ, "modulate", {})
+        self.assertFalse(char.db.voice_modulator_active)
+        self.assertFalse(is_voice_modulated(char))
+        self.assertFalse(organ.ability_state["modulate"]["deployed"])
+
+    def test_custom_messages_used(self):
+        char, organ = _Char(), _Organ()
+        spec = {"deploy_msg": "DEPLOY!", "retract_msg": "RETRACT!"}
+        self.assertEqual(
+            _toggle_voice_modulator(char, organ, "modulate", spec), "DEPLOY!"
+        )
+        self.assertEqual(
+            _toggle_voice_modulator(char, organ, "modulate", spec), "RETRACT!"
+        )
+
+    def test_modulation_changes_voice_uid(self):
+        char, organ = _Char(), _Organ()
+        bare = get_apparent_voice_uid(char)
+        _toggle_voice_modulator(char, organ, "modulate", {})
+        masked = get_apparent_voice_uid(char)
+        self.assertNotEqual(bare, masked)
+
+    def test_modulation_defeats_recognition(self):
+        observer = _Char(sleeve_uid="obs")
+        speaker, organ = _Char(sleeve_uid="spk"), _Organ()
+        # Learn the speaker's natural voice...
+        remember_voice(observer, speaker, "Bob")
+        self.assertEqual(get_assigned_voice_name(observer, speaker), "Bob")
+        # ...then they engage the modulator → unknown voice.
+        _toggle_voice_modulator(speaker, organ, "modulate", {})
+        self.assertIsNone(get_assigned_voice_name(observer, speaker))
+        # Disengage → recognised again.
+        _toggle_voice_modulator(speaker, organ, "modulate", {})
+        self.assertEqual(get_assigned_voice_name(observer, speaker), "Bob")


### PR DESCRIPTION
The last augment seam — the voice-disguise parallel to a worn mask
(CAPACITY_CONSUMERS spec §4.2).

- voice_modulator ability type (world/medical/augments.py):
  _toggle_voice_modulator flips character.db.voice_modulator_active, which
  shifts the voice signature to a different UID so listeners no longer
  recognise the voice and the discernment determination re-rolls against the
  new presentation. Covert — engaging it draws no room message; only the
  changed voice when the wearer next speaks is observable. Registered in
  toggle_ability's dispatch.
- VOICE_MODULATOR prototype: a jaw-hardpoint module (JAWZ pattern) that seats
  into a CYBER_JAW, rebuilds the jaw so talking/eating survive, and adds a
  toggleable `modulate` ability. Dispatched by the existing /modulate
  cyberware command (CmdCyberware catches any ability name) — no command
  changes.

Tests: world/tests/test_voice_modulator.py (toggle flips flag + ability
state, custom messages, voice-UID shift, recognition defeat/restore).

Closes #599

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
