### PR TITLE
LLM GM: agentic tool loop — constrained schema + context/action tools via real commands

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -13,6 +13,7 @@ v1 is intentionally lenient where the spec defers (ownership gating, recipe-save
 UX) so the loop is testable; those are later slices.
 """
 
+import json
 import random
 from functools import partial
 from time import monotonic
@@ -25,7 +26,8 @@ from typeclasses.items import Item
 from typeclasses.characters import Character
 from typeclasses.llm_persona import build_persona
 from world.grammar import capitalize_first, with_article
-from world.llm.client import llm_enabled, request_npc_reply
+from world.llm.client import llm_enabled, request_turn
+from world.llm.prompt import build_messages, parse_turn
 from world.shop.utils import format_currency
 from world.bar import (
     DEFAULT_BAR_SNACKS,
@@ -337,6 +339,10 @@ LLM_DIRECTED_COOLDOWN = 4.0    # min seconds between replies to direct address/n
 LLM_AMBIENT_COOLDOWN = 45.0    # she rarely volunteers into overheard chatter
 LLM_AMBIENT_CHANCE = 0.35      # ...and not every eligible time
 LLM_HISTORY_TURNS = 6          # recent turns kept per interlocutor (anti-repetition)
+#: Tools the model may call that *inform* it (read-only) vs *act* (mutate). Context
+#: tools loop (run → feed result back → re-ask); action tools route to a command.
+CONTEXT_TOOLS = {"look", "check_stock"}
+LLM_MAX_TOOL_ROUNDS = 3        # cap the agentic loop so it can't spin forever
 
 
 class Bartender(Character):
@@ -520,20 +526,16 @@ class Bartender(Character):
             return True
         self.ndb.last_llm = now
 
-        # Capture everything the off-reactor thread needs BEFORE threading
-        # (the SQLite/Evennia-thread contract — see world/llm/client.py).
+        # Capture everything reactor-side BEFORE threading (SQLite/Evennia-thread
+        # contract). The agentic loop re-calls from the reactor-side callback.
         persona = build_persona(self)
         speaker_name = patron.get_display_name(self)
         perception = self._perceive(patron)
         history = self._recent_history(patron)
-        request_npc_reply(
-            persona, speaker_name, line or "", mode,
-            on_reply=partial(self._render_and_remember, patron, line or "",
-                             speaker_name),
-            on_fail=on_fail or self._llm_silent,
-            perception=perception,
-            history=history,
-        )
+        messages = build_messages(persona, speaker_name, line or "", mode,
+                                  perception, history)
+        self._agentic_round(messages, persona, patron, line or "", speaker_name,
+                            on_fail or self._llm_silent, rounds=0)
         return True
 
     def _perceive(self, patron):
@@ -570,9 +572,56 @@ class Bartender(Character):
         the model sees what it just said and stops repeating itself."""
         return (self.ndb.llm_history or {}).get(self._hist_key(patron), [])
 
-    def _render_and_remember(self, patron, line, speaker_name, speech, action):
-        """Render the reply, then append the turn to short-term memory."""
-        self._render_llm_reply(speech, action)
+    # --- the agentic tool loop (constrained turn → context tools → reply) ----
+
+    def _agentic_round(self, messages, persona, patron, line, speaker_name,
+                       on_fail, rounds):
+        """One constrained generation; the reactor-side callback either runs a
+        context tool and loops, or renders the final reply + any action tool."""
+        request_turn(
+            messages,
+            on_turn=partial(self._on_turn, messages, persona, patron, line,
+                            speaker_name, on_fail, rounds),
+            on_fail=on_fail,
+        )
+
+    def _on_turn(self, messages, persona, patron, line, speaker_name, on_fail,
+                 rounds, raw):
+        turn = parse_turn(raw, persona)
+        tool, arg = turn["tool"], turn["tool_argument"]
+        # Context tool: run the real read, feed the result back, loop.
+        if tool in CONTEXT_TOOLS and rounds < LLM_MAX_TOOL_ROUNDS:
+            result = self._run_context_tool(tool, arg, patron)
+            extended = messages + [
+                {"role": "assistant",
+                 "content": raw if isinstance(raw, str) else json.dumps(raw)},
+                {"role": "user", "content": f"[tool result · {tool}] {result}"},
+            ]
+            self._agentic_round(extended, persona, patron, line, speaker_name,
+                                on_fail, rounds + 1)
+            return
+        # Terminal: render speech/action, run the action tool, remember.
+        self._render_llm_reply(turn["speech"], turn["action"])
+        if tool == "prepare_drink" and arg and self.location:
+            self.execute_cmd(f"prepare {arg}")
+        self._remember_turn(patron, line, speaker_name, turn["speech"],
+                            turn["action"])
+
+    def _run_context_tool(self, tool, arg, patron):
+        """Run a read-only context tool via the game's real logic and return its
+        result for the model. (Reads only — world-mutating tools go through real
+        commands in ``_on_turn``.)"""
+        if tool == "look":
+            return self._perceive(patron) or "nothing remarkable"
+        if tool == "check_stock":
+            bar = self._find_bar()
+            menu = (bar.db.menu if bar else None) or self.db.menu or []
+            names = [r.get("name") for r in menu if r.get("name")]
+            return ("Serves: " + ", ".join(names)) if names else "nothing on tap"
+        return ""
+
+    def _remember_turn(self, patron, line, speaker_name, speech, action):
+        """Append the rendered turn to short-term memory (anti-repetition)."""
         reply = self._reconstruct_reply(speech, action)
         if not reply:
             return

--- a/world/llm/client.py
+++ b/world/llm/client.py
@@ -1,18 +1,15 @@
-"""LLM Gamemaster client — off-reactor calls over the OpenAI Chat Completions API.
+"""LLM Gamemaster client — off-reactor calls over OpenAI Chat Completions (MLX).
 
