### PR TITLE
Bars: flavour-only drinks (soda, recyc) now show their taste

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -123,10 +123,14 @@ class ConsumptionCommand(Command):
         """
         from world.substances import apply_substance
 
+        # A recipe-composed drink carries a ``db.drink_effects`` map — possibly
+        # *empty* for a flavour-only pour (soda water, a no-effect mixer). Test
+        # for None (the marker that it's a drink), not truthiness, so a
+        # no-effect drink still surfaces its taste.
         drink_effects = item.db.drink_effects
-        if drink_effects:
+        if drink_effects is not None:
             feedback = []
-            for substance_id, doses in drink_effects.items():
+            for substance_id, doses in (drink_effects or {}).items():
                 try:
                     n = max(1, int(doses))
                 except (TypeError, ValueError):

--- a/world/tests/test_consumption_rendering.py
+++ b/world/tests/test_consumption_rendering.py
@@ -200,6 +200,37 @@ def _run_consumption_cmd(
 # ===================================================================
 
 
+class TestFlavourOnlyDrinkTaste(TestCase):
+    """A no-effect drink (soda, black recyc) still surfaces its taste."""
+
+    def test_empty_effects_still_shows_taste(self):
+        from commands.CmdConsumption import CmdDrink
+        cmd = CmdDrink()
+        item = MagicMock()
+        item.db.drink_effects = {}      # flavour-only pour
+        item.db.drink_taste = "It tastes of clean soda fizz."
+        target = MagicMock()
+        msgs = []
+        target.msg = lambda *a, **k: msgs.append(a[0] if a else k.get("text"))
+        with patch("world.substances.apply_substance") as ap:
+            cmd._apply_substance_dose(item, target)
+        self.assertIn("It tastes of clean soda fizz.", msgs)
+        ap.assert_not_called()
+
+    def test_non_drink_uses_substance_path(self):
+        from commands.CmdConsumption import CmdDrink
+        cmd = CmdDrink()
+        item = MagicMock()
+        item.db.drink_effects = None    # not a recipe-composed drink
+        item.db.substance = None
+        target = MagicMock()
+        target.msg = MagicMock()
+        with patch("world.substances.apply_substance",
+                   return_value={"feedback": []}) as ap:
+            cmd._apply_substance_dose(item, target)
+        ap.assert_called_once()
+
+
 class TestOrdinalItemParse(TestCase):
     """`drink 2nd mug` keeps the ordinal attached to its noun for search."""
 


### PR DESCRIPTION
_apply_substance_dose tested drink_effects for truthiness, so a no-effect
drink (empty dict) skipped the taste branch entirely. Test for None (the
marker that it IS a recipe-composed drink) instead, so a flavour-only pour
still surfaces its taste.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
