### PR TITLE
Refactor: move sensory primitives from voice.py to perception.py

### DIFF
--- a/world/emote.py
+++ b/world/emote.py
@@ -108,7 +108,7 @@ def process_speech(
         Rendered speech string including quotes (redacted when unheard).
     """
     if observer is not speaker:
-        from world.voice import can_hear
+        from world.perception import can_hear
         if not can_hear(observer):
             return '"..."'
     return f'"{text}"'

--- a/world/perception.py
+++ b/world/perception.py
@@ -5,10 +5,11 @@ Perception gating — which sensory channels a looker currently receives
 The LOOK Sensory Category Framework (``LOOK_COMMAND_SPEC.md``) already tags
 ambient content (weather, crowd) by sense — visual / auditory / olfactory /
 tactile / atmospheric — and was built to "show reduced content" to players with
-sensory limitations. This module supplies the missing input: it reads a looker's
-``sight`` / ``hearing`` capacities (via the voice-layer perception primitives,
-which already honour the chrome-eye / cyber-ear override seams) and reports which
-sense categories are *blocked*.
+sensory limitations. This module supplies the missing input: its ``can_see`` /
+``can_hear`` / ``can_smell`` primitives read a looker's ``sight`` / ``hearing`` /
+``smell`` capacities (honouring the chrome-eye / cyber-ear / cyber-nose override
+seams) and ``blocked_senses`` reports which sense categories are *blocked*.
+(``world.voice`` consumes the same primitives for its speech-attribution chain.)
 
 Scope (decided, spec §5): this gates the *additive* sensory pools. The single-
 blob base room description stays valid as the visual layer — full base-desc
@@ -25,7 +26,100 @@ from __future__ import annotations
 
 from typing import Any
 
-from world.voice import can_hear, can_see, can_smell
+from world.combat.capacity import SIGHT_OVERRIDE_CONDITION
+
+
+# --------------------------------------------------------------------------
+# Capacity / condition reads (low-level helpers, shared with world.voice)
+# --------------------------------------------------------------------------
+def _read_capacity(char: Any, name: str) -> float | None:
+    """Raw body capacity *name* (0.0–1.0) for *char*, or ``None`` if unreadable.
+
+    ``None`` signals "no medical model" — callers fail open. Only a real number
+    is returned; anything else (e.g. a test mock) yields ``None``, mirroring
+    ``world.combat.dice.get_character_stat``.
+    """
+    state = getattr(char, "medical_state", None)
+    calc = getattr(state, "calculate_body_capacity", None)
+    if not callable(calc):
+        return None
+    try:
+        value = calc(name)
+    except Exception:
+        return None
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    return value
+
+
+def _has_condition(char: Any, condition_type: str) -> bool:
+    """True if *char* carries an active condition of *condition_type*."""
+    state = getattr(char, "medical_state", None)
+    getter = getattr(state, "get_conditions_by_type", None)
+    if not callable(getter):
+        return False
+    try:
+        return bool(getter(condition_type))
+    except Exception:
+        return False
+
+
+# --------------------------------------------------------------------------
+# Per-sense capability checks — can this character see / hear / smell?
+# --------------------------------------------------------------------------
+# Below these capacities the character has effectively lost the sense (blind /
+# deaf / anosmic). One eye / one ear (0.5) still perceives; total loss (0.0)
+# does not. Tunable. Each is restorable by a chrome override condition (cyber
+# eyes / ears / nose); reuse the combat sight-override so one augment is
+# coherent everywhere.
+SIGHT_PERCEPTION_THRESHOLD = 0.15
+HEARING_PERCEPTION_THRESHOLD = 0.15
+SMELL_PERCEPTION_THRESHOLD = 0.15
+HEARING_OVERRIDE_CONDITION = "hearing_override"
+SMELL_OVERRIDE_CONDITION = "smell_override"
+
+
+def can_see(char: Any) -> bool:
+    """True if *char* can see (enough ``sight`` to visually identify others).
+
+    Fails open with no medical model. A sight-override condition (chrome eyes)
+    restores sight regardless of organ state.
+    """
+    if _has_condition(char, SIGHT_OVERRIDE_CONDITION):
+        return True
+    sight = _read_capacity(char, "sight")
+    if sight is None:
+        return True
+    return sight >= SIGHT_PERCEPTION_THRESHOLD
+
+
+def can_hear(char: Any) -> bool:
+    """True if *char* can hear (enough ``hearing`` to receive a voice).
+
+    Fails open with no medical model. A hearing-override condition (cyber ears)
+    restores hearing regardless of organ state.
+    """
+    if _has_condition(char, HEARING_OVERRIDE_CONDITION):
+        return True
+    hearing = _read_capacity(char, "hearing")
+    if hearing is None:
+        return True
+    return hearing >= HEARING_PERCEPTION_THRESHOLD
+
+
+def can_smell(char: Any) -> bool:
+    """True if *char* can smell (enough ``smell`` for olfactory perception).
+
+    Fails open with no medical model. A smell-override condition (a cyber nose)
+    restores smell regardless of organ state.
+    """
+    if _has_condition(char, SMELL_OVERRIDE_CONDITION):
+        return True
+    smell = _read_capacity(char, "smell")
+    if smell is None:
+        return True
+    return smell >= SMELL_PERCEPTION_THRESHOLD
+
 
 #: Sense category gated by ``sight``.
 VISUAL_SENSE = "visual"

--- a/world/tests/test_blindsight.py
+++ b/world/tests/test_blindsight.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 from unittest import TestCase
 
 from world.combat.capacity import sight_hit_factor, BLINDSIGHT_FLAG
-from world.voice import can_see
+from world.perception import can_see
 from world.medical.augments import _toggle_blindsight
 
 

--- a/world/tests/test_capacity_chrome.py
+++ b/world/tests/test_capacity_chrome.py
@@ -22,7 +22,7 @@ from unittest import TestCase
 
 from world.medical.core import MedicalState, Organ
 from world.combat.capacity import sight_hit_factor, moving_dodge_factor
-from world.voice import can_see, can_hear
+from world.perception import can_see, can_hear
 from world.prototypes import (
     CYBER_LEFT_EYE,
     CYBER_RIGHT_EYE,

--- a/world/tests/test_voice_identity.py
+++ b/world/tests/test_voice_identity.py
@@ -244,7 +244,7 @@ class PerceptionTests(TestCase):
         self.assertFalse(can_hear(char))
 
     def test_override_conditions_restore_senses(self):
-        from world.voice import (
+        from world.perception import (
             SIGHT_OVERRIDE_CONDITION, HEARING_OVERRIDE_CONDITION,
         )
         char = _FakeChar(

--- a/world/voice.py
+++ b/world/voice.py
@@ -32,6 +32,10 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
+# Per-sense capability checks live in world.perception (the perception module);
+# voice's speech-attribution chain consumes them.
+from world.perception import can_hear, can_see, _read_capacity
+
 # Voice-UID digest size — matches the visual Apparent-UID convention
 # (``world.identity._APPARENT_UID_DIGEST_BYTES``) so the two axes read alike.
 _VOICE_UID_DIGEST_BYTES = 8
@@ -120,41 +124,6 @@ def has_voice_signature(char: Any) -> bool:
 
 
 # --------------------------------------------------------------------------
-# Capacity reads
-# --------------------------------------------------------------------------
-def _read_capacity(char: Any, name: str) -> float | None:
-    """Raw body capacity *name* (0.0–1.0) for *char*, or ``None`` if unreadable.
-
-    ``None`` signals "no medical model" — callers fail open. Only a real number
-    is returned; anything else (e.g. a test mock) yields ``None``, mirroring
-    ``world.combat.dice.get_character_stat``.
-    """
-    state = getattr(char, "medical_state", None)
-    calc = getattr(state, "calculate_body_capacity", None)
-    if not callable(calc):
-        return None
-    try:
-        value = calc(name)
-    except Exception:
-        return None
-    if not isinstance(value, (int, float)) or isinstance(value, bool):
-        return None
-    return value
-
-
-def _has_condition(char: Any, condition_type: str) -> bool:
-    """True if *char* carries an active condition of *condition_type*."""
-    state = getattr(char, "medical_state", None)
-    getter = getattr(state, "get_conditions_by_type", None)
-    if not callable(getter):
-        return False
-    try:
-        return bool(getter(condition_type))
-    except Exception:
-        return False
-
-
-# --------------------------------------------------------------------------
 # The talking-capacity gate (§4.7)
 # --------------------------------------------------------------------------
 def is_voice_garbled(char: Any) -> bool:
@@ -163,67 +132,6 @@ def is_voice_garbled(char: Any) -> bool:
     if talking is None:
         return False
     return talking < VOICE_GARBLE_THRESHOLD
-
-
-# --------------------------------------------------------------------------
-# Perception primitives — can the observer see / hear the speaker (§4.5)
-# --------------------------------------------------------------------------
-# Below these capacities the observer has effectively lost the sense (blind /
-# deaf). One eye / one ear (0.5) still perceives; total loss (0.0) does not.
-# These live here for the resolution chain; layer 3 (perception render) may
-# promote them to a shared perception module. Tunable.
-SIGHT_PERCEPTION_THRESHOLD = 0.15
-HEARING_PERCEPTION_THRESHOLD = 0.15
-SMELL_PERCEPTION_THRESHOLD = 0.15
-
-# Condition seams that restore a lost sense (chrome eyes / cyber ears / a cyber
-# nose). Reuse the combat sight-override constant so one augment is coherent
-# everywhere.
-from world.combat.capacity import SIGHT_OVERRIDE_CONDITION  # noqa: E402
-HEARING_OVERRIDE_CONDITION = "hearing_override"
-SMELL_OVERRIDE_CONDITION = "smell_override"
-
-
-def can_see(char: Any) -> bool:
-    """True if *char* can see (enough ``sight`` to visually identify others).
-
-    Fails open with no medical model. A sight-override condition (chrome eyes)
-    restores sight regardless of organ state.
-    """
-    if _has_condition(char, SIGHT_OVERRIDE_CONDITION):
-        return True
-    sight = _read_capacity(char, "sight")
-    if sight is None:
-        return True
-    return sight >= SIGHT_PERCEPTION_THRESHOLD
-
-
-def can_hear(char: Any) -> bool:
-    """True if *char* can hear (enough ``hearing`` to receive a voice).
-
-    Fails open with no medical model. A hearing-override condition (cyber ears)
-    restores hearing regardless of organ state.
-    """
-    if _has_condition(char, HEARING_OVERRIDE_CONDITION):
-        return True
-    hearing = _read_capacity(char, "hearing")
-    if hearing is None:
-        return True
-    return hearing >= HEARING_PERCEPTION_THRESHOLD
-
-
-def can_smell(char: Any) -> bool:
-    """True if *char* can smell (enough ``smell`` for olfactory perception).
-
-    Fails open with no medical model. A smell-override condition (a cyber nose)
-    restores smell regardless of organ state.
-    """
-    if _has_condition(char, SMELL_OVERRIDE_CONDITION):
-        return True
-    smell = _read_capacity(char, "smell")
-    if smell is None:
-        return True
-    return smell >= SMELL_PERCEPTION_THRESHOLD
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
can_see/can_hear/can_smell + their capacity/condition helpers,
thresholds and override-condition constants were in voice.py only for
historical reasons (born for the speech-attribution chain). They are
general perception primitives -> moved to perception.py beside
can_perceive_sense/blocked_senses.

- perception.py now owns the primitives and imports SIGHT_OVERRIDE_CONDITION
  from combat.capacity (a leaf, no cycle).
- voice.py imports can_see/can_hear/_read_capacity back from perception;
  perception no longer imports voice (deps point one way now:
  voice -> perception -> combat.capacity).
- Repointed: emote.py, tests (blindsight, capacity_chrome, voice_identity).

Pure relocation, no behavior change. 195 tests green.

Closes #637

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
