### PR TITLE
Guard assigned names: content words required, common tokens stopworded

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -524,10 +524,16 @@ class LLMNpcMixin:
         name = " ".join(str(name).split())[:40].strip(" .,!?;:'\"")
         if not name or " as " in name.lower():
             return
-        # Pronouns aren't names — a stored "you"/"him" becomes the address
-        # handle and poisons every subsequent pose reference.
-        if name.lower() in ("you", "your", "yours", "me", "my", "him", "his",
-                            "her", "hers", "them", "their", "they", "it", "us"):
+        # A name needs at least one CONTENT word. Pronouns, demonstratives,
+        # and generic person-words aren't names — "you", "that guy", "the
+        # one" would become the address handle and poison every subsequent
+        # pose reference (and their common tokens would spuriously match
+        # ordinary prose in the emote matcher).
+        from world.emote import _ASSIGNED_NAME_STOPWORDS
+        junk = _ASSIGNED_NAME_STOPWORDS | {
+            "me", "my", "mine", "us", "we", "who", "someone", "anybody",
+        }
+        if all(w.lower() in junk for w in name.split()):
             return
         try:
             from world.identity import get_assigned_name

--- a/world/emote.py
+++ b/world/emote.py
@@ -265,6 +265,14 @@ def _spans_overlap(
 _ASSIGNED_NAME_STOPWORDS = frozenset({
     "the", "a", "an", "of", "and", "to", "in", "on", "at", "with", "for",
     "from", "by",
+    # demonstratives / pronouns / quantifiers — a name like "that guy" must
+    # not make every prose "that" a match for this character
+    "that", "this", "these", "those", "one", "ones", "two", "some", "any",
+    "you", "your", "he", "she", "it", "him", "her", "his", "hers",
+    "they", "them", "their",
+    # generic person-words: matchable via the full name or the sdesc
+    # composites, but too common in prose to stand alone as a candidate
+    "guy", "man", "woman", "girl", "boy", "person", "lady", "fellow",
 })
 
 

--- a/world/tests/test_emote.py
+++ b/world/tests/test_emote.py
@@ -1096,7 +1096,12 @@ class TestAssignedNameTokenTargeting(TestCase):
         names = [name for name, _char, _rc in candidates]
         self.assertNotIn("the", names)
         self.assertIn("labor", names)   # content words still target
-        self.assertIn("guy", names)
+        # generic person-words are too common in prose to stand alone as
+        # candidates ("watches the guy by the door" must not resolve to
+        # whoever happens to be remembered as "the labor guy"); the full
+        # name still matches
+        self.assertNotIn("guy", names)
+        self.assertIn("the labor guy", names)
 
     def test_article_in_assigned_name_not_resolved_in_prose(self) -> None:
         """End-to-end: a literal "the" in a pose does not resolve to the
@@ -2025,3 +2030,20 @@ class TestSecondPersonObserverRef(TestCase):
         toks = self.tok_emote("nods at the droog", self.actor, [self.you])
         out = self.render_emote(toks, self.actor, stranger).lower()
         self.assertIn("droog", out)               # named, not "you"
+
+
+class TestAssignedNameStopwords(TestCase):
+    """Common-word tokens of an assigned name must not become standalone
+    match candidates — a name like "that guy" would otherwise make every
+    prose "that" a reference to this character."""
+
+    def test_dangerous_tokens_stopworded(self):
+        from world.emote import _ASSIGNED_NAME_STOPWORDS as sw
+        for word in ("that", "this", "one", "you", "her", "guy", "man",
+                     "woman", "person"):
+            self.assertIn(word, sw)
+
+    def test_content_words_still_candidates(self):
+        from world.emote import _ASSIGNED_NAME_STOPWORDS as sw
+        for word in ("ninja", "dodger", "foot", "wendy"):
+            self.assertNotIn(word, sw)

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -524,6 +524,25 @@ class TestRememberNameGuard(TestCase):
             b._remember_person(MagicMock(), junk)
             b.execute_cmd.assert_not_called()
 
+    def test_contentless_names_rejected(self):
+        # determiner/demonstrative + generic person-word = not a name
+        for junk in ("that guy", "the one", "this one", "that man",
+                     "the lady", "you two"):
+            b = self._npc()
+            b._remember_person(MagicMock(), junk)
+            b.execute_cmd.assert_not_called()
+
+    def test_contentful_names_accepted(self):
+        for good in ("the foot guy", "tab dodger", "Roony",
+                     "the negotiating ninja"):
+            b = self._npc()
+            patron = MagicMock()
+            patron.get_display_name = lambda looker=None, **k: "a lean man"
+            with patch("world.identity.get_assigned_name", return_value=None):
+                b._remember_person(patron, good)
+            b.execute_cmd.assert_called_once_with(
+                f"remember a lean man as {good}")
+
     def test_trailing_punctuation_stripped(self):
         b = self._npc()
         patron = MagicMock()


### PR DESCRIPTION
Closes #963

- extend _ASSIGNED_NAME_STOPWORDS with demonstratives, pronouns,
  quantifiers, and generic person-words so a name like "that guy"
  can't make every prose "that"/"guy" a spurious char-ref candidate;
  full-name and content-word targeting unchanged
- _remember_person rejects names with no content word ("that guy",
  "the one", "you two"); idiomatic nicknames ("the foot guy",
  "tab dodger") store fine
- update the article-token pin: bare "guy" no longer targets
  "the labor guy" (the full name still does)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
