### PR TITLE
Filter function words from assigned-name targeting handles

### DIFF
--- a/world/emote.py
+++ b/world/emote.py
@@ -256,6 +256,18 @@ def _spans_overlap(
     return False
 
 
+#: Function words never used as standalone targeting handles. When an assigned
+#: recognition name is tokenized into single-word candidates (step 2b below), a
+#: name like "the labor guy" must NOT make a literal "the" (or "a"/"of"/…) in
+#: emote prose resolve to that character — every "the" in "sets it on the bar"
+#: would otherwise be rewritten to their name. Matching the full assigned name
+#: or its content words ("labor", "guy") still works.
+_ASSIGNED_NAME_STOPWORDS = frozenset({
+    "the", "a", "an", "of", "and", "to", "in", "on", "at", "with", "for",
+    "from", "by",
+})
+
+
 def build_char_candidates(
     actor: "Character",
     room_occupants: Sequence["Character"],
@@ -318,7 +330,8 @@ def build_char_candidates(
         if assigned:
             existing = [n for n, _rc in names]
             for token in assigned.split():
-                if token and token not in existing:
+                if (token and token.lower() not in _ASSIGNED_NAME_STOPWORDS
+                        and token not in existing):
                     names.append((token, False))
                     existing.append(token)
 

--- a/world/tests/test_emote.py
+++ b/world/tests/test_emote.py
@@ -1083,6 +1083,30 @@ class TestAssignedNameTokenTargeting(TestCase):
         names = [name for name, _char, _rc in candidates]
         self.assertEqual(names.count("Wendy"), 1)
 
+    def test_article_token_not_a_candidate(self) -> None:
+        """An assigned name like "the labor guy" must NOT make a bare article
+        a targeting handle — else every literal "the" in emote prose resolves
+        to the character ("sets it on the bar" -> "sets it on <name> bar")."""
+        self.actor.recognition_memory = {
+            apparent_uid_for(self.wendy): {"assigned_name": "the labor guy"},
+        }
+        candidates = build_char_candidates(
+            self.actor, [self.actor, self.wendy]
+        )
+        names = [name for name, _char, _rc in candidates]
+        self.assertNotIn("the", names)
+        self.assertIn("labor", names)   # content words still target
+        self.assertIn("guy", names)
+
+    def test_article_in_assigned_name_not_resolved_in_prose(self) -> None:
+        """End-to-end: a literal "the" in a pose does not resolve to the
+        remembered character whose assigned name begins with "the"."""
+        self.actor.recognition_memory = {
+            apparent_uid_for(self.wendy): {"assigned_name": "the labor guy"},
+        }
+        refs = self._resolve("set a glass down on the counter.")
+        self.assertEqual(refs, [])
+
     def test_sdesc_word_does_not_overmatch(self) -> None:
         """Assigned-name tokenizing must not affect sdesc word matching.
 


### PR DESCRIPTION
Closes #780.

When Sully remembered a patron under the assigned name **"the labor guy"**, every literal "the" in her emotes resolved to that patron (per-observer):

> draws a scalding measure straight from **Laszlo XLIV** battered caf urn, and sets a mug of black recyc on **Laszlo XLIV** hull-slab bar.

`build_char_candidates` step 2b tokenizes an assigned recognition name into single-word handles (so "Wendy" targets "Whimsical Wendy") but didn't filter function words — so "the labor guy" emitted a bare `"the"` candidate, and the char-ref matcher rewrites every `"the"` in that actor's emote prose to the character.

**Fix:** skip a small stopword set (articles + common prepositions/conjunctions) when tokenizing. The full assigned name and its content words ("labor", "guy") still target. This is the shared emote engine, so it fixes the bug for **all players**, not just LLM NPCs.

Tests: `test_emote.TestAssignedNameTokenTargeting` — `test_article_token_not_a_candidate` + `test_article_in_assigned_name_not_resolved_in_prose`. 128 emote tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)