### PR TITLE
Add 'think' command: interiority as a Builder-perceivable thoughtbubble

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -17,6 +17,7 @@ from evennia.commands.command import Command
 from world.emote import (
     render_dot_pose,
     render_emote,
+    render_think,
     tokenize_dot_pose,
     tokenize_emote,
 )
@@ -335,3 +336,39 @@ class CmdDotPose(Command):
 
         # Broadcast to room (each observer gets a unique rendering)
         render_dot_pose(tokens, caller, location)
+
+
+class CmdThink(Command):
+    """
+    Think to yourself — private roleplay, shown as a thoughtbubble.
+
+    Usage:
+        think <thought>
+
+    Your thought is normally private. For now, staff (Builder+) in the room
+    can also perceive it — a window into what characters (and NPCs) are
+    thinking. A telepathy/psychic sense will gate this for players later.
+
+    Example:
+        think these are my innermost thoughts.
+          You see:        You think . o O ( these are my innermost thoughts. )
+          A builder sees: A lanky man thinks . o O ( these are my innermost thoughts. )
+    """
+
+    key = "think"
+    locks = "cmd:all()"
+    help_category = "Social"
+
+    def func(self) -> None:
+        caller = self.caller
+
+        if not self.args or not self.args.strip():
+            caller.msg("Think what?")
+            return
+
+        location = caller.location
+        if not location:
+            caller.msg("You have nowhere to think.")
+            return
+
+        render_think(caller, self.args.strip(), location)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -40,7 +40,8 @@ from commands.CmdExplosives import (
 from commands.CmdGraffiti import CmdGraffiti, CmdPress
 from commands.CmdCharacter import CmdDescribe, CmdSkintone, CmdVoice
 from commands.CmdCharacter import CmdRemember, CmdForget, CmdRecall, CmdMemory
-from commands.CmdCommunication import CmdSay, CmdTo, CmdWhisper, CmdEmote, CmdDotPose
+from commands.CmdCommunication import (
+    CmdSay, CmdTo, CmdWhisper, CmdEmote, CmdDotPose, CmdThink)
 from commands.CmdFurniture import CmdSit, CmdLie, CmdStand
 from commands.forensics import CmdAutopsy, CmdSever
 from commands import CmdSurgical
@@ -226,6 +227,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdWhisper())
         self.add(CmdEmote())
         self.add(CmdDotPose())
+        self.add(CmdThink())
 
         # Add pre-built social emote template commands (nod, shrug, etc.)
         for cmd_cls in SOCIAL_COMMANDS:

--- a/specs/EMOTE_POSE_SPEC.md
+++ b/specs/EMOTE_POSE_SPEC.md
@@ -166,6 +166,30 @@ class CmdWhisper(Command):
 
 **Visibility rule:** Room observers see that a whisper occurred and between whom, but NOT the speech content. Only the speaker and target receive the content.
 
