### PR TITLE
Chrome: combat blindsight (targeting processor augment)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -475,9 +475,17 @@ locomotion restored, no special-case needed:
   (the voice-disguise; shifts the voice UID so recognition fails). `/modulate`.
 
 The `*_override` conditions (`sight_override`/`hearing_override`/`moving_override`/
-`manipulation_override`) remain a distinct, still-open **enhancer** seam — for a
-future augment that grants a sense *without* the organ (blindsight / sonar /
-targeting computer), where replacement doesn't apply.
+`manipulation_override`) remain a distinct **enhancer** seam — for an augment that
+grants a sense *without* the organ, where replacement doesn't apply.
+
+- **Combat blindsight ✅ SHIPPED** (decided 2026-06-20: combat-only, "enhance to
+  full perception later"). `TARGETING_PROCESSOR` forearm-hardpoint module → a
+  toggleable `blindsight` ability (`/blindsight`) sets `db.blindsight_active`,
+  which `world/combat/capacity.py` `sight_hit_factor` honours to restore combat
+  aim with the eyes gone. **Combat-only by construction:** it's a separate flag
+  from `sight_override`, so `can_see` (perception/recognition) stays false —
+  rooms and faces remain dark. A future fuller-sense suite would set the real
+  `sight_override` to also light up perception. Tests: `test_blindsight.py`.
 
 ## 10 · Cross-references
 

--- a/world/combat/capacity.py
+++ b/world/combat/capacity.py
@@ -97,6 +97,20 @@ def _has_override(character, condition_type: str) -> bool:
         return False
 
 
+# Combat-only "blindsight" — a targeting / sonar suite that restores combat
+# aim when the eyes are gone, WITHOUT restoring perception (``can_see`` stays
+# false: rooms and faces remain dark). Distinct from SIGHT_OVERRIDE_CONDITION,
+# which is the *full-vision* seam. Set as a db flag by the targeting-processor
+# augment ability. (CAPACITY_CONSUMERS spec — enhancer seam; user-decided
+# combat-only 2026-06-20, "maybe enhance toward full perception later".)
+BLINDSIGHT_FLAG = "blindsight_active"
+
+
+def _blindsight_active(character) -> bool:
+    db = getattr(character, "db", None)
+    return bool(getattr(db, BLINDSIGHT_FLAG, False)) if db is not None else False
+
+
 def sight_hit_factor(character, is_ranged: bool) -> float:
     """Multiplier applied to *character*'s motorics skill term when attacking.
 
@@ -107,9 +121,9 @@ def sight_hit_factor(character, is_ranged: bool) -> float:
 
     Returns:
         A factor in ``[0.0, 1.0]``.  ``1.0`` means no sight penalty (full
-        sight, no medical model, or an active suppressor).
+        sight, no medical model, a full sight-override, or combat blindsight).
     """
-    if _has_override(character, SIGHT_OVERRIDE_CONDITION):
+    if _has_override(character, SIGHT_OVERRIDE_CONDITION) or _blindsight_active(character):
         return 1.0
 
     raw = _read_capacity(character, "sight")

--- a/world/medical/augments.py
+++ b/world/medical/augments.py
@@ -98,6 +98,8 @@ def toggle_ability(character, name) -> str:
         return _toggle_natural_weapon(character, organ, name, spec)
     if ability_type == "voice_modulator":
         return _toggle_voice_modulator(character, organ, name, spec)
+    if ability_type == "blindsight":
+        return _toggle_blindsight(character, organ, name, spec)
     return f"{name} doesn't respond. (unknown ability type {ability_type!r})"
 
 
@@ -324,6 +326,35 @@ def _toggle_voice_modulator(character, organ, name, spec) -> str:
     _persist(character)
     return spec.get("retract_msg") or (
         "Your voice modulator powers down — your own voice returns."
+    )
+
+
+def _toggle_blindsight(character, organ, name, spec) -> str:
+    """Toggle a combat targeting / sonar suite — "blindsight".
+
+    Sets ``character.db.blindsight_active``, which `world.combat.capacity`
+    honours to restore combat aim even when the eyes are gone. Combat-only:
+    it does NOT restore perception (rooms / faces stay dark) — that's the
+    separate full-vision seam. (CAPACITY_CONSUMERS spec; user-decided
+    combat-only 2026-06-20.)
+    """
+    from world.combat.capacity import BLINDSIGHT_FLAG
+
+    state = _ability_state(organ, name)
+    if not state.get("deployed"):
+        state["deployed"] = True
+        setattr(character.db, BLINDSIGHT_FLAG, True)
+        _persist(character)
+        return spec.get("deploy_msg") or (
+            "Your targeting suite spins up — the world goes to wireframe and "
+            "ranging data, and your aim steadies even with your eyes shut."
+        )
+
+    state["deployed"] = False
+    setattr(character.db, BLINDSIGHT_FLAG, False)
+    _persist(character)
+    return spec.get("retract_msg") or (
+        "Your targeting suite powers down; the firing solutions fade."
     )
 
 

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2109,6 +2109,36 @@ SHOTGUN_MODULE = {
     ],
 }
 
