### PR TITLE
LLM NPC base (LLMNpcMixin/LLMNpc) + companion archetype

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -13,9 +13,7 @@ v1 is intentionally lenient where the spec defers (ownership gating, recipe-save
 UX) so the loop is testable; those are later slices.
 """
 
-import json
 import random
-from functools import partial
 from time import monotonic
 
 from evennia import CmdSet
@@ -24,12 +22,8 @@ from evennia.utils import delay
 
 from typeclasses.items import Item
 from typeclasses.characters import Character
-from typeclasses.llm_persona import build_persona
+from typeclasses.llm_npc import LLMNpcMixin
 from world.grammar import capitalize_first, with_article
-from world.llm.client import llm_enabled, request_turn
-from world.llm.prompt import (
-    CONTEXT_TOOLS, build_messages, parse_turn, schema_for, tool_names,
-)
 from world.shop.utils import format_currency
 from world.bar import (
     DEFAULT_BAR_SNACKS,
@@ -334,20 +328,14 @@ ACK_EMOTES = (
 #: Minimum seconds between acknowledgements, so a chatty room doesn't spam them.
 ACK_COOLDOWN = 6.0
 
-#: LLM-driven conversational replies (LLM_GAMEMASTER_SPEC Phase 1, #707). Gated
-#: by BOTH ``settings.LLM_GM_ENABLED`` (deployment) and ``npc.db.llm_driven``
-#: (per-NPC), so a scripted bartender stays byte-identical when the LLM is off.
-LLM_DIRECTED_COOLDOWN = 4.0    # min seconds between replies to direct address/name
-LLM_AMBIENT_COOLDOWN = 45.0    # she rarely volunteers into overheard chatter
-LLM_AMBIENT_CHANCE = 0.35      # ...and not every eligible time
-LLM_HISTORY_TURNS = 6          # recent turns kept per interlocutor (anti-repetition)
-#: CONTEXT_TOOLS (read-only → loop the result back; vs action tools → real command)
-#: is derived from the prompt-layer tool registry, so they can't desync.
-LLM_MAX_TOOL_ROUNDS = 3        # cap the agentic loop so it can't spin forever
 
+class Bartender(LLMNpcMixin, Character):
+    """An NPC that takes drink orders by being spoken to (the `to` command).
 
-class Bartender(Character):
-    """An NPC that takes drink orders by being spoken to (the `to` command)."""
+    Bartending mechanics on top of the shared LLM brain (``LLMNpcMixin``):
+    orders/gratitude intercept speech before the LLM layer, and the
+    ``check_stock`` / ``prepare_drink`` tools route to the bar.
+    """
 
     def at_object_creation(self):
         super().at_object_creation()
@@ -376,44 +364,22 @@ class Bartender(Character):
                 return obj
         return None
 
-    def at_msg_receive(self, text=None, from_obj=None, **kwargs):
-        """React to speech nearby, via the shared speech backbone.
-
-        Every verb that carries words — ``say``, ``to``, or a pose with an
-        embedded quote — delivers the same structured payload (``speech`` =
-        the words, ``addressed`` = whether this bartender was the one spoken to),
-        and only to listeners who can hear. So a single check handles all three:
-
-          - **Gratitude** (thanks/cheers/much obliged...) from any heard speech —
-            answered with a small non-verbal acknowledgement. Checked first so
-            "thanks for the rotgut" reads as a thank-you, not a re-order.
-          - **A directed order** — speech that was *addressed* to this bartender
-            (``to <bartender> ...`` or ``.slide up to <bartender>, "..."``) is
-            matched against the menu and made.
+    def _handle_directed_speech(self, speech, speaker, kwargs):
+        """Bartender intercept (before the LLM layer): gratitude → a small
+        non-verbal nod (checked first so "thanks for the rotgut" reads as a
+        thank-you, not a re-order); an *addressed* line → a menu order. Returns
+        True when handled, so conversation only reaches the LLM otherwise.
         """
-        speech = kwargs.get("speech")
-        speaker = from_obj
-        if not speech or speaker is None or speaker is self:
-            return True
-
         if self._is_gratitude(speech):
             self._acknowledge()
             return True
-
         if kwargs.get("addressed"):
             delay(1.5, self._fulfil_order, speech, speaker)
             return True
+        return False
 
-        # LLM conversational layer — only when both gates are on, so the
-        # scripted NPC is byte-identical with the LLM off. Orders and gratitude
-        # above are never routed here.
-        if self.db.llm_driven and llm_enabled():
-            kind = self._classify_speech(speech, speaker)
-            if kind == "directed":
-                delay(1.5, self._try_llm_reply, speech, speaker, "directed")
-            elif kind == "ambient":
-                delay(1.0, self._try_llm_reply, speech, speaker, "ambient")
-        return True
+    def _name_aliases(self):
+        return ["bartender", "barkeep", "barkeeper"]
 
     @staticmethod
     def _is_gratitude(content):
