### PR TITLE
Director: dispatch core (pathfinder-driven NPC travel + event routing)

### DIFF
--- a/commands/CmdDispatch.py
+++ b/commands/CmdDispatch.py
@@ -1,0 +1,87 @@
+"""``@dispatch`` — raise a world event here and route responders to it.
+
+A builder/debug window onto the director's dispatch core
+(``world/director/dispatch.py``). Eligible NPCs (by ``db.role``) walk to
+your location via the spatial pathfinder.
+"""
+
+from evennia import Command
+
+from world.director import WorldEvent, find_responders, raise_event
+from world.director.dispatch import ROLE_RESPONDS_TO
+
+
+class CmdDispatch(Command):
+    """
+    Raise a world event at your location and dispatch responders.
+
+    Usage:
+        @dispatch <type> [severity]   - raise an event; send responders
+        @dispatch                     - list event types and who'd respond
+
+    Eligible NPCs are those whose ``db.role`` responds to the event type
+    (set one with ``@set <npc>/role = security``). The nearest are routed
+    to you over the exit graph; ``severity`` (default 1) scales how many.
+
+    Example:
+        @set guard/role = security
+        @dispatch assault
+    """
+
+    key = "@dispatch"
+    locks = "cmd:perm(Builders) or perm(Developers)"
+    help_category = "Building"
+
+    def func(self):
+        caller = self.caller
+        args = self.args.strip()
+
+        if not args:
+            caller.msg("|cEvent types → responding roles:|n")
+            for etype, roles in sorted(ROLE_RESPONDS_TO.items()):
+                caller.msg(f"  {etype}: {', '.join(roles)}")
+            caller.msg("Usage: @dispatch <type> [severity]")
+            return
+
+        parts = args.split()
+        etype = parts[0].lower()
+        severity = 1
+        if len(parts) > 1 and parts[1].isdigit():
+            severity = int(parts[1])
+
+        if etype not in ROLE_RESPONDS_TO:
+            caller.msg(
+                f"Unknown event type '{etype}'. Known: "
+                f"{', '.join(sorted(ROLE_RESPONDS_TO))}."
+            )
+            return
+
+        if caller.location is None:
+            caller.msg("You have no location to raise an event in.")
+            return
+
+        event = WorldEvent(
+            type=etype, location=caller.location,
+            severity=severity, source=caller,
+        )
+        ranked = find_responders(event)
+        if not ranked:
+            caller.msg(
+                f"|y{etype}|n raised — but no reachable responder "
+                f"({', '.join(ROLE_RESPONDS_TO[etype])}) found."
+            )
+            return
+
+        dispatched = raise_event(event)
+        caller.msg(
+            f"|r{etype}|n (severity {severity}) raised at "
+            f"{caller.location.get_display_name(caller)}. "
+            f"Dispatched {len(dispatched)} of {len(ranked)} eligible:"
+        )
+        sent = set(dispatched)
+        for steps, npc in ranked:
+            mark = "|g→ en route|n" if npc in sent else "|x(standby)|n"
+            caller.msg(
+                f"  {npc.get_display_name(caller)} "
+                f"({steps} steps away) {mark}"
+            )

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -28,6 +28,7 @@ from commands import CmdSmoke
 from commands.CmdSpawnMob import CmdSpawnMob
 from commands.CmdCoordSeed import CmdCoordSeed
 from commands.CmdPath import CmdPath
+from commands.CmdDispatch import CmdDispatch
 from commands.bar_menu import CmdSpawnIngredient
 from commands.CmdBug import CmdBug
 from commands.CmdAdmin import CmdHeal, CmdPeace, CmdTestDeathCurtain, CmdWeather, CmdResetMedical, CmdMedicalAudit, CmdTestDeath, CmdTestUnconscious
@@ -141,6 +142,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdSpawnMob())
         self.add(CmdCoordSeed())
         self.add(CmdPath())
+        self.add(CmdDispatch())
         self.add(CmdSpawnIngredient())
         self.add(CmdAdmin.CmdHeal())
         self.add(CmdAdmin.CmdPeace())

