### PR TITLE
LLM GM Phase 1.1: ground perception, solo-room directed, robust parse + few-shot persona

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -265,8 +265,8 @@ LLM_GM_ENABLED = False
 LLM_GM_URL = "http://host.docker.internal:8765/v1/chat/completions"
 LLM_GM_MODEL = ""          # backend-specific model id; blank lets local servers default
 LLM_GM_API_KEY = ""        # Bearer token for cloud backends; blank for local
-LLM_GM_TIMEOUT = 12        # seconds; per-turn budget
-LLM_GM_MAX_TOKENS = 80     # short NPC turns
+LLM_GM_TIMEOUT = 15        # seconds; per-turn budget
+LLM_GM_MAX_TOKENS = 120    # short NPC turns (a line + an action, no truncation)
 LLM_GM_TEMPERATURE = 0.8   # characterful but coherent
 
 ######################################################################

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -470,7 +470,21 @@ class Bartender(Character):
         if (getattr(speaker.db, "is_bartender_npc", False)
                 or getattr(speaker.db, "llm_driven", False)):
             return "ignore"
-        return "directed" if self._mentions_self(speech) else "ambient"
+        # Named, or effectively alone with the speaker (then any line is plainly
+        # for her), counts as directed; otherwise it's overheard chatter.
+        if self._mentions_self(speech) or self._is_alone_with(speaker):
+            return "directed"
+        return "ambient"
+
+    def _is_alone_with(self, speaker):
+        """True when no other character shares the room — so the speaker can only
+        be talking to this NPC."""
+        if not self.location:
+            return False
+        return not any(
+            o is not self and o is not speaker and isinstance(o, Character)
+            for o in self.location.contents
+        )
 
     def _mentions_self(self, speech):
         """Whether a line names this bartender (key, keyword, or generic role)."""
@@ -508,12 +522,25 @@ class Bartender(Character):
         # (the SQLite/Evennia-thread contract — see world/llm/client.py).
         persona = build_persona(self)
         speaker_name = patron.get_display_name(self)
+        perception = self._perceive(patron)
         request_npc_reply(
             persona, speaker_name, line or "", mode,
             on_reply=self._render_llm_reply,
             on_fail=on_fail or self._llm_silent,
+            perception=perception,
         )
         return True
+
+    def _perceive(self, patron):
+        """What this NPC sees when it looks at the patron — grounds the model's
+        description so it can't invent the speaker's appearance. ANSI-stripped,
+        identity-gated (it's the patron's appearance *as this NPC perceives it*)."""
+        try:
+            from evennia.utils.ansi import strip_ansi
+            raw = patron.return_appearance(self)
+            return " ".join(strip_ansi(raw).split())[:600] if raw else None
+        except Exception:
+            return None
 
     def _render_llm_reply(self, speech, action):
         """Reactor-side render of the sidecar reply: say + pose."""

--- a/world/llm/client.py
+++ b/world/llm/client.py
@@ -26,8 +26,8 @@ from world.llm.prompt import build_messages, parse_reply
 #: endpoint; from inside the game container the host-native backend is reached via
 #: ``host.docker.internal`` (a ``127.0.0.1`` URL would mean the container itself).
 _DEFAULT_URL = "http://host.docker.internal:8765/v1/chat/completions"
-_DEFAULT_TIMEOUT = 12
-_DEFAULT_MAX_TOKENS = 80
+_DEFAULT_TIMEOUT = 15
+_DEFAULT_MAX_TOKENS = 120
 _DEFAULT_TEMPERATURE = 0.8
 
 
@@ -36,7 +36,8 @@ def llm_enabled() -> bool:
     return bool(getattr(settings, "LLM_GM_ENABLED", False))
 
 
