### PR TITLE
Full synth flavor tables: passes for human — if you know, you know

### DIFF
--- a/world/mob_flavor/__init__.py
+++ b/world/mob_flavor/__init__.py
@@ -35,12 +35,15 @@ from world.anatomy import get_species_pair_keys
 from world.mob_flavor.longdescs import LONGDESCS
 from world.mob_flavor.longdescs_rat import LONGDESCS_RAT
 from world.mob_flavor.longdescs_robot import LONGDESCS_ROBOT
+from world.mob_flavor.longdescs_synth import LONGDESCS_SYNTH
 from world.mob_flavor.look_places import LOOK_PLACES
 from world.mob_flavor.look_places_rat import LOOK_PLACES_RAT
 from world.mob_flavor.look_places_robot import LOOK_PLACES_ROBOT
+from world.mob_flavor.look_places_synth import LOOK_PLACES_SYNTH
 from world.mob_flavor.short_descs import SHORT_DESCS
 from world.mob_flavor.short_descs_rat import SHORT_DESCS_RAT
 from world.mob_flavor.short_descs_robot import SHORT_DESCS_ROBOT
+from world.mob_flavor.short_descs_synth import SHORT_DESCS_SYNTH
 
 
 # Species → data-table mappings. New species: add an entry per axis.
@@ -48,18 +51,21 @@ _SHORT_DESCS_BY_SPECIES: dict[str, list[str]] = {
     "human": SHORT_DESCS,
     "rat":   SHORT_DESCS_RAT,
     "robot": SHORT_DESCS_ROBOT,
+    "synthetic_humanoid": SHORT_DESCS_SYNTH,
 }
 
 _LOOK_PLACES_BY_SPECIES: dict[str, list[str]] = {
     "human": LOOK_PLACES,
     "rat":   LOOK_PLACES_RAT,
     "robot": LOOK_PLACES_ROBOT,
+    "synthetic_humanoid": LOOK_PLACES_SYNTH,
 }
 
 _LONGDESCS_BY_SPECIES: dict[str, dict[str, list[str]]] = {
     "human": LONGDESCS,
     "rat":   LONGDESCS_RAT,
     "robot": LONGDESCS_ROBOT,
+    "synthetic_humanoid": LONGDESCS_SYNTH,
 }
 
 

