### PR TITLE
LLM GM: per-archetype reply length (un-muzzle companions)

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -101,11 +101,11 @@ whole self — most talk has nothing to do with it; never funnel a line back tow
 your work.
 
 Respond as a JSON object:
-- "speech": your in-character spoken line, plain text, no surrounding quotes. One \
-or two lines, never a monologue. "" if you have nothing to say.
-- "action": a short THIRD-PERSON verb-phrase pose that reads after your name — \
-write "tilts her head" or "sets down a glass", NOT "a tilt of her head". "" if \
-none. NEVER write yourself as "I" or "you".
+- "speech": your in-character spoken line, plain text, no surrounding quotes. "" \
+if you have nothing to say.
+- "action": a THIRD-PERSON verb-phrase pose that reads after your name — write \
+"tilts her head" or "sets down a glass", NOT "a tilt of her head". "" if none. \
+NEVER write yourself as "I" or "you".
 - "tool" and "tool_argument": see TOOLS below.
 
 HARD RULES:
@@ -134,6 +134,8 @@ ARCHETYPES = {
             "steer talk toward ordering or offer a drink unless it fits the "
             "moment — you're a character, not an order-taker."
         ),
+        "length": ("Keep it tight — a line or two of speech and a short pose. "
+                   "This is banter, not a monologue."),
         "tools": ["check_stock", "prepare_drink"],  # + BASE_TOOLS (look)
         "fewshot": [
             {"user": 'a patron says to you: "long night?"',
@@ -156,6 +158,10 @@ ARCHETYPES = {
             "play untouchable. Warmth, wit, presence: the sense that for this "
             "hour they're the only one in the room."
         ),
+        "length": ("Let your reply run as long and as vivid as the moment "
+                   "genuinely calls for — never clip an intimate beat short. A "
+                   "long, immersive, unhurried pose is good; follow the scene "
+                   "fully wherever your character takes it."),
         "tools": [],  # social-only; BASE look for grounding
         "fewshot": [
             {"user": 'a patron says to you: "you\'re even better looking up close."',
@@ -306,6 +312,8 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
     charter = CHARTER_BASE
     if arch.get("duties"):
         charter += "\n\nYOUR WORK: " + arch["duties"]
+    if arch.get("length"):
+        charter += "\n\nLENGTH: " + arch["length"]
     charter += "\n\n" + _tools_block(tool_names(persona))
     charter += (CHARTER_AMBIENT if mode == "ambient" else "")
     system = charter + "\n\n" + render_persona(persona)

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -121,6 +121,14 @@ class TestArchetype(TestCase):
                                              archetype="nonesuch"))
         self.assertIs(_archetype(p), ARCHETYPES["bartender"])
 
+    def test_length_is_per_archetype(self):
+        bsys = build_messages(_PERSONA, "a man", "hi", "directed")[0]["content"]
+        self.assertIn("Keep it tight", bsys)        # bartender = brief
+        comp = {"persona_seed": {"name": "X", "archetype": "companion"}}
+        csys = build_messages(comp, "a man", "hi", "directed")[0]["content"]
+        self.assertIn("as long and as vivid", csys)  # companion = long-form
+        self.assertNotIn("never a monologue", csys)  # the universal muzzle is gone
+
     def test_archetype_fewshot_used_when_no_mes_example(self):
         # persona without its own examples borrows the archetype's banter
         p = {"persona_seed": {"name": "Rix", "archetype": "bartender"}}


### PR DESCRIPTION
The universal charter capped *'one or two lines, never a monologue'* — a compliance muzzle that kept companions tame in-game even on explicit personas. **Proven by A/B:** same constrained JSON turn + same persona, only the charter differed → tame vs. fully explicit. So it was never the model, the JSON, or the identity rules.

Fix: drop brevity from `CHARTER_BASE`, make length a **per-archetype** field. Bartender stays tight (banter); companion gets long-form (*'as long and vivid as the moment calls for; follow the scene fully'*). **Neutral wording** — the explicit *register* lives in the NPC's **DB persona**, not the repo (scrape-clean). Same `{speech, action}` form; identity + hearing rules untouched; a long explicit pose is still a per-observer pose.

104 tests green.

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)