### PR TITLE
Perception: five-senses room descriptions (capacity §5)

### DIFF
--- a/commands/CmdCharacter.py
+++ b/commands/CmdCharacter.py
@@ -1825,6 +1825,89 @@ class CmdVoice(Command):
         )
 
 
+class CmdRoomSense(Command):
+    """
+    Author the non-visual sense layers of the room you're in (builders).
+
+    The room's normal description is its |wvisual|n layer. These add what the
+    room |wsounds|n, |wsmells|n, and |wfeels|n like — so a blind player reads
+    the room by ear and nose, a deaf one loses the sounds, and a fully-sensed
+    player gets the rich, layered picture.
+
+    Usage:
+      @roomsense                      - show this room's sense layers
+      @roomsense <sense> = <text>     - set a layer
+      @roomsense/clear <sense>        - clear a layer
+
+    Senses: |cauditory|n, |colfactory|n, |ctactile|n, |catmospheric|n.
+
+    Example:
+      @roomsense auditory = Distant sirens rise and fall; water drips somewhere close.
+      @roomsense olfactory = Wet concrete, old smoke, and the sweetness of rot.
+    """
+
+    key = "@roomsense"
+    aliases = ["roomsense"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+    switch_options = ("clear",)
+
+    def func(self):
+        from typeclasses.rooms import Room
+        caller = self.caller
+        room = caller.location
+        if not isinstance(room, Room):
+            caller.msg("You're not standing in a room that takes sense layers.")
+            return
+
+        senses = Room.SENSE_LAYER_ORDER
+        args = (self.args or "").strip()
+        current = dict(room.db.sense_descs or {})
+
+        if "clear" in self.switches:
+            sense = args.lower()
+            if sense not in senses:
+                caller.msg(f"Sense must be one of: {', '.join(senses)}.")
+                return
+            if current.pop(sense, None) is None:
+                caller.msg(f"This room has no {sense} layer set.")
+                return
+            room.db.sense_descs = current
+            caller.msg(f"Cleared the |c{sense}|n layer.")
+            return
+
+        if not args or args.lower() == "list":
+            if not current:
+                caller.msg(
+                    "This room has no sense layers yet. Add one: "
+                    "|w@roomsense auditory = <text>|n  "
+                    f"(senses: {', '.join(senses)})"
+                )
+                return
+            caller.msg("|wRoom sense layers:|n")
+            for sense in senses:
+                if current.get(sense):
+                    caller.msg(f"  |c{sense}|n: {current[sense]}")
+            return
+
+        if "=" not in args:
+            caller.msg("Usage: |w@roomsense <sense> = <text>|n")
+            return
+
+        sense, _, text = args.partition("=")
+        sense = sense.strip().lower()
+        text = text.strip()
+        if sense not in senses:
+            caller.msg(f"Sense must be one of: {', '.join(senses)}.")
+            return
+        if not text:
+            caller.msg("Give the layer some text, or use |w@roomsense/clear|n.")
+            return
+        current[sense] = text
+        room.db.sense_descs = current
+        caller.msg(f"Set the |c{sense}|n layer for this room.")
+
+
 class CmdSkintone(Command):
     """
     Set your character's skintone for longdesc display coloring.

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -37,7 +37,7 @@ from commands.CmdExplosives import (
     CmdClearDetonator,
 )
 from commands.CmdGraffiti import CmdGraffiti, CmdPress
-from commands.CmdCharacter import CmdDescribe, CmdSkintone, CmdVoice
+from commands.CmdCharacter import CmdDescribe, CmdSkintone, CmdVoice, CmdRoomSense
 from commands.CmdCharacter import CmdRemember, CmdForget, CmdRecall, CmdMemory
 from commands.CmdCommunication import CmdSay, CmdWhisper, CmdEmote, CmdDotPose
 from commands.forensics import CmdAutopsy, CmdSever
@@ -183,6 +183,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         # Replaces @longdesc, @shortdesc, and Evennia's default setdesc.
         self.add(CmdDescribe())
         self.add(CmdVoice())
+        self.add(CmdRoomSense())
         # Remove Evennia's default setdesc; the Short Description menu option
         # and `describe short <text>` now own the main description.
         self.remove(CmdSetDesc())

--- a/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
+++ b/specs/proposals/CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC.md
@@ -234,11 +234,17 @@ limitation; this spec supplies the input.**
 (`blocked_senses` / `can_perceive_sense` / `has_reduced_perception`) gates the
 weather + crowd ambient pools on `sight`→visual / `hearing`→auditory (chrome
 override seams honoured), with a +1 compensatory ambient message when a sense
-is missing. **⏭️ NEXT (this slice): base room-desc five-senses decomposition** —
-let authors split a room's description into per-sense layers so the blind/deaf
-get a genuinely different room view (not just trimmed ambient pools). The
-single-blob desc remains the default visual layer; the decomposition is additive
-and opt-in per room.
+is missing.
+
+**✅ SHIPPED (base room-desc five-senses decomposition):** `Room.get_display_desc`
+(`typeclasses/rooms.py`) composes the room description from only the sense layers
+the looker can perceive — the visual blob (`db.desc`) when sighted, plus authored
+non-visual layers (`db.sense_descs`: auditory/olfactory/tactile/atmospheric) for
+senses they still have. **A blind looker loses the visual prose but reads the
+room by sound/smell/feel; deaf drops the auditory layer.** Opt-in per room via
+the `@roomsense` builder command — rooms with no sense layers + a sighted looker
+render exactly as before (zero regression). Weather/crowd still append (also
+perception-gated). Tests: `test_room_five_senses.py`.
 
 ## 6 · Manipulation & Moving — the per-effector resolver (decided)
 

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -34,12 +34,55 @@ class Room(ObjectParent, DefaultRoom):
     # Outside room flag for weather system
     outside = AttributeProperty(default=False, autocreate=True)
     
-    # Room description
+    # Room description (the VISUAL layer — see get_display_desc)
     desc = AttributeProperty(default="", autocreate=True)
-    
+
+    # Per-sense description layers (CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §5):
+    # {"auditory": ..., "olfactory": ..., "tactile": ..., "atmospheric": ...}.
+    # Opt-in per room; the single-blob `desc` is the default visual layer, so
+    # rooms without this render exactly as before. Authored via `@roomsense`.
+    sense_descs = AttributeProperty(default={}, autocreate=True)
+
     # Crowd system base level
     crowd_base_level = AttributeProperty(default=0, autocreate=True)
     
+    #: Non-visual sense layers, in render order.
+    SENSE_LAYER_ORDER = ("auditory", "olfactory", "tactile", "atmospheric")
+
+    def get_display_desc(self, looker, **kwargs):
+        """Perception-aware room description (CAPACITY_CONSUMERS spec §5).
+
+        Composes the room's description from only the sense layers *looker* can
+        perceive: the visual blob (`db.desc`) when they can see, plus any
+        authored non-visual layers (`db.sense_descs`) for senses they still
+        have. A blind looker loses the visual prose but still 'reads' the room
+        by sound / smell / feel; deaf drops the auditory layer; and so on.
+
+        Rooms with no `sense_descs` and a sighted looker return the plain visual
+        desc exactly as before (zero regression). Weather/crowd still append in
+        ``return_appearance`` (themselves perception-gated, #592).
+        """
+        from world.perception import can_perceive_sense
+
+        parts = []
+        visual = self.db.desc or ""
+        if visual and can_perceive_sense(looker, "visual"):
+            parts.append(visual)
+
+        sense_descs = self.db.sense_descs or {}
+        for sense in self.SENSE_LAYER_ORDER:
+            text = sense_descs.get(sense)
+            if text and can_perceive_sense(looker, sense):
+                parts.append(text)
+
+        if parts:
+            return " ".join(parts)
+
+        # Nothing perceivable — give a sense-appropriate void rather than blank.
+        if not can_perceive_sense(looker, "visual"):
+            return "You can't see a thing here, and nothing else reaches you."
+        return visual or "You see nothing special."
+
     def at_object_creation(self):
         """
         Called when room is first created.

--- a/world/tests/test_room_five_senses.py
+++ b/world/tests/test_room_five_senses.py
@@ -1,0 +1,124 @@
+"""
+Tests for perception-aware room descriptions — the five-senses framework
+(CAPACITY_CONSUMERS_AND_PERCEPTION_SPEC §5).
+
+`Room.get_display_desc` composes the room's description from only the sense
+layers the looker can perceive: visual blob (when sighted) + authored
+non-visual layers (auditory/olfactory/tactile/atmospheric) for senses they
+still have. A blind looker loses the visual prose but reads the room by sound
+/ smell / feel. Rooms with no sense layers + a sighted looker are unchanged.
+
+The method only touches ``self.db.desc`` / ``self.db.sense_descs`` /
+``self.SENSE_LAYER_ORDER`` and ``can_perceive_sense(looker)``, so it's driven
+here with a stub ``self`` and stub lookers — no DB room needed.
+
+Run via::
+
+    evennia test --keepdb world.tests.test_room_five_senses
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from typeclasses.rooms import Room
+
+
+def _room(desc="A neon-lit alley.", **sense_descs):
+    return SimpleNamespace(
+        db=SimpleNamespace(desc=desc, sense_descs=dict(sense_descs)),
+        SENSE_LAYER_ORDER=Room.SENSE_LAYER_ORDER,
+    )
+
+
+class _Med:
+    def __init__(self, sight=1.0, hearing=1.0):
+        self._caps = {"sight": sight, "hearing": hearing}
+
+    def calculate_body_capacity(self, name):
+        return self._caps.get(name, 1.0)
+
+    def get_conditions_by_type(self, condition_type):
+        return []
+
+
+def _looker(sight=1.0, hearing=1.0, medical=True):
+    return SimpleNamespace(
+        medical_state=_Med(sight, hearing) if medical else None
+    )
+
+
+def _desc(room, looker):
+    return Room.get_display_desc(room, looker)
+
+
+class FullSensesTests(TestCase):
+    def test_sighted_hearing_gets_all_layers(self):
+        room = _room(auditory="Sirens wail.", olfactory="Wet garbage.")
+        out = _desc(room, _looker())
+        self.assertEqual(out, "A neon-lit alley. Sirens wail. Wet garbage.")
+
+    def test_no_sense_layers_is_just_visual(self):
+        # Zero-regression: a plain room renders exactly its visual desc.
+        self.assertEqual(
+            _desc(_room(), _looker()), "A neon-lit alley."
+        )
+
+
+class BlindTests(TestCase):
+    def test_blind_drops_visual_keeps_other_senses(self):
+        room = _room(auditory="Sirens wail.", olfactory="Wet garbage.")
+        out = _desc(room, _looker(sight=0.0))
+        self.assertEqual(out, "Sirens wail. Wet garbage.")
+        self.assertNotIn("neon-lit alley", out)
+
+    def test_blind_with_no_other_senses_gets_void(self):
+        out = _desc(_room(), _looker(sight=0.0))
+        self.assertIn("can't see", out.lower())
+
+
+class DeafTests(TestCase):
+    def test_deaf_drops_auditory_only(self):
+        room = _room(
+            auditory="Sirens wail.", olfactory="Wet garbage.",
+            tactile="Cold mist clings.",
+        )
+        out = _desc(room, _looker(hearing=0.0))
+        self.assertNotIn("Sirens", out)
+        self.assertIn("A neon-lit alley.", out)
+        self.assertIn("Wet garbage.", out)
+        self.assertIn("Cold mist clings.", out)
+
+
+class BlindAndDeafTests(TestCase):
+    def test_only_smell_and_touch_remain(self):
+        room = _room(
+            auditory="Sirens wail.", olfactory="Wet garbage.",
+            tactile="Cold mist clings.",
+        )
+        out = _desc(room, _looker(sight=0.0, hearing=0.0))
+        self.assertEqual(out, "Wet garbage. Cold mist clings.")
+
+
+class LayerOrderTests(TestCase):
+    def test_layers_render_in_canonical_order(self):
+        room = _room(
+            atmospheric="Dread hangs heavy.",
+            auditory="Sirens wail.",
+            tactile="Cold mist clings.",
+            olfactory="Wet garbage.",
+        )
+        out = _desc(room, _looker())
+        # visual, then auditory, olfactory, tactile, atmospheric.
+        self.assertEqual(
+            out,
+            "A neon-lit alley. Sirens wail. Wet garbage. "
+            "Cold mist clings. Dread hangs heavy.",
+        )
+
+
+class FailOpenTests(TestCase):
+    def test_no_medical_model_perceives_everything(self):
+        room = _room(auditory="Sirens wail.")
+        out = _desc(room, _looker(medical=False))
+        self.assertIn("A neon-lit alley.", out)
+        self.assertIn("Sirens wail.", out)


### PR DESCRIPTION
Decompose room descriptions into per-sense layers so the blind/deaf get a
genuinely different room view (CAPACITY_CONSUMERS spec §5).

- Room.get_display_desc(looker) (typeclasses/rooms.py) — the clean Evennia
  desc hook — composes the room description from only the sense layers the
  looker can perceive: the visual blob (db.desc) when sighted, plus authored
  non-visual layers (db.sense_descs: auditory/olfactory/tactile/atmospheric)
  for senses they still have. A blind looker loses the visual prose but reads
  the room by sound/smell/feel (or a void cue); deaf drops the auditory layer.
- db.sense_descs AttributeProperty on Room (opt-in). Rooms with no sense
  layers + a sighted looker render EXACTLY as before — zero regression.
  Weather/crowd still append (already perception-gated, #592).
- @roomsense builder command (Builder-locked): set/list/clear the
  auditory/olfactory/tactile/atmospheric layers of the current room.

Tests: world/tests/test_room_five_senses.py (full senses, blind drops visual,
deaf drops auditory, blind+deaf, render order, void fallback, fail-open,
zero-regression plain room). 27-test perception+render sweep green.

Realizes the original "a blind player doesn't see the room, only senses it"
vision.

Closes #623

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