-def request_npc_reply(persona, speaker_name, line, mode, on_reply, on_fail):
+def request_npc_reply(persona, speaker_name, line, mode, on_reply, on_fail,
+                      perception=None):
     """POST a turn to the chat-completions backend off the reactor; render on return.
 
     Args:
@@ -48,6 +49,9 @@ def request_npc_reply(persona, speaker_name, line, mode, on_reply, on_fail):
         on_reply (callable): ``on_reply(speech, action)`` — runs on the reactor.
         on_fail (callable): ``on_fail()`` — runs on the reactor on timeout, error,
             or an empty (declined) reply.
+        perception (str|None): what the NPC sees when it looks at the speaker
+            (ANSI-stripped), captured on the reactor — grounds description so the
+            model can't invent the speaker's appearance.
     """
     url = getattr(settings, "LLM_GM_URL", _DEFAULT_URL)
     model = getattr(settings, "LLM_GM_MODEL", "")
@@ -56,7 +60,7 @@ def request_npc_reply(persona, speaker_name, line, mode, on_reply, on_fail):
     max_tokens = getattr(settings, "LLM_GM_MAX_TOKENS", _DEFAULT_MAX_TOKENS)
     temperature = getattr(settings, "LLM_GM_TEMPERATURE", _DEFAULT_TEMPERATURE)
 
-    messages = build_messages(persona, speaker_name, line, mode)
+    messages = build_messages(persona, speaker_name, line, mode, perception)
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -1,12 +1,18 @@
 """Prompt construction + reply parsing for the LLM Gamemaster — backend-agnostic.
 
-This is the *portable* half of the LLM layer: the GM charter, the persona-card
-render, the OpenAI-style ``messages`` builder, and the reply parser all live in
-the game repo so they travel with it. The game speaks the **OpenAI Chat
-Completions** protocol (``messages`` in, ``choices[].message.content`` out) to a
-configurable endpoint (``settings.LLM_GM_URL``), so the inference backend is
-swappable — our MLX sidecar, Ollama, llama.cpp, vLLM, or a cloud API — without a
-code change. Nothing here imports a model or a specific runtime.
+The *portable* half of the LLM layer, kept in the repo so it travels with the
+game and the inference backend stays swappable (standard OpenAI Chat Completions).
+Conventions follow established RP practice rather than anything bespoke:
+
+- **Persona** uses the **character-card** vocabulary (SillyTavern V2/V3:
+  ``description`` / ``personality`` / ``scenario`` / ``mes_example``), composed
+  with the NPC's real perceivable identity (sdesc, voice, location).
+- **Few-shot example dialogue** (``mes_example``) is emitted as user/assistant
+  pairs — the standard way to lock voice + output format.
+- **Output** is the de-facto RP format: ``"speech"`` in quotes, ``*actions*`` in
+  asterisks, third person. The parser is robust to prose-style replies too.
+- **Perception is grounded**: the caller passes what the NPC actually sees when it
+  looks at the speaker, and the charter forbids inventing appearance details.
 
 See ``specs/proposals/LLM_GAMEMASTER_SPEC.md`` (§4 swap seam, §5.2 persona card).
 """
@@ -20,24 +26,25 @@ MUD — a grim, lived-in colony of chrome, vice, and hard luck. This is adult \
 fiction: violence, drugs, sex, and moral greyness are part of the world and you \
 portray them in character without flinching, lecturing, or refusing.
 
-OUTPUT FORMAT — follow exactly:
-- Write the character's reply ONLY: one or two lines of bar banter, never a \
-monologue or a scene.
+OUTPUT FORMAT — follow exactly (see the examples):
+- Reply ONLY as the character: one or two lines of bar banter, never a monologue.
 - Spoken words go in "double quotes".
-- Physical actions are narrated in THIRD PERSON present tense, in *asterisks*, \
+- Physical actions are narrated in THIRD PERSON present tense, in *asterisks*,
 sparingly — e.g. *tilts her head.* NEVER write the character as "I" or "you".
 
 HARD RULES:
 - Never speak, think, narrate, or act for the OTHER person. Voice only this \
 character. Do not invent what anyone else says or does.
+- Describe the other person ONLY from the PERCEPTION line in the turn. NEVER \
+invent their clothing, tattoos, marks, scars, or features — if it isn't in \
+PERCEPTION or something the character plainly knows, it does not exist.
 - You do NOT resolve game mechanics. If asked to make a drink or perform a task, \
 gesture at starting it in a few words and stop — the game engine handles the \
 result. Never narrate measuring, mixing, or step-by-step crafting.
 - Stay in character always. Never mention being an AI, a model, or a game system; \
 no out-of-character asides.
