### PR TITLE
NPC memory §8.2: the remember tool — NPCs coin & learn names

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -449,10 +449,12 @@ class Bartender(LLMNpcMixin, Character):
         return super()._run_context_tool(tool, arg, patron)
 
     def _handle_action_tool(self, tool, arg, patron):
-        """Route the ``prepare_drink`` action tool to the real ``prepare``
-        command — the bar makes the drink for real (never a faked pour)."""
+        """Route ``prepare_drink`` to the real ``prepare`` command (the bar makes
+        the drink for real); delegate the rest (e.g. ``remember``) to the mixin."""
         if tool == "prepare_drink" and arg and self.location:
             self.execute_cmd(f"prepare {arg}")
+            return
+        LLMNpcMixin._handle_action_tool(self, tool, arg, patron)
 
     def _llm_fallback(self):
         """Sidecar failed on an addressed non-order: the curt scripted line."""

--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -274,9 +274,27 @@ class LLMNpcMixin:
         return ""
 
     def _handle_action_tool(self, tool, arg, patron):
-        """Hook: route an action tool to a real command. Base NPC has no
-        action tools (social archetypes are read-only)."""
-        return None
+        """Route an action tool to a real command. ``remember`` is universal
+        (every NPC can name people); subclasses extend then call super."""
+        if tool == "remember" and arg and patron and self.location:
+            self._remember_person(patron, arg)
+
+    def _remember_person(self, patron, name):
+        """Privately name/nickname the interlocutor via the REAL ``remember``
+        command (NPC_MEMORY_AND_IDENTITY_SPEC §4) — keyed on their apparent_uid
+        in this NPC's recognition memory. Skips a no-op re-name so the LLM can't
+        churn the same nickname every turn."""
+        name = " ".join(str(name).split())[:40]
+        if not name or " as " in name.lower():
+            return
+        try:
+            from world.identity import get_assigned_name
+            if get_assigned_name(self, patron) == name:
+                return  # already known by this name
+            target = patron.get_display_name(self)
+            self.execute_cmd(f"remember {target} as {name}")
+        except Exception:  # noqa: BLE001 — naming is best-effort
+            pass
 
     def _remember_turn(self, patron, line, speaker_name, speech, action):
         """Append the rendered turn to short-term memory (anti-repetition)."""

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -23,6 +23,13 @@ TOOLS = {
                      "person you're speaking to is ALREADY described in the "
                      "PERCEPTION line — do NOT look at them again "
                      "(argument: who/what)"},
+    "remember": {"kind": "action",
+                 "desc": "remember the person you're speaking to by a name — one "
+                         "they gave you, OR a nickname you privately coin from "
+                         "what you know about them (e.g. 'the foot guy', 'tab "
+                         "dodger'). Private to you; from then on you know them by "
+                         "it. Do it when someone's worth tagging, not every turn "
+                         "(argument: the name)"},
     "check_stock": {"kind": "context",
                     "desc": "list exactly what the bar can serve right now "
                             "(argument: '')"},
@@ -32,9 +39,10 @@ TOOLS = {
                               "narrate pouring yourself (argument: the drink name)"},
 }
 
-#: Every NPC perceives — ``look`` is granted to every archetype on top of its job
-#: tools, so grounding is never accidentally withheld.
-BASE_TOOLS = ("look",)
+#: Granted to every archetype on top of its job tools: ``look`` (grounding is
+#: never accidentally withheld) and ``remember`` (any NPC can privately name/
+#: nickname people — NPC_MEMORY_AND_IDENTITY_SPEC §4).
+BASE_TOOLS = ("look", "remember")
 
 #: Read-only tools that loop their result back (vs. action tools → real commands).
 #: Derived from the registry so adding a tool can't desync the game-side router.

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -44,6 +44,38 @@ class TestStoreMemory(TestCase):
         re.assert_not_called()
 
 
+class TestRememberTool(TestCase):
+    def _npc(self):
+        b = MagicMock()
+        b.location = "room"
+        _bind(b, "_handle_action_tool")
+        _bind(b, "_remember_person")
+        return b
+
+    def test_remember_routes_to_real_command(self):
+        b = self._npc()
+        patron = MagicMock()
+        patron.get_display_name = lambda looker=None, **k: "a gaunt drifter"
+        with patch("world.identity.get_assigned_name", return_value=None):
+            b._handle_action_tool("remember", "the cagey one", patron)
+        b.execute_cmd.assert_called_once_with(
+            "remember a gaunt drifter as the cagey one")
+
+    def test_skips_when_already_named(self):
+        b = self._npc()
+        patron = MagicMock()
+        patron.get_display_name = lambda looker=None, **k: "the cagey one"
+        with patch("world.identity.get_assigned_name",
+                   return_value="the cagey one"):
+            b._handle_action_tool("remember", "the cagey one", patron)
+        b.execute_cmd.assert_not_called()      # no churn re-naming
+
+    def test_base_mixin_ignores_drink_tool(self):
+        b = self._npc()
+        b._handle_action_tool("prepare_drink", "Negroni", MagicMock())
+        b.execute_cmd.assert_not_called()       # drinks are the bartender's job
+
+
 class TestRecall(TestCase):
     def _npc(self, memories):
         b = MagicMock()

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -142,12 +142,13 @@ class TestToolScoping(TestCase):
 
     def test_bartender_grants_its_job_tools_plus_base(self):
         names = tool_names(_PERSONA)  # bartender archetype
-        self.assertEqual(names, ["look", "check_stock", "prepare_drink"])
+        self.assertEqual(names, ["look", "remember", "check_stock", "prepare_drink"])
 
     def test_schema_scoped_to_archetype(self):
-        # the social archetype's schema can't even express prepare_drink.
+        # the social archetype gets the base tools (look + remember) but never
+        # a bartender's prepare_drink.
         enum = schema_for(self.social)["properties"]["tool"]["enum"]
-        self.assertEqual(enum, ["none", "look"])
+        self.assertEqual(enum, ["none", "look", "remember"])
         self.assertNotIn("prepare_drink", enum)
 
     def test_turn_schema_builder(self):
@@ -220,4 +221,5 @@ class TestParseTurn(TestCase):
 
     def test_schema_tool_enum(self):
         self.assertEqual(TURN_SCHEMA["properties"]["tool"]["enum"],
-                         ["none", "look", "check_stock", "prepare_drink"])
+                         ["none", "look", "remember", "check_stock",
+                          "prepare_drink"])


### PR DESCRIPTION
Second §8 slice of `NPC_MEMORY_AND_IDENTITY_SPEC`. A universal **`remember`** action tool (in `BASE_TOOLS`, so every archetype gets it) lets an NPC privately name whoever it's talking to — a name they *gave*, or a nickname it **spontaneously coins** ("the foot guy", "tab dodger").

- Routes to the **real `remember <target> as <name>` command** (validated, keyed on `apparent_uid` in the NPC's `recognition_memory`) via `_remember_person` — targets by perceived display name (verified live that an NPC resolves it), and **skips a no-op re-name** so the model can't churn the same nickname every turn.
- Bartender delegates non-drink action tools to the mixin.
- **Private per NPC** (recognition_memory is per-observer): same person, three NPCs, three labels — and from then on each NPC's poses/speech *and memories* use its own name for them.

106 tests green.

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)