### PR TITLE
Spatial Phase 2: A* exit-graph pathfinder + @path

### DIFF
--- a/commands/CmdPath.py
+++ b/commands/CmdPath.py
@@ -1,0 +1,72 @@
+"""``@path`` — show the travel route from here to another room.
+
+A builder/debug window onto the Phase 2 pathfinder
+(``world/spatial/pathfind.py``): A* over the real exit graph with the
+seeded coordinates as the heuristic.
+"""
+
+from evennia import Command
+
+from world.spatial import distance, find_path, find_path_exits
+from world.spatial.coordinates import exit_direction
+
+
+class CmdPath(Command):
+    """
+    Show the shortest travel route from your room to another.
+
+    Usage:
+        @path <room>          - route from here to <room> (name or #dbref)
+
+    Walks the real exit graph (A* guided by seeded coordinates), so the
+    route respects actual connectivity — locked doors, warp links, and
+    non-cardinal exits all count. Reports the step-by-step directions, the
+    travel-step count, and (when both rooms are on-grid) the straight-line
+    coordinate distance for comparison.
+    """
+
+    key = "@path"
+    locks = "cmd:perm(Builders) or perm(Developers)"
+    help_category = "Building"
+
+    def func(self):
+        caller = self.caller
+        if not self.args.strip():
+            caller.msg("Usage: @path <room>")
+            return
+
+        origin = caller.location
+        if origin is None:
+            caller.msg("You have no location to route from.")
+            return
+
+        target = caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return  # search already reported the failure
+
+        path = find_path(origin, target)
+        if path is None:
+            caller.msg(
+                f"No route from {origin.get_display_name(caller)} to "
+                f"{target.get_display_name(caller)} over the exit graph."
+            )
+            return
+
+        steps = len(path) - 1
+        if steps == 0:
+            caller.msg("You're already there.")
+            return
+
+        exits = find_path_exits(origin, target) or []
+        directions = [exit_direction(ex) or ex.key for ex in exits]
+
+        caller.msg(
+            f"|gRoute to {target.get_display_name(caller)}|n — "
+            f"{steps} step(s): {', '.join(directions)}."
+        )
+        los = distance(origin, target)
+        if los is not None:
+            caller.msg(
+                f"  (straight-line coordinate distance: {los:.1f}; "
+                f"travel steps: {steps})"
+            )

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -27,6 +27,7 @@ from commands import CmdMedicalItems
 from commands import CmdSmoke
 from commands.CmdSpawnMob import CmdSpawnMob
 from commands.CmdCoordSeed import CmdCoordSeed
+from commands.CmdPath import CmdPath
 from commands.bar_menu import CmdSpawnIngredient
 from commands.CmdBug import CmdBug
 from commands.CmdAdmin import CmdHeal, CmdPeace, CmdTestDeathCurtain, CmdWeather, CmdResetMedical, CmdMedicalAudit, CmdTestDeath, CmdTestUnconscious
@@ -139,6 +140,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdCharacter.CmdStats)
         self.add(CmdSpawnMob())
         self.add(CmdCoordSeed())
+        self.add(CmdPath())
         self.add(CmdSpawnIngredient())
         self.add(CmdAdmin.CmdHeal())
         self.add(CmdAdmin.CmdPeace())

--- a/world/spatial/__init__.py
+++ b/world/spatial/__init__.py
@@ -25,6 +25,12 @@ from world.spatial.coordinates import (
     seed_coordinates,
     set_xyz,
 )
