### PR TITLE
Crowd hider bonus + wanted-gated hunt engagement

### DIFF
--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -31,9 +31,17 @@
 > PROPAGATE (every other security unit seeded to Searching at the
 > sighting room); budget out / record decayed → give-up beat, records
 > dropped, patrol resumes. v1 fan-out is adjacency, not full Dijkstra;
-> hunters are role=security. NOT yet built: ambush advantage (§6.1),
-> theft (§6.2), environmental modifiers (light/cover/crowd — v1 is the
-> flat tier spread).
+> hunters are role=security. **2026-07-03 follow-ups (user-decided):**
+> the CROWD hider bonus is live (first environmental modifier — crowd
+> density, up to +3, helps the hider at every contest tier; "blending
+> in" is mechanically real; light/cover still ride the coordinate
+> integration), and REACQUIRE IS WANTED-GATED — hiding is suspicious
+> enough to investigate, but the full response (challenge + disturbance
+> + propagation) is reserved for a target on the wanted record (same
+> apparent-uid key); a clean colonist caught lurking gets "Loitering
+> noted, Colonist. Move along." and the record is zeroed (roll-stamped
+> to rate-limit an instant re-flag). NOT yet built: ambush advantage
+> (§6.1), theft (§6.2), light/cover modifiers.
 > Original abstract: designs the **presence-concealment**
 > layer: `hide` (self or object) vs `search` (a room), resolved as an opposed
 > **Resonance/Motorics** contest, surfaced as a **per-observer graded awareness

--- a/world/director/hunt.py
+++ b/world/director/hunt.py
@@ -35,6 +35,7 @@ ORIENT_EMOTE = ("snaps alert, optics sweeping for something it "
                 "half-caught.")
 GIVEUP_EMOTE = "abandons its sweep and resumes its rounds."
 CHALLENGE_LINE = "Halt, Colonist. Remain where you are."
+MOVE_ALONG_LINE = "Loitering noted, Colonist. Move along."
 
 
 def _room_by_id(room_id) -> Optional[Any]:
@@ -78,8 +79,26 @@ def _give_up(npc, target_key) -> None:
 
 
 def _engage(npc, target) -> None:
-    """Reacquired: challenge, hand off to dispatch, propagate the alert."""
-    from world.stealth import ALERT, _target_key, set_awareness
+    """Reacquired. WHO you are decides what happens next: hiding is
+    suspicious enough to investigate, but the full response is reserved
+    for people security has actual cause against (the wanted record,
+    keyed on the same apparent-uid as awareness). A clean colonist caught
+    lurking gets a move-along, not an incident."""
+    from world.director.intel import is_wanted
+    from world.stealth import (
+        ALERT, UNAWARE, _target_key, set_awareness,
+    )
+    key = _target_key(target)
+    if not is_wanted(key):
+        # Case closed: no dispatch, no propagation. The zeroed-but-stamped
+        # record rate-limits an immediate re-flag of the same lurker.
+        npc.ndb.hunt = None
+        set_awareness(npc, target, UNAWARE, roll_stamp=True)
+        try:
+            npc.execute_cmd(f"say {MOVE_ALONG_LINE}")
+        except Exception:  # noqa: BLE001
+            pass
+        return
     set_awareness(npc, target, ALERT)
     npc.ndb.hunt = None
     try:

--- a/world/stealth.py
+++ b/world/stealth.py
@@ -130,10 +130,25 @@ def _passive_ready(observer, target) -> bool:
     return time.time() - float(rec.get("t_roll", 0)) >= PASSIVE_COOLDOWN
 
 
