### PR TITLE
Fix: @civilians census TypeError (None role vs format spec)

### DIFF
--- a/commands/CmdCivilians.py
+++ b/commands/CmdCivilians.py
@@ -92,8 +92,11 @@ class CmdCivilians(default_cmds.MuxCommand):
         caller.msg(f"|cRoles:|n {', '.join(sorted(CIVILIAN_ROLES))}")
         caller.msg(f"|cLive civilians: {len(civs)}|n")
         for npc in civs[:30]:
+            # NB: Evennia's .db returns None for unset attrs (getattr
+            # defaults never fire) — coerce before format specs.
+            role = npc.db.role or "?"
             caller.msg(
-                f"  {npc.key[:24]:24} [{getattr(npc.db, 'role', '?'):8}] @ "
+                f"  {npc.key[:24]:24} [{role:8}] @ "
                 f"{npc.location.key[:28] if npc.location else '(none)'}")
         if len(civs) > 30:
             caller.msg(f"  … and {len(civs) - 30} more.")


### PR DESCRIPTION
Evennia's .db returns None for unset attributes — getattr defaults never
fire — so a role-less civilian reached the :8 format spec as None.
Coerce with `or "?"`.

Closes #922

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
