### PR TITLE
Specs: spatial coordinate system + NPC dispatch/simulation proposals

### DIFF
--- a/specs/proposals/NPC_DISPATCH_AND_SIMULATION_SPEC.md
+++ b/specs/proposals/NPC_DISPATCH_AND_SIMULATION_SPEC.md
@@ -1,0 +1,253 @@
+# NPC Dispatch & World Simulation Specification
+
+> **Status:** 📋 Proposal — not implemented. Designs the **director**: a
+> hardcoded, deterministic world-simulation engine that manages the NPC
+> population (spawn / despawn / routine / death) and **dispatches** them in
+> response to world events — routing them through the spatial pathfinder. The
+> LLM-NPC puppeting layer brings selected NPCs to life **only when a player is
+> there to witness it and the moment is worth the cost.** Depends on
+> `SPATIAL_COORDINATE_SYSTEM_SPEC` (traversal, proximity, routing).
+
+## 1 · Intent
+
+We want the colony to feel **inhabited and reactive** without a builder
+hand-scripting every life. A population of NPCs — civilians (flash-temp miners,
+bartenders, companions, gangers) and authority (security robots, LEO
+dispatchers) — should live on routines and **respond to events**: an assault
+triggers a LEO response, a mining incident deploys a search-and-rescue crew, a
+shift change sends a worker in for a drink. Gigs, tasks, and events for *players*
+hang off the same machinery.
+
+This is a **core hardcoded element** — a world simulation that runs whether or
+not anyone is watching. The LLM NPC system (`LLM_GAMEMASTER_SPEC`) is the
+**performance layer on top**: when the simulation puts a meaningful NPC in front
+of a player, the director may hand that beat to the model. Most of the
+simulation never touches the LLM at all.
+
+Two layers, one engine:
+* **Simulation / dispatch** — population lifecycle, routines, event response,
+  traversal. Deterministic, always-on, cheap.
+* **Tasks / gigs / events** — the player-facing hooks (the favor/gig loop) and
+  the world-event triggers, both feeding the same dispatcher.
+
+## 2 · Design stance — simulate deterministically, narrate selectively
+
+The governing principle, because LLM time is the scarcest resource:
+
+> **The simulation always runs on rules. The LLM is a camera light — switched on
+> only when a player is present, the beat is salient, and budget allows.**
+
+| Mode | When | Cost |
+|---|---|---|
+| **Abstract** | No player anywhere near (off-screen) | ~zero — state advances as data, NPCs need not even be instantiated (§3 LOD) |
+| **Deterministic on-screen** | Player present, ordinary beat | cheap — real in-game commands with templated content (§6) |
+| **LLM-narrated** | Player present **and** salient beat **and** within budget | expensive — gated hand-off to the model |
+
+This is what makes the **NPC↔NPC problem** tractable. Two NPCs interacting
+off-screen is pure data (or skipped). On-screen, they interact through a
+**deterministic interaction vocabulary** (templated poses/says via real
+commands) — the simulation visibly "does its thing" for free. The model is
+spent only on the rare witnessed, high-salience exchange — never as the default
+for NPC-to-NPC chatter. The existing bartender engagement gate (directed /
+ambient / cooldown) is the seed of this idea; the director generalizes it to the
+whole population with a shared budget.
+
+**Mandate inherited from the LLM-NPC work:** every NPC action — dispatched,
+routine, deterministic, or LLM-driven — executes through **real in-game
+commands** (`execute_cmd`), never a Python backdoor. The director decides
+*what an NPC does*; the NPC *does it* the same way a player would, respecting
+command validation and messaging. (See `LLM_GAMEMASTER_SPEC`; this is a hard
+rule.)
+
+## 3 · Population & lifecycle
+
+A **population registry** (`world/director/population.py`) is the census: who
+exists, their role, home region, state, and whether they are persistent or
+ephemeral.
+
+* **Persistent NPCs** — named, durable citizens (Sable the bartender, Doctor
+  Vance, companions). They have stable identity, recognition memory, voice.
+* **Ephemeral / flash-temp NPCs** — spawned for a shift, a gig, or an event
+  (a flash-temp mining crew, a LEO response squad) and **despawned** when the
+  reason ends. The bulk of the visible population is ephemeral.
+
+**Level-of-detail (LOD) — spawn-on-approach.** The director does **not**
+instantiate the whole city. Off-screen population is **virtual** — a row of
+state in the registry. When a player enters (or nears, via the coordinate
+proximity query) a region, its due NPCs **materialize** as real objects; when
+the last player leaves and a grace period passes, they **dematerialize** back to
+state. This bounds object count and tick cost to where players actually are.
+
+**Death & lifecycle monitoring.** The director subscribes to the medical/death
+system (death-curtain hooks). An NPC death is itself a **world event** (§5): a
+murder may summon LEO; a mining death may trigger S&R; a flash-temp's death just
+updates the census and schedules cleanup. The director owns despawn, corpse
+handling hand-off, and any respawn/replacement cadence — so the world neither
+leaks corpses nor depopulates permanently.
+
+## 4 · Roles & routines
+
+Each NPC has a **role** defining its spawn rules, schedule, event
+subscriptions, and jurisdiction. Roles are data-authored, not hardcoded per-NPC.
+
+```python
+@dataclass(frozen=True)
+class Role:
+    id: str                     # "miner", "bartender", "security_bot", "ganger"
+    faction: str | None         # NPC-only factions (see growth direction)
+    routine: str                # schedule key -> deterministic behavior
+    responds_to: list[str]      # event types this role is dispatched for
+    jurisdiction: str | None    # region/zone scoping for response eligibility
+    persistence: str            # "persistent" | "ephemeral"
+    llm_persona: str | None     # if set, eligible for LLM narration when salient
+```
+
+**Routines** are deterministic behavior — a state machine / lightweight behavior
+tree driven by the time system and the NPC's role: a miner cycles shaft → break
+→ home; a shift change routes a worker to the bar for a drink; a security bot
+patrols a beat. Routines move NPCs via the **pathfinder** (§5 of the coordinate
+spec) and act via real commands. No LLM required for any of it.
+
+## 5 · The event bus & dispatch
+
+The heart of "both layers."
+
+**Events** (`world/director/events.py`) are typed, located, and weighted:
+
+```python
+@dataclass
+class WorldEvent:
+    type: str            # "assault", "mining_incident", "shift_change", "death", "gig"
+    location: object      # a room (carries coordinates -> distance/routing)
+    severity: int         # drives responder count & LLM salience
+    source: object | None # instigator (a PC, an NPC, a system tick)
+    payload: dict         # event-specific detail
+```
+
+Events are raised by the world: combat (assault), the mining system (incident),
+the time system (shift change), the medical system (death), the gig system
+(task posted). They land on a bus the **dispatcher** consumes.
+
+**The dispatcher** (`world/director/dispatch.py`):
+
+1. **Match** — find candidate responders by `role.responds_to`, `jurisdiction`,
+   and **coordinate proximity** (`rooms_within` / straight-line distance).
+2. **Select** — pick responder count from `severity`; nearest-first by travel
+   path. Materialize a flash-temp squad if no standing responders exist (a LEO
+   van rolls in; an S&R crew is deployed).
+3. **Route** — A\* over the real exit graph (coordinate spec §5) toward the
+   event; respects locks, warps, and collapsed tunnels automatically.
+4. **Monitor** — track arrival, resolution, and casualties; a responder death
+   re-enters the bus as a new event.
+5. **Resolve** — on completion, return standing NPCs to routine; despawn the
+   flash-temp squad after a grace period.
+
+Dispatch is the bridge between the **simulation** (who exists, where, doing
+what) and the **spatial system** (how they get there). It is fully
+deterministic; the LLM enters only if step 4 puts a responder in front of a
+player during a salient beat.
+
+## 6 · Interaction & the LLM escalation gate
+
+The hardest part, by your call, is **NPC↔NPC interaction** — and the answer is
+to make the *default* free.
+
+* **Deterministic interaction vocabulary** — templated exchanges keyed by the
+  role pair + context, rendered through real `pose`/`say`/`emote` commands:
+  two gangers posture; a miner orders from the bartender; a security bot
+  challenges a loiterer. Cheap, on-brand, and visible. This is what "the
+  simulation does its thing" looks like on-screen with zero model cost.
+* **The escalation gate** — a single director-owned decision, generalizing the
+  bartender's directed/ambient gate, that hands a beat to the LLM only when
+  **all** hold:
+  1. **Witnessed** — a player can perceive it (coordinate proximity +
+     perception). No witness → never spend.
+  2. **Salient** — `severity` / role significance clears a threshold (a
+     named-NPC confrontation, not ambient banter).
+  3. **In budget** — a global/regional **LLM budget** (rate + cooldown) has
+     room. The director spends scarce budget on the highest-salience witnessed
+     beats and lets the rest run deterministic.
+* When the gate opens, narration uses the existing LLM-NPC pipeline
+  (`build_persona`, `execute_cmd`) — the director chooses *that this NPC speaks
+  now*; the LLM chooses *what it says*; the NPC says it through the real command.
+
+**Third-party action safety.** When a dispatched NPC acts **on a player**
+(a security bot restrains, a companion touches, a ganger shoves), that action
+must route through the future **trust/consent gate** (`TRUST_AND_CONSENT_SPEC`,
+flagged SUPER IMPORTANT). The director must not paint this into a corner:
+NPC-initiated actions targeting able-to-resist players are subject to the same
+consent rules as player-initiated ones. Reserve the seam now.
+
+## 7 · Worked examples
+
+* **Assault → LEO response.** Combat raises `assault` at a room. Dispatcher
+  matches `security_bot` / LEO by jurisdiction + proximity, materializes a squad
+  if none stand nearby, routes them via A\* to the scene, monitors. If a player
+  is present when they arrive and severity is high, the dispatcher (LEO) may get
+  an LLM line ("Hands where I can see them"); otherwise it acts on templated
+  commands.
+* **Mining incident → S&R.** Mining system raises `mining_incident` (a collapse,
+  a death) deep at `Z < 0`. Dispatcher deploys a flash-temp S&R crew, routes
+  them down through the vertical/undercity rooms, runs the rescue
+  deterministically; despawns the crew after.
+* **Shift change → a drink.** Time system raises `shift_change`. A worker's
+  routine reroutes to the bar; they order from Sable via the deterministic
+  vocabulary. If a player is at the bar, the director *may* escalate the
+  exchange to the LLM — usually it stays templated.
+
+## 8 · Integration seams
+
+* **Spatial coordinate system (dependency).** Proximity (`rooms_within`),
+  distance, and the A\* dispatch routing all come from
+  `SPATIAL_COORDINATE_SYSTEM_SPEC`. The director is its first major consumer.
+* **LLM Gamemaster.** This spec is the *when/why* an NPC acts; that spec is the
+  *what it says*. Sable, Vance, and companions become director-managed citizens
+  whose existing LLM behavior is now budgeted and scheduled by the director.
+* **Trust/consent.** §6 — NPC-initiated actions on players go through the gate.
+* **Gigs / favor loop.** Player-facing gigs (the NPC-faction freelancer/favor
+  economy from the growth direction) are events on the same bus: a posted gig is
+  a `WorldEvent`; completing it shifts faction/rep state. Gigs are the player's
+  *interface into* the simulation.
+* **NPC memory & identity.** Persistent NPCs carry recognition memory / voice;
+  ephemerals generally do not (cost). The director decides who is "someone."
+* **Medical / death-curtain.** Lifecycle monitoring (§3) hooks death here.
+
+## 9 · Build ladder
+
+| Phase | Scope | Notes |
+|---|---|---|
+| **1 — Population registry & LOD** | Census, persistent vs ephemeral, spawn-on-approach / despawn-on-leave | Needs coordinate proximity (spatial Phase 1) |
+| **2 — Roles & routines** | Role data model, deterministic schedules, routine movement via pathfinder | Needs spatial Phase 2 |
+| **3 — Event bus & dispatcher** | Events, matching, selection, routing, monitor, resolve | The "dispatch system" proper |
+| **4 — Deterministic interaction vocabulary** | Templated NPC↔NPC / NPC↔PC exchanges via real commands | Zero-LLM baseline |
+| **5 — LLM escalation gate** | Witnessed + salient + budget; generalize bartender gate | Reuses LLM-NPC pipeline |
+| **— Parallel —** | Gig/favor loop as events; faction/rep state | Player hook |
+| **Reserved** | Mining-incident integration; LEO jurisdictions at scale | Tie to mines (spatial reserved seam) |
+
+Phases 1–3 are the deterministic simulation core and are worth shipping before
+any LLM escalation exists — the world should feel alive on rules alone.
+
+## 10 · Risks & open questions
+
+* **NPC↔NPC combinatorics.** Even deterministic exchanges can explode if every
+  pair interacts every tick. **Lean:** rate-limit interactions per NPC, gate on
+  co-presence + a low ambient roll (mirror the bartender ambient cooldown),
+  and only render to actual witnesses.
+* **LOD materialization consistency.** State must survive the
+  virtual↔instantiated round-trip (an NPC mid-route when it dematerializes must
+  resume correctly). Off-screen state is the source of truth; objects are a
+  projection.
+* **LLM budget tuning.** The witnessed+salient+budget gate needs real numbers
+  (per-region rate, cooldown, salience threshold) — tune against the live mini's
+  single-sidecar ceiling, the same constraint the bartender already lives under.
+* **Determinism vs. surprise.** Fully deterministic routines can feel
+  mechanical. Reserved: light stochastic variation in routine selection so the
+  city isn't a clockwork.
+* **Trust/consent timing.** NPC-on-player actions need the consent gate to exist
+  before authority NPCs (security bots) can lawfully grab a player. Sequence the
+  LEO-force content *after* that gate, or scope early authority NPCs to
+  non-coercive actions.
+* **Persistence cost.** The registry for a large virtual population must stay
+  light (data rows, lazy detail) so the census itself doesn't become the bottleneck.
+* **Ownership of corpses/cleanup** between the director and the existing
+  death-curtain / decay systems — avoid double-ownership of a dying NPC.