+def crowd_hider_bonus(room) -> int:
+    """Blending in: crowd density is concealment (spec §3.2). A hotspot
+    throng is worth up to +3 to the hider; an empty street gives nothing.
+    First environmental modifier to land — light/cover ride the
+    coordinate integration later."""
+    try:
+        from world.crowd import crowd_system
+        level = int(crowd_system.calculate_crowd_level(room) or 0)
+        return max(0, min(level, 3))
+    except Exception:  # noqa: BLE001 — no crowd system, no bonus
+        return 0
+
+
 def contest(hider, observer, *, hider_bonus=0, observer_bonus=0) -> int:
     """One opposed roll. Positive margin = the OBSERVER wins (spots them);
     zero or negative = the hider holds. Hider leans Motorics, observer
-    Resonance (spec §3.1 working direction)."""
+    Resonance (spec §3.1 working direction). The hider's room's crowd
+    density always helps them — blending in is real at every tier."""
+    hider_bonus += crowd_hider_bonus(getattr(hider, "location", None))
     hide_total = randint(1, 20) + _stat(hider, "motorics") + hider_bonus
     seek_total = randint(1, 20) + _stat(observer, "resonance") + observer_bonus
     return seek_total - hide_total

--- a/world/tests/test_hunt.py
+++ b/world/tests/test_hunt.py
@@ -93,6 +93,8 @@ class TestHuntMachine(TestCase):
                 patch("world.stealth.set_awareness"), \
                 patch("world.stealth._target_key",
                       return_value="uid-prey"), \
+                patch("world.director.intel.is_wanted",
+                      return_value={"count": 2}), \
                 patch("world.director.dispatch.raise_event") as raised, \
                 patch.object(hunt, "propagate_alert") as propagate:
             self.assertTrue(tick_hunt(npc))
@@ -146,3 +148,34 @@ class TestPropagation(TestCase):
             n = propagate_alert(npc, "uid-prey", 55)
         self.assertEqual(n, 1)
         seed.assert_called_once_with(ally, "uid-prey", SEARCHING, 55)
+
+
+class TestInnocentLurker(TestCase):
+    """Hiding without a wanted record draws a move-along, not an incident
+    — the full response is reserved for actual cause."""
+
+    def test_clean_colonist_gets_move_along(self):
+        npc = _npc()
+        npc.location.id = 55
+        prey = MagicMock()
+        with patch("world.stealth.hunt_records",
+                   return_value=_rec(level=ALERT)), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False), \
+                patch.object(hunt, "_present_target", return_value=prey), \
+                patch("world.stealth.set_awareness") as aware, \
+                patch("world.stealth._target_key",
+                      return_value="uid-prey"), \
+                patch("world.director.intel.is_wanted",
+                      return_value=None), \
+                patch("world.director.dispatch.raise_event") as raised, \
+                patch.object(hunt, "propagate_alert") as propagate:
+            self.assertTrue(tick_hunt(npc))
+        say = [c.args[0] for c in npc.execute_cmd.call_args_list
+               if c.args[0].startswith("say ")]
+        self.assertTrue(say and "Move along" in say[0])
+        raised.assert_not_called()
+        propagate.assert_not_called()
+        self.assertFalse(is_hunting(npc))
+        # record zeroed but roll-stamped (rate-limits an instant re-flag)
+        self.assertTrue(aware.call_args.kwargs.get("roll_stamp"))

--- a/world/tests/test_stealth.py
+++ b/world/tests/test_stealth.py
@@ -462,3 +462,32 @@ class TestLeakSweep(TestCase):
             self.assertEqual(present(), [])
             set_awareness(npc, hidden, ALERT)
             self.assertEqual(present(), ["a shape"])
+
+
+class TestCrowdBonus(TestCase):
+    """Blending in is real: crowd density is a hider bonus at every tier."""
+
+    def test_dense_crowd_tips_the_contest(self):
+        from world.stealth import contest
+        hider, seeker = _char(motorics=1), _char(resonance=2)
+        room = MagicMock()
+        hider.location = room
+        with patch("world.stealth.randint", return_value=10), \
+                patch("world.crowd.CrowdSystem.calculate_crowd_level",
+                      return_value=3):
+            # 10+1+3 vs 10+2: hider holds in the throng
+            self.assertLessEqual(contest(hider, seeker), 0)
+        with patch("world.stealth.randint", return_value=10), \
+                patch("world.crowd.CrowdSystem.calculate_crowd_level",
+                      return_value=0):
+            # empty street: the same match-up loses
+            self.assertGreater(contest(hider, seeker), 0)
+
+    def test_bonus_clamped(self):
+        from world.stealth import crowd_hider_bonus
+        with patch("world.crowd.CrowdSystem.calculate_crowd_level",
+                   return_value=9):
+            self.assertEqual(crowd_hider_bonus(MagicMock()), 3)
+        with patch("world.crowd.CrowdSystem.calculate_crowd_level",
+                   side_effect=Exception("no crowd")):
+            self.assertEqual(crowd_hider_bonus(MagicMock()), 0)


### PR DESCRIPTION
Closes #987

- crowd_hider_bonus: the hider's room's crowd level (0..3) rides every
  contest tier — blending into a throng is mechanically real
- hunt._engage consults intel.is_wanted (same apparent-uid key):
  wanted -> full challenge/disturbance/propagation; clean colonist ->
  "Loitering noted, Colonist. Move along.", record zeroed +
  roll-stamped (no instant re-flag), no dispatch event
- spec banner updated; tests for both (crowd tips the contest, clamped;
  innocent lurker gets move-along with no event/propagation)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
