### PR TITLE
Bump LLM_GM_TIMEOUT 40->60s for the always-loaded sidecar

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -265,7 +265,10 @@ LLM_GM_ENABLED = False
 LLM_GM_URL = "http://host.docker.internal:8765/v1/chat/completions"
 LLM_GM_MODEL = ""          # backend-specific model id; blank lets local servers default
 LLM_GM_API_KEY = ""        # Bearer token for cloud backends; blank for local
-LLM_GM_TIMEOUT = 40        # seconds; per-round budget (warm 24B constrained gen ~17s/round)
+LLM_GM_TIMEOUT = 60        # seconds; per-round budget. The sidecar is always under
+                           # load (~30s/gen, spikes higher); 60 rescues slow-but-valid
+                           # turns from the curt fallback, and at MUD RP pace (30-60s
+                           # a turn) the wait still lands inside the natural beat.
 LLM_GM_MAX_TOKENS = 180    # a turn = a line + an action + a thought; headroom so
                            # the 3rd channel doesn't truncate (was 120 for 2 fields)
 LLM_GM_TEMPERATURE = 0.8   # characterful but coherent


### PR DESCRIPTION
Closes #796. The sidecar's always under load (~30s/gen, spikes higher), so turns occasionally exceed 40s → timeout → the curt 'Don't serve that here.' At MUD RP pace (a turn is naturally 30–60s) a 60s reply still lands inside the beat, so this rescues slow-but-valid turns with no perceptible cost. One-line, trivially reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)