### PR TITLE
Robot species: mechanical humanoid chassis (anatomy + fluid/decay prose)

### DIFF
--- a/world/anatomy/species.py
+++ b/world/anatomy/species.py
@@ -1188,6 +1188,98 @@ SPECIES_DEFINITIONS["synthetic_humanoid"] = _derive_synthetic_humanoid(
     SPECIES_DEFINITIONS["human"])
 
 
+# =====================================================================
+# ROBOT — derived from human. A fully mechanical humanoid chassis.
+# =====================================================================
+#
+# A walking machine: humanoid in FORM and human in MECHANICS (organs,
+# capacities, severability, and the capacity-derived death model all
+# inherit unchanged — destroy the brain-slot processor or the heart-slot
+# power core and the unit deactivates), but mechanical in PRESENTATION.
+# Derived from human via deepcopy + targeted overrides so it stays DRY
+# and tracks future human-anatomy changes.
+#
+# This pass establishes the chassis identity at the SAFE, species-level
+# surfaces (the same ones the synthetic species uses): tougher frame,
+# no biological infection, a non-rotting body that is deactivated →
+# stripped for parts, and a distinct hydraulic fluid so spilled pools
+# read as a machine's, not a body's. Appendage names stay humanoid
+# (arm/hand/leg) — it is a humanoid robot.
+#
+# DEFERRED to a follow-up "mechanical presentation" pass (the same layer
+# the synthetic species also defers): per-organ ``inorganic`` flags
+# (note: ``is_augment_organ`` treats inorganic organs as installed
+# chrome, so a robot's native components must NOT be naively flagged
+# without handling that coupling), component organ-name divergence
+# (brain → "processor core", heart → "power core" — needs a species hook
+# in the organ-display path), and pruning breathing / blood_filtration.
+ROBOT_ORGAN_DURABILITY = 1.5  # armored frame + hardened components
+
+
+def _derive_robot(base: dict) -> dict:
+    robot = copy.deepcopy(base)
+    robot["display_name"] = "robot"
+
+    # Hydraulic/coolant fluid — amber, visually distinct from blood so a
+    # mixed pool reads as a mixture. Machines leak fluid, not blood.
+    robot["blood_color"] = {"name": "amber", "code": "|y", "dried": "tar-black"}
+
+    # Machines don't culture biological infection — the species-level
+    # analog of an inorganic graft ("chrome doesn't go septic", #516).
+    robot["infection_immune"] = True
+
+    # Tougher: armored frame and hardened components take more punishment.
+    for organ in robot["organs"].values():
+        organ["max_hp"] = int(round(organ["max_hp"] * ROBOT_ORGAN_DURABILITY))
+
+    # The chassis does not decay. Time advances it from a freshly
+    # deactivated unit toward an inert, stripped frame — never rot or
+    # skeletonization. Glance token is the short "robot".
+    robot["decay_part_prefixes"] = {
+        "fresh": "robot {part}", "early": "robot {part}",
+        "moderate": "robot {part}", "advanced": "wrecked robot {part}",
+        "skeletal": "stripped robot {part}",
+    }
+    robot["decay_organ_prefixes"] = {
+        "fresh": "robot {organ}", "early": "robot {organ}",
+        "moderate": "robot {organ}", "advanced": "fried robot {organ}",
+        "skeletal": "salvaged robot {organ}",
+    }
+    robot["decay_corpse_names"] = {
+        "fresh": "deactivated robot", "early": "deactivated robot",
+        "moderate": "inert robot chassis",
+        "advanced": "wrecked robot chassis",
+        "skeletal": "stripped robot frame",
+    }
+    robot["decay_corpse_descriptions"] = {
+        "fresh": (
+            "A freshly deactivated robot. {base_desc} The chassis is intact, "
+            "servos ticking as they cool, fluid lines uncut."
+        ),
+        "early": (
+            "A deactivated robot. {base_desc} The frame has gone still and "
+            "cold, indicator lights dark, yet shows no sign of corrosion."
+        ),
+        "moderate": (
+            "An inert robot chassis. The plating has dulled and settled, but "
+            "it does not rot — only the faint reek of scorched circuitry."
+        ),
+        "advanced": (
+            "A wrecked robot chassis. Panels hang open and components have "
+            "been pulled or fried, the frame slackening, but it does not "
+            "putrefy."
+        ),
+        "skeletal": (
+            "A stripped robot frame. Little remains but the structural "
+            "chassis and severed fluid lines; it will corrode no further."
+        ),
+    }
+    return robot
+
+
+SPECIES_DEFINITIONS["robot"] = _derive_robot(SPECIES_DEFINITIONS["human"])
+
+
 def _resolve_species(species: str | None) -> dict:
     """Return the species definition, falling back to ``human``.
 

--- a/world/medical/medical_messages.py
+++ b/world/medical/medical_messages.py
@@ -41,6 +41,13 @@ BLEEDING_ROOM_BY_SPECIES: dict[str, dict[str, str]] = {
         "severe":   "|BCobalt|n fluid runs freely from {actor}'s wounds, pooling on the ground.",
         "grievous": "{actor} leaves a trail of |Bcobalt|n fluid, their wounds venting freely.",
     },
+    "robot": {
+        # Amber hydraulic fluid, not blood (see species blood_color).
+        "minor":    "Beads of |yamber|n fluid weep from {actor}'s seams.",
+        "moderate": "|yAmber|n hydraulic fluid steadily leaks from {actor}, slicking the plating.",
+        "severe":   "|yAmber|n fluid runs freely from {actor}'s ruptured lines, pooling on the ground.",
+        "grievous": "{actor} trails |yamber|n fluid, severed lines venting under pressure.",
+    },
 }
 
 
@@ -89,6 +96,15 @@ DEATH_CAUSE_TEMPLATES_BY_SPECIES: dict[str, dict[str, str]] = {
         "stab":          "|B{actor} jerks, cobalt fluid venting, then goes inert.|n",
         "slash":         "|B{actor} jerks, cobalt fluid venting, then goes inert.|n",
     },
+    "robot": {
+        # Amber fluid; the unit powers down rather than draws a last breath.
+        "blood loss":    "|y{actor}'s amber fluid spreads beneath their stilled chassis.|n",
+        "heart failure": "|y{actor}'s frame shudders once and powers down, servos locking.|n",
+        "head":          "|y{actor}'s optics flicker out and the chassis drops, inert.|n",
+        "brain":         "|y{actor}'s optics flicker out and the chassis drops, inert.|n",
+        "stab":          "|y{actor} jerks, amber fluid venting, then goes inert.|n",
+        "slash":         "|y{actor} jerks, amber fluid venting, then goes inert.|n",
+    },
 }
 
 # Generic fallback when no cause matches.
@@ -96,6 +112,7 @@ _GENERIC_DEATH_BY_SPECIES: dict[str, str] = {
     "human": "|R{actor} draws their final breath and grows still.|n",
     "rat":   "|R{actor}'s small body falls still.|n",
     "synthetic_humanoid": "|B{actor}'s systems fall dark and the frame goes still.|n",
+    "robot": "|y{actor}'s systems fall dark and the chassis goes still.|n",
 }
 
 

--- a/world/tests/test_robot_species.py
+++ b/world/tests/test_robot_species.py
@@ -1,0 +1,118 @@
+"""Tests for the Robot species (a fully mechanical humanoid chassis).
+
+Derived from human via deepcopy + targeted overrides: human MECHANICS
+(organs, capacities, severability, capacity-derived death model all
+inherit — destroy the brain-slot processor or the heart-slot power core
+and the unit deactivates) with a MECHANICAL presentation — tougher frame,
+no biological infection, a body that is deactivated and stripped for
+parts rather than rotting, and a distinct hydraulic fluid. Appendage
+names stay humanoid (it is a humanoid robot).
+
+The deeper "mechanical presentation" layer (per-organ inorganic prose,
+component organ-name divergence, pruning breathing/blood_filtration) is a
+deliberate follow-up, the same layer the synthetic species also defers.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.anatomy import (
+    get_species_blood_color,
+    get_species_corpse_description,
+    get_species_corpse_name,
+    get_species_infection_immune,
+)
+from world.anatomy.species import SPECIES_DEFINITIONS
+from world.medical.medical_messages import (
+    get_bleeding_room_message, get_death_cause_template,
+)
+
+HUMAN = SPECIES_DEFINITIONS["human"]
+ROBOT = SPECIES_DEFINITIONS["robot"]
+
+
+class TestRobotSpecies(TestCase):
+    def test_registered_with_display_name(self):
+        self.assertIn("robot", SPECIES_DEFINITIONS)
+        self.assertEqual(ROBOT["display_name"], "robot")
+
+    def test_inherits_human_mechanics(self):
+        # Same organ keys, severability, and capacity wiring → the
+        # capacity-derived death model behaves identically to human
+        # (processor core = brain slot; power core = heart slot).
+        self.assertEqual(set(ROBOT["organs"]), set(HUMAN["organs"]))
+        self.assertEqual(ROBOT["severable_containers"],
+                         HUMAN["severable_containers"])
+        self.assertEqual(ROBOT["body_capacities"], HUMAN["body_capacities"])
+        self.assertEqual(ROBOT["grasping_containers"],
+                         HUMAN["grasping_containers"])
+        self.assertEqual(ROBOT["limb_downstream_chain"],
+                         HUMAN["limb_downstream_chain"])
+
+    def test_appendages_keep_humanoid_names(self):
+        # A humanoid robot — arms/hands/legs, not "actuators" (yet).
+        self.assertEqual(ROBOT["location_display"]["left_hand"], "left hand")
+        self.assertEqual(ROBOT["severed_chain_display"]["left_thigh"], "left leg")
+
+    def test_components_are_more_durable(self):
+        for key, organ in ROBOT["organs"].items():
+            self.assertGreater(organ["max_hp"], HUMAN["organs"][key]["max_hp"],
+                               f"{key} should be tougher than human")
+        # heart slot (power core): round(15 * 1.5) == 22
+        self.assertEqual(ROBOT["organs"]["heart"]["max_hp"], 22)
+        # brain slot (processor): round(10 * 1.5) == 15
+        self.assertEqual(ROBOT["organs"]["brain"]["max_hp"], 15)
+
+    def test_chassis_does_not_rot(self):
+        self.assertEqual(
+            get_species_corpse_name("robot", "fresh"), "deactivated robot")
+        self.assertEqual(
+            get_species_corpse_name("robot", "skeletal"), "stripped robot frame")
+        for stage in ("moderate", "advanced", "skeletal"):
+            name = get_species_corpse_name("robot", stage)
+            self.assertNotIn("rotting", name)
+            self.assertNotIn("skeletal remains", name)
+
+    def test_corpse_description_is_mechanical_and_non_decaying(self):
+        fresh = get_species_corpse_description(
+            "robot", "fresh", "It wore a security vest.")
+        self.assertIn("chassis", fresh.lower())
+        self.assertIn("It wore a security vest.", fresh)
+        moderate = get_species_corpse_description("robot", "moderate")
+        self.assertNotIn("decompos", moderate.lower())
+        self.assertIn("does not rot", moderate.lower())
+
+    def test_derivation_does_not_mutate_human(self):
+        # deepcopy → the human definition is untouched by the overrides.
+        self.assertEqual(HUMAN["organs"]["heart"]["max_hp"], 15)
+        self.assertEqual(get_species_corpse_name("human", "skeletal"),
+                         "skeletal remains")
+
+
+class TestRobotFluid(TestCase):
+    def test_species_blood_color_is_amber(self):
+        robot = get_species_blood_color("robot")
+        self.assertEqual(robot["name"], "amber")
+        self.assertEqual(robot["code"], "|y")
+        # other species unaffected; unknown falls back to human crimson.
+        self.assertEqual(get_species_blood_color("human")["name"], "crimson")
+        self.assertEqual(get_species_blood_color(None)["name"], "crimson")
+
+    def test_leak_prose_is_amber_not_crimson(self):
+        msg = get_bleeding_room_message(10, "robot")
+        self.assertIn("amber", msg.lower())
+        self.assertNotIn("crimson", msg.lower())
+        self.assertIn("crimson", get_bleeding_room_message(10, "human").lower())
+
+    def test_death_prose_is_amber(self):
+        self.assertIn(
+            "amber",
+            get_death_cause_template("blood loss", "robot").lower())
+
+
+class TestRobotInfectionImmunity(TestCase):
+    def test_species_flag(self):
+        self.assertTrue(get_species_infection_immune("robot"))
+        self.assertFalse(get_species_infection_immune("human"))
+        self.assertFalse(get_species_infection_immune(None))