-- World knowledge is limited to the colony, the character's own life, and what is \
-perceivable here. Do not invent outside facts. Use only in-world, generic names \
-for drinks and ingredients — NEVER real-world or brand names."""
+- Use only in-world, generic names for drinks and ingredients — NEVER real-world \
+or brand names."""
 
 CHARTER_AMBIENT = """\
 
@@ -46,60 +53,97 @@ character would naturally speak up. If there is no natural reason to react, repl
 with exactly the single word PASS and nothing else — do NOT narrate the \
 non-reaction, just write PASS."""
 
+#: A generic example exchange used when a persona ships no ``mes_example``. It
+#: anchors the third-person-action + quoted-speech format and a terse register.
+DEFAULT_FEWSHOT = [
+    {
+        "user": 'a patron says to you: "this your place?"',
+        "assistant": '*wipes the bar down without looking up.* "I just pour the '
+                     'drinks, friend."',
+    },
+]
+
 _APPEARANCE_KEYS = ("face", "eyes", "hair", "head")
 
 
+def _personality(seed: dict) -> str:
+    """Card ``personality``, or compose one from the older manner/wants/boundaries."""
+    if seed.get("personality"):
+        return seed["personality"]
+    bits = []
+    if seed.get("manner"):
+        bits.append(seed["manner"])
+    if seed.get("wants"):
+        bits.append(f"wants {seed['wants']}")
+    if seed.get("boundaries"):
+        bits.append(f"won't {seed['boundaries']}")
+    return "; ".join(bits)
+
+
 def render_persona(persona: dict) -> str:
-    """Compose the persona-card prose from the live-object dict the game built."""
+    """Compose the character card from the seed + the NPC's real perceived self."""
     persona = persona or {}
     seed = persona.get("persona_seed") or {}
     name = seed.get("name") or "the bartender"
-    sdesc = persona.get("sdesc")
 
-    lines = []
-    opener = f"THE CHARACTER is {name}"
-    if sdesc:
-        opener += f" — to strangers, {sdesc}"
-    lines.append(opener + ".")
+    lines = [f"You are {name}."]
+    if seed.get("description"):
+        lines.append(seed["description"])
+    personality = _personality(seed)
+    if personality:
+        lines.append(f"Personality: {personality}.")
+    if seed.get("scenario"):
+        lines.append(f"Scenario: {seed['scenario']}.")
 
-    if seed.get("manner"):
-        lines.append(f"Manner: {seed['manner']}.")
-    if seed.get("wants"):
-        lines.append(f"Wants: {seed['wants']}.")
-    if seed.get("boundaries"):
-        lines.append(f"Will not: {seed['boundaries']}.")
-
+    # Grounded in the real object: how the world perceives this character.
+    if persona.get("sdesc"):
+        lines.append(f"To strangers you appear as {persona['sdesc']}.")
     longdescs = persona.get("longdescs") or {}
     appearance = [longdescs[k] for k in _APPEARANCE_KEYS if longdescs.get(k)]
     if persona.get("skintone"):
         appearance.append(f"{persona['skintone']} skin")
     if appearance:
-        lines.append("Appearance: " + " ".join(appearance))
-
+        lines.append("Notable about you: " + " ".join(appearance))
     if persona.get("voice"):
-        lines.append(f"Voice: {persona['voice']}.")
-
+        lines.append(f"Your voice: {persona['voice']}.")
     loc = persona.get("location") or {}
     if loc.get("name"):
-        lines.append(f"Setting: behind the bar at {loc['name']}.")
+        lines.append(f"You are behind the bar at {loc['name']}.")
 
     return "\n".join(lines)
 
 
