### PR TITLE
Bars/crafting: ingredient model + cocktail recognition (foundation)

### DIFF
--- a/world/bar.py
+++ b/world/bar.py
@@ -139,6 +139,211 @@ DEFAULT_BAR_SNACKS = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# Ingredients & mixing (BARS_AND_RECIPES_SPEC §3/§4)
+#
+# An ingredient is an ordinary item carrying a substance-contribution profile —
+# DOSES of real registered substances (world/substances/registry.py), summed
+# additively at mix time and capped. A garnish is a flavour-only ingredient
+# (empty contributions). v1 has no supplier economy, so this catalog seeds a
+# few spawnable ingredients to make crafting exercisable now.
+# ---------------------------------------------------------------------------
+
+#: Per-substance dose ceiling on a single mix — the light safety-net cap
+#: (decision #12) so stacking one ingredient can't overshoot. Tuned in play.
+MIX_EFFECT_CAP = 4
+
+#: Cocktail component roles (the identity layer — orthogonal to the substance
+#: contributions that drive effects). A spirit also carries a `spirit` type.
+ROLE_SPIRIT = "spirit"
+
+#: Each ingredient: substance `contributions` (DOSES → effects), a cocktail
+#: `role`, an optional `spirit` type (role == spirit only), and `flavour` prose.
+#: Spirits are alcohol 2, modifiers alcohol 1, garnishes/mixers flavour-only.
+#: Earth-import classics sit beside scuzzy colony spirits; loose role-matching
+#: (below) means a colony spirit makes a grimy spin of a classic.
+INGREDIENT_CATALOG = {
+    # ---- Earth-import spirits ------------------------------------------
+    "gin": {"name": "bottle of gin", "role": ROLE_SPIRIT, "spirit": "gin",
+            "contributions": {"alcohol": 2}, "flavour": "juniper-sharp and botanical",
+            "desc": "an Earth-import bottle of gin, label half scoured away", "keywords": ("gin",)},
+    "whiskey": {"name": "bottle of whiskey", "role": ROLE_SPIRIT, "spirit": "whiskey",
+            "contributions": {"alcohol": 2}, "flavour": "oaky and caramel-warm",
+            "desc": "a squat Earth-import bottle of amber whiskey", "keywords": ("whiskey", "whisky")},
+    "rum": {"name": "bottle of white rum", "role": ROLE_SPIRIT, "spirit": "rum",
+            "contributions": {"alcohol": 2}, "flavour": "light and sugarcane-sweet",
+            "desc": "a clear Earth-import bottle of white rum", "keywords": ("rum",)},
+    "mezcal": {"name": "bottle of mezcal", "role": ROLE_SPIRIT, "spirit": "mezcal",
+            "contributions": {"alcohol": 2}, "flavour": "smoky roasted agave",
+            "desc": "a hand-labelled Earth-import bottle of mezcal", "keywords": ("mezcal",)},
+    "tequila": {"name": "bottle of tequila", "role": ROLE_SPIRIT, "spirit": "tequila",
+            "contributions": {"alcohol": 2}, "flavour": "bright and peppery agave",
+            "desc": "an Earth-import bottle of silver tequila", "keywords": ("tequila",)},
+    "vodka": {"name": "bottle of vodka", "role": ROLE_SPIRIT, "spirit": "vodka",
+            "contributions": {"alcohol": 2}, "flavour": "clean and near-flavourless",
+            "desc": "a frosted Earth-import bottle of vodka", "keywords": ("vodka",)},
+    # ---- Scuzzy colony spirits (grimy spins of the classics) -----------
+    "grain_mash": {"name": "jar of grain mash", "role": ROLE_SPIRIT, "spirit": "grain mash",
+            "contributions": {"alcohol": 1}, "flavour": "raw, paint-stripping grain spirit",
+            "desc": "a sealed jar of cloudy fermented grain mash — the colony's base spirit", "keywords": ("grain", "mash")},
+    "reactor_cut": {"name": "flask of reactor cut", "role": ROLE_SPIRIT, "spirit": "reactor cut",
+            "contributions": {"alcohol": 2}, "flavour": "harsh chemical heat",
+            "desc": "a scratched flask of high-proof reactor cut, distilled too close to the coolant lines", "keywords": ("reactor", "cut", "proof")},
+    # ---- Modifiers (alcohol 1) -----------------------------------------
+    "bitter_aperitivo": {"name": "bottle of bitter aperitivo", "role": "bitter_aperitivo",
+            "contributions": {"alcohol": 1}, "flavour": "bitter blood-orange",
+            "desc": "a vivid red bottle of bitter aperitivo", "keywords": ("aperitivo", "bitter", "red")},
+    "sweet_vermouth": {"name": "bottle of sweet vermouth", "role": "sweet_vermouth",
+            "contributions": {"alcohol": 1}, "flavour": "herbal and sweet",
+            "desc": "a dark bottle of sweet red vermouth", "keywords": ("sweet", "vermouth")},
+    "dry_vermouth": {"name": "bottle of dry vermouth", "role": "dry_vermouth",
+            "contributions": {"alcohol": 1}, "flavour": "dry and grassy",
+            "desc": "a pale bottle of dry vermouth", "keywords": ("dry", "vermouth")},
+    "maraschino": {"name": "bottle of maraschino liqueur", "role": "maraschino",
+            "contributions": {"alcohol": 1}, "flavour": "nutty cherry",
+            "desc": "a square bottle of clear maraschino liqueur", "keywords": ("maraschino", "cherry")},
+    "herbal_liqueur": {"name": "bottle of green herbal liqueur", "role": "herbal_liqueur",
+            "contributions": {"alcohol": 1}, "flavour": "green, alpine, and herbal",
+            "desc": "a heavy bottle of green herbal liqueur, faintly medicinal", "keywords": ("herbal", "green", "chartreuse")},
+    "orange_liqueur": {"name": "bottle of orange liqueur", "role": "orange_liqueur",
+            "contributions": {"alcohol": 1}, "flavour": "sweet orange peel",
+            "desc": "a clear bottle of orange liqueur", "keywords": ("orange", "triple", "sec", "curacao")},
+    # ---- Non-alcoholic (flavour / structure only) ----------------------
+    "lime": {"name": "lime", "role": "citrus", "contributions": {},
+            "flavour": "sharp, sour citrus", "desc": "a precious Earth-import lime", "keywords": ("lime",)},
+    "lemon": {"name": "lemon", "role": "citrus", "contributions": {},
+            "flavour": "bright, sour citrus", "desc": "a precious Earth-import lemon", "keywords": ("lemon",)},
+    "sugar_syrup": {"name": "flask of sugar syrup", "role": "sweetener", "contributions": {},
+            "flavour": "plain sweetness", "desc": "a sticky flask of sugar syrup", "keywords": ("sugar", "syrup", "simple")},
+    "bitters": {"name": "dasher of aromatic bitters", "role": "bitters", "contributions": {},
+            "flavour": "spiced, concentrated bitterness", "desc": "a small dasher bottle of aromatic bitters", "keywords": ("bitters", "aromatic", "dasher")},
+}
+
+
+def make_ingredient(catalog_key, *, location=None):
+    """Spawn a catalog ingredient as a real item (effects + cocktail identity)."""
+    from world.search import strip_leading_article
+
+    proto = INGREDIENT_CATALOG[catalog_key]
+    name = strip_leading_article((proto["name"] or "").strip())
+    ing = create_object(DRINK_TYPECLASS, key=name, location=location)
+    ing.db.desc = proto.get("desc", name)
+    ing.db.is_ingredient = True
+    ing.db.contributions = dict(proto.get("contributions", {}))
+    ing.db.flavour = proto.get("flavour", "")
+    ing.db.consumed_per_use = int(proto.get("consumed_per_use", 1) or 1)
+    ing.db.role = proto.get("role")            # cocktail component role
+    ing.db.spirit = proto.get("spirit")        # spirit type (role == spirit)
+    aliases = _drink_aliases(name, proto.get("keywords", ()))
+    if aliases:
+        ing.aliases.add(aliases)
+    return ing
+
+
+def compose_flavour(ingredients):
+    """Join the loaded ingredients' flavour notes into one description.
+
+    Order-preserving and de-duplicated, so two pours of gin read once. Used as
+    the free-mix drink's taste until a save/brand authors its own prose.
+    """
+    notes = []
+    for ing in ingredients:
+        f = getattr(ing.db, "flavour", "") or ""
+        if f and f not in notes:
+            notes.append(f)
+    return "; ".join(notes)
+
+
+# ---------------------------------------------------------------------------
+# Classic cocktails (the hidden recognition layer). A template names a set of
+# required component roles; loose matching (decision: roles present, ratios and
+# extra garnishes ignored) recognizes the classic and, on a swapped spirit, the
+# spin ("Mezcal Negroni"). Cocktail names are generic/public-domain; nothing is
+# matched on brand names. `spin` formats non-canonical spirits; `spirit_names`
+# overrides specific spirits where the family name differs (rum sour = Daiquiri).
+# ---------------------------------------------------------------------------
+COCKTAILS = [
+    {"name": "Last Word", "canonical": "gin",
+     "roles": {"herbal_liqueur", "maraschino", "citrus"}},
+    {"name": "Margarita", "canonical": "tequila",
+     "roles": {"orange_liqueur", "citrus"}},
+    {"name": "Negroni", "canonical": "gin",
+     "roles": {"bitter_aperitivo", "sweet_vermouth"}},
+    {"name": "Manhattan", "canonical": "whiskey",
+     "roles": {"sweet_vermouth", "bitters"}},
+    {"name": "Old Fashioned", "canonical": "whiskey",
+     "roles": {"sweetener", "bitters"}},
+    {"name": "Daiquiri", "canonical": "rum", "spin": "{spirit} Sour",
+     "spirit_names": {"whiskey": "Whiskey Sour", "gin": "Gin Sour"},
+     "roles": {"citrus", "sweetener"}},
+    {"name": "Martini", "canonical": "gin",
+     "roles": {"dry_vermouth"}},
+]
+
+
+def _spirit_display(spirit):
+    """Title-case a spirit type for spin names ('mezcal' -> 'Mezcal')."""
+    return " ".join(w.capitalize() for w in (spirit or "").split())
+
+
+def name_cocktail(template, spirit):
+    """Name a recognized cocktail for the spirit used (canonical or a spin)."""
+    if spirit == template["canonical"]:
+        return template["name"]
+    overrides = template.get("spirit_names", {})
+    if spirit in overrides:
+        return overrides[spirit]
+    spin = template.get("spin", "{spirit} {base}")
+    return spin.format(spirit=_spirit_display(spirit), base=template["name"])
+
+
+def recognize_cocktail(ingredients):
+    """Recognize a classic (or spin) from loaded ingredients. Returns the
+    composed name string, or ``None`` for an unrecognized free-mix.
+
+    Loose match: a template fires when all its required roles are present and a
+    spirit is loaded; extra roles/garnishes are ignored. When several templates
+    match, the most specific (most roles) wins. The first loaded spirit names it.
+    """
+    roles_present = set()
+    spirit = None
+    for ing in ingredients:
+        role = getattr(ing.db, "role", None)
+        if role:
+            roles_present.add(role)
+        if role == ROLE_SPIRIT and spirit is None:
+            spirit = getattr(ing.db, "spirit", None)
+    if spirit is None:
+        return None
+    best = None
+    for template in COCKTAILS:
+        if template["roles"] <= roles_present:
+            if best is None or len(template["roles"]) > len(best["roles"]):
+                best = template
+    if best is None:
+        return None
+    return name_cocktail(best, spirit)
+
+
+def project_mix(ingredients):
+    """Project what the loaded ingredients would make, without making it.
+
+    Returns ``{"effects", "flavour", "capped", "cocktail"}``: the additive
+    substance sum (each clamped to MIX_EFFECT_CAP), the composed flavour, any
+    substances the cap trimmed (for UI feedback), and the recognized classic /
+    spin name (or ``None`` for an unrecognized free-mix).
+    """
+    raw = mix_effects(ingredients)
+    effects = {sid: min(d, MIX_EFFECT_CAP) for sid, d in raw.items()}
+    capped = {sid: d for sid, d in raw.items() if d > MIX_EFFECT_CAP}
+    return {
+        "effects": effects,
+        "flavour": compose_flavour(ingredients),
+        "capped": capped,
+        "cocktail": recognize_cocktail(ingredients),
+    }
+
+
 def match_snack(text, snacks):
     """Find the first snack whose keywords appear in `text`. Returns dict/None."""
     if not text or not snacks:

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -68,6 +68,98 @@ class TestDrinkNaming(BaseEvenniaTest):
         self.assertIn("mug", aliases)
 
 
