### PR TITLE
Combat: weapon auto-prioritizer — best weapon for the engagement (§6.1 Q2)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -244,13 +244,28 @@ them into one body-wide number is wrong.
   manipulation ≈ `0.5` for one arm would wrongly halve it.)
 - **(Q2) Breadth / readiness — from the *count of functional manipulators vs
   baseline*.** Buys breadth, not accuracy: **initiative + hard-to-fully-disarm
-  + loadout-readiness** (a grenade *and* a 2H melee *and* a pistol all ready at
-  once). NOT extra attacks or raw damage (combat-balance guardrail). *Which*
-  readied option to bring to bear when is a future combat revision.
+  + loadout-readiness**. NOT extra attacks or raw damage (combat-balance
+  guardrail). Three sub-payoffs, all **decided 2026-06-20**:
+  - **Loadout-readiness ✅ SHIPPED — the auto-prioritizer.** Rather than a
+    weapon-swap action economy, combat *automatically* brings the best in-hand
+    weapon to bear for the engagement: **range-appropriate first** (only ranged
+    reach at range; anything works point-blank), **then highest damage** (skill
+    weighting joins this once skills exist). The engagement — not the weapon —
+    decides melee vs ranged. `world/combat/utils.py`
+    `select_weapon_for_engagement` (used by `process_attack`); natural-weapon
+    precedence preserved; single-weapon fighters unchanged. Tests:
+    `test_weapon_autoprioritizer.py`. Holding several weapons (multi-armed /
+    cyber tail) is what feeds the picker more options.
+  - **Disarm — *once per gripping hand* (decided, not built).** A disarm must
+    succeed against *each* gripping hand to fully disarm; a four-armed gunslinger
+    is near-impossible to strip. Hooks the existing disarm mechanic.
+  - **Initiative — ramp then cap (decided, not built).** NOT a big 3rd-hand
+    jump; the bonus **scales up through ~6 limbs** (a reason to keep adding),
+    then **tapers off completely**. Hooks the existing initiative order.
 
 So: one-armed → full per-weapon accuracy, reduced breadth; four-armed → same
-per-weapon accuracy, large breadth (multiple weapons up, near-undisarmable,
-faster initiative).
+per-weapon accuracy, large breadth (the right weapon auto-selected, near-
+undisarmable, faster initiative).
 
 **Minimum requirements + scaled penalty.** A weapon's `hands_required` is a
 *minimum*; the gripping effectors must meet it. **Under-gripping** (2H weapon

--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -29,6 +29,7 @@ from .constants import (
 from .utils import (
     get_numeric_stat, get_display_name_safe,
     get_wielded_weapon, is_wielding_ranged_weapon,
+    select_weapon_for_engagement,
     get_weapon_damage, get_combatant_grappling_target,
     get_character_dbref,
 )
@@ -301,8 +302,16 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
         )
         return
 
-    # Check if attacker is wielding a ranged weapon
-    is_ranged_attack = is_wielding_ranged_weapon(attacker)
+    # Auto-prioritizer (CAPACITY_CONSUMERS spec §6.1 Q2): pick the best in-hand
+    # weapon for THIS engagement — range-appropriate first, then highest damage.
+    # The engagement (not the weapon) decides melee vs ranged. A one-weapon
+    # fighter gets that weapon unchanged; holding several (multi-armed / cyber
+    # tail) lets combat bring the right one to bear automatically.
+    chosen_weapon = select_weapon_for_engagement(attacker, target)
+    is_ranged_attack = bool(
+        chosen_weapon
+        and getattr(getattr(chosen_weapon, "db", None), "is_ranged", False)
+    )
 
     # For melee attacks, check same-room and proximity requirements
     if not is_ranged_attack:
@@ -387,7 +396,9 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
                 )
 
     # ── Get weapon and stats ───────────────────────────────────────────
