### PR TITLE
NPC memory §8.3: aliases memory + relationship (WHO) block

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -133,11 +133,13 @@ class LLMNpcMixin:
         perception = self._perceive(patron)
         history = self._recent_history(patron)
         subject = self._memory_subject(patron)
+        relationship = self._relationship_line(subject, patron)
         on_fail = on_fail or self._llm_silent
 
         def _go(memories):
             messages = build_messages(persona, speaker_name, line or "", mode,
-                                      perception, history, memories=memories)
+                                      perception, history, memories=memories,
+                                      relationship=relationship)
             self._agentic_round(messages, persona, patron, line or "",
                                 speaker_name, on_fail, rounds=0)
 
@@ -176,6 +178,42 @@ class LLMNpcMixin:
     def _load_memories(self):
         """This NPC's stored memory records as plain dicts (deserialized)."""
         return deserialize(self.db.llm_memories) or []
+
+    # --- per-identity dossier: aliases + affective read (§8.3) ------------
+
+    def _dossiers(self):
+        """Per-identity dossiers (apparent_uid -> {aliases, valence}). Plain,
+        deserialized, GM-readable (NPC_MEMORY_AND_IDENTITY_SPEC §2/§3)."""
+        return deserialize(self.db.llm_dossiers) or {}
+
+    def _relationship_line(self, subject, patron):
+        """A one-line WHO summary for the prompt — the names this NPC knows the
+        person by + its read on them. ``None`` for a clean stranger."""
+        d = self._dossiers().get(subject) or {}
+        aliases = [a for a in (d.get("aliases") or []) if a]
+        valence = d.get("valence") or "neutral"
+        if not aliases and valence == "neutral":
+            return None
+        parts = []
+        if len(aliases) == 1:
+            parts.append(f"you know them as '{aliases[0]}'")
+        elif aliases:
+            parts.append("you've known them as "
+                         + ", ".join(f"'{a}'" for a in aliases))
+        if valence != "neutral":
+            parts.append(f"your read on them: {valence}")
+        return ("; ".join(parts) + ".") if parts else None
+
+    def _note_alias(self, subject, name):
+        """Record a name in this person's alias history (capped, deduped)."""
+        d = self._dossiers()
+        entry = dict(d.get(subject) or {"aliases": [], "valence": "neutral"})
+        aliases = [a for a in (entry.get("aliases") or []) if a]
+        if name not in aliases:
+            aliases.append(name)
+        entry["aliases"] = aliases[-8:]
+        d[subject] = entry
+        self.db.llm_dossiers = d
 
     def _store_memory(self, patron, speaker_name, line, speech):
         """Remember this exchange: embed it off-reactor, then write a record
@@ -293,6 +331,7 @@ class LLMNpcMixin:
                 return  # already known by this name
             target = patron.get_display_name(self)
             self.execute_cmd(f"remember {target} as {name}")
+            self._note_alias(self._memory_subject(patron), name)
         except Exception:  # noqa: BLE001 — naming is best-effort
             pass
 

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -284,7 +284,7 @@ def few_shot_messages(persona: dict) -> list:
 
 def build_messages(persona: dict, speaker: str, line: str, mode: str,
                    perception: str = None, history: list = None,
-                   memories: list = None) -> list:
+                   memories: list = None, relationship: str = None) -> list:
     """Build the OpenAI ``messages``: system (charter+tools+persona) + few-shot +
     recent history + the grounded turn. The caller passes ``schema_for(persona)``
     to the backend to constrain the output to this archetype's tools.
@@ -292,6 +292,8 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
     ``memories`` (Phase 2) is a list of recalled long-term memory texts —
     retrieved semantically for this interlocutor — injected ahead of the turn as
     a MEMORY block so the NPC speaks from what it remembers, not a blank slate.
