### PR TITLE
Population slice 1: security base (spawn/sync/respawn) + @patrol/base

### DIFF
--- a/commands/CmdPatrol.py
+++ b/commands/CmdPatrol.py
@@ -27,6 +27,10 @@ class CmdPatrol(Command):
                                             every loop automatically
         @patrol/auto <npc> = <radius>     - auto-beat: sample nearby rooms
                                             within <radius> of the base
+        @patrol/base [complement]         - designate THIS room the security
+                                            base: secbots spawn/post/sync/
+                                            respawn here; the heartbeat keeps
+                                            <complement> units alive (default 1)
         @patrol/status [npc]              - show posts and beats
         @patrol/clear <npc>               - take <npc> off patrol (keeps post)
 
@@ -52,6 +56,25 @@ class CmdPatrol(Command):
         caller = self.caller
         switches = self.switches or []
         args = self.args.strip()
+
+        if "base" in switches:
+            from world.director.population import set_security_base
+            if caller.location is None:
+                caller.msg("You have no location to designate.")
+                return
+            try:
+                complement = int(args) if args else 1
+            except ValueError:
+                caller.msg("Complement must be a number.")
+                return
+            set_security_base(caller.location, complement)
+            ensure_heartbeat()
+            caller.msg(
+                f"{caller.location.get_display_name(caller)} is now the "
+                f"security base: secbots spawn, post, sync, and respawn "
+                f"here; the heartbeat maintains a complement of "
+                f"{complement}.")
+            return
 
         if "status" in switches:
             from evennia.objects.models import ObjectDB

--- a/commands/CmdSpawnMob.py
+++ b/commands/CmdSpawnMob.py
@@ -63,29 +63,6 @@ class CmdSpawnMob(Command):
     key = "@spawnmob"
     locks = "cmd:perm(Builders) or perm(Developers)"
 
-    @staticmethod
-    def _factory_fit_armament(mob, side="right"):
-        """Seat the integrated shotgun module as a standalone augment organ
-        (the tail pattern): the robot left the plant with it, so no surgery
-        pipeline — the formatted ``organ_spec`` goes straight onto the
-        medical state. Same backend as installed human chrome; ``/shotgun``
-        deploys it via the normal ability layer."""
-        from world.medical.core import Organ
-        from world.prototypes import ROBOT_SHOTGUN_MODULE_SPEC
-
-        def _fmt(value):
-            if isinstance(value, str):
-                return value.replace("{side}", side)
-            if isinstance(value, dict):
-                return {k: _fmt(v) for k, v in value.items()}
-            return value
-
-        spec = _fmt(dict(ROBOT_SHOTGUN_MODULE_SPEC))
-        organ_name = "integrated_shotgun_module"
-        state = mob.medical_state
-        state.organs[organ_name] = Organ(organ_name, organ_data=spec)
-        mob.save_medical_state()
-
     def func(self):
         caller = self.caller
 
@@ -143,14 +120,25 @@ class CmdSpawnMob(Command):
         else:
             mob_name = raw_args or f"a {species}"
 
-        # Create the character. A security unit gets the LLMNpc typeclass
-        # (Character + the LLM brain, dormant until db.llm_driven) so the
-        # same body can be dispatched by the director AND voiced by the
-        # model when spoken to.
-        typeclass = ("typeclasses.llm_npc.LLMNpc" if secbot
-                     else "typeclasses.characters.Character")
+        # /secbot delegates wholesale to the population factory — the SAME
+        # code the director's respawn loop uses, so a hand-spawned unit and
+        # an alcove replacement are identical (posted to the base, armed,
+        # voiced). See world/director/population.py.
+        if secbot:
+            from world.director.population import spawn_secbot
+            mob = spawn_secbot(caller.location, name=(raw_args or None))
+            caller.msg(f"You manifest {mob.key} into the world.")
+            msg_room_identity(
+                location=caller.location,
+                template="{mob} powers up, status lights climbing to green.",
+                char_refs={"mob": mob},
+                exclude=[caller],
+            )
+            return
+
+        # Create the character
         mob = create_object(
-            typeclass=typeclass,
+            typeclass="typeclasses.characters.Character",
             key=mob_name,
             location=caller.location,
             home=caller.location
@@ -212,30 +200,6 @@ class CmdSpawnMob(Command):
             )
         else:
             apply_random_flavor(mob)
