### PR TITLE
NPC memory §8.4: ambient action-awareness (observe, don't react)

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -38,6 +38,7 @@ LLM_AMBIENT_CHANCE = 0.35      # ...and not every eligible time
 LLM_HISTORY_TURNS = 6          # recent turns kept per interlocutor (anti-repetition)
 LLM_MAX_TOOL_ROUNDS = 3        # cap the agentic loop so it can't spin forever
 LLM_MEMORY_TOPK = 3            # long-term memories recalled into a turn (Phase 2)
+LLM_ACTION_BUFFER = 6          # room actions observed (no LLM) → next reply (§8.4)
 
 
 class LLMNpcMixin:
@@ -48,9 +49,18 @@ class LLMNpcMixin:
         """React to heard speech. Job-specific handlers get first crack; the
         LLM layer only runs when both gates (per-NPC + deployment) are on, so a
         scripted NPC is byte-identical with the LLM off."""
-        speech = kwargs.get("speech")
         speaker = from_obj
-        if not speech or speaker is None or speaker is self:
+        if speaker is None or speaker is self:
+            return True
+        # §8.4 ambient action-awareness: a pure pose/emote (an *action*, not
+        # words) is OBSERVED cheaply into a buffer — NO LLM call — and consumed
+        # on the next reply. This is what keeps the single-threaded model from
+        # saturating: poses cost nothing until they ride a turn we're making.
+        speech = kwargs.get("speech")
+        if (kwargs.get("type") == "pose" and not speech and self.db.llm_driven):
+            self._observe_action(speaker, text)
+            return True
+        if not speech:
             return True
         if self._handle_directed_speech(speech, speaker, kwargs):
             return True
@@ -134,12 +144,13 @@ class LLMNpcMixin:
         history = self._recent_history(patron)
         subject = self._memory_subject(patron)
         relationship = self._relationship_line(subject, patron)
+        events = self._drain_actions()  # what we've witnessed since last reply
         on_fail = on_fail or self._llm_silent
 
         def _go(memories):
             messages = build_messages(persona, speaker_name, line or "", mode,
                                       perception, history, memories=memories,
-                                      relationship=relationship)
+                                      relationship=relationship, events=events)
             self._agentic_round(messages, persona, patron, line or "",
                                 speaker_name, on_fail, rounds=0)
 
@@ -178,6 +189,27 @@ class LLMNpcMixin:
     def _load_memories(self):
         """This NPC's stored memory records as plain dicts (deserialized)."""
         return deserialize(self.db.llm_memories) or []
