### PR TITLE
Spec: resolve TRUST_AND_CONSENT core design (identity-keyed grants, restraint gate)

### DIFF
--- a/specs/proposals/TRUST_AND_CONSENT_SPEC.md
+++ b/specs/proposals/TRUST_AND_CONSENT_SPEC.md
@@ -1,97 +1,167 @@
 # Trust & Consent Spec
 
-> **Status: 🚧 DESIGN IN PROGRESS — NOT FOR IMPLEMENTATION.** Captures a
-> decided core stance plus the open questions. The user has flagged this as
-> **"SUPER IMPORTANT"** and explicitly wants **much further discussion before
-> any implementation**. Do not build from this doc yet. It exists so the
-> decisions so far survive, and so new third-party commands have a clean
-> integration point to defer to rather than inventing one-off gates.
+> **Status: 🚧 DESIGN RESOLVED — NOT YET CLEARED FOR BUILD.** The core model is
+> now settled (2026-06-26 design pass); what remains is build sequencing and a
+> short list of edge cases (§7). The user has flagged this as **"SUPER
+> IMPORTANT"** and decides when implementation starts — do not build ahead of
+> that call. This doc exists so the decisions survive and so new third-party
+> commands have a clean gate to defer to rather than inventing one-off logic.
 
 ## 0 · Purpose
 
 Many in-game actions are **third-party** — one character acting *on* another:
-surgery, harvesting organs, installing/removing augments, dragging a body,
-dressing/undressing, frisking, injecting, restraining. Without a consent layer,
-every such command has to decide ad-hoc whether the target can refuse. This
-spec defines the rule for when consent is required and how it's granted, so the
-behaviour is consistent and not painted into a corner.
+medical treatment, surgery, harvesting organs, frisking, restraining, escorting.
+Without a consent layer, every such command has to decide ad-hoc whether the
+target can refuse. This spec defines **when consent is required, how it's
+granted, and how it binds to perceived identity**, so the behaviour is
+consistent and not painted into a corner.
 
-## 1 · Decided core stance (2026-06-20)
+## 1 · Core stance — consent is the *conscious, unrestrained* path
 
-**Consent is required only when the target can resist** — i.e. an **awake /
-conscious** character must agree (or be subdued first) before an invasive
-third-party action lands. **Unconscious, restrained, or dead targets can be
-acted on freely** — no consent needed.
+**A target can refuse an invasive third-party action only when it can contest —
+i.e. when it is conscious *and* unrestrained.** Otherwise the action lands
+freely.
 