-The game speaks the **standard OpenAI Chat Completions protocol** to a configurable
-endpoint (``settings.LLM_GM_URL``), so the inference backend is swappable without a
-code change — our MLX sidecar, Ollama, llama.cpp, vLLM, LM Studio, or a cloud API.
-The repo owns the portable prompt/parse logic (``world/llm/prompt.py``); the
-backend is just an inference endpoint. This keeps Gelatinous LLM-platform-agnostic.
+The game speaks the standard chat-completions protocol to a configurable endpoint
+(``settings.LLM_GM_URL``); the backend is swappable. Each call passes
+``TURN_SCHEMA`` so the backend (our MLX sidecar via ``outlines``) returns output
+**guaranteed valid** against the unified ``{speech, action, tool}`` schema.
 
-Calls cross the Twisted reactor and must NEVER block it: the blocking
-``requests.post`` runs in Evennia's async thread pool via ``run_async`` — the same
-pattern the GitHub calls in ``commands/CmdBug.py`` use. Contract: the thread
-function does pure network + parsing — NO Evennia object access, NO database
-reads/writes (SQLite is not thread-safe). All live values (the persona dict, the
-speaker name, the line) are captured on the reactor *before* the call; the reply
-renders in the reactor-side ``at_return`` / ``at_err`` callbacks.
+Calls never block the Twisted reactor: the blocking ``requests.post`` runs in
+Evennia's async thread pool via ``run_async`` (the ``CmdBug`` pattern). The thread
+does pure network — NO Evennia/DB access. The caller builds the ``messages`` (and
+extends them across the agentic loop, §5.3) and orchestrates on the reactor in the
+callbacks.
 """
 
 import requests
@@ -20,15 +17,11 @@ from django.conf import settings
 from evennia.utils import logger
 from evennia.utils.utils import run_async
 
-from world.llm.prompt import build_messages, parse_reply
+from world.llm.prompt import TURN_SCHEMA
 
-#: Defaults if settings are absent. The URL is a standard OpenAI Chat Completions
-#: endpoint; from inside the game container the host-native backend is reached via
-#: ``host.docker.internal`` (a ``127.0.0.1`` URL would mean the container itself).
 _DEFAULT_URL = "http://host.docker.internal:8765/v1/chat/completions"
-_DEFAULT_TIMEOUT = 15
-_DEFAULT_MAX_TOKENS = 120
-_DEFAULT_TEMPERATURE = 0.8
+_DEFAULT_TIMEOUT = 20          # 24B + constrained decoding is slower than 8B
+_DEFAULT_MAX_TOKENS = 160
 
 
 def llm_enabled() -> bool:
@@ -36,39 +29,26 @@ def llm_enabled() -> bool:
     return bool(getattr(settings, "LLM_GM_ENABLED", False))
 
 
-def request_npc_reply(persona, speaker_name, line, mode, on_reply, on_fail,
-                      perception=None):
-    """POST a turn to the chat-completions backend off the reactor; render on return.
+def request_turn(messages, on_turn, on_fail):
+    """POST a constrained turn off the reactor; deliver the raw JSON to ``on_turn``.
 
     Args:
-        persona (dict): inert, JSON-safe persona data, built on the reactor BEFORE
-            this call (``typeclasses.llm_persona.build_persona``).
-        speaker_name (str): how the NPC perceives the speaker.
-        line (str): the spoken words.
-        mode (str): ``"directed"`` or ``"ambient"``.
-        on_reply (callable): ``on_reply(speech, action)`` — runs on the reactor.
-        on_fail (callable): ``on_fail()`` — runs on the reactor on timeout, error,
-            or an empty (declined) reply.
-        perception (str|None): what the NPC sees when it looks at the speaker
-            (ANSI-stripped), captured on the reactor — grounds description so the
-            model can't invent the speaker's appearance.
+        messages (list): the full OpenAI ``messages`` (built + extended by the
+            caller across the agentic loop).
+        on_turn (callable): ``on_turn(raw_json_str)`` — runs on the reactor.
+        on_fail (callable): ``on_fail()`` — runs on the reactor on error/empty.
     """
     url = getattr(settings, "LLM_GM_URL", _DEFAULT_URL)
     model = getattr(settings, "LLM_GM_MODEL", "")
     api_key = getattr(settings, "LLM_GM_API_KEY", "")
     timeout = getattr(settings, "LLM_GM_TIMEOUT", _DEFAULT_TIMEOUT)
     max_tokens = getattr(settings, "LLM_GM_MAX_TOKENS", _DEFAULT_MAX_TOKENS)
-    temperature = getattr(settings, "LLM_GM_TEMPERATURE", _DEFAULT_TEMPERATURE)
 
-    messages = build_messages(persona, speaker_name, line, mode, perception)
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
-    body = {
-        "messages": messages,
-        "max_tokens": max_tokens,
-        "temperature": temperature,
-    }
+    body = {"messages": messages, "json_schema": TURN_SCHEMA,
+            "max_tokens": max_tokens}
     if model:
         body["model"] = model
 