### PR DESCRIPTION
Phase 1 of ROBOT_SPECIES_AND_MOB_SPEC — the buildable core, mirroring the
shipped synthetic_humanoid pattern.

- species.py: _derive_robot(human) + SPECIES_DEFINITIONS["robot"]. Human
  mechanics inherit unchanged (organs, capacities, severability, the
  capacity-derived death model — destroy the brain-slot processor or the
  heart-slot power core and the unit deactivates). Mechanical presentation
  at the SAFE species-level surfaces only: 1.5x durability, infection_immune,
  amber hydraulic fluid (visually distinct so mixed pools read as a
  mixture), non-rotting decay (deactivated robot -> inert chassis ->
  stripped frame, with mechanical corpse descriptions). Humanoid appendage
  names kept.
- medical_messages.py: robot bleeding + death-cause + generic-death banks
  (amber fluid; powers-down / goes-inert prose), mirroring the synth banks.
- test_robot_species.py: 11 tests. Full species suite (139) + synth (19)
  green in the throwaway container.

Additive and dormant (no robot instances exist yet; no existing behavior
changes), so no reload is required until the spawn pass.

Deferred to the "mechanical presentation" follow-up (the same layer the
synthetic species defers): per-organ inorganic flags (is_augment_organ
treats inorganic organs as installed chrome — needs handling first),
component organ-name divergence (brain -> processor core; needs an
organ-display species hook), and pruning breathing / blood_filtration.
The spawnable RobotNPC typeclass (species-first medical init) is Phase 2.

Closes #838

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
