### PR TITLE
Whisper rides the say parent; stealth-aware voice attribution

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -169,9 +169,13 @@ class CmdWhisper(Command):
             return  # search() already sent error message
 
         # A whisper never breaks stealth (STEALTH_AND_DETECTION_SPEC §6.4
-        # carve-out): it's the creepy channel. From a hidden speaker the
-        # target can't see, the voice arrives with no owner — and leaves
-        # them knowing SOMETHING is there.
+        # carve-out): it's the creepy channel. It rides the SAY parent —
+        # the shared speech rails — so attribution follows the full
+        # sight→voice→someone chain (a hidden whisperer with a KNOWN voice
+        # gets named by it; a modulator defeats that), voice flavour and
+        # garble apply, and the structured payload reaches NPC brains.
+        from world.speech import render_speech_line, speech_payload
+        from world.speech import visible_voice_flavor
         from world.stealth import (
             SUSPICIOUS, get_awareness, is_hidden_from, set_awareness,
         )
@@ -181,47 +185,32 @@ class CmdWhisper(Command):
         target_name_for_actor = target.get_display_name(caller)
         caller.msg(f'You whisper to {target_name_for_actor}, "{speech}"')
 
-        # Target hears the full message — unless deaf, in which case they feel
-        # the lean-in but can't make out the words (CAPACITY_CONSUMERS §4).
-        if unseen:
-            speaker_name_for_target = "Someone unseen"
-        else:
-            speaker_name_for_target = capitalize_first(
-                caller.get_display_name(target)
-            )
-        if can_hear(target):
-            if unseen:
-                target_text = (
-                    f'Someone unseen whispers at your ear, "{speech}"'
-                )
-            else:
-                target_text = (
-                    f'{speaker_name_for_target} whispers to you, "{speech}"'
-                )
-        else:
-            if unseen:
-                target_text = (
-                    "You feel a breath at your ear, but you can't make "
-                    "out a word of it."
-                )
-            else:
-                target_text = (
-                    f"{speaker_name_for_target} leans in to whisper, but you "
-                    f"can't make out a word of it."
-                )
-        target.msg(text=target_text, type="whisper", from_obj=caller)
-        if unseen:
-            if get_awareness(target, caller) < SUSPICIOUS:
-                set_awareness(target, caller, SUSPICIOUS)
+        # Target line via the parent renderer: hearing gates content,
+        # sight/voice/stealth gate attribution (CAPACITY_CONSUMERS §4.5).
+        flavor = visible_voice_flavor(caller)
+        target_text = render_speech_line(
+            caller, target, speech, target=target, flavor=flavor,
+            verb="whispers",
+        )
+        payload = speech_payload(target, caller, speech, addressed=True)
+        target.msg(text=target_text, type="whisper", from_obj=caller,
+                   **payload)
+        if unseen and get_awareness(target, caller) < SUSPICIOUS:
+            # A voice with no visible owner: they know SOMETHING is here.
+            set_awareness(target, caller, SUSPICIOUS)
 
-        # Room observers see that a whisper occurred, but NOT the content.
-        # Observers who can't see the whisperer see nothing at all.
+        # Room observers see that a whisper occurred, but NOT the content —
+        # a whisper is a visual event to bystanders (the lean-in), so only
+        # those who can see the whisperer perceive it at all.
+        from world.perception import can_see
         for observer in location.contents:
             if observer is caller or observer is target:
                 continue
             if not hasattr(observer, "msg"):
                 continue
             if is_hidden_from(caller, observer):
+                continue
+            if not can_see(observer):
                 continue
             speaker_name = caller.get_display_name(observer)
             target_name = target.get_display_name(observer)

--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -252,11 +252,18 @@ an action (speech, a pose), observers who couldn't see you get
 materializes mid-sentence. Trackers who watched you lurk get no redundant line.
 
 **The whisper carve-out (2026-07-03, user-decided):** `whisper` does NOT break
