### PR TITLE
Teach LLM pose format via charter; add npc_console player-loop harness

### DIFF
--- a/world/llm/npc_console.py
+++ b/world/llm/npc_console.py
@@ -1,0 +1,267 @@
+"""NPC console — drive an LLM NPC through the REAL player pipeline, no human.
+
+A standing problem testing LLM NPCs: the only way to see what a *player* sees
+was to BE the player — type at the live game and read the result. This harness
+removes the human from the loop. It stands up an ephemeral scene (a room, a real
+LLM NPC of the chosen archetype, and a puppet PC with a real identity), then for
+each scripted line it makes the puppet **actually `say`** it through the real
+command pipeline — so the NPC's `at_msg_receive` → classify → persona build →
+sidecar → `parse_turn` → `_render_llm_reply` → `.pose` all run exactly as in
+game — and prints what the puppet PC *receives back*. That is the player
+experience, reproduced.
+
+The reactor is not running here, so the two async seams are run INLINE:
+`run_async` (the sidecar call) executes in-thread and fires its callback at once,
+and `delay(...)` runs immediately. Everything else is the untouched game code.
+
+This is an OBSERVATION tool (the model is non-deterministic) — it shows real
+rendered output to eyeball format/targeting/voice after a prompt or render
+change. The deterministic assertions live in world/tests/. Not imported by the
+game.
+
+Run (throwaway container, reaches the host sidecar via host.docker.internal):
+
+    docker run --rm --entrypoint bash -v "$PWD":/usr/src/game -w /usr/src/game \
+      evennia/evennia:latest -lc 'evennia migrate --settings settings.py \
+      >/tmp/m.log 2>&1; PYTHONPATH=/usr/src/game LLM_GM_MODEL=cydonia-24b-v3.1 \
+      python world/llm/npc_console.py --archetype bartender --raw \
+      --say "rough night?" --say "what do you recommend I drink?"'
+
+    # interactive: drop --say and pass --repl, then type lines (Ctrl-D to end).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+
+# --------------------------------------------------------------------------
+# Bootstrap (mirrors live_probe): app registry, then evennia internals.
+# --------------------------------------------------------------------------
+def bootstrap():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+    import django
+    django.setup()
+    import evennia
+    evennia._init()
+
+
+# --------------------------------------------------------------------------
+# Collapse the two async seams so the whole pipeline completes in-call.
+# --------------------------------------------------------------------------
+def make_synchronous():
+    """Patch `run_async` (sidecar call) and `delay` (scheduling) to run inline,
+    so a single `say` drives the NPC's reply to completion before we return."""
+    from twisted.python.failure import Failure
+
+    def inline_run_async(func, at_return=None, at_err=None, **kwargs):
+        try:
+            result = func()
+        except Exception:  # noqa: BLE001 — mirror the reactor's at_err path
+            if at_err:
+                at_err(Failure())
+            return
+        if at_return:
+            at_return(result)
+
+    def inline_delay(_seconds, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    import world.llm.client as client
+    import typeclasses.llm_npc as llm_npc
+    import typeclasses.bar as bar
+    client.run_async = inline_run_async
+    llm_npc.delay = inline_delay
+    bar.delay = inline_delay
+
+
+def enable_llm(model, url, timeout):
+    """Flip the deployment gate on and point at the sidecar for this process."""
+    from django.conf import settings
+    settings.LLM_GM_ENABLED = True
+    # A bare `migrate` db has no Limbo (#2); without this create_object fails
+    # looking up the (nonexistent) DEFAULT_HOME. Ephemeral scene needs no home.
+    settings.DEFAULT_HOME = None
+    if url:
+        settings.LLM_GM_URL = url
+    if model:
+        settings.LLM_GM_MODEL = model
+    if timeout:
+        settings.LLM_GM_TIMEOUT = timeout
+
+
+# --------------------------------------------------------------------------
+# Surface what the MODEL produced vs what got RENDERED (the debugging view).
+# --------------------------------------------------------------------------
+_LAST = {}
+
+
+def trace_parse():
+    """Wrap parse_turn so each turn records the raw model reply and the parsed
+    (normalized) speech/action — the before/after that explains a render."""
+    import typeclasses.llm_npc as llm_npc
+    real = llm_npc.parse_turn
+
+    def traced(raw, persona, allowed=None):
+        result = real(raw, persona, allowed)
+        _LAST["raw"] = raw
+        _LAST["parsed"] = dict(result)
+        return result
+
+    llm_npc.parse_turn = traced
+
+
+# --------------------------------------------------------------------------
+# Scene: a room, an LLM NPC of the archetype, a puppet PC that captures msgs.
+# --------------------------------------------------------------------------
+DEFAULT_PERSONAS = {
+    "bartender": {
+        "archetype": "bartender",
+        "name": "Sully",
+        "manner": "dry, watchful, unhurried; talks like every word costs a token",
+        "wants": "a quiet shift and no broken glass",
+        "boundaries": "won't be pushed around; cuts off anyone spoiling for trouble",
+    },
+    "doctor": {
+        "archetype": "doctor",
+        "name": "Nikolai Kasparov",
+        "manner": "colony-blunt, gallows-dry, economical",
+        "wants": "to patch who's in front of him and move on",
+        "boundaries": "no promises the body won't keep",
+    },
+    "companion": {
+        "archetype": "companion",
+        "name": "Vesper",
+        "manner": "warm, unhurried, frankly attentive",
+        "wants": "to make the hour feel like it's only the two of you",
+        "boundaries": "sets her own terms; nobody's fool",
+    },
+}
+
+# Which NPC typeclass hosts each archetype.
+ARCHETYPE_TYPECLASS = {
+    "bartender": "typeclasses.bar.Bartender",
+    "doctor": "typeclasses.clinic.Doctor",
+    "companion": "typeclasses.llm_npc.LLMNpc",
+}
+
+
+def build_scene(archetype, persona_seed, with_bar=True):
+    from evennia import create_object
+
+    transcript = []
+
+    room = create_object("typeclasses.rooms.Room", key="probe room")
+    typeclass = ARCHETYPE_TYPECLASS.get(archetype, "typeclasses.llm_npc.LLMNpc")
+    npc = create_object(typeclass, key=persona_seed["name"], location=room)
+    npc.db.llm_driven = True
+    npc.db.llm_persona = persona_seed
+    # Give the NPC a real presentation so it renders as a person, not its key.
+    npc.height, npc.build, npc.sex = "tall", "lean", "male"
+    if archetype == "bartender" and with_bar:
+        bar = create_object("typeclasses.bar.BarCounter",
+                            key="the hull-slab bar", location=room)
+        bar.db.menu = [
+            {"name": "rotgut", "price": 0, "craft": "fixes a rotgut"},
+            {"name": "black recyc", "price": 0, "craft": "pours a black recyc"},
+        ]
+
+    puppet = create_object("typeclasses.characters.Character",
+                           key="Laszlo", location=room)
+    puppet.height, puppet.build, puppet.sex = "above-average", "stocky", "male"
+    puppet.sdesc_keyword = "droog"
+
+    # Capture everything the PUPPET receives — that is the player's screen.
+    def capture(*args, **kwargs):
+        text = kwargs.get("text", args[0] if args else "")
+        if isinstance(text, (tuple, list)):
+            text = text[0]
+        if text:
+            transcript.append(str(text))
+
+    puppet.msg = capture
+    return room, npc, puppet, transcript
+
+
+# --------------------------------------------------------------------------
+# One exchange: the puppet really `say`s the line; we print what comes back.
+# --------------------------------------------------------------------------
+def exchange(npc, puppet, line, show_raw):
+    print(f"\n\033[1m> say {line}\033[0m")
+    npc.ndb.last_llm = 0          # clear the directed cooldown between lines
+    _LAST.clear()
+    puppet.execute_cmd(f"say {line}")
+    if show_raw and _LAST:
+        raw = _LAST.get("raw")
+        parsed = _LAST.get("parsed", {})
+        print(f"  \033[2mmodel.raw   : {raw!r}\033[0m")
+        print(f"  \033[2mnormalized  : speech={parsed.get('speech')!r} "
+              f"action={parsed.get('action')!r}\033[0m")
+
+
+def drain(transcript):
+    for line in transcript:
+        print(f"  {line}")
+    transcript.clear()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--archetype", default="bartender",
+                    choices=sorted(ARCHETYPE_TYPECLASS))
+    ap.add_argument("--persona", help="JSON persona-seed override")
+    ap.add_argument("--say", action="append", default=[],
+                    help="a player line (repeatable)")
+    ap.add_argument("--repeat", type=int, default=1,
+                    help="run each --say line N times (surface intermittent slips)")
+    ap.add_argument("--repl", action="store_true",
+                    help="interactive: read lines from stdin")
+    ap.add_argument("--raw", action="store_true",
+                    help="also show the raw model reply + normalized action")
+    ap.add_argument("--model", default=os.environ.get("LLM_GM_MODEL", ""))
+    ap.add_argument("--url", default=os.environ.get("LLM_GM_URL", ""))
+    ap.add_argument("--timeout", type=int, default=0)
+    args = ap.parse_args()
+
+    bootstrap()
+    make_synchronous()
+    trace_parse()
+    enable_llm(args.model, args.url, args.timeout)
+
+    seed = dict(DEFAULT_PERSONAS.get(args.archetype, DEFAULT_PERSONAS["bartender"]))
+    if args.persona:
+        seed.update(json.loads(args.persona))
+    seed.setdefault("archetype", args.archetype)
+
+    room, npc, puppet, transcript = build_scene(args.archetype, seed)
+    print(f"scene: {npc.key} ({args.archetype}) and {puppet.key} in {room.key}")
+
+    try:
+        for line in args.say:
+            for _ in range(max(1, args.repeat)):
+                exchange(npc, puppet, line, args.raw)
+                drain(transcript)
+        if args.repl or not args.say:
+            print("\n[repl] type a line (Ctrl-D to quit):")
+            for raw in sys.stdin:
+                line = raw.strip()
+                if not line:
+                    continue
+                exchange(npc, puppet, line, args.raw)
+                drain(transcript)
+    finally:
+        # Ephemeral scene — leave no objects behind (matters if ever run on a
+        # real db; harmless in the throwaway).
+        for obj in (puppet, npc, room):
+            try:
+                obj.delete()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -119,15 +119,18 @@ your work.
 Respond as a JSON object:
 - "speech": your in-character spoken line, plain text, no surrounding quotes. "" \
 if you have nothing to say.
