### PR TITLE
Stealth Phase 4: the deterministic NPC hunt

### DIFF
--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -19,9 +19,21 @@
 > move announcements, whisper bystanders, and speech attribution
 > (stealth-aware `resolve_speaker_attribution` — hidden speakers attribute
 > by VOICE). Leak-completeness tests drive each real path. Deliberate
-> bypasses hold: AoE, area sound, `search`. NOT yet built: the NPC hunt
-> (§5), ambush advantage (§6.1), theft (§6.2), environmental modifiers
-> (light/cover/crowd — v1 is the flat tier spread).
+> bypasses hold: AoE, area sound, `search`. **PHASE 4 (THE HUNT) SHIPPED
+> (2026-07-03):** `world/director/hunt.py` — the deterministic state
+> machine off the awareness meter, ticked by the director heartbeat
+> before the patrol beat: Suspicious → orient beat (the player's audible
+> cue) + commit; Searching → director-travel to the LAST-KNOWN room
+> (stamped on awareness records) and sweep it with the REAL `search`
+> command, fanning through unswept adjacents on a bounded budget
+> (SEARCH_BUDGET=4); reacquire → challenge ("Halt, Colonist."), raise a
+> `disturbance` (existing dispatch/challenge machinery takes over), and
+> PROPAGATE (every other security unit seeded to Searching at the
+> sighting room); budget out / record decayed → give-up beat, records
+> dropped, patrol resumes. v1 fan-out is adjacency, not full Dijkstra;
+> hunters are role=security. NOT yet built: ambush advantage (§6.1),
+> theft (§6.2), environmental modifiers (light/cover/crowd — v1 is the
+> flat tier spread).
 > Original abstract: designs the **presence-concealment**
 > layer: `hide` (self or object) vs `search` (a room), resolved as an opposed
 > **Resonance/Motorics** contest, surfaced as a **per-observer graded awareness