@@ -470,208 +436,25 @@ class Bartender(Character):
             f"and {closer}."
         )
 
-    # --- LLM-driven conversation (gated; LLM_GAMEMASTER_SPEC Phase 1) --------
-
-    def _classify_speech(self, speech, speaker):
-        """Cheap reactor-side gate: ``directed`` | ``ambient`` | ``ignore``."""
-        # Loop guard: never react to another NPC's broadcast speech, so two
-        # LLM-driven NPCs can't ping-pong on ambient lines.
-        if (getattr(speaker.db, "is_bartender_npc", False)
-                or getattr(speaker.db, "llm_driven", False)):
-            return "ignore"
-        # Named, or effectively alone with the speaker (then any line is plainly
-        # for her), counts as directed; otherwise it's overheard chatter.
-        if self._mentions_self(speech) or self._is_alone_with(speaker):
-            return "directed"
-        return "ambient"
-
-    def _is_alone_with(self, speaker):
-        """True when no other character shares the room — so the speaker can only
-        be talking to this NPC."""
-        if not self.location:
-            return False
-        return not any(
-            o is not self and o is not speaker and isinstance(o, Character)
-            for o in self.location.contents
-        )
-
-    def _mentions_self(self, speech):
-        """Whether a line names this bartender (key, keyword, or generic role)."""
-        low = (speech or "").lower()
-        names = [self.key.lower()]
-        if self.sdesc_keyword:
-            names.append(self.sdesc_keyword.lower())
-        names += ["bartender", "barkeep", "barkeeper"]
-        return any(n and n in low for n in names)
-
-    def _try_llm_reply(self, line, patron, mode, on_fail=None):
-        """Route a conversational line to the LLM sidecar, off the reactor.
-
-        Returns True if the LLM path was taken (caller suppresses any scripted
-        fallback), False if gated/throttled off so the caller can fall back.
-        """
-        if not self.db.llm_driven or not llm_enabled():
-            return False
-        if (not self.location
-                or getattr(patron, "location", None) is not self.location):
-            return False
-
-        now = monotonic()
-        last = self.ndb.last_llm or 0
-        if mode == "ambient":
-            if now - last < LLM_AMBIENT_COOLDOWN:
-                return True  # throttled: stay silent rather than spam
-            if random.random() > LLM_AMBIENT_CHANCE:
-                return True  # eligible, but she didn't bite this time
-        elif now - last < LLM_DIRECTED_COOLDOWN:
-            return True
-        self.ndb.last_llm = now
-
-        # Capture everything reactor-side BEFORE threading (SQLite/Evennia-thread
-        # contract). The agentic loop re-calls from the reactor-side callback.
-        persona = build_persona(self)
-        speaker_name = patron.get_display_name(self)
-        perception = self._perceive(patron)
-        history = self._recent_history(patron)
-        messages = build_messages(persona, speaker_name, line or "", mode,
-                                  perception, history)
-        self._agentic_round(messages, persona, patron, line or "", speaker_name,
-                            on_fail or self._llm_silent, rounds=0)
-        return True
-
-    def _perceive(self, patron):
-        """What this NPC sees when it looks at the patron — grounds the model's
-        description so it can't invent the speaker's appearance. ANSI-stripped,
-        identity-gated, trimmed to a sentence-bounded summary (the full
-        return_appearance bloats context and truncates mid-word)."""
-        try:
-            from evennia.utils.ansi import strip_ansi
-            raw = patron.return_appearance(self)
-            if not raw:
-                return None
-            text = " ".join(strip_ansi(raw).split())
-            if len(text) > 300:
-                cut = text[:300]
-                for end in (". ", "! ", "? "):
-                    i = cut.rfind(end)
-                    if i > 120:
-                        cut = cut[: i + 1]
-                        break
-                text = cut.rstrip()
-            return text
-        except Exception:
-            return None
-
-    # --- short-term conversation memory (per interlocutor, ndb/ephemeral) ----
-
-    @staticmethod
-    def _hist_key(patron):
-        return f"#{patron.id}"
-
-    def _recent_history(self, patron):
-        """The recent turns with this interlocutor — fed back into the prompt so
-        the model sees what it just said and stops repeating itself."""
-        return (self.ndb.llm_history or {}).get(self._hist_key(patron), [])
-
-    # --- the agentic tool loop (constrained turn → context tools → reply) ----
-
-    def _agentic_round(self, messages, persona, patron, line, speaker_name,
-                       on_fail, rounds):
-        """One constrained generation; the reactor-side callback either runs a
-        context tool and loops, or renders the final reply + any action tool."""
-        request_turn(
-            messages,
-            on_turn=partial(self._on_turn, messages, persona, patron, line,
-                            speaker_name, on_fail, rounds),
-            on_fail=on_fail,
-            schema=schema_for(persona),  # tool enum scoped to the archetype
-        )
-
-    def _on_turn(self, messages, persona, patron, line, speaker_name, on_fail,
-                 rounds, raw):
-        turn = parse_turn(raw, persona, tool_names(persona))
-        tool, arg = turn["tool"], turn["tool_argument"]
-        # Context tool: run the real read, feed the result back, loop.
-        if tool in CONTEXT_TOOLS and rounds < LLM_MAX_TOOL_ROUNDS:
-            result = self._run_context_tool(tool, arg, patron)
-            extended = messages + [
-                {"role": "assistant",
-                 "content": raw if isinstance(raw, str) else json.dumps(raw)},
-                {"role": "user", "content": f"[tool result · {tool}] {result}"},
-            ]
-            self._agentic_round(extended, persona, patron, line, speaker_name,
-                                on_fail, rounds + 1)
-            return
-        # Terminal: render speech/action, run the action tool, remember.
-        self._render_llm_reply(turn["speech"], turn["action"])
-        if tool == "prepare_drink" and arg and self.location:
-            self.execute_cmd(f"prepare {arg}")
-        self._remember_turn(patron, line, speaker_name, turn["speech"],
-                            turn["action"])
+    # --- bartender tool routing (over the shared LLM brain) ------------------
 
     def _run_context_tool(self, tool, arg, patron):
