### PR TITLE
Playtest fixes: secbot identity + Engage rung (violence in progress)

### DIFF
--- a/commands/CmdSpawnMob.py
+++ b/commands/CmdSpawnMob.py
@@ -221,6 +221,12 @@ class CmdSpawnMob(Command):
             mob.db.role = "security"
             mob.db.llm_persona = dict(SECURITY_BOT_PERSONA)
             mob.db.llm_driven = True
+            # LLMNpc's at_object_creation seeds height/build="average" as an
+            # identity safety net (right for human LLM NPCs, wrong for a
+            # chassis — it composed "an average person"). Clear them so the
+            # sdesc falls back to the robot key ("a scuffed sentry robot").
+            mob.height = None
+            mob.build = None
             # Factory armament: seat the integrated shotgun module in the
             # right forearm as a standalone augment organ (the tail
             # pattern) — a robot's weapon is a subsystem it left the plant

--- a/specs/proposals/ROBOT_SPECIES_AND_MOB_SPEC.md
+++ b/specs/proposals/ROBOT_SPECIES_AND_MOB_SPEC.md
@@ -189,8 +189,14 @@ Patrol (routine) ─▶ Detect ─▶ Challenge ─▶ Escalate ─▶ Restrain 
   2. **Grapple — lawful restraint** *(⬜, sequenced behind the trust gate)*:
      an uncooperative or fleeing subject is subdued by grapple/cuff — the
      conscious-and-unrestrained contest per `TRUST_AND_CONSENT_SPEC`.
-  3. **Combat — force** *(⬜)*: only when attacked or when directives
-     authorize it; non-lethal bias.
+  3. **Combat — force** *(🟡 engage-on-violence SHIPPED)*: **violence in
+     progress in front of the unit authorizes force** — a confirmed suspect
+     currently in combat (on arrival, or turning violent under watch) skips
+     detainment: the unit warns once, deploys the arm gun (`/shotgun`), and
+     attacks (all real commands; the combat handler owns the fight from
+     there). A unit **never walks home mid-fight** (the watch loop defers
+     while it is in combat). Still ahead: force *initiation* beyond
+     violence-in-progress (fleeing-felon directives, lethality tuning).
 
   The **general NPC combat order-of-operations** (all NPCs, not just
   security) is the same requirement one level down — hardcoded reflexes for:

--- a/world/director/security.py
+++ b/world/director/security.py
@@ -130,6 +130,30 @@ def _release_aim(npc: Any) -> None:
         _cmd(npc, "aim stop")
 
 
