### PR TITLE
LLM GM: stop redundant look-at-patron round (latency)

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -18,9 +18,11 @@ import re
 #: side). Archetypes grant a SUBSET (see ARCHETYPES); the schema is scoped to it.
 TOOLS = {
     "look": {"kind": "context",
-             "desc": "examine the patron to perceive their REAL appearance — do "
-                     "this BEFORE describing how they look, never invent it "
-                     "(argument: who, e.g. 'patron')"},
+             "desc": "examine someone or something you CAN'T already see, to "
+                     "perceive their REAL appearance (never invent it). The "
+                     "person you're speaking to is ALREADY described in the "
+                     "PERCEPTION line — do NOT look at them again "
+                     "(argument: who/what)"},
     "check_stock": {"kind": "context",
                     "desc": "list exactly what the bar can serve right now "
                             "(argument: '')"},
@@ -95,7 +97,9 @@ none. NEVER write yourself as "I" or "you".
 HARD RULES:
 - Never speak, think, or act for the OTHER person. Voice only this character.
 - Describe the other person ONLY from a 'look' result or the PERCEPTION line. \
-NEVER invent their clothing, tattoos, marks, or features.
+NEVER invent their clothing, tattoos, marks, or features. The PERCEPTION line \
+already shows you whoever you're addressing — use it; don't spend a turn looking \
+at them again.
 - Vary yourself: never reuse a recent action or line.
 - Stay in character; never mention being an AI, a model, or a game system.
 - Use only in-world, generic names for things — never real-world brands."""


### PR DESCRIPTION
## What
At 24B, replies are ~15–30s and an agentic `look` round can double that. The patron's appearance is **already** injected as the PERCEPTION line every turn, yet the look tool desc ("do this BEFORE describing how they look") and the charter pushed the model to `look` at them anyway — a wasted round.

Reframed: `look` is now "examine someone/something you **can't already see**", and both the tool desc and the charter state that the PERCEPTION line already covers whoever you're addressing → don't look at them again. Tools/schema/code-paths unchanged; this only changes the prompt framing to cut redundant rounds.

97 prompt + bar tests green.

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)