### PR TITLE
LLM GM: raise turn timeout to 40s for warm 24B constrained latency

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -265,7 +265,7 @@ LLM_GM_ENABLED = False
 LLM_GM_URL = "http://host.docker.internal:8765/v1/chat/completions"
 LLM_GM_MODEL = ""          # backend-specific model id; blank lets local servers default
 LLM_GM_API_KEY = ""        # Bearer token for cloud backends; blank for local
-LLM_GM_TIMEOUT = 15        # seconds; per-turn budget
+LLM_GM_TIMEOUT = 40        # seconds; per-round budget (warm 24B constrained gen ~17s/round)
 LLM_GM_MAX_TOKENS = 120    # short NPC turns (a line + an action, no truncation)
 LLM_GM_TEMPERATURE = 0.8   # characterful but coherent
 

--- a/world/llm/client.py
+++ b/world/llm/client.py
@@ -20,7 +20,7 @@ from evennia.utils.utils import run_async
 from world.llm.prompt import TURN_SCHEMA
 
 _DEFAULT_URL = "http://host.docker.internal:8765/v1/chat/completions"
-_DEFAULT_TIMEOUT = 20          # 24B + constrained decoding is slower than 8B
+_DEFAULT_TIMEOUT = 40          # warm 24B constrained gen ~17s/round; cover one round + headroom
 _DEFAULT_MAX_TOKENS = 160
 
 


### PR DESCRIPTION
## What
Sable stopped responding in live. The sidecar is healthy, but every game call hit `ReadTimeout (read timeout=15)`.

Warm Mistral-Small-24B constrained-decoding generation of a realistic full prompt (charter + archetype duties + persona + few-shot + perception) measures **~17s/round**; the agentic loop's optional `look` round can double it. `LLM_GM_TIMEOUT = 15` dropped the reply before it returned. The 24B is the box's chosen ceiling, so the budget — not the model — was wrong.

Raise `LLM_GM_TIMEOUT` 15 → 40 (per-round HTTP budget, one warm round + headroom) and align `world/llm/client.py` default fallback.

## Not a quality issue
Output is already correct — measured live during diagnosis: *"Flattery won't get you a discount, sweetness." / flicks a rag over the bar.* This change only stops the in-character reply being discarded.

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)