### PR TITLE
Street fashion + companion line (style_configs); out-of-repo registers

### DIFF
--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -111,7 +111,8 @@ CIVILIAN_ROLES: dict[str, dict] = {
         },
     },
     "ganger": {
-        "wardrobe": ["GANG_CUT", "BLUE_JEANS", "COMBAT_BOOTS"],
+        "wardrobe": ["GANG_CUT", ["BLUE_JEANS", "LEATHER_TROUSERS"],
+                     ["COMBAT_BOOTS", "HIGH_TOPS"]],
         "reaction": "resist", "armed": True, "reports": "never",
         "weapon_pool": ["SHIV", "TIRE_IRON", "BRASS_KNUCKLES", "HEAVY_CHAIN",
                         "BASEBALL_BAT", "BOX_CUTTER"],
@@ -152,7 +153,12 @@ CIVILIAN_ROLES: dict[str, dict] = {
     },
     "synth_companion": {
         "species": "synthetic_humanoid",
-        "wardrobe": ["COTTON_TSHIRT", "BLUE_JEANS"],
+        "outfits": [
+            ["SYNTHWEAVE_SHEATH", "HEELED_BOOTS", "SYNTH_COLLAR"],
+            ["MESH_TOP", "SLIT_SKIRT", "HEELED_BOOTS", "CROPPED_JACKET"],
+            ["TANK_TOP", "LEATHER_TROUSERS", "HEELED_BOOTS", "LONG_COAT",
+             "SYNTH_COLLAR"],
+        ],
         "reaction": "flee", "armed": False, "reports": None,
         "ambient": [
             "catches a passerby's eye and holds it two heartbeats past casual.",
@@ -193,7 +199,8 @@ CIVILIAN_ROLES: dict[str, dict] = {
         },
     },
     "addict": {
-        "wardrobe": ["THERMAL_SHIRT", "BLUE_JEANS", "KNIT_CAP"],
+        "wardrobe": [["THERMAL_SHIRT", "FLANNEL_SHIRT", "TANK_TOP"],
+                     "BLUE_JEANS", ["KNIT_CAP", "HIGH_TOPS"]],
         "reaction": "flee", "armed": False, "reports": None,
         "ambient": [
             "pats through every pocket in an order worn smooth by habit.",
@@ -287,13 +294,30 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
     npc.db.role = role
     npc.tags.add(CIV_TAG, category=CIV_TAG_CATEGORY)
     npc.db.tokens = randint(*TOKEN_RANGE)
-    npc.db.llm_persona = dict(spec["persona"])
+    persona = dict(spec["persona"])
+    # Role registers (tone/explicitness directives) live OUT of the repo —
+    # a ServerConfig dict, set live, merged at spawn (the Sable pattern:
+    # content-sensitive direction never enters the codebase).
+    try:
+        from evennia.server.models import ServerConfig
+        registers = ServerConfig.objects.conf("LLM_ROLE_REGISTERS") or {}
+        if registers.get(role):
+            persona["register"] = registers[role]
+    except Exception:  # noqa: BLE001 — no conf, no register
+        pass
+    npc.db.llm_persona = persona
     npc.db.llm_driven = True
     npc.db.reaction = spec.get("reaction", "comply")
     npc.db.reports = spec.get("reports")
 
     # Wardrobe — spawned into inventory, worn through the real command.
-    for proto in spec["wardrobe"]:
+    # A role may define coherent "outfits" (one full look rolled per spawn)
+    # and/or a "wardrobe" whose entries are a prototype key OR a list of
+    # alternatives (pick one) — so a population mixes instead of cloning.
+    garments = list(choice(spec["outfits"])) if spec.get("outfits") else []
+    for entry in spec.get("wardrobe", []):
+        garments.append(choice(entry) if isinstance(entry, list) else entry)
+    for proto in garments:
         try:
             item = proto_spawn(proto)[0]
             item.move_to(npc, quiet=True)

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3632,3 +3632,276 @@ PIPE_WRENCH = {
     "weapon_type": "pipe_wrench",
     "damage_type": "blunt",
 }
+
+
+# ===================================================================
+# STREET FASHION + COMPANION LINE (style_configs give the nuance:
+# zip/unzip closures, rollup adjustments — same machinery as DEV_HOODIE)
+# ===================================================================
+
+SYNTHWEAVE_SHEATH = {
+    "prototype_key": "SYNTHWEAVE_SHEATH",
+    "key": "synthweave sheath dress",
+    "aliases": ["dress", "sheath"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A fitted sheath dress in liquid-black synthweave, cut to the knee with a side-zip from hip to hem. The fabric carries a faint pearlescent sheen and never wrinkles — engineered, like its usual wearers, to look effortless.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A liquid-{color}black|n synthweave sheath, fitted from shoulder to knee, its pearlescent sheen shifting as {they} move"),
+        ("coverage", ["chest", "back", "abdomen", "groin", "left_thigh", "right_thigh"]),
+        ("layer", 2),
+        ("color", "black"),
+        ("material", "synthweave"),
+        ("weight", 0.4),
+        ("style_configs", {
+            "closure": {
+                "zipped": {"coverage_mod": [], "desc_mod": ""},
+                "unzipped": {
+                    "coverage_mod": ["-left_thigh"],
+                    "desc_mod": "A liquid-{color}black|n synthweave sheath with the side-zip run open hip to hem, the slit baring one thigh with every stride",
+                },
+            },
+        }),
+        ("style_properties", {"closure": "zipped"}),
+    ],
+}
+
+MESH_TOP = {
+    "prototype_key": "MESH_TOP",
+    "key": "mesh top",
+    "aliases": ["mesh", "sheer top"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A long-sleeved top of fine industrial mesh, more suggestion than fabric. Colony street fashion at its most honest: it keeps off exactly nothing.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A fine {color}smoke|n-grey mesh top, more suggestion than fabric, skin reading through the weave"),
+        ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm"]),
+        ("layer", 1),
+        ("color", "smoke"),
+        ("material", "mesh"),
+        ("weight", 0.1),
+    ],
+}
+
+CROPPED_JACKET = {
+    "prototype_key": "CROPPED_JACKET",
+    "key": "cropped jacket",
+    "aliases": ["crop jacket"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A cropped moto-cut jacket in dyed synth-leather, hem stopping at the ribs, with an off-center zip and a collar built to be worn up.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A cropped {color}oxblood|n synth-leather jacket ending at the ribs, collar up, zip catching the light"),
+        ("coverage", ["chest", "back", "left_arm", "right_arm"]),
+        ("layer", 3),
+        ("color", "oxblood"),
+        ("material", "synth-leather"),
+        ("weight", 0.9),
+        ("style_configs", {
+            "closure": {
+                "zipped": {
+                    "coverage_mod": [],
+                    "desc_mod": "A cropped {color}oxblood|n synth-leather jacket zipped to the throat, collar up like a closed door",
+                },
+                "unzipped": {
+                    "coverage_mod": ["-chest"],
+                    "desc_mod": "A cropped {color}oxblood|n synth-leather jacket hanging open off the shoulders, framing whatever's worn beneath",
+                },
+            },
+        }),
+        ("style_properties", {"closure": "unzipped"}),
+    ],
+}
+
+HEELED_BOOTS = {
+    "prototype_key": "HEELED_BOOTS",
+    "key": "heeled boots",
+    "aliases": ["heels"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Knee-high boots in polished synth-leather on a sculpted heel — high enough to announce every step on ferrocrete, stable enough to run in if the night turns.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "Knee-high {color}black|n heeled boots, polished to a street-lamp shine, announcing every step"),
+        ("coverage", ["left_foot", "right_foot", "left_shin", "right_shin"]),
+        ("layer", 2),
+        ("color", "black"),
+        ("material", "synth-leather"),
+        ("weight", 1.0),
+    ],
+}
+
+SYNTH_COLLAR = {
+    "prototype_key": "SYNTH_COLLAR",
+    "key": "sleek collar",
+    "aliases": ["collar", "choker"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A slim collar of brushed alloy on a synthweave band, closed with a magnetic clasp. On some necks it's jewelry; on a synth's, it reads uncomfortably like a maker's mark.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A slim brushed-{color}silver|n collar at the throat, clasp winking with each turn of the head"),
+        ("coverage", ["neck"]),
+        ("layer", 1),
+        ("color", "silver"),
+        ("material", "alloy"),
+        ("weight", 0.1),
+    ],
+}
+
+LONG_COAT = {
+    "prototype_key": "LONG_COAT",
+    "key": "long coat",
+    "aliases": ["duster", "coat"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "An ankle-length coat in heavy stormcloth, collar wide enough to hide in, cut to move like weather. The colony's most democratic garment: everyone from companions to gun-hands wears one eventually.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "An ankle-length {color}charcoal|n stormcloth coat moving like low weather around {them}"),
+        ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm", "left_thigh", "right_thigh", "left_shin", "right_shin"]),
+        ("layer", 3),
+        ("color", "charcoal"),
+        ("material", "stormcloth"),
+        ("weight", 1.8),
+        ("style_configs", {
+            "closure": {
+                "zipped": {
+                    "coverage_mod": [],
+                    "desc_mod": "An ankle-length {color}charcoal|n stormcloth coat fastened to the collar, a moving column of weather",
+                },
+                "unzipped": {
+                    "coverage_mod": ["-chest", "-abdomen"],
+                    "desc_mod": "An ankle-length {color}charcoal|n stormcloth coat worn open, billowing back from whatever's underneath",
+                },
+            },
+        }),
+        ("style_properties", {"closure": "unzipped"}),
+    ],
+}
+
+BOMBER_JACKET = {
+    "prototype_key": "BOMBER_JACKET",
+    "key": "bomber jacket",
+    "aliases": ["bomber"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A nylon bomber with ribbed cuffs and a two-way zip, the shoulders patched with the ghost-stitching of insignia long since cut off.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A {color}forest|n-green nylon bomber, cuffs ribbed tight, ghost-stitching where patches used to live"),
+        ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm"]),
+        ("layer", 3),
+        ("color", "forest"),
+        ("material", "nylon"),
+        ("weight", 0.8),
+        ("style_configs", {
+            "closure": {
+                "zipped": {"coverage_mod": [], "desc_mod": ""},
+                "unzipped": {
+                    "coverage_mod": ["-chest"],
+                    "desc_mod": "A {color}forest|n-green nylon bomber hanging open, ribbed hem swinging loose",
+                },
+            },
+        }),
+        ("style_properties", {"closure": "zipped"}),
+    ],
+}
+
+FLANNEL_SHIRT = {
+    "prototype_key": "FLANNEL_SHIRT",
+    "key": "flannel shirt",
+    "aliases": ["flannel"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A brushed-flannel work shirt in a red-black check, buttons mismatched from a decade of replacements. Sleeves made to be rolled.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A {color}red|n-black check flannel, soft with wear, buttons mismatched down the front"),
+        ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm"]),
+        ("layer", 2),
+        ("color", "red"),
+        ("material", "flannel"),
+        ("weight", 0.6),
+        ("style_configs", {
+            "adjustable": {
+                "normal": {"coverage_mod": [], "desc_mod": ""},
+                "rolled": {
+                    "coverage_mod": [],
+                    "desc_mod": "A {color}red|n-black check flannel with the sleeves rolled past the elbow, forearms bare for work",
+                },
+            },
+            "closure": {
+                "zipped": {"coverage_mod": [], "desc_mod": ""},
+                "unzipped": {
+                    "coverage_mod": ["-chest", "-abdomen"],
+                    "desc_mod": "A {color}red|n-black check flannel worn open over whatever's beneath, tails loose",
+                },
+            },
+        }),
+        ("style_properties", {"adjustable": "normal", "closure": "zipped"}),
+    ],
+}
+
+TANK_TOP = {
+    "prototype_key": "TANK_TOP",
+    "key": "ribbed tank top",
+    "aliases": ["tank", "tank top"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A ribbed cotton tank in colony white — which is to say, grey. Cut close, holds its shape, asks nothing.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A ribbed {color}grey|n-white tank cut close to the body, shoulders bare"),
+        ("coverage", ["chest", "back", "abdomen"]),
+        ("layer", 1),
+        ("color", "grey"),
+        ("material", "cotton"),
+        ("weight", 0.2),
+    ],
+}
+
+SLIT_SKIRT = {
+    "prototype_key": "SLIT_SKIRT",
+    "key": "slit skirt",
+    "aliases": ["skirt"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A long bias-cut skirt in matte synthetic, slit high on one side. Moves like smoke; stops traffic like a wall.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "A long matte-{color}black|n skirt slit high up one side, baring a stripe of thigh with each step"),
+        ("coverage", ["groin", "right_thigh", "left_shin", "right_shin"]),
+        ("layer", 2),
+        ("color", "black"),
+        ("material", "synthetic"),
+        ("weight", 0.4),
+    ],
+}
+
+LEATHER_TROUSERS = {
+    "prototype_key": "LEATHER_TROUSERS",
+    "key": "leather trousers",
+    "aliases": ["leathers"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Close-cut trousers in matte synth-leather, seams double-stitched, knees pre-scuffed by the factory or the street — impossible to say which.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "Close-cut matte-{color}black|n synth-leather trousers, catching light along the seams"),
+        ("coverage", ["groin", "left_thigh", "right_thigh", "left_shin", "right_shin"]),
+        ("layer", 2),
+        ("color", "black"),
+        ("material", "synth-leather"),
+        ("weight", 0.9),
+    ],
+}
+
+HIGH_TOPS = {
+    "prototype_key": "HIGH_TOPS",
+    "key": "high-top sneakers",
+    "aliases": ["sneakers", "high-tops", "hightops"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Canvas high-tops re-soled at least once, laces replaced with paracord. Street standard: quiet, quick, and dry enough.",
+    "attrs": [
+        ("category", "clothing"),
+        ("worn_desc", "Scuffed {color}white|n canvas high-tops laced with paracord"),
+        ("coverage", ["left_foot", "right_foot"]),
+        ("layer", 2),
+        ("color", "white"),
+        ("material", "canvas"),
+        ("weight", 0.6),
+    ],
+}

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -27,7 +27,7 @@ class _Room:
 class TestRoles(TestCase):
     def test_every_role_is_complete(self):
         for role, spec in CIVILIAN_ROLES.items():
-            self.assertTrue(spec["wardrobe"], role)
+            self.assertTrue(spec.get("wardrobe") or spec.get("outfits"), role)
             self.assertGreaterEqual(len(spec["ambient"]), 3, role)
             self.assertIn(spec["reaction"], ("comply", "flee", "resist"), role)
             self.assertIn("armed", spec, role)
@@ -67,14 +67,61 @@ class TestRoles(TestCase):
         self.assertIn("colonist", ARCHETYPES)
         self.assertEqual(ARCHETYPES["colonist"]["tools"], ["release"])
 
+    def _all_garments(self, spec):
+        out = []
+        for entry in spec.get("wardrobe", []):
+            out.extend(entry if isinstance(entry, list) else [entry])
+        for outfit in spec.get("outfits", []):
+            out.extend(outfit)
+        return out
+
     def test_no_disguise_items_in_wardrobes(self):
         # Essential disguise items would scramble civilian apparent_uids
         # (witness/BOLO identity must stay stable).
         for role, spec in CIVILIAN_ROLES.items():
-            for proto in spec["wardrobe"]:
+            for proto in self._all_garments(spec):
                 self.assertNotIn("MASK", proto, role)
                 self.assertNotIn("HOOD_UP", proto, role)
                 self.assertNotIn("WIG", proto, role)
+
+    def test_all_garments_reference_real_prototypes(self):
+        from world import prototypes as protos
+        for role, spec in CIVILIAN_ROLES.items():
+            for key in self._all_garments(spec):
+                self.assertTrue(hasattr(protos, key), f"{role}: {key}")
+
+    def test_companion_outfits_are_coherent_looks(self):
+        outfits = CIVILIAN_ROLES["synth_companion"]["outfits"]
+        self.assertGreaterEqual(len(outfits), 3)
+        for outfit in outfits:
+            self.assertIn("HEELED_BOOTS", outfit)   # every look walks
+
+    def test_register_merged_from_serverconfig(self):
+        from unittest.mock import patch as _patch
+        import world.director.civilians as _c
+        with _patch("evennia.server.models.ServerConfig") as mock_sc, \
+             _patch("evennia.create_object") as mock_create, \
+             _patch("evennia.prototypes.spawner.spawn") as mock_spawn, \
+             _patch("world.mob_flavor.apply_random_flavor"), \
+             _patch("world.anatomy.get_species_default_longdesc_locations",
+                    return_value={}), \
+             _patch("world.medical.core.MedicalState"), \
+             _patch("world.spatial.rooms_within", return_value=[]), \
+             _patch("world.spatial.is_reachable", return_value=True):
+            mock_sc.objects.conf.return_value = {
+                "synth_companion": "EXPLICIT-DIRECTIVE-SENTINEL"}
+            garment = MagicMock(); garment.key = "dress"
+            mock_spawn.return_value = [garment]
+            npc = MagicMock(); npc.db = SimpleNamespace()
+            mock_create.return_value = npc
+            _c.spawn_civilian("synth_companion", _Room("alley"))
+            self.assertEqual(npc.db.llm_persona["register"],
+                             "EXPLICIT-DIRECTIVE-SENTINEL")
+            # roles WITHOUT a configured register stay clean
+            npc2 = MagicMock(); npc2.db = SimpleNamespace()
+            mock_create.return_value = npc2
+            _c.spawn_civilian("miner", _Room("street"))
+            self.assertNotIn("register", npc2.db.llm_persona)
 
     def test_ambient_beat_by_role(self):
         npc = SimpleNamespace(db=SimpleNamespace(role="miner"))


### PR DESCRIPTION
- 12 clothing prototypes: the companion line (synthweave sheath with
  side-zip closure states, mesh top, cropped jacket zip/unzip, heeled
  boots, sleek collar, long coat open/closed) and street staples (bomber
  zip/unzip, flannel with rollup+closure, ribbed tank, slit skirt,
  leather trousers, high-tops). Five carry style_configs nuance per the
  DEV_HOODIE pattern (zip/unzip, rollup, coverage mods).
- Outfit support in spawn_civilian: a role may define coherent "outfits"
  (one full look rolled per spawn — companions get three) and wardrobe
  entries may be alternatives-lists (ganger jeans/leathers + boots/
  high-tops; addict thermal/flannel/tank) so a population mixes instead
  of cloning.
- Out-of-repo role registers: spawn merges ServerConfig
  LLM_ROLE_REGISTERS[role] into persona["register"] — the Sable/Bliss
  pattern; tone/explicitness directives never enter the codebase. The
  companion's register is set live from Bliss's existing text.
- Tests: garment integrity across nested entries/outfits, coherent-look
  check, register merge + non-leak for unconfigured roles. 24 green.

Closes #932

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
