### PR TITLE
NPC memory §8.5: behaviour-driven valence (the feel tool)

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -247,6 +247,18 @@ class LLMNpcMixin:
         d[subject] = entry
         self.db.llm_dossiers = d
 
+    def _set_valence(self, subject, valence):
+        """Update the NPC's private read on a person (§8.5 behaviour-driven).
+        Surfaces in the WHO block next turn; consulted by trust/consent later."""
+        valence = " ".join(str(valence).split())[:40]
+        if not valence:
+            return
+        d = self._dossiers()
+        entry = dict(d.get(subject) or {"aliases": [], "valence": "neutral"})
+        entry["valence"] = valence
+        d[subject] = entry
+        self.db.llm_dossiers = d
+
     def _store_memory(self, patron, speaker_name, line, speech):
         """Remember this exchange: embed it off-reactor, then write a record
         (scoped to the interlocutor) and prune. Fire-and-forget — runs after the
@@ -344,10 +356,12 @@ class LLMNpcMixin:
         return ""
 
     def _handle_action_tool(self, tool, arg, patron):
-        """Route an action tool to a real command. ``remember`` is universal
-        (every NPC can name people); subclasses extend then call super."""
+        """Route an action tool to a real command. ``remember``/``feel`` are
+        universal; subclasses extend then call super."""
         if tool == "remember" and arg and patron and self.location:
             self._remember_person(patron, arg)
+        elif tool == "feel" and arg and patron:
+            self._set_valence(self._memory_subject(patron), arg)
 
     def _remember_person(self, patron, name):
         """Privately name/nickname the interlocutor via the REAL ``remember``

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -30,6 +30,12 @@ TOOLS = {
                          "dodger'). Private to you; from then on you know them by "
                          "it. Do it when someone's worth tagging, not every turn "
                          "(argument: the name)"},
+    "feel": {"kind": "action",
+             "desc": "update your private read on the person you're speaking to, "
+                     "based on what they've done and said (e.g. 'wary', 'fond', "
+                     "'fed up', 'amused', 'owes me one'). It colours how you treat "
+                     "them from now on — set it when their behaviour shifts how "
+                     "you feel, not every turn (argument: a short word/phrase)"},
     "check_stock": {"kind": "context",
                     "desc": "list exactly what the bar can serve right now "
                             "(argument: '')"},
@@ -39,10 +45,10 @@ TOOLS = {
                               "narrate pouring yourself (argument: the drink name)"},
 }
 
-#: Granted to every archetype on top of its job tools: ``look`` (grounding is
-#: never accidentally withheld) and ``remember`` (any NPC can privately name/
-#: nickname people — NPC_MEMORY_AND_IDENTITY_SPEC §4).
-BASE_TOOLS = ("look", "remember")
+#: Granted to every archetype on top of its job tools: ``look`` (grounding),
+#: ``remember`` (privately name/nickname people, §4) and ``feel`` (update the
+#: private affective read on a person, §3) — NPC_MEMORY_AND_IDENTITY_SPEC.
+BASE_TOOLS = ("look", "remember", "feel")
 
 #: Read-only tools that loop their result back (vs. action tools → real commands).
 #: Derived from the registry so adding a tool can't desync the game-side router.

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -81,9 +81,24 @@ class TestDossier(TestCase):
     def _npc(self, dossiers):
         b = MagicMock()
         b.db.llm_dossiers = dossiers
-        for m in ("_dossiers", "_relationship_line", "_note_alias"):
+        for m in ("_dossiers", "_relationship_line", "_note_alias",
+                  "_set_valence"):
             _bind(b, m)
         return b
+
+    def test_set_valence_persists(self):
+        b = self._npc({})
+        b._set_valence("#5", "fed up with their bullshit")
+        self.assertEqual(b.db.llm_dossiers["#5"]["valence"],
+                         "fed up with their bullshit")
+
+    def test_valence_surfaces_in_relationship_line(self):
+        b = self._npc({})
+        b._set_valence("#5", "wary")
+        # re-read what _set_valence wrote
+        b.db.llm_dossiers = b.db.llm_dossiers
+        line = b._relationship_line("#5", MagicMock())
+        self.assertIn("wary", line)
 
     def test_relationship_line_none_for_stranger(self):
         self.assertIsNone(self._npc({})._relationship_line("#5", MagicMock()))
@@ -135,6 +150,13 @@ class TestRememberTool(TestCase):
         b = self._npc()
         b._handle_action_tool("prepare_drink", "Negroni", MagicMock())
         b.execute_cmd.assert_not_called()       # drinks are the bartender's job
+
+    def test_feel_routes_to_set_valence(self):
+        b = self._npc()
+        b._memory_subject = lambda p: "#5"
+        b._set_valence = MagicMock()
+        b._handle_action_tool("feel", "wary", MagicMock())
+        b._set_valence.assert_called_once_with("#5", "wary")
 
 
 class TestRecall(TestCase):

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -161,13 +161,14 @@ class TestToolScoping(TestCase):
 
     def test_bartender_grants_its_job_tools_plus_base(self):
         names = tool_names(_PERSONA)  # bartender archetype
-        self.assertEqual(names, ["look", "remember", "check_stock", "prepare_drink"])
+        self.assertEqual(names, ["look", "remember", "feel",
+                                 "check_stock", "prepare_drink"])
 
     def test_schema_scoped_to_archetype(self):
-        # the social archetype gets the base tools (look + remember) but never
-        # a bartender's prepare_drink.
+        # the social archetype gets the base tools (look/remember/feel) but
+        # never a bartender's prepare_drink.
         enum = schema_for(self.social)["properties"]["tool"]["enum"]
-        self.assertEqual(enum, ["none", "look", "remember"])
+        self.assertEqual(enum, ["none", "look", "remember", "feel"])
         self.assertNotIn("prepare_drink", enum)
 
     def test_turn_schema_builder(self):
@@ -240,5 +241,5 @@ class TestParseTurn(TestCase):
 
     def test_schema_tool_enum(self):
         self.assertEqual(TURN_SCHEMA["properties"]["tool"]["enum"],
-                         ["none", "look", "remember", "check_stock",
+                         ["none", "look", "remember", "feel", "check_stock",
                           "prepare_drink"])


### PR DESCRIPTION
Final §8 slice — and it closes the loop.

A universal **`feel`** action tool lets the LLM update its private read on the person it's talking to, fed by the §8.4 `[RECENTLY]` events plus the conversation. `_set_valence` writes the dossier valence ("wary", "fond", "fed up", "owes me one"); it **surfaces in the `[WHO]` block next turn** (§8.3) and is the trust accumulator `TRUST_AND_CONSENT` will consult.

**The whole loop now runs:** an NPC *witnesses behaviour* (§8.4 observe) → *adjusts how it feels* (§8.5 feel) → *treats you accordingly next time* (§8.3 WHO block), all keyed on perceived identity (§8.1) with names it coins or learns (§8.2). Persona guides the weighting.

118 tests green.

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)