+# Targeting Processor - forearm-hardpoint module granting combat "blindsight".
+# Seats into a CYBER_ARM's forearm hardpoint (like the shotgun module). /blindsight
+# toggles a sonar/ranging suite that restores combat AIM with the eyes gone —
+# combat-only: it does NOT restore perception (rooms/faces stay dark; that's a
+# future fuller-sense upgrade). Needs a cyber arm to mount into; surgeon required.
+TARGETING_PROCESSOR = {
+    "key": "targeting processor",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["targeting suite", "smartlink processor", "sonar module"],
+    "desc": "A forearm-hardpoint module the size of a thick deck of cards: a sensor-fusion die, a ranging emitter behind a smoked window, and a coupling collar of standard chassis gauge. Engaged, it paints the world in wireframe and firing solutions straight into your motor cortex — you shoot true with your eyes shut. It wants a slot.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("module_type", "forearm"),
+        ("condition", "pristine"),
+        ("compatible_species", ["human"]),
+        ("organ_spec", {
+            "container": "{side}_arm", "max_hp": 10, "hit_weight": "rare",
+            "inorganic": True, "prosthetic_frame": True,
+            "hardpoint": "forearm", "module_type": "forearm",
+            "abilities": {
+                "blindsight": {
+                    "type": "blindsight",
+                    "deploy_msg": "The targeting suite spins up — the world resolves into wireframe and ranging data, and your aim holds true even with your eyes shut.",
+                    "retract_msg": "The targeting suite powers down; the firing solutions fade and the dark closes back in.",
+                },
+            },
+        }),
+    ],
+}
+
 # Nailz - flesh-mount natural weapon module (#526 M4)
 # Implants into LIVING anatomy at either hand (flesh or chrome) —
 # the host stays what it is; it just has claws in it now.  /nailz

--- a/world/tests/test_blindsight.py
+++ b/world/tests/test_blindsight.py
@@ -1,0 +1,81 @@
+"""
+Tests for combat blindsight — the targeting/sonar enhancer
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC enhancer seam; combat-only, decided
+2026-06-20).
+
+Restores combat AIM when the eyes are gone, but NOT perception — a blind
+character with blindsight still can't see (rooms/faces stay dark). Toggled by
+the targeting-processor augment ability.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_blindsight
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.combat.capacity import sight_hit_factor, BLINDSIGHT_FLAG
+from world.voice import can_see
+from world.medical.augments import _toggle_blindsight
+
+
+class _Med:
+    def __init__(self, sight=1.0):
+        self._sight = sight
+
+    def calculate_body_capacity(self, name):
+        return self._sight if name == "sight" else 1.0
+
+    def get_conditions_by_type(self, condition_type):
+        return []
+
+
+class _Char:
+    def __init__(self, sight=1.0, blindsight=False):
+        self.key = "P"
+        self.db = SimpleNamespace(blindsight_active=blindsight)
+        self.medical_state = _Med(sight)
+
+
+class _Organ:
+    def __init__(self):
+        self.ability_state = {}
+
+
+class BlindsightRestoresAimTests(TestCase):
+    def test_blind_without_blindsight_cannot_aim(self):
+        self.assertLess(sight_hit_factor(_Char(sight=0.0), is_ranged=True), 0.1)
+
+    def test_blind_with_blindsight_aims_full(self):
+        ch = _Char(sight=0.0, blindsight=True)
+        self.assertAlmostEqual(sight_hit_factor(ch, is_ranged=True), 1.0)
+        self.assertAlmostEqual(sight_hit_factor(ch, is_ranged=False), 1.0)
+
+
+class BlindsightIsCombatOnlyTests(TestCase):
+    def test_blindsight_does_not_restore_perception(self):
+        # The whole point: aim is restored, but the character still can't SEE.
+        ch = _Char(sight=0.0, blindsight=True)
+        self.assertAlmostEqual(sight_hit_factor(ch, is_ranged=True), 1.0)
+        self.assertFalse(can_see(ch))  # rooms / faces stay dark
+
+
+class BlindsightToggleTests(TestCase):
+    def test_toggle_sets_and_clears_flag(self):
+        ch, organ = _Char(), _Organ()
+        self.assertFalse(getattr(ch.db, BLINDSIGHT_FLAG))
+
+        _toggle_blindsight(ch, organ, "blindsight", {})
+        self.assertTrue(getattr(ch.db, BLINDSIGHT_FLAG))
+        self.assertTrue(organ.ability_state["blindsight"]["deployed"])
+
+        _toggle_blindsight(ch, organ, "blindsight", {})
+        self.assertFalse(getattr(ch.db, BLINDSIGHT_FLAG))
+        self.assertFalse(organ.ability_state["blindsight"]["deployed"])
+
+    def test_custom_messages(self):
+        ch, organ = _Char(), _Organ()
+        spec = {"deploy_msg": "ON", "retract_msg": "OFF"}
+        self.assertEqual(_toggle_blindsight(ch, organ, "blindsight", spec), "ON")
+        self.assertEqual(_toggle_blindsight(ch, organ, "blindsight", spec), "OFF")


### PR DESCRIPTION
Fills the enhancer seam (CAPACITY_CONSUMERS spec) — a sense granted WITHOUT
the organ. Decided 2026-06-20: combat-only, room to enhance to full
perception later.

- TARGETING_PROCESSOR: a forearm-hardpoint module (like the shotgun module)
  seating into a CYBER_ARM. A toggleable `blindsight` ability (/blindsight via
  the existing CmdCyberware) sets db.blindsight_active.
- world/combat/capacity.py: sight_hit_factor honours the blindsight flag ->
  restores combat aim (ranged + melee) with the eyes gone.
- Combat-only by construction: blindsight is a SEPARATE flag from
  sight_override, so can_see (perception / recognition / LOOK render) stays
  false -- rooms and faces remain dark. A future fuller suite would set the
  real sight_override to also restore perception.
- world/medical/augments.py: new `blindsight` ability type + _toggle_blindsight
  (mirrors the voice modulator).

Tests: world/tests/test_blindsight.py (restores aim when blind; does NOT
restore perception; toggle flips the flag). 103-test sweep green.

Closes #611

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
