### PR TITLE
Ground LLM NPCs in their room's actual description

### DIFF
--- a/typeclasses/llm_persona.py
+++ b/typeclasses/llm_persona.py
@@ -51,6 +51,35 @@ def _wardrobe(npc) -> tuple:
     return wearing, carrying
 
 
+def _room_desc(npc) -> str | None:
+    """The room as THIS NPC perceives it — ``get_display_desc`` composes the
+    sense layers for the looker (a blind NPC doesn't get the visual prose), so
+    the model grounds itself in the street it's actually standing on instead
+    of inventing a generic interior. ANSI-stripped, sentence-bounded trim."""
+    loc = npc.location
+    if not loc:
+        return None
+    try:
+        getter = getattr(loc, "get_display_desc", None)
+        raw = getter(npc) if callable(getter) else None
+        raw = raw or getattr(loc.db, "desc", None)
+        if not raw:
+            return None
+        from evennia.utils.ansi import strip_ansi
+        text = " ".join(strip_ansi(str(raw)).split())
+        if len(text) > 500:
+            cut = text[:500]
+            for end in (". ", "! ", "? "):
+                i = cut.rfind(end)
+                if i > 200:
+                    cut = cut[: i + 1]
+                    break
+            text = cut.rstrip()
+        return text
+    except Exception:  # noqa: BLE001 — never break persona-building over a room
+        return None
+
+
 def build_persona(npc) -> dict:
     """Build the persona dict from the NPC's real fields. Defensive throughout.
 
@@ -68,7 +97,7 @@ def build_persona(npc) -> dict:
     if npc.location:
         location = {
             "name": npc.location.key,
-            "desc": getattr(npc.location.db, "desc", None),
+            "desc": _room_desc(npc),
         }
 
     # The bar's real menu, so she knows exactly what she serves (and what she

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -487,6 +487,10 @@ def render_persona(persona: dict) -> str:
         # duties (a bartender tends the bar; a companion works the floor), never
         # from a hardcoded role baked into the shared persona render.
         lines.append(f"You are at {loc['name']}.")
+    if loc.get("desc"):
+        lines.append(f"Your surroundings: {loc['desc']} Ground your gestures "
+                     "in what is actually here — never invent fixtures, "
+                     "furniture, or weather this place doesn't offer.")
     menu = persona.get("menu")
     if menu:
         lines.append("Your bar serves ONLY: " + ", ".join(menu) + " (no beer, no "

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -428,3 +428,34 @@ class TestCmdForceHook(TestCase):
         targ.access.return_value = True
         self._cmd(targ).func()
         targ.execute_cmd.assert_called_once_with("say hello there")
+
+
+class TestRoomDescPerception(TestCase):
+    def test_perceived_desc_ansi_stripped(self):
+        from typeclasses.llm_persona import _room_desc
+        npc = MagicMock()
+        npc.location.get_display_desc = (
+            lambda looker, **kw: "|rNeon|n  bleeds over   wet ferrocrete.")
+        self.assertEqual(_room_desc(npc), "Neon bleeds over wet ferrocrete.")
+
+    def test_falls_back_to_db_desc(self):
+        from typeclasses.llm_persona import _room_desc
+        npc = MagicMock()
+        npc.location = MagicMock(spec=["db"])
+        npc.location.db.desc = "A bare service corridor."
+        self.assertEqual(_room_desc(npc), "A bare service corridor.")
+
+    def test_long_desc_sentence_bounded(self):
+        from typeclasses.llm_persona import _room_desc
+        npc = MagicMock()
+        npc.location.get_display_desc = (
+            lambda looker, **kw: ("A sentence about the street. " * 40))
+        out = _room_desc(npc)
+        self.assertLessEqual(len(out), 500)
+        self.assertTrue(out.endswith("street."))
+
+    def test_no_location_none(self):
+        from typeclasses.llm_persona import _room_desc
+        npc = MagicMock()
+        npc.location = None
+        self.assertIsNone(_room_desc(npc))

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -457,3 +457,19 @@ class TestStyleAdoption(TestCase):
         msgs = build_messages({"persona_seed": {"archetype": "bartender"}},
                               "a man", "hi", "directed")
         self.assertNotIn("REALLY changes", msgs[0]["content"])
+
+
+class TestSurroundings(TestCase):
+    """The room desc must reach the card — an NPC that only knows the room's
+    NAME invents carpet on a street."""
+
+    def test_room_desc_rendered_with_grounding_rule(self):
+        text = render_persona({"location": {
+            "name": "Dust Row",
+            "desc": "A cracked ferrocrete street under sodium light."}})
+        self.assertIn("A cracked ferrocrete street", text)
+        self.assertIn("never invent fixtures", text)
+
+    def test_no_desc_no_surroundings_line(self):
+        text = render_persona({"location": {"name": "Dust Row", "desc": None}})
+        self.assertNotIn("Your surroundings", text)


### PR DESCRIPTION
Closes #955

- _room_desc(npc): the room as this NPC perceives it via
  get_display_desc (sense-layer composed per looker; blind NPCs get
  no visual prose), db.desc fallback, ANSI-stripped, sentence-bounded
- render_persona renders it as "Your surroundings: ..." with a
  grounding rule against inventing fixtures/furniture/weather
- previously build_persona captured the desc but render_persona only
  used the room NAME — models improvised carpet on open streets

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
