### PR TITLE
Secbot addresses 'Colonist'; witness flees to cower via director travel

### DIFF
--- a/world/director/security.py
+++ b/world/director/security.py
@@ -32,7 +32,7 @@ from world.director.assignment import (
     resolve,
 )
 from world.director.intel import is_wanted, log_local_sighting, sync_bot_intel
-from world.identity import get_apparent_uid, get_short_sdesc
+from world.identity import get_apparent_uid
 from world.perception import can_see
 
 #: Seconds between watch re-scans when a high-confidence suspect is held.
@@ -147,9 +147,8 @@ def _engage(npc: Any, assignment: Any, suspect: Any) -> None:
     if assignment.payload.get("engaged"):
         return
     assignment.payload["engaged"] = True
-    handle = get_short_sdesc(suspect)
-    _cmd(npc, f"say Cease — {handle}. Violence in progress: "
-              f"force is authorized.")
+    _cmd(npc, "say Cease, Colonist. Violence in progress: "
+              "force is authorized.")
     _cmd(npc, "/shotgun")   # deploy the integrated riot gun
     _cmd(npc, f"attack {getattr(suspect, 'key', suspect)}")
 
@@ -195,9 +194,8 @@ def security_arrival(npc: Any, assignment: Any) -> None:
             # escalate straight to the Engage rung.
             _engage(npc, assignment, suspect)
         else:
-            handle = get_short_sdesc(suspect)
-            _cmd(npc, f"say You — {handle}. Hold your position. "
-                      f"You match an active report.")
+            _cmd(npc, "say Colonist. Hold your position. "
+                      "You match an active report.")
             _aim_lock(npc, suspect)
         assignment.payload["watch_rounds"] = WATCH_ROUNDS
         delay(WATCH_SECONDS, _watch_tick, npc)
@@ -210,16 +208,14 @@ def security_arrival(npc: Any, assignment: Any) -> None:
         if _in_combat(flagged):
             _engage(npc, assignment, flagged)
         else:
-            handle = get_short_sdesc(flagged)
-            _cmd(npc, f"say You — {handle}. You're flagged in the system. "
-                      f"Hold your position.")
+            _cmd(npc, "say Colonist. You're flagged in the system. "
+                      "Hold your position.")
             _aim_lock(npc, flagged)
         assignment.payload["watch_rounds"] = WATCH_ROUNDS
         delay(WATCH_SECONDS, _watch_tick, npc)
     elif confidence == "low":
