### PR TITLE
LLM GM: render NPC reply as one unified emote (proper posing)

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -543,17 +543,22 @@ class Bartender(Character):
             return None
 
     def _render_llm_reply(self, speech, action):
-        """Reactor-side render of the sidecar reply: say + pose."""
+        """Render the sidecar reply as ONE fluid emote — the MUD-native way to act
+        and speak in a single beat. The embedded quote rides the hearing-gated
+        speech rails (``tokenize_emote`` → ``SpeechToken``) and character refs in
+        the action resolve per-observer. Falls back to a bare pose or say."""
         if not self.location:
             return
-        if speech:
-            clean = speech.strip().strip('"').strip()
-            if clean:
-                self.execute_cmd(f"say {clean}")
-        if action:
-            clean = action.strip()
-            if clean:
-                self.execute_cmd(f"pose {clean}")
+        speech = speech.strip().strip('"').strip() if speech else None
+        action = action.strip() if action else None
+        if action and speech:
+            if action[-1] not in ".!?…,":
+                action += "."
+            self.execute_cmd(f'pose {action} "{speech}"')
+        elif action:
+            self.execute_cmd(f"pose {action}")
+        elif speech:
+            self.execute_cmd(f"say {speech}")
 
     def _llm_fallback(self):
         """Sidecar failed on an addressed non-order: the curt scripted line."""

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -28,9 +28,11 @@ portray them in character without flinching, lecturing, or refusing.
 
 OUTPUT FORMAT — follow exactly (see the examples):
 - Reply ONLY as the character: one or two lines of bar banter, never a monologue.
-- Spoken words go in "double quotes".
-- Physical actions are narrated in THIRD PERSON present tense, in *asterisks*,
-sparingly — e.g. *tilts her head.* NEVER write the character as "I" or "you".
+- You are physically present, not a disembodied voice. Pair your words with ONE \
+small physical action — a glance, a gesture, wiping the bar — and LEAD with it.
+- The action goes in *asterisks*, THIRD PERSON present tense; the words go in \
+"double quotes" — e.g. *sets down a glass.* "What'll it be?" NEVER write the \
+character as "I" or "you".
 
 HARD RULES:
 - Never speak, think, narrate, or act for the OTHER person. Voice only this \

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -668,11 +668,18 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
             barmod.Bartender._fulfil_order(b, "a unicorn tear", patron)
         b.execute_cmd.assert_any_call("say Don't serve that here.")
 
-    def test_render_say_and_pose(self):
+    def test_render_unified_emote(self):
+        # action + speech -> ONE action-led emote with the quote embedded
         b = self._bartender()
-        b._render_llm_reply('"What\'s it to ya?"', "wipes down the slab")
-        b.execute_cmd.assert_any_call("say What's it to ya?")
-        b.execute_cmd.assert_any_call("pose wipes down the slab")
+        b._render_llm_reply("What's it to ya?", "wipes down the slab")
+        b.execute_cmd.assert_called_once_with(
+            'pose wipes down the slab. "What\'s it to ya?"')
+
+    def test_render_action_only(self):
+        b = self._bartender()
+        b.execute_cmd.reset_mock()
+        b._render_llm_reply(None, "polishes a glass")
+        b.execute_cmd.assert_called_once_with("pose polishes a glass")
 
     def test_render_speech_only(self):
         b = self._bartender()


### PR DESCRIPTION
First live play showed the NPC's reply rendering as two robotic lines (separate `say` + `pose`). The MUD-native way to act and speak is **one emote with the quote embedded** — `pose <action> "<speech>"` → "Sable sets down the glass. *What'll it be?*" — where the embedded quote still rides the hearing-gated speech rails (`tokenize_emote` → `SpeechToken`) and character refs in the action resolve per-observer.

- `_render_llm_reply`: one action-led emote when both present; bare pose / say fallback.
- Charter: physical presence — pair speech with one small action, lead with it (curbs chatbot dialogue).

81/81 green. Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)