+from world.spatial.pathfind import (
+    find_path,
+    find_path_exits,
+    is_reachable,
+    path_length,
+)
 
 __all__ = [
     "DIRECTION_ALIASES",
@@ -34,9 +40,13 @@ __all__ = [
     "clear_xyz",
     "distance",
     "exit_direction",
+    "find_path",
+    "find_path_exits",
     "get_xyz",
+    "is_reachable",
     "is_warp_exit",
     "normalize_direction",
+    "path_length",
     "rooms_within",
     "seed_coordinates",
     "set_xyz",

--- a/world/spatial/pathfind.py
+++ b/world/spatial/pathfind.py
@@ -1,0 +1,152 @@
+"""A* pathfinding over the real exit graph (Phase 2).
+
+See ``specs/proposals/SPATIAL_COORDINATE_SYSTEM_SPEC.md`` §5.
+
+The search traverses the **actual exit network** (rooms = nodes, exits =
+edges), so locked doors, ``warp`` links, and any future destruction are
+honoured automatically — connectivity always reflects the world as it
+really is. The seeded coordinates supply only the **heuristic** (the
+estimated remaining steps), which makes A* fast and directed; rooms
+without coordinates degrade gracefully to a heuristic of 0 (i.e. plain
+Dijkstra) so the search stays correct off-grid.
+
+Edge weight is a flat 1 step for Phase 2 — terrain cost / hazard
+avoidance / traversal penalties are a reserved seam.
+
+Consumers: the NPC dispatch director (route an NPC toward a target),
+auto-walk, and "is B reachable from A, and how far by travel?" queries.
+This answers *travel* distance; ``coordinates.distance`` answers
+*line-of-sight* distance — they are different and both needed.
+"""
+
+from __future__ import annotations
+
+import heapq
+import itertools
+from typing import Any
+
+from world.spatial.coordinates import get_xyz
+
+
+def _heuristic(room: Any, goal: Any) -> int:
+    """Estimated remaining steps from *room* to *goal* using coordinates.
+
+    Movement model: a step changes one axis (cardinal / vertical) or two
+    axes at once in the XY plane (a diagonal). So the tightest admissible
+    estimate is ``max(|dx|, |dy|) + |dz|``. Off-grid either end → 0, which
+    turns A* into Dijkstra (still correct, just unguided).
+    """
+    a, b = get_xyz(room), get_xyz(goal)
+    if a is None or b is None:
+        return 0
+    dx, dy, dz = abs(a[0] - b[0]), abs(a[1] - b[1]), abs(a[2] - b[2])
+    return max(dx, dy) + dz
+
+
+def _neighbors(room: Any, traverser: Any):
+    """Yield ``(destination, exit)`` for every usable exit out of *room*.
+
+    When *traverser* is given, exits it cannot pass (locked doors, access
+    locks) are skipped — so dispatch routes around what the NPC can't open.
+    With no traverser the search uses pure connectivity (every exit).
+    """
+    for ex in (getattr(room, "exits", None) or []):
+        dest = getattr(ex, "destination", None)
+        if dest is None:
+            continue
+        if traverser is not None:
+            try:
+                if not ex.access(traverser, "traverse"):
+                    continue
+            except Exception:  # noqa: BLE001 — never break routing over a lock
+                pass
+        yield dest, ex
+
+
+def _search(start: Any, goal: Any, traverser: Any,
+            max_steps: int | None) -> dict | None:
+    """Run A* from *start* to *goal*. Returns the ``came_from`` map
+    (``room -> (prev_room, exit)``) when *goal* is reached, else ``None``.
+    """
+    counter = itertools.count()  # stable tie-breaker (never compare rooms)
+    open_heap = [(_heuristic(start, goal), 0, next(counter), start)]
+    came_from: dict = {}
+    g_score: dict = {start: 0}
+    closed: set = set()
+
+    while open_heap:
+        _f, g, _c, current = heapq.heappop(open_heap)
+        if current == goal:
+            return came_from
+        if current in closed:
+            continue
+        closed.add(current)
+        if max_steps is not None and g >= max_steps:
+            continue
+        for dest, ex in _neighbors(current, traverser):
+            if dest in closed:
+                continue
+            tentative = g + 1
+            if tentative < g_score.get(dest, float("inf")):
+                came_from[dest] = (current, ex)
+                g_score[dest] = tentative
+                heapq.heappush(
+                    open_heap,
+                    (tentative + _heuristic(dest, goal), tentative,
+                     next(counter), dest),
+                )
+    return None
+
+
+def _walk_back(came_from: dict, start: Any, goal: Any):
+    """Rebuild the chain from goal to start as ``[(prev, exit, room), ...]``
+    in forward order (start-exclusive)."""
+    chain = []
+    cur = goal
+    while cur != start:
+        prev, ex = came_from[cur]
+        chain.append((prev, ex, cur))
+        cur = prev
+    chain.reverse()
+    return chain
+
+
+def find_path(start: Any, goal: Any, traverser: Any = None,
+              max_steps: int | None = None) -> list | None:
+    """Shortest room path ``[start, …, goal]`` (inclusive), or ``None`` if
+    *goal* is unreachable (within *max_steps*, if given)."""
+    if start is goal or start == goal:
+        return [start]
+    came_from = _search(start, goal, traverser, max_steps)
+    if came_from is None:
+        return None
+    return [start] + [room for (_p, _e, room) in _walk_back(came_from, start, goal)]
+
+
+def find_path_exits(start: Any, goal: Any, traverser: Any = None,
+                    max_steps: int | None = None) -> list | None:
+    """The ordered list of **exits** to traverse from *start* to *goal*
+    (for auto-walk / step-by-step movement), or ``None`` if unreachable.
+    Empty list when ``start == goal``."""
+    if start is goal or start == goal:
+        return []
+    came_from = _search(start, goal, traverser, max_steps)
+    if came_from is None:
+        return None
+    return [ex for (_p, ex, _r) in _walk_back(came_from, start, goal)]
+
+
+def path_length(start: Any, goal: Any, traverser: Any = None,
+                max_steps: int | None = None) -> int | None:
+    """Number of travel steps from *start* to *goal*, or ``None`` if
+    unreachable. ``0`` when ``start == goal``."""
+    path = find_path(start, goal, traverser, max_steps)
+    return None if path is None else len(path) - 1
+
+
+def is_reachable(start: Any, goal: Any, traverser: Any = None,
+                 max_steps: int | None = None) -> bool:
+    """True if *goal* is reachable from *start* over the exit graph."""
+    if start is goal or start == goal:
+        return True
+    return _search(start, goal, traverser, max_steps) is not None

--- a/world/tests/test_spatial_pathfind.py
+++ b/world/tests/test_spatial_pathfind.py
@@ -1,0 +1,106 @@
+"""Tests for the A* exit-graph pathfinder (Phase 2)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.spatial import (
+    find_path,
+    find_path_exits,
+    is_reachable,
+    path_length,
+    set_xyz,
+)
+
+
+class _Exit:
+    def __init__(self, key, destination, locked=False):
+        self.key = key
+        self.destination = destination
+        self._locked = locked
+
+    def access(self, who, access_type):
+        return not self._locked
+
+
+class _Room:
+    def __init__(self, name):
+        self.name = name
+        self.db = SimpleNamespace(xyz=None)
+        self.exits = []
+
+    def __repr__(self):
+        return self.name
+
+
+def _link(a, b, direction, locked=False):
+    a.exits.append(_Exit(direction, b, locked=locked))
+
+
+class TestPathfind(TestCase):
+    def _diamond(self):
+        # A -E-> B -E-> D  (2 steps)   and   A -N-> X -N-> Y -E-> D (3 steps)
+        A, B, D, X, Y = (_Room(n) for n in ("A", "B", "D", "X", "Y"))
+        set_xyz(A, 0, 0, 0); set_xyz(B, 1, 0, 0); set_xyz(D, 2, 0, 0)
+        set_xyz(X, 0, 1, 0); set_xyz(Y, 0, 2, 0)
+        _link(A, B, "east"); _link(B, D, "east")
+        _link(A, X, "north"); _link(X, Y, "north"); _link(Y, D, "east")
+        return A, B, D, X, Y
+
+    def test_finds_shortest_path(self):
+        A, B, D, X, Y = self._diamond()
+        path = find_path(A, D)
+        self.assertEqual(path, [A, B, D])  # the 2-step branch, not the 3-step
+        self.assertEqual(path_length(A, D), 2)
+
+    def test_path_exits_and_directions(self):
+        A, B, D, X, Y = self._diamond()
+        exits = find_path_exits(A, D)
+        self.assertEqual([e.key for e in exits], ["east", "east"])
+        self.assertEqual([e.destination for e in exits], [B, D])
+
+    def test_same_room(self):
+        A = _Room("A")
+        self.assertEqual(find_path(A, A), [A])
+        self.assertEqual(find_path_exits(A, A), [])
+        self.assertEqual(path_length(A, A), 0)
+        self.assertTrue(is_reachable(A, A))
+
+    def test_unreachable(self):
+        A, B = _Room("A"), _Room("B")  # no exits between them
+        self.assertIsNone(find_path(A, B))
+        self.assertIsNone(path_length(A, B))
+        self.assertFalse(is_reachable(A, B))
+
+    def test_traverser_routes_around_locked_exit(self):
+        # A -E(locked)-> B ; A -N-> C -E-> B. A traverser must detour.
+        A, B, C = (_Room(n) for n in "ABC")
+        set_xyz(A, 0, 0, 0); set_xyz(B, 1, 0, 0); set_xyz(C, 0, 1, 0)
+        _link(A, B, "east", locked=True)
+        _link(A, C, "north"); _link(C, B, "east")
+        npc = SimpleNamespace(name="npc")
+        # No traverser → takes the direct (locked) edge.
+        self.assertEqual(find_path(A, B), [A, B])
+        # With a traverser the locked edge is skipped → the detour.
+        self.assertEqual(find_path(A, B, traverser=npc), [A, C, B])
+
+    def test_off_grid_still_routes(self):
+        # No coordinates anywhere → heuristic 0 → Dijkstra, still correct.
+        A, B, C = (_Room(n) for n in "ABC")
+        _link(A, B, "east"); _link(B, C, "east")
+        self.assertEqual(find_path(A, C), [A, B, C])
+
+    def test_max_steps_cutoff(self):
+        A, B, C, D = (_Room(n) for n in "ABCD")
+        _link(A, B, "east"); _link(B, C, "east"); _link(C, D, "east")
+        self.assertIsNone(find_path(A, D, max_steps=2))
+        self.assertEqual(find_path(A, D, max_steps=3), [A, B, C, D])
+
+
+class TestPathWiring(TestCase):
+    def test_path_command_registered(self):
+        from commands.default_cmdsets import CharacterCmdSet
+        cs = CharacterCmdSet()
+        cs.at_cmdset_creation()
+        self.assertIn("@path", [c.key for c in cs.commands])


### PR DESCRIPTION
A* over the REAL exit graph (rooms=nodes, exits=edges), seeded coordinates
as the heuristic — so connectivity always reflects the world (locked
doors, warp links, non-cardinal exits, future destruction all honoured
automatically), while coordinates just make the search fast and directed.

- world/spatial/pathfind.py: find_path (room list) / find_path_exits
  (exits to walk) / path_length / is_reachable. Heuristic
  max(|dx|,|dy|)+|dz|; off-grid -> 0 (Dijkstra, still correct). Optional
  traverser skips exits it can't pass (dispatch routes around locks);
  max_steps cutoff. Flat 1-step weight (terrain/hazard cost reserved).
- @path <room> builder/debug command: directions, step count, travel vs
  straight-line distance.
- 9 pathfind tests (optimality, exits, unreachable, same-room, locked-exit
  detour, off-grid fallback, max_steps, registration). 22-test spatial
  sweep green.

The reusable core the NPC dispatch director + auto-walk consume.

Closes #850

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
