### PR TITLE
Medical: blood_filtration -> infection course (capacity §7.1)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -298,10 +298,14 @@ system, species anatomy tables.
 neither combat nor perception — it modifies a **chronic condition over time**,
 proving the model spans the medical sim too.
 
-### 7.1 Infection resistance (v1 — wireable now)
+### 7.1 Infection resistance (v1 — wireable now) — ✅ SHIPPED
 `blood_filtration` is a **physiological multiplier parallel to
 `InfectionCondition.environmental_modifier`** — failing kidneys make an
 infection you *already have* worsen faster and clear slower:
+*(Built: `world/medical/conditions.py` `read_blood_filtration` + the
+worsen/heal multipliers in `InfectionCondition.tick_effect` — worsen
+×(1+slope·(1−filtration)), heal ×max(floor, filtration). Fail-open. Tests:
+`test_blood_filtration_infection.py`.)*
 - worsen-hazard `×` filtration factor (low filtration → faster progression),
 - treated-heal rate `×` filtration (low filtration → it lingers despite treatment).
 

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -40,6 +40,33 @@ def hazard_fires(p_per_minute: float, elapsed_minutes: float) -> bool:
     return random.random() < 1 - (1 - p) ** elapsed_minutes
 
 
+# blood_filtration → infection course (CAPACITY_CONSUMERS spec §7.1). Failing
+# kidneys can't help the body fight an infection it already has: it worsens
+# faster and clears slower. Tunable.
+BLOOD_FILTRATION_HEAL_FLOOR = 0.25     # clearance never stalls below 25% speed
+BLOOD_FILTRATION_WORSEN_SLOPE = 1.0    # worsen ×(1 + slope·(1−filtration)): 0.5→1.5x, 0→2.0x
+
+
+def read_blood_filtration(character):
+    """Raw ``blood_filtration`` capacity (0.0–1.0) for *character*, or ``None``.
+
+    ``None`` → fail open (no medical model means no filtration effect). Only a
+    real number gates the modifiers; anything else (e.g. a test mock) yields
+    ``None``, mirroring the combat-capacity reads.
+    """
+    state = getattr(character, "medical_state", None)
+    calc = getattr(state, "calculate_body_capacity", None)
+    if not callable(calc):
+        return None
+    try:
+        value = calc("blood_filtration")
+    except Exception:
+        return None
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    return value
+
+
 class MedicalCondition:
     """
     Base class for all medical conditions.
@@ -453,15 +480,26 @@ class InfectionCondition(MedicalCondition):
 
         splattercast = get_splattercast()
 
+        # blood_filtration (§7.1): a physiological multiplier parallel to the
+        # environmental modifier — failing kidneys can't clear the toxins of an
+        # infection you already have, so it worsens faster and heals slower.
+        # Not acquisition (wound care + environment gate that), just the course.
+        filtration = read_blood_filtration(character)
+
         if self.treated:
-            if hazard_fires(INFECTION_IMPROVE_HAZARD_PER_MINUTE, elapsed_minutes):
+            heal_hazard = INFECTION_IMPROVE_HAZARD_PER_MINUTE
+            if filtration is not None:
+                heal_hazard *= max(BLOOD_FILTRATION_HEAL_FLOOR, filtration)
+            if hazard_fires(heal_hazard, elapsed_minutes):
                 self.severity = max(0, self.severity - 1)
                 splattercast.msg(f"INFECTION_HEAL: {character.key} infection severity reduced to {self.severity}")
         else:
             worsen_hazard = INFECTION_WORSEN_HAZARD_PER_MINUTE * self.environmental_modifier
+            if filtration is not None:
+                worsen_hazard *= 1.0 + BLOOD_FILTRATION_WORSEN_SLOPE * (1.0 - filtration)
             if hazard_fires(worsen_hazard, elapsed_minutes):
                 self.severity = min(10, self.severity + 1)  # Cap at 10
-                splattercast.msg(f"INFECTION_WORSEN: {character.key} infection severity increased to {self.severity} (env modifier: {self.environmental_modifier}x)")
+                splattercast.msg(f"INFECTION_WORSEN: {character.key} infection severity increased to {self.severity} (env modifier: {self.environmental_modifier}x, filtration: {filtration})")
     
     def set_environmental_modifier(self, modifier):
         """Set environmental infection risk modifier (e.g., 3.0 for sewers, 0.5 for sterile conditions)"""

--- a/world/tests/test_blood_filtration_infection.py
+++ b/world/tests/test_blood_filtration_infection.py
@@ -1,0 +1,124 @@
+"""
+Tests for blood_filtration → infection course
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §7.1).
+
+Failing kidneys can't help fight an infection you already have: it worsens
+faster and clears slower. blood_filtration slots in as a multiplier parallel
+to ``InfectionCondition.environmental_modifier``. These tests capture the
+hazard actually handed to ``hazard_fires`` so the scaling is verified
+deterministically (no reliance on the random roll).
+
+Run via::
+
+    evennia test --keepdb world.tests.test_blood_filtration_infection
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.medical.conditions as C
+from world.medical.conditions import (
+    BLOOD_FILTRATION_HEAL_FLOOR,
+    InfectionCondition,
+    read_blood_filtration,
+)
+from world.medical.constants import (
+    INFECTION_IMPROVE_HAZARD_PER_MINUTE,
+    INFECTION_WORSEN_HAZARD_PER_MINUTE,
+)
+
+
+def _char(filtration=1.0, medical=True):
+    state = None
+    if medical:
+        state = SimpleNamespace(
+            calculate_body_capacity=lambda n: (
+                filtration if n == "blood_filtration" else 1.0
+            )
+        )
+    return SimpleNamespace(key="Patient", medical_state=state)
+
+
+def _captured_hazard(condition, character):
+    """Run one tick with hazard_fires stubbed to record (and not fire)."""
+    recorded = []
+    with patch.object(
+        C, "hazard_fires", side_effect=lambda p, t: recorded.append(p) or False
+    ), patch("world.combat.debug.get_splattercast", return_value=MagicMock()):
+        condition.tick_effect(character, elapsed_minutes=1.0)
+    return recorded[0]
+
+
+class ReadBloodFiltrationTests(TestCase):
+    def test_returns_value(self):
+        self.assertEqual(read_blood_filtration(_char(0.5)), 0.5)
+
+    def test_no_medical_model_none(self):
+        self.assertIsNone(read_blood_filtration(_char(medical=False)))
+
+    def test_non_numeric_fails_open(self):
+        # A MagicMock capacity (test stub) must not be treated as a number.
+        ch = SimpleNamespace(medical_state=MagicMock())
+        self.assertIsNone(read_blood_filtration(ch))
+
+
+class WorsenScalingTests(TestCase):
+    def _worsen(self, filtration, medical=True):
+        cond = InfectionCondition(severity=3)
+        cond.treated = False
+        return _captured_hazard(cond, _char(filtration, medical))
+
+    def test_healthy_filtration_no_change(self):
+        self.assertAlmostEqual(self._worsen(1.0), INFECTION_WORSEN_HAZARD_PER_MINUTE)
+
+    def test_one_kidney_worsens_50pct_faster(self):
+        self.assertAlmostEqual(
+            self._worsen(0.5), INFECTION_WORSEN_HAZARD_PER_MINUTE * 1.5
+        )
+
+    def test_no_kidneys_worsens_double(self):
+        self.assertAlmostEqual(
+            self._worsen(0.0), INFECTION_WORSEN_HAZARD_PER_MINUTE * 2.0
+        )
+
+    def test_no_medical_model_unscaled(self):
+        self.assertAlmostEqual(
+            self._worsen(0.0, medical=False), INFECTION_WORSEN_HAZARD_PER_MINUTE
+        )
+
+    def test_environmental_modifier_still_applies(self):
+        cond = InfectionCondition(severity=3)
+        cond.treated = False
+        cond.set_environmental_modifier(3.0)  # sewers
+        hazard = _captured_hazard(cond, _char(0.5))
+        self.assertAlmostEqual(
+            hazard, INFECTION_WORSEN_HAZARD_PER_MINUTE * 3.0 * 1.5
+        )
+
+
+class HealScalingTests(TestCase):
+    def _heal(self, filtration, medical=True):
+        cond = InfectionCondition(severity=3)
+        cond.treated = True
+        return _captured_hazard(cond, _char(filtration, medical))
+
+    def test_healthy_filtration_full_heal(self):
+        self.assertAlmostEqual(self._heal(1.0), INFECTION_IMPROVE_HAZARD_PER_MINUTE)
+
+    def test_one_kidney_heals_slower(self):
+        self.assertAlmostEqual(
+            self._heal(0.5), INFECTION_IMPROVE_HAZARD_PER_MINUTE * 0.5
+        )
+
+    def test_clearance_floor(self):
+        # Even near-zero filtration never stalls below the floor.
+        self.assertAlmostEqual(
+            self._heal(0.0),
+            INFECTION_IMPROVE_HAZARD_PER_MINUTE * BLOOD_FILTRATION_HEAL_FLOOR,
+        )
+
+    def test_no_medical_model_unscaled(self):
+        self.assertAlmostEqual(
+            self._heal(0.0, medical=False), INFECTION_IMPROVE_HAZARD_PER_MINUTE
+        )


### PR DESCRIPTION
First non-combat/non-perception capacity consumer (CAPACITY_CONSUMERS spec
§7.1): blood_filtration modifies a chronic condition over time, proving the
model spans the medical sim.

Failing kidneys can't help the body fight an infection it already has, so it
worsens faster and clears slower. blood_filtration slots in as a multiplier
parallel to InfectionCondition.environmental_modifier:
- worsen ×(1 + slope·(1−filtration)) : 1.0->1.0x, 0.5->1.5x, 0->2.0x
- heal (treated) ×max(floor, filtration) : low filtration drags clearance,
  floored at 25%

NOT acquisition (wound care + environment gate catching one); this governs
the course. Fail-open with no medical model.

world/medical/conditions.py: read_blood_filtration helper + multipliers in
InfectionCondition.tick_effect; tunable constants.

Tests: world/tests/test_blood_filtration_infection.py (worsen/heal scaling
captured deterministically + env stacking + fail-open). 65-test sweep green.

Closes #603

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