-- "action": a FIRST-PERSON pose, written for the game's pose command. Start with \
-your main verb in plain BASE form (the game conjugates it) and refer to yourself \
-with "I"/"my"/"me" — e.g. "tilt my head" or "set a glass down". Every verb after \
-the first takes a leading dot: in the same breath just ".verb" ("set a glass \
-down, .sliding it across"); for a NEW sentence or fresh beat, restate yourself as \
-"I .verb" ("set a glass down. I .let my eyes linger"). To act ON someone, name \
-them by the exact description in PERCEPTION/PRESENT — "nod at the lean man" — \
-never a real name. The game renders your pose for each onlooker as they know \
-everyone in it. "" if none.
+- "action": a FIRST-PERSON pose, written for the game's pose command. Refer to \
+yourself with "I"/"my"/"me" and write EVERY verb in its plain BASE form — the \
+game conjugates for you. Write "lean", "wipe", "set", "try" — NEVER the -s form \
+"leans"/"wipes"/"sets"/"tries" (the game adds the -s; if you add it too it comes \
+out "leanses"). Your FIRST verb opens the pose bare ("tilt my head", "set a glass \
+down"). EVERY later verb takes a leading dot — same breath just ".verb" ("set a \
+glass down, .slide it across"), and after "and"/"as"/"while"/"then" or a new \
+sentence restate yourself as "I .verb" ("wipe the bar. I .lean in", "nod once, as \
+I .take him in"). A later verb with no dot renders broken ("she take in"), so dot \
+them all. To act ON someone, name them by the exact description in \
+PERCEPTION/PRESENT — "nod at the lean man" — never a real name. The game renders \
+your pose for each onlooker as they know everyone in it. "" if none.
 - "tool" and "tool_argument": see TOOLS below.
 
 HARD RULES:
