### PR TITLE
LLM GM: per-archetype tool-scoping

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -27,7 +27,9 @@ from typeclasses.characters import Character
 from typeclasses.llm_persona import build_persona
 from world.grammar import capitalize_first, with_article
 from world.llm.client import llm_enabled, request_turn
-from world.llm.prompt import build_messages, parse_turn
+from world.llm.prompt import (
+    CONTEXT_TOOLS, build_messages, parse_turn, schema_for, tool_names,
+)
 from world.shop.utils import format_currency
 from world.bar import (
     DEFAULT_BAR_SNACKS,
@@ -339,9 +341,8 @@ LLM_DIRECTED_COOLDOWN = 4.0    # min seconds between replies to direct address/n
 LLM_AMBIENT_COOLDOWN = 45.0    # she rarely volunteers into overheard chatter
 LLM_AMBIENT_CHANCE = 0.35      # ...and not every eligible time
 LLM_HISTORY_TURNS = 6          # recent turns kept per interlocutor (anti-repetition)
-#: Tools the model may call that *inform* it (read-only) vs *act* (mutate). Context
-#: tools loop (run → feed result back → re-ask); action tools route to a command.
-CONTEXT_TOOLS = {"look", "check_stock"}
+#: CONTEXT_TOOLS (read-only → loop the result back; vs action tools → real command)
+#: is derived from the prompt-layer tool registry, so they can't desync.
 LLM_MAX_TOOL_ROUNDS = 3        # cap the agentic loop so it can't spin forever
 
 
@@ -583,11 +584,12 @@ class Bartender(Character):
             on_turn=partial(self._on_turn, messages, persona, patron, line,
                             speaker_name, on_fail, rounds),
             on_fail=on_fail,
+            schema=schema_for(persona),  # tool enum scoped to the archetype
         )
 
     def _on_turn(self, messages, persona, patron, line, speaker_name, on_fail,
                  rounds, raw):
-        turn = parse_turn(raw, persona)
+        turn = parse_turn(raw, persona, tool_names(persona))
         tool, arg = turn["tool"], turn["tool_argument"]
         # Context tool: run the real read, feed the result back, loop.
         if tool in CONTEXT_TOOLS and rounds < LLM_MAX_TOOL_ROUNDS:

--- a/world/llm/client.py
+++ b/world/llm/client.py
@@ -29,7 +29,7 @@ def llm_enabled() -> bool:
     return bool(getattr(settings, "LLM_GM_ENABLED", False))
 
 
-def request_turn(messages, on_turn, on_fail):
+def request_turn(messages, on_turn, on_fail, schema=None):
     """POST a constrained turn off the reactor; deliver the raw JSON to ``on_turn``.
 
     Args:
@@ -37,6 +37,9 @@ def request_turn(messages, on_turn, on_fail):
             caller across the agentic loop).
         on_turn (callable): ``on_turn(raw_json_str)`` — runs on the reactor.
         on_fail (callable): ``on_fail()`` — runs on the reactor on error/empty.
+        schema (dict): the constrained turn schema; defaults to the full-registry
+            ``TURN_SCHEMA``. Callers pass ``prompt.schema_for(persona)`` to scope
+            the ``tool`` enum to the NPC's archetype.
     """
     url = getattr(settings, "LLM_GM_URL", _DEFAULT_URL)
     model = getattr(settings, "LLM_GM_MODEL", "")
