### PR TITLE
Companion RP polish: quote repair, real strip, echo guard, conversation hold

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -29,14 +29,15 @@ from typeclasses.llm_persona import build_persona
 from world.llm import memory as mem
 from world.llm.client import llm_enabled, request_embedding, request_turn
 from world.llm.prompt import (
-    CONTEXT_TOOLS, build_messages, parse_turn, schema_for, tool_names,
+    CONTEXT_TOOLS, build_messages, is_echo, parse_turn, schema_for, tool_names,
 )
 
 LLM_DIRECTED_COOLDOWN = 4.0    # min seconds between replies to direct address/name
-LLM_ENGAGE_HOLD = 180.0        # conversation hold: an engaged NPC defers its
+LLM_ENGAGE_HOLD = 600.0        # conversation hold: an engaged NPC defers its
                                # routine (patrol/drift) until the model calls
                                # the `release` tool or this inactivity window
-                               # lapses (failsafe for walked-away-from NPCs)
+                               # lapses (failsafe for walked-away-from NPCs).
+                               # Generous: a long RP pose takes minutes to type.
 LLM_AMBIENT_COOLDOWN = 45.0    # rarely volunteers into overheard chatter
 LLM_AMBIENT_CHANCE = 0.35      # ...and not every eligible time
 LLM_HISTORY_TURNS = 6          # recent turns kept per interlocutor (anti-repetition)
@@ -100,9 +101,20 @@ class LLMNpcMixin:
         """Cheap reactor-side gate: ``directed`` | ``ambient`` | ``ignore``."""
         if self._is_npc_speaker(speaker):
             return "ignore"
+        # Mid-conversation, the engaged partner doesn't have to keep naming
+        # this NPC — their lines stay directed (else a busy room demotes them
+        # to ambient and the NPC goes near-mute mid-scene).
+        if self._is_engaged_with(speaker):
+            return "directed"
         if self._mentions_self(speech) or self._is_alone_with(speaker):
             return "directed"
         return "ambient"
+
+    def _is_engaged_with(self, speaker):
+        """Whether the conversation hold is active AND held for this speaker."""
+        until = self.ndb.llm_engaged_until
+        return bool(until and monotonic() < until
+                    and self.ndb.llm_engaged_with == self._hist_key(speaker))
 
     def _is_alone_with(self, speaker):
         """True when no other character shares the room — so the speaker can only
@@ -152,11 +164,14 @@ class LLMNpcMixin:
         elif now - last < LLM_DIRECTED_COOLDOWN:
             return True
         self.ndb.last_llm = now
-        if mode == "directed":
+        if mode in ("directed", "action"):
             # Conversation hold: don't wander off mid-exchange. Rolling —
-            # refreshed every directed turn; the model releases it early via
-            # the `release` tool.
+            # refreshed every directed turn AND every pose aimed at us (an RP
+            # scene is mostly poses); the model releases it early via the
+            # `release` tool. Keyed to the partner so their lines stay
+            # directed without re-naming us each turn.
             self.ndb.llm_engaged_until = now + LLM_ENGAGE_HOLD
+            self.ndb.llm_engaged_with = self._hist_key(patron)
 
         # Capture everything reactor-side BEFORE threading (SQLite/Evennia-thread
         # contract). The agentic loop re-calls from the reactor-side callback.
@@ -406,6 +421,11 @@ class LLMNpcMixin:
     def _on_turn(self, messages, persona, patron, line, speaker_name, on_fail,
                  rounds, raw):
         turn = parse_turn(raw, persona, tool_names(persona))
+        # Echo guard: a pose aimed at the NPC sometimes comes straight back
+        # as its "own" action (or speech). Parroting reads broken — drop it.
+        for field in ("action", "speech"):
+            if turn[field] and is_echo(turn[field], line):
+                turn[field] = None
         tool, arg = turn["tool"], turn["tool_argument"]
         # Context tool: run the real read, feed the result back, loop.
         if tool in CONTEXT_TOOLS and rounds < LLM_MAX_TOOL_ROUNDS:
@@ -448,7 +468,7 @@ class LLMNpcMixin:
             verb = parts[0].lower() if parts else ""
             garment = parts[1] if len(parts) > 1 else ""
             if verb in ("zip", "unzip", "button", "unbutton",
-                        "rollup", "unroll") and garment:
+                        "rollup", "unroll", "remove", "wear") and garment:
                 self.execute_cmd(f"{verb} {garment}")
         elif tool == "release":
             # The character has decided the exchange is over: drop the
@@ -456,6 +476,7 @@ class LLMNpcMixin:
             # the next heartbeat. The goodbye itself rides the normal
             # speech/action channels of this same turn.
             self.ndb.llm_engaged_until = None
+            self.ndb.llm_engaged_with = None
 
     def _remember_person(self, patron, name):
         """Privately name/nickname the interlocutor via the REAL ``remember``

