### PR TITLE
Bar is its own seating (sit at bar)

### DIFF
--- a/commands/CmdFurniture.py
+++ b/commands/CmdFurniture.py
@@ -11,7 +11,7 @@ import re
 from commands.command import Command
 from world.grammar import with_article
 
-from typeclasses.furniture import Furniture
+from typeclasses.furniture import Seating
 
 #: Leading prepositions a player may type ("sit DOWN ON the stool").
 _LEAD = re.compile(r"^(down\s+|back\s+)?(on|in|at|onto|into)\s+", re.I)
@@ -40,7 +40,7 @@ def _find_furniture(caller, arg, posture):
     if not loc:
         caller.msg("There's nothing here to do that on.")
         return None
-    furnis = [o for o in loc.contents if isinstance(o, Furniture)]
+    furnis = [o for o in loc.contents if isinstance(o, Seating)]
     on_what = "lie on" if posture == "lying" else "sit on"
     if arg:
         matches = caller.search(arg, candidates=furnis, quiet=True) or []

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -22,6 +22,7 @@ from evennia.utils import delay
 
 from typeclasses.items import Item
 from typeclasses.characters import Character
+from typeclasses.furniture import Seating
 from typeclasses.llm_npc import LLMNpcMixin
 from world.grammar import capitalize_first, with_article
 from world.shop.utils import format_currency
@@ -214,13 +215,16 @@ class BarCmdSet(CmdSet):
 # ---------------------------------------------------------------------------
 # The bar counter — an @integrate room fixture with a surface
 # ---------------------------------------------------------------------------
-class BarCounter(Item):
-    """An interactive bar counter — the first crafting station.
+class BarCounter(Seating, Item):
+    """An interactive bar counter — the first crafting station, and its own
+    seating (FURNITURE_AND_POSTURE).
 
     An ``Item`` (so the @integrate room display recognises it) but a fixed
     fixture: ``db.integrate`` folds it into the room description rather than the
     loose-object list, and a ``get:false()`` lock keeps it from being picked up.
-    Served drinks rest in its ``contents`` (the surface).
+    Served drinks rest in its ``contents`` (the surface). The stools are part of
+    the bar — ``sit at bar`` takes one of its ``capacity`` slots, not a loose
+    object (``Seating`` provides the occupancy API).
     """
 
     def at_object_creation(self):
@@ -236,42 +240,17 @@ class BarCounter(Item):
         self.db.integrate = True          # part of the room, not a loose object
         self.locks.add("get:false()")     # stuck — can't be pocketed
         self.cmdset.add(BarCmdSet, persistent=True)
-        # @integrate weaves the counter into the room description via
-        # db.sensory_contributions (builders author a per-bar 'visual' line, e.g.
-        # `@roomsense`-style data). Until they do, fall back to a plain generic
-        # line rather than the bare "<key> is here" the room would otherwise use.
-        # Highlight the targetable noun in cyan (house style for things you can
-        # interact with), matching the typical 'bar' key word so `look bar`
-        # reads as clickable.
+        # Seating: the stools ARE the bar — `sit at bar` fills one of these slots.
+        self.db.postures = ("sitting",)
+        self.db.capacity = BAR_STOOL_COUNT   # ten stools' worth
+        self.db.preposition = "at"
+        # @integrate weaves the counter into the room description (the stools are
+        # described as part of it, so players see them without a loose listing).
         self.db.integration_fallback = (
             "A salvaged |cbar|n runs along one side of the room, its surface "
-            "scarred by years of set-down glasses."
+            "scarred by years of set-down glasses, a row of mismatched stools "
+            "bolted along its base."
         )
-        # Seating: a bar comes with stools (FURNITURE_AND_POSTURE). Idempotent,
-        # and safe if the counter has no room yet. Existing bars are backfilled
-        # once at the DB level (`for b in BarCounter.objects.all(): b.stock_stools()`).
-        self.stock_stools()
-
-    def stock_stools(self, count=BAR_STOOL_COUNT):
-        """Spawn this bar's seating into its room — once (guarded by a flag).
-        Returns how many stools were added."""
-        if self.db.stools_spawned:
-            return 0
-        room = self.location
-        if not room:
-            return 0
-        from evennia.prototypes.spawner import spawn
-        from world.prototypes import BAR_STOOL
-        added = 0
-        for _ in range(count):
-            try:
-                stool = spawn(BAR_STOOL)[0]
-                stool.move_to(room, quiet=True, move_hooks=False)
-                added += 1
-            except Exception:  # noqa: BLE001 — never let seating break bar setup
-                break
-        self.db.stools_spawned = bool(added)
-        return added
 
     @staticmethod
     def _is_staff(char):

--- a/typeclasses/furniture.py
+++ b/typeclasses/furniture.py
@@ -14,20 +14,15 @@ object), never stored, so it can't desync when someone is moved, KO'd, or delete
 from typeclasses.objects import Object
 
 
-class Furniture(Object):
-    """Something you can sit on or lie on — a stool, a couch, a stretcher."""
+class Seating:
+    """Mixin: the occupancy/posture API for anything you can sit on or lie in —
+    a loose :class:`Furniture` object, OR a fixed fixture like a bar (the stools
+    are part of it). The owning class sets ``db.postures`` / ``db.capacity`` /
+    ``db.preposition`` in its own ``at_object_creation``; these methods only read
+    them, so an object with no postures set isn't sittable. Occupancy is derived
+    from the room — a moved/KO'd/deleted occupant never lingers."""
 