-- Rationale: fits the deliberately dangerous, squishy world. You can do anything
-  to someone you've **subdued**; you can't grief someone who's **awake** and
-  unwilling.
-- This is **not** "always require consent" (that kills the danger) and **not**
-  "never" (that's open griefing).
-- It **generalizes the existing workaround.** Today, invasive commands gate on
-  unconscious/dead state. That gate *is* the free-action path; the consent layer
-  is simply the missing **conscious-target** path — a way for an awake character
-  to *grant* permission (and to resist/refuse otherwise).
+```
+can_contest(target) = is_conscious(target) and not is_restrained(target)
+```
 
-## 2 · Current mechanism (what exists today)
+* **Unconscious / dead** → cannot contest → **free action** (the existing gate).
+* **Restrained** → cannot contest → **free action**. Restraint comes from a
+  **grapple** *or* from a **restraint device** — e.g. being strapped into a
+  healing pod or a restraint chair. A grappled or pod-bound patient cannot
+  contest healing or search/frisk; the action simply proceeds.
+* **Conscious *and* unrestrained** → **can contest** → the action requires
+  **pre-granted trust** from the target (§2). Without it, the action is blocked;
+  to proceed, the actor must first **restrain** the target (grapple them, get
+  them into a pod), after which the free-action path applies.
 
-Invasive commands (operate/harvest/install, dress/undress, etc.) gate to
-**unconscious / dead / severed** targets. A conscious target generally can't be
-acted on. This is the accepted interim per [[project-gelatinous-trust-consent]]:
-new third-party commands either keep that gate or leave a clean comment marking
-the conscious-target path as deferred to this system. **No hard-coded
-"reject on conscious target" logic** that the consent layer would have to unpick.
+Rationale: fits the deliberately dangerous, squishy world. You can do anything
+to someone you've **subdued or strapped down**; you can't grief someone who is
+**awake, free, and unwilling** — unless they've **trusted** you. This is not
+"always require consent" (kills the danger) and not "never" (open griefing). It
+**generalizes the existing workaround**: invasive commands already gate to
+unconscious/dead; trust is the missing *conscious-and-willing* path, and
+restraint devices are the missing *conscious-but-subdued* path.
 
-## 3 · The gap to build (later)
+### Build around restraint, not around NPC consent
 
-The conscious-target permission path. At minimum:
-- A way for an awake character to **grant** another permission to perform
-  (some set of) invasive actions on them.
-- A way to **resist / refuse** — and what happens when an unwilling awake target
-  is targeted (hard block? or an opposed/grapple path to *subdue* them first,
-  after which the free-action path applies?).
+In practice the world is built around **restraint devices**, not around NPCs
+granting trust. The **healing pod** is the canonical example: it establishes the
+restrained state, and *that* is what authorizes the AutoDoc (or a doctor) to
+operate — no trust grant needed. NPCs are character objects and *can* hold trust
+grants like anyone (§6), but it will be rare; the structural systems (pods,
+chairs, restraints) do most of the consent work.
 
-## 4 · Open questions (the "discuss much further" list)
+## 2 · Trust binds to *perceived identity*, not to the person
 
-These are deliberately unresolved — they need a design conversation before any
-build:
+The defining requirement: **trusting "batman" must not mean trusting "bruce
+wayne."** This rides entirely on the existing identity machinery — no new
+identity logic.
 
-1. **Granularity.** Per-action, per-person, or blanket? "I trust Bob to operate
-   on me" vs "I trust Bob with anything" vs "anyone may treat me." Is there a
-   trust *level* or just a yes/no per (person, action-class)?
-2. **Grant/revoke UX.** What command(s)? (`allow <who> [to <action>]`,
-   `trust`/`distrust`, `consent`?) Time-limited or until revoked? Does it
-   survive logout / death / sleeve change?
-3. **Resistance model.** If an awake unwilling target is targeted, does the
-   action simply **fail**, or does it open an **opposed/grapple** path (you can
-   try to *subdue* them, and once subdued the existing free-action path applies)?
-   How does this relate to the existing grapple/restrain systems?
-4. **Action taxonomy.** Exactly which commands are gated — and are there tiers
-   (e.g. "treat me" is lower-stakes than "cut out my kidney")? Candidate set:
-   surgery (incise/operate/install/harvest), drag/move-body, dress/undress,
-   frisk/loot, inject/apply, restrain. Where do borderline ones (e.g. handing
-   someone an item, bandaging a willing ally) sit?
-5. **Consciousness thresholds.** Is "can resist" strictly the unconscious gate,
-   or is a groggy/restrained-but-awake target somewhere in between? Does the
-   `consciousness` runtime value pick the line?
-6. **NPCs / mobs.** Do NPCs participate (AI-granted consent / refusal), or are
-   they free-action? Faction/relationship implications.
-7. **Visibility / UX.** How does the actor learn they need consent? How does the
-   target learn they're being asked / acted upon? Any prompt/confirm flow, or
-   purely a pre-granted standing permission?
-8. **Trust & the broader social loop.** Does consent tie into the planned
-   gig/favor/rep system (a RipperDoc you've paid has standing consent; betrayal
-   has rep cost)? See [[project-gelatinous-growth-direction]].
-9. **Abuse / edge cases.** Consent extracted under duress; revoking mid-
-   procedure; consent to one persona vs the person behind a disguise (ties to
-   the identity system); severed parts and corpses (already free — confirm).
+* **Key = `get_apparent_uid(actor)`** (`world/identity.py`). It hashes the
+  identity signature
+  `(sleeve_uid, height_override, build_override, keyword_override,
+  essential_disguise_item_type_ids)`:
+  * Bruce doffs the cowl → an **essential disguise item** leaves the signature →
+    his apparent UID flips from the batman UID to the bruce-wayne UID → a grant
+    made to "batman" **no longer matches**. Exactly the requirement.
+  * `sleeve_uid` is a per-character salt → an **impostor** in an identical
+    batman getup produces a *different* UID. Trust can't be spoofed by copying
+    an outfit.
+  * The worn-item axis is **only essential disguise items**, not all clothing →
+    swapping a non-essential jacket does **not** change the UID, so trust does
+    not silently lapse over a wardrobe tweak — only over a real identity change.
+* **Re-sleeve lapses trust.** If the trusted person re-sleeves into a new body
+  (new `sleeve_uid`), their UID changes and the grant lapses. You trusted *that
+  body/presentation*, not an abstract soul.
 
-## 5 · Cross-references
+### Storage
 
-- [[project-gelatinous-trust-consent]] — the standing project note + decided stance.
-- Identity/recognition system — consent is granted to a *recognised identity*;
-  disguises complicate "who did I consent to."
-- Grapple / restrain (`world/combat/grappling.py`) — the likely "subdue first"
-  substrate for the resistance model (§4.3).
-- `world/medical` operate/harvest/install flows — the primary consumers that
-  currently gate on unconscious/dead.
+Grants live on the **grantor** (the potential target), e.g.
+`db.consent_grants = { apparent_uid: set(action_classes) }`, plus a snapshot
+display label per UID for the listing. Grants survive logout until revoked.
+
+## 3 · Action classes
+
+Trust is granted per **action class** (a class maps to a set of gated commands;
+not all commands exist yet):
+
+| Class | Covers | Notes |
+|---|---|---|
+| `escort` / `follow` | movement-coupling (lead/drag the target's movement) | |
+| `grab` / `grapple` | consensual restraint (let them grab/restrain you uncontested) | the "strap me in willingly" path |
+| `heal` | **all** medical commands — treat, bandage, inject, install, **operate, harvest** | **deliberately blanket** (§3.1) |
+| `search` / `frisk` | frisk / search / loot the target | |
+
+### 3.1 · `heal` is intentionally all-medical — betrayal included
+
+`heal` is **one blanket class covering every medical command**, by design. It is
+a deep level of trust: granting it lets the holder do anything medical to you
+while you're awake — including malpractice and **harvesting your organs**. The
+betrayal affordance (you trusted your ripperdoc; they cut out your kidney) is a
+**feature**, not a footgun. We do *not* split benevolent treatment from invasive
+surgery in the trust layer — the danger is the point.
+
+## 4 · Command surface
+
+| Command | Effect |
+|---|---|
+| `trust <person> to <action>` | grant one action class to that person's *current apparent identity* |
+| `trust <person> to all` | grant every action class (blanket) |
+| `trust` | list who you trust and with what (rendered via recognition names, §5) |
+| `trust <person>` | show that person's grants (**not** a blanket — blanket is `to all`) |
+| `distrust` / `untrust <person> [to <action>]` | revoke one class, or all of that person's grants when `to <action>` is omitted |
+| `distrust all` / `trust no one` | wipe every grant |
+
+## 5 · Listing & perception
+
+`trust` (and per-person `trust <person>`) renders each stored UID back through
+recognition — `get_assigned_name(observer=you, uid)` — so the list reads in
+*your* terms: "You trust **batman** to heal you; **the lean droog** to escort
+you." A UID you've since forgotten falls back to the display-label snapshot taken
+at grant time. You always see trust the way you *perceive* the trusted party —
+consistent with how the rest of the identity system renders.
+
+## 6 · NPC participation
+
+NPCs are character objects and use the same `db.consent_grants` store, so an NPC
+*can* grant or hold trust — but it will be **rare**. Two relevant cases:
+
+* **NPC as grantor** — a paid RipperDoc with standing `heal` consent; betrayal
+  carries rep cost (ties to the gig/favor loop, growth direction). AI decides.
+* **NPC as actor on a player** — a security bot cannot heal/search a *conscious,
+  unrestrained, untrusting* player; it must lawfully **restrain** them first
+  (grapple / cuffs / pod). This is the dispatch spec's reserved seam
+  (`NPC_DISPATCH_AND_SIMULATION_SPEC` §6) — sequence coercive authority content
+  *after* this gate exists.
+
+## 7 · Open edge cases (remaining)
+
+The model is resolved; these are the corners to settle during build:
+
+1. **Consent under duress** — trust granted while grappled/threatened. Probably
+   valid-but-revocable; confirm.
+2. **Revoke mid-procedure** — distrusting someone partway through a multi-step
+   medical/surgical action. Does the in-flight action complete or abort?
+3. **Restraint detection** — the exact predicate for `is_restrained` must unify
+   the grapple state (`world/combat/grappling.py`) with restraint-device state
+   (healing pod / chair furniture, clinic furniture system). One shared helper.
+4. **Consciousness threshold** — does a groggy-but-awake target (low
+   `consciousness`) still `can_contest`, or is there a middle band? Lean: strict
+   conscious/unconscious line via the runtime `consciousness` value.
+5. **Command parse / target resolution** — resolving `<person>` to an apparent
+   UID when the target is present vs. only in recognition memory vs. disguised.
+
+## 8 · Cross-references
+
+- [[project-gelatinous-trust-consent]] — standing project note + decided stance.
+- `IDENTITY_RECOGNITION_SPEC` — `get_apparent_uid` / `get_identity_signature` /
+  `get_assigned_name` / `recognition_memory`; the entire identity key (§2).
+- Grapple / restrain (`world/combat/grappling.py`) — one source of the
+  restrained state (§1, §7.3).
+- Clinic furniture / AutoDoc (`project-gelatinous-clinic`) — the restraint-device
+  source (healing pod) and the primary `heal` consumer.
+- `world/medical` operate/harvest/install — invasive consumers that gate on the
+  free-action path today and defer the conscious path here.
+- `NPC_DISPATCH_AND_SIMULATION_SPEC` §6 — NPC-on-player actions defer to this gate.


### PR DESCRIPTION
Folds the 2026-06-26 design pass into the proposal (banner stays 🚧 —
build remains gated on the user's call):

- Contest predicate: refuse only when conscious AND unrestrained;
  unconscious/dead/restrained => free action. Restraint = grapple OR a
  restraint device (healing pod / chair).
- Trust binds to get_apparent_uid(actor): batman != bruce wayne, impostor
  != real (sleeve_uid salt), not brittle to ordinary clothing (only
  essential disguise items shift the UID); re-sleeve lapses trust.
- Action classes: escort/follow, grab/grapple, heal (all medical —
  deliberately blanket; betrayal/malpractice is the point), search/frisk.
- Command surface: trust <person> to <action> / to all / bare trust lists
  / distrust|untrust / distrust all == "trust no one".
- Build around restraint devices, not NPC consent; NPC participation
  rare. Dispatch spec §6 defers NPC-on-player actions to this gate.

Closes #822

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
