### PR TITLE
Whisper carve-out + emergence beat for breaking stealth

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -120,33 +120,43 @@ class CmdWhisper(Command):
     Whisper a message to a specific target.
 
     Usage:
-        whisper <target> = <message>
+        whisper "Wakka." to <person>
+        whisper <person> = <message>     (legacy form)
 
-    The target hears the full message. Other observers only see that
-    a whisper occurred — they do not see the content.
+    The target hears the full message. Other observers only see that a
+    whisper occurred — never the content.
+
+    Whispering does NOT give you away: a whisper from someone the target
+    cannot see arrives as a voice with no owner — they'll know something
+    is there, not who or where.
     """
 
     key = "whisper"
     locks = "cmd:all()"
     help_category = "Social"
 
+    def parse(self):
+        """Accept `whisper "text" to <person>` (canonical) or the legacy
+        `whisper <person> = <text>`."""
+        import re
+        self.speech = self.target_str = ""
+        raw = (self.args or "").strip()
+        match = re.match(r'^"(?P<speech>[^"]+)"\s+to\s+(?P<target>.+)$', raw)
+        if match:
+            self.speech = match.group("speech").strip()
+            self.target_str = match.group("target").strip()
+            return
+        if "=" in raw:
+            target_str, _, speech = raw.partition("=")
+            self.target_str = target_str.strip()
+            self.speech = speech.strip()
+
     def func(self):
         caller = self.caller
-        # Speaking gives you away (STEALTH_AND_DETECTION_SPEC §6.4).
-        from world.stealth import break_stealth
-        break_stealth(caller)
-
-        if not self.args or "=" not in self.args:
-            caller.msg("Usage: whisper <target> = <message>")
+        if not self.speech or not self.target_str:
+            caller.msg('Usage: whisper "<message>" to <person>')
             return
-
-        target_str, _, speech = self.args.partition("=")
-        target_str = target_str.strip()
-        speech = speech.strip()
-
-        if not target_str or not speech:
-            caller.msg("Usage: whisper <target> = <message>")
-            return
+        speech, target_str = self.speech, self.target_str
 
         location = caller.location
         if not location:
@@ -158,31 +168,60 @@ class CmdWhisper(Command):
         if not target:
             return  # search() already sent error message
 
+        # A whisper never breaks stealth (STEALTH_AND_DETECTION_SPEC §6.4
+        # carve-out): it's the creepy channel. From a hidden speaker the
+        # target can't see, the voice arrives with no owner — and leaves
+        # them knowing SOMETHING is there.
+        from world.stealth import (
+            SUSPICIOUS, get_awareness, is_hidden_from, set_awareness,
+        )
+        unseen = is_hidden_from(caller, target)
+
         # Actor sees their own message
         target_name_for_actor = target.get_display_name(caller)
         caller.msg(f'You whisper to {target_name_for_actor}, "{speech}"')
 
         # Target hears the full message — unless deaf, in which case they feel
         # the lean-in but can't make out the words (CAPACITY_CONSUMERS §4).
-        speaker_name_for_target = capitalize_first(
-            caller.get_display_name(target)
-        )
-        if can_hear(target):
-            target_text = (
-                f'{speaker_name_for_target} whispers to you, "{speech}"'
-            )
+        if unseen:
+            speaker_name_for_target = "Someone unseen"
         else:
-            target_text = (
-                f"{speaker_name_for_target} leans in to whisper, but you "
-                f"can't make out a word of it."
+            speaker_name_for_target = capitalize_first(
+                caller.get_display_name(target)
             )
+        if can_hear(target):
+            if unseen:
+                target_text = (
+                    f'Someone unseen whispers at your ear, "{speech}"'
+                )
+            else:
+                target_text = (
+                    f'{speaker_name_for_target} whispers to you, "{speech}"'
+                )
+        else:
+            if unseen:
+                target_text = (
+                    "You feel a breath at your ear, but you can't make "
+                    "out a word of it."
+                )
+            else:
+                target_text = (
+                    f"{speaker_name_for_target} leans in to whisper, but you "
+                    f"can't make out a word of it."
+                )
         target.msg(text=target_text, type="whisper", from_obj=caller)
+        if unseen:
+            if get_awareness(target, caller) < SUSPICIOUS:
+                set_awareness(target, caller, SUSPICIOUS)
 
-        # Room observers see that a whisper occurred, but NOT the content
+        # Room observers see that a whisper occurred, but NOT the content.
+        # Observers who can't see the whisperer see nothing at all.
         for observer in location.contents:
             if observer is caller or observer is target:
                 continue
             if not hasattr(observer, "msg"):
+                continue
+            if is_hidden_from(caller, observer):
                 continue
             speaker_name = caller.get_display_name(observer)
             target_name = target.get_display_name(observer)

--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -246,6 +246,18 @@ relevant observers to **Alert** and drops your hidden state for them. Stealth
 breaks **per-observer**: ambushing or robbing one guard doesn't auto-reveal you
 to one across the building (until alert propagation reaches them).
 
+**The emergence beat (2026-07-03):** when stealth breaks as a side effect of
+an action (speech, a pose), observers who couldn't see you get
+"…emerges from concealment." *before* the words render — a voice never just
+materializes mid-sentence. Trackers who watched you lurk get no redundant line.
+
+**The whisper carve-out (2026-07-03, user-decided):** `whisper` does NOT break
+stealth — it's the creepy channel. A whisper from a speaker the target cannot
+see arrives **unattributed** ("Someone unseen whispers at your ear, …"), leaves
+the target **Suspicious**, and bystanders who can't see the whisperer see
+nothing at all. Syntax: ``whisper "Wakka." to <person>`` (legacy
+``whisper <person> = <message>`` still accepted).
+
 ---
 
 ## 7 · Perception-gate integration (the safety model)

--- a/world/stealth.py
+++ b/world/stealth.py
@@ -185,17 +185,38 @@ def break_stealth(char, *, quiet=False):
     hidden state and makes everyone present fully aware (spec §6.4 —
     per-room here; alert propagation is the hunt phase's job). Strict
     ``is True``: the state is only ever written as a literal, and test
-    doubles with auto-attributes must not read as hidden."""
+    doubles with auto-attributes must not read as hidden.
+
+    Non-quiet breaks add the EMERGENCE beat: observers who couldn't see
+    the character get "…emerges from concealment." *before* whatever gave
+    them away renders, so a voice never just materializes mid-sentence.
+    Trackers (who've been watching them lurk) get no redundant line.
+    Quiet is for callers that narrate the moment themselves (unhide) or
+    where emergence reads wrong (collapsing unconscious, movement)."""
     if getattr(getattr(char, "db", None), "hidden", False) is not True:
         return False
-    char.db.hidden = False
     room = char.location
+    emergence = []
+    if not quiet:
+        emergence = [obs for obs in (room.contents if room else [])
+                     if obs is not char and hasattr(obs, "get_sdesc")
+                     and is_hidden_from(char, obs)]
+    char.db.hidden = False
     for observer in (room.contents if room else []):
         if observer is char or not hasattr(observer, "get_sdesc"):
             continue
         set_awareness(observer, char, ALERT)
     if not quiet:
         char.msg("You abandon any pretense of hiding.")
+        from world.grammar import capitalize_first
+        for observer in emergence:
+            try:
+                observer.msg(
+                    f"{capitalize_first(char.get_display_name(observer))} "
+                    f"emerges from concealment."
+                )
+            except Exception:  # noqa: BLE001 — narration is best-effort
+                pass
     return True
 
 

--- a/world/tests/test_communication.py
+++ b/world/tests/test_communication.py
@@ -623,6 +623,7 @@ class TestCmdWhisper(TestCase):
         cmd.caller = caller
         cmd.args = f" {args}"
         cmd.cmdstring = "whisper"
+        cmd.parse()
 
         room = MagicMock()
         room.contents = room_contents
@@ -744,11 +745,12 @@ class TestCmdWhisper(TestCase):
         cmd.caller = jorge
         cmd.args = " just talking"
         cmd.cmdstring = "whisper"
+        cmd.parse()
         jorge.location = MagicMock()
 
         cmd.func()
         jorge.msg.assert_called_once_with(
-            "Usage: whisper <target> = <message>"
+            'Usage: whisper "<message>" to <person>'
         )
 
 

--- a/world/tests/test_stealth.py
+++ b/world/tests/test_stealth.py
@@ -237,3 +237,103 @@ class TestStateTransitionsBreakStealth(TestCase):
                               f"override_place write without break_stealth "
                               f"nearby: {anchor}")
                 idx += len(anchor)
+
+
+class TestEmergenceBeat(TestCase):
+    """A voice must never materialize mid-sentence: a non-quiet break gives
+    formerly-unaware observers the emergence line; trackers get nothing."""
+
+    def test_unaware_observers_get_emergence_line(self):
+        room = _room()
+        hider = _char(hidden=True, room=room)
+        hider.get_display_name = lambda looker=None, **k: "a lean man"
+        unaware, tracker = _char(), _char()
+        unaware.get_sdesc = tracker.get_sdesc = lambda: "x"
+        room.contents = [hider, unaware, tracker]
+        with _uid_for(None):
+            set_awareness(tracker, hider, ALERT)
+            break_stealth(hider)
+        self.assertIn("emerges from concealment",
+                      unaware.msg.call_args.args[0])
+        tracker.msg.assert_not_called()
+
+    def test_quiet_break_has_no_emergence(self):
+        room = _room()
+        hider = _char(hidden=True, room=room)
+        unaware = _char()
+        unaware.get_sdesc = lambda: "x"
+        room.contents = [hider, unaware]
+        with _uid_for(None):
+            break_stealth(hider, quiet=True)
+        unaware.msg.assert_not_called()
+
+
+class TestWhisperStealth(TestCase):
+    """Whisper is the creepy channel: it never breaks stealth, arrives
+    unattributed from an unseen speaker, and leaves the target Suspicious."""
+
+    def _cmd(self, caller, args):
+        from commands.CmdCommunication import CmdWhisper
+        cmd = CmdWhisper()
+        cmd.caller = caller
+        cmd.args = args
+        cmd.parse()
+        return cmd
+
+    def _pair(self, hidden=False):
+        room = _room()
+        caller = _char(hidden=hidden, room=room)
+        target = _char(room=room)
+        target.get_display_name = lambda looker=None, **k: "a lean man"
+        caller.get_display_name = lambda looker=None, **k: "a shadow"
+        caller.search.return_value = target
+        room.contents = [caller, target]
+        return caller, target
+
+    def test_new_syntax_parses(self):
+        caller, target = self._pair()
+        cmd = self._cmd(caller, '"Wakka." to lean man')
+        self.assertEqual(cmd.speech, "Wakka.")
+        self.assertEqual(cmd.target_str, "lean man")
+
+    def test_legacy_syntax_still_parses(self):
+        caller, target = self._pair()
+        cmd = self._cmd(caller, "lean man = Wakka.")
+        self.assertEqual(cmd.speech, "Wakka.")
+        self.assertEqual(cmd.target_str, "lean man")
+
+    def test_hidden_whisper_stays_hidden_and_unattributed(self):
+        caller, target = self._pair(hidden=True)
+        cmd = self._cmd(caller, '"Wakka." to lean man')
+        with _uid_for(None), \
+                patch("commands.CmdCommunication.can_hear",
+                      return_value=True):
+            cmd.func()
+        self.assertTrue(caller.db.hidden)               # never breaks
+        text = target.msg.call_args.kwargs.get("text")
+        self.assertIn("Someone unseen whispers", text)
+        self.assertNotIn("shadow", text)                # no attribution
+        with _uid_for(None):
+            self.assertEqual(get_awareness(target, caller), SUSPICIOUS)
+
+    def test_visible_whisper_attributed(self):
+        caller, target = self._pair(hidden=False)
+        cmd = self._cmd(caller, '"Wakka." to lean man')
+        with _uid_for(None), \
+                patch("commands.CmdCommunication.can_hear",
+                      return_value=True):
+            cmd.func()
+        text = target.msg.call_args.kwargs.get("text")
+        self.assertIn("A shadow whispers to you", text)
+
+    def test_bystander_who_cannot_see_whisperer_sees_nothing(self):
+        caller, target = self._pair(hidden=True)
+        bystander = _char()
+        bystander.get_sdesc = lambda: "x"
+        caller.location.contents.append(bystander)
+        cmd = self._cmd(caller, '"Wakka." to lean man')
+        with _uid_for(None), \
+                patch("commands.CmdCommunication.can_hear",
+                      return_value=True):
+            cmd.func()
+        bystander.msg.assert_not_called()


### PR DESCRIPTION
Closes #977

- whisper no longer breaks stealth: unseen whisperer renders
  unattributed ("Someone unseen whispers at your ear"), target bumped
  to Suspicious, bystanders who can't see the whisperer see nothing
- whisper syntax: canonical `whisper "Wakka." to <person>`, legacy
  `<person> = <message>` retained; usage pin updated; old harness now
  calls parse() before func() (matches the real command lifecycle)
- break_stealth non-quiet adds the emergence beat: formerly-unaware
  observers get "X emerges from concealment." before the give-away
  action renders; trackers get no redundant line
- spec §6.4: both refinements recorded

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