-        handle = get_short_sdesc(suspect)
-        _cmd(npc, f"say You there — {handle}. You fit a description. "
-                  f"State your business here.")
+        _cmd(npc, "say You there, Colonist. You fit a description. "
+                  "State your business here.")
         delay(INVESTIGATE_SECONDS, resolve, npc)
     else:
         _cmd(npc, "emote finds nothing that matches its report and "

--- a/world/director/witness.py
+++ b/world/director/witness.py
@@ -98,8 +98,11 @@ def can_report(witness: Any) -> bool:
 def witness_report(witness: Any, event: Any) -> bool:
     """The window closes: if the witness can still report, the event goes
     to the dispatcher (magic radio until ``RADIO_COMMS_SPEC`` builds the
-    transmission for real). Either way the witness is scheduled to leave.
-    Returns whether the report went out."""
+    transmission for real). Then the witness **flees the scene to cower**
+    — real movement over the exit graph via the director's travel
+    primitive, not a vanish — the proof-of-concept for the future where
+    every NPC's comings and goings run on the dispatch system. Returns
+    whether the report went out."""
     from world.director.dispatch import raise_event
     reported = False
     if can_report(witness):
@@ -114,9 +117,50 @@ def witness_report(witness: Any, event: Any) -> bool:
             reported = True
         except Exception:  # noqa: BLE001 — a broken dispatch must not strand us
             pass
-    if witness is not None:
+        flee_and_cower(witness)
+    elif witness is not None:
+        # Silenced (dead/unconscious) — cleanup only; the dead belong to
+        # the corpse pipeline, the downed get hauled off eventually.
         delay(WITNESS_DESPAWN_DELAY, despawn_witness, witness)
     return reported
+
+
+#: How far (straight-line rooms) the witness will run to find a corner.
+COWER_RADIUS = 4
+
+
+def flee_and_cower(witness: Any) -> None:
+    """Walk the witness to a nearby room (director travel — visible,
+    step-by-step, through real exits) and have it cower there; it slips
+    away and despawns only after a long grace, off the scene instead of
+    evaporating in front of everyone."""
+    from world.director.travel import travel_to
+    from world.spatial import rooms_within
+    destination = None
+    try:
+        nearby = rooms_within(witness.location, COWER_RADIUS)
+        if nearby:
+            destination = choice(nearby)
+    except Exception:  # noqa: BLE001 — no spatial data, cower in place
+        pass
+    try:
+        witness.execute_cmd("emote bolts from the scene, head down.")
+    except Exception:  # noqa: BLE001
+        pass
+    if destination is None or not travel_to(
+            witness, destination, on_arrive=_cower, on_fail=_cower):
+        _cower(witness)
+
+
+def _cower(witness: Any) -> None:
+    """Arrived (or cornered): hunker down, then despawn after the grace."""
+    try:
+        witness.look_place = ("cowering against the wall, arms wrapped "
+                              "tight, eyes on the door.")
+        witness.execute_cmd("emote presses into cover, shaking.")
+    except Exception:  # noqa: BLE001
+        pass
+    delay(WITNESS_DESPAWN_DELAY, despawn_witness, witness)
 
 
 def despawn_witness(witness: Any) -> None:

--- a/world/llm/personas.py
+++ b/world/llm/personas.py
@@ -28,7 +28,8 @@ SECURITY_BOT_PERSONA: dict = {
     ),
     "manner": (
         "speaks in clipped procedural phrases; cites directives and "
-        "regulation numbers; refers to people as 'citizen' or 'subject'"
+        "regulation numbers; addresses people as 'Colonist' (or 'subject' "
+        "when they are under review) — never by name or description"
     ),
     "wants": (
         "an orderly street, compliant citizens, and a clean patrol log"

--- a/world/tests/test_director_security.py
+++ b/world/tests/test_director_security.py
@@ -80,7 +80,6 @@ class TestBolo(TestCase):
         self.assertIsNone(match_bolo({}, _Char("x", uid="abc123")))
 
 
-@patch("world.director.security.get_short_sdesc", return_value="a tall lean drifter")
 @patch("world.director.security.get_apparent_uid", side_effect=_fake_uid)
 @patch("world.director.security.can_see", return_value=True)
 @patch("world.director.security.delay")

--- a/world/tests/test_director_witness.py
+++ b/world/tests/test_director_witness.py
@@ -92,16 +92,16 @@ class TestInterdiction(TestCase):
         self.assertFalse(can_report(_witness(located=False)))
         self.assertFalse(can_report(None))
 
-    @patch("world.director.witness.delay")
+    @patch("world.director.witness.flee_and_cower")
     @patch("world.director.dispatch.raise_event")
-    def test_live_witness_reports_and_leaves(self, mock_raise, mock_delay):
+    def test_live_witness_reports_then_flees_to_cower(self, mock_raise,
+                                                      mock_flee):
         w = _witness()
         event = MagicMock()
         self.assertTrue(witness_report(w, event))
         mock_raise.assert_called_once_with(event)
-        # calls it in visibly, then is scheduled to slip away
-        self.assertTrue(w.execute_cmd.called)
-        self.assertIs(mock_delay.call_args.args[1], despawn_witness)
+        self.assertTrue(w.execute_cmd.called)      # calls it in visibly
+        mock_flee.assert_called_once_with(w)       # then RUNS, not vanishes
 
     @patch("world.director.witness.delay")
     @patch("world.director.dispatch.raise_event")
@@ -110,6 +110,35 @@ class TestInterdiction(TestCase):
         self.assertFalse(witness_report(w, MagicMock()))
         mock_raise.assert_not_called()   # the force never learns
         mock_delay.assert_called_once()  # the body still gets cleanup
+
+    @patch("world.director.witness.delay")
+    @patch("world.director.travel.travel_to")
+    def test_flee_travels_to_nearby_room_then_cowers(self, mock_travel,
+                                                     mock_delay):
+        from world.director.witness import flee_and_cower
+        dest = _Room("alley")
+        w = _witness()
+        mock_travel.return_value = True
+        with patch("world.spatial.rooms_within", return_value=[dest]):
+            flee_and_cower(w)
+        self.assertEqual(mock_travel.call_args.args[1], dest)
+        # arrival callback = the cower
+        on_arrive = mock_travel.call_args.kwargs["on_arrive"]
+        on_arrive(w)
+        self.assertIn("cowering", w.look_place)
+        self.assertIs(mock_delay.call_args.args[1], despawn_witness)
+
+    @patch("world.director.witness.delay")
+    @patch("world.director.travel.travel_to")
+    def test_flee_cowers_in_place_when_nowhere_to_run(self, mock_travel,
+                                                      mock_delay):
+        from world.director.witness import flee_and_cower
+        w = _witness()
+        with patch("world.spatial.rooms_within", return_value=[]):
+            flee_and_cower(w)
+        mock_travel.assert_not_called()
+        self.assertIn("cowering", w.look_place)
+        self.assertIs(mock_delay.call_args.args[1], despawn_witness)
 
     def test_despawn_deletes_living_witness(self):
         w = _witness()


### PR DESCRIPTION
1. The unit no longer calls out a person's sdesc in its deterministic
   lines — every challenge/engage line addresses "Colonist" (machine
   register: you are a category, not a description). The LLM persona's
   manner is aligned ("addresses people as 'Colonist'... never by name
   or description") so both voices match. get_short_sdesc dropped from
   security.py.
2. The witness no longer emotes and evaporates in place: it bolts and
   TRAVELS (director travel_to — real exits, step-by-step, visible) to a
   nearby room (rooms_within <= 4) and cowers there (look_place:
   "cowering against the wall, arms wrapped tight, eyes on the door"),
   despawning only after the long grace, off-scene. Cowers in place when
   there is nowhere to run. Explicitly the proof-of-concept for the
   future where every NPC's comings and goings run on the dispatch
   system. Silenced witnesses keep the cleanup-only path.

Tests updated + 2 new flee/cower tests; 51-test sweep green.

Closes #888

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
