### PR TITLE
Bars polish: diegetic payment, interior crowd, fixture+surface, drink msgs

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -114,17 +114,19 @@ class ConsumptionCommand(Command):
 
         drink_effects = item.db.drink_effects
         if drink_effects:
+            feedback = []
             for substance_id, doses in drink_effects.items():
                 try:
                     n = max(1, int(doses))
                 except (TypeError, ValueError):
                     continue
                 dose_result = apply_substance(target, substance_id, doses=n)
-                for line in dose_result.get("feedback", ()):
-                    target.msg(f"|c{line}|n")
+                feedback.extend(dose_result.get("feedback", ()))
             taste = item.db.drink_taste
-            if taste:
-                target.msg(f"|x{taste}|n")
+            # One concise line in the default colour: the taste, then the effect.
+            parts = ([taste] if taste else []) + list(feedback)
+            if parts:
+                target.msg(" ".join(parts))
             return
 
         dose_result = apply_substance(target, item.db.substance)
@@ -868,9 +870,9 @@ class CmdDrink(ConsumptionCommand):
                 caller.msg(errors[0])
                 return
                 
-        # Execute drinking
+        # Execute drinking (the actor's own line is sent below, sip-aware, so
+        # we don't double up with a "You drink" here)
         if is_self:
-            caller.msg(f"You drink {item.get_display_name(caller)}.")
             msg_room_identity(
                 location=caller.location,
                 template=f"{{actor}} drinks {item.key}.",
@@ -895,9 +897,15 @@ class CmdDrink(ConsumptionCommand):
                 target.msg(f"You feel the effects: {result_msg}")
             self._apply_substance_dose(item, target)
         else:
-            # Regular drink — pharmacology (if any) rides the
-            # delivery, then the generic consumable lifecycle.
-            caller.msg(f"You drank {item.get_display_name(caller)}.")
+            # Regular drink — one actor line per sip (a sip, or the final
+            # mouthful), then pharmacology, then the consumable lifecycle.
+            if is_self:
+                uses_left = item.db.uses_left
+                name = item.get_display_name(caller)
+                if uses_left is None or int(uses_left or 0) <= 1:
+                    caller.msg(f"You finish off {name}.")
+                else:
+                    caller.msg(f"You take a sip of {name}.")
             self._apply_substance_dose(item, target)
             self._consume(item)
 

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -1,21 +1,23 @@
 """
 Bars (BARS_AND_RECIPES_SPEC) — the crafting station and its bartender.
 
-``BarCounter`` is the interactive counter object: a container that holds loaded
-ingredients and served drinks, carries the menu/register/ownership, and exposes
-the `menu` / `use` verbs. ``Bartender`` is an NPC that responds to a patron
-talking to it (the `to` command's structured directed speech) by making a drink
-from its menu, serving it on the bar, and charging on order.
+``BarCounter`` is the interactive counter: an ``@integrate`` room fixture (folds
+into the room description, not listed as a loose object, can't be picked up) that
+holds served drinks on its surface, carries the menu/register/ownership, and
+exposes the `read menu on <bar>` / `use <bar>` verbs. ``Bartender`` is an NPC that
+responds to a patron talking to it (the `to` command's structured directed
+speech) by making a drink from its menu, setting it on the bar, and taking
+payment diegetically (it says the price; no system text).
 
-v1 is intentionally lenient where the spec defers detail (ownership gating,
-recipe-saving UX) so the loop is testable; those are later slices.
+v1 is intentionally lenient where the spec defers (ownership gating, recipe-save
+UX) so the loop is testable; those are later slices.
 """
 
 from evennia import CmdSet
 from evennia.commands.command import Command
 from evennia.utils import delay
 
-from typeclasses.objects import Object
+from typeclasses.items import Item
 from typeclasses.characters import Character
 from world.bar import (
     make_drink,
@@ -30,10 +32,13 @@ from world.bar import (
 # ---------------------------------------------------------------------------
 class CmdBarMenu(Command):
     """
-    Read the bar's menu.
+    Read a bar's menu.
 
     Usage:
+        read menu on <bar>
         menu
+
+    Defaults to the bar in the room, so a bare ``menu`` / ``read menu`` works.
     """
 
     key = "menu"
@@ -42,27 +47,27 @@ class CmdBarMenu(Command):
     help_category = "Bar"
 
     def func(self):
-        bar = self.obj
+        bar = self.obj   # the bar this cmdset is attached to
         menu = bar.db.menu or []
+        name = bar.get_display_name(self.caller)
         if not menu:
-            self.caller.msg(f"{bar.get_display_name(self.caller)} has nothing on offer.")
+            self.caller.msg(f"{name} has nothing on offer.")
             return
-        lines = [f"|w{bar.get_display_name(self.caller)} — menu|n"]
+        lines = [f"|w{name} — menu|n"]
         for r in menu:
-            price = r.get("price", 0)
-            lines.append(f"  {r['name']}  |y({price})|n")
+            lines.append(f"  {r['name']}  |y({r.get('price', 0)})|n")
         self.caller.msg("\n".join(lines))
 
 
 class CmdBarUse(Command):
     """
-    Work the bar: mix whatever ingredients are loaded into it.
+    Work the bar: mix whatever ingredients are loaded onto it.
 
     Usage:
         use <bar>
 
-    Load ingredients first (``put <ingredient> in <bar>``), then ``use`` the
-    bar to mix them into a drink. The drink lands on the bar.
+    Load ingredients first (``put <ingredient> on <bar>``), then ``use`` the bar
+    to mix them into a drink. The drink lands on the bar.
     """
 
     key = "use"
@@ -75,13 +80,10 @@ class CmdBarUse(Command):
         if not bar.is_bartender(caller):
             caller.msg("You aren't working this bar.")
             return
-        ingredients = [
-            o for o in bar.contents
-            if getattr(o.db, "is_ingredient", False)
-        ]
+        ingredients = [o for o in bar.contents if getattr(o.db, "is_ingredient", False)]
         if not ingredients:
             caller.msg(
-                f"Nothing's loaded to mix. Put ingredients in "
+                f"Nothing's loaded to mix. Put ingredients on "
                 f"{bar.get_display_name(caller)} first."
             )
             return
@@ -93,7 +95,7 @@ class CmdBarUse(Command):
             effects=effects,
             sips=3,
             taste="A rough, improvised mix — it does the job.",
-            location=bar.location,   # onto the room (narrated on the bar)
+            location=bar,   # onto the bar surface
         )
         for i in ingredients:
             i.delete()
@@ -111,10 +113,16 @@ class BarCmdSet(CmdSet):
 
 
 # ---------------------------------------------------------------------------
-# The bar counter
+# The bar counter — an @integrate room fixture with a surface
 # ---------------------------------------------------------------------------
-class BarCounter(Object):
-    """An interactive bar counter — the first crafting station."""
+class BarCounter(Item):
+    """An interactive bar counter — the first crafting station.
+
+    An ``Item`` (so the @integrate room display recognises it) but a fixed
+    fixture: ``db.integrate`` folds it into the room description rather than the
+    loose-object list, and a ``get:false()`` lock keeps it from being picked up.
+    Served drinks rest in its ``contents`` (the surface).
+    """
 
     def at_object_creation(self):
         super().at_object_creation()
@@ -122,29 +130,35 @@ class BarCounter(Object):
         self.db.register = 0
         self.db.owner = None
         self.db.staff = []
-        self.locks.add("get:false()")  # the bar itself isn't pocketable
+        self.db.integrate = True          # part of the room, not a loose object
+        self.locks.add("get:false()")     # stuck — can't be pocketed
         self.cmdset.add(BarCmdSet, persistent=True)
 
     def is_bartender(self, char):
-        """True if `char` may work this bar (owner, staff, or — v1 — anyone
-        if no ownership is set yet)."""
+        """True if `char` may work this bar (owner, staff, or — v1 — anyone if
+        no ownership is configured yet)."""
         owner = self.db.owner
         staff = self.db.staff or []
         if owner is None and not staff:
-            return True  # lenient until ownership is configured
+            return True
         return char is owner or char in staff
 
     def return_appearance(self, looker, **kwargs):
         base = super().return_appearance(looker, **kwargs)
+        # Show drinks resting on the surface.
+        drinks = [o for o in self.contents if getattr(o.db, "is_drink", False)]
+        if drinks:
+            served = ", ".join(d.get_display_name(looker) for d in drinks)
+            base += f"\n\nOn the bar: {served}."
         guide = (
             "\n\n|wFor patrons|n\n"
-            "  |cmenu|n                 — read what's on offer\n"
-            "  |corder ... |n / |cto <bartender> ...|n — ask the bartender for a drink\n"
-            "  |cget <drink> from " + self.key + "|n — take a drink served to you\n"
-            "  |cdrink <drink>|n        — sip it\n"
+            "  |cread menu on " + self.key + "|n — see what's on offer\n"
+            "  |cto <bartender> ...|n       — ask for a drink\n"
+            "  |cget <drink> from " + self.key + "|n — take a drink off the bar\n"
+            "  |cdrink <drink>|n            — sip it\n"
             "\n|wFor bartenders|n\n"
-            "  |cput <ingredient> in " + self.key + "|n — load ingredients\n"
-            "  |cuse " + self.key + "|n            — mix the loaded ingredients"
+            "  |cput <ingredient> on " + self.key + "|n — load ingredients\n"
+            "  |cuse " + self.key + "|n             — mix the loaded ingredients"
         )
         return base + guide
 
@@ -172,34 +186,26 @@ class Bartender(Character):
         order = kwargs.get("to_speech")
         speaker = kwargs.get("to_speaker") or from_obj
         if order and speaker is not None and speaker is not self:
-            # A small beat, then fulfil — feels natural and avoids reentrancy.
             delay(1.5, self._fulfil_order, order, speaker)
         return True
 
     def _fulfil_order(self, order_text, patron):
-        if not self.location:
+        if not self.location or getattr(patron, "location", None) is not self.location:
             return
-        if getattr(patron, "location", None) is not self.location:
-            return  # patron wandered off
         bar = self._find_bar()
         menu = (bar.db.menu if bar else None) or self.db.menu or []
         recipe = match_recipe(order_text, menu)
         if not recipe:
-            self.location.msg_contents(
-                f'{self.key} shakes their head. "Don\'t serve that here."'
-            )
+            self.execute_cmd("say Don't serve that here.")
             return
         price = int(recipe.get("price", 0) or 0)
         have = int(getattr(patron, "tokens", 0) or 0)
         if price and have < price:
-            self.location.msg_contents(
-                f'{self.key} looks {patron.key} over. '
-                f'"That\'s {price}. Come back when you\'ve got it."'
-            )
+            self.execute_cmd(f"say That's {price}. Come back when you've got it.")
             return
-        # Served into the room (narrated "on the bar") so a plain `get` works;
-        # the bar-as-surface container is a later polish.
-        drink = make_drink_from_recipe(recipe, location=self.location)
+        # Make it on the bar surface, take the cash as part of the gesture.
+        loc = bar if bar else self.location
+        drink = make_drink_from_recipe(recipe, location=loc)
         if price:
             patron.tokens = have - price
             if bar:
@@ -207,7 +213,8 @@ class Bartender(Character):
         craft = recipe.get("craft", "fixes the drink")
         where = bar.key if bar else "the bar"
         self.location.msg_contents(
-            f"{self.key} {craft}, then sets {drink.key} on {where}."
+            f"{self.key} {craft}, sets {drink.key} on {where}, and sweeps the "
+            f"payment off the slab with a practiced hand."
         )
         if price:
-            patron.msg(f"|y(That's {price} tokens.)|n")
+            self.execute_cmd(f"say {price}.")

--- a/world/crowd/crowd_messages.py
+++ b/world/crowd/crowd_messages.py
@@ -298,10 +298,149 @@ CROWD_MESSAGES = {
                 "there's no telling where one body ends and the next begins",
             ],
         },
-    }
+    },
+    # ------------------------------------------------------------------
+    # Interior profile — bars, venues, and other enclosed rooms. The street
+    # 'default' pool is all open-air crush (haulers, drones, gutters); indoors
+    # the crowd is the room's own patrons, so it reads smaller and closer. Same
+    # five sense layers, smaller pools, no weather/traffic imagery. Selected by
+    # room.type via get_crowd_messages(profile=...).
+    # ------------------------------------------------------------------
+    'interior': {
+        'sparse': {
+            'visual': [
+                "a lone drinker nurses something at the far end of the counter, in no hurry to finish it",
+                "two regulars hunch over a table, talking low, and don't look up",
+                "someone sits alone in a booth with their back to the wall and their eyes on the door",
+                "a barfly counts out chits one at a time, weighing another round against the walk home",
+                "a synth wipes down an already-clean table with slow, even strokes",
+                "someone dozes against the wall in the corner, drink forgotten on the floor",
+            ],
+            'auditory': [
+                "a single low conversation murmurs somewhere behind you and goes quiet",
+                "a glass sets down on wood, and the room is quiet enough to hear it",
+                "a stool scrapes back, and bootsteps cross to the door and out",
+                "somewhere a handpad chimes and a voice answers it in a mutter",
+                "the slow drip of a tap counts off the quiet",
+            ],
+            'olfactory': [
+                "spilled liquor and old smoke have soaked into the wood over years",
+                "stale beer and somebody's cheap cigarette hang in the still air",
+                "the close smell of a near-empty room: damp coats, ash, and cold grease",
+            ],
+            'tactile': [
+                "the near-empty room holds the warmth of its few bodies and little else",
+                "the quiet leaves the air still and close around the tables",
+            ],
+            'atmospheric': [
+                "half the seats are empty and the lights over them have been left low",
+                "the room has the settled hush of a place between its busy hours",
+                "rings from a hundred glasses ghost the bartop where the light catches it",
+            ],
+        },
+        'moderate': {
+            'visual': [
+                "a working crowd fills the tables, drinks moving and chits changing hands",
+                "two crews share a booth, voices easy, eyes still tracking the room",
+                "someone works the floor table to table, selling something held close to the chest",
+                "a knot of regulars props up the counter, trading the same complaints they always do",
+                "a synth ferries empties back two-handed and never spills",
+                "a hand of cards goes round a corner table, the pot a small heap of chits",
+            ],
+            'auditory': [
+                "a dozen overlapping conversations fill the room with a steady warm churn",
+                "laughter goes up at one table and turns a few heads",
+                "glasses clink and a stool scrapes under the talk",
+                "someone calls an order across the room and gets a grunt back",
+                "a low argument simmers at the bar and settles before it boils",
+            ],
+            'olfactory': [
+                "warm bodies, spilled beer, and cigarette smoke thicken the air",
+                "the smells of a working bar: liquor, sweat, and something frying out back",
+                "smoke hangs in a flat layer at head height over the tables",
+            ],
+            'tactile': [
+                "the room's warm with bodies now, the chill of the door long gone",
+                "the heat of a full house takes the edge off the night",
+            ],
+            'atmospheric': [
+                "the tables are mostly full and the talk runs steady over them",
+                "the floor's gone tacky underfoot where the night's spills have dried",
+                "smoke and low light blur the far end of the room together",
+            ],
+        },
+        'heavy': {
+            'visual': [
+                "the room's packed shoulder to shoulder, every table taken and the bar three deep",
+                "people stand wherever they can find floor, drinks held high out of the crush",
+                "a scuffle breaks out near the bar and folds back into the press before it goes anywhere",
+                "the line at the counter has stopped being a line and become a wall of backs and elbows",
+            ],
+            'auditory': [
+                "the noise is a solid wall of voices with no gaps in it",
+                "you can't hear the person beside you without leaning in close",
+                "a glass shatters somewhere in the press and a cheer goes up after it",
+                "shouted orders pile on top of each other at the bar and lose all meaning",
+            ],
+            'olfactory': [
+                "the packed room reeks of sweat, smoke, and spilled drink",
+                "body heat pushes a thick stink of bodies and stale beer through the air",
+                "the smoke's so thick now it stings the eyes",
+            ],
+            'tactile': [
+                "the packed bodies throw off a steady heat that comes from every side",
+                "there's no still air left in here, just the warm press of the crowd",
+            ],
+            'atmospheric': [
+                "there's no clear floor left, just a room full of shifting backs",
+                "breath and smoke fog the air under the low lights",
+                "the heat of the crowd has become its own weather in here",
+            ],
+        },
+        'packed': {
+            'visual': [
+                "the crush is total, jammed too tight for anyone to do more than inch toward the bar",
+                "drinks ride overhead hand to hand because there's no room to carry them any other way",
+                "faces press close enough to count on every side",
+                "a fight breaks out somewhere in the pack, has nowhere to go, and dies in the press",
+            ],
+            'auditory': [
+                "the roar of the packed room is total, every voice drowned in every other",
+                "the din is so complete it starts to feel like silence",
+                "not even a shout carries past the next body",
+            ],
+            'olfactory': [
+                "the crush stinks of close-packed bodies, sweat, and breath gone stale",
+                "there's no clean air left, only the thick reek of the packed room",
+            ],
+            'tactile': [
+                "the crush radiates a smothering heat from every side at once",
+                "the press holds everyone upright whether they like it or not",
+            ],
+            'atmospheric': [
+                "there are no walls anymore, just packed bodies in every direction",
+                "the air is thick, warm, and short",
+                "the crowd has stopped being people and become one solid thing",
+            ],
+        },
+    },
 }
 