-    def at_object_creation(self):
-        super().at_object_creation()
-        self.db.postures = ("sitting",)   # postures this furniture allows
-        self.db.capacity = 1              # how many can occupy it at once
-        self.db.preposition = "on"        # "sits ON a stool" / "lies IN a pod"
-        self.locks.add("get:false()")     # furniture stays put
-
-    # --- occupancy (derived live from the room) --------------------------
     def occupants(self):
-        """Characters currently occupying this furniture (same room, pointed
-        here). Derived, so a moved/KO'd/deleted occupant never lingers."""
         loc = self.location
         if not loc:
             return []
@@ -43,6 +38,17 @@ class Furniture(Object):
 
     def primary_posture(self):
         return (self.db.postures or ("sitting",))[0]
+
+
+class Furniture(Seating, Object):
+    """A loose object you can sit on or lie on — a stool, a couch, a stretcher."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.postures = ("sitting",)   # postures this furniture allows
+        self.db.capacity = 1              # how many can occupy it at once
+        self.db.preposition = "on"        # "sits ON a stool" / "lies IN a pod"
+        self.locks.add("get:false()")     # furniture stays put
 
 
 class AutoDoc(Furniture):

--- a/world/tests/test_furniture.py
+++ b/world/tests/test_furniture.py
@@ -177,20 +177,26 @@ class TestFurnitureIntegration(BaseEvenniaTest):
 
 
 class TestBarSeating(BaseEvenniaTest):
-    """A bar comes stocked with stools, and many can sit at once."""
+    """The bar IS the seating — `sit at bar` fills one of its slots; no loose
+    stool objects clutter the room."""
 
-    def test_bar_spawns_stools(self):
+    def test_bar_is_sittable_capacity_ten(self):
         from typeclasses.bar import BarCounter, BAR_STOOL_COUNT
+        from typeclasses.furniture import Seating
         bar = create_object(BarCounter, key="bar", location=self.room1)
-        stools = [o for o in self.room1.contents if isinstance(o, Furniture)]
-        self.assertEqual(len(stools), BAR_STOOL_COUNT)
-        self.assertEqual(bar.stock_stools(), 0)        # idempotent
+        self.assertIsInstance(bar, Seating)
+        self.assertTrue(bar.allows("sitting"))
+        self.assertEqual(bar.db.capacity, BAR_STOOL_COUNT)
+        # no loose stool objects spawned into the room
+        self.assertEqual(
+            [o for o in self.room1.contents if isinstance(o, Furniture)], [])
 
-    def test_many_sit_on_distinct_stools(self):
+    def test_many_sit_at_the_bar(self):
         from typeclasses.bar import BarCounter
-        create_object(BarCounter, key="bar", location=self.room1)
+        bar = create_object(BarCounter, key="bar", location=self.room1)
         sitters = [_char(self.room1, key=f"P{i}") for i in range(3)]
         for s in sitters:
-            _run(s, CmdSit, "on stool")
-        self.assertTrue(all(s.db.furniture is not None for s in sitters))
-        self.assertEqual(len({s.db.furniture for s in sitters}), 3)  # distinct
+            _run(s, CmdSit, "at bar")
+        # all seated, all on the one fixture (the bar), filling its slots
+        self.assertTrue(all(s.db.furniture == bar for s in sitters))
+        self.assertEqual(len(bar.occupants()), 3)


### PR DESCRIPTION
Closes #776. BarCounter becomes a capacity-10 `Seating` fixture; stools described in its @integrate line instead of 10 loose objects. 103 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)