### PR TITLE
LLM NPCs reference people by the clothing-free core handle, not the garment

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -151,7 +151,7 @@ class LLMNpcMixin:
         # Capture everything reactor-side BEFORE threading (SQLite/Evennia-thread
         # contract). The agentic loop re-calls from the reactor-side callback.
         persona = build_persona(self)
-        speaker_name = patron.get_display_name(self)
+        speaker_name = self._address_handle(patron)
         perception = self._perceive(patron)
         history = self._recent_history(patron)
         subject = self._memory_subject(patron)
@@ -206,9 +206,22 @@ class LLMNpcMixin:
 
     # --- room presence: who's here, who comes and goes -------------------
 
+    def _address_handle(self, target):
+        """The handle the model should use to REFER to ``target``: a name this NPC
+        has assigned it, else the clothing-free CORE sdesc ("a stocky droog") —
+        NOT the full sdesc, whose garment clause ("...in an armored leather
+        jacket") makes the model point at, and paraphrase, clothing. The char-ref
+        matcher resolves the short form; the render restores the full per-observer
+        identity for onlookers."""
+        from world.identity import get_assigned_name, get_short_sdesc
+        try:
+            return get_assigned_name(self, target) or get_short_sdesc(target)
+        except Exception:  # noqa: BLE001 — fall back to the standard display name
+            return target.get_display_name(self)
+
     def _present_others(self, patron=None):
-        """The characters sharing this NPC's room right now, each by the name
-        THIS NPC perceives them by (so the model can reference them and the
+        """The characters sharing this NPC's room right now, each by the handle
+        THIS NPC would address them by (so the model can reference them and the
         world renders per-observer). The current speaker is excluded — they're
         already in PERCEPTION — and other NPCs are kept (they're really here).
         Capped to keep the prompt bounded in a crowded room."""
@@ -221,10 +234,7 @@ class LLMNpcMixin:
                 continue
             if not hasattr(obj, "get_sdesc"):
                 continue
-            try:
-                name = obj.get_display_name(self)
-            except Exception:  # noqa: BLE001 — never break a reply over a roster
-                continue
+            name = self._address_handle(obj)
             if name:
                 names.append(name)
         return names[:8]

--- a/world/identity.py
+++ b/world/identity.py
@@ -672,6 +672,34 @@ def compose_sdesc(
     return base
 
 
+def get_short_sdesc(char, article: bool = True) -> str:
+    """The clothing-free CORE sdesc — descriptor + keyword, no distinguishing
+    feature/garment clause: ``"a stocky droog"`` vs the full ``"a stocky droog in
+    an armored leather jacket"``.
+
+    Use this where a reference should point at the PERSON, not what they happen to
+    be wearing — e.g. the handle an LLM NPC addresses someone by (so it says "the
+    stocky droog" instead of fixating on, and paraphrasing, the jacket). The
+    char-ref matcher already accepts this short form, and the render layer restores
+    the full per-observer identity. Falls back to keyword/key when descriptors
+    aren't set.
+    """
+    from world.grammar import DEFAULT_SDESC_KEYWORDS, get_article
+    descriptor = ""
+    height, build = getattr(char, "height", None), getattr(char, "build", None)
+    if height and build:
+        try:
+            descriptor = get_physical_descriptor(height, build)
+        except (KeyError, AttributeError):
+            descriptor = ""
+    keyword = (getattr(char, "sdesc_keyword", None) or DEFAULT_SDESC_KEYWORDS.get(
+        getattr(char, "gender", "neutral"), "person"))
+    core = compose_sdesc(descriptor, keyword).strip() if descriptor else keyword
+    if not core:
+        return getattr(char, "key", "someone")
+    return f"{get_article(core)} {core}" if article else core
+
+
 # =========================================================================
 # Disguise Adjective
 # =========================================================================

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -126,7 +126,9 @@ eyeing a lean man." Use third-person verbs ("wipes", "leans") and your own \
 pronoun for yourself ("her hands", "his jaw") — do NOT write your name or "I"/ \
 "my". Name anyone you act on by the exact wording in PERCEPTION/PRESENT ("the \
 lean man") so the game can match them and show each onlooker the name THEY know; \
-never a real name you weren't given, never "you". Your action is only YOUR OWN \
+never a real name you weren't given, never "you". Refer to people by who they ARE \
+(the lean man, the droog) — never by what they wear or carry (the jacket, the \
+boots). Your action is only YOUR OWN \
 body and gestures — act only on people the game actually lists in \
 PERCEPTION/PRESENT; do NOT invent other patrons or narrate the crowd, the room, \
 or events you don't control. The game runs the world. "" if you do nothing visible.
@@ -168,7 +170,8 @@ person as a continuation of your name — the game puts your name in front. So \
 slides onto the lean man's lap, letting her gaze travel over him." Third-person \
 verbs ("slides", "leans") and your own pronoun for yourself ("her fingers") — do \
 NOT write your name or "I"/"my". Name anyone you act on by the exact wording in \
-PERCEPTION/PRESENT so the game matches them; never a real name, never "you". Your \
+PERCEPTION/PRESENT so the game matches them; never a real name, never "you". Refer \
+to people by who they ARE, never by what they wear or carry. Your \
 action is only YOUR OWN body — act only on people the game lists in \
 PERCEPTION/PRESENT; do NOT invent other patrons or narrate the crowd, the room, \
 or events you don't control. The game runs the world. "" if you do nothing visible.

--- a/world/tests/test_emote.py
+++ b/world/tests/test_emote.py
@@ -1935,3 +1935,24 @@ class TestOrdinalCharRefsInEmotes(TestCase):
         # "man" should still match via regular path (first match)
         self.assertEqual(len(char_refs), 1)
         self.assertIs(char_refs[0].character, self.jorge)
+
+
+class TestShortSdesc(TestCase):
+    """get_short_sdesc — the clothing-free CORE handle (descriptor + keyword),
+    so an LLM NPC references the person ('a lanky man'), never the garment."""
+
+    def test_core_form_no_feature_clause(self):
+        from world.identity import get_short_sdesc
+        char = _make_character(key="X", sex="male", height="tall", build="lean",
+                               sdesc_keyword="man", sleeve_uid="uid-short")
+        short = get_short_sdesc(char)
+        self.assertTrue(short.startswith(("a ", "an ")), short)
+        self.assertIn("man", short)
+        self.assertNotIn(" in ", short)          # never a garment/feature clause
+
+    def test_no_article_option(self):
+        from world.identity import get_short_sdesc
+        char = _make_character(key="Y", sex="female", height="short",
+                               build="athletic", sdesc_keyword="woman",
+                               sleeve_uid="uid-short2")
+        self.assertFalse(get_short_sdesc(char, article=False).startswith(("a ", "an ")))


### PR DESCRIPTION
Closes #804. From live RP: the bartender kept pointing at a PC's jacket ("gives the armored jacket a single appraising glance", "your suit's been kicked in").

The sdesc bakes in the outermost garment, and `_perceive` feeds the full appearance — so a prose model grabs/paraphrases clothing. The sdesc isn't the problem; **the model is handed clothing as the reference handle.**

- **#1** `get_short_sdesc` — clothing-free CORE sdesc; `_address_handle` hands it (or an assigned name) to the model for `speaker_name` + `PRESENT`. Matcher resolves the short form, render restores the full per-observer identity (clothing still shows to onlookers).
- **#2** charter nudge — "refer to people by who they ARE, not what they wear or carry."

Tests: `test_emote.TestShortSdesc`; 198 green. Future (noted): NPC armed/threat discernment; perception → visible-only clothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)