### PR TITLE
Ops: deploy-reload times out the reload call (hang blocked recovery)

### DIFF
--- a/scripts/deploy-reload.sh
+++ b/scripts/deploy-reload.sh
@@ -24,7 +24,10 @@ status_server() {
 }
 
 echo "--- reload ---"
-docker exec -w "$GAME" "$CONTAINER" evennia reload --settings settings.py 2>&1 | tail -2
+# timeout: a reload with an LLM generation in flight can block forever
+# inside `evennia reload` itself — cap it so the recovery branch below
+# always gets its turn.
+timeout 45 docker exec -w "$GAME" "$CONTAINER" evennia reload --settings settings.py 2>&1 | tail -2     || echo "(reload command timed out — falling through to recovery)"
 
 sleep 8
 if [ "$(status_server)" -ge 1 ]; then


### PR DESCRIPTION
With 13 LLM-driven NPCs live, an in-flight generation hung the reload
and `evennia reload` blocked forever — the script never reached its own
recovery branch and needed a manual rescue. Cap the reload with
`timeout 45`; on expiry fall through to the existing verify ->
kill-lingering -> cold-start -> greeting-check recovery.

Closes #915

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
