### PR TITLE
NPC memory §8.1: re-key episodic memory on apparent_uid

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -132,7 +132,7 @@ class LLMNpcMixin:
         speaker_name = patron.get_display_name(self)
         perception = self._perceive(patron)
         history = self._recent_history(patron)
-        subject = self._hist_key(patron)
+        subject = self._memory_subject(patron)
         on_fail = on_fail or self._llm_silent
 
         def _go(memories):
@@ -162,6 +162,17 @@ class LLMNpcMixin:
 
     # --- long-term memory (Phase 2) --------------------------------------
 
+    def _memory_subject(self, patron):
+        """The recognition identity to scope memory by — the *perceived*
+        identity (apparent_uid), so memory rides the same spine as recognition
+        and a disguise reads as a stranger (NPC_MEMORY_AND_IDENTITY_SPEC §1).
+        Falls back to object id for pre-chargen shells with no apparent_uid."""
+        try:
+            from world.identity import get_apparent_uid
+            return get_apparent_uid(patron) or self._hist_key(patron)
+        except Exception:  # noqa: BLE001 — never break a reply over keying
+            return self._hist_key(patron)
+
     def _load_memories(self):
         """This NPC's stored memory records as plain dicts (deserialized)."""
         return deserialize(self.db.llm_memories) or []
@@ -175,7 +186,7 @@ class LLMNpcMixin:
         text = f'{speaker_name} said: "{line}"'
         if speech:
             text += f' — I answered: "{speech}"'
-        subject = self._hist_key(patron)
+        subject = self._memory_subject(patron)
 
         def _save(vec):
             recs = self._load_memories()

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -18,7 +18,7 @@ def _bind(b, name):
 class TestStoreMemory(TestCase):
     def test_embeds_then_saves_record(self):
         b = MagicMock()
-        b._hist_key = lambda p: f"#{p.id}"
+        b._memory_subject = lambda p: f"#{p.id}"
         b._load_memories = lambda: []
         b._llm_silent = lambda: None
         _bind(b, "_store_memory")
@@ -50,7 +50,7 @@ class TestRecall(TestCase):
         b.db.llm_driven = True
         b.location = "room"
         b.ndb.last_llm = 0
-        b._hist_key = lambda p: f"#{p.id}"
+        b._memory_subject = lambda p: f"#{p.id}"
         b._load_memories = lambda: memories
         b._perceive = lambda p: None
         b._recent_history = lambda p: []


### PR DESCRIPTION
First §8 slice of `NPC_MEMORY_AND_IDENTITY_SPEC`. Episodic memory now keys on the **perceived** identity (`apparent_uid`) rather than object id, so it rides the same spine as recognition — slip on a mask and the bartender doesn't connect you to last week's tab. `_memory_subject(patron) = get_apparent_uid(patron)` (fallback to object id for pre-chargen shells); used by both recall and write. Short-term ndb history stays object-keyed (ephemeral). 75 tests green.

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)