### PR TITLE
Medical: RenalFailure chronic condition (capacity §7.2)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -314,7 +314,15 @@ worsen/heal multipliers in `InfectionCondition.tick_effect` — worsen
 off*. `disease_resistance` = "how you process an infection," not "whether you
 catch one." Slots straight into the existing multiplier.
 
-### 7.2 Renal failure (buildable on the chronic-conditions substrate)
+### 7.2 Renal failure (buildable on the chronic-conditions substrate) — ✅ SHIPPED
+*(Built: `RenalFailureCondition` (`world/medical/conditions.py`) spawned/cleared
+by `MedicalState._update_renal_failure` in `update_vital_signs` (onset at
+filtration ≤0.05, clears ≥0.4 — hysteresis). Obtunds via `get_consciousness_penalty`
+(reuses the existing suppression sum); slow-kills via `get_blood_loss_rate` once
+terminal (rides the existing blood-loss death floor — no new death-verdict path);
+shows `uremic` via the §7.3 hook. Restoring filtration (cyber/donor kidney) clears
+it. Tests: `test_renal_failure.py`.)*
+
 Total kidney loss (filtration `0`) → a **RenalFailure** chronic condition,
 realizing the table's declared-but-unenforced `total_loss_fatal` *and* the
 `blood_filtration → consciousness` modifier that `update_vital_signs` doesn't

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -46,6 +46,16 @@ def hazard_fires(p_per_minute: float, elapsed_minutes: float) -> bool:
 BLOOD_FILTRATION_HEAL_FLOOR = 0.25     # clearance never stalls below 25% speed
 BLOOD_FILTRATION_WORSEN_SLOPE = 1.0    # worsen ×(1 + slope·(1−filtration)): 0.5→1.5x, 0→2.0x
 
