### PR TITLE
Bars: let staff (Builder+) work and manage any bar

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -148,9 +148,29 @@ class BarCounter(Item):
             "scarred by years of set-down glasses."
         )
 
+    @staticmethod
+    def _is_staff(char):
+        """True if `char` is game staff (Builder permission or higher).
+
+        Uses the ``perm()`` lock function so the check honours the permission
+        hierarchy and the controlling account's permissions, matching how the
+        rest of the codebase detects staff (see :mod:`world.emote`).
+        """
+        try:
+            return bool(char.locks.check_lockstring(char, "perm(Builder)"))
+        except Exception:
+            return False
+
     def is_bartender(self, char):
-        """True if `char` may work this bar (owner, staff, or — v1 — anyone if
-        no ownership is configured yet)."""
+        """True if `char` may work and manage this bar.
+
+        Game staff (Builder+) can always work and manage any bar — they keep the
+        place running regardless of who owns it. Otherwise: the owner, anyone on
+        the staff list, or — while no ownership is configured (v1) — anyone
+        present.
+        """
+        if self._is_staff(char):
+            return True
         owner = self.db.owner
         staff = self.db.staff or []
         if owner is None and not staff:

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -107,6 +107,49 @@ class TestPosePayload(BaseEvenniaTest):
         self.assertTrue(target.last.get("addressed"))
 
 
+class TestBarStaffAccess(BaseEvenniaTest):
+    """Staff (Builder+) can work/manage any bar; ownership still gates others."""
+
+    def _bar(self, owner=None, staff=None):
+        b = MagicMock()
+        b.db.owner = owner
+        b.db.staff = staff or []
+        b._is_staff = barmod.BarCounter._is_staff  # real staticmethod
+        return b
+
+    def _char(self, is_staff=False):
+        c = MagicMock()
+        c.locks.check_lockstring = lambda obj, lockstr: is_staff
+        return c
+
+    def _is_bartender(self, bar, char):
+        return barmod.BarCounter.is_bartender(bar, char)
+
+    def test_staff_can_work_owned_bar(self):
+        bar = self._bar(owner=object())  # owned by someone else
+        self.assertTrue(self._is_bartender(bar, self._char(is_staff=True)))
+
+    def test_non_staff_blocked_on_owned_bar(self):
+        bar = self._bar(owner=object())
+        self.assertFalse(self._is_bartender(bar, self._char(is_staff=False)))
+
+    def test_owner_allowed(self):
+        owner = self._char(is_staff=False)
+        bar = self._bar(owner=owner)
+        self.assertTrue(self._is_bartender(bar, owner))
+
+    def test_unowned_allows_anyone(self):
+        bar = self._bar()
+        self.assertTrue(self._is_bartender(bar, self._char(is_staff=False)))
+
+    def test_staff_check_failure_is_safe(self):
+        bar = self._bar(owner=object())
+        char = MagicMock()
+        char.locks.check_lockstring.side_effect = RuntimeError("boom")
+        # A lock-check hiccup must not crash; it just denies non-owners.
+        self.assertFalse(self._is_bartender(bar, char))
+
+
 class TestBartenderReaction(BaseEvenniaTest):
     """at_msg_receive routes the unified payload to ack / order / nothing."""
 


### PR DESCRIPTION
is_bartender now short-circuits True for game staff via a perm(Builder)
lock check (BarCounter._is_staff, matching world.emote's staff detection),
so any builder/staff can `use <bar>` and manage it regardless of ownership.
Ownership still gates non-staff. Lock-check failures fail safe (deny).

Adds TestBarStaffAccess to world/tests/test_bar.py.

Closes #658

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
