### PR TITLE
Secbot armament: integrated shotgun module (robot cyberware, not wielded)

### DIFF
--- a/commands/CmdSpawnMob.py
+++ b/commands/CmdSpawnMob.py
@@ -63,6 +63,29 @@ class CmdSpawnMob(Command):
     key = "@spawnmob"
     locks = "cmd:perm(Builders) or perm(Developers)"
 
+    @staticmethod
+    def _factory_fit_armament(mob, side="right"):
+        """Seat the integrated shotgun module as a standalone augment organ
+        (the tail pattern): the robot left the plant with it, so no surgery
+        pipeline — the formatted ``organ_spec`` goes straight onto the
+        medical state. Same backend as installed human chrome; ``/shotgun``
+        deploys it via the normal ability layer."""
+        from world.medical.core import Organ
+        from world.prototypes import ROBOT_SHOTGUN_MODULE_SPEC
+
+        def _fmt(value):
+            if isinstance(value, str):
+                return value.replace("{side}", side)
+            if isinstance(value, dict):
+                return {k: _fmt(v) for k, v in value.items()}
+            return value
+
+        spec = _fmt(dict(ROBOT_SHOTGUN_MODULE_SPEC))
+        organ_name = "integrated_shotgun_module"
+        state = mob.medical_state
+        state.organs[organ_name] = Organ(organ_name, organ_data=spec)
+        mob.save_medical_state()
+
     def func(self):
         caller = self.caller
 
@@ -198,15 +221,15 @@ class CmdSpawnMob(Command):
             mob.db.role = "security"
             mob.db.llm_persona = dict(SECURITY_BOT_PERSONA)
             mob.db.llm_driven = True
-            # Issue sidearm + wield it (via the real command) so the unit
-            # can hold suspects at aim — the innocuous detainment rung.
+            # Factory armament: seat the integrated shotgun module in the
+            # right forearm as a standalone augment organ (the tail
+            # pattern) — a robot's weapon is a subsystem it left the plant
+            # with, not a wielded item. Same augment backend as human
+            # chrome; robot-true presentation. /shotgun deploys it.
             try:
-                from evennia.prototypes.spawner import spawn as proto_spawn
-                pistol = proto_spawn("LIGHT_PISTOL")[0]
-                pistol.move_to(mob, quiet=True)
-                mob.execute_cmd("wield pistol")
+                self._factory_fit_armament(mob)
             except Exception:
