### PR TITLE
Unify say/to/pose onto one speech backbone; bartender reads payload

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -20,18 +20,11 @@ from world.emote import (
     tokenize_dot_pose,
     tokenize_emote,
 )
-from random import random
 
 from world.grammar import capitalize_first
 from world.identity_utils import msg_room_identity
-from world.voice import (
-    can_hear,
-    can_see,
-    garbled_voice_phrase,
-    resolve_speaker_attribution,
-    voice_phrase,
-    VOICE_FLAVOR_SPRINKLE_CHANCE,
-)
+from world.perception import can_hear
+from world.speech import broadcast_speech
 
 
 class CmdSay(Command):
@@ -64,50 +57,11 @@ class CmdSay(Command):
             caller.msg("You have no location to speak in.")
             return
 
-        # Actor sees their own message
+        # Actor sees their own message; the room hears it through the shared
+        # speech backbone (per-observer attribution, hearing-gated content,
+        # voice flavour, and the structured speech payload NPCs react to).
         caller.msg(f'You say, "{speech}"')
-
-        # Voice flavour for observers who can SEE the speaker (CAPACITY_CONSUMERS
-        # spec §4.6 can-see branch): a garbled voice always renders — a ruined
-        # voice is conspicuous — otherwise a sporadic, low-frequency sprinkle,
-        # rolled once per utterance for a consistent reading.
-        visible_flavor = garbled_voice_phrase(caller)
-        if visible_flavor is None:
-            phrase = voice_phrase(caller)
-            if phrase and random() < VOICE_FLAVOR_SPRINKLE_CHANCE:
-                visible_flavor = phrase
-        visible_verb = f"says, |x*{visible_flavor}*|n" if visible_flavor else "says,"
-
-        # Each observer's perception resolves per the sight/hearing chain
-        # (§4.5). Hearing gates the *content* (the words); sight + the voice
-        # channel gate the *attribution* (who):
-        #   - can hear → the words, attributed by sight (name + flavour) or by
-        #     voice discernment (name / "someone").
-        #   - deaf but can see → they watch the speaker mouth something but
-        #     can't make it out (no content).
-        #   - deaf and blind → no channel at all; the utterance is suppressed.
-        for observer in location.contents:
-            if observer is caller:
-                continue
-            if not hasattr(observer, "msg"):
-                continue
-
-            heard = can_hear(observer)
-            seen = can_see(observer)
-            if not heard and not seen:
-                continue  # no channel — suppress entirely
-
-            speaker_name = resolve_speaker_attribution(caller, observer)
-            if heard:
-                verb = visible_verb if seen else "says,"
-                text = f'{capitalize_first(speaker_name)} {verb} "{speech}"'
-            else:
-                # Deaf but watching: speech is visible, content is not.
-                text = (
-                    f"{capitalize_first(speaker_name)} says something "
-                    f"you can't make out."
-                )
-            observer.msg(text=text, type="say", from_obj=caller)
+        broadcast_speech(caller, speech, location)
 
 
 class CmdTo(Command):
@@ -146,56 +100,12 @@ class CmdTo(Command):
         if not target:
             return  # search() already sent the error message
 
-        # Actor sees their own message.
+        # Actor sees their own message; the room hears it through the shared
+        # speech backbone. `to` is just `say` with a target: the addressee is
+        # rendered "you", and the structured payload marks them `addressed` so
+        # an NPC can tell being spoken to directly from ambient room chatter.
         caller.msg(f'You say to {target.get_display_name(caller)}, "{speech}"')
