### PR TITLE
Fix civilian clothing layer collisions and spawn wear order

### DIFF
--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -79,7 +79,7 @@ CIVILIAN_ROLES: dict[str, dict] = {
                      ["THERMAL_SHIRT", "FLANNEL_SHIRT", "TANK_TOP"],
                      ["CARGO_TROUSERS", "LEATHER_TROUSERS", "BLUE_JEANS"],
                      ["PIT_BOOTS", "HIGH_TOPS", "COMBAT_BOOTS"],
-                     ["KNIT_CAP", "DUST_PONCHO"]],
+                     ["KNIT_CAP", "MINING_HELMET"]],
         "reaction": "flee", "armed": True, "reports": None,
         "weapon_pool": ["BOX_CUTTER", "SHIV", "CROWBAR", "PIPE_WRENCH"],
         "ambient": [
@@ -353,13 +353,23 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
     garments = list(choice(outfits)) if outfits else []
     for entry in spec.get("wardrobe", []):
         garments.append(choice(entry) if isinstance(entry, list) else entry)
+    # Spawn everything first, then wear inner-to-outer (ascending layer):
+    # the clothing system refuses an inner layer over an outer one, so a
+    # role listing its identity piece first (cut, apron, harness) was
+    # silently stripping the tops worn after it.
+    items = []
     for proto in garments:
         try:
             item = proto_spawn(proto)[0]
             item.move_to(npc, quiet=True)
+            items.append(item)
+        except Exception:  # noqa: BLE001 — a missing garment isn't fatal
+            continue
+    for item in sorted(items, key=lambda i: getattr(i, "layer", 2)):
+        try:
             npc.execute_cmd(f"wear {item.key}")
             _randomize_styles(npc, item)
-        except Exception:  # noqa: BLE001 — a missing garment isn't fatal
+        except Exception:  # noqa: BLE001
             continue
 
     # Stock (a hawker sells something real — and muggable) + a blade for

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3380,7 +3380,7 @@ PIT_BOOTS = {
         ("category", "clothing"),
         ("worn_desc", "Steel-shanked {color}brown|n pit boots laced to the shin, gum-rubber soled"),
         ("coverage", ["left_foot", "right_foot"]),
-        ("layer", 2),
+        ("layer", 3),  # footwear layer — worn over trousers, never conflicts
         ("color", "brown"),
         ("material", "leather"),
         ("weight", 1.6),
@@ -3441,7 +3441,7 @@ HIVIS_VEST = {
         ("category", "clothing"),
         ("worn_desc", "A signal-{color}orange|n hi-vis vest, reflective bands catching the light, company stencil across the back"),
         ("coverage", ["chest", "back"]),
-        ("layer", 3),
+        ("layer", 4),  # worn OVER the jacket/coat (armor-layer precedent)
         ("color", "orange"),
         ("material", "mesh"),
         ("weight", 0.3),
@@ -3780,7 +3780,7 @@ HEELED_BOOTS = {
         ("category", "clothing"),
         ("worn_desc", "Knee-high {color}black|n heeled boots, polished to a street-lamp shine, announcing every step"),
         ("coverage", ["left_foot", "right_foot", "left_shin", "right_shin"]),
-        ("layer", 2),
+        ("layer", 3),  # footwear layer — worn over trousers, never conflicts
         ("color", "black"),
         ("material", "synth-leather"),
         ("weight", 1.0),
@@ -3814,7 +3814,7 @@ LONG_COAT = {
         ("category", "clothing"),
         ("worn_desc", "An ankle-length {color}charcoal|n stormcloth coat moving like low weather around {them}"),
         ("coverage", ["chest", "back", "abdomen", "left_arm", "right_arm", "left_thigh", "right_thigh", "left_shin", "right_shin"]),
-        ("layer", 3),
+        ("layer", 4),  # over-everything duster — clears knee-high boots at the shins
         ("color", "charcoal"),
         ("material", "stormcloth"),
         ("weight", 1.8),
@@ -3956,7 +3956,7 @@ HIGH_TOPS = {
         ("category", "clothing"),
         ("worn_desc", "Scuffed {color}white|n canvas high-tops laced with paracord"),
         ("coverage", ["left_foot", "right_foot"]),
-        ("layer", 2),
+        ("layer", 3),  # footwear layer — worn over trousers, never conflicts
         ("color", "white"),
         ("material", "canvas"),
         ("weight", 0.6),

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -130,6 +130,7 @@ class TestRoles(TestCase):
             mock_sc.objects.conf.return_value = {
                 "synth_companion": "EXPLICIT-DIRECTIVE-SENTINEL"}
             garment = MagicMock(); garment.key = "dress"
+            garment.layer = 2                  # sortable for inner-to-outer
             mock_spawn.return_value = [garment]
             npc = MagicMock(); npc.db = SimpleNamespace()
             mock_create.return_value = npc
@@ -164,6 +165,7 @@ class TestSpawn(TestCase):
         mock_within.return_value = haunts + [sky]
         garment = MagicMock()
         garment.key = "cotton t-shirt"
+        garment.layer = 1                      # sortable for inner-to-outer
         mock_spawn.return_value = [garment]
         npc = MagicMock()
         npc.db = SimpleNamespace()
@@ -467,3 +469,58 @@ class TestSynthFlavor(TestCase):
         for robot_word in ("servo", "actuator", "chassis", "optics",
                            "vocalizer"):
             self.assertNotIn(robot_word, joined)
+
+
+class TestWardrobeLayering(TestCase):
+    """The barefoot-companion bug class: same-layer collisions and
+    outer-before-inner wear orders silently strip garments."""
+
+    def _proto_attr(self, key, attr):
+        from world import prototypes as protos
+        proto = getattr(protos, key)
+        return dict(a[:2] for a in proto["attrs"]).get(attr)
+
+    def test_footwear_sits_on_the_footwear_layer(self):
+        # COMBAT_BOOTS convention: layer 3, "doesn't conflict with pants".
+        for key in ("HEELED_BOOTS", "PIT_BOOTS", "HIGH_TOPS"):
+            self.assertGreaterEqual(self._proto_attr(key, "layer"), 3, key)
+
+    def test_no_same_layer_same_slot_collisions_in_any_look(self):
+        # Simulate every role's possible look; no two garments may claim
+        # the same location on the same layer.
+        from itertools import product
+        from world import prototypes as protos
+
+        def garment(key):
+            attrs = dict(a[:2] for a in getattr(protos, key)["attrs"])
+            return attrs.get("layer", 2), attrs.get("coverage", [])
+
+        for role, spec in CIVILIAN_ROLES.items():
+            looks = []
+            outfits = spec.get("outfits") or []
+            if isinstance(outfits, dict):
+                for pool in outfits.values():
+                    looks.extend([list(o) for o in pool])
+            else:
+                looks.extend([list(o) for o in outfits])
+            wardrobe = spec.get("wardrobe") or []
+            if wardrobe:
+                slots = [e if isinstance(e, list) else [e] for e in wardrobe]
+                looks.extend([list(c) for c in product(*slots)])
+            for look in looks:
+                seen = {}
+                for key in look:
+                    layer, coverage = garment(key)
+                    for loc in coverage:
+                        self.assertNotIn(
+                            (loc, layer), seen,
+                            f"{role}: {key} vs {seen.get((loc, layer))} "
+                            f"at {loc} layer {layer}")
+                        seen[(loc, layer)] = key
+
+    def test_spawn_wears_inner_to_outer(self):
+        import inspect
+        from world.director import civilians as _c
+        source = inspect.getsource(_c.spawn_civilian)
+        self.assertIn('sorted(items, key=lambda i: getattr(i, "layer", 2))',
+                      source)


### PR DESCRIPTION
Closes #946

Three failure classes behind the barefoot-companion report:

1. New footwear (HEELED_BOOTS, PIT_BOOTS, HIGH_TOPS) was authored at layer 2, colliding with trousers/skirts at the shins — the boots were refused at wear time and civilians spawned barefoot. Moved to layer 3 per the COMBAT_BOOTS convention.
2. Same-layer outerwear collisions: HIVIS_VEST vs windbreaker/coat, LONG_COAT vs knee-high boots at the shins, scavver's poncho vs harness at the chest. Vest and coat move to layer 4 (over-everything); scavver's headwear slot swaps the poncho for MINING_HELMET.
3. `spawn_civilian` wore garments in roster order, and the clothing system refuses an inner layer over an outer one — roles listing an outer identity piece first (gang cut, apron, harness, company coat) silently stripped the base tops worn afterward. Spawn now spawns everything first, then wears inner-to-outer.

Tests: new `TestWardrobeLayering` pins the footwear-layer convention, the ascending wear order, and exhaustively sweeps every role's every possible look asserting no two garments claim the same location on the same layer (this sweep is what caught collisions 2 and 3's siblings). 72 tests green in the throwaway container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
