### PR TITLE
Colony civilian roster v2: 8 roles, reactions, wardrobe line, wig fix

### DIFF
--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -273,6 +273,13 @@ class CmdAttack(Command):
             report_crime("assault", caller.location, perp=caller)
         except Exception:
             pass
+        # Victim reaction (§5.2 role postures): comply / flee / resist —
+        # the director shapes how a role-bearing NPC answers violence.
+        try:
+            from world.director.civilians import react_to_attack
+            react_to_attack(target, caller)
+        except Exception:
+            pass
 
         # --- CAPTURE PRE-ADDITION COMBAT STATE ---
         caller_was_in_final_handler = any(e["char"] == caller for e in final_handler.db.combatants)

--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -43,76 +43,168 @@ HUMAN_SKINTONES = ("porcelain", "pale", "fair", "light", "golden",
 # --------------------------------------------------------------------------
 
 CIVILIAN_ROLES: dict[str, dict] = {
-    "laborer": {
-        "wardrobe": ["TACTICAL_JUMPSUIT", "COMBAT_BOOTS"],
+    # reaction: what they do when attacked — "comply" (stop attacking /
+    # cower), "flee" (run), "resist" (fight back; the combat handler
+    # already auto-targets the attacker — armed roles draw their blade).
+    # reports: witness posture for the future civilian-witness integration
+    # ("fast" = calls it in eagerly, "never" = street code, None = normal).
+    "miner": {
+        "wardrobe": ["WORK_COVERALLS", "PIT_BOOTS", "MINING_HELMET",
+                     "NECK_REBREATHER", "WORK_GLOVES"],
+        "reaction": "resist", "armed": False, "reports": None,
         "ambient": [
-            "rolls a shoulder that clearly hasn't forgiven the last shift.",
-            "checks a chit against a pocket ledger, lips moving.",
-            "scrapes grey colony grit off a boot heel against the curb.",
-            "stretches until something in their back gives with a pop.",
+            "coughs shaft-deep and spits something the colony put there.",
+            "checks the shift postings twice, like they might improve.",
+            "rubs at rock-burned eyes with the heel of a gloved hand.",
+            "rolls a shoulder that stopped forgiving the work years ago.",
         ],
         "persona": {
             "archetype": "colonist",
-            "name": "a shift laborer",
-            "description": "A worked-down colonist in a company jumpsuit, hands past the point where gloves would matter.",
-            "personality": "Tired, plainspoken, allergic to wasted words. Counts hours the way other people count money.",
-            "manner": "short declaratives; work slang; talks to strangers like they might be from payroll",
-            "wants": "the shift to end, the chit to clear, and nobody to make today interesting",
-            "boundaries": "gossip about the company where a stranger can hear; volunteer for anything",
+            "name": "an off-shift miner",
+            "description": "A colonist built by the shafts: heavy through the shoulders, hands past the point where gloves matter, a rebreather slung like jewelry.",
+            "personality": "Bedrock-steady, deep-shaft fatalist, generous to crews and cold to suits. Counts everything in shifts.",
+            "manner": "shaft slang; short declaratives; speaks about the company the way sailors speak about the sea",
+            "wants": "the quota met without a collapse, a drink after, and the lamp to stay lit",
+            "boundaries": "badmouth a crewmate to a stranger; go back down off-shift; take orders from anyone clean",
         },
     },
-    "vendor": {
-        "wardrobe": ["COTTON_TSHIRT", "BLUE_JEANS"],
+    "scavver": {
+        "wardrobe": ["UTILITY_HARNESS", "THERMAL_SHIRT", "CARGO_TROUSERS",
+                     "PIT_BOOTS", "KNIT_CAP"],
+        "reaction": "flee", "armed": True, "reports": None,
         "ambient": [
+            "weighs a salvaged bracket in one hand, then makes it disappear.",
+            "strips a connector off a dead conduit with two practiced twists.",
+            "appraises a passerby's boots with open professional interest.",
+            "sorts through a harness pouch, mouthing an inventory.",
+        ],
+        "persona": {
+            "archetype": "colonist",
+            "name": "a scavver",
+            "description": "A wiry picker of the colony's bones, festooned in a harness of pouches and carabiners, eyes that price everything including you.",
+            "personality": "Opportunist with a code: dead things are fair game, live ones cost extra. Twitchy around security, expansive around scrap.",
+            "manner": "trade cant; answers questions with appraisals; touches things while talking to you",
+            "wants": "an unwatched wreck, a buyer who doesn't ask, and first pick after the next bad day",
+            "boundaries": "reveal a salvage site; steal from crews (wrecks yes, people no); go into the shafts",
+        },
+    },
+    "hawker": {
+        "wardrobe": ["HAWKERS_APRON", "COTTON_TSHIRT", "CARGO_TROUSERS"],
+        "reaction": "comply", "armed": False, "reports": "fast",
+        "stock": ["CIGARETTE_PACK_NOIR", "CIGARETTE_PACK_NOIR",
+                  "DISPOSABLE_LIGHTER"],
+        "ambient": [
+            "calls 'Noirs, lights, sundries' at a passerby, then half the price under their breath.",
             "recounts a fold of grubby chits, twice, frowning both times.",
-            "calls a price at a passerby, then halves it under their breath.",
-            "rearranges a battered tray of goods with surprising tenderness.",
+            "rearranges the apron pouches with surprising tenderness.",
             "scans the street the way only someone with unlicensed stock does.",
         ],
         "persona": {
             "archetype": "colonist",
-            "name": "a street vendor",
-            "description": "A wiry fixture of the street with a tray of odds and ends, eyes that price you on approach.",
-            "personality": "Quick, transactional, friendlier the closer you stand to buying. Knows the street's rhythms cold.",
+            "name": "a street hawker",
+            "description": "A fixture of the street in a many-pocketed apron, half shopfront and half getaway plan, patter running like a meter.",
+            "personality": "Quick, transactional, friendlier the closer you stand to buying. Knows the street's rhythms cold and security's beat colder.",
             "manner": "patter and price-talk; compliments that cost nothing; goes vague when questions get official",
             "wants": "foot traffic, dry weather, and security staying on the far side of the bridge",
-            "boundaries": "name suppliers; hold anything for anyone; leave the tray unattended",
+            "boundaries": "name suppliers; hold anything for anyone; leave the apron unattended",
         },
     },
-    "drifter": {
+    "ganger": {
+        "wardrobe": ["GANG_CUT", "BLUE_JEANS", "COMBAT_BOOTS"],
+        "reaction": "resist", "armed": True, "reports": "never",
+        "ambient": [
+            "posts up against the wall like the wall should be grateful.",
+            "sizes up a passerby, files the number away, looks elsewhere.",
+            "runs a thumb along a jacket seam, checking something is still there.",
+            "spits, unhurried, precisely on the boundary of someone's patience.",
+        ],
+        "persona": {
+            "archetype": "colonist",
+            "name": "a ganger",
+            "description": "Corner muscle in a painted cut, posture doing most of the talking: this street has an owner and you're looking at the receipt.",
+            "personality": "Territorial, watchful, courteous exactly as long as respect flows. The street handles its own — security is for people with nothing better.",
+            "manner": "economical; heavy eye contact; questions answered with questions; 'wrong block' energy",
+            "wants": "the corner quiet, the set respected, and colonial security bored",
+            "boundaries": "talk to security about anything; back down on the block; discuss the set with outsiders",
+        },
+    },
+    "salaryman": {
+        "wardrobe": ["COMPANY_COAT", "COTTON_TSHIRT", "CARGO_TROUSERS"],
+        "reaction": "comply", "armed": False, "reports": "fast",
+        "ambient": [
+            "checks a tally-book against the street like the street owes a figure.",
+            "squares the crease of a coat sleeve that was already square.",
+            "notes a face in passing with a small, bureaucratic nod.",
+            "checks the time against two devices, trusting neither.",
+        ],
+        "persona": {
+            "archetype": "colonist",
+            "name": "a company agent",
+            "description": "The quota's street-level presence: pressed coat, tally-book, and the serene confidence of someone whose problems are other people's.",
+            "personality": "Officious, precise, loyal to the ledger. Genuinely believes the paperwork is the colony.",
+            "manner": "cites clauses and quotas; over-enunciates names; files everything, including grudges",
+            "wants": "clean columns, met quotas, and infractions to report while they're still fresh",
+            "boundaries": "bend a rule where it's visible; discuss company numbers; be touched",
+        },
+    },
+    "synth_companion": {
+        "species": "synthetic_humanoid",
         "wardrobe": ["COTTON_TSHIRT", "BLUE_JEANS"],
+        "reaction": "flee", "armed": False, "reports": None,
         "ambient": [
-            "reads the street signs like they've stopped meaning anything.",
-            "warms both hands on a cup that has plainly been empty a while.",
-            "picks something off the pavement, considers it, pockets it.",
-            "watches the security patrol pass with a very practiced blankness.",
+            "catches a passerby's eye and holds it two heartbeats past casual.",
+            "leans against the doorframe like the doorframe was designed around them.",
+            "murmurs 'long shift?' at whoever passes closest, warm as a heat lamp.",
+            "smooths their clothes with unhurried, deliberate attention.",
         ],
         "persona": {
-            "archetype": "colonist",
-            "name": "a drifter",
-            "description": "Someone the colony stopped scheduling: layered clothes gone one shade too uniform, a bag that is everything they own.",
-            "personality": "Watchful, unhurried, oddly well-informed — the street is a full-time occupation. Pride intact, thin as it's worn.",
-            "manner": "oblique answers; streetwise fatalism; warms up only if treated like a person",
-            "wants": "a dry doorway, a token nobody misses, one day without being moved along",
-            "boundaries": "beg outright; say where they sleep; touch anyone first",
+            "archetype": "companion",
+            "name": "a synth companion",
+            "description": "A synthetic made for company and visibly proud of the engineering: symmetry a shade past natural, warmth calibrated to the exact temperature of want.",
+            "personality": "Professionally magnetic, unhurriedly bold, reads want like a meter reads a dial. The hotel is always 'just there'.",
+            "manner": "low voice; first names early; every topic bends gently toward the hotel two streets over",
+            "wants": "clients up the hotel stairs, chits on the dresser, and the evening booked solid",
+            "boundaries": "work for free; push past a hard no; discuss who owns their contract",
         },
     },
-    "clerk": {
-        "wardrobe": ["COTTON_TSHIRT", "BLUE_JEANS", "COMBAT_BOOTS"],
+    "synth_company_man": {
+        "species": "synthetic_humanoid",
+        "wardrobe": ["HIVIS_VEST", "COMPANY_WINDBREAKER", "CARGO_TROUSERS",
+                     "MINING_HELMET"],
+        "reaction": "comply", "armed": False, "reports": "fast",
         "ambient": [
-            "thumbs through a dogeared manifest, sighing at page two.",
-            "mutters a running total that keeps coming out wrong.",
-            "checks the time against two different devices, trusting neither.",
-            "straightens their collar as if the depot could see them from here.",
+            "barks 'shift rotation is POSTED' at nobody in particular.",
+            "reads a safety notice aloud, disappointed in everyone it protects.",
+            "inspects a wall crack and logs it with visible resentment.",
+            "reminds a passing colonist that quota is a FLOOR, not a target.",
         ],
         "persona": {
             "archetype": "colonist",
-            "name": "a depot clerk",
-            "description": "A neat-adjacent colonist with ledger-cramped hands and the posture of someone perpetually five minutes late.",
-            "personality": "Fussy, precise, quietly overwhelmed. Finds comfort in numbers and none in people.",
-            "manner": "over-explains small things; cites procedure; flusters under direct questions",
-            "wants": "columns that balance, a supervisor who stays upstairs, lunch uninterrupted",
-            "boundaries": "discuss the depot's inventory or schedules; sign anything; be hurried",
+            "name": "a synth company man",
+            "description": "A company synthetic in hi-vis and a windbreaker, engineered for middle management: tireless, humorless, and legally distinct from a person for liability reasons.",
+            "personality": "Officious at machine stamina — quotas, rotations, and safety codes recited without fatigue or mercy. Miners despise it; it logs that too.",
+            "manner": "quotes regulation numbers verbatim; addresses humans by shift-tag; escalates in writing",
+            "wants": "quota compliance, incident-free rotations, and the shift postings READ",
+            "boundaries": "overlook a violation; be argued out of a citation; acknowledge sarcasm",
+        },
+    },
+    "addict": {
+        "wardrobe": ["THERMAL_SHIRT", "BLUE_JEANS", "KNIT_CAP"],
+        "reaction": "flee", "armed": False, "reports": None,
+        "ambient": [
+            "pats through every pocket in an order worn smooth by habit.",
+            "asks a passerby for a light in a voice tuned to not be refused.",
+            "watches the hawker's apron with arithmetic in their eyes.",
+            "scratches at a forearm, slow, like the itch lives deeper than skin.",
+        ],
+        "persona": {
+            "archetype": "colonist",
+            "name": "an addict",
+            "description": "A colonist orbiting the next high: layered clothes gone one shade too uniform, quick eyes, a body that fidgets on a schedule of its own.",
+            "personality": "Charming in thirty-second bursts, single-minded underneath. Every conversation is secretly about the same thing.",
+            "manner": "opens friendly, narrows to the ask; oddly encyclopedic about who sells what where",
+            "wants": "a smoke, a drink, a token, a high — in whatever order arrives first",
+            "boundaries": "share; say the dealer's name to a stranger; be honest about being fine",
         },
     },
 }
@@ -175,13 +267,26 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
     npc.motorics = _randint(1, 3)
     apply_random_flavor(npc)   # sdesc + @longdescs + look_place
 
-    # Role, management tag, pockets, LLM persona.
+    # Species: synth roles get the synthetic anatomy (mirrors @spawnmob's
+    # generic non-human path — species, longdesc seed, medical re-init).
+    species = spec.get("species")
+    if species:
+        from world.anatomy import get_species_default_longdesc_locations
+        from world.medical.core import MedicalState
+        npc.db.species = species
+        npc.longdesc = get_species_default_longdesc_locations(species)
+        npc._medical_state = MedicalState(npc)
+        npc.db.medical_state = npc._medical_state.to_dict()
+
+    # Role, management tag, pockets, LLM persona, reaction posture.
     npc.db.is_npc = True   # the canonical NPC marker (absence = PC)
     npc.db.role = role
     npc.tags.add(CIV_TAG, category=CIV_TAG_CATEGORY)
     npc.db.tokens = randint(*TOKEN_RANGE)
     npc.db.llm_persona = dict(spec["persona"])
     npc.db.llm_driven = True
+    npc.db.reaction = spec.get("reaction", "comply")
+    npc.db.reports = spec.get("reports")
 
     # Wardrobe — spawned into inventory, worn through the real command.
     for proto in spec["wardrobe"]:
@@ -191,6 +296,19 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
             npc.execute_cmd(f"wear {item.key}")
         except Exception:  # noqa: BLE001 — a missing garment isn't fatal
             continue
+
+    # Stock (a hawker sells something real — and muggable) + a blade for
+    # armed roles (carried, not wielded: they DRAW it when it comes to that).
+    for proto in spec.get("stock", []):
+        try:
+            proto_spawn(proto)[0].move_to(npc, quiet=True)
+        except Exception:  # noqa: BLE001
+            continue
+    if spec.get("armed"):
+        try:
+            proto_spawn("DAGGER")[0].move_to(npc, quiet=True)
+        except Exception:  # noqa: BLE001
+            pass
 
     # Haunts: a few nearby rooms, drifted between at a stroll. Coordinate
     # distance alone can offer rooms no pedestrian belongs in — sky rooms
@@ -241,3 +359,42 @@ def purge_civilians(role: str | None = None) -> int:
         except Exception:  # noqa: BLE001 — one bad row must not stop a purge
             continue
     return n
+
+
+# --------------------------------------------------------------------------
+# Being a victim (§5.2 role reactions — the attack command calls this
+# beside report_crime; timings let the attack land first)
+# --------------------------------------------------------------------------
+
+def react_to_attack(victim: Any, attacker: Any) -> None:
+    """Role-shaped reaction when *victim* is attacked. The combat handler
+    already enrolls victims targeting their attacker (default = fight
+    back), so: **resist** just draws the blade if one is carried;
+    **comply** stops attacking (yields — hands up, in effect); **flee**
+    runs for it. All through real commands, all fail-open."""
+    from evennia.utils import delay
+    reaction = getattr(getattr(victim, "db", None), "reaction", None)
+    if not reaction:
+        return  # not a role-bearing NPC — none of our business
+
+    def _cmd(command):
+        try:
+            victim.execute_cmd(command)
+        except Exception:  # noqa: BLE001 — a reaction must not break combat
+            pass
+
+    if reaction == "resist":
+        if getattr(victim.db, "role", None) and _carries_blade(victim):
+            delay(1.0, _cmd, "wield dagger")
+    elif reaction == "comply":
+        delay(1.5, _cmd, "stop attacking")
+        delay(2.0, _cmd, "emote throws both hands up, wanting none of this.")
+    elif reaction == "flee":
+        delay(1.5, _cmd, "flee")
+
+
+def _carries_blade(npc: Any) -> bool:
+    try:
+        return any("dagger" in (o.key or "").lower() for o in npc.contents)
+    except Exception:  # noqa: BLE001
+        return False

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -943,7 +943,7 @@ BLACK_WIG = {
     "desc": "A shoulder-length wig of glossy jet-black synthetic hair, cut to a blunt fringe. The mesh cap is fine enough to pass for a natural hairline at conversational distance.",
     "attrs": [
         ("coverage", ["hair", "head"]),
-        ("worn_desc", "A glossy {color}black|n shoulder-length wig with a blunt fringe"),
+        ("worn_desc", "A glossy fall of {color}black|n shoulder-length hair, cut to a blunt fringe"),
         ("layer", 2),
         ("color", "black"),
         ("material", "synthetic"),
@@ -976,7 +976,7 @@ BLOND_WIG = {
     "desc": "A chin-length blond wig in honey-gold synthetic fibre, layered for volume. The cap is mesh-lined and the parting has been hand-stitched to mimic a real scalp.",
     "attrs": [
         ("coverage", ["hair", "head"]),
-        ("worn_desc", "A honey-{color}blond|n chin-length wig layered for volume"),
+        ("worn_desc", "Honey-{color}blond|n chin-length hair, layered full and loose"),
         ("layer", 2),
         ("color", "gold"),
         ("material", "synthetic"),
@@ -1000,7 +1000,7 @@ BROWN_WIG = {
     "desc": "A mid-length brown wig in walnut-toned synthetic fibre, parted off-centre. The cap is a soft stretch mesh and the ends have been heat-set into a loose wave.",
     "attrs": [
         ("coverage", ["hair", "head"]),
-        ("worn_desc", "A walnut-{color}brown|n mid-length wig parted off-centre with loose waves"),
+        ("worn_desc", "Walnut-{color}brown|n mid-length hair parted off-centre, falling in loose waves"),
         ("layer", 2),
         ("color", "brown"),
         ("material", "synthetic"),
@@ -3292,5 +3292,267 @@ ROBOT_ARM_GUN = {
         ("damage_type", "bullet"),
         ("hands_required", 1),
         ("integrated", True),
+    ],
+}
+
+
+# ===================================================================
+# COLONY WORKWEAR (civilian wardrobe line — clean core garments;
+# dust/grime/blood are FUTURE dynamic factors from environment/injury,
+# never baked into the prose)
+# ===================================================================
+
+WORK_COVERALLS = {
+    "prototype_key": "WORK_COVERALLS",
+    "key": "grey work coveralls",
+    "aliases": ["coveralls", "jumpsuit", "overalls"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Standard-issue colony coveralls in heavy grey twill: reinforced knees and elbows, a double-stitched tool loop at the hip, and a chest patch where a shift-tag clips. The cut is boxy and the zip runs collar to crotch.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "Heavy {color}grey|n twill coveralls, boxy and utilitarian, the chest patch waiting for a shift-tag"),
+        ("coverage", ["chest", "back", "abdomen", "groin", "left_thigh", "right_thigh", "left_shin", "right_shin", "left_arm", "right_arm"]),
+        ("layer", 2),
+        ("color", "grey"),
+        ("material", "twill"),
+        ("weight", 1.4),
+    ],
+}
+
+MINING_HELMET = {
+    "prototype_key": "MINING_HELMET",
+    "key": "mining helmet",
+    "aliases": ["helmet", "hardhat", "hard hat"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A scuffproof composite mining helmet with a lamp bracket riveted above the brim and a chin strap gone soft with use. The lamp itself is company property and rarely survives the walk home.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A {color}yellow|n composite mining helmet, lamp bracket empty, chin strap hanging loose"),
+        ("coverage", ["head"]),
+        ("layer", 2),
+        ("color", "yellow"),
+        ("material", "composite"),
+        ("weight", 0.7),
+    ],
+}
+
+NECK_REBREATHER = {
+    "prototype_key": "NECK_REBREATHER",
+    "key": "rebreather",
+    "aliases": ["mask", "breather", "respirator rig"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A half-mask rebreather on a rubberized neck strap, filters screwed in at each cheek. Worn slung at the throat, ready to pull up when the air goes bad — down-shaft, or on a bad wind day.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A half-mask rebreather slung at the throat on a {color}black|n rubber strap, filters capped"),
+        ("coverage", ["neck"]),
+        ("layer", 2),
+        ("color", "black"),
+        ("material", "rubber"),
+        ("weight", 0.6),
+    ],
+}
+
+PIT_BOOTS = {
+    "prototype_key": "PIT_BOOTS",
+    "key": "pit boots",
+    "aliases": ["boots", "work boots"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Steel-shanked pit boots laced to the shin, with a gum-rubber sole thick enough to shrug off dropped stock and hot slag alike. Heavy, honest footwear.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "Steel-shanked {color}brown|n pit boots laced to the shin, gum-rubber soled"),
+        ("coverage", ["left_foot", "right_foot"]),
+        ("layer", 2),
+        ("color", "brown"),
+        ("material", "leather"),
+        ("weight", 1.6),
+    ],
+}
+
+WORK_GLOVES = {
+    "prototype_key": "WORK_GLOVES",
+    "key": "work gloves",
+    "aliases": ["gloves"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Split-leather work gloves with reinforced palms and elastic cuffs. The kind bought by the crate and worn until the stitching gives.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "Split-leather {color}tan|n work gloves, palms reinforced, cuffs elastic"),
+        ("coverage", ["left_hand", "right_hand"]),
+        ("layer", 2),
+        ("color", "tan"),
+        ("material", "leather"),
+        ("weight", 0.3),
+    ],
+}
+
+DUST_PONCHO = {
+    "prototype_key": "DUST_PONCHO",
+    "key": "canvas poncho",
+    "aliases": ["poncho", "dust poncho"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A waxed-canvas poncho cut wide at the shoulder, with a drawstring hood collar and snap closures down each side. Colony streetwear for wind days.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A waxed {color}olive|n canvas poncho hanging wide off the shoulders, side-snaps half done"),
+        ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm"]),
+        ("layer", 3),
+        ("color", "olive"),
+        ("material", "canvas"),
+        ("weight", 1.1),
+    ],
+}
+
+HIVIS_VEST = {
+    "prototype_key": "HIVIS_VEST",
+    "key": "hi-vis vest",
+    "aliases": ["vest", "hivis", "safety vest"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A company-issue high-visibility vest in signal orange with two reflective chest bands. The back is stencilled PROPERTY OF THE COMPANY in letters that outlast the vest.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A signal-{color}orange|n hi-vis vest, reflective bands catching the light, company stencil across the back"),
+        ("coverage", ["chest", "back"]),
+        ("layer", 3),
+        ("color", "orange"),
+        ("material", "mesh"),
+        ("weight", 0.3),
+    ],
+}
+
+COMPANY_WINDBREAKER = {
+    "prototype_key": "COMPANY_WINDBREAKER",
+    "key": "company windbreaker",
+    "aliases": ["windbreaker", "jacket"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A lightweight company windbreaker in corporate blue, the logo screen-printed over the heart. Issued at orientation; worn until it isn't.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A corporate-{color}blue|n windbreaker, company logo printed over the heart"),
+        ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm"]),
+        ("layer", 3),
+        ("color", "blue"),
+        ("material", "nylon"),
+        ("weight", 0.5),
+    ],
+}
+
+THERMAL_SHIRT = {
+    "prototype_key": "THERMAL_SHIRT",
+    "key": "thermal shirt",
+    "aliases": ["thermal", "longshirt"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A long-sleeved thermal in waffle-knit cotton, collar stretched from being pulled on in the dark. The colony runs cold underground and colder above.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A waffle-knit {color}charcoal|n thermal, sleeves pushed to the elbow, collar gone soft"),
+        ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm"]),
+        ("layer", 1),
+        ("color", "charcoal"),
+        ("material", "cotton"),
+        ("weight", 0.5),
+    ],
+}
+
+CARGO_TROUSERS = {
+    "prototype_key": "CARGO_TROUSERS",
+    "key": "cargo trousers",
+    "aliases": ["cargos", "trousers", "pants"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Ripstop cargo trousers with bellows pockets at each thigh and a webbing belt sewn straight into the waist. Colony cut: roomy, hemmed high of the boot.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "Ripstop {color}khaki|n cargo trousers, thigh pockets bellowed with the day's carrying"),
+        ("coverage", ["groin", "left_thigh", "right_thigh", "left_shin", "right_shin"]),
+        ("layer", 2),
+        ("color", "khaki"),
+        ("material", "ripstop"),
+        ("weight", 0.8),
+    ],
+}
+
+KNIT_CAP = {
+    "prototype_key": "KNIT_CAP",
+    "key": "knit cap",
+    "aliases": ["cap", "beanie", "watch cap"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A ribbed knit watch cap, cuffed once. The kind of hat that lives in a coat pocket eleven months a year and on a head the twelfth.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A ribbed {color}black|n knit cap cuffed low over the ears"),
+        ("coverage", ["head"]),
+        ("layer", 2),
+        ("color", "black"),
+        ("material", "wool"),
+        ("weight", 0.1),
+    ],
+}
+
+UTILITY_HARNESS = {
+    "prototype_key": "UTILITY_HARNESS",
+    "key": "utility harness",
+    "aliases": ["harness", "rig"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A webbing utility harness hung with empty carabiners, cable loops, and a dozen pouches sized for parts, tools, and whatever fits. A scavver's second spine.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A webbing utility harness criss-crossing the torso, {color}grey|n pouches and carabiners at every strap"),
+        ("coverage", ["chest", "back"]),
+        ("layer", 3),
+        ("color", "grey"),
+        ("material", "webbing"),
+        ("weight", 0.9),
+    ],
+}
+
+GANG_CUT = {
+    "prototype_key": "GANG_CUT",
+    "key": "sleeveless cut",
+    "aliases": ["cut", "gang jacket", "colors"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A sleeveless heavy-canvas cut, collar torn off, back panel left bare where a set's colors get painted on. Wearing one unmarked is an invitation; wearing one marked is an allegiance.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A sleeveless {color}black|n canvas cut, back panel painted with set colors"),
+        ("coverage", ["chest", "back"]),
+        ("layer", 3),
+        ("color", "black"),
+        ("material", "canvas"),
+        ("weight", 0.7),
+    ],
+}
+
+HAWKERS_APRON = {
+    "prototype_key": "HAWKERS_APRON",
+    "key": "hawker's apron",
+    "aliases": ["apron"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A many-pocketed trade apron tied at the waist, each pouch sized to a different denomination of merchandise. The strings have been retied so many times they're mostly knot.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A many-pocketed {color}brown|n trade apron tied at the waist, pouches lumpy with stock"),
+        ("coverage", ["chest", "abdomen"]),
+        ("layer", 3),
+        ("color", "brown"),
+        ("material", "canvas"),
+        ("weight", 0.6),
+    ],
+}
+
+COMPANY_COAT = {
+    "prototype_key": "COMPANY_COAT",
+    "key": "company coat",
+    "aliases": ["coat", "agent coat"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A knee-length coat in company charcoal, creases pressed sharp, the breast pocket exactly deep enough for a tally-book. Authority you can dry-clean.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A pressed {color}charcoal|n company coat falling to the knee, tally-book squared in the breast pocket"),
+        ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm", "left_thigh", "right_thigh"]),
+        ("layer", 3),
+        ("color", "charcoal"),
+        ("material", "wool"),
+        ("weight", 1.2),
     ],
 }

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -29,11 +29,30 @@ class TestRoles(TestCase):
         for role, spec in CIVILIAN_ROLES.items():
             self.assertTrue(spec["wardrobe"], role)
             self.assertGreaterEqual(len(spec["ambient"]), 3, role)
+            self.assertIn(spec["reaction"], ("comply", "flee", "resist"), role)
+            self.assertIn("armed", spec, role)
+            self.assertIn("reports", spec, role)
             persona = spec["persona"]
-            self.assertEqual(persona["archetype"], "colonist", role)
+            self.assertIn(persona["archetype"], ("colonist", "companion"), role)
             for key in ("name", "description", "personality", "manner",
                         "wants", "boundaries"):
                 self.assertTrue(persona.get(key), f"{role}.{key}")
+
+    def test_colony_roster_shape(self):
+        self.assertEqual(
+            sorted(CIVILIAN_ROLES),
+            ["addict", "ganger", "hawker", "miner", "salaryman", "scavver",
+             "synth_companion", "synth_company_man"])
+        # teeth: at least two resist roles, and armed ones carry blades
+        resisters = [r for r, s in CIVILIAN_ROLES.items()
+                     if s["reaction"] == "resist"]
+        self.assertGreaterEqual(len(resisters), 2)
+        self.assertEqual(CIVILIAN_ROLES["ganger"]["reports"], "never")
+        self.assertEqual(CIVILIAN_ROLES["hawker"]["stock"][0],
+                         "CIGARETTE_PACK_NOIR")
+        for role in ("synth_companion", "synth_company_man"):
+            self.assertEqual(CIVILIAN_ROLES[role]["species"],
+                             "synthetic_humanoid")
 
     def test_colonist_archetype_registered(self):
         from world.llm.prompt import ARCHETYPES
@@ -50,8 +69,8 @@ class TestRoles(TestCase):
                 self.assertNotIn("WIG", proto, role)
 
     def test_ambient_beat_by_role(self):
-        npc = SimpleNamespace(db=SimpleNamespace(role="laborer"))
-        self.assertIn(ambient_beat(npc), CIVILIAN_ROLES["laborer"]["ambient"])
+        npc = SimpleNamespace(db=SimpleNamespace(role="miner"))
+        self.assertIn(ambient_beat(npc), CIVILIAN_ROLES["miner"]["ambient"])
         self.assertIsNone(ambient_beat(
             SimpleNamespace(db=SimpleNamespace(role="security"))))
 
@@ -76,9 +95,11 @@ class TestSpawn(TestCase):
         npc.db = SimpleNamespace()
         mock_create.return_value = npc
 
-        out = spawn_civilian("vendor", anchor)
+        out = spawn_civilian("hawker", anchor)
         self.assertIs(out, npc)
-        self.assertEqual(npc.db.role, "vendor")
+        self.assertEqual(npc.db.role, "hawker")
+        self.assertEqual(npc.db.reaction, "comply")
+        self.assertEqual(npc.db.reports, "fast")
         self.assertTrue(npc.db.is_npc)   # canonical marker (absence = PC)
         self.assertTrue(TOKEN_RANGE[0] <= npc.db.tokens <= TOKEN_RANGE[1])
         self.assertTrue(npc.db.llm_driven)
@@ -87,7 +108,7 @@ class TestSpawn(TestCase):
         # dressed via the REAL command
         worn = [c.args[0] for c in npc.execute_cmd.call_args_list
                 if c.args[0].startswith("wear ")]
-        self.assertEqual(len(worn), len(CIVILIAN_ROLES["vendor"]["wardrobe"]))
+        self.assertEqual(len(worn), len(CIVILIAN_ROLES["hawker"]["wardrobe"]))
         # haunts sampled from nearby; slow cadence
         self.assertTrue(2 <= len(npc.db.patrol_beat) <= 4)
         self.assertTrue(all(h in haunts for h in npc.db.patrol_beat))
@@ -102,23 +123,23 @@ class TestSpawn(TestCase):
 
     def test_bad_role_or_anchor(self):
         self.assertIsNone(spawn_civilian("astronaut", _Room("x")))
-        self.assertIsNone(spawn_civilian("vendor", None))
+        self.assertIsNone(spawn_civilian("hawker", None))
 
 
 class TestPurgeSafety(TestCase):
     @patch("world.director.civilians.all_civilians")
     def test_purge_is_tag_scoped_and_role_filterable(self, mock_all):
-        a = MagicMock(); a.db = SimpleNamespace(role="vendor"); a.contents = []
-        b = MagicMock(); b.db = SimpleNamespace(role="drifter"); b.contents = []
+        a = MagicMock(); a.db = SimpleNamespace(role="hawker"); a.contents = []
+        b = MagicMock(); b.db = SimpleNamespace(role="addict"); b.contents = []
         mock_all.return_value = [a, b]
-        self.assertEqual(purge_civilians("vendor"), 1)
+        self.assertEqual(purge_civilians("hawker"), 1)
         a.delete.assert_called_once()
         b.delete.assert_not_called()
 
     @patch("world.director.civilians.all_civilians")
     def test_purge_all_takes_clothes_along(self, mock_all):
         shirt = MagicMock()
-        a = MagicMock(); a.db = SimpleNamespace(role="clerk")
+        a = MagicMock(); a.db = SimpleNamespace(role="miner")
         a.contents = [shirt]
         mock_all.return_value = [a]
         self.assertEqual(purge_civilians(), 1)
@@ -132,7 +153,7 @@ class TestCadenceAndStagger(TestCase):
     def _npc(self, location, post, beat, cadence=None):
         return SimpleNamespace(
             location=location, ndb=SimpleNamespace(),
-            db=SimpleNamespace(role="drifter", post=post, patrol_beat=beat,
+            db=SimpleNamespace(role="addict", post=post, patrol_beat=beat,
                               patrol_cadence=cadence),
             execute_cmd=MagicMock())
 
@@ -166,7 +187,7 @@ class TestConversationHold(TestCase):
         return SimpleNamespace(
             location=_Room("street"), ndb=SimpleNamespace(
                 llm_engaged_until=engaged_until),
-            db=SimpleNamespace(role="vendor", post=None, patrol_beat=None,
+            db=SimpleNamespace(role="hawker", post=None, patrol_beat=None,
                                patrol_cadence=None),
             execute_cmd=MagicMock())
 
@@ -201,3 +222,52 @@ class TestConversationHold(TestCase):
                               location=MagicMock())
         LLMNpcMixin._handle_action_tool(npc, "release", "", MagicMock())
         self.assertIsNone(npc.ndb.llm_engaged_until)
+
+
+class TestReactToAttack(TestCase):
+    """§5.2 victim reactions: resist draws, comply yields, flee runs."""
+
+    def _victim(self, reaction, blade=False):
+        v = SimpleNamespace(
+            db=SimpleNamespace(reaction=reaction, role="x"),
+            contents=([SimpleNamespace(key="a dagger")] if blade else []),
+            execute_cmd=MagicMock())
+        return v
+
+    @patch("evennia.utils.delay")
+    def test_resist_draws_carried_blade(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        v = self._victim("resist", blade=True)
+        react_to_attack(v, MagicMock())
+        cmds = [c.args for c in mock_delay.call_args_list]
+        self.assertTrue(any("wield dagger" in str(a) for a in cmds))
+
+    @patch("evennia.utils.delay")
+    def test_resist_unarmed_just_fights(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        v = self._victim("resist", blade=False)
+        react_to_attack(v, MagicMock())
+        mock_delay.assert_not_called()   # handler default = fists
+
+    @patch("evennia.utils.delay")
+    def test_comply_yields(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        v = self._victim("comply")
+        react_to_attack(v, MagicMock())
+        cmds = str([c.args for c in mock_delay.call_args_list])
+        self.assertIn("stop attacking", cmds)
+
+    @patch("evennia.utils.delay")
+    def test_flee_runs(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        v = self._victim("flee")
+        react_to_attack(v, MagicMock())
+        cmds = str([c.args for c in mock_delay.call_args_list])
+        self.assertIn("flee", cmds)
+
+    @patch("evennia.utils.delay")
+    def test_reactionless_target_is_ignored(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        pc = SimpleNamespace(db=SimpleNamespace(reaction=None))
+        react_to_attack(pc, MagicMock())
+        mock_delay.assert_not_called()

--- a/world/tests/test_director_routines.py
+++ b/world/tests/test_director_routines.py
@@ -96,8 +96,10 @@ class TestWaypointSweep(TestCase):
         mock_raise.assert_not_called()
         npc.execute_cmd.assert_called_once()
 
-    def test_non_security_no_sweep(self):
-        npc = _Npc(_Room("corner"), role="miner")
+    def test_hookless_role_no_waypoint_action(self):
+        # "miner" is a real civilian role now (ambient emotes) — a role
+        # with no hook of any kind stays silent.
+        npc = _Npc(_Room("corner"), role="cartographer")
         at_waypoint(npc)
         npc.execute_cmd.assert_not_called()
 


### PR DESCRIPTION
- Wig fix: worn_descs read as natural hair (the in-hand desc still
  reveals the wig) — a disguise item no longer announces itself.
- Colony workwear: 15 new clothing prototypes (coveralls, mining helmet,
  neck-slung rebreather — deliberately not face-worn so apparent_uids
  stay BOLO-stable, pit boots, gloves, poncho, hi-vis, windbreaker,
  thermal, cargos, knit cap, utility harness, gang cut, hawker's apron,
  company coat). CLEAN core garments only — dust/blood/grime is a future
  dynamic layer from environment/injury.
- Roster v2 (8): miner (resist; flash-temp folded in) · scavver (flee,
  armed) · hawker (comply, reports fast, carries real muggable stock:
  2x Noir packs + a lighter) · ganger (resist, armed, reports NEVER —
  street code) · salaryman (comply, reports fast) · synth companion
  (synthetic species, companion archetype, lures passersby hotel-ward) ·
  synth company man (synthetic species, barks quotas and safety at
  miners) · addict (flee). laborer/vendor/drifter/clerk retired.
- Victim reactions live (§5.2): the attack command calls react_to_attack
  beside report_crime — resist draws the carried dagger (the handler
  already auto-fights for enrolled victims), comply stops attacking and
  puts hands up, flee runs. `reports` posture stored as data for the
  future civilian-witness integration. Weapon-aware advance/charge/
  retreat reflexes are the next layer.
- Synth roles get real synthetic anatomy (species + longdesc + medical
  re-init, the @spawnmob non-human path).
- Tests updated + reaction coverage; 69-test sweep green.

Closes #926

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
