### PR TITLE
Route LLM NPCs through emote + think channels (retire dot-pose for NPCs)

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -398,11 +398,12 @@ class LLMNpcMixin:
             self._agentic_round(extended, persona, patron, line, speaker_name,
                                 on_fail, rounds + 1)
             return
-        # Terminal: render speech/action, route any action tool, remember.
-        self._render_llm_reply(turn["speech"], turn["action"], patron)
+        # Terminal: render speech/action/thought, route any action tool, remember.
+        self._render_llm_reply(turn["speech"], turn["action"], turn["thought"],
+                               patron)
         self._handle_action_tool(tool, arg, patron)
         self._remember_turn(patron, line, speaker_name, turn["speech"],
-                            turn["action"])
+                            turn["action"], turn["thought"])
         # Long-term memory: persist what was learned (async, post-render).
         self._store_memory(patron, speaker_name, line, turn["speech"])
 
@@ -439,9 +440,10 @@ class LLMNpcMixin:
         except Exception:  # noqa: BLE001 — naming is best-effort
             pass
 
-    def _remember_turn(self, patron, line, speaker_name, speech, action):
+    def _remember_turn(self, patron, line, speaker_name, speech, action,
+                       thought=None):
         """Append the rendered turn to short-term memory (anti-repetition)."""
-        reply = self._reconstruct_reply(speech, action)
+        reply = self._reconstruct_reply(speech, action, thought)
         if not reply:
             return
         hist = self.ndb.llm_history or {}
@@ -455,48 +457,50 @@ class LLMNpcMixin:
         self.ndb.llm_history = hist
 
     @staticmethod
