### PR TITLE
Cigarette pack self-destructs when its last cigarette is drawn

### DIFF
--- a/typeclasses/smoke.py
+++ b/typeclasses/smoke.py
@@ -8,6 +8,7 @@ uses-left are set via prototype attributes + Tags.
 from __future__ import annotations
 
 from evennia.prototypes.spawner import spawn
+from evennia.utils import delay
 
 from typeclasses.items import Item
 from world.smoke import (
@@ -70,3 +71,22 @@ class CigarettePack(Item):
             # smoke command picks the right flavor bank even after
             # the cigarette has been removed from the pack.
             cig.db.substance = substance
+
+    def at_object_leave(self, moved_obj, target_location, **kwargs):
+        """Crush the empty pack once its last cigarette is drawn.
+
+        ``at_object_leave`` fires while the cigarette is *still* in
+        ``self.contents`` (its move hasn't committed yet), so we check
+        whether anything OTHER than the leaver remains. If not, this was the
+        last one — defer the delete to the next tick (``delay(0, …)``) so the
+        cigarette's move finishes first and ``self.delete()`` doesn't try to
+        relocate the in-flight cigarette.
+        """
+        super().at_object_leave(moved_obj, target_location, **kwargs)
+        if any(obj is not moved_obj for obj in self.contents):
+            return                              # cigarettes still inside
+        taker = target_location
+        if taker and hasattr(taker, "msg"):
+            taker.msg(f"That's the last one — you crumple the empty "
+                      f"{self.key} and toss it aside.")
+        delay(0, self.delete)

--- a/world/tests/test_smoke.py
+++ b/world/tests/test_smoke.py
@@ -497,3 +497,40 @@ class TestCmdSnuff(TestCase):
         room.contents.append(caller)
         self._run(caller, "cigarette")
         self.assertTrue(any("isn't lit" in m for m in caller.msgs))
+
+
+# ---------------------------------------------------------------------
+# CigarettePack self-destruct (real DB — at_object_leave hook)
+# ---------------------------------------------------------------------
+from evennia import create_object  # noqa: E402
+from evennia.utils.test_resources import BaseEvenniaTest  # noqa: E402
+
+
+class TestCigarettePackEmptyDestroys(BaseEvenniaTest):
+    """Pulling the LAST cigarette crushes the empty pack (#: drink-pack hygiene)."""
+
+    def _pack_with(self, n):
+        # Patch the auto-fill spawn (the prototype registry isn't loaded in
+        # tests) and control the contents directly.
+        with patch("typeclasses.smoke.spawn", return_value=[]):
+            pack = create_object("typeclasses.smoke.CigarettePack",
+                                 key="pack of Noir cigarettes",
+                                 location=self.room1)
+        cigs = [create_object("typeclasses.objects.Object", key=f"cig{i}",
+                              location=pack) for i in range(n)]
+        return pack, cigs
+
+    def test_last_cigarette_destroys_pack(self):
+        # delay(0, …) runs inline so the deferred delete fires within the test.
+        with patch("typeclasses.smoke.delay", lambda _t, fn, *a, **k: fn(*a, **k)):
+            pack, cigs = self._pack_with(2)
+            cigs[0].move_to(self.char1, quiet=True)
+            self.assertTrue(pack.pk, "pack must survive while a cigarette remains")
+            cigs[1].move_to(self.char1, quiet=True)
+            self.assertIsNone(pack.pk, "empty pack must self-destruct")
+
+    def test_pack_survives_with_cigs_left(self):
+        with patch("typeclasses.smoke.delay", lambda _t, fn, *a, **k: fn(*a, **k)):
+            pack, cigs = self._pack_with(3)
+            cigs[0].move_to(self.char1, quiet=True)
+            self.assertTrue(pack.pk)


### PR DESCRIPTION
Closes #800. An emptied `CigarettePack` shouldn't linger as a husk.

`CigarettePack.at_object_leave` — fires while the leaving cigarette is still in `self.contents`, so it checks whether anything else remains; if not, message the taker ("that's the last one — you crumple the empty pack") and `delay(0, self.delete)` so the cigarette's move commits before the pack is removed.

Tests: `test_smoke.TestCigarettePackEmptyDestroys` (last cig destroys; survives while cigs remain) — 34 smoke tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)