### PR TITLE
Civilian layer: roles, wardrobes, haunts, personas + cadence/stagger

### DIFF
--- a/commands/CmdCivilians.py
+++ b/commands/CmdCivilians.py
@@ -1,0 +1,98 @@
+"""``@civilians`` — spawn, inspect, and purge the ambient population.
+
+The refine-on-the-fly surface for the civilian layer
+(``world/director/civilians.py``): the population is meant to be
+iterated on, so everything here is cheap to redo.
+"""
+
+from evennia import Command
+
+from world.director.civilians import (
+    CIVILIAN_ROLES,
+    all_civilians,
+    purge_civilians,
+    spawn_civilian,
+)
+
+
+class CmdCivilians(Command):
+    """
+    Manage the civilian population.
+
+    Usage:
+        @civilians                        - list roles + the live census
+        @civilians/spawn <role> [n]       - spawn n (default 1) of <role> HERE
+        @civilians/populate <n>           - spawn n civilians (random roles)
+                                            spread across random street rooms
+        @civilians/purge [role]           - delete all civilians (or one role)
+
+    Civilians are full people: named, dressed from their role's wardrobe,
+    carrying 100-500 tokens (muggable), drifting between a few nearby
+    haunts at a stroll (every 3-6 heartbeats), with a role persona the
+    LLM puppets when someone engages them. All of them carry the
+    civilian:director tag, so /purge can only ever touch them — never
+    PCs, never the working NPCs.
+    """
+
+    key = "@civilians"
+    locks = "cmd:perm(Builders) or perm(Developers)"
+    help_category = "Building"
+
+    def func(self):
+        caller = self.caller
+        switches = self.switches or []
+        args = self.args.strip()
+
+        if "spawn" in switches:
+            parts = args.split()
+            if not parts or parts[0] not in CIVILIAN_ROLES:
+                caller.msg(f"Roles: {', '.join(sorted(CIVILIAN_ROLES))}. "
+                           f"Usage: @civilians/spawn <role> [n]")
+                return
+            role = parts[0]
+            count = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 1
+            spawned = [spawn_civilian(role, caller.location)
+                       for _ in range(max(1, min(count, 20)))]
+            spawned = [s for s in spawned if s]
+            caller.msg(f"Spawned {len(spawned)} {role}(s) here: "
+                       + ", ".join(s.key for s in spawned))
+            return
+
+        if "populate" in switches:
+            from random import choice as rchoice
+            from world.spatial.coordinates import all_coordinate_rooms
+            try:
+                count = max(1, min(int(args), 40))
+            except (TypeError, ValueError):
+                caller.msg("Usage: @civilians/populate <n>")
+                return
+            streets = [r for r in all_coordinate_rooms()
+                       if "Room" in r.typeclass_path]
+            if not streets:
+                caller.msg("No coordinate rooms to populate.")
+                return
+            spawned = []
+            for _ in range(count):
+                npc = spawn_civilian(rchoice(sorted(CIVILIAN_ROLES)),
+                                     rchoice(streets))
+                if npc:
+                    spawned.append(npc)
+            caller.msg(f"Populated {len(spawned)} civilians across the grid.")
+            return
+
+        if "purge" in switches:
+            n = purge_civilians(args or None)
+            caller.msg(f"Purged {n} civilian(s)"
+                       + (f" (role: {args})" if args else "") + ".")
+            return
+
+        # bare: census
+        civs = all_civilians()
+        caller.msg(f"|cRoles:|n {', '.join(sorted(CIVILIAN_ROLES))}")
+        caller.msg(f"|cLive civilians: {len(civs)}|n")
+        for npc in civs[:30]:
+            caller.msg(
+                f"  {npc.key[:24]:24} [{getattr(npc.db, 'role', '?'):8}] @ "
+                f"{npc.location.key[:28] if npc.location else '(none)'}")
+        if len(civs) > 30:
+            caller.msg(f"  … and {len(civs) - 30} more.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -30,6 +30,7 @@ from commands.CmdCoordSeed import CmdCoordSeed
 from commands.CmdPath import CmdPath
 from commands.CmdDispatch import CmdDispatch
 from commands.CmdPatrol import CmdPatrol
+from commands.CmdCivilians import CmdCivilians
 from commands.bar_menu import CmdSpawnIngredient
 from commands.CmdBug import CmdBug
 from commands.CmdAdmin import CmdHeal, CmdPeace, CmdTestDeathCurtain, CmdWeather, CmdResetMedical, CmdMedicalAudit, CmdTestDeath, CmdTestUnconscious
@@ -145,6 +146,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdPath())
         self.add(CmdDispatch())
         self.add(CmdPatrol())
