### PR TITLE
Crowd: make interior heavy/packed tiers distinct from street

### DIFF
--- a/room_desc_snapshot_20260620-060409.json
+++ b/room_desc_snapshot_20260620-060409.json
@@ -1,0 +1,172 @@
+{
+  "2": {
+    "key": "Limbo",
+    "desc": "Welcome to your new |wEvennia|n-based game! Visit https://www.evennia.com if you need\nhelp, want to contribute, report issues or just join the community.\n\nAs a privileged user, write |wbatchcommand tutorial_world.build|n to build\ntutorial content. Once built, try |wintro|n for starting help and |wtutorial|n to\nplay the demo game.",
+    "sense_descs": {}
+  },
+  "4": {
+    "key": "Braddock Avenue",
+    "desc": "The avenue widens here where an old mining shaft entrance has been sealed with composite plating, the metal warped from some long-ago structural failure. Graffiti covers the sealed entrance—layer upon layer of tags, territorial markers, and cryptic symbols that might be gang signs or philosophical statements or both. A row of storage containers lines the northern side, their doors secured with mismatched locks suggesting whoever owns them doesn't trust corporate security to care. The crater wall shows water staining here, dark streaks where condensation or leakage has marked the stone for years. Distant machinery hums constantly, the sound building like pressure behind your eardrums.",
+    "sense_descs": {}
+  },
+  "13": {
+    "key": "Braddock Avenue",
+    "desc": "Prefab modules crowd both sides of the avenue here, their walls so close you could touch them simultaneously if you stretched. The narrow passage between them channels wind into a constant low whistle, the sound mixing with voices and machinery from adjacent streets. Someone has strung cable lights overhead, their intermittent flicker creating strobing shadows that make navigation feel like moving through discrete moments rather than continuous space. A small shrine occupies a wall niche—candles, some unidentifiable offering wrapped in cloth, and a printed image so faded the subject has become pure abstraction. The ground is worn smooth here, polished by endless passage.",
+    "sense_descs": {}
+  },
+  "17": {
+    "key": "Braddock Avenue",
+    "desc": "A corner store occupies the northern side, its entrance marked by a hand-painted sign offering \"Provisions & Sundries\" in lettering that's been touched up so many times the original color is just archaeological speculation. To the south, a laundromat's windows glow with condensation, the humid air escaping through vents carrying the scent of industrial detergent and heated fabric. Between them, the avenue serves as an impromptu marketplace—a synthetic vendor stands beside a folding table displaying protein bars and recycled water bottles, their prices marked in both scrip and trade goods. The sound of the laundromat's tumbling machines provides a rhythmic backdrop, almost hypnotic in its mechanical constancy.",
+    "sense_descs": {}
+  },
+  "178": {
+    "key": "Ramirez Provisions & Sundries",
+    "desc": "The store crams itself into a space that might have been designed for storage rather than commerce, shelving units bolted to every available wall surface and extending overhead in a precarious geometry that defies standard safety codes. Protein rations, recycled water, salvaged electronics, and medical supplies compete for shelf space with items whose purpose has been forgotten but might prove useful someday.",
+    "sense_descs": {}
+  },
+  "181": {
+    "key": "Market Rooftop",
+    "desc": "This rooftop offers a commanding view of the neighborhood, its surface a patchwork of weathered tar paper, gravel, and the occasional patch where someone tried to seal a leak. The building's old brick chimney rises like a monument to forgotten heating systems, while newer additions—satellite dishes, cell phone antennas, and a small forest of PVC pipes—create an urban jungle of technology. A few overturned milk crates serve as makeshift seating near the roof's edge, where someone has clearly spent time watching the street below. The smell of the market drifts up through ventilation grates: a mix of produce, cleaning supplies, and the faint sweetness of overripe fruit. From here, the gap to the neighboring laundromat rooftop looks both impossibly far and tantalizingly close, depending on your nerve. The city spreads out in a grid of possibilities, each rooftop a potential stepping stone for those bold enough to take the leap. Wind whistles between the buildings, carrying the sounds of traffic, distant music, and the endless hum of urban life.",
+    "sense_descs": {}
+  },
+  "184": {
+    "key": "Suds & Bubbles Laundromat",
+    "desc": "Heat hits you immediately upon entry, the atmospheric recyclers struggling against humidity that turns the air thick and almost liquid. Industrial washers and dryers line both walls, their mismatched models suggesting decades of replacement and repair - some still bearing manufacturer plates from Terran companies that no longer exist. The floor tiles, cracked and stained, channel water toward drains that gurgle constantly with the optimism of systems designed for lighter use. Folding tables occupy the center, their surfaces warped from moisture and heat, scattered with forgotten socks and the occasional left-behind garment that's achieved the status of permanent resident. The mechanical thunder of tumbling drums creates a white noise that makes conversation require raised voices, rendering the space into a cathedral of industrial necessity where people come to maintain the fiction that cleanliness still matters.",
+    "sense_descs": {}
+  },
+  "187": {
+    "key": "Laundromat Rooftop",
+    "desc": "The flat rooftop stretches out under the open sky, its tar and gravel surface baking in the sun and dotted with puddles that never quite dry. A cluster of industrial ventilation units hums and rattles, exhausting the humid air from the laundromat below in periodic clouds of steam that smell faintly of soap and fabric softener. The roof's edge is marked by a low concrete parapet, just high enough to lean against while surveying the urban landscape. Rusty fire escape ladders cling to the building's sides, and a few weathered lawn chairs sit abandoned near a makeshift clothesline strung between two antenna masts. From here, you can see across the gap to the neighboring buildings, their rooftops forming a concrete archipelago above the streets below. The city sprawls in all directions, a maze of brick, steel, and possibility.",
+    "sense_descs": {}
+  },
+  "190": {
+    "key": "In the Air",
+    "desc": "Wind whips past your ears as the city spreads below in a patchwork of rooftops, fire escapes, and narrow alleys. The air carries the mingled scents of exhaust fumes, cooking food, and the distant tang of the river. Traffic sounds drift up from the streets - horns, engines, the occasional siren - while closer at hand you can hear the creak of metal structures and the flutter of fabric in the breeze. The urban landscape stretches in every direction, a maze of brick and concrete punctuated by the occasional splash of neon or greenery.",
+    "sense_descs": {}
+  },
+  "220": {
+    "key": "Braddock Avenue",
+    "desc": "The avenue begins to widen here, industrial grating replacing the improvised surfaces of the southwestern reaches. Prefab housing gives way to structures with an almost deliberate quality, their placement suggesting planning rather than organic desperation. To the north, you can see where the colony transitions from edge to established—streetlights that actually function, signage that hasn't been hand-painted over salvage. The atmospheric processor looms larger now, its northeastern bulk close enough that you can make out individual exhaust stacks and the scaffolding of maintenance platforms. The air tastes of metal and ozone, warmer but still carrying that edge of mineral cold from the crater's depths.",
+    "sense_descs": {}
+  },
+  "223": {
+    "key": "South Marlowe Street and Braddock Avenue",
+    "desc": "The intersection sprawls where South Marlowe Street cuts north through the colony's industrial heart, its width marking it as a major artery designed when someone still believed in planning for growth. Industrial grating forms a near-perfect grid here, maintenance hatches dotting the surface at regular intervals like punctuation marks in a language of buried infrastructure. To the north, Marlowe climbs toward the distant promise of the Balboa Channel and the Central Span beyond, its perspective lines disappearing into the maze of prefab structures and the hazy glow of functional street lighting. The atmospheric processor dominates the eastern view, close enough now that its mechanical rhythm becomes something you feel in your chest rather than merely hear. South, the crater wall curves dark and final, reminding you that even in a place built for expansion, some boundaries remain absolute.",
+    "sense_descs": {}
+  },
+  "888": {
+    "key": "Braddock Avenue",
+    "desc": "Heavy machinery dominates here, parked mining haulers forming impromptu walls that channel foot traffic into narrow paths between their massive treads. The vehicles still carry the day's work—regolith dust coating their surfaces, ice melt freezing in the joints of their hydraulics. Someone has welded a crude shelter between two hauler cabs, the space barely large enough for a person to lie down, its entrance curtained with thermal sheeting. The air carries the mixed scents of hydraulic fluid and stone dust, warmer than the southwestern edge but still holding the crater's mineral chill.",
+    "sense_descs": {}
+  },
+  "894": {
+    "key": "South Marlowe Street",
+    "desc": "The street opens with a width that speaks to ambition - someone designed this as a thoroughfare when the colony still had pretensions toward planning. Industrial grating forms an almost perfect grid underfoot, maintenance hatches at regular intervals suggesting infrastructure that actually gets attention. The atmospheric processor dominates the eastern horizon, close enough that its waste heat creates shimmering air currents that make distant structures waver. Prefab housing lines both sides, their walls showing the kind of maintenance that comes from being near a major route—fresh patches, functional seals, the occasional coat of protective sealant still tacky enough to smell.",
+    "sense_descs": {}
+  },
+  "897": {
+    "key": "Braddock Avenue",
+    "desc": "The avenue shifts character here, leaving behind the improvised sprawl of the western reaches for something that almost resembles intentional design. The street surface is intact industrial grating, warm to the touch from the atmospheric processor's proximity—close enough now that its waste heat has transformed this corner of the colony into the most habitable real estate on Braddock. Prefab modules line the northern side in relatively good repair, their walls showing fresh patches rather than decades of accumulated damage. To the south, the crater wall still looms, but here it's been integrated with better engineering—proper seals, functioning drainage, structural supports that look like someone actually calculated load-bearing rather than guessing. The air carries that thick metallic warmth that makes you realize cold is a choice the western colony makes by necessity rather than preference.",
+    "sense_descs": {}
+  },
+  "1682": {
+    "key": "Tsiolkovsky Corridor",
+    "desc": "",
+    "sense_descs": {}
+  },
+  "1685": {
+    "key": "Tsiolkovsky Corridor",
+    "desc": "",
+    "sense_descs": {}
+  },
+  "1688": {
+    "key": "Tsiolkovsky Corridor",
+    "desc": "",
+    "sense_descs": {}
+  },
+  "1691": {
+    "key": "Ada Avenue and Tsiolkovsky Corridor",
+    "desc": "The avenue terminates at Tsiolkovsky Corridor, the colony's eastern boundary where residential and industrial zones meet the crater wall's unyielding presence. The intersection carries the particular energy of a terminus - workers arriving and departing, materials moving in transit, the circulation of colony life concentrated at this endpoint. The processor's output colors the air in the distance, rising into the horizon. The crater wall rises behind the intersection, its surface marked by ventilation shafts and maintenance access points. The colony extends as far as it can in this direction; beyond lies only stone and the machinery required to make it habitable.",
+    "sense_descs": {}
+  },
+  "1694": {
+    "key": "Tsiolkovsky Corridor",
+    "desc": "",
+    "sense_descs": {}
+  },
+  "1697": {
+    "key": "Tsiolkovsky Corridor",
+    "desc": "",
+    "sense_descs": {}
+  },
+  "1703": {
+    "key": "Tsiolkovsky Corridor and Arcturus Row",
+    "desc": "",
+    "sense_descs": {}
+  },
+  "1935": {
+    "key": "Queen of Cups - Rooftop",
+    "desc": "The stairs end at a hatch that opens onto the roof, patched metal sheets forming a jagged surface underfoot. From here, Pessoa Street stretches eastward, alive with noise and smoke. The atmospheric processor dominates the skyline in pale light. Makeshift chairs and crates litter the roof. Evidence of gatherings are left behind with empty bottles and burnt offerings. The wind carries the smell of spice and smoke, mixing with the hum of machinery. Shadows stretch long across the colony, broken by neon glows from below.",
+    "sense_descs": {}
+  },
+  "1961": {
+    "key": "Colonial Armory",
+    "desc": "The seal above the entrance has been painted over so many times it's become an abstract smear suggesting authority without claiming it. The west wall features a faded mural - possibly depicting colonial marines, possibly depicting anyone with guns who looked heroic before the paint oxidized - its details lost to time and nobody caring enough to restore what might have been propaganda or might have just been decoration.",
+    "sense_descs": {}
+  },
+  "1968": {
+    "key": "Helix Lounge",
+    "desc": "The warehouse shell is gutted, steel beams exposed like ribs. Concrete walls sweat with condensation, patched with cables that pulse faint light. Speakers hang heavy from chains, their casings scarred, humming with static even when silent. The floor is grating over old drainage channels, steam rising in bursts from vents below. Neon strips flicker against rusted panels, painting the room in jagged color. Screens loop fractured visuals, VHS static bleeding into industrial patterns. The air smells of ozone, oil, and burnt circuitry.",
+    "sense_descs": {}
+  },
+  "1971": {
+    "key": "Helix Lounge - Balcony",
+    "desc": "A steel staircase climbs to the balcony, its steps worn smooth by decades of use. The balcony runs the length of the warehouse, railings patched with welded plates. Chairs sit in clusters, scavenged from offices and ships, their cushions torn but functional. Tables are slabs of metal bolted to the floor, scarred with cigarette burns and knife marks. The walls are lined with old monitors, looping static and half-forgotten logos. Light filters through cracked panels above, casting long shadows across the seating. The hum of the main floor rises here, muffled but constant.",
+    "sense_descs": {}
+  },
+  "1974": {
+    "key": "Helix Lounge - VIP",
+    "desc": "Behind a reinforced door, the VIP zone glows with its own neon palette. A bar stretches along one wall, steel counter polished to a dull shine, bottles lined in uneven rows. Hot tubs sit recessed into the floor, their surfaces steaming, framed by rusted piping and flickering lights. The walls are paneled with old advertising screens, looping broken commercials in endless cycles. The ceiling is low, cables dangling like vines, dripping condensation into the tubs. The air is thick with heat and chemical tang, heavy and close. It feels sealed off, a hidden chamber of excess carved from ruin.",
+    "sense_descs": {}
+  },
+  "1983": {
+    "key": "Thawn-Harrison Cryogenics - Courtyard",
+    "desc": "Composite decking replaces industrial grating here, geometric patterns suggesting corporate resources rather than desperate improvisation. Security lighting mounted on telescoping poles creates overlapping coverage. The building's northern facade displays brushed composite panels and Thawn-Harrison's backlit name in letters that maintain their glow regardless of day cycle. Prefab walls flank east and west, showing maintenance that speaks to professional facilities management. The western and southern approaches open to the street, bollards and low barriers guiding traffic.",
+    "sense_descs": {}
+  },
+  "1986": {
+    "key": "Thawn-Harrison Cryogenics - Lobby",
+    "desc": "The reception area maintains corporate aesthetics while acknowledging colonial reality — composite flooring polished to a sheen that won't last, furniture arranged with deliberate spacing that suggests crowd management protocols. The main desk curves along the eastern wall, its surface integrating displays and biometric scanners, the attendant station currently occupied by a synthetic whose professional demeanor doesn't quite mask the security subroutines running beneath. Waiting area chairs line the southern wall, their upholstery showing wear patterns from populations who wait because they have no choice.",
+    "sense_descs": {}
+  },
+  "1989": {
+    "key": "Thawn-Harrison Cryogenics - Decantation Chamber",
+    "desc": "Ten decanting pods dominate the floor in parallel rows, cylinders of reinforced composite and transparent polymer three meters tall, interiors lit by soft blue illumination that makes the synthetic gel appear both liquid and solid. Control consoles flank each pod, displays cycling through biometric data — neural activity, tissue integration, cardiovascular function rendered as numbers. Supply stations line the walls with refrigerated biochemical storage, equipment racks, emergency medical kits behind break-glass panels. The northern observation station monitors all pods from an elevated platform. Environmental systems maintain precise temperature and humidity, filtered air circulation constant. The floor is composite rated for chemical resistance, drainage channels positioned at intervals. The air tastes clinical — sterilization compounds and refrigerant chemistry. Warning placards cover designated walls in multiple languages.",
+    "sense_descs": {}
+  },
+  "2008": {
+    "key": "Gaia's Treasures",
+    "desc": "The viewport displays speak to careful curation rather than desperate acquisition — a brass sextant behind climate-controlled glass, paper books sealed in preservation cases, what might be genuine wood furniture arranged to suggest Earth living rooms most colonists have only seen in recordings. The proprietor keeps the lighting low, each artifact spotlit like museum pieces, the kind of presentation that makes you think twice before asking prices. Deeper inside, shelves hold smaller items — porcelain that survived the crossing, mechanical watches, photographs in actual silver frames. The air smells faintly of old paper and polishing compound, a Terran scent manufactured through careful maintenance rather than natural accumulation.",
+    "sense_descs": {}
+  },
+  "2430": {
+    "key": "dbg_room9",
+    "desc": "",
+    "sense_descs": {}
+  },
+  "2461": {
+    "key": "dbg_head_corpse_room",
+    "desc": "",
+    "sense_descs": {}
+  },
+  "2480": {
+    "key": "dbg_corpse_amp_room",
+    "desc": "",
+    "sense_descs": {}
+  },
+  "2496": {
+    "key": "dbg_jit_room",
+    "desc": "",
+    "sense_descs": {}
+  }
+}

--- a/room_desc_snapshot_COMPLETE_20260620-065805.json
+++ b/room_desc_snapshot_COMPLETE_20260620-065805.json
@@ -1,0 +1,2374 @@
+{
+ "996": {
+  "key": "Central Span",
+  "desc": "The roadway begins its climb, grating transitioning from street-level composite to reinforced bridge decking designed for loads that make haulers look like toys. Support towers rise on both sides, their foundations disappearing into the channel's dark water below, structural members braced against lateral forces the Balboa generates. Safety barriers line both edges - composite railings backed by cable restraints, the kind of redundancy that suggests people have gone over despite the precautions. Behind, the southern colony sprawls in its familiar maze of prefab and crater wall. Ahead, the span extends across dark water toward the northern districts.",
+  "sense_descs": {
+   "auditory": "The channel works against the support-tower foundations far below; cable restraints thrum where the wind catches them.",
+   "olfactory": "Cold open water and the mineral edge of the channel.",
+   "tactile": "The grade pulls at the legs; reinforced decking sits hard and unflexing underfoot.",
+   "atmospheric": "Navigation lights pulse amber at regular intervals, marking the span's edges."
+  }
+ },
+ "999": {
+  "key": "Central Span",
+  "desc": "The bridge climbs steadily, elevation enough now that the channel's surface becomes visible between support members - dark water moving with currents that draw shifting surface patterns. The span's framework surrounds the roadway, structural trusses overhead forming a latticework against whatever sky exists above the colony's atmospheric envelope. Support towers continue at measured intervals, their composite and steel construction showing maintenance that speaks to not letting this infrastructure fail. Traffic marks on the decking show wear from decades of crossings, but the surface itself remains solid. The southern colony recedes behind, its density becoming abstract geography.",
+  "sense_descs": {
+   "auditory": "Wind cuts across the exposed roadway with force enough to snap loose clothing; it whistles through the overhead trusses.",
+   "olfactory": "Clean cold water, the filtered prefab air left behind.",
+   "tactile": "The wind, no longer broken by walls or crater geography, pushes steadily across the open deck.",
+   "atmospheric": "Navigation lights create a corridor of pulsing amber along the span."
+  }
+ },
+ "1002": {
+  "key": "Central Span",
+  "desc": "Midway to the span's center, the exposure becomes total - open air on all sides, only the framework above and the bridge deck below. The Balboa Channel stretches east and west, its scale apparent from this height, water extending until distance and atmospheric haze make the boundaries theoretical. The channel's current shows in surface tension and the occasional debris passing underneath. Support cables angle down from the overhead framework, their tension visible in how they refuse to move despite the wind. The roadway's surface shows intentional scoring now, traction grooves cut deep enough to remain functional despite decades of traffic. Behind and ahead, the colonies resolve into distinct masses - south with its processor bulk and crater boundary, north with whatever sprawl has claimed that side of the water.",
+  "sense_descs": {
+   "auditory": "Wind dominates everything here, a steady roar past the cables and trusses.",
+   "olfactory": "Open channel water, cold and mineral, scoured clean of the colony.",
+   "tactile": "Traction grooves catch underfoot; the wind shoves with nothing to break it.",
+   "atmospheric": "Navigation lights continue their amber pulse, markers that work day cycle or night."
+  }
+ },
+ "1005": {
+  "key": "Central Span",
+  "desc": "The span's apex, where the roadway reaches its highest elevation above the channel. The framework overhead reaches its most complex configuration - trusses, cross-bracing, cable anchorages all converging at structural nodes. The Balboa's surface below looks almost calm from this height, the current's force reduced to abstract patterns, though anyone who's been down there knows better. Support towers at the midpoint are reinforced beyond the approach sections, foundations descending deep enough to find bedrock or whatever passes for it beneath the channel. A maintenance platform juts from the eastern side, accessible only by service ladder, its deck scattered with equipment covers and tool caches.",
+  "sense_descs": {
+   "auditory": "The wind is constant and unfiltered at the apex, a sustained rush through the converging framework.",
+   "olfactory": "Water and distance, threaded with the chemical signature of whatever the upstream processors dump.",
+   "tactile": "The highest, most exposed point on the span; the wind never lets up.",
+   "atmospheric": "Navigation lights mark the midpoint with doubled frequency, impossible to miss even in the worst visibility."
+  }
+ },
+ "1008": {
+  "key": "Central Span",
+  "desc": "Past the midpoint, the roadway begins its descent toward the northern colony, grade reversing with the same measured precision as the southern approach. The framework remains total overhead, structural members creating consistent geometry as the span extends toward its northern terminus. The channel stretches below, its surface showing more detail on the downward slope - eddies where support towers interrupt the current, debris collected against structural members. Safety barriers show different wear patterns on this side, graffiti in scripts that suggest northern population demographics. The northern colony resolves into increasing detail ahead - prefab configurations that follow different organizational logic.",
+  "sense_descs": {
+   "auditory": "The wind shifts direction here, its rush changing pitch on the northern approach.",
+   "olfactory": "The prevailing currents carry different smells now, less processor dominance, more varied commercial chemistry.",
+   "tactile": "The grade tips forward into the descent; the wind comes from a new quarter.",
+   "atmospheric": "Navigation lights continue their amber pulse, maintaining the corridor that guides crossing."
+  }
+ },
+ "1011": {
+  "key": "Central Span",
+  "desc": "The northern colony's geography becomes clear from this elevation - the channel's northern bank extends into districts without the southern crater wall to define their boundary, sprawl that suggests growth without the same constraints. The descent steepens slightly, bridge decking transitioning back toward street-level elevation, support towers spacing wider as the span approaches solid ground. The framework overhead begins to open up, structural density reducing toward the terminus. The Balboa below narrows slightly as the channel bends around unseen geography. Safety barriers show more active maintenance on the northern approach - fresh welds, recent paint touch-ups.",
+  "sense_descs": {
+   "auditory": "Traffic builds as commuters converge on the approach, footfall and hauler-drone reclaiming the air from the wind.",
+   "olfactory": "The channel water gives way to the varied chemistry of the northern districts.",
+   "tactile": "The descent steepens underfoot; the framework opens and the wind eases as the span nears ground.",
+   "atmospheric": "Navigation lights maintain their pulse, though northern fixtures show updated models."
+  }
+ },
+ "1014": {
+  "key": "Central Span",
+  "desc": "The span's descent completes, bridge decking merging with street-level grating in a junction reinforced for the transition between span and colony infrastructure. Support towers anchor into the northern bank, their foundations visible where they emerge from water level, concrete and composite showing decades of channel exposure - mineral staining, organic growth in protected corners. The northern colony spreads ahead, its configuration different from the south - street patterns following local geography rather than imposed grid, prefab density clustering around commercial nodes. Behind, the Central Span extends back across the channel toward the southern terminus.",
+  "sense_descs": {
+   "auditory": "Two-way traffic flows steady here, haulers and commuters reclaiming the soundscape from the channel wind.",
+   "olfactory": "Channel brine and the organic note of growth in the tower foundations, mixing with northern street smells.",
+   "tactile": "Bridge decking gives way to familiar street grating; the open wind drops behind the structures.",
+   "atmospheric": "Navigation lights mark the terminus with increased density, amber pulse joined by directional markers."
+  }
+ },
+ "1867": {
+  "key": "The Hub and Howl",
+  "desc": "Nestled in the rusted ribs of an abandoned orbital hangar, The Hull & Howl's walls are patched with scorched hull plates and slabs of floor paneling. A bent slab of starship hull, bolted and smashed into shape, serves as the bar - wedged between the seating zone and the rigged-up back wall. Half-open cryopods leak silvery vapor around crates of beer, liquor, and whatever else the bar wants kept cold. Tables are cobbled together from cockpit dashboards, crate stacks, and radar discs, while chairs are carved, cut, or beaten out of anything that looked the right size.",
+  "sense_descs": {
+   "auditory": "Salvaged hardware buzzes; the cryopods hiss faint vapor around the cold crates.",
+   "olfactory": "Cold beer and liquor, scorched metal, and the chemical tang of leaking cryopod vapor.",
+   "tactile": "The patched hull underfoot is uneven; cold rolls off the half-open cryopods behind the bar.",
+   "atmospheric": "A sickly yellow glow from salvaged hardware spills over the cobbled-together seating."
+  }
+ },
+ "1917": {
+  "key": "Queen of Cups - Lobby",
+  "desc": "The lobby is crowded, shelves sagging under piles of faded charms and jury-rigged digital signage. A cracked neon sign buzzes faintly above the counter, its letters flickering in an odd rhythm. Customers shuffle between vending machines and the almighty rental kiosk, its terminal glowing pale blue and offering storage or poverty-aligned living space. Near the counter, a small intercom has been installed. Posters promise privacy guaranteed, though the cameras tucked in corners betray the lie.",
+  "sense_descs": {
+   "auditory": "The cracked neon buzzes in an odd rhythm; vending machines and the rental kiosk hum under shuffling customers.",
+   "olfactory": "Machine oil and fried food drifting in from the street, clinging to every surface.",
+   "tactile": "The lobby is crowded close, bodies and sagging shelves pressing the space tight.",
+   "atmospheric": "The rental kiosk's terminal glows pale blue; cameras tuck into corners beneath the privacy posters."
+  }
+ },
+ "1920": {
+  "key": "Queen of Cups - Stairwell",
+  "desc": "A side door opens into a narrow back room, cluttered with crates and half-sorted junk. A single bulb dangles overhead. In the far corner, a staircase rises upward, its steps creaking with every shift of weight.",
+  "sense_descs": {
+   "auditory": "The staircase steps creak with every shift of weight.",
+   "olfactory": "Dust and rust, heavy and close in the still air.",
+   "tactile": "Clutter crowds the narrow space; the floor grits with settled dust.",
+   "atmospheric": "A single dangling bulb casts shadows that make the clutter seem alive."
+  }
+ },
+ "1923": {
+  "key": "Queen of Cups - First Level",
+  "desc": "The first flight of stairs climbs steeply, the walls close and claustrophobic. Rust stains streak the metal rails. A small landing halfway up holds a broken chair and a pile of discarded wrappers, evidence of someone's brief refuge.",
+  "sense_descs": {
+   "auditory": "Every step groans underfoot; muffled voices filter down from the cubes above, blending into the hum of machinery.",
+   "olfactory": "Sweat and stale smoke, lingering from the tenants above.",
+   "tactile": "The walls press close and claustrophobic; the stairs climb steeply.",
+   "atmospheric": "A single lamp flickers overhead, buzzing like an insect trapped in glass."
+  }
+ },
+ "1926": {
+  "key": "Queen of Cups - Second Level",
+  "desc": "The second level opens onto a narrow landing lined with locked cube doors, each humming faintly with recycled air. The walls are scratched with graffiti - gang marks, prayers, and jokes layered together. A cracked window lets in faint light from the street, distorted by grime. Every door feels like a secret, hiding lives stacked together in anonymity.",
+  "sense_descs": {
+   "auditory": "Muffled arguments and laughter bleed through the thin walls; the cube doors hum faintly with recycled air.",
+   "olfactory": "Fried food drifting upward, mixed with the sharp tang of ozone from the cube terminals.",
+   "tactile": "The air is warmer here, close with stacked-together living.",
+   "atmospheric": "A cracked window lets in faint street light, distorted by grime."
+  }
+ },
+ "1929": {
+  "key": "Queen of Cups - Third Level",
+  "desc": "The third flight is quieter, the landing dimly lit by a single bulb. The walls are more worn, paint peeling in strips that reveal older layers beneath. A few doors line the hall, their locks scarred from repeated tampering. A forgotten crate sits in the corner, covered in dust and graffiti.",
+  "sense_descs": {
+   "auditory": "Silence dominates here, broken only by the faint vibration of the processor carried through the walls.",
+   "olfactory": "Damp metal and recycled air, heavy and persistent.",
+   "tactile": "The processor's vibration carries faint through the walls; the air sits heavy and still.",
+   "atmospheric": "A single bulb flickers like it's ready to die, paint peeling in strips down the worn walls."
+  }
+ },
+ "1932": {
+  "key": "Queen of Cups - Fourth Level",
+  "desc": "The fourth level feels emptier, with fewer doors and more silence. The landing is bare except for a single bench, its surface carved with initials and crude symbols. The walls are marked with faded chalk prayers, remnants of tenants who've long moved on. A dim light filters in from above, hinting at the roof.",
+  "sense_descs": {
+   "auditory": "The hum of the processor is louder here, steady and unyielding.",
+   "olfactory": "Cool, faintly metallic air, thinned by drafts from the structure.",
+   "tactile": "The air is cooler, carrying faint drafts from cracks in the structure.",
+   "atmospheric": "A dim light filters in from above, hinting at the roof; chalk prayers fade across the walls."
+  }
+ },
+ "2": {
+  "key": "Limbo",
+  "desc": "Welcome to your new |wEvennia|n-based game! Visit https://www.evennia.com if you need\nhelp, want to contribute, report issues or just join the community.\n\nAs a privileged user, write |wbatchcommand tutorial_world.build|n to build\ntutorial content. Once built, try |wintro|n for starting help and |wtutorial|n to\nplay the demo game.",
+  "sense_descs": {}
+ },
+ "4": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue widens where an old mining-shaft entrance has been sealed with composite plating, the metal warped from some long-ago structural failure. Graffiti buries the seal — layer on layer of tags, territorial markers, and cryptic symbols that might be gang signs or philosophy or both. A row of storage containers lines the northern side, doors held with mismatched locks. Dark streaks mark the crater wall where water has run and dried for years.",
+  "sense_descs": {
+   "auditory": "A constant low hum of distant machinery, felt more than heard, pressed flat beneath everything else.",
+   "olfactory": "Cold stone, rust, and the faint mineral bite leaking from the sealed shaft.",
+   "tactile": "The crater wall throws off a mineral chill; the composite plating stays cold.",
+   "atmospheric": "A claimed, hand-me-down stretch — everything here is locked, tagged, or both."
+  }
+ },
+ "13": {
+  "key": "Braddock Avenue",
+  "desc": "Prefab modules crowd both sides so close you could brush both walls at once. Cable lights strung overhead flicker on and off, chopping the passage into separate moments. A small shrine fills a wall niche — candles, an offering wrapped in cloth, a printed image faded past all subject. The ground is worn smooth and faintly glossy from endless passage.",
+  "sense_descs": {
+   "auditory": "The cable lights buzz and tick overhead, their current uneven.",
+   "olfactory": "Wax and candle-smoke from the shrine, thin against cold concrete.",
+   "tactile": "The walls press close on both sides; the polished ground gives no grip.",
+   "atmospheric": "A pinched, threshold place — people move through it, and a few stop to leave something at the niche."
+  }
+ },
+ "17": {
+  "key": "Braddock Avenue",
+  "desc": "A corner store holds the northern side, its hand-painted Provisions and Sundries sign retouched so many times the original color is anyone's guess. South, a laundromat's windows glow with condensation, vents breathing humid air into the street. Between them a synthetic vendor works a folding table of protein bars and recycled water, prices marked in scrip and trade goods alike.",
+  "sense_descs": {
+   "auditory": "The laundromat's tumbling machines lay down a steady mechanical rhythm, almost hypnotic in its constancy.",
+   "olfactory": "Industrial detergent and heated fabric roll out of the laundromat vents, sweet and synthetic.",
+   "tactile": "Warm, damp air pushes from the laundromat side; the rest of the street stays cold."
+  }
+ },
+ "178": {
+  "key": "Ramirez Provisions & Sundries",
+  "desc": "The store crams into a space built for storage, not commerce — shelving bolted to every wall and climbing overhead in a precarious geometry that defies any safety code. Protein rations, recycled water, salvaged electronics, and medical supplies fight for shelf space with objects whose purpose has been forgotten but might prove useful someday.",
+  "sense_descs": {
+   "auditory": "A low electrical hum from a cooler somewhere in the stacks, and the tick of a shelf settling under its load.",
+   "olfactory": "Dust, cardboard, and the chemical sweetness of ration wrappers.",
+   "tactile": "The aisles pinch tight, shelving leaning close overhead.",
+   "atmospheric": "Abundance by accumulation — nothing thrown out, everything maybe-useful."
+  }
+ },
+ "181": {
+  "key": "Market Rooftop",
+  "desc": "A patchwork of weathered tar paper and gravel, scarred with failed leak-seals. An old brick chimney rises like a monument to dead heating systems; newer growth — satellite dishes, antennas, a thicket of PVC — crowds around it. Overturned milk crates make seats near the edge, where someone has clearly spent time watching the street below. Across the gap, the laundromat rooftop waits, impossibly far and tantalizingly close by turns.",
+  "sense_descs": {
+   "auditory": "Market noise filters up thin through the ventilation grates — voices, a clatter, the scrape of trade.",
+   "olfactory": "The market rises through the grates: produce, cleaning supplies, the faint sweetness of overripe fruit.",
+   "tactile": "The tar holds the day's warmth; grit shifts underfoot near the unguarded edge.",
+   "atmospheric": "A perch and a launch point — every neighboring roof reads as a possible next step."
+  }
+ },
+ "184": {
+  "key": "Suds & Bubbles Laundromat",
+  "desc": "Mismatched washers and dryers line both walls, several still wearing the manufacturer plates of Terran firms long since folded. Cracked, stained tiles slope toward sluggish drains; warped folding tables hold a litter of forgotten socks and a few left-behind garments gone grey with permanence.",
+  "sense_descs": {
+   "auditory": "The tumbling drums keep up a churning mechanical roar, a wall of white noise; under it runs the steady gurgle of the drains and the periodic buzz-clunk of a cycle ending.",
+   "olfactory": "Hot lint and cheap floral detergent over a sweet-sour undertone of mildew, thickest near the drains.",
+   "tactile": "The air sits hot and dense, humidity the recyclers never clear; condensation beads on the machines, and the tables come away faintly damp.",
+   "atmospheric": "Everything is worn down to bare function - nothing decorative has survived the damp."
+  }
+ },
+ "187": {
+  "key": "Laundromat Rooftop",
+  "desc": "A flat expanse of tar and gravel dotted with puddles that never quite dry. A cluster of industrial ventilation units crowds one side; a low concrete parapet rims the edge, just high enough to lean on. Rusty fire-escape ladders cling to the building's flanks, and a few weathered lawn chairs sit abandoned by a clothesline strung between two antenna masts. Across the gap, neighboring rooftops form a concrete archipelago.",
+  "sense_descs": {
+   "auditory": "The ventilation units hum and rattle, venting the laundromat below in periodic gusts.",
+   "olfactory": "Each vent-cloud carries soap and fabric softener, warm and faintly chemical.",
+   "tactile": "The vents breathe damp heat across this end of the roof; the parapet is cool and gritty.",
+   "atmospheric": "Someone's half-abandoned rooftop refuge — chairs, a clothesline, a long view."
+  }
+ },
+ "190": {
+  "key": "In the Air",
+  "desc": "The city spreads below in a patchwork of rooftops, fire escapes, and narrow alleys — brick and concrete in every direction, broken by the odd splash of neon or green.",
+  "sense_descs": {
+   "olfactory": "Exhaust and cooking-smoke and the distant tang of the river, snatched together at height.",
+   "tactile": "Open air on every side, nothing solid within reach.",
+   "atmospheric": "A held breath between rooftops — committed, weightless, exposed."
+  }
+ },
+ "220": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue widens, industrial grating taking over from the improvised surfaces to the southwest. The structures sit with an almost deliberate placement — planning rather than desperation. North, the colony shades from edge to established: streetlights that work, signage not hand-painted over salvage. The atmospheric processor looms close enough now to pick out individual exhaust stacks and the scaffolding of maintenance platforms.",
+  "sense_descs": {
+   "auditory": "The processor's bulk lays a deep mechanical drone over everything, steady and close.",
+   "olfactory": "Metal and ozone, sharp on the tongue, edged with the mineral cold rising from the crater.",
+   "tactile": "The air runs warmer here off the processor, though the crater's chill still threads through it."
+  }
+ },
+ "223": {
+  "key": "South Marlowe Street and Braddock Avenue",
+  "desc": "The intersection sprawls where South Marlowe Street cuts north through the colony's industrial heart, broad enough to mark it a major artery from a time someone still planned for growth. Industrial grating forms a near-perfect grid, maintenance hatches dotting it at regular intervals like punctuation in a buried language. North, Marlowe climbs toward the distant Balboa Channel and the Central Span beyond. East, the atmospheric processor dominates the view; south, the crater wall curves dark and final.",
+  "sense_descs": {
+   "auditory": "The processor's mechanical rhythm registers in the chest as much as the ears, a slow industrial pulse.",
+   "olfactory": "Ozone and hot metal off the processor, under a constant mineral coldness.",
+   "tactile": "Grating underfoot, warmed unevenly by the processor's waste heat."
+  }
+ },
+ "888": {
+  "key": "Braddock Avenue",
+  "desc": "Heavy machinery dominates — parked mining haulers forming impromptu walls that funnel foot traffic into narrow paths between their massive treads. The vehicles still wear the day's work: regolith dust filming every surface, ice-melt freezing in the joints of their hydraulics. Someone has welded a crude shelter between two hauler cabs, barely long enough to lie down in, its entrance curtained with thermal sheeting.",
+  "sense_descs": {
+   "auditory": "Hydraulics tick and settle as the parked haulers cool, metal pinging somewhere in the dark.",
+   "olfactory": "Hydraulic fluid and pulverized stone, warm machine-oil over cold mineral dust.",
+   "tactile": "Regolith grit coats everything; the crater's chill hangs in the gaps between the treads.",
+   "atmospheric": "A motor pool turned warren — work-machines doubling as walls and shelter."
+  }
+ },
+ "894": {
+  "key": "South Marlowe Street",
+  "desc": "The street opens with a width that speaks to ambition — laid out as a thoroughfare back when the colony still had pretensions of planning. Industrial grating forms an almost perfect grid underfoot, maintenance hatches at regular intervals. East, the atmospheric processor dominates the horizon, its waste heat bending the air into shimmer that makes distant structures waver. Prefab housing lines both sides, walls carrying the upkeep of a place near a major route — fresh patches, functional seals.",
+  "sense_descs": {
+   "auditory": "The processor's drone carries clean across the open grid, low and unbroken.",
+   "olfactory": "Hot metal and ozone, cut with the faint tack of fresh sealant still curing on the prefab walls.",
+   "tactile": "Waste heat rolls off the processor in slow waves; the grating holds it underfoot."
+  }
+ },
+ "897": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue shifts character, trading the improvised western sprawl for something near intentional. The surface is intact industrial grating, warm underfoot from the processor close enough to make this the most habitable real estate on Braddock. Prefab modules line the north in fair repair, fresh patches instead of decades of damage. South, the crater wall still looms, but integrated with real engineering — proper seals, working drainage, supports that look calculated rather than guessed.",
+  "sense_descs": {
+   "auditory": "The processor's hum is a near, steady presence here, almost domestic.",
+   "olfactory": "Thick metallic warmth, the ozone softened, the mineral cold pushed back.",
+   "tactile": "The grating runs genuinely warm — heat as a feature rather than a fight."
+  }
+ },
+ "1691": {
+  "key": "Ada Avenue and Tsiolkovsky Corridor",
+  "desc": "The avenue terminates at Tsiolkovsky Corridor, the colony's eastern boundary where residential and industrial zones meet the crater wall's unyielding presence. The crater wall rises behind the intersection, its face marked by ventilation shafts and maintenance-access points. The processor's output colors the distant air, rising into the horizon. The colony reaches as far as it can here; beyond lies only stone and the machinery to make it habitable.",
+  "sense_descs": {
+   "auditory": "Ventilation shafts in the crater wall exhale a low, hollow draft-sound, constant at the boundary.",
+   "olfactory": "Cold rock and processed air, the mineral edge sharpest where the colony ends.",
+   "tactile": "The crater wall radiates a flat, unmoving cold.",
+   "atmospheric": "The energy of a terminus — everything arriving or leaving, nothing staying."
+  }
+ },
+ "1935": {
+  "key": "Queen of Cups - Rooftop",
+  "desc": "The stairs end at a hatch onto a roof of patched metal sheets, jagged underfoot. Pessoa Street runs east below, alive with light and smoke. The atmospheric processor dominates the skyline in pale light. Makeshift chairs and crates litter the surface; empty bottles and burnt offerings mark old gatherings. Neon glows from below break the long shadows.",
+  "sense_descs": {
+   "auditory": "The processor's hum sits steady under the roof; the street below leaks a muffled churn.",
+   "olfactory": "Spice and smoke drift up from Pessoa Street, threaded through with machine-warmth.",
+   "tactile": "The patched sheeting flexes and tilts underfoot; the air carries the processor's faint warmth.",
+   "atmospheric": "A used gathering-place — somebody's roof, marked by everyone who's burned an offering here."
+  }
+ },
+ "1961": {
+  "key": "Colonial Armory",
+  "desc": "The seal above the entrance has been painted over so many times it's become an abstract smear — authority suggested without being claimed. The west wall carries a faded mural, possibly colonial marines, possibly anyone with guns who looked heroic before the paint oxidized, its details lost to time and indifference.",
+  "sense_descs": {
+   "auditory": "Sound goes flat and close in here, swallowed by concrete; a ventilation fan turns somewhere out of sight.",
+   "olfactory": "Gun oil, old paint, and the dry mineral smell of stored metal.",
+   "tactile": "The air sits still and cool, the kind that doesn't move unless you move it.",
+   "atmospheric": "Institutional bones worn shabby — function outlasting whatever pride built it."
+  }
+ },
+ "1968": {
+  "key": "Helix Lounge",
+  "desc": "A gutted warehouse shell, steel beams bared like ribs. Concrete walls sweat with condensation, patched with cables that pulse faint light. Speakers hang heavy from chains, casings scarred. The floor is grating over old drainage channels; neon strips flicker against rusted panels, painting the room in jagged color. Screens loop fractured visuals, VHS static bleeding into industrial patterns.",
+  "sense_descs": {
+   "auditory": "The speakers hum with static even when silent; below, steam vents hiss in bursts and the grating rings faintly underfoot.",
+   "olfactory": "Ozone, machine oil, and burnt circuitry, sharp and electric.",
+   "tactile": "Steam rises from the vents below in damp bursts; the condensation-slick walls run cold beside it.",
+   "atmospheric": "Ruin dressed as a venue — the warehouse never stopped being a warehouse, it just got wired for the night."
+  }
+ },
+ "1971": {
+  "key": "Helix Lounge - Balcony",
+  "desc": "A steel staircase climbs to a balcony running the warehouse's length, railings patched with welded plates. Chairs cluster in scavenged groups — office and ship salvage, cushions torn but holding. Tables are metal slabs bolted down, scarred with cigarette burns and knife marks. Old monitors line the walls, looping static and half-forgotten logos. Light filters through cracked panels above.",
+  "sense_descs": {
+   "auditory": "The main floor's hum rises here, muffled but constant, the monitors' static threading through it.",
+   "olfactory": "Stale smoke worked into the cushions, over the oil-and-ozone breath of the floor below.",
+   "tactile": "The steel underfoot carries the floor's vibration; the bolted tables are cold and faintly greasy.",
+   "atmospheric": "An overlook for watching rather than being watched — worn, scarred, comfortable in its damage."
+  }
+ },
+ "1974": {
+  "key": "Helix Lounge - VIP",
+  "desc": "Behind a reinforced door, the VIP zone glows in its own neon palette. A steel bar runs one wall, polished to a dull shine, bottles in uneven rows. Hot tubs sit recessed in the floor, surfaces steaming, framed by rusted piping and flickering lights. The walls are paneled in old advertising screens looping broken commercials; the ceiling hangs low, cables dangling like vines.",
+  "sense_descs": {
+   "auditory": "The looping ad-screens murmur broken audio; cables drip steadily into the tubs, each drop a soft tick.",
+   "olfactory": "Heat and chemical tang — tub treatment, hot piping, and something synthetic-sweet underneath.",
+   "tactile": "The air is thick, hot, and close; tub-steam beads on every surface, the low ceiling pressing it down.",
+   "atmospheric": "Excess carved out of ruin — sealed off, indulgent, one failed seal from squalor."
+  }
+ },
+ "1983": {
+  "key": "Thawn-Harrison Cryogenics - Courtyard",
+  "desc": "Composite decking replaces industrial grating here, laid in geometric patterns that read corporate resources rather than desperate improvisation. Security lighting on telescoping poles throws overlapping coverage. The northern facade shows brushed composite panels and Thawn-Harrison's backlit name, holding its glow regardless of day cycle. Prefab walls flank east and west with professionally managed upkeep; bollards and low barriers guide the western and southern approaches.",
+  "sense_descs": {
+   "auditory": "A clean electrical hum off the security lighting, and the soft cycling of climate units — engineered quiet.",
+   "olfactory": "Filtered, faintly antiseptic air, scrubbed of the street's mineral edge.",
+   "tactile": "The decking is even and firm; the air sits temperature-controlled and unmoving.",
+   "atmospheric": "Corporate order pressed onto colony stone — deliberate, lit, and watched."
+  }
+ },
+ "1986": {
+  "key": "Thawn-Harrison Cryogenics - Lobby",
+  "desc": "The reception area keeps corporate aesthetics over colonial reality — composite flooring polished to a sheen that won't last, furniture spaced with the deliberate logic of crowd-management protocol. The main desk curves along the eastern wall, its surface set with displays and biometric scanners, the station held by a synthetic whose professional calm doesn't quite cover the security subroutines beneath. Waiting chairs line the southern wall, upholstery worn by populations who wait because they have no choice.",
+  "sense_descs": {
+   "auditory": "Climate units cycle in soft, even breaths; the desk displays chime now and then as they refresh.",
+   "olfactory": "Filtered air and synthetic upholstery, a manufactured cleanliness with nothing organic in it.",
+   "tactile": "The polished floor is hard and cool; the controlled air neither warms nor stirs.",
+   "atmospheric": "Hospitality as protocol — comfortable-looking, processed, quietly surveilled."
+  }
+ },
+ "1989": {
+  "key": "Thawn-Harrison Cryogenics - Decantation Chamber",
+  "desc": "Ten decanting pods dominate the floor in parallel rows — reinforced composite and clear polymer, three meters tall, their interiors lit soft blue, the synthetic gel inside reading as both liquid and solid. Control consoles flank each pod, displays cycling biometric data: neural activity, tissue integration, cardiovascular function rendered as numbers. Refrigerated storage and equipment racks line the walls, emergency kits behind break-glass panels. An elevated northern station overlooks the rows. Warning placards crowd the designated walls in several languages.",
+  "sense_descs": {
+   "auditory": "A constant filtered-air circulation underlies everything, punctuated by the soft beat of console monitors and the low cycling of the refrigeration.",
+   "olfactory": "Sterilization compounds and refrigerant chemistry, sharp and clinical.",
+   "tactile": "Precisely held cool and dry; chemical-rated composite hard underfoot, drainage channels breaking it at intervals.",
+   "atmospheric": "A place engineered to keep the half-living suspended — precise, lit, and indifferent."
+  }
+ },
+ "2008": {
+  "key": "Gaia's Treasures",
+  "desc": "The viewport displays speak to curation, not desperation — a brass sextant behind climate-controlled glass, paper books in preservation cases, what might be genuine wood furniture arranged to suggest Earth living rooms most colonists have only seen in recordings. The lighting stays low, each artifact spotlit like a museum piece. Deeper in, shelves hold smaller things: porcelain that survived the crossing, mechanical watches, photographs in actual silver frames.",
+  "sense_descs": {
+   "auditory": "Near silence, deliberately kept — the faint tick of mechanical watches and a climate case's low hum the only sounds.",
+   "olfactory": "Old paper and polishing compound, a Terran scent maintained by hand rather than accumulated.",
+   "tactile": "The air is climate-steady and still; the quiet feels padded, careful.",
+   "atmospheric": "Reverence for sale — everything lit and cased to make you think twice before asking a price."
+  }
+ },
+ "900": {
+  "key": "Braddock Avenue",
+  "desc": "Equipment yards sprawl north — a taxonomy of industrial failure: mining rigs awaiting parts that won't arrive, haulers cannibalized to skeletal frames, prefab sections stacked like archaeological strata of corporate optimism. The processor towers northeast now, close enough that its rhythmic exhalations of steam make their own weather. South, the crater wall stands constant, dark stone scarred by drilling and the faded paint of decades-old survey markers.",
+  "sense_descs": {
+   "olfactory": "Cold regolith dust and machine-rust, with the processor's hot-metal exhaust drifting in from the northeast.",
+   "auditory": "The processor breathes in slow rhythmic gusts; the yards tick and settle with cooling metal.",
+   "tactile": "Crater-cold off the stone south; the processor's exhaust pushes warm, damp air over the yards.",
+   "atmospheric": "An open-air graveyard of machines — wreckage filed as inventory."
+  }
+ },
+ "903": {
+  "key": "Braddock Avenue",
+  "desc": "A shuttle's forward section lies half-buried in compacted regolith, its cockpit windows turned skylights for some dwelling beneath. The hull still wears scorch marks — atmospheric entry or combat, impossible to tell, the distinction long since irrelevant. Heavy treads cross-hatch the dust, patterns lasting until the next vehicle erases them.",
+  "sense_descs": {
+   "olfactory": "The processor's hot industrial breath mixed with the sharper bite of working machinery and scorched hull.",
+   "auditory": "Heavy treads grind through the dust; the processor's rhythm carries warmer and nearer.",
+   "tactile": "The air grows warmer here, the cold stone giving ground to the processor's radiant heat.",
+   "atmospheric": "A wreck made home — the line between salvage and shelter erased."
+  }
+ },
+ "906": {
+  "key": "Braddock Avenue",
+  "desc": "Industrial detritus clusters here — discarded equipment housings, coiled cable too damaged to salvage, pressure tanks with their gauges long since cannibalized. The crater wall south shows excavation, shallow caves carved for storage or shelter or just the human need to dig deeper. Northeast, the processor has grown perceptibly larger, beginning to dominate the sky.",
+  "sense_descs": {
+   "olfactory": "Cold rust and stripped cable, the processor's hot-metal note thickening from the northeast.",
+   "auditory": "The processor's breathing grows louder; the detritus ticks as the temperature shifts across it.",
+   "tactile": "Cool by the excavated stone, warmer toward the processor — the gradient tilts east."
+  }
+ },
+ "909": {
+  "key": "Braddock Avenue",
+  "desc": "The street narrows where a derelict hauler hull has been sectioned and stacked three levels high against the crater wall, joined by welded ladder rungs. Laundry hangs motionless between the hauler sections and the opposing prefab. Faded red protection symbols cover every surface — Celtic knots bleeding into geometric patterns that might be mandalas or circuit diagrams or both. The ground is packed regolith worn smooth.",
+  "sense_descs": {
+   "olfactory": "Recycled breath and old machinery, close and stale in the still air.",
+   "auditory": "The air is dead-still here; only the muffled, distant industrial pulse reaches in.",
+   "tactile": "Still, close air that tastes of being breathed too many times; the packed regolith is smooth underfoot.",
+   "atmospheric": "Warded on every surface — red symbols against whatever the dark might send."
+  }
+ },
+ "912": {
+  "key": "Braddock Avenue",
+  "desc": "Salvaged ship plating forms makeshift walls, still bearing the faded logos and hull-IDs of vessels that died elsewhere. The sections don't quite meet, leaving gaps. A converted cargo module squats against the southern wall, its airlock door repurposed as an entrance to housing or storage — the distinction meaningless this far from administration. East, the processor stands distant but undeniable.",
+  "sense_descs": {
+   "olfactory": "Cold metal and old paint off the scavenged plating.",
+   "auditory": "The gaps between the plates whistle thinly; the processor murmurs far to the east.",
+   "tactile": "Cold leaks through every misaligned seam; the salvaged plating is frigid to the touch.",
+   "atmospheric": "A wall of dead ships — everything here exists at the processor's sufferance."
+  }
+ },
+ "915": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue runs hard along the southern crater wall, close enough to see prefab modules bolted directly into the stone face, structural supports vanishing into the rock at odd angles. The metal plating underfoot has buckled into shallow pools where condensation collects off the temperature gap between warm breath and cold stone. North, the street opens toward the industrial heart, but here on the edge everything feels provisional.",
+  "sense_descs": {
+   "olfactory": "Cold wet stone and the mineral damp of the crater wall.",
+   "auditory": "Condensation drips off the buckled plating; the crater stone gives back a flat, dead quiet.",
+   "tactile": "Cold radiates from the stone; the buckled plating holds standing pools that wet the boots.",
+   "atmospheric": "The colony's frayed edge — as if the crater might reclaim it at any moment."
+  }
+ },
+ "918": {
+  "key": "Kaspar Street and Bhavani Corridor",
+  "desc": "The intersection opens where Kaspar Street extends east from Bhavani through the outer edges of the sprawl, the confluence showing the accumulated wear of populations moving through space that stopped pretending to be officially planned decades ago. The grating here is a patchwork of different materials and ages, some sections original colony infrastructure, others replaced with whatever composite or metal could be salvaged when failure became critical.",
+  "sense_descs": {
+   "auditory": "Footfall over the mismatched grating, each salvaged section ringing a different note.",
+   "olfactory": "Rock dust off the crater wall and the stale closeness of the sprawl.",
+   "tactile": "The crater wall presses close; cold radiates off the rock to the west.",
+   "atmospheric": "Structures built into the stone make west a vertical impossibility rather than a direction."
+  }
+ },
+ "921": {
+  "key": "Bhavani Corridor",
+  "desc": "The eastern structures here have given up on pretending they were built according to any plan, their frameworks leaning at angles that suggest either different physics or structural failure taking its time. Scaffolding props up sections of the upper levels, composite beams wedged into positions that look temporary until the rust reveals they've been load-bearing for years. The western side has become more excavation than construction, entire sections carved into the crater wall and sealed with whatever materials could be scavenged - composite panels, sheet metal, sections of what looks like decommissioned hull plating.",
+  "sense_descs": {
+   "auditory": "Scaffolding ticks and settles overhead; muffled life leaks from the carved-out western dwellings.",
+   "olfactory": "Rock dust and rust, the cold-stone breath of the crater wall.",
+   "tactile": "A fine grit of excavated rock coats every surface."
+  }
+ },
+ "927": {
+  "key": "South Marlowe Street",
+  "desc": "A cargo depot occupies the western side, its roll-up doors marked with loading bay numbers in faded corporate stenciling. Composite pallets sit stacked in orderly rows, their contents shrouded in weather-resistant tarps that bear the grime of long-term storage. The eastern side shows mixed use - a machine shop visible through reinforced viewports, its interior cluttered with equipment in various states of disassembly, and a small commissary, its entrance marked by a hand-painted sign advertising hot meals and cold storage.",
+  "sense_descs": {
+   "auditory": "The processor's rhythmic mechanical breathing runs as a constant backdrop, louder with each block north.",
+   "olfactory": "Tarp, machine oil, and a thread of cooking from the commissary.",
+   "tactile": "Heat off the processor builds the further north you stand."
+  }
+ },
+ "930": {
+  "key": "South Marlowe Street",
+  "desc": "The street maintains its industrial character, but residential density increases - prefab modules stacked two and sometimes three high where someone trusted the foundations enough to risk the weight. External access ladders connect the levels, their rungs worn smooth by shift workers moving at predictable intervals. Laundry hangs from improvised lines strung between structures.",
+  "sense_descs": {
+   "auditory": "Shift workers move on the external ladders at predictable intervals; the processor breathes on.",
+   "olfactory": "Cooking cuts through the industrial baseline - garlic and synthetic protein.",
+   "tactile": "Warm air currents carry processor heat up through the stacked modules.",
+   "atmospheric": "Laundry stirs on improvised lines, marking the heat-driven air currents."
+  }
+ },
+ "933": {
+  "key": "South Marlowe Street and Kaspar Street",
+  "desc": "The intersection sprawls where Kaspar Street cuts through the industrial districts, reinforced grating rated for heavy cross-traffic. To the east, Kaspar extends toward Spillane Corridor and the processor - worker housing, shift facilities, the infrastructure of sustained industrial presence. West, the street descends through heavier manufacturing districts. South Marlowe continues north and south, its width undiminished, grating showing decades of wear as the colony's primary artery.",
+  "sense_descs": {
+   "auditory": "Heavy cross-traffic grinds over the reinforced grating.",
+   "olfactory": "Waste heat and machine oil, the processor's industrial baseline.",
+   "tactile": "Warmth bleeds west from the manufacturing districts; the grating sits solid underfoot."
+  }
+ },
+ "936": {
+  "key": "Kaspar Street",
+  "desc": "Worker dormitories dominate both sides, prefab blocks so uniform they were clearly installed in a single operation back when the colony still planned. Four levels, identical but for accumulated damage — fire scoring around one third-floor viewport, structural patches where something heavy hit a corner, another block simply surrendered to rust. External stairwells zigzag between the levels, treads worn concave by decades of shift workers.",
+  "sense_descs": {
+   "olfactory": "Cold metal and rust, threaded with smoke from cheap cooking-fuel.",
+   "auditory": "The stairwells tick and groan with the cold; the colony's hum sits under it all.",
+   "tactile": "The crater wall's shadow keeps this stretch cold; the grating leaches heat from boot soles.",
+   "atmospheric": "Identical blocks distinguished only by how they have failed."
+  }
+ },
+ "939": {
+  "key": "Kaspar Street",
+  "desc": "A repair dock holds the northern side, its bay door perpetually half-open over the skeletal remains of mining equipment in various stages of cannibalization. South, prefab modules — storage or abandoned housing, viewports missing or sheeted over and weathered the same gray as everything. Shift-rotation codes glow faintly in luminescent paint on the grating, ground down by years of foot traffic.",
+  "sense_descs": {
+   "olfactory": "Machine oil, cutting-torch tang, and cold metal off the open dock.",
+   "auditory": "From the dock, the intermittent ring and hiss of salvage work; the colony hums beneath.",
+   "tactile": "Cold pools in the half-open bay; the grating is gritty with shop-dust."
+  }
+ },
+ "942": {
+  "key": "South Marlowe Street",
+  "desc": "The street continues its northward climb, the slight grade noticeable only in how it affects loaded haulers grinding through their gears. A bunkhouse dominates the eastern side, four levels of narrow viewports suggesting dormitory space built for the processor's shift workers - people who sleep close to where they work because the alternative is worse. Fire escapes zigzag up the western face of the structure opposite, their composite treads showing the wear of daily use rather than emergency preparation.",
+  "sense_descs": {
+   "auditory": "Loaded haulers grind through their gears against the grade.",
+   "olfactory": "Hot metal and the close smell of shared dormitory space.",
+   "tactile": "The processor's heat radiates from the east with enough intensity to feel on the skin.",
+   "atmospheric": "Heat shimmers in the gaps between structures, creating false distance."
+  }
+ },
+ "945": {
+  "key": "South Marlowe Street",
+  "desc": "A repair facility occupies the western side, its entrance wide enough to accommodate mining equipment, the interior visible through the open bay door - the organized chaos of things being fixed rather than replaced. The processor towers to the east, its bulk creating a perpetual shadow that keeps this side of the street cooler than the western exposure. Overhead cabling runs in dense parallel lines, power and data feeds branching off in a web that's grown organically rather than by design.",
+  "sense_descs": {
+   "auditory": "Welding crackles and pneumatic tools stutter from the open repair bay.",
+   "olfactory": "Arc-welder ozone, hot metal, and machine oil.",
+   "tactile": "The processor's shadow keeps this side cooler than the sun-struck western exposure."
+  }
+ },
+ "948": {
+  "key": "South Marlowe Street",
+  "desc": "The street straightens here, running true through districts that balance industrial function with residential density. The sides show mixed use - a small machine shop on the ground level, housing above, the vertical integration suggesting efficiency or desperation or both.",
+  "sense_descs": {
+   "auditory": "The processor's mechanical breathing is so constant it sinks beneath notice, baseline rather than sound.",
+   "olfactory": "Machine oil and the layered cooking of housing stacked above the shops.",
+   "tactile": "Steady processor warmth, even and unremarkable here."
+  }
+ },
+ "951": {
+  "key": "South Marlowe Street and Pessoa Street",
+  "desc": "The intersection sprawls where Pessoa Street cuts through the colony's industrial spine, heavier reinforcement than Kaspar suggesting expensive lessons learned. Pessoa extends through refinery districts and processing plants clustered near the channel and processor, worker traffic constant between shifts. South Marlowe continues unchanged, grating polished from decades of hauler traffic.",
+  "sense_descs": {
+   "auditory": "Steam vents release pressure through the grating in hissing bursts.",
+   "olfactory": "Refinery chemistry and hot metal off the processor.",
+   "tactile": "Heat radiates from the processor's near presence; grating polished smooth underfoot.",
+   "atmospheric": "The processor dominates the eastern horizon, close enough to resolve access hatches, sensor arrays, and massive conduits."
+  }
+ },
+ "954": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa curves wide here, grating polished to a shine by decades of hauler traffic. Steam vents punctuate the street; the processor looms east, its conduits sharp against the skyline.",
+  "sense_descs": {
+   "olfactory": "Exhaust, cheap perfume, and frying food fold into a single thick breath.",
+   "auditory": "Steam vents hiss in wet bursts; under them runs the processor's steady hum.",
+   "tactile": "The vented steam leaves the air damp and metallic; the polished grating is slick underfoot."
+  }
+ },
+ "957": {
+  "key": "Pessoa Street",
+  "desc": "The street broadens toward Marlowe, housing stacked into improvised towers. A shrine sits tucked into a corner, its candles burning low. The cracked road is worn smooth toward the busy intersection ahead.",
+  "sense_descs": {
+   "olfactory": "Damp stone and frying oil, heavy and persistent, with a thread of candle-smoke from the shrine.",
+   "auditory": "The processor's hum holds steady from the east, unyielding.",
+   "tactile": "Cold damp rises off the stone; the worn road is smooth underfoot."
+  }
+ },
+ "960": {
+  "key": "South Marlowe Street",
+  "desc": "A salvage yard sprawls on the western side, composite panels and structural beams sorted into rough categories, price tags spray-painted directly onto the materials. The eastern warehouse shows signs of recent fire damage - scorched composite around a viewport, fresh patches that don't match the original construction.",
+  "sense_descs": {
+   "auditory": "Salvage shifts and clangs as someone sorts the western yard.",
+   "olfactory": "Brine off the channel cuts through, salt mixing with processor heat and machine oil into something mineral.",
+   "tactile": "Scorched composite still holds the warehouse fire's heat near the patched viewport."
+  }
+ },
+ "963": {
+  "key": "South Marlowe Street",
+  "desc": "The eastern parts supplier has spread their overflow onto the street - component bins arranged outside the viewport. Prefab warehouses sprawl out on both sides, sealing the street in like a canyon.",
+  "sense_descs": {
+   "auditory": "The warehouse canyon funnels and flattens the street's noise.",
+   "olfactory": "Cold metal and machine oil off the overflow component bins.",
+   "tactile": "Warehouses wall the street into a canyon; the air sits trapped and still.",
+   "atmospheric": "The Central Span's framework rises into view between the structures."
+  }
+ },
+ "966": {
+  "key": "South Marlowe Street",
+  "desc": "A commissary's posted menu lists prices in both tokens and trade goods - protein rations, hot water, even charging time for personal devices. The eastern modules bear corporate numbering that actually follows a pattern, suggesting someone approved this section before chaos became standard.",
+  "sense_descs": {
+   "auditory": "The commissary's kitchen exhaust roars; its serving counter clatters.",
+   "olfactory": "Recycled protein and synthetic spices on the venting steam.",
+   "tactile": "Warmth and kitchen steam thicken the air near the commissary.",
+   "atmospheric": "The Central Span's navigation lights stand steady against the northern sky."
+  }
+ },
+ "969": {
+  "key": "South Marlowe Street and Volta Street",
+  "desc": "The intersection sprawls with heavier reinforcement than the crossings south - doubled grating, support columns that suggest this junction handles serious weight. Volta extends through waterfront service districts, shift schedules and cargo facilities defining its character. South Marlowe continues unchanged, polished by constant hauler traffic.",
+  "sense_descs": {
+   "auditory": "Serious cross-traffic rumbles over the doubled grating.",
+   "olfactory": "Machine oil and a first thread of channel brine from the north.",
+   "tactile": "Support columns brace a junction built for weight; the grating doesn't give underfoot.",
+   "atmospheric": "The Central Span dominates the north, close enough to resolve support towers and elevated roadway."
+  }
+ },
+ "972": {
+  "key": "Volta Street",
+  "desc": "The street widens where South Marlowe approaches, heavier grating handling cross-traffic. Industrial operations cluster both sides - northern fabrication facility with stacked materials, southern testing station with viewports revealing expensive equipment. The atmospheric processor looms larger to the east.",
+  "sense_descs": {
+   "auditory": "Industrial exhaust hisses across the street under the dying-ballast buzz of failing emergency lights.",
+   "olfactory": "Industrial exhaust and hot metal.",
+   "tactile": "Heat radiates up through the grating in waves.",
+   "atmospheric": "Emergency lighting flickers intermittently, dying ballasts adding a random rhythm."
+  }
+ },
+ "975": {
+  "key": "Volta Street",
+  "desc": "The grating here aligns with mechanical precision, panels laid with deliberate exactness. Northern prefab modules show planned modifications rather than hasty patches - sealed conduit runs, matching climate vents, proper composite panel replacements. To the south, the crater wall stands integrated with calculated engineering - functional drainage, deliberate structural supports. The atmospheric processor looms distant to the east.",
+  "sense_descs": {
+   "auditory": "The low filtered hush of properly sealed climate vents.",
+   "olfactory": "Filtered chemical cleanness, scrubbed and neutral.",
+   "tactile": "Every panel sits flush underfoot, the grating laid with mechanical exactness."
+  }
+ },
+ "978": {
+  "key": "South Marlowe Street",
+  "desc": "The street climbs toward the Central Span, the grade noticeable in how haulers shift gears, engines grinding against the slope. Waterfront operations dominate both sides now - a marine supply depot on the western side, its roll-up doors revealing cable spools and hardware stacked to the ceiling, and a shipfitting facility on the east, composite materials and hull plating visible through reinforced viewports. The Central Span rises ahead, its support towers and the roadway's underside resolving with proximity. The processor remains visible to the southeast, its bulk familiar enough to serve as orientation.",
+  "sense_descs": {
+   "auditory": "Haulers grind through their gears against the slope; the channel moves somewhere ahead.",
+   "olfactory": "Brine and marine tar overtaking the processor's hot-metal baseline.",
+   "tactile": "The grade pulls at loaded legs; cooler channel air meets the processor heat here."
+  }
+ },
+ "981": {
+  "key": "South Marlowe Street",
+  "desc": "The approach to the Central Span continues, the street widening slightly where traffic patterns require space for vehicles queueing for the crossing. Navigation lights mark the span's edges, a constellation that guides movement across the channel. The Balboa's presence asserts itself here, dark water visible beyond the immediate structures, moving with a current that explains why the colony built a bridge rather than attempting something more ambitious.",
+  "sense_descs": {
+   "auditory": "The channel's current works steadily past the span's foundations.",
+   "olfactory": "Full channel brine, cold and mineral.",
+   "tactile": "Open wind comes off the water where the street widens for the crossing.",
+   "atmospheric": "Navigation lights mark the span's edges in a constellation across the channel."
+  }
+ },
+ "984": {
+  "key": "South Marlowe Street",
+  "desc": "A power substation dominates both sides of the street, transformers behind chain-link fencing. The span's southern terminus looms ahead, support towers rising from foundations that descend into the channel's depths, the roadway elevated high enough for water traffic to pass beneath. The channel's presence dominates - dark water visible beyond the structures, moving with force that makes the bridge's engineering seem less ambitious and more necessary.",
+  "sense_descs": {
+   "auditory": "Transformers hum steadily behind the chain-link fencing.",
+   "olfactory": "Ozone off the substation cut with channel brine.",
+   "tactile": "The transformers' vibration carries up through the grating into the feet.",
+   "atmospheric": "The span's support towers rise from foundations descending into the channel's depths."
+  }
+ },
+ "987": {
+  "key": "South Marlowe Street and Maxwell Street",
+  "desc": "The intersection opens where South Marlowe Street cuts north toward the Central Span, the confluence designed to handle the traffic that defines this district as vital rather than merely functional. The grating here is reinforced composite rated for constant heavy loads, the surface marked with directional paint maintained with enough regularity to suggest official concern for traffic flow. To the north, Marlowe climbs the final approach to the Central Span - the bridge's southern terminus visible as a framework spanning the Balboa Channel, its support towers resolving into structural detail. Further south, Marlowe descends through residential and commercial districts that cluster in the processor's shadow.",
+  "sense_descs": {
+   "auditory": "Heavy traffic moves through the confluence with the steady purpose of a vital artery.",
+   "olfactory": "Hot metal and machine oil giving way to channel air toward the north.",
+   "tactile": "Reinforced composite underfoot, rated for constant heavy loads.",
+   "atmospheric": "The bridge dominates the view north, its navigation lights a constellation marking the crossing."
+  }
+ },
+ "990": {
+  "key": "Maxwell Street",
+  "desc": "The street angles upward toward the Central Span. The processor looms east, its industrial bulk giving way to prefab dwellings and scuttled pleasure cruisers making the most of the waterfront. Structures tier up the slope on reinforced foundations; through the gaps, the Central Span shows itself — an industrial bridge across the channel, its framework strung with navigation lights. Twin tracks lie polished into the grating where haulers make the climb.",
+  "sense_descs": {
+   "olfactory": "Channel damp and cold metal, with an oily thread off the beached cruisers.",
+   "auditory": "The processor drones from the east; the channel moves somewhere below, a low continuous wash.",
+   "tactile": "Moisture off the channel beads on everything; the climb's polished tracks are slick.",
+   "atmospheric": "Where the industrial east meets the waterfront — a slope reaching for the Span."
+  }
+ },
+ "993": {
+  "key": "Maxwell Street",
+  "desc": "The street runs the Balboa Channel's southern bank, the waterway dominating the northern horizon at a scale that makes human infrastructure feel temporary. Prefab lines the south, northern walls rust-stained and mineral-crusted from decades of channel proximity. A loading dock juts north over the dark water, tie-down points and cargo winches marking it for waterborne freight. Northeast, the Central Span rises across the channel.",
+  "sense_descs": {
+   "olfactory": "Cold mineral water and wet rust, the breath of the channel.",
+   "auditory": "The channel moves past in a steady dark wash; dock winches creak on their mounts.",
+   "tactile": "Channel-damp coats the rails and decking; the grating runs slick toward the water.",
+   "atmospheric": "Built right up against water that makes the colony feel provisional."
+  }
+ },
+ "1017": {
+  "key": "North Marlowe Street and Tolliver Row",
+  "desc": "The intersection opens where Tolliver Row cuts east-west through the waterfront district, the confluence marked by grating reinforced for cross-traffic between channel operations. South, the Central Span's terminus is immediately visible, the bridge's roadway descending from mid-channel to meet the street. Cargo staging areas occupy corners where the streets meet, composite pallets and loading equipment showing constant use.",
+  "sense_descs": {
+   "auditory": "Cargo loading equipment works the corners; the channel moves beyond the barriers.",
+   "olfactory": "Channel brine and diesel off the staging areas.",
+   "tactile": "Reinforced grating underfoot; cool channel air comes off the dark water south.",
+   "atmospheric": "The Central Span's terminus descends to meet the street, the channel moving with purpose beyond the safety barriers."
+  }
+ },
+ "1020": {
+  "key": "North Marlowe Street",
+  "desc": "Multi-story structures line both sides, their composite facades showing regular maintenance - fresh sealant, functioning lighting, transparent viewports. The western side houses commercial operations with proper signage, businesses that assume currency rather than barter. Eastern residential towers suggest the colony's administrative class lives here. The Central Span remains visible to the south.",
+  "sense_descs": {
+   "auditory": "Subdued and orderly, the quiet hum of functioning lighting and climate units.",
+   "olfactory": "Clean filtered air, scrubbed of the colony's industrial baseline.",
+   "tactile": "Fresh sealant and functioning surfaces; even the air feels conditioned.",
+   "atmospheric": "The Central Span remains visible to the south."
+  }
+ },
+ "1023": {
+  "key": "North Marlowe Street",
+  "desc": "A medical facility occupies the western side, four levels marked with caduceus and corporate logos - private healthcare rather than colony clinics. The eastern side hosts professional offices, legal services and accounting firms managing colonial commerce. Street-level retail shows actual inventory in secured displays. The grating is newer composite, drainage systems that function. Pedestrian traffic moves with purpose.",
+  "sense_descs": {
+   "auditory": "Purposeful footfall on clean grating; the muted tone of a private medical lobby.",
+   "olfactory": "Antiseptic from the medical facility cut with filtered office air.",
+   "tactile": "Newer composite underfoot, drainage that actually carries the wet away."
+  }
+ },
+ "1026": {
+  "key": "North Marlowe Street",
+  "desc": "Residential towers rise six and seven levels, showing architectural ambition - curved facades, decorative panels, balconies suggesting space beyond survival. A small plaza opens on the western side with composite benches and deliberate landscaping.",
+  "sense_descs": {
+   "auditory": "Quiet enough that the plaza's landscaping rustles audibly.",
+   "olfactory": "Clean air with a green note off the deliberate landscaping.",
+   "tactile": "Composite benches and tended plantings; the street feels designed for lingering.",
+   "atmospheric": "Biometric checkpoints control access, keeping the working classes in their districts."
+  }
+ },
+ "1029": {
+  "key": "North Marlowe Street and Ada Avenue",
+  "desc": "The intersection opens where Ada Avenue cuts through the northern district's administrative core. The Thawn-Harrison Cryogenics complex sprawls across the northeast corner, structures that actually match rather than improvised expansion. West, Ada extends toward residential towers and professional services. East, the avenue connects to corporate facilities and the atmospheric processor approach.",
+  "sense_descs": {
+   "auditory": "The orderly quiet of the administrative core, checkpoint systems chiming as they process credentials.",
+   "olfactory": "Clean filtered air with the scentless cold off the cryogenics complex.",
+   "tactile": "Level, maintained grating; the conditioned air sits cool and even.",
+   "atmospheric": "Uniformed security and checkpoint systems mark the Thawn-Harrison corner."
+  }
+ },
+ "1032": {
+  "key": "North Marlowe Street",
+  "desc": "The Thawn-Harrison Cryogenics courtyard opens to the east, composite decking replacing standard grating. The facility's facade displays brushed composite panels and the corporate name in backlit letters. The western side shows construction barriers cordoning off what corporate signage promises will be cultural facilities. Street furniture includes actual benches and informational kiosks.",
+  "sense_descs": {
+   "auditory": "The low cycling of cryogenic systems behind the courtyard's facade.",
+   "olfactory": "Clean air with the faint scentless bite of cold off the cryogenics facility.",
+   "tactile": "Composite decking underfoot replaces standard grating, smooth and even.",
+   "atmospheric": "Overlapping security lighting leaves no shadows; the corporate name glows backlit above the courtyard."
+  }
+ },
+ "1035": {
+  "key": "North Marlowe Street",
+  "desc": "A transit hub occupies the western side with covered platforms, posted schedules, and functioning ticket kiosks. The eastern side shows luxury retail, storefronts displaying Earth imports most colonists will never afford.",
+  "sense_descs": {
+   "auditory": "Transit announcements and the hum of ticket kiosks under the covered platforms.",
+   "olfactory": "Clean filtered air, a faint trace of imported goods from the luxury storefronts.",
+   "tactile": "Covered platforms shelter the air, still and temperate."
+  }
+ },
+ "1038": {
+  "key": "North Marlowe Street",
+  "desc": "Corporate housing towers rise on both sides, eight and nine levels where bedrock foundation permits. The structures feature amenities that don't exist in working districts - climate control, water pressure, waste management that functions. Building signage lists corporate sponsors, company housing for management rather than labor.",
+  "sense_descs": {
+   "auditory": "The deep quiet of well-insulated corporate towers, climate systems barely audible.",
+   "olfactory": "Conditioned air, neutral and clean, the industrial colony scrubbed away.",
+   "tactile": "Everything works here - the air tempered, the surfaces maintained, no grit anywhere."
+  }
+ },
+ "1041": {
+  "key": "North Marlowe Street and Arcturus Row",
+  "desc": "The park opens where North Marlowe meets Arcturus Row along the crater wall's base, the intersection transformed into the northern district's most deliberate public space. Imported soil supports actual vegetation - ornamental rather than functional. Composite benches follow geometric patterns around a central fountain that functions more often than not. Arcturus Row extends east and west along the wall's base, connecting corporate facilities and secure residential districts. Marlowe descends toward the Central Span, visible in the distance as a reminder of what separates the north and south sides.",
+  "sense_descs": {
+   "auditory": "The central fountain cycles water; vegetation rustles in the deliberate quiet.",
+   "olfactory": "Imported soil and growing things, a rare green note in the colony.",
+   "tactile": "Composite benches and tended ground; cool air spills off the crater wall to the north.",
+   "atmospheric": "The crater wall rises dark to the north, its face interrupted by access tunnels leading beyond view."
+  }
+ },
+ "1053": {
+  "key": "Ada Avenue",
+  "desc": "Storage facilities line the avenue here, warehouses holding materials and equipment for the colony's industrial operations. Security varies by contents - some buildings show multiple lock systems and monitoring equipment, others apparently rely on the assumption that no one would want what's inside. The lighting grows more sparse, fixtures serving function over comfort. Pools of shadow stretch between the buildings, dark enough to hide intention.",
+  "sense_descs": {
+   "auditory": "Lock systems cycle and reset behind blank doors; a monitoring camera whirs as it tracks past.",
+   "olfactory": "Cold metal, machine oil, and the dry dust of crates that have sat sealed for a long time.",
+   "tactile": "The shadow between buildings holds a chill no fixture reaches into."
+  }
+ },
+ "1056": {
+  "key": "Tolliver Row",
+  "desc": "The northern side shows a marine supply depot, roll-up doors revealing stacked cable spools, deck plating, and equipment for channel vessels. The southern side rises in residential towers, four and five levels with better maintenance than industrial districts - fresh sealant, functioning mechanisms. The grating is newer composite, drainage systems that actually function. Street lighting includes decorative elements alongside functional fixtures.",
+  "sense_descs": {
+   "auditory": "Roll-up doors rumble at the marine depot; far off, water works steadily against the channel structures.",
+   "olfactory": "Salt air and the tar-and-cable smell of marine supply.",
+   "tactile": "Newer composite underfoot, drains that actually carry the wet away.",
+   "atmospheric": "The Central Span's navigation lights blink through the gaps in the structures."
+  }
+ },
+ "1059": {
+  "key": "Tolliver Row",
+  "desc": "The street runs straight east, industrial grating showing the wear patterns of constant cargo traffic moving between the channel and inland facilities. A freight consolidation yard occupies the northern side, chain-link fencing enclosing stacked shipping containers organized with enough deliberation to suggest active inventory management rather than abandonment. Forklifts move between the stacks with shift-change regularity, their operators navigating the narrow passages with the confidence that comes from years of repetition. The southern side shows mixed commercial use - a hydraulics repair shop, its bay doors open to reveal machinery in various states of disassembly, and a parts supplier, composite shelving visible through reinforced viewports stacked with equipment that serves the waterfront's operational demands.",
+  "sense_descs": {
+   "auditory": "Forklifts beep and rumble between the container stacks; bay doors clatter at the hydraulics shop.",
+   "olfactory": "Salt, diesel, and hydraulic fluid.",
+   "tactile": "The grating is worn into cargo-traffic ruts underfoot."
+  }
+ },
+ "1062": {
+  "key": "Tolliver Row",
+  "desc": "Faded block lettering declares the bunker on the northern side the |510Colony Armory|n, its reinforced facade marked with weapon inspection protocols posted in multiple languages. The southern side continues the waterfront theme with composite benches facing the channel, safety railings showing wear from constant contact with salt air. A small vendor cart sits abandoned between shifts, its wheels locked, tarp secured against wind. The grating here shows pedestrian wear rather than hauler tracks, foot traffic having polished the composite to a softer sheen.",
+  "sense_descs": {
+   "auditory": "The channel laps steadily past the safety railings; the abandoned cart's tarp snaps in the wind.",
+   "olfactory": "Salt air with gun-oil drifting from the armory's vents.",
+   "tactile": "Foot traffic has polished the composite grating to a softer, smoother sheen."
+  }
+ },
+ "1065": {
+  "key": "Tolliver Row",
+  "desc": "A public information kiosk stands on the northern side, its digital display cycling through colony announcements and service advisories, the screen cracked but functional. The southern side continues the waterfront theme with composite benches facing the channel, safety railings showing wear from constant contact with salt air. A small vendor cart sits abandoned between shifts, its wheels locked, tarp secured against wind. The grating here shows pedestrian wear rather than hauler tracks, foot traffic having polished the composite to a softer sheen.",
+  "sense_descs": {
+   "auditory": "The kiosk buzzes faintly through its cracked screen; the channel laps past the railings.",
+   "olfactory": "Salt air and the mineral scent of the channel.",
+   "tactile": "Foot traffic has polished the composite grating to a softer sheen."
+  }
+ },
+ "1068": {
+  "key": "Tolliver Row",
+  "desc": "A maintenance depot dominates the northern side, its composite walls showing the kind of upkeep that suggests corporate backing rather than independent operation. Roll-up doors are stenciled with equipment codes and maintenance schedules, their surfaces clean enough to suggest someone cares about appearances. The southern structures house a marine equipment supplier on ground level, with residential units stacked above - two and three story modules connected by external staircases, their viewports showing the glow of habitation.",
+  "sense_descs": {
+   "auditory": "The depot's roll-up doors cycle on a schedule; residential murmur drifts down from the stacked modules.",
+   "olfactory": "Clean machine oil and salt air.",
+   "tactile": "The depot keeps its walls clean; even the grating feels maintained here."
+  }
+ },
+ "1071": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor narrows further here where construction has happened without coordination, each structure claiming space until the street between them barely accommodates two people walking abreast. The eastern side shows evidence of multiple building phases - composite panels in three different shades marking additions that happened whenever someone scraped together enough materials. The western structures have carved deeper into the crater wall, rock face visible through gaps in the composite where someone decided covering everything was optional.",
+  "sense_descs": {
+   "auditory": "Voices carry close in the pinched space, neighbors audible through thin composite.",
+   "olfactory": "Rock dust and the stale closeness of crowded dwellings.",
+   "tactile": "The street barely fits two abreast; the walls press in on both sides."
+  }
+ },
+ "1074": {
+  "key": "Bhavani Corridor",
+  "desc": "Prefab structures rise five and sometimes six levels here, their construction showing the vertical desperation of populations needing space in a colony that stopped expanding outward decades ago. The western side presses against the crater wall with enough force that stress fractures radiate from the connection points, composite panels bowing slightly under loads they protest but haven't quite refused.",
+  "sense_descs": {
+   "auditory": "The structures creak as their upper levels lean and settle against each other.",
+   "olfactory": "Stale trapped air, cooking and bodies layered under rock dust.",
+   "tactile": "The air hangs close and still beneath the canopy of leaning upper floors.",
+   "atmospheric": "The eastern structures lean into each other overhead, blocking what little light filters from above."
+  }
+ },
+ "1077": {
+  "key": "Pessoa Street and Bhavani Corridor",
+  "desc": "The intersection sprawls where Pessoa Street cuts across Bhavani, grating worn from industrial traffic mixing with residential transit. The crater wall presses close, limiting western approach and concentrating flow through remaining routes. Pessoa extends toward refineries and processing plants. The street climbs through districts transitioning from edge-colony survival to maintained infrastructure. The intersection shows neglect fighting maintenance to a draw - some grating replaced within recent years, composite a slightly different shade, while others show stress fractures. Prefab structures press close on all sides, rising four and five levels in questionable configurations.",
+  "sense_descs": {
+   "auditory": "Industrial transit grinds against residential foot traffic through the confluence.",
+   "olfactory": "Industrial haze drifts through from the refineries, chemical and warm.",
+   "tactile": "The crater wall presses close west; mismatched grating shifts underfoot.",
+   "atmospheric": "Refinery haze drifts through the intersection at shift change."
+  }
+ },
+ "1080": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor widens slightly here, though not from design - the eastern structures have collapsed or been demolished at some point, leaving a gap filled with smaller prefab modules arranged in a configuration that suggests temporary became permanent decades ago. These newer structures sit lower than their surroundings, their rooflines creating an uneven skyline like a mouth with missing teeth. The western side maintains its press against the crater wall, but here someone has cut into the rock face itself, creating alcoves that house storage units or possibly living spaces, the entrances secured with composite panels and heavy locks.",
+  "sense_descs": {
+   "auditory": "The open gap swallows sound; footsteps echo oddly off the lower rooflines.",
+   "olfactory": "Rock dust and the chemical seal of locked storage alcoves.",
+   "tactile": "The uneven skyline lets a thread of cooler crater air settle into the gap."
+  }
+ },
+ "1083": {
+  "key": "Bhavani Corridor",
+  "desc": "Prefab structures on both sides show the accumulated modifications of populations finding ways to squeeze more life from limited space - balconies extended without permits, viewports cut into walls that weren't designed for them, external storage cages welded to frameworks that protest the additional weight with visible stress fractures. The eastern side rises five levels in places, each floor showing slightly different construction methods. The western structures press against the crater wall, their foundations built into the rock face itself.",
+  "sense_descs": {
+   "auditory": "External storage cages creak against their welds; residential murmur stacks floor on floor.",
+   "olfactory": "Trapped cooking smells and the mineral cold of rock foundations.",
+   "tactile": "The colony seems to hold up the wall and be crushed by it at once; the air is thick and close."
+  }
+ },
+ "1086": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor narrows here where prefab structures press close on both sides, rising four and sometimes five levels in configurations approved by necessity rather than engineering review. The eastern structures show more uniformity, suggesting they were part of some original plan before improvisation became the default. The western side follows the crater wall's curve, buildings cantilevered over the street on supports. The grating here shows foot traffic exclusively, the wear pattern suggesting thousands of daily transits.",
+  "sense_descs": {
+   "auditory": "Thousands of daily footfalls murmur constant through the pinched corridor.",
+   "olfactory": "Close residential air, rock dust, and old cooking oil.",
+   "tactile": "The grating is worn smooth by foot traffic alone.",
+   "atmospheric": "Western buildings cantilever over the street, a perpetual sense of being beneath something waiting to fall."
+  }
+ },
+ "1089": {
+  "key": "Volta Street and Bhavani Corridor",
+  "desc": "The intersection opens where Volta Street extends east from Bhavani through the colony's western residential districts, the crater wall dominating the western horizon beyond the immediate prefab structures. To the east, Volta extends through territories that house the colony's working class - synthetic laborers, human shift workers, the populations that keep the waterfront and processor operations running. Prefab structures rise three and four levels on the eastern sides. The western side presses against the crater's curve, structures built into the wall itself. The intersection itself sees regular maintenance - directional paint refreshed often enough to remain legible, drainage grates that actually function.",
+  "sense_descs": {
+   "auditory": "Predictable daily foot traffic moving between work and home.",
+   "olfactory": "Close residential air, cooking and rock dust.",
+   "tactile": "The crater's curve presses from the west; drainage grates that actually function underfoot.",
+   "atmospheric": "Prefab structures rise three and four levels east, the crater wall built into the west."
+  }
+ },
+ "1092": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor descends through residential territory, prefab structures pressing close with density that speaks to populations arriving after planning stopped. A flickering neon sign on the remnants of a scuttled ship to the east declares |MThe Hub and Howl|n, operating from its converted orbital hangar - viewport turned serving counter, cooking heat routed up jury-rigged ductwork. Western structures show more modification - balconies added at second and third levels without engineering approval, composite platforms cantilevered on supports that look adequate until you consider the load calculations.",
+  "sense_descs": {
+   "auditory": "The clatter and murmur of The Hub and Howl's serving counter; exhaust fans push cooking heat up improvised ductwork.",
+   "olfactory": "Protein cooking in recycled oil dominates, cut with the chemical tang of liberally applied cleaning agents.",
+   "tactile": "Warmth and grease haze the air near the converted ship.",
+   "atmospheric": "Steam vents through improvised exhaust routing, fogging the neon sign."
+  }
+ },
+ "1095": {
+  "key": "Bhavani Corridor",
+  "desc": "Residential density increases here, prefab structures rising three and four levels on both sides, their vertical growth speaking to space constraints and populations that need housing more than comfort. External staircases zigzag up the western structures, composite treads showing wear patterns that map daily routines. The grating shows less hauler traffic here, more the wear of foot traffic moving with routine purpose - morning commutes, evening returns, the predictable flows of people tied to shifts and schedules.",
+  "sense_descs": {
+   "auditory": "Footfall rises and falls on the external staircases, mapping the shift hours.",
+   "olfactory": "Detergent and damp fabric off the strung laundry, cooking underneath.",
+   "tactile": "The grating shows foot-traffic wear, smooth under routine daily transit.",
+   "atmospheric": "Laundry hangs from improvised lines between buildings, marking wind direction and humidity."
+  }
+ },
+ "1098": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor descends from the waterfront intersection, the grating sloping enough that drainage becomes deliberate - water channeled south away from the channel operations toward collection systems that service the residential blocks below. Prefab structures rise on both sides, their construction showing the transition from commercial to mixed-use - ground floors with roll-up doors, upper levels with residential viewports marked by accumulated personalization. A loading bay occupies the eastern side, its platform level with hauler beds, composite decking scored from years of cargo. The bay's security shutter shows fresh maintenance, new hydraulics installed within recent months.",
+  "sense_descs": {
+   "auditory": "Water trickles down the sloped grating toward the collection systems; a loading bay's fresh hydraulics cycle.",
+   "olfactory": "Channel damp gives way to the closer smell of residential blocks.",
+   "tactile": "The grating slopes underfoot, drainage channeled deliberately south."
+  }
+ },
+ "1101": {
+  "key": "Maxwell Street and Bhavani Corridor",
+  "desc": "The intersection sprawls where Bhavani cuts south through the colony's western districts, grating worn from cross-traffic between waterfront commerce and residential sprawl inland. The Balboa Channel dominates north, dark water moving with relentless current that has defined this waterfront since founding, safety barriers showing decades of corrosion and impact damage. Bhavani descends through districts transitioning from waterfront operations to edge-colony improvisation. The intersection shows regular maintenance - reinforced grating at the confluence, directional paint refreshed within the last year.",
+  "sense_descs": {
+   "auditory": "The channel's current works past corroded barriers to the north.",
+   "olfactory": "Channel brine giving way to the inland smell of residential sprawl.",
+   "tactile": "Cool damp comes off the channel north; reinforced grating at the confluence.",
+   "atmospheric": "The Central Span rises to the northeast, framework and navigation lights anchoring the channel's scale."
+  }
+ },
+ "1104": {
+  "key": "Braddock Avenue",
+  "desc": "Housing clusters both sides, prefab in better repair than the western edge but still utilitarian — reinforced doors, barred ground-level windows, the architecture of people who work hard and sleep harder. South, the crater wall stays close, dark stone a reminder that warmth is not safety. The grating radiates enough heat to shimmer the air.",
+  "sense_descs": {
+   "olfactory": "The radiant grating amplifies every industrial smell from above — hot metal, machine oil, processed air.",
+   "auditory": "The colony's working hum presses up through the warm grating; the crater stone deadens it from the south.",
+   "tactile": "Heat rises off the grating, shimmering the air; step toward the wall and the cold stone takes it back.",
+   "atmospheric": "Warmth here only means a different set of problems to manage."
+  }
+ },
+ "1107": {
+  "key": "Braddock Avenue",
+  "desc": "The street narrows where massive industrial conduits run overhead — water, coolant, waste, whatever the processor is moving this week — dripping intermittently, staining the grating dark in patches that never dry. Construction supplies sit stacked against the southern wall, composite panels still in their packaging, bound for an expansion that might come next year or never.",
+  "sense_descs": {
+   "olfactory": "A processed chemical tang beneath the metallic warmth, something artificial that coats the back of the throat.",
+   "auditory": "The overhead conduits drip and tick; the colony's working heart pulses steady from the north.",
+   "tactile": "Warm and damp under the dripping pipes; chemical-laced moisture beads on the conduit runs."
+  }
+ },
+ "1110": {
+  "key": "Braddock Avenue",
+  "desc": "A repair bay holds the north, its roll-up door permanently stuck at half-mast over the skeletal frames of mining equipment in disassembly. The tools are old but functional, repaired so many times the manufacturer wouldn't know them. Welding scorch-marks pattern walls and floor in abstract constellations. Beside the bay, calculations scratch into the crater wall — load ratings or shift schedules or gambling debts in permanent graffiti.",
+  "sense_descs": {
+   "olfactory": "Hot welding-ozone, scorched metal, and machine-oil, thick in the trapped warmth.",
+   "auditory": "From the bay, the ring and hiss and spark of repair work; the processor's heat-laden hum collects here.",
+   "tactile": "The warmth is almost oppressive, the processor's radiant heat pooling in the narrow stretch."
+  }
+ },
+ "1116": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue opens where a loading platform juts from the northern wall, its surface ghosted with decades of spilled cargo — ore dust, hydraulic fluid, something organic scrubbed away but discoloring the metal still. Empty pallets stack in precarious towers against the crater wall; a cargo dolly lies on its side, one wheel gone, sitting exactly where it fell.",
+  "sense_descs": {
+   "olfactory": "Ore dust and hydraulic fluid worked into the platform metal, over the processor's hot breath.",
+   "auditory": "The processor's rhythmic mechanical breathing is the constant backdrop now, the colony's smaller sounds beneath it.",
+   "tactile": "The heat intensifies with each step east, the processor felt more than seen."
+  }
+ },
+ "1119": {
+  "key": "Braddock Avenue",
+  "desc": "Housing dominates both sides, prefab stacked two-high where someone trusted the foundation. Exterior ladders connect the levels, rungs worn smooth. Windows show long habitation — patched thermal sheeting, cargo-wrap curtains, the occasional actual plant struggling in some soil-substitute. The grating's been swept recently, debris pushed into the corners.",
+  "sense_descs": {
+   "olfactory": "Cooking nearby — cumin and chili powder cutting clean through the metallic warmth.",
+   "auditory": "Domestic sounds leak from the stacked windows; the processor's warm hum underlies it all.",
+   "tactile": "The metallic warmth saturates everything this close to the processor; the swept grating is gritless underfoot.",
+   "atmospheric": "Lived-in and holding — plants and patched curtains against the metal."
+  }
+ },
+ "1122": {
+  "key": "Braddock Avenue",
+  "desc": "The street narrows where support columns rise floor to ceiling, reinforcement added when someone decided the weight above needed better distribution. The columns carry the usual strata — official safety markings under graffiti under protective symbols, rust bleeding through all of it. A water-reclamation unit sits against the north wall, condensation pooling where its seals have degraded past caring.",
+  "sense_descs": {
+   "olfactory": "Processed, over-recycled air, thick and faintly stale, the chemical edge of reclaimed water.",
+   "auditory": "Somewhere above, metal groans under thermal expansion — the colony's skeleton adjusting; the reclamation unit gurgles.",
+   "tactile": "The heat is on the skin now, the air thick with the quality of being breathed too many times."
+  }
+ },
+ "1125": {
+  "key": "Braddock Avenue",
+  "desc": "The crater wall begins to curve away, opening more space than the western stretches allowed. Someone has claimed it for storage — shipping containers stacked into a maze of narrow corrugated passages, labeled in faded corporate serial codes that once meant something. A few have cut-out doors and welded ventilation, suggesting habitation or workshop or both.",
+  "sense_descs": {
+   "olfactory": "Metallic warmth and cold steel, the breath of industrial infrastructure half-maintained.",
+   "auditory": "Sound bends and doubles through the container maze; the processor hums warm beyond it.",
+   "tactile": "Warm but not uncomfortable here; the corrugated walls hold the day's radiant heat.",
+   "atmospheric": "A box-maze of kept things — storage drifting into shelter."
+  }
+ },
+ "1128": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue straightens along the crater wall's retreat. Industrial light fixtures hang overhead at irregular intervals, most dark, their power long since redistributed to more critical systems. A power-junction box sits exposed on the north wall, cover gone, baring a nest of cables color-coded to a system that predates current standards. The grating shows the wear of regular equipment throughput.",
+  "sense_descs": {
+   "olfactory": "Hot insulation and dust, the dry electrical smell of the exposed junction.",
+   "auditory": "The colony's infrastructure is clearer here — the constant hum and clank of systems working just hard enough to keep functioning.",
+   "tactile": "Steady metallic warmth; the exposed junction throws a little extra heat from the north wall."
+  }
+ },
+ "1131": {
+  "key": "Braddock Avenue",
+  "desc": "A ventilation grate dominates the north wall, its mesh caked with decades of particulates, the fan blades beyond turning with a squeak that says the bearings went years ago. Empty crates stack against the crater wall, their purpose forgotten. Overhead, conduit and cabling snake along the ceiling in configurations that read as organic growth — additions made whenever need arose.",
+  "sense_descs": {
+   "olfactory": "The fan pushes machine-shop and industrial-processing smells down in sluggish currents — hot metal and solvent.",
+   "auditory": "The ventilation fan squeaks on its rhythm; air moves in slow, audible currents.",
+   "tactile": "Sluggish warm air pushes past from the fan; the metal stays tepid.",
+   "atmospheric": "A pass-through, not a place — a connection between somewheres."
+  }
+ },
+ "1134": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue straightens and widens toward Spillane Corridor east, the intersection visible ahead where the colony's easternmost corridor cuts north toward the processor. The crater wall continues its southward retreat into an almost unsettling openness. The grating here is newer, or better kept — Spillane's approach sees more official attention. Utility access panels line the north wall, covers intact, stenciled with warnings that follow current standards.",
+  "sense_descs": {
+   "olfactory": "Hot metal and ozone, the processor's waste heat more deliberate here, almost clean.",
+   "auditory": "The processor's working hum is close and clear; the grid's newer fixtures buzz steadily overhead.",
+   "tactile": "The metallic warmth feels intentional here — the processor's waste heat, not accident, radiating off the new grating.",
+   "atmospheric": "Braddock's orderly eastern end, where the colony starts paying attention again."
+  }
+ },
+ "1137": {
+  "key": "Braddock Avenue and Spillane Corridor",
+  "desc": "The intersection sits at the southeastern corner of the colony, where Spillane Corridor cuts north through the industrial districts toward the atmospheric processor. The grating underfoot is industrial-grade reinforced composite, built to handle the moisture that seeps up from below. To the north, Spillane extends toward the colony's industrial heart. South, the crater wall curves away, offering more space than Braddock has known for most of its length.",
+  "sense_descs": {
+   "auditory": "The spillway murmurs constant beneath the grating, water moving between the channel and the filtration complex.",
+   "olfactory": "Minerals and distance-processed chemistry on warm air.",
+   "tactile": "Condensation makes every surface slick; the grating hums faintly with the water below.",
+   "atmospheric": "Functional utility lighting paints everything institutional yellow."
+  }
+ },
+ "1140": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor runs straight north, wider than the typical street, built to accommodate heavy equipment and the infrastructure beneath the grating. Emergency lighting fixtures line both walls at regular intervals, their institutional yellow glow giving the corridor the feel of corporate maintenance access rather than public thoroughfare. Prefab modules cluster on the eastern side, their walls showing better maintenance than most of Braddock - fresh welds, functional door seals. To the west, utility access panels are stenciled with maintenance codes and pressure ratings, each one a reminder that this corridor exists to serve the water system first, pedestrians second.",
+  "sense_descs": {
+   "auditory": "The spillway's hydraulic murmur runs constant beneath everything, the baseline the rest builds on.",
+   "olfactory": "Warm mineral water and wet composite.",
+   "tactile": "Warmth and moisture in equal measure leave everything faintly damp.",
+   "atmospheric": "Yellow emergency lighting marches the corridor's length in even intervals."
+  }
+ },
+ "1143": {
+  "key": "Spillane Corridor",
+  "desc": "A maintenance alcove cuts into the western wall here, its depth suggesting this was once meant for equipment storage or emergency access. Now it holds the usual accumulation - empty chemical drums stacked three high, coiled hose with couplings that don't match current fittings, a hand truck with one wheel missing. Someone has spray-painted flow-direction arrows on the grating, bright orange pointing north. Mineral staining patterns every vertical surface in abstract geography.",
+  "sense_descs": {
+   "auditory": "The spillway's passage intensifies here through some acoustic quirk; condensation drips from pipe junctions with rhythmic persistence.",
+   "olfactory": "Mineral wet and the chemical ghost of empty drums.",
+   "tactile": "Condensation beads cold on every vertical surface."
+  }
+ },
+ "1146": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor widens slightly here where structural supports brace the eastern wall, heavy-gauge composite beams bolted at angles that speak to engineering concern rather than aesthetic choice. Between the supports, someone has stacked rolls of insulation material wrapped in deteriorating plastic, layers of thermal foam visible through splits in the covering. A pressure gauge juts from the western wall at chest height, its needle hovering in the green zone, the glass face cracked but still readable.",
+  "sense_descs": {
+   "auditory": "The spillway murmurs steadily below; insulation plastic crackles when the air moves.",
+   "olfactory": "Damp thermal foam and mineral water.",
+   "tactile": "The grating is polished by heavy equipment passage, slick where treads have worn it.",
+   "atmospheric": "The worn composite catches the yellow emergency lighting in unexpected ways."
+  }
+ },
+ "1149": {
+  "key": "Kaspar Street and Spillane Corridor",
+  "desc": "The intersection opens where Kaspar Street crosses the Spillane, the confluence marked by wider grating and reinforced support columns that speak to the engineering demands of bearing both street traffic and the spillway infrastructure below. To the east and west, Kaspar extends through the colony's working districts, its character caught between Braddock's raw industry to the south and the relative order of the northern streets. North, the corridor continues its climb toward the processor, the path ahead showing worn grating and fresh maintenance marks.",
+  "sense_descs": {
+   "auditory": "The hydraulic murmur is louder here, the crossing channels amplifying it into a low-frequency resonance.",
+   "olfactory": "Warm mineral water and wet composite.",
+   "tactile": "The resonance carries up through the grating; the air hangs humid and close.",
+   "atmospheric": "The spillway's moisture haze diffuses the yellow emergency lighting into soft halos."
+  }
+ },
+ "1152": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor narrows slightly past the intersection, utility conduits running overhead in parallel lines that channel processor runoff toward distant filtration systems. Handrails bolted at intervals along both sides show the ghostly outlines where hazard tape once marked them, adhesive residue collecting dust. The grating shows two parallel tracks worn into its surface where equipment wheels have polished the composite to a dull shine. North, the yellow emergency lighting continues its institutional march toward the processor.",
+  "sense_descs": {
+   "auditory": "The spillway takes on a purposeful rush here, water moving with direction and intent.",
+   "olfactory": "Something acrid cuts through the mineral and moisture, a slow leak from a cracked junction seal.",
+   "tactile": "Polished tracks run worn smooth into the grating underfoot."
+  }
+ },
+ "1155": {
+  "key": "Spillane Corridor",
+  "desc": "A junction box the size of a shipping crate dominates the eastern wall, its access panel secured with a lock that has been replaced multiple times - the mounting holes showing the archaeology of different security systems, each generation more paranoid than the last. Warning placards in three languages cover the box's surface, their symbols ranging in tone from bureaucratic to threatening. Condensation runs in continuous streams down both walls, following paths worn into the composite by years of the same water taking the same route to the floor drains.",
+  "sense_descs": {
+   "auditory": "The spillway builds from rush to roar here; something inside the junction box hums at a frequency that sits low and constant.",
+   "olfactory": "Mineral wet and the faint ozone of heavy power loads.",
+   "tactile": "Condensation streams cold down both walls; the junction box's vibration carries through the floor."
+  }
+ },
+ "1158": {
+  "key": "Spillane Corridor",
+  "desc": "The western wall here has been cut away and patched multiple times, a patchwork of different composite materials where someone fixed structural damage or upgraded systems without caring about aesthetic consistency. A cable tray runs along the ceiling, sagging under decades of additions, zip ties and improvised brackets holding newer lines alongside originals that still technically function.",
+  "sense_descs": {
+   "auditory": "The spillway's roar turns almost conversational here, rhythmic enough to parse for patterns that aren't there.",
+   "olfactory": "Hot mineral steam and wet metal.",
+   "tactile": "Heat radiates up through the grating in waves, mixing with moisture into air thick enough to move through.",
+   "atmospheric": "Emergency lights flicker intermittently, dying ballasts strobing the corridor unstable."
+  }
+ },
+ "1161": {
+  "key": "Pessoa Street and Spillane Corridor",
+  "desc": "The intersection sprawls where Pessoa Street cuts across the Spillane, the space marked by heavier reinforcement than Kaspar - thicker support beams, doubled grating sections, the kind of overengineering that suggests someone learned expensive lessons here. To the west, Pessoa extends through districts that handle the colony's heavier industrial work - refineries, processing plants that need proximity to both the channel and the processor.",
+  "sense_descs": {
+   "auditory": "The spillway's roar bounces off the wider walls, dead zones dropping to near-silence before crashing back at full volume two steps later.",
+   "olfactory": "Mineral water cut with refinery chemistry, sharp and warm.",
+   "tactile": "Steam vents puncture the grating in hissing bursts, leaving temporary clearings in the moisture.",
+   "atmospheric": "Half the yellow emergency fixtures are dark or browning out, pooling the intersection with shadow."
+  }
+ },
+ "1164": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor straightens here, the walls showing scorch marks from some incident or maybe just accumulated heat damage from decades of thermal cycling. An emergency shutoff valve protrudes from the western wall, its wheel painted in warning stripes faded to barely-there suggestions. Equipment tracks in the floor show recent passage - fresh scrapes in the composite where something heavy dragged against resistance. Overhead, the cable trays multiply, layers of conduit suggesting this section feeds multiple systems near the atmospheric processor.",
+  "sense_descs": {
+   "auditory": "The spillway's roar settles back to baseline past the Pessoa confluence, but louder now, more present.",
+   "olfactory": "Scorched composite and hot mineral water.",
+   "tactile": "Heat lingers in the scorched walls; the floor shows fresh drag scrapes."
+  }
+ },
+ "1167": {
+  "key": "Spillane Corridor",
+  "desc": "A thermal expansion joint cuts across the corridor here, the gap bridged by interlocking plates that allow the structure to shift without tearing itself apart. The plates show wear at their edges, metal ground against metal for years until the surfaces have taken on a mirror polish. Someone has wedged rubber matting into the gaps, already cracking from constant thermal cycling. Prefab modules line the eastern wall, their foundations sitting at slightly different heights, connected by makeshift ramps welded from scrap.",
+  "sense_descs": {
+   "auditory": "The spillway changes pitch where the joint crosses, a harmonic with no steady center.",
+   "olfactory": "Hot metal and cracked rubber matting.",
+   "tactile": "The mirror-polished joint plates are slick; the matting gives unevenly underfoot.",
+   "atmospheric": "Yellow emergency lighting reflects off the polished joints in bright dividing lines."
+  }
+ },
+ "1170": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor begins to angle slightly here, following structural logic that has more to do with the processor's foundation than surface-level planning. Massive conduits emerge from the western wall and run exposed across the ceiling, their diameter suggesting they carry primary feeds - water, power, data, the essential flows that keep the processor operational. Heat has begun to warp some of the wall panels, creating slight bulges where the composite has softened and reformed.",
+  "sense_descs": {
+   "auditory": "The spillway reaches a crescendo here, no longer distinguishable as water but pure sustained hydraulic roar.",
+   "olfactory": "Hot composite and heavy mineral steam.",
+   "tactile": "The roar resonates through the grating; heat radiates from the warped, bulging wall panels."
+  }
+ },
+ "1173": {
+  "key": "Spillane Corridor",
+  "desc": "A massive reinforced bulkhead dominates the western wall here, its surface marked with corporate logos weathered to abstract patterns and shift schedules spray-painted over decades of worker traffic. The door stands sealed between shifts, a status indicator above the frame cycling between red and amber. Biometric scanners flank the entrance, their interfaces worn smooth by thousands of daily authentications. Workers pass through here in shifts, heading down to the ice mines beneath the processor or returning with the bone-deep cold that takes hours to shake.",
+  "sense_descs": {
+   "auditory": "The spillway's roar echoes from the north, the water passing through toward the Balboa Channel.",
+   "olfactory": "Hot metal overlaid with a thread of deep cold venting off returning ice-mine crews.",
+   "tactile": "Heat radiates constant but manageable from the bulkhead, just another layer of warmth.",
+   "atmospheric": "The door's status indicator cycles red to amber above the worn biometric scanners."
+  }
+ },
+ "1176": {
+  "key": "Spillane Corridor",
+  "desc": "A series of viewport panels are set into the eastern wall at irregular intervals, their armored glass offering glimpses into prefab structures built directly against the corridor - workshops, storage spaces, the kind of commercial squat that happens when proximity to infrastructure matters more than official permission. Cable runs snake along both walls at waist height, newer additions zip-tied to older infrastructure in organic tangles that suggest decades of improvised power distribution. The yellow emergency lighting continues its march north, supplemented by jury-rigged fixtures.",
+  "sense_descs": {
+   "auditory": "The spillway maintains its roar, channeled beneath at full force.",
+   "olfactory": "Wet mineral air and the warm-dust smell of crowded prefab squats.",
+   "tactile": "The hydraulic force registers as a constant low-frequency pressure through the grating."
+  }
+ },
+ "1179": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor widens here where a loading zone has been carved into the eastern wall, the space designated by faded floor markings that still guide foot traffic out of habit. Cargo pallets sit stacked against the wall in deliberate configurations, staging areas for goods moving through at regular intervals. Tie-down points stud the floor at measured intervals, their bolts showing fresh wear. Overhead, a section of ceiling panels has been removed for access, exposing raw infrastructure - water pipes, electrical conduits, structural supports in cross-section.",
+  "sense_descs": {
+   "auditory": "The spillway echoes strangely in the expanded space, overlapping harmonics blurring any sense of distance.",
+   "olfactory": "Mineral wet and machine oil off the staged cargo.",
+   "tactile": "A steady hydraulic vibration carries up through the widened floor."
+  }
+ },
+ "1182": {
+  "key": "Spillane Corridor",
+  "desc": "The eastern wall shows signs of constant dampness - composite panels stained in abstract patterns where condensation has run for years, algae or something similar growing in the protected corners where cleaning is theoretical at best. A heavy drainage channel cuts diagonally across the corridor, its grating reinforced to handle overflow from the systems ahead, the metal slick enough that crossing requires attention.",
+  "sense_descs": {
+   "auditory": "The spillway's roar gains an edge here, approaching some transition, its force no longer content to stay beneath the surface.",
+   "olfactory": "A sharp mineral scent rides the rising mist and coats everything.",
+   "tactile": "The grating vibrates with increasing intensity; mist rises through it in tendrils, leaving a fine film of moisture.",
+   "atmospheric": "Mist curls up through the grating in visible tendrils, hazing the corridor."
+  }
+ },
+ "1185": {
+  "key": "Maxwell Street and Spillane Corridor",
+  "desc": "The intersection opens into something larger than the engineering suggested - not a street crossing but a threshold where the spillway's entire journey culminates in a waterfall that plunges into the Balboa Channel below. The grating here is reinforced to the point of overkill, industrial composite layered over structural beams that speak to both weight and vibration. Safety railings line the northern edge where the street drops away.",
+  "sense_descs": {
+   "auditory": "The roar is omnipresent here, total but not overwhelming, the kind of sound that makes silence a foreign concept.",
+   "olfactory": "Cold mineral spray and channel water.",
+   "tactile": "The metal trembles constantly from the hydraulic thunder beneath; the railings run slick with perpetual mist.",
+   "atmospheric": "Mist rises from the channel's depths in shifting curtains where the waterfall plunges."
+  }
+ },
+ "1188": {
+  "key": "Maxwell Street",
+  "desc": "A bunkhouse dominates the south, four levels of narrow viewports built for function over comfort, external fire escapes zigzagging up the eastern face. Laundry hangs from lines strung between the landings. North, a ground-level commissary advertises hot meals and cold-storage rental by hand-painted sign. The Central Span dominates the northern view now, navigation lights steady against the channel's sprawl.",
+  "sense_descs": {
+   "olfactory": "Channel damp, frozen laundry, and the cooking-smell leaking from the commissary.",
+   "auditory": "The channel's steady wash carries from the north; the fire escapes tick and flex in the damp.",
+   "tactile": "Damp settles into everything; the metal landings are cold and beaded with moisture."
+  }
+ },
+ "1191": {
+  "key": "Maxwell Street",
+  "desc": "A power substation fills the south behind chain-link and multilingual warnings, transformers in orderly rows. Amber warning strobes pulse at the fence corners, catching moisture into brief halos. North, a sealed marine supply depot, cable spools and hardware visible through grimy viewports. Overhead cabling webs denser here, power lines branching to feed the substation.",
+  "sense_descs": {
+   "olfactory": "Ozone off the transformers, sharp over the channel's mineral damp.",
+   "auditory": "The transformers hum low — a high-voltage thrum felt through the grating more than heard.",
+   "tactile": "The substation's hum buzzes faintly up through the soles; mist beads in the strobe-light.",
+   "atmospheric": "Raw power fenced and warned, humming behind the wire."
+  }
+ },
+ "1194": {
+  "key": "Maxwell Street and Riveter's Way",
+  "desc": "The intersection sprawls where Riveter's Way cuts through the colony's industrial spine, the confluence marked by reinforced grating rated for constant heavy traffic and the weight of machinery that defines this district. To the west, Maxwell Street climbs toward the Central Span, its lights marking the threshold of crossing. South, the way descends toward one of the atmospheric processor's primary entrances, the street lined with shift markers and worker facilities. The processor wall dominates the southern horizon, its entrance infrastructure resolving into bulkheads and security checkpoints.",
+  "sense_descs": {
+   "auditory": "Heavy machinery traffic grinds through; the processor's roar builds from the south.",
+   "olfactory": "Machine oil, ozone, and the hot-metal baseline of the processor.",
+   "tactile": "Heat radiates from the processor wall south; reinforced grating handles the weight underfoot.",
+   "atmospheric": "The processor wall dominates the southern horizon, an industrial cathedral where colony becomes machine."
+  }
+ },
+ "1197": {
+  "key": "Maxwell Street",
+  "desc": "The processor wall shows heavier use here — access panels fresh-scratched around their seals, the kind of attention that means regular intervention. A faded loading zone marks the north, tie-down points studding the grating, worn smooth from countless securing cycles. The prefab has an almost official quality: uniform modules, proper seals, navigation numbers stenciled on the walls.",
+  "sense_descs": {
+   "olfactory": "Hot metal and ozone off the processor wall, under the channel's damp.",
+   "auditory": "The processor's mass swallows sound from the south; access-panel seals tick as the wall works.",
+   "tactile": "The processor wall radiates a dry heat that holds the mist back along the south."
+  }
+ },
+ "1200": {
+  "key": "Maxwell Street",
+  "desc": "The processor wall keeps its presence to the south — an unbroken composite expanse that swallows sound and gives nothing back. A thermal exhaust duct bleeds hot air through a mineral-caked grill, drying a warm zone into the grating. Someone has wedged a broken pallet against the northern prefabs into a bench, the wood gone dark with damp. Overhead, cracking insulation peels in strips, baring copper gone green.",
+  "sense_descs": {
+   "olfactory": "Hot ducted air and damp wood, with the dry-metal smell of the dead wall.",
+   "auditory": "The exhaust duct sighs hot air; otherwise the wall eats every sound from the south.",
+   "tactile": "The exhaust duct's warm zone never holds moisture; step off it and the damp returns."
+  }
+ },
+ "1203": {
+  "key": "Maxwell Street",
+  "desc": "A pressure-relief valve juts from the processor wall at head height, brass fittings oxidized green, its release pipe angled down to vent condensation that's built mineral stalactites on the grating below. The northern prefab has consolidated into something deliberate — modules welded with real intent, the roofline overhanging into a catch basin still maintained. The street is a mosaic of repair patches, each a slightly different shade.",
+  "sense_descs": {
+   "olfactory": "Wet mineral deposits and oxidized brass, sharp and metallic.",
+   "auditory": "The relief valve vents in slow drips and hisses; condensation ticks off the stalactites.",
+   "tactile": "Damp and cold under the dripping valve; the patched grating shifts shade and texture underfoot."
+  }
+ },
+ "1206": {
+  "key": "Maxwell Street",
+  "desc": "The street angles along the processor's foundation as it arcs southeast. The wall dominates the south — massive, featureless but for the occasional access port or sensor array, built to last centuries without aesthetics. The northern prefab shows its age, composite warped from moisture, module seams gummed with weather-stripping long degraded to black residue.",
+  "sense_descs": {
+   "olfactory": "Dry processor-heat against wet, mineral channel-air — the two never quite mix.",
+   "auditory": "The processor's deep hum carries through its foundation; the channel washes faint behind it.",
+   "tactile": "The wall throws dry heat south; the damp reclaims everything a few steps north."
+  }
+ },
+ "1209": {
+  "key": "Maxwell Street",
+  "desc": "Prefab presses close on the north, walling the street off from the Balboa Channel. South, the processor's foundation rises in a sheer wall of industrial composite and reinforced plating, marked with maintenance hatches, conduit runs, and the occasional dark viewport.",
+  "sense_descs": {
+   "olfactory": "Cold mineral damp off the channel, edged with processor-warm metal.",
+   "auditory": "The spillway's roar rumbles faintly in the distance — enough to orient by, not enough to drown the processor's hum.",
+   "tactile": "Channel-damp on the north side, dry wall-heat on the south, the street split between them."
+  }
+ },
+ "1212": {
+  "key": "Maxwell Street",
+  "desc": "Mist drifts through the street at waist height, clinging to everything with the persistence of a permanent condition. A service alcove cuts into the north wall, once equipment or access, now just another place condensation pools and rust blooms across exposed metal. The processor's bulk dominates the south, its foundations vanishing into a prefab warren. Faded yellow arrows point west along the grating — wayfinding for a place people get lost in.",
+  "sense_descs": {
+   "olfactory": "Saturated mineral damp and blooming rust, the smell of permanent wet.",
+   "auditory": "Drips and trickles everywhere in the alcove; the processor hums beyond the mist.",
+   "tactile": "Mist coats the skin and the grating alike; nothing here is ever quite dry.",
+   "atmospheric": "A misted warren you can get lost in — hence the arrows."
+  }
+ },
+ "1215": {
+  "key": "Maxwell Street",
+  "desc": "Mist saturates everything — not thick enough to blind, constant enough to coat every surface. The street runs straight, the grating solid but slick. Prefab lines the north, southern walls water-damaged in abstract patterns. Beyond the maze, the processor rises through the haze, close enough to see but lost in the unplanned labyrinth. Drainage channels run both sides, gutters clogged with sediment.",
+  "sense_descs": {
+   "olfactory": "Wet mineral and silt, the heavy damp of standing drainage.",
+   "auditory": "The waterfall's roar carries from the east, the background note that defines this stretch; water trickles through the clogged gutters.",
+   "tactile": "Every surface is filmed with moisture that never dries; the slick grating makes you mind your footing.",
+   "atmospheric": "Defined by water it can't escape — mist above, roar to the east, drainage below."
+  }
+ },
+ "1228": {
+  "key": "Maxwell Street",
+  "desc": "A warehouse dominates the south, prefab expanded with welded additions across decades. Sealed roll-up doors line its northern face, marked with faded corporate logos and loading-bay numbers from when this was official commerce. The channel runs north, dark water visible through gaps, moving with a current that suggests real depth. Redundant composite safety barriers bolt the northern edge; yellow hazard strobes mark the cargo zone. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cold channel water, dust, and the dry rust of sealed doors.",
+   "auditory": "The channel moves dark and heavy below; hazard strobes tick at their intervals.",
+   "tactile": "Channel-damp along the barriers; the sealed warehouse doors are cold and dead."
+  }
+ },
+ "1231": {
+  "key": "Maxwell Street",
+  "desc": "Waterfront commerce continues, southern prefab carrying the modifications of long-surviving operations. A repair facility fills one module, hand-painted sign offering synthetic maintenance and component calibration. The channel dominates the north at undiminished scale, dark water that makes the safety barriers make sense. Northeast, the Central Span's navigation lights mark the colony's primary crossing.",
+  "sense_descs": {
+   "olfactory": "Channel damp, solvent, and machine-oil from the repair facility.",
+   "auditory": "The channel's steady dark wash; from the repair bay, the whine and tick of calibration work.",
+   "tactile": "Damp coats the barriers; the air carries the channel's mineral cold."
+  }
+ },
+ "1234": {
+  "key": "Maxwell Street and Wolfe Way",
+  "desc": "The intersection opens where Wolfe Way cuts south from the waterfront, the confluence marked by grating that shows the mixed wear patterns of cross-traffic - haulers moving along Maxwell between warehouse operations, foot traffic flowing between the channel and the residential districts inland. To the south, Wolfe Way descends through districts that house the colony's working population, the street's character shifting from commercial waterfront to residential density with each block away from the water. Signage here shows directional markers in multiple languages and maintenance schedules posted in weather-sealed cases.",
+  "sense_descs": {
+   "auditory": "Haulers move along Maxwell; foot traffic flows between the channel and the inland districts.",
+   "olfactory": "Channel brine fading to residential air south down Wolfe.",
+   "tactile": "Cool channel air off the dark water north; mixed-wear grating underfoot.",
+   "atmospheric": "The Balboa Channel dominates the northern horizon; the Central Span anchors the northeast."
+  }
+ },
+ "1237": {
+  "key": "Maxwell Street",
+  "desc": "The Balboa Channel dominates the north beyond the barriers, dark water moving with a force that makes human infrastructure feel provisional. Southern prefab carries waterfront wear — mineral staining, faded panels, the weathering of proximity to something larger than planning. A cargo staging area holds against the south, composite pallets stacked under weather-resistant tarps, anonymous but cycled regularly. Twin tracks polish the grating. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cold channel water and wet tarpaulin, mineral and faintly plastic.",
+   "auditory": "The channel runs heavy and dark past the barriers; tarps snap and shift on the staged pallets.",
+   "tactile": "Channel-damp settles cold on everything along the barrier line.",
+   "atmospheric": "Working the edge of water that won't give back what falls in."
+  }
+ },
+ "1240": {
+  "key": "Maxwell Street",
+  "desc": "An aquaponics facility holds the south, drainage pipes emptying into collection troughs built into the grating, the metal stained dark with years of organic runoff. The channel stretches north, dark water and the source of whatever still gets pulled from unmapped depths. A ventilation stack rises abruptly from mid-street; the safety barriers here carry extra welded bracing. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Brine and decay and the chemicals used to mask both, with refrigerant venting off the stack.",
+   "auditory": "Runoff trickles into the troughs; the vent stack exhales in low chemical gusts; the channel washes north.",
+   "tactile": "Wet, cold, and faintly greasy; organic damp clings where the troughs drain.",
+   "atmospheric": "Where the channel's catch is processed — brine, rot, and refrigerant in one breath."
+  }
+ },
+ "1243": {
+  "key": "Maxwell Street",
+  "desc": "The waterfront opens where the southern prefab pulls back, the wider corridor doubling as an informal market — composite-frame stalls draped in weather-resistant fabric, folding tables of salvage and questionable foodstuffs. The channel dominates the north beyond barriers worn by constant contact, rust blooming through coatings, panels cracked from impacts. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cold channel water, wet fabric, and cooking-smoke off the stalls.",
+   "auditory": "The channel runs heavy past the barriers; stall fabric cracks and luffs at the water's edge.",
+   "tactile": "Channel-damp and the cold off the water make everything by the edge feel temporary."
+  }
+ },
+ "1246": {
+  "key": "Maxwell Street",
+  "desc": "A narrow alley cuts between the southern prefab, barely two abreast, the dark beyond swallowing whatever lies deeper. Trash piles at the mouth — composite fragments, broken equipment, things discarded where the street meets the hidden. The channel stretches north, dark water moving with the persistence that made the colony build along it rather than fight it. Northeast, the Central Span holds its lights.",
+  "sense_descs": {
+   "olfactory": "Channel damp and the sour reek of the trash heaped at the alley mouth.",
+   "auditory": "The channel washes steady to the north; the alley gives back only a damp, swallowing silence.",
+   "tactile": "Cold channel-damp at the street; a colder, closer stillness breathing from the alley.",
+   "atmospheric": "The alley-mouth swallows light and sound — the street's discard pile and its threshold."
+  }
+ },
+ "1249": {
+  "key": "Maxwell Street",
+  "desc": "The waterfront narrows where the southern prefab reaches toward the channel edge, functional but not constricted. A storage facility dominates the south, roll-up doors secured with heavy-duty locks — contents worth protecting, or at least worth the paranoia. The channel keeps its overwhelming presence north, dark water beyond barriers cracked by thermal cycling and corroded by constant moisture. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cold channel water and corroded metal, nothing else permitted.",
+   "auditory": "The channel moves dark and constant; the heavy locks creak faintly in the damp.",
+   "tactile": "Channel-damp on the barriers; the locked doors are cold and unyielding."
+  }
+ },
+ "1252": {
+  "key": "Maxwell Street",
+  "desc": "The street widens for a fuel depot — composite tanks behind chain-link topped with deterrent wire, faded multilingual warning placards covering the fence. The channel stretches north, its relentless current beyond the usual corroded barriers. A pressure-relief system rises from the depot, venting to atmosphere in occasional hissing bursts as the tanks breathe with temperature. The grating here is heavier-gauge, reinforced for spills and tanker weight. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Fuel vapor sharp over the channel's cold damp, chemical and volatile.",
+   "auditory": "The relief system hisses in bursts as the tanks expand and contract; the channel washes beneath.",
+   "tactile": "The reinforced grating is solid and cold; channel-damp beads on the tank fittings.",
+   "atmospheric": "Volatile storage on a wet edge — fenced, placarded, and venting."
+  }
+ },
+ "1255": {
+  "key": "Maxwell Street",
+  "desc": "Prefab returns to flank the south, carrying the modifications of operations outlasting their purpose. A fabrication shop fills one section, its exterior cluttered with stock — metal sheets leaned on the wall, structural composite stacked on improvised racks, cable coils strapped down with deteriorating bindings. The channel holds the north, dark water that makes everything along it feel built on borrowed permission. The grating shows mixed hauler-and-foot wear; the barriers are a patchwork timeline of welds and replacements. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cut metal and machine-oil from the fab shop, over the channel's mineral damp.",
+   "auditory": "From the fab shop, the intermittent shriek of cutting and the ring of stacked stock; the channel washes north.",
+   "tactile": "Channel-damp and metal-cold; raw stock and cut edges crowd the south."
+  }
+ },
+ "1261": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor feels less like a street and more like a trench carved between structures that have grown together at their upper levels, creating a tunnel effect where whatever sky exists above becomes theoretical rather than visible. The eastern side shows construction that stopped consulting engineers and started consulting desperation - modules stacked in configurations that defy standard load calculations, connected by welds done by someone who learned the skill yesterday and needed shelter today. The western excavations have become living spaces without pretense, cave-like openings carved directly into the crater wall.",
+  "sense_descs": {
+   "auditory": "The tunnel deadens outside sound to a muffled hush; welds and rock alike tick as temperatures shift.",
+   "olfactory": "Rock dust and trapped air, no draft to move it.",
+   "tactile": "Structures meet overhead; the corridor closes to a trench with only theoretical sky.",
+   "atmospheric": "Upper levels have grown together into a tunnel, whatever sky exists above gone theoretical."
+  }
+ },
+ "1264": {
+  "key": "Bhavani Corridor",
+  "desc": "The tunnel effect intensifies here where upper-level construction has created what amounts to a ceiling, composite panels and salvaged sheeting bridging the gap between structures - temporary weather protection that became permanent load-bearing architecture through sheer optimism. The eastern structures show continuous modification - additions welded to additions, each generation building on the last. The western excavations run deeper here, some entrances marked with crude signage suggesting businesses or services, others sealed with nothing but fabric.",
+  "sense_descs": {
+   "auditory": "Sound bounces flat under the improvised ceiling; muffled commerce leaks from the deep western excavations.",
+   "olfactory": "Rock dust, cooking, and the stale air of a sealed-over street.",
+   "tactile": "The air sits dead and unmoving beneath the load-bearing canopy.",
+   "atmospheric": "Light penetrates in shafts through gaps in the ceiling, columns of illumination that move with the day cycle."
+  }
+ },
+ "1267": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor opens slightly here where structural collapse created a gap that's never been rebuilt, giving way to what amounts to an open plaza by fringe colony standards - maybe ten meters across where the eastern structures simply stopped existing and no one had the resources to fill the space. The remaining eastern modules lean inward, their upper levels extending over the void in cantilevers sustained by mutual support and being wedged against each other. The western excavations show their deepest penetration into the crater wall here, multiple levels carved into the rock, openings at different heights connected by ladders and improvised stairways.",
+  "sense_descs": {
+   "auditory": "The open plaza scatters sound; ladders and improvised stairways rattle in the western warren.",
+   "olfactory": "Cold crater-rock air pools in the open gap, mineral and dry.",
+   "tactile": "The gap opens overhead, a rare breath of space in the warren.",
+   "atmospheric": "Eastern modules cantilever over the void; the western wall is a vertical warren carved into rock, more mine than dwelling."
+  }
+ },
+ "1270": {
+  "key": "Braddock Avenue and Bhavani Corridor",
+  "desc": "The intersection sprawls at the southwestern edge of the colony, where the crater wall curves close enough to touch. Metal plating and exposed regolith create an uneven patchwork underfoot, the ground sloping slightly where prefab structures have settled into the rock over decades. The atmospheric processor looms distant on the eastern horizon, its scale undiminished by miles of industrial sprawl.",
+  "sense_descs": {
+   "auditory": "Out on the edge, the sprawl thins to a sparse, wind-scoured quiet.",
+   "olfactory": "The mineral smell of ancient stone and the faint ozone tang of atmosphere meeting void.",
+   "tactile": "Cold air seeps from the crater wall; exposed regolith and metal plating shift uneven underfoot.",
+   "atmospheric": "The atmospheric processor looms distant on the eastern horizon, its scale undiminished by miles of sprawl."
+  }
+ },
+ "1276": {
+  "key": "Kaspar Street",
+  "desc": "Shuttered warehouses line both sides, roll-up doors sealed with the finality of operations that stopped expecting resumption decades ago. Early-colony prefab, panels warped and composite gone brittle from thermal cycling, corporate logos weathered to abstract suggestion. Faded loading-zone paint still marks spaces nobody uses.",
+  "sense_descs": {
+   "olfactory": "Cold dust and dry rust, the dead air of sealed buildings.",
+   "auditory": "The brittle panels tick and pop as the cold works them; otherwise quiet, the colony's hum distant.",
+   "tactile": "Deep cold here, out of any traffic; the sealed doors are frigid to the touch.",
+   "atmospheric": "A district that stopped expecting to reopen."
+  }
+ },
+ "1279": {
+  "key": "Kaspar Street",
+  "desc": "Converted storage modules stack two-high on the northern side, external ladders welded from pipe and rebar. Laundry hangs stiff between buildings. South, a drinking hole marked only by a hand-painted bottle on sheet metal, its entrance cut raw into a cargo container's side.",
+  "sense_descs": {
+   "olfactory": "Frozen laundry, cold rust, and woodsmoke leaking from the bar's cut doorway.",
+   "auditory": "Ladders and sheeting rattle in the cold; voices and clatter leak from the container bar.",
+   "tactile": "Everything here is cold-stiff — laundry frozen on the lines, metal that bites bare skin."
+  }
+ },
+ "1282": {
+  "key": "Kaspar Street",
+  "desc": "Empty shipping containers wall both sides, corrugated flanks bearing the faded logos of freight companies long gone or never here. They sit stacked at haphazard angles, doors sealed with composite welded over the original mechanisms — solid walls over whatever they once held.",
+  "sense_descs": {
+   "olfactory": "Cold steel and old paint, nothing living.",
+   "auditory": "The stacked containers boom faintly as the cold contracts them.",
+   "tactile": "The corrugated walls are ice-cold; the corridor between them holds the chill.",
+   "atmospheric": "A canyon of sealed boxes — storage that became architecture."
+  }
+ },
+ "1285": {
+  "key": "Kaspar Street",
+  "desc": "The street pinches where a collapsed prefab section was left to rot rather than cleared, its twisted frame forcing traffic single-file. Someone has claimed the wreckage — tarps stretched across the skeletal structure, a barrel fire burning despite regulations nobody enforces this far south.",
+  "sense_descs": {
+   "olfactory": "Barrel-fire smoke and the cold-metal smell of the rotting wreck.",
+   "auditory": "The barrel fire snaps; tarps crack and lift; the ruined frame ticks as it cools.",
+   "tactile": "Barrel-fire heat in a narrow pocket, the cold pressing back at its edges.",
+   "atmospheric": "A collapse turned squat — failure made into shelter."
+  }
+ },
+ "1288": {
+  "key": "Kaspar Street",
+  "desc": "A fighting pit opens off the southern side, a composite ramp descending into what was a cargo bay before blood sport proved more profitable than storage. North, housing crowds in desperate density — modules subdivided past reason, external water pipes frozen solid inside their thermal wrap.",
+  "sense_descs": {
+   "olfactory": "Too many cooking-fires burning the cheapest fuel, over cold rust and frozen pipe.",
+   "auditory": "From the pit ramp rise muffled impacts and a swell of roar, then the dead quiet after a fight ends badly.",
+   "tactile": "The frozen pipes radiate cold; the ramp breathes a warmer, closer air up from the pit.",
+   "atmospheric": "Density and blood-sport pressed together — south you bleed, north you freeze."
+  }
+ },
+ "1291": {
+  "key": "Kaspar Street",
+  "desc": "The street kinks around a large utility box bolted to a rusted prefab. A storefront advertises |gBEST PRICES - NO QUESTIONS|n in bright letters, reinforced windows displaying the accumulated desperation of workers needing tokens before payday — tools, electronics, things maybe stolen, maybe earned. Fresh welds patch the grating where sections have been replaced.",
+  "sense_descs": {
+   "olfactory": "Hot solder and cold metal, with the ozone bite of recent welding.",
+   "auditory": "The utility box hums and clicks; the storefront sign buzzes; the colony drones beneath.",
+   "tactile": "Fresh welds still hold a little warmth in an otherwise cold grid."
+  }
+ },
+ "1294": {
+  "key": "Kaspar Street",
+  "desc": "Cube hotels march along both sides, but here the modules show the personalization of longer stays — tapestries and flags strung alongside the laundry. A community water point juts from the northern wall, spigots worn from constant use, frozen puddles ringing its base in miniature landscapes of ice.",
+  "sense_descs": {
+   "olfactory": "Cold mineral water, frozen cloth, and the faint smoke of many small fires.",
+   "auditory": "The water point drips and the drips freeze; fabric snaps in the cold.",
+   "tactile": "Ice slicks the ground around the spigots; the cold has a permanence here.",
+   "atmospheric": "Stacked transience worn into something almost like home."
+  }
+ },
+ "1297": {
+  "key": "Kaspar Street",
+  "desc": "A drinking establishment fills a double-wide prefab on the southern side, its entrance a mismatch of salvaged signage reading |mLast Shift|n in letters that flicker with the persistence of something broken and repaired past counting. Someone has strung lights between buildings, pooling relative warmth against the crater wall's perpetual shadow.",
+  "sense_descs": {
+   "olfactory": "Spilled liquor and smoke leaking from the bar, against the cold outside.",
+   "auditory": "Music bleeds through thin insulation — fiddle and pipe tangled with synth, the hybrid sound of cultural memory meeting whatever instruments survived the crossing.",
+   "tactile": "The strung lights throw a thin warmth; step out of it and the crater-shadow cold returns.",
+   "atmospheric": "A lit pocket of warmth holding the line against the wall's shadow."
+  }
+ },
+ "1300": {
+  "key": "Kaspar Street",
+  "desc": "The street widens where a maintenance yard claims the southern side, industrial equipment parked in orderly rows that suggest actual management. Haulers sit awaiting repair, treads caked with deep-mine mud — regolith, ice melt, and hydraulic fluid frozen solid in the patterns of their last run.",
+  "sense_descs": {
+   "olfactory": "Hydraulic fluid and frozen regolith mud, cold machine-oil over stone.",
+   "auditory": "Cooling hydraulics tick in the parked haulers; the yard is otherwise still.",
+   "tactile": "The frozen tread-mud is rock-hard; cold radiates off the idle machines."
+  }
+ },
+ "1303": {
+  "key": "Kaspar Street",
+  "desc": "A shift facility dominates the north — showers, lockers, sleeping coffins, the infrastructure of changing between work and life in prefab utility. South, a medical clinic occupies a reinforced module, its sign advertising |50424 HOUR - INDUSTRIAL INJURIES - URGENT CARE|n in letters that speak to frontier medicine.",
+  "sense_descs": {
+   "olfactory": "Cheap soap and disinfectant from the shift facility, antiseptic from the clinic, over cold metal.",
+   "auditory": "Showers run and drains gurgle behind the facility wall; the clinic's door cycles with a pneumatic sigh.",
+   "tactile": "Damp warmth leaks from the shower block; the clinic's threshold is clinic-cold.",
+   "atmospheric": "Where bodies are serviced between shifts — washed, bunked, and patched."
+  }
+ },
+ "1308": {
+  "key": "Kaspar Street",
+  "desc": "Scrap yards flank the street, contents organized by a logic either brilliant or insane — hull plating sorted by thickness, cable by gauge, structural components stacked by size. The northern yard runs active commerce with a weighing station; the southern is pure archaeology, detritus compressed at the bottom into something load-bearing. Chain-link and razor wire fence both, symbolically, given the cut-and-resealed access panels everywhere.",
+  "sense_descs": {
+   "olfactory": "Rust, cold steel, and the faint electrical tang of stripped cable.",
+   "auditory": "Metal shifts and settles in the stacks; a loose chain-link panel taps somewhere.",
+   "tactile": "Sharp cold off the sorted metal; razor wire and cut edges everywhere underhand."
+  }
+ },
+ "1311": {
+  "key": "Kaspar Street",
+  "desc": "The street narrows to barely two meters where prefab modules have encroached from both sides — northern structures leaning south, southern leaning north, a claustrophobic tunnel you could almost touch both walls of. Overhead, cables and pipes web so densely they form an accidental ceiling, composite sheeting draped across to keep what passes for precipitation from dripping through.",
+  "sense_descs": {
+   "olfactory": "Close, stale cold air, damp where the overhead pipes sweat.",
+   "auditory": "Drips tick from the pipe-web overhead; sound goes flat and close between the walls.",
+   "tactile": "The walls press in from both sides; the air is dead and cold and unmoving.",
+   "atmospheric": "A swallowed thoroughfare — public space taken to a tunnel."
+  }
+ },
+ "1314": {
+  "key": "Kaspar Street",
+  "desc": "A marketplace claims both sides, vendors set up on composite pallets and folding tables in configurations that change daily but keep the same character — food, salvage, personal items, and things nobody's sure how to categorize.",
+  "sense_descs": {
+   "olfactory": "Cooking-smoke and fried food over the constant cold-metal undertone of salvage.",
+   "auditory": "The colony's hum and the clatter of carts under the market's churn.",
+   "tactile": "Cooking-heat pools at the food stalls; the cold reclaims the gaps between them."
+  }
+ },
+ "1317": {
+  "key": "Kaspar Street",
+  "desc": "Prefab housing climbs six levels on the northern side, swaying faintly — wind or structural insufficiency, impossible to tell. Each level betrays its method: original colony prefab at the bottom, welded salvage additions at three and four, shipping-container-and-optimism at five and six. External ladders connect them in a vertical maze that must be learned, not intuited. South runs lower and looser, three-level structures with actual space between them.",
+  "sense_descs": {
+   "olfactory": "Cold metal and cooking-smoke, thicker where the northern stack crowds the air.",
+   "auditory": "The six-level stack creaks and shifts overhead; ladders ring as the cold flexes them.",
+   "tactile": "The northern stack's sway is faintly unnerving; the grating underfoot stays cold.",
+   "atmospheric": "Vertical desperation north, a little breathing room south."
+  }
+ },
+ "1320": {
+  "key": "Kaspar Street",
+  "desc": "A large windowless facility dominates the southern side, its entrance protected by security measures serious enough to deter rather than merely discourage. The building is older construction, composite in a shade unmanufactured for decades — it predates most of the surrounding sprawl.",
+  "sense_descs": {
+   "olfactory": "Cold sealed concrete, scrubbed of any smell at all.",
+   "auditory": "A deep, sealed quiet — only a faint mechanical thrum behind the windowless wall.",
+   "tactile": "The blank wall radiates a flat institutional cold.",
+   "atmospheric": "Something deliberately closed — older, harder, and not explaining itself."
+  }
+ },
+ "1323": {
+  "key": "Kaspar Street",
+  "desc": "Collapsed prefab litters the southern side, a failure recent enough that nobody's decided whether to clear it or absorb it. Composite barriers and hazard tape cordon the wreck, the tape broken in places, the barriers shifted and replaced many times. Through gaps, interior spaces lie open to atmosphere — furniture and belongings in cross-section like an excavation. The northern structures have answered by welding angled supports onto their southern walls.",
+  "sense_descs": {
+   "olfactory": "Cold dust and exposed interiors — stale habitation opened to the air.",
+   "auditory": "The wreck ticks and settles; loose hazard tape snaps against the barriers.",
+   "tactile": "Cold pours from the opened interiors; grit and debris underfoot.",
+   "atmospheric": "A fresh collapse the neighbors are bracing against — failure expected to spread."
+  }
+ },
+ "1326": {
+  "key": "Kaspar Street",
+  "desc": "The street opens into something near a plaza — a rare twenty meters of relatively clear grating. The northern side reads as a transit hub: composite benches in rows, posted schedules that might be current or merely aspirational. South, a row of vague unmarked storefronts.",
+  "sense_descs": {
+   "olfactory": "Cold open air, faint cooking-smoke drifting from the storefronts.",
+   "auditory": "The colony's hum carries clean across the open space; a schedule board buzzes and refreshes.",
+   "tactile": "Exposed and cold in the open, no walls to trap any warmth.",
+   "atmospheric": "A rare clearing in the density — a place built to wait."
+  }
+ },
+ "1329": {
+  "key": "Kaspar Street",
+  "desc": "A tool-lending operation holds the northern side, its reinforced viewport displaying organized rows behind security mesh — drills, torches, detection gear. Posted rates run by the shift, deposits calibrated to people who own nothing but their labor. South, housing subdivided to fabric walls, privacy a matter of collective agreement rather than barrier.",
+  "sense_descs": {
+   "olfactory": "Machine oil and cold metal from the tool racks, cooking-smoke from the crowded south.",
+   "auditory": "Equipment clinks behind the mesh; thin walls leak the muffled sounds of too many lives.",
+   "tactile": "The tool-shop viewport is cold glass; the subdivided south is close and stale-warm."
+  }
+ },
+ "1332": {
+  "key": "Kaspar Street",
+  "desc": "Three-level prefab rises both sides, standard construction aged into merely functional. Door seals gap, viewports trap condensation, utility brackets are more weld than metal from endless replacement. Laundry hangs between buildings, stained by recycled water that's never quite clean.",
+  "sense_descs": {
+   "olfactory": "Damp recycled water, cold metal, and the mildew of trapped condensation.",
+   "auditory": "Gapped seals whistle thinly; condensation drips behind fogged viewports.",
+   "tactile": "Cold drafts leak through the gapped seals; everything is faintly damp."
+  }
+ },
+ "1338": {
+  "key": "Kaspar Street",
+  "desc": "Four-level prefab blocks flank the street, identical but for their damage. External staircases zigzag up, treads worn smooth, railings rusted at every joint. Viewports fog with age, some curtained from inside — a checkerboard of transparency and privacy. The grating is functional, patched in a dozen places.",
+  "sense_descs": {
+   "olfactory": "Cold rust and cooking-smoke, the standard breath of the worker blocks.",
+   "auditory": "The staircases creak underfoot; rusted railings groan in the cold.",
+   "tactile": "Rusted rail and cold tread; the patched grating shifts faintly underfoot.",
+   "atmospheric": "Worker housing aged to the bone — identical, patched, and still standing."
+  }
+ },
+ "1345": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa opens in a crush of stalls against patched walls, awnings stitched from scavenged cloth. A faded mural of a rising sun shows through the graffiti, half-hopeful, half-forgotten.",
+  "sense_descs": {
+   "olfactory": "Frying oil and cardamom, thick enough to mask the metallic tang of rust beneath.",
+   "auditory": "The processor's hum is faint here, carried thin from the east like a far-off heartbeat.",
+   "tactile": "Warm cooking-air pools between the stalls."
+  }
+ },
+ "1348": {
+  "key": "Pessoa Street",
+  "desc": "The street narrows under sagging laundry lines. Condensation streaks dark across the ground; every surface is layered with chalk prayers and gang marks fading into one another.",
+  "sense_descs": {
+   "olfactory": "Turmeric and damp stone hang heavy in the close air.",
+   "auditory": "Condensation drips steadily from the lines; the processor murmurs beneath.",
+   "tactile": "The ground is slick underfoot; the air presses warm and wet between the walls.",
+   "atmospheric": "Faith and turf overwritten on every surface, prayer under tag under prayer."
+  }
+ },
+ "1351": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa widens into a row of food carts. The ground is uneven, patched with scavenged boards. Eastward, the processor's glow is faintly visible.",
+  "sense_descs": {
+   "olfactory": "Spice and cooking-smoke fill the air, oily and warm.",
+   "auditory": "The scavenged boards creak and shift; the processor's drone carries from the east.",
+   "tactile": "The patched boards flex underfoot; cooking-heat hangs over the carts."
+  }
+ },
+ "1354": {
+  "key": "Pessoa Street",
+  "desc": "The street dips, water pooling to reflect neon in fractured color. Crooked makeshift tables line the low ground, marked with painted symbols no one fully reads. A single lamp buzzes overhead.",
+  "sense_descs": {
+   "olfactory": "Cheap whiskey clings to everything, mixed through with frying oil.",
+   "auditory": "The lamp buzzes and stutters overhead; from deep south, the mine machinery hums faint.",
+   "tactile": "Standing water films the low ground; the air is cool and damp here.",
+   "atmospheric": "Charlatan's row — symbols and luck for sale where the street pools."
+  }
+ },
+ "1357": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa tightens, stacked housing leaning into the street, narrow alleys cutting between them hung with drying clothes. A shrine sits tucked into a corner, candles flickering.",
+  "sense_descs": {
+   "olfactory": "Incense and damp metal, heavy and persistent.",
+   "auditory": "The processor's hum comes through the walls more than the air.",
+   "tactile": "The processor's vibration carries through the close walls, steady and unrelenting."
+  }
+ },
+ "1360": {
+  "key": "Pessoa Street",
+  "desc": "The street opens into a communal spot strung with lanterns overhead. A cracked statue of a forgotten saint leans against the wall, its face worn smooth.",
+  "sense_descs": {
+   "olfactory": "Cooking-smoke and dust, with the wax-sweetness of guttering lanterns.",
+   "auditory": "Distant machinery grinds steady beneath the open space.",
+   "tactile": "Fine dust hangs in the lantern-light, settling on everything.",
+   "atmospheric": "A gathering-ground waiting on something — the worn saint presiding over it."
+  }
+ },
+ "1363": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa narrows again, crowded with stalls of fried food and cheap liquor. Chalk prayers fade day by day, layered over gang symbols.",
+  "sense_descs": {
+   "olfactory": "Greasy cooking-smoke leaves a film on the skin; fried food and cheap liquor underneath.",
+   "auditory": "Steam and the processor's drone fill the gaps between the stalls.",
+   "tactile": "Cooking-grease hazes the close air, settling damp on the skin."
+  }
+ },
+ "1366": {
+  "key": "Pessoa Street",
+  "desc": "The street dips, uneven boards laid over soft regolith. A gang's colors are painted bold across one wall, daring anyone to cross.",
+  "sense_descs": {
+   "olfactory": "Fried noodles dominate, sharp and oily.",
+   "auditory": "The processor's hum is louder here, carried clear from the east.",
+   "tactile": "The boards give over soft regolith underfoot."
+  }
+ },
+ "1369": {
+  "key": "Pessoa Street",
+  "desc": "A pawn shop squats against the street, windows packed with broken tools and faded charms. The ground is uneven, patched with scavenged stone.",
+  "sense_descs": {
+   "olfactory": "Sweat and smoke cling to every surface, heavy and close.",
+   "auditory": "The processor's drone presses under the street's clamor.",
+   "tactile": "The patched stone is uneven; the air sits warm and stale.",
+   "atmospheric": "A pawn-shop corner wound tight — the kind of quiet that could break the wrong way."
+  }
+ },
+ "1372": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa widens into a small square. Faded corporate logos paper the walls, buried under gang symbols and graffiti. A crudely cut three-pointed crown hangs over the southern arch — |yQueen of Cups|n — its patina faded but defiant.",
+  "sense_descs": {
+   "olfactory": "Spice and barrel-fire smoke cling to clothes and hair.",
+   "auditory": "Barrel fires snap and pop; the processor's hum runs steady beneath.",
+   "tactile": "Barrel-fire heat pushes back the chill in pockets across the square.",
+   "atmospheric": "The Queen's crown over the arch — a claimed square, faded but holding."
+  }
+ },
+ "1382": {
+  "key": "Pessoa Street",
+  "desc": "The street narrows, walls lined with sweating pipes. Steam rises in thin curtains, catching the dim light.",
+  "sense_descs": {
+   "olfactory": "Oil and sweat hang thick, clinging to clothes.",
+   "auditory": "The grating rattles under cart-wheels; steam hisses; the processor's hum grows louder, steady as a heartbeat.",
+   "tactile": "The pipes sweat onto the walls; steam leaves the air damp and warm."
+  }
+ },
+ "1385": {
+  "key": "Pessoa Street",
+  "desc": "The street dips, water pooling in shallow depressions; emergency lights flicker overhead. A food stall clings to the corner. North, a narrow alley disappears into shadow, its silence heavier than the street.",
+  "sense_descs": {
+   "olfactory": "Curry-spiced protein cuts sharp through the damp air.",
+   "auditory": "Emergency lights buzz and cycle; the processor's drone carries from the east.",
+   "tactile": "Standing water films the dip; the damp air clings.",
+   "atmospheric": "The alley-mouth north holds a silence the street can't fill."
+  }
+ },
+ "1388": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa widens into a vendor stretch, tables sagging under tools, charms, and patched clothing. Steam bursts from the vents, clearing space for a moment before it closes again.",
+  "sense_descs": {
+   "olfactory": "Fried noodles and cheap liquor over the constant oily smoke.",
+   "auditory": "Vent-steam bursts hiss; the machinery's hum presses harder than any voice.",
+   "tactile": "Each steam-burst rolls warm and damp across the tables."
+  }
+ },
+ "1391": {
+  "key": "Pessoa Street",
+  "desc": "The grating is doubled here, thicker support beams showing beneath — someone learned lessons in collapse. A single lamp buzzes overhead, its light dying before it reaches the ground.",
+  "sense_descs": {
+   "olfactory": "Damp, recycled moisture and cold metal.",
+   "auditory": "The lamp buzzes; boots ring on doubled steel; the processor hums beneath.",
+   "tactile": "The processor's vibration carries up through the soles; the air hangs damp and heavy."
+  }
+ },
+ "1394": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa tightens, walls close and claustrophobic, pipes running overhead and dripping onto the grating. A pawn shop squats here, windows full of broken tools and faded charms. South, a dark alley cuts away, its mouth marked by silence and damp.",
+  "sense_descs": {
+   "olfactory": "Rust and damp air dominate, close and metallic.",
+   "auditory": "Pipes drip steadily onto the grating; the processor's hum carries through the walls.",
+   "tactile": "The walls press close; the dripping pipes keep the grating wet.",
+   "atmospheric": "The dark alley south breathes damp silence into the street."
+  }
+ },
+ "1397": {
+  "key": "Pessoa Street",
+  "desc": "The street dips, steam rising from the vents in irregular bursts. Shadows stretch long across the grating, broken by flashes of yellow light. North, a narrow alley vanishes into shadow.",
+  "sense_descs": {
+   "olfactory": "Frying oil clings to the damp air.",
+   "auditory": "Steam hisses in bursts; from the north alley, only dripping water; the processor drones east.",
+   "tactile": "Steam-bursts leave the grating slick and warm."
+  }
+ },
+ "1400": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa widens into a small square strung with lanterns. Children's drawings cover the walls, layered over gang symbols. The processor dominates the horizon, its heat pressing closer.",
+  "sense_descs": {
+   "olfactory": "Spice and cooking-smoke cling to clothes and hair.",
+   "auditory": "Steam bursts punctuate the square; the processor's hum sits steady and close.",
+   "tactile": "The processor's heat presses in now, warming the square unevenly.",
+   "atmospheric": "Children's chalk over gang-marks — small claims layered on hard ones."
+  }
+ },
+ "1403": {
+  "key": "Pessoa Street",
+  "desc": "The grating rattles under heavy carts pushed east. A fortune-teller's tent flaps at the corner, its colors faded but defiant. South, a narrow alley cuts away, its mouth damp and silent.",
+  "sense_descs": {
+   "olfactory": "Sweat and machine oil, with steam-vents leaving a metallic edge.",
+   "auditory": "Cart-wheels rattle the grating; steam vents hiss; the machinery's hum presses against every sound.",
+   "tactile": "Vented steam leaves the air metallic and damp."
+  }
+ },
+ "1406": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa narrows, walls lined with pipes and patched panels. Half the emergency fixtures are dark or cycling through brownouts, and the pools of shadow make the street feel larger than it is.",
+  "sense_descs": {
+   "olfactory": "Cheap whiskey and fried food hang heavy in the dark.",
+   "auditory": "The failing lights tick and buzz; the processor's vibration runs constant, steady as breath.",
+   "tactile": "The processor's hum fills the bones here, close and unbroken.",
+   "atmospheric": "Brownout dark where the nightlife starts to stir."
+  }
+ },
+ "1409": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa stretches east on reinforced beams and doubled grating. Steam vents puncture the street in hissing bursts. Yellow lights flicker and fail against the damp; the processor looms close now, its conduits and arrays sharp.",
+  "sense_descs": {
+   "olfactory": "Hot metal and steam, the ozone edge of the processor sharpening as it nears.",
+   "auditory": "The spillway's roar echoes oddly here, bouncing into dead zones before crashing back; steam hisses; the processor's drone is close and heavy.",
+   "tactile": "The processor's heat is undeniable now; vented steam slicks the doubled grating.",
+   "atmospheric": "The street's industrial end — heat, roar, and chrome where Pessoa meets the machine."
+  }
+ },
+ "1414": {
+  "key": "Volta Street",
+  "desc": "The character transitions here - technical precision giving way to functional industrial. Northern structures still show decent maintenance, but the clinical atmosphere fades. Older repairs sit alongside newer work, patches over damage rather than full replacements. Conduit overhead remains organized but shows zip-tied improvised additions. A repair bay displays the mixed character - clean-room protocols at the threshold, oil stains and burn marks within. The grating shows twin tracks polished by regular equipment passage.",
+  "sense_descs": {
+   "auditory": "The clatter of a repair bay working past its clean-room pretensions.",
+   "olfactory": "Clinical filtering gives way to oil and burnt metal.",
+   "tactile": "Twin tracks run polished into the grating by regular equipment passage."
+  }
+ },
+ "1417": {
+  "key": "Volta Street",
+  "desc": "A machine shop dominates the northern side, bays revealing mechanical archaeology - lathes and mills maintained through countless part replacements until only frames remain original. Scrap metal piles against the southern wall in sorted categories - ferrous, non-ferrous, composite fragments.",
+  "sense_descs": {
+   "auditory": "Grinding wheels bite into metal; the shop's lathes turn in steady cycles.",
+   "olfactory": "Cutting fluid, hot swarf, the metallic tang of fresh-worked steel.",
+   "tactile": "Grit and metal filings underfoot near the open bays.",
+   "atmospheric": "Sparks flare visible through the viewports."
+  }
+ },
+ "1420": {
+  "key": "Volta Street",
+  "desc": "A marketplace sprawls along both sides of the street, stalls displaying synthetic components alongside organic goods. Optical sensors rest in ice-filled bins, their lenses clouded but functional. Hydraulic actuators hang from hooks, cleaned and catalogued by pressure rating. A vendor displays myoelectric interfaces on velvet - gold contacts still bright, connector pins intact. Another stall offers biofluid pumps, their chambers flushed and ready. Memory cores sit in anti-static foam, capacity and condition hand-labeled.",
+  "sense_descs": {
+   "auditory": "Vendors call stock and prices over the market sprawl.",
+   "olfactory": "Machine oil, antiseptic, and the cold wet of ice-filled bins.",
+   "tactile": "Stalls crowd the grating; the street pinches to browsing-width."
+  }
+ },
+ "1423": {
+  "key": "Volta Street",
+  "desc": "Calibration equipment marks the northern prefabs - laser alignment stations visible through viewports, their beams creating reference grids. The structures show technical precision, sealed against particulate contamination. Southern modules house testing facilities, environmental chambers maintaining controlled conditions.",
+  "sense_descs": {
+   "auditory": "The soft cycling of environmental chambers holding their conditions.",
+   "olfactory": "Sealed-clean air, faintly electric.",
+   "tactile": "The structures are sealed tight against particulate; the air sits still and dry.",
+   "atmospheric": "Laser alignment beams draw faint reference grids through the viewports."
+  }
+ },
+ "1426": {
+  "key": "Volta Street",
+  "desc": "A research annex occupies the northern prefabs, viewports revealing lab benches and microscopy stations. A loading bay sits between modules, configured for careful material transfer. Decontamination protocols are posted at every entrance. The grating shows chemical staining in abstract patterns, decades of careful spillage creating unintentional art.",
+  "sense_descs": {
+   "auditory": "The whir of fume extraction behind sealed lab doors.",
+   "olfactory": "Solvents and reagents, the sharp note of decontamination chemicals.",
+   "tactile": "The grating is chemical-stained in abstract patterns, etched smooth in places.",
+   "atmospheric": "Biohazard placards mark the containment sections in vivid yellow and orange."
+  }
+ },
+ "1429": {
+  "key": "Volta Street",
+  "desc": "Cryogenic storage units line the northern side, their insulated housings marked with temperature warnings and frost patterns. A transfer station occupies the south - reinforced loading dock with cold chain equipment.",
+  "sense_descs": {
+   "auditory": "Liquid nitrogen vents hiss at intervals along the storage units.",
+   "olfactory": "The scentless bite of extreme cold, frost and clean metal.",
+   "tactile": "Cold rolls off the cryogenic units; frost rimes the grating near their housings.",
+   "atmospheric": "White vapor rolls across the grating; amber warning lights pulse along the street."
+  }
+ },
+ "1432": {
+  "key": "Volta Street",
+  "desc": "Northern prefabs house quality control facilities, inspection stations with magnification equipment visible through windows. The southern side displays certification placards - compliance standards, testing protocols, audit schedules current. Emergency equipment stations stand ready, fire suppression and medical kits behind clearly marked panels. The grating gleams, actually maintained.",
+  "sense_descs": {
+   "auditory": "Quiet and orderly, the hum of inspection equipment behind windows.",
+   "olfactory": "Clean, faintly antiseptic.",
+   "tactile": "The grating gleams, actually maintained, smooth underfoot."
+  }
+ },
+ "1435": {
+  "key": "Volta Street and Wolfe Way",
+  "desc": "Prefab walls press close on both sides, their composite panels showing decades of scuff marks and impact damage. Overhead conduit runs exposed, zip-tied and improvised, carrying power and data between the technical districts.",
+  "sense_descs": {
+   "auditory": "The grating rattles with each step, loose bolts long past tightening.",
+   "olfactory": "Scuffed composite, machine oil, stale enclosed air.",
+   "tactile": "Walls press close enough to touch on both sides; loose grating shifts underfoot.",
+   "atmospheric": "Emergency lighting casts harsh shadows, half the fixtures dead or flickering."
+  }
+ },
+ "1438": {
+  "key": "Volta Street",
+  "desc": "Industrial character asserts itself. Northern workshops house fabrication equipment, welding stations, accumulated machine-shop grime. Salvaged equipment stacks against the southern crater wall. The grating shows heavy staining and scoring. Yellow institutional lighting replaces the western section's spectrum-balanced fixtures.",
+  "sense_descs": {
+   "auditory": "Arc welders crackle; salvage clangs as it's sorted against the crater wall.",
+   "olfactory": "Cutting fluid, arc-welder ozone, the metallic tang of fresh-worked steel.",
+   "tactile": "Heat builds here, the first suggestion of the processor's influence.",
+   "atmospheric": "Yellow institutional lighting flattens the street to a sodium monochrome."
+  }
+ },
+ "1441": {
+  "key": "Volta Street",
+  "desc": "Industrial storage dominates - warehoused prefabs filled with raw materials. Through open doors: stacked composite sheets, coiled steel stock, chemical drums with hazard symbols. Northern structures lean slightly, settled into uneven geology at angles now permanent. A loading platform extends from the southern wall, stained with accumulated spills.",
+  "sense_descs": {
+   "auditory": "Forklifts move stock through the open warehouse doors.",
+   "olfactory": "Raw composite, cold steel stock, the chemical seep of hazard drums.",
+   "tactile": "Heat off the processor presses closer here; the air thickens with it.",
+   "atmospheric": "The processor towers to the east, close enough to read its rust staining and patch welding."
+  }
+ },
+ "1446": {
+  "key": "Volta Street",
+  "desc": "Diagnostic terminals mount at regular intervals along the northern prefabs, screens dark but ready, ports open. The street surface shows minimal wear, actually maintained. Color-coded conduit runs overhead in organized parallels, properly insulated. A ventilation shaft rises from the grating, its grill remarkably clean. The southern crater wall shows fewer drill scars - pristine compared to western sections.",
+  "sense_descs": {
+   "auditory": "The steady draw of the clean ventilation shaft rising from the grating.",
+   "olfactory": "Ozone and filtered organics.",
+   "tactile": "Minimal wear underfoot, the surface still true."
+  }
+ },
+ "1449": {
+  "key": "Volta Street and Riveter's Way",
+  "desc": "The intersection sprawls where Volta terminates at Riveter's Way, dominated by the processor's overwhelming presence. The processor wall rises south in sheer industrial composite, marked with massive bulkhead doors. Biometric scanners flank entrances, amber interfaces in standby. North, Riveter's Way extends through industrial districts clustered in the processor's shadow. Reinforced grating handles constant heavy equipment - mining haulers, chemical tankers, the traffic serving the colony's breathing apparatus.",
+  "sense_descs": {
+   "auditory": "The processor's mechanical heartbeat is overwhelming here, rhythmic thunder drowning everything else.",
+   "olfactory": "Ozone, hot metal, and chemical-tanker fumes.",
+   "tactile": "Heat pours off the processor wall; the reinforced grating trembles with its pulse.",
+   "atmospheric": "Warning strobes pulse through the haze along the processor wall."
+  }
+ },
+ "1452": {
+  "key": "Riveter's Way",
+  "desc": "The street ends at the processor's entrance plaza - a hardened courtyard where industrial scale becomes architectural statement. Bulkhead doors rise six meters high, composite and steel designed to contain catastrophic failures. Security checkpoints bracket the entrance, manned by personnel whose weapons suggest shoot-first protocols. Warning placards in multiple languages cover every surface, bright colors warning of pressure zones and contamination risks. The plaza grating is reinforced to extremes, rated for moving massive components.",
+  "sense_descs": {
+   "auditory": "The processor's bulk fills the plaza with a deep, close roar, no longer distant.",
+   "olfactory": "Ozone, hot metal, and the chemical tang of pressure-zone venting.",
+   "tactile": "Heat radiates off the processor wall; the reinforced grating sits solid underfoot.",
+   "atmospheric": "Overhead floods create a zone of artificial day; the processor wall is immediate presence, not horizon."
+  }
+ },
+ "1455": {
+  "key": "Riveter's Way",
+  "desc": "A shift facility dominates the western side - lockers, showers, briefing rooms. Workers move in and out with shift-change regularity, coveralls marked with division codes and atmospheric-maintenance grime. Posted boards display schedules and safety bulletins. The eastern structures house administrative functions - offices with reinforced viewports, security checkpoints with biometric scanners. A pedestrian bridge at third-level height connects facility to admin, its deck worn from decades of crossings.",
+  "sense_descs": {
+   "auditory": "The processor's individual systems are audible here - compressor cycling, turbine spin, the layered symphony of atmospheric transformation.",
+   "olfactory": "Shower steam and locker-room damp cut with atmospheric-maintenance grime.",
+   "tactile": "Warmth radiates steadily from the processor; the third-level bridge deck is worn smooth."
+  }
+ },
+ "1458": {
+  "key": "Riveter's Way",
+  "desc": "Equipment staging yards flank both sides behind chain-link fencing and security lighting. The western yard holds diagnostic equipment - calibration rigs, sensor arrays, atmospheric testing modules. The eastern side stores larger components - pressure vessels, composite ducting sections, valve assemblies that dwarf human scale. The grating shows heavy vehicle wear, polished smooth by hauler treads.",
+  "sense_descs": {
+   "auditory": "Gantries clank overhead; the steady industrial hum of the processor underlies it all.",
+   "olfactory": "Machine oil, ozone, and cold metal off the staged components.",
+   "tactile": "The grating is polished smooth by hauler treads, slick underfoot.",
+   "atmospheric": "Overhead gantries span the street at regular intervals, rated for whatever the processor demands."
+  }
+ },
+ "1462": {
+  "key": "Volta Street",
+  "desc": "A calibration facility occupies the southern side, its placard displaying precise operating hours. Through viewports: clean-room environments, white surfaces, equipment on anti-vibration platforms, where tolerances matter in micrometers. Southern structures show technical modifications - sensor arrays, environmental monitors, properly sealed junction boxes. The grating reflects the overhead lights, swept with unusual frequency.",
+  "sense_descs": {
+   "auditory": "Near-silence, the faintest hum of equipment held on anti-vibration platforms.",
+   "olfactory": "Filtered clean-room air, neutral and dry.",
+   "tactile": "The grating is swept with unusual frequency, smooth and clean underfoot.",
+   "atmospheric": "The lighting here actually gets maintained, brighter than most of the colony."
+  }
+ },
+ "1468": {
+  "key": "Dark Alley",
+  "desc": "The alley narrows immediately, prefab walls close enough to touch both sides with outstretched arms. Composite underfoot is uneven, gaps filled with compacted debris. Cargo netting and propped composite panels form improvised storage and makeshift shelters along both walls. Dim lights glow deeper in.",
+  "sense_descs": {
+   "auditory": "Water drips steadily from above; voices echo strangely between the walls, making distance impossible to judge.",
+   "olfactory": "Organic waste, chemical runoff, and cooking from unseen sources, intensifying the deeper in you go.",
+   "tactile": "Walls close enough to touch on both sides; uneven composite and puddles that never dry underfoot.",
+   "atmospheric": "Darkness dominates - street lighting doesn't reach here, the fixtures long since scavenged."
+  }
+ },
+ "1471": {
+  "key": "Wolfe Way",
+  "desc": "The largest agricultural dome dominates the western side, its scale suggesting ambition the colony couldn't sustain. Through the clouded panels: a vast empty space, ceiling high enough for trees that were never planted. The eastern side shows conversion attempts - prefab modules built into the dome's foundation, trying to repurpose the space for storage or housing before being abandoned themselves.",
+  "sense_descs": {
+   "auditory": "The dome's climate control hums intermittently, automatic systems running maintenance cycles for crops that don't exist.",
+   "olfactory": "Damp stale air and the mineral smell of endless condensation.",
+   "tactile": "A cool dampness seeps from the dome; condensation pools and reforms on its interior surfaces.",
+   "atmospheric": "Through the clouded panels, a vast empty space opens, ceiling high enough for trees never planted."
+  }
+ },
+ "1474": {
+  "key": "Wolfe Way",
+  "desc": "Two agricultural domes flank the corridor here, both long abandoned. The western dome shows catastrophic decompression damage - entire sections blown out, panels missing, framework exposed. The eastern dome maintained structural integrity but sits dark and empty, its airlock sealed with warning tape weathered to illegibility. Between them, the corridor narrows to a maintenance width, grating replaced with composite walkway.",
+  "sense_descs": {
+   "auditory": "Wind moves thinly through the blown-out western dome; otherwise a dead, abandoned quiet.",
+   "olfactory": "Cold scoured metal and faint mineral dust off the ruptured panels.",
+   "tactile": "A thin draft pulls through the western dome's missing sections; the composite walkway narrows close.",
+   "atmospheric": "Emergency egress signs still glow, amber LEDs somehow still powered."
+  }
+ },
+ "1477": {
+  "key": "Wolfe Way",
+  "desc": "A defunct agricultural dome looms to the west, its translucent composite panels clouded with decades of mineral deposits and failed sealant. The dome's framework shows through the haze - geodesic steel ribs corroded to rust-orange, structural members sagging where supports failed. Through gaps in the panels: empty growing beds, irrigation lines hanging disconnected, the skeletal remains of hydroponic racks. The eastern side houses repurposed storage - sealed modules containing whatever couldn't fit elsewhere.",
+  "sense_descs": {
+   "auditory": "The dead dome holds a hollow silence, broken only by wind finding the gaps in its panels.",
+   "olfactory": "Rust, mineral dust, and the faint ghost of old organic growing medium.",
+   "tactile": "The corridor floor carries soil staining tracked in during the dome's operational years, gritty and never fully cleaned.",
+   "atmospheric": "Geodesic steel ribs show rust-orange through the haze, structural members sagging where supports failed."
+  }
+ },
+ "1482": {
+  "key": "Gilroy Street and Tolliver Row",
+  "desc": "The intersection opens where Gilroy Street cuts through the waterfront's residential districts, grating showing moderate wear from mixed traffic. A transit shelter occupies the northeast corner, its composite benches occupied by waiting commuters, posted schedules promising connections deeper into the colony. The southern side shows the Balboa Channel stretching beyond safety barriers, dark water moving with constant purpose.",
+  "sense_descs": {
+   "auditory": "Waiting commuters murmur at the transit shelter; the channel moves beyond the barriers.",
+   "olfactory": "Channel brine and the residential closeness of the waterfront blocks.",
+   "tactile": "Moderate-wear grating underfoot; cool channel air drifts up from the south.",
+   "atmospheric": "The Balboa Channel stretches beyond the safety barriers to the south."
+  }
+ },
+ "1485": {
+  "key": "Tolliver Row",
+  "desc": "An aquaponic market dominates the northern side, bubbling display cases visible through viewports, the day's offering arranged on crushed ice. The southern side shows a public access point, composite stairs descending toward the channel's edge, safety railings and warning signs suggesting official acknowledgment of waterfront activity. Small boats are tied off below, their hulls knocking against composite pilings with the rhythm of current and wind.",
+  "sense_descs": {
+   "auditory": "The market's display tanks bubble; small boats knock against the composite pilings with the current.",
+   "olfactory": "Brine and fish, the mineral scent of the channel made commercial.",
+   "tactile": "Damp air comes up off the open water, cold and close."
+  }
+ },
+ "1488": {
+  "key": "Tolliver Row",
+  "desc": "Residential structures on the northern side checkerboard in a mix of red, green, and gold - some modules maintained, others showing deferred maintenance, the gradient visible in fresh paint versus faded composite. The southern side continues its waterfront access, another set of stairs leading to a lower platform where channel workers manage lines and cargo nets. The grating shows salt corrosion despite regular maintenance attempts.",
+  "sense_descs": {
+   "auditory": "Wind-driven waves break close enough to hear; channel workers call over lines and cargo nets.",
+   "olfactory": "Heavy brine, salt thick enough to taste.",
+   "tactile": "Spray off the wind-driven waves occasionally reaches street level, cold and stinging.",
+   "atmospheric": "The Balboa Channel presses close here, its surface restless under the wind."
+  }
+ },
+ "1491": {
+  "key": "Tolliver Row",
+  "desc": "A community center occupies the northern side, its prefab construction expanded with additions that suggest ongoing use - meeting rooms visible through viewports, posted announcements on weather-sealed boards advertising job opportunities and training programs. The southern side shows the channel at its widest point along this stretch. A small park opens at street level, composite benches facing the water, the kind of public space that exists because someone fought for it.",
+  "sense_descs": {
+   "auditory": "The channel runs broad and quiet here; posted boards flutter against their frames.",
+   "olfactory": "Open-water brine and the green note of the park's plantings.",
+   "tactile": "A steady wind comes in off the channel's widest stretch.",
+   "atmospheric": "The far bank shows as a dark line against the colony's industrial haze."
+  }
+ },
+ "1494": {
+  "key": "Beach Street and Tolliver Row",
+  "desc": "The intersection widens where Beach Street descends toward the waterfront, reinforced grating giving way to composite decking that marks the transition from street to public space. The beach opens to the south - imported sand spread across composite substrate, the colony's attempt at recreation. Safety barriers line the boundary, their placement suggesting actual drownings have informed the regulations.",
+  "sense_descs": {
+   "auditory": "The channel laps steadily against the artificial shore.",
+   "olfactory": "Brine and damp imported sand.",
+   "tactile": "Reinforced grating gives way to composite decking; cooler, open air off the beach.",
+   "atmospheric": "Imported sand spreads south to where dark water meets pale shore behind the safety barriers."
+  }
+ },
+ "1497": {
+  "key": "Tolliver Row",
+  "desc": "The street continues west past the beach. The northern side shows apartment blocks rising four and five levels, their southern-facing balconies suggesting premium rent for channel views. Ground-level businesses cater to beachgoers - a rental shop, a cafe with outdoor seating, a small clinic advertising first aid and sunburn treatment. The southern side maintains channel access, though the beach has ended, replaced by composite embankments and safety railings.",
+  "sense_descs": {
+   "auditory": "Cafe chatter mixes with the wash of small waves against the embankments.",
+   "olfactory": "Salt, sunscreen, and coffee from the cafe's outdoor seating.",
+   "tactile": "Warmer here, the open beach exposure catching what light there is."
+  }
+ },
+ "1500": {
+  "key": "Tolliver Row",
+  "desc": "The waterfront is a parade of warehouse structures with loading equipment and cargo staging areas. The southern side reveals dock facilities extending into the channel, composite pilings supporting platforms where smaller vessels tie off.",
+  "sense_descs": {
+   "auditory": "Loading equipment grinds and reverses across the cargo staging areas.",
+   "olfactory": "Diesel, hydraulic fluid, and the organic decay of maritime commerce.",
+   "tactile": "The composite pilings creak; the platforms shift faintly with the channel's movement."
+  }
+ },
+ "1503": {
+  "key": "Tolliver Row",
+  "desc": "A water treatment facility dominates the northern side, its bulk enclosed behind security fencing, warning signs and biometric scanners marking restricted access. Massive intake pipes extend from the facility toward the channel, their diameter suggesting major processing capacity. The southern side displays larger vessels visible at berth, cargo cranes standing idle between shifts. The grating shows heavy vehicle wear, composite polished smooth by constant hauler traffic.",
+  "sense_descs": {
+   "auditory": "A deep churn of intake pumps draws water through the treatment facility.",
+   "olfactory": "Chlorine and treated water cut with channel brine.",
+   "tactile": "The grating is polished smooth by constant hauler traffic, slick underfoot."
+  }
+ },
+ "1506": {
+  "key": "Tolliver Row and Fermi Corridor",
+  "desc": "The intersection sprawls where Fermi Corridor cuts through the colony's western waterfront districts, Tolliver Row terminating here at its western extent. Reinforced grating shows heavy industrial wear, composite polished smooth by constant hauler traffic between the docks and inland facilities. The western crater wall looms close, dark stone rising as the colony's boundary, its face interrupted by sealed maintenance hatches and what might be old mine workings. A cargo transfer station occupies the northwest corner.",
+  "sense_descs": {
+   "auditory": "Cargo loading equipment works the northwest corner; water rushes into the culvert south.",
+   "olfactory": "Channel brine, machine oil, and rock dust off the crater wall.",
+   "tactile": "Hauler-polished grating underfoot; cold radiates off the close western crater wall.",
+   "atmospheric": "The crater wall looms west with sealed hatches and old mine workings; the channel disappears into a culvert south."
+  }
+ },
+ "1518": {
+  "key": "Ada Avenue and Fermi Corridor",
+  "desc": "The intersection of Ada Avenue and Fermi Corridor sits at the colony's northwestern professional district, where corporate offices and administrative services cluster in reinforced structures that suggest both permanence and paranoia. The Meridian Logistics building dominates the corner - four stories of pre-fabricated corporate architecture with the company's faded blue logo peeling from impact-resistant windows.",
+  "sense_descs": {
+   "auditory": "The subdued hush of a corporate district, quiet behind reinforced facades.",
+   "olfactory": "Clean filtered air, neutral and processed.",
+   "tactile": "Reinforced structures and level grating; the air sits conditioned and still.",
+   "atmospheric": "The Meridian Logistics building dominates the corner, its faded blue logo peeling from impact-resistant windows."
+  }
+ },
+ "1542": {
+  "key": "Ada Avenue and Beach Street",
+  "desc": "Beach Street cuts north-south through the avenue, offering respite in this crater-bound installation. The intersection serves as an informal boundary - professional services clustering to the west, light manufacturing beginning its slow encroachment from the east. A transit hub occupies the corner, its waiting area populated by workers moving between shifts.",
+  "sense_descs": {
+   "auditory": "Shift workers move through the transit hub; overhead screens cycle their schedule updates.",
+   "olfactory": "Filtered professional air thinning toward machine oil eastward.",
+   "tactile": "A respite of open space in the crater-bound installation; level grating underfoot.",
+   "atmospheric": "Schedule screens update overhead, a reminder the colony never truly sleeps, merely rotates through states of relative exhaustion."
+  }
+ },
+ "1566": {
+  "key": "Ada Avenue and Gilroy Street",
+  "desc": "This passage creates a crossroads of workers - professional services personnel from the west meeting manufacturing crews from the east, both groups occupying the same space without meaningful intersection. The intersection hosts a small market, stalls selling personal items, secondhand equipment, and food options that span the colony's cultural spectrum.",
+  "sense_descs": {
+   "auditory": "Bargaining in multiple languages carries across the market stalls.",
+   "olfactory": "Food options spanning the colony's cultural spectrum, cut with machine oil.",
+   "tactile": "Market stalls crowd the crossroads; the space pinches close with browsing traffic.",
+   "atmospheric": "Workers from west and east share the space without meaningful intersection."
+  }
+ },
+ "1581": {
+  "key": "Ada Avenue",
+  "desc": "Professional services line the avenue here - a synthetic showroom, a contract adjustor, a communications relay station with antenna arrays sprouting from its roof like mechanical vegetation. The buildings share a prefabricated uniformity, their modular construction suggesting they could be disassembled and relocated if corporate priorities shifted.",
+  "sense_descs": {
+   "auditory": "A static murmur leaks from the relay station; antenna servos tick as they adjust overhead.",
+   "olfactory": "New prefab resin and the faint ozone of the communications gear.",
+   "tactile": "The relay's hum carries up faintly through the decking."
+  }
+ },
+ "1584": {
+  "key": "Ada Avenue",
+  "desc": "The corridor here passes between a datacenter and a colony services office, their competing hums creating an industrial harmony. Cooling vents from the datacenter push warm air across the avenue, encouraging opportunistic mold to creep along the facing wall.",
+  "sense_descs": {
+   "auditory": "Two industrial hums braid together, datacenter and services office trading frequencies.",
+   "olfactory": "Warm electronics overlaid with the sour-green note of mold on the facing wall.",
+   "tactile": "A band of warmth crosses the avenue where the cooling vents vent their exhaust."
+  }
+ },
+ "1587": {
+  "key": "Ada Avenue",
+  "desc": "Light manufacturing begins its presence here. A fabrication shop occupies a reinforced building, its windows opaque with residue from cutting operations. Across the way, a supply depot serves the surrounding businesses - raw materials in, finished components out, the circulation of resources that keeps the colony's secondary economy functioning.",
+  "sense_descs": {
+   "auditory": "The high whine of precision tools cuts through at irregular intervals.",
+   "olfactory": "Cutting residue hangs in the air, hot metal and scorched lubricant.",
+   "tactile": "Fine grit from the fabrication shop settles on every surface within reach."
+  }
+ },
+ "1593": {
+  "key": "Ada Avenue",
+  "desc": "A component testing facility operates here, quality control for parts destined for installation throughout the colony's infrastructure. Rejected pieces accumulate in bins along the exterior wall, each failure representing someone's miscalculation or someone else's cost-cutting measure.",
+  "sense_descs": {
+   "auditory": "A constant low-frequency hum rolls out of the facility's exhaust system.",
+   "olfactory": "Ozone and the burnt-insulation smell of parts pushed until they failed.",
+   "tactile": "The exhaust vibration travels up through the decking into the soles of the feet."
+  }
+ },
+ "1596": {
+  "key": "Ada Avenue",
+  "desc": "The avenue's central stretch shows the neighborhood's mixed character most clearly. A precision instrument calibration service operates next to a hydraulic repair shop, their clientele overlapping in unexpected ways. The buildings here predate the current tenants, their construction reflecting earlier standards - thicker walls, heavier doors, the assumption that permanence required physical mass rather than legal protection.",
+  "sense_descs": {
+   "auditory": "The hiss and thump of hydraulic rigs runs against the fine ticking of calibration benches.",
+   "olfactory": "Hydraulic fluid and the sharp bite of cleaning solvent.",
+   "tactile": "The old thick walls hold the cold; the air sits a few degrees lower here."
+  }
+ },
+ "1599": {
+  "key": "Ada Avenue",
+  "desc": "A large facility occupies this stretch, providing operational equipment throughout the colony's industrial sectors. Across the avenue, an assortment of depots serve the surrounding facilities, high fencing suggesting the importance of their contents.",
+  "sense_descs": {
+   "auditory": "Muffled machinery leaks from interior spaces, the rehearsal before louder work.",
+   "olfactory": "Machine grease and the metallic tang of stored equipment.",
+   "tactile": "Chain-link fencing rattles faintly when the avenue's air shifts."
+  }
+ },
+ "1604": {
+  "key": "Ada Avenue",
+  "desc": "Heavy equipment maintenance dominates this section, repair bays opening onto the avenue with the casual confidence of essential services. Mining machinery in various states of disassembly occupies the available space. A parts supplier operates from a reinforced structure, inventory visible through the windows - rows of components organized by systems that presumably make sense to those who work here.",
+  "sense_descs": {
+   "auditory": "Impact wrenches stutter and dropped components clang out of the open repair bays.",
+   "olfactory": "Diesel, hot brake metal, and grease worked deep into the concrete.",
+   "tactile": "The floor underfoot is slick with oil ground in over years."
+  }
+ },
+ "1607": {
+  "key": "Ada Avenue",
+  "desc": "The avenue narrows slightly here, buildings pressing closer as architecture shifts toward industrial utility over professional presentation. Overhead pipes and conduits create a partial ceiling, infrastructure that serves the surrounding facilities regardless of aesthetic impact. A recycling operation processes industrial waste, converting failed components and worn materials into raw stock for fabrication.",
+  "sense_descs": {
+   "auditory": "The grind and crush of the recycling line reduces failed components to stock.",
+   "olfactory": "Hot plastic and melted resin off the reclamation process.",
+   "tactile": "The overhead pipes lower the ceiling; the air feels closer, more enclosed."
+  }
+ },
+ "1610": {
+  "key": "Ada Avenue",
+  "desc": "Industrial operations dominate the avenue here, their presence unapologetic in the way of essential services. A cable manufacturing facility runs continuous shifts, spooling the colony's nervous system onto massive drums for distribution. Across the avenue, a chemical processing station handles materials too hazardous for the main atmospheric processor but too necessary to eliminate. Warning signage covers every available surface.",
+  "sense_descs": {
+   "auditory": "The steady whir of spinning drums reels cable onto its spools without pause.",
+   "olfactory": "Hot insulation overlaid with the acrid bite of processed chemicals.",
+   "tactile": "The spinning equipment's vibration translates steadily through the decking."
+  }
+ },
+ "1652": {
+  "key": "Tolliver Row",
+  "desc": "The street narrows slightly where structural supports rise on both sides, composite columns that speak to engineering concerns about the weight distribution above. Between the supports on the northern side, someone has established a fabrication shop, its entrance marked by a hand-painted sign advertising custom metalwork and composite repair. The southern side shows a shift facility for waterfront workers - lockers visible through viewports, posted schedules on weather-resistant boards outside the entrance, the kind of infrastructure that exists because people need somewhere to change before and after handling cargo that has been sitting in channel moisture for weeks.",
+  "sense_descs": {
+   "auditory": "The crack and hiss of welding carries from the open fabrication bay.",
+   "olfactory": "Hot metal, flux, and the damp-cargo smell off the shift facility.",
+   "tactile": "Composite support columns crowd the street; the space feels braced and close.",
+   "atmospheric": "Welding flashes throw intermittent light that makes the shadows jump."
+  }
+ },
+ "1655": {
+  "key": "Cobb Street and Tolliver Row",
+  "desc": "The intersection opens where Cobb Street cuts north-south through the waterfront district, the confluence marked by grating reinforced for cross-traffic between channel operations and inland facilities. A warehouse complex sprawls on the northeast corner, its construction showing corporate planning - matched modules, uniform viewports, loading bays marked with sequential bay numbers. Cargo haulers sit idle outside, their flatbeds empty or stacked with pallets. The southern side shows mixed-use character, ground-level commercial topped with residential density. A small commissary occupies one corner.",
+  "sense_descs": {
+   "auditory": "Idle cargo haulers tick as they cool; a commissary's serving counter clatters at the corner.",
+   "olfactory": "Diesel and channel brine cut with cooking from the commissary.",
+   "tactile": "Reinforced grating underfoot; cool channel air moves through the confluence.",
+   "atmospheric": "A commissary's digital display cycles daily specials in multiple languages."
+  }
+ },
+ "1658": {
+  "key": "Tolliver Row",
+  "desc": "The street widens as it approaches the Coltrane intersection ahead, directional signage posted in multiple languages. A cargo staging area occupies the northern side, composite pallets arranged in organized rows beneath weather-resistant tarps. Forklifts and haulers navigate with purposeful efficiency. The southern side shows service businesses - equipment rental, synthetic maintenance, a small medical clinic. The channel remains visible beyond the stacked cargo.",
+  "sense_descs": {
+   "auditory": "Forklifts and haulers work the staging area with purposeful efficiency.",
+   "olfactory": "Weather-resistant tarp, diesel, and salt.",
+   "tactile": "The street broadens, the air opening up toward the intersection ahead.",
+   "atmospheric": "A small clinic's illuminated cross flickers among the service-front signage."
+  }
+ },
+ "1661": {
+  "key": "Tolliver Row",
+  "desc": "The street straightens and agriculture domes fill the horizon through industrial haze. A machinery yard occupies the northern side, chain-link fencing enclosing mining vehicles, construction rigs, and haulers awaiting parts. The gate stands open during shifts, security minimal. The southern side shows prefab residential stacked four high, fire escapes zigzagging upward, laundry hanging between landings. The structures show decades of wear - faded panels, patched seals, housing built for ten years pushing past thirty. Twin tracks polish the grating where haulers have worn it smooth.",
+  "sense_descs": {
+   "auditory": "Mining rigs and haulers idle in the machinery yard behind minimal security.",
+   "olfactory": "Machine grease and fuel, with a faint thread of detergent off the hung laundry.",
+   "tactile": "Twin polished tracks run where haulers have worn the grating smooth.",
+   "atmospheric": "Agriculture domes fill the horizon through the haze; cabling runs overhead in thick organic bundles."
+  }
+ },
+ "1664": {
+  "key": "Tolliver Row",
+  "desc": "A fuel depot dominates the northern side, composite tanks behind security fencing with warning signs and functional surveillance cameras. Pumping stations line the street-facing wall, the concrete pad stained dark from years of spills. The southern side shows a repair facility expanded beyond its original footprint, welded additions creating a warren of work bays. The entrance reveals disassembled equipment, tool carts, and technicians under harsh utility lighting.",
+  "sense_descs": {
+   "auditory": "Pumping stations cycle along the depot's wall; impact tools ring from the repair bays.",
+   "olfactory": "Diesel and synthetic lubricant cut through the air with chemical sharpness.",
+   "tactile": "The concrete pad is stained dark and tacky from years of spills.",
+   "atmospheric": "Hazard warnings cover every surface in multiple languages."
+  }
+ },
+ "1667": {
+  "key": "Battery Street and Tolliver Row",
+  "desc": "The intersection widens where Battery Street cuts into the waterfront's agricultural district, reinforced grating and traffic control signage marking significant volume. North, Battery extends toward the agriculture dome access points. Traffic is mixed - light cargo haulers moving produce, pedestrian traffic from the residential towers, corporate vehicles serving the biotech facilities.",
+  "sense_descs": {
+   "auditory": "Light cargo haulers and pedestrian traffic mix through the widened crossing.",
+   "olfactory": "A green, loamy note from the agricultural district north, cut with channel brine.",
+   "tactile": "Reinforced grating underfoot; the intersection opens wider here.",
+   "atmospheric": "Traffic control signage marks the volume where Battery extends toward the dome access points."
+  }
+ },
+ "1670": {
+  "key": "Tolliver Row",
+  "desc": "The northern side shows a marine supply depot, roll-up doors revealing stacked cable spools, deck plating, and equipment for channel vessels. The southern side rises in residential towers, four and five levels with better maintenance than industrial districts - fresh sealant, functioning mechanisms. The grating is newer composite, drainage systems that actually function. Street lighting includes decorative elements alongside functional fixtures.",
+  "sense_descs": {
+   "auditory": "Roll-up doors rumble at the marine depot; far off, water works steadily against the channel structures.",
+   "olfactory": "Salt air and the tar-and-cable smell of marine supply.",
+   "tactile": "Newer composite underfoot, drains that actually carry the wet away.",
+   "atmospheric": "The Central Span's navigation lights blink through the gaps in the structures."
+  }
+ },
+ "1673": {
+  "key": "Tolliver Row",
+  "desc": "A commercial plaza opens on the northern side, three prefab structures around a central courtyard housing a grocer, clothing supplier, and cafe with outdoor seating. The plaza's grating has been replaced with decorative decking arranged in patterns. The southern side continues its waterfront character, a boat repair facility with work bays open to reveal vessels in maintenance. The channel stretches beyond, its scale making the boats look like toys.",
+  "sense_descs": {
+   "auditory": "Cafe chatter mixes with the knock of tools from the boat repair bays.",
+   "olfactory": "Cooking from the cafe cut with the resin-and-brine of boat repair.",
+   "tactile": "Decorative decking underfoot, arranged in patterns instead of plain grating."
+  }
+ },
+ "1676": {
+  "key": "Tolliver Row",
+  "desc": "Residential towers rise six levels on the northern side, showing architectural ambition - curved facades, decorative panels, balconies suggesting space for living. Security checkpoints mark entrances with biometric scanners and guard stations. Viewports show actual furniture and office workers at terminals. The street surface is pristine composite with visible installation seams. Street furniture appears - benches, waste receptacles, informational kiosks. The Balboa Channel remains visible to the south, but here it feels like background rather than defining feature.",
+  "sense_descs": {
+   "auditory": "Quiet here, the channel reduced to a distant background wash.",
+   "olfactory": "Clean composite and a faint salt thread, the working-waterfront reek left behind.",
+   "tactile": "Pristine composite underfoot, installation seams still visible.",
+   "atmospheric": "Biometric checkpoints and guard stations mark the tower entrances."
+  }
+ },
+ "1679": {
+  "key": "Tsiolkovsky Corridor and Tolliver Row",
+  "desc": "The intersection sprawls where Tsiolkovsky Corridor cuts through the northern district's administrative core, grating maintained to corporate standards - clean, level, functioning drainage. Tolliver Row terminates here at the crater wall, the colony's eastern boundary rising as dark stone interrupted by sealed bulkheads and carved openings. Old mine entrances sit behind security barriers, their depths disappearing into darkness. Corporate signage marks some tunnels as restricted access; others show no markings at all, just darkness and the suggestion of passages that predate current occupation.",
+  "sense_descs": {
+   "auditory": "The orderly quiet of the admin core; a faint draft breathes from the old mine openings.",
+   "olfactory": "Clean filtered air with the cold mineral breath of the crater wall.",
+   "tactile": "Corporate-standard grating, clean and level underfoot; cold radiates off the eastern stone.",
+   "atmospheric": "The crater wall rises east, dark stone interrupted by sealed bulkheads and mine entrances behind security barriers."
+  }
+ },
+ "1715": {
+  "key": "Ada Avenue and Battery Street",
+  "desc": "Agricultural support infrastructure clusters here - processing facilities with equipment rusting behind viewports nobody cleans. The southern side shows salvage operations, components stripped and sorted by material. A vendor offers hydroponic equipment to anyone optimistic enough to try again.",
+  "sense_descs": {
+   "auditory": "A refrigeration unit's compressor cycles with mechanical stubbornness, preserving nothing.",
+   "olfactory": "Rust, cold leaking refrigerant, and the faint loam of old hydroponics.",
+   "tactile": "Cold leaks through the refrigeration unit's degraded seals into the air.",
+   "atmospheric": "Processing equipment rusts behind viewports nobody cleans."
+  }
+ },
+ "1739": {
+  "key": "Ada Avenue and Cobb Street",
+  "desc": "Cobb Street cuts through the avenue here, its passage connecting the northern industrial reaches to the crater's central areas. The intersection serves as an informal boundary - respectable industrial operations to the west, rougher territory claiming the eastern stretches.",
+  "sense_descs": {
+   "auditory": "Industrial transit grinds west; the east stretches quieter, warier.",
+   "olfactory": "Machine oil and the metallic tang of industrial operations.",
+   "tactile": "Worn grating underfoot at the boundary between respectable and rough.",
+   "atmospheric": "The intersection marks an informal line - respectable industry west, rougher territory east."
+  }
+ },
+ "1754": {
+  "key": "Ada Avenue",
+  "desc": "Heavy industry dominates the avenue here, any pretense of mixed-use development abandoned in favor of pure functionality. A smelting operation processes recovered metals, its furnaces casting orange light through heat-resistant windows.",
+  "sense_descs": {
+   "auditory": "The furnaces roar behind their heat-resistant glass.",
+   "olfactory": "Scorched metal and the mineral reek of slag.",
+   "tactile": "Waste heat rolls off the smelting operation; the air sits noticeably warmer.",
+   "atmospheric": "Orange furnace-light bleeds through the heat-resistant windows and stains the avenue."
+  }
+ },
+ "1757": {
+  "key": "Ada Avenue",
+  "desc": "The avenue's eastern reaches show the colony's industrial infrastructure at its most raw. Maintenance access points open onto crucial systems - power distribution, atmospheric processing, water reclamation. Protective barriers separate foot traffic from industrial operations, their placement suggesting hard lessons about the cost of casual proximity. The barriers show impact damage, evidence that separation remains a negotiation between convenience and safety.",
+  "sense_descs": {
+   "auditory": "A deep thrum of power distribution and atmospheric processing runs behind the barriers.",
+   "olfactory": "Ozone off the power systems and the flat smell of reclaimed water.",
+   "tactile": "Where you pass close, the barriers radiate the machinery's heat and vibration."
+  }
+ },
+ "1762": {
+  "key": "Ada Avenue",
+  "desc": "The last dome's framework remains visible to the east, but the avenue returns to professional-industrial character here - equipment suppliers, calibration services, the infrastructure of maintenance rather than growth. A transit point marks this block with composite benches.",
+  "sense_descs": {
+   "auditory": "Shift-change footfall moves against the idle drone of the equipment suppliers.",
+   "olfactory": "Familiar lubricants and ozone; the organic decay smell fades out behind.",
+   "tactile": "The composite benches at the transit point are cold and worn smooth."
+  }
+ },
+ "1765": {
+  "key": "Ada Avenue",
+  "desc": "The dome district transitions here, failed agriculture giving way to functioning industrial baseline. A fabrication shop repurposes salvaged equipment - growing racks becoming storage, irrigation pipes becoming conduit. Southern structures show mixed residential and commercial use, populations displaced when the domes failed finding housing in their shadows. A small market offers salvaged agricultural components to hobbyists and true believers.",
+  "sense_descs": {
+   "auditory": "Fabrication work echoes oddly in space that was built to grow things.",
+   "olfactory": "Machine oil cut with a lingering loamy ghost of old growing medium.",
+   "tactile": "Salvaged irrigation pipe, conduit now, runs cold along the walls."
+  }
+ },
+ "1768": {
+  "key": "Ada Avenue",
+  "desc": "A seed vault occupies a reinforced structure on the northern side, its entrance sealed with security measures suggesting contents worth protecting. Southern structures house agricultural administration offices - terminals still displaying crop rotation schedules from decades past, planning documents for harvests that never happened.",
+  "sense_descs": {
+   "auditory": "The seed vault's climate seals cycle and hiss on the northern side.",
+   "olfactory": "Cold mineral air, frost and refrigerant.",
+   "tactile": "A breath of deep cold escapes the vault seals; frost rimes the nearby grating.",
+   "atmospheric": "Vapor clouds drift from the vault each time its seals cycle open."
+  }
+ },
+ "1773": {
+  "key": "Ada Avenue",
+  "desc": "The largest dome dominates the northern side, its scale suggesting ambitions the colony couldn't sustain. Through clouded panels: a vast empty space, ceiling high enough for trees never planted, floor covered in desiccated growing medium. Graffiti covers the lower panels - generations marking their passage, the newest tags barely weeks old.",
+  "sense_descs": {
+   "auditory": "Climate control wheezes on intermittently, running its cycles for crops that don't exist.",
+   "olfactory": "Dry desiccated growing medium, dust with no green left in it.",
+   "tactile": "The dome breathes its stale recycled air out through the gaps where panels have failed.",
+   "atmospheric": "Through the clouded panels the dome opens into a cathedral of empty space, ceiling high enough for trees never planted."
+  }
+ },
+ "1776": {
+  "key": "Ada Avenue",
+  "desc": "Two domes flank the avenue, their frameworks rising like the ribcages of creatures that died waiting. The western dome shows catastrophic decompression damage - sections blown out, panels scattered. The eastern maintained integrity but sits dark and abandoned. Between them, maintenance infrastructure still hums despite having nothing to feed, and faded instructional placards post optimal growing temperatures for crops that never matured.",
+  "sense_descs": {
+   "auditory": "Maintenance infrastructure still hums between the domes with nothing left to feed.",
+   "olfactory": "Cold vacuum-scoured metal off the blown-out western dome, faint mineral dust.",
+   "tactile": "A thin draft pulls through the western dome's ruptured panels."
+  }
+ },
+ "1779": {
+  "key": "Ada Avenue",
+  "desc": "A defunct agricultural dome dominates the northern side, its geodesic framework visible through panels clouded by decades of mineral deposits. The airlock stands permanently sealed, interior dark, growing beds and hydroponic infrastructure visible through gaps where panels have failed. Southern structures house light manufacturing operations repurposing the space.",
+  "sense_descs": {
+   "auditory": "Light manufacturing clatters under the dead dome's silence.",
+   "olfactory": "Faint organic decay mixed with an industrial chemical tang.",
+   "tactile": "The grating carries old soil staining from the dome's operational years, gritty underfoot.",
+   "atmospheric": "The geodesic framework looms over the avenue, its panels clouded by decades of mineral deposits."
+  }
+ }
+}

--- a/room_desc_snapshot_COMPLETE_20260620-071335.json
+++ b/room_desc_snapshot_COMPLETE_20260620-071335.json
@@ -1,0 +1,2974 @@
+{
+ "996": {
+  "key": "Central Span",
+  "desc": "The roadway begins its climb, grating transitioning from street-level composite to reinforced bridge decking designed for loads that make haulers look like toys. Support towers rise on both sides, their foundations disappearing into the channel's dark water below, structural members braced against lateral forces the Balboa generates. Safety barriers line both edges - composite railings backed by cable restraints, the kind of redundancy that suggests people have gone over despite the precautions. Behind, the southern colony sprawls in its familiar maze of prefab and crater wall. Ahead, the span extends across dark water toward the northern districts.",
+  "sense_descs": {
+   "auditory": "The channel works against the support-tower foundations far below; cable restraints thrum where the wind catches them.",
+   "olfactory": "Cold open water and the mineral edge of the channel.",
+   "tactile": "The grade pulls at the legs; reinforced decking sits hard and unflexing underfoot.",
+   "atmospheric": "Navigation lights pulse amber at regular intervals, marking the span's edges."
+  }
+ },
+ "999": {
+  "key": "Central Span",
+  "desc": "The bridge climbs steadily, elevation enough now that the channel's surface becomes visible between support members - dark water moving with currents that draw shifting surface patterns. The span's framework surrounds the roadway, structural trusses overhead forming a latticework against whatever sky exists above the colony's atmospheric envelope. Support towers continue at measured intervals, their composite and steel construction showing maintenance that speaks to not letting this infrastructure fail. Traffic marks on the decking show wear from decades of crossings, but the surface itself remains solid. The southern colony recedes behind, its density becoming abstract geography.",
+  "sense_descs": {
+   "auditory": "Wind cuts across the exposed roadway with force enough to snap loose clothing; it whistles through the overhead trusses.",
+   "olfactory": "Clean cold water, the filtered prefab air left behind.",
+   "tactile": "The wind, no longer broken by walls or crater geography, pushes steadily across the open deck.",
+   "atmospheric": "Navigation lights create a corridor of pulsing amber along the span."
+  }
+ },
+ "1002": {
+  "key": "Central Span",
+  "desc": "Midway to the span's center, the exposure becomes total - open air on all sides, only the framework above and the bridge deck below. The Balboa Channel stretches east and west, its scale apparent from this height, water extending until distance and atmospheric haze make the boundaries theoretical. The channel's current shows in surface tension and the occasional debris passing underneath. Support cables angle down from the overhead framework, their tension visible in how they refuse to move despite the wind. The roadway's surface shows intentional scoring now, traction grooves cut deep enough to remain functional despite decades of traffic. Behind and ahead, the colonies resolve into distinct masses - south with its processor bulk and crater boundary, north with whatever sprawl has claimed that side of the water.",
+  "sense_descs": {
+   "auditory": "Wind dominates everything here, a steady roar past the cables and trusses.",
+   "olfactory": "Open channel water, cold and mineral, scoured clean of the colony.",
+   "tactile": "Traction grooves catch underfoot; the wind shoves with nothing to break it.",
+   "atmospheric": "Navigation lights continue their amber pulse, markers that work day cycle or night."
+  }
+ },
+ "1005": {
+  "key": "Central Span",
+  "desc": "The span's apex, where the roadway reaches its highest elevation above the channel. The framework overhead reaches its most complex configuration - trusses, cross-bracing, cable anchorages all converging at structural nodes. The Balboa's surface below looks almost calm from this height, the current's force reduced to abstract patterns, though anyone who's been down there knows better. Support towers at the midpoint are reinforced beyond the approach sections, foundations descending deep enough to find bedrock or whatever passes for it beneath the channel. A maintenance platform juts from the eastern side, accessible only by service ladder, its deck scattered with equipment covers and tool caches.",
+  "sense_descs": {
+   "auditory": "The wind is constant and unfiltered at the apex, a sustained rush through the converging framework.",
+   "olfactory": "Water and distance, threaded with the chemical signature of whatever the upstream processors dump.",
+   "tactile": "The highest, most exposed point on the span; the wind never lets up.",
+   "atmospheric": "Navigation lights mark the midpoint with doubled frequency, impossible to miss even in the worst visibility."
+  }
+ },
+ "1008": {
+  "key": "Central Span",
+  "desc": "Past the midpoint, the roadway begins its descent toward the northern colony, grade reversing with the same measured precision as the southern approach. The framework remains total overhead, structural members creating consistent geometry as the span extends toward its northern terminus. The channel stretches below, its surface showing more detail on the downward slope - eddies where support towers interrupt the current, debris collected against structural members. Safety barriers show different wear patterns on this side, graffiti in scripts that suggest northern population demographics. The northern colony resolves into increasing detail ahead - prefab configurations that follow different organizational logic.",
+  "sense_descs": {
+   "auditory": "The wind shifts direction here, its rush changing pitch on the northern approach.",
+   "olfactory": "The prevailing currents carry different smells now, less processor dominance, more varied commercial chemistry.",
+   "tactile": "The grade tips forward into the descent; the wind comes from a new quarter.",
+   "atmospheric": "Navigation lights continue their amber pulse, maintaining the corridor that guides crossing."
+  }
+ },
+ "1011": {
+  "key": "Central Span",
+  "desc": "The northern colony's geography becomes clear from this elevation - the channel's northern bank extends into districts without the southern crater wall to define their boundary, sprawl that suggests growth without the same constraints. The descent steepens slightly, bridge decking transitioning back toward street-level elevation, support towers spacing wider as the span approaches solid ground. The framework overhead begins to open up, structural density reducing toward the terminus. The Balboa below narrows slightly as the channel bends around unseen geography. Safety barriers show more active maintenance on the northern approach - fresh welds, recent paint touch-ups.",
+  "sense_descs": {
+   "auditory": "Traffic builds as commuters converge on the approach, footfall and hauler-drone reclaiming the air from the wind.",
+   "olfactory": "The channel water gives way to the varied chemistry of the northern districts.",
+   "tactile": "The descent steepens underfoot; the framework opens and the wind eases as the span nears ground.",
+   "atmospheric": "Navigation lights maintain their pulse, though northern fixtures show updated models."
+  }
+ },
+ "1014": {
+  "key": "Central Span",
+  "desc": "The span's descent completes, bridge decking merging with street-level grating in a junction reinforced for the transition between span and colony infrastructure. Support towers anchor into the northern bank, their foundations visible where they emerge from water level, concrete and composite showing decades of channel exposure - mineral staining, organic growth in protected corners. The northern colony spreads ahead, its configuration different from the south - street patterns following local geography rather than imposed grid, prefab density clustering around commercial nodes. Behind, the Central Span extends back across the channel toward the southern terminus.",
+  "sense_descs": {
+   "auditory": "Two-way traffic flows steady here, haulers and commuters reclaiming the soundscape from the channel wind.",
+   "olfactory": "Channel brine and the organic note of growth in the tower foundations, mixing with northern street smells.",
+   "tactile": "Bridge decking gives way to familiar street grating; the open wind drops behind the structures.",
+   "atmospheric": "Navigation lights mark the terminus with increased density, amber pulse joined by directional markers."
+  }
+ },
+ "1867": {
+  "key": "The Hub and Howl",
+  "desc": "Nestled in the rusted ribs of an abandoned orbital hangar, The Hull & Howl's walls are patched with scorched hull plates and slabs of floor paneling. A bent slab of starship hull, bolted and smashed into shape, serves as the bar - wedged between the seating zone and the rigged-up back wall. Half-open cryopods leak silvery vapor around crates of beer, liquor, and whatever else the bar wants kept cold. Tables are cobbled together from cockpit dashboards, crate stacks, and radar discs, while chairs are carved, cut, or beaten out of anything that looked the right size.",
+  "sense_descs": {
+   "auditory": "Salvaged hardware buzzes; the cryopods hiss faint vapor around the cold crates.",
+   "olfactory": "Cold beer and liquor, scorched metal, and the chemical tang of leaking cryopod vapor.",
+   "tactile": "The patched hull underfoot is uneven; cold rolls off the half-open cryopods behind the bar.",
+   "atmospheric": "A sickly yellow glow from salvaged hardware spills over the cobbled-together seating."
+  }
+ },
+ "1917": {
+  "key": "Queen of Cups - Lobby",
+  "desc": "The lobby is crowded, shelves sagging under piles of faded charms and jury-rigged digital signage. A cracked neon sign buzzes faintly above the counter, its letters flickering in an odd rhythm. Customers shuffle between vending machines and the almighty rental kiosk, its terminal glowing pale blue and offering storage or poverty-aligned living space. Near the counter, a small intercom has been installed. Posters promise privacy guaranteed, though the cameras tucked in corners betray the lie.",
+  "sense_descs": {
+   "auditory": "The cracked neon buzzes in an odd rhythm; vending machines and the rental kiosk hum under shuffling customers.",
+   "olfactory": "Machine oil and fried food drifting in from the street, clinging to every surface.",
+   "tactile": "The lobby is crowded close, bodies and sagging shelves pressing the space tight.",
+   "atmospheric": "The rental kiosk's terminal glows pale blue; cameras tuck into corners beneath the privacy posters."
+  }
+ },
+ "1920": {
+  "key": "Queen of Cups - Stairwell",
+  "desc": "A side door opens into a narrow back room, cluttered with crates and half-sorted junk. A single bulb dangles overhead. In the far corner, a staircase rises upward, its steps creaking with every shift of weight.",
+  "sense_descs": {
+   "auditory": "The staircase steps creak with every shift of weight.",
+   "olfactory": "Dust and rust, heavy and close in the still air.",
+   "tactile": "Clutter crowds the narrow space; the floor grits with settled dust.",
+   "atmospheric": "A single dangling bulb casts shadows that make the clutter seem alive."
+  }
+ },
+ "1923": {
+  "key": "Queen of Cups - First Level",
+  "desc": "The first flight of stairs climbs steeply, the walls close and claustrophobic. Rust stains streak the metal rails. A small landing halfway up holds a broken chair and a pile of discarded wrappers, evidence of someone's brief refuge.",
+  "sense_descs": {
+   "auditory": "Every step groans underfoot; muffled voices filter down from the cubes above, blending into the hum of machinery.",
+   "olfactory": "Sweat and stale smoke, lingering from the tenants above.",
+   "tactile": "The walls press close and claustrophobic; the stairs climb steeply.",
+   "atmospheric": "A single lamp flickers overhead, buzzing like an insect trapped in glass."
+  }
+ },
+ "1926": {
+  "key": "Queen of Cups - Second Level",
+  "desc": "The second level opens onto a narrow landing lined with locked cube doors, each humming faintly with recycled air. The walls are scratched with graffiti - gang marks, prayers, and jokes layered together. A cracked window lets in faint light from the street, distorted by grime. Every door feels like a secret, hiding lives stacked together in anonymity.",
+  "sense_descs": {
+   "auditory": "Muffled arguments and laughter bleed through the thin walls; the cube doors hum faintly with recycled air.",
+   "olfactory": "Fried food drifting upward, mixed with the sharp tang of ozone from the cube terminals.",
+   "tactile": "The air is warmer here, close with stacked-together living.",
+   "atmospheric": "A cracked window lets in faint street light, distorted by grime."
+  }
+ },
+ "1929": {
+  "key": "Queen of Cups - Third Level",
+  "desc": "The third flight is quieter, the landing dimly lit by a single bulb. The walls are more worn, paint peeling in strips that reveal older layers beneath. A few doors line the hall, their locks scarred from repeated tampering. A forgotten crate sits in the corner, covered in dust and graffiti.",
+  "sense_descs": {
+   "auditory": "Silence dominates here, broken only by the faint vibration of the processor carried through the walls.",
+   "olfactory": "Damp metal and recycled air, heavy and persistent.",
+   "tactile": "The processor's vibration carries faint through the walls; the air sits heavy and still.",
+   "atmospheric": "A single bulb flickers like it's ready to die, paint peeling in strips down the worn walls."
+  }
+ },
+ "1932": {
+  "key": "Queen of Cups - Fourth Level",
+  "desc": "The fourth level feels emptier, with fewer doors and more silence. The landing is bare except for a single bench, its surface carved with initials and crude symbols. The walls are marked with faded chalk prayers, remnants of tenants who've long moved on. A dim light filters in from above, hinting at the roof.",
+  "sense_descs": {
+   "auditory": "The hum of the processor is louder here, steady and unyielding.",
+   "olfactory": "Cool, faintly metallic air, thinned by drafts from the structure.",
+   "tactile": "The air is cooler, carrying faint drafts from cracks in the structure.",
+   "atmospheric": "A dim light filters in from above, hinting at the roof; chalk prayers fade across the walls."
+  }
+ },
+ "2": {
+  "key": "Limbo",
+  "desc": "Welcome to your new |wEvennia|n-based game! Visit https://www.evennia.com if you need\nhelp, want to contribute, report issues or just join the community.\n\nAs a privileged user, write |wbatchcommand tutorial_world.build|n to build\ntutorial content. Once built, try |wintro|n for starting help and |wtutorial|n to\nplay the demo game.",
+  "sense_descs": {}
+ },
+ "4": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue widens where an old mining-shaft entrance has been sealed with composite plating, the metal warped from some long-ago structural failure. Graffiti buries the seal — layer on layer of tags, territorial markers, and cryptic symbols that might be gang signs or philosophy or both. A row of storage containers lines the northern side, doors held with mismatched locks. Dark streaks mark the crater wall where water has run and dried for years.",
+  "sense_descs": {
+   "auditory": "A constant low hum of distant machinery, felt more than heard, pressed flat beneath everything else.",
+   "olfactory": "Cold stone, rust, and the faint mineral bite leaking from the sealed shaft.",
+   "tactile": "The crater wall throws off a mineral chill; the composite plating stays cold.",
+   "atmospheric": "A claimed, hand-me-down stretch — everything here is locked, tagged, or both."
+  }
+ },
+ "13": {
+  "key": "Braddock Avenue",
+  "desc": "Prefab modules crowd both sides so close you could brush both walls at once. Cable lights strung overhead flicker on and off, chopping the passage into separate moments. A small shrine fills a wall niche — candles, an offering wrapped in cloth, a printed image faded past all subject. The ground is worn smooth and faintly glossy from endless passage.",
+  "sense_descs": {
+   "auditory": "The cable lights buzz and tick overhead, their current uneven.",
+   "olfactory": "Wax and candle-smoke from the shrine, thin against cold concrete.",
+   "tactile": "The walls press close on both sides; the polished ground gives no grip.",
+   "atmospheric": "A pinched, threshold place — people move through it, and a few stop to leave something at the niche."
+  }
+ },
+ "17": {
+  "key": "Braddock Avenue",
+  "desc": "A corner store holds the northern side, its hand-painted Provisions and Sundries sign retouched so many times the original color is anyone's guess. South, a laundromat's windows glow with condensation, vents breathing humid air into the street. Between them a synthetic vendor works a folding table of protein bars and recycled water, prices marked in scrip and trade goods alike.",
+  "sense_descs": {
+   "auditory": "The laundromat's tumbling machines lay down a steady mechanical rhythm, almost hypnotic in its constancy.",
+   "olfactory": "Industrial detergent and heated fabric roll out of the laundromat vents, sweet and synthetic.",
+   "tactile": "Warm, damp air pushes from the laundromat side; the rest of the street stays cold."
+  }
+ },
+ "178": {
+  "key": "Ramirez Provisions & Sundries",
+  "desc": "The store crams into a space built for storage, not commerce — shelving bolted to every wall and climbing overhead in a precarious geometry that defies any safety code. Protein rations, recycled water, salvaged electronics, and medical supplies fight for shelf space with objects whose purpose has been forgotten but might prove useful someday.",
+  "sense_descs": {
+   "auditory": "A low electrical hum from a cooler somewhere in the stacks, and the tick of a shelf settling under its load.",
+   "olfactory": "Dust, cardboard, and the chemical sweetness of ration wrappers.",
+   "tactile": "The aisles pinch tight, shelving leaning close overhead.",
+   "atmospheric": "Abundance by accumulation — nothing thrown out, everything maybe-useful."
+  }
+ },
+ "181": {
+  "key": "Market Rooftop",
+  "desc": "A patchwork of weathered tar paper and gravel, scarred with failed leak-seals. An old brick chimney rises like a monument to dead heating systems; newer growth — satellite dishes, antennas, a thicket of PVC — crowds around it. Overturned milk crates make seats near the edge, where someone has clearly spent time watching the street below. Across the gap, the laundromat rooftop waits, impossibly far and tantalizingly close by turns.",
+  "sense_descs": {
+   "auditory": "Market noise filters up thin through the ventilation grates — voices, a clatter, the scrape of trade.",
+   "olfactory": "The market rises through the grates: produce, cleaning supplies, the faint sweetness of overripe fruit.",
+   "tactile": "The tar holds the day's warmth; grit shifts underfoot near the unguarded edge.",
+   "atmospheric": "A perch and a launch point — every neighboring roof reads as a possible next step."
+  }
+ },
+ "184": {
+  "key": "Suds & Bubbles Laundromat",
+  "desc": "Mismatched washers and dryers line both walls, several still wearing the manufacturer plates of Terran firms long since folded. Cracked, stained tiles slope toward sluggish drains; warped folding tables hold a litter of forgotten socks and a few left-behind garments gone grey with permanence.",
+  "sense_descs": {
+   "auditory": "The tumbling drums keep up a churning mechanical roar, a wall of white noise; under it runs the steady gurgle of the drains and the periodic buzz-clunk of a cycle ending.",
+   "olfactory": "Hot lint and cheap floral detergent over a sweet-sour undertone of mildew, thickest near the drains.",
+   "tactile": "The air sits hot and dense, humidity the recyclers never clear; condensation beads on the machines, and the tables come away faintly damp.",
+   "atmospheric": "Everything is worn down to bare function - nothing decorative has survived the damp."
+  }
+ },
+ "187": {
+  "key": "Laundromat Rooftop",
+  "desc": "A flat expanse of tar and gravel dotted with puddles that never quite dry. A cluster of industrial ventilation units crowds one side; a low concrete parapet rims the edge, just high enough to lean on. Rusty fire-escape ladders cling to the building's flanks, and a few weathered lawn chairs sit abandoned by a clothesline strung between two antenna masts. Across the gap, neighboring rooftops form a concrete archipelago.",
+  "sense_descs": {
+   "auditory": "The ventilation units hum and rattle, venting the laundromat below in periodic gusts.",
+   "olfactory": "Each vent-cloud carries soap and fabric softener, warm and faintly chemical.",
+   "tactile": "The vents breathe damp heat across this end of the roof; the parapet is cool and gritty.",
+   "atmospheric": "Someone's half-abandoned rooftop refuge — chairs, a clothesline, a long view."
+  }
+ },
+ "190": {
+  "key": "In the Air",
+  "desc": "The city spreads below in a patchwork of rooftops, fire escapes, and narrow alleys — brick and concrete in every direction, broken by the odd splash of neon or green.",
+  "sense_descs": {
+   "olfactory": "Exhaust and cooking-smoke and the distant tang of the river, snatched together at height.",
+   "tactile": "Open air on every side, nothing solid within reach.",
+   "atmospheric": "A held breath between rooftops — committed, weightless, exposed."
+  }
+ },
+ "220": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue widens, industrial grating taking over from the improvised surfaces to the southwest. The structures sit with an almost deliberate placement — planning rather than desperation. North, the colony shades from edge to established: streetlights that work, signage not hand-painted over salvage. The atmospheric processor looms close enough now to pick out individual exhaust stacks and the scaffolding of maintenance platforms.",
+  "sense_descs": {
+   "auditory": "The processor's bulk lays a deep mechanical drone over everything, steady and close.",
+   "olfactory": "Metal and ozone, sharp on the tongue, edged with the mineral cold rising from the crater.",
+   "tactile": "The air runs warmer here off the processor, though the crater's chill still threads through it."
+  }
+ },
+ "223": {
+  "key": "South Marlowe Street and Braddock Avenue",
+  "desc": "The intersection sprawls where South Marlowe Street cuts north through the colony's industrial heart, broad enough to mark it a major artery from a time someone still planned for growth. Industrial grating forms a near-perfect grid, maintenance hatches dotting it at regular intervals like punctuation in a buried language. North, Marlowe climbs toward the distant Balboa Channel and the Central Span beyond. East, the atmospheric processor dominates the view; south, the crater wall curves dark and final.",
+  "sense_descs": {
+   "auditory": "The processor's mechanical rhythm registers in the chest as much as the ears, a slow industrial pulse.",
+   "olfactory": "Ozone and hot metal off the processor, under a constant mineral coldness.",
+   "tactile": "Grating underfoot, warmed unevenly by the processor's waste heat."
+  }
+ },
+ "888": {
+  "key": "Braddock Avenue",
+  "desc": "Heavy machinery dominates — parked mining haulers forming impromptu walls that funnel foot traffic into narrow paths between their massive treads. The vehicles still wear the day's work: regolith dust filming every surface, ice-melt freezing in the joints of their hydraulics. Someone has welded a crude shelter between two hauler cabs, barely long enough to lie down in, its entrance curtained with thermal sheeting.",
+  "sense_descs": {
+   "auditory": "Hydraulics tick and settle as the parked haulers cool, metal pinging somewhere in the dark.",
+   "olfactory": "Hydraulic fluid and pulverized stone, warm machine-oil over cold mineral dust.",
+   "tactile": "Regolith grit coats everything; the crater's chill hangs in the gaps between the treads.",
+   "atmospheric": "A motor pool turned warren — work-machines doubling as walls and shelter."
+  }
+ },
+ "894": {
+  "key": "South Marlowe Street",
+  "desc": "The street opens with a width that speaks to ambition — laid out as a thoroughfare back when the colony still had pretensions of planning. Industrial grating forms an almost perfect grid underfoot, maintenance hatches at regular intervals. East, the atmospheric processor dominates the horizon, its waste heat bending the air into shimmer that makes distant structures waver. Prefab housing lines both sides, walls carrying the upkeep of a place near a major route — fresh patches, functional seals.",
+  "sense_descs": {
+   "auditory": "The processor's drone carries clean across the open grid, low and unbroken.",
+   "olfactory": "Hot metal and ozone, cut with the faint tack of fresh sealant still curing on the prefab walls.",
+   "tactile": "Waste heat rolls off the processor in slow waves; the grating holds it underfoot."
+  }
+ },
+ "897": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue shifts character, trading the improvised western sprawl for something near intentional. The surface is intact industrial grating, warm underfoot from the processor close enough to make this the most habitable real estate on Braddock. Prefab modules line the north in fair repair, fresh patches instead of decades of damage. South, the crater wall still looms, but integrated with real engineering — proper seals, working drainage, supports that look calculated rather than guessed.",
+  "sense_descs": {
+   "auditory": "The processor's hum is a near, steady presence here, almost domestic.",
+   "olfactory": "Thick metallic warmth, the ozone softened, the mineral cold pushed back.",
+   "tactile": "The grating runs genuinely warm — heat as a feature rather than a fight."
+  }
+ },
+ "1682": {
+  "key": "Tsiolkovsky Corridor",
+  "desc": "Tsiolkovsky Corridor runs north from the waterfront along the colony's eastern boundary, the crater wall pressing close on the right. The grating is corporate-standard here - clean, level, drainage that functions. Administrative frontage lines the west; the eastern wall is dark stone broken by sealed bulkheads.",
+  "sense_descs": {
+   "auditory": "The orderly quiet of the administrative reach; a faint draft from the eastern wall.",
+   "olfactory": "Clean filtered air with the cold mineral breath of the crater wall.",
+   "tactile": "Corporate-standard grating, clean and level; cold off the eastern stone.",
+   "atmospheric": "The crater wall rises dark and close to the east, sealed bulkheads in its face."
+  }
+ },
+ "1685": {
+  "key": "Tsiolkovsky Corridor",
+  "desc": "The corridor continues north between administrative frontage and the crater wall, the buildings maintained to corporate standard - matched facades, functioning fixtures, the order that money buys. Old mine entrances sit behind security barriers in the eastern stone, their depths disappearing into darkness.",
+  "sense_descs": {
+   "auditory": "The administrative hush; a deeper draft breathing from the old mine openings.",
+   "olfactory": "Scrubbed corporate air over the cold mineral stone.",
+   "tactile": "The eastern wall's chill steady on the right; level grating underfoot.",
+   "atmospheric": "Old mine entrances sit behind barriers in the crater wall, marked restricted."
+  }
+ },
+ "1688": {
+  "key": "Tsiolkovsky Corridor",
+  "desc": "Tsiolkovsky approaches the avenue through the heart of the administrative core, reinforced corporate structures suggesting both permanence and the paranoia that attends real assets. Survey warnings post in multiple languages where the mine workings breach the eastern wall.",
+  "sense_descs": {
+   "auditory": "The deep quiet of the corporate core, climate units barely audible.",
+   "olfactory": "Clean processed air, neutral and cold.",
+   "tactile": "Level maintained grating; the crater wall's chill on the right.",
+   "atmospheric": "Geological survey warnings post where the mine workings breach the eastern wall."
+  }
+ },
+ "1691": {
+  "key": "Ada Avenue and Tsiolkovsky Corridor",
+  "desc": "The avenue terminates at Tsiolkovsky Corridor, the colony's eastern boundary where residential and industrial zones meet the crater wall's unyielding presence. The crater wall rises behind the intersection, its face marked by ventilation shafts and maintenance-access points. The processor's output colors the distant air, rising into the horizon. The colony reaches as far as it can here; beyond lies only stone and the machinery to make it habitable.",
+  "sense_descs": {
+   "auditory": "Ventilation shafts in the crater wall exhale a low, hollow draft-sound, constant at the boundary.",
+   "olfactory": "Cold rock and processed air, the mineral edge sharpest where the colony ends.",
+   "tactile": "The crater wall radiates a flat, unmoving cold.",
+   "atmospheric": "The energy of a terminus — everything arriving or leaving, nothing staying."
+  }
+ },
+ "1694": {
+  "key": "Tsiolkovsky Corridor",
+  "desc": "North of the avenue, Tsiolkovsky runs through secure administration, the frontage growing blanker and more watchful. Surveillance fixtures track the corridor in overlapping coverage; the eastern wall holds its sealed bulkheads and the dark mouths of unmarked tunnels.",
+  "sense_descs": {
+   "auditory": "The servo-tick of surveillance fixtures tracking the empty corridor.",
+   "olfactory": "Cold stone and scrubbed air.",
+   "tactile": "The eastern wall's chill deepening; clean grating underfoot.",
+   "atmospheric": "Unmarked tunnels open dark in the eastern wall beneath the surveillance coverage."
+  }
+ },
+ "1697": {
+  "key": "Tsiolkovsky Corridor",
+  "desc": "The corridor climbs the last reach toward Arcturus, administration thinning into secure frontage and blank service doors. The crater wall dominates the east entirely now, dark stone rising sheer, the colony's edge made literal.",
+  "sense_descs": {
+   "auditory": "The near-silence of the colony's edge, a faint draft off the tunnels.",
+   "olfactory": "The cold mineral breath of the crater wall over scrubbed air.",
+   "tactile": "Cold radiates off the sheer eastern stone; level grating underfoot.",
+   "atmospheric": "The crater wall rises sheer to the east, the colony's literal edge."
+  }
+ },
+ "1703": {
+  "key": "Tsiolkovsky Corridor and Arcturus Row",
+  "desc": "The northeast corner of the district, where Tsiolkovsky Corridor meets Arcturus Row and the crater wall closes the colony off on two sides. Sealed bulkheads and the mouths of old mine workings mark the dark stone, some restricted, some only darkness.",
+  "sense_descs": {
+   "auditory": "The deep quiet of the closed corner, drafts breathing from the mine workings.",
+   "olfactory": "Cold mineral stone, the air still and scrubbed.",
+   "tactile": "Cold off the dark wall on two sides; clean grating underfoot.",
+   "atmospheric": "The crater wall closes the colony off, old mine workings hinting at older passage."
+  }
+ },
+ "1935": {
+  "key": "Queen of Cups - Rooftop",
+  "desc": "The stairs end at a hatch onto a roof of patched metal sheets, jagged underfoot. Pessoa Street runs east below, alive with light and smoke. The atmospheric processor dominates the skyline in pale light. Makeshift chairs and crates litter the surface; empty bottles and burnt offerings mark old gatherings. Neon glows from below break the long shadows.",
+  "sense_descs": {
+   "auditory": "The processor's hum sits steady under the roof; the street below leaks a muffled churn.",
+   "olfactory": "Spice and smoke drift up from Pessoa Street, threaded through with machine-warmth.",
+   "tactile": "The patched sheeting flexes and tilts underfoot; the air carries the processor's faint warmth.",
+   "atmospheric": "A used gathering-place — somebody's roof, marked by everyone who's burned an offering here."
+  }
+ },
+ "1961": {
+  "key": "Colonial Armory",
+  "desc": "The seal above the entrance has been painted over so many times it's become an abstract smear — authority suggested without being claimed. The west wall carries a faded mural, possibly colonial marines, possibly anyone with guns who looked heroic before the paint oxidized, its details lost to time and indifference.",
+  "sense_descs": {
+   "auditory": "Sound goes flat and close in here, swallowed by concrete; a ventilation fan turns somewhere out of sight.",
+   "olfactory": "Gun oil, old paint, and the dry mineral smell of stored metal.",
+   "tactile": "The air sits still and cool, the kind that doesn't move unless you move it.",
+   "atmospheric": "Institutional bones worn shabby — function outlasting whatever pride built it."
+  }
+ },
+ "1968": {
+  "key": "Helix Lounge",
+  "desc": "A gutted warehouse shell, steel beams bared like ribs. Concrete walls sweat with condensation, patched with cables that pulse faint light. Speakers hang heavy from chains, casings scarred. The floor is grating over old drainage channels; neon strips flicker against rusted panels, painting the room in jagged color. Screens loop fractured visuals, VHS static bleeding into industrial patterns.",
+  "sense_descs": {
+   "auditory": "The speakers hum with static even when silent; below, steam vents hiss in bursts and the grating rings faintly underfoot.",
+   "olfactory": "Ozone, machine oil, and burnt circuitry, sharp and electric.",
+   "tactile": "Steam rises from the vents below in damp bursts; the condensation-slick walls run cold beside it.",
+   "atmospheric": "Ruin dressed as a venue — the warehouse never stopped being a warehouse, it just got wired for the night."
+  }
+ },
+ "1971": {
+  "key": "Helix Lounge - Balcony",
+  "desc": "A steel staircase climbs to a balcony running the warehouse's length, railings patched with welded plates. Chairs cluster in scavenged groups — office and ship salvage, cushions torn but holding. Tables are metal slabs bolted down, scarred with cigarette burns and knife marks. Old monitors line the walls, looping static and half-forgotten logos. Light filters through cracked panels above.",
+  "sense_descs": {
+   "auditory": "The main floor's hum rises here, muffled but constant, the monitors' static threading through it.",
+   "olfactory": "Stale smoke worked into the cushions, over the oil-and-ozone breath of the floor below.",
+   "tactile": "The steel underfoot carries the floor's vibration; the bolted tables are cold and faintly greasy.",
+   "atmospheric": "An overlook for watching rather than being watched — worn, scarred, comfortable in its damage."
+  }
+ },
+ "1974": {
+  "key": "Helix Lounge - VIP",
+  "desc": "Behind a reinforced door, the VIP zone glows in its own neon palette. A steel bar runs one wall, polished to a dull shine, bottles in uneven rows. Hot tubs sit recessed in the floor, surfaces steaming, framed by rusted piping and flickering lights. The walls are paneled in old advertising screens looping broken commercials; the ceiling hangs low, cables dangling like vines.",
+  "sense_descs": {
+   "auditory": "The looping ad-screens murmur broken audio; cables drip steadily into the tubs, each drop a soft tick.",
+   "olfactory": "Heat and chemical tang — tub treatment, hot piping, and something synthetic-sweet underneath.",
+   "tactile": "The air is thick, hot, and close; tub-steam beads on every surface, the low ceiling pressing it down.",
+   "atmospheric": "Excess carved out of ruin — sealed off, indulgent, one failed seal from squalor."
+  }
+ },
+ "1983": {
+  "key": "Thawn-Harrison Cryogenics - Courtyard",
+  "desc": "Composite decking replaces industrial grating here, laid in geometric patterns that read corporate resources rather than desperate improvisation. Security lighting on telescoping poles throws overlapping coverage. The northern facade shows brushed composite panels and Thawn-Harrison's backlit name, holding its glow regardless of day cycle. Prefab walls flank east and west with professionally managed upkeep; bollards and low barriers guide the western and southern approaches.",
+  "sense_descs": {
+   "auditory": "A clean electrical hum off the security lighting, and the soft cycling of climate units — engineered quiet.",
+   "olfactory": "Filtered, faintly antiseptic air, scrubbed of the street's mineral edge.",
+   "tactile": "The decking is even and firm; the air sits temperature-controlled and unmoving.",
+   "atmospheric": "Corporate order pressed onto colony stone — deliberate, lit, and watched."
+  }
+ },
+ "1986": {
+  "key": "Thawn-Harrison Cryogenics - Lobby",
+  "desc": "The reception area keeps corporate aesthetics over colonial reality — composite flooring polished to a sheen that won't last, furniture spaced with the deliberate logic of crowd-management protocol. The main desk curves along the eastern wall, its surface set with displays and biometric scanners, the station held by a synthetic whose professional calm doesn't quite cover the security subroutines beneath. Waiting chairs line the southern wall, upholstery worn by populations who wait because they have no choice.",
+  "sense_descs": {
+   "auditory": "Climate units cycle in soft, even breaths; the desk displays chime now and then as they refresh.",
+   "olfactory": "Filtered air and synthetic upholstery, a manufactured cleanliness with nothing organic in it.",
+   "tactile": "The polished floor is hard and cool; the controlled air neither warms nor stirs.",
+   "atmospheric": "Hospitality as protocol — comfortable-looking, processed, quietly surveilled."
+  }
+ },
+ "1989": {
+  "key": "Thawn-Harrison Cryogenics - Decantation Chamber",
+  "desc": "Ten decanting pods dominate the floor in parallel rows — reinforced composite and clear polymer, three meters tall, their interiors lit soft blue, the synthetic gel inside reading as both liquid and solid. Control consoles flank each pod, displays cycling biometric data: neural activity, tissue integration, cardiovascular function rendered as numbers. Refrigerated storage and equipment racks line the walls, emergency kits behind break-glass panels. An elevated northern station overlooks the rows. Warning placards crowd the designated walls in several languages.",
+  "sense_descs": {
+   "auditory": "A constant filtered-air circulation underlies everything, punctuated by the soft beat of console monitors and the low cycling of the refrigeration.",
+   "olfactory": "Sterilization compounds and refrigerant chemistry, sharp and clinical.",
+   "tactile": "Precisely held cool and dry; chemical-rated composite hard underfoot, drainage channels breaking it at intervals.",
+   "atmospheric": "A place engineered to keep the half-living suspended — precise, lit, and indifferent."
+  }
+ },
+ "2008": {
+  "key": "Gaia's Treasures",
+  "desc": "The viewport displays speak to curation, not desperation — a brass sextant behind climate-controlled glass, paper books in preservation cases, what might be genuine wood furniture arranged to suggest Earth living rooms most colonists have only seen in recordings. The lighting stays low, each artifact spotlit like a museum piece. Deeper in, shelves hold smaller things: porcelain that survived the crossing, mechanical watches, photographs in actual silver frames.",
+  "sense_descs": {
+   "auditory": "Near silence, deliberately kept — the faint tick of mechanical watches and a climate case's low hum the only sounds.",
+   "olfactory": "Old paper and polishing compound, a Terran scent maintained by hand rather than accumulated.",
+   "tactile": "The air is climate-steady and still; the quiet feels padded, careful.",
+   "atmospheric": "Reverence for sale — everything lit and cased to make you think twice before asking a price."
+  }
+ },
+ "900": {
+  "key": "Braddock Avenue",
+  "desc": "Equipment yards sprawl north — a taxonomy of industrial failure: mining rigs awaiting parts that won't arrive, haulers cannibalized to skeletal frames, prefab sections stacked like archaeological strata of corporate optimism. The processor towers northeast now, close enough that its rhythmic exhalations of steam make their own weather. South, the crater wall stands constant, dark stone scarred by drilling and the faded paint of decades-old survey markers.",
+  "sense_descs": {
+   "olfactory": "Cold regolith dust and machine-rust, with the processor's hot-metal exhaust drifting in from the northeast.",
+   "auditory": "The processor breathes in slow rhythmic gusts; the yards tick and settle with cooling metal.",
+   "tactile": "Crater-cold off the stone south; the processor's exhaust pushes warm, damp air over the yards.",
+   "atmospheric": "An open-air graveyard of machines — wreckage filed as inventory."
+  }
+ },
+ "903": {
+  "key": "Braddock Avenue",
+  "desc": "A shuttle's forward section lies half-buried in compacted regolith, its cockpit windows turned skylights for some dwelling beneath. The hull still wears scorch marks — atmospheric entry or combat, impossible to tell, the distinction long since irrelevant. Heavy treads cross-hatch the dust, patterns lasting until the next vehicle erases them.",
+  "sense_descs": {
+   "olfactory": "The processor's hot industrial breath mixed with the sharper bite of working machinery and scorched hull.",
+   "auditory": "Heavy treads grind through the dust; the processor's rhythm carries warmer and nearer.",
+   "tactile": "The air grows warmer here, the cold stone giving ground to the processor's radiant heat.",
+   "atmospheric": "A wreck made home — the line between salvage and shelter erased."
+  }
+ },
+ "906": {
+  "key": "Braddock Avenue",
+  "desc": "Industrial detritus clusters here — discarded equipment housings, coiled cable too damaged to salvage, pressure tanks with their gauges long since cannibalized. The crater wall south shows excavation, shallow caves carved for storage or shelter or just the human need to dig deeper. Northeast, the processor has grown perceptibly larger, beginning to dominate the sky.",
+  "sense_descs": {
+   "olfactory": "Cold rust and stripped cable, the processor's hot-metal note thickening from the northeast.",
+   "auditory": "The processor's breathing grows louder; the detritus ticks as the temperature shifts across it.",
+   "tactile": "Cool by the excavated stone, warmer toward the processor — the gradient tilts east."
+  }
+ },
+ "909": {
+  "key": "Braddock Avenue",
+  "desc": "The street narrows where a derelict hauler hull has been sectioned and stacked three levels high against the crater wall, joined by welded ladder rungs. Laundry hangs motionless between the hauler sections and the opposing prefab. Faded red protection symbols cover every surface — Celtic knots bleeding into geometric patterns that might be mandalas or circuit diagrams or both. The ground is packed regolith worn smooth.",
+  "sense_descs": {
+   "olfactory": "Recycled breath and old machinery, close and stale in the still air.",
+   "auditory": "The air is dead-still here; only the muffled, distant industrial pulse reaches in.",
+   "tactile": "Still, close air that tastes of being breathed too many times; the packed regolith is smooth underfoot.",
+   "atmospheric": "Warded on every surface — red symbols against whatever the dark might send."
+  }
+ },
+ "912": {
+  "key": "Braddock Avenue",
+  "desc": "Salvaged ship plating forms makeshift walls, still bearing the faded logos and hull-IDs of vessels that died elsewhere. The sections don't quite meet, leaving gaps. A converted cargo module squats against the southern wall, its airlock door repurposed as an entrance to housing or storage — the distinction meaningless this far from administration. East, the processor stands distant but undeniable.",
+  "sense_descs": {
+   "olfactory": "Cold metal and old paint off the scavenged plating.",
+   "auditory": "The gaps between the plates whistle thinly; the processor murmurs far to the east.",
+   "tactile": "Cold leaks through every misaligned seam; the salvaged plating is frigid to the touch.",
+   "atmospheric": "A wall of dead ships — everything here exists at the processor's sufferance."
+  }
+ },
+ "915": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue runs hard along the southern crater wall, close enough to see prefab modules bolted directly into the stone face, structural supports vanishing into the rock at odd angles. The metal plating underfoot has buckled into shallow pools where condensation collects off the temperature gap between warm breath and cold stone. North, the street opens toward the industrial heart, but here on the edge everything feels provisional.",
+  "sense_descs": {
+   "olfactory": "Cold wet stone and the mineral damp of the crater wall.",
+   "auditory": "Condensation drips off the buckled plating; the crater stone gives back a flat, dead quiet.",
+   "tactile": "Cold radiates from the stone; the buckled plating holds standing pools that wet the boots.",
+   "atmospheric": "The colony's frayed edge — as if the crater might reclaim it at any moment."
+  }
+ },
+ "918": {
+  "key": "Kaspar Street and Bhavani Corridor",
+  "desc": "The intersection opens where Kaspar Street extends east from Bhavani through the outer edges of the sprawl, the confluence showing the accumulated wear of populations moving through space that stopped pretending to be officially planned decades ago. The grating here is a patchwork of different materials and ages, some sections original colony infrastructure, others replaced with whatever composite or metal could be salvaged when failure became critical.",
+  "sense_descs": {
+   "auditory": "Footfall over the mismatched grating, each salvaged section ringing a different note.",
+   "olfactory": "Rock dust off the crater wall and the stale closeness of the sprawl.",
+   "tactile": "The crater wall presses close; cold radiates off the rock to the west.",
+   "atmospheric": "Structures built into the stone make west a vertical impossibility rather than a direction."
+  }
+ },
+ "921": {
+  "key": "Bhavani Corridor",
+  "desc": "The eastern structures here have given up on pretending they were built according to any plan, their frameworks leaning at angles that suggest either different physics or structural failure taking its time. Scaffolding props up sections of the upper levels, composite beams wedged into positions that look temporary until the rust reveals they've been load-bearing for years. The western side has become more excavation than construction, entire sections carved into the crater wall and sealed with whatever materials could be scavenged - composite panels, sheet metal, sections of what looks like decommissioned hull plating.",
+  "sense_descs": {
+   "auditory": "Scaffolding ticks and settles overhead; muffled life leaks from the carved-out western dwellings.",
+   "olfactory": "Rock dust and rust, the cold-stone breath of the crater wall.",
+   "tactile": "A fine grit of excavated rock coats every surface."
+  }
+ },
+ "927": {
+  "key": "South Marlowe Street",
+  "desc": "A cargo depot occupies the western side, its roll-up doors marked with loading bay numbers in faded corporate stenciling. Composite pallets sit stacked in orderly rows, their contents shrouded in weather-resistant tarps that bear the grime of long-term storage. The eastern side shows mixed use - a machine shop visible through reinforced viewports, its interior cluttered with equipment in various states of disassembly, and a small commissary, its entrance marked by a hand-painted sign advertising hot meals and cold storage.",
+  "sense_descs": {
+   "auditory": "The processor's rhythmic mechanical breathing runs as a constant backdrop, louder with each block north.",
+   "olfactory": "Tarp, machine oil, and a thread of cooking from the commissary.",
+   "tactile": "Heat off the processor builds the further north you stand."
+  }
+ },
+ "930": {
+  "key": "South Marlowe Street",
+  "desc": "The street maintains its industrial character, but residential density increases - prefab modules stacked two and sometimes three high where someone trusted the foundations enough to risk the weight. External access ladders connect the levels, their rungs worn smooth by shift workers moving at predictable intervals. Laundry hangs from improvised lines strung between structures.",
+  "sense_descs": {
+   "auditory": "Shift workers move on the external ladders at predictable intervals; the processor breathes on.",
+   "olfactory": "Cooking cuts through the industrial baseline - garlic and synthetic protein.",
+   "tactile": "Warm air currents carry processor heat up through the stacked modules.",
+   "atmospheric": "Laundry stirs on improvised lines, marking the heat-driven air currents."
+  }
+ },
+ "933": {
+  "key": "South Marlowe Street and Kaspar Street",
+  "desc": "The intersection sprawls where Kaspar Street cuts through the industrial districts, reinforced grating rated for heavy cross-traffic. To the east, Kaspar extends toward Spillane Corridor and the processor - worker housing, shift facilities, the infrastructure of sustained industrial presence. West, the street descends through heavier manufacturing districts. South Marlowe continues north and south, its width undiminished, grating showing decades of wear as the colony's primary artery.",
+  "sense_descs": {
+   "auditory": "Heavy cross-traffic grinds over the reinforced grating.",
+   "olfactory": "Waste heat and machine oil, the processor's industrial baseline.",
+   "tactile": "Warmth bleeds west from the manufacturing districts; the grating sits solid underfoot."
+  }
+ },
+ "936": {
+  "key": "Kaspar Street",
+  "desc": "Worker dormitories dominate both sides, prefab blocks so uniform they were clearly installed in a single operation back when the colony still planned. Four levels, identical but for accumulated damage — fire scoring around one third-floor viewport, structural patches where something heavy hit a corner, another block simply surrendered to rust. External stairwells zigzag between the levels, treads worn concave by decades of shift workers.",
+  "sense_descs": {
+   "olfactory": "Cold metal and rust, threaded with smoke from cheap cooking-fuel.",
+   "auditory": "The stairwells tick and groan with the cold; the colony's hum sits under it all.",
+   "tactile": "The crater wall's shadow keeps this stretch cold; the grating leaches heat from boot soles.",
+   "atmospheric": "Identical blocks distinguished only by how they have failed."
+  }
+ },
+ "939": {
+  "key": "Kaspar Street",
+  "desc": "A repair dock holds the northern side, its bay door perpetually half-open over the skeletal remains of mining equipment in various stages of cannibalization. South, prefab modules — storage or abandoned housing, viewports missing or sheeted over and weathered the same gray as everything. Shift-rotation codes glow faintly in luminescent paint on the grating, ground down by years of foot traffic.",
+  "sense_descs": {
+   "olfactory": "Machine oil, cutting-torch tang, and cold metal off the open dock.",
+   "auditory": "From the dock, the intermittent ring and hiss of salvage work; the colony hums beneath.",
+   "tactile": "Cold pools in the half-open bay; the grating is gritty with shop-dust."
+  }
+ },
+ "942": {
+  "key": "South Marlowe Street",
+  "desc": "The street continues its northward climb, the slight grade noticeable only in how it affects loaded haulers grinding through their gears. A bunkhouse dominates the eastern side, four levels of narrow viewports suggesting dormitory space built for the processor's shift workers - people who sleep close to where they work because the alternative is worse. Fire escapes zigzag up the western face of the structure opposite, their composite treads showing the wear of daily use rather than emergency preparation.",
+  "sense_descs": {
+   "auditory": "Loaded haulers grind through their gears against the grade.",
+   "olfactory": "Hot metal and the close smell of shared dormitory space.",
+   "tactile": "The processor's heat radiates from the east with enough intensity to feel on the skin.",
+   "atmospheric": "Heat shimmers in the gaps between structures, creating false distance."
+  }
+ },
+ "945": {
+  "key": "South Marlowe Street",
+  "desc": "A repair facility occupies the western side, its entrance wide enough to accommodate mining equipment, the interior visible through the open bay door - the organized chaos of things being fixed rather than replaced. The processor towers to the east, its bulk creating a perpetual shadow that keeps this side of the street cooler than the western exposure. Overhead cabling runs in dense parallel lines, power and data feeds branching off in a web that's grown organically rather than by design.",
+  "sense_descs": {
+   "auditory": "Welding crackles and pneumatic tools stutter from the open repair bay.",
+   "olfactory": "Arc-welder ozone, hot metal, and machine oil.",
+   "tactile": "The processor's shadow keeps this side cooler than the sun-struck western exposure."
+  }
+ },
+ "948": {
+  "key": "South Marlowe Street",
+  "desc": "The street straightens here, running true through districts that balance industrial function with residential density. The sides show mixed use - a small machine shop on the ground level, housing above, the vertical integration suggesting efficiency or desperation or both.",
+  "sense_descs": {
+   "auditory": "The processor's mechanical breathing is so constant it sinks beneath notice, baseline rather than sound.",
+   "olfactory": "Machine oil and the layered cooking of housing stacked above the shops.",
+   "tactile": "Steady processor warmth, even and unremarkable here."
+  }
+ },
+ "951": {
+  "key": "South Marlowe Street and Pessoa Street",
+  "desc": "The intersection sprawls where Pessoa Street cuts through the colony's industrial spine, heavier reinforcement than Kaspar suggesting expensive lessons learned. Pessoa extends through refinery districts and processing plants clustered near the channel and processor, worker traffic constant between shifts. South Marlowe continues unchanged, grating polished from decades of hauler traffic.",
+  "sense_descs": {
+   "auditory": "Steam vents release pressure through the grating in hissing bursts.",
+   "olfactory": "Refinery chemistry and hot metal off the processor.",
+   "tactile": "Heat radiates from the processor's near presence; grating polished smooth underfoot.",
+   "atmospheric": "The processor dominates the eastern horizon, close enough to resolve access hatches, sensor arrays, and massive conduits."
+  }
+ },
+ "954": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa curves wide here, grating polished to a shine by decades of hauler traffic. Steam vents punctuate the street; the processor looms east, its conduits sharp against the skyline.",
+  "sense_descs": {
+   "olfactory": "Exhaust, cheap perfume, and frying food fold into a single thick breath.",
+   "auditory": "Steam vents hiss in wet bursts; under them runs the processor's steady hum.",
+   "tactile": "The vented steam leaves the air damp and metallic; the polished grating is slick underfoot."
+  }
+ },
+ "957": {
+  "key": "Pessoa Street",
+  "desc": "The street broadens toward Marlowe, housing stacked into improvised towers. A shrine sits tucked into a corner, its candles burning low. The cracked road is worn smooth toward the busy intersection ahead.",
+  "sense_descs": {
+   "olfactory": "Damp stone and frying oil, heavy and persistent, with a thread of candle-smoke from the shrine.",
+   "auditory": "The processor's hum holds steady from the east, unyielding.",
+   "tactile": "Cold damp rises off the stone; the worn road is smooth underfoot."
+  }
+ },
+ "960": {
+  "key": "South Marlowe Street",
+  "desc": "A salvage yard sprawls on the western side, composite panels and structural beams sorted into rough categories, price tags spray-painted directly onto the materials. The eastern warehouse shows signs of recent fire damage - scorched composite around a viewport, fresh patches that don't match the original construction.",
+  "sense_descs": {
+   "auditory": "Salvage shifts and clangs as someone sorts the western yard.",
+   "olfactory": "Brine off the channel cuts through, salt mixing with processor heat and machine oil into something mineral.",
+   "tactile": "Scorched composite still holds the warehouse fire's heat near the patched viewport."
+  }
+ },
+ "963": {
+  "key": "South Marlowe Street",
+  "desc": "The eastern parts supplier has spread their overflow onto the street - component bins arranged outside the viewport. Prefab warehouses sprawl out on both sides, sealing the street in like a canyon.",
+  "sense_descs": {
+   "auditory": "The warehouse canyon funnels and flattens the street's noise.",
+   "olfactory": "Cold metal and machine oil off the overflow component bins.",
+   "tactile": "Warehouses wall the street into a canyon; the air sits trapped and still.",
+   "atmospheric": "The Central Span's framework rises into view between the structures."
+  }
+ },
+ "966": {
+  "key": "South Marlowe Street",
+  "desc": "A commissary's posted menu lists prices in both tokens and trade goods - protein rations, hot water, even charging time for personal devices. The eastern modules bear corporate numbering that actually follows a pattern, suggesting someone approved this section before chaos became standard.",
+  "sense_descs": {
+   "auditory": "The commissary's kitchen exhaust roars; its serving counter clatters.",
+   "olfactory": "Recycled protein and synthetic spices on the venting steam.",
+   "tactile": "Warmth and kitchen steam thicken the air near the commissary.",
+   "atmospheric": "The Central Span's navigation lights stand steady against the northern sky."
+  }
+ },
+ "969": {
+  "key": "South Marlowe Street and Volta Street",
+  "desc": "The intersection sprawls with heavier reinforcement than the crossings south - doubled grating, support columns that suggest this junction handles serious weight. Volta extends through waterfront service districts, shift schedules and cargo facilities defining its character. South Marlowe continues unchanged, polished by constant hauler traffic.",
+  "sense_descs": {
+   "auditory": "Serious cross-traffic rumbles over the doubled grating.",
+   "olfactory": "Machine oil and a first thread of channel brine from the north.",
+   "tactile": "Support columns brace a junction built for weight; the grating doesn't give underfoot.",
+   "atmospheric": "The Central Span dominates the north, close enough to resolve support towers and elevated roadway."
+  }
+ },
+ "972": {
+  "key": "Volta Street",
+  "desc": "The street widens where South Marlowe approaches, heavier grating handling cross-traffic. Industrial operations cluster both sides - northern fabrication facility with stacked materials, southern testing station with viewports revealing expensive equipment. The atmospheric processor looms larger to the east.",
+  "sense_descs": {
+   "auditory": "Industrial exhaust hisses across the street under the dying-ballast buzz of failing emergency lights.",
+   "olfactory": "Industrial exhaust and hot metal.",
+   "tactile": "Heat radiates up through the grating in waves.",
+   "atmospheric": "Emergency lighting flickers intermittently, dying ballasts adding a random rhythm."
+  }
+ },
+ "975": {
+  "key": "Volta Street",
+  "desc": "The grating here aligns with mechanical precision, panels laid with deliberate exactness. Northern prefab modules show planned modifications rather than hasty patches - sealed conduit runs, matching climate vents, proper composite panel replacements. To the south, the crater wall stands integrated with calculated engineering - functional drainage, deliberate structural supports. The atmospheric processor looms distant to the east.",
+  "sense_descs": {
+   "auditory": "The low filtered hush of properly sealed climate vents.",
+   "olfactory": "Filtered chemical cleanness, scrubbed and neutral.",
+   "tactile": "Every panel sits flush underfoot, the grating laid with mechanical exactness."
+  }
+ },
+ "978": {
+  "key": "South Marlowe Street",
+  "desc": "The street climbs toward the Central Span, the grade noticeable in how haulers shift gears, engines grinding against the slope. Waterfront operations dominate both sides now - a marine supply depot on the western side, its roll-up doors revealing cable spools and hardware stacked to the ceiling, and a shipfitting facility on the east, composite materials and hull plating visible through reinforced viewports. The Central Span rises ahead, its support towers and the roadway's underside resolving with proximity. The processor remains visible to the southeast, its bulk familiar enough to serve as orientation.",
+  "sense_descs": {
+   "auditory": "Haulers grind through their gears against the slope; the channel moves somewhere ahead.",
+   "olfactory": "Brine and marine tar overtaking the processor's hot-metal baseline.",
+   "tactile": "The grade pulls at loaded legs; cooler channel air meets the processor heat here."
+  }
+ },
+ "981": {
+  "key": "South Marlowe Street",
+  "desc": "The approach to the Central Span continues, the street widening slightly where traffic patterns require space for vehicles queueing for the crossing. Navigation lights mark the span's edges, a constellation that guides movement across the channel. The Balboa's presence asserts itself here, dark water visible beyond the immediate structures, moving with a current that explains why the colony built a bridge rather than attempting something more ambitious.",
+  "sense_descs": {
+   "auditory": "The channel's current works steadily past the span's foundations.",
+   "olfactory": "Full channel brine, cold and mineral.",
+   "tactile": "Open wind comes off the water where the street widens for the crossing.",
+   "atmospheric": "Navigation lights mark the span's edges in a constellation across the channel."
+  }
+ },
+ "984": {
+  "key": "South Marlowe Street",
+  "desc": "A power substation dominates both sides of the street, transformers behind chain-link fencing. The span's southern terminus looms ahead, support towers rising from foundations that descend into the channel's depths, the roadway elevated high enough for water traffic to pass beneath. The channel's presence dominates - dark water visible beyond the structures, moving with force that makes the bridge's engineering seem less ambitious and more necessary.",
+  "sense_descs": {
+   "auditory": "Transformers hum steadily behind the chain-link fencing.",
+   "olfactory": "Ozone off the substation cut with channel brine.",
+   "tactile": "The transformers' vibration carries up through the grating into the feet.",
+   "atmospheric": "The span's support towers rise from foundations descending into the channel's depths."
+  }
+ },
+ "987": {
+  "key": "South Marlowe Street and Maxwell Street",
+  "desc": "The intersection opens where South Marlowe Street cuts north toward the Central Span, the confluence designed to handle the traffic that defines this district as vital rather than merely functional. The grating here is reinforced composite rated for constant heavy loads, the surface marked with directional paint maintained with enough regularity to suggest official concern for traffic flow. To the north, Marlowe climbs the final approach to the Central Span - the bridge's southern terminus visible as a framework spanning the Balboa Channel, its support towers resolving into structural detail. Further south, Marlowe descends through residential and commercial districts that cluster in the processor's shadow.",
+  "sense_descs": {
+   "auditory": "Heavy traffic moves through the confluence with the steady purpose of a vital artery.",
+   "olfactory": "Hot metal and machine oil giving way to channel air toward the north.",
+   "tactile": "Reinforced composite underfoot, rated for constant heavy loads.",
+   "atmospheric": "The bridge dominates the view north, its navigation lights a constellation marking the crossing."
+  }
+ },
+ "990": {
+  "key": "Maxwell Street",
+  "desc": "The street angles upward toward the Central Span. The processor looms east, its industrial bulk giving way to prefab dwellings and scuttled pleasure cruisers making the most of the waterfront. Structures tier up the slope on reinforced foundations; through the gaps, the Central Span shows itself — an industrial bridge across the channel, its framework strung with navigation lights. Twin tracks lie polished into the grating where haulers make the climb.",
+  "sense_descs": {
+   "olfactory": "Channel damp and cold metal, with an oily thread off the beached cruisers.",
+   "auditory": "The processor drones from the east; the channel moves somewhere below, a low continuous wash.",
+   "tactile": "Moisture off the channel beads on everything; the climb's polished tracks are slick.",
+   "atmospheric": "Where the industrial east meets the waterfront — a slope reaching for the Span."
+  }
+ },
+ "993": {
+  "key": "Maxwell Street",
+  "desc": "The street runs the Balboa Channel's southern bank, the waterway dominating the northern horizon at a scale that makes human infrastructure feel temporary. Prefab lines the south, northern walls rust-stained and mineral-crusted from decades of channel proximity. A loading dock juts north over the dark water, tie-down points and cargo winches marking it for waterborne freight. Northeast, the Central Span rises across the channel.",
+  "sense_descs": {
+   "olfactory": "Cold mineral water and wet rust, the breath of the channel.",
+   "auditory": "The channel moves past in a steady dark wash; dock winches creak on their mounts.",
+   "tactile": "Channel-damp coats the rails and decking; the grating runs slick toward the water.",
+   "atmospheric": "Built right up against water that makes the colony feel provisional."
+  }
+ },
+ "1017": {
+  "key": "North Marlowe Street and Tolliver Row",
+  "desc": "The intersection opens where Tolliver Row cuts east-west through the waterfront district, the confluence marked by grating reinforced for cross-traffic between channel operations. South, the Central Span's terminus is immediately visible, the bridge's roadway descending from mid-channel to meet the street. Cargo staging areas occupy corners where the streets meet, composite pallets and loading equipment showing constant use.",
+  "sense_descs": {
+   "auditory": "Cargo loading equipment works the corners; the channel moves beyond the barriers.",
+   "olfactory": "Channel brine and diesel off the staging areas.",
+   "tactile": "Reinforced grating underfoot; cool channel air comes off the dark water south.",
+   "atmospheric": "The Central Span's terminus descends to meet the street, the channel moving with purpose beyond the safety barriers."
+  }
+ },
+ "1020": {
+  "key": "North Marlowe Street",
+  "desc": "Multi-story structures line both sides, their composite facades showing regular maintenance - fresh sealant, functioning lighting, transparent viewports. The western side houses commercial operations with proper signage, businesses that assume currency rather than barter. Eastern residential towers suggest the colony's administrative class lives here. The Central Span remains visible to the south.",
+  "sense_descs": {
+   "auditory": "Subdued and orderly, the quiet hum of functioning lighting and climate units.",
+   "olfactory": "Clean filtered air, scrubbed of the colony's industrial baseline.",
+   "tactile": "Fresh sealant and functioning surfaces; even the air feels conditioned.",
+   "atmospheric": "The Central Span remains visible to the south."
+  }
+ },
+ "1023": {
+  "key": "North Marlowe Street",
+  "desc": "A medical facility occupies the western side, four levels marked with caduceus and corporate logos - private healthcare rather than colony clinics. The eastern side hosts professional offices, legal services and accounting firms managing colonial commerce. Street-level retail shows actual inventory in secured displays. The grating is newer composite, drainage systems that function. Pedestrian traffic moves with purpose.",
+  "sense_descs": {
+   "auditory": "Purposeful footfall on clean grating; the muted tone of a private medical lobby.",
+   "olfactory": "Antiseptic from the medical facility cut with filtered office air.",
+   "tactile": "Newer composite underfoot, drainage that actually carries the wet away."
+  }
+ },
+ "1026": {
+  "key": "North Marlowe Street",
+  "desc": "Residential towers rise six and seven levels, showing architectural ambition - curved facades, decorative panels, balconies suggesting space beyond survival. A small plaza opens on the western side with composite benches and deliberate landscaping.",
+  "sense_descs": {
+   "auditory": "Quiet enough that the plaza's landscaping rustles audibly.",
+   "olfactory": "Clean air with a green note off the deliberate landscaping.",
+   "tactile": "Composite benches and tended plantings; the street feels designed for lingering.",
+   "atmospheric": "Biometric checkpoints control access, keeping the working classes in their districts."
+  }
+ },
+ "1029": {
+  "key": "North Marlowe Street and Ada Avenue",
+  "desc": "The intersection opens where Ada Avenue cuts through the northern district's administrative core. The Thawn-Harrison Cryogenics complex sprawls across the northeast corner, structures that actually match rather than improvised expansion. West, Ada extends toward residential towers and professional services. East, the avenue connects to corporate facilities and the atmospheric processor approach.",
+  "sense_descs": {
+   "auditory": "The orderly quiet of the administrative core, checkpoint systems chiming as they process credentials.",
+   "olfactory": "Clean filtered air with the scentless cold off the cryogenics complex.",
+   "tactile": "Level, maintained grating; the conditioned air sits cool and even.",
+   "atmospheric": "Uniformed security and checkpoint systems mark the Thawn-Harrison corner."
+  }
+ },
+ "1032": {
+  "key": "North Marlowe Street",
+  "desc": "The Thawn-Harrison Cryogenics courtyard opens to the east, composite decking replacing standard grating. The facility's facade displays brushed composite panels and the corporate name in backlit letters. The western side shows construction barriers cordoning off what corporate signage promises will be cultural facilities. Street furniture includes actual benches and informational kiosks.",
+  "sense_descs": {
+   "auditory": "The low cycling of cryogenic systems behind the courtyard's facade.",
+   "olfactory": "Clean air with the faint scentless bite of cold off the cryogenics facility.",
+   "tactile": "Composite decking underfoot replaces standard grating, smooth and even.",
+   "atmospheric": "Overlapping security lighting leaves no shadows; the corporate name glows backlit above the courtyard."
+  }
+ },
+ "1035": {
+  "key": "North Marlowe Street",
+  "desc": "A transit hub occupies the western side with covered platforms, posted schedules, and functioning ticket kiosks. The eastern side shows luxury retail, storefronts displaying Earth imports most colonists will never afford.",
+  "sense_descs": {
+   "auditory": "Transit announcements and the hum of ticket kiosks under the covered platforms.",
+   "olfactory": "Clean filtered air, a faint trace of imported goods from the luxury storefronts.",
+   "tactile": "Covered platforms shelter the air, still and temperate."
+  }
+ },
+ "1038": {
+  "key": "North Marlowe Street",
+  "desc": "Corporate housing towers rise on both sides, eight and nine levels where bedrock foundation permits. The structures feature amenities that don't exist in working districts - climate control, water pressure, waste management that functions. Building signage lists corporate sponsors, company housing for management rather than labor.",
+  "sense_descs": {
+   "auditory": "The deep quiet of well-insulated corporate towers, climate systems barely audible.",
+   "olfactory": "Conditioned air, neutral and clean, the industrial colony scrubbed away.",
+   "tactile": "Everything works here - the air tempered, the surfaces maintained, no grit anywhere."
+  }
+ },
+ "1041": {
+  "key": "North Marlowe Street and Arcturus Row",
+  "desc": "The park opens where North Marlowe meets Arcturus Row along the crater wall's base, the intersection transformed into the northern district's most deliberate public space. Imported soil supports actual vegetation - ornamental rather than functional. Composite benches follow geometric patterns around a central fountain that functions more often than not. Arcturus Row extends east and west along the wall's base, connecting corporate facilities and secure residential districts. Marlowe descends toward the Central Span, visible in the distance as a reminder of what separates the north and south sides.",
+  "sense_descs": {
+   "auditory": "The central fountain cycles water; vegetation rustles in the deliberate quiet.",
+   "olfactory": "Imported soil and growing things, a rare green note in the colony.",
+   "tactile": "Composite benches and tended ground; cool air spills off the crater wall to the north.",
+   "atmospheric": "The crater wall rises dark to the north, its face interrupted by access tunnels leading beyond view."
+  }
+ },
+ "1044": {
+  "key": "Arcturus Row",
+  "desc": "Arcturus Row runs east along the crater wall, the park frontage giving way to secure residential. Curved facades and decorative panels face the dark stone, balconies suggesting space beyond survival. Biometric checkpoints mark the entrances.",
+  "sense_descs": {
+   "auditory": "The secure quiet of controlled-entrance residential.",
+   "olfactory": "Clean conditioned air with a fading green note off the park.",
+   "tactile": "Cool air off the crater wall; pristine composite underfoot.",
+   "atmospheric": "Biometric checkpoints mark the residential entrances along the wall."
+  }
+ },
+ "1047": {
+  "key": "Arcturus Row",
+  "desc": "The western end of Arcturus Row opens near the district's park, ornamental landscaping spilling along the crater wall's base. Composite benches follow the geometric paths; a fountain cycles somewhere east. The dark stone rises to the north, its face softened here by deliberate plantings.",
+  "sense_descs": {
+   "auditory": "A fountain cycling water nearby; ornamental plantings rustling in the deliberate quiet.",
+   "olfactory": "Imported soil and growing things, a rare green note against cold stone.",
+   "tactile": "Tended ground and composite benches; cool air spilling off the crater wall.",
+   "atmospheric": "The crater wall rises dark to the north, its base softened by deliberate landscaping."
+  }
+ },
+ "1053": {
+  "key": "Ada Avenue",
+  "desc": "Storage facilities line the avenue here, warehouses holding materials and equipment for the colony's industrial operations. Security varies by contents - some buildings show multiple lock systems and monitoring equipment, others apparently rely on the assumption that no one would want what's inside. The lighting grows more sparse, fixtures serving function over comfort. Pools of shadow stretch between the buildings, dark enough to hide intention.",
+  "sense_descs": {
+   "auditory": "Lock systems cycle and reset behind blank doors; a monitoring camera whirs as it tracks past.",
+   "olfactory": "Cold metal, machine oil, and the dry dust of crates that have sat sealed for a long time.",
+   "tactile": "The shadow between buildings holds a chill no fixture reaches into."
+  }
+ },
+ "1056": {
+  "key": "Tolliver Row",
+  "desc": "The northern side shows a marine supply depot, roll-up doors revealing stacked cable spools, deck plating, and equipment for channel vessels. The southern side rises in residential towers, four and five levels with better maintenance than industrial districts - fresh sealant, functioning mechanisms. The grating is newer composite, drainage systems that actually function. Street lighting includes decorative elements alongside functional fixtures.",
+  "sense_descs": {
+   "auditory": "Roll-up doors rumble at the marine depot; far off, water works steadily against the channel structures.",
+   "olfactory": "Salt air and the tar-and-cable smell of marine supply.",
+   "tactile": "Newer composite underfoot, drains that actually carry the wet away.",
+   "atmospheric": "The Central Span's navigation lights blink through the gaps in the structures."
+  }
+ },
+ "1059": {
+  "key": "Tolliver Row",
+  "desc": "The street runs straight east, industrial grating showing the wear patterns of constant cargo traffic moving between the channel and inland facilities. A freight consolidation yard occupies the northern side, chain-link fencing enclosing stacked shipping containers organized with enough deliberation to suggest active inventory management rather than abandonment. Forklifts move between the stacks with shift-change regularity, their operators navigating the narrow passages with the confidence that comes from years of repetition. The southern side shows mixed commercial use - a hydraulics repair shop, its bay doors open to reveal machinery in various states of disassembly, and a parts supplier, composite shelving visible through reinforced viewports stacked with equipment that serves the waterfront's operational demands.",
+  "sense_descs": {
+   "auditory": "Forklifts beep and rumble between the container stacks; bay doors clatter at the hydraulics shop.",
+   "olfactory": "Salt, diesel, and hydraulic fluid.",
+   "tactile": "The grating is worn into cargo-traffic ruts underfoot."
+  }
+ },
+ "1062": {
+  "key": "Tolliver Row",
+  "desc": "Faded block lettering declares the bunker on the northern side the |510Colony Armory|n, its reinforced facade marked with weapon inspection protocols posted in multiple languages. The southern side continues the waterfront theme with composite benches facing the channel, safety railings showing wear from constant contact with salt air. A small vendor cart sits abandoned between shifts, its wheels locked, tarp secured against wind. The grating here shows pedestrian wear rather than hauler tracks, foot traffic having polished the composite to a softer sheen.",
+  "sense_descs": {
+   "auditory": "The channel laps steadily past the safety railings; the abandoned cart's tarp snaps in the wind.",
+   "olfactory": "Salt air with gun-oil drifting from the armory's vents.",
+   "tactile": "Foot traffic has polished the composite grating to a softer, smoother sheen."
+  }
+ },
+ "1065": {
+  "key": "Tolliver Row",
+  "desc": "A public information kiosk stands on the northern side, its digital display cycling through colony announcements and service advisories, the screen cracked but functional. The southern side continues the waterfront theme with composite benches facing the channel, safety railings showing wear from constant contact with salt air. A small vendor cart sits abandoned between shifts, its wheels locked, tarp secured against wind. The grating here shows pedestrian wear rather than hauler tracks, foot traffic having polished the composite to a softer sheen.",
+  "sense_descs": {
+   "auditory": "The kiosk buzzes faintly through its cracked screen; the channel laps past the railings.",
+   "olfactory": "Salt air and the mineral scent of the channel.",
+   "tactile": "Foot traffic has polished the composite grating to a softer sheen."
+  }
+ },
+ "1068": {
+  "key": "Tolliver Row",
+  "desc": "A maintenance depot dominates the northern side, its composite walls showing the kind of upkeep that suggests corporate backing rather than independent operation. Roll-up doors are stenciled with equipment codes and maintenance schedules, their surfaces clean enough to suggest someone cares about appearances. The southern structures house a marine equipment supplier on ground level, with residential units stacked above - two and three story modules connected by external staircases, their viewports showing the glow of habitation.",
+  "sense_descs": {
+   "auditory": "The depot's roll-up doors cycle on a schedule; residential murmur drifts down from the stacked modules.",
+   "olfactory": "Clean machine oil and salt air.",
+   "tactile": "The depot keeps its walls clean; even the grating feels maintained here."
+  }
+ },
+ "1071": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor narrows further here where construction has happened without coordination, each structure claiming space until the street between them barely accommodates two people walking abreast. The eastern side shows evidence of multiple building phases - composite panels in three different shades marking additions that happened whenever someone scraped together enough materials. The western structures have carved deeper into the crater wall, rock face visible through gaps in the composite where someone decided covering everything was optional.",
+  "sense_descs": {
+   "auditory": "Voices carry close in the pinched space, neighbors audible through thin composite.",
+   "olfactory": "Rock dust and the stale closeness of crowded dwellings.",
+   "tactile": "The street barely fits two abreast; the walls press in on both sides."
+  }
+ },
+ "1074": {
+  "key": "Bhavani Corridor",
+  "desc": "Prefab structures rise five and sometimes six levels here, their construction showing the vertical desperation of populations needing space in a colony that stopped expanding outward decades ago. The western side presses against the crater wall with enough force that stress fractures radiate from the connection points, composite panels bowing slightly under loads they protest but haven't quite refused.",
+  "sense_descs": {
+   "auditory": "The structures creak as their upper levels lean and settle against each other.",
+   "olfactory": "Stale trapped air, cooking and bodies layered under rock dust.",
+   "tactile": "The air hangs close and still beneath the canopy of leaning upper floors.",
+   "atmospheric": "The eastern structures lean into each other overhead, blocking what little light filters from above."
+  }
+ },
+ "1077": {
+  "key": "Pessoa Street and Bhavani Corridor",
+  "desc": "The intersection sprawls where Pessoa Street cuts across Bhavani, grating worn from industrial traffic mixing with residential transit. The crater wall presses close, limiting western approach and concentrating flow through remaining routes. Pessoa extends toward refineries and processing plants. The street climbs through districts transitioning from edge-colony survival to maintained infrastructure. The intersection shows neglect fighting maintenance to a draw - some grating replaced within recent years, composite a slightly different shade, while others show stress fractures. Prefab structures press close on all sides, rising four and five levels in questionable configurations.",
+  "sense_descs": {
+   "auditory": "Industrial transit grinds against residential foot traffic through the confluence.",
+   "olfactory": "Industrial haze drifts through from the refineries, chemical and warm.",
+   "tactile": "The crater wall presses close west; mismatched grating shifts underfoot.",
+   "atmospheric": "Refinery haze drifts through the intersection at shift change."
+  }
+ },
+ "1080": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor widens slightly here, though not from design - the eastern structures have collapsed or been demolished at some point, leaving a gap filled with smaller prefab modules arranged in a configuration that suggests temporary became permanent decades ago. These newer structures sit lower than their surroundings, their rooflines creating an uneven skyline like a mouth with missing teeth. The western side maintains its press against the crater wall, but here someone has cut into the rock face itself, creating alcoves that house storage units or possibly living spaces, the entrances secured with composite panels and heavy locks.",
+  "sense_descs": {
+   "auditory": "The open gap swallows sound; footsteps echo oddly off the lower rooflines.",
+   "olfactory": "Rock dust and the chemical seal of locked storage alcoves.",
+   "tactile": "The uneven skyline lets a thread of cooler crater air settle into the gap."
+  }
+ },
+ "1083": {
+  "key": "Bhavani Corridor",
+  "desc": "Prefab structures on both sides show the accumulated modifications of populations finding ways to squeeze more life from limited space - balconies extended without permits, viewports cut into walls that weren't designed for them, external storage cages welded to frameworks that protest the additional weight with visible stress fractures. The eastern side rises five levels in places, each floor showing slightly different construction methods. The western structures press against the crater wall, their foundations built into the rock face itself.",
+  "sense_descs": {
+   "auditory": "External storage cages creak against their welds; residential murmur stacks floor on floor.",
+   "olfactory": "Trapped cooking smells and the mineral cold of rock foundations.",
+   "tactile": "The colony seems to hold up the wall and be crushed by it at once; the air is thick and close."
+  }
+ },
+ "1086": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor narrows here where prefab structures press close on both sides, rising four and sometimes five levels in configurations approved by necessity rather than engineering review. The eastern structures show more uniformity, suggesting they were part of some original plan before improvisation became the default. The western side follows the crater wall's curve, buildings cantilevered over the street on supports. The grating here shows foot traffic exclusively, the wear pattern suggesting thousands of daily transits.",
+  "sense_descs": {
+   "auditory": "Thousands of daily footfalls murmur constant through the pinched corridor.",
+   "olfactory": "Close residential air, rock dust, and old cooking oil.",
+   "tactile": "The grating is worn smooth by foot traffic alone.",
+   "atmospheric": "Western buildings cantilever over the street, a perpetual sense of being beneath something waiting to fall."
+  }
+ },
+ "1089": {
+  "key": "Volta Street and Bhavani Corridor",
+  "desc": "The intersection opens where Volta Street extends east from Bhavani through the colony's western residential districts, the crater wall dominating the western horizon beyond the immediate prefab structures. To the east, Volta extends through territories that house the colony's working class - synthetic laborers, human shift workers, the populations that keep the waterfront and processor operations running. Prefab structures rise three and four levels on the eastern sides. The western side presses against the crater's curve, structures built into the wall itself. The intersection itself sees regular maintenance - directional paint refreshed often enough to remain legible, drainage grates that actually function.",
+  "sense_descs": {
+   "auditory": "Predictable daily foot traffic moving between work and home.",
+   "olfactory": "Close residential air, cooking and rock dust.",
+   "tactile": "The crater's curve presses from the west; drainage grates that actually function underfoot.",
+   "atmospheric": "Prefab structures rise three and four levels east, the crater wall built into the west."
+  }
+ },
+ "1092": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor descends through residential territory, prefab structures pressing close with density that speaks to populations arriving after planning stopped. A flickering neon sign on the remnants of a scuttled ship to the east declares |MThe Hub and Howl|n, operating from its converted orbital hangar - viewport turned serving counter, cooking heat routed up jury-rigged ductwork. Western structures show more modification - balconies added at second and third levels without engineering approval, composite platforms cantilevered on supports that look adequate until you consider the load calculations.",
+  "sense_descs": {
+   "auditory": "The clatter and murmur of The Hub and Howl's serving counter; exhaust fans push cooking heat up improvised ductwork.",
+   "olfactory": "Protein cooking in recycled oil dominates, cut with the chemical tang of liberally applied cleaning agents.",
+   "tactile": "Warmth and grease haze the air near the converted ship.",
+   "atmospheric": "Steam vents through improvised exhaust routing, fogging the neon sign."
+  }
+ },
+ "1095": {
+  "key": "Bhavani Corridor",
+  "desc": "Residential density increases here, prefab structures rising three and four levels on both sides, their vertical growth speaking to space constraints and populations that need housing more than comfort. External staircases zigzag up the western structures, composite treads showing wear patterns that map daily routines. The grating shows less hauler traffic here, more the wear of foot traffic moving with routine purpose - morning commutes, evening returns, the predictable flows of people tied to shifts and schedules.",
+  "sense_descs": {
+   "auditory": "Footfall rises and falls on the external staircases, mapping the shift hours.",
+   "olfactory": "Detergent and damp fabric off the strung laundry, cooking underneath.",
+   "tactile": "The grating shows foot-traffic wear, smooth under routine daily transit.",
+   "atmospheric": "Laundry hangs from improvised lines between buildings, marking wind direction and humidity."
+  }
+ },
+ "1098": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor descends from the waterfront intersection, the grating sloping enough that drainage becomes deliberate - water channeled south away from the channel operations toward collection systems that service the residential blocks below. Prefab structures rise on both sides, their construction showing the transition from commercial to mixed-use - ground floors with roll-up doors, upper levels with residential viewports marked by accumulated personalization. A loading bay occupies the eastern side, its platform level with hauler beds, composite decking scored from years of cargo. The bay's security shutter shows fresh maintenance, new hydraulics installed within recent months.",
+  "sense_descs": {
+   "auditory": "Water trickles down the sloped grating toward the collection systems; a loading bay's fresh hydraulics cycle.",
+   "olfactory": "Channel damp gives way to the closer smell of residential blocks.",
+   "tactile": "The grating slopes underfoot, drainage channeled deliberately south."
+  }
+ },
+ "1101": {
+  "key": "Maxwell Street and Bhavani Corridor",
+  "desc": "The intersection sprawls where Bhavani cuts south through the colony's western districts, grating worn from cross-traffic between waterfront commerce and residential sprawl inland. The Balboa Channel dominates north, dark water moving with relentless current that has defined this waterfront since founding, safety barriers showing decades of corrosion and impact damage. Bhavani descends through districts transitioning from waterfront operations to edge-colony improvisation. The intersection shows regular maintenance - reinforced grating at the confluence, directional paint refreshed within the last year.",
+  "sense_descs": {
+   "auditory": "The channel's current works past corroded barriers to the north.",
+   "olfactory": "Channel brine giving way to the inland smell of residential sprawl.",
+   "tactile": "Cool damp comes off the channel north; reinforced grating at the confluence.",
+   "atmospheric": "The Central Span rises to the northeast, framework and navigation lights anchoring the channel's scale."
+  }
+ },
+ "1104": {
+  "key": "Braddock Avenue",
+  "desc": "Housing clusters both sides, prefab in better repair than the western edge but still utilitarian — reinforced doors, barred ground-level windows, the architecture of people who work hard and sleep harder. South, the crater wall stays close, dark stone a reminder that warmth is not safety. The grating radiates enough heat to shimmer the air.",
+  "sense_descs": {
+   "olfactory": "The radiant grating amplifies every industrial smell from above — hot metal, machine oil, processed air.",
+   "auditory": "The colony's working hum presses up through the warm grating; the crater stone deadens it from the south.",
+   "tactile": "Heat rises off the grating, shimmering the air; step toward the wall and the cold stone takes it back.",
+   "atmospheric": "Warmth here only means a different set of problems to manage."
+  }
+ },
+ "1107": {
+  "key": "Braddock Avenue",
+  "desc": "The street narrows where massive industrial conduits run overhead — water, coolant, waste, whatever the processor is moving this week — dripping intermittently, staining the grating dark in patches that never dry. Construction supplies sit stacked against the southern wall, composite panels still in their packaging, bound for an expansion that might come next year or never.",
+  "sense_descs": {
+   "olfactory": "A processed chemical tang beneath the metallic warmth, something artificial that coats the back of the throat.",
+   "auditory": "The overhead conduits drip and tick; the colony's working heart pulses steady from the north.",
+   "tactile": "Warm and damp under the dripping pipes; chemical-laced moisture beads on the conduit runs."
+  }
+ },
+ "1110": {
+  "key": "Braddock Avenue",
+  "desc": "A repair bay holds the north, its roll-up door permanently stuck at half-mast over the skeletal frames of mining equipment in disassembly. The tools are old but functional, repaired so many times the manufacturer wouldn't know them. Welding scorch-marks pattern walls and floor in abstract constellations. Beside the bay, calculations scratch into the crater wall — load ratings or shift schedules or gambling debts in permanent graffiti.",
+  "sense_descs": {
+   "olfactory": "Hot welding-ozone, scorched metal, and machine-oil, thick in the trapped warmth.",
+   "auditory": "From the bay, the ring and hiss and spark of repair work; the processor's heat-laden hum collects here.",
+   "tactile": "The warmth is almost oppressive, the processor's radiant heat pooling in the narrow stretch."
+  }
+ },
+ "1116": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue opens where a loading platform juts from the northern wall, its surface ghosted with decades of spilled cargo — ore dust, hydraulic fluid, something organic scrubbed away but discoloring the metal still. Empty pallets stack in precarious towers against the crater wall; a cargo dolly lies on its side, one wheel gone, sitting exactly where it fell.",
+  "sense_descs": {
+   "olfactory": "Ore dust and hydraulic fluid worked into the platform metal, over the processor's hot breath.",
+   "auditory": "The processor's rhythmic mechanical breathing is the constant backdrop now, the colony's smaller sounds beneath it.",
+   "tactile": "The heat intensifies with each step east, the processor felt more than seen."
+  }
+ },
+ "1119": {
+  "key": "Braddock Avenue",
+  "desc": "Housing dominates both sides, prefab stacked two-high where someone trusted the foundation. Exterior ladders connect the levels, rungs worn smooth. Windows show long habitation — patched thermal sheeting, cargo-wrap curtains, the occasional actual plant struggling in some soil-substitute. The grating's been swept recently, debris pushed into the corners.",
+  "sense_descs": {
+   "olfactory": "Cooking nearby — cumin and chili powder cutting clean through the metallic warmth.",
+   "auditory": "Domestic sounds leak from the stacked windows; the processor's warm hum underlies it all.",
+   "tactile": "The metallic warmth saturates everything this close to the processor; the swept grating is gritless underfoot.",
+   "atmospheric": "Lived-in and holding — plants and patched curtains against the metal."
+  }
+ },
+ "1122": {
+  "key": "Braddock Avenue",
+  "desc": "The street narrows where support columns rise floor to ceiling, reinforcement added when someone decided the weight above needed better distribution. The columns carry the usual strata — official safety markings under graffiti under protective symbols, rust bleeding through all of it. A water-reclamation unit sits against the north wall, condensation pooling where its seals have degraded past caring.",
+  "sense_descs": {
+   "olfactory": "Processed, over-recycled air, thick and faintly stale, the chemical edge of reclaimed water.",
+   "auditory": "Somewhere above, metal groans under thermal expansion — the colony's skeleton adjusting; the reclamation unit gurgles.",
+   "tactile": "The heat is on the skin now, the air thick with the quality of being breathed too many times."
+  }
+ },
+ "1125": {
+  "key": "Braddock Avenue",
+  "desc": "The crater wall begins to curve away, opening more space than the western stretches allowed. Someone has claimed it for storage — shipping containers stacked into a maze of narrow corrugated passages, labeled in faded corporate serial codes that once meant something. A few have cut-out doors and welded ventilation, suggesting habitation or workshop or both.",
+  "sense_descs": {
+   "olfactory": "Metallic warmth and cold steel, the breath of industrial infrastructure half-maintained.",
+   "auditory": "Sound bends and doubles through the container maze; the processor hums warm beyond it.",
+   "tactile": "Warm but not uncomfortable here; the corrugated walls hold the day's radiant heat.",
+   "atmospheric": "A box-maze of kept things — storage drifting into shelter."
+  }
+ },
+ "1128": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue straightens along the crater wall's retreat. Industrial light fixtures hang overhead at irregular intervals, most dark, their power long since redistributed to more critical systems. A power-junction box sits exposed on the north wall, cover gone, baring a nest of cables color-coded to a system that predates current standards. The grating shows the wear of regular equipment throughput.",
+  "sense_descs": {
+   "olfactory": "Hot insulation and dust, the dry electrical smell of the exposed junction.",
+   "auditory": "The colony's infrastructure is clearer here — the constant hum and clank of systems working just hard enough to keep functioning.",
+   "tactile": "Steady metallic warmth; the exposed junction throws a little extra heat from the north wall."
+  }
+ },
+ "1131": {
+  "key": "Braddock Avenue",
+  "desc": "A ventilation grate dominates the north wall, its mesh caked with decades of particulates, the fan blades beyond turning with a squeak that says the bearings went years ago. Empty crates stack against the crater wall, their purpose forgotten. Overhead, conduit and cabling snake along the ceiling in configurations that read as organic growth — additions made whenever need arose.",
+  "sense_descs": {
+   "olfactory": "The fan pushes machine-shop and industrial-processing smells down in sluggish currents — hot metal and solvent.",
+   "auditory": "The ventilation fan squeaks on its rhythm; air moves in slow, audible currents.",
+   "tactile": "Sluggish warm air pushes past from the fan; the metal stays tepid.",
+   "atmospheric": "A pass-through, not a place — a connection between somewheres."
+  }
+ },
+ "1134": {
+  "key": "Braddock Avenue",
+  "desc": "The avenue straightens and widens toward Spillane Corridor east, the intersection visible ahead where the colony's easternmost corridor cuts north toward the processor. The crater wall continues its southward retreat into an almost unsettling openness. The grating here is newer, or better kept — Spillane's approach sees more official attention. Utility access panels line the north wall, covers intact, stenciled with warnings that follow current standards.",
+  "sense_descs": {
+   "olfactory": "Hot metal and ozone, the processor's waste heat more deliberate here, almost clean.",
+   "auditory": "The processor's working hum is close and clear; the grid's newer fixtures buzz steadily overhead.",
+   "tactile": "The metallic warmth feels intentional here — the processor's waste heat, not accident, radiating off the new grating.",
+   "atmospheric": "Braddock's orderly eastern end, where the colony starts paying attention again."
+  }
+ },
+ "1137": {
+  "key": "Braddock Avenue and Spillane Corridor",
+  "desc": "The intersection sits at the southeastern corner of the colony, where Spillane Corridor cuts north through the industrial districts toward the atmospheric processor. The grating underfoot is industrial-grade reinforced composite, built to handle the moisture that seeps up from below. To the north, Spillane extends toward the colony's industrial heart. South, the crater wall curves away, offering more space than Braddock has known for most of its length.",
+  "sense_descs": {
+   "auditory": "The spillway murmurs constant beneath the grating, water moving between the channel and the filtration complex.",
+   "olfactory": "Minerals and distance-processed chemistry on warm air.",
+   "tactile": "Condensation makes every surface slick; the grating hums faintly with the water below.",
+   "atmospheric": "Functional utility lighting paints everything institutional yellow."
+  }
+ },
+ "1140": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor runs straight north, wider than the typical street, built to accommodate heavy equipment and the infrastructure beneath the grating. Emergency lighting fixtures line both walls at regular intervals, their institutional yellow glow giving the corridor the feel of corporate maintenance access rather than public thoroughfare. Prefab modules cluster on the eastern side, their walls showing better maintenance than most of Braddock - fresh welds, functional door seals. To the west, utility access panels are stenciled with maintenance codes and pressure ratings, each one a reminder that this corridor exists to serve the water system first, pedestrians second.",
+  "sense_descs": {
+   "auditory": "The spillway's hydraulic murmur runs constant beneath everything, the baseline the rest builds on.",
+   "olfactory": "Warm mineral water and wet composite.",
+   "tactile": "Warmth and moisture in equal measure leave everything faintly damp.",
+   "atmospheric": "Yellow emergency lighting marches the corridor's length in even intervals."
+  }
+ },
+ "1143": {
+  "key": "Spillane Corridor",
+  "desc": "A maintenance alcove cuts into the western wall here, its depth suggesting this was once meant for equipment storage or emergency access. Now it holds the usual accumulation - empty chemical drums stacked three high, coiled hose with couplings that don't match current fittings, a hand truck with one wheel missing. Someone has spray-painted flow-direction arrows on the grating, bright orange pointing north. Mineral staining patterns every vertical surface in abstract geography.",
+  "sense_descs": {
+   "auditory": "The spillway's passage intensifies here through some acoustic quirk; condensation drips from pipe junctions with rhythmic persistence.",
+   "olfactory": "Mineral wet and the chemical ghost of empty drums.",
+   "tactile": "Condensation beads cold on every vertical surface."
+  }
+ },
+ "1146": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor widens slightly here where structural supports brace the eastern wall, heavy-gauge composite beams bolted at angles that speak to engineering concern rather than aesthetic choice. Between the supports, someone has stacked rolls of insulation material wrapped in deteriorating plastic, layers of thermal foam visible through splits in the covering. A pressure gauge juts from the western wall at chest height, its needle hovering in the green zone, the glass face cracked but still readable.",
+  "sense_descs": {
+   "auditory": "The spillway murmurs steadily below; insulation plastic crackles when the air moves.",
+   "olfactory": "Damp thermal foam and mineral water.",
+   "tactile": "The grating is polished by heavy equipment passage, slick where treads have worn it.",
+   "atmospheric": "The worn composite catches the yellow emergency lighting in unexpected ways."
+  }
+ },
+ "1149": {
+  "key": "Kaspar Street and Spillane Corridor",
+  "desc": "The intersection opens where Kaspar Street crosses the Spillane, the confluence marked by wider grating and reinforced support columns that speak to the engineering demands of bearing both street traffic and the spillway infrastructure below. To the east and west, Kaspar extends through the colony's working districts, its character caught between Braddock's raw industry to the south and the relative order of the northern streets. North, the corridor continues its climb toward the processor, the path ahead showing worn grating and fresh maintenance marks.",
+  "sense_descs": {
+   "auditory": "The hydraulic murmur is louder here, the crossing channels amplifying it into a low-frequency resonance.",
+   "olfactory": "Warm mineral water and wet composite.",
+   "tactile": "The resonance carries up through the grating; the air hangs humid and close.",
+   "atmospheric": "The spillway's moisture haze diffuses the yellow emergency lighting into soft halos."
+  }
+ },
+ "1152": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor narrows slightly past the intersection, utility conduits running overhead in parallel lines that channel processor runoff toward distant filtration systems. Handrails bolted at intervals along both sides show the ghostly outlines where hazard tape once marked them, adhesive residue collecting dust. The grating shows two parallel tracks worn into its surface where equipment wheels have polished the composite to a dull shine. North, the yellow emergency lighting continues its institutional march toward the processor.",
+  "sense_descs": {
+   "auditory": "The spillway takes on a purposeful rush here, water moving with direction and intent.",
+   "olfactory": "Something acrid cuts through the mineral and moisture, a slow leak from a cracked junction seal.",
+   "tactile": "Polished tracks run worn smooth into the grating underfoot."
+  }
+ },
+ "1155": {
+  "key": "Spillane Corridor",
+  "desc": "A junction box the size of a shipping crate dominates the eastern wall, its access panel secured with a lock that has been replaced multiple times - the mounting holes showing the archaeology of different security systems, each generation more paranoid than the last. Warning placards in three languages cover the box's surface, their symbols ranging in tone from bureaucratic to threatening. Condensation runs in continuous streams down both walls, following paths worn into the composite by years of the same water taking the same route to the floor drains.",
+  "sense_descs": {
+   "auditory": "The spillway builds from rush to roar here; something inside the junction box hums at a frequency that sits low and constant.",
+   "olfactory": "Mineral wet and the faint ozone of heavy power loads.",
+   "tactile": "Condensation streams cold down both walls; the junction box's vibration carries through the floor."
+  }
+ },
+ "1158": {
+  "key": "Spillane Corridor",
+  "desc": "The western wall here has been cut away and patched multiple times, a patchwork of different composite materials where someone fixed structural damage or upgraded systems without caring about aesthetic consistency. A cable tray runs along the ceiling, sagging under decades of additions, zip ties and improvised brackets holding newer lines alongside originals that still technically function.",
+  "sense_descs": {
+   "auditory": "The spillway's roar turns almost conversational here, rhythmic enough to parse for patterns that aren't there.",
+   "olfactory": "Hot mineral steam and wet metal.",
+   "tactile": "Heat radiates up through the grating in waves, mixing with moisture into air thick enough to move through.",
+   "atmospheric": "Emergency lights flicker intermittently, dying ballasts strobing the corridor unstable."
+  }
+ },
+ "1161": {
+  "key": "Pessoa Street and Spillane Corridor",
+  "desc": "The intersection sprawls where Pessoa Street cuts across the Spillane, the space marked by heavier reinforcement than Kaspar - thicker support beams, doubled grating sections, the kind of overengineering that suggests someone learned expensive lessons here. To the west, Pessoa extends through districts that handle the colony's heavier industrial work - refineries, processing plants that need proximity to both the channel and the processor.",
+  "sense_descs": {
+   "auditory": "The spillway's roar bounces off the wider walls, dead zones dropping to near-silence before crashing back at full volume two steps later.",
+   "olfactory": "Mineral water cut with refinery chemistry, sharp and warm.",
+   "tactile": "Steam vents puncture the grating in hissing bursts, leaving temporary clearings in the moisture.",
+   "atmospheric": "Half the yellow emergency fixtures are dark or browning out, pooling the intersection with shadow."
+  }
+ },
+ "1164": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor straightens here, the walls showing scorch marks from some incident or maybe just accumulated heat damage from decades of thermal cycling. An emergency shutoff valve protrudes from the western wall, its wheel painted in warning stripes faded to barely-there suggestions. Equipment tracks in the floor show recent passage - fresh scrapes in the composite where something heavy dragged against resistance. Overhead, the cable trays multiply, layers of conduit suggesting this section feeds multiple systems near the atmospheric processor.",
+  "sense_descs": {
+   "auditory": "The spillway's roar settles back to baseline past the Pessoa confluence, but louder now, more present.",
+   "olfactory": "Scorched composite and hot mineral water.",
+   "tactile": "Heat lingers in the scorched walls; the floor shows fresh drag scrapes."
+  }
+ },
+ "1167": {
+  "key": "Spillane Corridor",
+  "desc": "A thermal expansion joint cuts across the corridor here, the gap bridged by interlocking plates that allow the structure to shift without tearing itself apart. The plates show wear at their edges, metal ground against metal for years until the surfaces have taken on a mirror polish. Someone has wedged rubber matting into the gaps, already cracking from constant thermal cycling. Prefab modules line the eastern wall, their foundations sitting at slightly different heights, connected by makeshift ramps welded from scrap.",
+  "sense_descs": {
+   "auditory": "The spillway changes pitch where the joint crosses, a harmonic with no steady center.",
+   "olfactory": "Hot metal and cracked rubber matting.",
+   "tactile": "The mirror-polished joint plates are slick; the matting gives unevenly underfoot.",
+   "atmospheric": "Yellow emergency lighting reflects off the polished joints in bright dividing lines."
+  }
+ },
+ "1170": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor begins to angle slightly here, following structural logic that has more to do with the processor's foundation than surface-level planning. Massive conduits emerge from the western wall and run exposed across the ceiling, their diameter suggesting they carry primary feeds - water, power, data, the essential flows that keep the processor operational. Heat has begun to warp some of the wall panels, creating slight bulges where the composite has softened and reformed.",
+  "sense_descs": {
+   "auditory": "The spillway reaches a crescendo here, no longer distinguishable as water but pure sustained hydraulic roar.",
+   "olfactory": "Hot composite and heavy mineral steam.",
+   "tactile": "The roar resonates through the grating; heat radiates from the warped, bulging wall panels."
+  }
+ },
+ "1173": {
+  "key": "Spillane Corridor",
+  "desc": "A massive reinforced bulkhead dominates the western wall here, its surface marked with corporate logos weathered to abstract patterns and shift schedules spray-painted over decades of worker traffic. The door stands sealed between shifts, a status indicator above the frame cycling between red and amber. Biometric scanners flank the entrance, their interfaces worn smooth by thousands of daily authentications. Workers pass through here in shifts, heading down to the ice mines beneath the processor or returning with the bone-deep cold that takes hours to shake.",
+  "sense_descs": {
+   "auditory": "The spillway's roar echoes from the north, the water passing through toward the Balboa Channel.",
+   "olfactory": "Hot metal overlaid with a thread of deep cold venting off returning ice-mine crews.",
+   "tactile": "Heat radiates constant but manageable from the bulkhead, just another layer of warmth.",
+   "atmospheric": "The door's status indicator cycles red to amber above the worn biometric scanners."
+  }
+ },
+ "1176": {
+  "key": "Spillane Corridor",
+  "desc": "A series of viewport panels are set into the eastern wall at irregular intervals, their armored glass offering glimpses into prefab structures built directly against the corridor - workshops, storage spaces, the kind of commercial squat that happens when proximity to infrastructure matters more than official permission. Cable runs snake along both walls at waist height, newer additions zip-tied to older infrastructure in organic tangles that suggest decades of improvised power distribution. The yellow emergency lighting continues its march north, supplemented by jury-rigged fixtures.",
+  "sense_descs": {
+   "auditory": "The spillway maintains its roar, channeled beneath at full force.",
+   "olfactory": "Wet mineral air and the warm-dust smell of crowded prefab squats.",
+   "tactile": "The hydraulic force registers as a constant low-frequency pressure through the grating."
+  }
+ },
+ "1179": {
+  "key": "Spillane Corridor",
+  "desc": "The corridor widens here where a loading zone has been carved into the eastern wall, the space designated by faded floor markings that still guide foot traffic out of habit. Cargo pallets sit stacked against the wall in deliberate configurations, staging areas for goods moving through at regular intervals. Tie-down points stud the floor at measured intervals, their bolts showing fresh wear. Overhead, a section of ceiling panels has been removed for access, exposing raw infrastructure - water pipes, electrical conduits, structural supports in cross-section.",
+  "sense_descs": {
+   "auditory": "The spillway echoes strangely in the expanded space, overlapping harmonics blurring any sense of distance.",
+   "olfactory": "Mineral wet and machine oil off the staged cargo.",
+   "tactile": "A steady hydraulic vibration carries up through the widened floor."
+  }
+ },
+ "1182": {
+  "key": "Spillane Corridor",
+  "desc": "The eastern wall shows signs of constant dampness - composite panels stained in abstract patterns where condensation has run for years, algae or something similar growing in the protected corners where cleaning is theoretical at best. A heavy drainage channel cuts diagonally across the corridor, its grating reinforced to handle overflow from the systems ahead, the metal slick enough that crossing requires attention.",
+  "sense_descs": {
+   "auditory": "The spillway's roar gains an edge here, approaching some transition, its force no longer content to stay beneath the surface.",
+   "olfactory": "A sharp mineral scent rides the rising mist and coats everything.",
+   "tactile": "The grating vibrates with increasing intensity; mist rises through it in tendrils, leaving a fine film of moisture.",
+   "atmospheric": "Mist curls up through the grating in visible tendrils, hazing the corridor."
+  }
+ },
+ "1185": {
+  "key": "Maxwell Street and Spillane Corridor",
+  "desc": "The intersection opens into something larger than the engineering suggested - not a street crossing but a threshold where the spillway's entire journey culminates in a waterfall that plunges into the Balboa Channel below. The grating here is reinforced to the point of overkill, industrial composite layered over structural beams that speak to both weight and vibration. Safety railings line the northern edge where the street drops away.",
+  "sense_descs": {
+   "auditory": "The roar is omnipresent here, total but not overwhelming, the kind of sound that makes silence a foreign concept.",
+   "olfactory": "Cold mineral spray and channel water.",
+   "tactile": "The metal trembles constantly from the hydraulic thunder beneath; the railings run slick with perpetual mist.",
+   "atmospheric": "Mist rises from the channel's depths in shifting curtains where the waterfall plunges."
+  }
+ },
+ "1188": {
+  "key": "Maxwell Street",
+  "desc": "A bunkhouse dominates the south, four levels of narrow viewports built for function over comfort, external fire escapes zigzagging up the eastern face. Laundry hangs from lines strung between the landings. North, a ground-level commissary advertises hot meals and cold-storage rental by hand-painted sign. The Central Span dominates the northern view now, navigation lights steady against the channel's sprawl.",
+  "sense_descs": {
+   "olfactory": "Channel damp, frozen laundry, and the cooking-smell leaking from the commissary.",
+   "auditory": "The channel's steady wash carries from the north; the fire escapes tick and flex in the damp.",
+   "tactile": "Damp settles into everything; the metal landings are cold and beaded with moisture."
+  }
+ },
+ "1191": {
+  "key": "Maxwell Street",
+  "desc": "A power substation fills the south behind chain-link and multilingual warnings, transformers in orderly rows. Amber warning strobes pulse at the fence corners, catching moisture into brief halos. North, a sealed marine supply depot, cable spools and hardware visible through grimy viewports. Overhead cabling webs denser here, power lines branching to feed the substation.",
+  "sense_descs": {
+   "olfactory": "Ozone off the transformers, sharp over the channel's mineral damp.",
+   "auditory": "The transformers hum low — a high-voltage thrum felt through the grating more than heard.",
+   "tactile": "The substation's hum buzzes faintly up through the soles; mist beads in the strobe-light.",
+   "atmospheric": "Raw power fenced and warned, humming behind the wire."
+  }
+ },
+ "1194": {
+  "key": "Maxwell Street and Riveter's Way",
+  "desc": "The intersection sprawls where Riveter's Way cuts through the colony's industrial spine, the confluence marked by reinforced grating rated for constant heavy traffic and the weight of machinery that defines this district. To the west, Maxwell Street climbs toward the Central Span, its lights marking the threshold of crossing. South, the way descends toward one of the atmospheric processor's primary entrances, the street lined with shift markers and worker facilities. The processor wall dominates the southern horizon, its entrance infrastructure resolving into bulkheads and security checkpoints.",
+  "sense_descs": {
+   "auditory": "Heavy machinery traffic grinds through; the processor's roar builds from the south.",
+   "olfactory": "Machine oil, ozone, and the hot-metal baseline of the processor.",
+   "tactile": "Heat radiates from the processor wall south; reinforced grating handles the weight underfoot.",
+   "atmospheric": "The processor wall dominates the southern horizon, an industrial cathedral where colony becomes machine."
+  }
+ },
+ "1197": {
+  "key": "Maxwell Street",
+  "desc": "The processor wall shows heavier use here — access panels fresh-scratched around their seals, the kind of attention that means regular intervention. A faded loading zone marks the north, tie-down points studding the grating, worn smooth from countless securing cycles. The prefab has an almost official quality: uniform modules, proper seals, navigation numbers stenciled on the walls.",
+  "sense_descs": {
+   "olfactory": "Hot metal and ozone off the processor wall, under the channel's damp.",
+   "auditory": "The processor's mass swallows sound from the south; access-panel seals tick as the wall works.",
+   "tactile": "The processor wall radiates a dry heat that holds the mist back along the south."
+  }
+ },
+ "1200": {
+  "key": "Maxwell Street",
+  "desc": "The processor wall keeps its presence to the south — an unbroken composite expanse that swallows sound and gives nothing back. A thermal exhaust duct bleeds hot air through a mineral-caked grill, drying a warm zone into the grating. Someone has wedged a broken pallet against the northern prefabs into a bench, the wood gone dark with damp. Overhead, cracking insulation peels in strips, baring copper gone green.",
+  "sense_descs": {
+   "olfactory": "Hot ducted air and damp wood, with the dry-metal smell of the dead wall.",
+   "auditory": "The exhaust duct sighs hot air; otherwise the wall eats every sound from the south.",
+   "tactile": "The exhaust duct's warm zone never holds moisture; step off it and the damp returns."
+  }
+ },
+ "1203": {
+  "key": "Maxwell Street",
+  "desc": "A pressure-relief valve juts from the processor wall at head height, brass fittings oxidized green, its release pipe angled down to vent condensation that's built mineral stalactites on the grating below. The northern prefab has consolidated into something deliberate — modules welded with real intent, the roofline overhanging into a catch basin still maintained. The street is a mosaic of repair patches, each a slightly different shade.",
+  "sense_descs": {
+   "olfactory": "Wet mineral deposits and oxidized brass, sharp and metallic.",
+   "auditory": "The relief valve vents in slow drips and hisses; condensation ticks off the stalactites.",
+   "tactile": "Damp and cold under the dripping valve; the patched grating shifts shade and texture underfoot."
+  }
+ },
+ "1206": {
+  "key": "Maxwell Street",
+  "desc": "The street angles along the processor's foundation as it arcs southeast. The wall dominates the south — massive, featureless but for the occasional access port or sensor array, built to last centuries without aesthetics. The northern prefab shows its age, composite warped from moisture, module seams gummed with weather-stripping long degraded to black residue.",
+  "sense_descs": {
+   "olfactory": "Dry processor-heat against wet, mineral channel-air — the two never quite mix.",
+   "auditory": "The processor's deep hum carries through its foundation; the channel washes faint behind it.",
+   "tactile": "The wall throws dry heat south; the damp reclaims everything a few steps north."
+  }
+ },
+ "1209": {
+  "key": "Maxwell Street",
+  "desc": "Prefab presses close on the north, walling the street off from the Balboa Channel. South, the processor's foundation rises in a sheer wall of industrial composite and reinforced plating, marked with maintenance hatches, conduit runs, and the occasional dark viewport.",
+  "sense_descs": {
+   "olfactory": "Cold mineral damp off the channel, edged with processor-warm metal.",
+   "auditory": "The spillway's roar rumbles faintly in the distance — enough to orient by, not enough to drown the processor's hum.",
+   "tactile": "Channel-damp on the north side, dry wall-heat on the south, the street split between them."
+  }
+ },
+ "1212": {
+  "key": "Maxwell Street",
+  "desc": "Mist drifts through the street at waist height, clinging to everything with the persistence of a permanent condition. A service alcove cuts into the north wall, once equipment or access, now just another place condensation pools and rust blooms across exposed metal. The processor's bulk dominates the south, its foundations vanishing into a prefab warren. Faded yellow arrows point west along the grating — wayfinding for a place people get lost in.",
+  "sense_descs": {
+   "olfactory": "Saturated mineral damp and blooming rust, the smell of permanent wet.",
+   "auditory": "Drips and trickles everywhere in the alcove; the processor hums beyond the mist.",
+   "tactile": "Mist coats the skin and the grating alike; nothing here is ever quite dry.",
+   "atmospheric": "A misted warren you can get lost in — hence the arrows."
+  }
+ },
+ "1215": {
+  "key": "Maxwell Street",
+  "desc": "Mist saturates everything — not thick enough to blind, constant enough to coat every surface. The street runs straight, the grating solid but slick. Prefab lines the north, southern walls water-damaged in abstract patterns. Beyond the maze, the processor rises through the haze, close enough to see but lost in the unplanned labyrinth. Drainage channels run both sides, gutters clogged with sediment.",
+  "sense_descs": {
+   "olfactory": "Wet mineral and silt, the heavy damp of standing drainage.",
+   "auditory": "The waterfall's roar carries from the east, the background note that defines this stretch; water trickles through the clogged gutters.",
+   "tactile": "Every surface is filmed with moisture that never dries; the slick grating makes you mind your footing.",
+   "atmospheric": "Defined by water it can't escape — mist above, roar to the east, drainage below."
+  }
+ },
+ "1228": {
+  "key": "Maxwell Street",
+  "desc": "A warehouse dominates the south, prefab expanded with welded additions across decades. Sealed roll-up doors line its northern face, marked with faded corporate logos and loading-bay numbers from when this was official commerce. The channel runs north, dark water visible through gaps, moving with a current that suggests real depth. Redundant composite safety barriers bolt the northern edge; yellow hazard strobes mark the cargo zone. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cold channel water, dust, and the dry rust of sealed doors.",
+   "auditory": "The channel moves dark and heavy below; hazard strobes tick at their intervals.",
+   "tactile": "Channel-damp along the barriers; the sealed warehouse doors are cold and dead."
+  }
+ },
+ "1231": {
+  "key": "Maxwell Street",
+  "desc": "Waterfront commerce continues, southern prefab carrying the modifications of long-surviving operations. A repair facility fills one module, hand-painted sign offering synthetic maintenance and component calibration. The channel dominates the north at undiminished scale, dark water that makes the safety barriers make sense. Northeast, the Central Span's navigation lights mark the colony's primary crossing.",
+  "sense_descs": {
+   "olfactory": "Channel damp, solvent, and machine-oil from the repair facility.",
+   "auditory": "The channel's steady dark wash; from the repair bay, the whine and tick of calibration work.",
+   "tactile": "Damp coats the barriers; the air carries the channel's mineral cold."
+  }
+ },
+ "1234": {
+  "key": "Maxwell Street and Wolfe Way",
+  "desc": "The intersection opens where Wolfe Way cuts south from the waterfront, the confluence marked by grating that shows the mixed wear patterns of cross-traffic - haulers moving along Maxwell between warehouse operations, foot traffic flowing between the channel and the residential districts inland. To the south, Wolfe Way descends through districts that house the colony's working population, the street's character shifting from commercial waterfront to residential density with each block away from the water. Signage here shows directional markers in multiple languages and maintenance schedules posted in weather-sealed cases.",
+  "sense_descs": {
+   "auditory": "Haulers move along Maxwell; foot traffic flows between the channel and the inland districts.",
+   "olfactory": "Channel brine fading to residential air south down Wolfe.",
+   "tactile": "Cool channel air off the dark water north; mixed-wear grating underfoot.",
+   "atmospheric": "The Balboa Channel dominates the northern horizon; the Central Span anchors the northeast."
+  }
+ },
+ "1237": {
+  "key": "Maxwell Street",
+  "desc": "The Balboa Channel dominates the north beyond the barriers, dark water moving with a force that makes human infrastructure feel provisional. Southern prefab carries waterfront wear — mineral staining, faded panels, the weathering of proximity to something larger than planning. A cargo staging area holds against the south, composite pallets stacked under weather-resistant tarps, anonymous but cycled regularly. Twin tracks polish the grating. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cold channel water and wet tarpaulin, mineral and faintly plastic.",
+   "auditory": "The channel runs heavy and dark past the barriers; tarps snap and shift on the staged pallets.",
+   "tactile": "Channel-damp settles cold on everything along the barrier line.",
+   "atmospheric": "Working the edge of water that won't give back what falls in."
+  }
+ },
+ "1240": {
+  "key": "Maxwell Street",
+  "desc": "An aquaponics facility holds the south, drainage pipes emptying into collection troughs built into the grating, the metal stained dark with years of organic runoff. The channel stretches north, dark water and the source of whatever still gets pulled from unmapped depths. A ventilation stack rises abruptly from mid-street; the safety barriers here carry extra welded bracing. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Brine and decay and the chemicals used to mask both, with refrigerant venting off the stack.",
+   "auditory": "Runoff trickles into the troughs; the vent stack exhales in low chemical gusts; the channel washes north.",
+   "tactile": "Wet, cold, and faintly greasy; organic damp clings where the troughs drain.",
+   "atmospheric": "Where the channel's catch is processed — brine, rot, and refrigerant in one breath."
+  }
+ },
+ "1243": {
+  "key": "Maxwell Street",
+  "desc": "The waterfront opens where the southern prefab pulls back, the wider corridor doubling as an informal market — composite-frame stalls draped in weather-resistant fabric, folding tables of salvage and questionable foodstuffs. The channel dominates the north beyond barriers worn by constant contact, rust blooming through coatings, panels cracked from impacts. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cold channel water, wet fabric, and cooking-smoke off the stalls.",
+   "auditory": "The channel runs heavy past the barriers; stall fabric cracks and luffs at the water's edge.",
+   "tactile": "Channel-damp and the cold off the water make everything by the edge feel temporary."
+  }
+ },
+ "1246": {
+  "key": "Maxwell Street",
+  "desc": "A narrow alley cuts between the southern prefab, barely two abreast, the dark beyond swallowing whatever lies deeper. Trash piles at the mouth — composite fragments, broken equipment, things discarded where the street meets the hidden. The channel stretches north, dark water moving with the persistence that made the colony build along it rather than fight it. Northeast, the Central Span holds its lights.",
+  "sense_descs": {
+   "olfactory": "Channel damp and the sour reek of the trash heaped at the alley mouth.",
+   "auditory": "The channel washes steady to the north; the alley gives back only a damp, swallowing silence.",
+   "tactile": "Cold channel-damp at the street; a colder, closer stillness breathing from the alley.",
+   "atmospheric": "The alley-mouth swallows light and sound — the street's discard pile and its threshold."
+  }
+ },
+ "1249": {
+  "key": "Maxwell Street",
+  "desc": "The waterfront narrows where the southern prefab reaches toward the channel edge, functional but not constricted. A storage facility dominates the south, roll-up doors secured with heavy-duty locks — contents worth protecting, or at least worth the paranoia. The channel keeps its overwhelming presence north, dark water beyond barriers cracked by thermal cycling and corroded by constant moisture. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cold channel water and corroded metal, nothing else permitted.",
+   "auditory": "The channel moves dark and constant; the heavy locks creak faintly in the damp.",
+   "tactile": "Channel-damp on the barriers; the locked doors are cold and unyielding."
+  }
+ },
+ "1252": {
+  "key": "Maxwell Street",
+  "desc": "The street widens for a fuel depot — composite tanks behind chain-link topped with deterrent wire, faded multilingual warning placards covering the fence. The channel stretches north, its relentless current beyond the usual corroded barriers. A pressure-relief system rises from the depot, venting to atmosphere in occasional hissing bursts as the tanks breathe with temperature. The grating here is heavier-gauge, reinforced for spills and tanker weight. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Fuel vapor sharp over the channel's cold damp, chemical and volatile.",
+   "auditory": "The relief system hisses in bursts as the tanks expand and contract; the channel washes beneath.",
+   "tactile": "The reinforced grating is solid and cold; channel-damp beads on the tank fittings.",
+   "atmospheric": "Volatile storage on a wet edge — fenced, placarded, and venting."
+  }
+ },
+ "1255": {
+  "key": "Maxwell Street",
+  "desc": "Prefab returns to flank the south, carrying the modifications of operations outlasting their purpose. A fabrication shop fills one section, its exterior cluttered with stock — metal sheets leaned on the wall, structural composite stacked on improvised racks, cable coils strapped down with deteriorating bindings. The channel holds the north, dark water that makes everything along it feel built on borrowed permission. The grating shows mixed hauler-and-foot wear; the barriers are a patchwork timeline of welds and replacements. Northeast, the Central Span.",
+  "sense_descs": {
+   "olfactory": "Cut metal and machine-oil from the fab shop, over the channel's mineral damp.",
+   "auditory": "From the fab shop, the intermittent shriek of cutting and the ring of stacked stock; the channel washes north.",
+   "tactile": "Channel-damp and metal-cold; raw stock and cut edges crowd the south."
+  }
+ },
+ "1261": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor feels less like a street and more like a trench carved between structures that have grown together at their upper levels, creating a tunnel effect where whatever sky exists above becomes theoretical rather than visible. The eastern side shows construction that stopped consulting engineers and started consulting desperation - modules stacked in configurations that defy standard load calculations, connected by welds done by someone who learned the skill yesterday and needed shelter today. The western excavations have become living spaces without pretense, cave-like openings carved directly into the crater wall.",
+  "sense_descs": {
+   "auditory": "The tunnel deadens outside sound to a muffled hush; welds and rock alike tick as temperatures shift.",
+   "olfactory": "Rock dust and trapped air, no draft to move it.",
+   "tactile": "Structures meet overhead; the corridor closes to a trench with only theoretical sky.",
+   "atmospheric": "Upper levels have grown together into a tunnel, whatever sky exists above gone theoretical."
+  }
+ },
+ "1264": {
+  "key": "Bhavani Corridor",
+  "desc": "The tunnel effect intensifies here where upper-level construction has created what amounts to a ceiling, composite panels and salvaged sheeting bridging the gap between structures - temporary weather protection that became permanent load-bearing architecture through sheer optimism. The eastern structures show continuous modification - additions welded to additions, each generation building on the last. The western excavations run deeper here, some entrances marked with crude signage suggesting businesses or services, others sealed with nothing but fabric.",
+  "sense_descs": {
+   "auditory": "Sound bounces flat under the improvised ceiling; muffled commerce leaks from the deep western excavations.",
+   "olfactory": "Rock dust, cooking, and the stale air of a sealed-over street.",
+   "tactile": "The air sits dead and unmoving beneath the load-bearing canopy.",
+   "atmospheric": "Light penetrates in shafts through gaps in the ceiling, columns of illumination that move with the day cycle."
+  }
+ },
+ "1267": {
+  "key": "Bhavani Corridor",
+  "desc": "The corridor opens slightly here where structural collapse created a gap that's never been rebuilt, giving way to what amounts to an open plaza by fringe colony standards - maybe ten meters across where the eastern structures simply stopped existing and no one had the resources to fill the space. The remaining eastern modules lean inward, their upper levels extending over the void in cantilevers sustained by mutual support and being wedged against each other. The western excavations show their deepest penetration into the crater wall here, multiple levels carved into the rock, openings at different heights connected by ladders and improvised stairways.",
+  "sense_descs": {
+   "auditory": "The open plaza scatters sound; ladders and improvised stairways rattle in the western warren.",
+   "olfactory": "Cold crater-rock air pools in the open gap, mineral and dry.",
+   "tactile": "The gap opens overhead, a rare breath of space in the warren.",
+   "atmospheric": "Eastern modules cantilever over the void; the western wall is a vertical warren carved into rock, more mine than dwelling."
+  }
+ },
+ "1270": {
+  "key": "Braddock Avenue and Bhavani Corridor",
+  "desc": "The intersection sprawls at the southwestern edge of the colony, where the crater wall curves close enough to touch. Metal plating and exposed regolith create an uneven patchwork underfoot, the ground sloping slightly where prefab structures have settled into the rock over decades. The atmospheric processor looms distant on the eastern horizon, its scale undiminished by miles of industrial sprawl.",
+  "sense_descs": {
+   "auditory": "Out on the edge, the sprawl thins to a sparse, wind-scoured quiet.",
+   "olfactory": "The mineral smell of ancient stone and the faint ozone tang of atmosphere meeting void.",
+   "tactile": "Cold air seeps from the crater wall; exposed regolith and metal plating shift uneven underfoot.",
+   "atmospheric": "The atmospheric processor looms distant on the eastern horizon, its scale undiminished by miles of sprawl."
+  }
+ },
+ "1276": {
+  "key": "Kaspar Street",
+  "desc": "Shuttered warehouses line both sides, roll-up doors sealed with the finality of operations that stopped expecting resumption decades ago. Early-colony prefab, panels warped and composite gone brittle from thermal cycling, corporate logos weathered to abstract suggestion. Faded loading-zone paint still marks spaces nobody uses.",
+  "sense_descs": {
+   "olfactory": "Cold dust and dry rust, the dead air of sealed buildings.",
+   "auditory": "The brittle panels tick and pop as the cold works them; otherwise quiet, the colony's hum distant.",
+   "tactile": "Deep cold here, out of any traffic; the sealed doors are frigid to the touch.",
+   "atmospheric": "A district that stopped expecting to reopen."
+  }
+ },
+ "1279": {
+  "key": "Kaspar Street",
+  "desc": "Converted storage modules stack two-high on the northern side, external ladders welded from pipe and rebar. Laundry hangs stiff between buildings. South, a drinking hole marked only by a hand-painted bottle on sheet metal, its entrance cut raw into a cargo container's side.",
+  "sense_descs": {
+   "olfactory": "Frozen laundry, cold rust, and woodsmoke leaking from the bar's cut doorway.",
+   "auditory": "Ladders and sheeting rattle in the cold; voices and clatter leak from the container bar.",
+   "tactile": "Everything here is cold-stiff — laundry frozen on the lines, metal that bites bare skin."
+  }
+ },
+ "1282": {
+  "key": "Kaspar Street",
+  "desc": "Empty shipping containers wall both sides, corrugated flanks bearing the faded logos of freight companies long gone or never here. They sit stacked at haphazard angles, doors sealed with composite welded over the original mechanisms — solid walls over whatever they once held.",
+  "sense_descs": {
+   "olfactory": "Cold steel and old paint, nothing living.",
+   "auditory": "The stacked containers boom faintly as the cold contracts them.",
+   "tactile": "The corrugated walls are ice-cold; the corridor between them holds the chill.",
+   "atmospheric": "A canyon of sealed boxes — storage that became architecture."
+  }
+ },
+ "1285": {
+  "key": "Kaspar Street",
+  "desc": "The street pinches where a collapsed prefab section was left to rot rather than cleared, its twisted frame forcing traffic single-file. Someone has claimed the wreckage — tarps stretched across the skeletal structure, a barrel fire burning despite regulations nobody enforces this far south.",
+  "sense_descs": {
+   "olfactory": "Barrel-fire smoke and the cold-metal smell of the rotting wreck.",
+   "auditory": "The barrel fire snaps; tarps crack and lift; the ruined frame ticks as it cools.",
+   "tactile": "Barrel-fire heat in a narrow pocket, the cold pressing back at its edges.",
+   "atmospheric": "A collapse turned squat — failure made into shelter."
+  }
+ },
+ "1288": {
+  "key": "Kaspar Street",
+  "desc": "A fighting pit opens off the southern side, a composite ramp descending into what was a cargo bay before blood sport proved more profitable than storage. North, housing crowds in desperate density — modules subdivided past reason, external water pipes frozen solid inside their thermal wrap.",
+  "sense_descs": {
+   "olfactory": "Too many cooking-fires burning the cheapest fuel, over cold rust and frozen pipe.",
+   "auditory": "From the pit ramp rise muffled impacts and a swell of roar, then the dead quiet after a fight ends badly.",
+   "tactile": "The frozen pipes radiate cold; the ramp breathes a warmer, closer air up from the pit.",
+   "atmospheric": "Density and blood-sport pressed together — south you bleed, north you freeze."
+  }
+ },
+ "1291": {
+  "key": "Kaspar Street",
+  "desc": "The street kinks around a large utility box bolted to a rusted prefab. A storefront advertises |gBEST PRICES - NO QUESTIONS|n in bright letters, reinforced windows displaying the accumulated desperation of workers needing tokens before payday — tools, electronics, things maybe stolen, maybe earned. Fresh welds patch the grating where sections have been replaced.",
+  "sense_descs": {
+   "olfactory": "Hot solder and cold metal, with the ozone bite of recent welding.",
+   "auditory": "The utility box hums and clicks; the storefront sign buzzes; the colony drones beneath.",
+   "tactile": "Fresh welds still hold a little warmth in an otherwise cold grid."
+  }
+ },
+ "1294": {
+  "key": "Kaspar Street",
+  "desc": "Cube hotels march along both sides, but here the modules show the personalization of longer stays — tapestries and flags strung alongside the laundry. A community water point juts from the northern wall, spigots worn from constant use, frozen puddles ringing its base in miniature landscapes of ice.",
+  "sense_descs": {
+   "olfactory": "Cold mineral water, frozen cloth, and the faint smoke of many small fires.",
+   "auditory": "The water point drips and the drips freeze; fabric snaps in the cold.",
+   "tactile": "Ice slicks the ground around the spigots; the cold has a permanence here.",
+   "atmospheric": "Stacked transience worn into something almost like home."
+  }
+ },
+ "1297": {
+  "key": "Kaspar Street",
+  "desc": "A drinking establishment fills a double-wide prefab on the southern side, its entrance a mismatch of salvaged signage reading |mLast Shift|n in letters that flicker with the persistence of something broken and repaired past counting. Someone has strung lights between buildings, pooling relative warmth against the crater wall's perpetual shadow.",
+  "sense_descs": {
+   "olfactory": "Spilled liquor and smoke leaking from the bar, against the cold outside.",
+   "auditory": "Music bleeds through thin insulation — fiddle and pipe tangled with synth, the hybrid sound of cultural memory meeting whatever instruments survived the crossing.",
+   "tactile": "The strung lights throw a thin warmth; step out of it and the crater-shadow cold returns.",
+   "atmospheric": "A lit pocket of warmth holding the line against the wall's shadow."
+  }
+ },
+ "1300": {
+  "key": "Kaspar Street",
+  "desc": "The street widens where a maintenance yard claims the southern side, industrial equipment parked in orderly rows that suggest actual management. Haulers sit awaiting repair, treads caked with deep-mine mud — regolith, ice melt, and hydraulic fluid frozen solid in the patterns of their last run.",
+  "sense_descs": {
+   "olfactory": "Hydraulic fluid and frozen regolith mud, cold machine-oil over stone.",
+   "auditory": "Cooling hydraulics tick in the parked haulers; the yard is otherwise still.",
+   "tactile": "The frozen tread-mud is rock-hard; cold radiates off the idle machines."
+  }
+ },
+ "1303": {
+  "key": "Kaspar Street",
+  "desc": "A shift facility dominates the north — showers, lockers, sleeping coffins, the infrastructure of changing between work and life in prefab utility. South, a medical clinic occupies a reinforced module, its sign advertising |50424 HOUR - INDUSTRIAL INJURIES - URGENT CARE|n in letters that speak to frontier medicine.",
+  "sense_descs": {
+   "olfactory": "Cheap soap and disinfectant from the shift facility, antiseptic from the clinic, over cold metal.",
+   "auditory": "Showers run and drains gurgle behind the facility wall; the clinic's door cycles with a pneumatic sigh.",
+   "tactile": "Damp warmth leaks from the shower block; the clinic's threshold is clinic-cold.",
+   "atmospheric": "Where bodies are serviced between shifts — washed, bunked, and patched."
+  }
+ },
+ "1308": {
+  "key": "Kaspar Street",
+  "desc": "Scrap yards flank the street, contents organized by a logic either brilliant or insane — hull plating sorted by thickness, cable by gauge, structural components stacked by size. The northern yard runs active commerce with a weighing station; the southern is pure archaeology, detritus compressed at the bottom into something load-bearing. Chain-link and razor wire fence both, symbolically, given the cut-and-resealed access panels everywhere.",
+  "sense_descs": {
+   "olfactory": "Rust, cold steel, and the faint electrical tang of stripped cable.",
+   "auditory": "Metal shifts and settles in the stacks; a loose chain-link panel taps somewhere.",
+   "tactile": "Sharp cold off the sorted metal; razor wire and cut edges everywhere underhand."
+  }
+ },
+ "1311": {
+  "key": "Kaspar Street",
+  "desc": "The street narrows to barely two meters where prefab modules have encroached from both sides — northern structures leaning south, southern leaning north, a claustrophobic tunnel you could almost touch both walls of. Overhead, cables and pipes web so densely they form an accidental ceiling, composite sheeting draped across to keep what passes for precipitation from dripping through.",
+  "sense_descs": {
+   "olfactory": "Close, stale cold air, damp where the overhead pipes sweat.",
+   "auditory": "Drips tick from the pipe-web overhead; sound goes flat and close between the walls.",
+   "tactile": "The walls press in from both sides; the air is dead and cold and unmoving.",
+   "atmospheric": "A swallowed thoroughfare — public space taken to a tunnel."
+  }
+ },
+ "1314": {
+  "key": "Kaspar Street",
+  "desc": "A marketplace claims both sides, vendors set up on composite pallets and folding tables in configurations that change daily but keep the same character — food, salvage, personal items, and things nobody's sure how to categorize.",
+  "sense_descs": {
+   "olfactory": "Cooking-smoke and fried food over the constant cold-metal undertone of salvage.",
+   "auditory": "The colony's hum and the clatter of carts under the market's churn.",
+   "tactile": "Cooking-heat pools at the food stalls; the cold reclaims the gaps between them."
+  }
+ },
+ "1317": {
+  "key": "Kaspar Street",
+  "desc": "Prefab housing climbs six levels on the northern side, swaying faintly — wind or structural insufficiency, impossible to tell. Each level betrays its method: original colony prefab at the bottom, welded salvage additions at three and four, shipping-container-and-optimism at five and six. External ladders connect them in a vertical maze that must be learned, not intuited. South runs lower and looser, three-level structures with actual space between them.",
+  "sense_descs": {
+   "olfactory": "Cold metal and cooking-smoke, thicker where the northern stack crowds the air.",
+   "auditory": "The six-level stack creaks and shifts overhead; ladders ring as the cold flexes them.",
+   "tactile": "The northern stack's sway is faintly unnerving; the grating underfoot stays cold.",
+   "atmospheric": "Vertical desperation north, a little breathing room south."
+  }
+ },
+ "1320": {
+  "key": "Kaspar Street",
+  "desc": "A large windowless facility dominates the southern side, its entrance protected by security measures serious enough to deter rather than merely discourage. The building is older construction, composite in a shade unmanufactured for decades — it predates most of the surrounding sprawl.",
+  "sense_descs": {
+   "olfactory": "Cold sealed concrete, scrubbed of any smell at all.",
+   "auditory": "A deep, sealed quiet — only a faint mechanical thrum behind the windowless wall.",
+   "tactile": "The blank wall radiates a flat institutional cold.",
+   "atmospheric": "Something deliberately closed — older, harder, and not explaining itself."
+  }
+ },
+ "1323": {
+  "key": "Kaspar Street",
+  "desc": "Collapsed prefab litters the southern side, a failure recent enough that nobody's decided whether to clear it or absorb it. Composite barriers and hazard tape cordon the wreck, the tape broken in places, the barriers shifted and replaced many times. Through gaps, interior spaces lie open to atmosphere — furniture and belongings in cross-section like an excavation. The northern structures have answered by welding angled supports onto their southern walls.",
+  "sense_descs": {
+   "olfactory": "Cold dust and exposed interiors — stale habitation opened to the air.",
+   "auditory": "The wreck ticks and settles; loose hazard tape snaps against the barriers.",
+   "tactile": "Cold pours from the opened interiors; grit and debris underfoot.",
+   "atmospheric": "A fresh collapse the neighbors are bracing against — failure expected to spread."
+  }
+ },
+ "1326": {
+  "key": "Kaspar Street",
+  "desc": "The street opens into something near a plaza — a rare twenty meters of relatively clear grating. The northern side reads as a transit hub: composite benches in rows, posted schedules that might be current or merely aspirational. South, a row of vague unmarked storefronts.",
+  "sense_descs": {
+   "olfactory": "Cold open air, faint cooking-smoke drifting from the storefronts.",
+   "auditory": "The colony's hum carries clean across the open space; a schedule board buzzes and refreshes.",
+   "tactile": "Exposed and cold in the open, no walls to trap any warmth.",
+   "atmospheric": "A rare clearing in the density — a place built to wait."
+  }
+ },
+ "1329": {
+  "key": "Kaspar Street",
+  "desc": "A tool-lending operation holds the northern side, its reinforced viewport displaying organized rows behind security mesh — drills, torches, detection gear. Posted rates run by the shift, deposits calibrated to people who own nothing but their labor. South, housing subdivided to fabric walls, privacy a matter of collective agreement rather than barrier.",
+  "sense_descs": {
+   "olfactory": "Machine oil and cold metal from the tool racks, cooking-smoke from the crowded south.",
+   "auditory": "Equipment clinks behind the mesh; thin walls leak the muffled sounds of too many lives.",
+   "tactile": "The tool-shop viewport is cold glass; the subdivided south is close and stale-warm."
+  }
+ },
+ "1332": {
+  "key": "Kaspar Street",
+  "desc": "Three-level prefab rises both sides, standard construction aged into merely functional. Door seals gap, viewports trap condensation, utility brackets are more weld than metal from endless replacement. Laundry hangs between buildings, stained by recycled water that's never quite clean.",
+  "sense_descs": {
+   "olfactory": "Damp recycled water, cold metal, and the mildew of trapped condensation.",
+   "auditory": "Gapped seals whistle thinly; condensation drips behind fogged viewports.",
+   "tactile": "Cold drafts leak through the gapped seals; everything is faintly damp."
+  }
+ },
+ "1338": {
+  "key": "Kaspar Street",
+  "desc": "Four-level prefab blocks flank the street, identical but for their damage. External staircases zigzag up, treads worn smooth, railings rusted at every joint. Viewports fog with age, some curtained from inside — a checkerboard of transparency and privacy. The grating is functional, patched in a dozen places.",
+  "sense_descs": {
+   "olfactory": "Cold rust and cooking-smoke, the standard breath of the worker blocks.",
+   "auditory": "The staircases creak underfoot; rusted railings groan in the cold.",
+   "tactile": "Rusted rail and cold tread; the patched grating shifts faintly underfoot.",
+   "atmospheric": "Worker housing aged to the bone — identical, patched, and still standing."
+  }
+ },
+ "1345": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa opens in a crush of stalls against patched walls, awnings stitched from scavenged cloth. A faded mural of a rising sun shows through the graffiti, half-hopeful, half-forgotten.",
+  "sense_descs": {
+   "olfactory": "Frying oil and cardamom, thick enough to mask the metallic tang of rust beneath.",
+   "auditory": "The processor's hum is faint here, carried thin from the east like a far-off heartbeat.",
+   "tactile": "Warm cooking-air pools between the stalls."
+  }
+ },
+ "1348": {
+  "key": "Pessoa Street",
+  "desc": "The street narrows under sagging laundry lines. Condensation streaks dark across the ground; every surface is layered with chalk prayers and gang marks fading into one another.",
+  "sense_descs": {
+   "olfactory": "Turmeric and damp stone hang heavy in the close air.",
+   "auditory": "Condensation drips steadily from the lines; the processor murmurs beneath.",
+   "tactile": "The ground is slick underfoot; the air presses warm and wet between the walls.",
+   "atmospheric": "Faith and turf overwritten on every surface, prayer under tag under prayer."
+  }
+ },
+ "1351": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa widens into a row of food carts. The ground is uneven, patched with scavenged boards. Eastward, the processor's glow is faintly visible.",
+  "sense_descs": {
+   "olfactory": "Spice and cooking-smoke fill the air, oily and warm.",
+   "auditory": "The scavenged boards creak and shift; the processor's drone carries from the east.",
+   "tactile": "The patched boards flex underfoot; cooking-heat hangs over the carts."
+  }
+ },
+ "1354": {
+  "key": "Pessoa Street",
+  "desc": "The street dips, water pooling to reflect neon in fractured color. Crooked makeshift tables line the low ground, marked with painted symbols no one fully reads. A single lamp buzzes overhead.",
+  "sense_descs": {
+   "olfactory": "Cheap whiskey clings to everything, mixed through with frying oil.",
+   "auditory": "The lamp buzzes and stutters overhead; from deep south, the mine machinery hums faint.",
+   "tactile": "Standing water films the low ground; the air is cool and damp here.",
+   "atmospheric": "Charlatan's row — symbols and luck for sale where the street pools."
+  }
+ },
+ "1357": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa tightens, stacked housing leaning into the street, narrow alleys cutting between them hung with drying clothes. A shrine sits tucked into a corner, candles flickering.",
+  "sense_descs": {
+   "olfactory": "Incense and damp metal, heavy and persistent.",
+   "auditory": "The processor's hum comes through the walls more than the air.",
+   "tactile": "The processor's vibration carries through the close walls, steady and unrelenting."
+  }
+ },
+ "1360": {
+  "key": "Pessoa Street",
+  "desc": "The street opens into a communal spot strung with lanterns overhead. A cracked statue of a forgotten saint leans against the wall, its face worn smooth.",
+  "sense_descs": {
+   "olfactory": "Cooking-smoke and dust, with the wax-sweetness of guttering lanterns.",
+   "auditory": "Distant machinery grinds steady beneath the open space.",
+   "tactile": "Fine dust hangs in the lantern-light, settling on everything.",
+   "atmospheric": "A gathering-ground waiting on something — the worn saint presiding over it."
+  }
+ },
+ "1363": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa narrows again, crowded with stalls of fried food and cheap liquor. Chalk prayers fade day by day, layered over gang symbols.",
+  "sense_descs": {
+   "olfactory": "Greasy cooking-smoke leaves a film on the skin; fried food and cheap liquor underneath.",
+   "auditory": "Steam and the processor's drone fill the gaps between the stalls.",
+   "tactile": "Cooking-grease hazes the close air, settling damp on the skin."
+  }
+ },
+ "1366": {
+  "key": "Pessoa Street",
+  "desc": "The street dips, uneven boards laid over soft regolith. A gang's colors are painted bold across one wall, daring anyone to cross.",
+  "sense_descs": {
+   "olfactory": "Fried noodles dominate, sharp and oily.",
+   "auditory": "The processor's hum is louder here, carried clear from the east.",
+   "tactile": "The boards give over soft regolith underfoot."
+  }
+ },
+ "1369": {
+  "key": "Pessoa Street",
+  "desc": "A pawn shop squats against the street, windows packed with broken tools and faded charms. The ground is uneven, patched with scavenged stone.",
+  "sense_descs": {
+   "olfactory": "Sweat and smoke cling to every surface, heavy and close.",
+   "auditory": "The processor's drone presses under the street's clamor.",
+   "tactile": "The patched stone is uneven; the air sits warm and stale.",
+   "atmospheric": "A pawn-shop corner wound tight — the kind of quiet that could break the wrong way."
+  }
+ },
+ "1372": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa widens into a small square. Faded corporate logos paper the walls, buried under gang symbols and graffiti. A crudely cut three-pointed crown hangs over the southern arch — |yQueen of Cups|n — its patina faded but defiant.",
+  "sense_descs": {
+   "olfactory": "Spice and barrel-fire smoke cling to clothes and hair.",
+   "auditory": "Barrel fires snap and pop; the processor's hum runs steady beneath.",
+   "tactile": "Barrel-fire heat pushes back the chill in pockets across the square.",
+   "atmospheric": "The Queen's crown over the arch — a claimed square, faded but holding."
+  }
+ },
+ "1382": {
+  "key": "Pessoa Street",
+  "desc": "The street narrows, walls lined with sweating pipes. Steam rises in thin curtains, catching the dim light.",
+  "sense_descs": {
+   "olfactory": "Oil and sweat hang thick, clinging to clothes.",
+   "auditory": "The grating rattles under cart-wheels; steam hisses; the processor's hum grows louder, steady as a heartbeat.",
+   "tactile": "The pipes sweat onto the walls; steam leaves the air damp and warm."
+  }
+ },
+ "1385": {
+  "key": "Pessoa Street",
+  "desc": "The street dips, water pooling in shallow depressions; emergency lights flicker overhead. A food stall clings to the corner. North, a narrow alley disappears into shadow, its silence heavier than the street.",
+  "sense_descs": {
+   "olfactory": "Curry-spiced protein cuts sharp through the damp air.",
+   "auditory": "Emergency lights buzz and cycle; the processor's drone carries from the east.",
+   "tactile": "Standing water films the dip; the damp air clings.",
+   "atmospheric": "The alley-mouth north holds a silence the street can't fill."
+  }
+ },
+ "1388": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa widens into a vendor stretch, tables sagging under tools, charms, and patched clothing. Steam bursts from the vents, clearing space for a moment before it closes again.",
+  "sense_descs": {
+   "olfactory": "Fried noodles and cheap liquor over the constant oily smoke.",
+   "auditory": "Vent-steam bursts hiss; the machinery's hum presses harder than any voice.",
+   "tactile": "Each steam-burst rolls warm and damp across the tables."
+  }
+ },
+ "1391": {
+  "key": "Pessoa Street",
+  "desc": "The grating is doubled here, thicker support beams showing beneath — someone learned lessons in collapse. A single lamp buzzes overhead, its light dying before it reaches the ground.",
+  "sense_descs": {
+   "olfactory": "Damp, recycled moisture and cold metal.",
+   "auditory": "The lamp buzzes; boots ring on doubled steel; the processor hums beneath.",
+   "tactile": "The processor's vibration carries up through the soles; the air hangs damp and heavy."
+  }
+ },
+ "1394": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa tightens, walls close and claustrophobic, pipes running overhead and dripping onto the grating. A pawn shop squats here, windows full of broken tools and faded charms. South, a dark alley cuts away, its mouth marked by silence and damp.",
+  "sense_descs": {
+   "olfactory": "Rust and damp air dominate, close and metallic.",
+   "auditory": "Pipes drip steadily onto the grating; the processor's hum carries through the walls.",
+   "tactile": "The walls press close; the dripping pipes keep the grating wet.",
+   "atmospheric": "The dark alley south breathes damp silence into the street."
+  }
+ },
+ "1397": {
+  "key": "Pessoa Street",
+  "desc": "The street dips, steam rising from the vents in irregular bursts. Shadows stretch long across the grating, broken by flashes of yellow light. North, a narrow alley vanishes into shadow.",
+  "sense_descs": {
+   "olfactory": "Frying oil clings to the damp air.",
+   "auditory": "Steam hisses in bursts; from the north alley, only dripping water; the processor drones east.",
+   "tactile": "Steam-bursts leave the grating slick and warm."
+  }
+ },
+ "1400": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa widens into a small square strung with lanterns. Children's drawings cover the walls, layered over gang symbols. The processor dominates the horizon, its heat pressing closer.",
+  "sense_descs": {
+   "olfactory": "Spice and cooking-smoke cling to clothes and hair.",
+   "auditory": "Steam bursts punctuate the square; the processor's hum sits steady and close.",
+   "tactile": "The processor's heat presses in now, warming the square unevenly.",
+   "atmospheric": "Children's chalk over gang-marks — small claims layered on hard ones."
+  }
+ },
+ "1403": {
+  "key": "Pessoa Street",
+  "desc": "The grating rattles under heavy carts pushed east. A fortune-teller's tent flaps at the corner, its colors faded but defiant. South, a narrow alley cuts away, its mouth damp and silent.",
+  "sense_descs": {
+   "olfactory": "Sweat and machine oil, with steam-vents leaving a metallic edge.",
+   "auditory": "Cart-wheels rattle the grating; steam vents hiss; the machinery's hum presses against every sound.",
+   "tactile": "Vented steam leaves the air metallic and damp."
+  }
+ },
+ "1406": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa narrows, walls lined with pipes and patched panels. Half the emergency fixtures are dark or cycling through brownouts, and the pools of shadow make the street feel larger than it is.",
+  "sense_descs": {
+   "olfactory": "Cheap whiskey and fried food hang heavy in the dark.",
+   "auditory": "The failing lights tick and buzz; the processor's vibration runs constant, steady as breath.",
+   "tactile": "The processor's hum fills the bones here, close and unbroken.",
+   "atmospheric": "Brownout dark where the nightlife starts to stir."
+  }
+ },
+ "1409": {
+  "key": "Pessoa Street",
+  "desc": "Pessoa stretches east on reinforced beams and doubled grating. Steam vents puncture the street in hissing bursts. Yellow lights flicker and fail against the damp; the processor looms close now, its conduits and arrays sharp.",
+  "sense_descs": {
+   "olfactory": "Hot metal and steam, the ozone edge of the processor sharpening as it nears.",
+   "auditory": "The spillway's roar echoes oddly here, bouncing into dead zones before crashing back; steam hisses; the processor's drone is close and heavy.",
+   "tactile": "The processor's heat is undeniable now; vented steam slicks the doubled grating.",
+   "atmospheric": "The street's industrial end — heat, roar, and chrome where Pessoa meets the machine."
+  }
+ },
+ "1414": {
+  "key": "Volta Street",
+  "desc": "The character transitions here - technical precision giving way to functional industrial. Northern structures still show decent maintenance, but the clinical atmosphere fades. Older repairs sit alongside newer work, patches over damage rather than full replacements. Conduit overhead remains organized but shows zip-tied improvised additions. A repair bay displays the mixed character - clean-room protocols at the threshold, oil stains and burn marks within. The grating shows twin tracks polished by regular equipment passage.",
+  "sense_descs": {
+   "auditory": "The clatter of a repair bay working past its clean-room pretensions.",
+   "olfactory": "Clinical filtering gives way to oil and burnt metal.",
+   "tactile": "Twin tracks run polished into the grating by regular equipment passage."
+  }
+ },
+ "1417": {
+  "key": "Volta Street",
+  "desc": "A machine shop dominates the northern side, bays revealing mechanical archaeology - lathes and mills maintained through countless part replacements until only frames remain original. Scrap metal piles against the southern wall in sorted categories - ferrous, non-ferrous, composite fragments.",
+  "sense_descs": {
+   "auditory": "Grinding wheels bite into metal; the shop's lathes turn in steady cycles.",
+   "olfactory": "Cutting fluid, hot swarf, the metallic tang of fresh-worked steel.",
+   "tactile": "Grit and metal filings underfoot near the open bays.",
+   "atmospheric": "Sparks flare visible through the viewports."
+  }
+ },
+ "1420": {
+  "key": "Volta Street",
+  "desc": "A marketplace sprawls along both sides of the street, stalls displaying synthetic components alongside organic goods. Optical sensors rest in ice-filled bins, their lenses clouded but functional. Hydraulic actuators hang from hooks, cleaned and catalogued by pressure rating. A vendor displays myoelectric interfaces on velvet - gold contacts still bright, connector pins intact. Another stall offers biofluid pumps, their chambers flushed and ready. Memory cores sit in anti-static foam, capacity and condition hand-labeled.",
+  "sense_descs": {
+   "auditory": "Vendors call stock and prices over the market sprawl.",
+   "olfactory": "Machine oil, antiseptic, and the cold wet of ice-filled bins.",
+   "tactile": "Stalls crowd the grating; the street pinches to browsing-width."
+  }
+ },
+ "1423": {
+  "key": "Volta Street",
+  "desc": "Calibration equipment marks the northern prefabs - laser alignment stations visible through viewports, their beams creating reference grids. The structures show technical precision, sealed against particulate contamination. Southern modules house testing facilities, environmental chambers maintaining controlled conditions.",
+  "sense_descs": {
+   "auditory": "The soft cycling of environmental chambers holding their conditions.",
+   "olfactory": "Sealed-clean air, faintly electric.",
+   "tactile": "The structures are sealed tight against particulate; the air sits still and dry.",
+   "atmospheric": "Laser alignment beams draw faint reference grids through the viewports."
+  }
+ },
+ "1426": {
+  "key": "Volta Street",
+  "desc": "A research annex occupies the northern prefabs, viewports revealing lab benches and microscopy stations. A loading bay sits between modules, configured for careful material transfer. Decontamination protocols are posted at every entrance. The grating shows chemical staining in abstract patterns, decades of careful spillage creating unintentional art.",
+  "sense_descs": {
+   "auditory": "The whir of fume extraction behind sealed lab doors.",
+   "olfactory": "Solvents and reagents, the sharp note of decontamination chemicals.",
+   "tactile": "The grating is chemical-stained in abstract patterns, etched smooth in places.",
+   "atmospheric": "Biohazard placards mark the containment sections in vivid yellow and orange."
+  }
+ },
+ "1429": {
+  "key": "Volta Street",
+  "desc": "Cryogenic storage units line the northern side, their insulated housings marked with temperature warnings and frost patterns. A transfer station occupies the south - reinforced loading dock with cold chain equipment.",
+  "sense_descs": {
+   "auditory": "Liquid nitrogen vents hiss at intervals along the storage units.",
+   "olfactory": "The scentless bite of extreme cold, frost and clean metal.",
+   "tactile": "Cold rolls off the cryogenic units; frost rimes the grating near their housings.",
+   "atmospheric": "White vapor rolls across the grating; amber warning lights pulse along the street."
+  }
+ },
+ "1432": {
+  "key": "Volta Street",
+  "desc": "Northern prefabs house quality control facilities, inspection stations with magnification equipment visible through windows. The southern side displays certification placards - compliance standards, testing protocols, audit schedules current. Emergency equipment stations stand ready, fire suppression and medical kits behind clearly marked panels. The grating gleams, actually maintained.",
+  "sense_descs": {
+   "auditory": "Quiet and orderly, the hum of inspection equipment behind windows.",
+   "olfactory": "Clean, faintly antiseptic.",
+   "tactile": "The grating gleams, actually maintained, smooth underfoot."
+  }
+ },
+ "1435": {
+  "key": "Volta Street and Wolfe Way",
+  "desc": "Prefab walls press close on both sides, their composite panels showing decades of scuff marks and impact damage. Overhead conduit runs exposed, zip-tied and improvised, carrying power and data between the technical districts.",
+  "sense_descs": {
+   "auditory": "The grating rattles with each step, loose bolts long past tightening.",
+   "olfactory": "Scuffed composite, machine oil, stale enclosed air.",
+   "tactile": "Walls press close enough to touch on both sides; loose grating shifts underfoot.",
+   "atmospheric": "Emergency lighting casts harsh shadows, half the fixtures dead or flickering."
+  }
+ },
+ "1438": {
+  "key": "Volta Street",
+  "desc": "Industrial character asserts itself. Northern workshops house fabrication equipment, welding stations, accumulated machine-shop grime. Salvaged equipment stacks against the southern crater wall. The grating shows heavy staining and scoring. Yellow institutional lighting replaces the western section's spectrum-balanced fixtures.",
+  "sense_descs": {
+   "auditory": "Arc welders crackle; salvage clangs as it's sorted against the crater wall.",
+   "olfactory": "Cutting fluid, arc-welder ozone, the metallic tang of fresh-worked steel.",
+   "tactile": "Heat builds here, the first suggestion of the processor's influence.",
+   "atmospheric": "Yellow institutional lighting flattens the street to a sodium monochrome."
+  }
+ },
+ "1441": {
+  "key": "Volta Street",
+  "desc": "Industrial storage dominates - warehoused prefabs filled with raw materials. Through open doors: stacked composite sheets, coiled steel stock, chemical drums with hazard symbols. Northern structures lean slightly, settled into uneven geology at angles now permanent. A loading platform extends from the southern wall, stained with accumulated spills.",
+  "sense_descs": {
+   "auditory": "Forklifts move stock through the open warehouse doors.",
+   "olfactory": "Raw composite, cold steel stock, the chemical seep of hazard drums.",
+   "tactile": "Heat off the processor presses closer here; the air thickens with it.",
+   "atmospheric": "The processor towers to the east, close enough to read its rust staining and patch welding."
+  }
+ },
+ "1446": {
+  "key": "Volta Street",
+  "desc": "Diagnostic terminals mount at regular intervals along the northern prefabs, screens dark but ready, ports open. The street surface shows minimal wear, actually maintained. Color-coded conduit runs overhead in organized parallels, properly insulated. A ventilation shaft rises from the grating, its grill remarkably clean. The southern crater wall shows fewer drill scars - pristine compared to western sections.",
+  "sense_descs": {
+   "auditory": "The steady draw of the clean ventilation shaft rising from the grating.",
+   "olfactory": "Ozone and filtered organics.",
+   "tactile": "Minimal wear underfoot, the surface still true."
+  }
+ },
+ "1449": {
+  "key": "Volta Street and Riveter's Way",
+  "desc": "The intersection sprawls where Volta terminates at Riveter's Way, dominated by the processor's overwhelming presence. The processor wall rises south in sheer industrial composite, marked with massive bulkhead doors. Biometric scanners flank entrances, amber interfaces in standby. North, Riveter's Way extends through industrial districts clustered in the processor's shadow. Reinforced grating handles constant heavy equipment - mining haulers, chemical tankers, the traffic serving the colony's breathing apparatus.",
+  "sense_descs": {
+   "auditory": "The processor's mechanical heartbeat is overwhelming here, rhythmic thunder drowning everything else.",
+   "olfactory": "Ozone, hot metal, and chemical-tanker fumes.",
+   "tactile": "Heat pours off the processor wall; the reinforced grating trembles with its pulse.",
+   "atmospheric": "Warning strobes pulse through the haze along the processor wall."
+  }
+ },
+ "1452": {
+  "key": "Riveter's Way",
+  "desc": "The street ends at the processor's entrance plaza - a hardened courtyard where industrial scale becomes architectural statement. Bulkhead doors rise six meters high, composite and steel designed to contain catastrophic failures. Security checkpoints bracket the entrance, manned by personnel whose weapons suggest shoot-first protocols. Warning placards in multiple languages cover every surface, bright colors warning of pressure zones and contamination risks. The plaza grating is reinforced to extremes, rated for moving massive components.",
+  "sense_descs": {
+   "auditory": "The processor's bulk fills the plaza with a deep, close roar, no longer distant.",
+   "olfactory": "Ozone, hot metal, and the chemical tang of pressure-zone venting.",
+   "tactile": "Heat radiates off the processor wall; the reinforced grating sits solid underfoot.",
+   "atmospheric": "Overhead floods create a zone of artificial day; the processor wall is immediate presence, not horizon."
+  }
+ },
+ "1455": {
+  "key": "Riveter's Way",
+  "desc": "A shift facility dominates the western side - lockers, showers, briefing rooms. Workers move in and out with shift-change regularity, coveralls marked with division codes and atmospheric-maintenance grime. Posted boards display schedules and safety bulletins. The eastern structures house administrative functions - offices with reinforced viewports, security checkpoints with biometric scanners. A pedestrian bridge at third-level height connects facility to admin, its deck worn from decades of crossings.",
+  "sense_descs": {
+   "auditory": "The processor's individual systems are audible here - compressor cycling, turbine spin, the layered symphony of atmospheric transformation.",
+   "olfactory": "Shower steam and locker-room damp cut with atmospheric-maintenance grime.",
+   "tactile": "Warmth radiates steadily from the processor; the third-level bridge deck is worn smooth."
+  }
+ },
+ "1458": {
+  "key": "Riveter's Way",
+  "desc": "Equipment staging yards flank both sides behind chain-link fencing and security lighting. The western yard holds diagnostic equipment - calibration rigs, sensor arrays, atmospheric testing modules. The eastern side stores larger components - pressure vessels, composite ducting sections, valve assemblies that dwarf human scale. The grating shows heavy vehicle wear, polished smooth by hauler treads.",
+  "sense_descs": {
+   "auditory": "Gantries clank overhead; the steady industrial hum of the processor underlies it all.",
+   "olfactory": "Machine oil, ozone, and cold metal off the staged components.",
+   "tactile": "The grating is polished smooth by hauler treads, slick underfoot.",
+   "atmospheric": "Overhead gantries span the street at regular intervals, rated for whatever the processor demands."
+  }
+ },
+ "1462": {
+  "key": "Volta Street",
+  "desc": "A calibration facility occupies the southern side, its placard displaying precise operating hours. Through viewports: clean-room environments, white surfaces, equipment on anti-vibration platforms, where tolerances matter in micrometers. Southern structures show technical modifications - sensor arrays, environmental monitors, properly sealed junction boxes. The grating reflects the overhead lights, swept with unusual frequency.",
+  "sense_descs": {
+   "auditory": "Near-silence, the faintest hum of equipment held on anti-vibration platforms.",
+   "olfactory": "Filtered clean-room air, neutral and dry.",
+   "tactile": "The grating is swept with unusual frequency, smooth and clean underfoot.",
+   "atmospheric": "The lighting here actually gets maintained, brighter than most of the colony."
+  }
+ },
+ "1468": {
+  "key": "Dark Alley",
+  "desc": "The alley narrows immediately, prefab walls close enough to touch both sides with outstretched arms. Composite underfoot is uneven, gaps filled with compacted debris. Cargo netting and propped composite panels form improvised storage and makeshift shelters along both walls. Dim lights glow deeper in.",
+  "sense_descs": {
+   "auditory": "Water drips steadily from above; voices echo strangely between the walls, making distance impossible to judge.",
+   "olfactory": "Organic waste, chemical runoff, and cooking from unseen sources, intensifying the deeper in you go.",
+   "tactile": "Walls close enough to touch on both sides; uneven composite and puddles that never dry underfoot.",
+   "atmospheric": "Darkness dominates - street lighting doesn't reach here, the fixtures long since scavenged."
+  }
+ },
+ "1471": {
+  "key": "Wolfe Way",
+  "desc": "The largest agricultural dome dominates the western side, its scale suggesting ambition the colony couldn't sustain. Through the clouded panels: a vast empty space, ceiling high enough for trees that were never planted. The eastern side shows conversion attempts - prefab modules built into the dome's foundation, trying to repurpose the space for storage or housing before being abandoned themselves.",
+  "sense_descs": {
+   "auditory": "The dome's climate control hums intermittently, automatic systems running maintenance cycles for crops that don't exist.",
+   "olfactory": "Damp stale air and the mineral smell of endless condensation.",
+   "tactile": "A cool dampness seeps from the dome; condensation pools and reforms on its interior surfaces.",
+   "atmospheric": "Through the clouded panels, a vast empty space opens, ceiling high enough for trees never planted."
+  }
+ },
+ "1474": {
+  "key": "Wolfe Way",
+  "desc": "Two agricultural domes flank the corridor here, both long abandoned. The western dome shows catastrophic decompression damage - entire sections blown out, panels missing, framework exposed. The eastern dome maintained structural integrity but sits dark and empty, its airlock sealed with warning tape weathered to illegibility. Between them, the corridor narrows to a maintenance width, grating replaced with composite walkway.",
+  "sense_descs": {
+   "auditory": "Wind moves thinly through the blown-out western dome; otherwise a dead, abandoned quiet.",
+   "olfactory": "Cold scoured metal and faint mineral dust off the ruptured panels.",
+   "tactile": "A thin draft pulls through the western dome's missing sections; the composite walkway narrows close.",
+   "atmospheric": "Emergency egress signs still glow, amber LEDs somehow still powered."
+  }
+ },
+ "1477": {
+  "key": "Wolfe Way",
+  "desc": "A defunct agricultural dome looms to the west, its translucent composite panels clouded with decades of mineral deposits and failed sealant. The dome's framework shows through the haze - geodesic steel ribs corroded to rust-orange, structural members sagging where supports failed. Through gaps in the panels: empty growing beds, irrigation lines hanging disconnected, the skeletal remains of hydroponic racks. The eastern side houses repurposed storage - sealed modules containing whatever couldn't fit elsewhere.",
+  "sense_descs": {
+   "auditory": "The dead dome holds a hollow silence, broken only by wind finding the gaps in its panels.",
+   "olfactory": "Rust, mineral dust, and the faint ghost of old organic growing medium.",
+   "tactile": "The corridor floor carries soil staining tracked in during the dome's operational years, gritty and never fully cleaned.",
+   "atmospheric": "Geodesic steel ribs show rust-orange through the haze, structural members sagging where supports failed."
+  }
+ },
+ "1482": {
+  "key": "Gilroy Street and Tolliver Row",
+  "desc": "The intersection opens where Gilroy Street cuts through the waterfront's residential districts, grating showing moderate wear from mixed traffic. A transit shelter occupies the northeast corner, its composite benches occupied by waiting commuters, posted schedules promising connections deeper into the colony. The southern side shows the Balboa Channel stretching beyond safety barriers, dark water moving with constant purpose.",
+  "sense_descs": {
+   "auditory": "Waiting commuters murmur at the transit shelter; the channel moves beyond the barriers.",
+   "olfactory": "Channel brine and the residential closeness of the waterfront blocks.",
+   "tactile": "Moderate-wear grating underfoot; cool channel air drifts up from the south.",
+   "atmospheric": "The Balboa Channel stretches beyond the safety barriers to the south."
+  }
+ },
+ "1485": {
+  "key": "Tolliver Row",
+  "desc": "An aquaponic market dominates the northern side, bubbling display cases visible through viewports, the day's offering arranged on crushed ice. The southern side shows a public access point, composite stairs descending toward the channel's edge, safety railings and warning signs suggesting official acknowledgment of waterfront activity. Small boats are tied off below, their hulls knocking against composite pilings with the rhythm of current and wind.",
+  "sense_descs": {
+   "auditory": "The market's display tanks bubble; small boats knock against the composite pilings with the current.",
+   "olfactory": "Brine and fish, the mineral scent of the channel made commercial.",
+   "tactile": "Damp air comes up off the open water, cold and close."
+  }
+ },
+ "1488": {
+  "key": "Tolliver Row",
+  "desc": "Residential structures on the northern side checkerboard in a mix of red, green, and gold - some modules maintained, others showing deferred maintenance, the gradient visible in fresh paint versus faded composite. The southern side continues its waterfront access, another set of stairs leading to a lower platform where channel workers manage lines and cargo nets. The grating shows salt corrosion despite regular maintenance attempts.",
+  "sense_descs": {
+   "auditory": "Wind-driven waves break close enough to hear; channel workers call over lines and cargo nets.",
+   "olfactory": "Heavy brine, salt thick enough to taste.",
+   "tactile": "Spray off the wind-driven waves occasionally reaches street level, cold and stinging.",
+   "atmospheric": "The Balboa Channel presses close here, its surface restless under the wind."
+  }
+ },
+ "1491": {
+  "key": "Tolliver Row",
+  "desc": "A community center occupies the northern side, its prefab construction expanded with additions that suggest ongoing use - meeting rooms visible through viewports, posted announcements on weather-sealed boards advertising job opportunities and training programs. The southern side shows the channel at its widest point along this stretch. A small park opens at street level, composite benches facing the water, the kind of public space that exists because someone fought for it.",
+  "sense_descs": {
+   "auditory": "The channel runs broad and quiet here; posted boards flutter against their frames.",
+   "olfactory": "Open-water brine and the green note of the park's plantings.",
+   "tactile": "A steady wind comes in off the channel's widest stretch.",
+   "atmospheric": "The far bank shows as a dark line against the colony's industrial haze."
+  }
+ },
+ "1494": {
+  "key": "Beach Street and Tolliver Row",
+  "desc": "The intersection widens where Beach Street descends toward the waterfront, reinforced grating giving way to composite decking that marks the transition from street to public space. The beach opens to the south - imported sand spread across composite substrate, the colony's attempt at recreation. Safety barriers line the boundary, their placement suggesting actual drownings have informed the regulations.",
+  "sense_descs": {
+   "auditory": "The channel laps steadily against the artificial shore.",
+   "olfactory": "Brine and damp imported sand.",
+   "tactile": "Reinforced grating gives way to composite decking; cooler, open air off the beach.",
+   "atmospheric": "Imported sand spreads south to where dark water meets pale shore behind the safety barriers."
+  }
+ },
+ "1497": {
+  "key": "Tolliver Row",
+  "desc": "The street continues west past the beach. The northern side shows apartment blocks rising four and five levels, their southern-facing balconies suggesting premium rent for channel views. Ground-level businesses cater to beachgoers - a rental shop, a cafe with outdoor seating, a small clinic advertising first aid and sunburn treatment. The southern side maintains channel access, though the beach has ended, replaced by composite embankments and safety railings.",
+  "sense_descs": {
+   "auditory": "Cafe chatter mixes with the wash of small waves against the embankments.",
+   "olfactory": "Salt, sunscreen, and coffee from the cafe's outdoor seating.",
+   "tactile": "Warmer here, the open beach exposure catching what light there is."
+  }
+ },
+ "1500": {
+  "key": "Tolliver Row",
+  "desc": "The waterfront is a parade of warehouse structures with loading equipment and cargo staging areas. The southern side reveals dock facilities extending into the channel, composite pilings supporting platforms where smaller vessels tie off.",
+  "sense_descs": {
+   "auditory": "Loading equipment grinds and reverses across the cargo staging areas.",
+   "olfactory": "Diesel, hydraulic fluid, and the organic decay of maritime commerce.",
+   "tactile": "The composite pilings creak; the platforms shift faintly with the channel's movement."
+  }
+ },
+ "1503": {
+  "key": "Tolliver Row",
+  "desc": "A water treatment facility dominates the northern side, its bulk enclosed behind security fencing, warning signs and biometric scanners marking restricted access. Massive intake pipes extend from the facility toward the channel, their diameter suggesting major processing capacity. The southern side displays larger vessels visible at berth, cargo cranes standing idle between shifts. The grating shows heavy vehicle wear, composite polished smooth by constant hauler traffic.",
+  "sense_descs": {
+   "auditory": "A deep churn of intake pumps draws water through the treatment facility.",
+   "olfactory": "Chlorine and treated water cut with channel brine.",
+   "tactile": "The grating is polished smooth by constant hauler traffic, slick underfoot."
+  }
+ },
+ "1506": {
+  "key": "Tolliver Row and Fermi Corridor",
+  "desc": "The intersection sprawls where Fermi Corridor cuts through the colony's western waterfront districts, Tolliver Row terminating here at its western extent. Reinforced grating shows heavy industrial wear, composite polished smooth by constant hauler traffic between the docks and inland facilities. The western crater wall looms close, dark stone rising as the colony's boundary, its face interrupted by sealed maintenance hatches and what might be old mine workings. A cargo transfer station occupies the northwest corner.",
+  "sense_descs": {
+   "auditory": "Cargo loading equipment works the northwest corner; water rushes into the culvert south.",
+   "olfactory": "Channel brine, machine oil, and rock dust off the crater wall.",
+   "tactile": "Hauler-polished grating underfoot; cold radiates off the close western crater wall.",
+   "atmospheric": "The crater wall looms west with sealed hatches and old mine workings; the channel disappears into a culvert south."
+  }
+ },
+ "1509": {
+  "key": "Fermi Corridor",
+  "desc": "Fermi Corridor opens north from the waterfront, the western crater wall pressing close on the left. Cargo-transfer overflow spills from the docks - composite pallets, banded crates staged for the inland haul. Reinforced grating, hauler-polished, carries the freight traffic between channel and warehouses.",
+  "sense_descs": {
+   "auditory": "Loading equipment works the dock overflow; water moves in the nearby culvert.",
+   "olfactory": "Channel brine, machine oil, and rock dust off the close crater wall.",
+   "tactile": "Hauler-polished grating underfoot; cold radiates off the western stone.",
+   "atmospheric": "The crater wall rises dark and close to the west, sealed hatches set into its face."
+  }
+ },
+ "1512": {
+  "key": "Fermi Corridor",
+  "desc": "The corridor runs north between warehouse frontage and the crater wall, the freight character giving way by degrees to something more managed. Loading docks recess into the eastern structures; the western wall is bare stone broken by the occasional maintenance hatch.",
+  "sense_descs": {
+   "auditory": "The rumble of inland haulers fading as the docks thin behind.",
+   "olfactory": "Brine thinning toward machine oil and cold stone.",
+   "tactile": "Reinforced grating, level and maintained; the western wall breathes cold.",
+   "atmospheric": "Warehouse frontage stands to the east, bare crater stone to the west."
+  }
+ },
+ "1515": {
+  "key": "Fermi Corridor",
+  "desc": "The corridor tightens toward the professional district ahead, warehouse frontage yielding to reinforced office structures. Corporate signage begins to appear, faded logos on impact-resistant windows. The grating cleans up, drainage that functions.",
+  "sense_descs": {
+   "auditory": "The subdued hum of the professional district replacing the dockside clamor.",
+   "olfactory": "Filtered office air cutting through the last of the channel brine.",
+   "tactile": "Cleaner composite grating underfoot; the air conditioned, even.",
+   "atmospheric": "Corporate frontage rises ahead where Fermi meets the avenue."
+  }
+ },
+ "1518": {
+  "key": "Ada Avenue and Fermi Corridor",
+  "desc": "The intersection of Ada Avenue and Fermi Corridor sits at the colony's northwestern professional district, where corporate offices and administrative services cluster in reinforced structures that suggest both permanence and paranoia. The Meridian Logistics building dominates the corner - four stories of pre-fabricated corporate architecture with the company's faded blue logo peeling from impact-resistant windows.",
+  "sense_descs": {
+   "auditory": "The subdued hush of a corporate district, quiet behind reinforced facades.",
+   "olfactory": "Clean filtered air, neutral and processed.",
+   "tactile": "Reinforced structures and level grating; the air sits conditioned and still.",
+   "atmospheric": "The Meridian Logistics building dominates the corner, its faded blue logo peeling from impact-resistant windows."
+  }
+ },
+ "1521": {
+  "key": "Fermi Corridor",
+  "desc": "North of the avenue, Fermi runs through the colony's northwestern professional core - reinforced corporate structures suggesting both permanence and paranoia. Office frontage lines the east; the crater wall holds the west, its stone interrupted by sealed corporate access tunnels.",
+  "sense_descs": {
+   "auditory": "The orderly quiet of the corporate core, climate units barely audible.",
+   "olfactory": "Clean filtered air, neutral and processed.",
+   "tactile": "Level, maintained grating; cold seeps from the western crater wall.",
+   "atmospheric": "Reinforced corporate structures east, the crater wall's sealed tunnels west."
+  }
+ },
+ "1524": {
+  "key": "Fermi Corridor",
+  "desc": "The corridor climbs the last reach toward the crater wall's base, professional structures thinning into secure frontage and blank service doors. Surveillance fixtures track the empty stretches, the kind of coverage that suggests something worth watching.",
+  "sense_descs": {
+   "auditory": "The faint servo-tick of surveillance fixtures tracking the empty stretch.",
+   "olfactory": "Cold stone and scrubbed corporate air.",
+   "tactile": "The crater wall's chill deepens; the grating runs clean and level.",
+   "atmospheric": "Surveillance fixtures track the corridor in overlapping coverage."
+  }
+ },
+ "1527": {
+  "key": "Fermi Corridor",
+  "desc": "Fermi terminates at the crater wall's base, where it meets Arcturus Row along the dark stone. Access tunnels lead into the wall beyond view, their entrances marked with corporate restriction. The structures here are secure frontage, blank and watchful.",
+  "sense_descs": {
+   "auditory": "A faint draft breathes from the access tunnels in the crater wall.",
+   "olfactory": "The cold mineral breath of the crater wall, scrubbed air beneath.",
+   "tactile": "Cold radiates off the dark stone; clean grating underfoot.",
+   "atmospheric": "The crater wall rises sheer to the north, access tunnels disappearing into its face."
+  }
+ },
+ "1530": {
+  "key": "Arcturus Row and Fermi Corridor",
+  "desc": "The northwest corner of the district, where Fermi Corridor meets Arcturus Row and the crater wall turns the colony's edge. Dark stone rises on two sides, corporate frontage tucked into the angle, access tunnels disappearing into the rock.",
+  "sense_descs": {
+   "auditory": "The deep quiet of the colony's corner, drafts breathing from the access tunnels.",
+   "olfactory": "Cold mineral stone, scrubbed corporate air beneath.",
+   "tactile": "Cold off the dark wall on two sides; clean grating underfoot.",
+   "atmospheric": "The crater wall turns the colony's edge, dark stone rising on two sides."
+  }
+ },
+ "1533": {
+  "key": "Beach Street",
+  "desc": "Beach Street rises north from the artificial shore, composite decking still gritted with imported sand tracked up from the waterfront. Rental kiosks and a shuttered snack counter face the street, their signage sun-faded though the colony has no sun. Beachgoer traffic thins as the decking gives way to standard grating.",
+  "sense_descs": {
+   "auditory": "The wash of the channel against the artificial shore carries up the street.",
+   "olfactory": "Brine and damp imported sand, a thread of fried food from the shuttered counter.",
+   "tactile": "Composite decking gritted with tracked-up sand underfoot.",
+   "atmospheric": "Sun-faded recreation signage faces a shore the colony built by hand."
+  }
+ },
+ "1536": {
+  "key": "Beach Street",
+  "desc": "The street climbs from recreation toward residence, beachfront businesses giving way to apartment frontage with balconies angled for channel views. Ground-level cafes spill seating onto the walk, catering to the foot traffic between the beach and the inland blocks.",
+  "sense_descs": {
+   "auditory": "Cafe chatter and the fading wash of the shore behind.",
+   "olfactory": "Coffee and sunscreen cut with the last of the brine.",
+   "tactile": "Standard grating now, level underfoot; the open exposure catching what light there is.",
+   "atmospheric": "Balconies angle south overhead, premium frontage for the channel view."
+  }
+ },
+ "1539": {
+  "key": "Beach Street",
+  "desc": "Beach Street approaches the avenue, the recreation character fully spent. Professional frontage takes over - service offices, a clinic, ground-level retail with secured displays. The transition the colony zoned for, beach money meeting working money.",
+  "sense_descs": {
+   "auditory": "Purposeful foot traffic on clean grating, the shore gone quiet behind.",
+   "olfactory": "Filtered office air, the brine nearly faded out.",
+   "tactile": "Clean composite underfoot, drainage that functions.",
+   "atmospheric": "An informal boundary - recreation behind, professional frontage ahead."
+  }
+ },
+ "1542": {
+  "key": "Ada Avenue and Beach Street",
+  "desc": "Beach Street cuts north-south through the avenue, offering respite in this crater-bound installation. The intersection serves as an informal boundary - professional services clustering to the west, light manufacturing beginning its slow encroachment from the east. A transit hub occupies the corner, its waiting area populated by workers moving between shifts.",
+  "sense_descs": {
+   "auditory": "Shift workers move through the transit hub; overhead screens cycle their schedule updates.",
+   "olfactory": "Filtered professional air thinning toward machine oil eastward.",
+   "tactile": "A respite of open space in the crater-bound installation; level grating underfoot.",
+   "atmospheric": "Schedule screens update overhead, a reminder the colony never truly sleeps, merely rotates through states of relative exhaustion."
+  }
+ },
+ "1545": {
+  "key": "Beach Street",
+  "desc": "North of the avenue, Beach Street runs through light-manufacturing frontage encroaching from the east, reinforced shopfronts and fabrication bays. The street holds its maintained character, north-district money keeping the grating clean even where industry creeps in.",
+  "sense_descs": {
+   "auditory": "The muted clatter of light-manufacturing bays behind reinforced fronts.",
+   "olfactory": "Machine oil and hot metal thread into the conditioned air.",
+   "tactile": "Clean grating underfoot despite the encroaching industry.",
+   "atmospheric": "Light-manufacturing frontage encroaches from the east."
+  }
+ },
+ "1548": {
+  "key": "Beach Street",
+  "desc": "The street climbs the last blocks toward the crater wall, manufacturing yielding to secure residential. The buildings rise taller here, balconies and decorative panels marking the north district's wealth, the crater wall a darkening presence ahead.",
+  "sense_descs": {
+   "auditory": "The quiet of secure residential, the industrial clatter dropped behind.",
+   "olfactory": "Conditioned air, clean and neutral, cooling toward stone.",
+   "tactile": "The crater wall's chill begins to reach the street; level grating underfoot.",
+   "atmospheric": "Residential towers rise with decorative panels, the crater wall darkening to the north."
+  }
+ },
+ "1551": {
+  "key": "Beach Street",
+  "desc": "Beach Street ends at the crater wall's base, meeting Arcturus Row along the dark stone. Secure residential frontage faces the wall, viewports glowing with the habitation of people who can afford the quiet. Access tunnels lead into the rock beyond view.",
+  "sense_descs": {
+   "auditory": "The deep quiet of the crater wall's base, a faint draft from the tunnels.",
+   "olfactory": "The cold mineral breath of the stone, scrubbed residential air beneath.",
+   "tactile": "Cold radiates off the dark wall; clean grating underfoot.",
+   "atmospheric": "The crater wall rises sheer to the north, access tunnels set into its face."
+  }
+ },
+ "1554": {
+  "key": "Beach Street and Arcturus Row",
+  "desc": "Beach Street meets Arcturus Row at the crater wall's base, the recreation street ending in affluent stillness against dark stone. Secure residential frames the junction; the promenade runs east and west along the wall.",
+  "sense_descs": {
+   "auditory": "The affluent quiet of the promenade, sparse footfall on clean composite.",
+   "olfactory": "Clean conditioned air, cold mineral stone beneath.",
+   "tactile": "Cool air off the crater wall; pristine grating underfoot.",
+   "atmospheric": "The crater wall rises dark to the north, access tunnels set into its face."
+  }
+ },
+ "1557": {
+  "key": "Gilroy Street",
+  "desc": "Gilroy Street rises north from the waterfront's residential blocks, prefab towers stacked on both sides, their viewports marked with the personalization of people who live rather than work here. A transit shelter and ground-level shops serve the daily flow between channel and home.",
+  "sense_descs": {
+   "auditory": "Residential murmur stacked floor on floor; the channel moving somewhere behind.",
+   "olfactory": "Cooking from a hundred units, brine off the channel behind.",
+   "tactile": "Moderate-wear grating underfoot; cool damp off the waterfront.",
+   "atmospheric": "Prefab towers rise both sides, viewports glowing with habitation."
+  }
+ },
+ "1560": {
+  "key": "Gilroy Street",
+  "desc": "The street runs north through residential density, external staircases zigzagging up the prefab faces, laundry strung between buildings. Ground-level commerce fills the gaps - a grocer, a noodle counter, a repair stall, the small economy of a neighborhood that mostly stays put.",
+  "sense_descs": {
+   "auditory": "Footfall on external staircases, the small clatter of street-level commerce.",
+   "olfactory": "Noodle steam and detergent off the strung laundry.",
+   "tactile": "Worn grating smooth underfoot; the air close with stacked living.",
+   "atmospheric": "Laundry hangs strung between buildings, marking the air's slow currents."
+  }
+ },
+ "1563": {
+  "key": "Gilroy Street",
+  "desc": "Gilroy approaches the avenue where a small market claims the corner - stalls of personal items, secondhand gear, food from across the colony's cultures. The residential character mixes here with the working crews moving between the professional west and the manufacturing east.",
+  "sense_descs": {
+   "auditory": "Bargaining in several languages across the market stalls.",
+   "olfactory": "Food from across the colony's cultures, machine oil underneath.",
+   "tactile": "Market stalls crowd the street to browsing-width.",
+   "atmospheric": "Workers from west and east share the market without meaningful intersection."
+  }
+ },
+ "1566": {
+  "key": "Ada Avenue and Gilroy Street",
+  "desc": "This passage creates a crossroads of workers - professional services personnel from the west meeting manufacturing crews from the east, both groups occupying the same space without meaningful intersection. The intersection hosts a small market, stalls selling personal items, secondhand equipment, and food options that span the colony's cultural spectrum.",
+  "sense_descs": {
+   "auditory": "Bargaining in multiple languages carries across the market stalls.",
+   "olfactory": "Food options spanning the colony's cultural spectrum, cut with machine oil.",
+   "tactile": "Market stalls crowd the crossroads; the space pinches close with browsing traffic.",
+   "atmospheric": "Workers from west and east share the space without meaningful intersection."
+  }
+ },
+ "1569": {
+  "key": "Gilroy Street",
+  "desc": "North of the avenue, Gilroy holds its residential character but the maintenance improves, north-district money showing in fresh sealant and functioning fixtures. The towers rise taller, balconies appearing, the transition from working housing toward something more secure.",
+  "sense_descs": {
+   "auditory": "Quieter here, the market clatter dropped behind, climate units humming.",
+   "olfactory": "Cleaner air, cooking smells thinning toward conditioned neutral.",
+   "tactile": "Better-kept grating underfoot; fresh sealant on the frontage.",
+   "atmospheric": "Balconies appear on the rising towers, maintenance improving block by block."
+  }
+ },
+ "1572": {
+  "key": "Gilroy Street",
+  "desc": "The street climbs toward the crater wall through secure residential, the prefab density giving way to better-built towers with controlled entrances. The crater wall darkens the northern view, the channel a distant memory now.",
+  "sense_descs": {
+   "auditory": "The secure quiet of controlled-entrance residential.",
+   "olfactory": "Conditioned air cooling toward the crater wall's stone.",
+   "tactile": "The wall's chill reaching the street; clean grating underfoot.",
+   "atmospheric": "Controlled-entrance towers, the crater wall darkening to the north."
+  }
+ },
+ "1575": {
+  "key": "Gilroy Street",
+  "desc": "Gilroy ends at the crater wall's base where it meets Arcturus Row. Secure residential frontage faces the dark stone, the quietest and most expensive end of a working street. Access tunnels lead into the wall beyond view.",
+  "sense_descs": {
+   "auditory": "The deep quiet of the crater wall, a faint draft off the tunnels.",
+   "olfactory": "Cold mineral stone over scrubbed residential air.",
+   "tactile": "Cold off the dark wall; clean grating underfoot.",
+   "atmospheric": "The crater wall rises sheer north, access tunnels set into the rock."
+  }
+ },
+ "1581": {
+  "key": "Ada Avenue",
+  "desc": "Professional services line the avenue here - a synthetic showroom, a contract adjustor, a communications relay station with antenna arrays sprouting from its roof like mechanical vegetation. The buildings share a prefabricated uniformity, their modular construction suggesting they could be disassembled and relocated if corporate priorities shifted.",
+  "sense_descs": {
+   "auditory": "A static murmur leaks from the relay station; antenna servos tick as they adjust overhead.",
+   "olfactory": "New prefab resin and the faint ozone of the communications gear.",
+   "tactile": "The relay's hum carries up faintly through the decking."
+  }
+ },
+ "1584": {
+  "key": "Ada Avenue",
+  "desc": "The corridor here passes between a datacenter and a colony services office, their competing hums creating an industrial harmony. Cooling vents from the datacenter push warm air across the avenue, encouraging opportunistic mold to creep along the facing wall.",
+  "sense_descs": {
+   "auditory": "Two industrial hums braid together, datacenter and services office trading frequencies.",
+   "olfactory": "Warm electronics overlaid with the sour-green note of mold on the facing wall.",
+   "tactile": "A band of warmth crosses the avenue where the cooling vents vent their exhaust."
+  }
+ },
+ "1587": {
+  "key": "Ada Avenue",
+  "desc": "Light manufacturing begins its presence here. A fabrication shop occupies a reinforced building, its windows opaque with residue from cutting operations. Across the way, a supply depot serves the surrounding businesses - raw materials in, finished components out, the circulation of resources that keeps the colony's secondary economy functioning.",
+  "sense_descs": {
+   "auditory": "The high whine of precision tools cuts through at irregular intervals.",
+   "olfactory": "Cutting residue hangs in the air, hot metal and scorched lubricant.",
+   "tactile": "Fine grit from the fabrication shop settles on every surface within reach."
+  }
+ },
+ "1593": {
+  "key": "Ada Avenue",
+  "desc": "A component testing facility operates here, quality control for parts destined for installation throughout the colony's infrastructure. Rejected pieces accumulate in bins along the exterior wall, each failure representing someone's miscalculation or someone else's cost-cutting measure.",
+  "sense_descs": {
+   "auditory": "A constant low-frequency hum rolls out of the facility's exhaust system.",
+   "olfactory": "Ozone and the burnt-insulation smell of parts pushed until they failed.",
+   "tactile": "The exhaust vibration travels up through the decking into the soles of the feet."
+  }
+ },
+ "1596": {
+  "key": "Ada Avenue",
+  "desc": "The avenue's central stretch shows the neighborhood's mixed character most clearly. A precision instrument calibration service operates next to a hydraulic repair shop, their clientele overlapping in unexpected ways. The buildings here predate the current tenants, their construction reflecting earlier standards - thicker walls, heavier doors, the assumption that permanence required physical mass rather than legal protection.",
+  "sense_descs": {
+   "auditory": "The hiss and thump of hydraulic rigs runs against the fine ticking of calibration benches.",
+   "olfactory": "Hydraulic fluid and the sharp bite of cleaning solvent.",
+   "tactile": "The old thick walls hold the cold; the air sits a few degrees lower here."
+  }
+ },
+ "1599": {
+  "key": "Ada Avenue",
+  "desc": "A large facility occupies this stretch, providing operational equipment throughout the colony's industrial sectors. Across the avenue, an assortment of depots serve the surrounding facilities, high fencing suggesting the importance of their contents.",
+  "sense_descs": {
+   "auditory": "Muffled machinery leaks from interior spaces, the rehearsal before louder work.",
+   "olfactory": "Machine grease and the metallic tang of stored equipment.",
+   "tactile": "Chain-link fencing rattles faintly when the avenue's air shifts."
+  }
+ },
+ "1604": {
+  "key": "Ada Avenue",
+  "desc": "Heavy equipment maintenance dominates this section, repair bays opening onto the avenue with the casual confidence of essential services. Mining machinery in various states of disassembly occupies the available space. A parts supplier operates from a reinforced structure, inventory visible through the windows - rows of components organized by systems that presumably make sense to those who work here.",
+  "sense_descs": {
+   "auditory": "Impact wrenches stutter and dropped components clang out of the open repair bays.",
+   "olfactory": "Diesel, hot brake metal, and grease worked deep into the concrete.",
+   "tactile": "The floor underfoot is slick with oil ground in over years."
+  }
+ },
+ "1607": {
+  "key": "Ada Avenue",
+  "desc": "The avenue narrows slightly here, buildings pressing closer as architecture shifts toward industrial utility over professional presentation. Overhead pipes and conduits create a partial ceiling, infrastructure that serves the surrounding facilities regardless of aesthetic impact. A recycling operation processes industrial waste, converting failed components and worn materials into raw stock for fabrication.",
+  "sense_descs": {
+   "auditory": "The grind and crush of the recycling line reduces failed components to stock.",
+   "olfactory": "Hot plastic and melted resin off the reclamation process.",
+   "tactile": "The overhead pipes lower the ceiling; the air feels closer, more enclosed."
+  }
+ },
+ "1610": {
+  "key": "Ada Avenue",
+  "desc": "Industrial operations dominate the avenue here, their presence unapologetic in the way of essential services. A cable manufacturing facility runs continuous shifts, spooling the colony's nervous system onto massive drums for distribution. Across the avenue, a chemical processing station handles materials too hazardous for the main atmospheric processor but too necessary to eliminate. Warning signage covers every available surface.",
+  "sense_descs": {
+   "auditory": "The steady whir of spinning drums reels cable onto its spools without pause.",
+   "olfactory": "Hot insulation overlaid with the acrid bite of processed chemicals.",
+   "tactile": "The spinning equipment's vibration translates steadily through the decking."
+  }
+ },
+ "1615": {
+  "key": "Arcturus Row",
+  "desc": "The Row passes corporate frontage near the Fermi junction, reinforced structures with backlit signage facing the crater wall. Overlapping security lighting leaves no shadows; uniformed personnel process credentials at the checkpoints.",
+  "sense_descs": {
+   "auditory": "The low hum of corporate climate systems; checkpoint readers chiming.",
+   "olfactory": "Scrubbed corporate air, neutral and cold.",
+   "tactile": "Level pristine grating; the crater wall's chill steady to the north.",
+   "atmospheric": "Overlapping security lighting leaves no shadow along the corporate frontage."
+  }
+ },
+ "1618": {
+  "key": "Arcturus Row",
+  "desc": "Corporate housing towers rise along the Row, eight and nine levels where the bedrock permits, their amenities the kind that don't exist in working districts. Building signage lists corporate sponsors; the dark crater wall stands behind them all.",
+  "sense_descs": {
+   "auditory": "The deep quiet of well-insulated towers, systems barely audible.",
+   "olfactory": "Conditioned air, the industrial colony scrubbed entirely away.",
+   "tactile": "Everything works here - tempered air, maintained surfaces, no grit.",
+   "atmospheric": "Corporate sponsor signage marks the towers against the crater wall."
+  }
+ },
+ "1621": {
+  "key": "Arcturus Row",
+  "desc": "The Row continues east toward the Beach Street junction, secure residential frontage facing the crater wall. Street furniture appears - benches, kiosks, waste receptacles that get emptied. The dark stone holds access tunnels, their entrances marked with corporate restriction.",
+  "sense_descs": {
+   "auditory": "The affluent quiet, footfall sparse on clean composite.",
+   "olfactory": "Clean conditioned air over cold mineral stone.",
+   "tactile": "Cool air off the wall; pristine grating underfoot.",
+   "atmospheric": "Access tunnels mark the crater wall, entrances posted restricted."
+  }
+ },
+ "1626": {
+  "key": "Arcturus Row",
+  "desc": "Past the Beach junction, Arcturus runs through the district's quietest residential, viewports glowing with the habitation of people who can afford stillness. Decorative panels face the crater wall, the kind of frontage that markets a view of dark stone as exclusivity.",
+  "sense_descs": {
+   "auditory": "Stillness, the deep quiet that wealth buys at the colony's edge.",
+   "olfactory": "Clean neutral air, cold stone beneath.",
+   "tactile": "The crater wall's chill; level pristine grating.",
+   "atmospheric": "Viewports glow along the wall, habitation that can afford the quiet."
+  }
+ },
+ "1629": {
+  "key": "Arcturus Row",
+  "desc": "The promenade widens slightly here, a deliberate public space along the crater wall - composite seating, planters of ornamental growth, lighting that flatters rather than merely functions. The dark stone rises behind, access tunnels disappearing into the rock.",
+  "sense_descs": {
+   "auditory": "The soft cycling of irrigation in the planters; sparse, unhurried footfall.",
+   "olfactory": "Ornamental greenery and clean air against cold stone.",
+   "tactile": "Composite seating and tended planters; cool air off the wall.",
+   "atmospheric": "Flattering promenade lighting plays along the crater wall's dark face."
+  }
+ },
+ "1632": {
+  "key": "Arcturus Row",
+  "desc": "Arcturus approaches the Gilroy junction, residential frontage mixing with discreet commerce - a wine merchant, a private clinic, storefronts that don't post prices. The crater wall stands to the north, its base swept clean.",
+  "sense_descs": {
+   "auditory": "The discreet quiet of commerce that doesn't advertise.",
+   "olfactory": "Clean conditioned air, a faint trace of imported goods.",
+   "tactile": "Swept composite underfoot; the crater wall's chill to the north.",
+   "atmospheric": "Discreet storefronts face the wall, prices posted nowhere."
+  }
+ },
+ "1639": {
+  "key": "Gilroy Street and Arcturus Row",
+  "desc": "Gilroy Street meets Arcturus Row at the crater wall, its working-residential character spent in the affluent calm of the promenade. Secure frontage frames the junction; the dark stone stands to the north.",
+  "sense_descs": {
+   "auditory": "The promenade's deep quiet, the working street gone silent behind.",
+   "olfactory": "Clean neutral air over cold stone.",
+   "tactile": "The crater wall's chill; level pristine grating underfoot.",
+   "atmospheric": "The crater wall rises dark north, the promenade running east and west along it."
+  }
+ },
+ "1644": {
+  "key": "Arcturus Row",
+  "desc": "The Row runs between secure residential and the crater wall, the promenade holding its maintained calm. Surveillance fixtures track the stretches between entrances, coverage so routine it reads as part of the architecture.",
+  "sense_descs": {
+   "auditory": "The faint servo-tick of surveillance fixtures along the quiet stretch.",
+   "olfactory": "Scrubbed air, cold stone beneath.",
+   "tactile": "Pristine grating underfoot; cool air off the dark wall.",
+   "atmospheric": "Surveillance fixtures track the promenade in routine overlapping coverage."
+  }
+ },
+ "1647": {
+  "key": "Arcturus Row",
+  "desc": "Arcturus continues east, the frontage a steady run of secure residential and corporate annexes facing the crater wall. The dark stone is broken here by a sealed maintenance bulkhead, corporate logos weathered to abstraction across its face.",
+  "sense_descs": {
+   "auditory": "The affluent hush, climate systems a low constant.",
+   "olfactory": "Clean neutral air over cold mineral stone.",
+   "tactile": "The crater wall's chill; level pristine grating underfoot.",
+   "atmospheric": "A sealed bulkhead breaks the crater wall, its corporate logos weathered abstract."
+  }
+ },
+ "1652": {
+  "key": "Tolliver Row",
+  "desc": "The street narrows slightly where structural supports rise on both sides, composite columns that speak to engineering concerns about the weight distribution above. Between the supports on the northern side, someone has established a fabrication shop, its entrance marked by a hand-painted sign advertising custom metalwork and composite repair. The southern side shows a shift facility for waterfront workers - lockers visible through viewports, posted schedules on weather-resistant boards outside the entrance, the kind of infrastructure that exists because people need somewhere to change before and after handling cargo that has been sitting in channel moisture for weeks.",
+  "sense_descs": {
+   "auditory": "The crack and hiss of welding carries from the open fabrication bay.",
+   "olfactory": "Hot metal, flux, and the damp-cargo smell off the shift facility.",
+   "tactile": "Composite support columns crowd the street; the space feels braced and close.",
+   "atmospheric": "Welding flashes throw intermittent light that makes the shadows jump."
+  }
+ },
+ "1655": {
+  "key": "Cobb Street and Tolliver Row",
+  "desc": "The intersection opens where Cobb Street cuts north-south through the waterfront district, the confluence marked by grating reinforced for cross-traffic between channel operations and inland facilities. A warehouse complex sprawls on the northeast corner, its construction showing corporate planning - matched modules, uniform viewports, loading bays marked with sequential bay numbers. Cargo haulers sit idle outside, their flatbeds empty or stacked with pallets. The southern side shows mixed-use character, ground-level commercial topped with residential density. A small commissary occupies one corner.",
+  "sense_descs": {
+   "auditory": "Idle cargo haulers tick as they cool; a commissary's serving counter clatters at the corner.",
+   "olfactory": "Diesel and channel brine cut with cooking from the commissary.",
+   "tactile": "Reinforced grating underfoot; cool channel air moves through the confluence.",
+   "atmospheric": "A commissary's digital display cycles daily specials in multiple languages."
+  }
+ },
+ "1658": {
+  "key": "Tolliver Row",
+  "desc": "The street widens as it approaches the Coltrane intersection ahead, directional signage posted in multiple languages. A cargo staging area occupies the northern side, composite pallets arranged in organized rows beneath weather-resistant tarps. Forklifts and haulers navigate with purposeful efficiency. The southern side shows service businesses - equipment rental, synthetic maintenance, a small medical clinic. The channel remains visible beyond the stacked cargo.",
+  "sense_descs": {
+   "auditory": "Forklifts and haulers work the staging area with purposeful efficiency.",
+   "olfactory": "Weather-resistant tarp, diesel, and salt.",
+   "tactile": "The street broadens, the air opening up toward the intersection ahead.",
+   "atmospheric": "A small clinic's illuminated cross flickers among the service-front signage."
+  }
+ },
+ "1661": {
+  "key": "Tolliver Row",
+  "desc": "The street straightens and agriculture domes fill the horizon through industrial haze. A machinery yard occupies the northern side, chain-link fencing enclosing mining vehicles, construction rigs, and haulers awaiting parts. The gate stands open during shifts, security minimal. The southern side shows prefab residential stacked four high, fire escapes zigzagging upward, laundry hanging between landings. The structures show decades of wear - faded panels, patched seals, housing built for ten years pushing past thirty. Twin tracks polish the grating where haulers have worn it smooth.",
+  "sense_descs": {
+   "auditory": "Mining rigs and haulers idle in the machinery yard behind minimal security.",
+   "olfactory": "Machine grease and fuel, with a faint thread of detergent off the hung laundry.",
+   "tactile": "Twin polished tracks run where haulers have worn the grating smooth.",
+   "atmospheric": "Agriculture domes fill the horizon through the haze; cabling runs overhead in thick organic bundles."
+  }
+ },
+ "1664": {
+  "key": "Tolliver Row",
+  "desc": "A fuel depot dominates the northern side, composite tanks behind security fencing with warning signs and functional surveillance cameras. Pumping stations line the street-facing wall, the concrete pad stained dark from years of spills. The southern side shows a repair facility expanded beyond its original footprint, welded additions creating a warren of work bays. The entrance reveals disassembled equipment, tool carts, and technicians under harsh utility lighting.",
+  "sense_descs": {
+   "auditory": "Pumping stations cycle along the depot's wall; impact tools ring from the repair bays.",
+   "olfactory": "Diesel and synthetic lubricant cut through the air with chemical sharpness.",
+   "tactile": "The concrete pad is stained dark and tacky from years of spills.",
+   "atmospheric": "Hazard warnings cover every surface in multiple languages."
+  }
+ },
+ "1667": {
+  "key": "Battery Street and Tolliver Row",
+  "desc": "The intersection widens where Battery Street cuts into the waterfront's agricultural district, reinforced grating and traffic control signage marking significant volume. North, Battery extends toward the agriculture dome access points. Traffic is mixed - light cargo haulers moving produce, pedestrian traffic from the residential towers, corporate vehicles serving the biotech facilities.",
+  "sense_descs": {
+   "auditory": "Light cargo haulers and pedestrian traffic mix through the widened crossing.",
+   "olfactory": "A green, loamy note from the agricultural district north, cut with channel brine.",
+   "tactile": "Reinforced grating underfoot; the intersection opens wider here.",
+   "atmospheric": "Traffic control signage marks the volume where Battery extends toward the dome access points."
+  }
+ },
+ "1670": {
+  "key": "Tolliver Row",
+  "desc": "The northern side shows a marine supply depot, roll-up doors revealing stacked cable spools, deck plating, and equipment for channel vessels. The southern side rises in residential towers, four and five levels with better maintenance than industrial districts - fresh sealant, functioning mechanisms. The grating is newer composite, drainage systems that actually function. Street lighting includes decorative elements alongside functional fixtures.",
+  "sense_descs": {
+   "auditory": "Roll-up doors rumble at the marine depot; far off, water works steadily against the channel structures.",
+   "olfactory": "Salt air and the tar-and-cable smell of marine supply.",
+   "tactile": "Newer composite underfoot, drains that actually carry the wet away.",
+   "atmospheric": "The Central Span's navigation lights blink through the gaps in the structures."
+  }
+ },
+ "1673": {
+  "key": "Tolliver Row",
+  "desc": "A commercial plaza opens on the northern side, three prefab structures around a central courtyard housing a grocer, clothing supplier, and cafe with outdoor seating. The plaza's grating has been replaced with decorative decking arranged in patterns. The southern side continues its waterfront character, a boat repair facility with work bays open to reveal vessels in maintenance. The channel stretches beyond, its scale making the boats look like toys.",
+  "sense_descs": {
+   "auditory": "Cafe chatter mixes with the knock of tools from the boat repair bays.",
+   "olfactory": "Cooking from the cafe cut with the resin-and-brine of boat repair.",
+   "tactile": "Decorative decking underfoot, arranged in patterns instead of plain grating."
+  }
+ },
+ "1676": {
+  "key": "Tolliver Row",
+  "desc": "Residential towers rise six levels on the northern side, showing architectural ambition - curved facades, decorative panels, balconies suggesting space for living. Security checkpoints mark entrances with biometric scanners and guard stations. Viewports show actual furniture and office workers at terminals. The street surface is pristine composite with visible installation seams. Street furniture appears - benches, waste receptacles, informational kiosks. The Balboa Channel remains visible to the south, but here it feels like background rather than defining feature.",
+  "sense_descs": {
+   "auditory": "Quiet here, the channel reduced to a distant background wash.",
+   "olfactory": "Clean composite and a faint salt thread, the working-waterfront reek left behind.",
+   "tactile": "Pristine composite underfoot, installation seams still visible.",
+   "atmospheric": "Biometric checkpoints and guard stations mark the tower entrances."
+  }
+ },
+ "1679": {
+  "key": "Tsiolkovsky Corridor and Tolliver Row",
+  "desc": "The intersection sprawls where Tsiolkovsky Corridor cuts through the northern district's administrative core, grating maintained to corporate standards - clean, level, functioning drainage. Tolliver Row terminates here at the crater wall, the colony's eastern boundary rising as dark stone interrupted by sealed bulkheads and carved openings. Old mine entrances sit behind security barriers, their depths disappearing into darkness. Corporate signage marks some tunnels as restricted access; others show no markings at all, just darkness and the suggestion of passages that predate current occupation.",
+  "sense_descs": {
+   "auditory": "The orderly quiet of the admin core; a faint draft breathes from the old mine openings.",
+   "olfactory": "Clean filtered air with the cold mineral breath of the crater wall.",
+   "tactile": "Corporate-standard grating, clean and level underfoot; cold radiates off the eastern stone.",
+   "atmospheric": "The crater wall rises east, dark stone interrupted by sealed bulkheads and mine entrances behind security barriers."
+  }
+ },
+ "1700": {
+  "key": "Tsiolkovsky Corridor",
+  "desc": "Tsiolkovsky ends where the eastern crater wall meets Arcturus Row, dark stone closing the colony off on two sides. Sealed bulkheads and carved openings mark the rock, some restricted, some showing only darkness and the suggestion of passages that predate the current occupation.",
+  "sense_descs": {
+   "auditory": "The deep quiet of the closed corner, drafts breathing from the carved openings.",
+   "olfactory": "Cold mineral stone, the air gone still and scrubbed.",
+   "tactile": "Cold off the dark wall on two sides; clean grating underfoot.",
+   "atmospheric": "The crater wall closes the colony off, carved openings hinting at older passages."
+  }
+ },
+ "1706": {
+  "key": "Battery Street",
+  "desc": "Battery Street runs north from the waterfront into the agricultural district, traffic-control signage marking the volume of produce haulers. Biotech facilities line the way, their frontage cleaner than the industry elsewhere, the work that feeds the colony given a measure of care.",
+  "sense_descs": {
+   "auditory": "Produce haulers and pedestrian traffic mixing through the wide street.",
+   "olfactory": "A green, loamy note off the agricultural facilities, brine behind.",
+   "tactile": "Reinforced grating underfoot; the street running wide here.",
+   "atmospheric": "Traffic-control signage marks the produce-hauler volume."
+  }
+ },
+ "1709": {
+  "key": "Battery Street",
+  "desc": "The street continues north past processing facilities and biotech frontage, cold-storage units and refrigerated bays recessed into the structures. The agricultural economy runs on both sides, raw growth in, processed stock out.",
+  "sense_descs": {
+   "auditory": "Refrigeration compressors cycling behind the frontage.",
+   "olfactory": "Cold storage and refrigerant cut with the loam of growing stock.",
+   "tactile": "A chill leaks from the cold-storage bays into the street.",
+   "atmospheric": "Refrigerated bays recess into the biotech structures both sides."
+  }
+ },
+ "1712": {
+  "key": "Battery Street",
+  "desc": "Battery approaches the avenue where agricultural support clusters - processing facilities, equipment yards, salvage operations picking over what the failed domes left behind. The frontage runs to rust here, machinery aging behind viewports nobody cleans.",
+  "sense_descs": {
+   "auditory": "A refrigeration unit's compressor cycling with mechanical stubbornness.",
+   "olfactory": "Rust, leaking refrigerant, and the loam of old hydroponics.",
+   "tactile": "Cold leaks through degraded seals; rust-gritted grating underfoot.",
+   "atmospheric": "Agricultural processing equipment rusts behind uncleaned viewports."
+  }
+ },
+ "1715": {
+  "key": "Ada Avenue and Battery Street",
+  "desc": "Agricultural support infrastructure clusters here - processing facilities with equipment rusting behind viewports nobody cleans. The southern side shows salvage operations, components stripped and sorted by material. A vendor offers hydroponic equipment to anyone optimistic enough to try again.",
+  "sense_descs": {
+   "auditory": "A refrigeration unit's compressor cycles with mechanical stubbornness, preserving nothing.",
+   "olfactory": "Rust, cold leaking refrigerant, and the faint loam of old hydroponics.",
+   "tactile": "Cold leaks through the refrigeration unit's degraded seals into the air.",
+   "atmospheric": "Processing equipment rusts behind viewports nobody cleans."
+  }
+ },
+ "1718": {
+  "key": "Battery Street",
+  "desc": "North of the avenue, Battery runs toward the agriculture dome access points, the frontage shifting to dome-service operations - equipment suppliers, seed handling, the infrastructure of feeding a colony. The maintenance improves with the north-district money.",
+  "sense_descs": {
+   "auditory": "Dome-service equipment moving stock; the hum of climate-controlled storage.",
+   "olfactory": "Growing medium, refrigerant, and clean composite.",
+   "tactile": "Maintained grating underfoot; cool storage air spilling from the bays.",
+   "atmospheric": "Dome-service frontage lines the way toward the agriculture access points."
+  }
+ },
+ "1721": {
+  "key": "Battery Street",
+  "desc": "The street climbs toward the crater wall, dome-service operations giving way to secure agricultural administration and storage. Frost forms around the seals of a cold vault recessed into the eastern frontage, vapor escaping when crews access it.",
+  "sense_descs": {
+   "auditory": "The cycle and hiss of a cold vault's climate seals.",
+   "olfactory": "Frost, refrigerant, and cold mineral air.",
+   "tactile": "Deep cold spills from the vault seals; frost rimes the nearby grating.",
+   "atmospheric": "Vapor drifts from the cold vault's seals; the crater wall darkens north."
+  }
+ },
+ "1724": {
+  "key": "Battery Street",
+  "desc": "Battery ends at the crater wall's base where it meets Arcturus Row. Secure storage and administration face the dark stone, the quiet end of the agricultural reach. Access tunnels lead into the rock beyond view.",
+  "sense_descs": {
+   "auditory": "The deep quiet of the crater wall, a faint draft off the tunnels.",
+   "olfactory": "Cold mineral stone over a faint thread of refrigerant.",
+   "tactile": "Cold off the dark wall; clean grating underfoot.",
+   "atmospheric": "The crater wall rises sheer north, access tunnels set into the rock."
+  }
+ },
+ "1727": {
+  "key": "Battery Street and Arcturus Row",
+  "desc": "Battery Street meets Arcturus Row at the crater wall, the agricultural reach ending in the promenade's affluent calm. Secure frontage and biotech administration frame the junction; the dark stone stands to the north.",
+  "sense_descs": {
+   "auditory": "The administrative quiet of the junction, climate systems humming low.",
+   "olfactory": "Clean processed air, a faint cold-storage thread over stone.",
+   "tactile": "Cool air off the crater wall; level pristine grating underfoot.",
+   "atmospheric": "The crater wall rises dark north, the promenade running along its base."
+  }
+ },
+ "1730": {
+  "key": "Cobb Street",
+  "desc": "Cobb Street runs north from the waterfront's warehouse district, corporate-planned complexes lining the way - matched modules, uniform viewports, sequential loading bays. Cargo haulers sit idle between shifts, flatbeds empty or stacked with pallets awaiting the next move.",
+  "sense_descs": {
+   "auditory": "Idle haulers ticking as they cool; the clang of a loading bay working a late shift.",
+   "olfactory": "Diesel and cold steel, brine off the channel behind.",
+   "tactile": "Reinforced grating, hauler-polished smooth underfoot.",
+   "atmospheric": "Corporate-planned warehouse modules line the street in uniform rows."
+  }
+ },
+ "1733": {
+  "key": "Cobb Street",
+  "desc": "The street continues north through working industry, repair bays and parts suppliers opening onto the grating. The character is rougher than the corporate frontage south, independent operations filling the buildings the warehouses don't claim.",
+  "sense_descs": {
+   "auditory": "Impact tools and the grind of repair work from the open bays.",
+   "olfactory": "Hot metal, grease, and machine oil.",
+   "tactile": "Oil worked into the grating, slick in patches underfoot.",
+   "atmospheric": "Independent repair operations fill the gaps between corporate frontage."
+  }
+ },
+ "1736": {
+  "key": "Cobb Street",
+  "desc": "Cobb approaches the avenue at an informal boundary - respectable industrial operations holding the west, rougher territory claiming the eastern stretches. The grating shows mixed wear, the buildings a patchwork of maintained and neglected.",
+  "sense_descs": {
+   "auditory": "Industrial clatter from the west, the east quieter and warier.",
+   "olfactory": "Machine oil and the metallic tang of fabrication.",
+   "tactile": "Mixed-wear grating underfoot at the boundary.",
+   "atmospheric": "An informal line - respectable industry west, rougher territory east."
+  }
+ },
+ "1739": {
+  "key": "Ada Avenue and Cobb Street",
+  "desc": "Cobb Street cuts through the avenue here, its passage connecting the northern industrial reaches to the crater's central areas. The intersection serves as an informal boundary - respectable industrial operations to the west, rougher territory claiming the eastern stretches.",
+  "sense_descs": {
+   "auditory": "Industrial transit grinds west; the east stretches quieter, warier.",
+   "olfactory": "Machine oil and the metallic tang of industrial operations.",
+   "tactile": "Worn grating underfoot at the boundary between respectable and rough.",
+   "atmospheric": "The intersection marks an informal line - respectable industry west, rougher territory east."
+  }
+ },
+ "1742": {
+  "key": "Cobb Street",
+  "desc": "North of the avenue, Cobb runs through industrial operations that clean up by degrees as the north district's money asserts itself. Fabrication frontage gives way to managed light industry, the grating maintained even where the work stays heavy.",
+  "sense_descs": {
+   "auditory": "The steady hum of managed light industry behind reinforced fronts.",
+   "olfactory": "Hot metal thinning toward conditioned air.",
+   "tactile": "Maintained grating underfoot despite the heavy work.",
+   "atmospheric": "Light industry under north-district management, cleaner block by block."
+  }
+ },
+ "1745": {
+  "key": "Cobb Street",
+  "desc": "The street climbs toward the crater wall, industry yielding to service frontage and secure structures. Surveillance fixtures appear along the empty stretches, the crater wall a darkening presence to the north.",
+  "sense_descs": {
+   "auditory": "The faint tick of surveillance fixtures, the industrial noise dropped behind.",
+   "olfactory": "Cold stone and scrubbed air, the machine-oil baseline fading.",
+   "tactile": "The crater wall's chill reaching the street; clean grating underfoot.",
+   "atmospheric": "Surveillance fixtures track the empty stretches toward the crater wall."
+  }
+ },
+ "1748": {
+  "key": "Cobb Street",
+  "desc": "Cobb ends at the crater wall's base, meeting Arcturus Row along the dark stone. Secure service frontage faces the wall, blank doors and controlled access. Tunnels lead into the rock beyond view.",
+  "sense_descs": {
+   "auditory": "The deep quiet of the crater wall, a faint draft from the tunnels.",
+   "olfactory": "The cold mineral breath of the stone.",
+   "tactile": "Cold off the dark wall; clean grating underfoot.",
+   "atmospheric": "The crater wall rises sheer north, access tunnels set into its face."
+  }
+ },
+ "1751": {
+  "key": "Cobb Street and Arcturus Row",
+  "desc": "Cobb Street meets Arcturus Row at the crater wall, industry yielding fully to the secure frontage of the promenade. Dark stone rises to the north, swept clean at its base; the Row runs east and west.",
+  "sense_descs": {
+   "auditory": "The affluent quiet, the industrial clatter dropped well behind.",
+   "olfactory": "Scrubbed air, cold mineral stone beneath.",
+   "tactile": "Cool air off the dark wall; pristine grating underfoot.",
+   "atmospheric": "The crater wall stands dark to the north, access tunnels in its face."
+  }
+ },
+ "1754": {
+  "key": "Ada Avenue",
+  "desc": "Heavy industry dominates the avenue here, any pretense of mixed-use development abandoned in favor of pure functionality. A smelting operation processes recovered metals, its furnaces casting orange light through heat-resistant windows.",
+  "sense_descs": {
+   "auditory": "The furnaces roar behind their heat-resistant glass.",
+   "olfactory": "Scorched metal and the mineral reek of slag.",
+   "tactile": "Waste heat rolls off the smelting operation; the air sits noticeably warmer.",
+   "atmospheric": "Orange furnace-light bleeds through the heat-resistant windows and stains the avenue."
+  }
+ },
+ "1757": {
+  "key": "Ada Avenue",
+  "desc": "The avenue's eastern reaches show the colony's industrial infrastructure at its most raw. Maintenance access points open onto crucial systems - power distribution, atmospheric processing, water reclamation. Protective barriers separate foot traffic from industrial operations, their placement suggesting hard lessons about the cost of casual proximity. The barriers show impact damage, evidence that separation remains a negotiation between convenience and safety.",
+  "sense_descs": {
+   "auditory": "A deep thrum of power distribution and atmospheric processing runs behind the barriers.",
+   "olfactory": "Ozone off the power systems and the flat smell of reclaimed water.",
+   "tactile": "Where you pass close, the barriers radiate the machinery's heat and vibration."
+  }
+ },
+ "1762": {
+  "key": "Ada Avenue",
+  "desc": "The last dome's framework remains visible to the east, but the avenue returns to professional-industrial character here - equipment suppliers, calibration services, the infrastructure of maintenance rather than growth. A transit point marks this block with composite benches.",
+  "sense_descs": {
+   "auditory": "Shift-change footfall moves against the idle drone of the equipment suppliers.",
+   "olfactory": "Familiar lubricants and ozone; the organic decay smell fades out behind.",
+   "tactile": "The composite benches at the transit point are cold and worn smooth."
+  }
+ },
+ "1765": {
+  "key": "Ada Avenue",
+  "desc": "The dome district transitions here, failed agriculture giving way to functioning industrial baseline. A fabrication shop repurposes salvaged equipment - growing racks becoming storage, irrigation pipes becoming conduit. Southern structures show mixed residential and commercial use, populations displaced when the domes failed finding housing in their shadows. A small market offers salvaged agricultural components to hobbyists and true believers.",
+  "sense_descs": {
+   "auditory": "Fabrication work echoes oddly in space that was built to grow things.",
+   "olfactory": "Machine oil cut with a lingering loamy ghost of old growing medium.",
+   "tactile": "Salvaged irrigation pipe, conduit now, runs cold along the walls."
+  }
+ },
+ "1768": {
+  "key": "Ada Avenue",
+  "desc": "A seed vault occupies a reinforced structure on the northern side, its entrance sealed with security measures suggesting contents worth protecting. Southern structures house agricultural administration offices - terminals still displaying crop rotation schedules from decades past, planning documents for harvests that never happened.",
+  "sense_descs": {
+   "auditory": "The seed vault's climate seals cycle and hiss on the northern side.",
+   "olfactory": "Cold mineral air, frost and refrigerant.",
+   "tactile": "A breath of deep cold escapes the vault seals; frost rimes the nearby grating.",
+   "atmospheric": "Vapor clouds drift from the vault each time its seals cycle open."
+  }
+ },
+ "1773": {
+  "key": "Ada Avenue",
+  "desc": "The largest dome dominates the northern side, its scale suggesting ambitions the colony couldn't sustain. Through clouded panels: a vast empty space, ceiling high enough for trees never planted, floor covered in desiccated growing medium. Graffiti covers the lower panels - generations marking their passage, the newest tags barely weeks old.",
+  "sense_descs": {
+   "auditory": "Climate control wheezes on intermittently, running its cycles for crops that don't exist.",
+   "olfactory": "Dry desiccated growing medium, dust with no green left in it.",
+   "tactile": "The dome breathes its stale recycled air out through the gaps where panels have failed.",
+   "atmospheric": "Through the clouded panels the dome opens into a cathedral of empty space, ceiling high enough for trees never planted."
+  }
+ },
+ "1776": {
+  "key": "Ada Avenue",
+  "desc": "Two domes flank the avenue, their frameworks rising like the ribcages of creatures that died waiting. The western dome shows catastrophic decompression damage - sections blown out, panels scattered. The eastern maintained integrity but sits dark and abandoned. Between them, maintenance infrastructure still hums despite having nothing to feed, and faded instructional placards post optimal growing temperatures for crops that never matured.",
+  "sense_descs": {
+   "auditory": "Maintenance infrastructure still hums between the domes with nothing left to feed.",
+   "olfactory": "Cold vacuum-scoured metal off the blown-out western dome, faint mineral dust.",
+   "tactile": "A thin draft pulls through the western dome's ruptured panels."
+  }
+ },
+ "1779": {
+  "key": "Ada Avenue",
+  "desc": "A defunct agricultural dome dominates the northern side, its geodesic framework visible through panels clouded by decades of mineral deposits. The airlock stands permanently sealed, interior dark, growing beds and hydroponic infrastructure visible through gaps where panels have failed. Southern structures house light manufacturing operations repurposing the space.",
+  "sense_descs": {
+   "auditory": "Light manufacturing clatters under the dead dome's silence.",
+   "olfactory": "Faint organic decay mixed with an industrial chemical tang.",
+   "tactile": "The grating carries old soil staining from the dome's operational years, gritty underfoot.",
+   "atmospheric": "The geodesic framework looms over the avenue, its panels clouded by decades of mineral deposits."
+  }
+ },
+ "1784": {
+  "key": "Arcturus Row",
+  "desc": "The Row passes toward the Cobb junction, secure residential giving way to a mix of corporate service frontage. The crater wall holds its access tunnels and sealed doors, the colony's northern edge made permanent in dark stone.",
+  "sense_descs": {
+   "auditory": "The corporate-district quiet, sparse footfall on clean composite.",
+   "olfactory": "Conditioned air, cold stone beneath.",
+   "tactile": "Cool air off the wall; pristine grating underfoot.",
+   "atmospheric": "Access tunnels and sealed doors mark the crater wall's dark face."
+  }
+ },
+ "1787": {
+  "key": "Arcturus Row",
+  "desc": "Arcturus runs the approach to Cobb Street, the promenade narrowing between corporate annexes and the crater wall. Service entrances recess into the frontage, blank and watchful, the working face of the district's wealth.",
+  "sense_descs": {
+   "auditory": "The muted hum of service systems behind blank frontage.",
+   "olfactory": "Scrubbed air, faintly electric, over cold stone.",
+   "tactile": "The wall's chill steady to the north; level grating underfoot.",
+   "atmospheric": "Blank service entrances recess into the corporate frontage."
+  }
+ },
+ "1792": {
+  "key": "Arcturus Row",
+  "desc": "Past the Cobb junction, the Row returns to secure residential, taller towers with controlled entrances facing the crater wall. The dark stone rises sheer behind them, its base lit by fixtures that get maintained.",
+  "sense_descs": {
+   "auditory": "The controlled-entrance quiet, systems humming low.",
+   "olfactory": "Clean conditioned air, cold mineral stone beneath.",
+   "tactile": "Cool air off the wall; pristine composite underfoot.",
+   "atmospheric": "Maintained fixtures light the crater wall's base behind the towers."
+  }
+ },
+ "1795": {
+  "key": "Arcturus Row",
+  "desc": "The Row holds a steady run of secure residential along the crater wall, viewports showing furniture and the routines of people who never appear in the colony's harder stories. Decorative panels face the dark stone.",
+  "sense_descs": {
+   "auditory": "The deep residential quiet of the affluent edge.",
+   "olfactory": "Clean neutral air over cold stone.",
+   "tactile": "The crater wall's chill; level pristine grating.",
+   "atmospheric": "Viewports show the routines of lives lived away from the colony's harder stories."
+  }
+ },
+ "1798": {
+  "key": "Arcturus Row",
+  "desc": "Arcturus approaches the Battery junction, residential frontage mixing with the discreet face of biotech administration - clean offices, sealed labs, the management side of the work that feeds the colony. The crater wall stands to the north.",
+  "sense_descs": {
+   "auditory": "The administrative quiet, climate units cycling behind sealed frontage.",
+   "olfactory": "Clean processed air with a faint cold-storage thread.",
+   "tactile": "Swept composite underfoot; cool air off the wall.",
+   "atmospheric": "Biotech administration faces the crater wall behind sealed frontage."
+  }
+ },
+ "1803": {
+  "key": "Arcturus Row",
+  "desc": "Past the Battery junction, the Row runs secure residential toward the district's nightlife pocket, the frontage loosening from corporate blank toward something with signage and intent. The crater wall holds the north, dark and constant.",
+  "sense_descs": {
+   "auditory": "The quiet thinning, a thread of music carrying from the east.",
+   "olfactory": "Clean air with a first trace of nightlife - smoke, something poured.",
+   "tactile": "Cool air off the wall; pristine grating underfoot.",
+   "atmospheric": "The corporate frontage loosens toward signage and intent eastward."
+  }
+ },
+ "1806": {
+  "key": "Arcturus Row",
+  "desc": "The Row passes the Helix Lounge, its frontage the most alive on Arcturus - backlit signage, a doorway that breathes warm air and low music into the promenade. The crater wall stands behind it all, the dark stone catching the lounge's spill of color.",
+  "sense_descs": {
+   "auditory": "Low music and the murmur of the lounge spilling into the promenade.",
+   "olfactory": "Warm air off the lounge - smoke, poured liquor, something cooking.",
+   "tactile": "A band of warmth breathing from the lounge doorway; cool stone beyond.",
+   "atmospheric": "The Helix Lounge spills backlit color across the crater wall's dark face."
+  }
+ },
+ "1809": {
+  "key": "Arcturus Row",
+  "desc": "Arcturus runs its eastern end toward the Tsiolkovsky junction, the affluent frontage giving way to administrative and the crater wall closing in. The dark stone rises sheer where the colony's two edges meet, sealed bulkheads and the mouths of old mine workings set into the rock.",
+  "sense_descs": {
+   "auditory": "The quiet returning at the colony's corner, a draft off the mine workings.",
+   "olfactory": "Cold mineral stone, the lounge's warmth left behind.",
+   "tactile": "The crater wall's chill deepening; level grating underfoot.",
+   "atmospheric": "Sealed bulkheads and old mine workings mark the crater wall at the colony's corner."
+  }
+ }
+}


### PR DESCRIPTION
The interior profile reused the default (street) pool's generic crush lines
verbatim at heavy/packed (and one read 'no walls anymore', wrong indoors), so
a packed interior venue rendered messages identical to street — looking like
the wrong profile applied. Rewrote both tiers to read as an enclosed venue
(walls, low ceiling, the bar, under the lights). 0 interior messages now
overlap the street pool.

Closes #699

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
