### PR TITLE
Synthetic Humanoid species (foundation)

### DIFF
--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -56,6 +56,8 @@ Design notes
 
 from __future__ import annotations
 
+import copy
+
 #: Species registry.  Keys are stable species identifiers (lowercase,
 #: underscore-separated for multi-word species like ``"glitch_synth"``);
 #: values are dicts whose schema is documented inline below.
@@ -1091,6 +1093,80 @@ SPECIES_DEFINITIONS = {
         },
     },
 }
+
+
+# =====================================================================
+# SYNTHETIC HUMANOID — derived from human.
+# =====================================================================
+#
+# A replicant/Synth: humanoid in FORM, human in MECHANICS (organs,
+# capacities, severability, and the capacity-derived death model all
+# inherit unchanged), but synthetic in PRESENTATION. Derived from the
+# human definition via deepcopy + targeted overrides rather than
+# hand-authored — it stays DRY and tracks future human-anatomy changes.
+#
+# This pass establishes the chassis identity: organs run a bit more
+# durable, and the body does NOT rot (it goes inert, never "rotting" /
+# "skeletal"). Blood-colour and live organ-name divergence are authored
+# in follow-up passes; until then a synthetic still bleeds the human
+# prose. Appendage names stay humanoid (arm/hand/leg) by design.
+SYNTH_ORGAN_DURABILITY = 1.25  # synthetic tissue/frame takes more punishment
+
+
+def _derive_synthetic_humanoid(base: dict) -> dict:
+    synth = copy.deepcopy(base)
+    synth["display_name"] = "synthetic humanoid"
+
+    # Tougher: every organ/bone runs a bit more durable.
+    for organ in synth["organs"].values():
+        organ["max_hp"] = int(round(organ["max_hp"] * SYNTH_ORGAN_DURABILITY))
+
+    # The chassis does not decay. Time advances it toward a stripped,
+    # desiccated frame — never rot or skeletonization.
+    synth["decay_part_prefixes"] = {
+        "fresh": "synthetic {part}", "early": "synthetic {part}",
+        "moderate": "synthetic {part}", "advanced": "inert synthetic {part}",
+        "skeletal": "stripped synthetic {part}",
+    }
+    synth["decay_organ_prefixes"] = {
+        "fresh": "synthetic {organ}", "early": "synthetic {organ}",
+        "moderate": "synthetic {organ}", "advanced": "inert synthetic {organ}",
+        "skeletal": "desiccated synthetic {organ}",
+    }
+    synth["decay_corpse_names"] = {
+        "fresh": "deactivated synthetic", "early": "deactivated synthetic",
+        "moderate": "inert synthetic chassis",
+        "advanced": "inert synthetic chassis",
+        "skeletal": "stripped synthetic frame",
+    }
+    synth["decay_corpse_descriptions"] = {
+        "fresh": (
+            "A recently deactivated synthetic. {base_desc} The chassis is "
+            "intact, its synthetic flesh cooling but uncorrupted."
+        ),
+        "early": (
+            "A deactivated synthetic. {base_desc} The synthetic flesh has "
+            "gone slack and cool, yet shows no sign of decay."
+        ),
+        "moderate": (
+            "An inert synthetic chassis. The synthetic tissue has dulled and "
+            "settled, but does not rot — there is no odor of decay."
+        ),
+        "advanced": (
+            "A dormant synthetic chassis. The artificial tissue has "
+            "discoloured and drawn tight where exposed, the frame slackening, "
+            "but it does not putrefy."
+        ),
+        "skeletal": (
+            "A stripped synthetic frame. Little remains but the structural "
+            "chassis and dried synthetic tissue; it will decompose no further."
+        ),
+    }
+    return synth
+
+
+SPECIES_DEFINITIONS["synthetic_humanoid"] = _derive_synthetic_humanoid(
+    SPECIES_DEFINITIONS["human"])
 
 
 def _resolve_species(species: str | None) -> dict:

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -211,6 +211,18 @@ SKINTONE_PALETTE = {
     "olive": "|320",       # Olive undertone (3,2,0)
     "brown": "|210",       # Brown (2,1,0)
     "rich": "|310",        # Rich brown (3,1,0)
+
+    # Synthetic / alien spectrum — vaguely-unnatural tones for synthetic
+    # humanoids (replicants/Synths). Cool greys, off-tints, and metallics
+    # that read as "not quite human" beside the realistic range above.
+    "alabaster": "|554",   # Cool near-white synthetic (5,5,4)
+    "ashen": "|333",       # Mid neutral grey (3,3,3)
+    "slate": "|223",       # Blue-grey (2,2,3)
+    "pewter": "|222",      # Dark metallic grey (2,2,2)
+    "jade": "|242",        # Pale desaturated green (2,4,2)
+    "lilac": "|425",       # Pale violet (4,2,5)
+    "cobalt": "|114",      # Deep synthetic blue (1,1,4)
+    "chrome": "|445",      # Silvery off-white (4,4,5)
 }
 
 # Valid skintone names for validation

