### PR TITLE
Ambient text r3: five senses, named subjects, ambience-not-action

### DIFF
--- a/world/crowd/crowd_messages.py
+++ b/world/crowd/crowd_messages.py
@@ -1,22 +1,33 @@
 """
 Crowd system message pools (parallels the weather system architecture).
 
-Ambient, perception-gated observations about the people sharing a room. The
-guiding principle is to OFFER something to observe -- never to tell the player
-how to feel about it. But "observe" doesn't mean bland: these are the colony's
-streets, and things HAPPEN on them. A dog's bark cut short, feral kids stripping
-a wage-hand and gone before he can shout, a deal souring in the press. The grit
-and the menace live in the events themselves, concretely shown; the player draws
-their own conclusions. No "reality warps," no "you feel dread" -- but no empty
-wallpaper either.
+Ambient, perception-gated observations about the people sharing a room. Three
+rules, learned the hard way:
 
-Voice: the colony's own texture -- shift crews in stained coveralls, synthetics,
-corpsec drones, ripperdoc touts, chit-hustlers, haulers, feral kids, the channel,
-the prefab sprawl, the processor's hum. Kept generic to the whole colony (no
-named districts); a line should read true on any of its streets.
+  1. OFFER something to observe, don't narrate how to feel. The grit lives in
+     the concrete event (a dog's bark cut short, feral kids stripping a wage-hand
+     and gone), shown plainly; the player draws their own conclusions.
 
-Lines may run to two short sentences; the renderer capitalises only the first
-letter, so interior sentence capitals survive.
+  2. AMBIENCE, NOT ACTION ON THE PLAYER. Never describe something happening TO
+     the character that they'd want to react to but can't -- no hand in *your*
+     pocket, no shove that moves *you*, no pinning *your* arms. Those imply a
+     game action the text can't deliver. Redirect to other people or the scene.
+     Plain sensory perception ("you hear a dog bark", "the cold air bites") is
+     fine -- that's how senses work; it just doesn't act on the character.
+
+  3. NAME THE SUBJECT. "The roar is total" begs: roar of what? Keep referents
+     concrete -- the roar of the crowd, the crowd's din -- and don't be so terse
+     a line loses its anchor.
+
+Voice: the colony's own texture -- shift crews, synthetics, corpsec drones,
+ripperdoc touts, chit-hustlers, haulers, feral kids, the channel, the prefab
+sprawl, the processor's hum. Generic to the whole colony (no named districts).
+
+Five sense layers, matching the room model: visual / auditory / olfactory /
+tactile / atmospheric. The renderer gates visual on sight and auditory on
+hearing; olfactory, tactile and atmospheric always show (smell and touch
+survive blindness and deafness). Lines may run to two short sentences; the
+renderer capitalises only the first letter, so interior capitals survive.
 """
 
 # Crowd level intensity mapping