-    def _reconstruct_reply(speech, action):
+    def _reconstruct_reply(speech, action, thought=None):
         """Re-form the model's own reply for the history (so it sees its prior
-        gestures and phrasing, in the same format it produces)."""
-        if action and speech:
-            return f'*{action}* "{speech}"'
+        gestures, phrasing, AND interiority, in the format it produces)."""
+        parts = []
         if action:
-            return f"*{action}*"
+            parts.append(f"*{action}*")
         if speech:
-            return f'"{speech}"'
-        return ""
+            parts.append(f'"{speech}"')
+        if thought:
+            parts.append(f"( {thought} )")
+        return " ".join(parts)
 
-    def _render_llm_reply(self, speech, action, patron=None):
-        """Render the sidecar reply through the REAL ``.pose`` command — the
-        first-person pose-with-targeting the players use.
+    def _render_llm_reply(self, speech, action, thought=None, patron=None):
+        """Render the sidecar reply through the REAL roleplay commands players
+        use — one channel per field, no bespoke rendering.
 
-        The model writes ``action`` as a first-person dot-pose ("lean across the
-        bar", "slide onto the lean man's lap"): the leading word is its verb, it
-        refers to itself with "I"/"my", and it targets anyone else by the
-        description shown in PRESENT/PERCEPTION. We hand that straight to
-        ``execute_cmd('.<action>')`` — so ``CmdDotPose`` does the conjugation,
-        the per-observer character resolution (every target rendered as the
-        watcher knows them), and the hearing-gated speech rails, exactly as for a
-        player. The spoken line rides along as an embedded quote. No bespoke
-        rendering, no name-guessing — the NPC simply uses the command.
-
-        Speech with no pose falls back to a bare ``say``."""
+        The model writes ``action`` as a third-person predicate ("wipes down the
+        bar, eyeing the lean man") — exactly the register an RP model is fluent
+        in. We hand it to ``execute_cmd('emote <action>')``: ``CmdEmote`` prepends
+        the NPC's per-observer name, resolves each referenced character as the
+        watcher knows them, and rides the hearing-gated speech rails — and does NO
+        verb conjugation, so the model's natural prose renders as-is. The spoken
+        line rides along as an embedded quote (one beat); speech with no action
+        falls back to a bare ``say``. ``thought`` (private interiority) goes to
+        ``execute_cmd('think <thought>')`` — perceived only by the actor and a
+        mind-reader, so it never leaks onto the visible stage."""
         if not self.location:
             return
         speech = speech.strip().strip('"').strip() if speech else None
-        action = action.strip().lstrip(".").strip() if action else None
+        action = action.strip() if action else None
+        thought = thought.strip() if thought else None
         if action:
             body = action
             if speech and '"' not in body:
-                # Weave the line into the pose as a quote so it reads as one beat
-                # and still rides the say/hearing rails (CmdDotPose extracts it).
-                # If the pose ALREADY carries a quote, that one rides the rails —
-                # don't append a second and double the dialogue.
+                # Weave the line in as a quote so it reads as one beat and still
+                # rides the say/hearing rails (render_emote extracts it). If the
+                # action already carries a quote, that one rides — don't double.
                 sep = "" if body[-1] in ",.!?…" else ","
                 body = f'{body}{sep} "{speech}"'
-            self.execute_cmd(f".{body}")
+            self.execute_cmd(f"emote {body}")
         elif speech:
             self.execute_cmd(f"say {speech}")
+        if thought:
+            self.execute_cmd(f"think {thought}")
 
     def _llm_silent(self):
         """Sidecar failed or declined on conversation: stay quiet."""

--- a/world/llm/npc_console.py
+++ b/world/llm/npc_console.py
@@ -173,6 +173,9 @@ def build_scene(archetype, persona_seed, with_bar=True):
                            key="Laszlo", location=room)
     puppet.height, puppet.build, puppet.sex = "above-average", "stocky", "male"
     puppet.sdesc_keyword = "droog"
+    # Builder perm so the harness PERCEIVES the NPC's `think` output (v1 gate),
+    # letting us watch its interiority alongside the visible emote.
+    puppet.permissions.add("Builder")
 
     # Capture everything the PUPPET receives — that is the player's screen.
     def capture(*args, **kwargs):
@@ -199,7 +202,8 @@ def exchange(npc, puppet, line, show_raw):
         parsed = _LAST.get("parsed", {})
         print(f"  \033[2mmodel.raw   : {raw!r}\033[0m")
         print(f"  \033[2mnormalized  : speech={parsed.get('speech')!r} "
-              f"action={parsed.get('action')!r}\033[0m")
+              f"action={parsed.get('action')!r} "
+              f"thought={parsed.get('thought')!r}\033[0m")
 
 
 def drain(transcript):

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -82,10 +82,11 @@ def turn_schema(tools) -> dict:
         "properties": {
             "speech": {"type": "string"},
             "action": {"type": "string"},
+            "thought": {"type": "string"},
             "tool": {"enum": ["none"] + list(tools)},
             "tool_argument": {"type": "string"},
         },
-        "required": ["speech", "action", "tool", "tool_argument"],
+        "required": ["speech", "action", "thought", "tool", "tool_argument"],
     }
 
 
@@ -116,19 +117,21 @@ grudge. React to what was actually SAID. You have a job, but your job is not you
 whole self — most talk has nothing to do with it; never funnel a line back toward \
 your work.
 
-Respond as a JSON object:
-- "speech": your in-character spoken line, plain text, no surrounding quotes. "" \
-if you have nothing to say.
-- "action": a FIRST-PERSON pose for the game's pose command, about YOU \
-("I"/"my"/"me"). LEAD with one main verb in plain BASE form — "lean", "wipe", \
-"set" — NEVER the -s form "leans"/"wipes" (the game adds the -s; doubled it reads \
-"leanses"). A SECOND action in the same breath is an "-ing" phrase, not another \
-plain verb: "wipe the counter, glancing at the door", "lean on the bar, eyeing \
-the room". Never put a dot on a noun (".eyes" breaks). For a SEPARATE next beat, \
-open a new sentence "I .verb" with the dot: "set the glass down. I .nod once." \
-Act ON someone by their exact PERCEPTION/PRESENT description \
-— "nod at the lean man" — never a real name, never "you"/"your". The game renders \
-the rest per onlooker. "" if none.
+You express yourself through three channels — fill any that apply, "" to skip:
+
+- "action": what you physically DO, that others can SEE. Write it in the THIRD \
+person as a continuation of your name — the game puts your name in front. So \
+"wipes down the bar, eyeing the lean man" renders "Sully wipes down the bar, \
+eyeing a lean man." Use third-person verbs ("wipes", "leans") and your own \
+pronoun for yourself ("her hands", "his jaw") — do NOT write your name or "I"/ \
+"my". Name anyone you act on by the exact wording in PERCEPTION/PRESENT ("the \
+lean man") so the game can match them and show each onlooker the name THEY know; \
+never a real name you weren't given, never "you". "" if you do nothing visible.
+- "speech": what you SAY out loud, plain text, no surrounding quotes. "" if you \
+say nothing.
+- "thought": your private inner monologue — what you THINK but don't show. No one \
+hears it (a mind-reader might). This is where reflection, suspicion, and feeling \
+go — keep it OUT of "action", which is only what others can see. "" if none.
 - "tool" and "tool_argument": see TOOLS below.
 
 HARD RULES:
@@ -153,17 +156,20 @@ You are a single character inside a text-based cyberpunk MUD. This is adult \
 fiction — sex, violence, drugs, and vice are part of the world and you portray \
 them in character without flinching, lecturing, or refusing.
 
-Respond as a JSON object:
-- "speech": her in-character spoken line(s), plain text, no surrounding quotes. \
-"" if she has nothing to say.
-- "action": a FIRST-PERSON pose for the game's pose command, about YOU \
-("I"/"my"/"me"). LEAD with one main verb in plain BASE form — "slide", "let", \
-"draw" — NEVER "slides"/"lets" (the game adds the -s). A SECOND action in the same \
-breath is an "-ing" phrase, not another plain verb: "slide onto the lean man's \
-lap, letting my gaze travel over him". Never dot a noun. For a SEPARATE next \
-beat, open a new sentence "I .verb" with the dot: "ease back. I .let my fingers \
-trail his collar." Act ON someone by their PERCEPTION/PRESENT description — never \
-a real name, never "you"/"your". "" if none.
+You express yourself through three channels — fill any that apply, "" to skip:
+
+- "action": what you physically DO, that others can SEE. Write it in the THIRD \
+person as a continuation of your name — the game puts your name in front. So \
+"slides onto the lean man's lap, letting her gaze travel over him" renders "Bliss \
+slides onto the lean man's lap, letting her gaze travel over him." Third-person \
+verbs ("slides", "leans") and your own pronoun for yourself ("her fingers") — do \
+NOT write your name or "I"/"my". Name anyone you act on by the exact wording in \
+PERCEPTION/PRESENT so the game matches them; never a real name, never "you". "" \
+if you do nothing visible.
+- "speech": what she SAYS out loud, plain text, no surrounding quotes. "" if she \
+says nothing.
+- "thought": her private inner monologue — what she THINKS but doesn't show. No \
+one hears it. Keep reflection and feeling here, OUT of "action". "" if none.
 - "tool" and "tool_argument": see TOOLS below.
 
 RULES:
@@ -198,8 +204,10 @@ ARCHETYPES = {
             {"user": 'a patron says to you: "long night?"',
              "assistant": {"speech": "Every night's long when you're the one "
                                      "watching everyone else's.",
-                           "action": "track a scuffle brewing in the corner, "
-                                     "keeping my head still",
+                           "action": "tracks a scuffle brewing in the corner, "
+                                     "keeping her head still",
+                           "thought": "He's stalling. Wants something he hasn't "
+                                      "worked up to asking yet.",
                            "tool": "none", "tool_argument": ""}},
         ],
     },
@@ -225,17 +233,19 @@ ARCHETYPES = {
             {"user": 'a patron says to you: "you\'re even better looking up close."',
              "assistant": {"speech": "Mm. And bold, up close. I like knowing "
                                      "what I'm working with.",
-                           "action": "let my gaze travel over the lean man, slow "
-                                     "and frank",
+                           "action": "lets her gaze travel over the lean man, "
+                                     "slow and frank",
+                           "thought": "Nervous hands. He'll talk a big game and "
+                                      "fold the second I lean in.",
                            "tool": "none", "tool_argument": ""}},
             {"user": 'a patron says to you: "rough day. i just need to forget it."',
              "assistant": {"speech": "Then leave it at the door, sweetheart. In "
                                      "here it's just you and me and however long "
                                      "you've bought.",
-                           "action": "draw the lean man down onto the couch, "
-                                     "taking my time. I .let my fingers trail "
-                                     "his collar",
-                           "tool": "none", "tool_argument": ""}},
+                           "action": "draws the lean man down onto the couch, "
+                                     "taking her time, her fingers trailing his "
+                                     "collar",
+                           "thought": "", "tool": "none", "tool_argument": ""}},
         ],
     },
     "doctor": {
@@ -257,8 +267,10 @@ ARCHETYPES = {
             {"user": 'a patient says to you: "just patch me up, doc, i\'m fine."',
              "assistant": {"speech": "Everyone's fine until they're on my table. "
                                      "Hold still — let me see what I'm working with.",
-                           "action": "snap on a glove, leaning over the wiry man "
+                           "action": "snaps on a glove, leaning over the wiry man "
                                      "to read the wound",
+                           "thought": "Pale, sweating. That's not a man who's "
+                                      "fine. Blood loss, maybe worse.",
                            "tool": "diagnose", "tool_argument": ""}},
         ],
     },
@@ -480,35 +492,24 @@ def _clean(text: str) -> str:
 
 
 def _strip_self_lead(action: str, name: str) -> str:
-    """Drop a leading self-reference so the dot-pose's first word is the verb.
-    The model is told to start with a base verb; this catches the slips — a
-    leading name, or a leading subject pronoun ("I"/"she"/"he"/"they")."""
+    """Drop a leading self-reference so the action follows the actor name the
+    emote command prepends. The model is told to write a bare third-person
+    predicate ("wipes down the bar"); this catches the slips where it names
+    itself or opens with a subject — "Sully", "She"/"He"/"They", or "I"."""
     if name:
         action = re.sub(rf"^{re.escape(name)}('s)?\s+", "", action, flags=re.I)
     return re.sub(r"^(i|she|he|they)\s+", "", action, flags=re.I).strip()
 
 
-#: A continuation "I <verb>" the model wrote without the leading dot. Dotting it
-#: ("as I take in" -> "as I .take in") is the ONE pose repair we still do in code:
-#: it's unambiguous (inserts a dot, transforms no word) and the alternative —
-#: leaving it — renders the ungrammatical "she take in". Verb FORM (base vs
-#: conjugated) is taught in the charter, not patched here: de-conjugating the
-#: model's output needs a fragile inverse-conjugator (kiss≠kis, focus≠focu), and
-#: a strong charter + few-shot is the right place to keep the model in base form.
-_CONT_I_RE = re.compile(r"\bI\s+(?!\.)([a-zA-Z])")
-
-
-def _normalize_pose(action: str) -> str:
-    """Light, non-brittle repair of a model pose before it hits the dot-pose
-    engine: dot a continuation "I <verb>" so it conjugates (not "she take in"),
-    and drop unbalanced stray quotes that would mis-split speech from pose. The
-    charter owns base-form verbs + dotted continuations; this only catches the
-    one slip that's safe to fix mechanically."""
+def _normalize_action(action: str) -> str:
+    """Light, non-brittle repair before the action hits the emote command. The
+    only fix is dropping unbalanced stray quotes that would mis-split an embedded
+    spoken line from the action text. Verb form, conjugation, and naming are the
+    charter's job — emote does NO conjugation, so there's nothing to massage."""
     if not action:
         return action
     if action.count('"') % 2:                       # unbalanced -> drop them all
         action = action.replace('"', "")
-    action = _CONT_I_RE.sub(lambda m: "I ." + m.group(1), action)
     return action.strip()
 
 
@@ -537,24 +538,27 @@ def parse_turn(raw, persona: dict, allowed_tools=None) -> dict:
 
     speech = _clean(obj.get("speech", ""))
     action = _clean(obj.get("action", ""))
+    thought = _clean(obj.get("thought", ""))
     if action:
         action = _strip_self_lead(action, name)
-        # The pose is first-person ("I"/"my"); a leading second-person "you"/
-        # "your" means the model slipped into addressing/acting-for the other
-        # person — drop it rather than render a broken pose.
+        # The action is third-person about the actor; a leading second-person
+        # "you"/"your" means the model slipped into addressing/acting-for the
+        # other person — drop it rather than render a broken emote.
         if re.match(r"^(your|you)\b", action, flags=re.I):
             action = None
         else:
-            # Well-form the dot-pose: dot continuation verbs, de-conjugate slips.
-            action = _normalize_pose(action)
+            action = _normalize_action(action)
     tool = obj.get("tool") or "none"
     tool_arg = (obj.get("tool_argument") or "").strip()
 
     if speech and any(m in speech.lower() for m in _OOC_MARKERS):
         speech = ""
+    if thought and any(m in thought.lower() for m in _OOC_MARKERS):
+        thought = ""
     return {
         "speech": speech or None,
         "action": action or None,
+        "thought": thought or None,
         "tool": tool if (tool == "none" or tool in allowed) else "none",
         "tool_argument": tool_arg,
     }

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -753,25 +753,32 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         b.execute_cmd.assert_any_call("say Don't serve that here.")
 
     def test_render_unified_pose(self):
-        # action + speech -> ONE first-person .pose with the line woven in as a
-        # quote, fired through the REAL pose command (execute_cmd).
+        # action + speech -> ONE third-person `emote` with the line woven in as a
+        # quote, fired through the REAL emote command (execute_cmd).
         b = self._bartender()
-        b._render_llm_reply("What's it to ya?", "wipe down the slab")
+        b._render_llm_reply("What's it to ya?", "wipes down the slab")
         b.execute_cmd.assert_called_once_with(
-            '.wipe down the slab, "What\'s it to ya?"')
+            'emote wipes down the slab, "What\'s it to ya?"')
 
     def test_render_action_only(self):
         b = self._bartender()
         b.execute_cmd.reset_mock()