--- a/specs/proposals/SPATIAL_COORDINATE_SYSTEM_SPEC.md
+++ b/specs/proposals/SPATIAL_COORDINATE_SYSTEM_SPEC.md
@@ -1,0 +1,247 @@
+# Spatial Coordinate System Specification
+
+> **Status:** 📋 Proposal — not implemented. Designs a unified integer
+> `(X, Y, Z)` coordinate volume laid over the existing hand-built world, as
+> the shared backbone for navigation, ranged systems (vehicle combat / radar),
+> verticality & gravity, NPC dispatch, and — later — destructible and
+> procedurally-generated space. Inspired by Evennia's `XYZGrid` contrib but
+> deliberately adopting only its **data model**, not its authoring model.
+
+## 1 · Intent — why coordinates, and why now
+
+The game world is hand-authored: rich rooms (246 with five-senses
+descriptions), named exits, deliberate non-grid links (`enter bar`, `climb`,
+jump-across). That authoring stays. What it lacks is a notion of **where each
+room is in space** — and a growing list of systems all want exactly that:
+
+* **GPS minimap** — a device-gated map whose glyphs derive from room *terrain
+  type* (street / forest / desert / interior …), rendered with depth (see §8).
+* **Ranged systems** — vehicle combat and a radar system need real distance and
+  bearing between rooms.
+* **NPC dispatch & auto-walk** — responders, couriers, and gangers routing
+  across the city via shortest-path.
+* **Verticality & gravity** — sky rooms you fall *through* along a vertical
+  axis (the `jump` command already models a first version — see §6).
+* **Pie-in-the-sky** — room destruction/repair and procedurally-generated mines
+  that can be blown open and tunnelled.
+
+Every one of these reduces to two primitives: **a coordinate per room** and **a
+shortest path between rooms**. This spec builds those two primitives once, so
+each system above is a thin consumer rather than a bespoke reinvention. *This is
+the backbone for a lot of the roadmap — it is designed to be built on, not
+finished.*
+
+## 2 · Design stance — data model, not authoring model
+
+Evennia's `XYZGrid` contrib is the obvious reference, but its core proposition
+is **authoring the world as external ASCII maps** that `evennia xyzgrid spawn`
+batch-generates into rooms. That is the *inverse* of how this game is built and
+would collide with our authored content. We therefore **reject the authoring
+pipeline** and lift only the substrate.
+
+Three `XYZGrid` assumptions are explicitly overturned by our intent:
+
+1. **Z is a real integer altitude, not a map name.** `XYZGrid` makes `Z` a
+   string map-id and pathfinds per-map-island, never crossing `Z`. We want one
+   continuous volume with sky rooms you fall through. → **one world, integer Z,
+   no map-transition nodes.**
+2. **Pathfinding runs over the real exit graph, not the coordinate lattice.**
+   Our world has non-cardinal exits, locked doors, and (future) collapsed
+   tunnels. Routing over coordinates would send NPCs through walls. → **A\* over
+   the live exit network, with coordinates supplying only the distance
+   heuristic** (§5).
+3. **Coordinates are retrofitted onto existing rooms, never regenerated.** Rooms
+   keep their identity and authored descriptions; they merely *gain* coordinate
+   tags (§4).
+
+### The two sources of truth
+
+| Concern | Source of truth |
+|---|---|
+| Distance, bearing, altitude, gravity fall-path, minimap placement, proc-gen addressing | **Coordinate volume** (§3) |
+| Movement legality, reachability, dispatch routing | **Real exit graph** — coordinates only seed the A\* heuristic (§5) |
+
+Keeping these separate is what makes destruction and tunnelling "just work":
+they mutate the exit graph the pathfinder already reads, while coordinates
+remain a stable spatial address.
+
+### What we borrow from XYZGrid
+
+The coordinate **tag scheme** (categories `room_x_coordinate`,
+`room_y_coordinate`, `room_z_coordinate`) and the `.xyz` room property — so
+coordinate lookups are DB-indexed and a future builder could interoperate with
+contrib tooling. We do **not** inherit `XYZRoom` wholesale: its
+`return_appearance` injects the contrib minimap and would fight our
+`get_display_desc` sense-layer composition. We take the tag/query mixin, not the
+display. (Open question §10.)
+
+## 3 · The coordinate model
+
+* **Signed integers** `(x, y, z)`. Origin **`(0, 0, 0)`** at the central ground
+  space; the world extrapolates outward and downward from there.
+* **Axes:** `+X` east / `+Y` north / `+Z` up. Therefore **`Z < 0` =
+  undercity / mines**, **`Z = 0` = ground**, **`Z > 0` = upper levels / sky**.
+  A signed origin makes "below ground" literally negative — readable and
+  symmetric.
+* **One unit = one room step** along a cardinal exit. Visual/described distance
+  is irrelevant; adjacency in the exit graph defines the unit.
+
+### Storage
+
+Coordinates live as **indexed tags** (the XYZGrid scheme) so spatial queries
+(`all rooms at z = -1`, `rooms in this x/y box`) are DB-level and cheap. A
+cached `room.xyz -> (x, y, z)` property reads them for math; hot consumers
+(combat/radar) may cache the tuple on `ndb`. Tags are the truth; the property is
+the convenience.
+
+Rooms without coordinate tags are **off-grid** (legitimately — pocket spaces,
+limbo, test rooms). Every helper treats a missing coordinate as "not spatially
+present" and fails open, never raising.
+
+### Warp exits — the non-Euclidean escape hatch
+
+Coordinates are **authoritative geometry**: a cardinal exit whose direction
+disagrees with the coordinates of its rooms is a *build bug* (logged and fixed
+during seeding, §4). But deliberate non-Euclidean links — elevators, maglev,
+teleporters, a story warp — are legitimate. Those carry a
+**`("warp", "exit_type")` tag**: excluded from coordinate propagation, ignored
+by radar/gravity geometry, still fully walkable and still a valid edge for the
+dispatch pathfinder. This is the line between "a bug" and "a deliberate
+teleporter," and it keeps the ranged/gravity systems trustworthy.
+
+## 4 · Seeding coordinates onto the existing world
+
+A builder tool (`@coordseed`, staff-locked) assigns coordinates by **walking the
+exit graph** outward from a chosen origin room:
+
+1. Origin room ← `(0, 0, 0)`.
+2. Breadth-first over its exits. Each **cardinal** exit (`north`/`n`,
+   `south`, `east`, `west`, `up`/`u`, `down`/`d`, and the four diagonals)
+   applies its unit delta to the source coordinate and assigns the destination.
+3. **`warp`-tagged exits are skipped** (no coordinate inferred across them).
+4. **Contradiction handling (authoritative):** if a room is reached twice with
+   conflicting coordinates, that is a geometry bug in the build (e.g. a "north"
+   that doesn't come back "south"). The tool **logs it** — room, the two paths,
+   the conflicting coordinates — and the builder corrects the exit (or tags it
+   `warp` if the weirdness is intentional). Coordinates are not silently
+   averaged.
+
+This is a one-time backfill plus an incremental tool builders run as they extend
+the world. Per the design decision: *if we build correctly, contradictions are
+rare and each is a real bug worth surfacing.* Existing room descriptions are
+never touched — rooms only gain tags.
+
+## 5 · Pathfinding & dispatch
+
+A\*/Dijkstra over the **live exit graph** (rooms = nodes, exits = edges), in a
+new `world/spatial/pathfind.py`:
+
+* **Edges = real exits**, so locked doors, `warp` links, and (future) collapsed
+  tunnels are honoured automatically — connectivity always reflects the world as
+  it actually is.
+* **Heuristic = coordinate straight-line distance** (Manhattan or Euclidean),
+  making A\* fast and directed. Off-grid rooms fall back to Dijkstra (zero
+  heuristic) transparently.
+* **Edge weights** default to 1 per step; reserved for terrain cost, hazard
+  avoidance, and lock/traversal penalties later.
+
+Consumers: the **NPC dispatch system** (route an NPC toward an event/target),
+**auto-walk** (`goto`/`path` style player movement), and any "is B reachable
+from A, and how far by travel?" query. Pathfinding answers *travel* distance;
+§7 answers *line-of-sight* distance — they are different and both needed.
+
+## 6 · Verticality & gravity
+
+Gravity is **already partially built** in `commands/combat/jump.py`
+(`apply_gravity_to_items`, exit `db.sky_room` / `db.fall_damage`, edge-jump
+vertical descent). This spec **generalizes that existing mechanic onto the Z
+axis** rather than inventing a parallel one:
+
+* A room declares whether it has a floor — proposed `db.passable` /
+  `db.has_floor` (naming TBD; reconcile with the current `sky_room` flagging).
+* **Falling = −Z traversal:** an unsupported body moves down one room at a time
+  through `passable` rooms until it reaches one with a floor (or a landing
+  surface), accruing the existing `fall_damage`. The current sky-room transit
+  becomes the first concrete case of this general rule.
+* Flight/lift moves the inverse direction; jump-across stays a horizontal
+  special case already handled by `jump`.
+
+The aim is that the live jump/sky-room behaviour keeps working unchanged and
+simply becomes *expressible in coordinate terms*, so future vertical content
+(rooftops, lift shafts, the undercity) composes from the same primitive.
+
+## 7 · Ranged systems (parallel consumers)
+
+Once §3 lands, distance/bearing are available independent of pathfinding:
+
+* **`distance(room_a, room_b)`** — straight-line in the volume (line-of-sight /
+  signal distance, *not* travel distance).
+* **`rooms_within(room, n)`** — coordinate ball, for area effects and scans.
+* **bearing/direction** — for radar contacts and vehicle firing arcs.
+
+**Vehicle combat** reads distance bands (engagement ranges) and bearing.
+**Radar** enumerates contacts within range and renders them by bearing/altitude.
+Both are *parallel* consumers — unblocked the moment the substrate exists, with
+no dependency on the pathfinder.
+
+## 8 · Reserved seams (future phases — corner-proofed, not built)
+
+Designed-for now so we don't paint into a corner; implemented later.
+
+* **Room destruction / repair.** Mutating a room's exits (blow open a wall, seal
+  a door) changes the exit graph → the pathfinder adapts for free; coordinates
+  are unaffected. Repair restores edges. Needs a damage-state model on
+  rooms/exits (separate spec).
+* **Procedural mines.** Coordinates become the **addressing scheme for space
+  that doesn't exist yet**: tunnelling at `(x, y, z)` instantiates the room on
+  demand at that address and links it to its neighbour. The signed integer
+  volume is exactly the lattice this needs.
+* **GPS minimap (quiverbloom render).** Device-gated (a GPS item, not always-on)
+  and **perception-gated** (a blind character does not get an ASCII map dumped
+  on them — routes through the perception system like every other visual layer).
+  The display is **terrain-driven**, not hand-drawn: each room's glyph derives
+  from its terrain/room type. The target aesthetic is a
+  [quiverbloom](https://github.com/csnje/wasm-quiverbloom)-style point-field —
+  a dense cloud of text glyphs where depth reads through density/brightness,
+  driven by *terrain shape* instead of motion — for a 3D-esque relief rather
+  than a flat tile grid.
+  * **Substrate obligation:** expose a **volume-slice query** —
+    `slice(center, radius, z_range) -> [(x, y, z, terrain_type, occupancy)]` —
+    so a future renderer can project the cloud without reaching into room
+    internals. That query is the only thing this spec owes the minimap; the
+    renderer itself is a separate display spec.
+
+## 9 · Build ladder
+
+| Phase | Scope | Unblocks |
+|---|---|---|
+| **1 — Substrate** | Coordinate tags + `.xyz` property + `distance`/`rooms_within` + `@coordseed` seeding tool + warp-exit tag | Ranged systems; everything downstream |
+| **2 — Pathfinder** | A\* over exit graph w/ coordinate heuristic (`world/spatial/pathfind.py`) | NPC dispatch; auto-walk |
+| **3 — Verticality** | Generalize jump/sky-room gravity onto Z; `passable`/floor flags | Vertical content; falling |
+| **— Parallel —** | Vehicle combat + radar (consume Phase 1 distance/bearing) | — |
+| **Reserved** | Destruction/repair · procedural mines · GPS/quiverbloom minimap | Pie-in-the-sky roadmap |
+
+Phases 1–2 are the shippable, testable core. The dispatch system is a direct
+consumer of Phase 2 and gets its own spec.
+
+## 10 · Risks & open questions
+
+* **`XYZRoom` inheritance vs. lightweight mixin.** Inheriting the contrib room
+  pulls in `return_appearance` (its minimap) which collides with
+  `get_display_desc`. **Lean:** lift only the coordinate-tag/query mixin + `.xyz`
+  property; do not inherit the display. Confirm before Phase 1.
+* **Coordinate truth under destruction/tunnelling.** When space is created or
+  destroyed at runtime, coordinate assignment must stay collision-free. The
+  signed lattice gives unique addresses; the open question is reclamation of
+  addresses for destroyed-then-different rebuilt rooms.
+* **Tag-read cost in hot loops.** Distance math in combat/radar shouldn't hit
+  the tag store per call. **Lean:** cache `.xyz` on `ndb`, invalidate on move.
+* **Seeding a partially-inconsistent live world.** The first backfill will
+  surface existing geometry bugs. That is a feature (they're real), but the
+  initial run may produce a meaningful contradiction log to work through.
+* **`passable`/`has_floor` naming** must reconcile with the existing `sky_room`
+  flagging in `jump.py` so we don't end up with two vocabularies for "you fall
+  through this."
+* **Scipy dependency.** XYZGrid's pathfinder needs `scipy`; our own A\* over the
+  exit graph can be pure-Python (`heapq`) and avoid the dependency — preferred
+  for the Docker image unless profiling says otherwise.


### PR DESCRIPTION
Two coupled design proposals from the intent discussion:

- SPATIAL_COORDINATE_SYSTEM_SPEC: a unified signed-integer (X,Y,Z)
  coordinate volume over the hand-built world. Adopts XYZGrid's data
  model (coordinate tags + .xyz) but rejects its ASCII-map authoring
  pipeline and Z-as-mapname islanding. Two sources of truth: coordinates
  for distance/altitude/gravity/proc-gen addressing; the real exit graph
  for connectivity/dispatch, with coordinates supplying only the A*
  heuristic. Origin (0,0,0), signed Z (undercity<0<sky). warp-exit tag
  for deliberate non-Euclidean links. @coordseed retrofit tool.
  Generalizes the existing jump.py sky-room gravity onto the Z axis.
  Reserved seams: destruction/repair, procedural mines, quiverbloom GPS
  minimap.

- NPC_DISPATCH_AND_SIMULATION_SPEC: the director. Deterministic,
  always-on world simulation (population registry + spawn-on-approach
  LOD, roles/routines, death monitoring) that dispatches NPCs to world
  events (assault->LEO, mining incident->S&R, shift change->drink) via
  the spatial pathfinder. Cost principle: simulate on rules, narrate via
  LLM only when witnessed + salient + in-budget. NPC<->NPC defaults to a
  deterministic templated vocabulary through real commands. Reserves the
  trust/consent gate for NPC-on-player actions; gigs/favor loop as bus
  events. First major consumer of the coordinate spec.

Both are proposals (nothing built); not added to the README index.

Closes #820

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
