### PR TITLE
Bars: drinks must be Item (custom CmdGet only picks up Items)

### DIFF
--- a/world/bar.py
+++ b/world/bar.py
@@ -13,8 +13,9 @@ import re
 
 from evennia import create_object
 
-#: Base typeclass for spawned drinks.
-DRINK_TYPECLASS = "typeclasses.objects.Object"
+#: Base typeclass for spawned drinks. Must be an ``Item`` — the custom CmdGet
+#: only picks up ``typeclasses.items.Item`` instances.
+DRINK_TYPECLASS = "typeclasses.items.Item"
 
 #: Words dropped when deriving searchable aliases from a drink's display name.
 _ALIAS_STOPWORDS = {"a", "an", "the", "of", "with", "and", "in", "on", "to"}


### PR DESCRIPTION
Drinks were created as base Object, but the custom CmdGet rejects anything
not isinstance Item -> "You can't pick up a mug of rotgut." Drinks now spawn
as typeclasses.items.Item so they're gettable.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
