### PR TITLE
Heartbeat tick telemetry (db.last_tick/last_counts; @patrol/status shows it)

### DIFF
--- a/commands/CmdPatrol.py
+++ b/commands/CmdPatrol.py
@@ -77,7 +77,18 @@ class CmdPatrol(Command):
             return
 
         if "status" in switches:
+            import time
             from evennia.objects.models import ObjectDB
+            from evennia.scripts.models import ScriptDB
+            script = ScriptDB.objects.filter(
+                db_key="director_routines").first()
+            if script:
+                last = getattr(script.db, "last_tick", None)
+                ago = f"{int(time.time() - last)}s ago" if last else "NEVER"
+                caller.msg(f"Heartbeat: last tick {ago} "
+                           f"(counts: {getattr(script.db, 'last_counts', None)})")
+            else:
+                caller.msg("Heartbeat: no script exists.")
             npcs = ([self._find_npc(args)] if args else [
                 o for o in ObjectDB.objects.filter(
                     db_attributes__db_key="patrol_beat").distinct()])

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -143,12 +143,17 @@ class DirectorRoutineScript(DefaultScript):
         self.persistent = True
 
     def at_repeat(self):
-        tick_all()
+        counts = tick_all()
         try:
             from world.director.population import maintain_security_complement
             maintain_security_complement()
         except Exception:  # noqa: BLE001 — respawn must not stall the beats
             pass
+        # Tick telemetry (DB-backed → visible cross-process; surfaced by
+        # @patrol/status as "last tick Ns ago").
+        import time
+        self.db.last_tick = time.time()
+        self.db.last_counts = counts
 
 
 def ensure_heartbeat() -> Any:


### PR DESCRIPTION
DB-backed and therefore cross-process-visible — the diagnostic that
settles whether the server's repeat timer is firing at all.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