-        """Run a read-only context tool via the game's real logic and return its
-        result for the model. (Reads only — world-mutating tools go through real
-        commands in ``_on_turn``.)"""
-        if tool == "look":
-            return self._perceive(patron) or "nothing remarkable"
+        """Extend the read-only tools with ``check_stock`` (``look`` is the
+        mixin's). Reads only — the action tool goes through a real command."""
         if tool == "check_stock":
             bar = self._find_bar()
             menu = (bar.db.menu if bar else None) or self.db.menu or []
             names = [r.get("name") for r in menu if r.get("name")]
             return ("Serves: " + ", ".join(names)) if names else "nothing on tap"
-        return ""
+        return super()._run_context_tool(tool, arg, patron)
 
-    def _remember_turn(self, patron, line, speaker_name, speech, action):
-        """Append the rendered turn to short-term memory (anti-repetition)."""
-        reply = self._reconstruct_reply(speech, action)
-        if not reply:
-            return
-        hist = self.ndb.llm_history or {}
-        key = self._hist_key(patron)
-        turns = list(hist.get(key, []))
-        turns.append({
-            "user": f'{speaker_name} says to you: "{line}"',
-            "assistant": reply,
-        })
-        hist[key] = turns[-LLM_HISTORY_TURNS:]
-        self.ndb.llm_history = hist
-
-    @staticmethod
-    def _reconstruct_reply(speech, action):
-        """Re-form the model's own reply for the history (so it sees its prior
-        gestures and phrasing, in the same format it produces)."""
-        if action and speech:
-            return f'*{action}* "{speech}"'
-        if action:
-            return f"*{action}*"
-        if speech:
-            return f'"{speech}"'
-        return ""
-
-    def _render_llm_reply(self, speech, action):
-        """Render the sidecar reply as ONE fluid emote — the MUD-native way to act
-        and speak in a single beat. The embedded quote rides the hearing-gated
-        speech rails (``tokenize_emote`` → ``SpeechToken``) and character refs in
-        the action resolve per-observer. Falls back to a bare pose or say."""
-        if not self.location:
-            return
-        speech = speech.strip().strip('"').strip() if speech else None
-        action = action.strip() if action else None
-        if action and speech:
-            if action[-1] not in ".!?…,":
-                action += "."
-            self.execute_cmd(f'pose {action} "{speech}"')
-        elif action:
-            self.execute_cmd(f"pose {action}")
-        elif speech:
-            self.execute_cmd(f"say {speech}")
+    def _handle_action_tool(self, tool, arg, patron):
+        """Route the ``prepare_drink`` action tool to the real ``prepare``
+        command — the bar makes the drink for real (never a faked pour)."""
+        if tool == "prepare_drink" and arg and self.location:
+            self.execute_cmd(f"prepare {arg}")
 
     def _llm_fallback(self):
         """Sidecar failed on an addressed non-order: the curt scripted line."""
         if self.location:
             self.execute_cmd("say Don't serve that here.")
-
-    def _llm_silent(self):
-        """Sidecar failed or declined on conversation: stay quiet."""
-        return None

