### PR TITLE
LLM GM: fix _SaverDict mes_example crash that silenced the NPC

### DIFF
--- a/typeclasses/llm_persona.py
+++ b/typeclasses/llm_persona.py
@@ -9,6 +9,8 @@ model voices *this* character — the same sdesc/longdesc/voice the world percei
 See ``specs/proposals/LLM_GAMEMASTER_SPEC.md`` §5.2 (persona card).
 """
 
+from evennia.utils.dbserialize import deserialize
+
 from world.voice import get_voice_description, get_voice_ending, voice_phrase
 
 
@@ -54,5 +56,7 @@ def build_persona(npc) -> dict:
         "voice_ending": get_voice_ending(npc),
         "location": location,
         "menu": menu,
-        "persona_seed": npc.db.llm_persona or {},
+        # deserialize → plain dict/list (the seed's nested mes_example is a
+        # _SaverDict/_SaverList off the DB, which json.dumps can't serialize).
+        "persona_seed": deserialize(npc.db.llm_persona) or {},
     }

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -187,7 +187,15 @@ def few_shot_messages(persona: dict) -> list:
             parsed = parse_turn(assistant, persona)
             assistant = {"speech": parsed["speech"] or "", "action":
                          parsed["action"] or "", "tool": "none", "tool_argument": ""}
-        out.append({"role": "user", "content": user})
+        # Rebuild a plain, JSON-safe dict — a DB-sourced example arrives as a
+        # _SaverDict (or other Mapping) that json.dumps can't serialize directly.
+        assistant = {
+            "speech": str(assistant.get("speech", "") or ""),
+            "action": str(assistant.get("action", "") or ""),
+            "tool": str(assistant.get("tool", "none") or "none"),
+            "tool_argument": str(assistant.get("tool_argument", "") or ""),
+        }
+        out.append({"role": "user", "content": str(user)})
         out.append({"role": "assistant", "content": json.dumps(assistant)})
     return out
 

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -86,6 +86,26 @@ class TestArchetype(TestCase):
         msgs = build_messages(p, "a man", "hi", "directed")
         self.assertIn("assistant", [m["role"] for m in msgs])
 
+    def test_mapping_mes_example_is_json_safe(self):
+        # DB-sourced examples arrive as a Mapping (Evennia _SaverDict), not a
+        # plain dict — few_shot_messages must rebuild a json-serializable turn.
+        from collections.abc import Mapping
+
+        class FakeSaver(Mapping):  # mimics _SaverDict: a Mapping, not a dict
+            def __init__(self, d): self._d = d
+            def __getitem__(self, k): return self._d[k]
+            def __iter__(self): return iter(self._d)
+            def __len__(self): return len(self._d)
+
+        p = {"persona_seed": {"name": "Sable", "archetype": "bartender",
+             "mes_example": [FakeSaver({
+                 "user": 'a patron says to you: "hi"',
+                 "assistant": FakeSaver({"speech": "Hey.", "action": "nods",
+                                         "tool": "none", "tool_argument": ""})})]}}
+        msgs = build_messages(p, "a man", "hi", "directed")  # must not raise
+        asst = next(m["content"] for m in msgs if m["role"] == "assistant")
+        self.assertEqual(json.loads(asst)["speech"], "Hey.")
+
 
 class TestParseTurn(TestCase):
     def _t(self, **kw):


### PR DESCRIPTION
## What
The real reason Sable went silent. After #723 reseeded her `mes_example` to dict-form turns, every reply crashed **before** any model call:

```
build_messages → few_shot_messages → json.dumps(assistant)
TypeError: Object of type _SaverDict is not JSON serializable
```

DB-sourced examples deserialize lazily as Evennia `_SaverDict`/`_SaverList`; `json.dumps` can't encode them. The old prose examples were rebuilt into plain dicts first, so they never hit this. The 15s→40s timeout (#725) was a real latency finding but a red herring for the silence — this crash is upstream of the HTTP call.

## Fix (two seams)
- `typeclasses/llm_persona.build_persona`: `deserialize(npc.db.llm_persona)` → inert plain Python handed to the sidecar (matches the file's stated contract).
- `world/llm/prompt.few_shot_messages`: rebuild a plain, json-safe assistant dict from any Mapping, defensively.

## Tests
**Why 88 green tests missed it:** the mock persona uses plain dicts. Added a regression test that drives a `Mapping`-not-`dict` fake `_SaverDict` through `build_messages`. **89 passing** in the throwaway container.

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)