### PR TITLE
Persona self-gender: derive pronouns from the canonical gender engine

### DIFF
--- a/typeclasses/llm_persona.py
+++ b/typeclasses/llm_persona.py
@@ -11,7 +11,22 @@ See ``specs/proposals/LLM_GAMEMASTER_SPEC.md`` §5.2 (persona card).
 
 from evennia.utils.dbserialize import deserialize
 
+from world.grammar import transform_pronoun
+from world.identity import get_apparent_gender
 from world.voice import get_voice_description, get_voice_ending, voice_phrase
+
+
+def _self_pronouns(npc) -> str:
+    """The NPC's own subject/object pronouns ("he/him") from the SAME canonical
+    gender derivation the emote/identity engine uses (``get_apparent_gender`` ->
+    ``transform_pronoun``), so the persona never disagrees with how the world
+    renders this character's gender. Falls back to they/them on any hiccup."""
+    try:
+        gender = get_apparent_gender(npc)
+        return (f"{transform_pronoun('I', 'third', gender)}/"
+                f"{transform_pronoun('me', 'third', gender)}")
+    except Exception:  # noqa: BLE001 — never break persona-building over pronouns
+        return "they/them"
 
 
 def build_persona(npc) -> dict:
@@ -50,6 +65,7 @@ def build_persona(npc) -> dict:
         "height": npc.height,
         "build": npc.build,
         "sex": npc.sex,
+        "pronouns": _self_pronouns(npc),   # canonical self-gender (he/him, …)
         "species": npc.species,
         "voice": voice_phrase(npc),
         "voice_description": get_voice_description(npc),

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -338,14 +338,6 @@ them, target one person per description, and the world resolves the rest."""
 
 _APPEARANCE_KEYS = ("face", "eyes", "hair", "head")
 
-#: NPC sex -> (self-noun, pronoun set) — the authoritative self-gender injected
-#: into the persona so the model doesn't mis-gender itself. Anything not listed
-#: (ambiguous/neutral/nonbinary/other/unset) falls through to they/them.
-_SELF_PRONOUNS = {
-    "male": ("a man", "he/him"),
-    "female": ("a woman", "she/her"),
-}
-
 
 def _personality(seed: dict) -> str:
     if seed.get("personality"):
@@ -377,11 +369,11 @@ def render_persona(persona: dict) -> str:
 
     if persona.get("sdesc"):
         lines.append(f"To strangers you appear as {persona['sdesc']}.")
-    # Authoritative self-gender — the few-shot/charter examples can't be allowed to
-    # mis-gender the NPC (a male bartender rendered "her shoulder").
-    who, pron = _SELF_PRONOUNS.get((persona.get("sex") or "").lower(),
-                                   ("nonbinary", "they/them"))
-    lines.append(f"You are {who}; refer to yourself as {pron}.")
+    # Authoritative self-gender — build_persona derives `pronouns` from the same
+    # canonical gender engine the emote/identity layer uses, so the model can't
+    # mis-gender itself ("her shoulder" for a male NPC).
+    if persona.get("pronouns"):
+        lines.append(f"Refer to yourself as {persona['pronouns']}.")
     longdescs = persona.get("longdescs") or {}
     appearance = [longdescs[k] for k in _APPEARANCE_KEYS if longdescs.get(k)]
     if persona.get("skintone"):

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -65,15 +65,14 @@ class TestBuildMessages(TestCase):
     def test_render_persona_defensive(self):
         self.assertIn("the bartender", render_persona({}))
 
-    def test_persona_states_self_gender(self):
-        # Authoritative self-pronouns so the model doesn't mis-gender itself.
-        def p(sex):
-            return render_persona({"sdesc": "x", "sex": sex,
-                                   "persona_seed": {"name": "N"}})
-        self.assertIn("he/him", p("male"))
-        self.assertIn("she/her", p("female"))
-        self.assertIn("they/them", p("ambiguous"))   # falls through
-        self.assertIn("they/them", p(None))
+    def test_persona_surfaces_pronouns(self):
+        # render_persona surfaces the pronouns build_persona pre-derives from the
+        # canonical gender engine — no duplicate sex->pronoun mapping here.
+        out = render_persona({"persona_seed": {"name": "N"}, "pronouns": "he/him"})
+        self.assertIn("refer to yourself as he/him", out.lower())
+        # Absent (e.g. a hand-authored lint fixture) -> no gender line, no crash.
+        self.assertNotIn("refer to yourself",
+                         render_persona({"persona_seed": {"name": "N"}}).lower())
 
     def test_memories_injected_before_turn(self):
         msgs = build_messages(_PERSONA, "a man", "remember me?", "directed",


### PR DESCRIPTION
Closes #814. You were right — the persona should reference the character's sex through the *existing* system, not a parallel map.

#813 added `_SELF_PRONOUNS` in the portable prompt layer. This routes through the canonical `get_apparent_gender` + `transform_pronoun` (the same `GENDER_MAP`-based derivation emotes/identity use): `build_persona` computes `persona['pronouns']` reactor-side, `render_persona` just surfaces it. One source of truth; portable layer stays Evennia-free.

Verified male→he/him, female→she/her, ambiguous→they/them; 69 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)