### PR TITLE
Spell out the remember/feel argument contract in the tool prompts

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -28,14 +28,18 @@ TOOLS = {
                          "they gave you, OR a nickname you privately coin from "
                          "what you know about them (e.g. 'the foot guy', 'tab "
                          "dodger'). Private to you; from then on you know them by "
-                         "it. Do it when someone's worth tagging, not every turn "
-                         "(argument: the name)"},
+                         "it. Do it when someone's worth tagging, not every turn. "
+                         "The argument is the NAME ONLY: one to four plain "
+                         "words, no punctuation, no sentence, and never a "
+                         "pronoun like 'you' or 'him' — you'll be using this "
+                         "word as their name in your poses from now on"},
     "feel": {"kind": "action",
              "desc": "update your private read on the person you're speaking to, "
                      "based on what they've done and said (e.g. 'wary', 'fond', "
                      "'fed up', 'amused', 'owes me one'). It colours how you treat "
                      "them from now on — set it when their behaviour shifts how "
-                     "you feel, not every turn (argument: a short word/phrase)"},
+                     "you feel, not every turn (argument: a short plain-English "
+                     "word or phrase)"},
     "style": {"kind": "action",
               "desc": "adjust your OWN clothing for real — zip, unzip, "
                       "button, unbutton, rollup, unroll, remove, or wear a "

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -519,3 +519,10 @@ class TestSecondPersonRepair(TestCase):
     def test_dialogue_untouched(self):
         out = self._action('pins the lean man, "you, you magnificent thing"')
         self.assertIn('"you, you magnificent thing"', out)
+
+
+class TestRememberNamingDiscipline(TestCase):
+    def test_remember_desc_forbids_pronouns_and_punctuation(self):
+        desc = TOOLS["remember"]["desc"]
+        self.assertIn("no punctuation", desc)
+        self.assertIn("never a pronoun", desc)


### PR DESCRIPTION
Closes #961

The model stored 'the negotiating ninja.' (trailing period) as a name
and a Cyrillic word as a feeling; the name then poisoned every pose
reference to that player. The #960 guard cleans defensively — this
teaches the model the contract at the source: remember's argument is
the name ONLY (1-4 plain words, no punctuation, never a pronoun,
because it becomes the person's name in poses); feel takes a short
plain-English word or phrase.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
