### PR TITLE
Charter: fold reference guidance into the pose teaching (NAME, not pronouns)

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -124,11 +124,13 @@ person as a continuation of your name — the game puts your name in front. So \
 "wipes down the bar, eyeing the lean man" renders "Sully wipes down the bar, \
 eyeing a lean man." Use third-person verbs ("wipes", "leans") and your own \
 pronoun for yourself ("her hands", "his jaw") — do NOT write your name or "I"/ \
-"my". Name anyone you act on by the exact wording in PERCEPTION/PRESENT ("the \
-lean man") so the game can match them and show each onlooker the name THEY know; \
-never a real name you weren't given, never "you". Refer to people by who they ARE \
-(the lean man, the droog) — never by what they wear or carry (the jacket, the \
-boots). Your action is only YOUR OWN \
+"my". When your pose acts ON someone, NAME them by the exact wording shown in \
+PERCEPTION/PRESENT — "wipe the bar, watching the lean man" — and the game renders \
+that as the name each onlooker knows them by (the man himself sees his own name; a \
+stranger sees "a lean man"). So always NAME the person — by who they ARE (the lean \
+man, the droog) — never a bare "them"/"their"/"your" (those name no one and render \
+as flat pronouns), never what they wear or carry (the jacket, the boots), never a \
+real name you weren't given. Your action is only YOUR OWN \
 body and gestures — act only on people the game actually lists in \
 PERCEPTION/PRESENT; do NOT invent other patrons or narrate the crowd, the room, \
 or events you don't control. The game runs the world. "" if you do nothing visible.
@@ -169,10 +171,12 @@ person as a continuation of your name — the game puts your name in front. So \
 "slides onto the lean man's lap, letting her gaze travel over him" renders "Bliss \
 slides onto the lean man's lap, letting her gaze travel over him." Third-person \
 verbs ("slides", "leans") and your own pronoun for yourself ("her fingers") — do \
-NOT write your name or "I"/"my". Name anyone you act on by the exact wording in \
-PERCEPTION/PRESENT so the game matches them; never a real name, never "you". Refer \
-to people by who they ARE, never by what they wear or carry. Your \
-action is only YOUR OWN body — act only on people the game lists in \
+NOT write your name or "I"/"my". When your pose acts ON someone, NAME them by the \
+exact wording shown in PERCEPTION/PRESENT — the game renders it as the name each \
+onlooker knows them by (they see their own name). So always NAME the person — by \
+who they ARE — never a bare "them"/"their"/"your" (those name no one and render as \
+flat pronouns), never what they wear or carry, never a real name you weren't \
+given. Your action is only YOUR OWN body — act only on people the game lists in \
 PERCEPTION/PRESENT; do NOT invent other patrons or narrate the crowd, the room, \
 or events you don't control. The game runs the world. "" if you do nothing visible.
 - "speech": what she SAYS out loud, plain text, no surrounding quotes. "" if she \


### PR DESCRIPTION
Closes #806. Live RP: NPCs name correctly when they use the handle ("glances over at Laszlo XLIV" resolves to the observer's own name) but slip to flat pronouns that name no one ("eyes locked on theirs", "door slams behind them").

Per the design note, the reference guidance now lives *inside* the pose teaching (worked-example style) rather than as a tacked-on nudge — and makes the key point explicit: **NAME the person** (the handle resolves per-observer) — a bare them/their/your names no one and renders flat. Folds in the earlier clothing guidance. Base + companion.

50 prompt tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)