--- a/world/director/__init__.py
+++ b/world/director/__init__.py
@@ -1,0 +1,35 @@
+"""The director — the deterministic world-simulation engine that moves
+NPCs around and dispatches them to world events.
+
+See ``specs/proposals/NPC_DISPATCH_AND_SIMULATION_SPEC.md``.
+
+This first slice is the **dispatch core**: pathfinder-driven NPC travel
+(``travel``) plus event → responder routing (``dispatch``), built directly
+on the spatial substrate (``world/spatial``). Population LOD, routines, the
+deterministic interaction vocabulary, and the LLM escalation gate are
+later layers.
+"""
+
+from world.director.dispatch import (
+    ROLE_RESPONDS_TO,
+    WorldEvent,
+    dispatch,
+    find_responders,
+    raise_event,
+)
+from world.director.travel import (
+    is_travelling,
+    stop_travel,
+    travel_to,
+)
+
+__all__ = [
+    "ROLE_RESPONDS_TO",
+    "WorldEvent",
+    "dispatch",
+    "find_responders",
+    "is_travelling",
+    "raise_event",
+    "stop_travel",
+    "travel_to",
+]

--- a/world/director/dispatch.py
+++ b/world/director/dispatch.py
@@ -1,0 +1,92 @@
+"""World events and the dispatcher — match responders to an event by role
+and travel distance, and route them to it.
+
+This is the heart of the director's "both layers": the simulation (who
+exists, where, with what role) meets the spatial system (how they get
+there). Fully deterministic — no LLM. See
+``NPC_DISPATCH_AND_SIMULATION_SPEC.md`` §5.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from world.director.travel import travel_to
+from world.spatial import path_length
+
+
+@dataclass
+class WorldEvent:
+    """A typed, located thing that happened in the world."""
+
+    type: str
+    location: Any                 # the room it happened in
+    severity: int = 1             # drives how many responders are sent
+    source: Any = None            # the instigator (a PC, an NPC, a system)
+    payload: dict = field(default_factory=dict)
+
+
+#: Event type → the NPC roles that respond to it. New roles/events: add
+#: an entry. ``db.role`` on a Character names its role (e.g. "security").
+ROLE_RESPONDS_TO: dict[str, tuple[str, ...]] = {
+    "assault": ("security",),
+    "disturbance": ("security",),
+    "crime": ("security",),
+    "fire": ("security",),
+}
+
+
+def _npcs_with_roles(roles) -> list:
+    """Every Character whose ``db.role`` is one of *roles* (a targeted
+    attribute query — not a full object scan)."""
+    from evennia.objects.models import ObjectDB
+    roles = set(roles)
+    out = []
+    for obj in ObjectDB.objects.filter(db_attributes__db_key="role").distinct():
+        if not obj.is_typeclass("typeclasses.characters.Character", exact=False):
+            continue
+        if getattr(obj.db, "role", None) in roles:
+            out.append(obj)
+    return out
+
+
+def find_responders(event: WorldEvent) -> list:
+    """Candidate responders for *event*, **nearest-first by travel distance**.
+
+    Returns ``[(steps, npc), …]`` sorted ascending; unreachable and
+    locationless NPCs are dropped. Empty when no role responds to the type.
+    """
+    roles = ROLE_RESPONDS_TO.get(event.type)
+    if not roles or event.location is None:
+        return []
+    ranked = []
+    for npc in _npcs_with_roles(roles):
+        if npc.location is None or npc is event.source:
+            continue
+        steps = path_length(npc.location, event.location, traverser=npc)
+        if steps is None:
+            continue  # can't get there
+        ranked.append((steps, npc))
+    ranked.sort(key=lambda t: t[0])
+    return ranked
+
+
+def dispatch(event: WorldEvent) -> list:
+    """Send the nearest eligible responders to *event* (count scaled by
+    ``severity``). Returns the list of dispatched NPCs."""
+    ranked = find_responders(event)
+    if not ranked:
+        return []
+    count = min(len(ranked), max(1, int(event.severity)))
+    dispatched = []
+    for _steps, npc in ranked[:count]:
+        if travel_to(npc, event.location):
+            dispatched.append(npc)
+    return dispatched
+
+
+def raise_event(event: WorldEvent) -> list:
+    """Raise *event* onto the director. Currently routes straight to the
+    dispatcher; the seam where a full event bus / monitor lands later."""
+    return dispatch(event)

--- a/world/director/travel.py
+++ b/world/director/travel.py
@@ -1,0 +1,100 @@
+"""Pathfinder-driven NPC travel — walk an NPC to a room, one step per
+tick, over the real exit graph.
+
+The movement primitive every director behaviour rests on (routines and
+dispatch both). The NPC walks by **executing the real exit command**
+(``execute_cmd(exit.key)``) — the same way a player moves — so locks,
+messages, and proximity cleanup all apply, and the LLM-NPC mandate (NPCs
+act through real commands) is honoured for deterministic NPCs too.
+
+The route is re-pathed every step, so a changed graph (a blown-open wall,
+a locked door) is handled automatically.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from evennia.utils import delay
+
+from world.spatial import find_path_exits
+
+#: Seconds between room steps (walking pace).
+TRAVEL_STEP_DELAY = 2.0
+#: Hard cap on steps before giving up (anti-runaway).
+TRAVEL_MAX_STEPS = 200
+#: ndb key holding the in-flight travel state.
+_NDB_KEY = "director_travel"
+
+
+def is_travelling(npc: Any) -> bool:
+    """True if *npc* has an active director travel in progress."""
+    ndb = getattr(npc, "ndb", None)
+    return bool(getattr(ndb, _NDB_KEY, None)) if ndb is not None else False
+
+
+def stop_travel(npc: Any) -> None:
+    """Cancel any in-flight travel for *npc*."""
+    if npc is not None and getattr(npc, "ndb", None) is not None:
+        setattr(npc.ndb, _NDB_KEY, None)
+
+
+def travel_to(npc: Any, destination: Any, on_arrive=None, on_fail=None,
+              step_delay: float | None = None) -> bool:
+    """Walk *npc* to *destination* over the exit graph.
+
+    Returns ``True`` if travel started (or the NPC is already there),
+    ``False`` if *destination* is unreachable. ``on_arrive(npc)`` /
+    ``on_fail(npc)`` fire on completion. Starting a new travel cancels any
+    previous one.
+    """
+    if npc is None or destination is None:
+        return False
+    if npc.location == destination:
+        if on_arrive:
+            on_arrive(npc)
+        return True
+    if find_path_exits(npc.location, destination, traverser=npc) is None:
+        if on_fail:
+            on_fail(npc)
+        return False
+    npc.ndb.director_travel = {
+        "destination": destination,
+        "on_arrive": on_arrive,
+        "on_fail": on_fail,
+        "step_delay": step_delay or TRAVEL_STEP_DELAY,
+        "steps": 0,
+    }
+    _travel_step(npc)
+    return True
+
+
+def _finish(npc: Any, state: dict, key: str) -> None:
+    npc.ndb.director_travel = None
+    cb = state.get(key)
+    if cb:
+        try:
+            cb(npc)
+        except Exception:  # noqa: BLE001 — a bad callback must not break the tick
+            pass
+
+
+def _travel_step(npc: Any) -> None:
+    state = getattr(getattr(npc, "ndb", None), _NDB_KEY, None)
+    if not state:
+        return  # cancelled
+    destination = state["destination"]
+    if npc.location == destination:
+        _finish(npc, state, "on_arrive")
+        return
+    state["steps"] += 1
+    if state["steps"] > TRAVEL_MAX_STEPS:
+        _finish(npc, state, "on_fail")
+        return
+    exits = find_path_exits(npc.location, destination, traverser=npc)
+    if not exits:
+        _finish(npc, state, "on_fail")
+        return
+    # Walk through the next exit via its real command (locks, messages, etc.).
+    npc.execute_cmd(exits[0].key)
+    delay(state["step_delay"], _travel_step, npc)

