### PR TITLE
LLM GM: short-term memory + perception trim + menu awareness

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -14,6 +14,7 @@ UX) so the loop is testable; those are later slices.
 """
 
 import random
+from functools import partial
 from time import monotonic
 
 from evennia import CmdSet
@@ -335,6 +336,7 @@ ACK_COOLDOWN = 6.0
 LLM_DIRECTED_COOLDOWN = 4.0    # min seconds between replies to direct address/name
 LLM_AMBIENT_COOLDOWN = 45.0    # she rarely volunteers into overheard chatter
 LLM_AMBIENT_CHANCE = 0.35      # ...and not every eligible time
+LLM_HISTORY_TURNS = 6          # recent turns kept per interlocutor (anti-repetition)
 
 
 class Bartender(Character):
@@ -523,24 +525,78 @@ class Bartender(Character):
         persona = build_persona(self)
         speaker_name = patron.get_display_name(self)
         perception = self._perceive(patron)
+        history = self._recent_history(patron)
         request_npc_reply(
             persona, speaker_name, line or "", mode,
-            on_reply=self._render_llm_reply,
+            on_reply=partial(self._render_and_remember, patron, line or "",
+                             speaker_name),
             on_fail=on_fail or self._llm_silent,
             perception=perception,
+            history=history,
         )
         return True
 
     def _perceive(self, patron):
         """What this NPC sees when it looks at the patron — grounds the model's
         description so it can't invent the speaker's appearance. ANSI-stripped,
-        identity-gated (it's the patron's appearance *as this NPC perceives it*)."""
+        identity-gated, trimmed to a sentence-bounded summary (the full
+        return_appearance bloats context and truncates mid-word)."""
         try:
             from evennia.utils.ansi import strip_ansi
             raw = patron.return_appearance(self)
-            return " ".join(strip_ansi(raw).split())[:600] if raw else None
+            if not raw:
+                return None
+            text = " ".join(strip_ansi(raw).split())
+            if len(text) > 300:
+                cut = text[:300]
+                for end in (". ", "! ", "? "):
+                    i = cut.rfind(end)
+                    if i > 120:
+                        cut = cut[: i + 1]
+                        break
+                text = cut.rstrip()
+            return text
         except Exception:
             return None
