### PR TITLE
Director: assignment lifecycle (arrive -> investigate -> return-to-post)

### DIFF
--- a/commands/CmdDispatch.py
+++ b/commands/CmdDispatch.py
@@ -18,10 +18,13 @@ class CmdDispatch(Command):
     Usage:
         @dispatch <type> [severity]   - raise an event; send responders
         @dispatch                     - list event types and who'd respond
+        @dispatch/status              - show active assignments (the pool)
 
     Eligible NPCs are those whose ``db.role`` responds to the event type
     (set one with ``@set <npc>/role = security``). The nearest are routed
     to you over the exit graph; ``severity`` (default 1) scales how many.
+    A dispatched responder arrives, investigates, lingers, then returns
+    to its post; while assigned it will not answer other incidents.
 
     Example:
         @set guard/role = security
@@ -35,6 +38,23 @@ class CmdDispatch(Command):
     def func(self):
         caller = self.caller
         args = self.args.strip()
+
+        if "status" in (self.switches or []):
+            from world.director import active_assignments
+            assignments = active_assignments()
+            if not assignments:
+                caller.msg("No active assignments — the pool is idle.")
+                return
+            caller.msg(f"|cActive assignments ({len(assignments)}):|n")
+            for a in assignments:
+                loc = a.event.location
+                caller.msg(
+                    f"  {a.npc.get_display_name(caller)} — {a.event.type} at "
+                    f"{loc.get_display_name(caller) if loc else '?'} "
+                    f"[{a.state}] (post: "
+                    f"{a.post.get_display_name(caller) if a.post else '?'})"
+                )
+            return
 
         if not args:
             caller.msg("|cEvent types → responding roles:|n")

