### PR TITLE
NPC §8.4 fix: react to poses aimed AT the NPC

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -57,8 +57,15 @@ class LLMNpcMixin:
         # on the next reply. This is what keeps the single-threaded model from
         # saturating: poses cost nothing until they ride a turn we're making.
         speech = kwargs.get("speech")
-        if (kwargs.get("type") == "pose" and not speech and self.db.llm_driven):
-            self._observe_action(speaker, text)
+        if kwargs.get("type") == "pose" and not speech:
+            if self.db.llm_driven:
+                self._observe_action(speaker, text)
+                # A wordless pose aimed AT this NPC warrants a reaction (like
+                # directed speech). Ambient poses (not aimed at us) stay
+                # observe-only, so the model never saturates on room chatter.
+                if (kwargs.get("addressed") and llm_enabled()
+                        and not self._is_npc_speaker(speaker)):
+                    delay(1.5, self._try_llm_reply, text, speaker, "action")
             return True
         if not speech:
             return True
@@ -78,12 +85,15 @@ class LLMNpcMixin:
         return False
 
     # --- classification --------------------------------------------------
+    def _is_npc_speaker(self, speaker):
+        """Loop guard: another NPC, so we never react (speech or pose) and two
+        LLM-driven NPCs can't ping-pong."""
+        return bool(getattr(speaker.db, "is_bartender_npc", False)
+                    or getattr(speaker.db, "llm_driven", False))
+
     def _classify_speech(self, speech, speaker):
         """Cheap reactor-side gate: ``directed`` | ``ambient`` | ``ignore``."""
-        # Loop guard: never react to another NPC's broadcast speech, so two
-        # LLM-driven NPCs can't ping-pong on ambient lines.
-        if (getattr(speaker.db, "is_bartender_npc", False)
-                or getattr(speaker.db, "llm_driven", False)):
+        if self._is_npc_speaker(speaker):
             return "ignore"
         if self._mentions_self(speech) or self._is_alone_with(speaker):
             return "directed"

--- a/world/emote.py
+++ b/world/emote.py
@@ -934,9 +934,12 @@ def render_dot_pose(
         rendered = render_for_observer(tokens, actor, observer)
         # An embedded quote rides the shared speech rails: hearing listeners get
         # the words, and a listener the pose points at counts as addressed.
-        payload = speech_payload(
-            observer, actor, words, addressed=(id(observer) in referenced)
-        )
+        addressed = id(observer) in referenced
+        payload = speech_payload(observer, actor, words, addressed=addressed)
+        # A WORDLESS pose carries no speech_payload, but a listener it's aimed at
+        # still needs to know — so an action-aware NPC can REACT to a pose
+        # directed at it (`.runs a hand up her arm`), not just silently observe.
+        payload.setdefault("addressed", addressed)
         observer.msg(text=rendered, type="pose", from_obj=actor, **payload)
 
 

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -334,6 +334,10 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
         if perception else ""
     if mode == "ambient":
         turn = f'{mem}{perc}You overhear {speaker} say: "{line}"'
+    elif mode == "action":
+        # `line` is a rendered pose aimed at this NPC (already in its POV) —
+        # react to what was DONE, not said.
+        turn = f'{mem}{perc}{line}\n\n({speaker} just did that, directed at you — react.)'
     else:
         turn = f'{mem}{perc}{speaker} says to you: "{line}"'
     messages.append({"role": "user", "content": turn})

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -529,7 +529,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
     cooldown, loop-guard, fail-safe. Orders + gratitude paths stay untouched."""
 
     _REAL = (
-        "_classify_speech", "_mentions_self", "_name_aliases",
+        "_classify_speech", "_is_npc_speaker", "_mentions_self", "_name_aliases",
         "_handle_directed_speech", "_try_llm_reply",
         "_render_llm_reply", "_llm_fallback", "_llm_silent",
     )

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -49,19 +49,39 @@ class TestActionAwareness(TestCase):
         b = MagicMock()
         b.db.llm_driven = True
         b.ndb.action_buffer = None
+        b._is_npc_speaker = lambda s: False
         for m in ("at_msg_receive", "_observe_action", "_drain_actions"):
             _bind(b, m)
         return b
 
-    def test_pose_is_observed_not_reacted(self):
+    def test_ambient_pose_is_observed_not_reacted(self):
         b = self._npc()
         with patch.object(llmnpc, "llm_enabled", return_value=True), \
                 patch.object(llmnpc, "delay") as d:
             b.at_msg_receive(text="the drifter pisses on the bar",
-                             from_obj=MagicMock(), type="pose")
+                             from_obj=MagicMock(), type="pose")  # not addressed
         d.assert_not_called()   # observed cheaply, NO LLM reaction
         self.assertEqual(b.ndb.action_buffer,
                          ["the drifter pisses on the bar"])
+
+    def test_addressed_pose_triggers_action_reaction(self):
+        b = self._npc()
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as d:
+            b.at_msg_receive(text="a lean man runs a hand up your arm",
+                             from_obj=MagicMock(), type="pose", addressed=True)
+        self.assertIn("a lean man runs a hand up your arm", b.ndb.action_buffer)
+        d.assert_called_once()                  # observed AND reacts
+        self.assertIn("action", d.call_args.args)
+
+    def test_addressed_pose_from_npc_ignored(self):
+        b = self._npc()
+        b._is_npc_speaker = lambda s: True      # another NPC posing at us
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as d:
+            b.at_msg_receive(text="the bartender nods at you",
+                             from_obj=MagicMock(), type="pose", addressed=True)
+        d.assert_not_called()                   # loop guard: observe, don't react
 
     def test_drain_returns_and_clears(self):
         b = self._npc()

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -89,6 +89,14 @@ class TestBuildMessages(TestCase):
         msgs = build_messages(_PERSONA, "a man", "hi", "directed")
         self.assertNotIn("WHO", msgs[-1]["content"])
 
+    def test_action_mode_frames_a_directed_pose(self):
+        msgs = build_messages(_PERSONA, "a lean man",
+                              "a lean man runs a hand up your arm", "action")
+        turn = msgs[-1]["content"]
+        self.assertIn("runs a hand up your arm", turn)
+        self.assertIn("directed at you", turn)
+        self.assertNotIn("says to you", turn)   # not framed as speech
+
     def test_events_injected_as_recently_block(self):
         msgs = build_messages(_PERSONA, "a man", "hi", "directed",
                               events=["the drifter pissed on the bar",


### PR DESCRIPTION
Two live-play bugs behind 'she doesn't engage with poses at her':

1. **`world/emote.py`** — a wordless pose computes `addressed=(id(observer) in referenced)` but `speech_payload` *drops it when there are no words*, so a pose aimed at someone arrived as just `{type:'pose', options}`. `setdefault('addressed', ...)` so the pointed-at listener always knows.
2. **`typeclasses/llm_npc.py`** — a wordless **addressed** pose from a non-NPC (loop-guarded via `_is_npc_speaker`) now **reacts** (`mode='action'`), like directed speech. Ambient poses stay observe-only (no saturation).
3. **`world/llm/prompt.py`** — `build_messages` `'action'` mode frames it as *react to what they DID*, not speech.

Verified live (pose reaches `at_msg_receive` as `type='pose'`, ambient pose buffers). **122 LLM + 155 emote tests green.**

**Companion out-of-repo fix (already live):** the sidecar's constrained path was **greedy-decoding** (no sampler) → identical output every turn on *every* model. Added a temperature sampler — the repetition is gone (verified: same prompt ×3 now yields 3 distinct replies). So the repeats were a sampling bug, not Cydonia.

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)