### PR TITLE
Emote/pose: a char-ref pointing at the observer renders second-person (you/your)

### DIFF
--- a/specs/EMOTE_POSE_SPEC.md
+++ b/specs/EMOTE_POSE_SPEC.md
@@ -430,7 +430,7 @@ When `observer == actor`:
 | VerbToken | Base form (no conjugation): "lean", "ask" |
 | PronounToken | Second-person form: I→you, my→your, me→you, mine→yours, myself→yourself |
 | SpeechToken | `process_speech(text, speaker, observer)` (default: verbatim in quotes) |
-| CharRefToken | `get_display_name(actor)` for the referenced character |
+| CharRefToken | `_resolve_charref` — `"you"`/`"your"` if the ref is the actor (self-ref), else `get_display_name(actor)` |
 
 The actor's own reference (implicit from first verb, or explicit `I`) renders as **"You"** (capitalized if sentence-initial, lowercase otherwise).
 
@@ -444,7 +444,7 @@ When `observer != actor`:
 | VerbToken | `conjugate_third_person(base_form)`: lean→leans, ask→asks |
 | PronounToken | Third-person, gender-matched: I→he/she/they, my→his/her/their |
 | SpeechToken | `process_speech(text, speaker, observer)` |
-| CharRefToken | `get_display_name(observer)` for the referenced character |
+| CharRefToken | `_resolve_charref` — `"you"`/`"your"` if the ref IS the observer, else `get_display_name(observer)` |
 
 The actor's name renders as `get_display_name(observer)` — "Jorge", "a lanky man", etc.
 
@@ -467,7 +467,7 @@ The actor may be referenced multiple times in a single emote. The renderer track
 - Actor: "your", "you", "yours", "yourself"
 - Observer: "his"/"her"/"their", "him"/"her"/"them", etc.
 
-**Character references** (other characters in the emote) **always** render as full display names via `get_display_name(observer)`. No pronoun substitution for non-actor characters.
+**Character references** (other characters in the emote) render as full display names via `get_display_name(observer)` — with **one carve-out: a reference to the observer themselves renders second-person** (`you`, or `your` for the possessive). So a pose that targets you reads "watches **you**", never your own name; everyone else still resolves to the name that observer knows them by. No pronoun substitution for any other (non-actor, non-observer) character. This is the same rule for dot-pose and traditional emote — both resolve char-refs through `_resolve_charref(character, observer)`.
 
 ### Rendering Trace
 
