### PR TITLE
is_npc canonical marker + MuxCommand fix (@civilians traceback)

### DIFF
--- a/commands/CmdCivilians.py
+++ b/commands/CmdCivilians.py
@@ -5,7 +5,7 @@ The refine-on-the-fly surface for the civilian layer
 iterated on, so everything here is cheap to redo.
 """
 
-from evennia import Command
+from evennia import default_cmds
 
 from world.director.civilians import (
     CIVILIAN_ROLES,
@@ -15,7 +15,7 @@ from world.director.civilians import (
 )
 
 
-class CmdCivilians(Command):
+class CmdCivilians(default_cmds.MuxCommand):
     """
     Manage the civilian population.
 

--- a/commands/CmdCoordSeed.py
+++ b/commands/CmdCoordSeed.py
@@ -7,7 +7,7 @@ geometry contradictions (a direction that doesn't reverse) are reported,
 not silently resolved — fix the exit, or tag it ``warp`` to exclude it.
 """
 
-from evennia import Command
+from evennia import default_cmds
 
 from world.spatial import (
     clear_xyz,
@@ -17,7 +17,7 @@ from world.spatial import (
 from world.spatial.coordinates import all_coordinate_rooms
 
 
-class CmdCoordSeed(Command):
+class CmdCoordSeed(default_cmds.MuxCommand):
     """
     Seed the world with (x, y, z) coordinates.
 

--- a/commands/CmdDispatch.py
+++ b/commands/CmdDispatch.py
@@ -5,13 +5,13 @@ A builder/debug window onto the director's dispatch core
 your location via the spatial pathfinder.
 """
 
-from evennia import Command
+from evennia import default_cmds
 
 from world.director import WorldEvent, find_responders, raise_event
 from world.director.dispatch import ROLE_RESPONDS_TO
 
 
-class CmdDispatch(Command):
+class CmdDispatch(default_cmds.MuxCommand):
     """
     Raise a world event at your location and dispatch responders.
 

--- a/commands/CmdPatrol.py
+++ b/commands/CmdPatrol.py
@@ -5,7 +5,7 @@ The builder interface to the director's routines layer
 the bot, give it a beat — the heartbeat does the rest.
 """
 
-from evennia import Command
+from evennia import default_cmds
 
 from world.director.routines import (
     HEARTBEAT_SECONDS,
@@ -14,7 +14,7 @@ from world.director.routines import (
 )
 
 
-class CmdPatrol(Command):
+class CmdPatrol(default_cmds.MuxCommand):
     """
     Post an NPC to a base of operations and set its patrol beat.
 

--- a/commands/CmdSpawnMob.py
+++ b/commands/CmdSpawnMob.py
@@ -143,6 +143,7 @@ class CmdSpawnMob(Command):
             location=caller.location,
             home=caller.location
         )
+        mob.db.is_npc = True   # the canonical NPC marker (absence = PC)
 
         # Set species before re-initializing the species-dependent
         # surfaces (longdesc default set, medical state).

--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -88,7 +88,8 @@ class LLMNpcMixin:
     def _is_npc_speaker(self, speaker):
         """Loop guard: another NPC, so we never react (speech or pose) and two
         LLM-driven NPCs can't ping-pong."""
-        return bool(getattr(speaker.db, "is_bartender_npc", False)
+        return bool(getattr(speaker.db, "is_npc", False)
+                    or getattr(speaker.db, "is_bartender_npc", False)
                     or getattr(speaker.db, "llm_driven", False))
 
     def _classify_speech(self, speech, speaker):

--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -166,6 +166,7 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
     apply_random_flavor(npc)   # sdesc + @longdescs + look_place
 
     # Role, management tag, pockets, LLM persona.
+    npc.db.is_npc = True   # the canonical NPC marker (absence = PC)
     npc.db.role = role
     npc.tags.add(CIV_TAG, category=CIV_TAG_CATEGORY)
     npc.db.tokens = randint(*TOKEN_RANGE)

--- a/world/director/population.py
+++ b/world/director/population.py
@@ -111,6 +111,7 @@ def spawn_secbot(location: Any, name: str | None = None) -> Any:
     # Security wiring: dispatchable + voiced; deterministic layer stays
     # authoritative. Chassis renders via its robot key, not the humanoid
     # descriptor table (LLMNpc's safety-net seeds height/build).
+    mob.db.is_npc = True   # the canonical NPC marker (absence = PC)
     mob.db.role = "security"
     mob.db.llm_persona = dict(SECURITY_BOT_PERSONA)
     mob.db.llm_driven = True

--- a/world/director/witness.py
+++ b/world/director/witness.py
@@ -69,6 +69,7 @@ def spawn_witness(location: Any) -> Any | None:
         return None
     witness.height = choice(HEIGHTS)
     witness.build = choice(BUILDS)
+    witness.db.is_npc = True   # the canonical NPC marker (absence = PC)
     witness.db.tokens = randint(*WITNESS_TOKENS)          # §5.2 pockets
     witness.db.is_witness = True
     # The visible tell — this is who saw you, and what they're about to do.

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -76,6 +76,7 @@ class TestSpawn(TestCase):
         out = spawn_civilian("vendor", anchor)
         self.assertIs(out, npc)
         self.assertEqual(npc.db.role, "vendor")
+        self.assertTrue(npc.db.is_npc)   # canonical marker (absence = PC)
         self.assertTrue(TOKEN_RANGE[0] <= npc.db.tokens <= TOKEN_RANGE[1])
         self.assertTrue(npc.db.llm_driven)
         self.assertEqual(npc.db.llm_persona["archetype"], "colonist")

--- a/world/tests/test_director_population.py
+++ b/world/tests/test_director_population.py
@@ -101,6 +101,7 @@ class TestSpawnPostsToBase(TestCase):
         self.assertIs(unit.db.post, base)
         self.assertEqual(unit.db.patrol_beat, [street_a, street_b])
         self.assertEqual(unit.db.role, "security")
+        self.assertTrue(unit.db.is_npc)   # canonical marker (absence = PC)
         self.assertTrue(unit.db.llm_driven)
         self.assertIsNone(unit.height)   # chassis renders via its key
 

--- a/world/tests/test_director_witness.py
+++ b/world/tests/test_director_witness.py
@@ -71,6 +71,7 @@ class TestSpawnWitness(TestCase):
         self.assertIn("bystander", mock_create.call_args.kwargs["key"])
         self.assertTrue(WITNESS_TOKENS[0] <= w.db.tokens <= WITNESS_TOKENS[1])
         self.assertTrue(w.db.is_witness)
+        self.assertTrue(w.db.is_npc)   # canonical marker (absence = PC)
         self.assertIn("walkie-talkie", w.look_place)  # the visible tell
         w.execute_cmd.assert_called_once()            # reacts on the scene
 


### PR DESCRIPTION
1. db.is_npc = True — the canonical NPC marker. There was none (the
   Drivel deletion was the price of heuristics): every NPC factory now
   sets it (spawn_secbot, spawn_civilian, spawn_witness, @spawnmob), and
   the polarity is fail-safe — ABSENCE means "treat as PC", so bulk
   operations may only ever touch what is explicitly marked NPC. The LLM
   loop-guard consults it first. Pre-existing working NPCs get a live
   backfill at deploy.
2. @civilians traceback (live report): plain evennia.Command never
   parses switches — self.switches does not exist (MuxCommand owns
   that). The same latent bug sat in @patrol, @dispatch, and @coordseed,
   which had simply never been typed in-game (all prior driving went
   through the shell or crime auto-raise). All four commands now inherit
   default_cmds.MuxCommand.

79-test sweep green.

Closes #913

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