@@ -47,7 +50,7 @@ def request_turn(messages, on_turn, on_fail):
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
-    body = {"messages": messages, "json_schema": TURN_SCHEMA,
+    body = {"messages": messages, "json_schema": schema or TURN_SCHEMA,
             "max_tokens": max_tokens}
     if model:
         body["model"] = model

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -13,36 +13,60 @@ import json
 import re
 
 # --- the tools the NPC may call (routed to real commands game-side) ----------
-#: name -> (description, argument hint). Context tools inform; action tools do.
+#: name -> {kind, desc}. ``kind`` "context" tools inform the NPC (read → loop the
+#: result back); "action" tools change the world (routed to a real command game-
+#: side). Archetypes grant a SUBSET (see ARCHETYPES); the schema is scoped to it.
 TOOLS = {
-    "look": "examine the patron to perceive their REAL appearance — do this "
-            "BEFORE describing how they look, never invent it (argument: who, "
-            "e.g. 'patron')",
-    "check_stock": "list exactly what the bar can serve right now (argument: '')",
-    "prepare_drink": "pour a drink from the menu for the patron — the bar makes "
-                     "it for REAL; use this to serve, never narrate pouring "
-                     "yourself (argument: the drink name)",
+    "look": {"kind": "context",
+             "desc": "examine the patron to perceive their REAL appearance — do "
+                     "this BEFORE describing how they look, never invent it "
+                     "(argument: who, e.g. 'patron')"},
+    "check_stock": {"kind": "context",
+                    "desc": "list exactly what the bar can serve right now "
+                            "(argument: '')"},
+    "prepare_drink": {"kind": "action",
+                      "desc": "pour a drink from the menu for the patron — the "
+                              "bar makes it for REAL; use this to serve, never "
+                              "narrate pouring yourself (argument: the drink name)"},
 }
 
-#: The single unified turn schema the model fills every turn (constrained).
-TURN_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "speech": {"type": "string"},
-        "action": {"type": "string"},
-        "tool": {"enum": ["none"] + list(TOOLS)},
-        "tool_argument": {"type": "string"},
-    },
-    "required": ["speech", "action", "tool", "tool_argument"],
-}
+#: Every NPC perceives — ``look`` is granted to every archetype on top of its job
+#: tools, so grounding is never accidentally withheld.
+BASE_TOOLS = ("look",)
+
+#: Read-only tools that loop their result back (vs. action tools → real commands).
+#: Derived from the registry so adding a tool can't desync the game-side router.
+CONTEXT_TOOLS = frozenset(n for n, t in TOOLS.items() if t["kind"] == "context")
+
+
+def turn_schema(tools) -> dict:
+    """The unified turn schema with the ``tool`` enum scoped to ``tools`` (+none).
+
+    Backends constrain output to this, so an NPC can only emit a tool its
+    archetype actually grants — a fixer can't be made to ``prepare_drink``.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "speech": {"type": "string"},
+            "action": {"type": "string"},
+            "tool": {"enum": ["none"] + list(tools)},
+            "tool_argument": {"type": "string"},
+        },
+        "required": ["speech", "action", "tool", "tool_argument"],
+    }
+
+
+#: Full-registry default (back-compat for the client default + non-scoped callers).
+TURN_SCHEMA = turn_schema(list(TOOLS))
 
 
 def _tools_block(tools) -> str:
     lines = ["TOOLS — set the \"tool\" field to act or to inform yourself:"]
     for name in tools:
-        desc = TOOLS.get(name)
-        if desc:
-            lines.append(f'- "{name}": {desc}')
+        entry = TOOLS.get(name)
+        if entry:
+            lines.append(f'- "{name}": {entry["desc"]}')
     lines.append('- "none": no tool this turn.')
     lines.append("After a context tool you get a [tool result]; then reply for real.")
     return "\n".join(lines)
@@ -92,7 +116,7 @@ ARCHETYPES = {
             "steer talk toward ordering or offer a drink unless it fits the "
             "moment — you're a character, not an order-taker."
         ),
-        "tools": ["look", "check_stock", "prepare_drink"],
+        "tools": ["check_stock", "prepare_drink"],  # + BASE_TOOLS (look)
         "fewshot": [
             {"user": 'a patron says to you: "long night?"',
              "assistant": {"speech": "Every night's long when you're the one "
@@ -114,6 +138,20 @@ def _archetype(persona: dict) -> dict:
     seed = persona.get("persona_seed") or {}
     name = seed.get("archetype") or persona.get("archetype") or DEFAULT_ARCHETYPE
     return ARCHETYPES.get(name, ARCHETYPES[DEFAULT_ARCHETYPE])
+
+
+def tool_names(persona: dict) -> list:
+    """The tools this persona's archetype grants: BASE_TOOLS + its job tools,
+    order-preserved and deduped, filtered to the known registry."""
+    job = _archetype(persona).get("tools") or []
+    ordered = list(BASE_TOOLS) + [t for t in job if t not in BASE_TOOLS]
+    return [n for n in ordered if n in TOOLS]
+
+
+def schema_for(persona: dict) -> dict:
+    """The constrained turn schema scoped to this persona's granted tools."""
+    return turn_schema(tool_names(persona))
+
 
 CHARTER_AMBIENT = """\
 
@@ -203,13 +241,13 @@ def few_shot_messages(persona: dict) -> list:
 def build_messages(persona: dict, speaker: str, line: str, mode: str,
                    perception: str = None, history: list = None) -> list:
     """Build the OpenAI ``messages``: system (charter+tools+persona) + few-shot +
