### PR TITLE
@spawnmob/robot (+/synth): spawnable robots with full mechanical flavor

### DIFF
--- a/commands/CmdSpawnMob.py
+++ b/commands/CmdSpawnMob.py
@@ -10,6 +10,7 @@ from world.namebank import (
 from world.identity import (
     HEIGHTS, BUILDS, HAIR_COLORS, HAIR_STYLES,
     RAT_SIZES, RAT_COATS,
+    ROBOT_FINISHES, ROBOT_CHASSIS,
 )
 from world.identity_utils import msg_room_identity
 from world.mob_flavor import apply_random_flavor
@@ -40,12 +41,18 @@ class CmdSpawnMob(Command):
                    (stock filler description, no longdescs, no look_place)
                    for clean diagnostic spawns.
         /rat     - spawn an anatomically distinct rat instead of a
-                   humanoid. Skips the human-flavored short-description,
-                   longdesc, and look_place pass (it's all humanoid
-                   vocabulary).  Medical state initializes with rat
-                   organs; longdesc surfaces seed to the rat default set
-                   (snout / fur / forelegs / tail / etc.).  See
-                   ``SPECIES_AUTHORING.md`` for adding more species.
+                   humanoid. Medical state initializes with rat organs;
+                   flavor (short desc / longdesc / look_place) dispatches
+                   to the rat tables.  See ``SPECIES_AUTHORING.md``.
+        /robot   - spawn a humanoid robot. Mechanical chassis (amber
+                   hydraulic fluid, non-rotting frame, infection-immune,
+                   tougher components); key composes to "a {finish}
+                   {chassis} robot"; renders neutral (they/their); flavor
+                   dispatches to the robot tables.
+        /synth   - spawn a synthetic humanoid (replicant). Passes as
+                   human in appearance and flavor, but its medical state
+                   uses the synthetic anatomy (cobalt fluid, non-rotting,
+                   infection-immune).
     """
 
     key = "@spawnmob"
@@ -66,18 +73,25 @@ class CmdSpawnMob(Command):
                     blank = True
                 if "rat" in switches:
                     species = "rat"
+                if "robot" in switches:
+                    species = "robot"
+                if "synth" in switches:
+                    species = "synthetic_humanoid"
                 raw_args = parts[1] if len(parts) > 1 else ""
 
         # Assign sex with chance of ambiguity
         sex = choice(["male", "female"])
         if randint(1, 10) <= 2:  # 20% chance to use ambiguous
             sex = "ambiguous"
+        if species == "robot":
+            sex = "ambiguous"  # machines render neutral (they/their)
 
         # Name: humans pull from the name banks; non-humans compose
         # a rich species-flavored sdesc key (a rat gets a size + coat
         # pair like "a wiry brown rat" rather than the bare "a rat").
         # See world.identity.RAT_SIZES / RAT_COATS.
-        if species == "human":
+        if species in ("human", "synthetic_humanoid"):
+            # A synthetic passes as human — same name banks and identity.
             if sex == "male":
                 first = choice(FIRST_NAMES_MALE)
             elif sex == "female":
@@ -89,6 +103,10 @@ class CmdSpawnMob(Command):
         elif species == "rat":
             mob_name = raw_args or (
                 f"a {choice(RAT_SIZES)} {choice(RAT_COATS)} rat"
+            )
+        elif species == "robot":
+            mob_name = raw_args or (
+                f"a {choice(ROBOT_FINISHES)} {choice(ROBOT_CHASSIS)} robot"
             )
         else:
             mob_name = raw_args or f"a {species}"
@@ -125,10 +143,11 @@ class CmdSpawnMob(Command):
         mob.intellect = roll_stat()
         mob.motorics = roll_stat()
 
-        # Humanoid-only identity attributes — rats don't have human
-        # height / build / hair properties.  Sdesc rendering for non-
-        # humans falls back to ``.key`` ("a rat") naturally.
-        if species == "human":
+        # Humanoid-identity attributes (height / build / hair) — humans
+        # and synthetics (replicants pass as human).  Rats and robots
+        # skip these; their sdesc renders from the composed ``.key``
+        # ("a wiry brown rat", "a battered security robot") naturally.
+        if species in ("human", "synthetic_humanoid"):
             # Randomize so the mob gets a proper sdesc (e.g. "a gaunt
             # man with blonde braids") instead of falling back to
             # ``.key``.

--- a/world/identity.py
+++ b/world/identity.py
@@ -78,6 +78,33 @@ RAT_COATS: tuple[str, ...] = (
     "scarred",
 )
 
+#: Robot sdesc-key composition (parallels the rat size/coat axes). A
+#: spawned robot's key reads "a {finish} {chassis} robot" — e.g. "a
+#: battered security robot", "a rust-streaked utility robot".
+ROBOT_FINISHES: tuple[str, ...] = (
+    "matte-black",
+    "scuffed",
+    "battered",
+    "rust-streaked",
+    "olive-drab",
+    "dented",
+    "grimy",
+    "scorched",
+    "chrome-trimmed",
+    "weather-beaten",
+)
+
+ROBOT_CHASSIS: tuple[str, ...] = (
+    "industrial",
+    "security",
+    "utility",
+    "maintenance",
+    "loader",
+    "sentry",
+    "courier",
+    "labor",
+)
+
 #: Physical descriptor table.  ``PHYSICAL_DESCRIPTOR_TABLE[height][build]``
 #: yields a single adjective describing the character's silhouette.
 #:

--- a/world/mob_flavor/__init__.py
+++ b/world/mob_flavor/__init__.py
@@ -34,26 +34,32 @@ from random import choice
 from world.anatomy import get_species_pair_keys
 from world.mob_flavor.longdescs import LONGDESCS
 from world.mob_flavor.longdescs_rat import LONGDESCS_RAT
+from world.mob_flavor.longdescs_robot import LONGDESCS_ROBOT
 from world.mob_flavor.look_places import LOOK_PLACES
 from world.mob_flavor.look_places_rat import LOOK_PLACES_RAT
+from world.mob_flavor.look_places_robot import LOOK_PLACES_ROBOT
 from world.mob_flavor.short_descs import SHORT_DESCS
 from world.mob_flavor.short_descs_rat import SHORT_DESCS_RAT
+from world.mob_flavor.short_descs_robot import SHORT_DESCS_ROBOT
 
 
 # Species → data-table mappings. New species: add an entry per axis.
 _SHORT_DESCS_BY_SPECIES: dict[str, list[str]] = {
     "human": SHORT_DESCS,
     "rat":   SHORT_DESCS_RAT,
+    "robot": SHORT_DESCS_ROBOT,
 }
 
 _LOOK_PLACES_BY_SPECIES: dict[str, list[str]] = {
     "human": LOOK_PLACES,
     "rat":   LOOK_PLACES_RAT,
+    "robot": LOOK_PLACES_ROBOT,
 }
 
 _LONGDESCS_BY_SPECIES: dict[str, dict[str, list[str]]] = {
     "human": LONGDESCS,
     "rat":   LONGDESCS_RAT,
+    "robot": LONGDESCS_ROBOT,
 }
 
 

--- a/world/mob_flavor/longdescs_robot.py
+++ b/world/mob_flavor/longdescs_robot.py
@@ -1,0 +1,113 @@
+"""Longdesc templates for spawned robots.
+
+Per-location prose seeded into ``mob.longdesc[location]``. Same token
+conventions as the human module:
+
+* Pair-keyed nouns wrapped in braces (``{eyes}`` / ``{ears}`` /
+  ``{arms}`` / ``{hands}`` / ``{thighs}`` / ``{shins}`` / ``{feet}``) so
+  the renderer can flex them when one side collapses, with braced verbs
+  whose subject is that paired noun.
+* Singular locations (``head``, ``face``, ``chest`` ...) use plain prose
+  with pronoun tokens.
+
+Slot keys mirror the humanoid set in ``world/anatomy/species.py`` — a
+robot is a humanoid chassis, so it uses the human ``pair_keys`` /
+``default_longdesc_locations`` (no ``hair`` slot — robots are unhaired,
+so that slot stays unseeded).
+"""
+
+from __future__ import annotations
+
+LONGDESCS_ROBOT: dict[str, list[str]] = {
+    # Head region
+    "head": [
+        "{Their} head is a smooth alloy casing, seams running clean along the jaw and crown.",
+        "{Their} cranial housing is dented above one temple, the impact sealed with a rough weld.",
+        "A cluster of sensor ports rings the back of {their} skull, dark glass set flush with the plating.",
+        "{Their} head pivots on an exposed servo collar, the joint hissing faintly with each turn.",
+        "The crown of {their} head carries a faded designation stencil, half-scrubbed to bare metal.",
+    ],
+    "face": [
+        "{Their} face is a fixed sculpted plate, expressionless but for the glow of an optical band.",
+        "A horizontal sensor strip crosses {their} face where eyes would sit, lit a steady amber.",
+        "{Their} faceplate is scuffed and micro-scratched, the finish gone matte from years of grit.",
+        "Twin grilles flank a blank central plate, venting the faint warmth of internal processors.",
+        "{Their} face is featureless armor, the only motion the slow refocus of recessed lenses.",
+    ],
+    "neck": [
+        "{Their} neck is a stacked column of articulated rings, cabling visible between the segments.",
+        "Thick coolant lines run the length of {their} neck, ticking faintly as fluid cycles through.",
+        "{Their} neck joint rotates with a low servo whine, exposing a band of bare actuator beneath.",
+    ],
+
+    # Torso region
+    "chest": [
+        "{Their} chest is a broad armored plastron, a recessed access panel set over the core.",
+        "Status indicators glow in a row across {their} chest, pulsing in slow sequence.",
+        "{Their} chest plating is scorched along one edge, the alloy discoloured by old heat.",
+        "A faint reciprocating hum comes from deep in {their} chest where the power core sits.",
+    ],
+    "back": [
+        "{Their} back is a ridged heat-sink array, shedding a thin shimmer of warm air.",
+        "Cable runs and conduit trace {their} spine beneath a hinged maintenance panel.",
+        "{Their} back plating is gouged and re-welded, the repairs left honestly visible.",
+    ],
+    "abdomen": [
+        "{Their} midsection is a flexible segmented band, articulating as the frame bends.",
+        "An exposed actuator bundle works at {their} waist, hissing softly with each motion.",
+        "{Their} abdominal plating is patched with mismatched alloy, salvaged and bolted in place.",
+    ],
+    "groin": [
+        "{Their} hip assembly is a heavy articulated joint, the servos broad and exposed.",
+        "Hydraulic lines converge at {their} pelvis, the fittings beaded with old fluid.",
+    ],
+
+    # Arms
+    "eyes": [
+        "{Their} {eyes} {are} a pair of recessed optical lenses, refocusing with faint mechanical clicks.",
+        "{Their} {eyes} {glow} a steady amber, the apertures contracting as they track movement.",
+        "{Their} {eyes} {sit} behind scratched protective glass, whirring softly as they adjust.",
+        "{Their} {eyes} {are} cold pinpoints of sensor light, unblinking and always moving.",
+        "{Their} {eyes} {carry} a faint flicker at the edges — a processor reading the whole room at once.",
+    ],
+    "ears": [
+        "{Their} {ears} {are} flush audio grilles set where a person's would be, swiveling minutely toward sound.",
+        "{Their} {ears} {are} fine mesh intakes, filtering the room's noise into something the processor can parse.",
+        "{Their} {ears} {sit} as dark recessed ports, attentive to every shift in the ambient hum.",
+        "{Their} {ears} {are} paired pickups behind perforated plates, tracking the faintest sound.",
+    ],
+    "arms": [
+        "{Their} {arms} {are} segmented actuator assemblies, cabling visible at every joint.",
+        "{Their} {arms} {move} with a smooth servo-driven precision, never quite silent.",
+        "{Their} {arms} {are} armored and scuffed, the plating gouged from heavy use.",
+        "{Their} {arms} {hang} loose at {their} sides, the elbow servos ticking as they idle.",
+        "{Their} {arms} {carry} mismatched plating, one clearly a salvaged replacement.",
+    ],
+    "hands": [
+        "{Their} {hands} {are} three-fingered manipulators, the digits ending in worn grip pads.",
+        "{Their} {hands} {flex} with a faint servo whine, each joint articulating independently.",
+        "{Their} {hands} {are} heavy alloy graspers, scratched bright at the fingertips.",
+        "{Their} {hands} {carry} the scuffs of constant work, the grip surfaces polished smooth.",
+        "{Their} {hands} {close} with deliberate mechanical care, precise and unhurried.",
+    ],
+
+    # Legs
+    "thighs": [
+        "{Their} {thighs} {are} broad hydraulic struts, the pistons filmed with a sheen of fluid.",
+        "{Their} {thighs} {are} armored load-bearing members, dented along the leading edge.",
+        "{Their} {thighs} {flex} with a deep hydraulic sigh as the frame shifts its weight.",
+        "{Their} {thighs} {carry} thick bundled cabling beneath scuffed protective plating.",
+    ],
+    "shins": [
+        "{Their} {shins} {are} reinforced strut housings, scarred and scraped from rough ground.",
+        "{Their} {shins} {are} bare actuator columns, the servos exposed and ticking.",
+        "{Their} {shins} {carry} mismatched plating, one panel clearly a field repair.",
+        "{Their} {shins} {are} caked with grime along the lower joints, the alloy showing through.",
+    ],
+    "feet": [
+        "{Their} {feet} {are} broad splayed stabilizers, the soles worn smooth and bright.",
+        "{Their} {feet} {are} heavy magnetic pads, clicking faintly against the floor.",
+        "{Their} {feet} {carry} the dents of hard use, the toe plates scraped to bare metal.",
+        "{Their} {feet} {plant} with a solid mechanical certainty, distributing the frame's mass.",
+    ],
+}

--- a/world/mob_flavor/look_places_robot.py
+++ b/world/mob_flavor/look_places_robot.py
@@ -1,0 +1,31 @@
+"""Look-place fragments for spawned robots.
+
+Each string is consumed as ``mob.look_place`` and rendered by the room
+appearance system as ``<Name> is <look_place>`` (e.g. "A battered
+security robot is standing sentry against the wall.").  Entries should:
+
+* Begin with the verb/adjective phrase — *not* a leading "It is" / "It
+  [verb]", which the renderer supplies the copula for.
+* End with a period.
+* Read as something a humanoid machine would plausibly be doing in any
+  room of the colony.
+
+Mirrors the contract in ``look_places.py`` for human mobs.
+"""
+
+from __future__ import annotations
+
+LOOK_PLACES_ROBOT: list[str] = [
+    "standing sentry against the wall, optics sweeping the room in slow arcs.",
+    "powered down to an idle, status lights pulsing a slow amber.",
+    "rotating its head in measured increments to track every movement.",
+    "planted squarely in the open, servos ticking as it holds position.",
+    "running a slow diagnostic, panel lights cascading along its forearm.",
+    "standing motionless, the faint hiss of its coolant cycle the only sound.",
+    "scanning the room with a thin sweep of sensor light.",
+    "shifting its weight from one foot to the other with a soft hydraulic sigh.",
+    "waiting with the flat patience of a machine left on standby.",
+    "tracking a passerby, lenses refocusing with a series of faint clicks.",
+    "holding a corner with its back to the wall, arms loose at its sides.",
+    "venting a thin wisp of heat from a grille along its spine.",
+]

--- a/world/mob_flavor/short_descs_robot.py
+++ b/world/mob_flavor/short_descs_robot.py
@@ -1,0 +1,28 @@
+"""Short-description templates for randomly-spawned robots.
+
+Whole-body impressions of a humanoid machine. Per-part anatomy lives in
+``longdescs_robot.py``. Same token conventions as the human module —
+pronoun substitutions resolve per-observer, braced verbs flex for
+number/gender (robots spawn neutral, so ``{They}``/``{their}`` render as
+they/their).
+"""
+
+from __future__ import annotations
+
+SHORT_DESCS_ROBOT: list[str] = [
+    "{They} {are} a humanoid machine, joints articulating with a faint servo whine at every shift of weight.",
+    "{Their} chassis is scuffed and work-worn, the painted designation long since rubbed to bare alloy.",
+    "There is a deliberate, unhurried economy to the way {they} {move} — nothing wasted, nothing rushed.",
+    "A row of status indicators glows along {their} collar line, pulsing in slow patient sequence.",
+    "{They} {hold} {themselves} with the motionless poise of something that does not tire and does not fidget.",
+    "{Their} optics track movement in small mechanical increments, the lenses refocusing with a faint click.",
+    "Coolant lines trace visible conduits beneath {their} plating, ticking softly as the frame sheds its heat.",
+    "{They} {stand} squarely balanced, the low hydraulic hiss of {their} frame the only sign {they} {are} powered.",
+    "{Their} movements carry the slight latency of a machine thinking a half-second before it acts.",
+    "Servos compensate audibly as {they} {shift} stance, the whole frame settling with mechanical precision.",
+    "{They} {are} built broad and functional, every panel seam and fastener left honestly exposed.",
+    "A faint ozone smell hangs around {them}, the signature of hardworked actuators and warm circuitry.",
+    "{They} {regard} the room with the flat unblinking attention of a sensor suite that never looks away.",
+    "{Their} frame bears the dents and weld-scars of long service, repaired more than once and never prettily.",
+    "{They} {move} with the heavy certainty of something that outmasses most of what shares the room with it.",
+]

--- a/world/tests/test_robot_flavor.py
+++ b/world/tests/test_robot_flavor.py
@@ -1,0 +1,62 @@
+"""Tests for robot spawn flavor — short descs, longdescs, look places,
+and the sdesc-key vocabulary used by ``@spawnmob/robot``.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.identity import ROBOT_CHASSIS, ROBOT_FINISHES
+from world.mob_flavor import (
+    _LONGDESCS_BY_SPECIES,
+    _LOOK_PLACES_BY_SPECIES,
+    _SHORT_DESCS_BY_SPECIES,
+    random_longdesc,
+    random_look_place,
+    random_short_desc,
+)
+
+
+class TestRobotFlavor(TestCase):
+    def test_robot_registered_in_all_axes(self):
+        self.assertIn("robot", _SHORT_DESCS_BY_SPECIES)
+        self.assertIn("robot", _LOOK_PLACES_BY_SPECIES)
+        self.assertIn("robot", _LONGDESCS_BY_SPECIES)
+
+    def test_short_descs_are_mechanical(self):
+        joined = " ".join(_SHORT_DESCS_BY_SPECIES["robot"]).lower()
+        self.assertIn("servo", joined)
+        # no organic breathing imagery on a machine
+        for line in _SHORT_DESCS_BY_SPECIES["robot"]:
+            self.assertNotIn("breath", line.lower())
+
+    def test_longdesc_covers_humanoid_slots_no_hair(self):
+        slots = _LONGDESCS_BY_SPECIES["robot"]
+        for slot in ("head", "face", "neck", "chest", "back", "abdomen",
+                     "groin", "eyes", "ears", "arms", "hands", "thighs",
+                     "shins", "feet"):
+            self.assertIn(slot, slots)
+            self.assertTrue(slots[slot], f"{slot} has no options")
+        # robots are unhaired — that slot stays unseeded
+        self.assertNotIn("hair", slots)
+
+    def test_pair_slots_use_braced_nouns(self):
+        for line in _LONGDESCS_BY_SPECIES["robot"]["eyes"]:
+            self.assertIn("{eyes}", line)
+        for line in _LONGDESCS_BY_SPECIES["robot"]["arms"]:
+            self.assertIn("{arms}", line)
+
+    def test_name_vocab_composes(self):
+        self.assertTrue(ROBOT_FINISHES)
+        self.assertTrue(ROBOT_CHASSIS)
+        name = f"a {ROBOT_FINISHES[0]} {ROBOT_CHASSIS[0]} robot"
+        self.assertTrue(name.startswith("a "))
+        self.assertTrue(name.endswith(" robot"))
+
+    def test_random_helpers_return_robot_content(self):
+        self.assertIn(random_short_desc("robot"),
+                      _SHORT_DESCS_BY_SPECIES["robot"])
+        self.assertIn(random_look_place("robot"),
+                      _LOOK_PLACES_BY_SPECIES["robot"])
+        self.assertIn(random_longdesc("eyes", "robot"),
+                      _LONGDESCS_BY_SPECIES["robot"]["eyes"])


### PR DESCRIPTION
Robots and synths are spawnable through the existing generic non-human
path in CmdSpawnMob — no new typeclass (synths/rats are plain Characters
keyed by db.species; the command already sets species + rebuilds medical
state for non-humans, lines 109-119).

- @spawnmob/robot — composes "a {finish} {chassis} robot" from new
  ROBOT_FINISHES/ROBOT_CHASSIS (identity.py); forces neutral sex
  (they/their); skips human height/build/hair; gets robot flavor.
- @spawnmob/synth — synthetic humanoid; passes as human in name /
  identity / flavor (replicant), but its medical state uses the synthetic
  anatomy (cobalt fluid, non-rotting, infection-immune). Previously not
  spawnable at all.
- Robot flavor banks: short_descs_robot, longdescs_robot (humanoid slots,
  mechanical prose, braced pair nouns, no hair slot), look_places_robot,
  registered in mob_flavor/__init__'s species maps.
- test_robot_flavor.py (6 tests). 72-test sweep (mob_flavor + longdesc
  tokens + robot flavor/species + synth) green in the throwaway container.

Additive — existing human/rat/blank spawns unchanged. A reload exposes the
new switches in-game.

Closes #840

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
