### PR TITLE
Combat: surplus-limb initiative bonus (capacity §6.1 Q2)

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -256,12 +256,17 @@ them into one body-wide number is wrong.
     precedence preserved; single-weapon fighters unchanged. Tests:
     `test_weapon_autoprioritizer.py`. Holding several weapons (multi-armed /
     cyber tail) is what feeds the picker more options.
-  - **Disarm — *once per gripping hand* (decided, not built).** A disarm must
-    succeed against *each* gripping hand to fully disarm; a four-armed gunslinger
-    is near-impossible to strip. Hooks the existing disarm mechanic.
-  - **Initiative — ramp then cap (decided, not built).** NOT a big 3rd-hand
-    jump; the bonus **scales up through ~6 limbs** (a reason to keep adding),
-    then **tapers off completely**. Hooks the existing initiative order.
+  - **Disarm — *once per gripping hand* ✅ ALREADY SATISFIED.** `resolve_disarm`
+    (`world/combat/actions.py`) already knocks out **one** weapon per successful
+    attempt, so a multi-weapon fighter needs one disarm *per* gripping hand to be
+    fully stripped — exactly the decided behaviour, emergent from the existing
+    mechanic. (Edge: a 2H weapon held in two hands disarms as one item — fine.)
+  - **Initiative — ramp then cap ✅ SHIPPED.** `surplus_limb_initiative_bonus`
+    (`world/combat/utils.py`) adds to the `d20 + motorics` initiative roll.
+    Triangular (accelerating) increments per surplus grasping limb beyond the
+    species baseline — the 3rd hand is a small jump, the run to ~6 limbs is the
+    reason to chrome up, then it **caps completely** (extra limbs past 6 give
+    nothing). Decided 2026-06-20. Tests: `test_initiative_limbs.py`.
 
 So: one-armed → full per-weapon accuracy, reduced breadth; four-armed → same
 per-weapon accuracy, large breadth (the right weapon auto-selected, near-

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -260,6 +260,43 @@ def select_weapon_for_engagement(attacker, target):
     return max(usable, key=lambda w: get_weapon_damage(w, 0))
 
 
+# Surplus grasping limbs buy initiative (CAPACITY_CONSUMERS spec §6.1 Q2 —
+# breadth, not power). Decided 2026-06-20: NOT a big 3rd-hand jump — the bonus
+# RAMPS UP through ~6 limbs (a reason to keep adding), then TAPERS OFF
+# COMPLETELY (capped). Modelled as triangular (accelerating) increments per
+# surplus limb, capped. Magnitudes tunable.
+INITIATIVE_LIMB_SURPLUS_CAP = 4   # surplus limbs that still help (human: caps at 6 total)
+INITIATIVE_LIMB_BONUS_UNIT = 2    # initiative per triangular step; peak = UNIT × T(CAP) = 20
+
+
+def surplus_limb_initiative_bonus(char) -> int:
+    """Initiative bonus from grasping limbs beyond the species baseline.
+
+    More working hands / tails = you bring something to bear sooner. The
+    marginal value accelerates (the 3rd hand is small; the run up to ~6 is the
+    reason to chrome up) then caps — extra limbs past the cap give nothing.
+    Fail-open (0) for anything without a readable ``hands`` view / species.
+    """
+    hands = getattr(char, "hands", None)
+    if hands is None:
+        return 0
+    try:
+        functional = len(hands)
+    except Exception:
+        return 0
+
+    species = getattr(getattr(char, "db", None), "species", None)
+    try:
+        from world.anatomy import get_species_grasping_containers
+        baseline = len(get_species_grasping_containers(species) or ())
+    except Exception:
+        return 0
+
+    surplus = min(max(0, functional - baseline), INITIATIVE_LIMB_SURPLUS_CAP)
+    triangular = surplus * (surplus + 1) // 2   # 0, 1, 3, 6, 10
+    return triangular * INITIATIVE_LIMB_BONUS_UNIT
+
+
 # ===================================================================
 # MESSAGE FORMATTING
 # ===================================================================
@@ -531,7 +568,11 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
     target_dbref = get_character_dbref(target)
     entry = {
         DB_CHAR: char,
-        DB_INITIATIVE: randint(1, 20) + get_numeric_stat(char, "motorics", 0),
+        DB_INITIATIVE: (
+            randint(1, 20)
+            + get_numeric_stat(char, "motorics", 0)
+            + surplus_limb_initiative_bonus(char)
+        ),
         DB_TARGET_DBREF: target_dbref,
         DB_GRAPPLING_DBREF: get_character_dbref(initial_grappling),
         DB_GRAPPLED_BY_DBREF: get_character_dbref(initial_grappled_by),

--- a/world/tests/test_initiative_limbs.py
+++ b/world/tests/test_initiative_limbs.py
@@ -1,0 +1,67 @@
+"""
+Tests for the surplus-limb initiative bonus
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §6.1 Q2 — breadth, not power).
+
+Grasping limbs beyond the species baseline grant an initiative bonus whose
+marginal value ACCELERATES through ~6 limbs (a reason to keep adding) and then
+TAPERS OFF COMPLETELY (caps). Decided 2026-06-20: not a big 3rd-hand jump.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_initiative_limbs
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.combat.utils import (
+    INITIATIVE_LIMB_BONUS_UNIT,
+    surplus_limb_initiative_bonus,
+)
+
+
+def _char(num_hands, species="human"):
+    hands = {f"slot{i}": None for i in range(num_hands)}
+    return SimpleNamespace(hands=hands, db=SimpleNamespace(species=species))
+
+
+class SurplusLimbInitiativeTests(TestCase):
+    def test_human_baseline_no_bonus(self):
+        self.assertEqual(surplus_limb_initiative_bonus(_char(2)), 0)
+
+    def test_third_hand_is_a_small_jump(self):
+        # T(1) = 1 → one unit. Deliberately small.
+        self.assertEqual(
+            surplus_limb_initiative_bonus(_char(3)), 1 * INITIATIVE_LIMB_BONUS_UNIT
+        )
+
+    def test_ramp_accelerates_to_six_limbs(self):
+        bonuses = [surplus_limb_initiative_bonus(_char(n)) for n in (2, 3, 4, 5, 6)]
+        # 0, 2, 6, 12, 20 with UNIT=2.
+        self.assertEqual(
+            bonuses,
+            [0, 1 * INITIATIVE_LIMB_BONUS_UNIT, 3 * INITIATIVE_LIMB_BONUS_UNIT,
+             6 * INITIATIVE_LIMB_BONUS_UNIT, 10 * INITIATIVE_LIMB_BONUS_UNIT],
+        )
+        # Marginal gains strictly increase up to the cap (accelerating).
+        margins = [bonuses[i + 1] - bonuses[i] for i in range(len(bonuses) - 1)]
+        self.assertEqual(margins, sorted(margins))
+        self.assertTrue(all(m2 > m1 for m1, m2 in zip(margins, margins[1:])))
+
+    def test_caps_at_six_limbs(self):
+        peak = surplus_limb_initiative_bonus(_char(6))
+        self.assertEqual(surplus_limb_initiative_bonus(_char(7)), peak)
+        self.assertEqual(surplus_limb_initiative_bonus(_char(8)), peak)
+        self.assertEqual(surplus_limb_initiative_bonus(_char(12)), peak)
+
+    def test_lost_limb_no_bonus_and_no_penalty(self):
+        # Below baseline: no initiative bonus (and no negative — the per-weapon
+        # accuracy hit already covers losing a hand).
+        self.assertEqual(surplus_limb_initiative_bonus(_char(1)), 0)
+        self.assertEqual(surplus_limb_initiative_bonus(_char(0)), 0)
+
+    def test_fail_open_without_hands(self):
+        self.assertEqual(
+            surplus_limb_initiative_bonus(SimpleNamespace(db=SimpleNamespace(species="human"))),
+            0,
+        )


### PR DESCRIPTION
The initiative payoff of the multi-appendage design (CAPACITY_CONSUMERS spec
§6.1 Q2) — breadth, not power. More working hands/tails = you bring something
to bear sooner.

- world/combat/utils.py surplus_limb_initiative_bonus(char) adds to the
  d20 + motorics initiative roll (add_combatant_entry).
- Curve (decided 2026-06-20): NOT a big 3rd-hand jump. Triangular
  (accelerating) increments per grasping limb beyond the species baseline ->
  3rd hand small, the run to ~6 limbs is the reason to chrome up, then caps
  completely (limbs past 6 give nothing). Human: +0/+2/+6/+12/+20 for
  2/3/4/5/6 hands, flat beyond. Below baseline -> no bonus, no penalty
  (per-weapon accuracy already covers limb loss). Fail-open.

Also: the other Q2 payoff, disarm "once per gripping hand", is already
satisfied -- resolve_disarm knocks out one weapon per attempt.

Tests: world/tests/test_initiative_limbs.py. 48-test combat sweep green.

Completes the §6.1 Q2 breadth payoffs (loadout / disarm / initiative).

Closes #617

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
