### PR TITLE
LLM GM: cut model runaway into fabricated next turns

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -162,6 +162,17 @@ _DECLINE_MARKERS = (
 _MAX_LEN = 600
 
 
+#: A model without a chat template can't see turn boundaries and may continue
+#: into fabricated next turns that echo our framing ("a patron says to you: …").
+#: Keep only the first (real) reply, up to the first such marker.
+_RUNAWAY_RE = re.compile(r"\n[^\n]*?(?:says to you:|you overhear\b)", re.I)
+
+
+def _cut_runaway(raw: str) -> str:
+    m = _RUNAWAY_RE.search(raw or "")
+    return raw[:m.start()].strip() if m else raw
+
+
 def _is_ooc(text: str) -> bool:
     low = (text or "").lower()
     return any(m in low for m in _OOC_MARKERS)
@@ -192,7 +203,7 @@ def parse_reply(raw: str, persona: dict) -> dict:
     (narration around quotes). Returns ``{"speech": str|None, "action": str|None}``;
     empty / OOC / ambient-decline yields nulls so the game stays silent/scripted.
     """
-    raw = (raw or "").strip()
+    raw = _cut_runaway((raw or "").strip())
     if not raw or _is_ooc(raw):
         return {"speech": None, "action": None}
     # Ambient decline sentinel (model told to reply "PASS" when it wouldn't react).

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -109,6 +109,14 @@ class TestParseReply(TestCase):
         out = parse_reply("Sable does not react to the comment.", _PERSONA)
         self.assertEqual(out, {"speech": None, "action": None})
 
+    def test_runaway_continuation_is_cut(self):
+        raw = ('*sets down a glass.* "Define busy."\n\n'
+               'a patron says to you: "got anything strong?"\n\n'
+               '*a slow smile.* "Always."')
+        out = parse_reply(raw, _PERSONA)
+        self.assertEqual(out["speech"], "Define busy.")
+        self.assertEqual(out["action"], "sets down a glass.")
+
     def test_quoted_line_with_decline_word_still_speaks(self):
         out = parse_reply('"No response from the docks, last I heard."', _PERSONA)
         self.assertEqual(out["speech"], "No response from the docks, last I heard.")


### PR DESCRIPTION
Hotfix on top of #711. The few-shot examples fixed per-turn format but exposed that Rocinante's no-chat-template fallback can't see turn boundaries and continues into fabricated `a patron says to you: …` → reply loops. `_cut_runaway` keeps only the first real reply. Model-agnostic; the real fix is a chat-template tune (UnslopNemo / Rocinante-X), next. 17/17 prompt tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)