### PR TITLE
Stealth Phase 3: presence-gate choke + leak sweep

### DIFF
--- a/commands/_identity_targeting.py
+++ b/commands/_identity_targeting.py
@@ -130,6 +130,12 @@ def resolve_character_target(
     else:
         candidates = list(candidates)
 
+    # Presence gate (stealth spec §7): you can't passively TARGET someone
+    # you're unaware of — attack/operate/frisk/trust all resolve through
+    # here. Detection (a search, their slip) is the precondition.
+    from world.perception import filter_present
+    candidates = filter_present(caller, candidates)
+
     matches = identity_match_characters(caller, stripped, candidates)
 
     if not matches and caller.check_permstring(PERM_BUILDER):

--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -8,11 +8,20 @@
 > Unaware/Suspicious; the *Suspicious* "prickling sense" cue; the "lurking
 > in the shadows" placement for the Detected; hidden objects out of the
 > things list; hidden movers' announcements suppressed to the unaware), and
-> break-on-action (speech, attack, open movement). NOT yet built: the full
-> perception-gate choke (§7 — say/emote/combat-target leak sweep; note the
-> phase layer's `filter_present` does NOT exist yet, §7 must build it), the
-> NPC hunt (§5), ambush advantage (§6.1), theft (§6.2), environmental
-> modifiers (light/cover/crowd — v1 is the flat tier spread).
+> break-on-action (speech, attack, open movement). **PHASE 3 (LEAK SWEEP)
+> SHIPPED (2026-07-03):** `world/perception.py` now owns the presence gate —
+> `can_perceive(looker, target)` + the single enumeration choke
+> `filter_present` (built HERE; the phase layer's binary clause slots in
+> later) — wired through: room roster (P1), adjacent-room sightings,
+> identity targeting (`resolve_character_target` — attack/operate/frisk/
+> trust all refuse targets you're unaware of), emote char-ref candidacy
+> (can't pose AT someone you're unaware of), the LLM NPC PRESENT roster,
+> move announcements, whisper bystanders, and speech attribution
+> (stealth-aware `resolve_speaker_attribution` — hidden speakers attribute
+> by VOICE). Leak-completeness tests drive each real path. Deliberate
+> bypasses hold: AoE, area sound, `search`. NOT yet built: the NPC hunt
+> (§5), ambush advantage (§6.1), theft (§6.2), environmental modifiers
+> (light/cover/crowd — v1 is the flat tier spread).
 > Original abstract: designs the **presence-concealment**
 > layer: `hide` (self or object) vs `search` (a room), resolved as an opposed
 > **Resonance/Motorics** contest, surfaced as a **per-observer graded awareness

--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -254,11 +254,17 @@ class LLMNpcMixin:
         loc = self.location
         if not loc:
             return []
+        from world.perception import can_perceive
         names = []
         for obj in loc.contents:
             if obj is self or obj is patron:
                 continue
             if not hasattr(obj, "get_sdesc"):
+                continue
+            # Presence gate (stealth spec §7): the model's PRESENT roster
+            # only lists people this NPC actually perceives — a hidden
+            # character doesn't leak into an NPC brain's context.
+            if not can_perceive(self, obj):
                 continue
             name = self._address_handle(obj)
             if name:

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -614,12 +614,16 @@ class Room(ObjectParent, DefaultRoom):
             if not destination:
                 continue
                 
-            # Count visible characters (excluding looker)
+            # Count visible characters (excluding looker); the presence
+            # gate keeps hidden characters out of adjacent sightings
+            # (stealth spec §7 — no leak through the doorway glance)
+            from world.perception import can_perceive
             char_count = 0
             for obj in destination.contents:
                 if (obj.is_typeclass("typeclasses.characters.Character") 
                     and obj != looker 
-                    and obj.access(looker, "view")):
+                    and obj.access(looker, "view")
+                    and can_perceive(looker, obj)):
                     char_count += 1
             
             if char_count > 0:

--- a/world/emote.py
+++ b/world/emote.py
@@ -310,8 +310,13 @@ def build_char_candidates(
 
     candidates: list[tuple[str, "Character", bool]] = []
 
+    from world.perception import can_perceive
     for char in room_occupants:
         if char is actor:
+            continue
+        # Presence gate (stealth spec §7): you can't pose AT someone
+        # you're unaware of — no char-ref candidacy for hidden targets.
+        if not can_perceive(actor, char):
             continue
 
         names: list[tuple[str, bool]] = []

--- a/world/perception.py
+++ b/world/perception.py
@@ -170,3 +170,27 @@ def has_reduced_perception(looker: Any) -> bool:
     gets a little more texture from the senses that remain.
     """
     return bool(blocked_senses(looker))
+
+
+# ---------------------------------------------------------------------------
+# The presence gate (STEALTH_AND_DETECTION_SPEC §7 / PHASE_LAYER_SPEC §3)
+# ---------------------------------------------------------------------------
+
+def can_perceive(looker, target) -> bool:
+    """THE presence gate: whether *looker* passively perceives *target* as
+    present at all. Today this is stealth's graded clause (an Unaware /
+    Suspicious looker doesn't perceive a hidden target); the phase layer's
+    binary clause slots in here when it lands. Deliberate bypasses (AoE,
+    area sound, active `search`) must NOT route through this — hidden is
+    concealment, never invulnerability."""
+    try:
+        from world.stealth import is_hidden_from
+        return not is_hidden_from(target, looker)
+    except Exception:  # noqa: BLE001 — fail-open: perception over paranoia
+        return True
+
+
+def filter_present(looker, entities):
+    """The single enumeration choke (leak-completeness discipline): every
+    path that lists 'who is here' for a looker filters through this."""
+    return [e for e in entities if can_perceive(looker, e)]

--- a/world/tests/test_stealth.py
+++ b/world/tests/test_stealth.py
@@ -384,3 +384,81 @@ class TestStealthAttribution(TestCase):
                 patch("world.stealth.is_hidden_from", return_value=False):
             self.assertEqual(
                 resolve_speaker_attribution(speaker, observer), "a shadow")
+
+
+class TestLeakSweep(TestCase):
+    """Leak-completeness (spec §7): no enumeration path shows a hidden
+    target to an unaware observer. Each test drives one real path."""
+
+    def _hidden_char(self):
+        c = _char(hidden=True)
+        c.get_sdesc = lambda: "a shape"
+        return c
+
+    def test_choke_basics(self):
+        from world.perception import can_perceive, filter_present
+        looker = _char()
+        hidden, plain = self._hidden_char(), _char()
+        with _uid_for(None):
+            self.assertFalse(can_perceive(looker, hidden))
+            self.assertTrue(can_perceive(looker, plain))
+            self.assertEqual(filter_present(looker, [hidden, plain]),
+                             [plain])
+            set_awareness(looker, hidden, ALERT)
+            self.assertTrue(can_perceive(looker, hidden))
+
+    def test_adjacent_sightings_do_not_count_hidden(self):
+        from typeclasses.rooms import Room
+        looker = _char()
+        hidden = self._hidden_char()
+        adjacent = _room(hidden)
+        exit_obj = MagicMock()
+        exit_obj.destination = adjacent
+        exit_obj.key = "north"
+        room = MagicMock()
+        room.exits = [exit_obj]
+        sightings = Room.get_adjacent_character_sightings.__get__(room)
+        with _uid_for(None):
+            self.assertEqual(sightings(looker), "")
+            set_awareness(looker, hidden, ALERT)
+            self.assertIn("lone figure", sightings(looker))
+
+    def test_identity_targeting_refuses_hidden(self):
+        from commands._identity_targeting import resolve_character_target
+        caller = _char()
+        caller.check_permstring.return_value = False
+        hidden = self._hidden_char()
+        with _uid_for(None), \
+                patch("commands._identity_targeting."
+                      "identity_match_characters",
+                      side_effect=lambda c, q, cands: list(cands)):
+            self.assertIsNone(
+                resolve_character_target(caller, "shape",
+                                         candidates=[hidden]))
+            set_awareness(caller, hidden, ALERT)
+            self.assertIs(
+                resolve_character_target(caller, "shape",
+                                         candidates=[hidden]),
+                hidden)
+
+    def test_emote_charref_candidates_exclude_hidden(self):
+        from world.emote import build_char_candidates
+        actor = _char()
+        hidden = self._hidden_char()
+        with _uid_for(None):
+            names = [c for _n, c, _rc in
+                     build_char_candidates(actor, [actor, hidden])]
+        self.assertNotIn(hidden, names)
+
+    def test_llm_present_roster_excludes_hidden(self):
+        from typeclasses.llm_npc import LLMNpcMixin
+        npc = _char()
+        hidden = self._hidden_char()
+        room = _room(npc, hidden)
+        npc.location = room
+        npc._address_handle = lambda t: "a shape"
+        present = LLMNpcMixin._present_others.__get__(npc)
+        with _uid_for(None):
+            self.assertEqual(present(), [])
+            set_awareness(npc, hidden, ALERT)
+            self.assertEqual(present(), ["a shape"])


### PR DESCRIPTION
Closes #983

- world/perception.py: can_perceive(looker, target) + filter_present —
  THE enumeration choke (phase layer's binary clause slots in later)
- wired: identity targeting (attack/operate/frisk/trust refuse unaware
  targets), adjacent-room sightings, emote char-ref candidacy, LLM NPC
  PRESENT roster
- deliberate bypasses hold: AoE / area sound / active search
- leak-completeness tests drive each real path both ways (hidden
  filtered; Detected restored)
- spec banner -> Phase 3 shipped

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
