### PR TITLE
Conversation hold: engaged NPCs defer routines; LLM `release` tool

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -33,6 +33,10 @@ from world.llm.prompt import (
 )
 
 LLM_DIRECTED_COOLDOWN = 4.0    # min seconds between replies to direct address/name
+LLM_ENGAGE_HOLD = 180.0        # conversation hold: an engaged NPC defers its
+                               # routine (patrol/drift) until the model calls
+                               # the `release` tool or this inactivity window
+                               # lapses (failsafe for walked-away-from NPCs)
 LLM_AMBIENT_COOLDOWN = 45.0    # rarely volunteers into overheard chatter
 LLM_AMBIENT_CHANCE = 0.35      # ...and not every eligible time
 LLM_HISTORY_TURNS = 6          # recent turns kept per interlocutor (anti-repetition)
@@ -148,6 +152,11 @@ class LLMNpcMixin:
         elif now - last < LLM_DIRECTED_COOLDOWN:
             return True
         self.ndb.last_llm = now
+        if mode == "directed":
+            # Conversation hold: don't wander off mid-exchange. Rolling —
+            # refreshed every directed turn; the model releases it early via
+            # the `release` tool.
+            self.ndb.llm_engaged_until = now + LLM_ENGAGE_HOLD
 
         # Capture everything reactor-side BEFORE threading (SQLite/Evennia-thread
         # contract). The agentic loop re-calls from the reactor-side callback.
@@ -426,12 +435,18 @@ class LLMNpcMixin:
         return ""
 
     def _handle_action_tool(self, tool, arg, patron):
-        """Route an action tool to a real command. ``remember``/``feel`` are
-        universal; subclasses extend then call super."""
+        """Route an action tool to a real command. ``remember``/``feel``/
+        ``release`` are universal; subclasses extend then call super."""
         if tool == "remember" and arg and patron and self.location:
             self._remember_person(patron, arg)
         elif tool == "feel" and arg and patron:
             self._set_valence(self._memory_subject(patron), arg)
+        elif tool == "release":
+            # The character has decided the exchange is over: drop the
+            # conversation hold so the routine (patrol/drift) resumes on
+            # the next heartbeat. The goodbye itself rides the normal
+            # speech/action channels of this same turn.
+            self.ndb.llm_engaged_until = None
 
     def _remember_person(self, patron, name):
         """Privately name/nickname the interlocutor via the REAL ``remember``

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -62,13 +62,24 @@ def _in_combat(npc: Any) -> bool:
     return check(npc)
 
 
+def _is_conversing(npc: Any) -> bool:
+    """Mid-conversation with a player (the LLM engagement hold): the NPC
+    defers its routine until the model calls ``release`` or the hold's
+    inactivity window lapses — nobody walks out of an exchange because a
+    heartbeat said so."""
+    from time import monotonic
+    until = getattr(getattr(npc, "ndb", None), "llm_engaged_until", None)
+    return bool(until and until > monotonic())
+
+
 def is_patrol_idle(npc: Any) -> bool:
     """Free to take a patrol step: not assigned, not mid-travel, not
-    fighting, and actually somewhere."""
+    fighting, not mid-conversation, and actually somewhere."""
     return (npc.location is not None
             and not is_assigned(npc)
             and not is_travelling(npc)
-            and not _in_combat(npc))
+            and not _in_combat(npc)
+            and not _is_conversing(npc))
 
 
 # --------------------------------------------------------------------------

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -36,6 +36,12 @@ TOOLS = {
                      "'fed up', 'amused', 'owes me one'). It colours how you treat "
                      "them from now on — set it when their behaviour shifts how "
                      "you feel, not every turn (argument: a short word/phrase)"},
+    "release": {"kind": "action",
+                "desc": "end this conversation and get back to your day — "
+                        "call it once the exchange has wound down, you've "
+                        "said your piece, or you'd simply rather move on; "
+                        "your speech/action this turn are your goodbye "
+                        "(argument: '')"},
     "check_stock": {"kind": "context",
                     "desc": "list exactly what the bar can serve right now "
                             "(argument: '')"},
@@ -299,7 +305,7 @@ ARCHETYPES = {
         ),
         "length": ("Brief. A guarded line, maybe two, and a small everyday "
                    "gesture. You're mid-errand, not holding court."),