--- a/typeclasses/llm_persona.py
+++ b/typeclasses/llm_persona.py
@@ -29,6 +29,28 @@ def _self_pronouns(npc) -> str:
         return "they/them"
 
 
+def _wardrobe(npc) -> tuple:
+    """(wearing, carrying): worn garments — with their live style state, so the
+    model knows what's zipped/rolled and what the `style` tool can act on — and
+    the loose inventory. This is the NPC's real self-knowledge of its own kit;
+    without it the model invents clothing it isn't wearing."""
+    wearing, carrying = [], []
+    try:
+        worn = list(npc.get_worn_items() or [])
+        for item in worn:
+            entry = item.key
+            props = getattr(item, "style_properties", None) or {}
+            states = sorted(str(v) for v in props.values() if v and v != "normal")
+            if states:
+                entry += f" ({', '.join(states)})"
+            wearing.append(entry)
+        worn_ids = {id(i) for i in worn}
+        carrying = [obj.key for obj in npc.contents if id(obj) not in worn_ids]
+    except Exception:  # noqa: BLE001 — never break persona-building over kit
+        pass
+    return wearing, carrying
+
+
 def build_persona(npc) -> dict:
     """Build the persona dict from the NPC's real fields. Defensive throughout.
 
@@ -58,8 +80,12 @@ def build_persona(npc) -> dict:
         bar_menu = (bar.db.menu if bar else None) or npc.db.menu or []
         menu = [r.get("name") for r in bar_menu if r.get("name")] or None
 
+    wearing, carrying = _wardrobe(npc)
+
     return {
         "sdesc": npc.get_sdesc(),
+        "wearing": wearing,
+        "carrying": carrying,
         "longdescs": longdescs,
         "skintone": getattr(npc.db, "skintone", None),
         "height": npc.height,

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -38,10 +38,13 @@ TOOLS = {
                      "you feel, not every turn (argument: a short word/phrase)"},
     "style": {"kind": "action",
               "desc": "adjust your OWN clothing for real — zip, unzip, "
-                      "button, unbutton, rollup, or unroll a garment you're "
-                      "wearing; do it when the moment calls for it, and let "
-                      "your pose carry the gesture (argument: the verb and "
-                      "the garment, e.g. 'unzip jacket', 'rollup sleeves')"},
+                      "button, unbutton, rollup, unroll, remove, or wear a "
+                      "garment (what you're wearing and carrying is listed "
+                      "in your card). Undressing or dressing HAPPENS through "
+                      "this tool — never just narrate it in your pose; call "
+                      "it once per garment and let the pose carry the "
+                      "gesture (argument: the verb and the garment, e.g. "
+                      "'unzip jacket', 'remove mesh top', 'wear long coat')"},
     "release": {"kind": "action",
                 "desc": "end this conversation and get back to your day — "
                         "call it once the exchange has wound down, you've "
@@ -453,6 +456,16 @@ def render_persona(persona: dict) -> str:
         lines.append("Notable about you: " + " ".join(appearance))
     if persona.get("voice"):
         lines.append(f"Your voice: {persona['voice']}.")
+    wearing = persona.get("wearing")
+    if wearing:
+        lines.append("You are wearing (this is your COMPLETE outfit — the "
+                     "'style' tool acts on these, by these names): "
+                     + ", ".join(wearing) + ".")
+    elif persona.get("wearing") is not None:
+        lines.append("You are wearing nothing.")
+    carrying = persona.get("carrying")
+    if carrying:
+        lines.append("You are carrying: " + ", ".join(carrying) + ".")
     loc = persona.get("location") or {}
     if loc.get("name"):
         # Neutral placement — what the NPC *does* here comes from its archetype
@@ -576,7 +589,7 @@ _MAX_LEN = 500
 
 
 def _clean(text: str) -> str:
-    text = (text or "").strip().strip('"*').strip()
+    text = (text or "").strip().strip("\"'*").strip()
     text = re.sub(r"^[A-Z][a-z]+:\s*", "", text)
     return re.sub(r"\s+", " ", text).strip()[:_MAX_LEN]
 
@@ -591,13 +604,22 @@ def _strip_self_lead(action: str, name: str) -> str:
     return re.sub(r"^(i|she|he|they)\s+", "", action, flags=re.I).strip()
 
 
+_SINGLE_QUOTED_RE = re.compile(r"(?<!\w)'([^']+)'(?!\w)")
+
+
 def _normalize_action(action: str) -> str:
-    """Light, non-brittle repair before the action hits the emote command. The
-    only fix is dropping unbalanced stray quotes that would mis-split an embedded
-    spoken line from the action text. Verb form, conjugation, and naming are the
-    charter's job — emote does NO conjugation, so there's nothing to massage."""
+    """Light, non-brittle repair before the action hits the emote command:
+    drop unbalanced stray quotes that would mis-split an embedded spoken line,
+    and promote single-quoted dialogue to double quotes (the say/hearing rails
+    only extract ``"…"``, so a single-quoted line would render as flat pose
+    text). Verb form, conjugation, and naming are the charter's job — emote
+    does NO conjugation, so there's nothing to massage."""
     if not action:
         return action
