### PR TITLE
Crowd retune: neutralize street modifier + fix clumsy packed line

### DIFF
--- a/world/crowd/crowd_messages.py
+++ b/world/crowd/crowd_messages.py
@@ -246,7 +246,7 @@ CROWD_MESSAGES = {
         'packed': {
             'visual': [
                 "a scream goes up somewhere in the crush, short and sharp, and the mass swallows it without a ripple",
-                "the crowd locks solid, packed too tight for anyone to do more than shuffle when it shuffles",
+                "the crowd locks up solid, jammed too tight for anyone to do more than inch forward",
                 "a child rides overhead hand to hand above the crush, wide-eyed and silent, toward the edge",
                 "someone goes down underfoot and the mass grinds on over the gap",
                 "arms stay pinned in the crush, hands locked on whatever they were holding",

--- a/world/crowd/crowd_system.py
+++ b/world/crowd/crowd_system.py
@@ -12,9 +12,12 @@ class CrowdSystem:
     """
     
     def __init__(self):
-        # Base crowd levels for different room types
+        # Base crowd levels for different room types. Streets carry their
+        # busyness through each room's crowd_base_level (0 quiet .. 3 hotspot),
+        # so 'street' itself adds nothing -- otherwise a base-1 street can never
+        # read sparser than 'moderate'.
         self.room_type_modifiers = {
-            'street': 0.5,
+            'street': 0.0,
             'intersection': 1.0,
             'corner store': 0.5,
             'laundromat': 0.2,


### PR DESCRIPTION
278/311 rooms were base 3 + street (+0.5) -> 3.7 -> packed everywhere.

- crowd_system: 'street' room-type modifier 0.5 -> 0.0; streets carry
  busyness via per-room crowd_base_level alone (else a base-1 street can
  never read below moderate). Paired with a live-data crowd_base_level
  retune (most streets 1, waterfront/artery 2, a few markets/bar 3, dead
  zones 0) -> clear empty day reads 234 sparse / 44 moderate / 5 heavy /
  0 packed; packed now needs people to gather.
- crowd_messages: fix "shuffle when it shuffles" -> "jammed too tight for
  anyone to do more than inch forward".

Closes #633

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
