### PR TITLE
Spatial coordinate substrate (Phase 1): world/spatial + @coordseed

### DIFF
--- a/commands/CmdCoordSeed.py
+++ b/commands/CmdCoordSeed.py
@@ -1,0 +1,92 @@
+"""``@coordseed`` — assign (x, y, z) coordinates to the world by walking
+cardinal exits outward from a chosen origin room.
+
+Phase 1 of the spatial coordinate substrate
+(``specs/proposals/SPATIAL_COORDINATE_SYSTEM_SPEC.md``). Authoritative:
+geometry contradictions (a direction that doesn't reverse) are reported,
+not silently resolved — fix the exit, or tag it ``warp`` to exclude it.
+"""
+
+from evennia import Command
+
+from world.spatial import (
+    clear_xyz,
+    seed_coordinates,
+    set_xyz,
+)
+from world.spatial.coordinates import all_coordinate_rooms
+
+
+class CmdCoordSeed(Command):
+    """
+    Seed the world with (x, y, z) coordinates.
+
+    Usage:
+        @coordseed             - seed outward from this room as origin (0,0,0)
+        @coordseed/check       - dry run: report what would happen, write nothing
+        @coordseed/clear       - remove coordinates from every room
+
+    Walks cardinal exits (north/south/east/west, the diagonals, up/down)
+    breadth-first from your current room, assigning one coordinate unit per
+    step (+X east, +Y north, +Z up). Non-cardinal exits (enter, climb, out)
+    and ``warp``-tagged exits are skipped.
+
+    Contradictions — a room reached two ways with different coordinates —
+    are a geometry bug in the build (a "north" that doesn't come back
+    "south"). They are listed for you to fix; coordinates are never
+    averaged. Tag a deliberately non-Euclidean exit with
+    ``@tag <exit> = warp:exit_type`` to exclude it.
+    """
+
+    key = "@coordseed"
+    locks = "cmd:perm(Builders) or perm(Developers)"
+    help_category = "Building"
+
+    def func(self):
+        caller = self.caller
+        switches = self.switches or []
+
+        if "clear" in switches:
+            rooms = all_coordinate_rooms()
+            for room in rooms:
+                clear_xyz(room)
+            caller.msg(f"Cleared coordinates from {len(rooms)} room(s).")
+            return
+
+        origin = caller.location
+        if origin is None:
+            caller.msg("You have no location to seed from.")
+            return
+
+        assignments, contradictions = seed_coordinates(origin)
+        dry = "check" in switches
+
+        if not dry:
+            for room, coord in assignments.items():
+                set_xyz(room, *coord)
+
+        verb = "Would seed" if dry else "Seeded"
+        caller.msg(
+            f"|g{verb} {len(assignments)} room(s)|n from "
+            f"{origin.get_display_name(caller)} as origin (0, 0, 0)."
+        )
+
+        if contradictions:
+            caller.msg(
+                f"|r{len(contradictions)} geometry contradiction(s) "
+                f"— each is a build bug to fix (or tag warp):|n"
+            )
+            for c in contradictions[:40]:
+                caller.msg(
+                    f"  {c['from_room'].get_display_name(caller)} "
+                    f"--{c['direction']}--> "
+                    f"{c['dest'].get_display_name(caller)}: already at "
+                    f"{c['existing']}, this path expects {c['expected']}."
+                )
+            if len(contradictions) > 40:
+                caller.msg(f"  ... and {len(contradictions) - 40} more.")
+        else:
+            caller.msg("|gNo geometry contradictions — clean.|n")
+
+        if dry:
+            caller.msg("|y(dry run — nothing was written)|n")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -26,6 +26,7 @@ from commands import CmdConsumption
 from commands import CmdMedicalItems
 from commands import CmdSmoke
 from commands.CmdSpawnMob import CmdSpawnMob
+from commands.CmdCoordSeed import CmdCoordSeed
 from commands.bar_menu import CmdSpawnIngredient
 from commands.CmdBug import CmdBug
 from commands.CmdAdmin import CmdHeal, CmdPeace, CmdTestDeathCurtain, CmdWeather, CmdResetMedical, CmdMedicalAudit, CmdTestDeath, CmdTestUnconscious
