### PR TITLE
Fix: secbot aim/attack resolved nothing — target by sdesc, not gated key

### DIFF
--- a/world/director/security.py
+++ b/world/director/security.py
@@ -117,11 +117,27 @@ def _cmd(npc: Any, command: str) -> None:
         pass
 
 
+def _target_token(suspect: Any) -> str:
+    """A string the identity-aware combat resolver will actually match
+    for *suspect*: their current **sdesc**, which substring-matches
+    itself. Real keys are builder-gated by the recognition system —
+    ``attack Elizabeth von Fischer`` resolves nothing for an NPC. The
+    unit targets what it perceives, exactly like a player typing
+    ``attack stout woman``."""
+    try:
+        sdesc = suspect.get_sdesc()
+        if sdesc:
+            return sdesc
+    except Exception:  # noqa: BLE001
+        pass
+    return str(getattr(suspect, "key", suspect))
+
+
 def _aim_lock(npc: Any, suspect: Any) -> None:
     """The innocuous detainment rung: hold the suspect at aim (the aim
     lock pins them in place; a flee contest is their counterplay). A real
     command — the same aim any player uses."""
-    _cmd(npc, f"aim {getattr(suspect, 'key', suspect)}")
+    _cmd(npc, f"aim {_target_token(suspect)}")
 
 
 def _release_aim(npc: Any) -> None:
@@ -150,7 +166,7 @@ def _engage(npc: Any, assignment: Any, suspect: Any) -> None:
     _cmd(npc, "say Cease, Colonist. Violence in progress: "
               "force is authorized.")
     _cmd(npc, "/shotgun")   # deploy the integrated riot gun
-    _cmd(npc, f"attack {getattr(suspect, 'key', suspect)}")
+    _cmd(npc, f"attack {_target_token(suspect)}")
 
 
 def _scan_wanted(npc: Any):

--- a/world/tests/test_director_security.py
+++ b/world/tests/test_director_security.py
@@ -34,6 +34,10 @@ class _Char:
         self.db = SimpleNamespace(role="security")
         self.execute_cmd = MagicMock()
 
+    def get_sdesc(self):
+        # the identity handle the resolver matches (fakes use their name)
+        return self.name
+
     def is_typeclass(self, path, exact=False):
         return True
 
@@ -264,6 +268,41 @@ class TestSecurityArrival(TestCase):
         self.assertIn("flagged in the system", said)
         mock_log.assert_called_once_with(bot, "OLDFACE", "robbery")
         self.assertIs(mock_delay.call_args.args[1], smod._watch_tick)
+
+
+class TestTargetToken(TestCase):
+    """The unit must target via the identity-aware resolver's language —
+    validated against the REAL matcher, not a mock (the live bug: real
+    keys are builder-gated, so 'attack <key>' resolved nothing)."""
+
+    def test_token_is_the_sdesc_not_the_key(self):
+        suspect = _Char("Elizabeth von Fischer")
+        suspect.get_sdesc = lambda: "stout woman with black curls"
+        self.assertEqual(smod._target_token(suspect),
+                         "stout woman with black curls")
+
+    def test_sdesc_token_matches_via_real_identity_matcher(self):
+        from world.search import identity_match_characters
+
+        class _IdChar:
+            def __init__(self, key, sdesc):
+                self.key = key
+                self._sdesc = sdesc
+
+            def get_sdesc(self):
+                return self._sdesc
+
+        searcher = _IdChar("bot", "scuffed loader robot")
+        perp = _IdChar("Elizabeth von Fischer",
+                       "stout woman with black curls")
+        bystander = _IdChar("Joe Moody", "compact man with gray curls")
+        candidates = [searcher, perp, bystander]
+        token = smod._target_token(perp)
+        matches = identity_match_characters(searcher, token, candidates)
+        self.assertEqual(matches, [perp])
+        # and the real key would NOT have matched (the live bug)
+        self.assertEqual(
+            identity_match_characters(searcher, perp.key, candidates), [])
 
 
 @patch("world.director.security.sync_bot_intel")


### PR DESCRIPTION
Live playtest: the engage warning and riot-gun deploy fired, but attack
(and aim in the detain path) silently failed. Root cause: security
targeted via suspect.key ("attack Elizabeth von Fischer"), but combat
commands resolve through the identity-aware pipeline
(resolve_character_target -> identity_match_characters), which matches
assigned names and sdescs only — real-key matching is deliberately
builder-gated to protect the recognition system. The NPC was speaking a
language the parser refuses on principle.

Fix: _target_token(suspect) = the suspect's current get_sdesc() (which
substring-matches itself) — the unit targets what it perceives, exactly
like a player typing "attack stout woman". Used by _aim_lock and
_engage.

Tests validate against the REAL matcher: the sdesc token uniquely
resolves the perp among room candidates, and the real key resolves
nothing (the live bug, pinned). 25-test security suite green.

Closes #890

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