+# RenalFailure (§7.2): total kidney loss → chronic uremia. Numbers are
+# proof-of-concept; a balance pass is owed. Tunable.
+RENAL_FAILURE_ONSET_FILTRATION = 0.05            # ≤ this (both kidneys gone) → onset
+RENAL_FAILURE_RECOVERY_FILTRATION = 0.4          # ≥ this (a kidney restored) → clears
+RENAL_FAILURE_PROGRESSION_PER_MINUTE = 0.15      # toxin buildup: severity climbs
+RENAL_FAILURE_CONSCIOUSNESS_PER_SEVERITY = 0.06  # progressive obtundation
+RENAL_FAILURE_MAX_CONSCIOUSNESS_PENALTY = 0.6    # can't alone instantly zero consciousness
+RENAL_FAILURE_LETHAL_SEVERITY = 7                # uremic systemic decline begins
+RENAL_FAILURE_DECLINE_PER_TICK = 0.3             # %/update blood-equiv drain when terminal
+
 
 def read_blood_filtration(character):
     """Raw ``blood_filtration`` capacity (0.0–1.0) for *character*, or ``None``.
@@ -694,6 +704,64 @@ class ConsciousnessSuppressionCondition(MedicalCondition):
         return condition
 
 
+class RenalFailureCondition(MedicalCondition):
+    """Total kidney loss → chronic uremia (CAPACITY_CONSUMERS spec §7.2).
+
+    Spawned and cleared by :meth:`MedicalState.update_vital_signs` from the
+    ``blood_filtration`` capacity (both kidneys gone → onset; a kidney restored
+    — cyber or donor — → it clears). Toxins accumulate (severity climbs), which:
+
+    * **obtunds** the patient — :meth:`get_consciousness_penalty` ramps with
+      severity (reuses the existing consciousness-suppression summation), and
+    * **slowly kills** — at terminal severity a uremic systemic decline drains
+      blood-equivalent volume (:meth:`get_blood_loss_rate`) until the existing
+      blood-loss death floor trips. No new death-verdict path; it rides the
+      substrates bleeding already uses.
+
+    Its signature is a visible uremic pallor via the §7.3 appearance hook.
+    """
+
+    def __init__(self, severity=1, location=None):
+        super().__init__("renal_failure", severity, location, tick_interval=300)
+
+    def tick_effect(self, character, elapsed_minutes=1.0):
+        # Toxins accumulate while filtration is gone — severity climbs to max.
+        if hazard_fires(RENAL_FAILURE_PROGRESSION_PER_MINUTE, elapsed_minutes):
+            self.severity = min(10, self.severity + 1)
+
+    def get_consciousness_penalty(self):
+        """Progressive obtundation, capped (uremic encephalopathy)."""
+        return min(
+            RENAL_FAILURE_MAX_CONSCIOUSNESS_PENALTY,
+            self.severity * RENAL_FAILURE_CONSCIOUSNESS_PER_SEVERITY,
+        )
+
+    def get_blood_loss_rate(self):
+        """Uremic systemic decline — a slow drain once terminal, else none."""
+        if self.severity < RENAL_FAILURE_LETHAL_SEVERITY:
+            return 0.0
+        return RENAL_FAILURE_DECLINE_PER_TICK
+
+    def appearance_symptom(self):
+        """The §7.3 visible signature — sallow / uremic / ashen skin."""
+        return "uremic"
+
+    def should_end(self):
+        # Never self-resolves; removal is filtration-driven (update_vital_signs
+        # clears it when a kidney is restored).
+        return False
+
+    @classmethod
+    def from_dict(cls, data):
+        condition = cls(data.get("severity", 1), data.get("location"))
+        condition.max_severity = data.get("max_severity", condition.severity)
+        condition.tick_interval = data.get("tick_interval", 300)
+        condition.requires_ticker = data.get("requires_ticker", True)
+        condition.treated = data.get("treated", False)
+        condition.last_processed = data.get("last_processed", clock_now())
+        return condition
+
+
 class AddictionCondition(MedicalCondition):
     """Flavor-first substance addiction (issue #485).
 
@@ -818,6 +886,8 @@ def deserialize_condition(condition_dict):
         return AddictionCondition.from_dict(condition_dict)
     if condition_type == "consciousness_suppression":
         return ConsciousnessSuppressionCondition.from_dict(condition_dict)
+    if condition_type == "renal_failure":
+        return RenalFailureCondition.from_dict(condition_dict)
     return MedicalCondition.from_dict(condition_dict)
 
 

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -992,6 +992,11 @@ class MedicalState:
         
     def update_vital_signs(self):
         """Update vital signs based on current conditions and organ state."""
+        # Renal failure tracks the blood_filtration capacity (CAPACITY_CONSUMERS
+        # spec §7.2) — onset when both kidneys are gone, cleared when a kidney is
+        # restored. Run first so a fresh onset's penalties land this same tick.
+        self._update_renal_failure()
+
         # Update pain level
         self.pain_level = self.calculate_total_pain()
         
@@ -1018,9 +1023,34 @@ class MedicalState:
                 consciousness_suppression_penalty += condition.get_consciousness_penalty()
         
         self.consciousness = max(0.0, base_consciousness - pain_penalty - blood_penalty - consciousness_suppression_penalty)
-        
+
         # Mark cache as dirty after vital sign updates
         self._cache_dirty = True
+
+    def _update_renal_failure(self):
+        """Spawn / clear the RenalFailure condition from ``blood_filtration``.
+
+        Onset when filtration collapses (both kidneys gone); cleared when a
+        kidney is restored (cyber or donor transplant lifts filtration back up).
+        Idempotent — only ever one renal_failure condition at a time.
+        (CAPACITY_CONSUMERS spec §7.2.)
+        """
+        from .conditions import (
+            RenalFailureCondition,
+            RENAL_FAILURE_ONSET_FILTRATION,
+            RENAL_FAILURE_RECOVERY_FILTRATION,
+        )
+
+        filtration = self.calculate_body_capacity("blood_filtration")
+        existing = self.get_conditions_by_type("renal_failure")
+
+        if filtration <= RENAL_FAILURE_ONSET_FILTRATION:
+            if not existing:
+                self.add_condition(RenalFailureCondition(severity=1))
+        elif filtration >= RENAL_FAILURE_RECOVERY_FILTRATION:
+            # Filtration restored — uremia clears.
+            for condition in existing:
+                self.remove_condition(condition)
         
     def take_organ_damage(self, organ_name, damage_amount, injury_type="generic"):
         """

--- a/world/tests/test_renal_failure.py
+++ b/world/tests/test_renal_failure.py
@@ -1,0 +1,132 @@
+"""
+Tests for the RenalFailure chronic condition
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §7.2).
+
+Total kidney loss → chronic uremia: spawned/cleared from blood_filtration,
+obtunds (consciousness penalty), slowly kills (uremic decline via the existing
+blood-loss death floor), and shows a uremic skin tint (§7.3 hook). The
+spawn/clear decision is unit-tested against a fake state (the live path needs a
+full Character + ticker); the condition's own behaviour is tested directly.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_renal_failure
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+import world.medical.conditions as C
+from world.medical.conditions import (
+    RENAL_FAILURE_DECLINE_PER_TICK,
+    RENAL_FAILURE_LETHAL_SEVERITY,
+    RENAL_FAILURE_MAX_CONSCIOUSNESS_PENALTY,
+    RenalFailureCondition,
+    deserialize_condition,
+)
+from world.medical.core import MedicalState
+from world.medical.appearance import SYMPTOM_TINTS, get_appearance_tint
+
+
+class RenalFailureBehaviourTests(TestCase):
+    def test_consciousness_penalty_scales_and_caps(self):
+        self.assertAlmostEqual(RenalFailureCondition(severity=1).get_consciousness_penalty(), 0.06)
+        self.assertAlmostEqual(RenalFailureCondition(severity=5).get_consciousness_penalty(), 0.30)
+        self.assertAlmostEqual(
+            RenalFailureCondition(severity=10).get_consciousness_penalty(),
+            RENAL_FAILURE_MAX_CONSCIOUSNESS_PENALTY,
+        )
+
+    def test_blood_loss_only_when_terminal(self):
+        self.assertEqual(
+            RenalFailureCondition(severity=RENAL_FAILURE_LETHAL_SEVERITY - 1).get_blood_loss_rate(),
+            0.0,
+        )
+        self.assertAlmostEqual(
+            RenalFailureCondition(severity=RENAL_FAILURE_LETHAL_SEVERITY).get_blood_loss_rate(),
+            RENAL_FAILURE_DECLINE_PER_TICK,
+        )
+
+    def test_appearance_symptom_is_uremic(self):
+        self.assertEqual(RenalFailureCondition().appearance_symptom(), "uremic")
+
+    def test_does_not_self_resolve(self):
+        self.assertFalse(RenalFailureCondition(severity=1).should_end())
+
+    def test_tick_ramps_severity(self):
+        cond = RenalFailureCondition(severity=3)
+        with patch.object(C, "hazard_fires", return_value=True):
+            cond.tick_effect(SimpleNamespace(key="P"), elapsed_minutes=1.0)
+        self.assertEqual(cond.severity, 4)
+
+    def test_round_trips_through_factory(self):
+        cond = RenalFailureCondition(severity=6)
+        restored = deserialize_condition(cond.to_dict())
+        self.assertIsInstance(restored, RenalFailureCondition)
+        self.assertEqual(restored.severity, 6)
+        self.assertEqual(restored.condition_type, "renal_failure")
+
+
+class _FakeState:
+    """Minimal stand-in exposing what _update_renal_failure touches."""
+    def __init__(self, filtration, existing=()):
+        self._filtration = filtration
+        self._existing = list(existing)
+        self.added = []
+        self.removed = []
+
+    def calculate_body_capacity(self, name):
+        return self._filtration
+
+    def get_conditions_by_type(self, condition_type):
+        return list(self._existing) if condition_type == "renal_failure" else []
+
+    def add_condition(self, condition):
+        self.added.append(condition)
+
+    def remove_condition(self, condition):
+        self.removed.append(condition)
+
+
+class RenalFailureSpawnLogicTests(TestCase):
+    def _run(self, filtration, existing=()):
+        st = _FakeState(filtration, existing)
+        MedicalState._update_renal_failure(st)
+        return st
+
+    def test_onset_when_both_kidneys_gone(self):
+        st = self._run(0.0)
+        self.assertEqual(len(st.added), 1)
+        self.assertIsInstance(st.added[0], RenalFailureCondition)
+        self.assertEqual(st.removed, [])
+
+    def test_idempotent_when_already_present(self):
+        st = self._run(0.0, existing=[RenalFailureCondition()])
+        self.assertEqual(st.added, [])
+
+    def test_one_kidney_does_not_onset(self):
+        st = self._run(0.5)
+        self.assertEqual(st.added, [])
+
+    def test_recovery_clears_when_filtration_restored(self):
+        cond = RenalFailureCondition(severity=5)
+        st = self._run(0.5, existing=[cond])
+        self.assertEqual(st.removed, [cond])
+
+    def test_hysteresis_dead_zone_neither_spawns_nor_clears(self):
+        # Between onset (0.05) and recovery (0.4): leave the condition alone.
+        cond = RenalFailureCondition(severity=5)
+        st = self._run(0.2, existing=[cond])
+        self.assertEqual(st.added, [])
+        self.assertEqual(st.removed, [])
+
+
+class RenalFailureAppearanceTests(TestCase):
+    def test_renal_failure_tints_uremic(self):
+        char = SimpleNamespace(medical_state=SimpleNamespace(
+            calculate_body_capacity=lambda n: 1.0,
+            blood_level=100.0,
+            conditions=[RenalFailureCondition(severity=3)],
+        ))
+        self.assertEqual(get_appearance_tint(char), SYMPTOM_TINTS["uremic"])


### PR DESCRIPTION
Total kidney loss -> chronic uremia (CAPACITY_CONSUMERS spec §7.2): realizes
blood_filtration's declared-but-unenforced fatality and the filtration->
consciousness modifier, on the chronic-conditions substrate.

- RenalFailureCondition (world/medical/conditions.py): toxins accumulate
  (severity ramps); get_consciousness_penalty obtunds (reuses the existing
  consciousness-suppression sum); get_blood_loss_rate drives a slow uremic
  decline once terminal (severity >= 7) that trips the EXISTING blood-loss
  death floor (no new death-verdict path); appearance_symptom -> "uremic"
  (the §7.3 visible signature).
- Spawn/clear in MedicalState._update_renal_failure (from update_vital_signs):
  onset at filtration <= 0.05, clears at >= 0.4 (hysteresis dead-zone avoids
  flapping). Idempotent. Round-trips through deserialize_condition.

Numbers are proof-of-concept; balance pass owed.

Tests: world/tests/test_renal_failure.py (behaviour, spawn/clear incl.
hysteresis, appearance, round-trip). 211-test medical sweep green incl. the
vital-signs hot path.

Closes #607

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