-    weapon = get_wielded_weapon(attacker)
+    # Use the engagement-selected weapon (above) so damage/messages/is_ranged
+    # all agree on the one weapon being brought to bear.
+    weapon = chosen_weapon
     weapon_name = weapon.key if weapon else "unarmed"
 
     attacker_skill = get_numeric_stat(attacker, "motorics", 1)

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -202,8 +202,62 @@ def get_weapon_damage(weapon, default=0):
     # Ensure it's numeric and non-negative
     if not isinstance(damage, (int, float)) or damage < 0:
         return default
-    
+
     return int(damage)
+
+
+def _weapon_is_ranged(weapon) -> bool:
+    return bool(getattr(getattr(weapon, "db", None), "is_ranged", False))
+
+
+def _in_melee_range(attacker, target) -> bool:
+    """True when *target* is in *attacker*'s melee proximity (same room +
+    closed to melee). Mirrors the engagement gate in ``process_attack``."""
+    if getattr(attacker, "location", None) != getattr(target, "location", None):
+        return False
+    ndb = getattr(attacker, "ndb", None)
+    proximity = getattr(ndb, NDB_PROXIMITY, None) if ndb is not None else None
+    return bool(proximity) and target in proximity
+
+
+def select_weapon_for_engagement(attacker, target):
+    """Pick the best in-hand weapon for the current engagement (auto-prioritizer).
+
+    Combat fights with the right tool for the range automatically — the payoff
+    of holding several weapons at once (the loadout-readiness half of the
+    multi-appendage design, CAPACITY_CONSUMERS spec §6.1 Q2). Priority:
+
+    1. An active natural cyberweapon wins outright (settled precedence).
+    2. **Range-appropriate first.** At range, only ranged weapons reach; in
+       melee, anything works (a gun point-blank included).
+    3. **Then highest damage potential.** (Skill weighting joins this once a
+       skill system exists — for now, damage is the tiebreaker.)
+
+    A single-weapon fighter always gets that one weapon, so behaviour is
+    unchanged except for those actually holding a choice. Returns the chosen
+    weapon, or ``None`` when unarmed (caller falls back to fists).
+    """
+    try:
+        from world.medical.augments import get_active_natural_weapon
+        natural = get_active_natural_weapon(attacker)
+        if natural is not None:
+            return natural
+    except Exception:
+        pass
+
+    weapons = get_wielded_weapons(attacker)
+    if not weapons:
+        return None
+
+    if _in_melee_range(attacker, target):
+        usable = weapons  # everything is usable point-blank
+    else:
+        # At range only ranged weapons reach; if none, keep the held set so the
+        # caller's reach gate still produces the right "can't reach" message.
+        ranged = [w for w in weapons if _weapon_is_ranged(w)]
+        usable = ranged or weapons
+
+    return max(usable, key=lambda w: get_weapon_damage(w, 0))
 
 
 # ===================================================================