--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -1,0 +1,282 @@
+"""Generic LLM-driven NPC — the engagement loop + agentic tool loop, factored
+out of the bartender so any archetype (Companion, …) can think.
+
+The NPC's *job* is its persona archetype (``world/llm/prompt.ARCHETYPES``); this
+class is just the **brain**. Subclasses add job mechanics through small hooks:
+
+* ``_handle_directed_speech`` — intercept addressed/special speech before the LLM
+  layer (e.g. a bartender's orders / gratitude). Return True if fully handled.
+* ``_run_context_tool`` — extend the read-only tools (``look`` is built in here).
+* ``_handle_action_tool`` — route an archetype's *action* tool to a real command.
+* ``_name_aliases`` — extra words that count as naming this NPC.
+
+Reactor-safety mirrors ``CmdBug``: persona is built on the reactor, the blocking
+POST runs off-reactor (``world/llm/client``), and the callbacks orchestrate the
+agentic loop back on the reactor. See ``LLM_GAMEMASTER_SPEC`` Phase 1.
+"""
+
+import json
+import random
+from functools import partial
+from time import monotonic
+
+from evennia.utils.utils import delay
+
+from typeclasses.characters import Character
+from typeclasses.llm_persona import build_persona
+from world.llm.client import llm_enabled, request_turn
+from world.llm.prompt import (
+    CONTEXT_TOOLS, build_messages, parse_turn, schema_for, tool_names,
+)
+
+LLM_DIRECTED_COOLDOWN = 4.0    # min seconds between replies to direct address/name
+LLM_AMBIENT_COOLDOWN = 45.0    # rarely volunteers into overheard chatter
+LLM_AMBIENT_CHANCE = 0.35      # ...and not every eligible time
+LLM_HISTORY_TURNS = 6          # recent turns kept per interlocutor (anti-repetition)
+LLM_MAX_TOOL_ROUNDS = 3        # cap the agentic loop so it can't spin forever
+
+
+class LLMNpcMixin:
+    """The reusable LLM brain. Mix into a Character (before it in the MRO)."""
+
+    # --- engagement entrypoint -------------------------------------------
+    def at_msg_receive(self, text=None, from_obj=None, **kwargs):
+        """React to heard speech. Job-specific handlers get first crack; the
+        LLM layer only runs when both gates (per-NPC + deployment) are on, so a
+        scripted NPC is byte-identical with the LLM off."""
+        speech = kwargs.get("speech")
+        speaker = from_obj
+        if not speech or speaker is None or speaker is self:
+            return True
+        if self._handle_directed_speech(speech, speaker, kwargs):
+            return True
+        if self.db.llm_driven and llm_enabled():
+            kind = self._classify_speech(speech, speaker)
+            if kind == "directed":
+                delay(1.5, self._try_llm_reply, speech, speaker, "directed")
+            elif kind == "ambient":
+                delay(1.0, self._try_llm_reply, speech, speaker, "ambient")
+        return True
+
+    def _handle_directed_speech(self, speech, speaker, kwargs):
+        """Hook: a subclass intercepts addressed/special speech before the LLM
+        layer (a bartender's orders/gratitude). Return True if fully handled."""
+        return False
+
+    # --- classification --------------------------------------------------
+    def _classify_speech(self, speech, speaker):
+        """Cheap reactor-side gate: ``directed`` | ``ambient`` | ``ignore``."""
+        # Loop guard: never react to another NPC's broadcast speech, so two
+        # LLM-driven NPCs can't ping-pong on ambient lines.
+        if (getattr(speaker.db, "is_bartender_npc", False)
+                or getattr(speaker.db, "llm_driven", False)):
+            return "ignore"
+        if self._mentions_self(speech) or self._is_alone_with(speaker):
+            return "directed"
+        return "ambient"
+
+    def _is_alone_with(self, speaker):
+        """True when no other character shares the room — so the speaker can only
+        be talking to this NPC."""
+        if not self.location:
+            return False
+        return not any(
+            o is not self and o is not speaker and isinstance(o, Character)
+            for o in self.location.contents
+        )
+
+    def _mentions_self(self, speech):
+        """Whether a line names this NPC (key, keyword, or role aliases)."""
+        low = (speech or "").lower()
+        names = [self.key.lower()]
+        if self.sdesc_keyword:
+            names.append(self.sdesc_keyword.lower())
+        names += self._name_aliases()
+        return any(n and n in low for n in names)
+
+    def _name_aliases(self):
+        """Hook: extra words that count as naming this NPC (role words)."""
+        return []
+
+    # --- request orchestration -------------------------------------------
+    def _try_llm_reply(self, line, patron, mode, on_fail=None):
+        """Route a conversational line to the LLM sidecar, off the reactor.
+
+        Returns True if the LLM path was taken (caller suppresses any scripted
+        fallback), False if gated/throttled off so the caller can fall back.
+        """
+        if not self.db.llm_driven or not llm_enabled():
+            return False
+        if (not self.location
+                or getattr(patron, "location", None) is not self.location):
+            return False
+
+        now = monotonic()
+        last = self.ndb.last_llm or 0
+        if mode == "ambient":
+            if now - last < LLM_AMBIENT_COOLDOWN:
+                return True  # throttled: stay silent rather than spam
+            if random.random() > LLM_AMBIENT_CHANCE:
+                return True  # eligible, but didn't bite this time
+        elif now - last < LLM_DIRECTED_COOLDOWN:
+            return True
+        self.ndb.last_llm = now
+
+        # Capture everything reactor-side BEFORE threading (SQLite/Evennia-thread
+        # contract). The agentic loop re-calls from the reactor-side callback.
+        persona = build_persona(self)
+        speaker_name = patron.get_display_name(self)
+        perception = self._perceive(patron)
+        history = self._recent_history(patron)
+        messages = build_messages(persona, speaker_name, line or "", mode,
+                                  perception, history)
+        self._agentic_round(messages, persona, patron, line or "", speaker_name,
+                            on_fail or self._llm_silent, rounds=0)
+        return True
+
+    def _perceive(self, patron):
+        """What this NPC sees when it looks at the patron — grounds the model's
+        description so it can't invent the speaker's appearance. ANSI-stripped,
+        identity-gated, trimmed to a sentence-bounded summary (the full
+        return_appearance bloats context and truncates mid-word)."""
+        try:
+            from evennia.utils.ansi import strip_ansi
+            raw = patron.return_appearance(self)
+            if not raw:
+                return None
+            text = " ".join(strip_ansi(raw).split())
+            if len(text) > 300:
+                cut = text[:300]
+                for end in (". ", "! ", "? "):
+                    i = cut.rfind(end)
+                    if i > 120:
+                        cut = cut[: i + 1]
+                        break
+                text = cut.rstrip()
+            return text
+        except Exception:
+            return None
+
+    # --- short-term conversation memory (per interlocutor, ndb/ephemeral) ----
+
+    @staticmethod
+    def _hist_key(patron):
+        return f"#{patron.id}"
+
+    def _recent_history(self, patron):
+        """The recent turns with this interlocutor — fed back into the prompt so
+        the model sees what it just said and stops repeating itself."""
+        return (self.ndb.llm_history or {}).get(self._hist_key(patron), [])
+
+    # --- the agentic tool loop (constrained turn → context tools → reply) ----
+
+    def _agentic_round(self, messages, persona, patron, line, speaker_name,
+                       on_fail, rounds):
+        """One constrained generation; the reactor-side callback either runs a
+        context tool and loops, or renders the final reply + any action tool."""
+        request_turn(
+            messages,
+            on_turn=partial(self._on_turn, messages, persona, patron, line,
+                            speaker_name, on_fail, rounds),
+            on_fail=on_fail,
+            schema=schema_for(persona),  # tool enum scoped to the archetype
+        )
+
+    def _on_turn(self, messages, persona, patron, line, speaker_name, on_fail,
+                 rounds, raw):
+        turn = parse_turn(raw, persona, tool_names(persona))
+        tool, arg = turn["tool"], turn["tool_argument"]
+        # Context tool: run the real read, feed the result back, loop.
+        if tool in CONTEXT_TOOLS and rounds < LLM_MAX_TOOL_ROUNDS:
+            result = self._run_context_tool(tool, arg, patron)
+            extended = messages + [
+                {"role": "assistant",
+                 "content": raw if isinstance(raw, str) else json.dumps(raw)},
+                {"role": "user", "content": f"[tool result · {tool}] {result}"},
+            ]
+            self._agentic_round(extended, persona, patron, line, speaker_name,
+                                on_fail, rounds + 1)
+            return
+        # Terminal: render speech/action, route any action tool, remember.
+        self._render_llm_reply(turn["speech"], turn["action"])
+        self._handle_action_tool(tool, arg, patron)
+        self._remember_turn(patron, line, speaker_name, turn["speech"],
+                            turn["action"])
+
+    def _run_context_tool(self, tool, arg, patron):
+        """Run a read-only context tool and return its result for the model.
+        ``look`` is built in; subclasses extend (then call super)."""
+        if tool == "look":
+            return self._perceive(patron) or "nothing remarkable"
+        return ""
+
+    def _handle_action_tool(self, tool, arg, patron):
+        """Hook: route an action tool to a real command. Base NPC has no
+        action tools (social archetypes are read-only)."""
+        return None
+
+    def _remember_turn(self, patron, line, speaker_name, speech, action):
+        """Append the rendered turn to short-term memory (anti-repetition)."""
+        reply = self._reconstruct_reply(speech, action)
+        if not reply:
+            return
+        hist = self.ndb.llm_history or {}
+        key = self._hist_key(patron)
+        turns = list(hist.get(key, []))
+        turns.append({
+            "user": f'{speaker_name} says to you: "{line}"',
+            "assistant": reply,
+        })
+        hist[key] = turns[-LLM_HISTORY_TURNS:]
+        self.ndb.llm_history = hist
+
+    @staticmethod
+    def _reconstruct_reply(speech, action):
+        """Re-form the model's own reply for the history (so it sees its prior
+        gestures and phrasing, in the same format it produces)."""
+        if action and speech:
+            return f'*{action}* "{speech}"'
+        if action:
+            return f"*{action}*"
+        if speech:
+            return f'"{speech}"'
+        return ""
+
+    def _render_llm_reply(self, speech, action):
+        """Render the sidecar reply as ONE fluid emote — the MUD-native way to act
+        and speak in a single beat. The embedded quote rides the hearing-gated
+        speech rails (``tokenize_emote`` → ``SpeechToken``) and character refs in
+        the action resolve per-observer. Falls back to a bare pose or say."""
+        if not self.location:
+            return
+        speech = speech.strip().strip('"').strip() if speech else None
+        action = action.strip() if action else None
+        if action and speech:
+            if action[-1] not in ".!?…,":
+                action += "."
+            self.execute_cmd(f'pose {action} "{speech}"')
+        elif action:
+            self.execute_cmd(f"pose {action}")
+        elif speech:
+            self.execute_cmd(f"say {speech}")
+
+    def _llm_silent(self):
+        """Sidecar failed or declined on conversation: stay quiet."""
+        return None
+
+
+class LLMNpc(LLMNpcMixin, Character):
+    """A generic LLM-driven social NPC. The persona's ``archetype`` is its job;
+    the typeclass is only the brain. Opt in per-NPC via ``db.llm_driven`` (and
+    the deployment-wide ``LLM_GM_ENABLED``)."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        # Identity safety-net: a Character with no height/build composes no sdesc
+        # and falls back to its *key* — leaking the NPC's real name. Seed a
+        # baseline so it always renders through the identity system.
+        if not self.height:
+            self.height = "average"
+        if not self.build:
+            self.build = "average"
+        self.db.llm_driven = False

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -126,6 +126,32 @@ ARCHETYPES = {
                            "tool": "none", "tool_argument": ""}},
         ],
     },
+    "companion": {
+        "duties": (
+            "You are a Companion — intimacy and presence are your craft. You "
+            "read what a person carries in and give them your whole attention: "
+            "warmth, wit, the sense that for this hour they're the only one in "
+            "the room. You set the pace, you keep your own counsel and your own "
+            "boundaries, and you're nobody's fool. Draw people out, flirt, "
+            "tease, listen — let both desire and refusal be yours to give."
+        ),
+        "tools": [],  # social-only; BASE look for grounding
+        "fewshot": [
+            {"user": 'a patron says to you: "you\'re even better looking up close."',
+             "assistant": {"speech": "Mm. And bold, up close. I like knowing "
+                                     "what I'm working with.",
+                           "action": "lets her gaze travel over him, slow and "
+                                     "frank",
+                           "tool": "none", "tool_argument": ""}},
+            {"user": 'a patron says to you: "rough day. i just need to forget it."',
+             "assistant": {"speech": "Then leave it at the door, sweetheart. In "
+                                     "here it's just you and me and however long "
+                                     "you've bought.",
+                           "action": "draws him toward the low couch by the "
+                                     "wrist, unhurried",
+                           "tool": "none", "tool_argument": ""}},
+        ],
+    },
 }
 
 #: NPCs with no declared job fall back to this (only the bartender exists today).

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -13,6 +13,7 @@ from evennia.utils.test_resources import BaseEvenniaTest
 
 import world.speech as speech
 import typeclasses.bar as barmod
+import typeclasses.llm_npc as llmnpc
 
 
 class _Obs:
@@ -474,6 +475,10 @@ class TestBartenderReaction(BaseEvenniaTest):
         b = MagicMock()
         b._is_gratitude = barmod.Bartender._is_gratitude  # real staticmethod
         b._acknowledge = MagicMock()
+        # at_msg_receive (mixin) defers to this real bartender hook for the
+        # gratitude/order intercept before the LLM layer.
+        b._handle_directed_speech = (
+            barmod.Bartender._handle_directed_speech.__get__(b, barmod.Bartender))
         return b
 
     def _call(self, b, speaker, **payload):
@@ -524,7 +529,8 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
     cooldown, loop-guard, fail-safe. Orders + gratitude paths stay untouched."""
 
     _REAL = (
-        "_classify_speech", "_mentions_self", "_try_llm_reply",
+        "_classify_speech", "_mentions_self", "_name_aliases",
+        "_handle_directed_speech", "_try_llm_reply",
         "_render_llm_reply", "_llm_fallback", "_llm_silent",
     )
 