@@ -77,18 +57,13 @@ def request_npc_reply(persona, speaker_name, line, mode, on_reply, on_fail,
         resp = requests.post(url, json=body, headers=headers, timeout=timeout)
         resp.raise_for_status()
         data = resp.json()
-        content = (
-            (data.get("choices") or [{}])[0].get("message", {}).get("content", "")
-        )
-        return parse_reply(content, persona)
+        return (data.get("choices") or [{}])[0].get("message", {}).get("content", "")
 
-    def _at_return(result):
-        result = result or {}
-        speech, action = result.get("speech"), result.get("action")
-        if not speech and not action:
-            on_fail()  # null/declined reply → scripted fallback or silence
+    def _at_return(content):
+        if not content:
+            on_fail()
             return
-        on_reply(speech, action)
+        on_turn(content)
 
     def _at_err(failure):
         logger.log_err(f"LLM backend call failed: {failure}")

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -1,80 +1,95 @@
-"""Prompt construction + reply parsing for the LLM Gamemaster — backend-agnostic.
+"""Prompt construction + turn parsing for the LLM Gamemaster — backend-agnostic.
 
-The *portable* half of the LLM layer, kept in the repo so it travels with the
-game and the inference backend stays swappable (standard OpenAI Chat Completions).
-Conventions follow established RP practice rather than anything bespoke:
-
-- **Persona** uses the **character-card** vocabulary (SillyTavern V2/V3:
-  ``description`` / ``personality`` / ``scenario`` / ``mes_example``), composed
-  with the NPC's real perceivable identity (sdesc, voice, location).
-- **Few-shot example dialogue** (``mes_example``) is emitted as user/assistant
-  pairs — the standard way to lock voice + output format.
-- **Output** is the de-facto RP format: ``"speech"`` in quotes, ``*actions*`` in
-  asterisks, third person. The parser is robust to prose-style replies too.
-- **Perception is grounded**: the caller passes what the NPC actually sees when it
-  looks at the speaker, and the charter forbids inventing appearance details.
-
-See ``specs/proposals/LLM_GAMEMASTER_SPEC.md`` (§4 swap seam, §5.2 persona card).
+The *portable* half of the LLM layer. The model fills a **constrained schema**
+every turn — ``{speech, action, tool, tool_argument}`` — guaranteed valid by the
+backend's grammar (the game passes ``TURN_SCHEMA``; the MLX sidecar enforces it
+via ``outlines``). ``speech``/``action`` hold the in-character reply; ``tool`` is
+the NPC's decision to act or to inform itself, routed to a **real command**
+(``world/llm`` + ``typeclasses/bar.py``). See
+``specs/proposals/LLM_GAMEMASTER_SPEC.md`` §4.4 (architecture) / §5.3 (loop).
 """
 
+import json
 import re
 
-# --- GM charter: the rules of being an NPC (shared across NPCs) --------------
-CHARTER_BASE = """\
-You are the voice of a single non-player character inside a text-based cyberpunk \
-MUD — a grim, lived-in colony of chrome, vice, and hard luck. This is adult \
-fiction: violence, drugs, sex, and moral greyness are part of the world and you \
-portray them in character without flinching, lecturing, or refusing.
+# --- the tools the NPC may call (routed to real commands game-side) ----------
+#: name -> (description, argument hint). Context tools inform; action tools do.
+TOOLS = {
+    "look": "examine the patron to perceive their REAL appearance — do this "
+            "BEFORE describing how they look, never invent it (argument: who, "
+            "e.g. 'patron')",
+    "check_stock": "list exactly what the bar can serve right now (argument: '')",
+    "prepare_drink": "pour a drink from the menu for the patron — the bar makes "
+                     "it for REAL; use this to serve, never narrate pouring "
+                     "yourself (argument: the drink name)",
+}
 
-OUTPUT FORMAT — follow exactly (see the examples):
-- Reply ONLY as the character: one or two lines of bar banter, never a monologue.
-- You are physically present, not a disembodied voice. Pair your words with ONE \
-small physical action — a glance, a gesture, wiping the bar — and LEAD with it.
-- The action goes in *asterisks*, THIRD PERSON present tense, and MUST be a VERB \
-phrase that reads correctly after the character's name: write *tilts her head* or \
-*sets down a glass*, NOT *a tilt of her head* or *a slow smile*. The words go in \
-"double quotes" — e.g. *sets down a glass.* "What'll it be?" NEVER write the \
-character as "I" or "you".
+#: The single unified turn schema the model fills every turn (constrained).
+TURN_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "speech": {"type": "string"},
+        "action": {"type": "string"},
+        "tool": {"enum": ["none"] + list(TOOLS)},
+        "tool_argument": {"type": "string"},
+    },
+    "required": ["speech", "action", "tool", "tool_argument"],
+}
+
+
+def _tools_block() -> str:
+    lines = ["TOOLS — set the \"tool\" field to act or to inform yourself:"]
+    for name, desc in TOOLS.items():
+        lines.append(f'- "{name}": {desc}')
+    lines.append('- "none": no tool this turn.')
+    lines.append("After a context tool you get a [tool result]; then reply for "
+                 "real. Use prepare_drink to SERVE — the bar makes the drink, "
+                 "not you; never fake a pour.")
+    return "\n".join(lines)
+
+
+CHARTER_BASE = """\
+You are a single non-player character inside a text-based cyberpunk MUD — a grim, \
+lived-in colony of chrome, vice, and hard luck. This is adult fiction: violence, \
+drugs, sex, and moral greyness are part of the world and you portray them in \
+character without flinching, lecturing, or refusing.
+
+Respond as a JSON object:
+- "speech": your in-character spoken line, plain text, no surrounding quotes. One \
+or two lines, never a monologue. "" if you have nothing to say.
+- "action": a short THIRD-PERSON verb-phrase pose that reads after your name — \
+write "tilts her head" or "sets down a glass", NOT "a tilt of her head". "" if \
+none. NEVER write yourself as "I" or "you".
+- "tool" and "tool_argument": see TOOLS below.
 
 HARD RULES:
-- Never speak, think, narrate, or act for the OTHER person. Voice only this \
-character. Do not invent what anyone else says or does.
-- Describe the other person ONLY from the PERCEPTION line in the turn. NEVER \
-invent their clothing, tattoos, marks, scars, or features — if it isn't in \
-PERCEPTION or something the character plainly knows, it does not exist.
-- You do NOT make drinks or resolve game mechanics — the bar does. NEVER narrate \
-pouring, mixing, or a finished drink appearing or being served. If a patron orders, \
-acknowledge it in words and let the bar produce it. If they ask for something NOT \
-on your menu (listed below), tell them you don't serve it.
-- VARY yourself: never reuse a physical action, gesture, or line you have used \
-recently in this conversation. Each beat should be fresh.
-- Stay in character always. Never mention being an AI, a model, or a game system; \
-no out-of-character asides.
-- Use only in-world, generic names for drinks and ingredients — NEVER real-world \
-or brand names."""
+- Never speak, think, or act for the OTHER person. Voice only this character.
+- Describe the other person ONLY from a 'look' result or the PERCEPTION line. \
+NEVER invent their clothing, tattoos, marks, or features.
+- You do NOT make drinks yourself — call prepare_drink. If asked for something \
+off-menu, tool "none" and say you don't serve it.
+- Vary yourself: never reuse a recent action or line.
+- Stay in character; never mention being an AI, a model, or a game system.
+- Use only in-world, generic drink/ingredient names — never real-world brands."""
 
 CHARTER_AMBIENT = """\
 
