### PR TITLE
Bars: zero out drink prices (for now); free serve skips payment emote

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -311,12 +311,17 @@ class Bartender(Character):
             if bar:
                 bar.db.register = int(bar.db.register or 0) + price
         # The whole transaction is one wordless gesture — make it, set it down,
-        # take the cash. Routed through `emote` so the bartender renders by
-        # per-observer identity (a stranger sees "a lean man", not "Sully"),
-        # and no price is spoken: the swept payment says it.
+        # and (when there's a tab) take the cash. Routed through `emote` so the
+        # bartender renders by per-observer identity (a stranger sees "a lean
+        # man", not "Sully"), and no price is spoken: the swept payment says it.
+        # A free drink just gets slid over — no phantom payment.
         craft = recipe.get("craft", "fixes the drink")
         where = bar.key if bar else "the bar"
+        closer = (
+            "sweeps the payment off the slab with a practiced hand"
+            if price else "slides it over"
+        )
         self.execute_cmd(
-            f"emote {craft}, sets {with_article(drink.key)} on {where}, and "
-            f"sweeps the payment off the slab with a practiced hand."
+            f"emote {craft}, sets {with_article(drink.key)} on {where}, "
+            f"and {closer}."
         )

--- a/world/bar.py
+++ b/world/bar.py
@@ -121,7 +121,7 @@ HUB_AND_HOWL_MENU = [
     {
         "name": "mug of rotgut",
         "order_keywords": ("rotgut", "grain", "spirit", "cheap"),
-        "price": 8,
+        "price": 0,
         "sips": 3,
         "effects": {"alcohol": 1},
         "desc": "a dented tin mug of cloudy grain spirit, the colony's cheapest way to lose a shift",
@@ -131,7 +131,7 @@ HUB_AND_HOWL_MENU = [
     {
         "name": "glass of reactor wash",
         "order_keywords": ("reactor", "wash", "strong", "stiff"),
-        "price": 15,
+        "price": 0,
         "sips": 3,
         "effects": {"alcohol": 2},
         "desc": "a smudged glass of something amber and oily that catches the light wrong",
@@ -141,7 +141,7 @@ HUB_AND_HOWL_MENU = [
     {
         "name": "cup of channel fog",
         "order_keywords": ("fog", "channel", "milky", "smooth"),
-        "price": 20,
+        "price": 0,
         "sips": 4,
         "effects": {"alcohol": 1, "opium": 1},
         "desc": "a chipped ceramic cup of a milky, grey-green liquor that smells faintly of brine and poppy",
@@ -151,7 +151,7 @@ HUB_AND_HOWL_MENU = [
     {
         "name": "mug of black recyc",
         "order_keywords": ("recyc", "black", "coffee", "caf", "sober"),
-        "price": 5,
+        "price": 0,
         "sips": 4,
         "effects": {},
         "desc": "a scalding mug of reclaimed caf, black as the inside of a vent and twice as bitter",


### PR DESCRIPTION
All HUB_AND_HOWL_MENU prices set to 0 for now. The bartender's serve emote
closer is now conditional on price: a free drink ends "...and slides it
over" instead of the phantom "sweeps the payment off the slab". Re-pricing
later restores the payment line automatically.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
