### PR TITLE
Crime slice 3: crowd-gated witness NPC — the interdiction window is a person

### DIFF
--- a/world/director/__init__.py
+++ b/world/director/__init__.py
@@ -35,6 +35,12 @@ from world.director.security import (
     build_bolo,
     match_bolo,
 )
+from world.director.witness import (
+    can_report,
+    spawn_witness,
+    witness_chance,
+    witness_report,
+)
 from world.director.travel import (
     is_travelling,
     stop_travel,
@@ -49,6 +55,7 @@ __all__ = [
     "active_assignments",
     "assign",
     "build_bolo",
+    "can_report",
     "clear_assignment",
     "dispatch",
     "find_responders",
@@ -60,6 +67,9 @@ __all__ = [
     "register_arrival_handler",
     "report_crime",
     "resolve",
+    "spawn_witness",
     "stop_travel",
     "travel_to",
+    "witness_chance",
+    "witness_report",
 ]

--- a/world/director/crime.py
+++ b/world/director/crime.py
@@ -9,12 +9,12 @@ truths:
 * **The BOLO is snapshotted at crime time** — what witnesses saw *then*.
   Changing your presentation afterward defeats the match later; the
   report doesn't retroactively improve.
-* **The report takes time** (``REPORT_DELAY``): the force learns nothing
-  until the report "arrives". Today this delay is the acknowledged
-  magic placeholder for the witness→radio chain (slice 3 replaces it
-  with a real crowd-gated witness NPC + radio transmission); it already
-  functions as a proto **interdiction window** — leave the scene before
-  the response rolls.
+* **Someone has to see it** (slice 3, ``world/director/witness.py``): the
+  crowd gate decides whether a witness exists at all — no witness, **no
+  report ever** (an empty alley is free). When one spawns, the report
+  window is a *person*: silence them (dead/unconscious) before
+  ``WITNESS_REPORT_DELAY`` closes and the force never learns. (The radio
+  transmission itself stays magic until ``RADIO_COMMS_SPEC`` builds it.)
 * **One report per scene** (``REPORT_DEBOUNCE``, keyed room+type): a
   brawl is one incident, not a report per punch — and the BOLO belongs
   to the *first* aggressor.
@@ -30,13 +30,10 @@ from typing import Any
 
 from evennia.utils import delay
 
-from world.director.dispatch import WorldEvent, raise_event
+from world.director.dispatch import WorldEvent
 from world.director.security import build_bolo
+from world.director.witness import WITNESS_REPORT_DELAY, spawn_witness, witness_report
 
-#: Seconds between the act and the force learning of it (the report
-#: "arriving"). Placeholder for the witness→radio chain; also the proto
-#: interdiction window.
-REPORT_DELAY = 45.0
 #: One report per (room, crime type) within this window.
 REPORT_DEBOUNCE = 120.0
 
@@ -60,9 +57,10 @@ def report_crime(crime_type: str, location: Any, perp: Any = None,
                  severity: int | None = None) -> bool:
     """An instrumented act calls this at the moment of commission.
 
-    Snapshots the BOLO now, debounces per scene, and schedules the
-    delayed delivery to the dispatcher. Returns ``True`` if a report was
-    actually filed (not debounced/excluded).
+    Debounces per scene, rolls the **crowd-gated witness**, snapshots the
+    BOLO now, and hands the report window to the witness. Returns ``True``
+    if a witness saw it (a report is *pending* — not yet guaranteed: the
+    witness can still be silenced before the window closes).
     """
     if location is None:
         return False
@@ -77,6 +75,13 @@ def report_crime(crime_type: str, location: Any, perp: Any = None,
         return False
     _RECENT[key] = now
 
+    # §5.1: no witness, no report — the empty alley is free. (The scene
+    # stays debounced either way: the same brawl doesn't re-roll a witness
+    # every swing.)
+    witness = spawn_witness(location)
+    if witness is None:
+        return False
+
     event = WorldEvent(
         type=crime_type,
         location=location,
@@ -85,14 +90,5 @@ def report_crime(crime_type: str, location: Any, perp: Any = None,
         source=perp,
         payload={"bolo": build_bolo(perp)},   # crime-time presentation
     )
-    delay(REPORT_DELAY, _deliver, event)
+    delay(WITNESS_REPORT_DELAY, witness_report, witness, event)
     return True
-
-
-def _deliver(event: WorldEvent) -> None:
-    """The report 'arrives' — hand it to the dispatcher. (Slice 3 puts a
-    real witness + radio transmission between the act and this call.)"""
-    try:
-        raise_event(event)
-    except Exception:  # noqa: BLE001 — a broken report must not raise into delay
-        pass

--- a/world/director/witness.py
+++ b/world/director/witness.py
@@ -1,0 +1,134 @@
+"""Witnesses — crowd-gated, spawned, and interdictable.
+
+Crime slice 3 (``NPC_DISPATCH_AND_SIMULATION_SPEC`` §5.1): whether a crime
+*has* a witness derives from the room's **crowd** level — no crowd, no
+witness, **no report** (crime in an empty alley is free). When the roll
+passes, the witness **materializes as a real NPC** at the scene, visibly
+marked (edging away, hand on a walkie) — and the report only goes out if
+they are still **alive and conscious** when the window closes. Silence
+them first and the force never learns.
+
+This replaces slice 2's bare timer with a *person*: the interdiction
+window is now a target, not a clock. (The walkie is flavor until
+``RADIO_COMMS_SPEC`` ships a real device — then it becomes snatchable.)
+
+The witness is the game's first true **flash-temp ephemeral** (§3): it
+exists for the report, lingers briefly, and despawns. Per §5.2 it carries
+**100–500 tokens** — a bystander is also a mugging target, which is
+exactly the kind of loop this world wants.
+"""
+
+from __future__ import annotations
+
+from random import choice, randint, random
+from typing import Any
+
+from evennia import create_object
+from evennia.utils import delay
+
+from world.crowd import crowd_system
+from world.identity import BUILDS, HEIGHTS
+
+#: Seconds between the crime and the witness calling it in — the
+#: interdiction window (silence them before it closes).
+WITNESS_REPORT_DELAY = 40.0
+#: Seconds after reporting before the witness slips away and despawns.
+WITNESS_DESPAWN_DELAY = 90.0
+#: §5.2: civilians carry pockets worth mugging, not farming.
+WITNESS_TOKENS = (100, 500)
+
+_WITNESS_ADJECTIVES = (
+    "rattled", "shaken", "wide-eyed", "nervous", "pale",
+    "stunned", "jumpy",
+)
+
+#: crowd level -> chance someone actually saw it. 0 = empty room = free.
+def witness_chance(location: Any) -> float:
+    try:
+        level = crowd_system.calculate_crowd_level(location) or 0
+    except Exception:  # noqa: BLE001 — no crowd model, no witness
+        return 0.0
+    if level <= 0:
+        return 0.0
+    return min(0.95, 0.30 + 0.25 * float(level))
+
+
+def spawn_witness(location: Any) -> Any | None:
+    """Roll the crowd gate; on success materialize the witness NPC at
+    *location*, visibly marked. Returns the witness or ``None``."""
+    if location is None or random() >= witness_chance(location):
+        return None
+    try:
+        witness = create_object(
+            typeclass="typeclasses.characters.Character",
+            key=f"a {choice(_WITNESS_ADJECTIVES)} bystander",
+            location=location,
+            home=location,
+        )
+    except Exception:  # noqa: BLE001 — spawn failure = no witness, never a crash
+        return None
+    witness.height = choice(HEIGHTS)
+    witness.build = choice(BUILDS)
+    witness.db.tokens = randint(*WITNESS_TOKENS)          # §5.2 pockets
+    witness.db.is_witness = True
+    # The visible tell — this is who saw you, and what they're about to do.
+    witness.look_place = ("edging away from the scene, one hand on a "
+                          "battered walkie-talkie.")
+    try:
+        witness.execute_cmd(
+            "emote flinches back from the scene, fumbling for a "
+            "walkie-talkie.")
+    except Exception:  # noqa: BLE001
+        pass
+    return witness
+
+
+def can_report(witness: Any) -> bool:
+    """Alive and conscious — the §5.1 interdiction check."""
+    if witness is None or getattr(witness, "location", None) is None:
+        return False
+    try:
+        if witness.is_dead() or witness.is_unconscious():
+            return False
+    except Exception:  # noqa: BLE001 — no medical model, assume able
+        pass
+    return True
+
+
+def witness_report(witness: Any, event: Any) -> bool:
+    """The window closes: if the witness can still report, the event goes
+    to the dispatcher (magic radio until ``RADIO_COMMS_SPEC`` builds the
+    transmission for real). Either way the witness is scheduled to leave.
+    Returns whether the report went out."""
+    from world.director.dispatch import raise_event
+    reported = False
+    if can_report(witness):
+        try:
+            witness.execute_cmd(
+                "emote raises the walkie-talkie and calls it in, voice "
+                "shaking.")
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            raise_event(event)
+            reported = True
+        except Exception:  # noqa: BLE001 — a broken dispatch must not strand us
+            pass
+    if witness is not None:
+        delay(WITNESS_DESPAWN_DELAY, despawn_witness, witness)
+    return reported
+
+
+def despawn_witness(witness: Any) -> None:
+    """The flash-temp leaves: delete the witness unless the world has
+    other plans for the body (dead witnesses belong to the death/corpse
+    pipeline, not to us)."""
+    try:
+        if witness is None or not witness.pk:
+            return  # already gone
+        if witness.is_dead():
+            return  # the corpse pipeline owns it now
+        witness.execute_cmd("emote hurries off, wanting no more part of this.")
+        witness.delete()
+    except Exception:  # noqa: BLE001 — cleanup must never raise into delay
+        pass

--- a/world/tests/test_director_crime.py
+++ b/world/tests/test_director_crime.py
@@ -1,4 +1,4 @@
-"""Tests for the crime-report funnel (slice 2): delayed delivery,
+"""Tests for the crime-report funnel (slices 2+3): crowd-gated witness,
 crime-time BOLO snapshot, per-scene debounce, lawful-force exclusion."""
 
 from __future__ import annotations
@@ -34,59 +34,72 @@ class TestReportCrime(TestCase):
 
     @patch("world.director.crime.build_bolo",
            side_effect=lambda p: {"uid": getattr(p, "uid", None)})
+    @patch("world.director.crime.spawn_witness")
     @patch("world.director.crime.delay")
-    def test_report_schedules_delayed_delivery_with_crime_time_bolo(
-            self, mock_delay, _bolo):
+    def test_witnessed_crime_hands_window_to_witness(
+            self, mock_delay, mock_spawn, _bolo):
+        witness = MagicMock(name="witness")
+        mock_spawn.return_value = witness
         perp = _Char("perp", uid="AT_CRIME_TIME")
         self.assertTrue(report_crime("assault", _Room("scene"), perp=perp))
-        mock_delay.assert_called_once()
-        secs, fn, event = mock_delay.call_args.args
-        self.assertEqual(secs, cmod.REPORT_DELAY)
-        self.assertIs(fn, cmod._deliver)
+        secs, fn, w, event = mock_delay.call_args.args
+        self.assertEqual(secs, cmod.WITNESS_REPORT_DELAY)
+        self.assertIs(fn, cmod.witness_report)
+        self.assertIs(w, witness)
         self.assertEqual(event.type, "assault")
         self.assertEqual(event.severity, CRIME_SEVERITY["assault"])
         # BOLO captured NOW — changing presentation later can't touch it.
         self.assertEqual(event.payload["bolo"], {"uid": "AT_CRIME_TIME"})
 
+    @patch("world.director.crime.spawn_witness", return_value=None)
+    @patch("world.director.crime.delay")
+    def test_no_witness_no_report_ever(self, mock_delay, _spawn):
+        # The empty alley is free — no event is even built.
+        self.assertFalse(report_crime("assault", _Room("alley"),
+                                      perp=_Char("perp")))
+        mock_delay.assert_not_called()
+
+    @patch("world.director.crime.spawn_witness", return_value=None)
+    @patch("world.director.crime.delay")
+    def test_unwitnessed_scene_still_debounced(self, mock_delay, mock_spawn):
+        # The same brawl doesn't re-roll a witness every swing.
+        scene = _Room("scene")
+        report_crime("assault", scene)
+        report_crime("assault", scene)
+        self.assertEqual(mock_spawn.call_count, 1)
+
+    @patch("world.director.crime.spawn_witness", return_value=MagicMock())
     @patch("world.director.crime.build_bolo", return_value=None)
     @patch("world.director.crime.delay")
-    def test_debounce_one_report_per_scene(self, mock_delay, _b):
+    def test_debounce_one_report_per_scene(self, mock_delay, _b, _s):
         scene = _Room("scene")
         self.assertTrue(report_crime("assault", scene, perp=_Char("a")))
-        # the brawl continues — the counter-attacker does NOT file a second
         self.assertFalse(report_crime("assault", scene, perp=_Char("b")))
         self.assertEqual(mock_delay.call_count, 1)
         # a different crime type at the same scene is its own incident
         self.assertTrue(report_crime("vandalism", scene, perp=_Char("c")))
 
+    @patch("world.director.crime.spawn_witness", return_value=MagicMock())
     @patch("world.director.crime.build_bolo", return_value=None)
     @patch("world.director.crime.delay")
-    def test_debounce_expires(self, mock_delay, _b):
+    def test_debounce_expires(self, mock_delay, _b, _s):
         scene = _Room("scene")
         report_crime("assault", scene)
         cmod._RECENT[(scene, "assault")] -= cmod.REPORT_DEBOUNCE + 1
         self.assertTrue(report_crime("assault", scene))
 
+    @patch("world.director.crime.spawn_witness")
     @patch("world.director.crime.delay")
-    def test_security_actions_are_lawful(self, mock_delay):
+    def test_security_actions_are_lawful(self, mock_delay, mock_spawn):
         bot = _Char("bot", role="security")
         self.assertFalse(report_crime("assault", _Room("scene"), perp=bot))
+        mock_spawn.assert_not_called()
         mock_delay.assert_not_called()
 
     @patch("world.director.crime.delay")
     def test_no_location_no_report(self, mock_delay):
         self.assertFalse(report_crime("assault", None))
         mock_delay.assert_not_called()
-
-    @patch("world.director.crime.raise_event")
-    def test_deliver_hands_to_dispatcher(self, mock_raise):
-        event = MagicMock()
-        cmod._deliver(event)
-        mock_raise.assert_called_once_with(event)
-
-    @patch("world.director.crime.raise_event", side_effect=RuntimeError)
-    def test_deliver_never_raises(self, _r):
-        cmod._deliver(MagicMock())  # must not blow up inside delay
 
     def test_taxonomy_ladder_shape(self):
         self.assertEqual(CRIME_SEVERITY["murder"], 5)

--- a/world/tests/test_director_witness.py
+++ b/world/tests/test_director_witness.py
@@ -1,0 +1,122 @@
+"""Tests for the crowd-gated, interdictable witness (crime slice 3)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.director import witness as wmod
+from world.director.witness import (
+    WITNESS_TOKENS,
+    can_report,
+    despawn_witness,
+    spawn_witness,
+    witness_chance,
+    witness_report,
+)
+
+
+class _Room:
+    def __init__(self, name):
+        self.name = name
+
+
+def _witness(dead=False, unconscious=False, located=True):
+    w = MagicMock(name="witness")
+    w.location = _Room("scene") if located else None
+    w.is_dead.return_value = dead
+    w.is_unconscious.return_value = unconscious
+    w.pk = 42
+    return w
+
+
+class TestWitnessChance(TestCase):
+    def _with_level(self, level):
+        with patch.object(wmod.crowd_system, "calculate_crowd_level",
+                          return_value=level):
+            return witness_chance(_Room("r"))
+
+    def test_empty_room_is_free(self):
+        self.assertEqual(self._with_level(0), 0.0)
+
+    def test_scales_with_crowd_and_caps(self):
+        self.assertAlmostEqual(self._with_level(1), 0.55)
+        self.assertAlmostEqual(self._with_level(2), 0.80)
+        self.assertEqual(self._with_level(4), 0.95)  # capped
+
+    def test_no_crowd_model_no_witness(self):
+        with patch.object(wmod.crowd_system, "calculate_crowd_level",
+                          side_effect=RuntimeError):
+            self.assertEqual(witness_chance(_Room("r")), 0.0)
+
+
+class TestSpawnWitness(TestCase):
+    @patch("world.director.witness.random", return_value=0.99)
+    @patch("world.director.witness.witness_chance", return_value=0.5)
+    @patch("world.director.witness.create_object")
+    def test_failed_roll_spawns_no_one(self, mock_create, _c, _r):
+        self.assertIsNone(spawn_witness(_Room("scene")))
+        mock_create.assert_not_called()
+
+    @patch("world.director.witness.random", return_value=0.01)
+    @patch("world.director.witness.witness_chance", return_value=0.5)
+    @patch("world.director.witness.create_object")
+    def test_spawns_marked_bystander_with_pockets(self, mock_create, _c, _r):
+        shell = MagicMock()
+        shell.db = SimpleNamespace()
+        mock_create.return_value = shell
+        w = spawn_witness(_Room("scene"))
+        self.assertIs(w, shell)
+        self.assertIn("bystander", mock_create.call_args.kwargs["key"])
+        self.assertTrue(WITNESS_TOKENS[0] <= w.db.tokens <= WITNESS_TOKENS[1])
+        self.assertTrue(w.db.is_witness)
+        self.assertIn("walkie-talkie", w.look_place)  # the visible tell
+        w.execute_cmd.assert_called_once()            # reacts on the scene
+
+    def test_no_location_no_witness(self):
+        self.assertIsNone(spawn_witness(None))
+
+
+class TestInterdiction(TestCase):
+    def test_alive_and_conscious_can_report(self):
+        self.assertTrue(can_report(_witness()))
+
+    def test_dead_witness_is_silenced(self):
+        self.assertFalse(can_report(_witness(dead=True)))
+
+    def test_unconscious_witness_is_silenced(self):
+        self.assertFalse(can_report(_witness(unconscious=True)))
+
+    def test_gone_witness_is_silenced(self):
+        self.assertFalse(can_report(_witness(located=False)))
+        self.assertFalse(can_report(None))
+
+    @patch("world.director.witness.delay")
+    @patch("world.director.dispatch.raise_event")
+    def test_live_witness_reports_and_leaves(self, mock_raise, mock_delay):
+        w = _witness()
+        event = MagicMock()
+        self.assertTrue(witness_report(w, event))
+        mock_raise.assert_called_once_with(event)
+        # calls it in visibly, then is scheduled to slip away
+        self.assertTrue(w.execute_cmd.called)
+        self.assertIs(mock_delay.call_args.args[1], despawn_witness)
+
+    @patch("world.director.witness.delay")
+    @patch("world.director.dispatch.raise_event")
+    def test_silenced_witness_never_reports(self, mock_raise, mock_delay):
+        w = _witness(dead=True)
+        self.assertFalse(witness_report(w, MagicMock()))
+        mock_raise.assert_not_called()   # the force never learns
+        mock_delay.assert_called_once()  # the body still gets cleanup
+
+    def test_despawn_deletes_living_witness(self):
+        w = _witness()
+        despawn_witness(w)
+        w.delete.assert_called_once()
+
+    def test_despawn_leaves_corpse_to_death_pipeline(self):
+        w = _witness(dead=True)
+        despawn_witness(w)
+        w.delete.assert_not_called()


### PR DESCRIPTION
Replaces slice 2's bare report timer with a real, silenceable witness
(spec §5.1: no perceiver -> no chain -> no consequence).

- world/director/witness.py: witness_chance = the crowd gate (level 0 ->
  0%: the empty alley is free, no report ever; 55%/80%/95% cap above).
  spawn_witness materializes a real Character at the scene ("a rattled
  bystander", random height/build, 100-500 token pockets per §5.2 — a
  bystander is also a mugging target), visibly marked: look_place
  "edging away from the scene, one hand on a battered walkie-talkie" +
  a reaction emote — the tell that shows you WHO saw it. can_report =
  alive AND conscious. witness_report: when the 40s window closes, a
  living witness visibly calls it in (radio stays magic until
  RADIO_COMMS builds the transmission) and the event dispatches; a
  silenced witness means the force never learns. despawn_witness: the
  flash-temp slips away ~90s later; dead witnesses belong to the
  death/corpse pipeline. The game's first true ephemeral NPC (§3).
- crime.py rewired: report_crime rolls the witness; no witness -> no
  event is even built. Scene debounce unchanged (one roll per brawl).
- Crime tests updated for the witness flow + 14 new witness tests.
  54-test director sweep green.

Closes #872

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
