### PR TITLE
Director routines: bases of operations + patrol beats (@patrol, heartbeat)

### DIFF
--- a/commands/CmdPatrol.py
+++ b/commands/CmdPatrol.py
@@ -1,0 +1,147 @@
+"""``@patrol`` — post an NPC to a base and put it on a beat.
+
+The builder interface to the director's routines layer
+(``world/director/routines.py``). Build the precinct, stand in it, post
+the bot, give it a beat — the heartbeat does the rest.
+"""
+
+from evennia import Command
+
+from world.director.routines import (
+    HEARTBEAT_SECONDS,
+    ensure_heartbeat,
+    get_beat,
+)
+
+
+class CmdPatrol(Command):
+    """
+    Post an NPC to a base of operations and set its patrol beat.
+
+    Usage:
+        @patrol <npc>                     - post <npc> HERE (this room
+                                            becomes its base: assignments
+                                            return it here; intel syncs here)
+        @patrol/beat <npc> = <r1>, <r2>…  - set the beat (room names/#dbrefs);
+                                            the base is walked at the top of
+                                            every loop automatically
+        @patrol/auto <npc> = <radius>     - auto-beat: sample nearby rooms
+                                            within <radius> of the base
+        @patrol/status [npc]              - show posts and beats
+        @patrol/clear <npc>               - take <npc> off patrol (keeps post)
+
+    The heartbeat ticks every ~45s: an idle patroller walks one leg of
+    its beat, sweeps the waypoint (security NPCs scan for wanted faces —
+    a hit raises a disturbance on the spot), and moves on. Dispatch,
+    travel, and combat always preempt; the beat resumes after.
+    """
+
+    key = "@patrol"
+    locks = "cmd:perm(Builders) or perm(Developers)"
+    help_category = "Building"
+
+    def _find_npc(self, name):
+        npc = self.caller.search(name, global_search=True)
+        if npc and not npc.is_typeclass(
+                "typeclasses.characters.Character", exact=False):
+            self.caller.msg(f"{npc.get_display_name(self.caller)} is not a character.")
+            return None
+        return npc
+
+    def func(self):
+        caller = self.caller
+        switches = self.switches or []
+        args = self.args.strip()
+
+        if "status" in switches:
+            from evennia.objects.models import ObjectDB
+            npcs = ([self._find_npc(args)] if args else [
+                o for o in ObjectDB.objects.filter(
+                    db_attributes__db_key="patrol_beat").distinct()])
+            npcs = [n for n in npcs if n]
+            if not npcs:
+                caller.msg("No one is on patrol.")
+                return
+            for npc in npcs:
+                post = getattr(npc.db, "post", None)
+                beat = get_beat(npc)
+                caller.msg(
+                    f"{npc.get_display_name(caller)} — post: "
+                    f"{post.get_display_name(caller) if post else '(none)'}; "
+                    f"beat: "
+                    + (", ".join(r.get_display_name(caller) for r in beat)
+                       if beat else "(none)"))
+            return
+
+        if "clear" in switches:
+            npc = self._find_npc(args)
+            if not npc:
+                return
+            npc.db.patrol_beat = None
+            npc.ndb.patrol_idx = 0
+            caller.msg(f"{npc.get_display_name(caller)} is off patrol "
+                       f"(post kept).")
+            return
+
+        if "beat" in switches or "auto" in switches:
+            if "=" not in args:
+                caller.msg("Usage: @patrol/beat <npc> = <room>, <room>… "
+                           "or @patrol/auto <npc> = <radius>")
+                return
+            name, _, rest = args.partition("=")
+            npc = self._find_npc(name.strip())
+            if not npc:
+                return
+            post = getattr(npc.db, "post", None)
+            if post is None:
+                caller.msg("Post them first: stand in the base room and "
+                           "run @patrol <npc>.")
+                return
+            if "auto" in switches:
+                from random import sample
+                from world.spatial import rooms_within
+                try:
+                    radius = int(rest.strip())
+                except ValueError:
+                    caller.msg("Radius must be a number.")
+                    return
+                nearby = rooms_within(post, radius)
+                if not nearby:
+                    caller.msg("No coordinate rooms within that radius.")
+                    return
+                beat = sample(nearby, min(4, len(nearby)))
+            else:
+                beat = []
+                for token in rest.split(","):
+                    room = caller.search(token.strip(), global_search=True)
+                    if not room:
+                        return  # search already messaged
+                    beat.append(room)
+                if not beat:
+                    caller.msg("No rooms given.")
+                    return
+            npc.db.patrol_beat = beat
+            npc.ndb.patrol_idx = 0
+            ensure_heartbeat()
+            caller.msg(
+                f"{npc.get_display_name(caller)} now walks: "
+                + ", ".join(r.get_display_name(caller) for r in beat)
+                + f" (base first, every loop; ~{HEARTBEAT_SECONDS}s a leg).")
+            return
+
+        # bare: post <npc> here
+        if not args:
+            caller.msg("Usage: @patrol <npc>  (see help @patrol)")
+            return
+        npc = self._find_npc(args)
+        if not npc:
+            return
+        if caller.location is None:
+            caller.msg("You have no location to post them to.")
+            return
+        npc.db.post = caller.location
+        caller.msg(
+            f"{npc.get_display_name(caller)} is posted to "
+            f"{caller.location.get_display_name(caller)} — assignments "
+            f"return it here; intel syncs here. Set a beat with "
+            f"@patrol/beat or @patrol/auto.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -29,6 +29,7 @@ from commands.CmdSpawnMob import CmdSpawnMob
 from commands.CmdCoordSeed import CmdCoordSeed
 from commands.CmdPath import CmdPath
 from commands.CmdDispatch import CmdDispatch
+from commands.CmdPatrol import CmdPatrol
 from commands.bar_menu import CmdSpawnIngredient
 from commands.CmdBug import CmdBug
 from commands.CmdAdmin import CmdHeal, CmdPeace, CmdTestDeathCurtain, CmdWeather, CmdResetMedical, CmdMedicalAudit, CmdTestDeath, CmdTestUnconscious
@@ -143,6 +144,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdCoordSeed())
         self.add(CmdPath())
         self.add(CmdDispatch())