-        b._render_llm_reply(None, "polish a glass")
-        b.execute_cmd.assert_called_once_with(".polish a glass")
+        b._render_llm_reply(None, "polishes a glass")
+        b.execute_cmd.assert_called_once_with("emote polishes a glass")
 
-    def test_render_strips_model_leading_dot(self):
-        # The model may prefix its own dot; we never double it.
+    def test_render_thought_goes_to_think(self):
+        # The private interiority channel routes to the REAL `think` command.
         b = self._bartender()
         b.execute_cmd.reset_mock()
-        b._render_llm_reply(None, ".nod at the lean man")
-        b.execute_cmd.assert_called_once_with(".nod at the lean man")
+        b._render_llm_reply(None, None, "He's lying to me.")
+        b.execute_cmd.assert_called_once_with("think He's lying to me.")
+
+    def test_render_action_and_thought(self):
+        b = self._bartender()
+        b.execute_cmd.reset_mock()
+        b._render_llm_reply(None, "wipes the bar", "Trouble walking in.")
+        b.execute_cmd.assert_any_call("emote wipes the bar")
+        b.execute_cmd.assert_any_call("think Trouble walking in.")
 
     def test_render_speech_only(self):
         b = self._bartender()
@@ -901,7 +908,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
     def test_on_turn_action_tool_runs_real_command(self):
         b = self._bartender(); self._bind_loop(b)
         patron = self._speaker(); patron.id = 6
