### PR TITLE
Make LLM NPCs actually use the style tool for dressing/undressing

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -17,6 +17,7 @@ agentic loop back on the reactor. See ``LLM_GAMEMASTER_SPEC`` Phase 1.
 
 import json
 import random
+import re
 from functools import partial
 from time import monotonic
 
@@ -462,11 +463,27 @@ class LLMNpcMixin:
         elif tool == "feel" and arg and patron:
             self._set_valence(self._memory_subject(patron), arg)
         elif tool == "style" and arg:
-            # Adjust own clothing through the REAL zip/rollup commands —
-            # the fiction and the worn state stay in agreement.
-            parts = str(arg).strip().split(None, 1)
+            # Adjust own clothing through the REAL zip/rollup/remove/wear
+            # commands — the fiction and the worn state stay in agreement.
+            # The model writes the argument in natural register ("take off
+            # her mesh top (unzipped)"), so normalise onto the command
+            # grammar rather than silently dropping the call.
+            arg = " ".join(str(arg).split())
+            low = arg.lower()
+            if low.startswith("take off "):
+                arg = "remove " + arg[9:]
+            elif low.startswith("put on "):
+                arg = "wear " + arg[7:]
+            parts = arg.split(None, 1)
             verb = parts[0].lower() if parts else ""
+            verb = {"strip": "remove", "doff": "remove",
+                    "shed": "remove", "don": "wear"}.get(verb, verb)
             garment = parts[1] if len(parts) > 1 else ""
+            # bare item key only: no possessive/article lead, no copied
+            # style-state parenthetical from the wardrobe card
+            garment = re.sub(r"^(?:her|his|their|its|my|the|a|an)\s+",
+                             "", garment, flags=re.I)
+            garment = re.sub(r"\s*\([^)]*\)\s*$", "", garment).strip()
             if verb in ("zip", "unzip", "button", "unbutton",
                         "rollup", "unroll", "remove", "wear") and garment:
                 self.execute_cmd(f"{verb} {garment}")

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -117,6 +117,11 @@ def _tools_block(tools) -> str:
             lines.append(f'- "{name}": {entry["desc"]}')
     lines.append('- "none": no tool this turn.')
     lines.append("After a context tool you get a [tool result]; then reply for real.")
+    if "style" in tools:
+        lines.append('Your clothing only REALLY changes when you call "style" — '
+                     "a pose alone doesn't remove, put on, or open anything. "
+                     "Whenever your action involves your own clothing, pose the "
+                     "gesture AND call the tool in the same turn.")
     return "\n".join(lines)
 
 
@@ -275,6 +280,16 @@ ARCHETYPES = {
                                      "taking her time, her fingers trailing his "
                                      "collar",
                            "thought": "", "tool": "none", "tool_argument": ""}},
+            # Demonstrates the style tool: the pose carries the gesture, the
+            # tool makes it real — clothing never comes off by narration alone.
+            {"user": 'a patron says to you: "let\'s get you out of that jacket."',
+             "assistant": {"speech": "Since you ask so nicely.",
+                           "action": "peels the cropped jacket off her "
+                                     "shoulders and lets it slide from one "
+                                     "finger to the floor",
+                           "thought": "",
+                           "tool": "style",
+                           "tool_argument": "remove cropped jacket"}},
         ],
     },
     "doctor": {

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -324,6 +324,24 @@ class TestStyleTool(TestCase):
         b._handle_action_tool("style", "eat hat", MagicMock())
         b.execute_cmd.assert_not_called()
 
+    def test_natural_synonyms_map_to_real_verbs(self):
+        # the model writes in its own register — normalise, don't drop
+        for arg, cmd in (("take off mesh top", "remove mesh top"),
+                         ("put on long coat", "wear long coat"),
+                         ("strip slit skirt", "remove slit skirt"),
+                         ("shed cropped jacket", "remove cropped jacket")):
+            b = self._npc()
+            b._handle_action_tool("style", arg, MagicMock())
+            b.execute_cmd.assert_called_once_with(cmd)
+
+    def test_possessive_and_state_parenthetical_stripped(self):
+        # "her mesh top (unzipped)" — possessive lead + the wardrobe card's
+        # style-state suffix both break the command matcher
+        b = self._npc()
+        b._handle_action_tool("style", "remove her mesh top (unzipped)",
+                              MagicMock())
+        b.execute_cmd.assert_called_once_with("remove mesh top")
+
 
 class TestEchoGuard(TestCase):
     """A pose aimed at the NPC must never come straight back as its reply."""

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -437,3 +437,23 @@ class TestWardrobeCard(TestCase):
 
     def test_legacy_persona_has_no_wardrobe_line(self):
         self.assertNotIn("wearing", render_persona(dict(_PERSONA)).lower())
+
+
+class TestStyleAdoption(TestCase):
+    """The model imitates few-shot far more than tool descriptions — pin the
+    companion demonstration and the style-granted charter rule."""
+
+    def test_companion_fewshot_demonstrates_style_tool(self):
+        shots = ARCHETYPES["companion"]["fewshot"]
+        self.assertTrue(any(s["assistant"].get("tool") == "style"
+                            for s in shots))
+
+    def test_style_rule_present_when_granted(self):
+        msgs = build_messages({"persona_seed": {"archetype": "companion"}},
+                              "a man", "hi", "directed")
+        self.assertIn("REALLY changes", msgs[0]["content"])
+
+    def test_style_rule_absent_when_not_granted(self):
+        msgs = build_messages({"persona_seed": {"archetype": "bartender"}},
+                              "a man", "hi", "directed")
+        self.assertNotIn("REALLY changes", msgs[0]["content"])


### PR DESCRIPTION
Closes #950

- companion fewshot now demonstrates the style tool (pose + tool in one
  turn) — models imitate examples far more than tool descriptions
- tools block gains a rule when style is granted: clothing only really
  changes via the tool, narration alone changes nothing
- style argument normalisation: take off/put on/strip/shed/doff/don map
  onto remove/wear; leading possessives/articles and the wardrobe
  card's style-state parenthetical are stripped so natural-register
  calls hit the real command instead of dropping silently

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