--- a/world/director/hunt.py
+++ b/world/director/hunt.py
@@ -1,0 +1,199 @@
+"""The hunt — deterministic NPC search behaviour off the awareness meter.
+
+STEALTH_AND_DETECTION_SPEC §5: the MGS/Hitman/Thief loop, **no LLM**. A
+security NPC's awareness records (accrued exactly like a player's — passive
+checks on room entry, hide-time contests, unseen whispers) drive a state
+machine the director heartbeat ticks:
+
+    Unaware ──(detect)──▶ Suspicious ──(commit)──▶ Searching ──(reacquire)──▶ Alert
+       ▲                      │                        │                        │
+       └──(decay/give up)─────┴──────(budget out)──────┘                   (engage)
+
+* **Suspicious** — break routine, orient (a visible tell: the bot snapping
+  alert is the player's cue to move), commit to the hunt.
+* **Searching** — travel to the target's LAST-KNOWN room (stamped on the
+  awareness record), sweep it with the REAL ``search`` command, then fan
+  outward through adjacent rooms on a bounded budget.
+* **Reacquire → engage** — challenge, raise a ``disturbance`` (the existing
+  dispatch/challenge machinery takes over), and PROPAGATE: every other
+  security unit is seeded to Searching at the sighting room.
+* **Give up** — budget exhausted or the record decayed: drop it, one
+  give-up beat, and the patrol routine resumes on the next tick.
+
+Everything the hunter does goes through real commands (`search`, `say`,
+`emote`) and director travel (real exits) — the same world the players get.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+#: Rooms a hunter will sweep (last-known + adjacents) before giving up.
+SEARCH_BUDGET = 4
+
+ORIENT_EMOTE = ("snaps alert, optics sweeping for something it "
+                "half-caught.")
+GIVEUP_EMOTE = "abandons its sweep and resumes its rounds."
+CHALLENGE_LINE = "Halt, Colonist. Remain where you are."
+
+
+def _room_by_id(room_id) -> Optional[Any]:
+    if room_id is None:
+        return None
+    try:
+        from evennia.objects.models import ObjectDB
+        return ObjectDB.objects.get(id=int(room_id))
+    except Exception:  # noqa: BLE001 — a demolished room is just gone
+        return None
+
+
+def _present_target(npc, target_key) -> Optional[Any]:
+    """The hunted target, if perceivably HERE (reacquired)."""
+    from world.perception import can_perceive
+    from world.stealth import _target_key
+    room = npc.location
+    for obj in (room.contents if room else []):
+        if obj is npc or not hasattr(obj, "get_sdesc"):
+            continue
+        try:
+            if _target_key(obj) == target_key and can_perceive(npc, obj):
+                return obj
+        except Exception:  # noqa: BLE001
+            continue
+    return None
+
+
+def is_hunting(npc) -> bool:
+    return bool(getattr(getattr(npc, "ndb", None), "hunt", None))
+
+
+def _give_up(npc, target_key) -> None:
+    from world.stealth import UNAWARE, seed_awareness
+    npc.ndb.hunt = None
+    seed_awareness(npc, target_key, UNAWARE)
+    try:
+        npc.execute_cmd(f"emote {GIVEUP_EMOTE}")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _engage(npc, target) -> None:
+    """Reacquired: challenge, hand off to dispatch, propagate the alert."""
+    from world.stealth import ALERT, _target_key, set_awareness
+    set_awareness(npc, target, ALERT)
+    npc.ndb.hunt = None
+    try:
+        npc.execute_cmd(f"say {CHALLENGE_LINE}")
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        from world.director.dispatch import WorldEvent, raise_event
+        raise_event(WorldEvent("disturbance", npc.location, severity=2,
+                               source=target))
+    except Exception:  # noqa: BLE001 — dispatch down ≠ hunt crash
+        pass
+    propagate_alert(npc, _target_key(target),
+                    getattr(npc.location, "id", None))
+
+
+def propagate_alert(npc, target_key, room_id) -> int:
+    """Seed every OTHER security unit to Searching at the sighting room —
+    alert propagation (spec §5). Returns how many were seeded."""
+    from evennia.objects.models import ObjectDB
+    from world.stealth import SEARCHING, seed_awareness
+    seeded = 0
+    try:
+        candidates = ObjectDB.objects.filter(
+            db_attributes__db_key="role").distinct()
+    except Exception:  # noqa: BLE001
+        return 0
+    for other in candidates:
+        if other == npc or getattr(other.db, "role", None) != "security":
+            continue
+        try:
+            seed_awareness(other, target_key, SEARCHING, room_id)
+            seeded += 1
+        except Exception:  # noqa: BLE001
+            continue
+    return seeded
+
+
+def _next_sweep_room(npc, state) -> Optional[Any]:
+    """Where to sweep next: the last-known room first, then unswept
+    adjacents of it (the bounded fan-out)."""
+    swept = state.get("swept") or []
+    last_room = _room_by_id(state.get("last_room"))
+    if last_room is not None and last_room.id not in swept:
+        return last_room
+    anchor = last_room or npc.location
+    if anchor is None:
+        return None
+    for exit_obj in getattr(anchor, "exits", []) or []:
+        dest = getattr(exit_obj, "destination", None)
+        if dest is not None and dest.id not in swept:
+            return dest
+    return None
+
+
+def tick_hunt(npc) -> bool:
+    """One heartbeat of hunt behaviour. True = the hunt owns this NPC's
+    turn (the patrol routine stays out); False = nothing to hunt."""
+    from world.director.travel import is_travelling, travel_to
+    from world.stealth import ALERT, SEARCHING, SUSPICIOUS, hunt_records
+
+    state = getattr(npc.ndb, "hunt", None)
+    if is_travelling(npc):
+        return bool(state)          # en route to a sweep — stay committed
+
+    records = hunt_records(npc)
+    best = records[0] if records else None
+    if best is None:
+        if state:
+            _give_up(npc, state.get("key", ""))
+        return False
+    key, level, last_room_id, _t = best
+
+    # Reacquired in this very room → engage.
+    target = _present_target(npc, key)
+    if target is not None and level >= ALERT:
+        _engage(npc, target)
+        return True
+
+    if state is None:
+        if level < SUSPICIOUS:
+            return False
+        # Commit: the orient beat is the player's audible cue to move.
+        try:
+            npc.execute_cmd(f"emote {ORIENT_EMOTE}")
+        except Exception:  # noqa: BLE001
+            pass
+        npc.ndb.hunt = {"key": key, "budget": SEARCH_BUDGET,
+                        "swept": [], "last_room": last_room_id}
+        return True
+    if state.get("key") != key:
+        # A stronger scent supersedes the old hunt.
+        state = {"key": key, "budget": SEARCH_BUDGET,
+                 "swept": [], "last_room": last_room_id}
+        npc.ndb.hunt = state
+
+    dest = _next_sweep_room(npc, state)
+    if dest is None or state.get("budget", 0) <= 0:
+        _give_up(npc, key)
+        return True
+
+    if npc.location == dest:
+        # Sweep HERE with the real command — the same contest players get.
+        state["swept"] = list(state.get("swept") or []) + [dest.id]
+        state["budget"] = int(state.get("budget", 0)) - 1
+        npc.ndb.hunt = state
+        try:
+            npc.execute_cmd("search")
+        except Exception:  # noqa: BLE001
+            pass
+        found = _present_target(npc, key)
+        if found is not None:
+            _engage(npc, found)
+        return True
+
+    travel_to(npc, dest)
+    return True

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -103,6 +103,16 @@ def tick_npc(npc: Any) -> str:
         return "none"
     if not is_patrol_idle(npc):
         return "skip"
+    # The hunt owns an idle security unit before the beat does (stealth
+    # spec §5): awareness records of hidden presences turn the patroller
+    # into a hunter until it reacquires or gives up.
+    if getattr(npc.db, "role", None) == "security":
+        try:
+            from world.director.hunt import tick_hunt
+            if tick_hunt(npc):
+                return "hunt"
+        except Exception:  # noqa: BLE001 — a broken hunt must not stall beats
+            pass
     cadence = int(getattr(npc.db, "patrol_cadence", None) or 1)
     if cadence > 1:
         waited = int(getattr(npc.ndb, "patrol_wait", None) or 0) + 1

--- a/world/stealth.py
+++ b/world/stealth.py
@@ -69,7 +69,9 @@ def get_awareness(observer, target) -> int:
 
 def set_awareness(observer, target, level, *, roll_stamp=False):
     """Record awareness (only non-default records are stored — spec §12
-    bounding). ``roll_stamp`` also marks a passive-roll timestamp."""
+    bounding). ``roll_stamp`` also marks a passive-roll timestamp. A
+    SUSPICIOUS+ record stamps the target's LAST-KNOWN ROOM — the hunt's
+    destination (spec §5)."""
     records = _records(observer)
     key = _target_key(target)
     rec = dict(records.get(key) or {})