+def _in_combat(char: Any) -> bool:
+    """Is *char* currently in an active combat handler?"""
+    try:
+        from world.combat.constants import NDB_COMBAT_HANDLER
+        return getattr(getattr(char, "ndb", None), NDB_COMBAT_HANDLER,
+                       None) is not None
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _engage(npc: Any, assignment: Any, suspect: Any) -> None:
+    """The Engage rung: violence in progress in front of the unit
+    authorizes force. Deploy the arm gun and attack — real commands; the
+    combat handler owns the fight from here. Fires once per assignment."""
+    if assignment.payload.get("engaged"):
+        return
+    assignment.payload["engaged"] = True
+    handle = get_short_sdesc(suspect)
+    _cmd(npc, f"say Cease — {handle}. Violence in progress: "
+              f"force is authorized.")
+    _cmd(npc, "/shotgun")   # deploy the integrated riot gun
+    _cmd(npc, f"attack {getattr(suspect, 'key', suspect)}")
+
+
 def _scan_wanted(npc: Any):
     """First perceivable character whose *current* presentation is on the
     force-wide wanted record: ``(uid, char, entry)`` or ``(None,)*3``.
@@ -166,10 +190,15 @@ def security_arrival(npc: Any, assignment: Any) -> None:
         # returns to post and syncs (the §5.1 latency window).
         log_local_sighting(npc, bolo.get("uid"),
                            getattr(event, "type", "crime"))
-        handle = get_short_sdesc(suspect)
-        _cmd(npc, f"say You — {handle}. Hold your position. "
-                  f"You match an active report.")
-        _aim_lock(npc, suspect)
+        if _in_combat(suspect):
+            # Crime IN PROGRESS in front of the unit — skip detainment,
+            # escalate straight to the Engage rung.
+            _engage(npc, assignment, suspect)
+        else:
+            handle = get_short_sdesc(suspect)
+            _cmd(npc, f"say You — {handle}. Hold your position. "
+                      f"You match an active report.")
+            _aim_lock(npc, suspect)
         assignment.payload["watch_rounds"] = WATCH_ROUNDS
         delay(WATCH_SECONDS, _watch_tick, npc)
         return
@@ -178,10 +207,13 @@ def security_arrival(npc: Any, assignment: Any) -> None:
     if flagged is not None:
         log_local_sighting(npc, wanted_uid,
                            entry.get("last_crime") or "wanted")
-        handle = get_short_sdesc(flagged)
-        _cmd(npc, f"say You — {handle}. You're flagged in the system. "
-                  f"Hold your position.")
-        _aim_lock(npc, flagged)
+        if _in_combat(flagged):
+            _engage(npc, assignment, flagged)
+        else:
+            handle = get_short_sdesc(flagged)
+            _cmd(npc, f"say You — {handle}. You're flagged in the system. "
+                      f"Hold your position.")
+            _aim_lock(npc, flagged)
         assignment.payload["watch_rounds"] = WATCH_ROUNDS
         delay(WATCH_SECONDS, _watch_tick, npc)
     elif confidence == "low":
@@ -198,17 +230,27 @@ def security_arrival(npc: Any, assignment: Any) -> None:
 def _watch_tick(npc: Any) -> None:
     """Re-scan while holding a suspect (event-BOLO match *or* a face on
     the wanted record); give up after ``WATCH_ROUNDS`` cycles or when no
-    subject holds."""
+    subject holds. A unit in combat never walks home mid-fight, and a held
+    suspect who turns violent gets the Engage rung."""
     from world.director.assignment import get_assignment
     assignment = get_assignment(npc)
     if assignment is None:
         return  # stood down meanwhile
+    if _in_combat(npc):
+        # The fight owns the unit; keep monitoring without burning rounds.
+        delay(WATCH_SECONDS, _watch_tick, npc)
+        return
     bolo = (getattr(assignment.event, "payload", None) or {}).get("bolo")
     confidence, suspect = _scan(npc, bolo)
     holding = confidence == "high"
     if not holding:
-        _uid, flagged, _entry = _scan_wanted(npc)
-        holding = flagged is not None
+        _uid, suspect, _entry = _scan_wanted(npc)
+        holding = suspect is not None
+    if holding and _in_combat(suspect):
+        # The held suspect started (or resumed) violence under watch.
+        _engage(npc, assignment, suspect)
+        delay(WATCH_SECONDS, _watch_tick, npc)
+        return
     rounds = assignment.payload.get("watch_rounds", 0) - 1
     assignment.payload["watch_rounds"] = rounds
     if not holding or rounds <= 0:

--- a/world/tests/test_director_security.py
+++ b/world/tests/test_director_security.py
@@ -198,6 +198,58 @@ class TestSecurityArrival(TestCase):
         bot.execute_cmd.assert_not_called()
 
     @patch("world.director.security.log_local_sighting")