+class TestCocktailRecognition(BaseEvenniaTest):
+    """The hidden classics layer: loose role-match + spirit-swap spin naming."""
+
+    def _ing(self, role=None, spirit=None, contributions=None):
+        m = MagicMock()
+        m.db.role = role
+        m.db.spirit = spirit
+        m.db.contributions = contributions or {}
+        m.db.flavour = ""
+        return m
+
+    def _negroni(self, spirit):
+        return [self._ing("spirit", spirit),
+                self._ing("bitter_aperitivo"),
+                self._ing("sweet_vermouth")]
+
+    def test_canonical_negroni(self):
+        from world.bar import recognize_cocktail
+        self.assertEqual(recognize_cocktail(self._negroni("gin")), "Negroni")
+
+    def test_spirit_swap_spin(self):
+        from world.bar import recognize_cocktail
+        self.assertEqual(recognize_cocktail(self._negroni("mezcal")), "Mezcal Negroni")
+
+    def test_colony_spirit_spin(self):
+        from world.bar import recognize_cocktail
+        self.assertEqual(
+            recognize_cocktail(self._negroni("grain mash")), "Grain Mash Negroni"
+        )
+
+    def test_extra_garnish_ignored(self):
+        from world.bar import recognize_cocktail
+        ings = self._negroni("gin") + [self._ing("citrus")]
+        self.assertEqual(recognize_cocktail(ings), "Negroni")
+
+    def test_sour_family_names(self):
+        from world.bar import recognize_cocktail
+        sour = lambda s: [self._ing("spirit", s), self._ing("citrus"),
+                          self._ing("sweetener")]
+        self.assertEqual(recognize_cocktail(sour("rum")), "Daiquiri")
+        self.assertEqual(recognize_cocktail(sour("whiskey")), "Whiskey Sour")
+        self.assertEqual(recognize_cocktail(sour("mezcal")), "Mezcal Sour")
+
+    def test_most_specific_template_wins(self):
+        from world.bar import recognize_cocktail
+        last_word = [self._ing("spirit", "gin"), self._ing("herbal_liqueur"),
+                     self._ing("maraschino"), self._ing("citrus")]
+        self.assertEqual(recognize_cocktail(last_word), "Last Word")
+
+    def test_no_spirit_no_match(self):
+        from world.bar import recognize_cocktail
+        self.assertIsNone(recognize_cocktail(
+            [self._ing("bitter_aperitivo"), self._ing("sweet_vermouth")]
+        ))
+
+    def test_unrecognized_freemix(self):
+        from world.bar import recognize_cocktail
+        self.assertIsNone(recognize_cocktail([self._ing("spirit", "gin")]))
+
+    def test_project_mix_caps_and_names(self):
+        from world.bar import project_mix, MIX_EFFECT_CAP
+        ings = [self._ing("spirit", "gin", {"alcohol": 2}),
+                self._ing("bitter_aperitivo", None, {"alcohol": 1}),
+                self._ing("sweet_vermouth", None, {"alcohol": 1})]
+        proj = project_mix(ings)
+        self.assertEqual(proj["cocktail"], "Negroni")
+        self.assertEqual(proj["effects"], {"alcohol": 4})
+        # Overshoot is trimmed to the safety-net cap.
+        over = project_mix([self._ing("spirit", "gin", {"alcohol": 9})])
+        self.assertEqual(over["effects"]["alcohol"], MIX_EFFECT_CAP)
+
+    def test_catalog_covers_every_cocktail(self):
+        from world.bar import INGREDIENT_CATALOG, COCKTAILS
+        roles = {p.get("role") for p in INGREDIENT_CATALOG.values()}
+        spirits = {p.get("spirit") for p in INGREDIENT_CATALOG.values()
+                   if p.get("role") == "spirit"}
+        for c in COCKTAILS:
+            self.assertIn(c["canonical"], spirits,
+                          f"{c['name']}: canonical spirit not in catalog")
+            for role in c["roles"]:
+                self.assertIn(role, roles,
+                              f"{c['name']}: role {role} has no ingredient")
+
+    def test_make_ingredient_sets_identity(self):
+        from world.bar import make_ingredient
+        g = make_ingredient("mezcal", location=self.room1)
+        self.assertEqual(g.db.role, "spirit")
+        self.assertEqual(g.db.spirit, "mezcal")
+        self.assertEqual(g.db.contributions, {"alcohol": 2})
+        self.assertTrue(g.db.is_ingredient)
+
+
 class TestSnacks(BaseEvenniaTest):
     """Free bar snacks (§10): keyword match + room resolution."""
 


### PR DESCRIPTION
Two-layer ingredients — substance contributions (doses -> effects) plus a
cocktail role and spirit type. Seeded catalog (Earth-import spirits +
modifiers + structure, plus colony spirits). Hidden COCKTAILS library
recognized at mix time by loose role-match with spirit-swap spin naming
(gin->Negroni, mezcal->Mezcal Negroni, rum sour->Daiquiri, whiskey->Whiskey
Sour). project_mix returns capped effects, composed flavour, and the
recognized name. Generic/public-domain cocktail names; no brand-name
ingredients. No UI yet — CmdBarUse still does the one-shot mix.

Adds TestCocktailRecognition to world/tests/test_bar.py.

Closes #673

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
