### PR TITLE
Bars: drop baked-in article from drink keys (fixes 'A a mug of rotgut')

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -7,6 +7,7 @@ Implements the universal consumption system with inject, apply, bandage, etc.
 
 from evennia import Command
 from commands._identity_targeting import resolve_character_target
+from world.grammar import with_article
 from world.identity_utils import msg_room_identity
 from world.consumables import supports_delivery
 from world.medical.utils import (
@@ -875,16 +876,16 @@ class CmdDrink(ConsumptionCommand):
         if is_self:
             msg_room_identity(
                 location=caller.location,
-                template=f"{{actor}} drinks {item.key}.",
+                template=f"{{actor}} drinks {with_article(item.key)}.",
                 char_refs={"actor": caller},
                 exclude=[caller],
             )
         else:
-            caller.msg(f"You help {target.get_display_name(caller)} drink {item.get_display_name(caller)}.")
-            target.msg(f"{caller.get_display_name(target)} helps you drink {item.get_display_name(target)}.")
+            caller.msg(f"You help {target.get_display_name(caller)} drink {with_article(item.get_display_name(caller))}.")
+            target.msg(f"{caller.get_display_name(target)} helps you drink {with_article(item.get_display_name(target))}.")
             msg_room_identity(
                 location=caller.location,
-                template=f"{{actor}} helps {{target}} drink {item.key}.",
+                template=f"{{actor}} helps {{target}} drink {with_article(item.key)}.",
                 char_refs={"actor": caller, "target": target},
                 exclude=[caller, target],
             )
@@ -901,7 +902,7 @@ class CmdDrink(ConsumptionCommand):
             # mouthful), then pharmacology, then the consumable lifecycle.
             if is_self:
                 uses_left = item.db.uses_left
-                name = item.get_display_name(caller)
+                name = with_article(item.get_display_name(caller))
                 if uses_left is None or int(uses_left or 0) <= 1:
                     caller.msg(f"You finish off {name}.")
                 else:

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -22,6 +22,7 @@ from evennia.utils import delay
 
 from typeclasses.items import Item
 from typeclasses.characters import Character
+from world.grammar import capitalize_first, with_article
 from world.bar import (
     make_drink,
     make_drink_from_recipe,
@@ -58,7 +59,9 @@ class CmdBarMenu(Command):
             return
         lines = [f"|w{name} — menu|n"]
         for r in menu:
-            lines.append(f"  {r['name']}  |y({r.get('price', 0)})|n")
+            lines.append(
+                f"  {capitalize_first(r['name'])}  |y({r.get('price', 0)})|n"
+            )
         self.caller.msg("\n".join(lines))
 
 
@@ -93,7 +96,7 @@ class CmdBarUse(Command):
         effects = mix_effects(ingredients)
         names = ", ".join(i.key for i in ingredients)
         drink = make_drink(
-            name="a mixed drink",
+            name="mixed drink",
             desc=f"a freshly-mixed drink, thrown together from {names}",
             effects=effects,
             sips=3,
@@ -103,7 +106,8 @@ class CmdBarUse(Command):
         for i in ingredients:
             i.delete()
         caller.location.msg_contents(
-            f"{caller.key} mixes {names} into {drink.key} on {bar.key}."
+            f"{caller.key} mixes {names} into {with_article(drink.key)} "
+            f"on {bar.key}."
         )
 
 
@@ -184,7 +188,9 @@ class BarCounter(Item):
         base = super().return_appearance(looker, **kwargs)
         drinks = [o for o in self.contents if getattr(o.db, "is_drink", False)]
         if drinks:
-            served = ", ".join(d.get_display_name(looker) for d in drinks)
+            served = ", ".join(
+                with_article(d.get_display_name(looker)) for d in drinks
+            )
             base += f"\n\nOn the bar: {served}."
         return base
 
@@ -311,6 +317,6 @@ class Bartender(Character):
         craft = recipe.get("craft", "fixes the drink")
         where = bar.key if bar else "the bar"
         self.execute_cmd(
-            f"emote {craft}, sets {drink.key} on {where}, and sweeps the "
-            f"payment off the slab with a practiced hand."
+            f"emote {craft}, sets {with_article(drink.key)} on {where}, and "
+            f"sweeps the payment off the slab with a practiced hand."
         )

--- a/world/bar.py
+++ b/world/bar.py
@@ -59,9 +59,16 @@ def make_drink(*, name, desc, effects, sips=3, taste="", location=None, keywords
     The drink carries ``db.drink_effects`` (a ``{substance_id: doses}`` map
     applied per sip), ``db.uses_left`` (the number of sips), and the `drink`
     delivery tag so the existing consumption command accepts it. Aliases are
-    derived from the name (+ recipe keywords) so the article-prefixed display
-    name stays targetable.
+    derived from the name (+ recipe keywords) so the bare display name stays
+    targetable.
+
+    The item *key* carries no leading article (house convention — display sites
+    prepend "a"/"an"/"the"), so a stray "a " in a recipe name is stripped here
+    to avoid the double-article ("A a mug of rotgut...") render.
     """
+    from world.search import strip_leading_article
+
+    name = strip_leading_article((name or "").strip())
     drink = create_object(DRINK_TYPECLASS, key=name, location=location)
     drink.db.desc = desc
     drink.db.uses_left = max(1, int(sips))
@@ -112,7 +119,7 @@ def match_recipe(order_text, menu):
 # ---------------------------------------------------------------------------
 HUB_AND_HOWL_MENU = [
     {
-        "name": "a mug of rotgut",
+        "name": "mug of rotgut",
         "order_keywords": ("rotgut", "grain", "spirit", "cheap"),
         "price": 8,
         "sips": 3,
@@ -122,7 +129,7 @@ HUB_AND_HOWL_MENU = [
         "craft": "reaches under the slab for an unlabelled jug and sloshes cloudy spirit into a dented tin mug",
     },
     {
-        "name": "a glass of reactor wash",
+        "name": "glass of reactor wash",
         "order_keywords": ("reactor", "wash", "strong", "stiff"),
         "price": 15,
         "sips": 3,
@@ -132,7 +139,7 @@ HUB_AND_HOWL_MENU = [
         "craft": "pulls a smudged glass, free-pours two fingers of something amber and oily, and slides it over",
     },
     {
-        "name": "a cup of channel fog",
+        "name": "cup of channel fog",
         "order_keywords": ("fog", "channel", "milky", "smooth"),
         "price": 20,
         "sips": 4,
@@ -142,7 +149,7 @@ HUB_AND_HOWL_MENU = [
         "craft": "measures a milky grey-green liquor into a chipped ceramic cup with the care of someone who knows what's in it",
     },
     {
-        "name": "a mug of black recyc",
+        "name": "mug of black recyc",
         "order_keywords": ("recyc", "black", "coffee", "caf", "sober"),
         "price": 5,
         "sips": 4,

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -37,6 +37,37 @@ def _room(contents):
     return r
 
 
+class TestDrinkNaming(BaseEvenniaTest):
+    """Drink keys carry no leading article (display sites add it)."""
+
+    def test_make_drink_strips_leading_article(self):
+        from world.bar import make_drink
+
+        d = make_drink(
+            name="a mug of rotgut", desc="x", effects={}, location=self.room1
+        )
+        self.assertEqual(d.key, "mug of rotgut")
+
+    def test_menu_names_are_article_free(self):
+        from world.bar import HUB_AND_HOWL_MENU
+
+        for recipe in HUB_AND_HOWL_MENU:
+            self.assertFalse(
+                recipe["name"].lower().startswith(("a ", "an ", "the ")),
+                f"menu name {recipe['name']!r} still carries an article",
+            )
+
+    def test_aliases_still_targetable(self):
+        from world.bar import make_drink
+
+        d = make_drink(
+            name="a mug of rotgut", desc="x", effects={}, location=self.room1
+        )
+        aliases = d.aliases.all()
+        self.assertIn("rotgut", aliases)
+        self.assertIn("mug", aliases)
+
+
 class TestSpeechPayloadRouting(BaseEvenniaTest):
     """broadcast_speech attaches speech/addressed only to hearing listeners."""
 


### PR DESCRIPTION
Item keys are article-free by house convention (display sites prepend
A/a/the); drinks broke it by keying 'a mug of rotgut', so the hand/room
display doubled the article.

- make_drink strips a leading article from the name before keying the item
  (defensive against stale menu data too); HUB_AND_HOWL_MENU names are now
  article-free; the improvised mix is keyed 'mixed drink'.
- Inline drink-name sites re-add the article via with_article: the drink /
  help-drink / sip-finish lines, the bartender craft + mix emotes, and the
  'On the bar:' listing. Menu shows capitalized bare names.

Adds TestDrinkNaming to world/tests/test_bar.py.

Closes #660

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
