### PR TITLE
Fix: heartbeat timer never armed (shell-created row); ensure at boot

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -30,7 +30,15 @@ def at_server_start():
     This is called every time the server starts up, regardless of
     how it was shut down.
     """
-    pass
+    # Director heartbeat (patrol beats + security-complement respawn).
+    # Ensured HERE — in the server process at boot — because a script row
+    # created from an external `evennia shell` never gets its repeat
+    # timer armed by the running server (observed live 2026-07-02).
+    try:
+        from world.director.routines import ensure_heartbeat
+        ensure_heartbeat()
+    except Exception:  # noqa: BLE001 — the game must boot regardless
+        pass
 
 
 def at_server_stop():

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -152,14 +152,21 @@ class DirectorRoutineScript(DefaultScript):
 
 
 def ensure_heartbeat() -> Any:
-    """Get-or-create the global heartbeat script (idempotent; called by
-    ``@patrol`` so the first beat ever set starts the engine)."""
+    """Get-or-create the global heartbeat script and (re)arm its timer
+    **in the calling process**. Called from ``at_server_start`` (the
+    guarantee) and ``@patrol`` (belt-and-braces).
+
+    An existing row is ``restart()``-ed rather than trusted: the DB
+    ``is_active`` flag can be True while no timer is armed in this
+    process (e.g. a row created from an external ``evennia shell``)."""
     from evennia import create_script
     from evennia.scripts.models import ScriptDB
     existing = ScriptDB.objects.filter(db_key=SCRIPT_KEY).first()
     if existing:
-        if not existing.is_active:
-            existing.start()
+        try:
+            existing.restart(interval=HEARTBEAT_SECONDS)
+        except Exception:  # noqa: BLE001 — a broken row must not block boot
+            pass
         return existing
     return create_script(
         "world.director.routines.DirectorRoutineScript",


### PR DESCRIPTION
The patrol heartbeat's DB row (interval 45, active, persistent, correct
typeclass) never fired in the live server: a script row created from an
external evennia shell gets is_active set but no repeat timer armed in
the running server process, and boot did not re-arm it. Hand-running
tick_all() proved the beat logic itself correct ({'waypoint': 1}).

- at_server_start now calls ensure_heartbeat() in the server process on
  every boot — the guarantee.
- ensure_heartbeat restart()s an existing row instead of trusting the
  is_active flag (which can be True with no timer armed in-process).

Closes #904

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
