### PR TITLE
Consumption: guard chug/devour against medical items

### DIFF
--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -1112,6 +1112,14 @@ class CmdChug(ConsumptionCommand):
         if not supports_delivery(item, "drink"):
             caller.msg(f"You can't chug {item.get_display_name(caller)}.")
             return
+        # Medical items need proper administration, not a reckless chug — a
+        # dedicated verb for those is out of scope for now (#687 follow-up).
+        if is_medical_item(item):
+            caller.msg(
+                f"You wouldn't just chug {item.get_display_name(caller)} — "
+                f"that needs proper dosing."
+            )
+            return
         name = with_article(item.get_display_name(caller))
         if is_self:
             caller.msg(f"You chug {name} down in one long pull.")
@@ -1157,6 +1165,14 @@ class CmdDevour(ConsumptionCommand):
         is_self = (caller == target)
         if not supports_delivery(item, "eat"):
             caller.msg(f"You can't devour {item.get_display_name(caller)}.")
+            return
+        # Medical items need proper administration, not a reckless gulp — a
+        # dedicated verb for those is out of scope for now (#687 follow-up).
+        if is_medical_item(item):
+            caller.msg(
+                f"You wouldn't just devour {item.get_display_name(caller)} — "
+                f"that needs proper dosing."
+            )
             return
         name = with_article(item.get_display_name(caller))
         if is_self:

--- a/world/tests/test_consumption_rendering.py
+++ b/world/tests/test_consumption_rendering.py
@@ -219,6 +219,24 @@ class TestChugDevourFullDose(TestCase):
         ap.assert_called_once_with(target, "alcohol", doses=3)   # 1 × 3 sips
         self.assertTrue(any("scours the throat" in m for m in msgs))
 
+    def test_medical_item_is_guarded(self):
+        from commands.CmdConsumption import CmdChug
+        cmd = CmdChug()
+        caller = MagicMock()
+        caller.msg = MagicMock()
+        cmd.caller = caller
+        item = MagicMock()
+        item.get_display_name = lambda looker=None: "a stimpak"
+        parse = {"item": item, "target": caller, "errors": []}
+        with patch.object(cmd, "get_item_and_target", return_value=parse), \
+             patch("commands.CmdConsumption.supports_delivery", return_value=True), \
+             patch("commands.CmdConsumption.is_medical_item", return_value=True), \
+             patch.object(cmd, "_apply_full_dose") as full:
+            cmd.args = "stimpak"
+            cmd.func()
+        full.assert_not_called()
+        self.assertIn("proper dosing", caller.msg.call_args[0][0])
+
     def test_legacy_substance_scaled_by_uses(self):
         from commands.CmdConsumption import CmdDevour
         cmd = CmdDevour()


### PR DESCRIPTION
Medical items need proper administration, not a blunt chug/devour. Reject
them with a hint; a dedicated medical-administration verb is out of scope
for now (#687 follow-up).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
