### PR TITLE
Normalize LLM NPC poses: base verbs, dotted continuations, single quote

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -487,9 +487,11 @@ class LLMNpcMixin:
         action = action.strip().lstrip(".").strip() if action else None
         if action:
             body = action
-            if speech:
+            if speech and '"' not in body:
                 # Weave the line into the pose as a quote so it reads as one beat
                 # and still rides the say/hearing rails (CmdDotPose extracts it).
+                # If the pose ALREADY carries a quote, that one rides the rails —
+                # don't append a second and double the dialogue.
                 sep = "" if body[-1] in ",.!?…" else ","
                 body = f'{body}{sep} "{speech}"'
             self.execute_cmd(f".{body}")

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -486,6 +486,58 @@ def _strip_self_lead(action: str, name: str) -> str:
     return re.sub(r"^(i|she|he|they)\s+", "", action, flags=re.I).strip()
 
 
+#: Verbs whose base form already ends in -s/-ss — never strip them to a stem.
+_S_BASE_VERBS = frozenset({
+    "focus", "kiss", "miss", "press", "pass", "toss", "cross", "dress",
+    "bless", "hiss", "fuss", "brush", "address", "caress", "undress", "gas",
+})
+#: Leading subject words that aren't verbs (strip_self_lead handles most).
+_LEAD_NON_VERBS = frozenset({"i", "she", "he", "they", "you"})
+
+_CONT_I_RE = re.compile(r"\bI\s+(?!\.)([a-zA-Z])")
+_DOTTED_VERB_RE = re.compile(r"(?<!\.)\.([a-zA-Z]+)")
+_LEAD_VERB_RE = re.compile(r"^([a-zA-Z]+)")
+
+
+def _debase_verb(word: str) -> str:
+    """Best-effort de-conjugate a third-person verb the model slipped into back
+    to the base form the dot-pose engine expects (the engine does the
+    conjugating — feeding it "leans" yields "leanses"). Participles (-ing) and
+    known base-form -s verbs pass through untouched."""
+    low = word.lower()
+    if low in _S_BASE_VERBS or low.endswith("ing") or not low.endswith("s"):
+        return word
+    if low.endswith("ies") and len(low) > 3:
+        return word[:-3] + "y"
+    if low.endswith(("shes", "ches", "sses", "xes", "zes")):
+        return word[:-2]
+    if low.endswith("oes"):
+        return word[:-2]
+    if low.endswith("ss"):
+        return word                       # base "kiss"/"press" (defensive)
+    return word[:-1]                       # leans -> lean, smiles -> smile
+
+
+def _normalize_pose(action: str) -> str:
+    """Coerce a sloppy model pose into well-formed dot-pose input so the engine's
+    conjugation and per-observer targeting work. Three slips the model repeats:
+    a continuation verb that dropped its dot ("as I take in" -> "as I .take in",
+    so it conjugates instead of rendering "she take in"); an already-conjugated
+    verb where a base form is expected ("leans" -> "lean"); and unbalanced stray
+    quotes that would mis-split the speech/pose segments."""
+    if not action:
+        return action
+    if action.count('"') % 2:                       # unbalanced -> drop them all
+        action = action.replace('"', "")
+    action = _CONT_I_RE.sub(lambda m: "I ." + m.group(1), action)
+    if not action.startswith("."):
+        m = _LEAD_VERB_RE.match(action)
+        if m and m.group(1).lower() not in _LEAD_NON_VERBS:
+            action = _debase_verb(m.group(1)) + action[m.end():]
+    action = _DOTTED_VERB_RE.sub(lambda m: "." + _debase_verb(m.group(1)), action)
+    return action.strip()
+
+
 def parse_turn(raw, persona: dict, allowed_tools=None) -> dict:
     """Normalise a constrained turn into ``{speech, action, tool, tool_argument}``.
 
@@ -518,6 +570,9 @@ def parse_turn(raw, persona: dict, allowed_tools=None) -> dict:
         # person — drop it rather than render a broken pose.
         if re.match(r"^(your|you)\b", action, flags=re.I):
             action = None
+        else:
+            # Well-form the dot-pose: dot continuation verbs, de-conjugate slips.
+            action = _normalize_pose(action)
     tool = obj.get("tool") or "none"
     tool_arg = (obj.get("tool_argument") or "").strip()
 

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -255,13 +255,16 @@ class TestParseTurn(TestCase):
                                  tool="prepare_drink", tool_argument="Negroni"),
                          _PERSONA)
         self.assertEqual(out["speech"], "Coming up.")
-        self.assertEqual(out["action"], "grabs a glass")
+        self.assertEqual(out["action"], "grab a glass")  # de-conjugated to base
         self.assertEqual(out["tool"], "prepare_drink")
         self.assertEqual(out["tool_argument"], "Negroni")
 
     def test_self_lead_stripped(self):
+        # "Sable smirks" -> strip the name, then de-conjugate "smirks" -> "smirk"
+        # so the dot-pose engine conjugates it once ("Sable smirks"), not twice
+        # ("smirkses").
         out = parse_turn(self._t(speech="hi", action="Sable smirks"), _PERSONA)
-        self.assertEqual(out["action"], "smirks")
+        self.assertEqual(out["action"], "smirk")
 
     def test_pov_leak_action_dropped(self):
         out = parse_turn(self._t(speech="hey", action="your eyes meet his"),
@@ -286,10 +289,62 @@ class TestParseTurn(TestCase):
     def test_prose_fallback(self):
         out = parse_turn('*smirks* "what now?"', _PERSONA)
         self.assertEqual(out["speech"], "what now?")
-        self.assertEqual(out["action"], "smirks")
+        self.assertEqual(out["action"], "smirk")  # de-conjugated to base
         self.assertEqual(out["tool"], "none")
 
     def test_schema_tool_enum(self):
         self.assertEqual(TURN_SCHEMA["properties"]["tool"]["enum"],
                          ["none", "look", "remember", "feel", "check_stock",
                           "prepare_drink", "diagnose", "treat", "install"])
+
+
+class TestPoseNormalization(TestCase):
+    """parse_turn well-forms a sloppy model pose into valid dot-pose input:
+    conjugated verbs back to base, undotted continuation verbs dotted, and
+    unbalanced quotes dropped — so the engine conjugates/targets correctly."""
+
+    def _action(self, action):
+        return parse_turn(json.dumps(
+            {"speech": "", "action": action, "tool": "none",
+             "tool_argument": ""}), _PERSONA)["action"]
+
+    def test_leading_conjugated_verb_debased(self):
+        # "leans" would render "leanses"; feed the base so it conjugates once.
+        self.assertEqual(self._action("leans across the bar"),
+                         "lean across the bar")
+
+    def test_sibilant_conjugation_debased(self):
+        self.assertEqual(self._action("watches the door"), "watch the door")
+        self.assertEqual(self._action("tries the lock"), "try the lock")
+
+    def test_base_s_verb_preserved(self):
+        # "kiss"/"focus" are already base forms — don't mangle to "kis"/"focu".
+        self.assertEqual(self._action("kiss the man's knuckles"),
+                         "kiss the man's knuckles")
+        self.assertEqual(self._action("focus on the glass"), "focus on the glass")
+
+    def test_undotted_continuation_verb_gets_dotted(self):
+        # "as I take in" must dot so it conjugates ("takes"), not "she take in".
+        self.assertEqual(self._action("lean back as I take in the room"),
+                         "lean back as I .take in the room")
+
+    def test_new_sentence_I_verb_gets_dotted(self):
+        # A leading "I" is dropped by _strip_self_lead (first word becomes the
+        # verb); the dotting catches a SUBSEQUENT "I .verb" restating the subject.
+        self.assertEqual(self._action("nod, then I take a slow breath"),
+                         "nod, then I .take a slow breath")
+
+    def test_already_dotted_continuation_untouched(self):
+        self.assertEqual(self._action("lean back, .sliding it over"),
+                         "lean back, .sliding it over")
+
+    def test_dotted_conjugated_verb_debased(self):
+        self.assertEqual(self._action("set it down, .slides it across"),
+                         "set it down, .slide it across")
+
+    def test_participle_preserved(self):
+        self.assertEqual(self._action("lean in, smiling slow"),
+                         "lean in, smiling slow")
+
+    def test_unbalanced_quote_dropped(self):
+        self.assertEqual(self._action('nod once"'), "nod once")


### PR DESCRIPTION
Closes #778.

LLM-driven NPCs pose through the real `.pose` command. The model reliably slips in three ways the dot-pose engine then renders badly — what the user noticed RPing with Sully ("gaps in verb usage and quotes"):

| Model writes | Old render | New |
|---|---|---|
| `Sully smirks` | `smirkses` | `smirks` |
| `lean back as I take in the room` | `...as she take in...` | `...as she takes in...` |
| action `whisper "you sure?"` + speech `you sure?` | doubled quote | single |

### Change
- **`world/llm/prompt._normalize_pose`** (run inside `parse_turn`): de-conjugate slipped third-person verbs back to base (leading verb + every dotted verb; participle and base-form-`-s` guards), dot any subsequent `I <verb>` continuation so it conjugates, drop unbalanced stray quotes.
- **`typeclasses/llm_npc._render_llm_reply`**: only weave `speech` into the pose when the pose doesn't already carry a quote.

The charter and few-shot already teach base-form verbs + dotted continuations; this enforces it on the model's slips. **Players' hand-written dot-poses and the emote engine itself are unchanged** — the normalization is LLM-output-only.

### Tests
`world.tests.test_llm_prompt.TestPoseNormalization` (9 cases) + updated existing assertions that pinned the old conjugated forms. Full run: `test_bar` + `test_llm_npc` + `test_llm_prompt` + `test_emote` = 277 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)