@@ -137,6 +138,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         # Add individual character commands
         self.add(CmdCharacter.CmdStats)
         self.add(CmdSpawnMob())
+        self.add(CmdCoordSeed())
         self.add(CmdSpawnIngredient())
         self.add(CmdAdmin.CmdHeal())
         self.add(CmdAdmin.CmdPeace())

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -49,6 +49,13 @@ class Room(ObjectParent, DefaultRoom):
     #: Non-visual sense layers, in render order.
     SENSE_LAYER_ORDER = ("auditory", "olfactory", "tactile", "atmospheric")
 
+    @property
+    def xyz(self):
+        """The room's signed ``(x, y, z)`` coordinates, or ``None`` when
+        off-grid. Set by ``@coordseed`` (spatial substrate, Phase 1)."""
+        from world.spatial import get_xyz
+        return get_xyz(self)
+
     def get_display_desc(self, looker, **kwargs):
         """Perception-aware room description (CAPACITY_CONSUMERS spec §5).
 

--- a/world/spatial/__init__.py
+++ b/world/spatial/__init__.py
@@ -1,0 +1,43 @@
+"""Spatial coordinate substrate — a signed integer (x, y, z) volume laid
+over the hand-built world.
+
+Phase 1 of ``specs/proposals/SPATIAL_COORDINATE_SYSTEM_SPEC.md``: the
+coordinate data + read helpers + the ``@coordseed`` seeding walk. Pure
+Python, no scipy. Coordinates are stored as ``room.db.xyz`` (a signed
+``(x, y, z)`` int tuple, or ``None`` for off-grid rooms).
+
+This package adds no behaviour to existing rooms until they are seeded —
+an unseeded room's ``xyz`` is ``None`` and every helper fails open.
+"""
+
+from world.spatial.coordinates import (
+    DIRECTION_ALIASES,
+    DIRECTION_DELTAS,
+    all_coordinate_rooms,
+    bearing,
+    clear_xyz,
+    distance,
+    exit_direction,
+    get_xyz,
+    is_warp_exit,
+    normalize_direction,
+    rooms_within,
+    seed_coordinates,
+    set_xyz,
+)
+
+__all__ = [
+    "DIRECTION_ALIASES",
+    "DIRECTION_DELTAS",
+    "all_coordinate_rooms",
+    "bearing",
+    "clear_xyz",
+    "distance",
+    "exit_direction",
+    "get_xyz",
+    "is_warp_exit",
+    "normalize_direction",
+    "rooms_within",
+    "seed_coordinates",
+    "set_xyz",
+]

--- a/world/spatial/coordinates.py
+++ b/world/spatial/coordinates.py
@@ -1,0 +1,237 @@
+"""Coordinate read/write helpers, the direction system, and the seeding
+walk for the spatial substrate (Phase 1).
+
+See ``specs/proposals/SPATIAL_COORDINATE_SYSTEM_SPEC.md``.
+
+Axes: ``+X`` east / ``+Y`` north / ``+Z`` up. Origin ``(0, 0, 0)`` at the
+central ground room; the undercity is ``Z < 0``, upper levels ``Z > 0``.
+One unit = one room step along a cardinal exit.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+
+# --------------------------------------------------------------------------
+# Direction system
+# --------------------------------------------------------------------------
+
+#: Canonical cardinal/diagonal/vertical direction → unit coordinate delta.
+DIRECTION_DELTAS: dict[str, tuple[int, int, int]] = {
+    "north": (0, 1, 0),
+    "south": (0, -1, 0),
+    "east": (1, 0, 0),
+    "west": (-1, 0, 0),
+    "up": (0, 0, 1),
+    "down": (0, 0, -1),
+    "northeast": (1, 1, 0),
+    "northwest": (-1, 1, 0),
+    "southeast": (1, -1, 0),
+    "southwest": (-1, -1, 0),
+}
+
+#: Abbreviation → canonical direction (mirrors the exit alias convention).
+DIRECTION_ALIASES: dict[str, str] = {
+    "n": "north", "s": "south", "e": "east", "w": "west",
+    "u": "up", "d": "down",
+    "ne": "northeast", "nw": "northwest",
+    "se": "southeast", "sw": "southwest",
+}
+
+#: Tag marking an exit as a deliberate non-Euclidean link (elevator,
+#: teleporter, maglev). Excluded from coordinate propagation; still a
+#: normal, walkable exit.
+WARP_TAG = "warp"
+WARP_TAG_CATEGORY = "exit_type"
+
+
+def normalize_direction(token: Any) -> str | None:
+    """Return the canonical direction for *token* (a key or alias), or
+    ``None`` if it isn't a recognised cardinal/diagonal/vertical step."""
+    if not token:
+        return None
+    token = str(token).lower().strip()
+    if token in DIRECTION_DELTAS:
+        return token
+    return DIRECTION_ALIASES.get(token)
+
+
+def exit_direction(exit_obj: Any) -> str | None:
+    """Resolve an exit's canonical direction from its key, then aliases.
+
+    Returns ``None`` for non-cardinal exits (``enter bar``, ``out``,
+    ``climb`` …), which the seeder skips.
+    """
+    direction = normalize_direction(getattr(exit_obj, "key", None))
+    if direction:
+        return direction
+    aliases = getattr(exit_obj, "aliases", None)
+    if aliases is not None:
+        try:
+            for alias in aliases.all():
+                direction = normalize_direction(alias)
+                if direction:
+                    return direction
+        except Exception:  # noqa: BLE001 — never break seeding over aliases
+            pass
+    return None
+
+
+def is_warp_exit(exit_obj: Any) -> bool:
+    """True if the exit is tagged as a warp (excluded from geometry)."""
+    tags = getattr(exit_obj, "tags", None)
+    if tags is None:
+        return False
+    try:
+        return bool(tags.has(WARP_TAG, category=WARP_TAG_CATEGORY))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# --------------------------------------------------------------------------
+# Coordinate read / write
+# --------------------------------------------------------------------------
+
+def get_xyz(room: Any) -> tuple[int, int, int] | None:
+    """Return *room*'s ``(x, y, z)`` tuple, or ``None`` if off-grid."""
+    if room is None:
+        return None
+    db = getattr(room, "db", None)
+    coord = getattr(db, "xyz", None) if db is not None else None
+    if coord is None:
+        return None
+    try:
+        x, y, z = coord
+        return (int(x), int(y), int(z))
+    except (TypeError, ValueError):
+        return None
+
+
+def set_xyz(room: Any, x: int, y: int, z: int) -> None:
+    """Assign *room*'s coordinates."""
+    room.db.xyz = (int(x), int(y), int(z))
+
+
+def clear_xyz(room: Any) -> None:
+    """Remove *room*'s coordinates (return it to off-grid)."""
+    if getattr(room, "db", None) is not None:
+        room.db.xyz = None
+
+
+# --------------------------------------------------------------------------
+# Spatial queries (linear scan for Phase 1; spatial-hash escalation later)
+# --------------------------------------------------------------------------
+
+def distance(room_a: Any, room_b: Any) -> float | None:
+    """Straight-line distance between two rooms in the coordinate volume.
+
+    ``None`` if either room is off-grid. This is line-of-sight / signal
+    distance, *not* travel distance (that's the pathfinder, Phase 2).
+    """
+    a, b = get_xyz(room_a), get_xyz(room_b)
+    if a is None or b is None:
+        return None
+    return ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2) ** 0.5
+
+
+def all_coordinate_rooms() -> list:
+    """Every on-grid room. Linear scan (small worlds); the seam a spatial
+    hash slots behind later."""
+    from typeclasses.rooms import Room
+    return [r for r in Room.objects.all() if get_xyz(r) is not None]
+
+
+def rooms_within(room: Any, n: float) -> list:
+    """On-grid rooms within straight-line distance *n* of *room* (excluding
+    *room* itself). Empty when *room* is off-grid."""
+    if get_xyz(room) is None:
+        return []
+    out = []
+    for other in all_coordinate_rooms():
+        if other == room:
+            continue
+        d = distance(room, other)
+        if d is not None and d <= n:
+            out.append(other)
+    return out
+
+
+#: Compass labels for the eight horizontal octants, plus pure vertical.
+_BEARINGS = [
+    "east", "northeast", "north", "northwest",
+    "west", "southwest", "south", "southeast",
+]
+
+
+def bearing(room_a: Any, room_b: Any) -> str | None:
+    """Rough compass+altitude bearing from *a* to *b* (for radar / dispatch
+    facing). ``None`` if off-grid; ``"here"`` if co-located."""
+    import math
+    a, b = get_xyz(room_a), get_xyz(room_b)
+    if a is None or b is None:
+        return None
+    dx, dy, dz = b[0] - a[0], b[1] - a[1], b[2] - a[2]
+    horiz = None
+    if dx or dy:
+        octant = int(round(math.atan2(dy, dx) / (math.pi / 4))) % 8
+        horiz = _BEARINGS[octant]
+    vert = "up" if dz > 0 else "down" if dz < 0 else None
+    if horiz and vert:
+        return f"{horiz} and {vert}"
+    return horiz or vert or "here"
+
+
+# --------------------------------------------------------------------------
+# Seeding walk
+# --------------------------------------------------------------------------
+
+def seed_coordinates(origin: Any) -> tuple[dict, list]:
+    """Breadth-first assign coordinates outward from *origin* (= ``(0,0,0)``)
+    over cardinal exits.
+
+    **Authoritative**: a room reached twice with conflicting coordinates is
+    a geometry bug (a direction that doesn't reverse). It is recorded in the
+    contradiction list and *not* overwritten — coordinates are never
+    silently averaged. ``warp``-tagged and non-cardinal exits are skipped.
+
+    Pure traversal — assigns nothing to the DB. The caller (``@coordseed``)
+    writes ``assignments`` and reports ``contradictions``.
+
+    Returns ``(assignments, contradictions)`` where ``assignments`` maps
+    ``room -> (x, y, z)`` and each contradiction is a dict describing the
+    clash.
+    """
+    assignments: dict = {origin: (0, 0, 0)}
+    contradictions: list = []
+    queue: deque = deque([origin])
+
+    while queue:
+        room = queue.popleft()
+        x, y, z = assignments[room]
+        for ex in (getattr(room, "exits", None) or []):
+            if is_warp_exit(ex):
+                continue
+            direction = exit_direction(ex)
+            if direction is None:
+                continue
+            dest = getattr(ex, "destination", None)
+            if dest is None:
+                continue
+            dx, dy, dz = DIRECTION_DELTAS[direction]
+            expected = (x + dx, y + dy, z + dz)
+            if dest in assignments:
+                if assignments[dest] != expected:
+                    contradictions.append({
+                        "from_room": room,
+                        "exit": ex,
+                        "direction": direction,
+                        "dest": dest,
+                        "existing": assignments[dest],
+                        "expected": expected,
+                    })
+                continue
+            assignments[dest] = expected
+            queue.append(dest)
+
+    return assignments, contradictions

