### PR TITLE
Widen deploy-reload watchdog 45s -> 150s

### DIFF
--- a/scripts/deploy-reload.sh
+++ b/scripts/deploy-reload.sh
@@ -32,7 +32,7 @@ docker exec -w "$GAME" "$CONTAINER" evennia reload --settings settings.py 2>&1 |
 reload_pid=$!
 waited=0
 while kill -0 "$reload_pid" 2>/dev/null; do
-    if [ "$waited" -ge 45 ]; then
+    if [ "$waited" -ge 150 ]; then
         kill "$reload_pid" 2>/dev/null
         echo "(reload timed out after ${waited}s — falling through to recovery)"
         break


### PR DESCRIPTION
Closes #981

Third stall at 45s: reload on the grown codebase legitimately exceeds
it, tripping recovery unnecessarily (and stranding a lingering twistd
when the outer caller dies mid-recovery). Recovery stays for real hangs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
