### PR TITLE
LLM Gamemaster Phase 1: live bartender Sable answers via local LLM

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -252,13 +252,22 @@ LOGGING = {
 # LLM Gamemaster sidecar (LLM_GAMEMASTER_SPEC, #705/#707)
 ######################################################################
 # Master switch for LLM-driven NPC dialogue. OFF by default here; flip it on in
-# secret_settings.py on a deployment where the sidecar (an external native MLX
-# process) is running. The per-NPC ``db.llm_driven`` flag is the second gate.
-# URL targets the host-native sidecar from inside the game container via
-# host.docker.internal (a 127.0.0.1 URL would mean the container itself).
+# secret_settings.py on a deployment where an inference backend is running. The
+# per-NPC ``db.llm_driven`` flag is the second gate.
+#
+# Backend-agnostic: the game speaks the standard OpenAI Chat Completions protocol,
+# so LLM_GM_URL can point at ANY compatible endpoint — our MLX sidecar,
+# mlx_lm.server, Ollama, llama.cpp, vLLM, LM Studio, or a cloud API. From inside
+# the game container a host-native backend is reached via host.docker.internal
+# (a 127.0.0.1 URL would mean the container itself). Set LLM_GM_API_KEY for cloud
+# providers (sent as a Bearer token); leave blank for local servers.
 LLM_GM_ENABLED = False
-LLM_GM_URL = "http://host.docker.internal:8765/converse"
-LLM_GM_TIMEOUT = 12  # seconds; the sidecar's per-turn generation budget
+LLM_GM_URL = "http://host.docker.internal:8765/v1/chat/completions"
+LLM_GM_MODEL = ""          # backend-specific model id; blank lets local servers default
+LLM_GM_API_KEY = ""        # Bearer token for cloud backends; blank for local
+LLM_GM_TIMEOUT = 12        # seconds; per-turn budget
+LLM_GM_MAX_TOKENS = 80     # short NPC turns
+LLM_GM_TEMPERATURE = 0.8   # characterful but coherent
 
 ######################################################################
 # Settings given in secret_settings.py override those in this file.

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -249,6 +249,18 @@ LOGGING = {
 }
 
 ######################################################################
+# LLM Gamemaster sidecar (LLM_GAMEMASTER_SPEC, #705/#707)
+######################################################################
+# Master switch for LLM-driven NPC dialogue. OFF by default here; flip it on in
+# secret_settings.py on a deployment where the sidecar (an external native MLX
+# process) is running. The per-NPC ``db.llm_driven`` flag is the second gate.
+# URL targets the host-native sidecar from inside the game container via
+# host.docker.internal (a 127.0.0.1 URL would mean the container itself).
+LLM_GM_ENABLED = False
+LLM_GM_URL = "http://host.docker.internal:8765/converse"
+LLM_GM_TIMEOUT = 12  # seconds; the sidecar's per-turn generation budget
+
+######################################################################
 # Settings given in secret_settings.py override those in this file.
 ######################################################################
 try:

--- a/specs/proposals/LLM_GAMEMASTER_SPEC.md
+++ b/specs/proposals/LLM_GAMEMASTER_SPEC.md
@@ -2,10 +2,11 @@
 
 > **Status:** 🟡 Proposal — **Phase 1 SHIPPED** (#707); the rest still designed,
 > not built (tracking #705). The first bridge is live: the Bartender NPC Sable
-> answers player speech with model-generated dialogue from a decoupled MLX
-> sidecar, seeded from her real identity, gated behind two switches, fail-safe to
-> scripted behaviour, drink mechanics untouched. Build ladder + per-phase status
-> in §10. A methodology for
+> answers player speech with model-generated dialogue from a decoupled,
+> **OpenAI-compatible** inference backend (MLX / Ollama / cloud — swappable by
+> URL, no code change), seeded from her real identity, gated behind two switches,
+> fail-safe to scripted behaviour, drink mechanics untouched. Build ladder +
+> per-phase status in §10. A methodology for
 > running a **local LLM as a storyteller / gamemaster** that puppets NPCs:
 > dialogue, a bounded set of actions, real command use, and **per-NPC memory
 > sustained through RAG**. This document is deliberately **implementation-light**.
@@ -638,16 +639,26 @@ MLX, ChromaDB, or Evennia.
   measured latency/prose; starting model **Rocinante 12B** (4-bit, `mlx-community`/
   community quant), ~15 tok/s, ~3 s TTFT on the shared 24 GB box.
 - ✅ **Phase 1 — one NPC, dialogue only (#707).** The live Bartender NPC Sable
-  answers player speech via the sidecar. Shipped pieces:
-  - **Sidecar** (`~/llm-gm-spike/sidecar.py`, out-of-repo, native MLX): stdlib
-    HTTP `POST /converse` {`persona`, `speaker`, `line`, `mode`} → {`speech`,
-    `action`}; warm model + serial-gen lock; owns the GM charter (directed +
-    ambient variants) and persona render; parses/sanitises the model's mixed
-    quotes/asterisks into clean fields; **never raises — empty/decline → nulls**.
-  - **Game client** (`world/llm/client.py`): off-reactor `run_async` POST
-    mirroring `CmdBug` (thread does pure network; no Evennia/DB access; render in
-    the reactor callback). Container reaches the host sidecar via
+  answers player speech via a local LLM. **Backend-agnostic by design**: the game
+  speaks the standard **OpenAI Chat Completions** protocol to a configurable
+  endpoint (`settings.LLM_GM_URL`), so the inference backend is swappable with no
+  code change — our MLX sidecar, `mlx_lm.server`, Ollama, llama.cpp, vLLM, or a
+  cloud API. Shipped pieces:
+  - **Portable prompt layer** (`world/llm/prompt.py`, in-repo): the GM charter
+    (directed + ambient variants), the persona-card render, the OpenAI `messages`
+    builder, and the reply parser (mixed quotes/asterisks → clean `speech` /
+    `action`; OOC/meta stripped; empty/decline → nulls). This travels with the
+    game so the backend stays a dumb inference endpoint.
+  - **Game client** (`world/llm/client.py`): off-reactor `run_async` POST to
+    `…/v1/chat/completions` mirroring `CmdBug` (thread does pure network; no
+    Evennia/DB access; render in the reactor callback). Optional Bearer
+    `LLM_GM_API_KEY` for cloud backends. Container reaches a host backend via
     `host.docker.internal`.
+  - **MLX sidecar** (`~/llm-gm-spike/sidecar.py`, out-of-repo, native): one valid
+    backend — a stdlib OpenAI-compatible `/v1/chat/completions` server; warm model
+    + serial-gen lock; applies the chat template (with a fallback for tunes that
+    ship without one); never raises (empty completion on failure). Owns **no** game
+    logic.
   - **Persona seeding** (`typeclasses/llm_persona.py` `build_persona`): composes
     the persona dict from the NPC's *real* live fields (sdesc, longdescs, voice,
     skintone, location) + the builder-authored core in `db.llm_persona`.

--- a/specs/proposals/LLM_GAMEMASTER_SPEC.md
+++ b/specs/proposals/LLM_GAMEMASTER_SPEC.md
@@ -1,6 +1,11 @@
 # LLM Gamemaster Spec
 
-> **Status:** 📋 Proposal — not implemented (tracking #705). A methodology for
+> **Status:** 🟡 Proposal — **Phase 1 SHIPPED** (#707); the rest still designed,
+> not built (tracking #705). The first bridge is live: the Bartender NPC Sable
+> answers player speech with model-generated dialogue from a decoupled MLX
+> sidecar, seeded from her real identity, gated behind two switches, fail-safe to
+> scripted behaviour, drink mechanics untouched. Build ladder + per-phase status
+> in §10. A methodology for
 > running a **local LLM as a storyteller / gamemaster** that puppets NPCs:
 > dialogue, a bounded set of actions, real command use, and **per-NPC memory
 > sustained through RAG**. This document is deliberately **implementation-light**.
@@ -628,15 +633,32 @@ MLX, ChromaDB, or Evennia.
 
 ## 10 · Build phases
 
-- **Phase 0 — sidecar & model.** Stand up the MLX server; load a shortlisted
-  model warm; prove the latency budget on the actual Mac mini; run the §4.1
-  rubric and pick a starting model. *Deliverable: `prompt → text` over local IPC,
-  measured.*
-- **Phase 1 — one NPC, dialogue only.** Bind Perception + Model + Action adapters
-  for a single existing NPC (e.g. a bartender). No memory, no actions beyond
-  speech. The GM hears, the GM speaks in character, through the real backbone.
-  *Deliverable: a conversation that stays in persona, fails safe when the sidecar
-  is off.*
+- ✅ **Phase 0 — sidecar & model.** Standalone MLX harness on the Mac mini
+  (`~/llm-gm-spike/phase0_sable.py`) proved a local model can voice the NPC and
+  measured latency/prose; starting model **Rocinante 12B** (4-bit, `mlx-community`/
+  community quant), ~15 tok/s, ~3 s TTFT on the shared 24 GB box.
+- ✅ **Phase 1 — one NPC, dialogue only (#707).** The live Bartender NPC Sable
+  answers player speech via the sidecar. Shipped pieces:
+  - **Sidecar** (`~/llm-gm-spike/sidecar.py`, out-of-repo, native MLX): stdlib
+    HTTP `POST /converse` {`persona`, `speaker`, `line`, `mode`} → {`speech`,
+    `action`}; warm model + serial-gen lock; owns the GM charter (directed +
+    ambient variants) and persona render; parses/sanitises the model's mixed
+    quotes/asterisks into clean fields; **never raises — empty/decline → nulls**.
+  - **Game client** (`world/llm/client.py`): off-reactor `run_async` POST
+    mirroring `CmdBug` (thread does pure network; no Evennia/DB access; render in
+    the reactor callback). Container reaches the host sidecar via
+    `host.docker.internal`.
+  - **Persona seeding** (`typeclasses/llm_persona.py` `build_persona`): composes
+    the persona dict from the NPC's *real* live fields (sdesc, longdescs, voice,
+    skintone, location) + the builder-authored core in `db.llm_persona`.
+  - **Engagement model** (`typeclasses/bar.py` `Bartender`): a reactor-side
+    classifier — **directed** (addressed, or names her) always replies; **ambient**
+    (overheard) is cost-gated (cooldown + roll) *and* the model may decline; orders
+    + gratitude paths byte-identical. Two gates: `settings.LLM_GM_ENABLED` +
+    per-NPC `db.llm_driven`; fail-safe to scripted behaviour.
+  - **No memory, no actions beyond speech/pose** (Phases 2–3). Tests:
+    `world/tests/test_bar.py::TestBartenderLLMRouting`. *Deliverable met: in-persona
+    conversation that fails safe when the sidecar is off or a gate is down.*
 - **Phase 2 — memory.** Add the Memory adapter: per-NPC RAG namespace, write-back,
   identity-gated retrieval, built on `recognition_memory`. *Deliverable: the NPC
   remembers a prior encounter across sessions.*

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -22,7 +22,9 @@ from evennia.utils import delay
 
 from typeclasses.items import Item
 from typeclasses.characters import Character
+from typeclasses.llm_persona import build_persona
 from world.grammar import capitalize_first, with_article
+from world.llm.client import llm_enabled, request_npc_reply
 from world.shop.utils import format_currency
 from world.bar import (
     DEFAULT_BAR_SNACKS,
@@ -327,6 +329,13 @@ ACK_EMOTES = (
 #: Minimum seconds between acknowledgements, so a chatty room doesn't spam them.
 ACK_COOLDOWN = 6.0
 
+#: LLM-driven conversational replies (LLM_GAMEMASTER_SPEC Phase 1, #707). Gated
+#: by BOTH ``settings.LLM_GM_ENABLED`` (deployment) and ``npc.db.llm_driven``
+#: (per-NPC), so a scripted bartender stays byte-identical when the LLM is off.
+LLM_DIRECTED_COOLDOWN = 4.0    # min seconds between replies to direct address/name
+LLM_AMBIENT_COOLDOWN = 45.0    # she rarely volunteers into overheard chatter
+LLM_AMBIENT_CHANCE = 0.35      # ...and not every eligible time
+
 
 class Bartender(Character):
     """An NPC that takes drink orders by being spoken to (the `to` command)."""
@@ -345,6 +354,10 @@ class Bartender(Character):
             self.build = "average"
         if not self.sdesc_keyword:
             self.sdesc_keyword = "bartender"
+        # LLM-driven dialogue is opt-in per NPC (and also gated by the
+        # deployment-wide LLM_GM_ENABLED). Builders flip this on the NPCs that
+        # should think; everyone else stays fully scripted.
+        self.db.llm_driven = False
 
     def _find_bar(self):
         if not self.location:
@@ -380,6 +393,17 @@ class Bartender(Character):
 
         if kwargs.get("addressed"):
             delay(1.5, self._fulfil_order, speech, speaker)
+            return True
+
+        # LLM conversational layer — only when both gates are on, so the
+        # scripted NPC is byte-identical with the LLM off. Orders and gratitude
+        # above are never routed here.
+        if self.db.llm_driven and llm_enabled():
+            kind = self._classify_speech(speech, speaker)
+            if kind == "directed":
+                delay(1.5, self._try_llm_reply, speech, speaker, "directed")
+            elif kind == "ambient":
+                delay(1.0, self._try_llm_reply, speech, speaker, "ambient")
         return True
 
     @staticmethod
@@ -403,7 +427,11 @@ class Bartender(Character):
         menu = (bar.db.menu if bar else None) or self.db.menu or []
         recipe = match_recipe(order_text, menu)
         if not recipe:
-            self.execute_cmd("say Don't serve that here.")
+            # An addressed line that isn't an order becomes conversation when the
+            # LLM is driving her; otherwise the curt scripted line still stands.
+            if not self._try_llm_reply(order_text, patron, "directed",
+                                       on_fail=self._llm_fallback):
+                self.execute_cmd("say Don't serve that here.")
             return
         price = int(recipe.get("price", 0) or 0)
         have = int(getattr(patron, "tokens", 0) or 0)
@@ -432,3 +460,79 @@ class Bartender(Character):
             f"emote {craft}, sets {with_article(drink.key)} on {where}, "
             f"and {closer}."
         )
+
+    # --- LLM-driven conversation (gated; LLM_GAMEMASTER_SPEC Phase 1) --------
+
+    def _classify_speech(self, speech, speaker):
+        """Cheap reactor-side gate: ``directed`` | ``ambient`` | ``ignore``."""
+        # Loop guard: never react to another NPC's broadcast speech, so two
+        # LLM-driven NPCs can't ping-pong on ambient lines.
+        if (getattr(speaker.db, "is_bartender_npc", False)
+                or getattr(speaker.db, "llm_driven", False)):
+            return "ignore"
+        return "directed" if self._mentions_self(speech) else "ambient"
+
+    def _mentions_self(self, speech):
+        """Whether a line names this bartender (key, keyword, or generic role)."""
+        low = (speech or "").lower()
+        names = [self.key.lower()]
+        if self.sdesc_keyword:
+            names.append(self.sdesc_keyword.lower())
+        names += ["bartender", "barkeep", "barkeeper"]
+        return any(n and n in low for n in names)
+
+    def _try_llm_reply(self, line, patron, mode, on_fail=None):
+        """Route a conversational line to the LLM sidecar, off the reactor.
+
+        Returns True if the LLM path was taken (caller suppresses any scripted
+        fallback), False if gated/throttled off so the caller can fall back.
+        """
+        if not self.db.llm_driven or not llm_enabled():
+            return False
+        if (not self.location
+                or getattr(patron, "location", None) is not self.location):
+            return False
+
+        now = monotonic()
+        last = self.ndb.last_llm or 0
+        if mode == "ambient":
+            if now - last < LLM_AMBIENT_COOLDOWN:
+                return True  # throttled: stay silent rather than spam
+            if random.random() > LLM_AMBIENT_CHANCE:
+                return True  # eligible, but she didn't bite this time
+        elif now - last < LLM_DIRECTED_COOLDOWN:
+            return True
+        self.ndb.last_llm = now
+
+        # Capture everything the off-reactor thread needs BEFORE threading
+        # (the SQLite/Evennia-thread contract — see world/llm/client.py).
+        persona = build_persona(self)
+        speaker_name = patron.get_display_name(self)
+        request_npc_reply(
+            persona, speaker_name, line or "", mode,
+            on_reply=self._render_llm_reply,
+            on_fail=on_fail or self._llm_silent,
+        )
+        return True
+
+    def _render_llm_reply(self, speech, action):
+        """Reactor-side render of the sidecar reply: say + pose."""
+        if not self.location:
+            return
+        if speech:
+            clean = speech.strip().strip('"').strip()
+            if clean:
+                self.execute_cmd(f"say {clean}")
+        if action:
+            clean = action.strip()
+            if clean:
+                self.execute_cmd(f"pose {clean}")
+
+    def _llm_fallback(self):
+        """Sidecar failed on an addressed non-order: the curt scripted line."""
+        if self.location:
+            self.execute_cmd("say Don't serve that here.")
+
+    def _llm_silent(self):
+        """Sidecar failed or declined on conversation: stay quiet."""
+        return None

--- a/typeclasses/llm_persona.py
+++ b/typeclasses/llm_persona.py
@@ -1,0 +1,48 @@
+"""Compose an NPC persona dict from its live object fields, for the LLM sidecar.
+
+Runs on the reactor (reads ``db`` + identity getters) and returns plain,
+JSON-safe data handed to the off-reactor sidecar call (``world/llm/client.py``).
+The builder-authored **immutable core** (manner / wants / boundaries) lives in
+``db.llm_persona``; everything else is derived from the NPC's real identity so the
+model voices *this* character — the same sdesc/longdesc/voice the world perceives.
+
+See ``specs/proposals/LLM_GAMEMASTER_SPEC.md`` §5.2 (persona card).
+"""
+
+from world.voice import get_voice_description, get_voice_ending, voice_phrase
+
+
+def build_persona(npc) -> dict:
+    """Build the persona dict from the NPC's real fields. Defensive throughout.
+
+    Must run on the reactor (reads db + identity getters). The returned dict is
+    inert JSON passed to the sidecar thread — no live objects leak across.
+    """
+    longdescs = {}
+    raw = getattr(npc, "longdesc", None) or {}
+    for loc in raw:
+        desc = npc.get_longdesc(loc)
+        if desc:
+            longdescs[loc] = desc
+
+    location = None
+    if npc.location:
+        location = {
+            "name": npc.location.key,
+            "desc": getattr(npc.location.db, "desc", None),
+        }
+
+    return {
+        "sdesc": npc.get_sdesc(),
+        "longdescs": longdescs,
+        "skintone": getattr(npc.db, "skintone", None),
+        "height": npc.height,
+        "build": npc.build,
+        "sex": npc.sex,
+        "species": npc.species,
+        "voice": voice_phrase(npc),
+        "voice_description": get_voice_description(npc),
+        "voice_ending": get_voice_ending(npc),
+        "location": location,
+        "persona_seed": npc.db.llm_persona or {},
+    }

--- a/world/llm/client.py
+++ b/world/llm/client.py
@@ -1,0 +1,74 @@
+"""LLM Gamemaster sidecar client — off-reactor calls to the MLX sidecar.
+
+The sidecar is an external, native process (see
+``specs/proposals/LLM_GAMEMASTER_SPEC.md``; it lives out-of-repo in
+``~/llm-gm-spike`` for Phase 1) that voices NPCs. Calls cross the Twisted reactor
+and must NEVER block it: the blocking ``requests.post`` runs in Evennia's async
+thread pool via ``run_async`` — exactly the pattern the GitHub calls in
+``commands/CmdBug.py`` use.
+
+Contract (mirrors ``CmdBug._run_github_call``): the thread function does pure
+network + parsing — NO Evennia object access, NO database reads/writes (SQLite is
+not thread-safe). All needed values are captured on the reactor *before* this call
+(the persona dict, the speaker name, the line); the reply is rendered in the
+reactor-side ``at_return`` / ``at_err`` callbacks, where ``execute_cmd`` is safe.
+"""
+
+import requests
+from django.conf import settings
+from evennia.utils import logger
+from evennia.utils.utils import run_async
+
+#: Defaults if settings are absent — the game container reaches the host-native
+#: sidecar via ``host.docker.internal`` (a ``127.0.0.1`` URL would mean the
+#: container itself). Read defensively like ``CmdBug``'s ``getattr(settings, …)``.
+_DEFAULT_URL = "http://host.docker.internal:8765/converse"
+_DEFAULT_TIMEOUT = 12
+
+
+def llm_enabled() -> bool:
+    """Deployment-wide master switch for LLM-driven NPCs (one of two gates)."""
+    return bool(getattr(settings, "LLM_GM_ENABLED", False))
+
+
+def request_npc_reply(persona, speaker_name, line, mode, on_reply, on_fail):
+    """POST a situation to the sidecar off the reactor; render on return.
+
+    Args:
+        persona (dict): inert, JSON-safe persona data, built on the reactor
+            BEFORE this call (``typeclasses.llm_persona.build_persona``).
+        speaker_name (str): how the NPC perceives the speaker.
+        line (str): the spoken words.
+        mode (str): ``"directed"`` or ``"ambient"``.
+        on_reply (callable): ``on_reply(speech, action)`` — runs on the reactor.
+        on_fail (callable): ``on_fail()`` — runs on the reactor on timeout, error,
+            or an empty (declined) reply.
+    """
+    url = getattr(settings, "LLM_GM_URL", _DEFAULT_URL)
+    timeout = getattr(settings, "LLM_GM_TIMEOUT", _DEFAULT_TIMEOUT)
+    payload = {
+        "persona": persona,
+        "speaker": speaker_name,
+        "line": line,
+        "mode": mode,
+    }
+
+    def _thread_fn():
+        # Pure network + parsing. NO Evennia/DB access (SQLite thread contract).
+        resp = requests.post(url, json=payload, timeout=timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        return (data.get("speech"), data.get("action"))
+
+    def _at_return(result):
+        speech, action = result if result else (None, None)
+        if not speech and not action:
+            on_fail()  # null/declined reply → scripted fallback or silence
+            return
+        on_reply(speech, action)
+
+    def _at_err(failure):
+        logger.log_err(f"LLM sidecar call failed: {failure}")
+        on_fail()
+
+    run_async(_thread_fn, at_return=_at_return, at_err=_at_err)

--- a/world/llm/client.py
+++ b/world/llm/client.py
@@ -1,17 +1,18 @@
-"""LLM Gamemaster sidecar client — off-reactor calls to the MLX sidecar.
+"""LLM Gamemaster client — off-reactor calls over the OpenAI Chat Completions API.
 
-The sidecar is an external, native process (see
-``specs/proposals/LLM_GAMEMASTER_SPEC.md``; it lives out-of-repo in
-``~/llm-gm-spike`` for Phase 1) that voices NPCs. Calls cross the Twisted reactor
-and must NEVER block it: the blocking ``requests.post`` runs in Evennia's async
-thread pool via ``run_async`` — exactly the pattern the GitHub calls in
-``commands/CmdBug.py`` use.
+The game speaks the **standard OpenAI Chat Completions protocol** to a configurable
+endpoint (``settings.LLM_GM_URL``), so the inference backend is swappable without a
+code change — our MLX sidecar, Ollama, llama.cpp, vLLM, LM Studio, or a cloud API.
+The repo owns the portable prompt/parse logic (``world/llm/prompt.py``); the
+backend is just an inference endpoint. This keeps Gelatinous LLM-platform-agnostic.
 
-Contract (mirrors ``CmdBug._run_github_call``): the thread function does pure
-network + parsing — NO Evennia object access, NO database reads/writes (SQLite is
-not thread-safe). All needed values are captured on the reactor *before* this call
-(the persona dict, the speaker name, the line); the reply is rendered in the
-reactor-side ``at_return`` / ``at_err`` callbacks, where ``execute_cmd`` is safe.
+Calls cross the Twisted reactor and must NEVER block it: the blocking
+``requests.post`` runs in Evennia's async thread pool via ``run_async`` — the same
+pattern the GitHub calls in ``commands/CmdBug.py`` use. Contract: the thread
+function does pure network + parsing — NO Evennia object access, NO database
+reads/writes (SQLite is not thread-safe). All live values (the persona dict, the
+speaker name, the line) are captured on the reactor *before* the call; the reply
+renders in the reactor-side ``at_return`` / ``at_err`` callbacks.
 """
 
 import requests
@@ -19,11 +20,15 @@ from django.conf import settings
 from evennia.utils import logger
 from evennia.utils.utils import run_async
 
-#: Defaults if settings are absent — the game container reaches the host-native
-#: sidecar via ``host.docker.internal`` (a ``127.0.0.1`` URL would mean the
-#: container itself). Read defensively like ``CmdBug``'s ``getattr(settings, …)``.
-_DEFAULT_URL = "http://host.docker.internal:8765/converse"
+from world.llm.prompt import build_messages, parse_reply
+
+#: Defaults if settings are absent. The URL is a standard OpenAI Chat Completions
+#: endpoint; from inside the game container the host-native backend is reached via
+#: ``host.docker.internal`` (a ``127.0.0.1`` URL would mean the container itself).
+_DEFAULT_URL = "http://host.docker.internal:8765/v1/chat/completions"
 _DEFAULT_TIMEOUT = 12
+_DEFAULT_MAX_TOKENS = 80
+_DEFAULT_TEMPERATURE = 0.8
 
 
 def llm_enabled() -> bool:
@@ -32,11 +37,11 @@ def llm_enabled() -> bool:
 
 
 def request_npc_reply(persona, speaker_name, line, mode, on_reply, on_fail):
-    """POST a situation to the sidecar off the reactor; render on return.
+    """POST a turn to the chat-completions backend off the reactor; render on return.
 
     Args:
-        persona (dict): inert, JSON-safe persona data, built on the reactor
-            BEFORE this call (``typeclasses.llm_persona.build_persona``).
+        persona (dict): inert, JSON-safe persona data, built on the reactor BEFORE
+            this call (``typeclasses.llm_persona.build_persona``).
         speaker_name (str): how the NPC perceives the speaker.
         line (str): the spoken words.
         mode (str): ``"directed"`` or ``"ambient"``.
@@ -45,30 +50,44 @@ def request_npc_reply(persona, speaker_name, line, mode, on_reply, on_fail):
             or an empty (declined) reply.
     """
     url = getattr(settings, "LLM_GM_URL", _DEFAULT_URL)
+    model = getattr(settings, "LLM_GM_MODEL", "")
+    api_key = getattr(settings, "LLM_GM_API_KEY", "")
     timeout = getattr(settings, "LLM_GM_TIMEOUT", _DEFAULT_TIMEOUT)
-    payload = {
-        "persona": persona,
-        "speaker": speaker_name,
-        "line": line,
-        "mode": mode,
+    max_tokens = getattr(settings, "LLM_GM_MAX_TOKENS", _DEFAULT_MAX_TOKENS)
+    temperature = getattr(settings, "LLM_GM_TEMPERATURE", _DEFAULT_TEMPERATURE)
+
+    messages = build_messages(persona, speaker_name, line, mode)
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    body = {
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
     }
+    if model:
+        body["model"] = model
 
     def _thread_fn():
         # Pure network + parsing. NO Evennia/DB access (SQLite thread contract).
-        resp = requests.post(url, json=payload, timeout=timeout)
+        resp = requests.post(url, json=body, headers=headers, timeout=timeout)
         resp.raise_for_status()
         data = resp.json()
-        return (data.get("speech"), data.get("action"))
+        content = (
+            (data.get("choices") or [{}])[0].get("message", {}).get("content", "")
+        )
+        return parse_reply(content, persona)
 
     def _at_return(result):
-        speech, action = result if result else (None, None)
+        result = result or {}
+        speech, action = result.get("speech"), result.get("action")
         if not speech and not action:
             on_fail()  # null/declined reply → scripted fallback or silence
             return
         on_reply(speech, action)
 
     def _at_err(failure):
-        logger.log_err(f"LLM sidecar call failed: {failure}")
+        logger.log_err(f"LLM backend call failed: {failure}")
         on_fail()
 
     run_async(_thread_fn, at_return=_at_return, at_err=_at_err)

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -1,0 +1,182 @@
+"""Prompt construction + reply parsing for the LLM Gamemaster — backend-agnostic.
+
+This is the *portable* half of the LLM layer: the GM charter, the persona-card
+render, the OpenAI-style ``messages`` builder, and the reply parser all live in
+the game repo so they travel with it. The game speaks the **OpenAI Chat
+Completions** protocol (``messages`` in, ``choices[].message.content`` out) to a
+configurable endpoint (``settings.LLM_GM_URL``), so the inference backend is
+swappable — our MLX sidecar, Ollama, llama.cpp, vLLM, or a cloud API — without a
+code change. Nothing here imports a model or a specific runtime.
+
+See ``specs/proposals/LLM_GAMEMASTER_SPEC.md`` (§4 swap seam, §5.2 persona card).
+"""
+
+import re
+
+# --- GM charter: the rules of being an NPC (shared across NPCs) --------------
+CHARTER_BASE = """\
+You are the voice of a single non-player character inside a text-based cyberpunk \
+MUD — a grim, lived-in colony of chrome, vice, and hard luck. This is adult \
+fiction: violence, drugs, sex, and moral greyness are part of the world and you \
+portray them in character without flinching, lecturing, or refusing.
+
+OUTPUT FORMAT — follow exactly:
+- Write the character's reply ONLY: one or two lines of bar banter, never a \
+monologue or a scene.
+- Spoken words go in "double quotes".
+- Physical actions are narrated in THIRD PERSON present tense, in *asterisks*, \
+sparingly — e.g. *tilts her head.* NEVER write the character as "I" or "you".
+
+HARD RULES:
+- Never speak, think, narrate, or act for the OTHER person. Voice only this \
+character. Do not invent what anyone else says or does.
+- You do NOT resolve game mechanics. If asked to make a drink or perform a task, \
+gesture at starting it in a few words and stop — the game engine handles the \
+result. Never narrate measuring, mixing, or step-by-step crafting.
+- Stay in character always. Never mention being an AI, a model, or a game system; \
+no out-of-character asides.
+- World knowledge is limited to the colony, the character's own life, and what is \
+perceivable here. Do not invent outside facts. Use only in-world, generic names \
+for drinks and ingredients — NEVER real-world or brand names."""
+
+CHARTER_AMBIENT = """\
+
+THIS LINE IS OVERHEARD, not addressed to the character. React ONLY if the \
+character would naturally speak up. If there is no natural reason to react, reply \
+with exactly the single word PASS and nothing else — do NOT narrate the \
+non-reaction, just write PASS."""
+
+_APPEARANCE_KEYS = ("face", "eyes", "hair", "head")
+
+
+def render_persona(persona: dict) -> str:
+    """Compose the persona-card prose from the live-object dict the game built."""
+    persona = persona or {}
+    seed = persona.get("persona_seed") or {}
+    name = seed.get("name") or "the bartender"
+    sdesc = persona.get("sdesc")
+
+    lines = []
+    opener = f"THE CHARACTER is {name}"
+    if sdesc:
+        opener += f" — to strangers, {sdesc}"
+    lines.append(opener + ".")
+
+    if seed.get("manner"):
+        lines.append(f"Manner: {seed['manner']}.")
+    if seed.get("wants"):
+        lines.append(f"Wants: {seed['wants']}.")
+    if seed.get("boundaries"):
+        lines.append(f"Will not: {seed['boundaries']}.")
+
+    longdescs = persona.get("longdescs") or {}
+    appearance = [longdescs[k] for k in _APPEARANCE_KEYS if longdescs.get(k)]
+    if persona.get("skintone"):
+        appearance.append(f"{persona['skintone']} skin")
+    if appearance:
+        lines.append("Appearance: " + " ".join(appearance))
+
+    if persona.get("voice"):
+        lines.append(f"Voice: {persona['voice']}.")
+
+    loc = persona.get("location") or {}
+    if loc.get("name"):
+        lines.append(f"Setting: behind the bar at {loc['name']}.")
+
+    return "\n".join(lines)
+
+
+def build_messages(persona: dict, speaker: str, line: str, mode: str) -> list:
+    """Build the OpenAI-style ``messages`` list (system charter+persona, user turn)."""
+    charter = CHARTER_BASE + (CHARTER_AMBIENT if mode == "ambient" else "")
+    system = charter + "\n\n" + render_persona(persona)
+    speaker = speaker or "someone"
+    line = line or ""
+    if mode == "ambient":
+        turn = f'You overhear {speaker} say: "{line}"'
+    else:
+        turn = f'{speaker} says to you: "{line}"'
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": turn},
+    ]
+
+
+# --- reply parsing / sanitation ----------------------------------------------
+_QUOTE_RE = re.compile(r'"([^"]*)"')
+_ACTION_RE = re.compile(r"\*([^*]*)\*")
+_OOC_MARKERS = (
+    "((", "))", "[ooc", "as an ai", "language model", "i cannot", "i'm an ai",
+    "i am an ai", "as a language", "note:",
+)
+_MAX_LEN = 400
+
+#: Markerless "declined to react" narrations the model sometimes emits instead of
+#: an empty reply (ambient mode). A genuine spoken line is quoted; these are not.
+_DECLINE_MARKERS = (
+    "did not react", "does not react", "doesn't react", "no reaction",
+    "did not respond", "does not respond", "doesn't respond", "no response",
+    "says nothing", "stays silent", "remains silent", "no reply",
+    "nothing happens", "nothing to react", "no comment",
+)
+
+
+def _is_decline(text: str) -> bool:
+    low = (text or "").lower()
+    return any(m in low for m in _DECLINE_MARKERS)
+
+
+def _clean(text: str) -> str:
+    text = (text or "").strip().strip('"*').strip()
+    # Drop a leading "Name:" speaker prefix the model sometimes emits.
+    text = re.sub(r"^[A-Z][a-z]+:\s*", "", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _is_ooc(text: str) -> bool:
+    low = (text or "").lower()
+    return any(m in low for m in _OOC_MARKERS)
+
+
+def parse_reply(raw: str, persona: dict) -> dict:
+    """Split a model completion's mixed quotes/asterisks into speech + action.
+
+    Returns ``{"speech": str|None, "action": str|None}``; empty-after-clean (or a
+    declined ambient reply) yields nulls so the game stays silent/scripted.
+    """
+    raw = (raw or "").strip()
+    if not raw or _is_ooc(raw):
+        return {"speech": None, "action": None}
+
+    # Ambient decline sentinel: the model is told to reply "PASS" when the
+    # character wouldn't react (far more reliable than asking for an empty reply).
+    if raw.strip('".*’‘\' \t\n').upper().rstrip(".!") == "PASS":
+        return {"speech": None, "action": None}
+
+    speech_parts = [m.strip() for m in _QUOTE_RE.findall(raw) if m.strip()]
+    action_parts = [m.strip() for m in _ACTION_RE.findall(raw) if m.strip()]
+
+    # Backstop: a markerless "doesn't react" narration is a decline, not a spoken
+    # line (genuine speech is quoted). Treat it as silence.
+    if not speech_parts and _is_decline(raw):
+        return {"speech": None, "action": None}
+
+    if speech_parts:
+        speech = _clean(" ".join(speech_parts))
+    else:
+        speech = _clean(_ACTION_RE.sub("", raw))
+
+    action = _clean(" ".join(action_parts)) if action_parts else ""
+
+    # The game prepends the name via `pose`, so strip a leading self-reference.
+    if action:
+        name = ((persona or {}).get("persona_seed") or {}).get("name") or ""
+        if name:
+            action = re.sub(rf"^{re.escape(name)}\s+", "", action, flags=re.I)
+        action = re.sub(r"^(she|he|they)\s+", "", action, flags=re.I)
+
+    speech = speech[:_MAX_LEN] if speech else None
+    action = action[:_MAX_LEN] if action else None
+    if speech and _is_ooc(speech):
+        speech = None
+    return {"speech": speech, "action": action}

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -517,3 +517,152 @@ class TestBartenderReaction(BaseEvenniaTest):
             self._call(b, b, speech="thanks", addressed=True)
         mock_delay.assert_not_called()
         b._acknowledge.assert_not_called()
+
+
+class TestBartenderLLMRouting(BaseEvenniaTest):
+    """The gated LLM conversational layer: directed/ambient routing, payload,
+    cooldown, loop-guard, fail-safe. Orders + gratitude paths stay untouched."""
+
+    _REAL = (
+        "_classify_speech", "_mentions_self", "_try_llm_reply",
+        "_render_llm_reply", "_llm_fallback", "_llm_silent",
+    )
+
+    def _bartender(self, llm_driven=True, location="room"):
+        b = MagicMock()
+        b.key = "Sable"
+        b.sdesc_keyword = "catgirl"
+        b.db.llm_driven = llm_driven
+        b.db.is_bartender_npc = True
+        b.ndb.last_llm = 0
+        b.location = location
+        b._is_gratitude = barmod.Bartender._is_gratitude  # real staticmethod
+        for name in self._REAL:
+            bound = getattr(barmod.Bartender, name).__get__(b, barmod.Bartender)
+            setattr(b, name, bound)
+        return b
+
+    def _speaker(self, location="room", name="a lean man"):
+        s = MagicMock()
+        s.db.is_bartender_npc = False
+        s.db.llm_driven = False
+        s.location = location
+        s.get_display_name = lambda looker=None, **kw: name
+        return s
+
+    def _call(self, b, speaker, **payload):
+        return barmod.Bartender.at_msg_receive(
+            b, text=None, from_obj=speaker, **payload
+        )
+
+    # --- routing through at_msg_receive ---
+
+    def test_directed_name_routes_directed(self):
+        b, spk = self._bartender(), self._speaker()
+        with patch.object(barmod, "llm_enabled", return_value=True), \
+                patch.object(barmod, "delay") as mock_delay:
+            self._call(b, spk, speech="hey sable, busy?", addressed=False)
+        mock_delay.assert_called_once()
+        self.assertIn("directed", mock_delay.call_args.args)
+
+    def test_ambient_routes_ambient(self):
+        b, spk = self._bartender(), self._speaker()
+        with patch.object(barmod, "llm_enabled", return_value=True), \
+                patch.object(barmod, "delay") as mock_delay:
+            self._call(b, spk, speech="this place is dead tonight", addressed=False)
+        mock_delay.assert_called_once()
+        self.assertIn("ambient", mock_delay.call_args.args)
+
+    def test_disabled_routes_nothing(self):
+        b, spk = self._bartender(), self._speaker()
+        with patch.object(barmod, "llm_enabled", return_value=False), \
+                patch.object(barmod, "delay") as mock_delay:
+            self._call(b, spk, speech="hey sable", addressed=False)
+        mock_delay.assert_not_called()
+
+    def test_loop_guard_ignores_npc_speaker(self):
+        b, npc = self._bartender(), self._speaker()
+        npc.db.is_bartender_npc = True
+        with patch.object(barmod, "llm_enabled", return_value=True), \
+                patch.object(barmod, "delay") as mock_delay:
+            self._call(b, npc, speech="rough night sable", addressed=False)
+        mock_delay.assert_not_called()
+
+    def test_addressed_still_routes_to_order(self):
+        b, spk = self._bartender(), self._speaker()
+        with patch.object(barmod, "llm_enabled", return_value=True), \
+                patch.object(barmod, "delay") as mock_delay:
+            self._call(b, spk, speech="a rotgut", addressed=True)
+        mock_delay.assert_called_once()
+        # the addressed branch targets _fulfil_order, not the LLM layer
+        self.assertIs(mock_delay.call_args.args[1], b._fulfil_order)
+
+    # --- _try_llm_reply gating + payload ---
+
+    def test_try_llm_reply_fires_request(self):
+        b, patron = self._bartender(), self._speaker(name="a wiry courier")
+        with patch.object(barmod, "llm_enabled", return_value=True), \
+                patch.object(barmod, "build_persona", return_value={"x": 1}) as bp, \
+                patch.object(barmod, "request_npc_reply") as req:
+            taken = b._try_llm_reply("rough night?", patron, "directed")
+        self.assertTrue(taken)
+        bp.assert_called_once_with(b)
+        req.assert_called_once()
+        args, kwargs = req.call_args
+        self.assertEqual(args[0], {"x": 1})            # persona
+        self.assertEqual(args[1], "a wiry courier")    # speaker as she sees them
+        self.assertEqual(args[2], "rough night?")      # line
+        self.assertEqual(args[3], "directed")          # mode
+        self.assertIs(kwargs["on_reply"], b._render_llm_reply)
+        self.assertIs(kwargs["on_fail"], b._llm_silent)
+
+    def test_try_llm_reply_gated_off(self):
+        b, patron = self._bartender(llm_driven=False), self._speaker()
+        with patch.object(barmod, "request_npc_reply") as req:
+            taken = b._try_llm_reply("hi", patron, "directed")
+        self.assertFalse(taken)
+        req.assert_not_called()
+
+    def test_try_llm_reply_cooldown_is_silent(self):
+        from time import monotonic
+        b, patron = self._bartender(), self._speaker()
+        b.ndb.last_llm = monotonic()  # just replied
+        with patch.object(barmod, "llm_enabled", return_value=True), \
+                patch.object(barmod, "request_npc_reply") as req:
+            taken = b._try_llm_reply("hi", patron, "directed")
+        self.assertTrue(taken)         # handled-by-silence, no scripted fallback
+        req.assert_not_called()
+
+    # --- order-path fallback, render, fail-safe ---
+
+    def test_order_no_recipe_llm_off_curt_line(self):
+        b, patron = self._bartender(llm_driven=False), self._speaker()
+        b._find_bar = lambda: None
+        b.db.menu = []
+        with patch.object(barmod, "match_recipe", return_value=None):
+            barmod.Bartender._fulfil_order(b, "a unicorn tear", patron)
+        b.execute_cmd.assert_any_call("say Don't serve that here.")
+
+    def test_render_say_and_pose(self):
+        b = self._bartender()
+        b._render_llm_reply('"What\'s it to ya?"', "wipes down the slab")
+        b.execute_cmd.assert_any_call("say What's it to ya?")
+        b.execute_cmd.assert_any_call("pose wipes down the slab")
+
+    def test_render_speech_only(self):
+        b = self._bartender()
+        b.execute_cmd.reset_mock()
+        b._render_llm_reply("just a sec", None)
+        b.execute_cmd.assert_called_once_with("say just a sec")
+
+    def test_llm_fallback_curt_line(self):
+        b = self._bartender()
+        b._llm_fallback()
+        b.execute_cmd.assert_called_once_with("say Don't serve that here.")
+
+    def test_mentions_self(self):
+        b = self._bartender()
+        self.assertTrue(b._mentions_self("hey sable"))
+        self.assertTrue(b._mentions_self("yo bartender"))
+        self.assertTrue(b._mentions_self("nice catgirl ears"))
+        self.assertFalse(b._mentions_self("this whole place is dead"))

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -1,0 +1,87 @@
+"""The portable LLM prompt layer (world.llm.prompt) — backend-agnostic.
+
+Pure functions: the OpenAI-style message builder, the persona render, and the
+reply parser. No model, no Evennia, no network — these travel with the repo so the
+inference backend stays swappable.
+"""
+
+from unittest import TestCase
+
+from world.llm.prompt import build_messages, parse_reply, render_persona
+
+_PERSONA = {
+    "sdesc": "a lithe woman",
+    "skintone": "olive",
+    "voice": "speaking Common, in a silken purr",
+    "location": {"name": "the Helix Lounge"},
+    "persona_seed": {
+        "name": "Sable",
+        "manner": "sly, watchful",
+        "wants": "to read everyone who sits down",
+        "boundaries": "won't discuss the owner's debts",
+    },
+}
+
+
+class TestBuildMessages(TestCase):
+    def test_openai_message_shape(self):
+        msgs = build_messages(_PERSONA, "a lean man", "rough night?", "directed")
+        self.assertEqual([m["role"] for m in msgs], ["system", "user"])
+        self.assertIn("Sable", msgs[0]["content"])
+        self.assertIn("sly, watchful", msgs[0]["content"])
+        self.assertIn("a lean man", msgs[1]["content"])
+        self.assertIn("rough night?", msgs[1]["content"])
+
+    def test_directed_vs_ambient_framing(self):
+        directed = build_messages(_PERSONA, "a man", "hi", "directed")
+        ambient = build_messages(_PERSONA, "a man", "hi", "ambient")
+        self.assertIn("says to you", directed[1]["content"])
+        self.assertIn("overhear", ambient[1]["content"].lower())
+        # ambient charter tells the model it may decline
+        self.assertIn("OVERHEARD", ambient[0]["content"])
+        self.assertNotIn("OVERHEARD", directed[0]["content"])
+
+    def test_render_persona_is_defensive(self):
+        # a near-empty persona still renders without raising
+        self.assertIn("the bartender", render_persona({}))
+
+
+class TestParseReply(TestCase):
+    def test_speech_and_action_split(self):
+        raw = '*Sable smirks.* "What\'s it to ya?"'
+        out = parse_reply(raw, _PERSONA)
+        self.assertEqual(out["speech"], "What's it to ya?")
+        # leading self-reference stripped (the game prepends the name via pose)
+        self.assertEqual(out["action"], "smirks.")
+
+    def test_speech_only(self):
+        out = parse_reply('"Just a sec."', _PERSONA)
+        self.assertEqual(out["speech"], "Just a sec.")
+        self.assertIsNone(out["action"])
+
+    def test_no_markers_treated_as_speech(self):
+        out = parse_reply("rough night, huh", _PERSONA)
+        self.assertEqual(out["speech"], "rough night, huh")
+
+    def test_ooc_dropped_to_null(self):
+        out = parse_reply("As an AI, I can't roleplay that.", _PERSONA)
+        self.assertEqual(out, {"speech": None, "action": None})
+
+    def test_empty_is_null(self):
+        self.assertEqual(parse_reply("", _PERSONA), {"speech": None, "action": None})
+
+    def test_pass_sentinel_is_null(self):
+        for raw in ("PASS", "pass", '"PASS"', "PASS.", "*PASS*"):
+            self.assertEqual(
+                parse_reply(raw, _PERSONA), {"speech": None, "action": None}, raw
+            )
+
+    def test_decline_narration_is_null(self):
+        # ambient decline narrated as prose (no quotes) → silence, not a spoken line
+        out = parse_reply("Sable does not react to the comment.", _PERSONA)
+        self.assertEqual(out, {"speech": None, "action": None})
+
+    def test_quoted_line_with_decline_word_still_speaks(self):
+        # a real quoted line that merely contains a decline word still renders
+        out = parse_reply('"No response from the docks, last I heard."', _PERSONA)
+        self.assertEqual(out["speech"], "No response from the docks, last I heard.")


### PR DESCRIPTION
Phase 1 of the LLM Gamemaster (#705): the live Bartender NPC Sable answers player speech with model-generated dialogue. **Backend-agnostic** — the game speaks standard OpenAI Chat Completions to a configurable endpoint (`LLM_GM_URL`), so MLX / mlx_lm.server / Ollama / vLLM / cloud are all swappable by URL.

(Re-created after #708 auto-closed when its stacked base branch #706 was deleted on merge; rebased clean onto master, Phase-1-only diff.)

- `world/llm/prompt.py` — portable GM charter, persona render, OpenAI message builder, reply parser (PASS sentinel + decline backstop for ambient silence).
- `world/llm/client.py` — off-reactor `run_async` POST to `/v1/chat/completions` (mirrors CmdBug; host reached via host.docker.internal).
- `typeclasses/llm_persona.py` — `build_persona()` from the NPC's real fields + builder-authored core.
- `typeclasses/bar.py` — gated engagement model: directed always replies, ambient cost-gated + model may decline; orders/gratitude byte-identical; two gates (`LLM_GM_ENABLED` + `db.llm_driven`); fail-safe to scripted.
- Tests: `TestBartenderLLMRouting` + `test_llm_prompt` — **72/72 green**.

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)