-                pass  # an unarmed unit still functions; arm it by hand
+                pass  # an unarmed unit still functions; refit by hand
 
         caller.msg(f"You manifest {mob_name} into the world.")
         msg_room_identity(

--- a/specs/proposals/ROBOT_SPECIES_AND_MOB_SPEC.md
+++ b/specs/proposals/ROBOT_SPECIES_AND_MOB_SPEC.md
@@ -178,8 +178,14 @@ Patrol (routine) ─▶ Detect ─▶ Challenge ─▶ Escalate ─▶ Restrain 
      contest as the counterplay**: breaking the lock and running is allowed,
      and fleeing an aim lock is itself information. No touch, no consent
      question — detainment by threat posture. The unit lowers its weapon
-     when it stands down. Secbots spawn with a wielded `LIGHT_PISTOL` (the
-     colony security sidearm).
+     when it stands down. **Robots don't wield weapons — they mount them:**
+     secbots are factory-fitted with the `ROBOT_SHOTGUN_MODULE` (an
+     `integrated_weapon` forearm module seated as a standalone augment
+     organ, the tail pattern). Same augment backend as human chrome
+     (`SHOTGUN_MODULE`), species-true presentation — a subsystem on the
+     frame's bill of materials, not grafted chrome. `/shotgun` deploys the
+     `ROBOT_ARM_GUN` (which reuses the already-machine-toned
+     `cybernetic_shotgun` combat bank).
   2. **Grapple — lawful restraint** *(⬜, sequenced behind the trust gate)*:
      an uncooperative or fleeing subject is subdued by grapple/cuff — the
      conscious-and-unrestrained contest per `TRUST_AND_CONSENT_SPEC`.

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3223,3 +3223,72 @@ AUTODOC = {
             "waiting for a body to work on.",
     "tags": [("furniture", "category"), ("medical", "category")],
 }
+
+
+# ===================================================================
+# ROBOT MODULES (ROBOT_SPECIES_AND_MOB_SPEC)
+# ===================================================================
+# Robots use the SAME augment backend as human chrome (organ_spec,
+# hardpoints, integrated-weapon abilities) but present it species-true:
+# a robot's "cyberware" is factory equipment — modules seated in a
+# frame, not chrome grafted into flesh.  The deployed weapon reuses the
+# ``cybernetic_shotgun`` combat message bank (already machine-toned:
+# "servos whine up to pressure", "the forearm housing locks rigid").
+
+#: The security unit's factory armament, shared by the item prototype
+#: below and the ``@spawnmob/secbot`` factory-fit (which seats it as a
+#: standalone augment organ — the tail pattern — since a robot's frame
+#: comes from the plant with the module already in it).
+ROBOT_SHOTGUN_MODULE_SPEC = {
+    "container": "{side}_arm", "max_hp": 12, "hit_weight": "rare",
+    "inorganic": True, "prosthetic_frame": True,
+    "hardpoint": "forearm", "module_type": "forearm",
+    "abilities": {
+        "shotgun": {
+            "type": "integrated_weapon",
+            "slot": "{side}_hand",
+            "weapon_prototype": "ROBOT_ARM_GUN",
+            "deploy_msg": "Your {side} forearm housing unlocks along its service seam — the manipulator folds back into its stowage recess and the riot gun rotates up and seats with a hard mechanical clack.",
+            "retract_msg": "The riot gun swings down into the forearm housing; the panel seals and the manipulator redeploys, actuators cycling through their check pattern.",
+            "deployed_longdesc": "The forearm housing stands open along its service seam, a stub riot-gun barrel deployed and locked where the manipulator should be.",
+            "deployed_longdesc_slot": "Where the {side} manipulator should be, the wrist assembly terminates in a hardmounted firing socket — the hand has folded back into its stowage recess.",
+            "deploy_room": "{actor}'s forearm housing unlocks with a clack of releasing latches — a stub riot gun rotates up out of the frame where its hand just stowed.",
+            "retract_room": "{actor}'s arm-gun folds down into the forearm housing; the service panel seals and its manipulator redeploys, fingers cycling once.",
+        },
+    },
+}
+
+# Integrated Shotgun Module — the robot-frame counterpart of the human
+# SHOTGUN_MODULE.  Same coupling standard, species-gated to robot frames;
+# harvestable from a wrecked chassis and reseatable in another.
+ROBOT_SHOTGUN_MODULE = {
+    "key": "integrated shotgun module",
+    "typeclass": "typeclasses.items.Organ",
+    "aliases": ["riot module", "robot weapon module", "arm gun module"],
+    "desc": "A riot shotgun in a robot-frame module format: barrel shroud, feed system, and deployment servos in a sealed unit stenciled with a municipal parts code. The coupling collar is standard chassis gauge. This is not aftermarket chrome — it left the plant as part of a security frame's bill of materials.",
+    "tags": [("medical_item", "item_type"), ("augment", "item_type")],
+    "attrs": [
+        ("module_type", "forearm"),
+        ("condition", "pristine"),
+        ("compatible_species", ["robot"]),
+        ("organ_spec", ROBOT_SHOTGUN_MODULE_SPEC),
+    ],
+}
+
+# The integrated weapon the module deploys.  Locked + flagged integrated
+# by the ability layer; reuses the machine-toned ``cybernetic_shotgun``
+# combat message bank.
+ROBOT_ARM_GUN = {
+    "prototype_parent": "RANGED_WEAPON_BASE",
+    "key": "arm-mounted riot gun",
+    "aliases": ["riot gun", "arm gun"],
+    "desc": "A riot shotgun hardmounted in a robot forearm — short, shrouded, and structural. The barrel shroud is load-bearing frame member; the feed system disappears into the elbow actuator housing. No grip, no trigger, no sling mount: the weapon is a subsystem, fired the way the arm is moved — by the frame that owns it.",
+    "damage": 20,
+    "locks": "get:false();drop:false();give:false()",
+    "attrs": [
+        ("weapon_type", "cybernetic_shotgun"),
+        ("damage_type", "bullet"),
+        ("hands_required", 1),
+        ("integrated", True),
+    ],
+}

--- a/world/tests/test_robot_module.py
+++ b/world/tests/test_robot_module.py
@@ -1,0 +1,66 @@
+"""Tests for the robot integrated shotgun module — same augment backend
+as human chrome, robot-true presentation, factory-fitted at secbot spawn."""
+
+from __future__ import annotations
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from world.prototypes import (
+    ROBOT_ARM_GUN,
+    ROBOT_SHOTGUN_MODULE,
+    ROBOT_SHOTGUN_MODULE_SPEC,
+)
+
+
+def _attr(proto, key):
+    return dict(a[:2] for a in proto["attrs"]).get(key)
+
+
+class TestRobotModulePrototypes(TestCase):
+    def test_module_is_robot_species_gated(self):
+        self.assertEqual(_attr(ROBOT_SHOTGUN_MODULE, "compatible_species"),
+                         ["robot"])
+        self.assertEqual(_attr(ROBOT_SHOTGUN_MODULE, "module_type"), "forearm")
+        self.assertIs(_attr(ROBOT_SHOTGUN_MODULE, "organ_spec"),
+                      ROBOT_SHOTGUN_MODULE_SPEC)
+
+    def test_spec_is_standard_augment_backend(self):
+        # Same shape as the human SHOTGUN_MODULE: hardpoint module organ
+        # with an integrated_weapon ability — one backend, two presentations.
+        spec = ROBOT_SHOTGUN_MODULE_SPEC
+        self.assertTrue(spec["inorganic"])
+        self.assertEqual(spec["hardpoint"], "forearm")
+        ability = spec["abilities"]["shotgun"]
+        self.assertEqual(ability["type"], "integrated_weapon")
+        self.assertEqual(ability["weapon_prototype"], "ROBOT_ARM_GUN")
+
+    def test_presentation_is_robot_true(self):
+        # Module/deploy prose reads as factory equipment, not grafted chrome.
+        ability = ROBOT_SHOTGUN_MODULE_SPEC["abilities"]["shotgun"]
+        joined = " ".join(str(v) for v in ability.values()).lower()
+        self.assertIn("manipulator", joined)
+        self.assertIn("housing", joined)
+        self.assertNotIn("flesh", joined)
+        self.assertNotIn("skin", joined)
+        self.assertIn("plant", ROBOT_SHOTGUN_MODULE["desc"])
+
+    def test_arm_gun_reuses_machine_toned_bank(self):
+        self.assertEqual(_attr(ROBOT_ARM_GUN, "weapon_type"),
+                         "cybernetic_shotgun")
+        self.assertTrue(_attr(ROBOT_ARM_GUN, "integrated"))
+        self.assertIn("get:false()", ROBOT_ARM_GUN["locks"])
+
+
+class TestFactoryFit(TestCase):
+    def test_seats_side_formatted_organ_and_saves(self):
+        from commands.CmdSpawnMob import CmdSpawnMob
+        mob = MagicMock()
+        mob.medical_state.organs = {}
+        CmdSpawnMob._factory_fit_armament(mob, side="right")
+        organ = mob.medical_state.organs["integrated_shotgun_module"]
+        self.assertEqual(organ.data["container"], "right_arm")
+        ability = organ.data["abilities"]["shotgun"]
+        self.assertEqual(ability["slot"], "right_hand")
+        self.assertIn("right forearm", ability["deploy_msg"])
+        mob.save_medical_state.assert_called_once()


### PR DESCRIPTION
Design correction: robots don't wield weapons — they mount them. Robot
"cyberware" is factory equipment: the SAME augment backend as human
chrome, presented species-true (a module on the frame's bill of
materials, not chrome grafted into flesh).

- ROBOT_SHOTGUN_MODULE (+ shared ROBOT_SHOTGUN_MODULE_SPEC): the
  robot-frame counterpart of the human SHOTGUN_MODULE — identical
  organ_spec shape (forearm hardpoint, integrated_weapon ability) with
  robot-true prose (the manipulator stows into its recess, service
  seams, municipal parts code, "left the plant as part of a security
  frame's bill of materials"); compatible_species ["robot"].
- ROBOT_ARM_GUN: the deployed weapon — structural, "fired the way the
  arm is moved — by the frame that owns it"; reuses the
  cybernetic_shotgun combat bank, which is already machine-toned
  ("servos whine up to pressure", "the forearm housing locks rigid") —
  one message bank, two species presentations.
- @spawnmob/secbot: the LIGHT_PISTOL issuance is replaced by
  _factory_fit_armament — seats the module as a standalone augment
  organ (the tail pattern; no surgery pipeline, it left the plant
  installed; side-formatted, right forearm). /shotgun deploys via the
  normal ability layer. Aim-lock detainment unaffected (target-aim
  requires no wielded weapon).
- ROBOT spec §5 ladder text corrected (LIGHT_PISTOL -> the module).
- test_robot_module.py (5 tests: species gating, backend shape,
  robot-true prose, bank reuse, factory-fit formatting+save); 39-test
  sweep green.

Closes #882

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
