### PR TITLE
Synth chest/groin longdescs: sex-keyed, anatomically correct, alluring

### DIFF
--- a/world/mob_flavor/__init__.py
+++ b/world/mob_flavor/__init__.py
@@ -86,7 +86,7 @@ def random_look_place(species=None) -> str:
     return choice(table)
 
 
-def random_longdesc(slot: str, species=None) -> str | None:
+def random_longdesc(slot: str, species=None, sex=None) -> str | None:
     """Return a random longdesc template for ``slot``.
 
     ``slot`` is the data-side key — either a singular location (``"hair"``,
@@ -94,9 +94,19 @@ def random_longdesc(slot: str, species=None) -> str | None:
     for symmetric pairs. Returns ``None`` when no entries are seeded for
     this species — extended anatomy and any new locations fall into this
     case until flavor data is authored.
+
+    A slot's entries may be a flat list (unisex) or a **sex-keyed dict**
+    (``{"male": [...], "female": [...], "any": [...]}``) for anatomy where
+    gender-correct prose matters (chest, groin). Resolution: the mob's
+    sex → the ``"any"`` pool → all pools flattened (never empty-handed).
     """
     table = _LONGDESCS_BY_SPECIES[_resolve_species(species)]
     entries = table.get(slot)
+    if isinstance(entries, dict):
+        pool = entries.get(sex) or entries.get("any")
+        if not pool:
+            pool = [line for lines in entries.values() for line in lines]
+        entries = pool
     if not entries:
         return None
     return choice(entries)
@@ -137,7 +147,8 @@ def apply_random_flavor(mob) -> None:
         sides_present = [loc for loc in (left, right) if loc in available]
         if not sides_present:
             continue
-        entry = random_longdesc(pair_key, species)
+        entry = random_longdesc(pair_key, species,
+                                sex=getattr(mob, "sex", None))
         if entry is None:
             continue
         for side in sides_present:
@@ -147,6 +158,7 @@ def apply_random_flavor(mob) -> None:
     # Remaining (singular) locations — keyed in the species' longdesc
     # table by location name.
     for location in available - handled:
-        entry = random_longdesc(location, species)
+        entry = random_longdesc(location, species,
+                                sex=getattr(mob, "sex", None))
         if entry is not None:
             mob.set_longdesc(location, entry)

--- a/world/mob_flavor/longdescs_synth.py
+++ b/world/mob_flavor/longdescs_synth.py
@@ -41,12 +41,24 @@ LONGDESCS_SYNTH: dict[str, list[str]] = {
         "{Their} throat moves in a swallow now and then, evenly spaced, a habit kept for company.",
         "Under the jaw, where a razor would nick anyone else, {their} skin runs unbroken and faintly seamless.",
     ],
