### PR TITLE
Trust & Consent Phase 3: follow + escort movement coupling

### DIFF
--- a/commands/CmdFollow.py
+++ b/commands/CmdFollow.py
@@ -1,0 +1,201 @@
+"""``follow`` / ``escort`` — voluntary movement coupling.
+
+Follow is ungated self-action (you trail someone, openly). Escort is the
+trust-gated lead (TRUST_AND_CONSENT_SPEC §3 ``escort`` class): the escortee
+is ushered through each exit AHEAD of the leader. Forcible movement is NOT
+here — dragging is emergent from grapple + movement, no command by design.
+"""
+
+from evennia import Command
+
+from world.identity_utils import msg_room_identity
+from world.movement_coupling import sever_follow
+
+
+def _resolve_present_character(caller, phrase):
+    """A character here, by identity-aware search. Not yourself."""
+    target = caller.search(phrase)
+    if target is None:
+        return None
+    if target is caller:
+        caller.msg("You can't couple your movement to yourself.")
+        return None
+    if not hasattr(target, "get_sdesc"):
+        caller.msg(f"{target.get_display_name(caller)} doesn't go anywhere.")
+        return None
+    return target
+
+
+class CmdFollow(Command):
+    """
+    Follow someone — trail them through exits as they move.
+
+    Usage:
+        follow <person>
+        stop following
+
+    You couple your own movement to theirs: when they leave a room, you
+    take the same exit right after them (a follower moves second). It's
+    open — they see you fall in behind them. You stop with ``stop
+    following``, and you lose the trail naturally if you can't keep up
+    (a door that refuses you, being unable to move).
+
+    ``stop following`` also breaks away from someone escorting you.
+    """
+
+    key = "follow"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+        if not args:
+            caller.msg("Follow whom?")
+            return
+        target = _resolve_present_character(caller, args)
+        if target is None:
+            return
+        if caller.db.escorting == target:
+            caller.msg("You're escorting them — they move with you already.")
+            return
+        if caller.db.following == target:
+            caller.msg(
+                f"You're already following {target.get_display_name(caller)}."
+            )
+            return
+        caller.db.following = target
+        caller.msg(f"You fall in behind {target.get_display_name(caller)}.")
+        target.msg(f"{caller.get_display_name(target)} falls in behind you.")
+        msg_room_identity(
+            location=caller.location,
+            template="{actor} falls in behind {target}.",
+            char_refs={"actor": caller, "target": target},
+            exclude=[caller, target],
+        )
+
+
+class CmdStopFollowing(Command):
+    """
+    Stop following (or break away from an escort).
+
+    Usage:
+        stop following
+    """
+
+    key = "stop following"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        if caller.db.following:
+            sever_follow(caller)
+            return
+        # Break away from anyone escorting us — it's our movement.
+        location = caller.location
+        escorts = [obj for obj in (location.contents if location else [])
+                   if getattr(obj.db, "escorting", None) == caller]
+        if escorts:
+            for leader in escorts:
+                leader.db.escorting = None
+                leader.msg(
+                    f"{caller.get_display_name(leader)} breaks away from "
+                    f"your lead."
+                )
+            caller.msg("You break away.")
+            return
+        caller.msg("You aren't following anyone.")
+
+
+class CmdEscort(Command):
+    """
+    Escort someone — lead them along as you move.
+
+    Usage:
+        escort <person>
+        stop escorting
+
+    Your escort moves FIRST: each time you take an exit, they are ushered
+    through ahead of you and you come behind. A conscious, free person
+    must have trusted you to escort them (``trust <you> to escort``);
+    someone restrained (cuffed, grappled by another) can be led without
+    asking — and someone unconscious can't walk at all (drag them by
+    grapple instead). Consent is re-checked at every move: a revoked
+    grant releases them at the next doorway.
+    """
+
+    key = "escort"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+        if not args:
+            caller.msg("Escort whom?")
+            return
+        target = _resolve_present_character(caller, args)
+        if target is None:
+            return
+        if caller.db.following == target:
+            caller.msg("You're following them — you can't also lead them.")
+            return
+        from world.consent import check_consent, is_conscious
+        if not is_conscious(target):
+            caller.msg(
+                f"{target.get_display_name(caller)} can't walk anywhere — "
+                f"carry or drag them."
+            )
+            return
+        if not check_consent(caller, target, "escort"):
+            caller.msg(
+                f"{target.get_display_name(caller)} is conscious and won't "
+                f"be led — they'd need to trust you to escort them (or be "
+                f"restrained)."
+            )
+            return
+        if caller.db.escorting and caller.db.escorting != target:
+            old = caller.db.escorting
+            caller.msg(
+                f"You stop escorting {old.get_display_name(caller)}."
+            )
+        caller.db.escorting = target
+        caller.msg(f"You take {target.get_display_name(caller)} under your "
+                   f"lead — they'll move ahead of you.")
+        target.msg(f"{caller.get_display_name(target)} takes you under "
+                   f"their lead.")
+        msg_room_identity(
+            location=caller.location,
+            template="{actor} takes {target} under their lead.",
+            char_refs={"actor": caller, "target": target},
+            exclude=[caller, target],
+        )
+
+
+class CmdStopEscorting(Command):
+    """
+    Release your escort.
+
+    Usage:
+        stop escorting
+    """
+
+    key = "stop escorting"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        escortee = caller.db.escorting
+        if not escortee:
+            caller.msg("You aren't escorting anyone.")
+            return
+        caller.db.escorting = None
+        caller.msg(f"You release {escortee.get_display_name(caller)} from "
+                   f"your lead.")
+        try:
+            escortee.msg(f"{caller.get_display_name(escortee)} releases you "
+                         f"from their lead.")
+        except Exception:  # noqa: BLE001
+            pass

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -36,6 +36,9 @@ from commands.CmdBug import CmdBug
 from commands.CmdAdmin import CmdHeal, CmdPeace, CmdTestDeathCurtain, CmdWeather, CmdResetMedical, CmdMedicalAudit, CmdTestDeath, CmdTestUnconscious
 from commands.CmdFixCharacterOwnership import CmdFixCharacterOwnership
 from commands.CmdTrust import CmdDistrust, CmdTrust