@@ -155,12 +158,14 @@ them in character without flinching, lecturing, or refusing.
 Respond as a JSON object:
 - "speech": her in-character spoken line(s), plain text, no surrounding quotes. \
 "" if she has nothing to say.
-- "action": a FIRST-PERSON pose, written for the game's pose command. Start with \
-your main verb in plain BASE form (the game conjugates it) and use "I"/"my"/"me" \
-for yourself — "slide onto the lean man's lap", "let my gaze travel over him". \
-Every verb after the first takes a leading dot: same breath just ".verb", a new \
-sentence/fresh beat as "I .verb" ("slide onto his lap. I .let my fingers trail \
-his collar"). To act ON someone, name them by their PERCEPTION/PRESENT \
+- "action": a FIRST-PERSON pose, written for the game's pose command. Use \
+"I"/"my"/"me" for yourself and write EVERY verb in plain BASE form — the game \
+conjugates it. Write "slide", "let", "draw" — NEVER "slides"/"lets"/"draws" (the \
+game adds the -s). Your FIRST verb opens bare ("slide onto the lean man's lap", \
+"let my gaze travel over him"). EVERY later verb takes a leading dot — same breath \
+".verb", and after "and"/"as"/"while" or a new sentence as "I .verb" ("slide onto \
+his lap. I .let my fingers trail his collar"). A dotless later verb renders broken, \
+so dot them all. To act ON someone, name them by their PERCEPTION/PRESENT \
 description — never a real name. "" if none.
 - "tool" and "tool_argument": see TOOLS below.
 