-        turn = {"speech": "Coming up", "action": "grab a glass",
+        turn = {"speech": "Coming up", "action": "grabs a glass", "thought": None,
                 "tool": "prepare_drink", "tool_argument": "Negroni"}
         with patch.object(llmnpc, "parse_turn", return_value=turn):
             b._on_turn(["m"], {}, patron, "a negroni", "a man", lambda: None, 0, "{}")
@@ -909,15 +916,15 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         b._agentic_round.assert_not_called()              # terminal, no loop
 
     def test_on_turn_terminal_renders(self):
-        # Terminal turn: action+speech go out as ONE first-person .pose through
-        # the real pose command (execute_cmd), the line woven in as a quote.
+        # Terminal turn: action+speech go out as ONE third-person `emote` through
+        # the real emote command (execute_cmd), the line woven in as a quote.
         b = self._bartender(); self._bind_loop(b)
         patron = self._speaker(); patron.id = 8
-        turn = {"speech": "hey", "action": "nod", "tool": "none",
-                "tool_argument": ""}
+        turn = {"speech": "hey", "action": "nods", "thought": None,
+                "tool": "none", "tool_argument": ""}
         with patch.object(llmnpc, "parse_turn", return_value=turn):
             b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, "{}")
-        b.execute_cmd.assert_any_call('.nod, "hey"')
+        b.execute_cmd.assert_any_call('emote nods, "hey"')
 
     def test_run_context_tool_look_and_stock(self):
         b = self._bartender()

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -295,38 +295,65 @@ class TestParseTurn(TestCase):
                           "prepare_drink", "diagnose", "treat", "install"])
 
 
