### PR TITLE
Bars: free snacks (spec §10)

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -766,13 +766,50 @@ class CmdEat(ConsumptionCommand):
     aliases = ["consume", "swallow"]
     help_category = "Medical"
     
+    def _eat_bar_snack(self, args):
+        """Free bar snacks (§10): ``eat <snack> [from <bar>]`` nibbles a no-cost
+        snack off a bar's snack list in the room. Pure ambiance — bottomless,
+        nothing enters inventory. Returns True if a snack was served."""
+        from world.bar import find_room_bar_snack
+        from world.substances import apply_substance
+
+        caller = self.caller
+        match = find_room_bar_snack(getattr(caller, "location", None), args or "")
+        if not match:
+            return False
+        bar, snack = match
+        name = snack["name"]
+        caller.msg(
+            f"You help yourself to {with_article(name)} from "
+            f"{bar.get_display_name(caller)}."
+        )
+        msg_room_identity(
+            location=caller.location,
+            template=f"{{actor}} helps themselves to {with_article(name)} "
+                     f"from {bar.key}.",
+            char_refs={"actor": caller},
+            exclude=[caller],
+        )
+        taste = snack.get("taste")
+        if taste:
+            caller.msg(taste)
+        for sid, doses in (snack.get("effects") or {}).items():
+            try:
+                apply_substance(caller, sid, doses=max(1, int(doses)))
+            except (TypeError, ValueError):
+                continue
+        return True
+
     def func(self):
         """Execute the eat command."""
         caller = self.caller
-        
-        # Parse arguments  
+
+        # Parse arguments
         result = self.get_item_and_target(self.args, require_medical=False)
         if result["errors"]:
