### PR TITLE
Bars: drink ordinals (2nd mug) + a 'prepare' shortcut command

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -59,8 +59,18 @@ class ConsumptionCommand(Command):
             
         # Parse arguments
         parts = args.split()
-        item_name = parts[0]
-        
+        # Keep an ordinal prefix attached to its noun ("2nd mug", "second mug")
+        # so the search's ordinal handling (ObjectParent.get_search_query_
+        # replacement) can resolve it, instead of splitting the ordinal off as
+        # the item and the noun as a (bogus) target.
+        ordinal_words = getattr(caller, "ORDINAL_WORDS", {})
+        if len(parts) > 1 and parts[0].lower() in ordinal_words:
+            item_name = f"{parts[0]} {parts[1]}"
+            rest = parts[2:]
+        else:
+            item_name = parts[0]
+            rest = parts[1:]
+
         # Find the item
         item = caller.search(item_name, location=caller, quiet=True)
         if not item:
@@ -69,18 +79,18 @@ class ConsumptionCommand(Command):
         elif len(item) > 1:
             result["errors"].append(f"Multiple items match '{item_name}'. Be more specific.")
             return result
-        
+
         result["item"] = item[0]
-        
+
         # Check if it's a medical item (skipped for tag-gated
         # ingestion verbs — see require_medical above)
         if require_medical and not is_medical_item(result["item"]):
             result["errors"].append(f"{result['item'].get_display_name(caller)} is not a medical item.")
             return result
-            
+
         # Parse target (if specified)
-        if len(parts) > 1:
-            target_name = parts[1]
+        if rest:
+            target_name = rest[0]
             if target_name.lower() in ["me", "myself", "self"]:
                 result["target"] = caller
             else:
@@ -93,9 +103,9 @@ class ConsumptionCommand(Command):
                 result["target"] = target
                 
         # Parse body location (for commands that support it)
-        if allow_body_location and len(parts) > 2:
-            result["body_location"] = parts[2]
-            
+        if allow_body_location and len(rest) > 1:
+            result["body_location"] = rest[1]
+
         return result
         
     def _apply_substance_dose(self, item, target):

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -101,12 +101,57 @@ class CmdBarUse(Command):
         start_bar_menu(caller, bar)
 
 
+class CmdBarPrepare(Command):
+    """
+    Prepare a known drink from the bar's menu, on the fly.
+
+    Usage:
+        prepare <drink>
+
+    A shortcut past the mixing menu: matches the bar's menu and makes the drink
+    straight onto the bar (no ingredients to load — like the bartender pouring a
+    known recipe). For bartenders.
+
+    Example:
+        prepare recyc
+    """
+
+    key = "prepare"
+    locks = "cmd:all()"
+    help_category = "Bar"
+
+    def func(self):
+        import re
+        bar = self.obj
+        caller = self.caller
+        if not bar.is_bartender(caller):
+            caller.msg("You aren't working this bar.")
+            return
+        # Tolerate a trailing "on <bar>" — the command is already bound to a bar.
+        query = re.split(r"\bon\b", (self.args or "").strip(), maxsplit=1)[0].strip()
+        if not query:
+            caller.msg("Prepare what? (try the menu to see what's on offer.)")
+            return
+        recipe = match_recipe(query, bar.db.menu or [])
+        if not recipe:
+            caller.msg(
+                f"That's not on {bar.get_display_name(caller)}'s menu."
+            )
+            return
+        drink = make_drink_from_recipe(recipe, location=bar)
+        craft = recipe.get("craft", "builds the drink")
+        caller.execute_cmd(
+            f"emote {craft}, and sets {with_article(drink.key)} on {bar.key}."
+        )
+
+
 class BarCmdSet(CmdSet):
     key = "bar_cmdset"
 
     def at_cmdset_creation(self):
         self.add(CmdBarMenu())
         self.add(CmdBarUse())
+        self.add(CmdBarPrepare())
 
 
 # ---------------------------------------------------------------------------

--- a/world/tests/test_consumption_rendering.py
+++ b/world/tests/test_consumption_rendering.py
@@ -200,6 +200,43 @@ def _run_consumption_cmd(
 # ===================================================================
 
 
+class TestOrdinalItemParse(TestCase):
+    """`drink 2nd mug` keeps the ordinal attached to its noun for search."""
+
+    def _cmd(self):
+        from commands.CmdConsumption import CmdDrink
+        cmd = CmdDrink()
+        caller = MagicMock()
+        caller.ORDINAL_WORDS = {"first": 1, "second": 2, "1st": 1, "2nd": 2}
+        caller._searched = []
+        def fake_search(q, location=None, quiet=False):
+            caller._searched.append(q)
+            return [MagicMock()]
+        caller.search = fake_search
+        cmd.caller = caller
+        return cmd, caller
+
+    def test_numeric_ordinal_kept_with_noun(self):
+        cmd, caller = self._cmd()
+        res = cmd.get_item_and_target("2nd mug", require_medical=False)
+        self.assertEqual(caller._searched, ["2nd mug"])
+        self.assertEqual(res["target"], caller)  # no bogus target
+
+    def test_word_ordinal_kept_with_noun(self):
+        cmd, caller = self._cmd()
+        cmd.get_item_and_target("second rotgut", require_medical=False)
+        self.assertEqual(caller._searched, ["second rotgut"])
+
+    def test_plain_item_then_target_still_splits(self):
+        cmd, caller = self._cmd()
+        with patch("commands.CmdConsumption.resolve_character_target",
+                   return_value=MagicMock()) as rct:
+            cmd.get_item_and_target("pill alice", require_medical=False)
+        self.assertEqual(caller._searched, ["pill"])
+        rct.assert_called_once()
+        self.assertEqual(rct.call_args[0][1], "alice")
+
+
 class TestConsumptionPerObserverRendering(TestCase):
     """Each consumption verb broadcasts per-observer-rendered text."""
 


### PR DESCRIPTION
- get_item_and_target keeps an ordinal prefix attached to its noun ("2nd
  mug", "second rotgut") so the search's ordinal handling resolves it,
  instead of splitting the ordinal off as the item and the noun as a bogus
  target. Plain "item target" still splits.
- CmdBarPrepare ("prepare <drink>") on the bar cmdset: a shortcut past the
  mixing menu that matches the bar's menu and pours a known recipe onto the
  bar (e.g. "prepare recyc"). Bartender-gated, tolerates a trailing "on <bar>".

Closes #681

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
