### PR TITLE
LLM NPC: state authoritative self-pronouns (stop mis-gendering itself)

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -219,7 +219,7 @@ ARCHETYPES = {
              "assistant": {"speech": "Every night's long when you're the one "
                                      "watching everyone else's.",
                            "action": "tracks a scuffle brewing in the corner, "
-                                     "keeping her head still",
+                                     "staying perfectly still",
                            "thought": "He's stalling. Wants something he hasn't "
                                       "worked up to asking yet.",
                            "tool": "none", "tool_argument": ""}},
@@ -338,6 +338,14 @@ them, target one person per description, and the world resolves the rest."""
 
 _APPEARANCE_KEYS = ("face", "eyes", "hair", "head")
 
+#: NPC sex -> (self-noun, pronoun set) — the authoritative self-gender injected
+#: into the persona so the model doesn't mis-gender itself. Anything not listed
+#: (ambiguous/neutral/nonbinary/other/unset) falls through to they/them.
+_SELF_PRONOUNS = {
+    "male": ("a man", "he/him"),
+    "female": ("a woman", "she/her"),
+}
+
 
 def _personality(seed: dict) -> str:
     if seed.get("personality"):
@@ -369,6 +377,11 @@ def render_persona(persona: dict) -> str:
 
     if persona.get("sdesc"):
         lines.append(f"To strangers you appear as {persona['sdesc']}.")
+    # Authoritative self-gender — the few-shot/charter examples can't be allowed to
+    # mis-gender the NPC (a male bartender rendered "her shoulder").
+    who, pron = _SELF_PRONOUNS.get((persona.get("sex") or "").lower(),
+                                   ("nonbinary", "they/them"))
+    lines.append(f"You are {who}; refer to yourself as {pron}.")
     longdescs = persona.get("longdescs") or {}
     appearance = [longdescs[k] for k in _APPEARANCE_KEYS if longdescs.get(k)]
     if persona.get("skintone"):

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -65,6 +65,16 @@ class TestBuildMessages(TestCase):
     def test_render_persona_defensive(self):
         self.assertIn("the bartender", render_persona({}))
 
+    def test_persona_states_self_gender(self):
+        # Authoritative self-pronouns so the model doesn't mis-gender itself.
+        def p(sex):
+            return render_persona({"sdesc": "x", "sex": sex,
+                                   "persona_seed": {"name": "N"}})
+        self.assertIn("he/him", p("male"))
+        self.assertIn("she/her", p("female"))
+        self.assertIn("they/them", p("ambiguous"))   # falls through
+        self.assertIn("they/them", p(None))
+
     def test_memories_injected_before_turn(self):
         msgs = build_messages(_PERSONA, "a man", "remember me?", "directed",
                               memories=["he stiffed you on a tab last week",


### PR DESCRIPTION
Closes #812. From the RP tests you asked for: the male bartender called itself "her" ("flicks a rag over **her** shoulder").

Causes: the bartender few-shot primed female ("keeping her head still"), and the persona only *implied* gender via the sdesc. Fix:
- `render_persona` injects an authoritative line from `sex`: "You are a man; refer to yourself as he/him."
- bartender few-shot de-gendered.

Verified via npc_console (0 slips post-fix; also confirmed the reference fix working — "the droog's knuckles" → "your knuckles"). 51 prompt tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)