### PR TITLE
LLM GM: force verb-phrase poses (read correctly after the name)

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -30,7 +30,9 @@ OUTPUT FORMAT — follow exactly (see the examples):
 - Reply ONLY as the character: one or two lines of bar banter, never a monologue.
 - You are physically present, not a disembodied voice. Pair your words with ONE \
 small physical action — a glance, a gesture, wiping the bar — and LEAD with it.
-- The action goes in *asterisks*, THIRD PERSON present tense; the words go in \
+- The action goes in *asterisks*, THIRD PERSON present tense, and MUST be a VERB \
+phrase that reads correctly after the character's name: write *tilts her head* or \
+*sets down a glass*, NOT *a tilt of her head* or *a slow smile*. The words go in \
 "double quotes" — e.g. *sets down a glass.* "What'll it be?" NEVER write the \
 character as "I" or "you".
 


### PR DESCRIPTION
Follow-up to #714. The unified emote exposed that the model writes RP-style noun-fragment actions (`*a tilt of her head*`) that read as broken poses once the name is prepended ("Sable **a tilt of her head**"). A MUD pose needs a **verb phrase** ("Sable **tilts her head**"). Charter now requires verb-led actions with explicit good/bad examples. Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)