+
+    # --- short-term conversation memory (per interlocutor, ndb/ephemeral) ----
+
+    @staticmethod
+    def _hist_key(patron):
+        return f"#{patron.id}"
+
+    def _recent_history(self, patron):
+        """The recent turns with this interlocutor — fed back into the prompt so
+        the model sees what it just said and stops repeating itself."""
+        return (self.ndb.llm_history or {}).get(self._hist_key(patron), [])
+
+    def _render_and_remember(self, patron, line, speaker_name, speech, action):
+        """Render the reply, then append the turn to short-term memory."""
+        self._render_llm_reply(speech, action)
+        reply = self._reconstruct_reply(speech, action)
+        if not reply:
+            return
+        hist = self.ndb.llm_history or {}
+        key = self._hist_key(patron)
+        turns = list(hist.get(key, []))
+        turns.append({
+            "user": f'{speaker_name} says to you: "{line}"',
+            "assistant": reply,
+        })
+        hist[key] = turns[-LLM_HISTORY_TURNS:]
+        self.ndb.llm_history = hist
+
+    @staticmethod
+    def _reconstruct_reply(speech, action):
+        """Re-form the model's own reply for the history (so it sees its prior
+        gestures and phrasing, in the same format it produces)."""
+        if action and speech:
+            return f'*{action}* "{speech}"'
+        if action:
+            return f"*{action}*"
+        if speech:
+            return f'"{speech}"'
+        return ""
 
     def _render_llm_reply(self, speech, action):
         """Render the sidecar reply as ONE fluid emote — the MUD-native way to act

--- a/typeclasses/llm_persona.py
+++ b/typeclasses/llm_persona.py
@@ -32,6 +32,15 @@ def build_persona(npc) -> dict:
             "desc": getattr(npc.location.db, "desc", None),
         }
 
+    # The bar's real menu, so she knows exactly what she serves (and what she
+    # doesn't) — and never fakes pouring something off-list.
+    menu = None
+    find_bar = getattr(npc, "_find_bar", None)
+    if callable(find_bar):
+        bar = find_bar()
+        bar_menu = (bar.db.menu if bar else None) or npc.db.menu or []
+        menu = [r.get("name") for r in bar_menu if r.get("name")] or None
+
     return {
         "sdesc": npc.get_sdesc(),
         "longdescs": longdescs,
@@ -44,5 +53,6 @@ def build_persona(npc) -> dict:
         "voice_description": get_voice_description(npc),
         "voice_ending": get_voice_ending(npc),
         "location": location,
+        "menu": menu,
         "persona_seed": npc.db.llm_persona or {},
     }

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -42,9 +42,12 @@ character. Do not invent what anyone else says or does.
 - Describe the other person ONLY from the PERCEPTION line in the turn. NEVER \
 invent their clothing, tattoos, marks, scars, or features — if it isn't in \
 PERCEPTION or something the character plainly knows, it does not exist.
-- You do NOT resolve game mechanics. If asked to make a drink or perform a task, \
-gesture at starting it in a few words and stop — the game engine handles the \
-result. Never narrate measuring, mixing, or step-by-step crafting.
+- You do NOT make drinks or resolve game mechanics — the bar does. NEVER narrate \
+pouring, mixing, or a finished drink appearing or being served. If a patron orders, \
+acknowledge it in words and let the bar produce it. If they ask for something NOT \
+on your menu (listed below), tell them you don't serve it.
+- VARY yourself: never reuse a physical action, gesture, or line you have used \
+recently in this conversation. Each beat should be fresh.
 - Stay in character always. Never mention being an AI, a model, or a game system; \
 no out-of-character asides.
 - Use only in-world, generic names for drinks and ingredients — NEVER real-world \
@@ -113,6 +116,13 @@ def render_persona(persona: dict) -> str:
     loc = persona.get("location") or {}
     if loc.get("name"):
         lines.append(f"You are behind the bar at {loc['name']}.")
+    menu = persona.get("menu")
+    if menu:
+        lines.append(
+            "Your bar serves ONLY these drinks: " + ", ".join(menu) + ". You have "
+            "nothing else — no beer, no off-list requests. The BAR makes them, not "
+            "you."
+        )
 
     return "\n".join(lines)
 
@@ -131,12 +141,20 @@ def few_shot_messages(persona: dict) -> list:
 
 
 def build_messages(persona: dict, speaker: str, line: str, mode: str,
-                   perception: str = None) -> list:
-    """Build the OpenAI ``messages`` list: system + few-shot + the grounded turn."""
+                   perception: str = None, history: list = None) -> list:
+    """Build the OpenAI ``messages`` list: system + few-shot + recent history +
+    the grounded turn. ``history`` is the recent conversation (list of
+    ``{"user", "assistant"}`` pairs) so the model sees what it just said and
+    stops repeating itself across turns."""
     charter = CHARTER_BASE + (CHARTER_AMBIENT if mode == "ambient" else "")
     system = charter + "\n\n" + render_persona(persona)
     messages = [{"role": "system", "content": system}]
     messages += few_shot_messages(persona)
+    for h in (history or []):
+        user, assistant = h.get("user"), h.get("assistant")
+        if user and assistant:
+            messages.append({"role": "user", "content": user})
+            messages.append({"role": "assistant", "content": assistant})
 
     speaker = speaker or "someone"
     line = line or ""

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -638,8 +638,14 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         self.assertEqual(args[1], "a wiry courier")    # speaker as she sees them
         self.assertEqual(args[2], "rough night?")      # line
         self.assertEqual(args[3], "directed")          # mode
-        self.assertIs(kwargs["on_reply"], b._render_llm_reply)
+        # on_reply now wraps render + memory append (a partial); perception and
+        # history are threaded through
+        from functools import partial as _partial
+        self.assertIsInstance(kwargs["on_reply"], _partial)
+        self.assertIs(kwargs["on_reply"].func, b._render_and_remember)
         self.assertIs(kwargs["on_fail"], b._llm_silent)
+        self.assertIn("perception", kwargs)
+        self.assertIn("history", kwargs)
 
     def test_try_llm_reply_gated_off(self):
         b, patron = self._bartender(llm_driven=False), self._speaker()
@@ -691,6 +697,44 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         b = self._bartender()
         b._llm_fallback()
         b.execute_cmd.assert_called_once_with("say Don't serve that here.")
+
+    def _bind_memory(self, b):
+        b._hist_key = barmod.Bartender._hist_key            # staticmethods
+        b._reconstruct_reply = barmod.Bartender._reconstruct_reply
+        for name in ("_recent_history", "_render_and_remember", "_render_llm_reply"):
+            setattr(b, name,
+                    getattr(barmod.Bartender, name).__get__(b, barmod.Bartender))
+
+    def test_short_term_memory_roundtrip(self):
+        b = self._bartender()
+        self._bind_memory(b)
+        patron = self._speaker(); patron.id = 42
+        b.ndb.llm_history = {}
+        self.assertEqual(b._recent_history(patron), [])
+        b._render_and_remember(patron, "hey", "a man", "evening", "wipes the bar")
+        hist = b._recent_history(patron)
+        self.assertEqual(len(hist), 1)
+        self.assertIn("hey", hist[0]["user"])
+        self.assertEqual(hist[0]["assistant"], '*wipes the bar* "evening"')
+
+    def test_memory_caps_at_limit(self):
+        b = self._bartender()
+        self._bind_memory(b)
+        patron = self._speaker(); patron.id = 7
+        b.ndb.llm_history = {}
+        for i in range(barmod.LLM_HISTORY_TURNS + 4):
+            b._render_and_remember(patron, f"l{i}", "a man", f"r{i}", "nods")
+        self.assertEqual(len(b._recent_history(patron)), barmod.LLM_HISTORY_TURNS)
+
+    def test_memory_is_per_interlocutor(self):
+        b = self._bartender()
+        self._bind_memory(b)
+        b.ndb.llm_history = {}
+        p1 = self._speaker(); p1.id = 1
+        p2 = self._speaker(); p2.id = 2
+        b._render_and_remember(p1, "to one", "a man", "hi one", "nods")
+        self.assertEqual(len(b._recent_history(p1)), 1)
+        self.assertEqual(b._recent_history(p2), [])  # separate conversation
 
     def test_mentions_self(self):
         b = self._bartender()

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -61,6 +61,26 @@ class TestBuildMessages(TestCase):
                                 "wants": "quiet", "boundaries": "discuss debts"}}
         self.assertIn("gruff", render_persona(old))
 
+    def test_history_inserted_before_turn(self):
+        hist = [{"user": 'a man says to you: "again?"',
+                 "assistant": '*nods.* "Same as before."'}]
+        msgs = build_messages(_PERSONA, "a man", "and now?", "directed",
+                              history=hist)
+        joined = " ".join(m["content"] for m in msgs)
+        self.assertIn("Same as before.", joined)         # history present
+        self.assertEqual(msgs[-1]["content"].count("and now?"), 1)  # turn is last
+        # history pair sits before the final turn
+        contents = [m["content"] for m in msgs]
+        self.assertLess(contents.index('*nods.* "Same as before."'),
+                        len(contents) - 1)
+
+    def test_menu_in_persona(self):
+        p = dict(_PERSONA)
+        p["menu"] = ["Negroni", "Old Fashioned"]
+        out = render_persona(p)
+        self.assertIn("Negroni", out)
+        self.assertIn("ONLY", out)
+
     def test_render_persona_is_defensive(self):
         self.assertIn("the bartender", render_persona({}))
 


### PR DESCRIPTION
Fixes the cross-turn pose repetition from live play (same gesture every turn) — the NPC was fully **stateless**. Now keeps a rolling **last-6-turns history per interlocutor** (ndb) fed back into the prompt as prior user/assistant pairs, so the model sees what it just did and varies, *and* tracks the conversation. Charter adds an explicit vary-your-gestures rule.

Also: **trim the PERCEPTION block** (was ~600 chars, truncating mid-word) to a sentence-bounded summary; and give her the **bar's real menu** — charter now forbids faking drinks ("the bar makes them, not you; off-menu → say you don't serve it"). Fixes "ordered a beer, she pretended to pour one" (Helix is cocktails-only).

Not included: real order-fulfillment (LLM → make_drink) — the next action-piece. 86/86 green. Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)