### PR TITLE
Stealth Phases 1-2 + passive tier: hide/sneak/search + graded awareness

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -47,6 +47,9 @@ class CmdSay(Command):
 
     def func(self):
         caller = self.caller
+        # Speaking gives you away (STEALTH_AND_DETECTION_SPEC §6.4).
+        from world.stealth import break_stealth
+        break_stealth(caller)
 
         if not self.args:
             caller.msg("Say what?")
@@ -84,6 +87,9 @@ class CmdTo(Command):
 
     def func(self):
         caller = self.caller
+        # Speaking gives you away (STEALTH_AND_DETECTION_SPEC §6.4).
+        from world.stealth import break_stealth
+        break_stealth(caller)
 
         args = (self.args or "").strip()
         parts = args.split(None, 1)
@@ -126,6 +132,9 @@ class CmdWhisper(Command):
 
     def func(self):
         caller = self.caller
+        # Speaking gives you away (STEALTH_AND_DETECTION_SPEC §6.4).
+        from world.stealth import break_stealth
+        break_stealth(caller)
 
         if not self.args or "=" not in self.args:
             caller.msg("Usage: whisper <target> = <message>")
@@ -217,6 +226,9 @@ class CmdEmote(Command):
 
     def func(self):
         caller = self.caller
+        # Speaking gives you away (STEALTH_AND_DETECTION_SPEC §6.4).
+        from world.stealth import break_stealth
+        break_stealth(caller)
 
         if not self.args:
             caller.msg("What do you want to emote?")
@@ -288,6 +300,9 @@ class CmdDotPose(Command):
 
     def func(self) -> None:
         caller = self.caller
+        # Speaking gives you away (STEALTH_AND_DETECTION_SPEC §6.4).
+        from world.stealth import break_stealth
+        break_stealth(caller)
 
         # Extract the emote text from raw_string.
         # raw_string looks like ".lean back." — strip the leading "."