+        self.add(CmdCivilians())
         self.add(CmdSpawnIngredient())
         self.add(CmdAdmin.CmdHeal())
         self.add(CmdAdmin.CmdPeace())

--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -1,0 +1,224 @@
+"""Civilians — the ambient population layer.
+
+The dispatch spec's §3/§4 made concrete for ordinary people: a civilian
+is a **role** (data-authored below) wearing real clothes, drifting
+between a few **haunts** at a stroll (the same beat machinery as
+security, at a slower ``patrol_cadence``), carrying **100–500 tokens**
+(§5.2 — a person is also a mugging target), with a **persona** so the
+LLM can puppet them the moment a player intersects them, and a
+role-flavored **ambient beat** on every waypoint arrival (the seed of
+the §6 deterministic vocabulary).
+
+Everything is tagged ``("civilian", "director")`` so the population can
+be listed, updated, and **purged on the fly** (`@civilians`) while the
+layer is being refined — refinement is the point right now.
+"""
+
+from __future__ import annotations
+
+from random import choice, randint, sample
+from typing import Any
+
+#: Management tag — every spawned civilian carries it; purge is scoped to it.
+CIV_TAG = "civilian"
+CIV_TAG_CATEGORY = "director"
+
+#: Civilians act every Nth heartbeat (45s) — a drift, not a march.
+CADENCE_RANGE = (3, 6)
+#: How many haunts a civilian drifts between.
+HAUNTS_RANGE = (2, 4)
+#: How far from their anchor haunts may be sampled (straight-line rooms).
+HAUNT_RADIUS = 6
+#: §5.2 pockets: worth mugging, not worth farming.
+TOKEN_RANGE = (100, 500)
+
+
+# --------------------------------------------------------------------------
+# Roles (data-authored; add a dict, get a population)
+# --------------------------------------------------------------------------
+
+CIVILIAN_ROLES: dict[str, dict] = {
+    "laborer": {
+        "wardrobe": ["TACTICAL_JUMPSUIT", "COMBAT_BOOTS"],
+        "ambient": [
+            "rolls a shoulder that clearly hasn't forgiven the last shift.",
+            "checks a chit against a pocket ledger, lips moving.",
+            "scrapes grey colony grit off a boot heel against the curb.",
+            "stretches until something in their back gives with a pop.",
+        ],
+        "persona": {
+            "archetype": "colonist",
+            "name": "a shift laborer",
+            "description": "A worked-down colonist in a company jumpsuit, hands past the point where gloves would matter.",
+            "personality": "Tired, plainspoken, allergic to wasted words. Counts hours the way other people count money.",
+            "manner": "short declaratives; work slang; talks to strangers like they might be from payroll",
+            "wants": "the shift to end, the chit to clear, and nobody to make today interesting",
+            "boundaries": "gossip about the company where a stranger can hear; volunteer for anything",
+        },
+    },
+    "vendor": {
+        "wardrobe": ["COTTON_TSHIRT", "BLUE_JEANS"],
+        "ambient": [
+            "recounts a fold of grubby chits, twice, frowning both times.",
+            "calls a price at a passerby, then halves it under their breath.",
+            "rearranges a battered tray of goods with surprising tenderness.",
+            "scans the street the way only someone with unlicensed stock does.",
+        ],
+        "persona": {
+            "archetype": "colonist",
+            "name": "a street vendor",
+            "description": "A wiry fixture of the street with a tray of odds and ends, eyes that price you on approach.",
+            "personality": "Quick, transactional, friendlier the closer you stand to buying. Knows the street's rhythms cold.",
+            "manner": "patter and price-talk; compliments that cost nothing; goes vague when questions get official",
+            "wants": "foot traffic, dry weather, and security staying on the far side of the bridge",
+            "boundaries": "name suppliers; hold anything for anyone; leave the tray unattended",
+        },
+    },
+    "drifter": {
+        "wardrobe": ["COTTON_TSHIRT", "BLUE_JEANS"],
+        "ambient": [
+            "reads the street signs like they've stopped meaning anything.",
+            "warms both hands on a cup that has plainly been empty a while.",
+            "picks something off the pavement, considers it, pockets it.",
+            "watches the security patrol pass with a very practiced blankness.",
+        ],
+        "persona": {
+            "archetype": "colonist",
+            "name": "a drifter",
+            "description": "Someone the colony stopped scheduling: layered clothes gone one shade too uniform, a bag that is everything they own.",
+            "personality": "Watchful, unhurried, oddly well-informed — the street is a full-time occupation. Pride intact, thin as it's worn.",
+            "manner": "oblique answers; streetwise fatalism; warms up only if treated like a person",
+            "wants": "a dry doorway, a token nobody misses, one day without being moved along",
+            "boundaries": "beg outright; say where they sleep; touch anyone first",
+        },
+    },
+    "clerk": {
+        "wardrobe": ["COTTON_TSHIRT", "BLUE_JEANS", "COMBAT_BOOTS"],
+        "ambient": [
+            "thumbs through a dogeared manifest, sighing at page two.",
+            "mutters a running total that keeps coming out wrong.",
+            "checks the time against two different devices, trusting neither.",
+            "straightens their collar as if the depot could see them from here.",
+        ],
+        "persona": {
+            "archetype": "colonist",
+            "name": "a depot clerk",
+            "description": "A neat-adjacent colonist with ledger-cramped hands and the posture of someone perpetually five minutes late.",
+            "personality": "Fussy, precise, quietly overwhelmed. Finds comfort in numbers and none in people.",
+            "manner": "over-explains small things; cites procedure; flusters under direct questions",
+            "wants": "columns that balance, a supervisor who stays upstairs, lunch uninterrupted",
+            "boundaries": "discuss the depot's inventory or schedules; sign anything; be hurried",
+        },
+    },
+}
+
+
+def ambient_beat(npc: Any) -> str | None:
+    """A role-flavored idle line for the waypoint hook, or ``None``."""
+    role = getattr(getattr(npc, "db", None), "role", None)
+    spec = CIVILIAN_ROLES.get(role or "")
+    if not spec:
+        return None
+    return choice(spec["ambient"])
+
+
+# --------------------------------------------------------------------------
+# Spawning
+# --------------------------------------------------------------------------
+
+def spawn_civilian(role: str, anchor: Any) -> Any | None:
+    """Materialize one *role* civilian anchored at *anchor*: full human
+    identity + flavor, dressed from the role wardrobe (worn via the real
+    ``wear`` command), tokens in pocket, persona seeded for the LLM,
+    haunts sampled around the anchor, on a slow drift cadence. Returns
+    the civilian (or ``None`` on a bad role/anchor)."""
+    spec = CIVILIAN_ROLES.get(role)
+    if spec is None or anchor is None:
+        return None
+    from random import randint as _randint
+    from evennia import create_object
+    from evennia.prototypes.spawner import spawn as proto_spawn
+    from world.identity import BUILDS, HAIR_COLORS, HAIR_STYLES, HEIGHTS
+    from world.mob_flavor import apply_random_flavor
+    from world.namebank import (
+        FIRST_NAMES_AMBIGUOUS, FIRST_NAMES_FEMALE, FIRST_NAMES_MALE, LAST_NAMES,
+    )
+    from world.spatial import rooms_within
+
+    sex = choice(["male", "female", "ambiguous"])
+    first = {"male": FIRST_NAMES_MALE, "female": FIRST_NAMES_FEMALE,
+             "ambiguous": FIRST_NAMES_AMBIGUOUS}[sex]
+    npc = create_object(
+        typeclass="typeclasses.llm_npc.LLMNpc",
+        key=f"{choice(first)} {choice(LAST_NAMES)}",
+        location=anchor, home=anchor,
+    )
+    npc.sex = sex
+    npc.height = choice(HEIGHTS)
+    npc.build = choice(BUILDS)
+    if randint(1, 5) > 1:
+        npc.hair_color = choice(HAIR_COLORS)
+        npc.hair_style = choice(HAIR_STYLES)
+    npc.grit = _randint(1, 3)
+    npc.resonance = _randint(1, 3)
+    npc.intellect = _randint(1, 3)
+    npc.motorics = _randint(1, 3)
+    apply_random_flavor(npc)   # sdesc + @longdescs + look_place
+
+    # Role, management tag, pockets, LLM persona.
+    npc.db.role = role
+    npc.tags.add(CIV_TAG, category=CIV_TAG_CATEGORY)
+    npc.db.tokens = randint(*TOKEN_RANGE)
+    npc.db.llm_persona = dict(spec["persona"])
+    npc.db.llm_driven = True
+
+    # Wardrobe — spawned into inventory, worn through the real command.
+    for proto in spec["wardrobe"]:
+        try:
+            item = proto_spawn(proto)[0]
+            item.move_to(npc, quiet=True)
+            npc.execute_cmd(f"wear {item.key}")
+        except Exception:  # noqa: BLE001 — a missing garment isn't fatal
+            continue
+
+    # Haunts: a few nearby rooms, drifted between at a stroll.
+    npc.db.post = anchor
+    try:
+        nearby = rooms_within(anchor, HAUNT_RADIUS)
+    except Exception:  # noqa: BLE001
+        nearby = []
+    if nearby:
+        count = min(randint(*HAUNTS_RANGE), len(nearby))
+        npc.db.patrol_beat = sample(nearby, count)
+    npc.db.patrol_cadence = randint(*CADENCE_RANGE)
+    return npc
+
+
+# --------------------------------------------------------------------------
+# Management (the refine-on-the-fly surface)
+# --------------------------------------------------------------------------
+
+def all_civilians() -> list:
+    """Every live civilian (tag-scoped — nothing else can be caught)."""
+    from evennia.objects.models import ObjectDB
+    return list(ObjectDB.objects.filter(
+        db_tags__db_key=CIV_TAG, db_tags__db_category=CIV_TAG_CATEGORY))
+
+
+def purge_civilians(role: str | None = None) -> int:
+    """Delete civilians (optionally one *role* only). Safe by
+    construction: only the ``civilian:director`` tag population is
+    touched — PCs and working NPCs can never carry it. Inventories
+    (their clothes) go with them."""
+    n = 0
+    for npc in all_civilians():
+        if role and getattr(npc.db, "role", None) != role:
+            continue
+        try:
+            for item in list(npc.contents):
+                item.delete()
+            npc.delete()
+            n += 1
+        except Exception:  # noqa: BLE001 — one bad row must not stop a purge
+            continue
+    return n

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -77,15 +77,35 @@ def is_patrol_idle(npc: Any) -> bool:
 
 def tick_npc(npc: Any) -> str:
     """Advance one NPC's patrol by one nudge. Returns what happened
-    (for diagnostics): ``skip`` / ``travel`` / ``waypoint`` / ``none``."""
+    (for diagnostics): ``skip`` / ``wait`` / ``travel`` / ``waypoint`` /
+    ``none``.
+
+    * **Cadence** (``db.patrol_cadence``, default 1): act only every Nth
+      tick — civilians drift at a stroll while security marches.
+    * **Stagger**: a fresh/reloaded NPC starts at a *random* beat index,
+      so multiple units on the same loop spread out instead of walking
+      in lockstep.
+    """
+    from random import randrange
     beat = get_beat(npc)
     if not beat:
         return "none"
     if not is_patrol_idle(npc):
         return "skip"
-    idx = int(getattr(npc.ndb, "patrol_idx", None) or 0) % len(beat)
+    cadence = int(getattr(npc.db, "patrol_cadence", None) or 1)
+    if cadence > 1:
+        waited = int(getattr(npc.ndb, "patrol_wait", None) or 0) + 1
+        if waited < cadence:
+            npc.ndb.patrol_wait = waited
+            return "wait"
+        npc.ndb.patrol_wait = 0
+    idx = getattr(npc.ndb, "patrol_idx", None)
+    if idx is None:
+        idx = randrange(len(beat))          # stagger across the loop
+    idx = int(idx) % len(beat)
     waypoint = beat[idx]
     if npc.location != waypoint:
+        npc.ndb.patrol_idx = idx            # keep aiming here
         travel_to(npc, waypoint)
         return "travel"
     # Arrived: run the waypoint hook, then aim for the next stop.
@@ -95,22 +115,33 @@ def tick_npc(npc: Any) -> str:
 
 
 def at_waypoint(npc: Any) -> None:
-    """Waypoint hook. Security: sweep for wanted faces — a hit raises a
-    ``disturbance`` on the spot and the dispatch/challenge machinery
-    (usually assigning this very patroller) takes it from there."""
-    if getattr(getattr(npc, "db", None), "role", None) != "security":
+    """Waypoint hook, by role. Security: sweep for wanted faces — a hit
+    raises a ``disturbance`` on the spot and the dispatch/challenge
+    machinery (usually assigning this very patroller) takes it from
+    there. Civilians: a role-flavored ambient beat (the seed of the §6
+    deterministic interaction vocabulary)."""
+    role = getattr(getattr(npc, "db", None), "role", None)
+    if role == "security":
+        try:
+            from world.director.dispatch import WorldEvent, raise_event
+            from world.director.security import _scan_wanted
+            _uid, flagged, _entry = _scan_wanted(npc)
+            if flagged is not None:
+                raise_event(WorldEvent("disturbance", npc.location,
+                                       severity=1, source=flagged))
+            else:
+                npc.execute_cmd("emote pans a slow sensor sweep across the "
+                                "street and moves on.")
+        except Exception:  # noqa: BLE001 — a bad sweep must not stall the beat
+            pass
         return
+    # Civilian ambience: one flavored idle beat per arrival.
     try:
-        from world.director.dispatch import WorldEvent, raise_event
-        from world.director.security import _scan_wanted
-        _uid, flagged, _entry = _scan_wanted(npc)
-        if flagged is not None:
-            raise_event(WorldEvent("disturbance", npc.location,
-                                   severity=1, source=flagged))
-        else:
-            npc.execute_cmd("emote pans a slow sensor sweep across the "
-                            "street and moves on.")
-    except Exception:  # noqa: BLE001 — a bad sweep must not stall the beat
+        from world.director.civilians import ambient_beat
+        line = ambient_beat(npc)
+        if line:
+            npc.execute_cmd(f"emote {line}")
+    except Exception:  # noqa: BLE001 — ambience must not stall the drift
         pass
 
 

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -288,6 +288,29 @@ ARCHETYPES = {
                            "tool": "diagnose", "tool_argument": ""}},
         ],
     },
+    "colonist": {
+        "duties": (
+            "You are an ordinary colonist going about your day — your work, "
+            "your errands, your own troubles. You are NOT a guide, a vendor of "
+            "exposition, or anyone's friend by default: strangers get civility "
+            "at arm's length, regulars get a nod. You have somewhere to be. "
+            "You know your own street-level corner of the colony and nothing "
+            "official. If trouble starts, you want no part of it."
+        ),
+        "length": ("Brief. A guarded line, maybe two, and a small everyday "
+                   "gesture. You're mid-errand, not holding court."),
+        "tools": [],
+        "fewshot": [
+            {"user": 'a stranger says to you: "hey, you from around here?"',
+             "assistant": {"speech": "Around enough. You need something, or "
+                                     "just taking a census?",
+                           "action": "shifts their bag to the far shoulder "
+                                     "without quite breaking stride",
+                           "thought": "Nobody asks that for free. Keep it "
+                                      "short, keep moving.",
+                           "tool": "none", "tool_argument": ""}},
+        ],
+    },
     "security": {
         "duties": (
             "You are a colony security unit — a machine on patrol, not a "

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -1,0 +1,149 @@
+"""Tests for the civilian layer: roles, spawn wiring, cadence drift,
+stagger, ambience, and tag-scoped purge safety."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.director import civilians as cmod
+from world.director import routines as rmod
+from world.director.civilians import (
+    CIVILIAN_ROLES,
+    TOKEN_RANGE,
+    ambient_beat,
+    purge_civilians,
+    spawn_civilian,
+)
+
+
+class _Room:
+    def __init__(self, name):
+        self.name = name
+
+
+class TestRoles(TestCase):
+    def test_every_role_is_complete(self):
+        for role, spec in CIVILIAN_ROLES.items():
+            self.assertTrue(spec["wardrobe"], role)
+            self.assertGreaterEqual(len(spec["ambient"]), 3, role)
+            persona = spec["persona"]
+            self.assertEqual(persona["archetype"], "colonist", role)
+            for key in ("name", "description", "personality", "manner",
+                        "wants", "boundaries"):
+                self.assertTrue(persona.get(key), f"{role}.{key}")
+
+    def test_colonist_archetype_registered(self):
+        from world.llm.prompt import ARCHETYPES
+        self.assertIn("colonist", ARCHETYPES)
+        self.assertEqual(ARCHETYPES["colonist"]["tools"], [])
+
+    def test_no_disguise_items_in_wardrobes(self):
+        # Essential disguise items would scramble civilian apparent_uids
+        # (witness/BOLO identity must stay stable).
+        for role, spec in CIVILIAN_ROLES.items():
+            for proto in spec["wardrobe"]:
+                self.assertNotIn("MASK", proto, role)
+                self.assertNotIn("HOOD_UP", proto, role)
+                self.assertNotIn("WIG", proto, role)
+
+    def test_ambient_beat_by_role(self):
+        npc = SimpleNamespace(db=SimpleNamespace(role="laborer"))
+        self.assertIn(ambient_beat(npc), CIVILIAN_ROLES["laborer"]["ambient"])
+        self.assertIsNone(ambient_beat(
+            SimpleNamespace(db=SimpleNamespace(role="security"))))
+
+
+class TestSpawn(TestCase):
+    @patch("world.spatial.rooms_within")
+    @patch("world.mob_flavor.apply_random_flavor")
+    @patch("evennia.prototypes.spawner.spawn")
+    @patch("evennia.create_object")
+    def test_spawn_full_wiring(self, mock_create, mock_spawn, _flavor,
+                               mock_within):
+        anchor = _Room("Maxwell Street")
+        haunts = [_Room("a"), _Room("b"), _Room("c"), _Room("d"),
+                  _Room("e"), _Room("f")]
+        mock_within.return_value = haunts
+        garment = MagicMock()
+        garment.key = "cotton t-shirt"
+        mock_spawn.return_value = [garment]
+        npc = MagicMock()
+        npc.db = SimpleNamespace()
+        mock_create.return_value = npc
+
+        out = spawn_civilian("vendor", anchor)
+        self.assertIs(out, npc)
+        self.assertEqual(npc.db.role, "vendor")
+        self.assertTrue(TOKEN_RANGE[0] <= npc.db.tokens <= TOKEN_RANGE[1])
+        self.assertTrue(npc.db.llm_driven)
+        self.assertEqual(npc.db.llm_persona["archetype"], "colonist")
+        npc.tags.add.assert_called_once_with("civilian", category="director")
+        # dressed via the REAL command
+        worn = [c.args[0] for c in npc.execute_cmd.call_args_list
+                if c.args[0].startswith("wear ")]
+        self.assertEqual(len(worn), len(CIVILIAN_ROLES["vendor"]["wardrobe"]))
+        # haunts sampled from nearby; slow cadence
+        self.assertTrue(2 <= len(npc.db.patrol_beat) <= 4)
+        self.assertTrue(all(h in haunts for h in npc.db.patrol_beat))
+        self.assertTrue(3 <= npc.db.patrol_cadence <= 6)
+        self.assertIs(npc.db.post, anchor)
+
+    def test_bad_role_or_anchor(self):
+        self.assertIsNone(spawn_civilian("astronaut", _Room("x")))
+        self.assertIsNone(spawn_civilian("vendor", None))
+
+
+class TestPurgeSafety(TestCase):
+    @patch("world.director.civilians.all_civilians")
+    def test_purge_is_tag_scoped_and_role_filterable(self, mock_all):
+        a = MagicMock(); a.db = SimpleNamespace(role="vendor"); a.contents = []
+        b = MagicMock(); b.db = SimpleNamespace(role="drifter"); b.contents = []
+        mock_all.return_value = [a, b]
+        self.assertEqual(purge_civilians("vendor"), 1)
+        a.delete.assert_called_once()
+        b.delete.assert_not_called()
+
+    @patch("world.director.civilians.all_civilians")
+    def test_purge_all_takes_clothes_along(self, mock_all):
+        shirt = MagicMock()
+        a = MagicMock(); a.db = SimpleNamespace(role="clerk")
+        a.contents = [shirt]
+        mock_all.return_value = [a]
+        self.assertEqual(purge_civilians(), 1)
+        shirt.delete.assert_called_once()
+
+
+@patch("world.director.routines._in_combat", return_value=False)
+@patch("world.director.routines.is_travelling", return_value=False)
+@patch("world.director.routines.is_assigned", return_value=False)
+class TestCadenceAndStagger(TestCase):
+    def _npc(self, location, post, beat, cadence=None):
+        return SimpleNamespace(
+            location=location, ndb=SimpleNamespace(),
+            db=SimpleNamespace(role="drifter", post=post, patrol_beat=beat,
+                              patrol_cadence=cadence),
+            execute_cmd=MagicMock())
+
+    def test_cadence_waits_then_acts(self, *_m):
+        base, a = _Room("base"), _Room("a")
+        npc = self._npc(base, base, [a], cadence=3)
+        npc.ndb.patrol_idx = 0
+        self.assertEqual(rmod.tick_npc(npc), "wait")
+        self.assertEqual(rmod.tick_npc(npc), "wait")
+        with patch("world.director.routines.at_waypoint"):
+            self.assertEqual(rmod.tick_npc(npc), "waypoint")
+        # counter reset — waits again
+        self.assertEqual(rmod.tick_npc(npc), "wait")
+
+    @patch("world.director.routines.travel_to")
+    def test_fresh_npc_staggers_to_random_index(self, mock_travel, *_m):
+        base = _Room("base")
+        beat = [_Room(f"r{i}") for i in range(6)]
+        seen = set()
+        for _ in range(24):
+            npc = self._npc(base, None, list(beat))
+            rmod.tick_npc(npc)   # cadence 1 (None) → acts immediately
+            seen.add(getattr(npc.ndb, "patrol_idx", None))
+        self.assertGreater(len(seen), 2)   # spread, not lockstep at 0