@@ -791,7 +791,7 @@ Multiple characters match the same name: The ordinal system applies (`2nd tall m
 
 ### Self-Reference
 
-Actor types their own name as a character reference in an emote: The system resolves it to the actor's character object. At render time, it renders via `get_display_name(observer)` for the actor object. For dot-pose self-view, this would produce the actor's own name (from `get_display_name(self)` returning `.key`). Technically valid but unusual.
+Actor types their own name as a character reference in an emote: The system resolves it to the actor's character object. At render time, `_resolve_charref` makes it **second-person for the actor's own view** ("you") — since the referenced character is the observer — and the per-observer name for everyone else. (Previously this rendered the actor's own `.key` via `get_display_name(self)`, which was "technically valid but unusual"; the second-person carve-out fixes it.)
 
 ### Combat Context
 

--- a/world/emote.py
+++ b/world/emote.py
@@ -750,6 +750,29 @@ def tokenize_dot_pose(
 # =========================================================================
 
 
+def _resolve_charref(character: "Character", observer: "Character") -> str:
+    """Render a character reference for one observer.
+
+    The carve-out to "char-refs are always names" (EMOTE_POSE_SPEC §Per-Observer
+    Rendering): when the referenced character IS the observer, render **second
+    person** — you read "watches you", not your own name. Anyone else resolves to
+    the name THAT observer knows them by (their sdesc, or a name they've assigned).
+    """
+    if character is observer:
+        return "you"
+    return character.get_display_name(observer)
+
+
+#: Possessive cleanup: a second-person char-ref leaves "you's" where the source
+#: had "the droog's" (the ref became "you", the trailing "'s" stayed). Fix it to
+#: "your", preserving sentence-initial capitalisation.
+_YOU_POSSESSIVE_RE = re.compile(r"\b([Yy])ou's\b")
+
+
+def _fix_you_possessive(text: str) -> str:
+    return _YOU_POSSESSIVE_RE.sub(lambda m: f"{m.group(1)}our", text)
+
+
 def render_for_observer(
     tokens: list[
         TextToken | VerbToken | PronounToken | SpeechToken | CharRefToken
@@ -872,17 +895,18 @@ def render_for_observer(
             has_prior_content = True
 
         elif isinstance(token, CharRefToken):
-            # Resolve character reference per-observer
-            display_name = token.character.get_display_name(observer)
+            # Resolve per-observer (second-person when it points at the observer).
+            display_name = _resolve_charref(token.character, observer)
             # Drop a redundant article right before the ref — the resolved name
             # carries its own ("the a gaunt courier" -> "a gaunt courier", "the
-            # Roony" -> "Roony"). Both players and LLM NPCs write "the <sdesc>".
+            # Roony" -> "Roony", "the lean man" -> "you"). Players and NPCs alike
+            # write "the <sdesc>".
             if parts:
                 parts[-1] = re.sub(r"\b(?:the|an?)\s+$", "", parts[-1], flags=re.I)
             parts.append(display_name)
             has_prior_content = True
 
-    result = "".join(parts)
+    result = _fix_you_possessive("".join(parts))
 
     # Post-processing: capitalize first alphabetic character
     result = capitalize_first(result)
@@ -1069,13 +1093,14 @@ def render_emote_for_observer(
                 )
             )
         elif isinstance(token, CharRefToken):
-            display_name = token.character.get_display_name(observer)
+            # Second-person when the ref points at the observer (see _resolve_charref).
+            display_name = _resolve_charref(token.character, observer)
             # Drop a redundant article right before the ref (see render_for_observer).
             if parts:
                 parts[-1] = re.sub(r"\b(?:the|an?)\s+$", "", parts[-1], flags=re.I)
             parts.append(display_name)
 
-    action = "".join(parts)
+    action = _fix_you_possessive("".join(parts))
 
     # Prepend actor name
     actor_name = actor.get_display_name(observer)

--- a/world/tests/test_emote.py
+++ b/world/tests/test_emote.py
@@ -1956,3 +1956,46 @@ class TestShortSdesc(TestCase):
                                build="athletic", sdesc_keyword="woman",
                                sleeve_uid="uid-short2")
         self.assertFalse(get_short_sdesc(char, article=False).startswith(("a ", "an ")))
+
+
+class TestSecondPersonObserverRef(TestCase):
+    """A char-ref pointing at the OBSERVER renders second-person (you/your), not
+    the observer's own name — in both dot-pose and traditional emote. A third
+    party still sees the referenced character's sdesc."""
+
+    def setUp(self):
+        from world.emote import (tokenize_emote, render_emote_for_observer,
+                                  tokenize_dot_pose, render_for_observer)
+        self.tok_emote, self.render_emote = tokenize_emote, render_emote_for_observer
+        self.tok_dot, self.render_dot = tokenize_dot_pose, render_for_observer
+        self.actor = _make_character(key="Sully", sex="female", height="tall",
+                                     build="lean", sdesc_keyword="bartender",
+                                     sleeve_uid="uid-sully")
+        self.you = _make_character(key="Laszlo", sex="male", height="short",
+                                   build="stocky", sdesc_keyword="droog",
+                                   sleeve_uid="uid-laszlo")
+
+    def test_emote_ref_to_observer_is_you(self):
+        toks = self.tok_emote("nods at the droog", self.actor, [self.you])
+        out = self.render_emote(toks, self.actor, self.you).lower()
+        self.assertIn("nods at you", out)
+
+    def test_emote_possessive_is_your(self):
+        toks = self.tok_emote("eyes the droog's hands", self.actor, [self.you])
+        out = self.render_emote(toks, self.actor, self.you).lower()
+        self.assertIn("your hands", out)
+        self.assertNotIn("you's", out)
+
+    def test_dotpose_ref_to_observer_is_you(self):
+        toks = self.tok_dot("nod at the droog", self.actor, [self.actor, self.you])
+        out = self.render_dot(toks, self.actor, self.you).lower()
+        self.assertIn("you", out)
+        self.assertNotIn("droog", out)            # not the observer's own sdesc
+
+    def test_third_party_still_sees_sdesc(self):
+        stranger = _make_character(key="S", sex="male", height="average",
+                                   build="average", sdesc_keyword="figure",
+                                   sleeve_uid="uid-str", recognition_memory={})
+        toks = self.tok_emote("nods at the droog", self.actor, [self.you])
+        out = self.render_emote(toks, self.actor, stranger).lower()
+        self.assertIn("droog", out)               # named, not "you"


### PR DESCRIPTION
Closes #808. When someone's pose references *you*, you now read **you/your** instead of your own name.

**Analysis finding:** this was **spec'd as the current behavior**, not an oversight — EMOTE_POSE_SPEC explicitly said "char references always render as full display names… No pronoun substitution for non-actor characters." Both render paths resolve char-refs identically (they differ only in *actor-self* handling). So this is a deliberate **spec refinement**, carving the one exception: ref == observer → second-person.

- Shared `_resolve_charref(character, observer)` used by dot-pose + emote; possessive `the droog's` → `your` via `_fix_you_possessive`.
- Spec updated (rule + render tables + Self-Reference edge).
- `test_emote.TestSecondPersonObserverRef`; 134 green.

Players and NPCs share the render, so this fixes it everywhere at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)