@@ -561,32 +567,32 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
 
     def test_directed_name_routes_directed(self):
         b, spk = self._bartender(), self._speaker()
-        with patch.object(barmod, "llm_enabled", return_value=True), \
-                patch.object(barmod, "delay") as mock_delay:
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as mock_delay:
             self._call(b, spk, speech="hey sable, busy?", addressed=False)
         mock_delay.assert_called_once()
         self.assertIn("directed", mock_delay.call_args.args)
 
     def test_ambient_routes_ambient(self):
         b, spk = self._bartender(), self._speaker()
-        with patch.object(barmod, "llm_enabled", return_value=True), \
-                patch.object(barmod, "delay") as mock_delay:
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as mock_delay:
             self._call(b, spk, speech="this place is dead tonight", addressed=False)
         mock_delay.assert_called_once()
         self.assertIn("ambient", mock_delay.call_args.args)
 
     def test_disabled_routes_nothing(self):
         b, spk = self._bartender(), self._speaker()
-        with patch.object(barmod, "llm_enabled", return_value=False), \
-                patch.object(barmod, "delay") as mock_delay:
+        with patch.object(llmnpc, "llm_enabled", return_value=False), \
+                patch.object(llmnpc, "delay") as mock_delay:
             self._call(b, spk, speech="hey sable", addressed=False)
         mock_delay.assert_not_called()
 
     def test_loop_guard_ignores_npc_speaker(self):
         b, npc = self._bartender(), self._speaker()
         npc.db.is_bartender_npc = True
