### PR TITLE
Bars/crafting: bottomless house stock + pick-from-stock + colony recipes

### DIFF
--- a/commands/bar_menu.py
+++ b/commands/bar_menu.py
@@ -22,8 +22,11 @@ from evennia.utils.evmenu import EvMenu
 
 from world.grammar import with_article
 from world.bar import (
+    INGREDIENT_CATALOG,
+    derive_bar_stock,
     make_drink,
     make_drink_from_recipe,
+    make_ingredient,
     project_mix,
 )
 
@@ -60,6 +63,7 @@ def start_bar_menu(caller, bar):
         caller,
         {
             "node_top": node_top,
+            "node_add_stock": node_add_stock,
             "node_save_name": node_save_name,
             "node_save_taste": node_save_taste,
             "node_pick_recipe": node_pick_recipe,
@@ -77,6 +81,25 @@ def start_bar_menu(caller, bar):
 # ---------------------------------------------------------------------------
 def _loaded(bar):
     return [o for o in bar.contents if getattr(o.db, "is_ingredient", False)]
+
+
+def _bar_stock(bar):
+    """The bottomless ingredient keys this bar carries — an explicit db.stock if
+    a builder set one, else auto-derived from the menu + base pantry."""
+    stock = bar.db.stock
+    if stock:
+        return [k for k in stock if k in INGREDIENT_CATALOG]
+    return derive_bar_stock(bar.db.menu or [])
+
+
+def _clear_load(caller, bar):
+    n = 0
+    for o in list(bar.contents):
+        if getattr(o.db, "is_ingredient", False):
+            o.delete()
+            n += 1
+    caller.msg(f"Swept {n} ingredient(s) off the bar." if n
+               else "Nothing loaded to clear.")
 
 
 def _effect_summary(effects):
@@ -161,9 +184,12 @@ def node_top(caller, raw_string, **kwargs):
             f"(put <thing> on {bar.key}).|n"
         )
     lines.append("")
+    if _bar_stock(bar):
+        lines.append(f"  {MUTED}[a]|n Add an ingredient from the bar stock")
     if ings:
         lines.append(f"  {MUTED}[1]|n Pour it")
         lines.append(f"  {MUTED}[2]|n Save as a recipe")
+        lines.append(f"  {MUTED}[c]|n Clear the load")
     if bar.db.menu:
         lines.append(f"  {MUTED}[3]|n Make a known recipe")
     lines.append(f"  {MUTED}[x]|n Step away")
@@ -176,6 +202,14 @@ def _process_top(caller, raw_string, **kwargs):
     bar = getattr(caller.ndb, "_bar_menu", None)
     if choice in ("x", "exit", "quit", "q", ""):
         return "node_exit" if choice else None
+    if choice == "a":
+        if _bar_stock(bar):
+            return "node_add_stock"
+        caller.msg("This bar carries no stock.")
+        return None
+    if choice == "c":
+        _clear_load(caller, bar)
+        return "node_top"
     if choice == "1":
         if _loaded(bar):
             _pour(caller, bar)
@@ -190,7 +224,33 @@ def _process_top(caller, raw_string, **kwargs):
             return "node_pick_recipe"
         caller.msg("Nothing on the menu yet.")
         return None