-
-        # Voice flavour for observers who can SEE the speaker (as in `say`):
-        # a garbled voice always renders; otherwise a sporadic sprinkle, rolled
-        # once per utterance for a consistent reading across observers.
-        visible_flavor = garbled_voice_phrase(caller)
-        if visible_flavor is None:
-            phrase = voice_phrase(caller)
-            if phrase and random() < VOICE_FLAVOR_SPRINKLE_CHANCE:
-                visible_flavor = phrase
-
-        # Directed but audible: everyone present resolves it through the same
-        # sight/hearing chain as `say`. The target is addressed as "you".
-        for observer in location.contents:
-            if observer is caller:
-                continue
-            if not hasattr(observer, "msg"):
-                continue
-
-            heard = can_hear(observer)
-            seen = can_see(observer)
-            if not heard and not seen:
-                continue  # no channel — suppress entirely
-
-            speaker_name = resolve_speaker_attribution(caller, observer)
-            target_ref = (
-                "you" if observer is target
-                else target.get_display_name(observer)
-            )
-            if heard:
-                if seen and visible_flavor:
-                    verb = f"says to {target_ref}, |x*{visible_flavor}*|n"
-                else:
-                    verb = f"says to {target_ref},"
-                text = f'{capitalize_first(speaker_name)} {verb} "{speech}"'
-            else:
-                # Deaf but watching: the address is visible, the words are not.
-                text = (
-                    f"{capitalize_first(speaker_name)} says something to "
-                    f"{target_ref}, but you can't make it out."
-                )
-            # The addressed target also receives the raw content structurally
-            # (only when they can hear it), so NPCs/systems can react to being
-            # spoken to directly — e.g. a bartender taking an order.
-            directed = (
-                {"to_speech": speech, "to_speaker": caller}
-                if (observer is target and heard) else {}
-            )
-            observer.msg(text=text, type="say", from_obj=caller, **directed)
+        broadcast_speech(caller, speech, location, target=target)
 
 
 class CmdWhisper(Command):

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -184,11 +184,11 @@ GRATITUDE_TRIGGERS = (
 #: rather than words. Phrased as emote actions (the identity system prepends his
 #: per-observer name).
 ACK_EMOTES = (
-    "tips his chin a fraction, not looking up from the taps",
-    "raises two fingers off the slab in a flat, unhurried salute",
-    "grunts once, low, and keeps wiping down a glass",
-    "gives a single slow nod, the kind that's already moved on to the next thing",
-    "knocks two knuckles against the slab and lets that be the answer",
+    "tips his chin a fraction, not looking up from the taps.",
+    "raises two fingers off the slab in a flat, unhurried salute.",
+    "grunts once, low, and keeps wiping down a glass.",
+    "gives a single slow nod, the kind that's already moved on to the next thing.",
+    "knocks two knuckles against the slab and lets that be the answer.",
 )
 
 #: Minimum seconds between acknowledgements, so a chatty room doesn't spam them.
@@ -222,36 +222,31 @@ class Bartender(Character):
         return None
 
     def at_msg_receive(self, text=None, from_obj=None, **kwargs):
-        """React to speech nearby.
+        """React to speech nearby, via the shared speech backbone.
 
-        Two triggers, gratitude checked first so "thanks for the rotgut" reads
-        as a thank-you, not a re-order:
+        Every verb that carries words — ``say``, ``to``, or a pose with an
+        embedded quote — delivers the same structured payload (``speech`` =
+        the words, ``addressed`` = whether this bartender was the one spoken to),
+        and only to listeners who can hear. So a single check handles all three:
 
-          - **Gratitude** (thanks/cheers/much obliged...) heard from anyone in
-            the room, whether said plainly or directed via ``to`` — answered
-            with a small non-verbal acknowledgement.
-          - **A directed order** (the ``to`` command's ``to_speech``) — fulfilled
-            from the menu.
+          - **Gratitude** (thanks/cheers/much obliged...) from any heard speech —
+            answered with a small non-verbal acknowledgement. Checked first so
+            "thanks for the rotgut" reads as a thank-you, not a re-order.
+          - **A directed order** — speech that was *addressed* to this bartender
+            (``to <bartender> ...`` or ``.slide up to <bartender>, "..."``) is
+            matched against the menu and made.
         """
-        order = kwargs.get("to_speech")
-        speaker = kwargs.get("to_speaker") or from_obj
-        if speaker is None or speaker is self:
+        speech = kwargs.get("speech")
+        speaker = from_obj
+        if not speech or speaker is None or speaker is self:
             return True
 
-        # Spoken content: the raw directed order if present, else the rendered
-        # say text (which still contains the quoted words to scan).
-        if order:
-            content = order
-        else:
-            raw = text[0] if isinstance(text, (tuple, list)) else text
-            content = raw if isinstance(raw, str) else ""
-
-        if self._is_gratitude(content):
+        if self._is_gratitude(speech):
             self._acknowledge()
             return True
 
-        if order:
-            delay(1.5, self._fulfil_order, order, speaker)
+        if kwargs.get("addressed"):
+            delay(1.5, self._fulfil_order, speech, speaker)
         return True
 
     @staticmethod

--- a/world/emote.py
+++ b/world/emote.py
@@ -882,6 +882,24 @@ def render_for_observer(
 # =========================================================================
 
 
+def _extract_speech(tokens) -> tuple[str, set[int]]:
+    """Pull the spoken words and addressed-character ids out of a token stream.
+
+    A pose can carry an embedded quote (``.nod at man, "..."``); when it does,
+    that speech should ride the same rails as ``say``/``to`` so NPCs react to it
+    uniformly. Returns ``(words, referenced_char_ids)`` — ``words`` is the joined
+    quoted content (empty if the pose has none), and ``referenced_char_ids`` are
+    the ``id()``s of characters the pose points at, which count as *addressed*.
+    """
+    words = " ".join(
+        t.text for t in tokens if isinstance(t, SpeechToken)
+    ).strip()
+    referenced = {
+        id(t.character) for t in tokens if isinstance(t, CharRefToken)
+    }
+    return words, referenced
+
+
 def render_dot_pose(
     tokens: list[
         TextToken | VerbToken | PronounToken | SpeechToken | CharRefToken
@@ -902,7 +920,10 @@ def render_dot_pose(
         exclude: Characters/objects to exclude from receiving the
             message.
     """
+    from world.speech import speech_payload
+
     exclude_set = set(exclude) if exclude else set()
+    words, referenced = _extract_speech(tokens)
 
     for observer in location.contents:
         if observer in exclude_set:
@@ -911,7 +932,12 @@ def render_dot_pose(
             continue
 
         rendered = render_for_observer(tokens, actor, observer)
-        observer.msg(text=rendered, type="pose", from_obj=actor)
+        # An embedded quote rides the shared speech rails: hearing listeners get
+        # the words, and a listener the pose points at counts as addressed.
+        payload = speech_payload(
+            observer, actor, words, addressed=(id(observer) in referenced)
+        )
+        observer.msg(text=rendered, type="pose", from_obj=actor, **payload)
 
 
 # =========================================================================
@@ -1040,7 +1066,10 @@ def render_emote(
         exclude: Characters/objects to exclude from receiving the
             message.
     """
+    from world.speech import speech_payload
+
     exclude_set = set(exclude) if exclude else set()
+    words, referenced = _extract_speech(tokens)
 
     for observer in location.contents:
         if observer in exclude_set:
@@ -1049,4 +1078,9 @@ def render_emote(
             continue
 
         rendered = render_emote_for_observer(tokens, actor, observer)
-        observer.msg(text=rendered, type="pose", from_obj=actor)
+        # An embedded quote rides the shared speech rails: hearing listeners get
+        # the words, and a listener the emote points at counts as addressed.
+        payload = speech_payload(
+            observer, actor, words, addressed=(id(observer) in referenced)
+        )
+        observer.msg(text=rendered, type="pose", from_obj=actor, **payload)

--- a/world/speech.py
+++ b/world/speech.py
@@ -1,0 +1,133 @@
+"""
+Speech backbone shared by ``say``, ``to``, and pose/emote.
+
+All three verbs put spoken words into a room, and all three should reach
+listeners — players and NPCs alike — through one channel rather than three
+near-duplicate ones. This module is that channel. It owns:
+
+  - :func:`render_speech_line` — the per-observer attribution line for
+    ``say``/``to`` (sight vs. voice attribution, hearing-gated content, voice
+    flavour), so the two commands share rendering instead of copying it.
+  - :func:`broadcast_speech` — the room loop ``say``/``to`` both call.
+  - :func:`speech_payload` — the *structured speech payload* attached to each
+    hearing listener's ``msg``, so reaction code (an NPC's ``at_msg_receive``)
+    reads one shape regardless of which verb carried the words.
+
+The payload travels as ``msg(..., speech=<words>, addressed=<bool>)``:
+
+  - ``speech`` — the raw spoken words. Delivered only to listeners who can hear
+    the speaker; a deaf listener receives no words to react to.
+  - ``addressed`` — whether *this* listener was the one spoken to: ``to <them>``,
+    or a pose that references them (``.nod at <them>, "..."``). Lets an NPC tell
+    "ordered me a drink" from "said something in the room".
+
+Pose/emote *rendering* stays in :mod:`world.emote`; it imports
+:func:`speech_payload` so an embedded quote rides the same rails as ``say``.
+"""
+
+from __future__ import annotations
+
+from random import random
+
+from world.grammar import capitalize_first
+from world.perception import can_hear, can_see
+from world.voice import (
+    VOICE_FLAVOR_SPRINKLE_CHANCE,
+    garbled_voice_phrase,
+    resolve_speaker_attribution,
+    voice_phrase,
+)
+
+
+def visible_voice_flavor(speaker):
+    """Voice flavour shown to observers who can SEE the speaker.
+
+    A garbled voice always renders (a wrecked voice is conspicuous); otherwise a
+    sporadic, low-frequency sprinkle, rolled once per utterance so every observer
+    reads it consistently. Returns the flavour string or ``None``.
+    """
+    flavor = garbled_voice_phrase(speaker)
+    if flavor is None:
+        phrase = voice_phrase(speaker)
+        if phrase and random() < VOICE_FLAVOR_SPRINKLE_CHANCE:
+            flavor = phrase
+    return flavor
+
+
+def speech_payload(observer, speaker, words, *, addressed=False):
+    """The structured speech kwargs to attach to a listener's ``msg``.
+
+    Empty (no payload) when there are no words, the listener is the speaker, or
+    the listener can't hear — a deaf NPC shouldn't react to content it never
+    received. Otherwise ``{"speech": words, "addressed": bool}``.
+    """
+    if not words or observer is speaker:
+        return {}
+    if not can_hear(observer):
+        return {}
+    return {"speech": words, "addressed": bool(addressed)}
+
+
+def render_speech_line(speaker, observer, speech, *, target=None, flavor=None):
+    """The per-observer ``say``/``to`` line.
+
+    Hearing gates the *content* (the words); sight + the voice channel gate the
+    *attribution* (who). Mirrors the sight/hearing chain (CAPACITY_CONSUMERS
+    §4.5). Passing ``target`` makes it a directed ``to`` line
+    ("... says to you/<name>, ..."); the caller is responsible for skipping
+    observers with no channel at all.
+    """
+    heard = can_hear(observer)
+    seen = can_see(observer)
+    speaker_name = capitalize_first(
+        resolve_speaker_attribution(speaker, observer)
+    )
+
+    target_ref = None
+    if target is not None:
+        target_ref = (
+            "you" if observer is target else target.get_display_name(observer)
+        )
+
+    if heard:
+        if target is None:
+            verb = f"says, |x*{flavor}*|n" if (seen and flavor) else "says,"
+        else:
+            verb = (
+                f"says to {target_ref}, |x*{flavor}*|n"
+                if (seen and flavor)
+                else f"says to {target_ref},"
+            )
+        return f'{speaker_name} {verb} "{speech}"'
+
+    # Deaf but watching: the act is visible, the content is not.
+    if target is None:
+        return f"{speaker_name} says something you can't make out."
+    return (
+        f"{speaker_name} says something to {target_ref}, "
+        f"but you can't make it out."
+    )
+
+
+def broadcast_speech(speaker, speech, location, *, target=None, speech_type="say"):
+    """Render and broadcast a spoken line to a room.
+
+    Shared by ``say`` (``target=None``) and ``to`` (``target=<character>``).
+    Each observer gets the sight/voice-attributed, hearing-gated line plus the
+    structured speech payload (for those who can hear). Observers with no
+    channel at all — deaf *and* blind — are skipped entirely; the speaker is
+    expected to have already received their own copy.
+    """
+    flavor = visible_voice_flavor(speaker)
+    for observer in location.contents:
+        if observer is speaker or not hasattr(observer, "msg"):
+            continue
+        if not can_hear(observer) and not can_see(observer):
+            continue  # no channel — suppressed
+        text = render_speech_line(
+            speaker, observer, speech, target=target, flavor=flavor
+        )
+        payload = speech_payload(
+            observer, speaker, speech, addressed=(observer is target)
+        )
+        observer.msg(text=text, type=speech_type, from_obj=speaker, **payload)

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -1,0 +1,159 @@
+"""
+Tests for the unified speech backbone payload and the bartender's reaction.
+
+The backbone (world.speech) attaches a structured ``speech``/``addressed``
+payload to every *hearing* listener's msg, regardless of which verb (say / to /
+pose) carried the words. The bartender reacts off that single shape. These
+tests pin the payload routing and the bartender's branch selection.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from evennia.utils.test_resources import BaseEvenniaTest
+
+import world.speech as speech
+import typeclasses.bar as barmod
+
+
+class _Obs:
+    """A minimal listener that records msg kwargs."""
+
+    def __init__(self, name):
+        self.name = name
+        self.calls = []
+
+    def msg(self, *args, **kwargs):
+        self.calls.append(kwargs)
+
+    def get_display_name(self, looker=None, **kw):
+        return self.name
+
+    last = property(lambda self: self.calls[-1] if self.calls else {})
+
+
+def _room(contents):
+    r = MagicMock()
+    r.contents = contents
+    return r
+
+
+class TestSpeechPayloadRouting(BaseEvenniaTest):
+    """broadcast_speech attaches speech/addressed only to hearing listeners."""
+
+    def setUp(self):
+        super().setUp()
+        self.speaker = _Obs("a lean man")
+        self.target = _Obs("a tall woman")
+        self.bystander = _Obs("a short man")
+        self.room = _room([self.speaker, self.target, self.bystander])
+
+    def _patch_perception(self, hear=True, see=True):
+        # Backbone reads can_hear/can_see + attribution; stub them flat.
+        return [
+            patch.object(speech, "can_hear", lambda o: hear),
+            patch.object(speech, "can_see", lambda o: see),
+            patch.object(speech, "resolve_speaker_attribution",
+                         lambda s, o: "a lean man"),
+            patch.object(speech, "visible_voice_flavor", lambda s: None),
+        ]
+
+    def _run(self, **kw):
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            for p in self._patch_perception(**kw.pop("perc", {})):
+                stack.enter_context(p)
+            speech.broadcast_speech(self.speaker, "hi", self.room, **kw)
+
+    def test_say_not_addressed(self):
+        self._run()
+        self.assertEqual(self.target.last.get("speech"), "hi")
+        self.assertFalse(self.target.last.get("addressed"))
+        self.assertFalse(self.bystander.last.get("addressed"))
+
+    def test_to_marks_only_target_addressed(self):
+        self._run(target=self.target)
+        self.assertTrue(self.target.last.get("addressed"))
+        self.assertEqual(self.bystander.last.get("speech"), "hi")
+        self.assertFalse(self.bystander.last.get("addressed"))
+
+    def test_deaf_listener_gets_no_words(self):
+        self._run(perc={"hear": False, "see": True})
+        # Deaf-but-sighted still receives a line, but no speech payload.
+        self.assertIsNone(self.target.last.get("speech"))
+        self.assertNotIn("addressed", self.target.last)
+
+    def test_no_channel_skipped(self):
+        self._run(perc={"hear": False, "see": False})
+        self.assertEqual(self.target.calls, [])
+
+
+class TestPosePayload(BaseEvenniaTest):
+    """A pose's embedded quote rides the same rails; refs count as addressed."""
+
+    def test_pose_speech_payload_addressed(self):
+        from world.emote import SpeechToken, CharRefToken, render_dot_pose
+
+        actor = _Obs("a lean man")
+        target = _Obs("a tall woman")
+        room = _room([actor, target])
+        tokens = [CharRefToken(target, "woman"),
+                  SpeechToken("Let me get some rotgut.", actor)]
+
+        with patch.object(speech, "can_hear", lambda o: True):
+            with patch("world.emote.render_for_observer", lambda t, a, o: "rendered"):
+                render_dot_pose(tokens, actor, room)
+
+        self.assertEqual(target.last.get("speech"), "Let me get some rotgut.")
+        self.assertTrue(target.last.get("addressed"))
+
+
+class TestBartenderReaction(BaseEvenniaTest):
+    """at_msg_receive routes the unified payload to ack / order / nothing."""
+
+    def _bartender(self):
+        b = MagicMock()
+        b._is_gratitude = barmod.Bartender._is_gratitude  # real staticmethod
+        b._acknowledge = MagicMock()
+        return b
+
+    def _call(self, b, speaker, **payload):
+        return barmod.Bartender.at_msg_receive(
+            b, text=None, from_obj=speaker, **payload
+        )
+
+    def test_addressed_order_fulfils(self):
+        b = self._bartender()
+        speaker = object()
+        with patch.object(barmod, "delay") as mock_delay:
+            self._call(b, speaker, speech="a rotgut please", addressed=True)
+        mock_delay.assert_called_once()
+        b._acknowledge.assert_not_called()
+
+    def test_unaddressed_speech_does_nothing(self):
+        b = self._bartender()
+        with patch.object(barmod, "delay") as mock_delay:
+            self._call(b, object(), speech="a rotgut please", addressed=False)
+        mock_delay.assert_not_called()
+        b._acknowledge.assert_not_called()
+
+    def test_gratitude_acks_even_if_addressed(self):
+        b = self._bartender()
+        with patch.object(barmod, "delay") as mock_delay:
+            self._call(b, object(), speech="much obliged", addressed=True)
+        mock_delay.assert_not_called()
+        b._acknowledge.assert_called_once()
+
+    def test_no_speech_payload_ignored(self):
+        b = self._bartender()
+        with patch.object(barmod, "delay") as mock_delay:
+            self._call(b, object(), speech=None, addressed=True)
+        mock_delay.assert_not_called()
+        b._acknowledge.assert_not_called()
+
+    def test_own_speech_ignored(self):
+        b = self._bartender()
+        with patch.object(barmod, "delay") as mock_delay:
+            # from_obj is the bartender itself
+            self._call(b, b, speech="thanks", addressed=True)
+        mock_delay.assert_not_called()
+        b._acknowledge.assert_not_called()


### PR DESCRIPTION
Add world/speech.py as the single channel for spoken words:
- render_speech_line / broadcast_speech: shared per-observer say/to
  rendering (sight-vs-voice attribution, hearing-gated content, voice
  flavour). CmdSay/CmdTo are now thin wrappers over it instead of two
  near-identical loops.
- speech_payload: a uniform {speech, addressed} payload attached to every
  hearing listener, so reaction code reads one shape regardless of which
  verb carried the words. Deaf listeners get no words.

world/emote.py: render_dot_pose/render_emote attach the same payload, so
a pose's embedded quote rides the same rails; a referenced character counts
as addressed (`.flick a nod at man, "..."` now reaches an NPC like `to`).

typeclasses/bar.py: at_msg_receive reacts off speech/addressed only —
gratitude from any heard speech, orders from speech addressed to it. Drops
the to_speech/to_speaker special-case and the rendered-text scan. ACK_EMOTES
end in periods.

Adds world/tests/test_bar.py (payload routing, pose payload, bartender
branch selection). 280-test say/to/pose/voice/bar sweep green.

Closes #656

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