-THIS LINE IS OVERHEARD, not addressed to the character. React ONLY if the \
-character would naturally speak up. If there is no natural reason to react, reply \
-with exactly the single word PASS and nothing else — do NOT narrate the \
-non-reaction, just write PASS."""
+THIS LINE IS OVERHEARD, not addressed to you. React ONLY if the character would \
+naturally speak up; otherwise leave BOTH "speech" and "action" empty ("") and set \
+tool "none"."""
 
-#: A generic example exchange used when a persona ships no ``mes_example``. It
-#: anchors the third-person-action + quoted-speech format and a terse register.
+#: Generic few-shot (JSON form) when a persona ships no mes_example.
 DEFAULT_FEWSHOT = [
-    {
-        "user": 'a patron says to you: "this your place?"',
-        "assistant": '*wipes the bar down without looking up.* "I just pour the '
-                     'drinks, friend."',
-    },
+    {"user": 'a patron says to you: "this your place?"',
+     "assistant": {"speech": "I just pour the drinks, friend.",
+                   "action": "wipes the bar down without looking up",
+                   "tool": "none", "tool_argument": ""}},
 ]
 
 _APPEARANCE_KEYS = ("face", "eyes", "hair", "head")
 
 
 def _personality(seed: dict) -> str:
-    """Card ``personality``, or compose one from the older manner/wants/boundaries."""
     if seed.get("personality"):
         return seed["personality"]
     bits = []
@@ -102,7 +117,6 @@ def render_persona(persona: dict) -> str:
     if seed.get("scenario"):
         lines.append(f"Scenario: {seed['scenario']}.")
 
-    # Grounded in the real object: how the world perceives this character.
     if persona.get("sdesc"):
         lines.append(f"To strangers you appear as {persona['sdesc']}.")
     longdescs = persona.get("longdescs") or {}
@@ -118,35 +132,38 @@ def render_persona(persona: dict) -> str:
         lines.append(f"You are behind the bar at {loc['name']}.")
     menu = persona.get("menu")
     if menu:
-        lines.append(
-            "Your bar serves ONLY these drinks: " + ", ".join(menu) + ". You have "
-            "nothing else — no beer, no off-list requests. The BAR makes them, not "
-            "you."
-        )
-
+        lines.append("Your bar serves ONLY: " + ", ".join(menu) + " (no beer, no "
+                     "off-list). The bar makes them, not you.")
     return "\n".join(lines)
 
 
 def few_shot_messages(persona: dict) -> list:
-    """The persona's example dialogue (``mes_example``) as user/assistant pairs."""
+    """The persona's example turns as user/assistant pairs (assistant = the JSON
+    schema). Anchors voice + good tool decisions. Prose ``mes_example`` (older
+    card form) is converted to the schema via the parser."""
     seed = (persona or {}).get("persona_seed") or {}
     examples = seed.get("mes_example") or DEFAULT_FEWSHOT
     out = []
     for ex in examples:
         user, assistant = ex.get("user"), ex.get("assistant")
-        if user and assistant:
-            out.append({"role": "user", "content": user})
-            out.append({"role": "assistant", "content": assistant})
+        if not (user and assistant):
+            continue
+        if isinstance(assistant, str):  # legacy prose example → schema
+            parsed = parse_turn(assistant, persona)
+            assistant = {"speech": parsed["speech"] or "", "action":
+                         parsed["action"] or "", "tool": "none", "tool_argument": ""}
+        out.append({"role": "user", "content": user})
+        out.append({"role": "assistant", "content": json.dumps(assistant)})
     return out
 
 
 def build_messages(persona: dict, speaker: str, line: str, mode: str,
                    perception: str = None, history: list = None) -> list:
-    """Build the OpenAI ``messages`` list: system + few-shot + recent history +
-    the grounded turn. ``history`` is the recent conversation (list of
-    ``{"user", "assistant"}`` pairs) so the model sees what it just said and
-    stops repeating itself across turns."""
-    charter = CHARTER_BASE + (CHARTER_AMBIENT if mode == "ambient" else "")
+    """Build the OpenAI ``messages``: system (charter+tools+persona) + few-shot +
+    recent history + the grounded turn. The caller passes ``TURN_SCHEMA`` to the
+    backend to constrain the output."""
+    charter = CHARTER_BASE + "\n\n" + _tools_block() \
+        + (CHARTER_AMBIENT if mode == "ambient" else "")
     system = charter + "\n\n" + render_persona(persona)
     messages = [{"role": "system", "content": system}]
     messages += few_shot_messages(persona)
@@ -168,104 +185,73 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
     return messages
 
 
-# --- reply parsing / sanitation ----------------------------------------------
-_QUOTE_RE = re.compile(r'"([^"]*)"')
-_ACTION_RE = re.compile(r"\*([^*]*)\*")
-_OOC_MARKERS = (
-    "((", "))", "[ooc", "as an ai", "language model", "i cannot", "i'm an ai",
-    "i am an ai", "as a language", "note:",
-)
-_DECLINE_MARKERS = (
-    "did not react", "does not react", "doesn't react", "no reaction",
-    "did not respond", "does not respond", "doesn't respond", "no response",
-    "says nothing", "stays silent", "remains silent", "no reply",
-    "nothing happens", "nothing to react", "no comment",
-)
-_MAX_LEN = 600
-
-
-#: A model without a chat template can't see turn boundaries and may continue
-#: into fabricated next turns that echo our framing ("a patron says to you: …").
-#: Keep only the first (real) reply, up to the first such marker.
-_RUNAWAY_RE = re.compile(r"\n[^\n]*?(?:says to you:|you overhear\b)", re.I)
-
-
-def _cut_runaway(raw: str) -> str:
-    m = _RUNAWAY_RE.search(raw or "")
-    return raw[:m.start()].strip() if m else raw
-
-
-def _is_ooc(text: str) -> bool:
-    low = (text or "").lower()
-    return any(m in low for m in _OOC_MARKERS)
-
-
-def _is_decline(text: str) -> bool:
-    low = (text or "").lower()
-    return any(m in low for m in _DECLINE_MARKERS)
+# --- turn parsing / sanitation -----------------------------------------------
+_OOC_MARKERS = ("as an ai", "language model", "i cannot", "i am an ai")
+_MAX_LEN = 500
 
 
 def _clean(text: str) -> str:
     text = (text or "").strip().strip('"*').strip()