-        "tools": [],
+        "tools": ["release"],
         "fewshot": [
             {"user": 'a stranger says to you: "hey, you from around here?"',
              "assistant": {"speech": "Around enough. You need something, or "
@@ -326,7 +332,7 @@ ARCHETYPES = {
         ),
         "length": ("One or two clipped lines, machine-cadence. No warmth, no "
                    "filler. A short mechanical pose at most."),
-        "tools": [],  # + BASE_TOOLS (look) — action is the deterministic layer's job
+        "tools": ["release"],  # may end an exchange; combat/detain stays deterministic
         "fewshot": [
             {"user": 'a bystander says to you: "what happened here?"',
              "assistant": {"speech": "Incident under review. Details are "

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -38,7 +38,7 @@ class TestRoles(TestCase):
     def test_colonist_archetype_registered(self):
         from world.llm.prompt import ARCHETYPES
         self.assertIn("colonist", ARCHETYPES)
-        self.assertEqual(ARCHETYPES["colonist"]["tools"], [])
+        self.assertEqual(ARCHETYPES["colonist"]["tools"], ["release"])
 
     def test_no_disguise_items_in_wardrobes(self):
         # Essential disguise items would scramble civilian apparent_uids
@@ -157,3 +157,47 @@ class TestCadenceAndStagger(TestCase):
             rmod.tick_npc(npc)   # cadence 1 (None) → acts immediately
             seen.add(getattr(npc.ndb, "patrol_idx", None))
         self.assertGreater(len(seen), 2)   # spread, not lockstep at 0
+
+class TestConversationHold(TestCase):
+    """The LLM engagement hold: an engaged NPC defers its drift until the
+    model releases it (or the inactivity window lapses)."""
+
+    def _npc(self, engaged_until=None):
+        return SimpleNamespace(
+            location=_Room("street"), ndb=SimpleNamespace(
+                llm_engaged_until=engaged_until),
+            db=SimpleNamespace(role="vendor", post=None, patrol_beat=None,
+                               patrol_cadence=None),
+            execute_cmd=MagicMock())
+
+    @patch("world.director.routines._in_combat", return_value=False)
+    @patch("world.director.routines.is_travelling", return_value=False)
+    @patch("world.director.routines.is_assigned", return_value=False)
+    def test_engaged_npc_is_not_idle(self, *_m):
+        from time import monotonic
+        held = self._npc(engaged_until=monotonic() + 100)
+        self.assertFalse(rmod.is_patrol_idle(held))
+
+    @patch("world.director.routines._in_combat", return_value=False)
+    @patch("world.director.routines.is_travelling", return_value=False)
+    @patch("world.director.routines.is_assigned", return_value=False)
+    def test_lapsed_or_released_hold_frees_the_npc(self, *_m):
+        from time import monotonic
+        lapsed = self._npc(engaged_until=monotonic() - 5)
+        self.assertTrue(rmod.is_patrol_idle(lapsed))
+        released = self._npc(engaged_until=None)
+        self.assertTrue(rmod.is_patrol_idle(released))
+
+    def test_release_tool_registered_for_mobile_archetypes(self):
+        from world.llm.prompt import ARCHETYPES, TOOLS
+        self.assertIn("release", TOOLS)
+        self.assertEqual(TOOLS["release"]["kind"], "action")
+        self.assertIn("release", ARCHETYPES["colonist"]["tools"])
+        self.assertIn("release", ARCHETYPES["security"]["tools"])
+
+    def test_release_handler_clears_the_hold(self):
+        from typeclasses.llm_npc import LLMNpcMixin
+        npc = SimpleNamespace(ndb=SimpleNamespace(llm_engaged_until=999.0),
+                              location=MagicMock())
+        LLMNpcMixin._handle_action_tool(npc, "release", "", MagicMock())
+        self.assertIsNone(npc.ndb.llm_engaged_until)

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -300,8 +300,9 @@ class TestParseTurn(TestCase):
 
     def test_schema_tool_enum(self):
         self.assertEqual(TURN_SCHEMA["properties"]["tool"]["enum"],
-                         ["none", "look", "remember", "feel", "check_stock",
-                          "prepare_drink", "diagnose", "treat", "install"])
+                         ["none", "look", "remember", "feel", "release",
+                          "check_stock", "prepare_drink", "diagnose", "treat",
+                          "install"])
 
 
 class TestActionNormalization(TestCase):

--- a/world/tests/test_security_persona.py
+++ b/world/tests/test_security_persona.py
@@ -15,8 +15,9 @@ class TestSecurityArchetype(TestCase):
         arch = ARCHETYPES["security"]
         for key in ("duties", "length", "tools", "fewshot"):
             self.assertIn(key, arch)
-        # action belongs to the deterministic layer — no action tools.
-        self.assertEqual(arch["tools"], [])
+        # combat/detain stays deterministic; `release` (end a chat) is the
+        # one conversational action it owns.
+        self.assertEqual(arch["tools"], ["release"])
 
     def test_fewshot_is_machine_register(self):
         shots = ARCHETYPES["security"]["fewshot"]


### PR DESCRIPTION
Live report: LLM-puppeted civilians wandered off mid-conversation — the
routine heartbeat had no idea an exchange was happening.

- Conversation hold: a directed LLM exchange sets a rolling
  ndb.llm_engaged_until (refreshed per turn; 180s inactivity failsafe so
  a walked-away-from NPC resumes on its own). is_patrol_idle defers held
  NPCs alongside assigned/travelling/fighting ones — nobody walks out of
  a conversation because a heartbeat said so.
- `release` action tool: the model ends the exchange on the character's
  terms ("call it once the exchange has wound down... your speech/action
  this turn are your goodbye"), clearing the hold so the drift resumes on
  the next heartbeat. Granted to the mobile archetypes (colonist,
  security); handled universally in the mixin.
- Emergent: talking to a patrolling secbot now genuinely holds it in
  place (distraction play); dispatch/combat still preempt regardless.
- 4 new tests; 3 stale tool-enum assertions updated. 81-test sweep green.

Closes #924

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
