### PR TITLE
Street-tier weapons: armed civilians draw from random contemporary pools

### DIFF
--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -72,6 +72,7 @@ CIVILIAN_ROLES: dict[str, dict] = {
         "wardrobe": ["UTILITY_HARNESS", "THERMAL_SHIRT", "CARGO_TROUSERS",
                      "PIT_BOOTS", "KNIT_CAP"],
         "reaction": "flee", "armed": True, "reports": None,
+        "weapon_pool": ["BOX_CUTTER", "SHIV", "CROWBAR", "PIPE_WRENCH"],
         "ambient": [
             "weighs a salvaged bracket in one hand, then makes it disappear.",
             "strips a connector off a dead conduit with two practiced twists.",
@@ -112,6 +113,8 @@ CIVILIAN_ROLES: dict[str, dict] = {
     "ganger": {
         "wardrobe": ["GANG_CUT", "BLUE_JEANS", "COMBAT_BOOTS"],
         "reaction": "resist", "armed": True, "reports": "never",
+        "weapon_pool": ["SHIV", "TIRE_IRON", "BRASS_KNUCKLES", "HEAVY_CHAIN",
+                        "BASEBALL_BAT", "BOX_CUTTER"],
         "ambient": [
             "posts up against the wall like the wall should be grateful.",
             "sizes up a passerby, files the number away, looks elsewhere.",
@@ -306,7 +309,9 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
             continue
     if spec.get("armed"):
         try:
-            proto_spawn("DAGGER")[0].move_to(npc, quiet=True)
+            weapon = proto_spawn(choice(spec.get("weapon_pool") or ["SHIV"]))[0]
+            weapon.move_to(npc, quiet=True)
+            npc.db.carried_weapon = weapon.key   # what react_to_attack draws
         except Exception:  # noqa: BLE001
             pass
 
@@ -384,17 +389,12 @@ def react_to_attack(victim: Any, attacker: Any) -> None:
             pass
 
     if reaction == "resist":
-        if getattr(victim.db, "role", None) and _carries_blade(victim):
-            delay(1.0, _cmd, "wield dagger")
+        weapon = getattr(victim.db, "carried_weapon", None)
+        if weapon:
+            delay(1.0, _cmd, f"wield {weapon}")
     elif reaction == "comply":
         delay(1.5, _cmd, "stop attacking")
         delay(2.0, _cmd, "emote throws both hands up, wanting none of this.")
     elif reaction == "flee":
         delay(1.5, _cmd, "flee")
 
-
-def _carries_blade(npc: Any) -> bool:
-    try:
-        return any("dagger" in (o.key or "").lower() for o in npc.contents)
-    except Exception:  # noqa: BLE001
-        return False

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3556,3 +3556,79 @@ COMPANY_COAT = {
         ("weight", 1.2),
     ],
 }
+
+
+# ===================================================================
+# STREET-TIER WEAPONS (low-tier contemporary arms — the colony's back
+# alleys; message banks already existed, prototypes now match)
+# ===================================================================
+
+SHIV = {
+    "prototype_parent": "MELEE_WEAPON_BASE",
+    "key": "shiv",
+    "aliases": ["spike"],
+    "desc": "A hand-ground spike of scrap steel wound with tape for a grip. Nobody manufactures these; everybody makes them.",
+    "damage": 5,
+    "weapon_type": "shiv",
+    "damage_type": "stab",
+}
+
+TIRE_IRON = {
+    "prototype_parent": "MELEE_WEAPON_BASE",
+    "key": "tire iron",
+    "aliases": ["iron", "lug wrench"],
+    "desc": "A cross-ended tire iron in pitted chrome. Its second career began the night somebody realized it fit the hand better than the lug.",
+    "damage": 8,
+    "weapon_type": "tire_iron",
+    "damage_type": "blunt",
+}
+
+BRASS_KNUCKLES = {
+    "prototype_parent": "MELEE_WEAPON_BASE",
+    "key": "brass knuckles",
+    "aliases": ["knuckles", "knucks"],
+    "desc": "Four finger-holes and a palm bar in dull cast brass, edges worn smooth by pockets and use.",
+    "damage": 6,
+    "weapon_type": "brass_knuckles",
+    "damage_type": "blunt",
+}
+
+HEAVY_CHAIN = {
+    "prototype_parent": "MELEE_WEAPON_BASE",
+    "key": "heavy chain",
+    "aliases": ["chain"],
+    "desc": "A meter of galvanized cargo chain with the last link ground open. Loud to carry, louder to use.",
+    "damage": 7,
+    "weapon_type": "chain",
+    "damage_type": "blunt",
+}
+
+BOX_CUTTER = {
+    "prototype_parent": "MELEE_WEAPON_BASE",
+    "key": "box cutter",
+    "aliases": ["cutter", "razor knife"],
+    "desc": "A workaday box cutter with a thumb-slide and a fresh segment snapped forward. A tool, mostly.",
+    "damage": 5,
+    "weapon_type": "box_cutter",
+    "damage_type": "cut",
+}
+
+CROWBAR = {
+    "prototype_parent": "MELEE_WEAPON_BASE",
+    "key": "crowbar",
+    "aliases": ["prybar", "pry bar"],
+    "desc": "A flat-ended crowbar in chipped red enamel. Opens crates, doors, and arguments.",
+    "damage": 9,
+    "weapon_type": "crowbar",
+    "damage_type": "blunt",
+}
+
+PIPE_WRENCH = {
+    "prototype_parent": "MELEE_WEAPON_BASE",
+    "key": "pipe wrench",
+    "aliases": ["wrench"],
+    "desc": "A foot and a half of drop-forged pipe wrench, jaw rusted open at a permanent two inches. Still a tool; increasingly an argument.",
+    "damage": 8,
+    "weapon_type": "pipe_wrench",
+    "damage_type": "blunt",
+}

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -54,6 +54,14 @@ class TestRoles(TestCase):
             self.assertEqual(CIVILIAN_ROLES[role]["species"],
                              "synthetic_humanoid")
 
+    def test_weapon_pools_reference_real_prototypes(self):
+        from world import prototypes as protos
+        for role, spec in CIVILIAN_ROLES.items():
+            for key in spec.get("weapon_pool", []):
+                self.assertTrue(hasattr(protos, key), f"{role}: {key}")
+            if spec.get("armed"):
+                self.assertTrue(spec.get("weapon_pool"), f"{role} armed, no pool")
+
     def test_colonist_archetype_registered(self):
         from world.llm.prompt import ARCHETYPES
         self.assertIn("colonist", ARCHETYPES)
@@ -227,25 +235,24 @@ class TestConversationHold(TestCase):
 class TestReactToAttack(TestCase):
     """§5.2 victim reactions: resist draws, comply yields, flee runs."""
 
-    def _victim(self, reaction, blade=False):
-        v = SimpleNamespace(
-            db=SimpleNamespace(reaction=reaction, role="x"),
-            contents=([SimpleNamespace(key="a dagger")] if blade else []),
+    def _victim(self, reaction, weapon=None):
+        return SimpleNamespace(
+            db=SimpleNamespace(reaction=reaction, role="x",
+                               carried_weapon=weapon),
             execute_cmd=MagicMock())
-        return v
 
     @patch("evennia.utils.delay")
-    def test_resist_draws_carried_blade(self, mock_delay):
+    def test_resist_draws_carried_weapon(self, mock_delay):
         from world.director.civilians import react_to_attack
-        v = self._victim("resist", blade=True)
+        v = self._victim("resist", weapon="tire iron")
         react_to_attack(v, MagicMock())
         cmds = [c.args for c in mock_delay.call_args_list]
-        self.assertTrue(any("wield dagger" in str(a) for a in cmds))
+        self.assertTrue(any("wield tire iron" in str(a) for a in cmds))
 
     @patch("evennia.utils.delay")
     def test_resist_unarmed_just_fights(self, mock_delay):
         from world.director.civilians import react_to_attack
-        v = self._victim("resist", blade=False)
+        v = self._victim("resist", weapon=None)
         react_to_attack(v, MagicMock())
         mock_delay.assert_not_called()   # handler default = fists
 


### PR DESCRIPTION
Dagger reads medieval; the colony's back alleys don't. Seven street-tier
prototypes matching their long-existing message banks: SHIV (5 stab),
BOX_CUTTER (5 cut), BRASS_KNUCKLES (6), HEAVY_CHAIN (7), TIRE_IRON (8),
PIPE_WRENCH (8), CROWBAR (9). Armed roles spawn from per-role
weapon_pools (ganger: shiv/tire iron/knuckles/chain/bat/box cutter;
scavver: box cutter/shiv/crowbar/pipe wrench — tools first), remember the
pick as db.carried_weapon, and react_to_attack draws whatever they
actually carry. Pool-integrity test asserts every pool key is a real
prototype.

Closes #928

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