+### Think (`think`)
+
+Private roleplay — a character's interiority, rendered as the MUSH thoughtbubble. The thinker's name resolves per-observer like an emote; the content is shown only to perceivers.
+
+**Command class:**
+
+```python
+class CmdThink(Command):
+    key = "think"
+    locks = "cmd:all()"
+    help_category = "Social"
+```
+
+**Examples** (actor thinks "these are my innermost thoughts."):
+
+| Audience | Sees |
+|---|---|
+| Actor | You think . o O ( these are my innermost thoughts. ) |
+| Builder+ in room (knows actor as "Bob") | Bob thinks . o O ( these are my innermost thoughts. ) |
+| Builder+ in room (doesn't know actor) | A lanky man thinks . o O ( these are my innermost thoughts. ) |
+| Everyone else | (nothing) |
+
+**Perceiver rule (v1):** only the actor and **Builder+** in the room perceive a thought — staff watching a scene see what characters (and LLM NPCs) are thinking. The implementation (`render_think`) gates on a single perceiver test, so a future **telepathy/psychic sense** drops in there (slotting into `world/perception.py`'s capacity/sense framework) without changing callers. This is the channel an LLM NPC uses for interiority instead of leaking private thought into its visible `emote`.
+
 ---
 
 ## First-Person Pose Syntax

--- a/world/emote.py
+++ b/world/emote.py
@@ -1120,3 +1120,32 @@ def render_emote(
             observer, actor, words, addressed=(id(observer) in referenced)
         )
         observer.msg(text=rendered, type="pose", from_obj=actor, **payload)
+
+
+#: The MUSH thoughtbubble: ``Name thinks . o O ( ... )``.
+_THINK_BUBBLE = "thinks . o O ( {text} )"
+
+
+def render_think(actor: "Character", thought: str, location: object) -> None:
+    """Broadcast an inner thought, heard only by who can perceive it.
+
+    A thought is private roleplay (an NPC's interiority, a player musing). For
+    now the only perceivers are the actor themselves and any **Builder+** in the
+    room — staff watching a scene see what characters are thinking. The hook is
+    deliberately a perceiver test so a future telepathy/psychic SENSE can drop in
+    here (see EMOTE_POSE_SPEC.md) without touching callers. The actor's name is
+    resolved per-observer, exactly like an emote.
+    """
+    for observer in location.contents:
+        if not hasattr(observer, "msg"):
+            continue
+        if observer is actor:
+            observer.msg(f"You think . o O ( {thought} )")
+            continue
+        try:
+            perceives = observer.check_permstring("Builder")
+        except Exception:  # noqa: BLE001 — non-account observers can't perceive
+            perceives = False
+        if perceives:
+            name = capitalize_first(actor.get_display_name(observer))
+            observer.msg(name + " " + _THINK_BUBBLE.format(text=thought))

--- a/world/tests/test_think.py
+++ b/world/tests/test_think.py
@@ -1,0 +1,57 @@
+"""The `think` command — private interiority as a thoughtbubble.
+
+For now only the actor and any Builder+ in the room perceive a thought; a plain
+observer hears nothing. The thinker's name resolves per-observer (the emote
+machinery), and the format is the MUSH bubble `Name thinks . o O ( ... )`.
+"""
+
+from unittest.mock import MagicMock
+
+from evennia import create_object
+from evennia.utils.test_resources import BaseEvenniaTest
+
+from world.emote import render_think
+
+
+def _char(location, key="C"):
+    return create_object("typeclasses.characters.Character", key=key,
+                         location=location)
+
+
+class TestRenderThink(BaseEvenniaTest):
+    def setUp(self):
+        super().setUp()
+        self.room = create_object("typeclasses.rooms.Room", key="room")
+        self.thinker = _char(self.room, key="Bob")
+        self.thinker.height, self.thinker.build = "tall", "lean"
+        self.thinker.sdesc_keyword = "man"
+
+    def _spy(self, char, is_builder):
+        """Replace .msg with a recorder and stub the perm check."""
+        char.msg = MagicMock()
+        char.check_permstring = MagicMock(return_value=is_builder)
+        return char.msg
+
+    def test_actor_sees_own_thought(self):
+        spy = self._spy(self.thinker, is_builder=False)
+        render_think(self.thinker, "these are my thoughts.", self.room)
+        spy.assert_called_once_with(
+            "You think . o O ( these are my thoughts. )")
+
+    def test_builder_in_room_hears_it_by_perceived_name(self):
+        watcher = _char(self.room, key="Staff")
+        spy = self._spy(watcher, is_builder=True)
+        self._spy(self.thinker, is_builder=False)   # silence actor recorder
+        render_think(self.thinker, "secret plan.", self.room)
+        # Watcher doesn't know Bob -> sees his sdesc, capitalized, in the bubble.
+        (msg,), _ = spy.call_args
+        self.assertTrue(msg.endswith("thinks . o O ( secret plan. )"), msg)
+        self.assertIn("man", msg.lower())          # by description, not "Bob"
+        self.assertNotIn("Bob", msg)
+
+    def test_non_builder_hears_nothing(self):
+        bystander = _char(self.room, key="Rando")
+        spy = self._spy(bystander, is_builder=False)
+        self._spy(self.thinker, is_builder=False)
+        render_think(self.thinker, "private.", self.room)
+        spy.assert_not_called()


### PR DESCRIPTION
Closes #786.

A real RP command for private interiority, rendered as the classic MUSH thoughtbubble:

```
think these are my innermost thoughts.
  You see:        You think . o O ( these are my innermost thoughts. )
  A builder sees: A lanky man thinks . o O ( these are my innermost thoughts. )
  Everyone else:  (nothing)
```

**v1 perceiver rule:** actor + **Builder+** in the room. `render_think` gates on a single perceiver test, so a future telepathy/psychic *sense* (slotting into `world/perception.py`) drops in without changing callers. The thinker's name resolves per-observer via the existing emote machinery.

**Why:** gives an LLM NPC a real channel for interiority instead of leaking private thought into its visible `emote` (the "sighs internally. Same face, same threats." problem from live RP). Part of giving NPCs the same RP palette players have — `emote`, dot-pose, `say`, and now `think`.

### Changes
- `world/emote.render_think` — per-observer name, Builder-gated perceivers.
- `commands/CmdCommunication.CmdThink` (key `think`, Social) + registered in `CharacterCmdSet`.
- `specs/EMOTE_POSE_SPEC.md` — Think command section.

### Tests
`world.tests.test_think` — 3 green (actor sees own; builder hears by perceived name, not real name; non-builder hears nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)