### PR TITLE
Crime slice 1: BOLO + security scan-and-match (perceiver, not oracle)

### DIFF
--- a/commands/CmdDispatch.py
+++ b/commands/CmdDispatch.py
@@ -80,9 +80,14 @@ class CmdDispatch(Command):
             caller.msg("You have no location to raise an event in.")
             return
 
+        # Attach a BOLO snapshot of the instigator (§5.1: the responder
+        # gets a description, never the perp object). Raising the event
+        # on yourself means YOU match the report when the unit arrives.
+        from world.director import build_bolo
         event = WorldEvent(
             type=etype, location=caller.location,
             severity=severity, source=caller,
+            payload={"bolo": build_bolo(caller)},
         )
         ranked = find_responders(event)
         if not ranked:

--- a/world/director/__init__.py
+++ b/world/director/__init__.py
@@ -27,6 +27,10 @@ from world.director.dispatch import (
     find_responders,
     raise_event,
 )
+from world.director.security import (
+    build_bolo,
+    match_bolo,
+)
 from world.director.travel import (
     is_travelling,
     stop_travel,
@@ -39,12 +43,14 @@ __all__ = [
     "WorldEvent",
     "active_assignments",
     "assign",
+    "build_bolo",
     "clear_assignment",
     "dispatch",
     "find_responders",
     "get_assignment",
     "is_assigned",
     "is_travelling",
+    "match_bolo",
     "raise_event",
     "register_arrival_handler",
     "resolve",

--- a/world/director/security.py
+++ b/world/director/security.py
@@ -1,0 +1,157 @@
+"""Security response — BOLOs and the on-scene scan-and-match.
+
+Crime slice 1 (``NPC_DISPATCH_AND_SIMULATION_SPEC`` §5.1): the responder
+is a **perceiver, not an oracle**. A crime event never hands security the
+perpetrator object — it carries a **BOLO**: a snapshot of what the perp
+*looked like* (their ``apparent_uid`` presentation hash, plus the coarse
+height/build silhouette). On scene, the responder scans who it can
+*currently perceive* and matches against the BOLO with **tiered
+confidence**:
+
+* **high** — the candidate's current ``apparent_uid`` equals the BOLO's
+  (same presentation): challenge and *watch* (stay on scene, re-scan).
+* **low** — only the coarse silhouette matches (same height + build):
+  question — which can put an innocent lookalike in the hot seat.
+  Mistaken identity is intended (§5.2).
+* none — no match: investigate and move on.
+
+Everything §5.1 promises falls out: flee the scene (not perceived),
+change presentation (UID no longer matches), look generic (coarse
+matches are shared), blind the bot (it can't scan at all).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from evennia.utils import delay
+
+from world.director.assignment import register_arrival_handler, resolve
+from world.identity import get_apparent_uid, get_short_sdesc
+from world.perception import can_see
+
+#: Seconds between watch re-scans when a high-confidence suspect is held.
+WATCH_SECONDS = 15.0
+#: How many watch cycles before the responder gives up and resolves.
+WATCH_ROUNDS = 4
+#: Seconds an unmatched investigation lingers before resolving.
+INVESTIGATE_SECONDS = 30.0
+
+
+# --------------------------------------------------------------------------
+# BOLO — build & match
+# --------------------------------------------------------------------------
+
+def build_bolo(perp: Any) -> dict | None:
+    """Snapshot *perp*'s current presentation as a BOLO dict.
+
+    ``uid`` is the precise presentation hash; ``height``/``build`` are the
+    coarse silhouette fallback. ``None`` when there is nothing to describe.
+    """
+    if perp is None:
+        return None
+    uid = get_apparent_uid(perp)
+    height = getattr(perp, "height", None)
+    build = getattr(perp, "build", None)
+    if uid is None and not (height or build):
+        return None
+    return {"uid": uid, "height": height, "build": build}
+
+
+def match_bolo(bolo: dict | None, candidate: Any) -> str | None:
+    """Match *candidate*'s **current** presentation against *bolo*.
+
+    Returns ``"high"`` (presentation hash matches), ``"low"`` (only the
+    height+build silhouette matches), or ``None``.
+    """
+    if not bolo or candidate is None:
+        return None
+    uid = bolo.get("uid")
+    if uid and get_apparent_uid(candidate) == uid:
+        return "high"
+    height, build = bolo.get("height"), bolo.get("build")
+    if height and build:
+        if (getattr(candidate, "height", None) == height
+                and getattr(candidate, "build", None) == build):
+            return "low"
+    return None
+
+
+# --------------------------------------------------------------------------
+# The security arrival handler
+# --------------------------------------------------------------------------
+
+def _scan(npc: Any, bolo: dict | None):
+    """Best (confidence, suspect) among characters *npc* can perceive at
+    its location — ``(None, None)`` when nothing matches or it can't see."""
+    if not can_see(npc):
+        return None, None  # a blinded responder scans nothing
+    location = npc.location
+    if location is None:
+        return None, None
+    best = (None, None)
+    for obj in getattr(location, "contents", None) or []:
+        if obj is npc:
+            continue
+        if not (hasattr(obj, "is_typeclass")
+                and obj.is_typeclass("typeclasses.characters.Character",
+                                     exact=False)):
+            continue
+        confidence = match_bolo(bolo, obj)
+        if confidence == "high":
+            return "high", obj
+        if confidence == "low" and best[0] is None:
+            best = ("low", obj)
+    return best
+
+
+def _cmd(npc: Any, command: str) -> None:
+    try:
+        npc.execute_cmd(command)
+    except Exception:  # noqa: BLE001 — flavour must never strand the responder
+        pass
+
+
+def security_arrival(npc: Any, assignment: Any) -> None:
+    """On-scene behavior for ``role == "security"``: scan, match, act."""
+    _cmd(npc, "emote sweeps the scene with a slow sensor pass.")
+    bolo = (getattr(assignment.event, "payload", None) or {}).get("bolo")
+    confidence, suspect = _scan(npc, bolo)
+    if confidence == "high":
+        handle = get_short_sdesc(suspect)
+        _cmd(npc, f"say You — {handle}. Hold your position. "
+                  f"You match an active report.")
+        assignment.payload["watch_rounds"] = WATCH_ROUNDS
+        delay(WATCH_SECONDS, _watch_tick, npc)
+    elif confidence == "low":
+        handle = get_short_sdesc(suspect)
+        _cmd(npc, f"say You there — {handle}. You fit a description. "
+                  f"State your business here.")
+        delay(INVESTIGATE_SECONDS, resolve, npc)
+    else:
+        _cmd(npc, "emote finds nothing that matches its report and "
+                  "logs the scene.")
+        delay(INVESTIGATE_SECONDS, resolve, npc)
+
+
+def _watch_tick(npc: Any) -> None:
+    """Re-scan while holding a high-confidence suspect; give up after
+    ``WATCH_ROUNDS`` cycles or when the suspect no longer matches."""
+    from world.director.assignment import get_assignment
+    assignment = get_assignment(npc)
+    if assignment is None:
+        return  # stood down meanwhile
+    bolo = (getattr(assignment.event, "payload", None) or {}).get("bolo")
+    confidence, suspect = _scan(npc, bolo)
+    rounds = assignment.payload.get("watch_rounds", 0) - 1
+    assignment.payload["watch_rounds"] = rounds
+    if confidence != "high" or rounds <= 0:
+        if confidence == "high":
+            _cmd(npc, "emote logs the subject's presence and stands down.")
+        resolve(npc)
+        return
+    _cmd(npc, "emote holds position, optics locked on its subject.")
+    delay(WATCH_SECONDS, _watch_tick, npc)
+
+
+register_arrival_handler("security", security_arrival)

--- a/world/tests/test_director_security.py
+++ b/world/tests/test_director_security.py
@@ -1,0 +1,162 @@
+"""Tests for the security BOLO + scan-and-match arrival handler
+(crime slice 1): the responder is a perceiver, never an oracle."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.director import WorldEvent
+from world.director import assignment as amod
+from world.director import security as smod
+from world.director.assignment import ARRIVAL_HANDLERS, Assignment
+from world.director.security import build_bolo, match_bolo, security_arrival
+
+
+class _Room:
+    def __init__(self, name, contents=()):
+        self.name = name
+        self.contents = list(contents)
+
+
+class _Char:
+    """Hashable character stand-in; ``uid`` fakes its apparent presentation."""
+
+    def __init__(self, name, uid=None, height=None, build=None):
+        self.name = name
+        self.uid = uid
+        self.height = height
+        self.build = build
+        self.location = None
+        self.ndb = SimpleNamespace()
+        self.db = SimpleNamespace(role="security")
+        self.execute_cmd = MagicMock()
+
+    def is_typeclass(self, path, exact=False):
+        return True
+
+
+def _fake_uid(char):
+    return getattr(char, "uid", None)
+
+
+def _assignment(npc, bolo):
+    event = WorldEvent("assault", npc.location,
+                       payload={"bolo": bolo} if bolo is not None else {})
+    a = Assignment(npc=npc, event=event, post=_Room("post"))
+    amod._ACTIVE[npc] = a
+    return a
+
+
+@patch("world.director.security.get_apparent_uid", side_effect=_fake_uid)
+class TestBolo(TestCase):
+    def test_build_snapshots_uid_and_silhouette(self, _g):
+        perp = _Char("perp", uid="abc123", height="tall", build="lean")
+        self.assertEqual(build_bolo(perp),
+                         {"uid": "abc123", "height": "tall", "build": "lean"})
+        self.assertIsNone(build_bolo(None))
+
+    def test_precise_match_is_high(self, _g):
+        bolo = {"uid": "abc123", "height": "tall", "build": "lean"}
+        self.assertEqual(match_bolo(bolo, _Char("x", uid="abc123")), "high")
+
+    def test_changed_presentation_defeats_precise_match(self, _g):
+        # Disguise / re-sleeve => different current uid => at best coarse.
+        bolo = {"uid": "abc123", "height": "tall", "build": "lean"}
+        disguised = _Char("x", uid="OTHER", height="short", build="heavy")
+        self.assertIsNone(match_bolo(bolo, disguised))
+
+    def test_silhouette_match_is_low_mistaken_identity(self, _g):
+        # An innocent lookalike with the same height+build fits the report.
+        bolo = {"uid": "abc123", "height": "tall", "build": "lean"}
+        lookalike = _Char("bystander", uid="INNOCENT",
+                          height="tall", build="lean")
+        self.assertEqual(match_bolo(bolo, lookalike), "low")
+
+    def test_no_bolo_no_match(self, _g):
+        self.assertIsNone(match_bolo(None, _Char("x", uid="abc123")))
+        self.assertIsNone(match_bolo({}, _Char("x", uid="abc123")))
+
+
+@patch("world.director.security.get_short_sdesc", return_value="a tall lean drifter")
+@patch("world.director.security.get_apparent_uid", side_effect=_fake_uid)
+@patch("world.director.security.can_see", return_value=True)
+@patch("world.director.security.delay")
+class TestSecurityArrival(TestCase):
+    def setUp(self):
+        amod._ACTIVE.clear()
+
+    def tearDown(self):
+        amod._ACTIVE.clear()
+
+    def _scene(self, *others):
+        bot = _Char("bot", uid="BOT")
+        room = _Room("scene", contents=[bot, *others])
+        bot.location = room
+        for o in others:
+            o.location = room
+        return bot
+
+    def test_registered_for_security_role(self, *_m):
+        self.assertIs(ARRIVAL_HANDLERS.get("security"), security_arrival)
+
+    def test_high_confidence_challenges_and_watches(self, mock_delay, *_m):
+        perp = _Char("perp", uid="PERP", height="tall", build="lean")
+        bot = self._scene(perp)
+        a = _assignment(bot, {"uid": "PERP", "height": "tall", "build": "lean"})
+        security_arrival(bot, a)
+        said = " ".join(str(c) for c in bot.execute_cmd.call_args_list)
+        self.assertIn("Hold your position", said)
+        self.assertEqual(a.payload["watch_rounds"], smod.WATCH_ROUNDS)
+        self.assertIs(mock_delay.call_args.args[1], smod._watch_tick)
+
+    def test_low_confidence_questions_the_lookalike(self, mock_delay, *_m):
+        lookalike = _Char("bystander", uid="INNOCENT",
+                          height="tall", build="lean")
+        bot = self._scene(lookalike)
+        a = _assignment(bot, {"uid": "PERP", "height": "tall", "build": "lean"})
+        security_arrival(bot, a)
+        said = " ".join(str(c) for c in bot.execute_cmd.call_args_list)
+        self.assertIn("fit a description", said)
+        self.assertIs(mock_delay.call_args.args[1], amod.resolve)
+
+    def test_no_match_logs_and_resolves(self, mock_delay, *_m):
+        bot = self._scene(_Char("passerby", uid="X", height="short",
+                                build="heavy"))
+        a = _assignment(bot, {"uid": "PERP", "height": "tall", "build": "lean"})
+        security_arrival(bot, a)
+        said = " ".join(str(c) for c in bot.execute_cmd.call_args_list)
+        self.assertIn("nothing that matches", said)
+        self.assertIs(mock_delay.call_args.args[1], amod.resolve)
+
+    def test_blind_bot_scans_nothing(self, mock_delay, _cs, *_m):
+        with patch("world.director.security.can_see", return_value=False):
+            perp = _Char("perp", uid="PERP")
+            bot = self._scene(perp)
+            a = _assignment(bot, {"uid": "PERP", "height": None, "build": None})
+            security_arrival(bot, a)
+        said = " ".join(str(c) for c in bot.execute_cmd.call_args_list)
+        self.assertIn("nothing that matches", said)  # perceived no one
+
+    def test_watch_gives_up_when_suspect_leaves(self, mock_delay, *_m):
+        perp = _Char("perp", uid="PERP")
+        bot = self._scene(perp)
+        a = _assignment(bot, {"uid": "PERP", "height": None, "build": None})
+        a.payload["watch_rounds"] = 2
+        bot.location.contents.remove(perp)  # suspect slipped away
+        with patch.object(amod, "resolve") as mock_resolve:
+            with patch("world.director.security.resolve", mock_resolve):
+                smod._watch_tick(bot)
+        mock_resolve.assert_called_once_with(bot)
+
+    def test_watch_holds_then_stands_down_after_rounds(self, mock_delay, *_m):
+        perp = _Char("perp", uid="PERP")
+        bot = self._scene(perp)
+        a = _assignment(bot, {"uid": "PERP", "height": None, "build": None})
+        a.payload["watch_rounds"] = 2
+        smod._watch_tick(bot)                      # round 1: still watching
+        self.assertIs(mock_delay.call_args.args[1], smod._watch_tick)
+        with patch("world.director.security.resolve") as mock_resolve:
+            smod._watch_tick(bot)                  # round 2: gives up
+            mock_resolve.assert_called_once_with(bot)


### PR DESCRIPTION
The responder never receives the perpetrator object — it gets a BOLO
(apparent_uid presentation snapshot + coarse height/build silhouette)
and must recognize the suspect among who it can currently perceive.

- world/director/security.py: build_bolo/match_bolo with tiered
  confidence. high (current apparent_uid equals the snapshot) ->
  challenge + watch cycle (re-scans, holds, gives up after N rounds or
  when the suspect stops matching); low (silhouette-only — an innocent
  lookalike fits the description; mistaken identity intended) ->
  questioned; none -> logs and resolves. A blind bot scans nothing
  (can_see gate). All speech/action through real commands.
- Registered as the security arrival handler (the #863 seam).
- @dispatch attaches a BOLO of the instigator: raise assault and the
  arriving unit recognizes YOU — or your disguise defeats it, or a
  same-silhouette bystander catches the heat.
- 13 tests; 32-test director sweep green.

Consequences fall out of the identity system: flight (not perceived),
disguise/re-sleeve (UID mismatch), generic looks (shared silhouettes).
Detain-via-restraint deferred to the trust-gate work; v1 high confidence
= challenge + hold-watch.

Closes #866

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