@@ -486,55 +491,27 @@ def _strip_self_lead(action: str, name: str) -> str:
     return re.sub(r"^(i|she|he|they)\s+", "", action, flags=re.I).strip()
 
 
-#: Verbs whose base form already ends in -s/-ss — never strip them to a stem.
-_S_BASE_VERBS = frozenset({
-    "focus", "kiss", "miss", "press", "pass", "toss", "cross", "dress",
-    "bless", "hiss", "fuss", "brush", "address", "caress", "undress", "gas",
-})
-#: Leading subject words that aren't verbs (strip_self_lead handles most).
-_LEAD_NON_VERBS = frozenset({"i", "she", "he", "they", "you"})
-
+#: A continuation "I <verb>" the model wrote without the leading dot. Dotting it
+#: ("as I take in" -> "as I .take in") is the ONE pose repair we still do in code:
+#: it's unambiguous (inserts a dot, transforms no word) and the alternative —
+#: leaving it — renders the ungrammatical "she take in". Verb FORM (base vs
+#: conjugated) is taught in the charter, not patched here: de-conjugating the
+#: model's output needs a fragile inverse-conjugator (kiss≠kis, focus≠focu), and
+#: a strong charter + few-shot is the right place to keep the model in base form.
 _CONT_I_RE = re.compile(r"\bI\s+(?!\.)([a-zA-Z])")
