### PR TITLE
Fix "you you's" pose rendering: smart quotes + doubled char-refs

### DIFF
--- a/world/emote.py
+++ b/world/emote.py
@@ -765,8 +765,9 @@ def _resolve_charref(character: "Character", observer: "Character") -> str:
 
 #: Possessive cleanup: a second-person char-ref leaves "you's" where the source
 #: had "the droog's" (the ref became "you", the trailing "'s" stayed). Fix it to
-#: "your", preserving sentence-initial capitalisation.
-_YOU_POSSESSIVE_RE = re.compile(r"\b([Yy])ou's\b")
+#: "your", preserving sentence-initial capitalisation. Accepts the typographic
+#: apostrophe too — LLM-driven actors emit those.
+_YOU_POSSESSIVE_RE = re.compile(r"\b([Yy])ou[’']s\b")
 
 
 def _fix_you_possessive(text: str) -> str:
@@ -900,9 +901,12 @@ def render_for_observer(
             # Drop a redundant article right before the ref — the resolved name
             # carries its own ("the a gaunt courier" -> "a gaunt courier", "the
             # Roony" -> "Roony", "the lean man" -> "you"). Players and NPCs alike
-            # write "the <sdesc>".
+            # write "the <sdesc>". A dangling bare "you" is dropped the same
+            # way: an actor who doubles the reference ("buttons you the lean
+            # man's shirt") otherwise renders "you you's" for the target.
             if parts:
-                parts[-1] = re.sub(r"\b(?:the|an?)\s+$", "", parts[-1], flags=re.I)
+                parts[-1] = re.sub(r"(?:\b(?:the|an?|you)\s+)+$", "",
+                                   parts[-1], flags=re.I)
             parts.append(display_name)
             has_prior_content = True
 
@@ -1095,9 +1099,11 @@ def render_emote_for_observer(
         elif isinstance(token, CharRefToken):
             # Second-person when the ref points at the observer (see _resolve_charref).
             display_name = _resolve_charref(token.character, observer)
-            # Drop a redundant article right before the ref (see render_for_observer).
+            # Drop a redundant article or dangling bare "you" right before the
+            # ref (see render_for_observer).
             if parts:
-                parts[-1] = re.sub(r"\b(?:the|an?)\s+$", "", parts[-1], flags=re.I)
+                parts[-1] = re.sub(r"(?:\b(?:the|an?|you)\s+)+$", "",
+                                   parts[-1], flags=re.I)
             parts.append(display_name)
 
     action = _fix_you_possessive("".join(parts))

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -607,8 +607,16 @@ _OOC_MARKERS = ("as an ai", "language model", "i cannot", "i am an ai")
 _MAX_LEN = 500
 
 
+#: Models love typographic quotes; the game's speech rails, quote extraction,
+#: and the emote renderer's you's->your cleanup all key on ASCII. Normalise
+#: at the source so every downstream consumer sees straight quotes.
+_SMART_QUOTES = str.maketrans({"’": "'", "‘": "'",
+                               "“": '"', "”": '"'})
+
+
 def _clean(text: str) -> str:
-    text = (text or "").strip().strip("\"'*").strip()
+    text = (text or "").translate(_SMART_QUOTES)
+    text = text.strip().strip("\"'*").strip()
     text = re.sub(r"^[A-Z][a-z]+:\s*", "", text)
     return re.sub(r"\s+", " ", text).strip()[:_MAX_LEN]
 

--- a/world/tests/test_emote.py
+++ b/world/tests/test_emote.py
@@ -1986,6 +1986,32 @@ class TestSecondPersonObserverRef(TestCase):
         self.assertIn("your hands", out)
         self.assertNotIn("you's", out)
 
+    def test_emote_curly_possessive_is_your(self):
+        # LLM actors emit typographic apostrophes; the cleanup must catch them
+        toks = self.tok_emote("eyes the droog\u2019s hands", self.actor,
+                              [self.you])
+        out = self.render_emote(toks, self.actor, self.you).lower()
+        self.assertIn("your hands", out)
+        self.assertNotIn("you\u2019s", out)
+
+    def test_emote_doubled_ref_collapses_for_target(self):
+        # "you the droog's shirt" (bare you + the reference) must not render
+        # "you you's shirt" — the dangling you drops like an article
+        toks = self.tok_emote("buttons you the droog's shirt", self.actor,
+                              [self.you])
+        out = self.render_emote(toks, self.actor, self.you).lower()
+        self.assertIn("buttons your shirt", out)
+        self.assertNotIn("you you", out)
+
+    def test_emote_doubled_ref_collapses_for_third_party(self):
+        stranger = _make_character(key="S2", sex="male", height="average",
+                                   build="average", sdesc_keyword="figure",
+                                   sleeve_uid="uid-str2", recognition_memory={})
+        toks = self.tok_emote("buttons you the droog's shirt", self.actor,
+                              [self.you])
+        out = self.render_emote(toks, self.actor, stranger).lower()
+        self.assertNotIn("you", out.split("buttons", 1)[1].split("shirt")[0])
+
     def test_dotpose_ref_to_observer_is_you(self):
         toks = self.tok_dot("nod at the droog", self.actor, [self.actor, self.you])
         out = self.render_dot(toks, self.actor, self.you).lower()

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -473,3 +473,22 @@ class TestSurroundings(TestCase):
     def test_no_desc_no_surroundings_line(self):
         text = render_persona({"location": {"name": "Dust Row", "desc": None}})
         self.assertNotIn("Your surroundings", text)
+
+
+class TestSmartQuoteNormalization(TestCase):
+    def _turn(self, action="", speech=""):
+        raw = json.dumps({"speech": speech, "action": action, "thought": "",
+                          "tool": "none", "tool_argument": ""})
+        return parse_turn(raw, {})
+
+    def test_curly_apostrophe_normalized(self):
+        turn = self._turn(action="eyes the lean man\u2019s hands")
+        self.assertEqual(turn["action"], "eyes the lean man's hands")
+
+    def test_curly_double_quotes_normalized(self):
+        turn = self._turn(action="grins, \u201ccome closer,\u201d she purrs")
+        self.assertIn('"come closer,"', turn["action"])
+
+    def test_curly_single_quoted_dialogue_promoted(self):
+        turn = self._turn(action="leans in, \u2018stay a while,\u2019 she murmurs")
+        self.assertIn('"stay a while,"', turn["action"])


### PR DESCRIPTION
Closes #957

- LLM parse layer normalises typographic quotes/apostrophes to ASCII
  at the source (speech rails, quote extraction, and the emote
  possessive cleanup all key on straight quotes)
- _YOU_POSSESSIVE_RE accepts the curly apostrophe as well
- both emote render loops drop a dangling bare "you" before a resolved
  char-ref like a redundant article, and the strip repeats so "you the"
  collapses fully — "buttons you the droog's shirt" now renders
  "buttons your shirt" for the target, "buttons the droog's shirt"
  for a bystander

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
