### PR TITLE
Canon: the Z<0 domain is 'The Drifts' (replaces 'undercity')

### DIFF
--- a/specs/proposals/NPC_DISPATCH_AND_SIMULATION_SPEC.md
+++ b/specs/proposals/NPC_DISPATCH_AND_SIMULATION_SPEC.md
@@ -269,7 +269,7 @@ consent rules as player-initiated ones. Reserve the seam now.
   commands.
 * **Mining incident → S&R.** Mining system raises `mining_incident` (a collapse,
   a death) deep at `Z < 0`. Dispatcher deploys a flash-temp S&R crew, routes
-  them down through the vertical/undercity rooms, runs the rescue
+  them down through the vertical Drifts rooms, runs the rescue
   deterministically; despawns the crew after.
 * **Shift change → a drink.** Time system raises `shift_change`. A worker's
   routine reroutes to the bar; they order from Sable via the deterministic

--- a/specs/proposals/RADIO_COMMS_SPEC.md
+++ b/specs/proposals/RADIO_COMMS_SPEC.md
@@ -60,7 +60,7 @@ Traffic is organized by **channel** (a small integer dial / named band):
   channel, coverage extends to the union of the antenna network — practically
   city-wide *while the antennae stand*. Kill the right antenna → a **coverage
   hole** (a district goes dark for that channel).
-* **Vertical matters**: rooftop antennae see far; the undercity (`Z < 0`) is
+* **Vertical matters**: rooftop antennae see far; the Drifts (`Z < 0` — the future mines/sewers) is
   naturally radio-dark unless wired repeaters are placed — mines and tunnels
   are out of contact by default (ties to the mining/S&R fiction: a collapse
   cuts contact).
@@ -109,7 +109,7 @@ real play.
 * **Dispatch / director** — the §3 mapping; replaces the report placeholder.
 * **Spatial** — range/coverage from `distance` / `rooms_within`; antennae live
   at real coordinates (kill *this* rooftop → *this* district's hole);
-  undercity dark-by-default.
+  the Drifts dark-by-default.
 * **Voice / identity** — §2.4; voice recognition + modulators carry over.
 * **Perception** — hearing gates reception; a transmission into a room is an
   auditory event (stealth: a squawking radio gives you away).

--- a/specs/proposals/SPATIAL_COORDINATE_SYSTEM_SPEC.md
+++ b/specs/proposals/SPATIAL_COORDINATE_SYSTEM_SPEC.md
@@ -87,7 +87,7 @@ display. (Open question §10.)
 * **Signed integers** `(x, y, z)`. Origin **`(0, 0, 0)`** at the central ground
   space; the world extrapolates outward and downward from there.
 * **Axes:** `+X` east / `+Y` north / `+Z` up. Therefore **`Z < 0` =
-  undercity / mines**, **`Z = 0` = ground**, **`Z > 0` = upper levels / sky**.
+  the Drifts (mines / sewers)**, **`Z = 0` = ground**, **`Z > 0` = upper levels / sky**.
   A signed origin makes "below ground" literally negative — readable and
   symmetric.
 * **One unit = one room step** along a cardinal exit. Visual/described distance
@@ -175,7 +175,7 @@ axis** rather than inventing a parallel one:
 
 The aim is that the live jump/sky-room behaviour keeps working unchanged and
 simply becomes *expressible in coordinate terms*, so future vertical content
-(rooftops, lift shafts, the undercity) composes from the same primitive.
+(rooftops, lift shafts, the Drifts) composes from the same primitive.
 
 ### 6.1 · Face state — walls, floors, and breaching
 

--- a/world/spatial/coordinates.py
+++ b/world/spatial/coordinates.py
@@ -4,7 +4,7 @@ walk for the spatial substrate (Phase 1).
 See ``specs/proposals/SPATIAL_COORDINATE_SYSTEM_SPEC.md``.
 
 Axes: ``+X`` east / ``+Y`` north / ``+Z`` up. Origin ``(0, 0, 0)`` at the
-central ground room; the undercity is ``Z < 0``, upper levels ``Z > 0``.
+central ground room; the Drifts (mines/sewers) are ``Z < 0``, upper levels ``Z > 0``.
 One unit = one room step along a cardinal exit.
 """
 


### PR DESCRIPTION
'Undercity' was assistant-coined shorthand for the reserved Z<0 half of
the coordinate volume — nothing exists below ground yet (the live seed
confirmed 0 rooms at Z<0). User-picked canon name: The Drifts —
authentic mining vocabulary (a drift is a horizontal mine tunnel),
umbrella for the future mines + sewers. Renamed across the spatial,
dispatch, and radio specs and the world/spatial/coordinates.py
docstring. Docs/docstring-only; no behavior change.

Closes #860

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