+        self.add(CmdPatrol())
         self.add(CmdSpawnIngredient())
         self.add(CmdAdmin.CmdHeal())
         self.add(CmdAdmin.CmdPeace())

--- a/world/director/assignment.py
+++ b/world/director/assignment.py
@@ -80,14 +80,17 @@ def is_assigned(npc: Any) -> bool:
 
 
 def assign(npc: Any, event: Any) -> bool:
-    """Commit *npc* to *event*: record the assignment (posting it back to
-    its current room) and start travel. Returns ``False`` if travel could
-    not start (unreachable). Reassignment cancels the previous assignment.
-    """
+    """Commit *npc* to *event*: record the assignment and start travel.
+    The return point is the NPC's **base** (``db.post``) when one is set
+    — a posted responder goes home to the precinct, not to wherever it
+    happened to be standing — else its current room. Returns ``False`` if
+    travel could not start (unreachable). Reassignment cancels the
+    previous assignment."""
     if npc is None or event is None or getattr(event, "location", None) is None:
         return False
     clear_assignment(npc)
-    assignment = Assignment(npc=npc, event=event, post=npc.location)
+    post = getattr(getattr(npc, "db", None), "post", None) or npc.location
+    assignment = Assignment(npc=npc, event=event, post=post)
     _ACTIVE[npc] = assignment
     if npc.ndb is not None:
         setattr(npc.ndb, _NDB_KEY, assignment)

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -1,0 +1,161 @@
+"""Patrol routines — the director's heartbeat walking NPCs on beats.
+
+Dispatch-spec Phase 2 (roles & routines), first consumer: security bots
+with a **base of operations**. Three ideas:
+
+* **Post** (``db.post``) — the NPC's base room. A posted NPC's dispatch
+  assignments return it *there* (not wherever it happened to stand), so
+  "returns to base and syncs intel" becomes literal geography.
+* **Beat** (``db.patrol_beat``) — an ordered list of rooms the NPC walks
+  in a loop, base included implicitly at the top of every cycle.
+  Builder-authored (``@patrol/beat``) or coordinate-sampled
+  (``@patrol/auto``).
+* **The heartbeat** — a persistent Evennia script ticks every
+  ``HEARTBEAT_SECONDS`` and *nudges* idle patrollers one step: not at the
+  next waypoint → travel there (director ``travel_to``, real exits);
+  arrived → run the waypoint hook, advance the index. No delay-chains to
+  die on reload: the script survives restarts and simply resumes nudging.
+
+**Patrol→Detect composition:** on waypoint arrival a security NPC runs
+the wanted-scan; a flagged face raises a ``disturbance`` event on the
+spot — dispatch assigns (usually the patroller itself, distance 0) and
+the existing challenge/aim/watch machinery takes over. Detect costs no
+new behavior code.
+
+Anything urgent always preempts: an assigned, travelling, or fighting
+NPC is skipped by the heartbeat until it is free again.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from evennia import DefaultScript
+
+from world.director.assignment import is_assigned
+from world.director.travel import is_travelling, travel_to
+
+#: Seconds between heartbeat ticks (also the linger at each waypoint).
+HEARTBEAT_SECONDS = 45
+#: Global script key.
+SCRIPT_KEY = "director_routines"
+
+
+# --------------------------------------------------------------------------
+# Beat state helpers
+# --------------------------------------------------------------------------
+
+def get_beat(npc: Any) -> list:
+    """The NPC's patrol cycle: ``[post] + beat rooms`` (post-anchored so
+    every loop passes through base). Empty when it has no beat."""
+    beat = list(getattr(npc.db, "patrol_beat", None) or [])
+    if not beat:
+        return []
+    post = getattr(npc.db, "post", None)
+    if post is not None and post not in beat:
+        beat.insert(0, post)
+    return [room for room in beat if room is not None]
+
+
+def _in_combat(npc: Any) -> bool:
+    from world.director.security import _in_combat as check
+    return check(npc)
+
+
+def is_patrol_idle(npc: Any) -> bool:
+    """Free to take a patrol step: not assigned, not mid-travel, not
+    fighting, and actually somewhere."""
+    return (npc.location is not None
+            and not is_assigned(npc)
+            and not is_travelling(npc)
+            and not _in_combat(npc))
+
+
+# --------------------------------------------------------------------------
+# The tick
+# --------------------------------------------------------------------------
+
+def tick_npc(npc: Any) -> str:
+    """Advance one NPC's patrol by one nudge. Returns what happened
+    (for diagnostics): ``skip`` / ``travel`` / ``waypoint`` / ``none``."""
+    beat = get_beat(npc)
+    if not beat:
+        return "none"
+    if not is_patrol_idle(npc):
+        return "skip"
+    idx = int(getattr(npc.ndb, "patrol_idx", None) or 0) % len(beat)
+    waypoint = beat[idx]
+    if npc.location != waypoint:
+        travel_to(npc, waypoint)
+        return "travel"
+    # Arrived: run the waypoint hook, then aim for the next stop.
+    npc.ndb.patrol_idx = (idx + 1) % len(beat)
+    at_waypoint(npc)
+    return "waypoint"
+
+
+def at_waypoint(npc: Any) -> None:
+    """Waypoint hook. Security: sweep for wanted faces — a hit raises a
+    ``disturbance`` on the spot and the dispatch/challenge machinery
+    (usually assigning this very patroller) takes it from there."""
+    if getattr(getattr(npc, "db", None), "role", None) != "security":
+        return
+    try:
+        from world.director.dispatch import WorldEvent, raise_event
+        from world.director.security import _scan_wanted
+        _uid, flagged, _entry = _scan_wanted(npc)
+        if flagged is not None:
+            raise_event(WorldEvent("disturbance", npc.location,
+                                   severity=1, source=flagged))
+        else:
+            npc.execute_cmd("emote pans a slow sensor sweep across the "
+                            "street and moves on.")
+    except Exception:  # noqa: BLE001 — a bad sweep must not stall the beat
+        pass
+
+
+def tick_all() -> dict:
+    """One heartbeat over every NPC with a beat. Returns counts by
+    outcome (diagnostics)."""
+    from evennia.objects.models import ObjectDB
+    counts: dict = {}
+    for npc in ObjectDB.objects.filter(
+            db_attributes__db_key="patrol_beat").distinct():
+        try:
+            outcome = tick_npc(npc)
+        except Exception:  # noqa: BLE001 — one broken bot must not stall all
+            outcome = "error"
+        counts[outcome] = counts.get(outcome, 0) + 1
+    return counts
+
+
+# --------------------------------------------------------------------------
+# The heartbeat script
+# --------------------------------------------------------------------------
+
+class DirectorRoutineScript(DefaultScript):
+    """Persistent global heartbeat driving all patrol beats."""
+
+    def at_script_creation(self):
+        self.key = SCRIPT_KEY
+        self.desc = "Director heartbeat: walks NPCs on their patrol beats."
+        self.interval = HEARTBEAT_SECONDS
+        self.persistent = True
+
+    def at_repeat(self):
+        tick_all()
+
+
+def ensure_heartbeat() -> Any:
+    """Get-or-create the global heartbeat script (idempotent; called by
+    ``@patrol`` so the first beat ever set starts the engine)."""
+    from evennia import create_script
+    from evennia.scripts.models import ScriptDB
+    existing = ScriptDB.objects.filter(db_key=SCRIPT_KEY).first()
+    if existing:
+        if not existing.is_active:
+            existing.start()
+        return existing
+    return create_script(
+        "world.director.routines.DirectorRoutineScript",
+        key=SCRIPT_KEY, persistent=True, autostart=True)

--- a/world/tests/test_director_routines.py
+++ b/world/tests/test_director_routines.py
@@ -1,0 +1,129 @@
+"""Tests for patrol routines — posts, beats, the heartbeat tick, and the
+Patrol→Detect waypoint sweep."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.director import routines as rmod
+from world.director.routines import at_waypoint, get_beat, tick_npc
+
+
+class _Room:
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+
+class _Npc:
+    def __init__(self, location, role="security", post=None, beat=None):
+        self.location = location
+        self.db = SimpleNamespace(role=role, post=post, patrol_beat=beat)
+        self.ndb = SimpleNamespace()
+        self.execute_cmd = MagicMock()
+
+
+class TestBeat(TestCase):
+    def test_post_anchors_the_cycle(self):
+        base, a, b = _Room("base"), _Room("a"), _Room("b")
+        npc = _Npc(base, post=base, beat=[a, b])
+        self.assertEqual(get_beat(npc), [base, a, b])
+
+    def test_post_not_duplicated(self):
+        base, a = _Room("base"), _Room("a")
+        npc = _Npc(base, post=base, beat=[base, a])
+        self.assertEqual(get_beat(npc), [base, a])
+
+    def test_no_beat_no_cycle(self):
+        npc = _Npc(_Room("x"))
+        self.assertEqual(get_beat(npc), [])
+
+
+@patch("world.director.routines._in_combat", return_value=False)
+@patch("world.director.routines.is_travelling", return_value=False)
+@patch("world.director.routines.is_assigned", return_value=False)
+class TestTick(TestCase):
+    def test_no_beat_none(self, *_m):
+        self.assertEqual(tick_npc(_Npc(_Room("x"))), "none")
+
+    def test_busy_skips(self, mock_assigned, *_m):
+        base, a = _Room("base"), _Room("a")
+        npc = _Npc(base, post=base, beat=[a])
+        mock_assigned.return_value = True
+        self.assertEqual(tick_npc(npc), "skip")
+
+    @patch("world.director.routines.travel_to")
+    def test_walks_to_next_waypoint(self, mock_travel, *_m):
+        base, a = _Room("base"), _Room("a")
+        npc = _Npc(a, post=base, beat=[a])   # cycle [base, a]; idx 0 -> base
+        self.assertEqual(tick_npc(npc), "travel")
+        self.assertEqual(mock_travel.call_args.args[1], base)
+
+    @patch("world.director.routines.at_waypoint")
+    def test_arrival_advances_and_sweeps(self, mock_hook, *_m):
+        base, a = _Room("base"), _Room("a")
+        npc = _Npc(base, post=base, beat=[a])  # at waypoint 0 (base)
+        self.assertEqual(tick_npc(npc), "waypoint")
+        self.assertEqual(npc.ndb.patrol_idx, 1)
+        mock_hook.assert_called_once_with(npc)
+
+
+class TestWaypointSweep(TestCase):
+    @patch("world.director.security._scan_wanted")
+    @patch("world.director.dispatch.raise_event")
+    def test_wanted_face_raises_disturbance(self, mock_raise, mock_scan):
+        felon = MagicMock(name="felon")
+        mock_scan.return_value = ("UID", felon, {"count": 1})
+        npc = _Npc(_Room("corner"), role="security")
+        at_waypoint(npc)
+        event = mock_raise.call_args.args[0]
+        self.assertEqual(event.type, "disturbance")
+        self.assertIs(event.source, felon)
+        self.assertEqual(event.location, npc.location)
+
+    @patch("world.director.security._scan_wanted",
+           return_value=(None, None, None))
+    @patch("world.director.dispatch.raise_event")
+    def test_clean_sweep_just_emotes(self, mock_raise, _scan):
+        npc = _Npc(_Room("corner"), role="security")
+        at_waypoint(npc)
+        mock_raise.assert_not_called()
+        npc.execute_cmd.assert_called_once()
+
+    def test_non_security_no_sweep(self):
+        npc = _Npc(_Room("corner"), role="miner")
+        at_waypoint(npc)
+        npc.execute_cmd.assert_not_called()
+
+
+class TestPostedAssignments(TestCase):
+    @patch("world.director.assignment.travel_to", return_value=True)
+    def test_assignment_returns_to_the_base_not_the_spot(self, _t):
+        from world.director import assignment as amod
+        from world.director.assignment import assign, get_assignment
+
+        class _Char:
+            def __init__(self):
+                self.location = _Room("street corner")
+                self.db = SimpleNamespace(post=_Room("precinct"), role="security")
+                self.ndb = SimpleNamespace()
+
+        amod._ACTIVE.clear()
+        npc = _Char()
+        event = SimpleNamespace(location=_Room("scene"), type="assault",
+                                payload={})
+        self.assertTrue(assign(npc, event))
+        self.assertEqual(get_assignment(npc).post.name, "precinct")
+        amod._ACTIVE.clear()
+
+
+class TestWiring(TestCase):
+    def test_patrol_command_registered(self):
+        from commands.default_cmdsets import CharacterCmdSet
+        cs = CharacterCmdSet()
+        cs.at_cmdset_creation()
+        self.assertIn("@patrol", [c.key for c in cs.commands])


### PR DESCRIPTION
Dispatch-spec Phase 2 first slice, built for the precinct build-out:

- Post (db.post): the NPC's base. Dispatch assignments return a posted
  responder to its base rather than wherever it happened to stand —
  "returns to base and syncs intel" is now literal geography.
- Beat (db.patrol_beat): an ordered room loop with the base
  auto-anchored at the top of every cycle. @patrol <npc> posts it HERE;
  @patrol/beat npc = rooms...; @patrol/auto npc = radius (samples
  rooms_within); /status; /clear.
- Heartbeat: a persistent global script (45s) nudges idle patrollers one
  leg at a time — no delay-chains to die on reload, and the beat simply
  resumes after restarts. Assigned/travelling/fighting NPCs are skipped
  until free (urgency always preempts routine).
- Patrol->Detect by composition: on waypoint arrival a security NPC runs
  the wanted-scan; a flagged face raises a disturbance event on the spot
  -> dispatch assigns (usually the patroller itself, distance 0) -> the
  existing challenge/aim/watch machinery fires. Zero new behavior code.
  Clean sweeps get a sensor-pan emote.
- 13 tests; 57-test director sweep green.

Closes #898

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
