### PR TITLE
Balance: halve the surplus-limb initiative bonus

### DIFF
--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -266,7 +266,9 @@ them into one body-wide number is wrong.
     Triangular (accelerating) increments per surplus grasping limb beyond the
     species baseline — the 3rd hand is a small jump, the run to ~6 limbs is the
     reason to chrome up, then it **caps completely** (extra limbs past 6 give
-    nothing). Decided 2026-06-20. Tests: `test_initiative_limbs.py`.
+    nothing). Human: `+0/+1/+3/+6/+10` for 2/3/4/5/6 hands, flat beyond.
+    Decided 2026-06-20 (magnitudes halved per balance pass). Tests:
+    `test_initiative_limbs.py`.
 
 So: one-armed → full per-weapon accuracy, reduced breadth; four-armed → same
 per-weapon accuracy, large breadth (the right weapon auto-selected, near-

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -266,7 +266,7 @@ def select_weapon_for_engagement(attacker, target):
 # COMPLETELY (capped). Modelled as triangular (accelerating) increments per
 # surplus limb, capped. Magnitudes tunable.
 INITIATIVE_LIMB_SURPLUS_CAP = 4   # surplus limbs that still help (human: caps at 6 total)
-INITIATIVE_LIMB_BONUS_UNIT = 2    # initiative per triangular step; peak = UNIT × T(CAP) = 20
+INITIATIVE_LIMB_BONUS_UNIT = 1    # initiative per triangular step; peak = UNIT × T(CAP) = 10
 
 
 def surplus_limb_initiative_bonus(char) -> int:


### PR DESCRIPTION
Per playtest feel the surplus-limb initiative bonus (#618) ran a touch high.
Halve it via INITIATIVE_LIMB_BONUS_UNIT (2 -> 1).

Human values now +0/+1/+3/+6/+10 for 2/3/4/5/6 hands (was +0/+2/+6/+12/+20),
still capping completely past ~6 limbs. Curve shape (small 3rd hand,
accelerating to 6, then flat) unchanged. Tests reference the constant so they
stay green.

Closes #619

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