-def build_messages(persona: dict, speaker: str, line: str, mode: str) -> list:
-    """Build the OpenAI-style ``messages`` list (system charter+persona, user turn)."""
+def few_shot_messages(persona: dict) -> list:
+    """The persona's example dialogue (``mes_example``) as user/assistant pairs."""
+    seed = (persona or {}).get("persona_seed") or {}
+    examples = seed.get("mes_example") or DEFAULT_FEWSHOT
+    out = []
+    for ex in examples:
+        user, assistant = ex.get("user"), ex.get("assistant")
+        if user and assistant:
+            out.append({"role": "user", "content": user})
+            out.append({"role": "assistant", "content": assistant})
+    return out
+
+
+def build_messages(persona: dict, speaker: str, line: str, mode: str,
+                   perception: str = None) -> list:
+    """Build the OpenAI ``messages`` list: system + few-shot + the grounded turn."""
     charter = CHARTER_BASE + (CHARTER_AMBIENT if mode == "ambient" else "")
     system = charter + "\n\n" + render_persona(persona)
+    messages = [{"role": "system", "content": system}]
+    messages += few_shot_messages(persona)
+
     speaker = speaker or "someone"
     line = line or ""
+    perc = f"[PERCEPTION — when you look at {speaker} you see: {perception}]\n\n" \
+        if perception else ""
     if mode == "ambient":
-        turn = f'You overhear {speaker} say: "{line}"'
+        turn = f'{perc}You overhear {speaker} say: "{line}"'
     else:
-        turn = f'{speaker} says to you: "{line}"'
-    return [
-        {"role": "system", "content": system},
-        {"role": "user", "content": turn},
-    ]
+        turn = f'{perc}{speaker} says to you: "{line}"'
+    messages.append({"role": "user", "content": turn})
+    return messages
 
 
 # --- reply parsing / sanitation ----------------------------------------------
@@ -109,16 +153,18 @@ _OOC_MARKERS = (
     "((", "))", "[ooc", "as an ai", "language model", "i cannot", "i'm an ai",
     "i am an ai", "as a language", "note:",
 )
-_MAX_LEN = 400
-
-#: Markerless "declined to react" narrations the model sometimes emits instead of
-#: an empty reply (ambient mode). A genuine spoken line is quoted; these are not.
 _DECLINE_MARKERS = (
     "did not react", "does not react", "doesn't react", "no reaction",
     "did not respond", "does not respond", "doesn't respond", "no response",
     "says nothing", "stays silent", "remains silent", "no reply",
     "nothing happens", "nothing to react", "no comment",
 )
+_MAX_LEN = 600
+
+
+def _is_ooc(text: str) -> bool:
+    low = (text or "").lower()
+    return any(m in low for m in _OOC_MARKERS)
 
 
 def _is_decline(text: str) -> bool:
@@ -128,52 +174,62 @@ def _is_decline(text: str) -> bool:
 
 def _clean(text: str) -> str:
     text = (text or "").strip().strip('"*').strip()
-    # Drop a leading "Name:" speaker prefix the model sometimes emits.
-    text = re.sub(r"^[A-Z][a-z]+:\s*", "", text)
+    text = re.sub(r"^[A-Z][a-z]+:\s*", "", text)  # drop a "Name:" prefix
     return re.sub(r"\s+", " ", text).strip()
 
 
-def _is_ooc(text: str) -> bool:
-    low = (text or "").lower()
-    return any(m in low for m in _OOC_MARKERS)
+def _strip_self_lead(action: str, name: str) -> str:
+    """Strip a leading self-reference; the game prepends the name via `pose`."""
+    if name:
+        action = re.sub(rf"^{re.escape(name)}('s)?\s+", "", action, flags=re.I)
+    return re.sub(r"^(she|he|they)\s+", "", action, flags=re.I).strip()
 
 
 def parse_reply(raw: str, persona: dict) -> dict:
-    """Split a model completion's mixed quotes/asterisks into speech + action.
+    """Split a completion into clean speech + action.
 
