### PR TITLE
Perception: gate smell (olfactory) behind the nose organ

### DIFF
--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -182,12 +182,12 @@ SPECIES_DEFINITIONS = {
                 "can_be_harvested": True
             },
             # Nose — issue #355.  Surfaces at the ``face`` longdesc
-            # the same way jaw and tongue do.  Damage doesn't affect a
-            # named capacity (no smell capacity in scope), but it's
-            # disfiguring and harvestable.
+            # the same way jaw and tongue do.  Carries the ``smell``
+            # capacity (olfactory perception); disfiguring and harvestable.
             "nose": {
                 "container": "head", "display_location": "face",
                 "max_hp": 8, "hit_weight": "rare",
+                "capacity": "smell", "contribution": "total",
                 "disfiguring_if_lost": True,
                 "can_be_harvested": True,
             },
@@ -516,6 +516,12 @@ SPECIES_DEFINITIONS = {
                 "organ_contribution": 0.5,
                 "affects": ["trade_price_improvement"],
                 "total_loss_penalty": "deafness",
+            },
+            "smell": {
+                "organs": ["nose"],
+                "organ_contribution": 1.0,
+                "affects": [],
+                "total_loss_penalty": "anosmia",
             },
             "moving": {
                 "organs": ["thoracolumbar_spine", "pelvis",

--- a/world/perception.py
+++ b/world/perception.py
@@ -14,30 +14,33 @@ Scope (decided, spec §5): this gates the *additive* sensory pools. The single-
 blob base room description stays valid as the visual layer — full base-desc
 sense decomposition is a future authoring lift, not a prerequisite.
 
-``sight`` → visual, ``hearing`` → auditory. Olfactory / tactile / gustatory /
-atmospheric are never gated here (smell and touch survive blindness and
-deafness; atmospheric is the multi-sense mood catch-all). Fails open: a looker
-with no readable capacities perceives everything.
+``sight`` → visual, ``hearing`` → auditory, ``smell`` → olfactory (the nose
+organ). Tactile / gustatory / atmospheric are never gated here: ambient touch is
+whole-body sensation that survives losing a hand (a future *examine-by-touch* of
+an object would gate on hands instead), and atmospheric is the multi-sense mood
+catch-all. Fails open: a looker with no readable capacities perceives everything.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from world.voice import can_hear, can_see
+from world.voice import can_hear, can_see, can_smell
 
 #: Sense category gated by ``sight``.
 VISUAL_SENSE = "visual"
 #: Sense category gated by ``hearing``.
 AUDITORY_SENSE = "auditory"
+#: Sense category gated by ``smell`` (the nose organ).
+OLFACTORY_SENSE = "olfactory"
 
 
 def blocked_senses(looker: Any) -> set[str]:
     """Return the sense categories *looker* cannot currently perceive.
 
     Empty when the looker perceives everything (full senses, no medical model,
-    or restored by a chrome override). Only the sight/hearing-gated categories
-    can appear here; every other sense passes through.
+    or restored by a chrome override). Only the sight/hearing/smell-gated
+    categories can appear here; every other sense passes through.
     """
     blocked: set[str] = set()
     if looker is None:
@@ -46,6 +49,8 @@ def blocked_senses(looker: Any) -> set[str]:
         blocked.add(VISUAL_SENSE)
     if not can_hear(looker):
         blocked.add(AUDITORY_SENSE)
+    if not can_smell(looker):
+        blocked.add(OLFACTORY_SENSE)
     return blocked
 
 

--- a/world/tests/test_perception.py
+++ b/world/tests/test_perception.py
@@ -14,6 +14,7 @@ from unittest import TestCase
 
 from world.perception import (
     AUDITORY_SENSE,
+    OLFACTORY_SENSE,
     VISUAL_SENSE,
     blocked_senses,
     can_perceive_sense,
@@ -23,8 +24,8 @@ from world.perception import (
 
 
 class _MedState:
-    def __init__(self, sight=1.0, hearing=1.0):
-        self._caps = {"sight": sight, "hearing": hearing}
+    def __init__(self, sight=1.0, hearing=1.0, smell=1.0):
+        self._caps = {"sight": sight, "hearing": hearing, "smell": smell}
 
     def calculate_body_capacity(self, name):
         return self._caps.get(name, 1.0)
@@ -34,8 +35,10 @@ class _MedState:
 
 
 class _Looker:
-    def __init__(self, sight=1.0, hearing=1.0, medical=True):
-        self.medical_state = _MedState(sight, hearing) if medical else None
+    def __init__(self, sight=1.0, hearing=1.0, smell=1.0, medical=True):
+        self.medical_state = (
+            _MedState(sight, hearing, smell) if medical else None
+        )
 
 
 ALL_SENSES = ["visual", "auditory", "olfactory", "tactile", "atmospheric"]
@@ -60,6 +63,15 @@ class BlockedSensesTests(TestCase):
     def test_one_eye_one_ear_block_nothing(self):
         self.assertEqual(blocked_senses(_Looker(sight=0.5, hearing=0.5)), set())
 
+    def test_no_nose_blocks_olfactory_only(self):
+        self.assertEqual(blocked_senses(_Looker(smell=0.0)), {OLFACTORY_SENSE})
+
+    def test_blind_and_anosmic_blocks_both(self):
+        self.assertEqual(
+            blocked_senses(_Looker(sight=0.0, smell=0.0)),
+            {VISUAL_SENSE, OLFACTORY_SENSE},
+        )
+
     def test_none_looker_blocks_nothing(self):
         self.assertEqual(blocked_senses(None), set())
 
@@ -79,6 +91,12 @@ class CanPerceiveSenseTests(TestCase):
         looker = _Looker(hearing=0.0)
         self.assertFalse(can_perceive_sense(looker, "auditory"))
         self.assertTrue(can_perceive_sense(looker, "visual"))
+
+    def test_anosmic_cannot_perceive_olfactory_but_others_ok(self):
+        looker = _Looker(smell=0.0)
+        self.assertFalse(can_perceive_sense(looker, "olfactory"))
+        self.assertTrue(can_perceive_sense(looker, "visual"))
+        self.assertTrue(can_perceive_sense(looker, "tactile"))
 
 
 class FilterSensoryKeysTests(TestCase):

--- a/world/voice.py
+++ b/world/voice.py
@@ -174,11 +174,14 @@ def is_voice_garbled(char: Any) -> bool:
 # promote them to a shared perception module. Tunable.
 SIGHT_PERCEPTION_THRESHOLD = 0.15
 HEARING_PERCEPTION_THRESHOLD = 0.15
+SMELL_PERCEPTION_THRESHOLD = 0.15
 
-# Condition seams that restore a lost sense (chrome eyes / cyber ears). Reuse
-# the combat sight-override constant so one augment is coherent everywhere.
+# Condition seams that restore a lost sense (chrome eyes / cyber ears / a cyber
+# nose). Reuse the combat sight-override constant so one augment is coherent
+# everywhere.
 from world.combat.capacity import SIGHT_OVERRIDE_CONDITION  # noqa: E402
 HEARING_OVERRIDE_CONDITION = "hearing_override"
+SMELL_OVERRIDE_CONDITION = "smell_override"
 
 
 def can_see(char: Any) -> bool:
@@ -207,6 +210,20 @@ def can_hear(char: Any) -> bool:
     if hearing is None:
         return True
     return hearing >= HEARING_PERCEPTION_THRESHOLD
+
+
+def can_smell(char: Any) -> bool:
+    """True if *char* can smell (enough ``smell`` for olfactory perception).
+
+    Fails open with no medical model. A smell-override condition (a cyber nose)
+    restores smell regardless of organ state.
+    """
+    if _has_condition(char, SMELL_OVERRIDE_CONDITION):
+        return True
+    smell = _read_capacity(char, "smell")
+    if smell is None:
+        return True
+    return smell >= SMELL_PERCEPTION_THRESHOLD
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Mirrors sight->eyes / hearing->ears. User chose to gate smell and leave
touch (whole-body atmospheric; hands already covered by manipulation).

- species.py: new human 'smell' body_capacity (organs:[nose],
  organ_contribution 1.0); nose organ carries capacity:"smell",
  contribution:"total". Rat has no nose -> fails open.
- voice.py: can_smell() + SMELL_PERCEPTION_THRESHOLD (0.15) +
  SMELL_OVERRIDE_CONDITION seam (future cyber-nose restores smell).
- perception.py: blocked_senses adds 'olfactory' when not can_smell.
  Tactile/atmospheric stay ungated.
- test_perception: anosmia cases added.

Closes #635

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