+    def test_crime_in_progress_engages_instead_of_aiming(self, _log, *_m):
+        # Suspect actively in combat on arrival -> the Engage rung: deploy
+        # the arm gun and attack; no polite aim lock.
+        from world.combat.constants import NDB_COMBAT_HANDLER
+        perp = _Char("perp", uid="PERP", height="tall", build="lean")
+        setattr(perp.ndb, NDB_COMBAT_HANDLER, MagicMock())
+        bot = self._scene(perp)
+        a = _assignment(bot, {"uid": "PERP", "height": "tall", "build": "lean"})
+        security_arrival(bot, a)
+        cmds = [c.args[0] for c in bot.execute_cmd.call_args_list]
+        self.assertIn("/shotgun", cmds)
+        self.assertIn("attack perp", cmds)
+        self.assertNotIn("aim perp", cmds)
+        self.assertTrue(a.payload["engaged"])
+
+    @patch("world.director.security.log_local_sighting")
+    def test_engage_fires_once_per_assignment(self, _log, *_m):
+        perp = _Char("perp", uid="PERP")
+        bot = self._scene(perp)
+        a = _assignment(bot, {"uid": "PERP", "height": None, "build": None})
+        smod._engage(bot, a, perp)
+        first_count = bot.execute_cmd.call_count
+        smod._engage(bot, a, perp)
+        self.assertEqual(bot.execute_cmd.call_count, first_count)
+
+    def test_watch_never_walks_home_mid_fight(self, mock_delay, *_m):
+        from world.combat.constants import NDB_COMBAT_HANDLER
+        perp = _Char("perp", uid="PERP")
+        bot = self._scene(perp)
+        a = _assignment(bot, {"uid": "PERP", "height": None, "build": None})
+        a.payload["watch_rounds"] = 1
+        setattr(bot.ndb, NDB_COMBAT_HANDLER, MagicMock())  # bot is fighting
+        with patch("world.director.security.resolve") as mock_resolve:
+            smod._watch_tick(bot)
+            mock_resolve.assert_not_called()               # stays on scene
+        self.assertEqual(a.payload["watch_rounds"], 1)     # no round burned
+        self.assertIs(mock_delay.call_args.args[1], smod._watch_tick)
+
+    @patch("world.director.security.log_local_sighting")
+    def test_held_suspect_turning_violent_escalates(self, _log, mock_delay, *_m):
+        from world.combat.constants import NDB_COMBAT_HANDLER
+        perp = _Char("perp", uid="PERP")
+        bot = self._scene(perp)
+        a = _assignment(bot, {"uid": "PERP", "height": None, "build": None})
+        a.payload["watch_rounds"] = 3
+        setattr(perp.ndb, NDB_COMBAT_HANDLER, MagicMock())  # suspect fighting
+        smod._watch_tick(bot)
+        cmds = [c.args[0] for c in bot.execute_cmd.call_args_list]
+        self.assertIn("attack perp", cmds)
+        self.assertTrue(a.payload["engaged"])
+
+    @patch("world.director.security.log_local_sighting")
     @patch("world.director.security.is_wanted")
     def test_wanted_face_flagged_without_event_bolo(self, mock_wanted,
                                                     mock_log, mock_delay, *_m):


### PR DESCRIPTION
1. Secbot rendered as "an average person": LLMNpc.at_object_creation
   seeds height/build="average" as an identity safety net — right for
   human LLM NPCs, wrong for a chassis (the humanoid descriptor table
   composed "an average person"). @spawnmob/secbot now clears
   height/build so the sdesc falls back to the robot key.
2. The Engage rung: a confirmed suspect (BOLO-high or wanted-record) who
   is IN ACTIVE COMBAT — on arrival, or turning violent under watch —
   skips detainment: the unit warns once ("Violence in progress: force
   is authorized"), deploys the arm gun (/shotgun), and attacks. All
   real commands; the combat handler owns the fight from there. The
   watch loop defers while the unit is in combat (a unit never walks
   home mid-fight, and no watch rounds burn during an engagement).
   Engage fires once per assignment.

ROBOT spec §5 ladder synced (Combat rung: engage-on-violence shipped;
force initiation beyond violence-in-progress still ahead). 5 new tests;
41-test sweep green.

Closes #886

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