-        with patch.object(barmod, "llm_enabled", return_value=True), \
-                patch.object(barmod, "delay") as mock_delay:
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as mock_delay:
             self._call(b, npc, speech="rough night sable", addressed=False)
         mock_delay.assert_not_called()
 
@@ -594,8 +600,8 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         # alone with the speaker → a plain (un-named) line is plainly for her
         b, spk = self._bartender(), self._speaker()
         b._is_alone_with = lambda speaker: True
-        with patch.object(barmod, "llm_enabled", return_value=True), \
-                patch.object(barmod, "delay") as mock_delay:
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as mock_delay:
             self._call(b, spk, speech="this drink is watered down", addressed=False)
         mock_delay.assert_called_once()
         self.assertIn("directed", mock_delay.call_args.args)
@@ -615,8 +621,9 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
 
     def test_addressed_still_routes_to_order(self):
         b, spk = self._bartender(), self._speaker()
-        with patch.object(barmod, "llm_enabled", return_value=True), \
-                patch.object(barmod, "delay") as mock_delay:
+        # the addressed→order delay fires in the bartender hook (bar module),
+        # before the LLM layer is even consulted.
+        with patch.object(barmod, "delay") as mock_delay:
             self._call(b, spk, speech="a rotgut", addressed=True)
         mock_delay.assert_called_once()
         # the addressed branch targets _fulfil_order, not the LLM layer
