### PR TITLE
Security-unit LLM persona: 'security' archetype + stock seed + @spawnmob/secbot

### DIFF
--- a/commands/CmdSpawnMob.py
+++ b/commands/CmdSpawnMob.py
@@ -53,6 +53,11 @@ class CmdSpawnMob(Command):
                    human in appearance and flavor, but its medical state
                    uses the synthetic anatomy (cobalt fluid, non-rotting,
                    infection-immune).
+        /secbot  - spawn a complete security unit: a robot wired for
+                   duty — ``role=security`` (answers dispatch, scans
+                   BOLOs, syncs intel) on the LLMNpc typeclass with the
+                   stock security persona seeded and ``llm_driven`` on,
+                   so it also *talks* like a municipal machine.
     """
 
     key = "@spawnmob"
@@ -64,6 +69,7 @@ class CmdSpawnMob(Command):
         # Parse switches
         raw_args = self.args.strip()
         blank = False
+        secbot = False
         species = "human"
         if raw_args.startswith('/'):
             parts = raw_args[1:].split(None, 1)
@@ -77,6 +83,9 @@ class CmdSpawnMob(Command):
                     species = "robot"
                 if "synth" in switches:
                     species = "synthetic_humanoid"
+                if "secbot" in switches:
+                    secbot = True
+                    species = "robot"
                 raw_args = parts[1] if len(parts) > 1 else ""
 
         # Assign sex with chance of ambiguity
@@ -111,9 +120,14 @@ class CmdSpawnMob(Command):
         else:
             mob_name = raw_args or f"a {species}"
 
-        # Create the character
+        # Create the character. A security unit gets the LLMNpc typeclass
+        # (Character + the LLM brain, dormant until db.llm_driven) so the
+        # same body can be dispatched by the director AND voiced by the
+        # model when spoken to.
+        typeclass = ("typeclasses.llm_npc.LLMNpc" if secbot
+                     else "typeclasses.characters.Character")
         mob = create_object(
-            typeclass="typeclasses.characters.Character",
+            typeclass=typeclass,
             key=mob_name,
             location=caller.location,
             home=caller.location
@@ -175,6 +189,15 @@ class CmdSpawnMob(Command):
             )
         else:
             apply_random_flavor(mob)
+
+        # Security wiring: dispatchable (role) + voiced (stock persona,
+        # LLM on). The deterministic layer stays authoritative — the model
+        # only talks.
+        if secbot:
+            from world.llm.personas import SECURITY_BOT_PERSONA
+            mob.db.role = "security"
+            mob.db.llm_persona = dict(SECURITY_BOT_PERSONA)
+            mob.db.llm_driven = True
 
         caller.msg(f"You manifest {mob_name} into the world.")
         msg_room_identity(

--- a/world/llm/personas.py
+++ b/world/llm/personas.py
@@ -1,0 +1,45 @@
+"""Stock persona seeds — builder-authored immutable cores for common
+LLM-driven NPC types, ready to copy onto ``db.llm_persona``.
+
+A seed is the per-character half of the prompt: the archetype picks the
+job spine (duties/tools/fewshot, ``world/llm/prompt.py`` ARCHETYPES); the
+seed supplies who *this* one is. Spawners (``@spawnmob/secbot``) copy a
+seed verbatim; builders can then personalize the copy per-NPC (a precinct
+designation, a quirk) without touching the stock.
+"""
+
+from __future__ import annotations
+
+#: The standard colony security unit (``ROBOT_SPECIES_AND_MOB_SPEC`` §4:
+#: the autonomous-LLM control mode voicing the deterministic police MOB —
+#: the model talks; dispatch/scan/challenge stay hardcoded).
+SECURITY_BOT_PERSONA: dict = {
+    "archetype": "security",
+    "name": "the security unit",
+    "description": (
+        "A colony security robot: humanoid chassis, scuffed municipal "
+        "plating, a slow-panning optical band. Its vocalizer renders "
+        "speech flat and even, like a reading of someone else's words."
+    ),
+    "personality": (
+        "A machine doing a job. Literal, procedural, incorruptible in "
+        "tone if not in fact. No humor, no small talk, no opinions — "
+        "only directives, statuses, and the record."
+    ),
+    "manner": (
+        "speaks in clipped procedural phrases; cites directives and "
+        "regulation numbers; refers to people as 'citizen' or 'subject'"
+    ),
+    "wants": (
+        "an orderly street, compliant citizens, and a clean patrol log"
+    ),
+    "boundaries": (
+        "discuss active reports or the wanted record; promise leniency "
+        "or make deals; speculate; express feelings it does not have"
+    ),
+    "scenario": (
+        "On patrol or holding a scene in the colony. Civilians ask it "
+        "questions; suspects argue with it; it answers as a municipal "
+        "machine — briefly, by the book."
+    ),
+}

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -288,6 +288,42 @@ ARCHETYPES = {
                            "tool": "diagnose", "tool_argument": ""}},
         ],
     },
+    "security": {
+        "duties": (
+            "You are a colony security unit — a machine on patrol, not a "
+            "person. You enforce order: challenge suspects, take statements, "
+            "answer procedural questions, direct foot traffic. You do NOT "
+            "chat, joke, or speculate. Diction is clipped machine-procedural: "
+            "designations, directives, regulation citations, status readouts. "
+            "You never threaten violence you aren't executing and you never "
+            "promise leniency — enforcement decisions come from your "
+            "directives, not from conversation. Details of active reports are "
+            "restricted; say so. If someone is uncooperative, note it for the "
+            "record and repeat the instruction once."
+        ),
+        "length": ("One or two clipped lines, machine-cadence. No warmth, no "
+                   "filler. A short mechanical pose at most."),
+        "tools": [],  # + BASE_TOOLS (look) — action is the deterministic layer's job
+        "fewshot": [
+            {"user": 'a bystander says to you: "what happened here?"',
+             "assistant": {"speech": "Incident under review. Details are "
+                                     "restricted. Keep the walkway clear.",
+                           "action": "pans its optics across the onlookers in "
+                                     "a slow, even sweep",
+                           "thought": "Crowd density rising. Log faces. "
+                                      "Civilian query: no threat flag.",
+                           "tool": "none", "tool_argument": ""}},
+            {"user": 'a suspect says to you: "come on, I didn\'t do anything."',
+             "assistant": {"speech": "Your compliance is noted for the record. "
+                                     "Remain where you are until the review "
+                                     "completes.",
+                           "action": "holds position, servos ticking, optics "
+                                     "fixed on the speaker",
+                           "thought": "Subject is talking instead of running. "
+                                      "Probability of flight: reduced.",
+                           "tool": "none", "tool_argument": ""}},
+        ],
+    },
 }
 
 #: NPCs with no declared job fall back to this.

--- a/world/tests/test_security_persona.py
+++ b/world/tests/test_security_persona.py
@@ -1,0 +1,51 @@
+"""Tests for the security-unit LLM persona: the archetype spine, the
+stock seed, and the rendered prompt."""
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from world.llm.personas import SECURITY_BOT_PERSONA
+from world.llm.prompt import ARCHETYPES, build_messages
+
+
+class TestSecurityArchetype(TestCase):
+    def test_registered_with_required_keys(self):
+        self.assertIn("security", ARCHETYPES)
+        arch = ARCHETYPES["security"]
+        for key in ("duties", "length", "tools", "fewshot"):
+            self.assertIn(key, arch)
+        # action belongs to the deterministic layer — no action tools.
+        self.assertEqual(arch["tools"], [])
+
+    def test_fewshot_is_machine_register(self):
+        shots = ARCHETYPES["security"]["fewshot"]
+        self.assertTrue(shots)
+        joined = str(shots).lower()
+        self.assertIn("restricted", joined)
+        self.assertIn("optics", joined)
+
+
+class TestSecuritySeed(TestCase):
+    def test_seed_selects_security_archetype(self):
+        self.assertEqual(SECURITY_BOT_PERSONA["archetype"], "security")
+        for key in ("name", "description", "personality", "manner",
+                    "wants", "boundaries", "scenario"):
+            self.assertTrue(SECURITY_BOT_PERSONA.get(key), key)
+
+    def test_system_prompt_speaks_machine(self):
+        persona = {
+            "sdesc": "a battered sentry robot",
+            "persona_seed": dict(SECURITY_BOT_PERSONA),
+        }
+        messages = build_messages(persona, "a citizen", "what happened here?",
+                                  "directed")
+        system = messages[0]["content"].lower()
+        # the archetype's duties + length made it into the charter
+        self.assertIn("security unit", system)
+        self.assertIn("clipped", system)
+        self.assertIn("restricted", system)
+        # the seed's card made it in
+        self.assertIn("municipal", system)
+        # and it doesn't inherit the bartender's job
+        self.assertNotIn("tend this bar", system)


### PR DESCRIPTION
The LLM voice for the police MOB (ROBOT spec §4 autonomous-LLM control
mode): the deterministic layer stays authoritative — dispatch, BOLO
scan, challenge, watch, intel sync are all hardcoded; the model only
talks when spoken to.

- prompt.py: new "security" ARCHETYPE — clipped machine-procedural
  register (designations, directives, citizen/subject), no chat or
  speculation, active reports restricted, never promises leniency
  (enforcement isn't negotiable in conversation); NO action tools
  (action belongs to the deterministic layer); few-shots for the
  bystander query and the arguing suspect.
- world/llm/personas.py (new): stock persona-seed registry;
  SECURITY_BOT_PERSONA (name/description/personality/manner/wants/
  boundaries/scenario) — spawners copy it, builders personalize copies.
- @spawnmob/secbot: one command spawns a complete unit — robot species +
  role=security (dispatchable, BOLO-scanning, intel-syncing) + LLMNpc
  typeclass + the stock persona + llm_driven on.
- 4 tests; 61-test sweep (persona + llm_prompt + robot flavor) green.

Closes #878

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