+from commands.CmdFollow import (
+    CmdEscort, CmdFollow, CmdStopEscorting, CmdStopFollowing,
+)
 from commands.combat.cmdset_combat import CombatCmdSet
 from commands.combat.special_actions import CmdAim, CmdGrapple
 from commands.CmdThrow import CmdThrow, CmdPull, CmdCatch
@@ -168,6 +171,13 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         # behind the third-party action gate (world/consent.py).
         self.add(CmdTrust())
         self.add(CmdDistrust())
+
+        # Movement coupling (trust spec Phase 3): follow trails, escort
+        # ushers ahead; dragging stays emergent from grapple + movement.
+        self.add(CmdFollow())
+        self.add(CmdStopFollowing())
+        self.add(CmdEscort())
+        self.add(CmdStopEscorting())
         
         # Add aim command for ranged combat preparation
         self.add(CmdAim())

--- a/specs/proposals/TRUST_AND_CONSENT_SPEC.md
+++ b/specs/proposals/TRUST_AND_CONSENT_SPEC.md
@@ -1,6 +1,6 @@
 # Trust & Consent Spec
 
-> **Status: ✅ PHASE 1 SHIPPED (2026-07-03) — §9 P2/P3 pending.** The gate
+> **Status: ✅ SHIPPED IN FULL (2026-07-03, Phases 1–3).** The gate
 > (`world/consent.py`: `can_contest` / `is_restrained` / `check_consent`),
 > the grant store, the `trust`/`distrust` commands (§4), and the Phase-1
 > consumers — third-party clothing (`dress` class) and the full medical
@@ -10,13 +10,27 @@
 > retrofitted onto the `search` class — the legacy too-lively-to-frisk gate
 > replaced by `check_consent`; corpse objects stay always-searchable; the
 > manifest now reads the real worn registry, in-hand items, carried
