### PR TITLE
Appearance: fix extended-anatomy longdesc rendering twice

### DIFF
--- a/typeclasses/appearance_mixin.py
+++ b/typeclasses/appearance_mixin.py
@@ -191,8 +191,15 @@ class AppearanceMixin:
                         # Wound system not available, continue without wounds
                         pass
 
-        # Add any extended anatomy not in default order (clothing or longdesc)
-        all_locations = set(longdescs.keys()) | set(coverage_map.keys())
+        # Add any extended anatomy not in default order (clothing or longdesc).
+        # The main loop above already renders everything in ``render_order``
+        # (the species order PLUS extended longdesc keys like an augment tail),
+        # so exclude those here — otherwise an extended longdesc location renders
+        # twice. This loop's remaining job is coverage-only extended locations
+        # (clothing on an extended location that carries no longdesc).
+        all_locations = (
+            (set(longdescs.keys()) | set(coverage_map.keys())) - set(render_order)
+        )
         for location in all_locations:
             if location not in ANATOMICAL_DISPLAY_ORDER:
                 if location in collapse_skip:

--- a/world/tests/test_paired_longdesc_collapse.py
+++ b/world/tests/test_paired_longdesc_collapse.py
@@ -342,3 +342,49 @@ class PairedSeveredDescriptionTests(TestCase):
         ):
             out = get_paired_severed_description(None, "left_hand", "right_hand")
         self.assertIsNone(out)
+
+
+class _ExtAnatomy(AppearanceMixin):
+    """Minimal host to exercise extended-anatomy (e.g. an augment tail)
+    rendering through the real ``_get_visible_body_descriptions``."""
+
+    def __init__(self, longdescs):
+        self._longdescs = longdescs
+
+    @property
+    def longdesc(self):
+        return self._longdescs
+
+    class _DB:
+        species = None
+
+    db = _DB()
+
+    def _build_clothing_coverage_map(self):
+        return {}
+
+    def _get_destroyed_locations(self):
+        return set()
+
+    def _build_paired_longdesc_collapse(self, *a, **k):
+        return ({}, set())
+
+    def _build_destroyed_pair_collapse(self, *a, **k):
+        return ({}, set())
+
+    def _render_body_longdesc(self, location, text, looker):
+        return text
+
+
+class ExtendedAnatomyRenderTests(TestCase):
+    """An extended longdesc location (an augment tail) renders exactly once."""
+
+    def test_extended_longdesc_renders_once(self):
+        host = _ExtAnatomy(
+            {"chest": "A bare chest.", "tail": "A cybernetic tail sways."}
+        )
+        descriptions = host._get_visible_body_descriptions(looker=None)
+        locations = [loc for loc, _ in descriptions]
+        self.assertEqual(locations.count("tail"), 1)
+        joined = " ".join(text for _, text in descriptions)
+        self.assertEqual(joined.count("A cybernetic tail sways."), 1)


### PR DESCRIPTION
render_order was extended to include non-default longdesc keys (augment tail
etc.), but the older extended-anatomy loop still re-rendered them, doubling
the line. Exclude render_order locations from that loop so an extended
location renders once; the loop keeps only its coverage-only extended job.

Surfaced building a human bartender with a cybernetic tail.

Closes #697

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