--- a/world/director/__init__.py
+++ b/world/director/__init__.py
@@ -10,6 +10,16 @@ deterministic interaction vocabulary, and the LLM escalation gate are
 later layers.
 """
 
+from world.director.assignment import (
+    Assignment,
+    active_assignments,
+    assign,
+    clear_assignment,
+    get_assignment,
+    is_assigned,
+    register_arrival_handler,
+    resolve,
+)
 from world.director.dispatch import (
     ROLE_RESPONDS_TO,
     WorldEvent,
@@ -24,12 +34,20 @@ from world.director.travel import (
 )
 
 __all__ = [
+    "Assignment",
     "ROLE_RESPONDS_TO",
     "WorldEvent",
+    "active_assignments",
+    "assign",
+    "clear_assignment",
     "dispatch",
     "find_responders",
+    "get_assignment",
+    "is_assigned",
     "is_travelling",
     "raise_event",
+    "register_arrival_handler",
+    "resolve",
     "stop_travel",
     "travel_to",
 ]

--- a/world/director/assignment.py
+++ b/world/director/assignment.py
@@ -1,0 +1,149 @@
+"""Dispatch assignments — the lifecycle of a responder, from dispatch to
+return-to-post.
+
+Completes the dispatcher's monitor/resolve half
+(``NPC_DISPATCH_AND_SIMULATION_SPEC`` §5 steps 4–5): a dispatched NPC is
+*assigned* to an event; on arrival a **role-keyed arrival handler** runs
+(the seam the crime layer's scan-and-match plugs into); after a linger the
+assignment **resolves** and the NPC travels back to its post. A
+module-level registry tracks who is committed where — the finite-pool
+bookkeeping that makes "overwhelm the force" a real tactic.
+
+Assignment state lives on ``ndb`` + an in-memory registry (same
+volatility tier as travel state): a reload clears in-flight assignments,
+and NPCs simply resume their routine. Off-screen authority arrives with
+the population/LOD layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from evennia.utils import delay
+
+from world.director.travel import stop_travel, travel_to
+
+#: Seconds a responder investigates on scene before resolving.
+LINGER_SECONDS = 30.0
+#: ndb key holding the NPC's active assignment.
+_NDB_KEY = "director_assignment"
+
+#: Active assignments, npc -> Assignment. In-memory (cleared on reload).
+_ACTIVE: dict = {}
+
+#: role -> callable(npc, assignment) run when the responder arrives on
+#: scene. The seam the crime layer (scan/match/challenge) plugs into.
+ARRIVAL_HANDLERS: dict[str, Callable] = {}
+
+
+@dataclass
+class Assignment:
+    """One responder's commitment to one event."""
+
+    npc: Any
+    event: Any                    # the WorldEvent
+    post: Any                     # room to return to when resolved
+    state: str = "en_route"       # en_route | on_scene | returning | done
+    payload: dict = field(default_factory=dict)
+
+
+def register_arrival_handler(role: str, handler: Callable) -> None:
+    """Register *handler(npc, assignment)* to run when a responder with
+    ``db.role == role`` arrives on scene."""
+    ARRIVAL_HANDLERS[role] = handler
+
+
+def get_assignment(npc: Any):
+    """The NPC's active :class:`Assignment`, or ``None``."""
+    return _ACTIVE.get(npc)
+
+
+def active_assignments() -> list:
+    """Every in-flight assignment (the committed slice of the pool)."""
+    return list(_ACTIVE.values())
+
+
+def is_assigned(npc: Any) -> bool:
+    return npc in _ACTIVE
+
+
+def assign(npc: Any, event: Any) -> bool:
+    """Commit *npc* to *event*: record the assignment (posting it back to
+    its current room) and start travel. Returns ``False`` if travel could
+    not start (unreachable). Reassignment cancels the previous assignment.
+    """
+    if npc is None or event is None or getattr(event, "location", None) is None:
+        return False
+    clear_assignment(npc)
+    assignment = Assignment(npc=npc, event=event, post=npc.location)
+    _ACTIVE[npc] = assignment
+    if npc.ndb is not None:
+        setattr(npc.ndb, _NDB_KEY, assignment)
+    started = travel_to(npc, event.location,
+                        on_arrive=_on_scene, on_fail=_on_travel_fail)
+    if not started:
+        clear_assignment(npc)
+        return False
+    return True
+
+
+def clear_assignment(npc: Any) -> None:
+    """Drop any assignment state for *npc* and halt its travel (does not
+    move it — the NPC stands down wherever it is)."""
+    _ACTIVE.pop(npc, None)
+    stop_travel(npc)
+    if getattr(npc, "ndb", None) is not None:
+        setattr(npc.ndb, _NDB_KEY, None)
+
+
+def resolve(npc: Any) -> None:
+    """Finish the on-scene phase: send the responder back to its post."""
+    assignment = _ACTIVE.get(npc)
+    if assignment is None:
+        return
+    assignment.state = "returning"
+    post = assignment.post
+    if post is None or npc.location == post:
+        _done(npc)
+        return
+    if not travel_to(npc, post, on_arrive=_done, on_fail=_done):
+        _done(npc)
+
+
+# --- internal lifecycle steps --------------------------------------------
+
+def _on_scene(npc: Any) -> None:
+    assignment = _ACTIVE.get(npc)
+    if assignment is None:
+        return
+    assignment.state = "on_scene"
+    role = getattr(getattr(npc, "db", None), "role", None)
+    handler = ARRIVAL_HANDLERS.get(role, default_arrival)
+    try:
+        handler(npc, assignment)
+    except Exception:  # noqa: BLE001 — a bad handler must not strand the NPC
+        resolve(npc)
+
+
+def _on_travel_fail(npc: Any) -> None:
+    # Couldn't reach the scene — stand down where it is.
+    clear_assignment(npc)
+
+
+def _done(npc: Any) -> None:
+    assignment = _ACTIVE.get(npc)
+    if assignment is not None:
+        assignment.state = "done"
+    clear_assignment(npc)
+
+
+def default_arrival(npc: Any, assignment: Any) -> None:
+    """Default on-scene behavior: visibly investigate (via a real command),
+    linger, then resolve. Role handlers (the crime layer's scan-and-match)
+    replace this per role."""
+    try:
+        npc.execute_cmd("emote sweeps the area, taking stock of the scene.")
+    except Exception:  # noqa: BLE001
+        pass
+    delay(LINGER_SECONDS, resolve, npc)

--- a/world/director/dispatch.py
+++ b/world/director/dispatch.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from world.director.travel import travel_to
 from world.spatial import path_length
 
 
@@ -74,14 +73,23 @@ def find_responders(event: WorldEvent) -> list:
 
 def dispatch(event: WorldEvent) -> list:
     """Send the nearest eligible responders to *event* (count scaled by
-    ``severity``). Returns the list of dispatched NPCs."""
+    ``severity``) as tracked **assignments** (en route → on scene → linger
+    → return to post; see ``world/director/assignment.py``). Already-
+    assigned responders are committed elsewhere and skipped — the finite
+    pool is real, which is what makes overwhelming it a tactic. Returns
+    the list of dispatched NPCs."""
+    from world.director.assignment import assign, is_assigned
     ranked = find_responders(event)
     if not ranked:
         return []
-    count = min(len(ranked), max(1, int(event.severity)))
+    count = max(1, int(event.severity))
     dispatched = []
-    for _steps, npc in ranked[:count]:
-        if travel_to(npc, event.location):
+    for _steps, npc in ranked:
+        if len(dispatched) >= count:
+            break
+        if is_assigned(npc):
+            continue  # committed to another incident
+        if assign(npc, event):
             dispatched.append(npc)
     return dispatched
 

--- a/world/tests/test_director_assignment.py
+++ b/world/tests/test_director_assignment.py
@@ -1,0 +1,155 @@
+"""Tests for the dispatch assignment lifecycle — en route → on scene
+(role-keyed arrival handler) → linger → return to post → done."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.director import WorldEvent
+from world.director import assignment as amod
+from world.director.assignment import (
+    ARRIVAL_HANDLERS,
+    active_assignments,
+    assign,
+    clear_assignment,
+    get_assignment,
+    is_assigned,
+    register_arrival_handler,
+    resolve,
+)
+
+
+class _Room:
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+
+class _Npc:
+    """Hashable NPC stand-in (SimpleNamespace is unhashable and the
+    assignment registry keys on the NPC object, as real typeclasses do)."""
+
+    def __init__(self, location, role="security"):
+        self.location = location
+        self.ndb = SimpleNamespace()
+        self.db = SimpleNamespace(role=role)
+        self.execute_cmd = MagicMock()
+
+
+def _npc(location, role="security"):
+    return _Npc(location, role=role)
+
+
+class _Base(TestCase):
+    def setUp(self):
+        amod._ACTIVE.clear()
+        self._saved_handlers = dict(ARRIVAL_HANDLERS)
+        ARRIVAL_HANDLERS.clear()
+
+    def tearDown(self):
+        amod._ACTIVE.clear()
+        ARRIVAL_HANDLERS.clear()
+        ARRIVAL_HANDLERS.update(self._saved_handlers)
+
+
+class TestAssignmentLifecycle(_Base):
+    @patch("world.director.assignment.travel_to", return_value=True)
+    def test_assign_records_post_and_travels(self, mock_travel):
+        post = _Room("post")
+        scene = _Room("scene")
+        npc = _npc(post)
+        self.assertTrue(assign(npc, WorldEvent("assault", scene)))
+        a = get_assignment(npc)
+        self.assertIsNotNone(a)
+        self.assertEqual(a.post, post)
+        self.assertEqual(a.state, "en_route")
+        self.assertTrue(is_assigned(npc))
+        self.assertEqual(len(active_assignments()), 1)
+        mock_travel.assert_called_once()
+        self.assertEqual(mock_travel.call_args.args[1], scene)
+
+    @patch("world.director.assignment.travel_to", return_value=False)
+    def test_unreachable_clears_assignment(self, _t):
+        npc = _npc(_Room("post"))
+        self.assertFalse(assign(npc, WorldEvent("assault", _Room("scene"))))
+        self.assertFalse(is_assigned(npc))
+
+    @patch("world.director.assignment.delay")
+    @patch("world.director.assignment.travel_to", return_value=True)
+    def test_arrival_runs_default_handler_and_schedules_resolve(
+            self, mock_travel, mock_delay):
+        npc = _npc(_Room("post"))
+        assign(npc, WorldEvent("assault", _Room("scene")))
+        on_arrive = mock_travel.call_args.kwargs["on_arrive"]
+        on_arrive(npc)  # simulate arrival
+        self.assertEqual(get_assignment(npc).state, "on_scene")
+        npc.execute_cmd.assert_called_once()          # visible investigate
+        mock_delay.assert_called_once()               # linger → resolve
+
+    @patch("world.director.assignment.travel_to", return_value=True)
+    def test_arrival_uses_role_handler(self, mock_travel):
+        handler = MagicMock()
+        register_arrival_handler("security", handler)
+        npc = _npc(_Room("post"), role="security")
+        assign(npc, WorldEvent("assault", _Room("scene")))
+        mock_travel.call_args.kwargs["on_arrive"](npc)
+        handler.assert_called_once()
+        self.assertEqual(handler.call_args.args[0], npc)
+
+    @patch("world.director.assignment.travel_to", return_value=True)
+    def test_broken_handler_still_resolves(self, mock_travel):
+        register_arrival_handler("security", MagicMock(side_effect=RuntimeError))
+        post = _Room("post")
+        npc = _npc(post, role="security")
+        assign(npc, WorldEvent("assault", _Room("scene")))
+        npc.location = _Room("scene")
+        mock_travel.reset_mock()
+        # arrival: handler explodes -> resolve() -> travel back to post
+        amod._on_scene(npc)
+        self.assertEqual(mock_travel.call_args.args[1], post)
+
+    @patch("world.director.assignment.travel_to", return_value=True)
+    def test_resolve_travels_back_to_post_then_done(self, mock_travel):
+        post = _Room("post")
+        npc = _npc(post)
+        assign(npc, WorldEvent("assault", _Room("scene")))
+        npc.location = _Room("scene")            # it walked there
+        mock_travel.reset_mock()
+        resolve(npc)
+        self.assertEqual(get_assignment(npc).state, "returning")
+        self.assertEqual(mock_travel.call_args.args[1], post)
+        # simulate arrival back at post
+        mock_travel.call_args.kwargs["on_arrive"](npc)
+        self.assertFalse(is_assigned(npc))
+
+    @patch("world.director.assignment.travel_to", return_value=True)
+    def test_resolve_already_at_post_finishes_immediately(self, mock_travel):
+        post = _Room("post")
+        npc = _npc(post)
+        assign(npc, WorldEvent("assault", _Room("scene")))
+        mock_travel.reset_mock()
+        resolve(npc)                              # still at post (never left)
+        self.assertFalse(is_assigned(npc))
+        mock_travel.assert_not_called()
+
+    @patch("world.director.assignment.travel_to", return_value=True)
+    def test_reassignment_replaces_previous(self, _t):
+        npc = _npc(_Room("post"))
+        assign(npc, WorldEvent("assault", _Room("s1")))
+        first = get_assignment(npc)
+        assign(npc, WorldEvent("fire", _Room("s2")))
+        self.assertIsNot(get_assignment(npc), first)
+        self.assertEqual(get_assignment(npc).event.type, "fire")
+        self.assertEqual(len(active_assignments()), 1)
+
+    @patch("world.director.assignment.travel_to", return_value=True)
+    def test_clear_assignment_stands_down(self, _t):
+        npc = _npc(_Room("post"))
+        assign(npc, WorldEvent("assault", _Room("scene")))
+        clear_assignment(npc)
+        self.assertFalse(is_assigned(npc))
+        self.assertEqual(active_assignments(), [])

