### PR TITLE
Bars/crafting: a one-ingredient pour is 'a glass of <ingredient>'

### DIFF
--- a/commands/bar_menu.py
+++ b/commands/bar_menu.py
@@ -140,7 +140,7 @@ def _pour(caller, bar, *, name=None, method=None):
         return None
     proj = project_mix(ings)
     method = method or proj.get("method") or "build"
-    drink_name = name or proj["cocktail"] or "house mix"
+    drink_name = name or proj["name"]
     taste = proj["flavour"]
     desc = f"a freshly-mixed drink — {taste}" if taste else "a freshly-mixed drink"
     drink = make_drink(
@@ -205,7 +205,7 @@ def node_top(caller, raw_string, **kwargs):
             tail = f" {MUTED}({adverb})|n" if adverb else ""
             lines.append(f"  Reads as: {HEAD}{proj['cocktail']}|n{tail}")
         else:
-            lines.append(f"  {MUTED}Reads as: an unrecognized free-mix|n")
+            lines.append(f"  {MUTED}Reads as: {with_article(proj['name'])}|n")
     else:
         lines.append(
             f"  {MUTED}Nothing loaded. Put ingredients on the bar first "
@@ -310,7 +310,7 @@ def _process_method(caller, raw_string, **kwargs):
 def node_save_name(caller, raw_string, **kwargs):
     bar = getattr(caller.ndb, "_bar_menu", None)
     proj = project_mix(_loaded(bar))
-    default = proj["cocktail"] or "house mix"
+    default = proj["name"]
     text = (
         f"{HEAD}Name this pour.|n\n"
         f"  {MUTED}It reads as {default}. Press enter to keep that, or type "
@@ -322,7 +322,7 @@ def node_save_name(caller, raw_string, **kwargs):
 def _process_save_name(caller, raw_string, **kwargs):
     bar = getattr(caller.ndb, "_bar_menu", None)
     proj = project_mix(_loaded(bar))
-    name = raw_string.strip() or proj["cocktail"] or "house mix"
+    name = raw_string.strip() or proj["name"]
     caller.ndb._bar_save_name = name
     return "node_save_taste"
 

--- a/world/bar.py
+++ b/world/bar.py
@@ -462,6 +462,32 @@ def recognize_cocktail(ingredients):
     return name_cocktail(template, spirit) if template else None
 
 
+_VESSEL_RE = re.compile(r"^\w+ of (.+)$")
+
+
+def _ingredient_essence(ingredient):
+    """An ingredient's bare substance name, minus its container — a spirit's
+    type if it has one, else the name with any '<vessel> of ' prefix stripped
+    ('bottle of gin' -> 'gin', 'sprig of mint' -> 'mint')."""
+    spirit = getattr(ingredient.db, "spirit", None)
+    if spirit:
+        return spirit
+    name = ingredient.key or ""
+    m = _VESSEL_RE.match(name)
+    return m.group(1) if m else name
+
+
+def default_drink_name(ingredients, cocktail):
+    """The drink's default name: the recognized classic, else 'glass of <X>' for
+    a single-ingredient pour (a neat gin is just a glass of gin), else 'house
+    mix' for an unrecognized blend."""
+    if cocktail:
+        return cocktail
+    if ingredients and len({i.key for i in ingredients}) == 1:
+        return f"glass of {_ingredient_essence(ingredients[0])}"
+    return "house mix"
+
+
 def project_mix(ingredients):
     """Project what the loaded ingredients would make, without making it.
 
@@ -475,11 +501,13 @@ def project_mix(ingredients):
     effects = {sid: min(d, MIX_EFFECT_CAP) for sid, d in raw.items()}
     capped = {sid: d for sid, d in raw.items() if d > MIX_EFFECT_CAP}
     template, spirit = _best_template(ingredients)
+    cocktail = name_cocktail(template, spirit) if template else None
     return {
         "effects": effects,
         "flavour": compose_flavour(ingredients),
         "capped": capped,
-        "cocktail": name_cocktail(template, spirit) if template else None,
+        "cocktail": cocktail,
+        "name": default_drink_name(ingredients, cocktail),
         "method": COCKTAIL_METHOD.get(template["name"]) if template else None,
     }
 

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -171,6 +171,36 @@ class TestCocktailRecognition(BaseEvenniaTest):
         over = project_mix([self._ing("spirit", "gin", {"alcohol": 9})])
         self.assertEqual(over["effects"]["alcohol"], MIX_EFFECT_CAP)
 
+    def test_default_name_single_ingredient(self):
+        from world.bar import default_drink_name, project_mix
+        # A neat spirit is a glass of that spirit.
+        gin = self._ing("spirit", "gin")
+        gin.key = "bottle of gin"
+        self.assertEqual(default_drink_name([gin], None), "glass of gin")
+        # Two pours of the same thing is still a glass of it.
+        self.assertEqual(default_drink_name([gin, gin], None), "glass of gin")
+        # project_mix carries the default name.
+        self.assertEqual(project_mix([gin])["name"], "glass of gin")
+
+    def test_default_name_non_spirit_strips_vessel(self):
+        from world.bar import default_drink_name
+        verm = self._ing("sweet_vermouth")
+        verm.key = "bottle of sweet vermouth"
+        self.assertEqual(
+            default_drink_name([verm], None), "glass of sweet vermouth"
+        )
+
+    def test_default_name_multi_is_house_mix(self):
+        from world.bar import default_drink_name
+        a = self._ing("spirit", "vodka"); a.key = "bottle of vodka"
+        b = self._ing("cream"); b.key = "carton of cream"
+        self.assertEqual(default_drink_name([a, b], None), "house mix")
+
+    def test_default_name_prefers_cocktail(self):
+        from world.bar import default_drink_name
+        g = self._ing("spirit", "gin"); g.key = "bottle of gin"
+        self.assertEqual(default_drink_name([g], "Negroni"), "Negroni")
+
     def test_project_mix_suggests_method(self):
         from world.bar import project_mix
         negroni = [self._ing("spirit", "gin"), self._ing("bitter_aperitivo"),


### PR DESCRIPTION
default_drink_name: recognized classic > 'glass of <essence>' for a
single-ingredient pour (a neat gin = a glass of gin; spirit type or
vessel-stripped name) > 'house mix' for an unrecognized blend. project_mix
returns it as "name"; the menu pours/saves/labels off it instead of the
bare cocktail-or-house-mix fallback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
