### PR TITLE
LLM NPCs perceive admin-forced commands as their own acts

### DIFF
--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -1206,3 +1206,44 @@ class CmdKeywords(Command):
         else:
             caller.msg(f"|rFailed:|n {reason}")
 
+
+
+class CmdForce(Command):
+    """
+    Force an object to execute a command.
+
+    Usage:
+        force <object> = <command string>
+
+    Example:
+        force bob = get stick
+
+    An LLM-driven NPC perceives what it was made to do — the compelled
+    line or gesture enters its awareness as its own act, so it carries
+    the moment forward coherently in conversation.
+    """
+
+    key = "force"
+    locks = "cmd:perm(spawn) or perm(Builder)"
+    help_category = "Building"
+
+    def parse(self):
+        lhs, _, rhs = (self.args or "").partition("=")
+        self.lhs, self.rhs = lhs.strip(), rhs.strip()
+
+    def func(self):
+        if not self.lhs or not self.rhs:
+            self.msg("You must provide a target and a command string to execute.")
+            return
+        targ = self.caller.search(self.lhs)
+        if not targ:
+            return
+        if not targ.access(self.caller, "edit"):
+            self.msg(f"You don't have permission to force {targ} to execute commands.")
+            return
+        targ.execute_cmd(self.rhs)
+        # An LLM brain gets to know what its body was just made to do.
+        perceive = getattr(targ, "perceive_forced_command", None)
+        if callable(perceive):
+            perceive(self.rhs)
+        self.msg(f"You have forced {targ} to: {self.rhs}")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -159,6 +159,9 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         
         # Add bug reporting command
         self.add(CmdBug())
+
+        # force override: an LLM-driven NPC perceives what it was made to do
+        self.add(CmdAdmin.CmdForce())
         
         # Add aim command for ranged combat preparation
         self.add(CmdAim())

--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -286,6 +286,27 @@ class LLMNpcMixin:
 
     # --- ambient action-awareness (§8.4) ---------------------------------
 
+    def perceive_forced_command(self, raw):
+        """An outside will (the admin ``force`` command) just drove this body.
+
+        Let the brain perceive what it did as its OWN act — the GM speaks
+        *through* the NPC, so the model carries on owning the line/gesture
+        instead of having no memory of it next turn. Buffered like any
+        witnessed event; it rides the next reply's [RECENTLY] block."""
+        if not self.db.llm_driven or not raw:
+            return
+        raw = " ".join(str(raw).split())
+        parts = raw.split(None, 1)
+        verb = parts[0].lower() if parts else ""
+        rest = parts[1] if len(parts) > 1 else ""
+        if verb in ("say", "'") and rest:
+            text = f'You yourself just said: "{rest}"'
+        elif verb in ("pose", "emote", ";", ":") and rest:
+            text = f"You yourself just did: {rest}"
+        else:
+            text = f"You yourself just did this: {raw}"
+        self._observe_action(self, text)
+
     def _observe_action(self, actor, text):
         """Buffer a witnessed room action — reactor-side, NO LLM. Already
         rendered from this NPC's POV (names resolved), so just keep the text."""

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -367,3 +367,64 @@ class TestEchoGuard(TestCase):
              "action": "arches into the touch, unhurried"},
             "runs a hand down the synth's arm")[:2]
         self.assertEqual(action, "arches into the touch, unhurried")
+
+
+class TestForcePerception(TestCase):
+    """Admin `force` speaks THROUGH the NPC — the brain must own the act."""
+
+    def _npc(self):
+        b = MagicMock()
+        b.db.llm_driven = True
+        b.ndb.action_buffer = None
+        _bind(b, "perceive_forced_command")
+        _bind(b, "_observe_action")
+        return b
+
+    def test_forced_say_reads_as_own_words(self):
+        b = self._npc()
+        b.perceive_forced_command("say follow me, quick")
+        self.assertIn('You yourself just said: "follow me, quick"',
+                      b.ndb.action_buffer)
+
+    def test_forced_pose_reads_as_own_act(self):
+        b = self._npc()
+        b.perceive_forced_command("emote checks the door twice")
+        self.assertIn("You yourself just did: checks the door twice",
+                      b.ndb.action_buffer)
+
+    def test_other_commands_buffer_verbatim(self):
+        b = self._npc()
+        b.perceive_forced_command("remove slit skirt")
+        self.assertIn("You yourself just did this: remove slit skirt",
+                      b.ndb.action_buffer)
+
+    def test_not_llm_driven_ignored(self):
+        b = self._npc()
+        b.db.llm_driven = False
+        b.perceive_forced_command("say hi")
+        self.assertFalse(b.ndb.action_buffer)
+
+
+class TestCmdForceHook(TestCase):
+    def _cmd(self, targ):
+        from commands.CmdAdmin import CmdForce
+        cmd = CmdForce()
+        cmd.caller = MagicMock()
+        cmd.caller.search.return_value = targ
+        cmd.msg = MagicMock()
+        cmd.args = "bliss = say hello there"
+        cmd.parse()
+        return cmd
+
+    def test_force_notifies_llm_brain(self):
+        targ = MagicMock()
+        targ.access.return_value = True
+        self._cmd(targ).func()
+        targ.execute_cmd.assert_called_once_with("say hello there")
+        targ.perceive_forced_command.assert_called_once_with("say hello there")
+
+    def test_plain_object_without_brain_still_forced(self):
+        targ = MagicMock(spec=["access", "execute_cmd"])
+        targ.access.return_value = True
+        self._cmd(targ).func()
+        targ.execute_cmd.assert_called_once_with("say hello there")


### PR DESCRIPTION
Closes #952

- LLMNpcMixin.perceive_forced_command buffers the compelled command
  into the witnessed-events buffer as the NPC's OWN act (say -> "You
  yourself just said", pose/emote -> "You yourself just did", other
  commands verbatim), riding the next reply's [RECENTLY] block — the
  GM speaks through the NPC and the model carries the moment forward
- game-side force override (CmdAdmin.CmdForce, same key/locks/flow as
  Evennia core) calls the hook after execute_cmd when the target has
  a brain; objects without one are forced exactly as before
- registered in CharacterCmdSet (same-key add replaces the default)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