+
+    # --- ambient action-awareness (§8.4) ---------------------------------
+
+    def _observe_action(self, actor, text):
+        """Buffer a witnessed room action — reactor-side, NO LLM. Already
+        rendered from this NPC's POV (names resolved), so just keep the text."""
+        if not text:
+            return
+        from evennia.utils.ansi import strip_ansi
+        clean = " ".join(strip_ansi(text).split())[:200]
+        if not clean:
+            return
+        buf = list(self.ndb.action_buffer or [])
+        buf.append(clean)
+        self.ndb.action_buffer = buf[-LLM_ACTION_BUFFER:]
+
+    def _drain_actions(self):
+        """Recent witnessed actions, consumed (cleared) for this turn."""
+        buf = list(self.ndb.action_buffer or [])
+        self.ndb.action_buffer = []
+        return buf
 
     # --- per-identity dossier: aliases + affective read (§8.3) ------------
 

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -284,7 +284,8 @@ def few_shot_messages(persona: dict) -> list:
 
 def build_messages(persona: dict, speaker: str, line: str, mode: str,
                    perception: str = None, history: list = None,
-                   memories: list = None, relationship: str = None) -> list:
+                   memories: list = None, relationship: str = None,
+                   events: list = None) -> list:
     """Build the OpenAI ``messages``: system (charter+tools+persona) + few-shot +
     recent history + the grounded turn. The caller passes ``schema_for(persona)``
     to the backend to constrain the output to this archetype's tools.
@@ -313,11 +314,16 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
     speaker = speaker or "someone"
     line = line or ""
     who = f"[WHO — {relationship}]\n\n" if relationship else ""
+    seen = ""
+    if events:
+        seen = ("[RECENTLY — what you've just seen happen around you (it colours "
+                "how you feel, react if it warrants):\n"
+                + "\n".join(f"- {e}" for e in events if e) + "]\n\n")
     mem = ""
     if memories:
         mem = ("[MEMORY — what you recall (use it naturally, don't recite it):\n"
                + "\n".join(f"- {m}" for m in memories if m) + "]\n\n")
-    mem = who + mem
+    mem = who + seen + mem
     perc = f"[PERCEPTION — when you look at {speaker} you see: {perception}]\n\n" \
         if perception else ""
     if mode == "ambient":

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -44,6 +44,39 @@ class TestStoreMemory(TestCase):
         re.assert_not_called()
 
 
+class TestActionAwareness(TestCase):
+    def _npc(self):
+        b = MagicMock()
+        b.db.llm_driven = True
+        b.ndb.action_buffer = None
+        for m in ("at_msg_receive", "_observe_action", "_drain_actions"):
+            _bind(b, m)
+        return b
+
+    def test_pose_is_observed_not_reacted(self):
+        b = self._npc()
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as d:
+            b.at_msg_receive(text="the drifter pisses on the bar",
+                             from_obj=MagicMock(), type="pose")
+        d.assert_not_called()   # observed cheaply, NO LLM reaction
+        self.assertEqual(b.ndb.action_buffer,
+                         ["the drifter pisses on the bar"])
+
+    def test_drain_returns_and_clears(self):
+        b = self._npc()
+        b._observe_action(MagicMock(), "a does X")
+        b._observe_action(MagicMock(), "b does Y")
+        self.assertEqual(b._drain_actions(), ["a does X", "b does Y"])
+        self.assertEqual(b._drain_actions(), [])     # cleared after drain
+
+    def test_buffer_caps(self):
+        b = self._npc()
+        for i in range(llmnpc.LLM_ACTION_BUFFER + 5):
+            b._observe_action(MagicMock(), f"act {i}")
+        self.assertEqual(len(b.ndb.action_buffer), llmnpc.LLM_ACTION_BUFFER)
+
+
 class TestDossier(TestCase):
     def _npc(self, dossiers):
         b = MagicMock()
@@ -113,6 +146,7 @@ class TestRecall(TestCase):
         b._memory_subject = lambda p: f"#{p.id}"
         b._load_memories = lambda: memories
         b._relationship_line = lambda subject, patron: None
+        b._drain_actions = lambda: []
         b._perceive = lambda p: None
         b._recent_history = lambda p: []
         b._agentic_round = MagicMock()

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -89,6 +89,14 @@ class TestBuildMessages(TestCase):
         msgs = build_messages(_PERSONA, "a man", "hi", "directed")
         self.assertNotIn("WHO", msgs[-1]["content"])
 
+    def test_events_injected_as_recently_block(self):
+        msgs = build_messages(_PERSONA, "a man", "hi", "directed",
+                              events=["the drifter pissed on the bar",
+                                      "someone drew a knife"])
+        turn = msgs[-1]["content"]
+        self.assertIn("RECENTLY", turn)
+        self.assertIn("pissed on the bar", turn)
+
 
 class TestArchetype(TestCase):
     def test_empty_persona_defaults_to_bartender(self):


### PR DESCRIPTION
NPCs now perceive room **poses/emotes** (actions), not just speech — built the only way that scales.

**The poses-consumption answer: observe ≠ react.** Reacting per-pose would saturate the single-threaded 24B (~17s/call) in any busy room. Instead: a pure pose reaching `at_msg_receive` (`type='pose'`, no embedded speech) is **observed into a buffer** (`_observe_action` — reactor-side, **NO LLM call**, capped at `LLM_ACTION_BUFFER=6`) and **consumed on the NPC's next natural reply**, drained into a `[RECENTLY]` prompt block (`build_messages(events=)`).

Net impact: poses cost ~nothing until they ride a turn the NPC is already taking — a few extra context tokens, richer grounding, no extra calls, no saturation. This is the prerequisite for §8.5 behaviour-driven valence.

115 tests green.

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)