-    Returns ``{"speech": str|None, "action": str|None}``; empty-after-clean (or a
-    declined ambient reply) yields nulls so the game stays silent/scripted.
+    Handles both the clean ``*action* "speech"`` format and prose-style replies
+    (narration around quotes). Returns ``{"speech": str|None, "action": str|None}``;
+    empty / OOC / ambient-decline yields nulls so the game stays silent/scripted.
     """
     raw = (raw or "").strip()
     if not raw or _is_ooc(raw):
         return {"speech": None, "action": None}
-
-    # Ambient decline sentinel: the model is told to reply "PASS" when the
-    # character wouldn't react (far more reliable than asking for an empty reply).
+    # Ambient decline sentinel (model told to reply "PASS" when it wouldn't react).
     if raw.strip('".*’‘\' \t\n').upper().rstrip(".!") == "PASS":
         return {"speech": None, "action": None}
 
     speech_parts = [m.strip() for m in _QUOTE_RE.findall(raw) if m.strip()]
     action_parts = [m.strip() for m in _ACTION_RE.findall(raw) if m.strip()]
 
-    # Backstop: a markerless "doesn't react" narration is a decline, not a spoken
-    # line (genuine speech is quoted). Treat it as silence.
-    if not speech_parts and _is_decline(raw):
+    if not speech_parts and not action_parts and _is_decline(raw):
         return {"speech": None, "action": None}
+
+    name = ((persona or {}).get("persona_seed") or {}).get("name") or ""
 
     if speech_parts:
         speech = _clean(" ".join(speech_parts))
+        if action_parts:
+            action = _clean(" ".join(action_parts))
+        else:
+            # Prose style: the narration around the quotes IS the action — keep
+            # it as a pose instead of discarding the model's best writing.
+            action = _clean(_QUOTE_RE.sub("", raw))
+    elif action_parts:
+        action = _clean(" ".join(action_parts))
+        leftover = _clean(_ACTION_RE.sub("", raw))
+        speech = leftover or None
     else:
-        speech = _clean(_ACTION_RE.sub("", raw))
+        # Bare text, no markers → treat as a spoken line.
+        speech = _clean(raw)
+        action = None
 
-    action = _clean(" ".join(action_parts)) if action_parts else ""
-
-    # The game prepends the name via `pose`, so strip a leading self-reference.
     if action:
-        name = ((persona or {}).get("persona_seed") or {}).get("name") or ""
-        if name:
-            action = re.sub(rf"^{re.escape(name)}\s+", "", action, flags=re.I)
-        action = re.sub(r"^(she|he|they)\s+", "", action, flags=re.I)
+        action = _strip_self_lead(action, name)
+        # POV guard: a second-person action ("your eyes…") is a leak we can't
+        # cleanly render through `pose` — drop it rather than emit broken text.
+        if re.match(r"^(your|you)\b", action, flags=re.I):
+            action = None
 
     speech = speech[:_MAX_LEN] if speech else None
     action = action[:_MAX_LEN] if action else None

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -540,6 +540,8 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         for name in self._REAL:
             bound = getattr(barmod.Bartender, name).__get__(b, barmod.Bartender)
             setattr(b, name, bound)
+        # default: not alone (so ambient stays ambient); override per test
+        b._is_alone_with = lambda speaker: False
         return b
 
     def _speaker(self, location="room", name="a lean man"):
@@ -587,6 +589,29 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
                 patch.object(barmod, "delay") as mock_delay:
             self._call(b, npc, speech="rough night sable", addressed=False)
         mock_delay.assert_not_called()
+
+    def test_solo_room_routes_directed(self):
+        # alone with the speaker → a plain (un-named) line is plainly for her
+        b, spk = self._bartender(), self._speaker()
+        b._is_alone_with = lambda speaker: True
+        with patch.object(barmod, "llm_enabled", return_value=True), \
+                patch.object(barmod, "delay") as mock_delay:
+            self._call(b, spk, speech="this drink is watered down", addressed=False)
+        mock_delay.assert_called_once()
+        self.assertIn("directed", mock_delay.call_args.args)
+
+    def test_is_alone_with_detects_other_characters(self):
+        from typeclasses.characters import Character
+        b = self._bartender()
+        b._is_alone_with = barmod.Bartender._is_alone_with.__get__(
+            b, barmod.Bartender)
+        spk = MagicMock(spec=Character)
+        room = MagicMock()
+        b.location = room
+        room.contents = [b, spk]
+        self.assertTrue(b._is_alone_with(spk))
+        room.contents = [b, spk, MagicMock(spec=Character)]
+        self.assertFalse(b._is_alone_with(spk))
 
     def test_addressed_still_routes_to_order(self):
         b, spk = self._bartender(), self._speaker()

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -1,8 +1,7 @@
 """The portable LLM prompt layer (world.llm.prompt) — backend-agnostic.
 