@@ -81,8 +83,46 @@ def set_awareness(observer, target, level, *, roll_stamp=False):
         rec["t"] = now
         if roll_stamp:
             rec["t_roll"] = now
+        if level >= SUSPICIOUS:
+            room = getattr(target, "location", None)
+            room_id = getattr(room, "id", None)
+            if room_id is not None:
+                rec["last_room"] = room_id
         records[key] = rec
     observer.db.awareness = records
+
+
+def seed_awareness(observer, target_key, level, last_room_id=None):
+    """Write an awareness record BY KEY — alert propagation between NPCs
+    (spec §5) hands a colleague the target's key and last-known room
+    without ever holding the target object."""
+    records = _records(observer)
+    if level <= UNAWARE:
+        records.pop(target_key, None)
+    else:
+        rec = dict(records.get(target_key) or {})
+        rec["level"] = max(int(level), int(rec.get("level", UNAWARE)))
+        rec["t"] = time.time()
+        if last_room_id is not None:
+            rec["last_room"] = last_room_id
+        records[target_key] = rec
+    observer.db.awareness = records
+
+
+def hunt_records(observer) -> list:
+    """The observer's decayed awareness records for the hunt:
+    ``[(target_key, level, last_room_id, t)]``, strongest first."""
+    now = time.time()
+    out = []
+    for key, rec in _records(observer).items():
+        level = int(rec.get("level", UNAWARE))
+        elapsed = max(0.0, now - float(rec.get("t", 0)))
+        level = max(UNAWARE, level - int(elapsed // AWARENESS_DECAY))
+        if level > UNAWARE:
+            out.append((key, level, rec.get("last_room"),
+                        float(rec.get("t", 0))))
+    out.sort(key=lambda r: (-r[1], -r[3]))
+    return out
 
 
 def _passive_ready(observer, target) -> bool:

--- a/world/tests/test_hunt.py
+++ b/world/tests/test_hunt.py
@@ -1,0 +1,148 @@
+"""The NPC hunt (world/director/hunt.py) — STEALTH_AND_DETECTION_SPEC §5.
+
+MagicMock harness: travel, dispatch, and the awareness reads are patched at
+their source modules; what's under test is the state machine — commit,
+sweep-with-the-real-search-command, reacquire/engage/propagate, give up.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.director.hunt as hunt
+from world.director.hunt import (
+    SEARCH_BUDGET, is_hunting, propagate_alert, tick_hunt,
+)
+from world.stealth import ALERT, SEARCHING, SUSPICIOUS
+
+
+def _npc(room=None):
+    npc = MagicMock()
+    npc.ndb.hunt = None
+    npc.db.role = "security"
+    npc.location = room if room is not None else MagicMock()
+    return npc
+
+
+def _rec(key="uid-prey", level=SEARCHING, last_room=77):
+    return [(key, level, last_room, 100.0)]
+
+
+class TestHuntMachine(TestCase):
+    def test_no_records_no_hunt(self):
+        npc = _npc()
+        with patch("world.stealth.hunt_records", return_value=[]), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False):
+            self.assertFalse(tick_hunt(npc))
+        self.assertFalse(is_hunting(npc))
+
+    def test_suspicious_commits_with_orient_beat(self):
+        npc = _npc()
+        with patch("world.stealth.hunt_records",
+                   return_value=_rec(level=SUSPICIOUS)), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False), \
+                patch.object(hunt, "_present_target", return_value=None):
+            self.assertTrue(tick_hunt(npc))
+        npc.execute_cmd.assert_called_once()
+        self.assertIn("snaps alert", npc.execute_cmd.call_args.args[0])
+        self.assertTrue(is_hunting(npc))
+        self.assertEqual(npc.ndb.hunt["key"], "uid-prey")
+        self.assertEqual(npc.ndb.hunt["budget"], SEARCH_BUDGET)
+
+    def test_committed_hunter_travels_to_last_known(self):
+        npc = _npc()
+        last_room = MagicMock()
+        last_room.id = 77
+        npc.ndb.hunt = {"key": "uid-prey", "budget": SEARCH_BUDGET,
+                        "swept": [], "last_room": 77}
+        with patch("world.stealth.hunt_records", return_value=_rec()), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False), \
+                patch("world.director.travel.travel_to") as travel, \
+                patch.object(hunt, "_room_by_id", return_value=last_room), \
+                patch.object(hunt, "_present_target", return_value=None):
+            self.assertTrue(tick_hunt(npc))
+        travel.assert_called_once_with(npc, last_room)
+
+    def test_arrival_sweeps_with_the_real_search_command(self):
+        last_room = MagicMock()
+        last_room.id = 77
+        npc = _npc(room=last_room)
+        npc.ndb.hunt = {"key": "uid-prey", "budget": 2,
+                        "swept": [], "last_room": 77}
+        with patch("world.stealth.hunt_records", return_value=_rec()), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False), \
+                patch.object(hunt, "_room_by_id", return_value=last_room), \
+                patch.object(hunt, "_present_target", return_value=None):
+            self.assertTrue(tick_hunt(npc))
+        npc.execute_cmd.assert_called_once_with("search")
+        self.assertEqual(npc.ndb.hunt["budget"], 1)
+        self.assertIn(77, npc.ndb.hunt["swept"])
+
+    def test_reacquire_engages_and_propagates(self):
+        npc = _npc()
+        npc.location.id = 55
+        prey = MagicMock()
+        with patch("world.stealth.hunt_records",
+                   return_value=_rec(level=ALERT)), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False), \
+                patch.object(hunt, "_present_target", return_value=prey), \
+                patch("world.stealth.set_awareness"), \
+                patch("world.stealth._target_key",
+                      return_value="uid-prey"), \
+                patch("world.director.dispatch.raise_event") as raised, \
+                patch.object(hunt, "propagate_alert") as propagate:
+            self.assertTrue(tick_hunt(npc))
+        say = [c.args[0] for c in npc.execute_cmd.call_args_list
+               if c.args[0].startswith("say ")]
+        self.assertTrue(say and "Halt, Colonist" in say[0])
+        raised.assert_called_once()
+        propagate.assert_called_once_with(npc, "uid-prey", 55)
+        self.assertFalse(is_hunting(npc))     # dispatch owns it now
+
+    def test_budget_exhaustion_gives_up(self):
+        npc = _npc()
+        npc.ndb.hunt = {"key": "uid-prey", "budget": 0,
+                        "swept": [77], "last_room": 77}
+        with patch("world.stealth.hunt_records", return_value=_rec()), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False), \
+                patch.object(hunt, "_room_by_id", return_value=None), \
+                patch.object(hunt, "_present_target", return_value=None), \
+                patch("world.stealth.seed_awareness") as seed:
+            self.assertTrue(tick_hunt(npc))
+        self.assertFalse(is_hunting(npc))
+        self.assertIn("abandons its sweep",
+                      npc.execute_cmd.call_args.args[0])
+        seed.assert_called_once()             # record dropped to Unaware
+
+    def test_decayed_record_ends_hunt(self):
+        npc = _npc()
+        npc.ndb.hunt = {"key": "uid-prey", "budget": 2,
+                        "swept": [], "last_room": 77}
+        with patch("world.stealth.hunt_records", return_value=[]), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False), \
+                patch("world.stealth.seed_awareness"):
+            self.assertFalse(tick_hunt(npc))
+        self.assertFalse(is_hunting(npc))
+
+
+class TestPropagation(TestCase):
+    def test_other_security_seeded_to_searching(self):
+        npc = _npc()
+        ally = MagicMock()
+        ally.db.role = "security"
+        bystander = MagicMock()
+        bystander.db.role = "hawker"
+        qs = MagicMock()
+        qs.distinct.return_value = [npc, ally, bystander]
+        with patch("evennia.objects.models.ObjectDB") as odb, \
+                patch("world.stealth.seed_awareness") as seed:
+            odb.objects.filter.return_value = qs
+            n = propagate_alert(npc, "uid-prey", 55)
+        self.assertEqual(n, 1)
+        seed.assert_called_once_with(ally, "uid-prey", SEARCHING, 55)


### PR DESCRIPTION
Closes #985

- world/director/hunt.py: awareness-driven state machine on the
  director heartbeat — orient/commit at Suspicious, travel to the
  last-known room (stamped on awareness records) and sweep with the
  REAL search command at Searching, challenge + dispatch disturbance +
  alert propagation on reacquire, give-up on budget/decay
- world/stealth.py: last_room stamped on SUSPICIOUS+ records;
  seed_awareness (by-key writes for propagation); hunt_records
  (decayed, strongest-first)
- routines.tick_npc: the hunt owns an idle security unit before the
  beat does; assignments/combat/conversation still preempt
- v1: adjacency fan-out (full Dijkstra later); hunters are security

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