-def get_crowd_messages(crowd_level, message_category='all'):
+#: Room types that draw on the enclosed 'interior' crowd pool rather than the
+#: open-air street 'default'. Anything not listed falls back to 'default'.
+INTERIOR_ROOM_TYPES = {
+    'bar', 'interior', 'nightclub', 'club', 'venue', 'cantina', 'lounge',
+}
+
+
+def crowd_profile_for_room_type(room_type):
+    """Map a ``room.type`` to a crowd message profile name ('default'|'interior')."""
+    if room_type and str(room_type).lower() in INTERIOR_ROOM_TYPES:
+        return 'interior'
+    return 'default'
+
+
+def get_crowd_messages(crowd_level, message_category='all', profile='default'):
     """
     Get crowd messages for specified level and category.
 
@@ -309,6 +448,9 @@ def get_crowd_messages(crowd_level, message_category='all'):
         crowd_level (int): Crowd level (0-4+)
         message_category (str): 'visual', 'auditory', 'olfactory', 'tactile',
             'atmospheric', or 'all'
+        profile (str): Which message pool to draw from ('default' street crush
+            vs. 'interior' enclosed venues). Unknown profiles fall back to
+            'default'.
 
     Returns:
         dict or list: Message pools for the crowd level
@@ -318,10 +460,12 @@ def get_crowd_messages(crowd_level, message_category='all'):
     if intensity == 'none':
         return {} if message_category == 'all' else []
 
-    if intensity not in CROWD_MESSAGES['default']:
+    pool = CROWD_MESSAGES.get(profile) or CROWD_MESSAGES['default']
+
+    if intensity not in pool:
         intensity = 'packed'  # Fallback for very high crowd levels
 
-    crowd_pool = CROWD_MESSAGES['default'][intensity]
+    crowd_pool = pool[intensity]
 
     if message_category == 'all':
         return crowd_pool

--- a/world/crowd/crowd_system.py
+++ b/world/crowd/crowd_system.py
@@ -113,9 +113,13 @@ class CrowdSystem:
         if crowd_level == 0:
             return ""
         
-        # Get available crowd messages for this level
-        from .crowd_messages import get_crowd_messages
-        crowd_messages = get_crowd_messages(crowd_level)
+        # Get available crowd messages for this level. Enclosed rooms (bars,
+        # venues) draw on the 'interior' pool; open-air rooms get the street
+        # crush 'default'. The street-traffic imagery (haulers, drones, gutters)
+        # would read wrong indoors.
+        from .crowd_messages import crowd_profile_for_room_type, get_crowd_messages
+        profile = crowd_profile_for_room_type(room.type)
+        crowd_messages = get_crowd_messages(crowd_level, profile=profile)
         if not crowd_messages:
             return ""
         

--- a/world/tests/test_consumption_rendering.py
+++ b/world/tests/test_consumption_rendering.py
@@ -94,6 +94,8 @@ def _make_item(key="medkit"):
     # No substance — the #487 dose hook no-ops on None.
     item.db = MagicMock()
     item.db.substance = None
+    # Not a recipe-composed drink — the drink branch (#643) must no-op.
+    item.db.drink_effects = None
     return item
 
 


### PR DESCRIPTION
- Bartender takes payment diegetically (says price, sweeps cash as a
  crafted emote) instead of yellow system text.
- Add an 'interior' crowd message profile for bars/venues, selected by
  room.type via crowd_profile_for_room_type(); street-crush imagery
  (haulers, drones, gutters) no longer fires indoors.
- BarCounter is an @integrate fixture (folds into room desc, get:false),
  serves drinks onto its surface, and shows them in return_appearance.
- 'read menu on <bar>' / 'use <bar>' object verbs on the counter.
- Single concise consumption line: taste + effect in default colour,
  plus a sip/finish line; no duplicate drink/finished text.
- Test fixture: non-drink mock items set db.drink_effects=None so the
  drink branch no-ops (real DB returns None already).

Closes #648

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
