### PR TITLE
Bars/crafting: prep methods (build/stir/shake/muddle/blend)

### DIFF
--- a/commands/bar_menu.py
+++ b/commands/bar_menu.py
@@ -64,6 +64,7 @@ def start_bar_menu(caller, bar):
         {
             "node_top": node_top,
             "node_add_stock": node_add_stock,
+            "node_method": node_method,
             "node_save_name": node_save_name,
             "node_save_taste": node_save_taste,
             "node_pick_recipe": node_pick_recipe,
@@ -110,13 +111,35 @@ def _recipe_keywords(name):
     return tuple(w for w in name.lower().split() if len(w) > 2)
 
 
-def _pour(caller, bar, *, name=None):
-    """Make the loaded mix into a drink on the bar; consume the ingredients."""
+#: Preparation methods — flavour only (decision: no mechanical effect in v1).
+#: Phrased without the drink name ("it") so the same craft narration works in
+#: the menu pour AND the NPC serve emote.
+METHOD_ORDER = ("build", "stir", "shake", "muddle", "blend")
+METHOD_LABEL = {"build": "Build", "stir": "Stir", "shake": "Shake",
+                "muddle": "Muddle", "blend": "Blend"}
+METHOD_ADVERB = {"build": "built", "stir": "stirred", "shake": "shaken",
+                 "muddle": "muddled", "blend": "blended"}
+METHOD_CRAFT = {
+    "build": "builds it in the glass",
+    "stir": "stirs it down over ice, smooth and unhurried",
+    "shake": "shakes it hard over ice and strains it out",
+    "muddle": "muddles the base and churns it together",
+    "blend": "blends it into a frozen slurry",
+}
+
+
+def _pour(caller, bar, *, name=None, method=None):
+    """Make the loaded mix into a drink on the bar; consume the ingredients.
+
+    ``method`` drives only the craft narration (no mechanical effect); defaults
+    to the recognized classic's suggested method, else 'build'.
+    """
     ings = _loaded(bar)
     if not ings:
         caller.msg("Nothing's loaded to mix.")
         return None
     proj = project_mix(ings)
+    method = method or proj.get("method") or "build"
     drink_name = name or proj["cocktail"] or "house mix"
     taste = proj["flavour"]
     desc = f"a freshly-mixed drink — {taste}" if taste else "a freshly-mixed drink"
@@ -127,13 +150,15 @@ def _pour(caller, bar, *, name=None):
     for i in ings:
         i.delete()
     caller.execute_cmd(
-        f"emote builds {with_article(drink.key)} and sets it on {bar.key}."
+        f"emote {METHOD_CRAFT[method]}, and sets {with_article(drink.key)} "
+        f"on {bar.key}."
     )
     return proj
 
 
-def _save_recipe(bar, name, *, proj, taste=None):
+def _save_recipe(bar, name, *, proj, taste=None, method=None):
     """Append a branded recipe (from the projection) to the bar's menu."""
+    method = method or proj.get("method") or "build"
     recipe = {
         "name": name,
         "desc": (f"a house pour — {proj['flavour']}" if proj["flavour"]
@@ -143,8 +168,9 @@ def _save_recipe(bar, name, *, proj, taste=None):
         "effects": dict(proj["effects"]),
         "taste": taste or proj["flavour"],
         "base_cocktail": proj["cocktail"],
+        "method": method,
         "order_keywords": _recipe_keywords(name),
-        "craft": "builds the drink with practiced, economical motions",
+        "craft": METHOD_CRAFT.get(method, METHOD_CRAFT["build"]),
     }
     menu = list(bar.db.menu or [])
     menu.append(recipe)
@@ -175,7 +201,9 @@ def node_top(caller, raw_string, **kwargs):
         if proj["flavour"]:
             lines.append(f"  {MUTED}Flavour:  {proj['flavour']}|n")
         if proj["cocktail"]:
-            lines.append(f"  Reads as: {HEAD}{proj['cocktail']}|n")
+            adverb = METHOD_ADVERB.get(proj.get("method"))
+            tail = f" {MUTED}({adverb})|n" if adverb else ""
+            lines.append(f"  Reads as: {HEAD}{proj['cocktail']}|n{tail}")
         else:
             lines.append(f"  {MUTED}Reads as: an unrecognized free-mix|n")
     else:
@@ -212,7 +240,7 @@ def _process_top(caller, raw_string, **kwargs):
         return "node_top"
     if choice == "1":
         if _loaded(bar):
-            _pour(caller, bar)
+            return "node_method"
         return "node_top"
     if choice == "2":
         if not _loaded(bar):
@@ -250,6 +278,30 @@ def _process_add_stock(caller, raw_string, **kwargs):
         ing = make_ingredient(stock[int(choice) - 1], location=bar)
         caller.msg(f"Added {ing.key} to the mix.")
         return "node_add_stock"   # stay, to add more
+    caller.msg("|rPick a number, or x to go back.|n")
+    return None
+
+
+# ---- prep method ---------------------------------------------------------
+def node_method(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    suggested = project_mix(_loaded(bar)).get("method") if bar else None
+    lines = [f"{HEAD}How do you make it?|n", ""]
+    for idx, m in enumerate(METHOD_ORDER, 1):
+        tag = f"  {MUTED}(suggested)|n" if m == suggested else ""
+        lines.append(f"  {MUTED}[{idx}]|n {METHOD_LABEL[m]}{tag}")
+    lines.append(f"  {MUTED}[x]|n Back")
+    return "\n".join(lines), ({"key": "_default", "goto": _process_method},)
+
+
+def _process_method(caller, raw_string, **kwargs):
+    bar = getattr(caller.ndb, "_bar_menu", None)
+    choice = raw_string.strip().lower()
+    if choice in ("x", "back", ""):
+        return "node_top"
+    if choice.isdigit() and 1 <= int(choice) <= len(METHOD_ORDER):
+        _pour(caller, bar, method=METHOD_ORDER[int(choice) - 1])
+        return "node_top"
     caller.msg("|rPick a number, or x to go back.|n")
     return None
 
@@ -294,9 +346,10 @@ def _process_save_taste(caller, raw_string, **kwargs):
         caller.msg("The mix is gone; nothing saved.")
         return "node_top"
     proj = project_mix(ings)
-    _save_recipe(bar, name, proj=proj, taste=taste)
-    # Branding pours the first one.
-    _pour(caller, bar, name=name)
+    method = proj.get("method") or "build"
+    _save_recipe(bar, name, proj=proj, taste=taste, method=method)
+    # Branding pours the first one, in the suggested method.
+    _pour(caller, bar, name=name, method=method)
     base = f" ({proj['cocktail']})" if proj["cocktail"] else ""
     caller.msg(f"{HEAD}Saved {name}{base} to the menu.|n It's now orderable.")
     return "node_top"

--- a/world/bar.py
+++ b/world/bar.py
@@ -395,6 +395,19 @@ COCKTAILS = [
 ]
 
 
+#: Traditional preparation method per classic — a *suggestion* surfaced in the
+#: mixing menu, never enforced (loose ethos). Keyed by the template base name.
+COCKTAIL_METHOD = {
+    "Mojito": "muddle", "Cosmopolitan": "shake", "Last Word": "shake",
+    "Mai Tai": "shake", "French 75": "shake", "Tom Collins": "build",
+    "Margarita": "shake", "Negroni": "stir", "Manhattan": "stir",
+    "Old Fashioned": "stir", "Espresso Martini": "shake",
+    "White Russian": "build", "Pina Colada": "blend", "Moscow Mule": "build",
+    "Paloma": "build", "Daiquiri": "shake", "Martini": "stir",
+    "Gin & Tonic": "build", "Mimosa": "build", "Spritz": "build",
+}
+
+
 def _spirit_display(spirit):
     """Title-case a spirit type for spin names ('mezcal' -> 'Mezcal')."""
     return " ".join(w.capitalize() for w in (spirit or "").split())
@@ -413,14 +426,12 @@ def name_cocktail(template, spirit):
     return spin.format(spirit=_spirit_display(spirit), base=template["name"])
 
 
-def recognize_cocktail(ingredients):
-    """Recognize a classic (or spin) from loaded ingredients. Returns the
-    composed name string, or ``None`` for an unrecognized free-mix.
+def _best_template(ingredients):
+    """The most-specific matching cocktail template + the naming spirit.
 
     Loose match: a template fires when all its required roles are present (plus
     a spirit, for spirit-keyed templates); extra roles/garnishes are ignored.
-    When several templates match, the most specific (most required components)
-    wins. The first loaded spirit names it / its spin.
+    Most required components wins. Returns ``(template, spirit)`` or ``(None, None)``.
     """
     roles_present = set()
     spirit = None
@@ -442,27 +453,34 @@ def recognize_cocktail(ingredients):
         score = len(template["roles"]) + (1 if needs_spirit else 0)
         if score > best_score:
             best, best_score = template, score
-    if best is None:
-        return None
-    return name_cocktail(best, spirit)
+    return (best, spirit) if best else (None, None)
+
+
+def recognize_cocktail(ingredients):
+    """Recognized classic / spin name for a mix, or ``None`` for a free-mix."""
+    template, spirit = _best_template(ingredients)
+    return name_cocktail(template, spirit) if template else None
 
 
 def project_mix(ingredients):
     """Project what the loaded ingredients would make, without making it.
 
-    Returns ``{"effects", "flavour", "capped", "cocktail"}``: the additive
-    substance sum (each clamped to MIX_EFFECT_CAP), the composed flavour, any
-    substances the cap trimmed (for UI feedback), and the recognized classic /
-    spin name (or ``None`` for an unrecognized free-mix).
+    Returns ``{"effects", "flavour", "capped", "cocktail", "method"}``: the
+    additive substance sum (each clamped to MIX_EFFECT_CAP), the composed
+    flavour, any substances the cap trimmed (for UI feedback), the recognized
+    classic / spin name (or ``None``), and the suggested preparation method
+    (or ``None`` for a free-mix).
     """
     raw = mix_effects(ingredients)
     effects = {sid: min(d, MIX_EFFECT_CAP) for sid, d in raw.items()}
     capped = {sid: d for sid, d in raw.items() if d > MIX_EFFECT_CAP}
+    template, spirit = _best_template(ingredients)
     return {
         "effects": effects,
         "flavour": compose_flavour(ingredients),
         "capped": capped,
-        "cocktail": recognize_cocktail(ingredients),
+        "cocktail": name_cocktail(template, spirit) if template else None,
+        "method": COCKTAIL_METHOD.get(template["name"]) if template else None,
     }
 
 

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -171,6 +171,17 @@ class TestCocktailRecognition(BaseEvenniaTest):
         over = project_mix([self._ing("spirit", "gin", {"alcohol": 9})])
         self.assertEqual(over["effects"]["alcohol"], MIX_EFFECT_CAP)
 
+    def test_project_mix_suggests_method(self):
+        from world.bar import project_mix
+        negroni = [self._ing("spirit", "gin"), self._ing("bitter_aperitivo"),
+                   self._ing("sweet_vermouth")]
+        self.assertEqual(project_mix(negroni)["method"], "stir")
+        daiquiri = [self._ing("spirit", "rum"), self._ing("citrus"),
+                    self._ing("sweetener")]
+        self.assertEqual(project_mix(daiquiri)["method"], "shake")
+        # Free-mix has no suggested method.
+        self.assertIsNone(project_mix([self._ing("spirit", "vodka")])["method"])
+
     def test_catalog_covers_every_cocktail(self):
         from world.bar import INGREDIENT_CATALOG, COCKTAILS
         roles = {p.get("role") for p in INGREDIENT_CATALOG.values()}


### PR DESCRIPTION
Flavor + suggestion only (no mechanical effect, per the v1 line). project_mix
exposes the recognized classic's traditional method; node_top shows it
("Reads as: Negroni (stirred)"); [1] Pour routes through a method pick that
marks the suggested one and drives the craft narration. Saved recipes store
the method and use its craft phrasing for the NPC serve.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
