### PR TITLE
LLM GM: persona register (imperative tone directive, DB-sourced)

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -317,6 +317,12 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
     charter += "\n\n" + _tools_block(tool_names(persona))
     charter += (CHARTER_AMBIENT if mode == "ambient" else "")
     system = charter + "\n\n" + render_persona(persona)
+    # A persona may carry a `register` — an imperative directive placed LAST
+    # (most salient) to steer tone/explicitness. Lives in the NPC's DB persona,
+    # not the repo, so content-sensitive direction stays out of the codebase.
+    register = ((persona or {}).get("persona_seed") or {}).get("register")
+    if register:
+        system += "\n\n" + str(register)
     messages = [{"role": "system", "content": system}]
     messages += few_shot_messages(persona)
     for h in (history or []):

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -121,6 +121,12 @@ class TestArchetype(TestCase):
                                              archetype="nonesuch"))
         self.assertIs(_archetype(p), ARCHETYPES["bartender"])
 
+    def test_register_appended_last(self):
+        p = {"persona_seed": {"name": "X", "archetype": "companion",
+                              "register": "ZZ_REGISTER_ZZ"}}
+        sys = build_messages(p, "a man", "hi", "directed")[0]["content"]
+        self.assertTrue(sys.rstrip().endswith("ZZ_REGISTER_ZZ"))
+
     def test_length_is_per_archetype(self):
         bsys = build_messages(_PERSONA, "a man", "hi", "directed")[0]["content"]
         self.assertIn("Keep it tight", bsys)        # bartender = brief


### PR DESCRIPTION
In-game stayed tame even with an explicit persona because the permission was *descriptive and buried* mid-prompt; an **imperative at the end** of the system prompt wins (proven by the stripped-charter A/B). Adds a neutral `register` field on the persona seed, appended **last** (most salient) in `build_messages`. It lives in the NPC's **DB persona** — content-sensitive direction stays out of the repo. No-op when absent. 105 tests.

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)