### PR TITLE
Civilians: gendered weighting, skintones, voices; no sky-room haunts

### DIFF
--- a/commands/CmdCivilians.py
+++ b/commands/CmdCivilians.py
@@ -67,7 +67,8 @@ class CmdCivilians(default_cmds.MuxCommand):
                 caller.msg("Usage: @civilians/populate <n>")
                 return
             streets = [r for r in all_coordinate_rooms()
-                       if "Room" in r.typeclass_path]
+                       if "Room" in r.typeclass_path
+                       and not getattr(r.db, "is_sky_room", False)]
             if not streets:
                 caller.msg("No coordinate rooms to populate.")
                 return

--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -32,6 +32,11 @@ HAUNT_RADIUS = 6
 #: §5.2 pockets: worth mugging, not worth farming.
 TOKEN_RANGE = (100, 500)
 
+#: Human skintone spectrum (the alien/synthetic tones — alabaster, cobalt,
+#: chrome, … — belong to synths; a random civilian is baseline human).
+HUMAN_SKINTONES = ("porcelain", "pale", "fair", "light", "golden",
+                   "tan", "olive", "brown", "rich")
+
 
 # --------------------------------------------------------------------------
 # Roles (data-authored; add a dict, get a population)
@@ -145,7 +150,11 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
     )
     from world.spatial import rooms_within
 
-    sex = choice(["male", "female", "ambiguous"])
+    # Gendered by default; ~20% ambiguous (the even three-way roll made a
+    # third of the street read as ungendered — mirrors @spawnmob's weights).
+    sex = choice(["male", "female"])
+    if randint(1, 10) <= 2:
+        sex = "ambiguous"
     first = {"male": FIRST_NAMES_MALE, "female": FIRST_NAMES_FEMALE,
              "ambiguous": FIRST_NAMES_AMBIGUOUS}[sex]
     npc = create_object(
@@ -156,9 +165,14 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
     npc.sex = sex
     npc.height = choice(HEIGHTS)
     npc.build = choice(BUILDS)
+    npc.db.skintone = choice(HUMAN_SKINTONES)
     if randint(1, 5) > 1:
         npc.hair_color = choice(HAIR_COLORS)
         npc.hair_style = choice(HAIR_STYLES)
+    # A voice — so radio/blind recognition and say-flavor work like anyone's.
+    from world.voice import get_voice_descriptions, get_voice_endings
+    npc.db.voice_description = choice(sorted(get_voice_descriptions()))
+    npc.db.voice_ending = choice(sorted(get_voice_endings()))
     npc.grit = _randint(1, 3)
     npc.resonance = _randint(1, 3)
     npc.intellect = _randint(1, 3)
@@ -182,10 +196,18 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
         except Exception:  # noqa: BLE001 — a missing garment isn't fatal
             continue
 
-    # Haunts: a few nearby rooms, drifted between at a stroll.
+    # Haunts: a few nearby rooms, drifted between at a stroll. Coordinate
+    # distance alone can offer rooms no pedestrian belongs in — sky rooms
+    # ("In the Air", the jump/fall transit volume) and rooms with no
+    # walkable route — so filter to walkable, floored destinations.
     npc.db.post = anchor
     try:
-        nearby = rooms_within(anchor, HAUNT_RADIUS)
+        from world.spatial import is_reachable
+        nearby = [
+            room for room in rooms_within(anchor, HAUNT_RADIUS)
+            if not getattr(room.db, "is_sky_room", False)
+            and is_reachable(anchor, room, max_steps=HAUNT_RADIUS * 4)
+        ]
     except Exception:  # noqa: BLE001
         nearby = []
     if nearby:

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -19,8 +19,9 @@ from world.director.civilians import (
 
 
 class _Room:
-    def __init__(self, name):
+    def __init__(self, name, sky=False):
         self.name = name
+        self.db = SimpleNamespace(is_sky_room=sky)
 
 
 class TestRoles(TestCase):
@@ -56,16 +57,18 @@ class TestRoles(TestCase):
 
 
 class TestSpawn(TestCase):
+    @patch("world.spatial.is_reachable", return_value=True)
     @patch("world.spatial.rooms_within")
     @patch("world.mob_flavor.apply_random_flavor")
     @patch("evennia.prototypes.spawner.spawn")
     @patch("evennia.create_object")
     def test_spawn_full_wiring(self, mock_create, mock_spawn, _flavor,
-                               mock_within):
+                               mock_within, _reach):
         anchor = _Room("Maxwell Street")
         haunts = [_Room("a"), _Room("b"), _Room("c"), _Room("d"),
                   _Room("e"), _Room("f")]
-        mock_within.return_value = haunts
+        sky = _Room("In the Air", sky=True)
+        mock_within.return_value = haunts + [sky]
         garment = MagicMock()
         garment.key = "cotton t-shirt"
         mock_spawn.return_value = [garment]
@@ -88,6 +91,12 @@ class TestSpawn(TestCase):
         # haunts sampled from nearby; slow cadence
         self.assertTrue(2 <= len(npc.db.patrol_beat) <= 4)
         self.assertTrue(all(h in haunts for h in npc.db.patrol_beat))
+        self.assertNotIn(sky, npc.db.patrol_beat)   # no air haunts
+        # presentation completeness (live report: genders/skintones/voices)
+        from world.director.civilians import HUMAN_SKINTONES
+        self.assertIn(npc.db.skintone, HUMAN_SKINTONES)
+        self.assertTrue(npc.db.voice_description)
+        self.assertTrue(npc.db.voice_ending)
         self.assertTrue(3 <= npc.db.patrol_cadence <= 6)
         self.assertIs(npc.db.post, anchor)
 


### PR DESCRIPTION
Live playtest report: civilians lacked visible gender (the even three-way
sex roll made a third of the street "ambiguous person"), skintones (never
set), voices (never set), and haunts could land in unreachable rooms
("In the Air" — sky rooms sampled by pure coordinate distance).

- Sex weighted like @spawnmob: male/female with ~20% ambiguous.
- db.skintone from a new HUMAN_SKINTONES tuple (the alien/synthetic
  palette tones stay synth-only).
- db.voice_description/ending from the curated voice vocab — radio/blind
  recognition and say-flavor now work for civilians like anyone else.
- Haunt sampling filters is_sky_room and requires is_reachable (walkable
  route, capped search); @civilians/populate anchors exclude sky rooms.
- Tests updated (sky exclusion, presentation completeness).

Closes #917

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
