### PR TITLE
Fix: synth longdescs wiped at spawn; sex-keyed companion outfits

### DIFF
--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -170,12 +170,22 @@ CIVILIAN_ROLES: dict[str, dict] = {
     },
     "synth_companion": {
         "species": "synthetic_humanoid",
-        "outfits": [
-            ["SYNTHWEAVE_SHEATH", "HEELED_BOOTS", "SYNTH_COLLAR"],
-            ["MESH_TOP", "SLIT_SKIRT", "HEELED_BOOTS", "CROPPED_JACKET"],
-            ["TANK_TOP", "LEATHER_TROUSERS", "HEELED_BOOTS", "LONG_COAT",
-             "SYNTH_COLLAR"],
-        ],
+        "outfits": {
+            "female": [
+                ["SYNTHWEAVE_SHEATH", "HEELED_BOOTS", "SYNTH_COLLAR"],
+                ["MESH_TOP", "SLIT_SKIRT", "HEELED_BOOTS", "CROPPED_JACKET"],
+                ["TANK_TOP", "LEATHER_TROUSERS", "HEELED_BOOTS", "LONG_COAT",
+                 "SYNTH_COLLAR"],
+            ],
+            "male": [
+                ["MESH_TOP", "LEATHER_TROUSERS", "COMBAT_BOOTS",
+                 "SYNTH_COLLAR"],
+                ["TANK_TOP", "LEATHER_TROUSERS", "HIGH_TOPS",
+                 "CROPPED_JACKET", "SYNTH_COLLAR"],
+                ["TANK_TOP", "BLUE_JEANS", "LONG_COAT", "HIGH_TOPS",
+                 "SYNTH_COLLAR"],
+            ],
+        },
         "reaction": "flee", "armed": False, "reports": None,
         "ambient": [
             "catches a passerby's eye and holds it two heartbeats past casual.",
@@ -298,9 +308,7 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
     npc.resonance = _randint(1, 3)
     npc.intellect = _randint(1, 3)
     npc.motorics = _randint(1, 3)
-    apply_random_flavor(npc)   # sdesc + @longdescs + look_place
-
-    # Species: synth roles get the synthetic anatomy (mirrors @spawnmob's
+    # Species FIRST: synth roles get the synthetic anatomy (mirrors @spawnmob's
     # generic non-human path — species, longdesc seed, medical re-init).
     species = spec.get("species")
     if species:
@@ -310,6 +318,8 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
         npc.longdesc = get_species_default_longdesc_locations(species)
         npc._medical_state = MedicalState(npc)
         npc.db.medical_state = npc._medical_state.to_dict()
+
+    apply_random_flavor(npc)   # AFTER species — sdesc + @longdescs + look_place
 
     # Role, management tag, pockets, LLM persona, reaction posture.
     npc.db.is_npc = True   # the canonical NPC marker (absence = PC)
@@ -336,7 +346,11 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
     # A role may define coherent "outfits" (one full look rolled per spawn)
     # and/or a "wardrobe" whose entries are a prototype key OR a list of
     # alternatives (pick one) — so a population mixes instead of cloning.
-    garments = list(choice(spec["outfits"])) if spec.get("outfits") else []
+    outfits = spec.get("outfits")
+    if isinstance(outfits, dict):
+        # sex-keyed looks (ambiguous falls back to any pool)
+        outfits = outfits.get(sex) or next(iter(outfits.values()))
+    garments = list(choice(outfits)) if outfits else []
     for entry in spec.get("wardrobe", []):
         garments.append(choice(entry) if isinstance(entry, list) else entry)
     for proto in garments:

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -71,7 +71,10 @@ class TestRoles(TestCase):
         out = []
         for entry in spec.get("wardrobe", []):
             out.extend(entry if isinstance(entry, list) else [entry])
-        for outfit in spec.get("outfits", []):
+        outfits = spec.get("outfits") or []
+        if isinstance(outfits, dict):
+            outfits = [o for pool in outfits.values() for o in pool]
+        for outfit in outfits:
             out.extend(outfit)
         return out
 
@@ -90,11 +93,27 @@ class TestRoles(TestCase):
             for key in self._all_garments(spec):
                 self.assertTrue(hasattr(protos, key), f"{role}: {key}")
 
-    def test_companion_outfits_are_coherent_looks(self):
+    def test_companion_outfits_are_sex_keyed_and_shod(self):
         outfits = CIVILIAN_ROLES["synth_companion"]["outfits"]
-        self.assertGreaterEqual(len(outfits), 3)
-        for outfit in outfits:
-            self.assertIn("HEELED_BOOTS", outfit)   # every look walks
+        self.assertIn("female", outfits)
+        self.assertIn("male", outfits)
+        footwear = {"HEELED_BOOTS", "COMBAT_BOOTS", "HIGH_TOPS"}
+        for sex, pool in outfits.items():
+            self.assertGreaterEqual(len(pool), 3, sex)
+            for outfit in pool:
+                self.assertTrue(footwear & set(outfit), f"{sex}: {outfit}")
+        # dresses/skirts stay out of the male pool
+        male_garments = {g for o in outfits["male"] for g in o}
+        self.assertFalse({"SYNTHWEAVE_SHEATH", "SLIT_SKIRT"} & male_garments)
+
+    def test_synth_longdescs_survive_spawn_order(self):
+        # Live bug: the species longdesc re-seed ran AFTER the flavor pass
+        # and wiped all authored prose. Pin the order in the source.
+        import inspect
+        from world.director import civilians as _c
+        source = inspect.getsource(_c.spawn_civilian)
+        self.assertLess(source.index("get_species_default_longdesc_locations"),
+                        source.index("apply_random_flavor(npc)"))
 
     def test_register_merged_from_serverconfig(self):
         from unittest.mock import patch as _patch


### PR DESCRIPTION
1. Synth civilians spawned with 0/22 longdescs (humans had 22/22): the
   species block re-seeds npc.longdesc with the empty species-default
   map and ran AFTER apply_random_flavor, wiping the authored prose.
   Species surfaces now seed FIRST; a source-order test pins it.
2. Companion outfits are sex-keyed: female keeps the three existing
   looks; male gets three of its own (mesh+leathers+combat boots,
   tank+leathers+cropped jacket, tank+jeans+long coat) — the collar on
   every look either way; ambiguous falls back to the first pool.
   Dresses/skirts pinned out of the male pool by test.

Closes #940

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