--- a/world/tests/test_weapon_autoprioritizer.py
+++ b/world/tests/test_weapon_autoprioritizer.py
@@ -1,0 +1,128 @@
+"""
+Tests for the combat weapon auto-prioritizer
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §6.1 Q2 — loadout-readiness).
+
+Combat brings the best in-hand weapon to bear for the current engagement:
+range-appropriate first (only ranged weapons reach at range; anything works
+point-blank), then highest damage. A one-weapon fighter is unchanged; holding
+several (multi-armed / cyber tail) is what the picker rewards.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_weapon_autoprioritizer
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.combat.constants import NDB_PROXIMITY
+from world.combat.utils import select_weapon_for_engagement
+
+
+def _weapon(key, ranged, damage):
+    return SimpleNamespace(
+        key=key, db=SimpleNamespace(is_ranged=ranged, damage=damage)
+    )
+
+
+_ROOM = object()
+
+
+def _char(weapons, location=_ROOM, proximity=()):
+    hands = {f"hand{i}": w for i, w in enumerate(weapons)}
+    return SimpleNamespace(
+        hands=hands,
+        location=location,
+        ndb=SimpleNamespace(**{NDB_PROXIMITY: set(proximity)}),
+    )
+
+
+class _Target:
+    """Plain (hashable) target — real Characters go in the proximity set."""
+    def __init__(self, location=_ROOM):
+        self.location = location
+
+
+def _target(location=_ROOM):
+    return _Target(location)
+
+
+class SingleWeaponUnchangedTests(TestCase):
+    def test_single_weapon_returned(self):
+        gun = _weapon("pistol", True, 10)
+        attacker = _char([gun])
+        self.assertIs(
+            select_weapon_for_engagement(attacker, _target()), gun
+        )
+
+    def test_unarmed_returns_none(self):
+        self.assertIsNone(
+            select_weapon_for_engagement(_char([]), _target())
+        )
+
+
+class RangedEngagementTests(TestCase):
+    def test_at_range_picks_ranged_even_if_lower_damage(self):
+        # Sword hits harder but can't reach; the pistol is the only option.
+        tgt = _target()
+        attacker = _char(
+            [_weapon("sword", False, 20), _weapon("pistol", True, 10)],
+            proximity=(),  # not closed to melee → at range
+        )
+        chosen = select_weapon_for_engagement(attacker, tgt)
+        self.assertEqual(chosen.key, "pistol")
+
+    def test_at_range_highest_damage_ranged_wins(self):
+        tgt = _target()
+        attacker = _char(
+            [_weapon("pistol", True, 10), _weapon("rifle", True, 18)],
+            proximity=(),
+        )
+        self.assertEqual(
+            select_weapon_for_engagement(attacker, tgt).key, "rifle"
+        )
+
+    def test_at_range_only_melee_falls_back(self):
+        # No ranged option: return a held weapon so the caller's reach gate
+        # produces the right "can't reach" message.
+        tgt = _target()
+        attacker = _char([_weapon("sword", False, 20)], proximity=())
+        self.assertEqual(
+            select_weapon_for_engagement(attacker, tgt).key, "sword"
+        )
+
+
+class MeleeEngagementTests(TestCase):
+    def test_in_melee_highest_damage_wins(self):
+        tgt = _target()
+        attacker = _char(
+            [_weapon("pistol", True, 12), _weapon("sword", False, 20)],
+            proximity=(tgt,),  # closed to melee
+        )
+        self.assertEqual(
+            select_weapon_for_engagement(attacker, tgt).key, "sword"
+        )
+
+    def test_in_melee_gun_used_pointblank_if_higher_damage(self):
+        tgt = _target()
+        attacker = _char(
+            [_weapon("hand cannon", True, 28), _weapon("knife", False, 14)],
+            proximity=(tgt,),
+        )
+        self.assertEqual(
+            select_weapon_for_engagement(attacker, tgt).key, "hand cannon"
+        )
+
+
+class NaturalWeaponPrecedenceTests(TestCase):
+    def test_active_natural_weapon_wins_outright(self):
+        claws = _weapon("claws", False, 30)
+        attacker = _char([_weapon("pistol", True, 10)], proximity=())
+        with patch(
+            "world.medical.augments.get_active_natural_weapon",
+            return_value=claws,
+        ):
+            self.assertIs(
+                select_weapon_for_engagement(attacker, _target()), claws
+            )


### PR DESCRIPTION
The loadout-readiness payoff of the multi-appendage design (CAPACITY_CONSUMERS
spec §6.1 Q2), reframed (decided 2026-06-20): not a weapon-swap action
economy, but an auto-prioritizer — combat automatically fights with the best
in-hand weapon for the engagement.

- world/combat/utils.py select_weapon_for_engagement(attacker, target): inverts
  today's "weapon decides the range" into "engagement decides, then pick the
  weapon". Priority: (1) active natural cyberweapon wins outright; (2)
  range-appropriate first (at range only ranged reach; in melee anything works
  point-blank); (3) then highest damage (skill weighting joins once skills
  exist).
- process_attack uses it for both the chosen weapon and is_ranged_attack, so
  damage / messages / range all agree.
- Single-weapon fighters unchanged — only those holding a choice (multi-armed /
  cyber tail) get the new behaviour, so low regression risk.

Tests: world/tests/test_weapon_autoprioritizer.py. 121-test combat sweep green.

Also records (not built) the other two Q2 payoffs: disarm once per gripping
hand; initiative that ramps to ~6 limbs then tapers.

Closes #615

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
