### PR TITLE
Medical: condition-driven appearance symptoms (capacity §7.3)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -322,7 +322,13 @@ apply today. Effects: consciousness suppression + slow death, **and its
 signature — a visible skin-pigment shift** (sallow / uremic / ashen). Rides the
 chronic-conditions substrate (parallel to the parked ischemia clock).
 
-### 7.3 Condition-driven appearance symptoms (cross-cutting hook)
+### 7.3 Condition-driven appearance symptoms (cross-cutting hook) — ✅ SHIPPED
+*(Built: `world/medical/appearance.py` `get_appearance_tint` / `get_active_symptom`
+— tints the longdesc render via `appearance_mixin`, overriding base skintone.
+Capacity/vitals built-ins: `cyanosis` (failing breathing), `pallor` (blood loss).
+Condition hook: any condition exposing `appearance_symptom()` (e.g. RenalFailure
+→ `uremic`). Priority-ordered, fail-open. Tests: `test_condition_appearance.py`.)*
+
 Renal failure's pigment shift generalizes: **conditions can carry visible
 symptoms** that tint the rendered skintone / appearance (layered on the existing
 skintone system), legible to `look`, diagnosis, observers, *and* other systems.

--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -1176,14 +1176,25 @@ class AppearanceMixin:
 
         # Apply skintone coloring only if requested (for longdescs only)
         if apply_skintone:
-            skintone = self.db.skintone
-            if skintone:
-                from world.combat.constants import SKINTONE_PALETTE
-                color_code = SKINTONE_PALETTE.get(skintone)
-                if color_code:
-                    # Wrap the entire processed description in the skintone color
-                    # Reset color at end to prevent bleeding
-                    processed_desc = f"{color_code}{processed_desc}|n"
+            color_code = None
+            # A condition/vitals symptom (cyanosis, pallor, uremic…) tints the
+            # body and OVERRIDES the base skintone — the body's state legible at
+            # a glance (CAPACITY_CONSUMERS spec §7.3). Fail-open so look never
+            # breaks.
+            try:
+                from world.medical.appearance import get_appearance_tint
+                color_code = get_appearance_tint(self)
+            except Exception:
+                color_code = None
+            if color_code is None:
+                skintone = self.db.skintone
+                if skintone:
+                    from world.combat.constants import SKINTONE_PALETTE
+                    color_code = SKINTONE_PALETTE.get(skintone)
+            if color_code:
+                # Wrap the entire processed description in the colour.
+                # Reset at end to prevent bleeding.
+                processed_desc = f"{color_code}{processed_desc}|n"
 
         return processed_desc
 

--- a/world/medical/appearance.py
+++ b/world/medical/appearance.py
@@ -1,0 +1,97 @@
+"""
+Condition-driven appearance symptoms — the body's state, legible at a glance
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §7.3).
+
+A character's medical state tints their rendered skintone: the sick one *looks*
+sick, no ``diagnose`` required — a RipperDoc reads you across the room. Symptoms
+come from two places, unified here:
+
+* **Capacity / vitals driven** — built in: ``cyanosis`` (failing ``breathing`` →
+  oxygen-starved blue), ``pallor`` (blood loss → drained).
+* **Condition driven** — any ``MedicalCondition`` may expose an
+  ``appearance_symptom()`` returning a symptom keyword (e.g. RenalFailure →
+  ``uremic``). This is the cross-cutting hook §7.3 promises; conditions become
+  first-class visible signals other systems can read.
+
+The dominant symptom (by clinical priority) wins and overrides the base skintone
+in the longdesc render. Fail-open: anything unreadable yields no tint, so look
+never breaks.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Symptom keyword → xterm256 colour code (matches SKINTONE_PALETTE's ``|RGB``).
+SYMPTOM_TINTS = {
+    "cyanosis": "|115",   # oxygen-starved — dusky blue
+    "pallor":   "|444",   # blood-drained — ashen grey
+    "uremic":   "|431",   # renal failure — sallow grey-yellow
+    "jaundice": "|551",   # hepatic — yellow
+}
+
+#: Most clinically dominant first — first present wins.
+_SYMPTOM_PRIORITY = ("cyanosis", "pallor", "uremic", "jaundice")
+
+# Built-in capacity/vitals thresholds. Tunable.
+CYANOSIS_BREATHING_THRESHOLD = 0.5   # failing lungs can't oxygenate
+PALLOR_BLOOD_THRESHOLD = 95.0        # % of normal blood volume (death ~85)
+
+
+def _capacity(state, name):
+    calc = getattr(state, "calculate_body_capacity", None)
+    if not callable(calc):
+        return None
+    try:
+        value = calc(name)
+    except Exception:
+        return None
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    return value
+
+
+def get_active_symptom(character: Any) -> str | None:
+    """Return the dominant visible symptom keyword for *character*, or ``None``."""
+    state = getattr(character, "medical_state", None)
+    if state is None:
+        return None
+
+    present: set[str] = set()
+
+    # Condition-driven symptoms (the §7.3 hook).
+    for cond in getattr(state, "conditions", None) or []:
+        getter = getattr(cond, "appearance_symptom", None)
+        if not callable(getter):
+            continue
+        try:
+            symptom = getter()
+        except Exception:
+            symptom = None
+        if symptom:
+            present.add(symptom)
+
+    # Built-in capacity / vitals symptoms.
+    breathing = _capacity(state, "breathing")
+    if breathing is not None and breathing < CYANOSIS_BREATHING_THRESHOLD:
+        present.add("cyanosis")
+
+    blood = getattr(state, "blood_level", None)
+    if isinstance(blood, (int, float)) and not isinstance(blood, bool) \
+            and blood < PALLOR_BLOOD_THRESHOLD:
+        present.add("pallor")
+
+    for symptom in _SYMPTOM_PRIORITY:
+        if symptom in present:
+            return symptom
+    # An unranked condition-driven symptom still shows if it's the only one.
+    return next(iter(present), None)
+
+
+def get_appearance_tint(character: Any) -> str | None:
+    """Colour code for *character*'s dominant symptom, or ``None`` for no tint."""
+    try:
+        symptom = get_active_symptom(character)
+    except Exception:
+        return None
+    return SYMPTOM_TINTS.get(symptom) if symptom else None