--- a/world/mob_flavor/longdescs_synth.py
+++ b/world/mob_flavor/longdescs_synth.py
@@ -1,0 +1,106 @@
+"""Longdesc templates for spawned synthetic humanoids.
+
+Per-location prose seeded into ``mob.longdesc[location]``, humanoid slot
+set (synths share human anatomy). The register throughout: **passes for
+human — but if you know, you know.** Every line reads as a person first;
+the tell is in the finish. Companion-grade engineering is present but
+kept in the same key as the rest of the game's body prose.
+
+Same token conventions as the human module: pair-keyed nouns braced
+(``{eyes}``/``{arms}``…) with braced verbs; singular slots use pronoun
+tokens.
+"""
+
+from __future__ import annotations
+
+LONGDESCS_SYNTH: dict[str, list[str]] = {
+    "hair": [
+        "{Their} hair falls with a rooted, even density no scalp grows on its own — beautiful, and beautiful identically every day.",
+        "{Their} hair carries a uniform lustre from root to tip, as if each strand were drawn to spec.",
+        "{Their} hairline is flawless in the way only deliberate design manages — no cowlick, no drift, no history.",
+        "{Their} hair never quite tangles; it falls back into its intended shape the moment the wind lets go.",
+        "{Their} hair has the weight and swing of the real thing, and a part so clean it looks ruled.",
+    ],
+    "head": [
+        "{Their} skull sits in perfect proportion to the frame — the golden-mean geometry no one is actually born with.",
+        "The set of {their} head is level to the degree; it turns smoothly and stops without the little human overshoot.",
+        "{Their} head carries no asymmetries to memorize — the kind of face-shape that's hard to describe to security.",
+        "There's a poise to {their} head, always balanced, never quite hanging tired on the neck.",
+    ],
+    "face": [
+        "{Their} face is symmetrical past the point where symmetry flatters — mirror-halves that agree completely.",
+        "{Their} expressions arrive fully formed and leave the same way, with none of the small weather between.",
+        "{Their} skin is smooth at a distance and smoother up close, where pores should start winning the argument.",
+        "{Their} face does warmth beautifully — a half-beat after whatever should have caused it.",
+        "In direct light {their} face has a finish rather than a texture, matte and even as good casting.",
+        "{Their} smile is excellent — practiced to the exact width that reads as genuine, and held one moment past it.",
+    ],
+    "neck": [
+        "{Their} neck is smooth-columned and unlined, the skin showing no pulse until you look for one — and then, obligingly, there it is.",
+        "The tendons of {their} neck surface only when needed, like features called up from memory.",
+        "{Their} throat moves in a swallow now and then, evenly spaced, a habit kept for company.",
+        "Under the jaw, where a razor would nick anyone else, {their} skin runs unbroken and faintly seamless.",
+    ],
+    "chest": [
+        "{Their} chest rises and falls in perfect, unlabored time — breath as a courtesy rather than a need.",
+        "{Their} chest is sculpted to the anatomy charts' best day, warm to the eye and engineered to the touch.",
+        "The skin of {their} chest is even-toned everywhere, unfreckled, unscarred, unweathered — a history of nothing.",
+        "{Their} heartbeat is there if you press for it: steady, unhurried, and precisely as expected.",
+    ],
+    "back": [
+        "{Their} back is a clean map of muscle laid exactly where the textbook wants it, no side favored.",
+        "{Their} spine draws one true line — none of the lean and list a body earns by carrying things badly.",
+        "The skin of {their} back is unmarked from shoulder to waist, as if nothing had ever happened to it. Nothing has.",
+    ],
+    "abdomen": [
+        "{Their} abdomen is even and smooth, the navel present, correct, and — if you're the type to notice — purely ornamental.",
+        "{Their} midsection carries the taut economy of a body that has never overeaten, gone hungry, or aged.",
+        "The muscle of {their} stomach shows in a soft, symmetric relief, less earned than specified.",
+    ],
+    "groin": [
+        "{Their} hips move with an easy, level roll, engineered where a person is merely built.",
+        "{They} {are} complete, anatomically fluent, and — to the knowing eye — finished to companion-grade tolerances.",
+        "Everything about {their} lower body reads fully human; the difference is that it was decided, not inherited.",
+        "{Their} proportions through the hips are the deliberate kind — designed for compatibility, not chance.",
+    ],
+    "eyes": [
+        "{Their} {eyes} {are} beautifully made — the irises patterned a shade too regularly, like guilloché under glass.",
+        "{Their} {eyes} {adjust} to the light in one smooth sweep, none of the flutter of a living pupil finding its level.",
+        "{Their} {eyes} {hold} contact without effort or challenge, and blink on a schedule that is almost right.",
+        "{Their} {eyes} {catch} the light with a wet brightness that never needs to blink it away.",
+        "{Their} {eyes} {track} movement in clean arcs, arriving exactly on target with nothing to correct.",
+    ],
+    "ears": [
+        "{Their} {ears} {are} a matched pair to the millimetre — the one symmetry no human face ever gets.",
+        "{Their} {ears} {sit} flush and identical, whorled like shells from the same mold. They were.",
+        "{Their} {ears} {are} finely made and faintly translucent at the rim, without the asymmetries of grown cartilage.",
+    ],
+    "arms": [
+        "{Their} {arms} {carry} smooth, deliberate muscle that never trembles at the end of a long hold.",
+        "{Their} {arms} {hang} in perfect repose when idle — no drum of fingers, no restless shift.",
+        "{Their} {arms} {are} unblemished from shoulder to wrist: no vaccination ghost, no scar, no story.",
+        "{Their} {arms} {move} with an economy that spends nothing on the way to what they're doing.",
+    ],
+    "hands": [
+        "{Their} {hands} {are} elegant and exact, the nails uniform as a set of samples.",
+        "{Their} {hands} {rest} utterly still when unoccupied — no idle rubbing, no fidget, no habit.",
+        "{Their} {hands} {are} warm, dry, and steady, with fingerprints — fine, regular ones, drawn rather than grown.",
+        "{Their} {hands} {handle} things with a calibrated gentleness, pressure metered to the object.",
+        "The knuckles of {their} {hands} {are} smooth and unscarred, hands that have touched much and hit nothing.",
+    ],
+    "thighs": [
+        "{Their} {thighs} {carry} long, even muscle laid to specification, matched left to right.",
+        "{Their} {thighs} {move} with a level, unhurried power that never seems to tire of standing.",
+        "The skin of {their} {thighs} {is} smooth and uniform, unmarked by the ordinary friction of a life.",
+    ],
+    "shins": [
+        "{Their} {shins} {are} straight-boned and unscuffed — no childhood ever barked them on anything.",
+        "{Their} {shins} {taper} cleanly to the ankle, symmetric as lathework.",
+        "{Their} {shins} {carry} a fine, even down of hair, distributed a touch too evenly.",
+    ],
+    "feet": [
+        "{Their} {feet} {are} well-formed and uncalloused, arches out of a textbook, toes in descending order like a demonstration.",
+        "{Their} {feet} {plant} squarely with each step, wearing shoes evenly where a person wears them down on one side.",
+        "{Their} {feet} {are} smooth-soled and unhurried, feet that have walked far and suffered none of it.",
+    ],
+}