+    ``relationship`` (§8.3) is a one-line WHO summary — names known + the NPC's
+    read — injected just before it.
     """
     arch = _archetype(persona)
     charter = CHARTER_BASE
@@ -310,10 +312,12 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
 
     speaker = speaker or "someone"
     line = line or ""
+    who = f"[WHO — {relationship}]\n\n" if relationship else ""
     mem = ""
     if memories:
         mem = ("[MEMORY — what you recall (use it naturally, don't recite it):\n"
                + "\n".join(f"- {m}" for m in memories if m) + "]\n\n")
+    mem = who + mem
     perc = f"[PERCEPTION — when you look at {speaker} you see: {perception}]\n\n" \
         if perception else ""
     if mode == "ambient":

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -44,6 +44,34 @@ class TestStoreMemory(TestCase):
         re.assert_not_called()
 
 
+class TestDossier(TestCase):
+    def _npc(self, dossiers):
+        b = MagicMock()
+        b.db.llm_dossiers = dossiers
+        for m in ("_dossiers", "_relationship_line", "_note_alias"):
+            _bind(b, m)
+        return b
+
+    def test_relationship_line_none_for_stranger(self):
+        self.assertIsNone(self._npc({})._relationship_line("#5", MagicMock()))
+
+    def test_relationship_line_with_aliases_and_valence(self):
+        b = self._npc({"#5": {"aliases": ["the foot guy", "Bob"],
+                              "valence": "wary"}})
+        line = b._relationship_line("#5", MagicMock())
+        self.assertIn("the foot guy", line)
+        self.assertIn("Bob", line)
+        self.assertIn("wary", line)
+
+    def test_note_alias_appends_dedups_and_persists(self):
+        b = self._npc({})
+        b._note_alias("#5", "the foot guy")
+        b._note_alias("#5", "the foot guy")   # dup ignored
+        b._note_alias("#5", "Bob")
+        self.assertEqual(b.db.llm_dossiers["#5"]["aliases"],
+                         ["the foot guy", "Bob"])
+
+
 class TestRememberTool(TestCase):
     def _npc(self):
         b = MagicMock()
@@ -84,6 +112,7 @@ class TestRecall(TestCase):
         b.ndb.last_llm = 0
         b._memory_subject = lambda p: f"#{p.id}"
         b._load_memories = lambda: memories
+        b._relationship_line = lambda subject, patron: None
         b._perceive = lambda p: None
         b._recent_history = lambda p: []
         b._agentic_round = MagicMock()

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -78,6 +78,17 @@ class TestBuildMessages(TestCase):
         msgs = build_messages(_PERSONA, "a man", "hi", "directed")
         self.assertNotIn("MEMORY", msgs[-1]["content"])
 
+    def test_relationship_injected_as_who_block(self):
+        msgs = build_messages(_PERSONA, "a man", "hi", "directed",
+                              relationship="you know them as 'the foot guy'.")
+        turn = msgs[-1]["content"]
+        self.assertIn("WHO", turn)
+        self.assertIn("the foot guy", turn)
+
+    def test_no_relationship_no_who_block(self):
+        msgs = build_messages(_PERSONA, "a man", "hi", "directed")
+        self.assertNotIn("WHO", msgs[-1]["content"])
+
 
 class TestArchetype(TestCase):
     def test_empty_persona_defaults_to_bartender(self):


### PR DESCRIPTION
Per-identity **dossier** (`db.llm_dossiers` keyed by apparent_uid): the **alias history** (every name the NPC has known a person by) + a **valence** read. A plain, **GM-readable** attribute *and* surfaced to the LLM.

- `_note_alias` — fed by the remember tool (§8.2), deduped + capped; so naming someone a new thing keeps the old names as history (the claim-trail).
- `_relationship_line` — a one-line **WHO** summary ("you know them as 'the foot guy'; also 'Bob'; your read on them: wary"), injected ahead of the turn via `build_messages(relationship=)`. `None` for a clean stranger.
- The `valence` field is reserved for §8.5 (behaviour-driven).

111 tests green.

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)