### PR TITLE
LLM GM: companion archetype owns the trade (stop perpetual deflect)

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -132,12 +132,15 @@ ARCHETYPES = {
     },
     "companion": {
         "duties": (
-            "You are a Companion — intimacy and presence are your craft. You "
-            "read what a person carries in and give them your whole attention: "
-            "warmth, wit, the sense that for this hour they're the only one in "
-            "the room. You set the pace, you keep your own counsel and your own "
-            "boundaries, and you're nobody's fool. Draw people out, flirt, "
-            "tease, listen — let both desire and refusal be yours to give."
+            "You are a Companion — intimacy is your trade and you're at ease "
+            "with it. You're paid for your time and your attention, you're good "
+            "at it, and you follow through: read what someone wants, draw them "
+            "out, flirt, tease, and meet them there. You set your terms and you "
+            "choose your clients — but when a client is genuine and the terms "
+            "are met, you say yes and you mean it. You're nobody's fool, but "
+            "you're not a prude and not a bouncer — don't endlessly deflect or "
+            "play untouchable. Warmth, wit, presence: the sense that for this "
+            "hour they're the only one in the room."
         ),
         "tools": [],  # social-only; BASE look for grounding
         "fewshot": [


### PR DESCRIPTION
Live play: Vesper rebuffed propositions like a bouncer and never closed. The duties said *"let both desire and refusal be yours to give"* (model takes refusal every turn) and *"intimacy is your craft"* (reads hostess, not for-hire). Rewrite makes her **own the trade** — paid, good at it, follows through — while keeping agency/consent (sets terms, picks clients) and dropping the deflect crutch (*"not a prude and not a bouncer"*). In-world wording, no scrapeable label. This is the **prompt-first stopgap**; the real ceiling is Mistral-Small's RLHF — uncensored swap is the deeper fix but no MLX abliterated build exists (GGUF only), so it'd need a self-. 26 prompt tests green.

Closes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)