### PR TITLE
Furniture supports @integrate

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -370,12 +370,13 @@ class Room(ObjectParent, DefaultRoom):
             integrated_objects.append((priority, obj, True))
         
         for obj in self.contents:
-            # Check objects for integration - currently supports Items, GraffitiObjects, BloodPools, and ShopContainers
-            # TODO: Consider expanding to other object types or using a more generic approach
-            if not (obj.is_typeclass("typeclasses.items.Item") or 
-                    obj.is_typeclass("typeclasses.objects.GraffitiObject") or 
+            # Check objects for integration - Items, GraffitiObjects, BloodPools,
+            # ShopContainers, and Furniture (a fixed AutoDoc/bar woven into the desc).
+            if not (obj.is_typeclass("typeclasses.items.Item") or
+                    obj.is_typeclass("typeclasses.objects.GraffitiObject") or
                     obj.is_typeclass("typeclasses.objects.BloodPool") or
-                    obj.is_typeclass("typeclasses.shopkeeper.ShopContainer")):
+                    obj.is_typeclass("typeclasses.shopkeeper.ShopContainer") or
+                    obj.is_typeclass("typeclasses.furniture.Furniture")):
                 continue
             
             # Skip if already added as flying object
@@ -616,12 +617,13 @@ class Room(ObjectParent, DefaultRoom):
             if obj.is_typeclass("typeclasses.exits.Exit"):
                 continue
             
-            # Skip @integrate items - they're handled in room description  
-            # Check Items, GraffitiObjects, BloodPools, and ShopContainers for integration
-            if ((obj.is_typeclass("typeclasses.items.Item") or 
-                 obj.is_typeclass("typeclasses.objects.GraffitiObject") or 
+            # Skip @integrate objects - they're handled in room description
+            # (Items, GraffitiObjects, BloodPools, ShopContainers, Furniture).
+            if ((obj.is_typeclass("typeclasses.items.Item") or
+                 obj.is_typeclass("typeclasses.objects.GraffitiObject") or
                  obj.is_typeclass("typeclasses.objects.BloodPool") or
-                 obj.is_typeclass("typeclasses.shopkeeper.ShopContainer")) and 
+                 obj.is_typeclass("typeclasses.shopkeeper.ShopContainer") or
+                 obj.is_typeclass("typeclasses.furniture.Furniture")) and
                 obj.db.integrate):
                 continue
             

--- a/world/tests/test_furniture.py
+++ b/world/tests/test_furniture.py
@@ -161,6 +161,21 @@ class TestAutoDocApparatus(BaseEvenniaTest):
         self.assertEqual(r["station_bonus"], 3)
 
 
+class TestFurnitureIntegration(BaseEvenniaTest):
+    """An @integrate Furniture (a fixed AutoDoc) is woven into the room desc and
+    NOT listed as a loose object."""
+
+    def test_integrated_autodoc_woven_not_listed(self):
+        room = create_object("typeclasses.rooms.Room", key="op")
+        pod = create_object(AutoDoc, key="autodoc", location=room)
+        pod.db.integrate = True
+        pod.db.integration_fallback = "An autodoc squats at the center of the room."
+        looker = _char(room)
+        self.assertNotIn("autodoc", room.get_display_things(looker))
+        self.assertIn("squats at the center",
+                      room.get_integrated_objects_content(looker))
+
+
 class TestBarSeating(BaseEvenniaTest):
     """A bar comes stocked with stools, and many can sit at once."""
 


### PR DESCRIPTION
Closes #772. Adds Furniture to the room integrate-weave + display-skip lists so a fixed AutoDoc/bench is woven into the room desc, not listed. Tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)