+            # Not holding a matching item — maybe it's a free bar snack.
+            if self._eat_bar_snack(self.args):
+                return
             caller.msg(result["errors"][0])
             return
             

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -25,6 +25,7 @@ from typeclasses.characters import Character
 from world.grammar import capitalize_first, with_article
 from world.shop.utils import format_currency
 from world.bar import (
+    DEFAULT_BAR_SNACKS,
     make_drink,
     make_drink_from_recipe,
     match_recipe,
@@ -144,6 +145,7 @@ class BarCounter(Item):
     def at_object_creation(self):
         super().at_object_creation()
         self.db.menu = []
+        self.db.snacks = list(DEFAULT_BAR_SNACKS)  # free bottomless nibbles (§10)
         self.db.register = 0
         self.db.owner = None
         self.db.staff = []
@@ -218,6 +220,12 @@ class BarCounter(Item):
                 singular, plural = objs[0].get_numbered_name(count, looker)
                 parts.append(singular if count == 1 else plural)
             base += f"\n\nOn the bar: {iter_to_str(parts)}."
+        # Free bottomless snacks (§10) — pure ambiance, advertised so patrons
+        # know they can pick at them (`eat <snack> from <bar>`).
+        snacks = self.db.snacks or []
+        if snacks:
+            names = iter_to_str([s["name"] for s in snacks])
+            base += f"\n\nFree to pick at: {names}."
         return base
 
 

--- a/world/bar.py
+++ b/world/bar.py
@@ -113,6 +113,67 @@ def match_recipe(order_text, menu):
 
 
 # ---------------------------------------------------------------------------
+# Free snacks (BARS_AND_RECIPES_SPEC §10) — bottomless colony ambiance, no
+# cost, nothing enters inventory. A bar's db.snacks is a fixed list; patrons
+# `eat <snack> [from <bar>]` to nibble in place. Original content.
+# ---------------------------------------------------------------------------
+DEFAULT_BAR_SNACKS = [
+    {
+        "name": "brine pods",
+        "order_keywords": ("brine", "pods", "pod"),
+        "desc": "a chipped bowl of pale, rubbery brine pods, set out free for the taking",
+        "taste": "Salt-slick and faintly chemical, they squeak against your teeth and leave a briny sting at the back of the throat.",
+    },
+    {
+        "name": "synth-jerky",
+        "order_keywords": ("jerky", "synth-jerky", "synth", "meat"),
+        "desc": "a rack of dark, twisted synth-jerky strips, free for the taking",
+        "taste": "Tough, smoky, and aggressively over-salted — more chew than flavour, which is the point: it keeps you drinking.",
+    },
+    {
+        "name": "ration crackers",
+        "order_keywords": ("crackers", "cracker", "ration", "rations"),
+        "desc": "an open tin of dry ration crackers, free for the taking",
+        "taste": "Dry, bland, and faintly of cardboard — they soak up whatever you've been pouring down your neck.",
+    },
+]
+
+
+def match_snack(text, snacks):
+    """Find the first snack whose keywords appear in `text`. Returns dict/None."""
+    if not text or not snacks:
+        return None
+    low = text.lower()
+    for snack in snacks:
+        for kw in snack.get("order_keywords", (snack.get("name", ""),)):
+            if kw and kw.lower() in low:
+                return snack
+    return None
+
+
+def find_room_bar_snack(location, text):
+    """Resolve an ``eat <snack> [from <bar>]`` request against bars in a room.
+
+    Strips a trailing ``from <bar>`` disambiguator, then matches the remaining
+    words against each bar's ``db.snacks``. Bars are duck-typed (an object with
+    an ``is_bartender`` method) to avoid importing the typeclass here. Returns
+    ``(bar, snack_dict)`` or ``None``.
+    """
+    if not location or not text:
+        return None
+    snack_text = re.split(r"\bfrom\b", text.strip(), maxsplit=1)[0].strip()
+    if not snack_text:
+        return None
+    for obj in getattr(location, "contents", ()):
+        if not callable(getattr(obj, "is_bartender", None)):
+            continue
+        snack = match_snack(snack_text, obj.db.snacks or [])
+        if snack:
+            return obj, snack
+    return None
+
+
+# ---------------------------------------------------------------------------
 # A starter menu for the Hub & Howl — scuzzy colony drinks. Original content.
 # Effects use real substance ids (see world/substances/registry.py): `alcohol`
 # (sedation cap 4), `opium` (strong). Flavour-only drinks carry no effects.

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -68,6 +68,45 @@ class TestDrinkNaming(BaseEvenniaTest):
         self.assertIn("mug", aliases)
 
 
+class TestSnacks(BaseEvenniaTest):
+    """Free bar snacks (§10): keyword match + room resolution."""
+
+    def test_match_snack(self):
+        from world.bar import match_snack, DEFAULT_BAR_SNACKS
+
+        self.assertEqual(
+            match_snack("grab some brine pods", DEFAULT_BAR_SNACKS)["name"],
+            "brine pods",
+        )
+        self.assertEqual(
+            match_snack("jerky", DEFAULT_BAR_SNACKS)["name"], "synth-jerky"
+        )
+        self.assertIsNone(match_snack("a wrench", DEFAULT_BAR_SNACKS))
+        self.assertIsNone(match_snack("", DEFAULT_BAR_SNACKS))
+
+    def test_find_room_bar_snack_strips_from_clause(self):
+        from world.bar import find_room_bar_snack, DEFAULT_BAR_SNACKS
+
+        bar = MagicMock()
+        bar.is_bartender = lambda c: True  # duck-typed as a bar
+        bar.db.snacks = DEFAULT_BAR_SNACKS
+        room = MagicMock()
+        room.contents = [bar]
+
+        found = find_room_bar_snack(room, "crackers from the hull-slab bar")
+        self.assertIsNotNone(found)
+        self.assertIs(found[0], bar)
+        self.assertEqual(found[1]["name"], "ration crackers")
+
+    def test_find_room_bar_snack_no_bar(self):
+        from world.bar import find_room_bar_snack, DEFAULT_BAR_SNACKS
+
+        not_a_bar = MagicMock(spec=[])  # no is_bartender
+        room = MagicMock()
+        room.contents = [not_a_bar]
+        self.assertIsNone(find_room_bar_snack(room, "brine pods"))
+
+
 class TestSpeechPayloadRouting(BaseEvenniaTest):
     """broadcast_speech attaches speech/addressed only to hearing listeners."""
 


### PR DESCRIPTION
Bottomless colony ambiance — `eat <snack> [from <bar>]` nibbles a no-cost
snack off a bar's db.snacks list; nothing enters inventory.

- world/bar.py: DEFAULT_BAR_SNACKS (brine pods, synth-jerky, ration
  crackers), match_snack, find_room_bar_snack (duck-types bars, strips a
  trailing "from <bar>").
- BarCounter seeds db.snacks and advertises them on look ("Free to pick
  at: ...").
- CmdEat falls back to a bar snack when you're not holding a matching item,
  so there's no second `eat` command to collide with the global one.

Adds TestSnacks to world/tests/test_bar.py.

Closes #654

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
