### PR TITLE
Trust & Consent Phase 1: gate, grants, commands, clothing+medical consumers

### DIFF
--- a/commands/CmdClothing.py
+++ b/commands/CmdClothing.py
@@ -558,29 +558,19 @@ class CmdZip(Command):
 # the consent layer can't gracefully extend.
 
 
-def _can_third_party_clothing(target):
-    """Permission gate for dress / undress (#307 PR-H3 + memory).
+def _can_third_party_clothing(caller, target):
+    """Permission gate for dress / undress (#307 PR-H3; trust layer #967).
 
-    Returns True when the target is in a state where third-party
-    clothing manipulation is allowed without explicit consent:
-    severed appendage, unconscious character, dead character.
-    The trust/consent layer will extend this contract to cover
-    conscious cooperative targets; until then it's the limit.
+    Severed appendages are always dressable. Characters ride the shared
+    consent gate (TRUST_AND_CONSENT_SPEC ``dress`` class): free when the
+    target cannot contest (unconscious / dead / restrained), otherwise the
+    target must have trusted the caller to dress them.
     """
     from typeclasses.items import Appendage
     if isinstance(target, Appendage):
         return True
-
-    medical_state = getattr(target, "medical_state", None)
-    if medical_state is None:
-        return False
-    is_dead = getattr(medical_state, "is_dead", None)
-    is_unconscious = getattr(medical_state, "is_unconscious", None)
-    if callable(is_dead) and is_dead():
-        return True
-    if callable(is_unconscious) and is_unconscious():
-        return True
-    return False
+    from world.consent import check_consent
+    return check_consent(caller, target, "dress")
 
 
 def _resolve_clothing_target(caller, target_phrase):
@@ -660,11 +650,11 @@ class CmdDress(Command):
         dress severed left arm in leather glove
         dress corpse in burial shroud
 
-    Target must be unconscious, dead, or a severed appendage —
-    conscious cooperative dressing requires the trust/consent
-    system, which isn't implemented yet.  The clothing item must
-    be in your inventory; it transfers to the target along with
-    the worn registration.
+    Works freely on a target who cannot contest — unconscious,
+    dead, restrained, or a severed appendage. A conscious, free
+    target must have trusted you to dress them (see ``help
+    trust``). The clothing item must be in your inventory; it
+    transfers to the target along with the worn registration.
 
     Related: undress, wear, remove.
     """
@@ -699,12 +689,11 @@ class CmdDress(Command):
         if isinstance(item, list):
             item = item[0]
 
-        if not _can_third_party_clothing(target):
+        if not _can_third_party_clothing(caller, target):
             caller.msg(
                 f"{target.get_display_name(caller)} is conscious "
-                f"and would resist. (Cooperative dressing of a "
-                f"conscious target requires the trust/consent system, "
-                f"which isn't implemented yet.)"
+                f"and would resist — they'd need to trust you to "
+                f"dress them (or be restrained)."
             )
             return
 
@@ -805,8 +794,9 @@ class CmdUndress(Command):
     item by name (substring match against the target's worn
     items).  Removed items transfer to your inventory.
 
-    Target must be unconscious, dead, or a severed appendage —
-    same gate as ``dress``.
+    Works freely on a target who cannot contest (unconscious,
+    dead, restrained, or a severed appendage); a conscious, free
+    target must have trusted you — same gate as ``dress``.
 
     Related: dress, remove.
     """
@@ -838,12 +828,11 @@ class CmdUndress(Command):
         if target is None:
             return
 
-        if not _can_third_party_clothing(target):
+        if not _can_third_party_clothing(caller, target):
             caller.msg(
                 f"{target.get_display_name(caller)} is conscious "
-                f"and would resist. (Cooperative undressing of a "
-                f"conscious target requires the trust/consent "
-                f"system, which isn't implemented yet.)"
+                f"and would resist — they'd need to trust you to "
+                f"dress them (or be restrained)."
             )
             return
 

--- a/commands/CmdConsumption.py
+++ b/commands/CmdConsumption.py
@@ -224,6 +224,18 @@ class ConsumptionCommand(Command):
         except AttributeError:
             errors.append(f"{target.get_display_name(user)} cannot receive medical treatment.")
             
+        # Trust/consent gate (TRUST_AND_CONSENT_SPEC §3, `heal` class):
+        # treating someone ELSE who can contest requires their trust.
+        if target is not user:
+            from world.consent import check_consent
+            if not check_consent(user, target, "heal"):
+                errors.append(
+                    f"{target.get_display_name(user)} is conscious and "
+                    f"would resist treatment — they'd need to trust you "
+                    f"to heal them (or be restrained)."
+                )
+                return errors
+
         # Check consciousness for certain procedures
         if hasattr(target, 'is_unconscious') and target.is_unconscious():
             # Some procedures can be done on unconscious patients

--- a/commands/CmdSurgical.py
+++ b/commands/CmdSurgical.py
@@ -128,6 +128,19 @@ def _resolve_target(caller, raw_name):
         allow_self=False,
     )
     if identity_match is not None:
+        # Trust/consent gate (TRUST_AND_CONSENT_SPEC §3, `heal` class):
+        # surgery on someone ELSE who can contest requires their trust.
+        # One seam for every surgical verb (operate/incise/harvest/
+        # install/suture route their character targets through here).
+        from world.consent import check_consent
+        if identity_match is not caller and not check_consent(
+                caller, identity_match, "heal"):
+            caller.msg(
+                f"{identity_match.get_display_name(caller)} is conscious "
+                f"and would resist the knife — they'd need to trust you "
+                f"to heal them (or be restrained)."
+            )
+            return None
         return identity_match
 
     # Stage 2 — inventory fallback (non-character targets only;

--- a/commands/CmdTrust.py
+++ b/commands/CmdTrust.py
@@ -1,0 +1,210 @@
+"""``trust`` / ``distrust`` — managing consent grants (TRUST_AND_CONSENT_SPEC §4).
+
+Trust opens the conscious-and-willing path for invasive third-party actions
+(dress, heal, …). It binds to the trusted person's CURRENT apparent identity:
+if they change who they appear to be (doff an essential disguise, re-sleeve),
+the grant silently stops matching.
+"""
+
+from evennia import Command
+
+from world.consent import (
+    ACTION_CLASSES, get_grants, grant_display_name, grant_trust,
+    revoke_trust, wipe_trust,
+)
+
+_CLASSES_LINE = ", ".join(ACTION_CLASSES)
+
+
+def _resolve_present_person(caller, phrase):
+    """Resolve a phrase to a character PRESENT with the caller (grants are
+    made face-to-face — spec §7.5). Emits its own failure message."""
+    target = caller.search(phrase)
+    if target is None:
+        return None
+    if target is caller:
+        caller.msg("You don't need to trust yourself.")
+        return None
+    from world.identity import get_apparent_uid
+    if not get_apparent_uid(target):
+        caller.msg(
+            f"{target.get_display_name(caller)} isn't someone you can "
+            f"extend trust to."
+        )
+        return None
+    return target
+
+
+def _match_stored_grant(caller, phrase):
+    """Match a phrase against stored grants by how the caller perceives
+    them (recognition name or grant-time label) — the revoke path works
+    from memory even when the person isn't here. Returns (uid, name) or
+    (None, None); messages ambiguity/misses itself."""
+    phrase_low = phrase.lower().strip()
+    matches = []
+    for uid, entry in get_grants(caller).items():
+        name = grant_display_name(caller, uid, entry)
+        low = name.lower()
+        if phrase_low == low or phrase_low in low:
+            matches.append((uid, name))
+    if not matches:
+        caller.msg(f"You don't have any trust extended to '{phrase}'.")
+        return None, None
+    if len(matches) > 1:
+        names = ", ".join(name for _uid, name in matches)
+        caller.msg(f"That matches more than one person you trust: {names}.")
+        return None, None
+    return matches[0]
+
+
+class CmdTrust(Command):
+    """
+    Extend trust — let someone act on you while you're awake.
+
+    Usage:
+        trust                        - list who you trust, and with what
+        trust <person>               - show what you trust that person with
+        trust <person> to <action>   - grant one action class
+        trust <person> to all        - grant everything
+        trust no one                 - revoke every grant (same as distrust all)
+
+    Action classes: dress, escort, grab, heal, search
+
+    Most third-party actions land freely on someone who cannot contest —
+    unconscious, dead, or restrained (grappled, strapped into a pod). Trust
+    is the conscious-and-willing path: it lets the person you name do that
+    class of thing to you while you're awake and free.
+
+    Trust binds to the person AS YOU CURRENTLY PERCEIVE THEM. If they shed
+    the identity you trusted (drop an essential disguise, re-sleeve into a
+    new body), the grant no longer matches. Note that "heal" is deliberately
+    all of medicine — treating, surgery, and harvesting alike. Choose your
+    ripperdoc carefully.
+
+    See also: distrust.
+    """
+
+    key = "trust"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+
+        if not args:
+            self._list_grants()
+            return
+        if args.lower() in ("no one", "noone", "nobody"):
+            n = wipe_trust(caller)
+            caller.msg("You trust no one now."
+                       if n else "You already trust no one.")
+            return
+
+        person_phrase, sep, action = args.rpartition(" to ")
+        if not sep:
+            self._show_person(args)
+            return
+        person_phrase = person_phrase.strip()
+        action = action.strip().lower()
+        if action != "all" and action not in ACTION_CLASSES:
+            caller.msg(f"'{action}' isn't a trustable action. "
+                       f"Choose one of: {_CLASSES_LINE} — or 'all'.")
+            return
+        target = _resolve_present_person(caller, person_phrase)
+        if target is None:
+            return
+        classes = grant_trust(caller, target, action)
+        if not classes:
+            caller.msg("That grant didn't take.")
+            return
+        name = target.get_display_name(caller)
+        what = ("everything (" + ", ".join(classes) + ")"
+                if action == "all" else action)
+        caller.msg(
+            f"You now trust {name} to {what}. It binds to them as they "
+            f"appear now — if they become someone else, it lapses."
+        )
+
+    def _list_grants(self):
+        caller = self.caller
+        grants = get_grants(caller)
+        if not grants:
+            caller.msg("You trust no one.")
+            return
+        lines = ["You trust:"]
+        for uid, entry in grants.items():
+            name = grant_display_name(caller, uid, entry)
+            classes = ", ".join(entry.get("classes") or ())
+            lines.append(f"  {name} — {classes}")
+        caller.msg("\n".join(lines))
+
+    def _show_person(self, phrase):
+        caller = self.caller
+        target = _resolve_present_person(caller, phrase)
+        if target is None:
+            return
+        from world.identity import get_apparent_uid
+        entry = get_grants(caller).get(get_apparent_uid(target))
+        name = target.get_display_name(caller)
+        if not entry or not entry.get("classes"):
+            caller.msg(f"You don't trust {name} with anything.")
+            return
+        caller.msg(f"You trust {name} to: "
+                   + ", ".join(entry["classes"]) + ".")
+
+
+class CmdDistrust(Command):
+    """
+    Revoke trust.
+
+    Usage:
+        distrust <person>              - revoke everything from that person
+        distrust <person> to <action>  - revoke one action class
+        distrust all                   - revoke every grant you've made
+
+    Works from memory: the person doesn't need to be here — name them the
+    way you know them (your recognition name for them, or how they looked
+    when you granted it).
+
+    See also: trust.
+    """
+
+    key = "distrust"
+    aliases = ["untrust"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+        if not args:
+            caller.msg("Usage: distrust <person> [to <action>] | distrust all")
+            return
+        if args.lower() == "all":
+            n = wipe_trust(caller)
+            caller.msg("You trust no one now."
+                       if n else "You already trust no one.")
+            return
+
+        person_phrase, sep, action = args.rpartition(" to ")
+        action_class = None
+        if sep:
+            person_phrase = person_phrase.strip()
+            action_class = action.strip().lower()
+            if action_class not in ACTION_CLASSES:
+                caller.msg(f"'{action_class}' isn't a trustable action. "
+                           f"Choose one of: {_CLASSES_LINE}.")
+                return
+        else:
+            person_phrase = args
+
+        uid, name = _match_stored_grant(caller, person_phrase)
+        if uid is None:
+            return
+        if revoke_trust(caller, uid, action_class):
+            what = action_class or "anything"
+            caller.msg(f"You no longer trust {name} to {what}.")
+        else:
+            caller.msg(f"You didn't trust {name} to {action_class} "
+                       f"in the first place.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -35,6 +35,7 @@ from commands.bar_menu import CmdSpawnIngredient
 from commands.CmdBug import CmdBug
 from commands.CmdAdmin import CmdHeal, CmdPeace, CmdTestDeathCurtain, CmdWeather, CmdResetMedical, CmdMedicalAudit, CmdTestDeath, CmdTestUnconscious
 from commands.CmdFixCharacterOwnership import CmdFixCharacterOwnership
+from commands.CmdTrust import CmdDistrust, CmdTrust
 from commands.combat.cmdset_combat import CombatCmdSet
 from commands.combat.special_actions import CmdAim, CmdGrapple
 from commands.CmdThrow import CmdThrow, CmdPull, CmdCatch
@@ -162,6 +163,11 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
 
         # force override: an LLM-driven NPC perceives what it was made to do
         self.add(CmdAdmin.CmdForce())
+
+        # Trust & consent (TRUST_AND_CONSENT_SPEC Phase 1): the grant surface
+        # behind the third-party action gate (world/consent.py).
+        self.add(CmdTrust())
+        self.add(CmdDistrust())
         
         # Add aim command for ranged combat preparation
         self.add(CmdAim())

--- a/specs/proposals/TRUST_AND_CONSENT_SPEC.md
+++ b/specs/proposals/TRUST_AND_CONSENT_SPEC.md
@@ -1,14 +1,18 @@
 # Trust & Consent Spec
 
-> **Status: 🚧 DESIGN RESOLVED — NOT YET CLEARED FOR BUILD.** The core model is
-> settled (2026-06-26 design pass; 2026-07-02 deep-dig pass added the `dress`
-> action class, resolved NPC participation to *self-action only*, and recorded
-> recommended resolutions for the §7 edge cases + a proposed build sequence
-> §9). The user has flagged this as **"SUPER IMPORTANT"** and a **roadblock
-> before a true alpha**; they decide when implementation starts — do not build
-> ahead of that call. This doc exists so the decisions survive and so new
-> third-party commands have a clean gate to defer to rather than inventing
-> one-off logic.
+> **Status: ✅ PHASE 1 SHIPPED (2026-07-03) — §9 P2/P3 pending.** The gate
+> (`world/consent.py`: `can_contest` / `is_restrained` / `check_consent`),
+> the grant store, the `trust`/`distrust` commands (§4), and the Phase-1
+> consumers — third-party clothing (`dress` class) and the full medical
+> suite (`heal` class: treat items via `check_medical_requirements`,
+> operate/incise/harvest/install/suture via the shared surgical target
+> resolver) — are live. The §7 recommendations were implemented as written
+> (duress grants stand; per-command gate check; shared `is_restrained`
+> unifying grapple + `db.restraining` furniture with a legacy-AutoDoc
+> fallback; strict consciousness binary; presence-required grants /
+> memory-based revokes). Remaining: §9 P2 (`frisk`) and P3 (escort +
+> dispatch coercive seam). Design history: 2026-06-26 core pass;
+> 2026-07-02 deep-dig (`dress` class, NPC self-action only, §7/§9).
 
 ## 0 · Purpose
 

--- a/typeclasses/furniture.py
+++ b/typeclasses/furniture.py
@@ -62,6 +62,11 @@ class AutoDoc(Furniture):
         self.db.postures = ("lying",)
         self.db.preposition = "in"
         self.db.is_medical = True
+        # Restraint device (TRUST_AND_CONSENT_SPEC §1): a pod-bound patient
+        # cannot contest — being strapped in is what authorizes treatment.
+        # world/consent.is_restrained also treats any medical lie-in pod as
+        # restraining, so AutoDocs created before this flag behave the same.
+        self.db.restraining = True
         # Clinic apparatus: operating on a patient lying here steadies the work —
         # a bonus to the treatment check (world.medical.utils.calculate_treatment_
         # success). The clinic's medical-supply STOCK (real items the doctor draws)

--- a/world/consent.py
+++ b/world/consent.py
@@ -1,0 +1,196 @@
+"""Trust & consent — the third-party action gate.
+
+Implements TRUST_AND_CONSENT_SPEC Phase 1: one shared answer to "may this
+actor do this class of thing to that target?" so third-party commands stop
+inventing one-off gates.
+
+The core stance (spec §1): a target can refuse an invasive third-party
+action only when it can CONTEST — conscious AND unrestrained. Otherwise the
+action lands freely (the existing unconscious/dead gate, generalized to
+include restraint). The conscious-and-unwilling path is opened by TRUST,
+granted per action class and keyed to the actor's *perceived identity*
+(``get_apparent_uid`` — trusting "batman" is not trusting "bruce wayne";
+spec §2).
+
+Consumers call :func:`check_consent`; the ``trust``/``distrust`` commands
+(``commands/CmdTrust.py``) manage the grants.
+"""
+
+from evennia.utils.dbserialize import deserialize
+
+#: The grantable action classes (spec §3). A class maps to a set of gated
+#: commands; Phase 1 wires the ``dress`` (third-party clothing) and ``heal``
+#: (all-medical, deliberately blanket) consumers. ``escort``/``grab``/
+#: ``search`` grants are storable now, consumed by later phases.
+ACTION_CLASSES = ("dress", "escort", "grab", "heal", "search")
+
+
+# --------------------------------------------------------------------------
+# The contest predicate (spec §1)
+# --------------------------------------------------------------------------
+
+def is_conscious(target) -> bool:
+    """Whether the target is provably awake. A target with no readable
+    medical state is treated as conscious — we only take the free-action
+    path when helplessness is affirmative, matching the conservative
+    polarity of the old per-command gates."""
+    medical_state = getattr(target, "medical_state", None)
+    if medical_state is None:
+        return True
+    try:
+        if callable(medical_state.is_dead) and medical_state.is_dead():
+            return False
+        if (callable(medical_state.is_unconscious)
+                and medical_state.is_unconscious()):
+            return False
+    except Exception:  # noqa: BLE001 — unreadable state = assume awake
+        return True
+    return True
+
+
+def is_restrained(target) -> bool:
+    """The shared restraint predicate (spec §7.3): a grapple OR a restraint
+    device. Devices are furniture with ``db.restraining``; live AutoDocs
+    predate that flag, so a medical lie-in pod counts too (the healing pod
+    is the spec's canonical restraint device — no live backfill needed)."""
+    # Grapple (world/combat/grappling.py state).
+    try:
+        from world.combat.constants import NDB_COMBAT_HANDLER
+        from world.combat.grappling import is_grappled
+        handler = getattr(target.ndb, NDB_COMBAT_HANDLER, None)
+        if handler and is_grappled(handler, target):
+            return True
+    except Exception:  # noqa: BLE001 — no combat state = not grappled
+        pass
+    # Restraint device (furniture the target occupies).
+    try:
+        furniture = target.db.furniture
+        if furniture is not None:
+            if getattr(furniture.db, "restraining", False):
+                return True
+            if (getattr(furniture.db, "is_medical", False)
+                    and "lying" in (furniture.db.postures or ())):
+                return True
+    except Exception:  # noqa: BLE001
+        pass
+    return False
+
+
+def can_contest(target) -> bool:
+    """Spec §1: ``is_conscious(target) and not is_restrained(target)``."""
+    return is_conscious(target) and not is_restrained(target)
+
+
+# --------------------------------------------------------------------------
+# Grants (spec §2 storage: on the grantor, keyed by apparent uid)
+# --------------------------------------------------------------------------
+
+def get_grants(grantor) -> dict:
+    """The grantor's grants as a plain dict:
+    ``{apparent_uid: {"classes": [..], "label": "<snapshot>"}}``.
+    Defensive: a non-character "grantor" (a rock someone targeted)
+    simply holds no grants."""
+    db = getattr(grantor, "db", None)
+    return deserialize(getattr(db, "consent_grants", None)) or {}
+
+
+def grant_trust(grantor, actor, action_class) -> list:
+    """Grant ``action_class`` (or ``"all"``) to ``actor``'s CURRENT apparent
+    identity. Returns the actor's stored class list after the grant. The
+    display-label snapshot is refreshed each grant (spec §5 fallback)."""
+    from world.identity import get_apparent_uid
+    uid = get_apparent_uid(actor)
+    if not uid:
+        return []
+    grants = get_grants(grantor)
+    entry = dict(grants.get(uid) or {})
+    classes = list(entry.get("classes") or [])
+    wanted = list(ACTION_CLASSES) if action_class == "all" else [action_class]
+    for cls in wanted:
+        if cls in ACTION_CLASSES and cls not in classes:
+            classes.append(cls)
+    entry["classes"] = classes
+    try:
+        entry["label"] = actor.get_display_name(grantor)
+    except Exception:  # noqa: BLE001
+        entry["label"] = entry.get("label") or getattr(actor, "key", "someone")
+    grants[uid] = entry
+    grantor.db.consent_grants = grants
+    return classes
+
+
+def revoke_trust(grantor, uid, action_class=None) -> bool:
+    """Revoke one class (or, with ``action_class=None``, every grant) held
+    by ``uid``. Returns True if anything was removed."""
+    grants = get_grants(grantor)
+    entry = grants.get(uid)
+    if not entry:
+        return False
+    if action_class is None:
+        del grants[uid]
+        grantor.db.consent_grants = grants
+        return True
+    classes = list(entry.get("classes") or [])
+    if action_class not in classes:
+        return False
+    classes.remove(action_class)
+    if classes:
+        entry = dict(entry)
+        entry["classes"] = classes
+        grants[uid] = entry
+    else:
+        del grants[uid]
+    grantor.db.consent_grants = grants
+    return True
+
+
+def wipe_trust(grantor) -> int:
+    """``distrust all`` — wipe every grant. Returns how many were held."""
+    n = len(get_grants(grantor))
+    grantor.db.consent_grants = {}
+    return n
+
+
+def grant_display_name(grantor, uid, entry=None) -> str:
+    """How the grantor PERCEIVES a stored grant-holder (spec §5): their
+    recognition name for that uid if they still know one, else the label
+    snapshotted at grant time."""
+    try:
+        memory = deserialize(grantor.recognition_memory) or {}
+        assigned = (memory.get(uid) or {}).get("assigned_name")
+        if assigned:
+            return assigned
+    except Exception:  # noqa: BLE001
+        pass
+    entry = entry or get_grants(grantor).get(uid) or {}
+    return entry.get("label") or "someone"
+
+
+# --------------------------------------------------------------------------
+# The gate
+# --------------------------------------------------------------------------
+
+def has_trust(target, actor, action_class) -> bool:
+    """Whether ``target`` currently trusts ``actor``'s apparent identity
+    with ``action_class``. A disguise change or re-sleeve shifts the
+    actor's uid and the grant silently stops matching (spec §2)."""
+    try:
+        from world.identity import get_apparent_uid
+        uid = get_apparent_uid(actor)
+    except Exception:  # noqa: BLE001
+        return False
+    if not uid:
+        return False
+    entry = get_grants(target).get(uid)
+    return bool(entry and action_class in (entry.get("classes") or ()))
+
+
+def check_consent(actor, target, action_class) -> bool:
+    """THE gate. True when ``actor`` may perform an ``action_class`` action
+    on ``target``: self-action, a target that cannot contest (unconscious /
+    dead / restrained — the free path), or pre-granted trust."""
+    if actor is target:
+        return True
+    if not can_contest(target):
+        return True
+    return has_trust(target, actor, action_class)

--- a/world/tests/test_consent.py
+++ b/world/tests/test_consent.py
@@ -1,0 +1,278 @@
+"""Trust & consent gate (world/consent.py) — TRUST_AND_CONSENT_SPEC Phase 1.
+
+Predicates, grant storage, the gate, and the command surface, on MagicMock
+stand-ins (the LLM-test pattern) so no Evennia boot is needed for the pure
+logic. The identity key is patched — uid derivation has its own suite.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.consent as consent
+from world.consent import (
+    ACTION_CLASSES, can_contest, check_consent, get_grants,
+    grant_display_name, grant_trust, has_trust, is_conscious, is_restrained,
+    revoke_trust, wipe_trust,
+)
+
+
+def _char(dead=False, unconscious=False, furniture=None):
+    c = MagicMock()
+    c.medical_state.is_dead = lambda: dead
+    c.medical_state.is_unconscious = lambda: unconscious
+    c.db.furniture = furniture
+    c.ndb.combat_handler = None
+    c.db.consent_grants = None
+    c.recognition_memory = {}
+    return c
+
+
+class TestContestPredicate(TestCase):
+    def test_awake_free_target_contests(self):
+        self.assertTrue(can_contest(_char()))
+
+    def test_dead_cannot_contest(self):
+        self.assertFalse(can_contest(_char(dead=True)))
+
+    def test_unconscious_cannot_contest(self):
+        self.assertFalse(can_contest(_char(unconscious=True)))
+
+    def test_no_medical_state_treated_as_conscious(self):
+        # conservative polarity: only affirmative helplessness frees the
+        # action (matches the old per-command gates)
+        c = MagicMock()
+        c.medical_state = None
+        c.db.furniture = None
+        c.ndb.combat_handler = None
+        self.assertTrue(is_conscious(c))
+        self.assertTrue(can_contest(c))
+
+    def test_restraining_furniture_blocks_contest(self):
+        pod = MagicMock()
+        pod.db.restraining = True
+        self.assertTrue(is_restrained(_char(furniture=pod)))
+        self.assertFalse(can_contest(_char(furniture=pod)))
+
+    def test_legacy_autodoc_counts_via_medical_lying_fallback(self):
+        # live AutoDocs predate db.restraining — medical lie-in pod restrains
+        pod = MagicMock()
+        pod.db.restraining = False
+        pod.db.is_medical = True
+        pod.db.postures = ("lying",)
+        self.assertTrue(is_restrained(_char(furniture=pod)))
+
+    def test_ordinary_seat_does_not_restrain(self):
+        stool = MagicMock()
+        stool.db.restraining = False
+        stool.db.is_medical = False
+        stool.db.postures = ("sitting",)
+        self.assertFalse(is_restrained(_char(furniture=stool)))
+
+    def test_grapple_restrains(self):
+        from world.combat.constants import DB_CHAR, DB_GRAPPLED_BY_DBREF
+        c = _char()
+        handler = MagicMock()
+        handler.db.combatants = [{DB_CHAR: c, DB_GRAPPLED_BY_DBREF: "#42"}]
+        c.ndb.combat_handler = handler
+        self.assertTrue(is_restrained(c))
+        self.assertFalse(can_contest(c))
+
+    def test_in_combat_but_ungrappled_still_contests(self):
+        from world.combat.constants import DB_CHAR, DB_GRAPPLED_BY_DBREF
+        c = _char()
+        handler = MagicMock()
+        handler.db.combatants = [{DB_CHAR: c, DB_GRAPPLED_BY_DBREF: None}]
+        c.ndb.combat_handler = handler
+        self.assertFalse(is_restrained(c))
+
+
+class TestGrants(TestCase):
+    def _pair(self):
+        grantor = _char()
+        actor = MagicMock()
+        actor.get_display_name = lambda looker=None, **k: "a lean man"
+        return grantor, actor
+
+    def test_grant_revoke_roundtrip(self):
+        grantor, actor = self._pair()
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            grant_trust(grantor, actor, "heal")
+            self.assertTrue(has_trust(grantor, actor, "heal"))
+            self.assertFalse(has_trust(grantor, actor, "dress"))
+            revoke_trust(grantor, "uid-1", "heal")
+            self.assertFalse(has_trust(grantor, actor, "heal"))
+
+    def test_grant_all_is_blanket(self):
+        grantor, actor = self._pair()
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            classes = grant_trust(grantor, actor, "all")
+        self.assertEqual(sorted(classes), sorted(ACTION_CLASSES))
+
+    def test_grant_snapshots_label(self):
+        grantor, actor = self._pair()
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            grant_trust(grantor, actor, "dress")
+        entry = get_grants(grantor)["uid-1"]
+        self.assertEqual(entry["label"], "a lean man")
+
+    def test_display_prefers_recognition_name(self):
+        grantor, actor = self._pair()
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            grant_trust(grantor, actor, "dress")
+        grantor.recognition_memory = {"uid-1": {"assigned_name": "Roony"}}
+        self.assertEqual(grant_display_name(grantor, "uid-1"), "Roony")
+        grantor.recognition_memory = {}
+        self.assertEqual(grant_display_name(grantor, "uid-1"), "a lean man")
+
+    def test_revoking_last_class_drops_entry(self):
+        grantor, actor = self._pair()
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            grant_trust(grantor, actor, "heal")
+        revoke_trust(grantor, "uid-1", "heal")
+        self.assertEqual(get_grants(grantor), {})
+
+    def test_wipe(self):
+        grantor, actor = self._pair()
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            grant_trust(grantor, actor, "all")
+        self.assertEqual(wipe_trust(grantor), 1)
+        self.assertEqual(get_grants(grantor), {})
+
+    def test_identity_shift_lapses_trust(self):
+        # the batman/bruce requirement: a new apparent uid stops matching
+        grantor, actor = self._pair()
+        with patch("world.identity.get_apparent_uid", return_value="uid-bat"):
+            grant_trust(grantor, actor, "heal")
+            self.assertTrue(has_trust(grantor, actor, "heal"))
+        with patch("world.identity.get_apparent_uid",
+                   return_value="uid-bruce"):
+            self.assertFalse(has_trust(grantor, actor, "heal"))
+
+
+class TestCheckConsent(TestCase):
+    def test_self_action_always_allowed(self):
+        c = _char()
+        self.assertTrue(check_consent(c, c, "heal"))
+
+    def test_helpless_target_is_free(self):
+        actor = MagicMock()
+        self.assertTrue(check_consent(actor, _char(unconscious=True), "heal"))
+        self.assertTrue(check_consent(actor, _char(dead=True), "dress"))
+
+    def test_conscious_stranger_blocked(self):
+        actor = MagicMock()
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            self.assertFalse(check_consent(actor, _char(), "dress"))
+
+    def test_trust_opens_the_conscious_path(self):
+        actor = MagicMock()
+        actor.get_display_name = lambda looker=None, **k: "a medic"
+        target = _char()
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            grant_trust(target, actor, "heal")
+            self.assertTrue(check_consent(actor, target, "heal"))
+            self.assertFalse(check_consent(actor, target, "dress"))
+
+
+class TestClothingGate(TestCase):
+    def test_appendage_always_dressable(self):
+        from commands.CmdClothing import _can_third_party_clothing
+        from typeclasses.items import Appendage
+        limb = MagicMock(spec=Appendage)
+        self.assertTrue(_can_third_party_clothing(MagicMock(), limb))
+
+    def test_character_rides_consent_gate(self):
+        from commands.CmdClothing import _can_third_party_clothing
+        caller = MagicMock()
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            self.assertFalse(_can_third_party_clothing(caller, _char()))
+            self.assertTrue(
+                _can_third_party_clothing(caller, _char(unconscious=True)))
+
+
+class TestTrustCommand(TestCase):
+    def _cmd(self, args, grants=None):
+        from commands.CmdTrust import CmdTrust
+        cmd = CmdTrust()
+        cmd.caller = _char()
+        if grants is not None:
+            cmd.caller.db.consent_grants = grants
+        cmd.args = args
+        return cmd
+
+    def test_grant_via_command(self):
+        cmd = self._cmd("lean man to dress")
+        target = MagicMock()
+        target.get_display_name = lambda looker=None, **k: "a lean man"
+        cmd.caller.search.return_value = target
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            cmd.func()
+        entry = get_grants(cmd.caller)["uid-1"]
+        self.assertEqual(entry["classes"], ["dress"])
+        self.assertIn("You now trust a lean man to dress",
+                      cmd.caller.msg.call_args.args[0])
+
+    def test_unknown_class_refused(self):
+        cmd = self._cmd("lean man to tickle")
+        cmd.func()
+        self.assertIn("isn't a trustable action",
+                      cmd.caller.msg.call_args.args[0])
+        cmd.caller.search.assert_not_called()
+
+    def test_bare_trust_lists(self):
+        grants = {"uid-1": {"classes": ["heal"], "label": "a lean man"}}
+        cmd = self._cmd("", grants=grants)
+        cmd.func()
+        out = cmd.caller.msg.call_args.args[0]
+        self.assertIn("a lean man — heal", out)
+
+    def test_trust_no_one_wipes(self):
+        grants = {"uid-1": {"classes": ["heal"], "label": "a lean man"}}
+        cmd = self._cmd("no one", grants=grants)
+        cmd.func()
+        self.assertEqual(get_grants(cmd.caller), {})
+
+    def test_cannot_trust_self(self):
+        cmd = self._cmd("me to heal")
+        cmd.caller.search.return_value = cmd.caller
+        cmd.func()
+        self.assertIn("don't need to trust yourself",
+                      cmd.caller.msg.call_args.args[0])
+        self.assertEqual(get_grants(cmd.caller), {})
+
+
+class TestDistrustCommand(TestCase):
+    def _cmd(self, args, grants=None):
+        from commands.CmdTrust import CmdDistrust
+        cmd = CmdDistrust()
+        cmd.caller = _char()
+        cmd.caller.db.consent_grants = grants or {}
+        cmd.args = args
+        return cmd
+
+    def test_revoke_by_remembered_label_absent_person(self):
+        grants = {"uid-1": {"classes": ["heal", "dress"],
+                            "label": "a lean man"}}
+        cmd = self._cmd("lean man to heal", grants=grants)
+        cmd.func()
+        self.assertEqual(get_grants(cmd.caller)["uid-1"]["classes"],
+                         ["dress"])
+
+    def test_revoke_everything_from_person(self):
+        grants = {"uid-1": {"classes": ["heal"], "label": "a lean man"}}
+        cmd = self._cmd("lean man", grants=grants)
+        cmd.func()
+        self.assertEqual(get_grants(cmd.caller), {})
+
+    def test_distrust_all(self):
+        grants = {"uid-1": {"classes": ["heal"], "label": "a"},
+                  "uid-2": {"classes": ["dress"], "label": "b"}}
+        cmd = self._cmd("all", grants=grants)
+        cmd.func()
+        self.assertEqual(get_grants(cmd.caller), {})
+
+    def test_unknown_person_messaged(self):
+        cmd = self._cmd("stranger")
+        cmd.func()
+        self.assertIn("don't have any trust extended",
+                      cmd.caller.msg.call_args.args[0])

--- a/world/tests/test_dress_undress.py
+++ b/world/tests/test_dress_undress.py
@@ -78,15 +78,25 @@ def _no_medical_target():
 
 
 class PermissionGate(TestCase):
+    """The gate now rides world/consent.py (trust layer, #967): a caller
+    with no trust grant from the target. Free-path expectations are
+    unchanged from the pre-trust contract."""
+
+    def _caller(self):
+        from unittest.mock import MagicMock
+        return MagicMock()
 
     def test_conscious_character_rejected(self):
-        self.assertFalse(_can_third_party_clothing(_conscious_char()))
+        self.assertFalse(
+            _can_third_party_clothing(self._caller(), _conscious_char()))
 
     def test_unconscious_character_allowed(self):
-        self.assertTrue(_can_third_party_clothing(_unconscious_char()))
+        self.assertTrue(
+            _can_third_party_clothing(self._caller(), _unconscious_char()))
 
     def test_dead_character_allowed(self):
-        self.assertTrue(_can_third_party_clothing(_dead_char()))
+        self.assertTrue(
+            _can_third_party_clothing(self._caller(), _dead_char()))
 
     def test_target_without_medical_state_rejected(self):
         """Defensive: targets that have no medical surface and aren't
@@ -94,8 +104,20 @@ class PermissionGate(TestCase):
         non-character clothing targets (mannequins, idols) will need
         their own path."""
         self.assertFalse(
-            _can_third_party_clothing(_no_medical_target())
+            _can_third_party_clothing(self._caller(), _no_medical_target())
         )
+
+    def test_conscious_character_with_trust_allowed(self):
+        """The new path: a conscious target who has trusted the caller
+        to dress them passes the gate."""
+        from unittest.mock import patch
+        from world.consent import grant_trust
+        caller, target = self._caller(), _conscious_char()
+        target.db = type("D", (), {"consent_grants": None})()
+        caller.get_display_name = lambda looker=None, **k: "a medic"
+        with patch("world.identity.get_apparent_uid", return_value="uid-1"):
+            grant_trust(target, caller, "dress")
+            self.assertTrue(_can_third_party_clothing(caller, target))
 
     def test_severed_appendage_allowed(self):
         """Appendage targets are universally dressable (no consent
@@ -110,7 +132,8 @@ class PermissionGate(TestCase):
         # patching ``typeclasses.items.Appendage`` is what matters.
         with patch("typeclasses.items.Appendage", _FakeAppendage):
             sentinel = _FakeAppendage()
-            self.assertTrue(_can_third_party_clothing(sentinel))
+            from unittest.mock import MagicMock
+            self.assertTrue(_can_third_party_clothing(MagicMock(), sentinel))
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
Closes #967

- world/consent.py: can_contest (conscious AND unrestrained; conservative
  polarity for unreadable state), is_restrained (grapple + restraining
  furniture w/ legacy-AutoDoc fallback), uid-keyed grant store +
  grant/revoke/wipe/display helpers, check_consent gate
- trust/distrust commands (spec §4): per-class or blanket grants bound to
  the trustee's CURRENT apparent identity; presence-required grants,
  memory-based revokes; registered in CharacterCmdSet
- consumers: _can_third_party_clothing rides the dress class (placeholder
  messages retired); heal class gates check_medical_requirements (all
  treat items) and the shared surgical target resolver (operate/incise/
  harvest/install/suture)
- AutoDoc sets db.restraining (pod-bound = cannot contest)
- spec banner -> Phase 1 shipped; P2 frisk / P3 escort+dispatch pending
- 31 new tests + updated PermissionGate contract tests

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
