### PR TITLE
Bars: join the 'On the bar:' listing with iter_to_str (serial 'and')

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -204,6 +204,8 @@ class BarCounter(Item):
         # two mugs of rotgut") via the standard get_numbered_name. No chrome.
         from collections import defaultdict
 
+        from evennia.utils.utils import iter_to_str
+
         base = super().return_appearance(looker, **kwargs)
         groups = defaultdict(list)
         for o in self.contents:
@@ -215,7 +217,7 @@ class BarCounter(Item):
                 count = len(objs)
                 singular, plural = objs[0].get_numbered_name(count, looker)
                 parts.append(singular if count == 1 else plural)
-            base += f"\n\nOn the bar: {', '.join(parts)}."
+            base += f"\n\nOn the bar: {iter_to_str(parts)}."
         return base
 
 


### PR DESCRIPTION
Use evennia's iter_to_str (as CmdClothing does) so the surface listing reads
"a glass of reactor wash, two mugs of rotgut, and three mugs of black recyc".

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