--- a/commands/CmdStealth.py
+++ b/commands/CmdStealth.py
@@ -1,0 +1,206 @@
+"""``hide`` / ``unhide`` / ``sneak`` / ``search`` — presence concealment.
+
+STEALTH_AND_DETECTION_SPEC §3.3. The contest engine and awareness store live
+in ``world/stealth.py``; these commands are the player surface. Identity
+concealment (disguises) and phase are separate axes — this is only about
+whether you're NOTICED.
+"""
+
+from evennia import Command
+
+from world.stealth import (
+    active_search, attempt_hide, break_stealth,
+)
+
+
+class CmdHide(Command):
+    """
+    Slip out of sight — or stash an object.
+
+    Usage:
+        hide
+        hide <object>
+        unhide
+
+    Hiding is a contest: everyone watching rolls to keep track of you.
+    Those who win see exactly what you are — someone lurking. Those who
+    lose forget you're there until they search, stumble over you, or you
+    give yourself away (speaking, attacking, or walking off openly all
+    break hiding; use ``sneak`` to move while staying hidden).
+
+    ``hide <object>`` stashes an item from your inventory somewhere in
+    the room — a searcher may turn it up.
+    """
+
+    key = "hide"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+        if args:
+            self._stash(args)
+            return
+        if caller.db.hidden:
+            caller.msg("You're already keeping out of sight.")
+            return
+        kept = attempt_hide(caller)
+        caller.msg("You slip out of sight.")
+        for observer in kept:
+            observer.msg(
+                f"{caller.get_display_name(observer)} tries to melt out of "
+                f"sight — but you keep track of them."
+            )
+
+    def _stash(self, phrase):
+        caller = self.caller
+        item = caller.search(phrase, location=caller, quiet=True)
+        if not item:
+            caller.msg(f"You aren't carrying '{phrase}'.")
+            return
+        if isinstance(item, list):
+            item = item[0]
+        if not caller.location:
+            return
+        from random import randint
+        item.move_to(caller.location, quiet=True)
+        item.db.hidden = True
+        # The stash quality is rolled once, at stash time — the hider's
+        # craft frozen into the hiding spot for later searches to beat.
+        item.db.stash_roll = randint(1, 20) + int(
+            getattr(caller, "motorics", 1) or 1)
+        caller.msg(f"You stash {item.get_display_name(caller)} out of sight.")
+
+
+class CmdUnhide(Command):
+    """
+    Step out of hiding.
+
+    Usage:
+        unhide
+    """
+
+    key = "unhide"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        if not caller.db.hidden:
+            caller.msg("You aren't hiding.")
+            return
+        break_stealth(caller, quiet=True)
+        caller.msg("You step out of hiding.")
+        from world.identity_utils import msg_room_identity
+        if caller.location:
+            msg_room_identity(
+                location=caller.location,
+                template="{actor} steps out of hiding.",
+                char_refs={"actor": caller},
+                exclude=[caller],
+            )
+
+
+class CmdSneak(Command):
+    """
+    Move while staying hidden.
+
+    Usage:
+        sneak <exit>
+
+    Carries you through an exit and re-attempts concealment on arrival —
+    a fresh contest against everyone in the new room, at a penalty
+    (hiding on the move is harder than hiding from cover). Anyone still
+    tracking you in the room you leave sees you slip away.
+    """
+
+    key = "sneak"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+        if not args:
+            caller.msg("Sneak where?")
+            return
+        location = caller.location
+        exit_obj = None
+        for obj in (location.contents if location else []):
+            if not getattr(obj, "destination", None):
+                continue
+            names = [obj.key.lower()] + [a.lower() for a in (obj.aliases.all()
+                                                             if obj.aliases
+                                                             else [])]
+            if args.lower() in names:
+                exit_obj = obj
+                break
+        if exit_obj is None:
+            caller.msg(f"There's no way '{args}' from here.")
+            return
+        if not caller.db.hidden:
+            # sneaking implies hiding: contest in the CURRENT room first,
+            # so witnesses here may keep track of your exit
+            attempt_hide(caller)
+        caller.ndb.sneaking = True
+        try:
+            caller.execute_cmd(exit_obj.key)
+        finally:
+            caller.ndb.sneaking = None
+        if caller.location is location:
+            caller.msg("You can't get through that way.")
+            return
+        kept = attempt_hide(caller, sneak=True)
+        caller.msg("You slip through, keeping to the edges.")
+        for observer in kept:
+            observer.msg(
+                f"You catch {caller.get_display_name(observer)} slipping in."
+            )
+
+
+class CmdSearch(Command):
+    """
+    Actively search the area for anything — or anyone — hidden.
+
+    Usage:
+        search
+
+    A deliberate sweep of the room: stronger than the glance you get by
+    walking in or looking around. Turns up hidden characters (for you)
+    and stashed objects (for everyone). Searching is visible — people
+    can see you hunting.
+    """
+
+    key = "search"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        if not caller.location:
+            return
+        from world.identity_utils import msg_room_identity
+        msg_room_identity(
+            location=caller.location,
+            template="{actor} searches the area carefully.",
+            char_refs={"actor": caller},
+            exclude=[caller],
+        )
+        found_chars, found_objs = active_search(caller)
+        if not found_chars and not found_objs:
+            caller.msg("You search the area and find nothing out of place.")
+            return
+        for char in found_chars:
+            caller.msg(
+                f"You spot {char.get_display_name(caller)} lurking here."
+            )
+            char.msg(
+                f"{caller.get_display_name(char)}'s eyes find you — "
+                f"you've been spotted."
+            )
+        for obj in found_objs:
+            caller.msg(
+                f"You turn up {obj.get_display_name(caller)}, "
+                f"stashed out of sight."
+            )

--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -56,6 +56,11 @@ class CmdAttack(Command):
     def func(self):
         caller = self.caller
         args = self.args.strip()
+        # Attacking gives you away (STEALTH_AND_DETECTION_SPEC §6.4) — the
+        # ambush ADVANTAGE (spec §6.1) lands with the ambush phase; v1 is
+        # just honesty: violence is loud.
+        from world.stealth import break_stealth
+        break_stealth(caller, quiet=True)
         splattercast = get_splattercast()
 
         if not args:

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -39,6 +39,7 @@ from commands.CmdTrust import CmdDistrust, CmdTrust
 from commands.CmdFollow import (
     CmdEscort, CmdFollow, CmdStopEscorting, CmdStopFollowing,
 )
+from commands.CmdStealth import CmdHide, CmdSearch, CmdSneak, CmdUnhide
 from commands.combat.cmdset_combat import CombatCmdSet
 from commands.combat.special_actions import CmdAim, CmdGrapple
 from commands.CmdThrow import CmdThrow, CmdPull, CmdCatch
@@ -178,6 +179,13 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdStopFollowing())
         self.add(CmdEscort())
         self.add(CmdStopEscorting())