--- a/world/tests/test_spatial_coordinates.py
+++ b/world/tests/test_spatial_coordinates.py
@@ -1,0 +1,205 @@
+"""Tests for the spatial coordinate substrate (Phase 1): direction
+parsing, coordinate read/write, distance/bearing, and the seeding walk
+with contradiction + warp handling.
+"""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from world.spatial import (
+    DIRECTION_DELTAS,
+    bearing,
+    distance,
+    exit_direction,
+    get_xyz,
+    is_warp_exit,
+    normalize_direction,
+    rooms_within,
+    seed_coordinates,
+    set_xyz,
+)
+
+
+# --- lightweight fakes (no Evennia boot) --------------------------------
+
+class _Aliases:
+    def __init__(self, items=()):
+        self._items = list(items)
+
+    def all(self):
+        return list(self._items)
+
+
+class _Tags:
+    def __init__(self, tags=()):
+        self._tags = set(tags)  # set of (key, category)
+
+    def has(self, key, category=None):
+        return (key, category) in self._tags
+
+
+class _Exit:
+    def __init__(self, key, destination, aliases=(), warp=False):
+        self.key = key
+        self.destination = destination
+        self.aliases = _Aliases(aliases)
+        self.tags = _Tags({("warp", "exit_type")} if warp else set())
+
+
+class _DB:
+    def __init__(self):
+        self.xyz = None
+
+
+class _Room:
+    def __init__(self, name):
+        self.name = name
+        self.db = _DB()
+        self.exits = []
+
+    def __repr__(self):
+        return f"<{self.name}>"
+
+
+def _link(a, b, direction, warp=False):
+    a.exits.append(_Exit(direction, b, warp=warp))
+
+
+# --- direction system ---------------------------------------------------
+
+class TestDirections(TestCase):
+    def test_all_deltas_unit(self):
+        for d, (dx, dy, dz) in DIRECTION_DELTAS.items():
+            self.assertTrue(all(v in (-1, 0, 1) for v in (dx, dy, dz)), d)
+        self.assertEqual(DIRECTION_DELTAS["north"], (0, 1, 0))
+        self.assertEqual(DIRECTION_DELTAS["east"], (1, 0, 0))
+        self.assertEqual(DIRECTION_DELTAS["up"], (0, 0, 1))
+        self.assertEqual(DIRECTION_DELTAS["down"], (0, 0, -1))
+
+    def test_normalize(self):
+        self.assertEqual(normalize_direction("north"), "north")
+        self.assertEqual(normalize_direction("N"), "north")
+        self.assertEqual(normalize_direction("ne"), "northeast")
+        self.assertIsNone(normalize_direction("enter"))
+        self.assertIsNone(normalize_direction(None))
+
+    def test_exit_direction_key_then_alias(self):
+        self.assertEqual(exit_direction(_Exit("north", None)), "north")
+        self.assertEqual(exit_direction(_Exit("n", None)), "north")
+        self.assertEqual(
+            exit_direction(_Exit("doorway", None, aliases=["s"])), "south")
+        self.assertIsNone(exit_direction(_Exit("enter bar", None)))
+
+    def test_is_warp(self):
+        self.assertTrue(is_warp_exit(_Exit("up", None, warp=True)))
+        self.assertFalse(is_warp_exit(_Exit("up", None)))
+
+
+# --- coordinate read / write + queries ----------------------------------
+
+class TestCoordinateMath(TestCase):
+    def test_set_get(self):
+        r = _Room("r")
+        self.assertIsNone(get_xyz(r))
+        set_xyz(r, 3, -4, 1)
+        self.assertEqual(get_xyz(r), (3, -4, 1))
+
+    def test_distance(self):
+        a, b = _Room("a"), _Room("b")
+        set_xyz(a, 0, 0, 0)
+        set_xyz(b, 3, 4, 0)
+        self.assertEqual(distance(a, b), 5.0)
+        # off-grid → None
+        self.assertIsNone(distance(a, _Room("c")))
+
+    def test_bearing(self):
+        a = _Room("a")
+        set_xyz(a, 0, 0, 0)
+
+        def to(x, y, z):
+            r = _Room("t")
+            set_xyz(r, x, y, z)
+            return bearing(a, r)
+
+        self.assertEqual(to(1, 0, 0), "east")
+        self.assertEqual(to(0, 1, 0), "north")
+        self.assertEqual(to(1, 1, 0), "northeast")
+        self.assertEqual(to(0, 0, 1), "up")
+        self.assertEqual(to(1, 0, 1), "east and up")
+        self.assertEqual(to(0, 0, 0), "here")
+
+    def test_rooms_within(self):
+        center = _Room("c")
+        near = _Room("near")
+        far = _Room("far")
+        set_xyz(center, 0, 0, 0)
+        set_xyz(near, 2, 0, 0)
+        set_xyz(far, 10, 0, 0)
+        with patch("world.spatial.coordinates.all_coordinate_rooms",
+                   return_value=[center, near, far]):
+            got = rooms_within(center, 3)
+        self.assertIn(near, got)
+        self.assertNotIn(far, got)
+        self.assertNotIn(center, got)
+
+
+# --- seeding walk -------------------------------------------------------
+
+class TestSeeding(TestCase):
+    def _grid(self):
+        # A(0,0,0) -E-> B(1,0,0), A -N-> C(0,1,0),
+        # B -N-> D(1,1,0), C -E-> D, plus reverse exits.
+        A, B, C, D = (_Room(n) for n in "ABCD")
+        _link(A, B, "east"); _link(B, A, "west")
+        _link(A, C, "north"); _link(C, A, "south")
+        _link(B, D, "north"); _link(D, B, "south")
+        _link(C, D, "east"); _link(D, C, "west")
+        return A, B, C, D
+
+    def test_consistent_grid(self):
+        A, B, C, D = self._grid()
+        assignments, contradictions = seed_coordinates(A)
+        self.assertEqual(assignments[A], (0, 0, 0))
+        self.assertEqual(assignments[B], (1, 0, 0))
+        self.assertEqual(assignments[C], (0, 1, 0))
+        self.assertEqual(assignments[D], (1, 1, 0))
+        self.assertEqual(contradictions, [])
+
+    def test_contradiction_detected(self):
+        A, B, C, D = self._grid()
+        # Add a bogus A -up-> D. D is now reachable two ways with different
+        # coords — a geometry contradiction (whichever path reaches it first
+        # wins the assignment; the others are flagged).
+        _link(A, D, "up")
+        assignments, contradictions = seed_coordinates(A)
+        self.assertTrue(contradictions)
+        for c in contradictions:
+            self.assertNotEqual(c["existing"], c["expected"])
+
+    def test_warp_exit_skipped(self):
+        A = _Room("A")
+        warp_dest = _Room("warp_dest")
+        _link(A, warp_dest, "east", warp=True)
+        assignments, _ = seed_coordinates(A)
+        self.assertNotIn(warp_dest, assignments)  # not reached through a warp
+
+    def test_non_cardinal_skipped(self):
+        A = _Room("A")
+        bar = _Room("bar")
+        A.exits.append(_Exit("enter bar", bar))
+        assignments, _ = seed_coordinates(A)
+        self.assertNotIn(bar, assignments)
+
+
+class TestWiring(TestCase):
+    def test_coordseed_registered_in_character_cmdset(self):
+        from commands.default_cmdsets import CharacterCmdSet
+        cs = CharacterCmdSet()
+        cs.at_cmdset_creation()
+        self.assertIn("@coordseed", [c.key for c in cs.commands])
+
+    def test_room_has_xyz_property(self):
+        from typeclasses.rooms import Room
+        self.assertIsInstance(Room.__dict__.get("xyz"), property)


### PR DESCRIPTION
Phase 1 of SPATIAL_COORDINATE_SYSTEM_SPEC — additive and dormant until
seeded.

- world/spatial/: get_xyz/set_xyz/clear_xyz (room.db.xyz, signed int
  tuple); the direction system (cardinal/diagonal/vertical -> unit deltas,
  key+alias parsing); distance/rooms_within/bearing (linear-scan; the
  spatial-hash escalation is deferred per spec §10); is_warp_exit; and
  seed_coordinates (authoritative BFS from origin (0,0,0): logs
  contradictions, never averages, skips warp + non-cardinal exits).
- @coordseed builder command: seeds from the current room; /check dry-run;
  /clear wipe; reports geometry contradictions to fix.
- Room.xyz read-only property (None until seeded).
- 14 tests (directions, distance/bearing/rooms_within, seeding incl.
  contradiction cascade + warp/non-cardinal skip, command registration,
  Room property).

No Room behavior change (xyz is None until @coordseed runs). Pure-Python,
no scipy. Storage is room.db.xyz, not XYZGrid tags — lighter and
codebase-idiomatic; indexed tags deferred. Seeding the live world is a
separate supervised step.

Closes #846

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
