### PR TITLE
Medical: @heal sobers up + admin recovery works while unconscious/dead

### DIFF
--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -162,6 +162,13 @@ class CmdHeal(Command):
             if amount is None and condition_type is None:
                 organs_healed = medical_state.full_heal()
 
+                # Reset the intoxication/addiction ledger too — full_heal clears
+                # the sedation/drunkenness *conditions*, but the lifetime
+                # substance-dose tally (cravings, addiction threshold) lives on
+                # the character; a full heal should sober them up clean.
+                if target.attributes.has("substance_doses"):
+                    target.attributes.remove("substance_doses")
+
                 # Stop medical script since no conditions remain
                 from world.medical.script import stop_medical_script
                 stop_medical_script(target)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -73,7 +73,14 @@ class UnconsciousCmdSet(CmdSet):
         # Staff commands (will be filtered by permissions anyway)
         self.add(default_cmds.CmdPy())        # Staff debugging
         self.add(default_cmds.CmdReload())    # Staff server management
-        
+
+        # Admin recovery commands stay available even while unconscious —
+        # they're perm-locked (Builders/Developers), so regular players can't
+        # use them, but staff can @heal themselves out of a state instead of
+        # being locked out by the very state they're trying to fix.
+        self.add(CmdHeal())
+        self.add(CmdResetMedical())
+
         # NO look, NO movement, NO actions when unconscious
 
 
@@ -99,7 +106,12 @@ class DeathCmdSet(CmdSet):
         # Staff commands (will be filtered by permissions anyway)
         self.add(default_cmds.CmdPy())        # Staff debugging
         self.add(default_cmds.CmdReload())    # Staff server management
-        
+
+        # Admin recovery commands stay available even while dead — perm-locked,
+        # so staff can @heal themselves back instead of being locked out.
+        self.add(CmdHeal())
+        self.add(CmdResetMedical())
+
         # NO look, NO time, NO movement, NO actions when dead
 
 


### PR DESCRIPTION
- @heal full-heal now also clears the character's substance_doses ledger, so
  drunkenness/sedation/cravings (the intoxication + addiction tally) reset
  cleanly, not just the conditions full_heal already cleared.
- UnconsciousCmdSet and DeathCmdSet now include CmdHeal and CmdResetMedical
  (perm-locked), so staff can @heal themselves out of an unconscious/dead
  state instead of being locked out by the state they're trying to fix.

Closes #690

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