+
+        # Stealth (STEALTH_AND_DETECTION_SPEC P1-2 + passive tier): the
+        # hide/search contest and the graded awareness store.
+        self.add(CmdHide())
+        self.add(CmdUnhide())
+        self.add(CmdSneak())
+        self.add(CmdSearch())
         
         # Add aim command for ranged combat preparation
         self.add(CmdAim())

--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -1,6 +1,19 @@
 # Stealth & Detection Spec — Hiding, Searching, and Graded Awareness
 
-> **Status:** 📋 Proposal — not implemented. Designs the **presence-concealment**
+> **Status:** 🚧 **PHASES 1–2 + PASSIVE TIER + DISPLAY INTEGRATION SHIPPED
+> (2026-07-03).** Live: `world/stealth.py` (opposed Motorics-hider vs
+> Resonance-searcher contest; per-observer graded awareness store keyed on
+> apparent-uid, lazy decay), `hide`/`unhide`/`sneak`/`search` commands, the
+> **passive tier** (§3.4), display integration (room roster filters
+> Unaware/Suspicious; the *Suspicious* "prickling sense" cue; the "lurking
+> in the shadows" placement for the Detected; hidden objects out of the
+> things list; hidden movers' announcements suppressed to the unaware), and
+> break-on-action (speech, attack, open movement). NOT yet built: the full
+> perception-gate choke (§7 — say/emote/combat-target leak sweep; note the
+> phase layer's `filter_present` does NOT exist yet, §7 must build it), the
+> NPC hunt (§5), ambush advantage (§6.1), theft (§6.2), environmental
+> modifiers (light/cover/crowd — v1 is the flat tier spread).
+> Original abstract: designs the **presence-concealment**
 > layer: `hide` (self or object) vs `search` (a room), resolved as an opposed
 > **Resonance/Motorics** contest, surfaced as a **per-observer graded awareness
 > meter** (unaware → suspicious → searching → alert) that drives **deterministic
@@ -98,6 +111,18 @@ keeps stealth *gear- and world-driven* rather than stat-driven:
 
 `search` is the active counter: it spends an action to roll against everything
 hidden in the room, raising the searcher's awareness on success.
+
+### 3.4 · The passive tier (2026-07-03, user-decided)
+
+Between "never noticed" and "actively searched" sits the free glance:
+**entering a room and looking around each run a passive check** against
+hidden things — weaker than `search` (the active bonus is withheld) and
+**rate-limited per observer→target** (repeat looks reuse the standing
+result until a cooldown passes or the hider re-rolls), so look-spam never
+equals searching. A clear win spots the hider outright (Detected); a near
+miss yields *Suspicious* ("you get the prickling sense that you are not
+alone here"). The point: someone perceptive vs someone terrible at hiding
+will spot them **inherently**, no action spent.
 
 ---
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1211,11 +1211,18 @@ class Character(
         template = (
             f"{{actor}} is leaving {origin_name}, heading for {dest_name}."
         )
+        exclude = [self]
+        if self.db.hidden is True:
+            # A hidden mover's departure only reaches those tracking them —
+            # you can't watch someone leave whom you never knew was there.
+            from world.stealth import is_hidden_from
+            exclude += [obs for obs in self.location.contents
+                        if obs is not self and is_hidden_from(self, obs)]
         msg_room_identity(
             self.location,
             template,
             {"actor": self},
-            exclude=[self],
+            exclude=exclude,
         )
 
     def announce_move_to(
@@ -1255,11 +1262,17 @@ class Character(
         template = (
             f"{{actor}} arrives to {dest_name} from {origin_name}."
         )
+        exclude = [self]
+        if self.db.hidden is True:
+            # A sneaking arrival isn't announced — the fresh hide contest in
+            # the new room (CmdSneak) decides who catches the slip-in.
+            exclude += [obs for obs in self.location.contents
+                        if obs is not self]
         msg_room_identity(
             self.location,
             template,
             {"actor": self},
-            exclude=[self],
+            exclude=exclude,
         )
 
     def at_post_move(self, source_location, **kwargs):
@@ -1288,13 +1301,28 @@ class Character(
         if source_location is not None:
             from world.movement_coupling import bring_followers
             bring_followers(self, source_location)
+        # Stealth passive tier (spec §4): entering a room is a free glance
+        # at anything hidden here — rate-limited, weaker than a search, but
+        # a perceptive walker inherently spots a clumsy hider.
+        if self.location:
+            from world.stealth import passive_check
+            for obj in self.location.contents:
+                if obj is not self \
+                        and getattr(obj.db, "hidden", False) is True \
+                        and hasattr(obj, "get_sdesc"):
+                    passive_check(self, obj)
 
     def at_pre_move(self, destination, **kwargs):
         """Extends the default: an escort moves FIRST — the escortee is
         ushered through the exit ahead of us; if the way refuses them, our
-        own move stops at the threshold too (movement_coupling)."""
+        own move stops at the threshold too (movement_coupling). Walking
+        off openly while hidden gives you away (stealth spec §6.4) —
+        ``sneak`` sets the ndb flag that keeps concealment through a move."""
         if not super().at_pre_move(destination, **kwargs):
             return False
+        if self.db.hidden is True and not self.ndb.sneaking:
+            from world.stealth import break_stealth
+            break_stealth(self, quiet=True)
         if self.db.escorting and destination is not None:
             from world.movement_coupling import usher_escortee
             return usher_escortee(self, destination)

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -485,19 +485,40 @@ class Room(ObjectParent, DefaultRoom):
         Returns:
             str: Combined crowd and character placement descriptions
         """
+        from world.stealth import (
+            SUSPICIOUS, get_awareness, is_hidden_from, passive_check,
+        )
+
         characters = []
-        
+        sensed_presence = False
+
         for obj in self.contents:
             if obj.is_typeclass("typeclasses.characters.Character") and obj != looker:
-                if obj.access(looker, "view"):
-                    characters.append(obj)
-        
+                if not obj.access(looker, "view"):
+                    continue
+                # Stealth (STEALTH_AND_DETECTION_SPEC §4): looking runs the
+                # free PASSIVE tier against hidden characters — penalized
+                # and rate-limited, so a glance can spot a clumsy hider but
+                # look-spam never equals a search. Unaware/Suspicious keep
+                # them off the roster; Suspicious earns the cue line.
+                if getattr(obj.db, "hidden", False) is True:
+                    passive_check(looker, obj)
+                    if is_hidden_from(obj, looker):
+                        if get_awareness(looker, obj) >= SUSPICIOUS:
+                            sensed_presence = True
+                        continue
+                characters.append(obj)
+
         # Get crowd contributions (appears before character listings)
         crowd_msg = crowd_system.get_crowd_contributions(self, looker)
-        
+
+        cue = ("You get the prickling sense that you are not alone here."
+               if sensed_presence else "")
+
         if not characters:
-            # No characters, but might still have crowd messages
-            return crowd_msg if crowd_msg else ""
+            # No characters, but might still have crowd/suspicion messages
+            parts = [p for p in (crowd_msg, cue) if p]
+            return "\n".join(parts) if parts else ""
         
         # Group characters by their placement description
         placement_groups = {}
@@ -513,6 +534,13 @@ class Room(ObjectParent, DefaultRoom):
                         temp_place if temp_place else
                         look_place if look_place else
                         "standing here.")
+
+            # The "lurking" tell (stealth spec §4): failed concealment
+            # doesn't restore a normal appearance — to whoever sees them,
+            # a hidden character reads as visibly furtive, top of the
+            # placement hierarchy.
+            if getattr(char.db, "hidden", False) is True:
+                placement = "lurking in the shadows."
 
             # Resolve {aim_target} template in placement (used by aim system)
             if "{aim_target}" in placement:
@@ -562,6 +590,8 @@ class Room(ObjectParent, DefaultRoom):
             all_displays.append(character_display)
         if adjacent_sightings:
             all_displays.append(adjacent_sightings)
+        if cue:
+            all_displays.append(cue)
         
         return " ".join(all_displays) if all_displays else ""
     
@@ -622,6 +652,11 @@ class Room(ObjectParent, DefaultRoom):
             
             # Skip exits (handled by get_display_footer)
             if obj.is_typeclass("typeclasses.exits.Exit"):
+                continue
+
+            # Skip stashed objects (stealth spec §3.3) until a search
+            # turns them up
+            if getattr(obj.db, "hidden", False) is True:
                 continue
             
             # Skip @integrate objects - they're handled in room description

--- a/world/stealth.py
+++ b/world/stealth.py
@@ -1,0 +1,208 @@
+"""Stealth & detection — the contest engine and graded awareness store.
+
+STEALTH_AND_DETECTION_SPEC Phases 1–2 (+ the passive tier): ``hide`` /
+``sneak`` / ``search`` resolved as an opposed **Motorics (hider) vs
+Resonance (searcher)** contest, recorded as **per-observer graded
+awareness** (Unaware → Suspicious → Searching → Alert/Detected).
+
+Three contest tiers, weakest to strongest:
+
+* **passive** — free, runs when an observer enters a room or looks around;
+  penalized and rate-limited (look-spam is not a search). A perceptive
+  observer still inherently spots a terrible hider.
+* **hide-time** — everyone watching when you try to vanish gets an unmodified
+  contest; those who win keep track of you (you read as *lurking*, §4).
+* **active search** — an action, with a bonus; the deliberate counter.
+
+Awareness keys on the target's **apparent uid** (identity spec): you can be
+made as a *presence* without being *identified* — a mask still protects the
+name. Environmental modifiers (light, cover/LoS, crowd) land with the
+coordinate integration; v1 is the flat tier spread below.
+"""
+
+import time
+from random import randint
+
+# Awareness levels (spec §4).
+UNAWARE, SUSPICIOUS, SEARCHING, ALERT = 0, 1, 2, 3
+
+ACTIVE_SEARCH_BONUS = 4      # deliberate searching beats a glance
+SNEAK_PENALTY = 3            # hiding on the move is harder than from cover
+PASSIVE_SUSPICION_MARGIN = 3  # passive near-miss => "you sense something"
+PASSIVE_COOLDOWN = 60.0      # seconds between free passive rolls per target
+AWARENESS_DECAY = 300.0      # seconds per level of decay once contact is lost
+
+
+def _stat(char, name):
+    try:
+        return int(getattr(char, name, 1) or 1)
+    except Exception:  # noqa: BLE001
+        return 1
+
+
+def _target_key(target):
+    """Awareness keys on apparent identity — presence ≠ name."""
+    try:
+        from world.identity import get_apparent_uid
+        return get_apparent_uid(target) or f"#{target.id}"
+    except Exception:  # noqa: BLE001
+        return f"#{getattr(target, 'id', id(target))}"
+
+
+def _records(observer) -> dict:
+    from evennia.utils.dbserialize import deserialize
+    db = getattr(observer, "db", None)
+    data = deserialize(getattr(db, "awareness", None))
+    return data if isinstance(data, dict) else {}
+
+
+def get_awareness(observer, target) -> int:
+    """The observer's current awareness of ``target``, with lazy time decay
+    (one level per AWARENESS_DECAY seconds since last contact)."""
+    rec = _records(observer).get(_target_key(target))
+    if not rec:
+        return UNAWARE
+    level = int(rec.get("level", UNAWARE))
+    elapsed = max(0.0, time.time() - float(rec.get("t", 0)))
+    return max(UNAWARE, level - int(elapsed // AWARENESS_DECAY))
+
+
+def set_awareness(observer, target, level, *, roll_stamp=False):
+    """Record awareness (only non-default records are stored — spec §12
+    bounding). ``roll_stamp`` also marks a passive-roll timestamp."""
+    records = _records(observer)
+    key = _target_key(target)
+    rec = dict(records.get(key) or {})
+    now = time.time()
+    if level <= UNAWARE and not roll_stamp:
+        records.pop(key, None)
+    else:
+        rec["level"] = int(level)
+        rec["t"] = now
+        if roll_stamp:
+            rec["t_roll"] = now
+        records[key] = rec
+    observer.db.awareness = records
+
+
+def _passive_ready(observer, target) -> bool:
+    rec = _records(observer).get(_target_key(target)) or {}
+    return time.time() - float(rec.get("t_roll", 0)) >= PASSIVE_COOLDOWN
+
+
+def contest(hider, observer, *, hider_bonus=0, observer_bonus=0) -> int:
+    """One opposed roll. Positive margin = the OBSERVER wins (spots them);
+    zero or negative = the hider holds. Hider leans Motorics, observer
+    Resonance (spec §3.1 working direction)."""
+    hide_total = randint(1, 20) + _stat(hider, "motorics") + hider_bonus
+    seek_total = randint(1, 20) + _stat(observer, "resonance") + observer_bonus
+    return seek_total - hide_total
+
+
+def _watchers(room, hider):
+    """Who could contest a hide attempt: present characters with working
+    sight (the visual layer; blind observers don't watch you vanish)."""
+    from world.perception import can_see
+    out = []
+    for obj in (room.contents if room else []):
+        if obj is hider or not hasattr(obj, "get_sdesc"):
+            continue
+        try:
+            if can_see(obj):
+                out.append(obj)
+        except Exception:  # noqa: BLE001
+            out.append(obj)
+    return out
+
+
+def attempt_hide(hider, *, sneak=False) -> list:
+    """Try to slip out of sight. Everyone watching gets an unmodified
+    contest: winners keep track (Detected — you read as lurking to them),
+    losers lose you (Unaware). Returns the observers who kept track."""
+    room = hider.location
+    hider.db.hidden = True
+    bonus = -SNEAK_PENALTY if sneak else 0
+    kept = []
+    for observer in _watchers(room, hider):
+        if contest(hider, observer, hider_bonus=bonus) > 0:
+            set_awareness(observer, hider, ALERT, roll_stamp=True)
+            kept.append(observer)
+        else:
+            set_awareness(observer, hider, UNAWARE, roll_stamp=True)
+    return kept
+
+
+def passive_check(observer, hider) -> int:
+    """The free glance — entering a room or looking around. Penalized (the
+    active-search bonus is withheld) and rate-limited per target so
+    look-spam never equals searching; repeat looks reuse the standing
+    result until the cooldown passes or the hider re-rolls.
+
+    Returns the observer's (possibly updated) awareness level. A clear win
+    spots them outright; a near miss leaves that prickling feeling."""
+    current = get_awareness(observer, hider)
+    if current >= ALERT:
+        return current
+    if not _passive_ready(observer, hider):
+        return current
+    margin = contest(hider, observer)
+    if margin > 0:
+        set_awareness(observer, hider, ALERT, roll_stamp=True)
+        return ALERT
+    if margin > -PASSIVE_SUSPICION_MARGIN and current < SUSPICIOUS:
+        set_awareness(observer, hider, SUSPICIOUS, roll_stamp=True)
+        return SUSPICIOUS
+    set_awareness(observer, hider, current, roll_stamp=True)
+    return current
+
+
+def active_search(searcher, room=None) -> tuple:
+    """The deliberate counter: one action, rolls (with the search bonus)
+    against every hidden character and stashed object here. Returns
+    (found_characters, found_objects)."""
+    room = room or searcher.location
+    found_chars, found_objs = [], []
+    for obj in (room.contents if room else []):
+        if obj is searcher:
+            continue
+        if getattr(obj.db, "hidden", False) is not True:
+            continue
+        if hasattr(obj, "get_sdesc"):
+            if contest(obj, searcher, observer_bonus=ACTIVE_SEARCH_BONUS) > 0:
+                set_awareness(searcher, obj, ALERT, roll_stamp=True)
+                found_chars.append(obj)
+        else:
+            stash_roll = int(getattr(obj.db, "stash_roll", 10) or 10)
+            if randint(1, 20) + _stat(searcher, "resonance") \
+                    + ACTIVE_SEARCH_BONUS > stash_roll:
+                obj.db.hidden = False   # objects reveal for everyone
+                found_objs.append(obj)
+    return found_chars, found_objs
+
+
+def break_stealth(char, *, quiet=False):
+    """Acting loudly (speaking, attacking, walking off openly) drops the
+    hidden state and makes everyone present fully aware (spec §6.4 —
+    per-room here; alert propagation is the hunt phase's job). Strict
+    ``is True``: the state is only ever written as a literal, and test
+    doubles with auto-attributes must not read as hidden."""
+    if getattr(getattr(char, "db", None), "hidden", False) is not True:
+        return False
+    char.db.hidden = False
+    room = char.location
+    for observer in (room.contents if room else []):
+        if observer is char or not hasattr(observer, "get_sdesc"):
+            continue
+        set_awareness(observer, char, ALERT)
+    if not quiet:
+        char.msg("You abandon any pretense of hiding.")
+    return True
+
+
+def is_hidden_from(target, looker) -> bool:
+    """The display gate: hidden AND the looker is not yet aware enough to
+    place them. Suspicious knows *a* presence, not who/where — still
+    filtered from the room roster (the cue renders instead)."""
+    if getattr(getattr(target, "db", None), "hidden", False) is not True:
+        return False
+    return get_awareness(looker, target) < ALERT

--- a/world/tests/test_stealth.py
+++ b/world/tests/test_stealth.py
@@ -1,0 +1,213 @@
+"""Stealth engine (world/stealth.py) — contest, awareness store, tiers.
+
+MagicMock stand-ins; randint/time patched for determinism. The identity key
+is patched (uid derivation has its own suite).
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.stealth as stealth
+from world.stealth import (
+    ALERT, SUSPICIOUS, UNAWARE,
+    active_search, attempt_hide, break_stealth, get_awareness,
+    is_hidden_from, passive_check, set_awareness,
+)
+
+
+def _char(motorics=1, resonance=1, hidden=False, room=None):
+    c = MagicMock()
+    c.motorics = motorics
+    c.resonance = resonance
+    c.db.hidden = hidden
+    c.db.awareness = None
+    c.location = room
+    return c
+
+
+def _room(*contents):
+    room = MagicMock()
+    room.contents = list(contents)
+    return room
+
+
+def _uid_for(chars):
+    """Patch uid derivation to a stable per-object key."""
+    return patch("world.identity.get_apparent_uid",
+                 side_effect=lambda t: f"uid-{id(t)}")
+
+
+class TestAwarenessStore(TestCase):
+    def test_default_unaware(self):
+        with _uid_for(None):
+            self.assertEqual(get_awareness(_char(), _char()), UNAWARE)
+
+    def test_set_and_get(self):
+        obs, target = _char(), _char()
+        with _uid_for(None):
+            set_awareness(obs, target, ALERT)
+            self.assertEqual(get_awareness(obs, target), ALERT)
+
+    def test_decay_over_time(self):
+        obs, target = _char(), _char()
+        with _uid_for(None):
+            set_awareness(obs, target, ALERT)
+            with patch("world.stealth.time") as t:
+                t.time.return_value = __import__("time").time() \
+                    + stealth.AWARENESS_DECAY * 2 + 1
+                self.assertEqual(get_awareness(obs, target), ALERT - 2)
+
+    def test_unaware_records_pruned(self):
+        obs, target = _char(), _char()
+        with _uid_for(None):
+            set_awareness(obs, target, ALERT)
+            set_awareness(obs, target, UNAWARE)
+        self.assertEqual(obs.db.awareness, {})
+
+
+class TestHideContest(TestCase):
+    def test_sharp_watcher_keeps_track_dull_loses(self):
+        room = _room()
+        hider = _char(motorics=5, room=room)
+        sharp = _char(resonance=20)
+        dull = _char(resonance=0)
+        room.contents = [hider, sharp, dull]
+        with _uid_for(None), \
+                patch("world.stealth.randint", return_value=10), \
+                patch("world.perception.can_see", return_value=True):
+            kept = attempt_hide(hider)
+        self.assertTrue(hider.db.hidden)
+        self.assertIn(sharp, kept)
+        self.assertNotIn(dull, kept)
+        with _uid_for(None):
+            self.assertEqual(get_awareness(sharp, hider), ALERT)
+            self.assertEqual(get_awareness(dull, hider), UNAWARE)
+
+    def test_blind_watcher_never_contests(self):
+        room = _room()
+        hider = _char(motorics=0, room=room)
+        blind = _char(resonance=20)
+        room.contents = [hider, blind]
+        with _uid_for(None), \
+                patch("world.stealth.randint", return_value=10), \
+                patch("world.perception.can_see", return_value=False):
+            kept = attempt_hide(hider)
+        self.assertEqual(kept, [])
+
+
+class TestPassiveTier(TestCase):
+    def test_clear_win_spots_outright(self):
+        hider, obs = _char(motorics=0, hidden=True), _char(resonance=10)
+        with _uid_for(None), \
+                patch("world.stealth.randint", return_value=10):
+            self.assertEqual(passive_check(obs, hider), ALERT)
+
+    def test_near_miss_reads_suspicious(self):
+        # equal totals: margin 0 -> hider holds, but it's within the
+        # suspicion band
+        hider, obs = _char(motorics=1, hidden=True), _char(resonance=1)
+        with _uid_for(None), \
+                patch("world.stealth.randint", return_value=10):
+            self.assertEqual(passive_check(obs, hider), SUSPICIOUS)
+
+    def test_clear_hold_stays_unaware(self):
+        hider, obs = _char(motorics=10, hidden=True), _char(resonance=0)
+        with _uid_for(None), \
+                patch("world.stealth.randint", return_value=10):
+            self.assertEqual(passive_check(obs, hider), UNAWARE)
+
+    def test_rate_limited_no_reroll_spam(self):
+        # first look: clear hold. Second look (better luck) inside the
+        # cooldown must NOT re-roll — look-spam is not a search.
+        hider, obs = _char(motorics=10, hidden=True), _char(resonance=0)
+        with _uid_for(None):
+            with patch("world.stealth.randint", return_value=10):
+                self.assertEqual(passive_check(obs, hider), UNAWARE)
+            with patch("world.stealth.randint",
+                       side_effect=[1, 20]) as rand:
+                self.assertEqual(passive_check(obs, hider), UNAWARE)
+                rand.assert_not_called()
+
+    def test_weaker_than_active_search(self):
+        # a margin the passive glance loses, the active search wins:
+        # totals equal (margin 0) passively, but the search bonus flips it
+        hider = _char(motorics=1, hidden=True)
+        room = _room(hider)
+        searcher = _char(resonance=1, room=room)
+        room.contents.append(searcher)
+        hider.get_sdesc = lambda: "a shape"
+        with _uid_for(None), \
+                patch("world.stealth.randint", return_value=10):
+            self.assertEqual(passive_check(searcher, hider), SUSPICIOUS)
+            found, _objs = active_search(searcher)
+        self.assertIn(hider, found)
+
+
+class TestSearchAndBreak(TestCase):
+    def test_search_reveals_stashed_object_for_everyone(self):
+        obj = MagicMock(spec=["db", "get_display_name"])
+        obj.db.hidden = True
+        obj.db.stash_roll = 5
+        room = _room(obj)
+        searcher = _char(resonance=1, room=room)
+        room.contents.append(searcher)
+        with patch("world.stealth.randint", return_value=10):
+            _chars, objs = active_search(searcher)
+        self.assertIn(obj, objs)
+        self.assertFalse(obj.db.hidden)
+
+    def test_break_stealth_alerts_everyone_present(self):
+        room = _room()
+        hider = _char(hidden=True, room=room)
+        a, b = _char(), _char()
+        a.get_sdesc = b.get_sdesc = lambda: "x"
+        room.contents = [hider, a, b]
+        with _uid_for(None):
+            self.assertTrue(break_stealth(hider, quiet=True))
+            self.assertFalse(hider.db.hidden)
+            self.assertEqual(get_awareness(a, hider), ALERT)
+            self.assertEqual(get_awareness(b, hider), ALERT)
+
+    def test_display_gate(self):
+        hider, looker = _char(hidden=True), _char()
+        with _uid_for(None):
+            self.assertTrue(is_hidden_from(hider, looker))
+            set_awareness(looker, hider, ALERT)
+            self.assertFalse(is_hidden_from(hider, looker))
+        hider.db.hidden = False
+        self.assertFalse(is_hidden_from(hider, looker))
+
+
+class TestHideCommand(TestCase):
+    def test_hide_self_sets_state_and_notifies_keepers(self):
+        from commands.CmdStealth import CmdHide
+        room = _room()
+        caller = _char(motorics=0, room=room)
+        watcher = _char(resonance=20)
+        watcher.get_display_name = lambda looker=None, **k: "you-know-who"
+        caller.get_display_name = lambda looker=None, **k: "a lean man"
+        room.contents = [caller, watcher]
+        cmd = CmdHide()
+        cmd.caller = caller
+        cmd.args = ""
+        with _uid_for(None), \
+                patch("world.stealth.randint", return_value=10), \
+                patch("world.perception.can_see", return_value=True):
+            cmd.func()
+        self.assertTrue(caller.db.hidden)
+        self.assertIn("keep track", watcher.msg.call_args.args[0])
+
+    def test_stash_object(self):
+        from commands.CmdStealth import CmdHide
+        room = _room()
+        caller = _char(motorics=3, room=room)
+        item = MagicMock()
+        item.get_display_name = lambda looker=None, **k: "a shiv"
+        caller.search.return_value = item
+        cmd = CmdHide()
+        cmd.caller = caller
+        cmd.args = "shiv"
+        cmd.func()
+        item.move_to.assert_called_once_with(room, quiet=True)
+        self.assertTrue(item.db.hidden)
+        self.assertTrue(item.db.stash_roll)


### PR DESCRIPTION
Closes #973

- world/stealth.py: opposed Motorics(hider)/Resonance(searcher) contest;
  per-observer awareness store (apparent-uid keyed, lazy decay); three
  tiers - passive glance (rate-limited), hide-time, active search (+4)
- hide/unhide/sneak/search commands; object stashing with frozen
  stash-roll; sneak suppresses announcements (departure only to
  trackers, arrival decided by the fresh contest)
- passive tier on room entry + look; Suspicious "prickling sense" cue;
  Detected hidden chars render "lurking in the shadows."; hidden
  objects out of things list
- breaking stealth: speech/attack/open movement alert the room
- strict is-True state checks (mock/junk-data safety)
- spec: §3.4 passive tier recorded; status banner -> P1-2 shipped

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