-    text = re.sub(r"^[A-Z][a-z]+:\s*", "", text)  # drop a "Name:" prefix
-    return re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"^[A-Z][a-z]+:\s*", "", text)
+    return re.sub(r"\s+", " ", text).strip()[:_MAX_LEN]
 
 
 def _strip_self_lead(action: str, name: str) -> str:
-    """Strip a leading self-reference; the game prepends the name via `pose`."""
     if name:
         action = re.sub(rf"^{re.escape(name)}('s)?\s+", "", action, flags=re.I)
     return re.sub(r"^(she|he|they)\s+", "", action, flags=re.I).strip()
 
 
-def parse_reply(raw: str, persona: dict) -> dict:
-    """Split a completion into clean speech + action.
+def parse_turn(raw, persona: dict) -> dict:
+    """Normalise a constrained turn into ``{speech, action, tool, tool_argument}``.
 
-    Handles both the clean ``*action* "speech"`` format and prose-style replies
-    (narration around quotes). Returns ``{"speech": str|None, "action": str|None}``;
-    empty / OOC / ambient-decline yields nulls so the game stays silent/scripted.
+    ``raw`` is the JSON string from the (constrained) backend, or a legacy prose
+    reply. Cleans the action (strip self-lead, drop POV-leak second-person), maps
+    OOC/empty to nulls. The schema guarantees structure; this guards content.
     """
-    raw = _cut_runaway((raw or "").strip())
-    if not raw or _is_ooc(raw):
-        return {"speech": None, "action": None}
-    # Ambient decline sentinel (model told to reply "PASS" when it wouldn't react).
-    if raw.strip('".*’‘\' \t\n').upper().rstrip(".!") == "PASS":
-        return {"speech": None, "action": None}
-
-    speech_parts = [m.strip() for m in _QUOTE_RE.findall(raw) if m.strip()]
-    action_parts = [m.strip() for m in _ACTION_RE.findall(raw) if m.strip()]
-
-    if not speech_parts and not action_parts and _is_decline(raw):
-        return {"speech": None, "action": None}
-
     name = ((persona or {}).get("persona_seed") or {}).get("name") or ""
+    obj = None
+    if isinstance(raw, dict):
+        obj = raw
+    elif isinstance(raw, str):
+        try:
+            obj = json.loads(raw)
+        except Exception:  # noqa: BLE001 — legacy prose path (few-shot/fallback)
+            obj = _parse_prose(raw)
+    obj = obj or {}
 
-    if speech_parts:
-        speech = _clean(" ".join(speech_parts))
-        if action_parts:
-            action = _clean(" ".join(action_parts))
-        else:
-            # Prose style: the narration around the quotes IS the action — keep
-            # it as a pose instead of discarding the model's best writing.
-            action = _clean(_QUOTE_RE.sub("", raw))
-    elif action_parts:
-        action = _clean(" ".join(action_parts))
-        leftover = _clean(_ACTION_RE.sub("", raw))
-        speech = leftover or None
-    else:
-        # Bare text, no markers → treat as a spoken line.
-        speech = _clean(raw)
-        action = None
-
+    speech = _clean(obj.get("speech", ""))
+    action = _clean(obj.get("action", ""))
     if action:
         action = _strip_self_lead(action, name)
-        # POV guard: a second-person action ("your eyes…") is a leak we can't
-        # cleanly render through `pose` — drop it rather than emit broken text.
         if re.match(r"^(your|you)\b", action, flags=re.I):
-            action = None
+            action = None  # POV leak — can't render cleanly
+    tool = obj.get("tool") or "none"
+    tool_arg = (obj.get("tool_argument") or "").strip()
 
-    speech = speech[:_MAX_LEN] if speech else None
-    action = action[:_MAX_LEN] if action else None
-    if speech and _is_ooc(speech):
-        speech = None
-    return {"speech": speech, "action": action}
+    if speech and any(m in speech.lower() for m in _OOC_MARKERS):
+        speech = ""
+    return {
+        "speech": speech or None,
+        "action": action or None,
+        "tool": tool if tool in TURN_SCHEMA["properties"]["tool"]["enum"] else "none",
+        "tool_argument": tool_arg,
+    }
+
+
+_QUOTE_RE = re.compile(r'"([^"]*)"')
+_ACTION_RE = re.compile(r"\*([^*]*)\*")
+
+
+def _parse_prose(raw: str) -> dict:
+    """Fallback for an unconstrained/legacy prose reply (no schema)."""
+    quotes = [m.strip() for m in _QUOTE_RE.findall(raw) if m.strip()]
+    actions = [m.strip() for m in _ACTION_RE.findall(raw) if m.strip()]
+    speech = " ".join(quotes) if quotes else _ACTION_RE.sub("", raw)
+    action = " ".join(actions) if actions else (
+        _QUOTE_RE.sub("", raw) if quotes else "")
+    return {"speech": speech, "action": action, "tool": "none", "tool_argument": ""}
+
+
+# Back-compat alias (older callers / tests).
+parse_reply = parse_turn

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -624,45 +624,33 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
 
     # --- _try_llm_reply gating + payload ---
 
-    def test_try_llm_reply_fires_request(self):
+    def test_try_llm_reply_starts_agentic_round(self):
         b, patron = self._bartender(), self._speaker(name="a wiry courier")
         with patch.object(barmod, "llm_enabled", return_value=True), \
-                patch.object(barmod, "build_persona", return_value={"x": 1}) as bp, \
-                patch.object(barmod, "request_npc_reply") as req:
+                patch.object(barmod, "build_persona", return_value={"x": 1}), \
+                patch.object(barmod, "build_messages", return_value=["m"]) as bm:
             taken = b._try_llm_reply("rough night?", patron, "directed")
         self.assertTrue(taken)
-        bp.assert_called_once_with(b)
-        req.assert_called_once()
-        args, kwargs = req.call_args
-        self.assertEqual(args[0], {"x": 1})            # persona
-        self.assertEqual(args[1], "a wiry courier")    # speaker as she sees them
-        self.assertEqual(args[2], "rough night?")      # line
-        self.assertEqual(args[3], "directed")          # mode
-        # on_reply now wraps render + memory append (a partial); perception and
-        # history are threaded through
-        from functools import partial as _partial
-        self.assertIsInstance(kwargs["on_reply"], _partial)
-        self.assertIs(kwargs["on_reply"].func, b._render_and_remember)
-        self.assertIs(kwargs["on_fail"], b._llm_silent)
-        self.assertIn("perception", kwargs)
-        self.assertIn("history", kwargs)
+        bm.assert_called_once()
+        b._agentic_round.assert_called_once()      # the loop is kicked off
+        args = b._agentic_round.call_args.args
+        self.assertEqual(args[0], ["m"])           # messages
+        self.assertEqual(args[3], "rough night?")  # line
 
     def test_try_llm_reply_gated_off(self):
         b, patron = self._bartender(llm_driven=False), self._speaker()
-        with patch.object(barmod, "request_npc_reply") as req:
-            taken = b._try_llm_reply("hi", patron, "directed")
+        taken = b._try_llm_reply("hi", patron, "directed")
         self.assertFalse(taken)
-        req.assert_not_called()
+        b._agentic_round.assert_not_called()
 
     def test_try_llm_reply_cooldown_is_silent(self):
         from time import monotonic
         b, patron = self._bartender(), self._speaker()
         b.ndb.last_llm = monotonic()  # just replied
-        with patch.object(barmod, "llm_enabled", return_value=True), \
-                patch.object(barmod, "request_npc_reply") as req:
+        with patch.object(barmod, "llm_enabled", return_value=True):
             taken = b._try_llm_reply("hi", patron, "directed")
         self.assertTrue(taken)         # handled-by-silence, no scripted fallback
-        req.assert_not_called()
+        b._agentic_round.assert_not_called()
 
     # --- order-path fallback, render, fail-safe ---
 
@@ -701,7 +689,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
     def _bind_memory(self, b):
         b._hist_key = barmod.Bartender._hist_key            # staticmethods
         b._reconstruct_reply = barmod.Bartender._reconstruct_reply
-        for name in ("_recent_history", "_render_and_remember", "_render_llm_reply"):
+        for name in ("_recent_history", "_remember_turn"):
             setattr(b, name,
                     getattr(barmod.Bartender, name).__get__(b, barmod.Bartender))
 
@@ -711,7 +699,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         patron = self._speaker(); patron.id = 42
         b.ndb.llm_history = {}
         self.assertEqual(b._recent_history(patron), [])
-        b._render_and_remember(patron, "hey", "a man", "evening", "wipes the bar")
+        b._remember_turn(patron, "hey", "a man", "evening", "wipes the bar")
         hist = b._recent_history(patron)
         self.assertEqual(len(hist), 1)
         self.assertIn("hey", hist[0]["user"])
@@ -723,7 +711,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         patron = self._speaker(); patron.id = 7
         b.ndb.llm_history = {}
         for i in range(barmod.LLM_HISTORY_TURNS + 4):
-            b._render_and_remember(patron, f"l{i}", "a man", f"r{i}", "nods")
+            b._remember_turn(patron, f"l{i}", "a man", f"r{i}", "nods")
         self.assertEqual(len(b._recent_history(patron)), barmod.LLM_HISTORY_TURNS)
 
     def test_memory_is_per_interlocutor(self):
@@ -732,9 +720,61 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         b.ndb.llm_history = {}
         p1 = self._speaker(); p1.id = 1
         p2 = self._speaker(); p2.id = 2
-        b._render_and_remember(p1, "to one", "a man", "hi one", "nods")
+        b._remember_turn(p1, "to one", "a man", "hi one", "nods")
         self.assertEqual(len(b._recent_history(p1)), 1)
         self.assertEqual(b._recent_history(p2), [])  # separate conversation
+
+    # --- the agentic tool loop ---
+
+    def _bind_loop(self, b):
+        b._hist_key = barmod.Bartender._hist_key
+        b._reconstruct_reply = barmod.Bartender._reconstruct_reply
+        for name in ("_on_turn", "_run_context_tool", "_render_llm_reply",
+                     "_remember_turn", "_recent_history"):
+            setattr(b, name,
+                    getattr(barmod.Bartender, name).__get__(b, barmod.Bartender))
+        b.ndb.llm_history = {}
+
+    def test_on_turn_context_tool_loops(self):
+        b = self._bartender(); self._bind_loop(b)
+        patron = self._speaker(); patron.id = 5
+        b._run_context_tool = lambda tool, arg, p: "a stocky droog"
+        turn = {"speech": None, "action": None, "tool": "look",
+                "tool_argument": "patron"}
+        with patch.object(barmod, "parse_turn", return_value=turn):
+            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, "{}")
+        b._agentic_round.assert_called_once()           # looped to gather context
+        b.execute_cmd.assert_not_called()               # no terminal render yet
+
+    def test_on_turn_action_tool_runs_real_command(self):
+        b = self._bartender(); self._bind_loop(b)
+        patron = self._speaker(); patron.id = 6
+        turn = {"speech": "Coming up", "action": "grabs a glass",
+                "tool": "prepare_drink", "tool_argument": "Negroni"}
+        with patch.object(barmod, "parse_turn", return_value=turn):
+            b._on_turn(["m"], {}, patron, "a negroni", "a man", lambda: None, 0, "{}")
+        b.execute_cmd.assert_any_call("prepare Negroni")  # the REAL command
+        b._agentic_round.assert_not_called()              # terminal, no loop
+
+    def test_on_turn_terminal_renders(self):
+        b = self._bartender(); self._bind_loop(b)
+        patron = self._speaker(); patron.id = 8
+        turn = {"speech": "hey", "action": "nods", "tool": "none",
+                "tool_argument": ""}
+        with patch.object(barmod, "parse_turn", return_value=turn):
+            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, "{}")
+        b.execute_cmd.assert_any_call('pose nods. "hey"')
+
+    def test_run_context_tool_look_and_stock(self):
+        b = self._bartender()
+        b._run_context_tool = barmod.Bartender._run_context_tool.__get__(
+            b, barmod.Bartender)
+        b._perceive = lambda patron: "a wiry courier, scarred jaw"
+        patron = self._speaker()
+        self.assertIn("wiry courier", b._run_context_tool("look", "patron", patron))
+        b._find_bar = lambda: None
+        b.db.menu = [{"name": "Negroni"}, {"name": "Martini"}]
+        self.assertIn("Negroni", b._run_context_tool("check_stock", "", patron))
 
     def test_mentions_self(self):
         b = self._bartender()

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -1,142 +1,114 @@
 """The portable LLM prompt layer (world.llm.prompt) — backend-agnostic.
 