-    "chest": [
-        "{Their} chest rises and falls in perfect, unlabored time — breath as a courtesy rather than a need.",
-        "{Their} chest is sculpted to the anatomy charts' best day, warm to the eye and engineered to the touch.",
-        "The skin of {their} chest is even-toned everywhere, unfreckled, unscarred, unweathered — a history of nothing.",
-        "{Their} heartbeat is there if you press for it: steady, unhurried, and precisely as expected.",
-    ],
+    "chest": {
+        "female": [
+            "{Their} breasts are full and flawlessly matched, riding high with an engineered defiance of gravity, the skin smooth and even to the last inch.",
+            "{Their} breasts carry a soft, deliberate weight — shaped by intention rather than chance, and shaped well.",
+            "{Their} chest is a study in designed curves: breasts symmetrical to the millimetre, dark-tipped and unweathered, warm in a way that invites belief.",
+            "{Their} breasts rise and settle with each courteous breath, perfect in the way that makes a second look feel like the point.",
+        ],
+        "male": [
+            "{Their} chest is broad and cleanly muscled, pectorals cut to the anatomy charts' best day and finished smooth.",
+            "{Their} chest carries sculpted, even muscle beneath poreless skin — built the way sketches promise and bodies rarely deliver.",
+            "{Their} chest is warm, hard-planed, and utterly unscarred, a landscape of deliberate muscle with a heartbeat kept precisely where expected.",
+            "The lines of {their} chest descend in engineered relief, each muscle in agreement with the next — designed to be admired at close range.",
+        ],
+        "any": [
+            "{Their} chest rises and falls in perfect, unlabored time — breath as a courtesy rather than a need.",
+            "The skin of {their} chest is even-toned everywhere, unfreckled, unscarred, unweathered — a history of nothing.",
+        ],
+    },
     "back": [
         "{Their} back is a clean map of muscle laid exactly where the textbook wants it, no side favored.",
         "{Their} spine draws one true line — none of the lean and list a body earns by carrying things badly.",
@@ -57,12 +69,24 @@ LONGDESCS_SYNTH: dict[str, list[str]] = {
         "{Their} midsection carries the taut economy of a body that has never overeaten, gone hungry, or aged.",
         "The muscle of {their} stomach shows in a soft, symmetric relief, less earned than specified.",
     ],
-    "groin": [
-        "{Their} hips move with an easy, level roll, engineered where a person is merely built.",
-        "{They} {are} complete, anatomically fluent, and — to the knowing eye — finished to companion-grade tolerances.",
-        "Everything about {their} lower body reads fully human; the difference is that it was decided, not inherited.",
-        "{Their} proportions through the hips are the deliberate kind — designed for compatibility, not chance.",
-    ],
+    "groin": {
+        "female": [
+            "{Their} hips flare in a deliberate, generous curve, and what they frame is fully, warmly human in every way that matters — decided, not inherited, and decided well.",
+            "Between the smooth sweep of {their} hips, {they} {are} anatomically complete and companion-fluent — soft where softness persuades, and made to be discovered.",
+            "{Their} sex is as finished as the rest of the design: correct, inviting, and warm past the point where engineering usually stops.",
+            "{Their} lower body moves with a rolling, unhurried promise — hips built for the eye, and everything they carry built for more than that.",
+        ],
+        "male": [
+            "{Their} hips are lean and level, and {they} {are} generously, unambiguously male — anatomy specified rather than inherited, and specified with confidence.",
+            "{They} {are} complete and companion-fluent below the waist: correct in every particular, substantial by design, warm past where engineering usually stops.",
+            "The cut of {their} lower body draws the eye downward on purpose — deliberate lines converging on anatomy that was clearly nobody's afterthought.",
+            "{Their} sex is as considered as the rest of the build — fully human in form and function, sized to reassure, made to be found.",
+        ],
+        "any": [
+            "{Their} hips move with an easy, level roll, engineered where a person is merely built.",
+            "Everything about {their} lower body reads fully human; the difference is that it was decided, not inherited.",
+        ],
+    },
     "eyes": [
         "{Their} {eyes} {are} beautifully made — the irises patterned a shade too regularly, like guilloché under glass.",
         "{Their} {eyes} {adjust} to the light in one smooth sweep, none of the flutter of a living pupil finding its level.",

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -420,7 +420,35 @@ class TestSynthFlavor(TestCase):
         from world.mob_flavor.longdescs_synth import LONGDESCS_SYNTH
         self.assertEqual(set(LONGDESCS_SYNTH), set(LONGDESCS))
         for slot, options in LONGDESCS_SYNTH.items():
-            self.assertGreaterEqual(len(options), 3, slot)
+            if isinstance(options, dict):
+                for sex, pool in options.items():
+                    self.assertGreaterEqual(len(pool), 2, f"{slot}.{sex}")
+            else:
+                self.assertGreaterEqual(len(options), 3, slot)
+
+    def test_chest_groin_are_sex_keyed(self):
+        from world.mob_flavor.longdescs_synth import LONGDESCS_SYNTH
+        for slot in ("chest", "groin"):
+            entry = LONGDESCS_SYNTH[slot]
+            self.assertIsInstance(entry, dict, slot)
+            for sex in ("male", "female", "any"):
+                self.assertIn(sex, entry, slot)
+        # anatomically correct: female chest names breasts; male stays flat
+        female_chest = str(LONGDESCS_SYNTH["chest"]["female"]).lower()
+        male_chest = str(LONGDESCS_SYNTH["chest"]["male"]).lower()
+        self.assertIn("breast", female_chest)
+        self.assertNotIn("breast", male_chest)
+
+    def test_random_longdesc_resolves_sex_pools(self):
+        from world.mob_flavor import random_longdesc
+        from world.mob_flavor.longdescs_synth import LONGDESCS_SYNTH
+        line = random_longdesc("chest", "synthetic_humanoid", sex="female")
+        self.assertIn(line, LONGDESCS_SYNTH["chest"]["female"])
+        line = random_longdesc("chest", "synthetic_humanoid", sex="male")
+        self.assertIn(line, LONGDESCS_SYNTH["chest"]["male"])
+        # unknown sex falls to the any pool
+        line = random_longdesc("chest", "synthetic_humanoid", sex="ambiguous")
+        self.assertIn(line, LONGDESCS_SYNTH["chest"]["any"])
 
     def test_pair_slots_use_braced_nouns(self):
         from world.mob_flavor.longdescs_synth import LONGDESCS_SYNTH


### PR DESCRIPTION
Flavor infra gains sex-keyed slot entries: a longdesc slot may be a
{male/female/any} dict; random_longdesc resolves via the mob's sex ->
"any" -> all pools flattened, and apply_random_flavor passes the mob's
sex through. Pair slots unaffected.

Synth chest and groin rewritten per sex — anatomically correct (the
female chest names breasts; the male stays hard-planed — pinned by
test), alluring in the game's standard body-prose key, and "reasonable":
sensual suggestion lives in the repo, the explicit floor stays in the
out-of-repo registers. These lines render only when the location is
EXPOSED (the coverage system hides them under clothing), so the allure
is earned by the undressing. Companion-grade compatibility language kept
("companion-fluent", "decided, not inherited", "made to be found").

Closes #944

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
