### PR TITLE
Workwear style_configs retrofit (zip/rollup nuance for the plain 15)

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3316,6 +3316,23 @@ WORK_COVERALLS = {
         ("color", "grey"),
         ("material", "twill"),
         ("weight", 1.4),
+        ("style_configs", {
+            "adjustable": {
+                "normal": {"coverage_mod": [], "desc_mod": ""},
+                "rolled": {
+                    "coverage_mod": ["-left_arm", "-right_arm"],
+                    "desc_mod": "Heavy {color}grey|n twill coveralls with the sleeves rolled past the elbow, forearms bare for the work",
+                },
+            },
+            "closure": {
+                "zipped": {"coverage_mod": [], "desc_mod": ""},
+                "unzipped": {
+                    "coverage_mod": ["-chest"],
+                    "desc_mod": "Heavy {color}grey|n twill coveralls unzipped to the sternum, hanging open over whatever's beneath",
+                },
+            },
+        }),
+        ("style_properties", {"adjustable": "normal", "closure": "zipped"}),
     ],
 }
 
@@ -3401,6 +3418,16 @@ DUST_PONCHO = {
         ("color", "olive"),
         ("material", "canvas"),
         ("weight", 1.1),
+        ("style_configs", {
+            "closure": {
+                "zipped": {
+                    "coverage_mod": [],
+                    "desc_mod": "A waxed {color}olive|n canvas poncho snapped shut down both sides, a weatherproof tent of a garment",
+                },
+                "unzipped": {"coverage_mod": [], "desc_mod": ""},
+            },
+        }),
+        ("style_properties", {"closure": "unzipped"}),
     ],
 }
 
@@ -3435,6 +3462,16 @@ COMPANY_WINDBREAKER = {
         ("color", "blue"),
         ("material", "nylon"),
         ("weight", 0.5),
+        ("style_configs", {
+            "closure": {
+                "zipped": {"coverage_mod": [], "desc_mod": ""},
+                "unzipped": {
+                    "coverage_mod": ["-chest"],
+                    "desc_mod": "A corporate-{color}blue|n windbreaker hanging open, the logo\'d panel flapping with each step",
+                },
+            },
+        }),
+        ("style_properties", {"closure": "zipped"}),
     ],
 }
 
@@ -3446,12 +3483,22 @@ THERMAL_SHIRT = {
     "desc": "A long-sleeved thermal in waffle-knit cotton, collar stretched from being pulled on in the dark. The colony runs cold underground and colder above.",
     "attrs": [
         ("category", "clothing"),
-        ("worn_desc", "A waffle-knit {color}charcoal|n thermal, sleeves pushed to the elbow, collar gone soft"),
+        ("worn_desc", "A waffle-knit {color}charcoal|n thermal, collar gone soft with years of pulling on"),
         ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm"]),
         ("layer", 1),
         ("color", "charcoal"),
         ("material", "cotton"),
         ("weight", 0.5),
+        ("style_configs", {
+            "adjustable": {
+                "normal": {"coverage_mod": [], "desc_mod": ""},
+                "rolled": {
+                    "coverage_mod": [],
+                    "desc_mod": "A waffle-knit {color}charcoal|n thermal with the sleeves pushed past the elbow, collar gone soft",
+                },
+            },
+        }),
+        ("style_properties", {"adjustable": "normal"}),
     ],
 }
 
@@ -3554,6 +3601,16 @@ COMPANY_COAT = {
         ("color", "charcoal"),
         ("material", "wool"),
         ("weight", 1.2),
+        ("style_configs", {
+            "closure": {
+                "zipped": {"coverage_mod": [], "desc_mod": ""},
+                "unzipped": {
+                    "coverage_mod": ["-chest", "-abdomen"],
+                    "desc_mod": "A pressed {color}charcoal|n company coat worn open off the shoulders, authority at ease",
+                },
+            },
+        }),
+        ("style_properties", {"closure": "zipped"}),
     ],
 }
 


### PR DESCRIPTION
The fashion line shipped with style nuance but the workwear 15 were
authored plain — including physical absurdities: coveralls describing a
collar-to-crotch zip with no zip states, the poncho's worn_desc reading
"side-snaps half done" with no way to do them up, the thermal baking
"sleeves pushed to the elbow" into its base desc instead of a rollable
state. Retrofits where physically sensible:

- WORK_COVERALLS: closure (unzipped to the sternum, -chest) + adjustable
  (sleeves rolled, -arms)
- COMPANY_WINDBREAKER: closure
- COMPANY_COAT: closure ("authority at ease")
- THERMAL_SHIRT: adjustable roll (base desc un-baked)
- DUST_PONCHO: closure (snapped shut / hanging wide)

Deliberately skipped: the rebreather's face-pull (disguise-system
territory — stays neck-slung by design) and sleeveless/rigid items (cut,
hi-vis, helmet, harness, boots, gloves).

Closes #936

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