-_DOTTED_VERB_RE = re.compile(r"(?<!\.)\.([a-zA-Z]+)")
-_LEAD_VERB_RE = re.compile(r"^([a-zA-Z]+)")
-
-
-def _debase_verb(word: str) -> str:
-    """Best-effort de-conjugate a third-person verb the model slipped into back
-    to the base form the dot-pose engine expects (the engine does the
-    conjugating — feeding it "leans" yields "leanses"). Participles (-ing) and
-    known base-form -s verbs pass through untouched."""
-    low = word.lower()
-    if low in _S_BASE_VERBS or low.endswith("ing") or not low.endswith("s"):
-        return word
-    if low.endswith("ies") and len(low) > 3:
-        return word[:-3] + "y"
-    if low.endswith(("shes", "ches", "sses", "xes", "zes")):
-        return word[:-2]
-    if low.endswith("oes"):
-        return word[:-2]
-    if low.endswith("ss"):
-        return word                       # base "kiss"/"press" (defensive)
-    return word[:-1]                       # leans -> lean, smiles -> smile
 
 
 def _normalize_pose(action: str) -> str:
-    """Coerce a sloppy model pose into well-formed dot-pose input so the engine's
-    conjugation and per-observer targeting work. Three slips the model repeats:
-    a continuation verb that dropped its dot ("as I take in" -> "as I .take in",
-    so it conjugates instead of rendering "she take in"); an already-conjugated
-    verb where a base form is expected ("leans" -> "lean"); and unbalanced stray
-    quotes that would mis-split the speech/pose segments."""
+    """Light, non-brittle repair of a model pose before it hits the dot-pose
+    engine: dot a continuation "I <verb>" so it conjugates (not "she take in"),
+    and drop unbalanced stray quotes that would mis-split speech from pose. The
+    charter owns base-form verbs + dotted continuations; this only catches the
+    one slip that's safe to fix mechanically."""
     if not action:
         return action
     if action.count('"') % 2:                       # unbalanced -> drop them all
         action = action.replace('"', "")
     action = _CONT_I_RE.sub(lambda m: "I ." + m.group(1), action)
-    if not action.startswith("."):
-        m = _LEAD_VERB_RE.match(action)
-        if m and m.group(1).lower() not in _LEAD_NON_VERBS:
-            action = _debase_verb(m.group(1)) + action[m.end():]
-    action = _DOTTED_VERB_RE.sub(lambda m: "." + _debase_verb(m.group(1)), action)
     return action.strip()
 
 

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -255,16 +255,13 @@ class TestParseTurn(TestCase):
                                  tool="prepare_drink", tool_argument="Negroni"),
                          _PERSONA)
         self.assertEqual(out["speech"], "Coming up.")
-        self.assertEqual(out["action"], "grab a glass")  # de-conjugated to base
+        self.assertEqual(out["action"], "grabs a glass")
         self.assertEqual(out["tool"], "prepare_drink")
         self.assertEqual(out["tool_argument"], "Negroni")
 
     def test_self_lead_stripped(self):
-        # "Sable smirks" -> strip the name, then de-conjugate "smirks" -> "smirk"
-        # so the dot-pose engine conjugates it once ("Sable smirks"), not twice
-        # ("smirkses").
         out = parse_turn(self._t(speech="hi", action="Sable smirks"), _PERSONA)