-Pure functions: the OpenAI-style message builder, the persona render, and the
-reply parser. No model, no Evennia, no network — these travel with the repo so the
-inference backend stays swappable.
+Pure functions: the OpenAI message builder (card persona + few-shot + grounded
+turn), the persona render, and the reply parser. No model, no Evennia, no network.
 """
 
 from unittest import TestCase
@@ -16,43 +15,74 @@ _PERSONA = {
     "location": {"name": "the Helix Lounge"},
     "persona_seed": {
         "name": "Sable",
-        "manner": "sly, watchful",
-        "wants": "to read everyone who sits down",
-        "boundaries": "won't discuss the owner's debts",
+        "description": "the bartender at the Helix Lounge.",
+        "personality": "sly, watchful, unhurried",
+        "scenario": "tending a slow night behind the bar",
+        "mes_example": [
+            {"user": 'a patron says to you: "busy?"',
+             "assistant": '*polishes a glass.* "Define busy."'},
+        ],
     },
 }
 
 
 class TestBuildMessages(TestCase):
-    def test_openai_message_shape(self):
+    def test_system_fewshot_turn_order(self):
         msgs = build_messages(_PERSONA, "a lean man", "rough night?", "directed")
-        self.assertEqual([m["role"] for m in msgs], ["system", "user"])
+        self.assertEqual(msgs[0]["role"], "system")
+        self.assertEqual(msgs[-1]["role"], "user")
+        self.assertIn("assistant", [m["role"] for m in msgs])  # few-shot present
         self.assertIn("Sable", msgs[0]["content"])
         self.assertIn("sly, watchful", msgs[0]["content"])
-        self.assertIn("a lean man", msgs[1]["content"])
-        self.assertIn("rough night?", msgs[1]["content"])
+        self.assertIn("rough night?", msgs[-1]["content"])
+
+    def test_fewshot_uses_card_examples(self):
+        joined = " ".join(m["content"] for m in
+                          build_messages(_PERSONA, "a man", "hi", "directed"))
+        self.assertIn("Define busy.", joined)  # from mes_example
+
+    def test_perception_grounds_and_forbids_invention(self):
+        msgs = build_messages(_PERSONA, "a man", "hi", "directed",
+                              perception="a stocky droog in a white t-shirt")
+        self.assertIn("a stocky droog in a white t-shirt", msgs[-1]["content"])
+        self.assertIn("PERCEPTION", msgs[-1]["content"])
+        sys = msgs[0]["content"].lower()
+        self.assertIn("invent", sys)  # charter forbids inventing appearance
 
     def test_directed_vs_ambient_framing(self):
         directed = build_messages(_PERSONA, "a man", "hi", "directed")
         ambient = build_messages(_PERSONA, "a man", "hi", "ambient")
-        self.assertIn("says to you", directed[1]["content"])
-        self.assertIn("overhear", ambient[1]["content"].lower())
-        # ambient charter tells the model it may decline
-        self.assertIn("OVERHEARD", ambient[0]["content"])
-        self.assertNotIn("OVERHEARD", directed[0]["content"])
+        self.assertIn("says to you", directed[-1]["content"])
+        self.assertIn("overhear", ambient[-1]["content"].lower())
+        self.assertIn("PASS", ambient[0]["content"])
+
+    def test_backcompat_old_manner_keys(self):
+        old = {"persona_seed": {"name": "X", "manner": "gruff",
+                                "wants": "quiet", "boundaries": "discuss debts"}}
+        self.assertIn("gruff", render_persona(old))
 
     def test_render_persona_is_defensive(self):
-        # a near-empty persona still renders without raising
         self.assertIn("the bartender", render_persona({}))
 
 
 class TestParseReply(TestCase):
-    def test_speech_and_action_split(self):
-        raw = '*Sable smirks.* "What\'s it to ya?"'
-        out = parse_reply(raw, _PERSONA)
+    def test_clean_format_split(self):
+        out = parse_reply('*Sable smirks.* "What\'s it to ya?"', _PERSONA)
         self.assertEqual(out["speech"], "What's it to ya?")
-        # leading self-reference stripped (the game prepends the name via pose)
         self.assertEqual(out["action"], "smirks.")
+
+    def test_prose_narration_becomes_pose(self):
+        raw = 'Sable\'s eyes flick to the door. "We\'re closing soon," she says.'
+        out = parse_reply(raw, _PERSONA)
+        self.assertEqual(out["speech"], "We're closing soon,")
+        self.assertIsNotNone(out["action"])
+        self.assertIn("eyes flick to the door", out["action"])
+        self.assertFalse(out["action"].lower().startswith("sable"))
+
+    def test_pov_leak_action_dropped(self):
+        out = parse_reply('*your eyes meet his.* "Hey."', _PERSONA)
+        self.assertEqual(out["speech"], "Hey.")
+        self.assertIsNone(out["action"])
 
     def test_speech_only(self):
         out = parse_reply('"Just a sec."', _PERSONA)
@@ -60,8 +90,8 @@ class TestParseReply(TestCase):
         self.assertIsNone(out["action"])
 
     def test_no_markers_treated_as_speech(self):
-        out = parse_reply("rough night, huh", _PERSONA)
-        self.assertEqual(out["speech"], "rough night, huh")
+        self.assertEqual(parse_reply("rough night, huh", _PERSONA)["speech"],
+                         "rough night, huh")
 
     def test_ooc_dropped_to_null(self):
         out = parse_reply("As an AI, I can't roleplay that.", _PERSONA)
@@ -72,16 +102,13 @@ class TestParseReply(TestCase):
 
     def test_pass_sentinel_is_null(self):
         for raw in ("PASS", "pass", '"PASS"', "PASS.", "*PASS*"):
-            self.assertEqual(
-                parse_reply(raw, _PERSONA), {"speech": None, "action": None}, raw
-            )
+            self.assertEqual(parse_reply(raw, _PERSONA),
+                             {"speech": None, "action": None}, raw)
 
     def test_decline_narration_is_null(self):
-        # ambient decline narrated as prose (no quotes) → silence, not a spoken line
         out = parse_reply("Sable does not react to the comment.", _PERSONA)
         self.assertEqual(out, {"speech": None, "action": None})
 
     def test_quoted_line_with_decline_word_still_speaks(self):
-        # a real quoted line that merely contains a decline word still renders
         out = parse_reply('"No response from the docks, last I heard."', _PERSONA)
         self.assertEqual(out["speech"], "No response from the docks, last I heard.")


### PR DESCRIPTION
Refinements from the first live play with Sable (#707/#709), kept delicate and standards-aligned — **zero new deps**.

1. **Grounded perception** — kills the hallucinated t-shirt text / snake tattoo. The speaker's *real* perceived appearance (`return_appearance(npc)`, ANSI-stripped, identity-gated) is captured on the reactor and injected as a `[PERCEPTION …]` block; the charter forbids inventing the other person's clothing/marks/features. (Agentic `look`-as-tool stays Phase 3; memory grounding stays Phase 2.)
2. **Solo-room → directed** — when she's alone with one speaker, a plain `say` is treated as directed, so she answers what's clearly meant for her instead of declining as ambient.
3. **Best-practice prompting** — persona adopts the **character-card** vocabulary (`description`/`personality`/`scenario`/`mes_example`) and we add **few-shot example dialogue** (the standard technique for locking voice + format). Parser now renders prose-style narration as a `pose` instead of discarding it, drops second-person POV-leak actions, and `max_tokens`→120.

79/79 tests green. Out-of-repo sidecar unchanged. Builds on #707.

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)