-> pockets, and tokens. The §7 recommendations were implemented as written
+> pockets, and tokens. **PHASE 3 SHIPPED (2026-07-03):** movement coupling —
+> `follow <person>` (ungated self-action; the follower moves SECOND,
+> trailing the leader through the real exit; `stop following` ends it, and
+> a follower who can't keep up loses the trail), and `escort <person>`
+> (the `escort` class: the escortee is ushered AHEAD — they move FIRST
+> through each exit, consent re-checked per move so a revoked grant
+> releases them at the next doorway; a refused doorway stops the leader at
+> the threshold; unconscious targets can't walk — grapple-drag them).
+> Dragging remains EMERGENT from grapple + movement with no command, by
+> design. The dispatch coercive seam now needs only director/AI content
+> (when bots choose to restrain-then-move), which belongs to the dispatch
+> arc. Future (user-stated): motorics-based movement DELAY will sequence
+> these beats into organic chase scenes; a stealth `shadow` command =
+> follow while unseen (STEALTH_AND_DETECTION_SPEC). The §7 recommendations
+> were implemented as written
 > (duress grants stand; per-command gate check; shared `is_restrained`
 > unifying grapple + `db.restraining` furniture with a legacy-AutoDoc
 > fallback; strict consciousness binary; presence-required grants /
-> memory-based revokes). Remaining: §9 P3 (escort/movement-coupling +
-> the dispatch coercive-authority seam). Design history: 2026-06-26 core
-> pass; 2026-07-02 deep-dig (`dress` class, NPC self-action only, §7/§9).
+> memory-based revokes). **ALL §9 PHASES COMPLETE.** Design history:
+> 2026-06-26 core pass; 2026-07-02 deep-dig (`dress` class, NPC
+> self-action only, §7/§9).
 
 ## 0 · Purpose
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1282,6 +1282,23 @@ class Character(
         if self.db.furniture or (self.db.posture and self.db.posture != "standing"):
             self._clear_posture()
         self._refresh_recognition_recency()
+        # Movement coupling: followers trail through the exit just taken
+        # (a follower moves SECOND — we have already arrived). Terminates
+        # naturally on chains: only followers still in the source room move.
+        if source_location is not None:
+            from world.movement_coupling import bring_followers
+            bring_followers(self, source_location)
+
+    def at_pre_move(self, destination, **kwargs):
+        """Extends the default: an escort moves FIRST — the escortee is
+        ushered through the exit ahead of us; if the way refuses them, our
+        own move stops at the threshold too (movement_coupling)."""
+        if not super().at_pre_move(destination, **kwargs):
+            return False
+        if self.db.escorting and destination is not None:
+            from world.movement_coupling import usher_escortee
+            return usher_escortee(self, destination)
+        return True
 
     def _clear_posture(self):
         """Return to standing — drop any furniture occupancy and the transient

--- a/world/movement_coupling.py
+++ b/world/movement_coupling.py
@@ -1,0 +1,138 @@
+"""Movement coupling — follow (trail) and escort (usher ahead).
+
+TRUST_AND_CONSENT_SPEC §9 Phase 3, minus dragging: forcible movement already
+exists as an emergent property of grapple + movement (no command, by design).
+This module owns the two VOLUNTARY couplings:
+
+* **follow** — self-action, ungated: the follower couples their own movement
+  to a leader and moves SECONDARY (leader moves, follower trails through the
+  same exit). Open and visible; covert tailing is the stealth spec's future
+  ``shadow``.
+* **escort** — trust-gated (``escort`` class): the leader ushers the escortee
+  AHEAD — the escortee moves FIRST through the exit, the leader comes behind.
+  Re-checked per move (spec §7.2: revoking trust takes effect at the next
+  step, nothing aborts mid-swing).
+
+Every coupled move is a REAL exit traversal (``execute_cmd(exit.key)``), so
+exit locks, movement gates (unconsciousness, combat cmdsets), and the future
+motorics-timed movement all apply to coupled movers exactly as to anyone —
+the planned per-character movement delay will sequence these beats into
+organic chase scenes with no changes here.
+"""
+
+
+def _exit_to(source, destination):
+    """The exit object in ``source`` leading to ``destination`` (or None)."""
+    if not source or not destination:
+        return None
+    for obj in source.contents:
+        if getattr(obj, "destination", None) == destination:
+            return obj
+    return None
+
+
+def _valid(char) -> bool:
+    """Object still exists (not deleted mid-link)."""
+    return bool(char and getattr(char, "pk", None))
+
+
+def followers_of(leader, room):
+    """Characters in ``room`` currently following ``leader``."""
+    if not room:
+        return []
+    return [obj for obj in room.contents
+            if _valid(obj) and getattr(obj.db, "following", None) == leader]
+
+
+def sever_follow(follower, silent=False):
+    """Drop a follow link (both parties notified unless silent)."""
+    leader = follower.db.following
+    follower.db.following = None
+    if silent or not _valid(leader):
+        return
+    try:
+        follower.msg(f"You stop following {leader.get_display_name(follower)}.")
+        leader.msg(f"{follower.get_display_name(leader)} stops following you.")
+    except Exception:  # noqa: BLE001 — notification is best-effort
+        pass
+
+
+def bring_followers(leader, source_location):
+    """Trail the leader's followers through the exit just taken.
+
+    Called from the leader's ``at_post_move`` — the leader has ALREADY
+    arrived (followers move secondary). Each follower traverses the same
+    exit via the real exit command; a follower who can't make it (locked
+    out, unconscious, in combat) loses the trail and the link breaks. A
+    leader move with no traceable exit (teleport) sheds followers too.
+    """
+    destination = leader.location
+    if not source_location or destination is source_location:
+        return
+    followers = followers_of(leader, source_location)
+    if not followers:
+        return
+    exit_obj = _exit_to(source_location, destination)
+    for follower in followers:
+        if exit_obj is None:
+            sever_follow(follower, silent=True)
+            follower.msg("You lose them — they're simply gone.")
+            continue
+        follower.execute_cmd(exit_obj.key)
+        if follower.location is not destination:
+            # Couldn't keep up (lock, state, combat) — the trail is lost.
+            sever_follow(follower, silent=True)
+            follower.msg(
+                f"You can't keep up with "
+                f"{leader.get_display_name(follower)} and lose them."
+            )
+
+
+def usher_escortee(leader, destination):
+    """Send the escortee through the exit FIRST (an escort moves ahead).
+
+    Called from the leader's ``at_pre_move``. Returns True when the leader's
+    own move may proceed. Consent is re-checked per move — a revoked or
+    lapsed grant releases the escortee here, and the leader walks on alone.
+    """
+    escortee = leader.db.escorting
+    if not _valid(escortee):
+        leader.db.escorting = None
+        return True
+    if escortee.location is not leader.location:
+        # Separated (they broke away, fled, were moved) — link dissolves.
+        leader.db.escorting = None
+        leader.msg("Your escort is no longer with you.")
+        return True
+
+    from world.consent import check_consent, is_conscious
+    if not is_conscious(escortee) or not check_consent(
+            leader, escortee, "escort"):
+        # Can't walk, or no longer willing — release, leader proceeds alone.
+        leader.db.escorting = None
+        leader.msg(
+            f"{escortee.get_display_name(leader)} no longer follows "
+            f"your lead."
+        )
+        try:
+            escortee.msg(
+                f"You slip free of {leader.get_display_name(escortee)}'s lead."
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        return True
+
+    exit_obj = _exit_to(leader.location, destination)
+    if exit_obj is None:
+        return True  # teleport-style move: no doorway to usher through
+    escortee.execute_cmd(exit_obj.key)
+    if escortee.location is not destination:
+        # The escortee bounced (lock, state). Ushering someone through a
+        # door that refuses them stops YOU at the threshold too — the
+        # coupling holds, the move doesn't happen.
+        leader.msg(
+            f"You can't lead {escortee.get_display_name(leader)} through "
+            f"— the way refuses them."
+        )
+        return False
+    return True

--- a/world/tests/test_movement_coupling.py
+++ b/world/tests/test_movement_coupling.py
@@ -1,0 +1,224 @@
+"""Movement coupling (world/movement_coupling.py + commands/CmdFollow.py) —
+TRUST_AND_CONSENT_SPEC §9 Phase 3.
+
+MagicMock stand-ins throughout: the contract under test is that every
+coupled move goes through the REAL exit command (execute_cmd) and that the
+escort path re-checks consent per move. Ordering: followers trail (leader
+already arrived), escortees are ushered ahead (before the leader moves).
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.movement_coupling import (
+    bring_followers, followers_of, sever_follow, usher_escortee,
+)
+
+
+def _room(*contents):
+    room = MagicMock()
+    room.contents = list(contents)
+    return room
+
+
+def _exit(destination, key="north"):
+    ex = MagicMock()
+    ex.destination = destination
+    ex.key = key
+    return ex
+
+
+def _char(location=None):
+    c = MagicMock()
+    c.location = location
+    c.db.following = None
+    c.db.escorting = None
+    return c
+
+
+def _walker(location):
+    """A char whose execute_cmd actually 'moves' it to the exit's room."""
+    c = _char(location)
+
+    def _go(cmd):
+        for obj in c.location.contents:
+            if getattr(obj, "key", None) == cmd and hasattr(obj, "destination"):
+                c.location = obj.destination
+                return
+    c.execute_cmd.side_effect = _go
+    return c
+
+
+class TestFollow(TestCase):
+    def _setup(self):
+        dest = _room()
+        leader = _char(dest)                      # leader already arrived
+        source = _room(_exit(dest))
+        follower = _walker(source)
+        follower.db.following = leader
+        source.contents.append(follower)
+        return leader, source, dest, follower
+
+    def test_follower_trails_through_the_real_exit(self):
+        leader, source, dest, follower = self._setup()
+        bring_followers(leader, source)
+        follower.execute_cmd.assert_called_once_with("north")
+        self.assertIs(follower.location, dest)
+        self.assertIs(follower.db.following, leader)   # link holds
+
+    def test_follower_who_bounces_loses_the_trail(self):
+        leader, source, dest, follower = self._setup()
+        follower.execute_cmd.side_effect = None        # lock: no movement
+        bring_followers(leader, source)
+        self.assertIsNone(follower.db.following)
+        self.assertIn("lose", follower.msg.call_args.args[0])
+
+    def test_teleporting_leader_sheds_followers(self):
+        leader, source, dest, follower = self._setup()
+        source.contents = [follower]                   # no traceable exit
+        bring_followers(leader, source)
+        follower.execute_cmd.assert_not_called()
+        self.assertIsNone(follower.db.following)
+
+    def test_only_source_room_followers_move(self):
+        # chain termination: a follower already elsewhere isn't yanked
+        leader, source, dest, follower = self._setup()
+        elsewhere = _room()
+        follower.location = elsewhere
+        source.contents.remove(follower)
+        bring_followers(leader, source)
+        follower.execute_cmd.assert_not_called()
+
+    def test_sever_notifies_both(self):
+        leader, source, dest, follower = self._setup()
+        sever_follow(follower)
+        self.assertIsNone(follower.db.following)
+        self.assertIn("stop following", follower.msg.call_args.args[0])
+        self.assertIn("stops following you", leader.msg.call_args.args[0])
+
+
+class TestEscort(TestCase):
+    def _setup(self):
+        dest = _room()
+        source = _room(_exit(dest))
+        leader = _char(source)
+        escortee = _walker(source)
+        source.contents.append(escortee)
+        leader.db.escorting = escortee
+        return leader, source, dest, escortee
+
+    def test_escortee_ushered_ahead(self):
+        leader, source, dest, escortee = self._setup()
+        with patch("world.consent.check_consent", return_value=True), \
+                patch("world.consent.is_conscious", return_value=True):
+            ok = usher_escortee(leader, dest)
+        self.assertTrue(ok)                            # leader may proceed
+        escortee.execute_cmd.assert_called_once_with("north")
+        self.assertIs(escortee.location, dest)         # they went FIRST
+        self.assertIs(leader.db.escorting, escortee)   # coupling holds
+
+    def test_refused_doorway_stops_the_leader(self):
+        leader, source, dest, escortee = self._setup()
+        escortee.execute_cmd.side_effect = None        # they bounce
+        with patch("world.consent.check_consent", return_value=True), \
+                patch("world.consent.is_conscious", return_value=True):
+            ok = usher_escortee(leader, dest)
+        self.assertFalse(ok)                           # move aborted
+        self.assertIs(leader.db.escorting, escortee)   # coupling holds
+        self.assertIn("refuses them", leader.msg.call_args.args[0])
+
+    def test_revoked_consent_releases_at_the_next_move(self):
+        leader, source, dest, escortee = self._setup()
+        with patch("world.consent.check_consent", return_value=False), \
+                patch("world.consent.is_conscious", return_value=True):
+            ok = usher_escortee(leader, dest)
+        self.assertTrue(ok)                            # leader walks on alone
+        self.assertIsNone(leader.db.escorting)
+        escortee.execute_cmd.assert_not_called()
+
+    def test_unconscious_escortee_released(self):
+        leader, source, dest, escortee = self._setup()
+        with patch("world.consent.is_conscious", return_value=False):
+            ok = usher_escortee(leader, dest)
+        self.assertTrue(ok)
+        self.assertIsNone(leader.db.escorting)
+
+    def test_separated_escortee_dissolves_link(self):
+        leader, source, dest, escortee = self._setup()
+        escortee.location = _room()                    # they're gone
+        ok = usher_escortee(leader, dest)
+        self.assertTrue(ok)
+        self.assertIsNone(leader.db.escorting)
+
+
+class TestFollowCommands(TestCase):
+    def _cmd(self, cls, caller, args=""):
+        cmd = cls()
+        cmd.caller = caller
+        cmd.args = args
+        return cmd
+
+    def test_follow_sets_link(self):
+        from commands.CmdFollow import CmdFollow
+        room = _room()
+        caller, target = _char(room), _char(room)
+        target.get_sdesc = lambda: "a lean man"
+        caller.search.return_value = target
+        self._cmd(CmdFollow, caller, "lean man").func()
+        self.assertIs(caller.db.following, target)
+        self.assertIn("fall in behind", caller.msg.call_args.args[0])
+
+    def test_cannot_follow_self(self):
+        from commands.CmdFollow import CmdFollow
+        caller = _char(_room())
+        caller.search.return_value = caller
+        self._cmd(CmdFollow, caller, "me").func()
+        self.assertIsNone(caller.db.following)
+
+    def test_stop_following_breaks_escort_of_me(self):
+        from commands.CmdFollow import CmdStopFollowing
+        room = _room()
+        caller, leader = _char(room), _char(room)
+        leader.db.escorting = caller
+        room.contents = [caller, leader]
+        self._cmd(CmdStopFollowing, caller).func()
+        self.assertIsNone(leader.db.escorting)
+        self.assertIn("break away", caller.msg.call_args.args[0])
+
+
+class TestEscortCommand(TestCase):
+    def _pair(self):
+        room = _room()
+        caller, target = _char(room), _char(room)
+        target.get_sdesc = lambda: "a lean man"
+        caller.search.return_value = target
+        return caller, target
+
+    def _run(self, caller):
+        from commands.CmdFollow import CmdEscort
+        cmd = CmdEscort()
+        cmd.caller = caller
+        cmd.args = "lean man"
+        cmd.func()
+
+    def test_trusted_escort_couples(self):
+        caller, target = self._pair()
+        with patch("world.consent.check_consent", return_value=True), \
+                patch("world.consent.is_conscious", return_value=True):
+            self._run(caller)
+        self.assertIs(caller.db.escorting, target)
+
+    def test_untrusting_conscious_target_refused(self):
+        caller, target = self._pair()
+        with patch("world.consent.check_consent", return_value=False), \
+                patch("world.consent.is_conscious", return_value=True):
+            self._run(caller)
+        self.assertIsNone(caller.db.escorting)
+        self.assertIn("won't be led", caller.msg.call_args.args[0])
+
+    def test_unconscious_target_cannot_walk(self):
+        caller, target = self._pair()
+        with patch("world.consent.is_conscious", return_value=False):
+            self._run(caller)
+        self.assertIsNone(caller.db.escorting)
+        self.assertIn("carry or drag", caller.msg.call_args.args[0])


### PR DESCRIPTION
Closes #971

- world/movement_coupling.py: followers trail (leader moves first,
  follower traverses the same REAL exit after), escortees are ushered
  ahead (they move FIRST; a refused doorway stops the leader; consent
  re-checked per move so revocation releases at the next step)
- follow/stop following (ungated, visible) + escort/stop escorting
  (escort trust class; unconscious targets can't walk - grapple-drag
  exists for that, no command by design)
- Character.at_pre_move ushers the escortee; at_post_move trails
  followers; chains terminate naturally (source-room membership)
- spec banner -> SHIPPED IN FULL (P1-P3); future notes recorded:
  motorics movement delay (chase scenes), stealth shadow command

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
