### PR TITLE
LLM persona: neutral location line (stop bartender framing leaking)

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -228,7 +228,10 @@ def render_persona(persona: dict) -> str:
         lines.append(f"Your voice: {persona['voice']}.")
     loc = persona.get("location") or {}
     if loc.get("name"):
-        lines.append(f"You are behind the bar at {loc['name']}.")
+        # Neutral placement — what the NPC *does* here comes from its archetype
+        # duties (a bartender tends the bar; a companion works the floor), never
+        # from a hardcoded role baked into the shared persona render.
+        lines.append(f"You are at {loc['name']}.")
     menu = persona.get("menu")
     if menu:
         lines.append("Your bar serves ONLY: " + ", ".join(menu) + " (no beer, no "


### PR DESCRIPTION
## What
Vesper (Companion) was doing **bartending emotes**. `render_persona` baked `"You are behind the bar at {location}."` into the *shared* persona render, so any LLM NPC standing in a bar-room inherited a bartender's role.

Now neutral: **"You are at {location}."** What the NPC *does* there comes from its **archetype duties** — the bartender's duties already say "You tend this bar for a living"; the companion's say intimacy is her craft. The menu line stays gated on `menu` presence (only bartenders have one), so Sully is unaffected.

26 prompt tests green.

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)