--- a/world/tests/test_director_dispatch.py
+++ b/world/tests/test_director_dispatch.py
@@ -91,18 +91,28 @@ class TestDispatch(TestCase):
         ranked = find_responders(ev)
         self.assertEqual([npc for _s, npc in ranked], [other])
 
-    @patch("world.director.dispatch.travel_to", return_value=True)
+    @patch("world.director.assignment.assign", return_value=True)
+    @patch("world.director.assignment.is_assigned", return_value=False)
     @patch("world.director.dispatch.find_responders")
-    def test_dispatch_sends_severity_count_nearest(self, mock_fr, mock_travel):
+    def test_dispatch_sends_severity_count_nearest(self, mock_fr, _ia, mock_assign):
         a, b, c = _npc(_Room("a")), _npc(_Room("b")), _npc(_Room("c"))
         mock_fr.return_value = [(1, a), (2, b), (3, c)]
         sent = dispatch(WorldEvent("assault", _Room("e"), severity=2))
         self.assertEqual(sent, [a, b])  # nearest 2
-        self.assertEqual(mock_travel.call_count, 2)
+        self.assertEqual(mock_assign.call_count, 2)
 
-    @patch("world.director.dispatch.travel_to", return_value=True)
+    @patch("world.director.assignment.assign", return_value=True)
+    @patch("world.director.assignment.is_assigned")
+    @patch("world.director.dispatch.find_responders")
+    def test_dispatch_skips_committed_responders(self, mock_fr, mock_ia, _assign):
+        a, b, c = _npc(_Room("a")), _npc(_Room("b")), _npc(_Room("c"))
+        mock_fr.return_value = [(1, a), (2, b), (3, c)]
+        mock_ia.side_effect = lambda npc: npc is a  # nearest is busy
+        sent = dispatch(WorldEvent("assault", _Room("e"), severity=2))
+        self.assertEqual(sent, [b, c])  # skips the committed one
+
     @patch("world.director.dispatch.find_responders", return_value=[])
-    def test_dispatch_no_responders(self, _fr, _travel):
+    def test_dispatch_no_responders(self, _fr):
         self.assertEqual(dispatch(WorldEvent("assault", _Room("e"))), [])
 
 


### PR DESCRIPTION
Completes the dispatcher's monitor/resolve half (spec §5 steps 4-5):

- world/director/assignment.py: Assignment (npc/event/post/state:
  en_route -> on_scene -> returning -> done); assign() records the post,
  starts travel, and tracks the commitment in an in-memory registry;
  role-keyed ARRIVAL_HANDLERS + register_arrival_handler — the seam the
  crime layer's scan-and-match plugs into; default_arrival = visible
  investigate via a real emote command, linger, resolve; resolve()
  travels the responder back to its post; clear_assignment() stands an
  NPC down (halting travel); a broken handler never strands the NPC.
- dispatch() now creates assignments and skips already-committed
  responders — the finite pool is real, which is what makes overwhelming
  the force an actual tactic.
- @dispatch/status shows the active pool.
- 10 lifecycle tests; dispatch tests updated (committed-skip). 42-test
  director+spatial sweep green.

Assignment state is ndb/in-memory (same volatility tier as travel state);
off-screen authority arrives with the population/LOD layer.

Closes #862

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
