### PR TITLE
Disposable lighter: finite-use lighter that depletes and is binned

### DIFF
--- a/commands/CmdSmoke.py
+++ b/commands/CmdSmoke.py
@@ -161,7 +161,7 @@ class CmdLight(Command):
                 char_refs={"actor": caller},
                 exclude=[caller],
             )
-        del lighter  # used for the contract check; no further action
+        self._spend_lighter(caller, lighter)
 
     def _light_other(self, caller, owner_phrase, cigarette_phrase, lighter):
         target = resolve_character_target(caller, owner_phrase)
@@ -204,7 +204,28 @@ class CmdLight(Command):
                 char_refs={"actor": caller, "target": target},
                 exclude=[caller, target],
             )
-        del lighter
+        self._spend_lighter(caller, lighter)
+
+    @staticmethod
+    def _spend_lighter(caller, lighter):
+        """Burn a charge off a DISPOSABLE lighter and bin it when it's spent.
+
+        A disposable lighter carries ``uses_left``; each successful light costs
+        one, and the dead lighter is destroyed at zero. An infinite lighter (the
+        zippo — no ``uses_left``) is never touched, so this is a no-op for it.
+        """
+        uses = getattr(lighter.db, "uses_left", None)
+        if uses is None:
+            return                              # infinite-use (zippo)
+        uses = int(uses) - 1
+        if uses <= 0:
+            caller.msg(f"The {lighter.key} coughs out its last flame — "
+                       f"you toss the dead lighter.")
+            lighter.delete()
+            return
+        lighter.db.uses_left = uses
+        if uses <= 3:
+            caller.msg(f"The {lighter.key} is running low — {uses} left.")
 
 
 # ---------------------------------------------------------------------

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3092,6 +3092,25 @@ ZIPPO_LIGHTER = {
     ],
 }
 
+# Disposable lighter — finite ``uses_left``; CmdLight burns a charge per light
+# and bins it when spent (vs. the infinite zippo above).
+DISPOSABLE_LIGHTER = {
+    "typeclass": "typeclasses.items.Item",
+    "key": "disposable lighter",
+    "aliases": ["lighter", "disposable", "bic"],
+    "desc": (
+        "A cheap translucent-plastic lighter, the kind that lives in a "
+        "pocket until the flint gives out.  A sliver of fluid sloshes "
+        "behind the scratched casing."
+    ),
+    "tags": [
+        ("lighter", "item_role"),
+    ],
+    "attrs": [
+        ("uses_left", 20),
+    ],
+}
+
 
 # Base cigarette.  Branded subtypes override ``brand``.
 CIGARETTE_BASE = {

--- a/world/tests/test_smoke.py
+++ b/world/tests/test_smoke.py
@@ -534,3 +534,25 @@ class TestCigarettePackEmptyDestroys(BaseEvenniaTest):
             pack, cigs = self._pack_with(3)
             cigs[0].move_to(self.char1, quiet=True)
             self.assertTrue(pack.pk)
+
+
+class TestDisposableLighterDepletes(TestCase):
+    """A disposable lighter (``db.uses_left``) burns a charge per light and is
+    binned when spent; the infinite zippo (no ``uses_left``) is untouched."""
+
+    def test_disposable_depletes_then_dies(self):
+        from commands.CmdSmoke import CmdLight
+        caller, lighter = _FakeCharacter(), _lighter()
+        lighter.db.uses_left = 2
+        CmdLight._spend_lighter(caller, lighter)
+        self.assertEqual(lighter.db.uses_left, 1)
+        self.assertFalse(lighter.deleted)
+        CmdLight._spend_lighter(caller, lighter)
+        self.assertTrue(lighter.deleted)        # last charge spent
+
+    def test_infinite_lighter_untouched(self):
+        from commands.CmdSmoke import CmdLight
+        caller, lighter = _FakeCharacter(), _lighter()   # no uses_left set
+        CmdLight._spend_lighter(caller, lighter)
+        self.assertFalse(lighter.deleted)
+        self.assertIsNone(getattr(lighter.db, "uses_left", None))


### PR DESCRIPTION
Closes #802. The only lighter was the infinite `ZIPPO`; the street machine needs a true *disposable* one.

- `CmdLight._spend_lighter` — after a successful light, burns one `uses_left` charge off the lighter and destroys it at zero (with a message); the infinite zippo (no `uses_left`) is untouched. Reuses the codebase's `uses_left` decrement-and-delete convention.
- `DISPOSABLE_LIGHTER` prototype — cheap plastic, `uses_left=20`.

Tests: `test_smoke.TestDisposableLighterDepletes` — 36 smoke tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)