-    caller.msg("|rPick an option, or q to step back.|n")
+    caller.msg("|rPick an option, or x to step away.|n")
+    return None
+
+
+# ---- add from stock ------------------------------------------------------
+def node_add_stock(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    stock = _bar_stock(bar) if bar else []
+    lines = [f"{HEAD}Add from the bar stock|n",
+             f"  {MUTED}(bottomless — pick as many as you like)|n", ""]
+    for idx, key in enumerate(stock, 1):
+        lines.append(f"  {MUTED}[{idx}]|n {INGREDIENT_CATALOG[key]['name']}")
+    lines.append(f"  {MUTED}[x]|n Back")
+    return "\n".join(lines), ({"key": "_default", "goto": _process_add_stock},)
+
+
+def _process_add_stock(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    choice = raw_string.strip().lower()
+    if choice in ("x", "back", ""):
+        return "node_top"
+    stock = _bar_stock(bar) if bar else []
+    if choice.isdigit() and 1 <= int(choice) <= len(stock):
+        ing = make_ingredient(stock[int(choice) - 1], location=bar)
+        caller.msg(f"Added {ing.key} to the mix.")
+        return "node_add_stock"   # stay, to add more
+    caller.msg("|rPick a number, or x to go back.|n")
     return None
 
 

--- a/world/bar.py
+++ b/world/bar.py
@@ -189,6 +189,16 @@ INGREDIENT_CATALOG = {
     "reactor_cut": {"name": "flask of reactor cut", "role": ROLE_SPIRIT, "spirit": "reactor cut",
             "contributions": {"alcohol": 2}, "flavour": "harsh chemical heat",
             "desc": "a scratched flask of high-proof reactor cut, distilled too close to the coolant lines", "keywords": ("reactor", "cut", "proof")},
+    # ---- Colony additives / mixers (no cocktail role) ------------------
+    "poppy_tincture": {"name": "vial of poppy tincture", "role": None,
+            "contributions": {"opium": 1}, "flavour": "bitter brine-and-poppy",
+            "desc": "a dropper vial of dark poppy tincture, cut with channel brine", "keywords": ("poppy", "tincture", "opium")},
+    "channel_cordial": {"name": "bottle of channel cordial", "role": None, "contributions": {},
+            "flavour": "milky, grey-green, faintly sweet",
+            "desc": "a bottle of milky grey-green cordial pressed from channel kelp", "keywords": ("channel", "cordial", "kelp")},
+    "caf": {"name": "jug of reclaimed caf", "role": None, "contributions": {},
+            "flavour": "bitter, scalding reclaimed caf",
+            "desc": "a battered jug of black reclaimed caf", "keywords": ("caf", "coffee", "recyc")},
     # ---- Modifiers (alcohol 1) -----------------------------------------
     "bitter_aperitivo": {"name": "bottle of bitter aperitivo", "role": "bitter_aperitivo",
             "contributions": {"alcohol": 1}, "flavour": "bitter blood-orange",
@@ -371,7 +381,7 @@ COCKTAILS = [
      "roles": {"grapefruit", "soda"}},
     {"name": "Daiquiri", "canonical": "rum", "spin": "{spirit} Sour",
      "spirit_names": {"whiskey": "Whiskey Sour", "gin": "Gin Sour",
-                      "brandy": "Brandy Sour", "amaretto": "Amaretto Sour"},
+                      "brandy": "Brandy Sour"},
      "roles": {"citrus", "sweetener"}},
     {"name": "Martini", "canonical": "gin", "spin": "{spirit} Martini",
      "roles": {"dry_vermouth"}},
@@ -456,6 +466,25 @@ def project_mix(ingredients):
     }
 
 
+#: Structural non-alcoholic basics every bar keeps on hand, so even a scuzzy
+#: bar can build sours/highballs from its own spirits — the seed of riffs (§5).
+BASE_BAR_PANTRY = ("lime", "lemon", "sugar_syrup", "bitters", "soda")
+
+
+def derive_bar_stock(menu):
+    """The bottomless ingredient stock for a bar (decision: auto from the menu).
+
+    The base pantry plus every ingredient the bar's menu drinks call for, so a
+    bartender can always re-make and riff on what's on offer. Returns catalog
+    keys in catalog order (spirits, modifiers, structure…).
+    """
+    keys = set(BASE_BAR_PANTRY)
+    for recipe in (menu or []):
+        for k in recipe.get("ingredients", ()):
+            keys.add(k)
+    return [k for k in INGREDIENT_CATALOG if k in keys]
+
+
 def match_snack(text, snacks):
     """Find the first snack whose keywords appear in `text`. Returns dict/None."""
     if not text or not snacks:
@@ -499,6 +528,7 @@ HUB_AND_HOWL_MENU = [
     {
         "name": "mug of rotgut",
         "order_keywords": ("rotgut", "grain", "spirit", "cheap"),
+        "ingredients": ("grain_mash",),
         "price": 0,
         "sips": 3,
         "effects": {"alcohol": 1},
@@ -509,6 +539,7 @@ HUB_AND_HOWL_MENU = [
     {
         "name": "glass of reactor wash",
         "order_keywords": ("reactor", "wash", "strong", "stiff"),
+        "ingredients": ("reactor_cut",),
         "price": 0,
         "sips": 3,
         "effects": {"alcohol": 2},
@@ -519,6 +550,7 @@ HUB_AND_HOWL_MENU = [
     {
         "name": "cup of channel fog",
         "order_keywords": ("fog", "channel", "milky", "smooth"),
+        "ingredients": ("reactor_cut", "poppy_tincture", "channel_cordial"),
         "price": 0,
         "sips": 4,
         "effects": {"alcohol": 1, "opium": 1},
@@ -529,6 +561,7 @@ HUB_AND_HOWL_MENU = [
     {
         "name": "mug of black recyc",
         "order_keywords": ("recyc", "black", "coffee", "caf", "sober"),
+        "ingredients": ("caf",),
         "price": 0,
         "sips": 4,
         "effects": {},

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -224,6 +224,28 @@ class TestBarMenuSave(BaseEvenniaTest):
         self.assertIsNone(r["base_cocktail"])
 
 
+class TestBarStock(BaseEvenniaTest):
+    """A bar's bottomless stock = base pantry + its menu's ingredients."""
+
+    def test_derive_stock_from_menu(self):
+        from world.bar import (derive_bar_stock, BASE_BAR_PANTRY,
+                               HUB_AND_HOWL_MENU, INGREDIENT_CATALOG)
+        stock = derive_bar_stock(HUB_AND_HOWL_MENU)
+        for k in BASE_BAR_PANTRY:
+            self.assertIn(k, stock)
+        for k in ("grain_mash", "reactor_cut", "poppy_tincture", "caf"):
+            self.assertIn(k, stock)
+        for k in stock:
+            self.assertIn(k, INGREDIENT_CATALOG)
+
+    def test_menu_ingredients_are_catalog_keys(self):
+        from world.bar import HUB_AND_HOWL_MENU, INGREDIENT_CATALOG
+        for r in HUB_AND_HOWL_MENU:
+            for k in r.get("ingredients", ()):
+                self.assertIn(k, INGREDIENT_CATALOG,
+                              f"{r['name']}: unknown ingredient {k}")
+
+
 class TestSnacks(BaseEvenniaTest):
     """Free bar snacks (§10): keyword match + room resolution."""
 


### PR DESCRIPTION
Colony menu drinks now carry ingredient recipes (rotgut=grain mash, reactor
wash=reactor cut, channel fog=reactor cut+poppy+channel cordial, black
recyc=caf); re-added the colony additives (poppy tincture, channel cordial,
caf). derive_bar_stock = base pantry (lime/lemon/sugar/bitters/soda) + the
menu's ingredients, so every bar can re-make and riff what it serves.

The use<bar> menu gains [a] add-an-ingredient-from-stock (bottomless) and
[c] clear-the-load, so a bartender builds mixes without hauling bottles.
Dropped the dead amaretto sour override.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