--- a/world/tests/test_condition_appearance.py
+++ b/world/tests/test_condition_appearance.py
@@ -1,0 +1,100 @@
+"""
+Tests for condition-driven appearance symptoms
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §7.3).
+
+A character's medical state tints their rendered skintone — sick looks sick.
+Symptoms come from capacities/vitals (cyanosis, pallor) and from any condition
+exposing ``appearance_symptom()`` (the cross-cutting hook). The dominant one
+(by clinical priority) wins.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_condition_appearance
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.appearance import (
+    SYMPTOM_TINTS,
+    get_active_symptom,
+    get_appearance_tint,
+)
+
+
+class _Cond:
+    def __init__(self, symptom):
+        self._symptom = symptom
+
+    def appearance_symptom(self):
+        return self._symptom
+
+
+def _char(breathing=1.0, blood=100.0, conditions=(), medical=True):
+    if not medical:
+        return SimpleNamespace(medical_state=None)
+    state = SimpleNamespace(
+        calculate_body_capacity=lambda n: breathing if n == "breathing" else 1.0,
+        blood_level=blood,
+        conditions=list(conditions),
+    )
+    return SimpleNamespace(medical_state=state)
+
+
+class CapacityDrivenSymptomTests(TestCase):
+    def test_healthy_no_symptom(self):
+        self.assertIsNone(get_active_symptom(_char()))
+        self.assertIsNone(get_appearance_tint(_char()))
+
+    def test_failing_breathing_is_cyanosis(self):
+        ch = _char(breathing=0.3)
+        self.assertEqual(get_active_symptom(ch), "cyanosis")
+        self.assertEqual(get_appearance_tint(ch), SYMPTOM_TINTS["cyanosis"])
+
+    def test_blood_loss_is_pallor(self):
+        ch = _char(blood=90.0)
+        self.assertEqual(get_active_symptom(ch), "pallor")
+
+    def test_one_lung_boundary(self):
+        # Exactly at threshold is NOT cyanotic (strict less-than).
+        self.assertIsNone(get_active_symptom(_char(breathing=0.5)))
+        self.assertEqual(get_active_symptom(_char(breathing=0.49)), "cyanosis")
+
+
+class ConditionDrivenSymptomTests(TestCase):
+    def test_condition_supplies_symptom(self):
+        ch = _char(conditions=[_Cond("uremic")])
+        self.assertEqual(get_active_symptom(ch), "uremic")
+        self.assertEqual(get_appearance_tint(ch), SYMPTOM_TINTS["uremic"])
+
+    def test_unranked_condition_symptom_still_shows(self):
+        ch = _char(conditions=[_Cond("jaundice")])
+        self.assertEqual(get_active_symptom(ch), "jaundice")
+
+    def test_condition_without_hook_ignored(self):
+        ch = _char(conditions=[SimpleNamespace()])  # no appearance_symptom
+        self.assertIsNone(get_active_symptom(ch))
+
+
+class PriorityTests(TestCase):
+    def test_cyanosis_beats_pallor(self):
+        ch = _char(breathing=0.3, blood=90.0)  # both present
+        self.assertEqual(get_active_symptom(ch), "cyanosis")
+
+    def test_pallor_beats_uremic(self):
+        ch = _char(blood=90.0, conditions=[_Cond("uremic")])
+        self.assertEqual(get_active_symptom(ch), "pallor")
+
+
+class FailOpenTests(TestCase):
+    def test_no_medical_model(self):
+        self.assertIsNone(get_appearance_tint(_char(medical=False)))
+
+    def test_broken_state_does_not_raise(self):
+        class _Boom:
+            @property
+            def conditions(self):
+                raise RuntimeError("boom")
+        ch = SimpleNamespace(medical_state=_Boom())
+        # get_appearance_tint swallows errors → no tint, never raises.
+        self.assertIsNone(get_appearance_tint(ch))


### PR DESCRIPTION
The body's state, legible at a glance (CAPACITY_CONSUMERS spec §7.3) — the
sick one looks sick without a diagnose.

- world/medical/appearance.py: get_appearance_tint / get_active_symptom
  resolve the dominant medical symptom into an xterm256 tint.
  - Capacity/vitals built-ins: cyanosis (failing breathing -> dusky blue),
    pallor (blood loss -> ashen).
  - Condition hook (cross-cutting): any MedicalCondition may expose
    appearance_symptom() -> keyword (e.g. RenalFailure -> uremic). Conditions
    become first-class visible signals.
  - Priority-ordered (cyanosis > pallor > uremic > jaundice), fail-open.
- appearance_mixin._process_description_variables: the symptom tint OVERRIDES
  the base skintone in the longdesc render (applies even with no skintone).

This is the hook §7.2's RenalFailure pigment shift will use.

Tests: world/tests/test_condition_appearance.py (capacity-driven,
condition-driven, priority, fail-open). 40-test render sweep green.

Closes #605

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
