### PR TITLE
Secbots are security robots (identity), not courier/loader chassis

### DIFF
--- a/world/director/population.py
+++ b/world/director/population.py
@@ -84,12 +84,15 @@ def spawn_secbot(location: Any, name: str | None = None) -> Any:
     from evennia import create_object
     from random import randint as _randint
     from world.anatomy import get_species_default_longdesc_locations
-    from world.identity import ROBOT_CHASSIS, ROBOT_FINISHES
+    from world.identity import ROBOT_FINISHES
     from world.llm.personas import SECURITY_BOT_PERSONA
     from world.medical.core import MedicalState
     from world.mob_flavor import apply_random_flavor
 
-    key = name or f"a {choice(ROBOT_FINISHES)} {choice(ROBOT_CHASSIS)} robot"
+    # A secbot IS a security robot — the varied chassis vocabulary
+    # (courier/loader/industrial, ROBOT_CHASSIS) belongs to other robots.
+    # Finish still varies so units read as a fleet, not clones.
+    key = name or f"a {choice(ROBOT_FINISHES)} security robot"
     mob = create_object(
         typeclass="typeclasses.llm_npc.LLMNpc",
         key=key, location=location, home=location,

--- a/world/tests/test_director_population.py
+++ b/world/tests/test_director_population.py
@@ -120,3 +120,23 @@ class TestSpawnPostsToBase(TestCase):
                    return_value=None):
             unit = spawn_secbot(spawn_room)
         self.assertIs(unit.db.post, spawn_room)
+
+    @patch("world.director.population.factory_fit_armament")
+    @patch("world.mob_flavor.apply_random_flavor")
+    @patch("world.medical.core.MedicalState")
+    @patch("world.anatomy.get_species_default_longdesc_locations",
+           return_value={})
+    @patch("evennia.create_object")
+    def test_secbot_is_always_a_security_robot(self, mock_create, *_m):
+        # A secbot IS a security robot — never courier/loader/industrial
+        # (that chassis vocabulary belongs to other robots).
+        from world.director.population import spawn_secbot
+        mob = MagicMock()
+        mob.db = SimpleNamespace()
+        mock_create.return_value = mob
+        with patch("world.director.population.get_security_base",
+                   return_value=None):
+            for _ in range(6):
+                spawn_secbot(MagicMock(name="room"))
+                key = mock_create.call_args.kwargs["key"]
+                self.assertIn("security robot", key)


### PR DESCRIPTION
A secbot IS a security robot — the varied ROBOT_CHASSIS vocabulary
(courier/loader/industrial/...) belongs to other robots with other
identities. spawn_secbot now always composes "a {finish} security robot"
(finish still varies so units read as a fleet, not clones). Test pins it.

Closes #902

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
