### PR TITLE
Chrome: cyber kidney -> blood_filtration (capacity §7.4)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -347,7 +347,14 @@ the room; players see the sick one without a `diagnose`. The same hook yields
 from**: a toxin substance can trigger/worsen renal failure, diagnosis surfaces
 it, another condition compounds it.
 
-### 7.4 Remediation = chrome OR transplant (RipperDoc)
+### 7.4 Remediation = chrome OR transplant (RipperDoc) — ✅ SHIPPED
+*(Built: `CYBER_LEFT_KIDNEY` / `CYBER_RIGHT_KIDNEY` prototypes — single-organ
+replacements at the canonical kidney slots, capacity `blood_filtration`. A
+harvested **donor** kidney installs the same way (canonical name → capacity
+auto-restores) with no new code. Restoring filtration clears RenalFailure via
+the §7.2 despawn. Tests: `test_capacity_chrome.py`. Dialysis stopgap still
+future.)*
+
 Per §1: a **cyber kidney** *and* a **transplanted donor kidney** (harvested
 organ, canonical name → capacity auto-restores) both fix filtration — the
 general remediation principle for *any* capacity-restoring augment, not kidney-

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2364,6 +2364,50 @@ CYBER_RIGHT_EAR = {
     ],
 }
 
+# --- Cybernetic kidney → blood_filtration (infection course, renal failure) ---
+# Single-organ replacement at the canonical kidney slot (like CYBERNETIC_HEART
+# in the shared chest): restores blood_filtration, which clears RenalFailure
+# (§7.2) via update_vital_signs and steadies the infection course (§7.1). A
+# harvested DONOR kidney installs the same way (canonical name → capacity
+# auto-restores) — the modular dialysis stopgap is future.
+CYBER_LEFT_KIDNEY = {
+    "key": "cybernetic left kidney",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["cyber left kidney", "left filtration unit"],
+    "desc": "A bean-shaped filtration unit in a sealed perfusion cradle — a stack of micro-dialysis membranes behind a titanium shell, vascular couplers ringing the hilum like the real thing's renal artery and vein. It hums faintly even unpowered, holding pressure. Mounts on the left; surgical installation required.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("organ_name", "left_kidney"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "abdomen", "max_hp": 15, "hit_weight": "uncommon",
+            "capacity": "blood_filtration", "contribution": "major",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True, "prosthetic_frame": True,
+        }),
+    ],
+}
+
+CYBER_RIGHT_KIDNEY = {
+    "key": "cybernetic right kidney",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["cyber right kidney", "right filtration unit"],
+    "desc": "A bean-shaped filtration unit in a sealed perfusion cradle — a stack of micro-dialysis membranes behind a titanium shell, vascular couplers ringing the hilum like the real thing's renal artery and vein. It hums faintly even unpowered, holding pressure. Mounts on the right; surgical installation required.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("organ_name", "right_kidney"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "abdomen", "max_hp": 15, "hit_weight": "uncommon",
+            "capacity": "blood_filtration", "contribution": "major",
+            "can_be_harvested": True, "can_be_replaced": True,
+            "inorganic": True, "prosthetic_frame": True,
+        }),
+    ],
+}
+
 # --- Cybernetic leg → moving (dodge, flee, movement) ---
 # Side-agnostic chassis like CYBER_ARM: one prototype mounts left OR
 # right, the surgeon names the side, and the canonical bone names

--- a/world/tests/test_capacity_chrome.py
+++ b/world/tests/test_capacity_chrome.py
@@ -28,6 +28,8 @@ from world.prototypes import (
     CYBER_RIGHT_EYE,
     CYBER_LEFT_EAR,
     CYBER_RIGHT_EAR,
+    CYBER_LEFT_KIDNEY,
+    CYBER_RIGHT_KIDNEY,
     CYBER_LEG,
 )
 
@@ -132,12 +134,51 @@ class CyberLegRestoresMoving(TestCase):
         self.assertAlmostEqual(moving_dodge_factor(p), 1.0)
 
 
+class CyberKidneyRestoresFiltration(TestCase):
+    def test_failed_then_chromed(self):
+        p = _Patient()
+        state = p.attach()
+        self.assertAlmostEqual(
+            state.calculate_body_capacity("blood_filtration"), 1.0
+        )
+
+        # Both flesh kidneys destroyed → filtration collapses (renal failure
+        # territory: below the 0.05 onset threshold).
+        _destroy(state, "left_kidney", "right_kidney")
+        self.assertLessEqual(
+            state.calculate_body_capacity("blood_filtration"), 0.05
+        )
+
+        # Install chrome filtration units at the canonical kidney slots →
+        # filtration restored above the 0.4 recovery threshold (clears uremia).
+        _install(state, "left_kidney", _organ_spec(CYBER_LEFT_KIDNEY))
+        _install(state, "right_kidney", _organ_spec(CYBER_RIGHT_KIDNEY))
+        self.assertAlmostEqual(
+            state.calculate_body_capacity("blood_filtration"), 1.0
+        )
+
+    def test_single_donor_kidney_clears_recovery_threshold(self):
+        # One kidney (cyber or donor) restores filtration above the renal-
+        # failure recovery threshold (0.4) — you survive on one.
+        p = _Patient()
+        state = p.attach()
+        _destroy(state, "left_kidney", "right_kidney")
+        _install(state, "left_kidney", _organ_spec(CYBER_LEFT_KIDNEY))
+        self.assertGreaterEqual(
+            state.calculate_body_capacity("blood_filtration"), 0.4
+        )
+
+
 class ChromePrototypeShape(TestCase):
     """Guard the capacity wiring the consumers depend on."""
 
     def test_eyes_declare_sight(self):
         for proto in (CYBER_LEFT_EYE, CYBER_RIGHT_EYE):
             self.assertEqual(_organ_spec(proto)["capacity"], "sight")
+
+    def test_kidneys_declare_blood_filtration(self):
+        for proto in (CYBER_LEFT_KIDNEY, CYBER_RIGHT_KIDNEY):
+            self.assertEqual(_organ_spec(proto)["capacity"], "blood_filtration")
 
     def test_ears_declare_hearing(self):
         for proto in (CYBER_LEFT_EAR, CYBER_RIGHT_EAR):


### PR DESCRIPTION
Remediation for the blood_filtration capacity (CAPACITY_CONSUMERS spec §7.4),
completing the §7 metabolic arc.

- CYBER_LEFT_KIDNEY / CYBER_RIGHT_KIDNEY: single-organ replacements at the
  canonical kidney slots (like CYBERNETIC_HEART in the shared chest, the cyber
  eyes/ears), capacity blood_filtration. Restoring filtration steadies the
  infection course (§7.1) and clears RenalFailure (§7.2) via the
  update_vital_signs despawn.
- A harvested donor kidney installs the same way (canonical organ name ->
  capacity auto-restores) with no new code -- the RipperDoc transplant path.

Tests: world/tests/test_capacity_chrome.py (both kidneys destroyed ->
filtration <=0.05; chrome -> 1.0; single kidney clears the 0.4 recovery
threshold). 10-test chrome sweep green.

Finishes the §7 arc: blood_filtration now consumes (infection course + renal
failure + visible uremia) and remediates (cyber/donor kidney).

Closes #609

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