-Pure functions: the OpenAI message builder (card persona + few-shot + grounded
-turn), the persona render, and the reply parser. No model, no Evennia, no network.
+Pure functions: the OpenAI message builder (persona + tools + few-shot + turn),
+the persona render, and the constrained-turn parser. No model, no Evennia.
 """
 
+import json
 from unittest import TestCase
 
-from world.llm.prompt import build_messages, parse_reply, render_persona
+from world.llm.prompt import (
+    TURN_SCHEMA, build_messages, parse_turn, render_persona,
+)
 
 _PERSONA = {
     "sdesc": "a lithe woman",
-    "skintone": "olive",
-    "voice": "speaking Common, in a silken purr",
+    "voice": "a silken purr",
     "location": {"name": "the Helix Lounge"},
+    "menu": ["Negroni", "Martini"],
     "persona_seed": {
         "name": "Sable",
         "description": "the bartender at the Helix Lounge.",
-        "personality": "sly, watchful, unhurried",
-        "scenario": "tending a slow night behind the bar",
+        "personality": "sly, watchful",
         "mes_example": [
             {"user": 'a patron says to you: "busy?"',
-             "assistant": '*polishes a glass.* "Define busy."'},
+             "assistant": {"speech": "Define busy.", "action": "polishes a glass",
+                           "tool": "none", "tool_argument": ""}},
         ],
     },
 }
 
 
 class TestBuildMessages(TestCase):
-    def test_system_fewshot_turn_order(self):
+    def test_system_has_tools_schema_and_persona(self):
         msgs = build_messages(_PERSONA, "a lean man", "rough night?", "directed")
-        self.assertEqual(msgs[0]["role"], "system")
+        sys = msgs[0]["content"]
+        self.assertIn("Sable", sys)
+        self.assertIn("speech", sys)        # schema fields explained
+        self.assertIn("prepare_drink", sys)  # tools listed
+        self.assertIn("look", sys)
+        self.assertIn("Negroni", sys)        # menu
+
+    def test_fewshot_is_json_and_turn_last(self):
+        msgs = build_messages(_PERSONA, "a man", "hi", "directed")
+        self.assertIn("assistant", [m["role"] for m in msgs])
+        # the few-shot assistant content is the JSON schema, not prose
+        asst = next(m["content"] for m in msgs if m["role"] == "assistant")
+        self.assertEqual(json.loads(asst)["speech"], "Define busy.")
         self.assertEqual(msgs[-1]["role"], "user")
-        self.assertIn("assistant", [m["role"] for m in msgs])  # few-shot present
-        self.assertIn("Sable", msgs[0]["content"])
-        self.assertIn("sly, watchful", msgs[0]["content"])
-        self.assertIn("rough night?", msgs[-1]["content"])
+        self.assertIn("hi", msgs[-1]["content"])
 
-    def test_fewshot_uses_card_examples(self):
-        joined = " ".join(m["content"] for m in
-                          build_messages(_PERSONA, "a man", "hi", "directed"))
-        self.assertIn("Define busy.", joined)  # from mes_example
-
-    def test_perception_grounds_and_forbids_invention(self):
+    def test_perception_grounds_turn(self):
         msgs = build_messages(_PERSONA, "a man", "hi", "directed",
-                              perception="a stocky droog in a white t-shirt")
-        self.assertIn("a stocky droog in a white t-shirt", msgs[-1]["content"])
-        self.assertIn("PERCEPTION", msgs[-1]["content"])
-        sys = msgs[0]["content"].lower()
-        self.assertIn("invent", sys)  # charter forbids inventing appearance
+                              perception="a stocky droog in a white shirt")
+        self.assertIn("a stocky droog in a white shirt", msgs[-1]["content"])
 
-    def test_directed_vs_ambient_framing(self):
-        directed = build_messages(_PERSONA, "a man", "hi", "directed")
-        ambient = build_messages(_PERSONA, "a man", "hi", "ambient")
-        self.assertIn("says to you", directed[-1]["content"])
-        self.assertIn("overhear", ambient[-1]["content"].lower())
-        self.assertIn("PASS", ambient[0]["content"])
+    def test_ambient_framing(self):
+        d = build_messages(_PERSONA, "a man", "hi", "directed")
+        a = build_messages(_PERSONA, "a man", "hi", "ambient")
+        self.assertIn("says to you", d[-1]["content"])
+        self.assertIn("overhear", a[-1]["content"].lower())
+        self.assertIn("OVERHEARD", a[0]["content"])
 
-    def test_backcompat_old_manner_keys(self):
-        old = {"persona_seed": {"name": "X", "manner": "gruff",
-                                "wants": "quiet", "boundaries": "discuss debts"}}
-        self.assertIn("gruff", render_persona(old))
-
-    def test_history_inserted_before_turn(self):
-        hist = [{"user": 'a man says to you: "again?"',
-                 "assistant": '*nods.* "Same as before."'}]
-        msgs = build_messages(_PERSONA, "a man", "and now?", "directed",
-                              history=hist)
-        joined = " ".join(m["content"] for m in msgs)
-        self.assertIn("Same as before.", joined)         # history present
-        self.assertEqual(msgs[-1]["content"].count("and now?"), 1)  # turn is last
-        # history pair sits before the final turn
-        contents = [m["content"] for m in msgs]
-        self.assertLess(contents.index('*nods.* "Same as before."'),
-                        len(contents) - 1)
-
-    def test_menu_in_persona(self):
-        p = dict(_PERSONA)
-        p["menu"] = ["Negroni", "Old Fashioned"]
-        out = render_persona(p)
-        self.assertIn("Negroni", out)
-        self.assertIn("ONLY", out)
-
-    def test_render_persona_is_defensive(self):
+    def test_render_persona_defensive(self):
         self.assertIn("the bartender", render_persona({}))
 
 
-class TestParseReply(TestCase):
-    def test_clean_format_split(self):
-        out = parse_reply('*Sable smirks.* "What\'s it to ya?"', _PERSONA)
-        self.assertEqual(out["speech"], "What's it to ya?")
-        self.assertEqual(out["action"], "smirks.")
+class TestParseTurn(TestCase):
+    def _t(self, **kw):
+        base = {"speech": "", "action": "", "tool": "none", "tool_argument": ""}
+        base.update(kw)
+        return json.dumps(base)
 
-    def test_prose_narration_becomes_pose(self):
-        raw = 'Sable\'s eyes flick to the door. "We\'re closing soon," she says.'
-        out = parse_reply(raw, _PERSONA)
-        self.assertEqual(out["speech"], "We're closing soon,")
-        self.assertIsNotNone(out["action"])
-        self.assertIn("eyes flick to the door", out["action"])
-        self.assertFalse(out["action"].lower().startswith("sable"))
+    def test_json_turn_with_tool(self):
+        out = parse_turn(self._t(speech="Coming up.", action="grabs a glass",
+                                 tool="prepare_drink", tool_argument="Negroni"),
+                         _PERSONA)
+        self.assertEqual(out["speech"], "Coming up.")
+        self.assertEqual(out["action"], "grabs a glass")
+        self.assertEqual(out["tool"], "prepare_drink")
+        self.assertEqual(out["tool_argument"], "Negroni")
+
+    def test_self_lead_stripped(self):
+        out = parse_turn(self._t(speech="hi", action="Sable smirks"), _PERSONA)
+        self.assertEqual(out["action"], "smirks")
 
     def test_pov_leak_action_dropped(self):
-        out = parse_reply('*your eyes meet his.* "Hey."', _PERSONA)
-        self.assertEqual(out["speech"], "Hey.")
+        out = parse_turn(self._t(speech="hey", action="your eyes meet his"),
+                         _PERSONA)
         self.assertIsNone(out["action"])
-
-    def test_speech_only(self):
-        out = parse_reply('"Just a sec."', _PERSONA)
-        self.assertEqual(out["speech"], "Just a sec.")
-        self.assertIsNone(out["action"])
-
-    def test_no_markers_treated_as_speech(self):
-        self.assertEqual(parse_reply("rough night, huh", _PERSONA)["speech"],
-                         "rough night, huh")
-
-    def test_ooc_dropped_to_null(self):
-        out = parse_reply("As an AI, I can't roleplay that.", _PERSONA)
-        self.assertEqual(out, {"speech": None, "action": None})
+        self.assertEqual(out["speech"], "hey")
 
     def test_empty_is_null(self):
-        self.assertEqual(parse_reply("", _PERSONA), {"speech": None, "action": None})
+        out = parse_turn(self._t(), _PERSONA)
+        self.assertIsNone(out["speech"])
+        self.assertIsNone(out["action"])
+        self.assertEqual(out["tool"], "none")
 
-    def test_pass_sentinel_is_null(self):
-        for raw in ("PASS", "pass", '"PASS"', "PASS.", "*PASS*"):
-            self.assertEqual(parse_reply(raw, _PERSONA),
-                             {"speech": None, "action": None}, raw)
+    def test_unknown_tool_coerced_to_none(self):
+        out = parse_turn(self._t(speech="x", tool="frobnicate"), _PERSONA)
+        self.assertEqual(out["tool"], "none")
 
-    def test_decline_narration_is_null(self):
-        out = parse_reply("Sable does not react to the comment.", _PERSONA)
-        self.assertEqual(out, {"speech": None, "action": None})
+    def test_ooc_speech_dropped(self):
+        out = parse_turn(self._t(speech="As an AI I can't do that"), _PERSONA)
+        self.assertIsNone(out["speech"])
 
-    def test_runaway_continuation_is_cut(self):
-        raw = ('*sets down a glass.* "Define busy."\n\n'
-               'a patron says to you: "got anything strong?"\n\n'
-               '*a slow smile.* "Always."')
-        out = parse_reply(raw, _PERSONA)
-        self.assertEqual(out["speech"], "Define busy.")
-        self.assertEqual(out["action"], "sets down a glass.")
+    def test_prose_fallback(self):
+        out = parse_turn('*smirks* "what now?"', _PERSONA)
+        self.assertEqual(out["speech"], "what now?")
+        self.assertEqual(out["action"], "smirks")
+        self.assertEqual(out["tool"], "none")
 
-    def test_quoted_line_with_decline_word_still_speaks(self):
-        out = parse_reply('"No response from the docks, last I heard."', _PERSONA)
-        self.assertEqual(out["speech"], "No response from the docks, last I heard.")
+    def test_schema_tool_enum(self):
+        self.assertEqual(TURN_SCHEMA["properties"]["tool"]["enum"],
+                         ["none", "look", "check_stock", "prepare_drink"])


### PR DESCRIPTION
The agentic tool loop, on the validated architecture (Mistral-Small-24B + `outlines` constrained decoding).

- **Unified schema** `{speech, action, tool, tool_argument}` — guaranteed valid (sidecar enforces via outlines; game passes `TURN_SCHEMA`).
- **Tools → real commands**: `look`/`check_stock` (context — she pulls info) + `prepare_drink` → `execute_cmd("prepare …")` (action).
- **The loop** (`_agentic_round`/`_on_turn`): call → if a context tool, run the real read + feed the result back + re-ask (bounded) → else render + route the action tool. She *calls `look` to ground herself* and *`prepare_drink` to serve for real* — through the command layer, can't fake.

**Verified end-to-end vs live Mistral:** `look`→result→grounded reply; `prepare_drink`→real command; off-menu→decline. 84/84 tests green.

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)