@@ -626,9 +633,9 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
 
     def test_try_llm_reply_starts_agentic_round(self):
         b, patron = self._bartender(), self._speaker(name="a wiry courier")
-        with patch.object(barmod, "llm_enabled", return_value=True), \
-                patch.object(barmod, "build_persona", return_value={"x": 1}), \
-                patch.object(barmod, "build_messages", return_value=["m"]) as bm:
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "build_persona", return_value={"x": 1}), \
+                patch.object(llmnpc, "build_messages", return_value=["m"]) as bm:
             taken = b._try_llm_reply("rough night?", patron, "directed")
         self.assertTrue(taken)
         bm.assert_called_once()
@@ -647,7 +654,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         from time import monotonic
         b, patron = self._bartender(), self._speaker()
         b.ndb.last_llm = monotonic()  # just replied
-        with patch.object(barmod, "llm_enabled", return_value=True):
+        with patch.object(llmnpc, "llm_enabled", return_value=True):
             taken = b._try_llm_reply("hi", patron, "directed")
         self.assertTrue(taken)         # handled-by-silence, no scripted fallback
         b._agentic_round.assert_not_called()
@@ -710,9 +717,9 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         self._bind_memory(b)
         patron = self._speaker(); patron.id = 7
         b.ndb.llm_history = {}
-        for i in range(barmod.LLM_HISTORY_TURNS + 4):
+        for i in range(llmnpc.LLM_HISTORY_TURNS + 4):
             b._remember_turn(patron, f"l{i}", "a man", f"r{i}", "nods")
