### PR TITLE
Bars: clear <bar> command + temporary drink blackouts

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -145,6 +145,51 @@ class CmdBarPrepare(Command):
         )
 
 
+class CmdBarClear(Command):
+    """
+    Clear abandoned drinks and loose ingredients off the bar.
+
+    Usage:
+        clear <bar>
+
+    Wipes the bar surface down — served drinks nobody took and any ingredients
+    left loaded. Keeps the counter tidy between rounds. For bartenders.
+    """
+
+    key = "clear"
+    locks = "cmd:all()"
+    help_category = "Bar"
+
+    def func(self):
+        from world.identity_utils import msg_room_identity
+
+        bar = self.obj
+        caller = self.caller
+        if not bar.is_bartender(caller):
+            caller.msg("You aren't working this bar.")
+            return
+        clutter = [
+            o for o in bar.contents
+            if getattr(o.db, "is_drink", False) or getattr(o.db, "is_ingredient", False)
+        ]
+        n = len(clutter)
+        if not n:
+            caller.msg(f"{bar.get_display_name(caller)} is already clear.")
+            return
+        for o in clutter:
+            o.delete()
+        caller.msg(
+            f"You wipe down {bar.get_display_name(caller)}, clearing away "
+            f"{n} item{'s' if n != 1 else ''}."
+        )
+        msg_room_identity(
+            location=caller.location,
+            template=f"{{actor}} wipes down {bar.key}, clearing away the empties.",
+            char_refs={"actor": caller},
+            exclude=[caller],
+        )
+
+
 class BarCmdSet(CmdSet):
     key = "bar_cmdset"
 
@@ -152,6 +197,7 @@ class BarCmdSet(CmdSet):
         self.add(CmdBarMenu())
         self.add(CmdBarUse())
         self.add(CmdBarPrepare())
+        self.add(CmdBarClear())
 
 
 # ---------------------------------------------------------------------------

--- a/world/medical/constants.py
+++ b/world/medical/constants.py
@@ -204,7 +204,11 @@ BLEEDING_SEVERITY_LABELS = {
 
 CONSCIOUSNESS_RECOVERY_HAZARD_PER_MINUTE = {
     "knockout": 0.25,
-    "sedative": 0.15,
+    # Drink/drug sedation should sleep off, not strand the player — one severity
+    # drop (≈3 min at the 180s tick) is enough to regain consciousness; a few
+    # more clears the buzz. Raised from 0.15 so a blackout is a brief nap, not a
+    # ~30-minute lockout (player-experience: blacking out is temporary).
+    "sedative": 0.50,
     "anesthesia": 0.10,
     "trauma": 0.20,
 }


### PR DESCRIPTION
- CmdBarClear ("clear <bar>") on the bar cmdset: bartenders/owners/staff
  sweep abandoned drinks and loose ingredients off the surface.
- Drink/drug sedation recovery raised 0.15 -> 0.50/min so a blackout is a
  brief nap (~3 min to regain consciousness, ~15 to clear) rather than a
  ~30-minute lockout. Sedation is already capped; this is recovery speed.

Closes #693

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