@@ -34,79 +45,106 @@ CROWD_MESSAGES = {
             'visual': [
                 "down the quiet stretch a dog barks once, yelps, and goes silent. The few people out don't break stride",
                 "a pack of feral kids swarms a stumbling wage-hand by the prefabs, strips him to his undershirt, and scatters into the gaps before he can shout",
-                "a synthetic stands too long at a dead junction box, head cocked, listening to a frequency no one else hears",
-                "two figures trade something hand-to-hand in a doorway and split off in opposite directions without a word",
-                "a chit-hustler works an empty doorway, running the patter to no one out of habit",
+                "a synthetic stands too long at a dead junction box, head cocked, listening to a frequency no one else can hear",
+                "two figures trade something hand-to-hand in a doorway, then split off in opposite directions without a word",
+                "a chit-hustler works an empty doorway, running the patter to no one out of pure habit",
                 "a drunk argues with his own reflection in a dark viewport, and loses",
-                "someone in stained coveralls counts a thin fold of chits twice, pockets it, and moves on fast",
+                "someone in oil-stained coveralls counts a thin fold of chits twice, pockets it, and moves on fast",
                 "a beggar with a dead chrome arm rattles a cup at the few who pass, and they pass",
-                "a figure checks over one shoulder, then the other, then ducks into an unlit service gap",
-                "a lone corpsec drone drifts down the empty street at head height, lens swivelling, and moves on",
-                "someone sleeps in a doorway under a sheet of packing foam, one boot missing",
+                "a lone corpsec drone drifts down the empty street at head height, its lens swivelling as it goes",
+                "someone sleeps in a doorway under a sheet of packing foam, one boot gone",
                 "a synth sweeps the same patch of grating it already swept, patient and unhurried",
-                "a kid watches you from a stairwell, and is gone the moment you look back",
                 "two old shift-hands share a cigarette in the lee of a parked hauler, saying nothing",
-                "a figure works a maglock with the wrong tool and too much patience",
+                "a kid watches from a stairwell, and is gone at a second glance",
+                "a figure works a maglock with the wrong tool and far too much patience",
             ],
             'auditory': [
-                "a dog barks somewhere close, then yelps, then nothing",
-                "footsteps fall in behind you, keep your pace exactly, and peel off at the corner",
-                "a chit-hustler's patter rises and dies away down the empty street",
-                "glass breaks two blocks over, and no alarm follows",
-                "someone counts under their breath in a language you don't know",
-                "a handpad chimes in a dark doorway, answered by a low, quick voice",
-                "a cough racks somebody in a doorway, wet and long, and settles",
-                "boots scuff grit close behind, then stop, then nothing",
-                "a corpsec drone whines past overhead, its lens clicking as it tracks",
-                "somewhere a baby cries, briefly, through a prefab wall",
-                "a shutter rattles down and a bolt throws home",
-                "a voice argues a price with no one, and trails off",
+                "somewhere close a dog barks, then yelps, then nothing",
+                "down the empty street a chit-hustler's patter rises and dies away",
+                "glass breaks two blocks over, and no alarm follows it",
+                "someone nearby counts under their breath in a language you don't know",
+                "a handpad chimes in a dark doorway, and a low, quick voice answers it",
+                "a wet, racking cough goes on too long in a doorway, then settles",
+                "footsteps scuff the grit somewhere behind, slow, then stop",
+                "a corpsec drone whines past overhead, its lens clicking as it sweeps the street",
+                "through a prefab wall a baby cries, briefly, and is hushed",
+                "a shutter rattles down somewhere and a bolt throws home",
+                "a voice haggles a price with no one, and trails off",
+            ],
+            'olfactory': [
+                "the thin air carries little but cold metal and a thread of someone's smoke",
+                "a faint reek of piss and damp drifts out of the dark doorways",
+                "stale cigarette smoke hangs where the last few bodies passed",
+                "machine oil and cold grating are about all the empty street offers the nose",
+                "somewhere close, fried protein and cheap oil cut through the cold air",
+                "the sour smell of a sleeper's doorway carries on the still air",
+            ],
+            'tactile': [
+                "with so few people about, no one's warmth carries, and the air stays cold",
+                "the rare shoulder brushing past is the only contact the empty street offers",
+                "the thin foot traffic leaves the air cold and unstirred",
+                "the cold of the empty street settles in, undisturbed by any crowd",
+                "with nothing moving, there's nothing to warm the air between the buildings",
             ],
             'atmospheric': [
                 "the street is empty enough that the processor's hum carries",
                 "most of the doorways are dark, and the lit ones look worse",
                 "a bundle of foam and rags in the nearest doorway doesn't move",
-                "the few out keep to the walls and leave the middle of the street to no one",
-                "fresh blood, not yet browned, streaks the grating by a kicked-over cup",
-                "a corpsec drone's lens tracks you the length of the block",
+                "the few people out keep to the walls and leave the middle of the street to no one",
+                "fresh blood, not yet browned, streaks the grating beside a kicked-over cup",
                 "scorch marks fan up one wall where something burned and was put out",
                 "chalked gang-marks layer the shutters, the newest still bright",
-                "dropped chits glint in the gutter and nobody has stopped for them",
+                "dropped chits glint in the gutter, and no one has stopped for them",
                 "the quiet has the feel of a street that cleared in a hurry",
             ],
         },
         'moderate': {
             'visual': [
-                "the flow thins to a steady file of clean suits and synthetic faces, none of them meeting your eye",
+                "the flow thins to a steady file of clean suits and synthetic faces, none of them meeting an eye",
                 "a ripperdoc's tout works the crowd, flashing a tray of secondhand chrome still tacky at the contacts",
-                "a hauler crew shoulders through with a slung crate and scatters the slower foot traffic to the gutters",
+                "a hauler crew shoulders through with a slung crate, scattering the slower foot traffic to the gutters",
                 "two people trade a folded packet mid-stride and never break step",
                 "a vendor and a shift-hand haggle hard over a crate of channel fish on melting ice",
-                "a synth waves the foot traffic around a body that two men are still arguing over",
-                "a pickpocket drifts the crowd, hands easy, eyes on the belt-pouches",
-                "a corpsec pair moves through the flow and the crowd opens and closes around them like water",
+                "a synth waves the foot traffic around a body two men are still arguing over",
+                "a pickpocket drifts the edge of the crowd, hands easy, eyes on the belt-pouches of strangers",
+                "a corpsec pair wades through the flow, and the crowd opens and closes around them like water",
                 "a kid runs a three-cup hustle on an upturned crate, faster than the marks can follow",
                 "a drunk weaves the wrong way through the flow, shedding apologies he doesn't mean",
                 "someone counts a fat roll of chits in plain sight, too new to the street to know better",
-                "two synths pass close, exchange a burst of clicks, and part without slowing",
+                "two synths pass close, trade a quick burst of clicks, and part without slowing",
                 "a hauler idles half across the street while its crew argues over a manifest",
             ],
             'auditory': [
-                "a dozen conversations braid into a low, steady churn",
+                "a dozen overlapping conversations braid into a low, steady churn",
                 "a vendor calls the same price over and over until it stops meaning anything",
-                "a deal sours somewhere in the press; voices climb, then drop, then the crowd closes over it",
-                "haggling spikes and settles a few stalls down",
-                "a hauler's horn blares and the crowd-noise barely flinches",
+                "somewhere in the press a deal sours; voices climb, then drop, then the crowd closes over it",
+                "haggling spikes and settles again a few stalls down",
+                "a hauler's horn blares and the churn of the crowd barely flinches",
                 "a hustler's three-cup patter rattles fast over an upturned crate",
                 "snatches of four languages cross in a single breath",
                 "a synth's voice cuts in flat and clear, giving directions no one asked for",
-                "somewhere a bottle breaks and a laugh goes up",
-                "corpsec barks an order and the murmur drops a notch, then recovers",
+                "somewhere a bottle breaks and a laugh goes up after it",
+                "corpsec barks an order and the crowd's murmur drops a notch, then recovers",
+            ],
+            'olfactory': [
+                "the moving crowd carries its smells with it: sweat, fried protein, cheap synth-cologne",
+                "cooking smoke and body heat thicken the air over the flow",
+                "machine oil, coolant, and unwashed coveralls ride the moving crowd",
+                "the brine of a fish-vendor's crate cuts through the warmer crowd-smells",
+                "smoke, sweat, and street-fried oil hang over the steady flow",
+                "a waft of antiseptic and hot solder trails the ripperdoc's tout",
+            ],
+            'tactile': [
+                "the moving crowd stirs a warmth into the air, the press of it light but constant",
+                "shoulders and elbows brush in passing as the flow threads itself together",
+                "the foot traffic keeps the air moving, warm with bodies and breath",
+                "the crowd's heat takes the edge off the street's chill",
+                "the steady press of passing bodies leaves no still air to stand in",
             ],
             'atmospheric': [
                 "the crowd flows steady, everyone with somewhere to be and no reason to look up",
                 "stalls and crates pinch the street down to a single moving channel",
-                "handpad screens light faces here and there in the churn",
+                "handpad screens light faces here and there across the churn",
                 "spilled produce and trampled wrappers mark where the flow runs heaviest",
                 "a corpsec pair watches the flow from a doorway, saying nothing",
                 "foot traffic has worn the grating to a polished track down the middle",
@@ -115,29 +153,43 @@ CROWD_MESSAGES = {
         },
         'heavy': {
             'visual': [
-                "honking and a yelled trade of insults from a stalled hauler chokes the flow to a standstill while everyone cranes to see it",
-                "a pickpocket's hand comes out of a stranger's coat and is three bodies away before the mark even turns",
+                "honking and a yelled trade of insults from a stalled hauler chokes the flow to a standstill while everyone cranes to see the fight",
+                "a pickpocket's hand slips out of a stranger's coat and is three bodies away before the mark even turns",
                 "the crowd jams solid around a fight nobody can see, only hear",
-                "someone goes down in the press and the flow closes over the gap",
+                "someone goes down in the press, and the flow closes over the gap",
                 "a hauler noses into the crush, horn blaring, and the bodies grudge it an inch at a time",
                 "a preacher bellows about the processor from a crate; the crowd parts around him and ignores every word",
                 "a synth seizes mid-step in the crush, twitching, and the crowd flows around it like water around a post",
-                "hands rise above the heads holding crates, chits, and handpads clear of the grind",
-                "two crews square off across the flow and the space between them empties fast",
+                "hands rise above the heads, holding crates and chits and handpads clear of the grind",
+                "two crews square off across the flow, and the space between them empties fast",
                 "a kid worms through the forest of legs at waist height and is gone",
             ],
             'auditory': [
-                "the noise is a solid wall of voices with no gaps in it",
-                "a hauler leans on its horn and the crowd-roar barely gives",
-                "a scream cuts through somewhere ahead, then the churn swallows it",
+                "the noise of the crowd is a solid wall of voices with no gaps in it",
+                "a hauler leans on its horn, and the crowd's roar barely gives",
+                "a scream cuts through from somewhere ahead, then the churn swallows it",
                 "shouts pile on shouts until none of them mean anything",
-                "the shuffle of hundreds of feet drowns everything closer than your own voice",
-                "a vendor's amped pitch claws through the din and loses",
-                "glass shatters in the press and a cheer goes up",
-                "an alarm starts somewhere and folds into the general roar",
+                "the shuffle of hundreds of feet drowns out everything nearer than a raised voice",
+                "a vendor's amped pitch claws through the crowd's din and loses",
+                "glass shatters somewhere in the press and a cheer goes up",
+                "an alarm starts up somewhere and folds straight into the general roar",
+            ],
+            'olfactory': [
+                "the packed crowd reeks of sweat, smoke, and fried street food",
+                "body heat pushes up a thick stink of bodies, machine oil, and cheap cologne",
+                "the air goes heavy with breath, sweat, and the sweet rot of trampled food",
+                "smoke and sweat and coolant blend into one thick crowd-stink",
+                "the warm reek of too many bodies sits over the whole street",
+            ],
+            'tactile': [
+                "the packed bodies throw off a steady heat, and the press of them comes from every side",
+                "shoulder grinds against shoulder in the slow, constant shuffle",
+                "the crowd's heat thickens the air, close and damp with breath",
+                "there's no still air left in the press, just the warm push of the crowd",
+                "the jostle of the crowd never quite lets up on any side",
             ],
             'atmospheric': [
-                "the press of bodies turns the air close and warm and used",
+                "the press of bodies leaves the air close, warm, and used",
                 "there's no clear grating left, just a floor of moving people",
                 "breath and steam hang visible over the packed street",
                 "the crowd has filled every gap the stalls left",
@@ -149,28 +201,41 @@ CROWD_MESSAGES = {
         'packed': {
             'visual': [
                 "a scream goes up somewhere in the crush, short and sharp, and the mass swallows it without a ripple",
-                "the crowd locks solid; pinned shoulder to shoulder, you move when it moves and not before",
+                "the crowd locks solid, packed too tight for anyone to do more than shuffle when it shuffles",
                 "a child rides overhead hand to hand above the crush, wide-eyed and silent, toward the edge",
                 "someone goes down underfoot and the mass grinds on over the gap",
-                "your arms stay pinned to your sides; whatever your hands held, they hold now",
-                "faces press close enough to count and impossible to get clear of",
-                "a hand works your pockets in the crush, and there's no room to turn and catch it",
-                "the whole mass lurches a step as one and carries everyone with it",
+                "arms stay pinned in the crush, hands locked on whatever they were holding",
+                "faces press close enough to count on every side",
+                "a pickpocket works the crush, where the marks have no room to turn",
+                "the whole mass lurches a step as one, and everyone in it goes along",
+                "a fight breaks out somewhere in the pack, has nowhere to go, and folds back into the press",
             ],
             'auditory': [
-                "the roar is total, every voice drowned in every other",
-                "sound presses from all sides with no direction left in it",
-                "you can't pick your own voice out of the crush",
-                "a scream is indistinguishable from the rest of the din",
-                "the noise is so complete it starts to feel like silence",
+                "the roar of the packed crowd is total, every voice drowned in every other",
+                "the crowd's noise presses in from all sides with no direction left in it",
+                "the din of the crush is so complete it starts to feel like silence",
+                "not even a shout carries far in the packed roar",
                 "nothing carries; every sound dies in the press of bodies",
+                "a scream somewhere is indistinguishable from the rest of the crowd's din",
+            ],
+            'olfactory': [
+                "the crush stinks of close-packed bodies, sweat, and breath gone stale",
+                "the reek is overpowering: sweat, smoke, coolant, and unwashed skin",
+                "there's no clean air left, only the thick stink of the packed crowd",
+                "body heat cooks the smell of sweat and oil into something solid",
+            ],
+            'tactile': [
+                "the crush radiates a smothering heat from every side at once",
+                "packed this tight, there's no air that isn't warm with someone's breath",
+                "the press is total, a solid wall of heat and contact on all sides",
+                "the heat of the packed bodies is close, damp, and inescapable",
             ],
             'atmospheric': [
                 "the heat and breath of the crowd fog the air",
                 "there is no grating and no walls, only packed bodies in every direction",
                 "the air is thick, warm, and short",
-                "the crush leaves no room to lift your arms or turn around",
-                "the mass shifts as one and takes you with it",
+                "the crush leaves no room to lift an arm or turn around",
+                "the whole mass sways and shifts as one",
                 "the bodies on every side block out the light",
             ],
         },
@@ -183,7 +248,8 @@ def get_crowd_messages(crowd_level, message_category='all'):
 
     Args:
         crowd_level (int): Crowd level (0-4+)
-        message_category (str): 'visual', 'auditory', 'atmospheric', or 'all'
+        message_category (str): 'visual', 'auditory', 'olfactory', 'tactile',
+            'atmospheric', or 'all'
 
     Returns:
         dict or list: Message pools for the crowd level

--- a/world/weather/weather_messages.py
+++ b/world/weather/weather_messages.py
@@ -6,25 +6,32 @@ system flattens the perceivable-sense lines for the current weather+time into
 one pool and shows a couple at random, so every line is written as a single
 standalone observation that reads cleanly beside any other.
 
-Guiding principle (matches the room and crowd authoring): OFFER the player
-something concrete to observe -- the rain running the gutters brown, the acid
-drizzle hissing on warm metal, the lamps drowned in fog -- grounded in the
-colony's own texture (prefab sprawl, the grating, the channel, the crater rim,
-the processor's hum). No line tells the player how to feel or what the weather
-"means." Just the weather, as it lands on the street.
+Principles (shared with the room and crowd authoring):
+
+  * OFFER concrete observation, don't narrate how to feel. Ground it in the
+    colony's own texture (prefab sprawl, the grating, the channel, the crater
+    rim, the processor's hum).
+  * AMBIENCE, NOT ACTION ON THE PLAYER. Describe the weather and what it does to
+    the street and the air, not things done to the character. Plain sensation
+    ("the cold bites", "the air stings") is fine; it doesn't demand a reaction
+    the text can't deliver.
+  * NAME THE SUBJECT. The wind's howl, the crowd, the storm -- keep referents
+    concrete.
+
+Five sense layers, matching the room model: visual / auditory / olfactory /
+tactile / atmospheric. The system gates visual on sight and auditory on
+hearing; olfactory, tactile and atmospheric always show.
 
 The big WEATHER_MESSAGES dict (every weather type x time-of-day x sense) is
-built deterministically at import from two sources:
+built deterministically at import from:
 
   * WEATHER_POOLS -- per weather type, observational lines per sense category.
   * TIME_LIGHT / TIME_ACTIVITY -- diurnal light-level and street-activity lines,
-    phrased to hold true under any weather (they describe ambient light and
-    foot traffic, never clear-sky or long-distance visibility).
+    phrased to hold true under any weather (ambient light and foot traffic,
+    never clear-sky or long-distance visibility).
 
-Each weather+time entry draws a time-of-day light line + weather visuals, the
-weather's auditory/olfactory lines, and a time-of-day activity line + weather
-atmosphere. Rotating the pool by the time index gives per-time variation
-without random churn at import.
+Rotating each pool by the time index gives per-time variation without random
+churn at import.
 """
 
 # Weather intensity levels (used elsewhere for message length/impact tuning).
@@ -125,6 +132,12 @@ WEATHER_POOLS = {
             "a dry mineral edge rides the clear air off the crater",
             "there's nothing on the air but dust and the distant processor",
         ],
+        'tactile': [
+            "the dry air sits warm and unmoving",
+            "heat radiates up off the bone-dry grating",
+            "the still air holds the day's warmth close to the ground",
+            "nothing stirs the warm, dry air",
+        ],
         'atmospheric': [
             "the dry weather has people out and unhurried",
             "the gutters and drains sit dry and idle",
@@ -157,6 +170,12 @@ WEATHER_POOLS = {
             "damp composite and cold metal ride the heavy air",
             "the overcast traps the street's smells low and close",
             "moisture sits in the air without falling",
+        ],
+        'tactile': [
+            "the air hangs damp and heavy, neither warm nor cold",
+            "a clammy stillness sits over the street",
+            "the heavy air presses close without a breath of wind",
+            "the damp settles cool and unmoving over everything",
         ],
         'atmospheric': [
             "the flat grey light drains the colour out of everything",
@@ -191,6 +210,12 @@ WEATHER_POOLS = {
             "dust and ozone ride the driving air",
             "the moving air strips the street of its settled smells",
         ],
+        'tactile': [
+            "the wind shoves cold and steady down the street",
+            "the gusts fling grit and buffet everything left in the open",
+            "the moving air strips the warmth off every surface",
+            "the wind worries at every loose edge and seam",
+        ],
         'atmospheric': [
             "the wind has driven most people into the lee of the buildings",
             "grit collects deep in every windward corner",
@@ -218,11 +243,17 @@ WEATHER_POOLS = {
         ],
         'olfactory': [
             "the fog is wet and cold, tasting of mineral and metal",
-            "damp condenses on your lips with every breath",
+            "damp condenses cold on every surface",
             "the heavy wet air holds the street's smells suspended",
             "cold moisture and rust ride every breath",
             "the fog smells of standing water and cold stone",
             "wet composite and old metal thicken the air",
+        ],
+        'tactile': [
+            "the fog hangs cold and wet, beading on every surface",
+            "a clammy damp settles over the street",
+            "the wet cold of the fog works into everything",
+            "moisture gathers cold on rail and grating alike",
         ],
         'atmospheric': [
             "the fog beads and runs down every vertical surface",
@@ -257,6 +288,12 @@ WEATHER_POOLS = {
             "the air smells of rain and rinsed metal",
             "cold wet stone and runoff ride every breath",
         ],
+        'tactile': [
+            "the rain falls cold and steady over everything",
+            "a wet chill settles into every surface",
+            "the cold of the rain seeps into the grating and the walls",
+            "everything left in the open runs with cold water",
+        ],
         'atmospheric': [
             "the rain has cleared the street of all but the hurried",
             "puddles spread wide across the low grating",
@@ -289,6 +326,12 @@ WEATHER_POOLS = {
             "the air smells faintly of rinsed metal",
             "wet dust and cool mineral ride the soft rain",
             "a light wet edge rides the air",
+        ],
+        'tactile': [
+            "a fine cold damp settles out of the drizzle",
+            "the light rain leaves a cool film on every surface",
+            "the drizzle barely wets the grating, just enough to chill it",
+            "a cool dampness gathers slowly on everything",
         ],
         'atmospheric': [
             "the light rain hasn't cleared the street, only slowed it",
@@ -323,6 +366,12 @@ WEATHER_POOLS = {
             "cold metal and clean ice ride every breath",
             "the chilled air smells of nothing but cold",
         ],
+        'tactile': [
+            "the air bites cold and dry",
+            "a still, deep cold settles in with the snow",
+            "the cold sits heavy and unmoving over the white street",
+            "the chill creeps into every surface under the snow",
+        ],
         'atmospheric': [
             "snow settles undisturbed in the quiet corners",
             "the fresh white coat takes every footprint",
@@ -356,6 +405,12 @@ WEATHER_POOLS = {
             "the air smells only of cold metal and ice",
             "the deep cold numbs the smell of the street",
         ],
+        'tactile': [
+            "the cold drives hard behind the heavy snow",
+            "the wind-driven snow piles cold against every wall",
+            "the deep cold works fast into everything exposed",
+            "the chill of the heavy fall settles bone-deep over the street",
+        ],
         'atmospheric': [
             "drifts climb the windward walls and bury the low rails",
             "the heavy fall has driven the street near empty",
@@ -379,7 +434,7 @@ WEATHER_POOLS = {
             "snow and wind fill the street with a constant howl",
             "nothing carries through the storm's roar",
             "ice and grit crack past on the wind",
-            "the howl rises and falls but never stops",
+            "the wind's howl rises and falls but never stops",
         ],
         'olfactory': [
             "the storm scours the air to bitter, scentless cold",
@@ -388,6 +443,12 @@ WEATHER_POOLS = {
             "the blizzard strips away every smell",
             "hard cold and clean ice are all the air carries",
             "the freezing wind numbs the nose to anything",
+        ],
+        'tactile': [
+            "the wind tears bitter cold down the street",
+            "the driving cold cuts through every gap and seam",
+            "the blizzard's cold is brutal and total, with no still air to escape it",
+            "the wind packs cold and snow into anything that breaks it",
         ],
         'atmospheric': [
             "the blizzard has emptied the street entirely",
@@ -422,6 +483,12 @@ WEATHER_POOLS = {
             "a sharp electric tang hangs over the street",
             "hot dust and ozone ride every breath",
         ],
+        'tactile': [
+            "the air hangs hot, dry, and charged",
+            "the storm's wind drives warm grit down the street",
+            "the dry heat sits heavy under the churning cloud",
+            "the air feels tight and electric between the thunderclaps",
+        ],
         'atmospheric': [
             "the dry storm has people watching the sky and the doorways",
             "each flash throws hard shadows the length of the grating",
@@ -454,6 +521,12 @@ WEATHER_POOLS = {
             "cold rain and ozone ride every breath",
             "the downpour rinses the air to wet mineral and ozone",
             "wet composite and the burnt bite of lightning ride the air",
+        ],
+        'tactile': [
+            "the rain drives down cold and hard over everything",
+            "the cold downpour pools and soaks across the grating",
+            "the storm's wind drives the cold rain sidelong",
+            "the wet chill of the storm settles into every surface",
         ],
         'atmospheric': [
             "the storm has cleared the street of everyone unhurried",
@@ -488,6 +561,12 @@ WEATHER_POOLS = {
             "acrid particulate coats every breath",
             "the murk carries the taste of the smokestacks",
         ],
+        'tactile': [
+            "the air sits warm, thick, and gritty",
+            "a fine chemical grit settles over every surface",
+            "the heavy pall hangs close and unmoving",
+            "the gritty air leaves a film on everything it touches",
+        ],
         'atmospheric': [
             "the pall films every surface with grey grit",
             "people move through the murk with their mouths covered",
@@ -520,6 +599,12 @@ WEATHER_POOLS = {
             "the corrosive air bites at every breath",
             "chemical sting and rot ride the wet air",
             "the rain leaves a taste of solvent and decay",
+        ],
+        'tactile': [
+            "the air hangs warm and damp with a chemical sting",
+            "the acid drizzle eats slick at every surface it pools on",
+            "a faint chemical burn rides the wet air",
+            "the corrosive damp clings to everything in the open",
         ],
         'atmospheric': [
             "the tox rain has driven everyone under cover or indoors",
@@ -554,6 +639,12 @@ WEATHER_POOLS = {
             "the dry air rasps with mineral dust",
             "grit settles dry and metallic on the tongue",
         ],
+        'tactile': [
+            "the wind drives hot grit that scours every surface",
+            "blown sand abrades everything left in the open",
+            "the gritty wind sandblasts walls and signage alike",
+            "the hot, abrasive air leaves nothing untouched",
+        ],
         'atmospheric': [
             "the sandstorm has cleared the street of all but the desperate",
             "fine sand sifts into every seam and corner",
@@ -574,7 +665,7 @@ WEATHER_POOLS = {
         'auditory': [
             "the dense fog turns every sound around and flattens it",
             "footsteps come from impossible directions in the murk",
-            "sound is muffled enough to seem to come from inside your own ears",
+            "sound is muffled enough to seem to come from nowhere at all",
             "voices arrive close and bodiless out of the white",
             "the fog swallows the direction out of every noise",
             "dripping is the only sound that carries clear",
@@ -586,6 +677,12 @@ WEATHER_POOLS = {
             "wet stone and rust hang heavy on the still air",
             "the saturated air tastes of cold metal",
             "the fog holds the street's smells thick and close",
+        ],
+        'tactile': [
+            "the dense fog hangs cold and soaking",
+            "a heavy wet cold presses out of the white",
+            "the saturated fog beads and runs off every surface",
+            "the cold damp is thick enough to feel against the face",
         ],
         'atmospheric': [
             "the blind fog has all but stopped movement on the street",
@@ -614,11 +711,17 @@ WEATHER_POOLS = {
         ],
         'olfactory': [
             "the heavy fog is cold and wet, thick with mineral damp",
-            "saturated air condenses on your lips with every breath",
+            "saturated air condenses on every cold surface",
             "wet stone and old metal hang dense on the air",
             "the cold damp coats the mouth and the throat",
             "the fog holds the street's smells suspended and close",
             "rust and standing water thicken every breath",
+        ],
+        'tactile': [
+            "the heavy fog hangs cold and soaking wet",
+            "a clammy chill beads on every surface",
+            "the wet cold of the fog works deep into everything",
+            "moisture sheets cold off rail and grating",
         ],
         'atmospheric': [
             "the heavy fog has slowed the street to a crawl",
@@ -653,12 +756,18 @@ WEATHER_POOLS = {
             "a hard electric tang coats the mouth",
             "ozone and scorched dust hang heavy on the air",
         ],
+        'tactile': [
+            "the charged air prickles and crackles",
+            "the air hangs hot and electric between the bursts",
+            "each strike leaves the air tight and charged",
+            "a static charge hangs heavy over the whole street",
+        ],
         'atmospheric': [
             "the flashstorm has driven everyone off the open street",
             "each burst throws the street into hard white relief",
-            "the charged air raises the hair and prickles the skin",
             "the strobing leaves the street flickering black and white",
             "the storm hammers the sky without pause",
+            "the lamps are lost under the storm's white stutter",
         ],
     },
     'torrential_rain': {
@@ -685,6 +794,12 @@ WEATHER_POOLS = {
             "the downpour leaves only cold rain on every breath",
             "the flooded drains push up a smell of wet rot and runoff",
             "the rain-soaked air is thick with cold mineral",
+        ],
+        'tactile': [
+            "the rain hammers down cold and heavy",
+            "the deluge drives cold runoff across the grating",
+            "the downpour soaks everything in the open in seconds",
+            "the cold weight of the rain pounds every surface",
         ],
         'atmospheric': [
             "the torrential rain has emptied the street completely",
@@ -719,6 +834,12 @@ WEATHER_POOLS = {
             "cold damp coats the mouth, mineral and metallic",
             "the saturated air holds the street's smells thick and wet",
         ],
+        'tactile': [
+            "the air hangs cold, wet, and clinging",
+            "a soaking chill settles out of the fogged rain",
+            "the doubled damp works cold into everything",
+            "moisture clings cold to every surface at once",
+        ],
         'atmospheric': [
             "the fogged rain has slowed the street to almost nothing",
             "moisture sheets and beads on every surface at once",
@@ -751,6 +872,7 @@ def _build_weather_messages():
                 'visual': [TIME_LIGHT[period]] + _rotate(pools['visual'], i, 2),
                 'auditory': _rotate(pools['auditory'], i, 3),
                 'olfactory': _rotate(pools['olfactory'], i, 3),
+                'tactile': _rotate(pools['tactile'], i, 2),
                 'atmospheric': (
                     [TIME_ACTIVITY[period]] + _rotate(pools['atmospheric'], i * 2, 2)
                 ),


### PR DESCRIPTION
Feedback on r2: too terse with orphan referents, missing sense layers,
and some lines acted on the player.

- Five senses: crowd gains olfactory + tactile; weather gains tactile,
  matching the room SENSE_LAYER_ORDER. weather builder emits tactile;
  no other code change (renderers iterate categories generically and
  perception.py passes smell/touch/atmospheric ungated).
- Name the subject / less terse: anchor orphan referents (roar/din of
  the crowd, the wind's howl), flesh out the thinnest lines.
- Ambience not action: scrub lines doing something TO the character
  (hand in your pocket, crush pinning your arms, a shove that moves
  you); redirect to NPCs or the scene. Plain sensory perception kept.

Closes #629

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
