### PR TITLE
Break stealth on unconsciousness/death (override_place collision)

### DIFF
--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -335,6 +335,11 @@ class Character(
         
         # Set unconscious placement description
         self.override_place = "unconscious and motionless."
+
+        # Unconsciousness breaks stealth (you can't keep concealment out
+        # cold) — also keeps the KO placement from rendering as "lurking".
+        from world.stealth import break_stealth
+        break_stealth(self, quiet=True)
         
         # Check if character is in active combat - if so, defer unconsciousness message
         is_in_combat = hasattr(self.ndb, NDB_COMBAT_HANDLER) and getattr(self.ndb, NDB_COMBAT_HANDLER) is not None
@@ -637,6 +642,10 @@ class Character(
         
         # Set death placement description for persistent visual indication
         self.override_place = "lying motionless and deceased."
+
+        # Death breaks stealth — a corpse doesn't hide itself.
+        from world.stealth import break_stealth
+        break_stealth(self, quiet=True)
         
         # Always show death analysis when character dies.
         # debug_death_analysis is fail-soft internally and the audit
@@ -699,6 +708,10 @@ class Character(
         
         # Set placement description
         self.override_place = "unconscious and motionless."
+
+        # Unconsciousness breaks stealth (see set_unconscious).
+        from world.stealth import break_stealth
+        break_stealth(self, quiet=True)
         
         # Notify area
         if self.location:
@@ -850,6 +863,10 @@ class Character(
         
         # Update placement description for permanent death
         self.override_place = "lying motionless and deceased."
+
+        # Death breaks stealth — a corpse doesn't hide itself.
+        from world.stealth import break_stealth
+        break_stealth(self, quiet=True)
         
         # Ensure death cmdset is applied (should already be done)
         if not hasattr(self, '_death_cmdset_applied'):

--- a/world/tests/test_stealth.py
+++ b/world/tests/test_stealth.py
@@ -211,3 +211,29 @@ class TestHideCommand(TestCase):
         item.move_to.assert_called_once_with(room, quiet=True)
         self.assertTrue(item.db.hidden)
         self.assertTrue(item.db.stash_roll)
+
+
+class TestStateTransitionsBreakStealth(TestCase):
+    """KO/death own override_place — a hidden character who drops must stop
+    being hidden (no "lurking" corpse, no body fading to invisible as
+    trackers' awareness decays). Pins the source-level calls."""
+
+    def test_unconscious_and_death_paths_break_stealth(self):
+        import inspect
+        import typeclasses.characters as chars
+        source = inspect.getsource(chars)
+        anchors = [
+            'self.override_place = "unconscious and motionless."',
+            'self.override_place = "lying motionless and deceased."',
+        ]
+        for anchor in anchors:
+            idx = 0
+            while True:
+                idx = source.find(anchor, idx)
+                if idx == -1:
+                    break
+                window = source[idx:idx + 400]
+                self.assertIn("break_stealth", window,
+                              f"override_place write without break_stealth "
+                              f"nearby: {anchor}")
+                idx += len(anchor)


### PR DESCRIPTION
Closes #975

- all four override_place state-write sites (unconscious x2, death,
  final death) now break_stealth(quiet=True): no "lurking" corpses, no
  KO'd hidden body fading to invisible as tracker awareness decays,
  and the KO/death placement renders instead of the lurk
- pin test: every override_place write must have break_stealth
  adjacent (it caught the fourth site the grep pass missed)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