--- a/world/tests/test_synthetic_humanoid.py
+++ b/world/tests/test_synthetic_humanoid.py
@@ -1,0 +1,82 @@
+"""Tests for the Synthetic Humanoid species (replicant/Synth).
+
+Derived from human via deepcopy + targeted overrides: human MECHANICS
+(organs, capacities, severability, death model all inherit) with a
+synthetic PRESENTATION — a touch more durable, and a body that goes
+inert rather than rotting. Appendage names stay humanoid.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.anatomy import (
+    get_species_corpse_description,
+    get_species_corpse_name,
+)
+from world.anatomy.species import SPECIES_DEFINITIONS
+from world.combat.constants import SKINTONE_PALETTE, VALID_SKINTONES
+
+HUMAN = SPECIES_DEFINITIONS["human"]
+SYNTH = SPECIES_DEFINITIONS["synthetic_humanoid"]
+
+
+class TestSyntheticHumanoid(TestCase):
+    def test_registered_with_display_name(self):
+        self.assertIn("synthetic_humanoid", SPECIES_DEFINITIONS)
+        self.assertEqual(SYNTH["display_name"], "synthetic humanoid")
+
+    def test_inherits_human_mechanics(self):
+        # Same organ keys, severability, and capacity wiring → the
+        # capacity-derived death model behaves identically to human.
+        self.assertEqual(set(SYNTH["organs"]), set(HUMAN["organs"]))
+        self.assertEqual(SYNTH["severable_containers"],
+                         HUMAN["severable_containers"])
+        self.assertEqual(SYNTH["body_capacities"], HUMAN["body_capacities"])
+        self.assertEqual(SYNTH["grasping_containers"],
+                         HUMAN["grasping_containers"])
+        self.assertEqual(SYNTH["limb_downstream_chain"],
+                         HUMAN["limb_downstream_chain"])
+
+    def test_appendages_keep_humanoid_names(self):
+        self.assertEqual(SYNTH["location_display"]["left_hand"], "left hand")
+        self.assertEqual(SYNTH["severed_chain_display"]["left_thigh"], "left leg")
+
+    def test_organs_are_more_durable(self):
+        for key, organ in SYNTH["organs"].items():
+            self.assertGreater(organ["max_hp"], HUMAN["organs"][key]["max_hp"],
+                               f"{key} should be tougher than human")
+        self.assertEqual(SYNTH["organs"]["heart"]["max_hp"], 19)  # round(15*1.25)
+
+    def test_corpse_does_not_rot(self):
+        self.assertEqual(
+            get_species_corpse_name("synthetic_humanoid", "fresh"),
+            "deactivated synthetic")
+        self.assertEqual(
+            get_species_corpse_name("synthetic_humanoid", "skeletal"),
+            "stripped synthetic frame")
+        for stage in ("moderate", "advanced", "skeletal"):
+            name = get_species_corpse_name("synthetic_humanoid", stage)
+            self.assertNotIn("rotting", name)
+            self.assertNotIn("skeletal remains", name)
+
+    def test_corpse_description_is_synthetic_and_non_decaying(self):
+        fresh = get_species_corpse_description(
+            "synthetic_humanoid", "fresh", "It wore a grey coat.")
+        self.assertIn("synthetic", fresh.lower())
+        self.assertIn("It wore a grey coat.", fresh)
+        moderate = get_species_corpse_description("synthetic_humanoid", "moderate")
+        self.assertNotIn("decompos", moderate.lower())
+        self.assertIn("does not rot", moderate.lower())
+
+    def test_derivation_does_not_mutate_human(self):
+        # deepcopy → the human definition is untouched by the overrides.
+        self.assertEqual(HUMAN["organs"]["heart"]["max_hp"], 15)
+        self.assertEqual(get_species_corpse_name("human", "skeletal"),
+                         "skeletal remains")
+
+    def test_alien_skintones_registered(self):
+        for tone in ("alabaster", "ashen", "slate", "jade", "cobalt", "chrome"):
+            self.assertIn(tone, SKINTONE_PALETTE)
+            self.assertIn(tone, VALID_SKINTONES)
+        self.assertIn("tan", SKINTONE_PALETTE)  # human tones still present


### PR DESCRIPTION
## What
A new species — a replicant/Synth. The codebase already anticipates synths (the `species.py` docstring notes "can't tell a human from a synth without close examination"; cites `glitch_synth`). **Human MECHANICS + synthetic PRESENTATION**, derived from the human definition via `deepcopy` + targeted overrides so it inherits all human anatomy and tracks future changes to it.

## This pass (foundation)
- `SPECIES_DEFINITIONS["synthetic_humanoid"]`:
  - `display_name` = "synthetic humanoid"
  - organs a touch **more durable** (×1.25 `max_hp` — heart 15→19, etc.)
  - **does not rot**: decay-tier prose goes inert (`deactivated synthetic` → `inert synthetic chassis` → `stripped synthetic frame`), never "rotting"/"skeletal remains"; corpse descriptions read synthetic + non-decaying
  - **appendage names stay humanoid** (arm/hand/leg) by design
- **Alien skin-tone palette** added to `SKINTONE_PALETTE`: alabaster, ashen, slate, pewter, jade, lilac, cobalt, chrome.

Everything else — organs/capacities/severability/the capacity-derived death model — **inherits from human unchanged**.

## Follow-up passes (tracked in #730 thread)
Per-individual **blood colour** + the hardcoded-crimson audit; **live organ-name** divergence via `get_organ_display_name`; optional **infection immunity**. Until blood colour lands, a synthetic still bleeds the human prose.

## Safety / tests
Purely additive — human and rat definitions are untouched (a test asserts the deepcopy didn't mutate human). +8 tests (`test_synthetic_humanoid`); rat/corpse-description/skintone(augment) sweeps stay green. **78 passing** across the relevant packages in the throwaway container.

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)