### PR TITLE
LLM GM Phase 2 (slice 1): long-term memory core + prompt injection

### DIFF
--- a/world/llm/memory.py
+++ b/world/llm/memory.py
@@ -1,0 +1,103 @@
+"""Long-term NPC memory (LLM Gamemaster Phase 2) — portable core.
+
+Per-NPC semantic memory: short text records, each carrying an embedding vector
+(produced by the sidecar's embedder). Retrieval is **exact cosine top-k** at this
+scale — a handful of NPCs, hundreds–thousands of records each — so there's no ANN
+index, just a scan over the NPC's own records. Storage/IO and the embed round-trip
+live in the game layer (records are an Evennia attribute; embeddings come from the
+sidecar); this module is pure functions over record dicts + query vectors, so it's
+testable with no model and no Evennia.
+
+A record is a plain JSON/Attribute-safe dict::
+
+    {"text": str, "embedding": [float], "subject": str,
+     "created": float, "last_seen": float, "uses": int}
+
+``subject`` scopes a memory to an interlocutor (e.g. their stable uid/key); an
+empty subject is a general memory available to everyone.
+"""
+
+import math
+import time
+
+#: Recency half-life for salience (seconds) — a memory not recalled for this long
+#: is worth half as much when pruning. One week of game/real time by default.
+RECENCY_HALFLIFE = 7 * 24 * 3600.0
+
+#: Default per-subject cap; forgetting drops the least-salient beyond this.
+DEFAULT_CAP_PER_SUBJECT = 30
+
+
+def make_record(text, embedding, subject="", now=None):
+    """Build a fresh memory record (plain dict)."""
+    now = time.time() if now is None else now
+    return {
+        "text": text,
+        "embedding": list(embedding or []),
+        "subject": subject or "",
+        "created": now,
+        "last_seen": now,
+        "uses": 0,
+    }
+
+
+def _dot(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+
+def _norm(a):
+    return math.sqrt(sum(x * x for x in a)) or 1.0
+
+
+def cosine(a, b):
+    """Cosine similarity of two equal-length vectors; 0 for empty/missing."""
+    if not a or not b:
+        return 0.0
+    return _dot(a, b) / (_norm(a) * _norm(b))
+
+
+def salience(record, now=None):
+    """A record's keep-worthiness: recency decay + a small use-count bonus."""
+    now = time.time() if now is None else now
+    age = max(0.0, now - record.get("last_seen", record.get("created", now)))
+    recency = 0.5 ** (age / RECENCY_HALFLIFE)
+    return recency + 0.1 * record.get("uses", 0)
+
+
+def retrieve(query_vec, records, k=3, subject=None, now=None):
+    """Return the ``k`` records most similar to ``query_vec`` (cosine).
+
+    When ``subject`` is given, only that subject's records + general (empty-
+    subject) records are considered, so "what I recall about *this* person"
+    ranks above unrelated chatter. Records with non-positive similarity are
+    dropped. The returned records are bumped (``last_seen``/``uses``) so recall
+    feeds salience — frequently-relevant memories survive pruning.
+    """
+    now = time.time() if now is None else now
+    pool = [r for r in records
+            if subject is None or not r.get("subject") or r.get("subject") == subject]
+    scored = [(cosine(query_vec, r.get("embedding") or []), r) for r in pool]
+    scored.sort(key=lambda sr: sr[0], reverse=True)
+    hits = [r for sim, r in scored[:k] if sim > 0.0]
+    for r in hits:
+        r["last_seen"] = now
+        r["uses"] = r.get("uses", 0) + 1
+    return hits
+
+
+def prune(records, cap_per_subject=DEFAULT_CAP_PER_SUBJECT, now=None):
+    """Forgetting: keep the most-salient ``cap_per_subject`` records per subject."""
+    now = time.time() if now is None else now
+    by_subject = {}
+    for r in records:
+        by_subject.setdefault(r.get("subject", ""), []).append(r)
+    kept = []
+    for recs in by_subject.values():
+        recs.sort(key=lambda r: salience(r, now), reverse=True)
+        kept.extend(recs[:cap_per_subject])
+    return kept
+
+
+def memory_texts(records):
+    """The text lines of a record list, for prompt injection."""
+    return [r["text"] for r in records if r.get("text")]

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -275,10 +275,16 @@ def few_shot_messages(persona: dict) -> list:
 
 
 def build_messages(persona: dict, speaker: str, line: str, mode: str,
-                   perception: str = None, history: list = None) -> list:
+                   perception: str = None, history: list = None,
+                   memories: list = None) -> list:
     """Build the OpenAI ``messages``: system (charter+tools+persona) + few-shot +
     recent history + the grounded turn. The caller passes ``schema_for(persona)``
-    to the backend to constrain the output to this archetype's tools."""
+    to the backend to constrain the output to this archetype's tools.
+
+    ``memories`` (Phase 2) is a list of recalled long-term memory texts —
+    retrieved semantically for this interlocutor — injected ahead of the turn as
+    a MEMORY block so the NPC speaks from what it remembers, not a blank slate.
+    """
     arch = _archetype(persona)
     charter = CHARTER_BASE
     if arch.get("duties"):
@@ -296,12 +302,16 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
 
     speaker = speaker or "someone"
     line = line or ""
+    mem = ""
+    if memories:
+        mem = ("[MEMORY — what you recall (use it naturally, don't recite it):\n"
+               + "\n".join(f"- {m}" for m in memories if m) + "]\n\n")
     perc = f"[PERCEPTION — when you look at {speaker} you see: {perception}]\n\n" \
         if perception else ""
     if mode == "ambient":
-        turn = f'{perc}You overhear {speaker} say: "{line}"'
+        turn = f'{mem}{perc}You overhear {speaker} say: "{line}"'
     else:
-        turn = f'{perc}{speaker} says to you: "{line}"'
+        turn = f'{mem}{perc}{speaker} says to you: "{line}"'
     messages.append({"role": "user", "content": turn})
     return messages
 

--- a/world/tests/test_llm_memory.py
+++ b/world/tests/test_llm_memory.py
@@ -1,0 +1,92 @@
+"""The portable long-term-memory core (world.llm.memory) — pure, no model/Evennia.
+
+Exact cosine top-k retrieval, subject scoping, salience, and pruning.
+"""
+
+from unittest import TestCase
+
+from world.llm.memory import (
+    cosine, make_record, memory_texts, prune, retrieve, salience,
+)
+
+
+class TestCosine(TestCase):
+    def test_identical_vectors(self):
+        self.assertAlmostEqual(cosine([1, 0, 0], [1, 0, 0]), 1.0)
+
+    def test_orthogonal(self):
+        self.assertAlmostEqual(cosine([1, 0], [0, 1]), 0.0)
+
+    def test_scale_invariant(self):
+        self.assertAlmostEqual(cosine([1, 2, 3], [2, 4, 6]), 1.0)
+
+    def test_empty_is_zero(self):
+        self.assertEqual(cosine([], [1, 2]), 0.0)
+
+
+class TestRetrieve(TestCase):
+    def _recs(self):
+        return [
+            make_record("she ordered a negroni", [1, 0, 0], subject="#5", now=100),
+            make_record("he flashed a gun", [0, 1, 0], subject="#9", now=100),
+            make_record("the lounge was packed", [0, 0, 1], subject="", now=100),
+        ]
+
+    def test_top_k_by_similarity(self):
+        recs = self._recs()
+        hits = retrieve([1, 0, 0], recs, k=1)
+        self.assertEqual(hits[0]["text"], "she ordered a negroni")
+
+    def test_subject_scopes_out_other_subjects(self):
+        recs = self._recs()
+        # scoped to #5, retrieving #5's own record — #9's is never in the pool
+        hits = retrieve([1, 0, 0], recs, k=3, subject="#5")
+        texts = memory_texts(hits)
+        self.assertIn("she ordered a negroni", texts)
+        self.assertNotIn("he flashed a gun", texts)        # #9 excluded
+
+    def test_general_memories_visible_to_any_subject(self):
+        recs = self._recs()
+        hits = retrieve([0, 0, 1], recs, k=3, subject="#5")  # matches general
+        self.assertIn("the lounge was packed", memory_texts(hits))
+
+    def test_drops_nonpositive_similarity(self):
+        recs = self._recs()
+        # a query orthogonal to everything subject #5 can see → no hits
+        hits = retrieve([0, 1, 0], [recs[0]], k=3)
+        self.assertEqual(hits, [])
+
+    def test_recall_bumps_uses_and_last_seen(self):
+        recs = self._recs()
+        hit = retrieve([1, 0, 0], recs, k=1, now=500)[0]
+        self.assertEqual(hit["uses"], 1)
+        self.assertEqual(hit["last_seen"], 500)
+
+
+class TestSalienceAndPrune(TestCase):
+    def test_recency_decays(self):
+        from world.llm.memory import RECENCY_HALFLIFE
+        rec = make_record("x", [1], now=0)
+        fresh = salience(rec, now=0)
+        half = salience(rec, now=RECENCY_HALFLIFE)
+        self.assertAlmostEqual(half, fresh / 2, places=2)
+
+    def test_uses_raise_salience(self):
+        a = make_record("a", [1], now=0)
+        b = make_record("b", [1], now=0)
+        b["uses"] = 5
+        self.assertGreater(salience(b, now=0), salience(a, now=0))
+
+    def test_prune_caps_per_subject_keeping_salient(self):
+        now = 1000
+        recs = []
+        for i in range(5):
+            r = make_record(f"m{i}", [1], subject="#5", now=now - i * 10)
+            recs.append(r)
+        # also another subject, untouched by #5's cap
+        recs.append(make_record("other", [1], subject="#9", now=now))
+        kept = prune(recs, cap_per_subject=2, now=now)
+        subj5 = [r for r in kept if r["subject"] == "#5"]
+        self.assertEqual(len(subj5), 2)                 # capped
+        self.assertIn("m0", [r["text"] for r in subj5])  # freshest survives
+        self.assertEqual(len([r for r in kept if r["subject"] == "#9"]), 1)

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -65,6 +65,19 @@ class TestBuildMessages(TestCase):
     def test_render_persona_defensive(self):
         self.assertIn("the bartender", render_persona({}))
 
+    def test_memories_injected_before_turn(self):
+        msgs = build_messages(_PERSONA, "a man", "remember me?", "directed",
+                              memories=["he stiffed you on a tab last week",
+                                        "he asks too many questions"])
+        turn = msgs[-1]["content"]
+        self.assertIn("MEMORY", turn)
+        self.assertIn("stiffed you on a tab", turn)
+        self.assertIn("remember me?", turn)  # the turn still follows the block
+
+    def test_no_memories_no_block(self):
+        msgs = build_messages(_PERSONA, "a man", "hi", "directed")
+        self.assertNotIn("MEMORY", msgs[-1]["content"])
+
 
 class TestArchetype(TestCase):
     def test_empty_persona_defaults_to_bartender(self):


### PR DESCRIPTION
First slice of Phase 2 RAG memory — the portable core, fully tested, no embedder/Evennia yet.

- **`world/llm/memory.py`** — per-NPC semantic memory over plain record dicts `{text, embedding, subject, created, last_seen, uses}`. Exact cosine top-k `retrieve` (subject-scoped + general; bumps `last_seen`/`uses` on recall so what gets used survives pruning), recency+use `salience`, per-subject `prune` (forgetting). **No ANN index** — an exact scan is sub-millisecond at our scale (a handful of NPCs, hundreds–thousands of records each), per the TurboVec-is-overkill call.
- **`build_messages(..., memories=)`** — injects a MEMORY block ahead of the turn; defaults `None` → zero behaviour change.

### Next slices
2. sidecar `/v1/embeddings` endpoint + base embedder + `client.request_embedding`
3. wire retrieve/write into `LLMNpcMixin` (embed query → retrieve → inject → generate; embed + store after the turn)
4. salience tuning

40 memory + prompt tests green.

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)