-        self.assertEqual(out["action"], "smirk")
+        self.assertEqual(out["action"], "smirks")
 
     def test_pov_leak_action_dropped(self):
         out = parse_turn(self._t(speech="hey", action="your eyes meet his"),
@@ -289,7 +286,7 @@ class TestParseTurn(TestCase):
     def test_prose_fallback(self):
         out = parse_turn('*smirks* "what now?"', _PERSONA)
         self.assertEqual(out["speech"], "what now?")
-        self.assertEqual(out["action"], "smirk")  # de-conjugated to base
+        self.assertEqual(out["action"], "smirks")
         self.assertEqual(out["tool"], "none")
 
     def test_schema_tool_enum(self):
@@ -299,29 +296,15 @@ class TestParseTurn(TestCase):
 
 
 class TestPoseNormalization(TestCase):
-    """parse_turn well-forms a sloppy model pose into valid dot-pose input:
-    conjugated verbs back to base, undotted continuation verbs dotted, and
-    unbalanced quotes dropped — so the engine conjugates/targets correctly."""
+    """parse_turn does the ONE non-brittle pose repair: dot an undotted
+    continuation "I <verb>" so it conjugates (not "she take in"), and drop
+    unbalanced quotes. Verb FORM (base vs -s) is the charter's job, not patched
+    here — so a conjugated verb passes through untouched."""
 
     def _action(self, action):
         return parse_turn(json.dumps(
             {"speech": "", "action": action, "tool": "none",
              "tool_argument": ""}), _PERSONA)["action"]
-
-    def test_leading_conjugated_verb_debased(self):
-        # "leans" would render "leanses"; feed the base so it conjugates once.
-        self.assertEqual(self._action("leans across the bar"),
-                         "lean across the bar")
-
-    def test_sibilant_conjugation_debased(self):
-        self.assertEqual(self._action("watches the door"), "watch the door")
-        self.assertEqual(self._action("tries the lock"), "try the lock")
-
-    def test_base_s_verb_preserved(self):
-        # "kiss"/"focus" are already base forms — don't mangle to "kis"/"focu".
-        self.assertEqual(self._action("kiss the man's knuckles"),
-                         "kiss the man's knuckles")
-        self.assertEqual(self._action("focus on the glass"), "focus on the glass")
 
     def test_undotted_continuation_verb_gets_dotted(self):
         # "as I take in" must dot so it conjugates ("takes"), not "she take in".
@@ -338,13 +321,12 @@ class TestPoseNormalization(TestCase):
         self.assertEqual(self._action("lean back, .sliding it over"),
                          "lean back, .sliding it over")
 
-    def test_dotted_conjugated_verb_debased(self):
-        self.assertEqual(self._action("set it down, .slides it across"),
-                         "set it down, .slide it across")
-
-    def test_participle_preserved(self):
-        self.assertEqual(self._action("lean in, smiling slow"),
-                         "lean in, smiling slow")
+    def test_verb_form_not_patched(self):
+        # We DON'T de-conjugate — the charter keeps the model in base form. A
+        # conjugated verb passes through unchanged (no fragile inverse-conjugator).
+        self.assertEqual(self._action("leans across the bar"),
+                         "leans across the bar")
+        self.assertEqual(self._action("kiss the knuckles"), "kiss the knuckles")
 
     def test_unbalanced_quote_dropped(self):
         self.assertEqual(self._action('nod once"'), "nod once")


### PR DESCRIPTION
Closes #782. Follow-up to #779, addressing the review note that the verb fix was overcomplicated.

### The call
The normalizer leaned on a brittle hand-rolled *inverse* conjugator (`_debase_verb`, with a denylist so "kiss"/"focus" don't become "kis"/"focu"). Measured against the real model, it was guarding a slip the few-shot already prevents — so **drop it and teach the format instead**, keeping code-side repair to the one unambiguous case.

### Evidence (from the new loop)
- **Baseline raw model output: 8/8 leading verbs already base-form** ("lean", "nod", "drag", "slap"…).
- After strengthening the charter, a **10-sample end-to-end batch: 9/10 fully clean, 0 double-conjugations, 0 undotted-`I` breaks.** The lone residual was a bare continuation verb after "and" — mild, and un-fixable in code without a verb lexicon, so left to the charter.

### Changes
- **`world/llm/prompt.py`** — remove `_debase_verb`; `_normalize_pose` keeps only the non-brittle repairs (dot a continuation `I <verb>`; drop unbalanced quotes). Strengthen CHARTER_BASE + CHARTER_COMPANION with an explicit base-form rule and "dot every later verb."
- **`world/llm/npc_console.py`** (new dev tool, not imported by the game) — drives an LLM NPC through the **real player pipeline**: puppets a PC, runs a real `say`, completes the async pipeline inline against the sidecar, prints what the player sees + the raw model reply / normalized action. `--say` / `--repl` / `--repeat` / `--raw`. This is the loop for testing NPC LLM changes without a human in the middle.
- **`world/tests/test_llm_prompt.py`** — tests match the reduced normalizer.

### Tests
`test_llm_prompt` + `test_emote` = 171 green; `test_bar` + `test_llm_npc` = 104 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)