### PR TITLE
Bars/crafting: interactive use<bar> mixing menu + ingredient spawn

### DIFF
--- a/commands/bar_menu.py
+++ b/commands/bar_menu.py
@@ -1,0 +1,308 @@
+"""
+The `use <bar>` mixing menu (BARS_AND_RECIPES_SPEC §4/§5).
+
+An EvMenu in the style of medical ``operate`` — its own command, the same
+burnt-orange idiom — where a bartender sees the loaded ingredients, the
+projected effect profile, the composed flavour, and the recognized classic
+(or spin), then:
+
+  - **Pours** a one-off (named by recognition, or a free-mix),
+  - **Saves/brands** the mix as a named recipe on the bar's menu — free-text
+    naming, recognized name offered as the default ("Negroni" → "Kyoto
+    Negroni"); the recognized base is kept as metadata,
+  - **Makes a known recipe** straight from the bar's menu.
+
+State rides ``caller.ndb._bar_menu`` and is cleared on exit.
+"""
+
+from collections import defaultdict
+
+from evennia.commands.command import Command
+from evennia.utils.evmenu import EvMenu
+
+from world.grammar import with_article
+from world.bar import (
+    make_drink,
+    make_drink_from_recipe,
+    project_mix,
+)
+
+MUTED = "|520"   # burnt orange — matches the operate menu's secondary text
+HEAD = "|w"
+
+
+# ---------------------------------------------------------------------------
+# Menu plumbing
+# ---------------------------------------------------------------------------
+class _BarMenu(EvMenu):
+    """Suppress EvMenu's default decorations; nodes render their own layout."""
+
+    def nodetext_formatter(self, nodetext):
+        return nodetext
+
+    def options_formatter(self, optionlist):
+        return ""
+
+    def node_formatter(self, nodetext, optionstext):
+        return nodetext
+
+
+def _menu_exit(caller, menu):
+    for attr in ("_bar_menu", "_bar_save_name"):
+        if hasattr(caller.ndb, attr):
+            delattr(caller.ndb, attr)
+
+
+def start_bar_menu(caller, bar):
+    """Open the mixing menu for ``bar``."""
+    caller.ndb._bar_menu = bar
+    _BarMenu(
+        caller,
+        {
+            "node_top": node_top,
+            "node_save_name": node_save_name,
+            "node_save_taste": node_save_taste,
+            "node_pick_recipe": node_pick_recipe,
+            "node_exit": node_exit,
+        },
+        startnode="node_top",
+        cmd_on_exit=_menu_exit,
+        auto_quit=True,
+        auto_look=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _loaded(bar):
+    return [o for o in bar.contents if getattr(o.db, "is_ingredient", False)]
+
+
+def _effect_summary(effects):
+    return ", ".join(f"{sid} {d}" for sid, d in effects.items()) or "none"
+
+
+def _recipe_keywords(name):
+    return tuple(w for w in name.lower().split() if len(w) > 2)
+
+
+def _pour(caller, bar, *, name=None):
+    """Make the loaded mix into a drink on the bar; consume the ingredients."""
+    ings = _loaded(bar)
+    if not ings:
+        caller.msg("Nothing's loaded to mix.")
+        return None
+    proj = project_mix(ings)
+    drink_name = name or proj["cocktail"] or "house mix"
+    taste = proj["flavour"]
+    desc = f"a freshly-mixed drink — {taste}" if taste else "a freshly-mixed drink"
+    drink = make_drink(
+        name=drink_name, desc=desc, effects=proj["effects"], sips=3,
+        taste=taste, location=bar,
+    )
+    for i in ings:
+        i.delete()
+    caller.execute_cmd(
+        f"emote builds {with_article(drink.key)} and sets it on {bar.key}."
+    )
+    return proj
+
+
+def _save_recipe(bar, name, *, proj, taste=None):
+    """Append a branded recipe (from the projection) to the bar's menu."""
+    recipe = {
+        "name": name,
+        "desc": (f"a house pour — {proj['flavour']}" if proj["flavour"]
+                 else "a house pour"),
+        "price": 0,
+        "sips": 3,
+        "effects": dict(proj["effects"]),
+        "taste": taste or proj["flavour"],
+        "base_cocktail": proj["cocktail"],
+        "order_keywords": _recipe_keywords(name),
+        "craft": "builds the drink with practiced, economical motions",
+    }
+    menu = list(bar.db.menu or [])
+    menu.append(recipe)
+    bar.db.menu = menu
+    return recipe
+
+
+# ---------------------------------------------------------------------------
+# Nodes
+# ---------------------------------------------------------------------------
+def node_top(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    if bar is None:
+        return "|rThis bar is gone.|n", None
+
+    ings = _loaded(bar)
+    lines = [f"{HEAD}{bar.key} — mixing|n", ""]
+    if ings:
+        groups = defaultdict(int)
+        for i in ings:
+            groups[i.key] += 1
+        loaded = ", ".join(
+            f"{n}× {k}" if n > 1 else k for k, n in groups.items()
+        )
+        proj = project_mix(ings)
+        lines.append(f"  Loaded:   {loaded}")
+        lines.append(f"  {MUTED}Effect:   {_effect_summary(proj['effects'])}|n")
+        if proj["flavour"]:
+            lines.append(f"  {MUTED}Flavour:  {proj['flavour']}|n")
+        if proj["cocktail"]:
+            lines.append(f"  Reads as: {HEAD}{proj['cocktail']}|n")
+        else:
+            lines.append(f"  {MUTED}Reads as: an unrecognized free-mix|n")
+    else:
+        lines.append(
+            f"  {MUTED}Nothing loaded. Put ingredients on the bar first "
+            f"(put <thing> on {bar.key}).|n"
+        )
+    lines.append("")
+    if ings:
+        lines.append(f"  {MUTED}[1]|n Pour it")
+        lines.append(f"  {MUTED}[2]|n Save as a recipe")
+    if bar.db.menu:
+        lines.append(f"  {MUTED}[3]|n Make a known recipe")
+    lines.append(f"  {MUTED}[q]|n Step back")
+
+    return "\n".join(lines), ({"key": "_default", "goto": _process_top},)
+
+
+def _process_top(caller, raw_string, **kwargs):
+    choice = raw_string.strip().lower()
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    if choice in ("q", "x", "quit", "back", ""):
+        return "node_exit" if choice else None
+    if choice == "1":
+        if _loaded(bar):
+            _pour(caller, bar)
+        return "node_top"
+    if choice == "2":
+        if not _loaded(bar):
+            caller.msg("Nothing to save — load ingredients first.")
+            return None
+        return "node_save_name"
+    if choice == "3":
+        if bar and bar.db.menu:
+            return "node_pick_recipe"
+        caller.msg("Nothing on the menu yet.")
+        return None
+    caller.msg("|rPick an option, or q to step back.|n")
+    return None
+
+
+# ---- save / brand --------------------------------------------------------
+def node_save_name(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    proj = project_mix(_loaded(bar))
+    default = proj["cocktail"] or "house mix"
+    text = (
+        f"{HEAD}Name this pour.|n\n"
+        f"  {MUTED}It reads as {default}. Press enter to keep that, or type "
+        f"your own — e.g. Kyoto Negroni.|n"
+    )
+    return text, ({"key": "_default", "goto": _process_save_name},)
+
+
+def _process_save_name(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    proj = project_mix(_loaded(bar))
+    name = raw_string.strip() or proj["cocktail"] or "house mix"
+    caller.ndb._bar_save_name = name
+    return "node_save_taste"
+
+
+def node_save_taste(caller, raw_string, **kwargs):
+    name = getattr(caller.ndb, "_bar_save_name", "house mix")
+    text = (
+        f"{HEAD}Describe how {name} tastes.|n\n"
+        f"  {MUTED}Press enter to use the composed flavour, or write your own "
+        f"one-line taste.|n"
+    )
+    return text, ({"key": "_default", "goto": _process_save_taste},)
+
+
+def _process_save_taste(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    name = getattr(caller.ndb, "_bar_save_name", "house mix")
+    taste = raw_string.strip() or None
+    ings = _loaded(bar)
+    if not ings:
+        caller.msg("The mix is gone; nothing saved.")
+        return "node_top"
+    proj = project_mix(ings)
+    _save_recipe(bar, name, proj=proj, taste=taste)
+    # Branding pours the first one.
+    _pour(caller, bar, name=name)
+    base = f" ({proj['cocktail']})" if proj["cocktail"] else ""
+    caller.msg(f"{HEAD}Saved {name}{base} to the menu.|n It's now orderable.")
+    return "node_top"
+
+
+# ---- make a known recipe -------------------------------------------------
+def node_pick_recipe(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    menu = (bar.db.menu if bar else None) or []
+    lines = [f"{HEAD}Make which recipe?|n", ""]
+    for idx, r in enumerate(menu, 1):
+        lines.append(f"  {MUTED}[{idx}]|n {r['name']}")
+    lines.append(f"  {MUTED}[q]|n Back")
+    return "\n".join(lines), ({"key": "_default", "goto": _process_pick},)
+
+
+def _process_pick(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    choice = raw_string.strip().lower()
+    if choice in ("q", "x", "back", ""):
+        return "node_top"
+    menu = (bar.db.menu if bar else None) or []
+    if choice.isdigit() and 1 <= int(choice) <= len(menu):
+        recipe = menu[int(choice) - 1]
+        drink = make_drink_from_recipe(recipe, location=bar)
+        caller.execute_cmd(
+            f"emote {recipe.get('craft', 'builds the drink')}, and sets "
+            f"{with_article(drink.key)} on {bar.key}."
+        )
+        return "node_top"
+    caller.msg("|rPick a number, or q to go back.|n")
+    return None
+
+
+def node_exit(caller, raw_string, **kwargs):
+    return f"{MUTED}You step back from the bar.|n", None
+
+
+# ---------------------------------------------------------------------------
+# Builder tool — spawn catalog ingredients (no supplier economy yet, §3)
+# ---------------------------------------------------------------------------
+class CmdSpawnIngredient(Command):
+    """
+    Spawn a bar ingredient from the catalog (builder testing tool).
+
+    Usage:
+        @ingredient <key>
+        @ingredient            — list the catalog keys
+
+    The ingredient lands in your inventory; ``put`` it on a bar, then
+    ``use`` the bar to mix.
+    """
+
+    key = "@ingredient"
+    locks = "cmd:perm(Builder)"
+    help_category = "Building"
+
+    def func(self):
+        from world.bar import INGREDIENT_CATALOG, make_ingredient
+
+        key = self.args.strip().lower().replace(" ", "_").replace("-", "_")
+        if not key or key not in INGREDIENT_CATALOG:
+            self.caller.msg(
+                "Usage: @ingredient <key>\n  "
+                + ", ".join(sorted(INGREDIENT_CATALOG))
+            )
+            return
+        ing = make_ingredient(key, location=self.caller)
+        self.caller.msg(f"Spawned {ing.key} into your inventory.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -26,6 +26,7 @@ from commands import CmdConsumption
 from commands import CmdMedicalItems
 from commands import CmdSmoke
 from commands.CmdSpawnMob import CmdSpawnMob
+from commands.bar_menu import CmdSpawnIngredient
 from commands.CmdBug import CmdBug
 from commands.CmdAdmin import CmdHeal, CmdPeace, CmdTestDeathCurtain, CmdWeather, CmdResetMedical, CmdMedicalAudit, CmdTestDeath, CmdTestUnconscious
 from commands.CmdFixCharacterOwnership import CmdFixCharacterOwnership
@@ -122,6 +123,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         # Add individual character commands
         self.add(CmdCharacter.CmdStats)
         self.add(CmdSpawnMob())
+        self.add(CmdSpawnIngredient())
         self.add(CmdAdmin.CmdHeal())
         self.add(CmdAdmin.CmdPeace())
         self.add(CmdAdmin.CmdTestDeathCurtain())

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -26,10 +26,8 @@ from world.grammar import capitalize_first, with_article
 from world.shop.utils import format_currency
 from world.bar import (
     DEFAULT_BAR_SNACKS,
-    make_drink,
     make_drink_from_recipe,
     match_recipe,
-    mix_effects,
 )
 
 #: Price colour on the menu — the same burnt orange (XTERM-256 |520) the
@@ -97,29 +95,10 @@ class CmdBarUse(Command):
         if not bar.is_bartender(caller):
             caller.msg("You aren't working this bar.")
             return
-        ingredients = [o for o in bar.contents if getattr(o.db, "is_ingredient", False)]
-        if not ingredients:
-            caller.msg(
-                f"Nothing's loaded to mix. Put ingredients on "
-                f"{bar.get_display_name(caller)} first."
-            )
-            return
-        effects = mix_effects(ingredients)
-        names = ", ".join(i.key for i in ingredients)
-        drink = make_drink(
-            name="mixed drink",
-            desc=f"a freshly-mixed drink, thrown together from {names}",
-            effects=effects,
-            sips=3,
-            taste="A rough, improvised mix — it does the job.",
-            location=bar,   # onto the bar surface
-        )
-        for i in ingredients:
-            i.delete()
-        caller.location.msg_contents(
-            f"{caller.key} mixes {names} into {with_article(drink.key)} "
-            f"on {bar.key}."
-        )
+        # Open the operate-style mixing menu (load ingredients, see the
+        # projected effects + recognized classic, pour / save-brand / make).
+        from commands.bar_menu import start_bar_menu
+        start_bar_menu(caller, bar)
 
 
 class BarCmdSet(CmdSet):

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -160,6 +160,37 @@ class TestCocktailRecognition(BaseEvenniaTest):
         self.assertTrue(g.db.is_ingredient)
 
 
+class TestBarMenuSave(BaseEvenniaTest):
+    """The save/brand step records a free-text-named recipe to the bar menu."""
+
+    def test_save_recipe_brands_and_keeps_base(self):
+        from commands.bar_menu import _save_recipe
+
+        bar = MagicMock()
+        bar.db.menu = []
+        proj = {"effects": {"alcohol": 4}, "flavour": "juniper-sharp",
+                "cocktail": "Negroni"}
+        r = _save_recipe(bar, "Kyoto Negroni", proj=proj, taste=None)
+
+        self.assertEqual(r["name"], "Kyoto Negroni")
+        self.assertEqual(r["base_cocktail"], "Negroni")   # remembers the family
+        self.assertEqual(r["effects"], {"alcohol": 4})
+        self.assertEqual(r["taste"], "juniper-sharp")      # composed fallback
+        self.assertIn("kyoto", r["order_keywords"])
+        self.assertIn("negroni", r["order_keywords"])
+        self.assertEqual(bar.db.menu[-1]["name"], "Kyoto Negroni")
+
+    def test_custom_taste_overrides_composed(self):
+        from commands.bar_menu import _save_recipe
+
+        bar = MagicMock()
+        bar.db.menu = []
+        proj = {"effects": {}, "flavour": "auto flavour", "cocktail": None}
+        r = _save_recipe(bar, "House Pour", proj=proj, taste="silk and smoke")
+        self.assertEqual(r["taste"], "silk and smoke")
+        self.assertIsNone(r["base_cocktail"])
+
+
 class TestSnacks(BaseEvenniaTest):
     """Free bar snacks (§10): keyword match + room resolution."""
 


### PR DESCRIPTION
commands/bar_menu.py: an operate-style EvMenu for use <bar> — shows the
loaded ingredients, projected effects, composed flavour, and recognized
classic/spin, then pours, saves/brands (free-text name defaulting to the
recognized classic; stores base_cocktail; optional custom taste; brands to
the menu and pours one), or makes a known recipe.

CmdBarUse now launches the menu instead of the one-shot mix. Adds
@ingredient <key> (Builder) to spawn catalog ingredients for testing.

Adds TestBarMenuSave.

Closes #675

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