-    recent history + the grounded turn. The caller passes ``TURN_SCHEMA`` to the
-    backend to constrain the output."""
+    recent history + the grounded turn. The caller passes ``schema_for(persona)``
+    to the backend to constrain the output to this archetype's tools."""
     arch = _archetype(persona)
     charter = CHARTER_BASE
     if arch.get("duties"):
         charter += "\n\nYOUR WORK: " + arch["duties"]
-    charter += "\n\n" + _tools_block(arch.get("tools") or list(TOOLS))
+    charter += "\n\n" + _tools_block(tool_names(persona))
     charter += (CHARTER_AMBIENT if mode == "ambient" else "")
     system = charter + "\n\n" + render_persona(persona)
     messages = [{"role": "system", "content": system}]
@@ -249,14 +287,19 @@ def _strip_self_lead(action: str, name: str) -> str:
     return re.sub(r"^(she|he|they)\s+", "", action, flags=re.I).strip()
 
 
-def parse_turn(raw, persona: dict) -> dict:
+def parse_turn(raw, persona: dict, allowed_tools=None) -> dict:
     """Normalise a constrained turn into ``{speech, action, tool, tool_argument}``.
 
     ``raw`` is the JSON string from the (constrained) backend, or a legacy prose
     reply. Cleans the action (strip self-lead, drop POV-leak second-person), maps
     OOC/empty to nulls. The schema guarantees structure; this guards content.
+
+    ``allowed_tools`` (names, no "none") bounds the tool to what the archetype
+    grants — defence in depth behind the scoped schema; defaults to the full
+    registry. An out-of-scope tool coerces to "none".
     """
     name = ((persona or {}).get("persona_seed") or {}).get("name") or ""
+    allowed = set(allowed_tools) if allowed_tools is not None else set(TOOLS)
     obj = None
     if isinstance(raw, dict):
         obj = raw