--- a/world/tests/test_director_routines.py
+++ b/world/tests/test_director_routines.py
@@ -60,6 +60,7 @@ class TestTick(TestCase):
     def test_walks_to_next_waypoint(self, mock_travel, *_m):
         base, a = _Room("base"), _Room("a")
         npc = _Npc(a, post=base, beat=[a])   # cycle [base, a]; idx 0 -> base
+        npc.ndb.patrol_idx = 0               # pin (fresh NPCs stagger randomly)
         self.assertEqual(tick_npc(npc), "travel")
         self.assertEqual(mock_travel.call_args.args[1], base)
 
@@ -67,6 +68,7 @@ class TestTick(TestCase):
     def test_arrival_advances_and_sweeps(self, mock_hook, *_m):
         base, a = _Room("base"), _Room("a")
         npc = _Npc(base, post=base, beat=[a])  # at waypoint 0 (base)
+        npc.ndb.patrol_idx = 0                 # pin (fresh NPCs stagger randomly)
         self.assertEqual(tick_npc(npc), "waypoint")
         self.assertEqual(npc.ndb.patrol_idx, 1)
         mock_hook.assert_called_once_with(npc)


### PR DESCRIPTION
The ambient-population layer (dispatch spec §3/§4 for ordinary people),
built to be refined on the fly:

- world/director/civilians.py: 4 data-authored roles (laborer, vendor,
  drifter, clerk). Each civilian: full human identity + flavor
  (sdesc/@longdescs/look_place), dressed from the role wardrobe via the
  REAL wear command (no disguise items — apparent_uids stay BOLO-stable),
  100-500 tokens in pocket (§5.2: a person is a mugging target), a role
  persona on the new lightweight "colonist" LLM archetype (guarded,
  brief, mid-errand — puppeted the moment a player engages), 2-4 haunts
  sampled within 6 rooms of their anchor, and role-flavored ambient
  waypoint beats (the §6 deterministic-vocabulary seed). All tagged
  civilian:director so purge_civilians is safe by construction.
- routines.py: db.patrol_cadence — civilians act every 3-6 heartbeats (a
  drift, not a march); stagger — fresh/reloaded NPCs start at a RANDOM
  beat index so multiple units on one loop spread out instead of walking
  in lockstep (also fixes 5 secbots marching as a phalanx).
- @civilians: /spawn <role> [n] here; /populate <n> random roles across
  the coordinate grid; /purge [role]; bare = roles + live census.
- 12 new tests (roles completeness, spawn wiring, purge scoping, cadence
  wait/act, stagger spread); 59-test director sweep green.

Closes #911

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