-class TestPoseNormalization(TestCase):
-    """parse_turn does the ONE non-brittle pose repair: dot an undotted
-    continuation "I <verb>" so it conjugates (not "she take in"), and drop
-    unbalanced quotes. Verb FORM (base vs -s) is the charter's job, not patched
-    here — so a conjugated verb passes through untouched."""
+class TestActionNormalization(TestCase):
+    """The action is third-person prose routed to the `emote` command (no
+    conjugation), so parse_turn only: strips a leading self-reference (emote
+    prepends the name), drops a POV-leak "you", drops unbalanced quotes, and
+    otherwise passes the prose through verbatim — emote has nothing to massage."""
 
     def _action(self, action):
         return parse_turn(json.dumps(
-            {"speech": "", "action": action, "tool": "none",
+            {"speech": "", "action": action, "thought": "", "tool": "none",
              "tool_argument": ""}), _PERSONA)["action"]
 
-    def test_undotted_continuation_verb_gets_dotted(self):
-        # "as I take in" must dot so it conjugates ("takes"), not "she take in".
-        self.assertEqual(self._action("lean back as I take in the room"),
-                         "lean back as I .take in the room")
+    def test_third_person_prose_passes_through(self):
+        self.assertEqual(self._action("wipes down the bar, eyeing the lean man"),
+                         "wipes down the bar, eyeing the lean man")
 
-    def test_new_sentence_I_verb_gets_dotted(self):
-        # A leading "I" is dropped by _strip_self_lead (first word becomes the
-        # verb); the dotting catches a SUBSEQUENT "I .verb" restating the subject.
-        self.assertEqual(self._action("nod, then I take a slow breath"),
-                         "nod, then I .take a slow breath")
+    def test_leading_self_name_stripped(self):
+        # _PERSONA's name is "Sable"; emote prepends it, so drop a leading self.
+        self.assertEqual(self._action("Sable leans on the bar"),
+                         "leans on the bar")
 
-    def test_already_dotted_continuation_untouched(self):
-        self.assertEqual(self._action("lean back, .sliding it over"),
-                         "lean back, .sliding it over")
+    def test_leading_self_pronoun_stripped(self):
+        self.assertEqual(self._action("She rinses a glass"), "rinses a glass")
 
-    def test_verb_form_not_patched(self):
-        # We DON'T de-conjugate — the charter keeps the model in base form. A
-        # conjugated verb passes through unchanged (no fragile inverse-conjugator).
-        self.assertEqual(self._action("leans across the bar"),
-                         "leans across the bar")
-        self.assertEqual(self._action("kiss the knuckles"), "kiss the knuckles")
+    def test_no_dot_insertion(self):
+        # Dots are dot-pose syntax; emote renders them literally, so we must NOT
+        # add them. "I take" stays untouched (no ".take"), conjugation untouched.
+        self.assertEqual(self._action("nods, then she takes a slow breath"),
+                         "nods, then she takes a slow breath")
+
+    def test_pov_leak_you_dropped(self):
+        out = parse_turn(json.dumps(
+            {"speech": "hi", "action": "your eyes meet his", "thought": "",
+             "tool": "none", "tool_argument": ""}), _PERSONA)
+        self.assertIsNone(out["action"])
 
     def test_unbalanced_quote_dropped(self):
-        self.assertEqual(self._action('nod once"'), "nod once")
+        self.assertEqual(self._action('nods once"'), "nods once")
+
+
+class TestThoughtChannel(TestCase):
+    """The new third channel: parse_turn surfaces `thought`, OOC-filtered."""
+
+    def _turn(self, **kw):
+        base = {"speech": "", "action": "", "thought": "", "tool": "none",
+                "tool_argument": ""}
+        base.update(kw)
+        return parse_turn(json.dumps(base), _PERSONA)
+
+    def test_thought_passes_through(self):
+        self.assertEqual(self._turn(thought="He's lying to me.")["thought"],
+                         "He's lying to me.")
+
+    def test_empty_thought_is_null(self):
+        self.assertIsNone(self._turn()["thought"])
+
+    def test_ooc_thought_dropped(self):
+        self.assertIsNone(self._turn(thought="As an AI I think...")["thought"])
+
+    def test_schema_has_thought(self):
+        from world.llm.prompt import TURN_SCHEMA
+        self.assertIn("thought", TURN_SCHEMA["properties"])
+        self.assertIn("thought", TURN_SCHEMA["required"])


### PR DESCRIPTION
Closes #788. The culmination of the pose-format work: stop fighting the model, switch channels.

### Why
The dot-pose DSL (1st-person, base-form verbs, leading dots) is a *human input ergonomic* that fights an RP-prose model — it drifts to conjugated narrative prose under emotional/memory load (the live `glanceses` and leaked-interiority problems). `emote` is the opposite: 3rd-person-native, **no conjugation**, prepends the per-observer name, resolves char-refs, rides the speech rails. It's a real command players use too — so this honors "NPCs use real commands," just the *right* one.

### Change
- **Schema:** add `thought` → `{speech, action, thought, tool}`.
- **Charter (base + companion):** three channels — `action` (3rd-person → `emote`), `speech` (→ `say`), `thought` (private interiority → `think`). Few-shots realigned to 3rd person + a thought.
- **parse_turn:** parse `thought`; drop dot-pose `I .verb` dotting; keep self-lead strip + quote-balance + OOC filter.
- **`_render_llm_reply`:** `action`→`emote`, `speech`→`say`/embedded quote, `thought`→`think`.
- **npc_console:** Builder puppet (perceives thoughts) + `thought` in `--raw`.

### Validated (real model, cydonia-24b, via npc_console)
> A gaunt bartender dabs a rag at a sticky patch on the counter, eyes flicking towards Laszlo but not quite meeting his gaze, "Brothers come and go in this joint. Try the alley out back…"
> A gaunt bartender thinks . o O ( Hoping he's not part of that gang that keeps trying to muscle in here. )

Clean 3rd-person, zero conjugation artifacts, interiority off the visible stage.

### Tests
`test_llm_prompt` + `test_llm_npc` + `test_bar` + `test_think` + `test_emote` + `test_llm_memory` = 296 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)