--- a/world/tests/test_director_dispatch.py
+++ b/world/tests/test_director_dispatch.py
@@ -1,0 +1,114 @@
+"""Tests for the director's dispatch core — travel state machine,
+responder ranking, and severity-scaled dispatch."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.director import WorldEvent, dispatch, find_responders, travel_to
+from world.director.dispatch import ROLE_RESPONDS_TO
+
+
+class _Room:
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+
+def _npc(location, name="npc", source=False):
+    return SimpleNamespace(location=location, name=name,
+                           ndb=SimpleNamespace(), execute_cmd=MagicMock())
+
+
+# --- travel state machine -----------------------------------------------
+
+class TestTravel(TestCase):
+    def test_already_there_fires_arrive(self):
+        room = _Room("A")
+        on_arrive = MagicMock()
+        npc = _npc(room)
+        self.assertTrue(travel_to(npc, room, on_arrive=on_arrive))
+        on_arrive.assert_called_once_with(npc)
+        # no travel state left behind
+        self.assertIsNone(getattr(npc.ndb, "director_travel", None))
+
+    @patch("world.director.travel.find_path_exits", return_value=None)
+    def test_unreachable_fires_fail(self, _fpe):
+        on_fail = MagicMock()
+        npc = _npc(_Room("A"))
+        self.assertFalse(travel_to(npc, _Room("Z"), on_fail=on_fail))
+        on_fail.assert_called_once_with(npc)
+
+    @patch("world.director.travel.delay")
+    @patch("world.director.travel.find_path_exits")
+    def test_starts_and_walks_first_exit(self, mock_fpe, mock_delay):
+        ex = SimpleNamespace(key="north", destination=_Room("B"))
+        mock_fpe.return_value = [ex]
+        npc = _npc(_Room("A"))
+        started = travel_to(npc, _Room("Z"))
+        self.assertTrue(started)
+        npc.execute_cmd.assert_called_once_with("north")
+        self.assertIsNotNone(getattr(npc.ndb, "director_travel", None))
+        mock_delay.assert_called_once()  # next step scheduled
+
+
+# --- responder ranking + dispatch ---------------------------------------
+
+class TestDispatch(TestCase):
+    def test_role_table_shape(self):
+        self.assertIn("assault", ROLE_RESPONDS_TO)
+        self.assertIn("security", ROLE_RESPONDS_TO["assault"])
+
+    @patch("world.director.dispatch.path_length")
+    @patch("world.director.dispatch._npcs_with_roles")
+    def test_find_responders_ranked_nearest_first(self, mock_npcs, mock_pl):
+        near = _npc(_Room("near"), "near")
+        far = _npc(_Room("far"), "far")
+        unreachable = _npc(_Room("unr"), "unr")
+        mock_npcs.return_value = [far, near, unreachable]
+        steps = {near.location: 2, far.location: 9, unreachable.location: None}
+        mock_pl.side_effect = lambda start, goal, traverser=None: steps[start]
+
+        ranked = find_responders(WorldEvent("assault", _Room("event")))
+        self.assertEqual([npc for _s, npc in ranked], [near, far])  # unr dropped
+
+    @patch("world.director.dispatch._npcs_with_roles", return_value=[])
+    def test_unknown_event_type_no_responders(self, _m):
+        self.assertEqual(find_responders(WorldEvent("picnic", _Room("e"))), [])
+
+    @patch("world.director.dispatch.path_length")
+    @patch("world.director.dispatch._npcs_with_roles")
+    def test_source_excluded(self, mock_npcs, mock_pl):
+        src = _npc(_Room("s"), "src")
+        other = _npc(_Room("o"), "other")
+        mock_npcs.return_value = [src, other]
+        mock_pl.side_effect = lambda start, goal, traverser=None: 1
+        ev = WorldEvent("assault", _Room("e"), source=src)
+        ranked = find_responders(ev)
+        self.assertEqual([npc for _s, npc in ranked], [other])
+
+    @patch("world.director.dispatch.travel_to", return_value=True)
+    @patch("world.director.dispatch.find_responders")
+    def test_dispatch_sends_severity_count_nearest(self, mock_fr, mock_travel):
+        a, b, c = _npc(_Room("a")), _npc(_Room("b")), _npc(_Room("c"))
+        mock_fr.return_value = [(1, a), (2, b), (3, c)]
+        sent = dispatch(WorldEvent("assault", _Room("e"), severity=2))
+        self.assertEqual(sent, [a, b])  # nearest 2
+        self.assertEqual(mock_travel.call_count, 2)
+
+    @patch("world.director.dispatch.travel_to", return_value=True)
+    @patch("world.director.dispatch.find_responders", return_value=[])
+    def test_dispatch_no_responders(self, _fr, _travel):
+        self.assertEqual(dispatch(WorldEvent("assault", _Room("e"))), [])
+
+
+class TestDispatchWiring(TestCase):
+    def test_dispatch_command_registered(self):
+        from commands.default_cmdsets import CharacterCmdSet
+        cs = CharacterCmdSet()
+        cs.at_cmdset_creation()
+        self.assertIn("@dispatch", [c.key for c in cs.commands])


### PR DESCRIPTION
First slice of NPC_DISPATCH_AND_SIMULATION_SPEC, built on the spatial
substrate (Phases 1+2). Deterministic, no LLM.

- world/director/travel.py: travel_to(npc, destination, on_arrive,
  on_fail) walks an NPC to a room one step per tick over the real exit
  graph, re-pathing each step (handles a changed world). Moves by
  executing the real exit command so locks/messages/proximity apply and
  the NPC-real-commands mandate holds. stop_travel/is_travelling; an
  anti-runaway step cap.
- world/director/dispatch.py: WorldEvent (type/location/severity/source);
  ROLE_RESPONDS_TO (event type -> roles); find_responders (NPCs by
  db.role, nearest-first by travel distance, unreachable/source dropped);
  dispatch (severity-scaled nearest responders via travel_to); raise_event.
- @dispatch <type> [severity] builder/debug command.
- 10 director tests; 32-test director+spatial sweep green.

Population-LOD, routines, interaction vocab, and the LLM escalation gate
are later layers. Backbone for the robot police MOB.

Closes #852

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
