### PR TITLE
Bars: tighten black recyc craft emote (drop trailing comma-aside)

### DIFF
--- a/world/bar.py
+++ b/world/bar.py
@@ -156,6 +156,6 @@ HUB_AND_HOWL_MENU = [
         "effects": {},
         "desc": "a scalding mug of reclaimed caf, black as the inside of a vent and twice as bitter",
         "taste": "Bitter, scalding, and faintly of the recycler — but it's hot, and it's not alcohol.",
-        "craft": "draws a scalding measure from the battered caf urn at the end of the bar, no ceremony to it",
+        "craft": "draws a scalding measure straight from the battered caf urn",
     },
 ]


### PR DESCRIPTION
The craft ended "...at the end of the bar, no ceremony to it", which
comma-spliced into the template's set-down and clashed tonally with its
"with a practiced hand". Reduce to a single clean phrase so the assembled
serve line reads as one tidy three-beat.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
