### PR TITLE
Resolve LLM second-person pose slips onto the patron's handle

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -521,8 +521,13 @@ class LLMNpcMixin:
         command (NPC_MEMORY_AND_IDENTITY_SPEC §4) — keyed on their apparent_uid
         in this NPC's recognition memory. Skips a no-op re-name so the LLM can't
         churn the same nickname every turn."""
-        name = " ".join(str(name).split())[:40]
+        name = " ".join(str(name).split())[:40].strip(" .,!?;:'\"")
         if not name or " as " in name.lower():
+            return
+        # Pronouns aren't names — a stored "you"/"him" becomes the address
+        # handle and poisons every subsequent pose reference.
+        if name.lower() in ("you", "your", "yours", "me", "my", "him", "his",
+                            "her", "hers", "them", "their", "they", "it", "us"):
             return
         try:
             from world.identity import get_assigned_name
@@ -582,6 +587,8 @@ class LLMNpcMixin:
         speech = speech.strip().strip('"').strip() if speech else None
         action = action.strip() if action else None
         thought = thought.strip() if thought else None
+        if action and patron:
+            action = self._resolve_second_person(action, patron)
         if action:
             body = action
             if speech and '"' not in body:
@@ -595,6 +602,33 @@ class LLMNpcMixin:
             self.execute_cmd(f"say {speech}")
         if thought:
             self.execute_cmd(f"think {thought}")
+
+    def _resolve_second_person(self, action, patron):
+        """Resolve the model's second-person slips onto the patron's handle.
+
+        Everything the model reads renders "you" as the NPC itself, so it
+        drifts into calling its interlocutor "you"/"your" in its own ACTION.
+        A literal "you" in a broadcast pose is wrong for every observer but
+        the target (a bystander reads it as themselves). Rewriting it to the
+        patron's handle (the PERCEPTION wording) lets the emote engine's
+        char-ref matcher resolve it per-observer — the target still reads
+        "you"/"your", a bystander reads the name THEY know. Quoted speech is
+        dialogue and stays verbatim; contractions (you've) are left alone."""
+        try:
+            handle = self._address_handle(patron)
+        except Exception:  # noqa: BLE001
+            return action
+        if not handle:
+            return action
+
+        def _rewrite(seg):
+            seg = re.sub(r"\byours?\b", f"{handle}'s", seg, flags=re.I)
+            return re.sub(r"\byou(?:rself)?\b(?!['’])", handle, seg,
+                          flags=re.I)
+
+        chunks = action.split('"')
+        chunks[0::2] = [_rewrite(c) for c in chunks[0::2]]
+        return '"'.join(chunks)
 
     def _llm_silent(self):
         """Sidecar failed or declined on conversation: stay quiet."""

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -616,7 +616,12 @@ _SMART_QUOTES = str.maketrans({"’": "'", "‘": "'",
 
 def _clean(text: str) -> str:
     text = (text or "").translate(_SMART_QUOTES)
-    text = text.strip().strip("\"'*").strip()
+    text = text.strip().strip("*").strip()
+    # Unwrap symmetric quote WRAPPING only ('"hi"' -> hi). A one-sided strip
+    # would eat the closing quote of an action that ENDS in embedded dialogue
+    # ('leans in, "hi"'), unbalancing it so every quote gets dropped.
+    while len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        text = text[1:-1].strip()
     text = re.sub(r"^[A-Z][a-z]+:\s*", "", text)
     return re.sub(r"\s+", " ", text).strip()[:_MAX_LEN]
 
@@ -643,6 +648,21 @@ def _normalize_action(action: str) -> str:
     does NO conjugation, so there's nothing to massage."""
     if not action:
         return action
+    # Second-person cleanup — the model's context is full of "you" meaning
+    # ITSELF (other people's poses rendered from its POV), so it slips into
+    # calling its interlocutor "you", doubling it, and even punctuating it
+    # like a name ("grabs you you.'s shirt"). Repair the mechanical damage
+    # OUTSIDE quoted speech (dialogue is verbatim); _render_llm_reply then
+    # resolves surviving second-person onto the patron's real handle so
+    # every observer reads the right name.
+    def _fix_second_person(seg):
+        seg = re.sub(r"\byou[.,]?\s+(?=you\b)", "", seg, flags=re.I)
+        seg = re.sub(r"\byou\.?'s\b", "your", seg, flags=re.I)
+        seg = re.sub(r"\byou\.\s+(?=[a-z])", "you ", seg)
+        return seg
+    chunks = action.split('"')
+    chunks[0::2] = [_fix_second_person(c) for c in chunks[0::2]]
+    action = '"'.join(chunks)
     if '"' not in action:
         # 'come here,' she purrs → "come here," — the lookarounds keep
         # contractions (don't, it's) from reading as quote marks.

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -612,7 +612,8 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         "_classify_speech", "_is_npc_speaker", "_is_engaged_with",
         "_mentions_self", "_name_aliases",
         "_handle_directed_speech", "_try_llm_reply",
-        "_render_llm_reply", "_llm_fallback", "_llm_silent",
+        "_render_llm_reply", "_resolve_second_person",
+        "_llm_fallback", "_llm_silent",
     )
 
     def _bartender(self, llm_driven=True, location="room"):
@@ -630,6 +631,8 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
             setattr(b, name, bound)
         # default: not alone (so ambient stays ambient); override per test
         b._is_alone_with = lambda speaker: False
+        # real _resolve_second_person needs a concrete handle
+        b._address_handle = lambda t: "a lean man"
         # default: no long-term memories → _try_llm_reply skips the embed round-
         # trip and goes straight to generation (Phase 2; override per test)
         b._load_memories = lambda: []

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -459,3 +459,76 @@ class TestRoomDescPerception(TestCase):
         npc = MagicMock()
         npc.location = None
         self.assertIsNone(_room_desc(npc))
+
+
+class TestSecondPersonResolution(TestCase):
+    """Surviving second-person in an ACTION resolves onto the patron's handle
+    so the emote engine renders it per-observer (bystanders read the name,
+    the target reads you/your)."""
+
+    def _npc(self):
+        b = MagicMock()
+        b._address_handle = lambda p: "the lean man"
+        _bind(b, "_resolve_second_person")
+        return b
+
+    def test_bare_you_becomes_handle(self):
+        b = self._npc()
+        out = b._resolve_second_person(
+            "presses you against the wall, pinning you there", MagicMock())
+        self.assertEqual(out, "presses the lean man against the wall, "
+                              "pinning the lean man there")
+
+    def test_your_becomes_handle_possessive(self):
+        b = self._npc()
+        out = b._resolve_second_person("traces your collarbone", MagicMock())
+        self.assertEqual(out, "traces the lean man's collarbone")
+
+    def test_yourself_becomes_handle(self):
+        b = self._npc()
+        out = b._resolve_second_person("lets you steady yourself", MagicMock())
+        self.assertEqual(out, "lets the lean man steady the lean man")
+
+    def test_contractions_survive(self):
+        b = self._npc()
+        out = b._resolve_second_person("hums like you've never heard",
+                                       MagicMock())
+        self.assertIn("you've never heard", out)
+
+    def test_quoted_speech_untouched(self):
+        b = self._npc()
+        out = b._resolve_second_person(
+            'leans close to you, "you want to play dress-up with me,"',
+            MagicMock())
+        self.assertIn('"you want to play dress-up with me,"', out)
+        self.assertTrue(out.startswith("leans close to the lean man"))
+
+    def test_no_handle_no_rewrite(self):
+        b = MagicMock()
+        b._address_handle = lambda p: None
+        _bind(b, "_resolve_second_person")
+        out = b._resolve_second_person("watches you", MagicMock())
+        self.assertEqual(out, "watches you")
+
+
+class TestRememberNameGuard(TestCase):
+    def _npc(self):
+        b = MagicMock()
+        b.location = "room"
+        _bind(b, "_remember_person")
+        return b
+
+    def test_pronoun_names_rejected(self):
+        for junk in ("you", "You.", "him", "her", "them"):
+            b = self._npc()
+            b._remember_person(MagicMock(), junk)
+            b.execute_cmd.assert_not_called()
+
+    def test_trailing_punctuation_stripped(self):
+        b = self._npc()
+        patron = MagicMock()
+        patron.get_display_name = lambda looker=None, **k: "a lean man"
+        with patch("world.identity.get_assigned_name", return_value=None):
+            b._remember_person(patron, "the negotiating ninja.")
+        b.execute_cmd.assert_called_once_with(
+            "remember a lean man as the negotiating ninja")

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -492,3 +492,30 @@ class TestSmartQuoteNormalization(TestCase):
     def test_curly_single_quoted_dialogue_promoted(self):
         turn = self._turn(action="leans in, \u2018stay a while,\u2019 she murmurs")
         self.assertIn('"stay a while,"', turn["action"])
+
+
+class TestSecondPersonRepair(TestCase):
+    """The screenshot class: "grabs you you.'s shirt", "presses you you.
+    against the wall" — model-written second-person damage, repaired outside
+    quoted speech."""
+
+    def _action(self, action):
+        raw = json.dumps({"speech": "", "action": action, "thought": "",
+                          "tool": "none", "tool_argument": ""})
+        return parse_turn(raw, {})["action"]
+
+    def test_doubled_you_possessive(self):
+        out = self._action("grabs you you's shirt by the collar")
+        self.assertEqual(out, "grabs your shirt by the collar")
+
+    def test_doubled_you_with_period_possessive(self):
+        out = self._action("grabs you you.'s shirt by the collar")
+        self.assertEqual(out, "grabs your shirt by the collar")
+
+    def test_doubled_you_with_stray_period(self):
+        out = self._action("presses you you. against the wall")
+        self.assertEqual(out, "presses you against the wall")
+
+    def test_dialogue_untouched(self):
+        out = self._action('pins the lean man, "you, you magnificent thing"')
+        self.assertIn('"you, you magnificent thing"', out)


### PR DESCRIPTION
Closes #959

- _normalize_action repairs model-written second-person damage outside
  quoted speech: "you you" dedupe, "you.'s"/"you's" -> your, stray
  mid-sentence period after "you"
- _resolve_second_person (render path) rewrites surviving you/your/
  yours/yourself outside dialogue onto the patron's address handle so
  the emote char-ref matcher renders per-observer (target reads you/
  your, bystanders read the name they know); contractions and quoted
  dialogue untouched
- _remember_person strips trailing punctuation and rejects bare
  pronouns as names (a stored "you" poisons the address handle)
- _clean unwraps only SYMMETRIC quote wrapping — one-sided end-strip
  ate the closing quote of actions ending in embedded dialogue,
  unbalancing them so all quotes dropped

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