+    if '"' not in action:
+        # 'come here,' she purrs → "come here," — the lookarounds keep
+        # contractions (don't, it's) from reading as quote marks.
+        action = _SINGLE_QUOTED_RE.sub(r'"\1"', action)
     if action.count('"') % 2:                       # unbalanced -> drop them all
         action = action.replace('"', "")
     action = action.strip()
@@ -659,6 +681,22 @@ def parse_turn(raw, persona: dict, allowed_tools=None) -> dict:
         "tool": tool if (tool == "none" or tool in allowed) else "none",
         "tool_argument": tool_arg,
     }
+
+
+def is_echo(reply: str, line: str) -> bool:
+    """True when the model parroted the incoming line back at the player —
+    a pose aimed at an NPC sometimes comes straight back as the NPC's own
+    action. Token-containment test: a reply of 4+ words whose words nearly
+    all appear in the incoming line is an echo, not a response. Short
+    gestures ("nods back", "smiles") legitimately overlap and pass."""
+    if not reply or not line:
+        return False
+    reply_words = re.sub(r"[^a-z0-9 ]+", "", reply.lower()).split()
+    if len(reply_words) < 4:
+        return False
+    line_words = set(re.sub(r"[^a-z0-9 ]+", "", line.lower()).split())
+    overlap = sum(1 for w in reply_words if w in line_words)
+    return overlap / len(reply_words) >= 0.8
 
 
 _QUOTE_RE = re.compile(r'"([^"]*)"')

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -609,7 +609,8 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
     cooldown, loop-guard, fail-safe. Orders + gratitude paths stay untouched."""
 
     _REAL = (
-        "_classify_speech", "_is_npc_speaker", "_mentions_self", "_name_aliases",
+        "_classify_speech", "_is_npc_speaker", "_is_engaged_with",
+        "_mentions_self", "_name_aliases",
         "_handle_directed_speech", "_try_llm_reply",
         "_render_llm_reply", "_llm_fallback", "_llm_silent",
     )
@@ -621,6 +622,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         b.db.llm_driven = llm_driven
         b.db.is_bartender_npc = True
         b.ndb.last_llm = 0
+        b.ndb.llm_engaged_until = None    # no conversation hold by default
         b.location = location
         b._is_gratitude = barmod.Bartender._is_gratitude  # real staticmethod
         for name in self._REAL:
@@ -637,6 +639,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         s = MagicMock()
         s.db.is_bartender_npc = False
         s.db.llm_driven = False
+        s.db.is_npc = False               # auto-mock truthiness reads as NPC
         s.location = location
         s.get_display_name = lambda looker=None, **kw: name
         return s
@@ -797,6 +800,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         # The roster is who ELSE is here, by the name this NPC perceives them by.
         b = self._bartender()
         self._bind(b, "_present_others")
+        b._address_handle = lambda t: t.get_display_name(b)
         patron = self._speaker(name="a lean man")
         other = self._speaker(name="a tall woman")
         loc = MagicMock(); loc.contents = [b, patron, other]

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -227,3 +227,125 @@ class TestRecall(TestCase):
         re.assert_not_called()                            # nothing to recall
         self.assertIsNone(bm.call_args.kwargs.get("memories"))
         b._agentic_round.assert_called_once()
+
+
+class TestConversationHold(TestCase):
+    """RP-session continuity: poses refresh the hold, the engaged partner
+    stays 'directed' without re-naming the NPC, release ends it."""
+
+    def _npc(self):
+        b = MagicMock()
+        b.db.llm_driven = True
+        b.location = "room"
+        b.ndb.last_llm = 0
+        b.ndb.llm_engaged_until = None
+        b.ndb.llm_engaged_with = None
+        b._memory_subject = lambda p: f"#{p.id}"
+        b._load_memories = lambda: []
+        b._relationship_line = lambda subject, patron: None
+        b._drain_actions = lambda: []
+        b._perceive = lambda p: None
+        b._recent_history = lambda p: []
+        b._agentic_round = MagicMock()
+        b._llm_silent = lambda: None
+        b._hist_key = lambda p: f"#{p.id}"
+        b._is_npc_speaker = lambda s: False
+        for m in ("_try_llm_reply", "_classify_speech", "_is_engaged_with",
+                  "_handle_action_tool"):
+            _bind(b, m)
+        return b
+
+    def _patron(self):
+        p = MagicMock()
+        p.id = 5
+        p.location = "room"
+        return p
+
+    def test_directed_pose_refreshes_hold(self):
+        b, patron = self._npc(), self._patron()
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "build_persona", return_value={}), \
+                patch.object(llmnpc, "build_messages", return_value=["m"]):
+            b._try_llm_reply("leans close", patron, "action")
+        self.assertIsNotNone(b.ndb.llm_engaged_until)
+        self.assertEqual(b.ndb.llm_engaged_with, "#5")
+
+    def test_engaged_partner_stays_directed_in_a_crowd(self):
+        from time import monotonic
+        b, patron = self._npc(), self._patron()
+        b.ndb.llm_engaged_until = monotonic() + 60
+        b.ndb.llm_engaged_with = "#5"
+        b._mentions_self = lambda s: False
+        b._is_alone_with = lambda s: False      # crowded room
+        self.assertEqual(b._classify_speech("more of that", patron), "directed")
+
+    def test_stranger_stays_ambient_while_npc_is_engaged(self):
+        from time import monotonic
+        b = self._npc()
+        b.ndb.llm_engaged_until = monotonic() + 60
+        b.ndb.llm_engaged_with = "#5"
+        b._mentions_self = lambda s: False
+        b._is_alone_with = lambda s: False
+        other = MagicMock()
+        other.id = 9
+        self.assertEqual(b._classify_speech("hey", other), "ambient")
+
+    def test_expired_hold_is_not_engagement(self):
+        b, patron = self._npc(), self._patron()
+        b.ndb.llm_engaged_until = 1.0          # long past
+        b.ndb.llm_engaged_with = "#5"
+        self.assertFalse(b._is_engaged_with(patron))
+
+    def test_release_clears_hold_and_partner(self):
+        b = self._npc()
+        b.ndb.llm_engaged_until = 123.0
+        b.ndb.llm_engaged_with = "#5"
+        b._handle_action_tool("release", "", MagicMock())
+        self.assertIsNone(b.ndb.llm_engaged_until)
+        self.assertIsNone(b.ndb.llm_engaged_with)
+
+
+class TestStyleTool(TestCase):
+    def _npc(self):
+        b = MagicMock()
+        _bind(b, "_handle_action_tool")
+        return b
+
+    def test_remove_and_wear_route_to_real_commands(self):
+        b = self._npc()
+        b._handle_action_tool("style", "remove mesh top", MagicMock())
+        b.execute_cmd.assert_called_once_with("remove mesh top")
+        b.execute_cmd.reset_mock()
+        b._handle_action_tool("style", "wear long coat", MagicMock())
+        b.execute_cmd.assert_called_once_with("wear long coat")
+
+    def test_unknown_verb_refused(self):
+        b = self._npc()
+        b._handle_action_tool("style", "eat hat", MagicMock())
+        b.execute_cmd.assert_not_called()
+
+
+class TestEchoGuard(TestCase):
+    """A pose aimed at the NPC must never come straight back as its reply."""
+
+    def _turn(self, turn, line):
+        b = MagicMock()
+        _bind(b, "_on_turn")
+        with patch.object(llmnpc, "parse_turn", return_value=dict(turn)), \
+                patch.object(llmnpc, "tool_names", return_value=[]):
+            b._on_turn([], {}, MagicMock(), line, "a man", lambda: None, 0, "{}")
+        return b._render_llm_reply.call_args.args
+
+    def test_parroted_pose_dropped_before_render(self):
+        line = "runs a hand down the synth's arm, smiling slowly"
+        speech, action = self._turn(
+            {"speech": None, "thought": None, "tool": "none", "tool_argument": "",
+             "action": "runs a hand down the synth's arm, smiling"}, line)[:2]
+        self.assertIsNone(action)
+
+    def test_original_action_renders(self):
+        speech, action = self._turn(
+            {"speech": "mm", "thought": None, "tool": "none", "tool_argument": "",
+             "action": "arches into the touch, unhurried"},
+            "runs a hand down the synth's arm")[:2]
+        self.assertEqual(action, "arches into the touch, unhurried")

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -9,8 +9,8 @@ from unittest import TestCase
 
 from world.llm.prompt import (
     ARCHETYPES, BASE_TOOLS, CONTEXT_TOOLS, TOOLS, TURN_SCHEMA, _archetype,
-    build_messages, parse_turn, render_persona, schema_for, tool_names,
-    turn_schema,
+    build_messages, is_echo, parse_turn, render_persona, schema_for,
+    tool_names, turn_schema,
 )
 
 _PERSONA = {
@@ -375,3 +375,65 @@ class TestThoughtChannel(TestCase):
         from world.llm.prompt import TURN_SCHEMA
         self.assertIn("thought", TURN_SCHEMA["properties"])
         self.assertIn("thought", TURN_SCHEMA["required"])
+
+
+class TestQuoteNormalization(TestCase):
+    """The say/hearing rails only extract double-quoted dialogue — a model that
+    slips into single quotes must be repaired, without eating contractions."""
+
+    def _turn(self, action="", speech=""):
+        raw = json.dumps({"speech": speech, "action": action, "thought": "",
+                          "tool": "none", "tool_argument": ""})
+        return parse_turn(raw, {})
+
+    def test_single_quoted_dialogue_promoted(self):
+        turn = self._turn(action="leans in, 'come closer,' she murmurs")
+        self.assertIn('"come closer,"', turn["action"])
+
+    def test_contractions_survive(self):
+        turn = self._turn(action="shrugs, it's fine, don't fuss")
+        self.assertEqual(turn["action"], "shrugs, it's fine, don't fuss")
+
+    def test_speech_sheds_single_quote_wrapper(self):
+        turn = self._turn(speech="'stay a while'")
+        self.assertEqual(turn["speech"], "stay a while")
+
+    def test_double_quotes_left_alone(self):
+        turn = self._turn(action='smiles, "you first," and waits')
+        self.assertEqual(turn["action"], 'smiles, "you first," and waits')
+
+
+class TestIsEcho(TestCase):
+    def test_parroted_pose_detected(self):
+        line = "traces a finger along the companion's jaw, slow and deliberate"
+        self.assertTrue(
+            is_echo("traces a finger along the companion's jaw, slow", line))
+
+    def test_short_gesture_allowed(self):
+        # brief overlapping gestures are legitimate reciprocation
+        self.assertFalse(is_echo("smiles back", "smiles at the synth warmly"))
+
+    def test_fresh_reply_allowed(self):
+        self.assertFalse(is_echo("tilts her head, amused, and pours a drink",
+                                 "asks about the weather outside"))
+
+    def test_empty_never_echo(self):
+        self.assertFalse(is_echo("", "anything"))
+        self.assertFalse(is_echo("anything", ""))
+
+
+class TestWardrobeCard(TestCase):
+    def test_wearing_and_carrying_rendered(self):
+        text = render_persona({"wearing": ["mesh top (unzipped)", "slit skirt"],
+                               "carrying": ["heeled boots"]})
+        self.assertIn("mesh top (unzipped), slit skirt", text)
+        self.assertIn("carrying: heeled boots", text)
+
+    def test_stripped_reads_naked(self):
+        # an empty (but present) wardrobe means undressed — the model must
+        # know it, not invent an outfit
+        text = render_persona({"wearing": [], "carrying": []})
+        self.assertIn("wearing nothing", text)
+
+    def test_legacy_persona_has_no_wardrobe_line(self):
+        self.assertNotIn("wearing", render_persona(dict(_PERSONA)).lower())


### PR DESCRIPTION
Closes #948

- _normalize_action promotes single-quoted dialogue to double quotes
  (contraction-safe) so it rides the say/hearing rails; _clean sheds
  single-quote speech wrappers
- style tool gains remove/wear; persona card lists the NPC's real
  wearing (with live style state) + carrying, so undressing happens
  through the tool and the model knows its own kit
- is_echo drops an action/speech that parrots the incoming pose back
- conversation hold: refreshed by directed poses (RP is mostly poses),
  raised 180s -> 600s, keyed to the partner so their lines classify
  directed in a crowd; release clears hold + partner key
- test_bar harness: speakers set db.is_npc=False (auto-mock truthiness
  made the real _is_npc_speaker classify everyone "ignore" — 5 pre-
  existing failures), bind _is_engaged_with, stub _address_handle

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
