### PR TITLE
Heartbeat via settings.GLOBAL_SCRIPTS (canonical always-on mechanism)

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -30,15 +30,7 @@ def at_server_start():
     This is called every time the server starts up, regardless of
     how it was shut down.
     """
-    # Director heartbeat (patrol beats + security-complement respawn).
-    # Ensured HERE — in the server process at boot — because a script row
-    # created from an external `evennia shell` never gets its repeat
-    # timer armed by the running server (observed live 2026-07-02).
-    try:
-        from world.director.routines import ensure_heartbeat
-        ensure_heartbeat()
-    except Exception:  # noqa: BLE001 — the game must boot regardless
-        pass
+    pass
 
 
 def at_server_stop():

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -271,6 +271,24 @@ LLM_GM_TIMEOUT = 60        # seconds; per-round budget. The sidecar is always un
                            # a turn) the wait still lands inside the natural beat.
 LLM_GM_MAX_TOKENS = 180    # a turn = a line + an action + a thought; headroom so
                            # the 3rd channel doesn't truncate (was 120 for 2 fields)
+
+######################################################################
+# Director (world simulation)
+######################################################################
+
+# The director heartbeat (patrol beats + security-complement respawn) as a
+# GLOBAL_SCRIPTS entry — Evennia's canonical always-on-script mechanism:
+# the server creates it, starts it, and keeps it alive at every boot.
+# (Hand-created script rows from an external `evennia shell` never get
+# their repeat timer armed by the running server — learned 2026-07-02.)
+GLOBAL_SCRIPTS = {
+    "director_routines": {
+        "typeclass": "world.director.routines.DirectorRoutineScript",
+        "interval": 45,
+        "persistent": True,
+        "desc": "Director heartbeat: patrol beats + complement respawn.",
+    },
+}
 LLM_GM_TEMPERATURE = 0.8   # characterful but coherent
 
 ######################################################################

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -157,22 +157,10 @@ class DirectorRoutineScript(DefaultScript):
 
 
 def ensure_heartbeat() -> Any:
-    """Get-or-create the global heartbeat script and (re)arm its timer
-    **in the calling process**. Called from ``at_server_start`` (the
-    guarantee) and ``@patrol`` (belt-and-braces).
-
-    An existing row is ``restart()``-ed rather than trusted: the DB
-    ``is_active`` flag can be True while no timer is armed in this
-    process (e.g. a row created from an external ``evennia shell``)."""
-    from evennia import create_script
-    from evennia.scripts.models import ScriptDB
-    existing = ScriptDB.objects.filter(db_key=SCRIPT_KEY).first()
-    if existing:
-        try:
-            existing.restart(interval=HEARTBEAT_SECONDS)
-        except Exception:  # noqa: BLE001 — a broken row must not block boot
-            pass
-        return existing
-    return create_script(
-        "world.director.routines.DirectorRoutineScript",
-        key=SCRIPT_KEY, persistent=True, autostart=True)
+    """The global heartbeat, via ``settings.GLOBAL_SCRIPTS`` — Evennia's
+    canonical always-on-script container (the server creates, starts, and
+    keeps it alive at every boot; a hand-created row from an external
+    ``evennia shell`` never gets its timer armed, learned the hard way).
+    Accessing the attribute triggers creation if it doesn't exist yet."""
+    from evennia import GLOBAL_SCRIPTS
+    return getattr(GLOBAL_SCRIPTS, SCRIPT_KEY, None)


### PR DESCRIPTION
Tick telemetry proved at_repeat NEVER fires for the hand-created script
row — even with an at_server_start ensure/restart hook. Stop fighting
it: settings.GLOBAL_SCRIPTS["director_routines"] is Evennia's canonical
always-on-script container — the server creates, starts, and keeps it
alive at every boot. ensure_heartbeat() now just accesses the container
(creation-on-access); the boot hook is reverted to pass; the stale
shell-created row is deleted at deploy.

Closes #907

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
