### PR TITLE
Bars: engine + BarCounter + Bartender (v1 testable loop)

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -188,7 +188,14 @@ class CmdTo(Command):
                     f"{capitalize_first(speaker_name)} says something to "
                     f"{target_ref}, but you can't make it out."
                 )
-            observer.msg(text=text, type="say", from_obj=caller)
+            # The addressed target also receives the raw content structurally
+            # (only when they can hear it), so NPCs/systems can react to being
+            # spoken to directly — e.g. a bartender taking an order.
+            directed = (
+                {"to_speech": speech, "to_speaker": caller}
+                if (observer is target and heard) else {}
+            )
+            observer.msg(text=text, type="say", from_obj=caller, **directed)
 
 
 class CmdWhisper(Command):

--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -98,13 +98,35 @@ class ConsumptionCommand(Command):
         return result
         
     def _apply_substance_dose(self, item, target):
-        """Apply one dose of the item's substance to ``target``.
+        """Apply one dose of the item's substance(s) to ``target``.
 
         The §1 layering (#487): the command validates the delivery,
         the substance entry owns the pharmacology.  Unknown/missing
         substances no-op, so flavor-only consumables stay legitimate.
+
+        A recipe-composed drink (BARS_AND_RECIPES_SPEC) carries a
+        ``db.drink_effects`` map of ``{substance_id: doses}`` instead of a
+        single ``db.substance`` — each canonical substance is applied through
+        the same pipeline, so the alcohol cap / tolerance / addiction all hold,
+        and the drink's own ``db.drink_taste`` is surfaced once per sip.
         """
         from world.substances import apply_substance
+
+        drink_effects = item.db.drink_effects
+        if drink_effects:
+            for substance_id, doses in drink_effects.items():
+                try:
+                    n = max(1, int(doses))
+                except (TypeError, ValueError):
+                    continue
+                dose_result = apply_substance(target, substance_id, doses=n)
+                for line in dose_result.get("feedback", ()):
+                    target.msg(f"|c{line}|n")
+            taste = item.db.drink_taste
+            if taste:
+                target.msg(f"|x{taste}|n")
+            return
+
         dose_result = apply_substance(target, item.db.substance)
         for line in dose_result.get("feedback", ()):
             target.msg(f"|c{line}|n")

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -1,0 +1,212 @@
+"""
+Bars (BARS_AND_RECIPES_SPEC) — the crafting station and its bartender.
+
+``BarCounter`` is the interactive counter object: a container that holds loaded
+ingredients and served drinks, carries the menu/register/ownership, and exposes
+the `menu` / `use` verbs. ``Bartender`` is an NPC that responds to a patron
+talking to it (the `to` command's structured directed speech) by making a drink
+from its menu, serving it on the bar, and charging on order.
+
+v1 is intentionally lenient where the spec defers detail (ownership gating,
+recipe-saving UX) so the loop is testable; those are later slices.
+"""
+
+from evennia import CmdSet
+from evennia.commands.command import Command
+from evennia.utils import delay
+
+from typeclasses.objects import Object
+from typeclasses.characters import Character
+from world.bar import (
+    make_drink,
+    make_drink_from_recipe,
+    match_recipe,
+    mix_effects,
+)
+
+
+# ---------------------------------------------------------------------------
+# Bar verbs (object command set, active when a bar is in the room)
+# ---------------------------------------------------------------------------
+class CmdBarMenu(Command):
+    """
+    Read the bar's menu.
+
+    Usage:
+        menu
+    """
+
+    key = "menu"
+    aliases = ["read menu"]
+    locks = "cmd:all()"
+    help_category = "Bar"
+
+    def func(self):
+        bar = self.obj
+        menu = bar.db.menu or []
+        if not menu:
+            self.caller.msg(f"{bar.get_display_name(self.caller)} has nothing on offer.")
+            return
+        lines = [f"|w{bar.get_display_name(self.caller)} — menu|n"]
+        for r in menu:
+            price = r.get("price", 0)
+            lines.append(f"  {r['name']}  |y({price})|n")
+        self.caller.msg("\n".join(lines))
+
+
+class CmdBarUse(Command):
+    """
+    Work the bar: mix whatever ingredients are loaded into it.
+
+    Usage:
+        use <bar>
+
+    Load ingredients first (``put <ingredient> in <bar>``), then ``use`` the
+    bar to mix them into a drink. The drink lands on the bar.
+    """
+
+    key = "use"
+    locks = "cmd:all()"
+    help_category = "Bar"
+
+    def func(self):
+        bar = self.obj
+        caller = self.caller
+        if not bar.is_bartender(caller):
+            caller.msg("You aren't working this bar.")
+            return
+        ingredients = [
+            o for o in bar.contents
+            if getattr(o.db, "is_ingredient", False)
+        ]
+        if not ingredients:
+            caller.msg(
+                f"Nothing's loaded to mix. Put ingredients in "
+                f"{bar.get_display_name(caller)} first."
+            )
+            return
+        effects = mix_effects(ingredients)
+        names = ", ".join(i.key for i in ingredients)
+        drink = make_drink(
+            name="a mixed drink",
+            desc=f"a freshly-mixed drink, thrown together from {names}",
+            effects=effects,
+            sips=3,
+            taste="A rough, improvised mix — it does the job.",
+            location=bar,
+        )
+        for i in ingredients:
+            i.delete()
+        caller.location.msg_contents(
+            f"{caller.key} mixes {names} into {drink.key} on {bar.key}."
+        )
+
+
+class BarCmdSet(CmdSet):
+    key = "bar_cmdset"
+
+    def at_cmdset_creation(self):
+        self.add(CmdBarMenu())
+        self.add(CmdBarUse())
+
+
+# ---------------------------------------------------------------------------
+# The bar counter
+# ---------------------------------------------------------------------------
+class BarCounter(Object):
+    """An interactive bar counter — the first crafting station."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.menu = []
+        self.db.register = 0
+        self.db.owner = None
+        self.db.staff = []
+        self.locks.add("get:false()")  # the bar itself isn't pocketable
+        self.cmdset.add(BarCmdSet, persistent=True)
+
+    def is_bartender(self, char):
+        """True if `char` may work this bar (owner, staff, or — v1 — anyone
+        if no ownership is set yet)."""
+        owner = self.db.owner
+        staff = self.db.staff or []
+        if owner is None and not staff:
+            return True  # lenient until ownership is configured
+        return char is owner or char in staff
+
+    def return_appearance(self, looker, **kwargs):
+        base = super().return_appearance(looker, **kwargs)
+        guide = (
+            "\n\n|wFor patrons|n\n"
+            "  |cmenu|n                 — read what's on offer\n"
+            "  |corder ... |n / |cto <bartender> ...|n — ask the bartender for a drink\n"
+            "  |cget <drink> from " + self.key + "|n — take a drink served to you\n"
+            "  |cdrink <drink>|n        — sip it\n"
+            "\n|wFor bartenders|n\n"
+            "  |cput <ingredient> in " + self.key + "|n — load ingredients\n"
+            "  |cuse " + self.key + "|n            — mix the loaded ingredients"
+        )
+        return base + guide
+
+
+# ---------------------------------------------------------------------------
+# The bartender NPC
+# ---------------------------------------------------------------------------
+class Bartender(Character):
+    """An NPC that takes drink orders by being spoken to (the `to` command)."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.is_bartender_npc = True
+
+    def _find_bar(self):
+        if not self.location:
+            return None
+        for obj in self.location.contents:
+            if isinstance(obj, BarCounter):
+                return obj
+        return None
+
+    def at_msg_receive(self, text=None, from_obj=None, **kwargs):
+        """React to being addressed directly (the `to` command)."""
+        order = kwargs.get("to_speech")
+        speaker = kwargs.get("to_speaker") or from_obj
+        if order and speaker is not None and speaker is not self:
+            # A small beat, then fulfil — feels natural and avoids reentrancy.
+            delay(1.5, self._fulfil_order, order, speaker)
+        return True
+
+    def _fulfil_order(self, order_text, patron):
+        if not self.location:
+            return
+        if getattr(patron, "location", None) is not self.location:
+            return  # patron wandered off
+        bar = self._find_bar()
+        menu = (bar.db.menu if bar else None) or self.db.menu or []
+        recipe = match_recipe(order_text, menu)
+        if not recipe:
+            self.location.msg_contents(
+                f'{self.key} shakes their head. "Don\'t serve that here."'
+            )
+            return
+        price = int(recipe.get("price", 0) or 0)
+        have = int(getattr(patron, "tokens", 0) or 0)
+        if price and have < price:
+            self.location.msg_contents(
+                f'{self.key} looks {patron.key} over. '
+                f'"That\'s {price}. Come back when you\'ve got it."'
+            )
+            return
+        loc = bar if bar else self.location
+        drink = make_drink_from_recipe(recipe, location=loc)
+        if price:
+            patron.tokens = have - price
+            if bar:
+                bar.db.register = int(bar.db.register or 0) + price
+        craft = recipe.get("craft", "fixes the drink")
+        where = bar.key if bar else "the bar"
+        self.location.msg_contents(
+            f"{self.key} {craft}, then sets {drink.key} on {where}."
+        )
+        if price:
+            patron.msg(f"|y(That's {price} tokens.)|n")

--- a/world/bar.py
+++ b/world/bar.py
@@ -1,0 +1,129 @@
+"""
+Bars & recipes engine (BARS_AND_RECIPES_SPEC).
+
+Ingredients carry canonical-substance contributions; a mix sums them (additive),
+and the resulting drink applies them through the existing consumption pipeline
+(`apply_substance`), so the per-effect caps (the alcohol cap), tolerance, and
+addiction come free. Drinks are multi-use consumables — one sip per use.
+
+All drink/ingredient content authored here is original to the colony.
+"""
+
+from evennia import create_object
+
+#: Base typeclass for spawned drinks.
+DRINK_TYPECLASS = "typeclasses.objects.Object"
+
+
+def mix_effects(ingredients):
+    """Sum the canonical-substance contributions of an iterable of ingredients.
+
+    Each ingredient carries ``db.contributions`` == ``{substance_id: doses}``.
+    Returns ``{substance_id: total_doses}``. Per-effect ceilings are enforced
+    downstream by ``apply_substance`` at drink time (decision: scarcity + the
+    existing caps balance it), not clamped here.
+    """
+    effects: dict[str, int] = {}
+    for ing in ingredients:
+        contrib = getattr(ing.db, "contributions", None) or {}
+        for sid, doses in contrib.items():
+            try:
+                effects[sid] = effects.get(sid, 0) + int(doses)
+            except (TypeError, ValueError):
+                continue
+    return {k: v for k, v in effects.items() if v}
+
+
+def make_drink(*, name, desc, effects, sips=3, taste="", location=None):
+    """Create a multi-use drink consumable that plugs into the `drink` verb.
+
+    The drink carries ``db.drink_effects`` (a ``{substance_id: doses}`` map
+    applied per sip), ``db.uses_left`` (the number of sips), and the `drink`
+    delivery tag so the existing consumption command accepts it.
+    """
+    drink = create_object(DRINK_TYPECLASS, key=name, location=location)
+    drink.db.desc = desc
+    drink.db.uses_left = max(1, int(sips))
+    drink.db.drink_effects = dict(effects or {})
+    drink.db.drink_taste = taste or ""
+    drink.db.is_drink = True
+    # Delivery tag — `supports_delivery(item, "drink")` looks for this.
+    drink.tags.add("drink", category="delivery_method")
+    return drink
+
+
+def make_drink_from_recipe(recipe, *, location=None):
+    """Create a drink from a recipe/menu dict (see HUB_AND_HOWL_MENU)."""
+    return make_drink(
+        name=recipe["name"],
+        desc=recipe.get("desc", recipe["name"]),
+        effects=recipe.get("effects", {}),
+        sips=recipe.get("sips", 3),
+        taste=recipe.get("taste", ""),
+        location=location,
+    )
+
+
+def match_recipe(order_text, menu):
+    """Find the first menu recipe whose order keywords appear in `order_text`.
+
+    `order_text` is the raw thing a patron said (e.g. "a rotgut, please").
+    Returns the recipe dict or ``None``.
+    """
+    if not order_text or not menu:
+        return None
+    low = order_text.lower()
+    for recipe in menu:
+        for kw in recipe.get("order_keywords", (recipe.get("name", ""),)):
+            if kw and kw.lower() in low:
+                return recipe
+    return None
+
+
+# ---------------------------------------------------------------------------
+# A starter menu for the Hub & Howl — scuzzy colony drinks. Original content.
+# Effects use real substance ids (see world/substances/registry.py): `alcohol`
+# (sedation cap 4), `opium` (strong). Flavour-only drinks carry no effects.
+# ---------------------------------------------------------------------------
+HUB_AND_HOWL_MENU = [
+    {
+        "name": "a mug of rotgut",
+        "order_keywords": ("rotgut", "grain", "spirit", "cheap"),
+        "price": 8,
+        "sips": 3,
+        "effects": {"alcohol": 1},
+        "desc": "a dented tin mug of cloudy grain spirit, the colony's cheapest way to lose a shift",
+        "taste": "It scours the throat like coolant — paint-thinner heat and a sour, metallic finish.",
+        "craft": "reaches under the slab for an unlabelled jug and sloshes cloudy spirit into a dented tin mug",
+    },
+    {
+        "name": "a glass of reactor wash",
+        "order_keywords": ("reactor", "wash", "strong", "stiff"),
+        "price": 15,
+        "sips": 3,
+        "effects": {"alcohol": 2},
+        "desc": "a smudged glass of something amber and oily that catches the light wrong",
+        "taste": "It hits like a dropped tool — hot, chemical, and gone numb before you swallow.",
+        "craft": "pulls a smudged glass, free-pours two fingers of something amber and oily, and slides it over",
+    },
+    {
+        "name": "a cup of channel fog",
+        "order_keywords": ("fog", "channel", "milky", "smooth"),
+        "price": 20,
+        "sips": 4,
+        "effects": {"alcohol": 1, "opium": 1},
+        "desc": "a chipped ceramic cup of a milky, grey-green liquor that smells faintly of brine and poppy",
+        "taste": "Smooth and cold going down, with a slow warmth that closes over you like the channel fog it's named for.",
+        "craft": "measures a milky grey-green liquor into a chipped ceramic cup with the care of someone who knows what's in it",
+    },
+    {
+        "name": "a mug of black recyc",
+        "order_keywords": ("recyc", "black", "coffee", "caf", "sober"),
+        "price": 5,
+        "sips": 4,
+        "effects": {},
+        "desc": "a scalding mug of reclaimed caf, black as the inside of a vent and twice as bitter",
+        "taste": "Bitter, scalding, and faintly of the recycler — but it's hot, and it's not alcohol.",
+        "craft": "fills a mug from the battered caf urn at the end of the bar, no ceremony to it",
+    },
+]


### PR DESCRIPTION
First slice of BARS_AND_RECIPES_SPEC — the order->drink loop.

- world/bar.py: mix_effects (sums ingredient canonical-substance
  contributions), make_drink (multi-use consumable w/ db.drink_effects +
  drink delivery tag), recipe helpers, original colony starter menu.
- CmdConsumption._apply_substance_dose: applies a composed drink's
  db.drink_effects through apply_substance (alcohol cap/tolerance/addiction
  hold) + surfaces taste.
- CmdTo: passes structured directed speech to the addressed target (when
  heard) so NPCs can react to being spoken to.
- typeclasses/bar.py: BarCounter (container station, menu/register/owner,
  menu/use verbs, examine guide) + Bartender NPC (hears a to-order, matches
  menu, makes + serves the drink, charges on order).

66 comms/consumption tests green.

Closes #643

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