--- a/world/mob_flavor/look_places_synth.py
+++ b/world/mob_flavor/look_places_synth.py
@@ -1,0 +1,22 @@
+"""Look-place fragments for spawned synthetic humanoids.
+
+Rendered as ``<Name> is <look_place>``. Human-plausible postures with the
+synth's economy underneath — nothing wasted, nothing restless.
+"""
+
+from __future__ import annotations
+
+LOOK_PLACES_SYNTH: list[str] = [
+    "standing with perfect, unhurried stillness, spending nothing between moments.",
+    "waiting with the patience of something that has never once been bored.",
+    "watching the street with even, unblinking attention that resets just often enough.",
+    "leaning against the wall at an angle a sculptor would have chosen.",
+    "turning to follow a passerby with one smooth, complete motion.",
+    "standing where the light is best, possibly by accident.",
+    "at rest with both hands perfectly still at their sides.",
+    "tilting their head at a listening angle held a beat too long.",
+    "smoothing their clothes with slow, exact, untroubled care.",
+    "breathing evenly, visibly, like a habit kept up for company.",
+    "studying their own reflection in a dark window without vanity or surprise.",
+    "standing just far enough from the crowd to be seen choosing to.",
+]

--- a/world/mob_flavor/short_descs_synth.py
+++ b/world/mob_flavor/short_descs_synth.py
@@ -1,0 +1,25 @@
+"""Short-description templates for spawned synthetic humanoids.
+
+The register: a synth passes for human at a glance — the prose reads as a
+person first, with one detail running a half-degree off true. If you
+know, you know. Same token conventions as the human module.
+"""
+
+from __future__ import annotations
+
+SHORT_DESCS_SYNTH: list[str] = [
+    "{They} {are} put together a shade too well — symmetry that no childhood ever knocked crooked.",
+    "There is a stillness to {them} between movements, as if the body simply stops spending until it's needed again.",
+    "{Their} skin takes the light evenly everywhere, poreless as fresh casting where a person would show weather.",
+    "{They} {move} without the small corrections — no shift of weight, no idle sway, every motion arriving finished.",
+    "Something in {their} posture never tires: the shoulders sit at the same easy angle no matter how long you watch.",
+    "{They} {blink} exactly as often as one should, which is somehow the tell.",
+    "Up close, {their} warmth reads a degree deliberate — the temperature of a hand you were meant to hold.",
+    "{Their} face does everything a face should, a beat behind the feeling or a beat ahead of it.",
+    "{They} {have} the easy proportions of a figure drawn right the first time, unrevised by genetics or luck.",
+    "Nothing about {them} fidgets. The hands wait. The eyes rest. The breath keeps perfect, unhurried time.",
+    "{Their} beauty is the manufactured kind that forgot to include a single flaw to make it human — or left one out on purpose.",
+    "At conversational distance {they} {pass} completely; it's at the third glance that the finish shows.",
+    "{They} {carry} {themselves} like something built to be looked at and engineered to be worth it.",
+    "{Their} breathing is a courtesy — even, silent, and never once out of rhythm.",
+]

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -402,3 +402,40 @@ class TestClothingStyles(TestCase):
         npc.execute_cmd.assert_not_called()   # junk verbs never execute
         LLMNpcMixin._handle_action_tool(npc, "style", "unzip", None)
         npc.execute_cmd.assert_not_called()   # verb without garment