-
-        # Security wiring: dispatchable (role) + voiced (stock persona,
-        # LLM on). The deterministic layer stays authoritative — the model
-        # only talks.
-        if secbot:
-            from world.llm.personas import SECURITY_BOT_PERSONA
-            mob.db.role = "security"
-            mob.db.llm_persona = dict(SECURITY_BOT_PERSONA)
-            mob.db.llm_driven = True
-            # LLMNpc's at_object_creation seeds height/build="average" as an
-            # identity safety net (right for human LLM NPCs, wrong for a
-            # chassis — it composed "an average person"). Clear them so the
-            # sdesc falls back to the robot key ("a scuffed sentry robot").
-            mob.height = None
-            mob.build = None
-            # Factory armament: seat the integrated shotgun module in the
-            # right forearm as a standalone augment organ (the tail
-            # pattern) — a robot's weapon is a subsystem it left the plant
-            # with, not a wielded item. Same augment backend as human
-            # chrome; robot-true presentation. /shotgun deploys it.
-            try:
-                self._factory_fit_armament(mob)
-            except Exception:
-                pass  # an unarmed unit still functions; refit by hand
 
         caller.msg(f"You manifest {mob_name} into the world.")
         msg_room_identity(

--- a/world/director/population.py
+++ b/world/director/population.py
@@ -1,0 +1,167 @@
+"""Population — the director's census layer, first slice: the security
+base and its complement.
+
+A room designated the **security base** (``@patrol/base``, tag
+``("security_base", "director")``) becomes the force's home:
+
+* **spawn** — new secbots materialize there (and any ``@spawnmob/secbot``
+  spawned elsewhere is still *posted* to the base);
+* **sync** — posted units return there after assignments, which is where
+  intel goes force-wide (existing completion handler);
+* **respawn** — the base carries a **complement** (``db.security_complement``);
+  every director heartbeat counts living posted units and, on a deficit,
+  cycles ONE replacement out of the charging alcoves. Dead, wrecked, or
+  deleted units simply fall out of the count — no death-hook plumbing,
+  the census self-heals.
+
+This is deliberately the seed of the spec's population registry (§3):
+role + home + lifecycle, for one role at one base. The general registry
+grows out of it.
+"""
+
+from __future__ import annotations
+
+from random import choice, randint
+from typing import Any
+
+#: Room tag marking the security base.
+BASE_TAG = "security_base"
+BASE_TAG_CATEGORY = "director"
+
+
+# --------------------------------------------------------------------------
+# The base
+# --------------------------------------------------------------------------
+
+def get_security_base() -> Any | None:
+    """The designated security-base room, or ``None``."""
+    from evennia.objects.models import ObjectDB
+    return ObjectDB.objects.filter(
+        db_tags__db_key=BASE_TAG,
+        db_tags__db_category=BASE_TAG_CATEGORY).first()
+
+
+def set_security_base(room: Any, complement: int = 1) -> None:
+    """Designate *room* as THE security base (single base v1 — any
+    previous designation is cleared) with a standing *complement*."""
+    old = get_security_base()
+    if old is not None and old != room:
+        old.tags.remove(BASE_TAG, category=BASE_TAG_CATEGORY)
+    room.tags.add(BASE_TAG, category=BASE_TAG_CATEGORY)
+    room.db.security_complement = int(complement)
+
+
+# --------------------------------------------------------------------------
+# The secbot factory (shared by @spawnmob/secbot and the respawner)
+# --------------------------------------------------------------------------
+
+def factory_fit_armament(mob: Any, side: str = "right") -> None:
+    """Seat the integrated shotgun module as a standalone augment organ
+    (the tail pattern): the robot left the plant with it. Same backend as
+    installed human chrome; ``/shotgun`` deploys via the ability layer."""
+    from world.medical.core import Organ
+    from world.prototypes import ROBOT_SHOTGUN_MODULE_SPEC
+
+    def _fmt(value):
+        if isinstance(value, str):
+            return value.replace("{side}", side)
+        if isinstance(value, dict):
+            return {k: _fmt(v) for k, v in value.items()}
+        return value
+
+    spec = _fmt(dict(ROBOT_SHOTGUN_MODULE_SPEC))
+    organ_name = "integrated_shotgun_module"
+    state = mob.medical_state
+    state.organs[organ_name] = Organ(organ_name, organ_data=spec)
+    mob.save_medical_state()
+
+
+def spawn_secbot(location: Any, name: str | None = None) -> Any:
+    """Build a complete security unit at *location*: robot species +
+    LLMNpc brain + persona + role + factory armament, **posted to the
+    security base** (or to *location* when no base is designated).
+    Returns the unit."""
+    from evennia import create_object
+    from random import randint as _randint
+    from world.anatomy import get_species_default_longdesc_locations
+    from world.identity import ROBOT_CHASSIS, ROBOT_FINISHES
+    from world.llm.personas import SECURITY_BOT_PERSONA
+    from world.medical.core import MedicalState
+    from world.mob_flavor import apply_random_flavor
+
+    key = name or f"a {choice(ROBOT_FINISHES)} {choice(ROBOT_CHASSIS)} robot"
+    mob = create_object(
+        typeclass="typeclasses.llm_npc.LLMNpc",
+        key=key, location=location, home=location,
+    )
+    # Robot species surfaces (mirrors @spawnmob's generic non-human path).
+    mob.db.species = "robot"
+    mob.longdesc = get_species_default_longdesc_locations("robot")
+    mob._medical_state = MedicalState(mob)
+    mob.db.medical_state = mob._medical_state.to_dict()
+    mob.sex = "ambiguous"          # machines render neutral (they/their)
+    mob.grit = _randint(1, 3)
+    mob.resonance = _randint(1, 3)
+    mob.intellect = _randint(1, 3)
+    mob.motorics = _randint(1, 3)
+    apply_random_flavor(mob)
+    # Security wiring: dispatchable + voiced; deterministic layer stays
+    # authoritative. Chassis renders via its robot key, not the humanoid
+    # descriptor table (LLMNpc's safety-net seeds height/build).
+    mob.db.role = "security"
+    mob.db.llm_persona = dict(SECURITY_BOT_PERSONA)
+    mob.db.llm_driven = True
+    mob.height = None
+    mob.build = None
+    try:
+        factory_fit_armament(mob)
+    except Exception:  # noqa: BLE001 — an unarmed unit still functions
+        pass
+    # Belong to the base: post there; adopt the base's standing beat.
+    base = get_security_base()
+    post = base or location
+    mob.db.post = post
+    beat = list(getattr(getattr(post, "db", None), "security_beat", None) or [])
+    if beat:
+        mob.db.patrol_beat = beat
+    return mob
+
+
+# --------------------------------------------------------------------------
+# Complement maintenance (the respawn loop)
+# --------------------------------------------------------------------------
+
+def count_posted_secbots(base: Any) -> int:
+    """Living security units posted to *base*."""
+    from evennia.objects.models import ObjectDB
+    n = 0
+    for obj in ObjectDB.objects.filter(db_attributes__db_key="post").distinct():
+        try:
+            if (getattr(obj.db, "post", None) == base
+                    and getattr(obj.db, "role", None) == "security"
+                    and not obj.is_dead()):
+                n += 1
+        except Exception:  # noqa: BLE001 — a broken record doesn't count
+            continue
+    return n
+
+
+def maintain_security_complement() -> Any | None:
+    """One heartbeat of the respawn loop: if living posted units fall
+    short of the base's complement, cycle ONE replacement out of the
+    alcoves (one per tick — losses are made good at machine-logistics
+    pace, not instantly). Returns the new unit or ``None``."""
+    base = get_security_base()
+    if base is None:
+        return None
+    complement = int(getattr(base.db, "security_complement", None) or 0)
+    if complement <= 0 or count_posted_secbots(base) >= complement:
+        return None
+    unit = spawn_secbot(base)
+    try:
+        unit.execute_cmd(
+            "emote cycles out of a charging alcove, status lights "
+            "climbing to green.")
+    except Exception:  # noqa: BLE001
+        pass
+    return unit

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -144,6 +144,11 @@ class DirectorRoutineScript(DefaultScript):
 
     def at_repeat(self):
         tick_all()
+        try:
+            from world.director.population import maintain_security_complement
+            maintain_security_complement()
+        except Exception:  # noqa: BLE001 — respawn must not stall the beats
+            pass
 
 
 def ensure_heartbeat() -> Any:

--- a/world/tests/test_director_population.py
+++ b/world/tests/test_director_population.py
@@ -1,0 +1,122 @@
+"""Tests for the population layer's first slice: the security base and
+complement maintenance (the respawn loop)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.director import population as pmod
+from world.director.population import (
+    count_posted_secbots,
+    maintain_security_complement,
+)
+
+
+def _room(complement=None, beat=None):
+    room = MagicMock(name="base")
+    room.db = SimpleNamespace(security_complement=complement,
+                              security_beat=beat)
+    return room
+
+
+def _bot(post, role="security", dead=False):
+    bot = MagicMock(name="bot")
+    bot.db = SimpleNamespace(post=post, role=role)
+    bot.is_dead.return_value = dead
+    return bot
+
+
+class TestComplementCount(TestCase):
+    @patch("evennia.objects.models.ObjectDB")
+    def test_counts_living_posted_security_only(self, mock_db):
+        base = _room()
+        elsewhere = _room()
+        units = [
+            _bot(base),                        # counts
+            _bot(base, dead=True),             # dead — fell out of census
+            _bot(elsewhere),                   # other post
+            _bot(base, role="miner"),          # wrong role
+        ]
+        mock_db.objects.filter.return_value.distinct.return_value = units
+        self.assertEqual(count_posted_secbots(base), 1)
+
+
+class TestMaintain(TestCase):
+    @patch("world.director.population.spawn_secbot")
+    @patch("world.director.population.count_posted_secbots", return_value=2)
+    @patch("world.director.population.get_security_base")
+    def test_full_complement_spawns_nothing(self, mock_base, _count, mock_spawn):
+        mock_base.return_value = _room(complement=2)
+        self.assertIsNone(maintain_security_complement())
+        mock_spawn.assert_not_called()
+
+    @patch("world.director.population.spawn_secbot")
+    @patch("world.director.population.count_posted_secbots", return_value=0)
+    @patch("world.director.population.get_security_base")
+    def test_deficit_cycles_one_replacement(self, mock_base, _count, mock_spawn):
+        base = _room(complement=3)
+        mock_base.return_value = base
+        unit = MagicMock()
+        mock_spawn.return_value = unit
+        self.assertIs(maintain_security_complement(), unit)
+        mock_spawn.assert_called_once_with(base)   # ONE per tick
+        unit.execute_cmd.assert_called_once()      # the alcove emote
+
+    @patch("world.director.population.spawn_secbot")
+    @patch("world.director.population.get_security_base", return_value=None)
+    def test_no_base_no_respawn(self, _base, mock_spawn):
+        self.assertIsNone(maintain_security_complement())
+        mock_spawn.assert_not_called()
+
+    @patch("world.director.population.spawn_secbot")
+    @patch("world.director.population.count_posted_secbots", return_value=0)
+    @patch("world.director.population.get_security_base")
+    def test_zero_complement_disables(self, mock_base, _count, mock_spawn):
+        mock_base.return_value = _room(complement=0)
+        self.assertIsNone(maintain_security_complement())
+        mock_spawn.assert_not_called()
+
+
+class TestSpawnPostsToBase(TestCase):
+    @patch("world.director.population.factory_fit_armament")
+    @patch("world.mob_flavor.apply_random_flavor")
+    @patch("world.medical.core.MedicalState")
+    @patch("world.anatomy.get_species_default_longdesc_locations",
+           return_value={})
+    @patch("evennia.create_object")
+    def test_unit_posted_to_base_and_adopts_standing_beat(
+            self, mock_create, _l, _ms, _flavor, _fit):
+        from world.director.population import spawn_secbot
+        street_a, street_b = MagicMock(name="a"), MagicMock(name="b")
+        base = _room(beat=[street_a, street_b])
+        spawn_room = MagicMock(name="alcove")
+        mob = MagicMock()
+        mob.db = SimpleNamespace()
+        mock_create.return_value = mob
+        with patch("world.director.population.get_security_base",
+                   return_value=base):
+            unit = spawn_secbot(spawn_room)
+        self.assertIs(unit.db.post, base)
+        self.assertEqual(unit.db.patrol_beat, [street_a, street_b])
+        self.assertEqual(unit.db.role, "security")
+        self.assertTrue(unit.db.llm_driven)
+        self.assertIsNone(unit.height)   # chassis renders via its key
+
+    @patch("world.director.population.factory_fit_armament")
+    @patch("world.mob_flavor.apply_random_flavor")
+    @patch("world.medical.core.MedicalState")
+    @patch("world.anatomy.get_species_default_longdesc_locations",
+           return_value={})
+    @patch("evennia.create_object")
+    def test_no_base_posts_to_spawn_room(self, mock_create, _l, _ms, _f, _fit):
+        from world.director.population import spawn_secbot
+        spawn_room = MagicMock(name="street")
+        mob = MagicMock()
+        mob.db = SimpleNamespace()
+        mock_create.return_value = mob
+        with patch("world.director.population.get_security_base",
+                   return_value=None):
+            unit = spawn_secbot(spawn_room)
+        self.assertIs(unit.db.post, spawn_room)

--- a/world/tests/test_robot_module.py
+++ b/world/tests/test_robot_module.py
@@ -91,10 +91,10 @@ class TestRobotRiotGunBank(TestCase):
 
 class TestFactoryFit(TestCase):
     def test_seats_side_formatted_organ_and_saves(self):
-        from commands.CmdSpawnMob import CmdSpawnMob
+        from world.director.population import factory_fit_armament
         mob = MagicMock()
         mob.medical_state.organs = {}
-        CmdSpawnMob._factory_fit_armament(mob, side="right")
+        factory_fit_armament(mob, side="right")
         organ = mob.medical_state.organs["integrated_shotgun_module"]
         self.assertEqual(organ.data["container"], "right_arm")
         ability = organ.data["abilities"]["shotgun"]


### PR DESCRIPTION
First slice of the dispatch spec's population registry (§3), built for
the user's Colonial Security precinct (#3255):

- world/director/population.py: set/get_security_base (room tag
  security_base:director + db.security_complement); spawn_secbot — the
  ONE secbot factory (robot species + LLMNpc brain + persona + role +
  factory armament, posted to the base and adopting the base's standing
  db.security_beat when set); maintain_security_complement — each
  heartbeat counts living posted units and cycles ONE replacement out of
  the charging alcoves on deficit. Dead/deleted units simply fall out of
  the census — self-healing, no death-hook plumbing.
- @spawnmob/secbot delegates wholesale to the factory: a hand-spawned
  unit and an alcove replacement are identical (the command's bespoke
  wiring and _factory_fit_armament moved into population.py).
- The routines heartbeat runs complement maintenance after beats.
- @patrol/base [complement] designates the room you stand in as THE
  security base (v1 single-base).
- 8 population tests; 53-test director sweep green.

Closes #900

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