-stealth — it's the creepy channel. A whisper from a speaker the target cannot
-see arrives **unattributed** ("Someone unseen whispers at your ear, …"), leaves
-the target **Suspicious**, and bystanders who can't see the whisperer see
-nothing at all. Syntax: ``whisper "Wakka." to <person>`` (legacy
-``whisper <person> = <message>`` still accepted).
+stealth — it's the creepy channel — and it **rides the say parent** (the
+shared speech rails, `world/speech.py`): voice flavour/garble apply, the
+structured speech payload reaches NPC brains, and attribution follows the
+full **sight → voice → someone** chain, now stealth-aware — concealment
+gates the VISUAL attribution channel (`resolve_speaker_attribution`), so a
+hidden whisperer with a voice the target KNOWS gets named by it ("Roony
+whispers to you, …"); an unknown voice reads "Someone whispers to you, …";
+a voice modulator defeats the recognition. An unseen whisper leaves the
+target **Suspicious**, and bystanders perceive a whisper visually (the
+lean-in) — those who can't see the whisperer see nothing. Syntax:
+``whisper "Wakka." to <person>`` (legacy ``whisper <person> = <message>``
+still accepted).
 
 ---
 

--- a/world/speech.py
+++ b/world/speech.py
@@ -68,14 +68,17 @@ def speech_payload(observer, speaker, words, *, addressed=False):
     return {"speech": words, "addressed": bool(addressed)}
 
 
-def render_speech_line(speaker, observer, speech, *, target=None, flavor=None):
-    """The per-observer ``say``/``to`` line.
+def render_speech_line(speaker, observer, speech, *, target=None, flavor=None,
+                       verb="says"):
+    """The per-observer ``say``/``to``/``whisper`` line.
 
     Hearing gates the *content* (the words); sight + the voice channel gate the
-    *attribution* (who). Mirrors the sight/hearing chain (CAPACITY_CONSUMERS
-    §4.5). Passing ``target`` makes it a directed ``to`` line
-    ("... says to you/<name>, ..."); the caller is responsible for skipping
-    observers with no channel at all.
+    *attribution* (who) — including stealth: a speaker hidden from the observer
+    attributes by VOICE, not sight (world.voice). Mirrors the sight/hearing
+    chain (CAPACITY_CONSUMERS §4.5). Passing ``target`` makes it a directed
+    line ("... says to you/<name>, ..."); ``verb`` swaps the register
+    ("whispers"). The caller is responsible for skipping observers with no
+    channel at all.
     """
     heard = can_hear(observer)
     seen = can_see(observer)
@@ -91,20 +94,21 @@ def render_speech_line(speaker, observer, speech, *, target=None, flavor=None):
 
     if heard:
         if target is None:
-            verb = f"says, |x*{flavor}*|n" if (seen and flavor) else "says,"
+            rendered_verb = (f"{verb}, |x*{flavor}*|n"
+                             if (seen and flavor) else f"{verb},")
         else:
-            verb = (
-                f"says to {target_ref}, |x*{flavor}*|n"
+            rendered_verb = (
+                f"{verb} to {target_ref}, |x*{flavor}*|n"
                 if (seen and flavor)
-                else f"says to {target_ref},"
+                else f"{verb} to {target_ref},"
             )
-        return f'{speaker_name} {verb} "{speech}"'
+        return f'{speaker_name} {rendered_verb} "{speech}"'
 
     # Deaf but watching: the act is visible, the content is not.
     if target is None:
-        return f"{speaker_name} says something you can't make out."
+        return f"{speaker_name} {verb} something you can't make out."
     return (
-        f"{speaker_name} says something to {target_ref}, "
+        f"{speaker_name} {verb} something to {target_ref}, "
         f"but you can't make it out."
     )
 

--- a/world/tests/test_stealth.py
+++ b/world/tests/test_stealth.py
@@ -269,8 +269,10 @@ class TestEmergenceBeat(TestCase):
 
 
 class TestWhisperStealth(TestCase):
-    """Whisper is the creepy channel: it never breaks stealth, arrives
-    unattributed from an unseen speaker, and leaves the target Suspicious."""
+    """Whisper is the creepy channel ON THE SAY PARENT: never breaks
+    stealth, rides the shared speech rails (attribution via the
+    sight/voice/stealth chain, payload for NPC brains), leaves an
+    unseen-whispered target Suspicious."""
 
     def _cmd(self, caller, args):
         from commands.CmdCommunication import CmdWhisper
@@ -290,6 +292,20 @@ class TestWhisperStealth(TestCase):
         room.contents = [caller, target]
         return caller, target
 
+    def _run(self, caller, rendered='Someone whispers to you, "Wakka."'):
+        cmd = self._cmd(caller, '"Wakka." to lean man')
+        with _uid_for(None), \
+                patch("world.speech.render_speech_line",
+                      return_value=rendered) as render, \
+                patch("world.speech.speech_payload",
+                      return_value={"speech": "Wakka.",
+                                    "addressed": True}), \
+                patch("world.speech.visible_voice_flavor",
+                      return_value=None), \
+                patch("world.perception.can_see", return_value=True):
+            cmd.func()
+        return render
+
     def test_new_syntax_parses(self):
         caller, target = self._pair()
         cmd = self._cmd(caller, '"Wakka." to lean man')
@@ -302,38 +318,69 @@ class TestWhisperStealth(TestCase):
         self.assertEqual(cmd.speech, "Wakka.")
         self.assertEqual(cmd.target_str, "lean man")
 
-    def test_hidden_whisper_stays_hidden_and_unattributed(self):
+    def test_hidden_whisper_never_breaks_stealth(self):
         caller, target = self._pair(hidden=True)
-        cmd = self._cmd(caller, '"Wakka." to lean man')
-        with _uid_for(None), \
-                patch("commands.CmdCommunication.can_hear",
-                      return_value=True):
-            cmd.func()
-        self.assertTrue(caller.db.hidden)               # never breaks
-        text = target.msg.call_args.kwargs.get("text")
-        self.assertIn("Someone unseen whispers", text)
-        self.assertNotIn("shadow", text)                # no attribution
+        self._run(caller)
+        self.assertTrue(caller.db.hidden)
         with _uid_for(None):
             self.assertEqual(get_awareness(target, caller), SUSPICIOUS)
 
-    def test_visible_whisper_attributed(self):
+    def test_rides_the_say_parent(self):
+        caller, target = self._pair()
+        render = self._run(caller)
+        render.assert_called_once()
+        self.assertEqual(render.call_args.kwargs.get("verb"), "whispers")
+        # the structured payload reaches the target's msg (NPC brains hear)
+        self.assertEqual(target.msg.call_args.kwargs.get("speech"), "Wakka.")
+        self.assertTrue(target.msg.call_args.kwargs.get("addressed"))
+
+    def test_visible_whisper_leaves_no_awareness_mark(self):
         caller, target = self._pair(hidden=False)
-        cmd = self._cmd(caller, '"Wakka." to lean man')
-        with _uid_for(None), \
-                patch("commands.CmdCommunication.can_hear",
-                      return_value=True):
-            cmd.func()
-        text = target.msg.call_args.kwargs.get("text")
-        self.assertIn("A shadow whispers to you", text)
+        self._run(caller, rendered='A shadow whispers to you, "Wakka."')
+        with _uid_for(None):
+            self.assertEqual(get_awareness(target, caller), UNAWARE)
 
     def test_bystander_who_cannot_see_whisperer_sees_nothing(self):
         caller, target = self._pair(hidden=True)
         bystander = _char()
         bystander.get_sdesc = lambda: "x"
         caller.location.contents.append(bystander)
-        cmd = self._cmd(caller, '"Wakka." to lean man')
-        with _uid_for(None), \
-                patch("commands.CmdCommunication.can_hear",
-                      return_value=True):
-            cmd.func()
+        self._run(caller)
         bystander.msg.assert_not_called()
+
+
+class TestStealthAttribution(TestCase):
+    """Concealment gates the VISUAL attribution channel: a hidden speaker
+    attributes by voice — a known voice names them, a stranger's reads as
+    'someone'."""
+
+    def test_hidden_speaker_attributes_by_voice(self):
+        from world.voice import resolve_speaker_attribution
+        speaker, observer = _char(hidden=True), _char()
+        with patch("world.voice.can_see", return_value=True), \
+                patch("world.voice.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern",
+                      return_value="Roony"), \
+                patch("world.stealth.is_hidden_from", return_value=True):
+            self.assertEqual(
+                resolve_speaker_attribution(speaker, observer), "Roony")
+
+    def test_hidden_speaker_unknown_voice_is_someone(self):
+        from world.voice import resolve_speaker_attribution
+        speaker, observer = _char(hidden=True), _char()
+        with patch("world.voice.can_see", return_value=True), \
+                patch("world.voice.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern",
+                      return_value=None), \
+                patch("world.stealth.is_hidden_from", return_value=True):
+            self.assertEqual(
+                resolve_speaker_attribution(speaker, observer), "someone")
+
+    def test_visible_speaker_attributes_by_sight(self):
+        from world.voice import resolve_speaker_attribution
+        speaker, observer = _char(), _char()
+        speaker.get_display_name = lambda looker=None, **k: "a shadow"
+        with patch("world.voice.can_see", return_value=True), \
+                patch("world.stealth.is_hidden_from", return_value=False):
+            self.assertEqual(
+                resolve_speaker_attribution(speaker, observer), "a shadow")

--- a/world/voice.py
+++ b/world/voice.py
@@ -455,8 +455,21 @@ def resolve_speaker_attribution(speaker: Any, observer: Any) -> str:
     """
     if observer is speaker:
         return getattr(speaker, "key", GENERIC_UNSEEN_SPEAKER)
-    if can_see(observer):
+    if can_see(observer) and not _speaker_concealed(speaker, observer):
         return speaker.get_display_name(observer)
     if can_hear(observer):
         return attempt_voice_discern(observer, speaker) or GENERIC_UNSEEN_SPEAKER
     return GENERIC_UNSEEN_SPEAKER
+
+
+def _speaker_concealed(speaker, observer) -> bool:
+    """Stealth gates the VISUAL attribution channel: a speaker hidden from
+    this observer can't be identified by sight, so attribution falls
+    through to the voice determination — you can hide your body, not a
+    voice someone knows (a modulator handles that). Best-effort: no
+    stealth state means not concealed."""
+    try:
+        from world.stealth import is_hidden_from
+        return is_hidden_from(speaker, observer)
+    except Exception:  # noqa: BLE001
+        return False


### PR DESCRIPTION
Closes #979

- render_speech_line gains a verb register ("whispers"); say/to
  unchanged
- resolve_speaker_attribution: concealment gates the VISUAL channel —
  a hidden speaker attributes by voice (known voice names them, else
  "someone"; modulator defeats it). General rule, not whisper-only.
- CmdWhisper rebuilt on the shared rails: voice flavour/garble,
  hearing-gated content, and the structured speech payload — NPC
  brains can now hear whispers (they previously got no payload at all)
- unseen-whisper Suspicious bump + visual bystander rules unchanged

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