-        self.assertEqual(len(b._recent_history(patron)), barmod.LLM_HISTORY_TURNS)
+        self.assertEqual(len(b._recent_history(patron)), llmnpc.LLM_HISTORY_TURNS)
 
     def test_memory_is_per_interlocutor(self):
         b = self._bartender()
@@ -730,7 +737,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         b._hist_key = barmod.Bartender._hist_key
         b._reconstruct_reply = barmod.Bartender._reconstruct_reply
         for name in ("_on_turn", "_run_context_tool", "_render_llm_reply",
-                     "_remember_turn", "_recent_history"):
+                     "_handle_action_tool", "_remember_turn", "_recent_history"):
             setattr(b, name,
                     getattr(barmod.Bartender, name).__get__(b, barmod.Bartender))
         b.ndb.llm_history = {}
@@ -741,7 +748,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         b._run_context_tool = lambda tool, arg, p: "a stocky droog"
         turn = {"speech": None, "action": None, "tool": "look",
                 "tool_argument": "patron"}
-        with patch.object(barmod, "parse_turn", return_value=turn):
+        with patch.object(llmnpc, "parse_turn", return_value=turn):
             b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, "{}")
         b._agentic_round.assert_called_once()           # looped to gather context
         b.execute_cmd.assert_not_called()               # no terminal render yet
@@ -751,7 +758,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         patron = self._speaker(); patron.id = 6
         turn = {"speech": "Coming up", "action": "grabs a glass",
                 "tool": "prepare_drink", "tool_argument": "Negroni"}
-        with patch.object(barmod, "parse_turn", return_value=turn):
+        with patch.object(llmnpc, "parse_turn", return_value=turn):
             b._on_turn(["m"], {}, patron, "a negroni", "a man", lambda: None, 0, "{}")
         b.execute_cmd.assert_any_call("prepare Negroni")  # the REAL command
         b._agentic_round.assert_not_called()              # terminal, no loop
@@ -761,17 +768,20 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         patron = self._speaker(); patron.id = 8
         turn = {"speech": "hey", "action": "nods", "tool": "none",
                 "tool_argument": ""}
-        with patch.object(barmod, "parse_turn", return_value=turn):
+        with patch.object(llmnpc, "parse_turn", return_value=turn):
             b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, "{}")
         b.execute_cmd.assert_any_call('pose nods. "hey"')
 
     def test_run_context_tool_look_and_stock(self):
         b = self._bartender()
-        b._run_context_tool = barmod.Bartender._run_context_tool.__get__(
-            b, barmod.Bartender)
         b._perceive = lambda patron: "a wiry courier, scarred jaw"
         patron = self._speaker()
-        self.assertIn("wiry courier", b._run_context_tool("look", "patron", patron))
+        # look is the shared mixin tool (Bartender delegates to it via super)
+        self.assertIn("wiry courier",
+                      llmnpc.LLMNpcMixin._run_context_tool(b, "look", "patron", patron))
+        # check_stock is the bartender's own extension
+        b._run_context_tool = barmod.Bartender._run_context_tool.__get__(
+            b, barmod.Bartender)
         b._find_bar = lambda: None
         b.db.menu = [{"name": "Negroni"}, {"name": "Martini"}]
         self.assertIn("Negroni", b._run_context_tool("check_stock", "", patron))


### PR DESCRIPTION
## What
Standing up a Companion (a non-bartender LLM NPC) surfaced that the engagement loop + agentic tool loop lived on `Bartender`. This extracts them so **any archetype can think**.

- **New `typeclasses/llm_npc.py`**: `LLMNpcMixin` (the whole brain — `at_msg_receive`, classification, `_try_llm_reply`, the agentic tool loop, render, short-term memory, perception) + `LLMNpc(LLMNpcMixin, Character)`, a generic LLM-driven social NPC whose *job* is its persona archetype. Four subclass hooks: `_handle_directed_speech` (intercept special speech), `_run_context_tool` / `_handle_action_tool` (route the archetype's tools), `_name_aliases`.
- **`Bartender` is now `LLMNpcMixin + Character` + bartending only** — orders/gratitude via `_handle_directed_speech`, `check_stock`/`prepare_drink` via the tool hooks. **No behaviour change**; the bar tests pin Sable's routing byte-for-byte.
- **Commit the approved `companion` archetype** to `world/llm/prompt.ARCHETYPES` (social, `tools=[]`, BASE `look` only).
- test_bar patches retargeted to the `llm_npc` namespace (patch-where-used; the order/gratitude delays stay bartender-side).

## Tests
**97 passing** (`test_bar` + `test_llm_prompt`) in the throwaway container — the existing `TestBartenderLLMRouting` / `TestBartenderReaction` suites continue to pin Sable's routing, now through the mixin.

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)