### PR TITLE
Dial in LLM turn budget for the thought channel: max_tokens 120->180 + reason-logging

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -266,7 +266,8 @@ LLM_GM_URL = "http://host.docker.internal:8765/v1/chat/completions"
 LLM_GM_MODEL = ""          # backend-specific model id; blank lets local servers default
 LLM_GM_API_KEY = ""        # Bearer token for cloud backends; blank for local
 LLM_GM_TIMEOUT = 40        # seconds; per-round budget (warm 24B constrained gen ~17s/round)
-LLM_GM_MAX_TOKENS = 120    # short NPC turns (a line + an action, no truncation)
+LLM_GM_MAX_TOKENS = 180    # a turn = a line + an action + a thought; headroom so
+                           # the 3rd channel doesn't truncate (was 120 for 2 fields)
 LLM_GM_TEMPERATURE = 0.8   # characterful but coherent
 
 ######################################################################

--- a/world/llm/client.py
+++ b/world/llm/client.py
@@ -64,12 +64,21 @@ def request_turn(messages, on_turn, on_fail, schema=None):
 
     def _at_return(content):
         if not content:
+            # Empty body = the model returned nothing usable — usually a turn
+            # truncated against LLM_GM_MAX_TOKENS, occasionally a genuine decline.
+            # Logged so a rash of fallbacks points at the right dial.
+            logger.log_warn("LLM turn empty (no content — likely truncation; "
+                            "check LLM_GM_MAX_TOKENS)")
             on_fail()
             return
         on_turn(content)
 
     def _at_err(failure):
-        logger.log_err(f"LLM backend call failed: {failure}")
+        # Name the failure mode so we can dial the right knob: a *Timeout means
+        # the turn ran past LLM_GM_TIMEOUT; a ConnectionError means the sidecar's
+        # down; anything else is a backend bug.
+        exc = getattr(failure, "value", failure)
+        logger.log_err(f"LLM backend call failed [{type(exc).__name__}]: {exc}")
         on_fail()
 
     run_async(_thread_fn, at_return=_at_return, at_err=_at_err)

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -131,7 +131,8 @@ never a real name you weren't given, never "you". "" if you do nothing visible.
 say nothing.
 - "thought": your private inner monologue — what you THINK but don't show. No one \
 hears it (a mind-reader might). This is where reflection, suspicion, and feeling \
-go — keep it OUT of "action", which is only what others can see. "" if none.
+go — keep it OUT of "action", which is only what others can see. A phrase or two, \
+not a paragraph. "" if none.
 - "tool" and "tool_argument": see TOOLS below.
 
 HARD RULES:
@@ -169,7 +170,8 @@ if you do nothing visible.
 - "speech": what she SAYS out loud, plain text, no surrounding quotes. "" if she \
 says nothing.
 - "thought": her private inner monologue — what she THINKS but doesn't show. No \
-one hears it. Keep reflection and feeling here, OUT of "action". "" if none.
+one hears it. Keep reflection and feeling here, OUT of "action". A phrase or two, \
+not a paragraph. "" if none.
 - "tool" and "tool_argument": see TOOLS below.
 
 RULES:


### PR DESCRIPTION
Closes #790. The "it seemed better before" fix.

`thought` (#789) made every turn a third, often-longest text field — but `LLM_GM_MAX_TOKENS` stayed `120`, sized (per its own comment) for "a line + an action". Verbose turns truncate against the ceiling and run nearer the 40s timeout → empty content → `on_fail` → the curt "Don't serve that here."

- **`settings.py`:** `LLM_GM_MAX_TOKENS` 120 → 180 — headroom for line + action + thought.
- **`prompt.py`:** charter (base + companion) — `thought` is "a phrase or two, not a paragraph," so we cap the added length rather than also raising the timeout (which would slow players down).
- **`client.py`:** `on_fail` logs *why* — `empty (truncation)` vs `[Timeout]`/`[ConnectionError]` — so the next time fallbacks spike we grep the log instead of guessing.

Tuning + observability only. 50 client/prompt tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)