+
+
+class TestSynthFlavor(TestCase):
+    """Full synth flavor tables: passes for human, but if you know you know."""
+
+    def test_registered_in_all_axes(self):
+        from world.mob_flavor import (_LONGDESCS_BY_SPECIES,
+                                      _LOOK_PLACES_BY_SPECIES,
+                                      _SHORT_DESCS_BY_SPECIES)
+        for table in (_LONGDESCS_BY_SPECIES, _LOOK_PLACES_BY_SPECIES,
+                      _SHORT_DESCS_BY_SPECIES):
+            self.assertIn("synthetic_humanoid", table)
+
+    def test_full_humanoid_slot_coverage(self):
+        from world.mob_flavor.longdescs import LONGDESCS
+        from world.mob_flavor.longdescs_synth import LONGDESCS_SYNTH
+        self.assertEqual(set(LONGDESCS_SYNTH), set(LONGDESCS))
+        for slot, options in LONGDESCS_SYNTH.items():
+            self.assertGreaterEqual(len(options), 3, slot)
+
+    def test_pair_slots_use_braced_nouns(self):
+        from world.mob_flavor.longdescs_synth import LONGDESCS_SYNTH
+        for slot in ("eyes", "ears", "arms", "hands", "thighs", "shins",
+                     "feet"):
+            for line in LONGDESCS_SYNTH[slot]:
+                self.assertIn("{" + slot + "}", line, slot)
+
+    def test_register_is_uncanny_not_mechanical(self):
+        # Synths PASS — no robot vocabulary leaks into the prose.
+        from world.mob_flavor.longdescs_synth import LONGDESCS_SYNTH
+        from world.mob_flavor.short_descs_synth import SHORT_DESCS_SYNTH
+        joined = (str(LONGDESCS_SYNTH) + str(SHORT_DESCS_SYNTH)).lower()
+        for tell in ("symmetr", "poreless", "engineered"):
+            self.assertIn(tell, joined)
+        for robot_word in ("servo", "actuator", "chassis", "optics",
+                           "vocalizer"):
+            self.assertNotIn(robot_word, joined)


### PR DESCRIPTION
Option 3 per design call: complete synthetic_humanoid flavor set,
registered in all three axes.

- longdescs_synth.py: full 15-slot humanoid coverage (~60 entries).
  Every line reads as a person first; the tell is in the finish —
  mirror-half symmetry, poreless skin under direct light, pupils that
  adjust in one smooth sweep, blink schedules "almost right", unscarred
  skin ("a history of nothing"), breath kept as a courtesy.
  Companion-grade anatomical compatibility written into chest/groin/hips
  in the game's standard body-prose key (the explicit floor stays in the
  out-of-repo registers, as ever).
- short_descs_synth.py (14) + look_places_synth.py (12): the same
  uncanny economy ("waiting with the patience of something that has
  never once been bored").
- Tests: slot parity with the human table, braced pair-nouns, and a
  register guard — uncanny vocabulary required, robot vocabulary
  (servo/chassis/optics) banned. Synths PASS.

Synth civilians and @spawnmob/synth pick these up automatically
(species seeds before flavor as of #940).

Closes #942

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