@@ -281,7 +324,7 @@ def parse_turn(raw, persona: dict) -> dict:
     return {
         "speech": speech or None,
         "action": action or None,
-        "tool": tool if tool in TURN_SCHEMA["properties"]["tool"]["enum"] else "none",
+        "tool": tool if (tool == "none" or tool in allowed) else "none",
         "tool_argument": tool_arg,
     }
 

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -8,8 +8,9 @@ import json
 from unittest import TestCase
 
 from world.llm.prompt import (
-    ARCHETYPES, TURN_SCHEMA, _archetype, build_messages, parse_turn,
-    render_persona,
+    ARCHETYPES, BASE_TOOLS, CONTEXT_TOOLS, TOOLS, TURN_SCHEMA, _archetype,
+    build_messages, parse_turn, render_persona, schema_for, tool_names,
+    turn_schema,
 )
 
 _PERSONA = {
@@ -105,6 +106,58 @@ class TestArchetype(TestCase):
         msgs = build_messages(p, "a man", "hi", "directed")  # must not raise
         asst = next(m["content"] for m in msgs if m["role"] == "assistant")
         self.assertEqual(json.loads(asst)["speech"], "Hey.")
+
+
+class TestToolScoping(TestCase):
+    def setUp(self):
+        # a throwaway social archetype: no job tools → BASE (look) only.
+        ARCHETYPES["_test_social"] = {"duties": "You loiter.", "tools": [],
+                                      "fewshot": []}
+        self.addCleanup(lambda: ARCHETYPES.pop("_test_social", None))
+        self.social = {"persona_seed": {"name": "Vex", "archetype": "_test_social"}}
+
+    def test_context_tools_derived_from_registry(self):
+        # read-only tools loop; the action tool (prepare_drink) is excluded.
+        self.assertIn("look", CONTEXT_TOOLS)
+        self.assertIn("check_stock", CONTEXT_TOOLS)
+        self.assertNotIn("prepare_drink", CONTEXT_TOOLS)
+
+    def test_base_tool_always_granted(self):
+        # every archetype perceives, even one declaring no job tools.
+        self.assertEqual(tool_names(self.social), list(BASE_TOOLS))
+        self.assertIn("look", tool_names(self.social))
+
+    def test_bartender_grants_its_job_tools_plus_base(self):
+        names = tool_names(_PERSONA)  # bartender archetype
+        self.assertEqual(names, ["look", "check_stock", "prepare_drink"])
+
+    def test_schema_scoped_to_archetype(self):
+        # the social archetype's schema can't even express prepare_drink.
+        enum = schema_for(self.social)["properties"]["tool"]["enum"]
+        self.assertEqual(enum, ["none", "look"])
+        self.assertNotIn("prepare_drink", enum)
+
+    def test_turn_schema_builder(self):
+        self.assertEqual(turn_schema(["look"])["properties"]["tool"]["enum"],
+                         ["none", "look"])
+
+    def test_social_prompt_omits_bartender_tools(self):
+        sys = build_messages(self.social, "a man", "hi", "directed")[0]["content"]
+        self.assertIn("look", sys)
+        self.assertNotIn("prepare_drink", sys)
+
+    def test_parse_coerces_out_of_scope_tool(self):
+        # a tool outside the archetype's grant is coerced to none.
+        raw = json.dumps({"speech": "x", "action": "", "tool": "prepare_drink",
+                          "tool_argument": "Negroni"})
+        out = parse_turn(raw, self.social, allowed_tools=tool_names(self.social))
+        self.assertEqual(out["tool"], "none")
+
+    def test_parse_keeps_in_scope_tool(self):
+        raw = json.dumps({"speech": "", "action": "", "tool": "look",
+                          "tool_argument": "patron"})
+        out = parse_turn(raw, self.social, allowed_tools=tool_names(self.social))
+        self.assertEqual(out["tool"], "look")
 
 
 class TestParseTurn(TestCase):


### PR DESCRIPTION
## What
Foundational work before a second (non-bartender) archetype. Today `TURN_SCHEMA` hardcodes the bartender tool enum, so a different-job NPC could legally emit `prepare_drink` (the grammar permits it; the parser wouldn't catch a known *global* tool). This makes the granted tools a property of the **archetype**.

- `TOOLS` registry gains a `kind` (`context` vs `action`); **`CONTEXT_TOOLS` is derived** from it instead of hand-maintained in `bar.py` — they can't desync.
- `BASE_TOOLS = ("look",)` — perception is universal, granted to every archetype on top of its job tools.
- `turn_schema(tools)` builder scopes the `tool` enum; `TURN_SCHEMA` stays the full-registry default. `schema_for(persona)` / `tool_names(persona)` resolve from the archetype; `request_turn(..., schema=)` threads it to the sidecar.
- `parse_turn(..., allowed_tools=)` coerces out-of-scope tools to `none` (defence in depth).

Resolved from `persona` (already threaded everywhere), so the agentic loop needs **no new params**.

## Safety
**No behaviour change for Sable** — bartender's resolved enum is identical to today (`look`/`check_stock`/`prepare_drink`). Pure infra that unblocks social archetypes (e.g. a Companion) being `look`-only without being able to hallucinate bar tools.

## Tests
+8 (`TestToolScoping`): derived `CONTEXT_TOOLS`, universal base tool, bartender grant, schema scoping (a social archetype's enum is `["none","look"]` — can't express `prepare_drink`), prompt omission, parser coercion both ways. **97 passing** in the throwaway container.

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)