### PR TITLE
Social: 'to' directed-speech command

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -110,6 +110,87 @@ class CmdSay(Command):
             observer.msg(text=text, type="say", from_obj=caller)
 
 
+class CmdTo(Command):
+    """
+    Speak aloud, directed at someone in the room.
+
+    Usage:
+        to <target> <message>
+
+    Like ``say``, but pointed at one person — everyone present still hears it.
+    The target is addressed directly ("... says to you, ..."); onlookers see
+    who it was aimed at. Perception applies exactly as with ``say``: hearing
+    gates the words, sight gates whether you can tell who is speaking.
+    """
+
+    key = "to"
+    locks = "cmd:all()"
+    help_category = "Social"
+
+    def func(self):
+        caller = self.caller
+
+        args = (self.args or "").strip()
+        parts = args.split(None, 1)
+        if len(parts) < 2 or not parts[1].strip():
+            caller.msg("Usage: to <target> <message>")
+            return
+        target_str, speech = parts[0], parts[1].strip()
+
+        location = caller.location
+        if not location:
+            caller.msg("You have no location to speak in.")
+            return
+
+        target = caller.search(target_str)
+        if not target:
+            return  # search() already sent the error message
+
+        # Actor sees their own message.
+        caller.msg(f'You say to {target.get_display_name(caller)}, "{speech}"')
+
+        # Voice flavour for observers who can SEE the speaker (as in `say`):
+        # a garbled voice always renders; otherwise a sporadic sprinkle, rolled
+        # once per utterance for a consistent reading across observers.
+        visible_flavor = garbled_voice_phrase(caller)
+        if visible_flavor is None:
+            phrase = voice_phrase(caller)
+            if phrase and random() < VOICE_FLAVOR_SPRINKLE_CHANCE:
+                visible_flavor = phrase
+
+        # Directed but audible: everyone present resolves it through the same
+        # sight/hearing chain as `say`. The target is addressed as "you".
+        for observer in location.contents:
+            if observer is caller:
+                continue
+            if not hasattr(observer, "msg"):
+                continue
+
+            heard = can_hear(observer)
+            seen = can_see(observer)
+            if not heard and not seen:
+                continue  # no channel — suppress entirely
+
+            speaker_name = resolve_speaker_attribution(caller, observer)
+            target_ref = (
+                "you" if observer is target
+                else target.get_display_name(observer)
+            )
+            if heard:
+                if seen and visible_flavor:
+                    verb = f"says to {target_ref}, |x*{visible_flavor}*|n"
+                else:
+                    verb = f"says to {target_ref},"
+                text = f'{capitalize_first(speaker_name)} {verb} "{speech}"'
+            else:
+                # Deaf but watching: the address is visible, the words are not.
+                text = (
+                    f"{capitalize_first(speaker_name)} says something to "
+                    f"{target_ref}, but you can't make it out."
+                )
+            observer.msg(text=text, type="say", from_obj=caller)
+
+
 class CmdWhisper(Command):
     """
     Whisper a message to a specific target.

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -39,7 +39,7 @@ from commands.CmdExplosives import (
 from commands.CmdGraffiti import CmdGraffiti, CmdPress
 from commands.CmdCharacter import CmdDescribe, CmdSkintone, CmdVoice
 from commands.CmdCharacter import CmdRemember, CmdForget, CmdRecall, CmdMemory
-from commands.CmdCommunication import CmdSay, CmdWhisper, CmdEmote, CmdDotPose
+from commands.CmdCommunication import CmdSay, CmdTo, CmdWhisper, CmdEmote, CmdDotPose
 from commands.forensics import CmdAutopsy, CmdSever
 from commands import CmdSurgical
 from world.emote_templates import SOCIAL_COMMANDS
@@ -202,6 +202,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
 
         # Add identity-aware communication commands (override Evennia defaults)
         self.add(CmdSay())
+        self.add(CmdTo())
         self.add(CmdWhisper())
         self.add(CmdEmote())
         self.add(CmdDotPose())

--- a/world/tests/test_communication.py
+++ b/world/tests/test_communication.py
@@ -506,6 +506,108 @@ class TestCmdSay(TestCase):
 
 
 # ===================================================================
+# Tests: CmdTo
+# ===================================================================
+
+
+class TestCmdTo(TestCase):
+    """Tests for the directed-speech `to` command (say, aimed at one person)."""
+
+    def _run_to(self, caller, args, room_contents, search_result=None):
+        """Invoke CmdTo.func() with mocked state."""
+        from commands.CmdCommunication import CmdTo
+
+        cmd = CmdTo()
+        cmd.caller = caller
+        cmd.args = f" {args}"
+        cmd.cmdstring = "to"
+
+        room = MagicMock()
+        room.contents = room_contents
+        caller.location = room
+        if search_result is not None:
+            caller.search = MagicMock(return_value=search_result)
+
+        cmd.func()
+
+    def test_actor_sees_directed_say(self):
+        """Actor sees 'You say to <target>, \"...\"'."""
+        jorge = _make_character(
+            key="Jorge", sex="male", height="tall", build="lean",
+            sdesc_keyword="man", sleeve_uid="uid-jorge",
+        )
+        maria = _make_character(
+            key="Maria", sex="female", height="short", build="athletic",
+            sdesc_keyword="woman", sleeve_uid="uid-maria",
+        )
+        self._run_to(jorge, "woman Evening.", [jorge, maria], search_result=maria)
+
+        jorge.msg.assert_called_once()
+        actor_msg = jorge.msg.call_args[0][0]
+        self.assertIn("You say to", actor_msg)
+        self.assertIn('"Evening."', actor_msg)
+
+    def test_target_is_addressed_as_you(self):
+        """The target hears '... says to you, \"...\"' with full content."""
+        jorge = _make_character(
+            key="Jorge", sex="male", height="tall", build="lean",
+            sdesc_keyword="man", sleeve_uid="uid-jorge",
+        )
+        maria = _make_character(
+            key="Maria", sex="female", height="short", build="athletic",
+            sdesc_keyword="woman", sleeve_uid="uid-maria",
+        )
+        self._run_to(jorge, "woman Evening.", [jorge, maria], search_result=maria)
+
+        maria.msg.assert_called_once()
+        text = maria.msg.call_args[1].get("text", "")
+        self.assertIn("says to you,", text)
+        self.assertIn('"Evening."', text)
+
+    def test_third_party_sees_who_it_was_aimed_at(self):
+        """A bystander hears the content, framed as directed at the target."""
+        jorge = _make_character(
+            key="Jorge", sex="male", height="tall", build="lean",
+            sdesc_keyword="man", sleeve_uid="uid-jorge",
+        )
+        maria = _make_character(
+            key="Maria", sex="female", height="short", build="athletic",
+            sdesc_keyword="woman", sleeve_uid="uid-maria",
+        )
+        alice = _make_character(
+            key="Alice", sex="female", height="average", build="average",
+            sleeve_uid="uid-alice",
+        )
+        self._run_to(
+            jorge, "woman Evening.", [jorge, maria, alice], search_result=maria
+        )
+
+        alice.msg.assert_called_once()
+        text = alice.msg.call_args[1].get("text", "")
+        self.assertIn("says to", text)
+        self.assertNotIn("says to you", text)  # alice isn't the target
+        self.assertIn('"Evening."', text)
+        self.assertEqual(alice.msg.call_args[1].get("type"), "say")
+
+    def test_to_bad_usage(self):
+        """`to` with no message shows usage."""
+        jorge = _make_character(
+            key="Jorge", sex="male", height="tall", build="lean",
+            sleeve_uid="uid-jorge",
+        )
+        from commands.CmdCommunication import CmdTo
+
+        cmd = CmdTo()
+        cmd.caller = jorge
+        cmd.args = " woman"   # target but no message
+        cmd.cmdstring = "to"
+        jorge.location = MagicMock()
+        cmd.func()
+
+        jorge.msg.assert_called_once_with("Usage: to <target> <message>")
+
+
+# ===================================================================
 # Tests: CmdWhisper
 # ===================================================================
 


### PR DESCRIPTION
`to <target> <message>` — like say, aimed at one person: everyone present
hears it, the target is addressed as "you", onlookers see who it was aimed
at. Reuses say's voice flavour + sight/hearing perception chain (hearing
gates words, sight gates attribution, deaf+blind suppressed).

General social primitive and the prerequisite for diegetic bar ordering
(BARS_AND_RECIPES_SPEC §7.1). 44 comms tests green (4 new for CmdTo).

Closes #641

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
