### PR TITLE
The hunt requires cause; innocents read as nervous faces

### DIFF
--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -35,13 +35,19 @@
 > the CROWD hider bonus is live (first environmental modifier — crowd
 > density, up to +3, helps the hider at every contest tier; "blending
 > in" is mechanically real; light/cover still ride the coordinate
-> integration), and REACQUIRE IS WANTED-GATED — hiding is suspicious
-> enough to investigate, but the full response (challenge + disturbance
-> + propagation) is reserved for a target on the wanted record (same
-> apparent-uid key); a clean colonist caught lurking gets "Loitering
-> noted, Colonist. Move along." and the record is zeroed (roll-stamped
-> to rate-limit an instant re-flag). NOT yet built: ambush advantage
-> (§6.1), theft (§6.2), light/cover modifiers.
+> integration), and **THE HUNT REQUIRES CAUSE** (user-decided, revised
+> same day): the wanted-record check (same apparent-uid key) is SILENT
+> and gates hunt COMMITMENT itself — an unwanted hidden presence is
+> ignored entirely (no orient, no sweep, no roust; hiding is not a
+> crime and security must not small-world every wallflower). The
+> detected innocent simply reads as visibly furtive via the crowd-aware
+> lurk placement ("a nervous, somewhat off face in the crowd" in a
+> throng; "lurking in the shadows" in an empty room). A pardon mid-hunt
+> stands the bot down silently. **Marked for eventual reconsideration
+> (user):** whether/where loitering itself warrants a response — e.g.
+> zone-dependent (corporate blocks vs the sprawl) — revisit with the
+> faction/zone work. NOT yet built: ambush advantage (§6.1), theft
+> (§6.2), light/cover modifiers.
 > Original abstract: designs the **presence-concealment**
 > layer: `hide` (self or object) vs `search` (a room), resolved as an opposed
 > **Resonance/Motorics** contest, surfaced as a **per-observer graded awareness

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -537,10 +537,12 @@ class Room(ObjectParent, DefaultRoom):
 
             # The "lurking" tell (stealth spec §4): failed concealment
             # doesn't restore a normal appearance — to whoever sees them,
-            # a hidden character reads as visibly furtive, top of the
-            # placement hierarchy.
+            # a hidden character reads as visibly furtive (crowd-aware:
+            # a nervous face in a throng, a shadow-skulker in an empty
+            # room), top of the placement hierarchy.
             if getattr(char.db, "hidden", False) is True:
-                placement = "lurking in the shadows."
+                from world.stealth import lurk_placement
+                placement = lurk_placement(self)
 
             # Resolve {aim_target} template in placement (used by aim system)
             if "{aim_target}" in placement:

--- a/world/director/hunt.py
+++ b/world/director/hunt.py
@@ -35,7 +35,6 @@ ORIENT_EMOTE = ("snaps alert, optics sweeping for something it "
                 "half-caught.")
 GIVEUP_EMOTE = "abandons its sweep and resumes its rounds."
 CHALLENGE_LINE = "Halt, Colonist. Remain where you are."
-MOVE_ALONG_LINE = "Loitering noted, Colonist. Move along."
 
 
 def _room_by_id(room_id) -> Optional[Any]:
@@ -78,26 +77,28 @@ def _give_up(npc, target_key) -> None:
         pass
 
 
+def _wanted_only(records) -> list:
+    """The silent uid check (user-decided 2026-07-03): a hunt requires
+    CAUSE. Awareness records whose apparent-uid isn't on the wanted
+    record are ignored — an innocent hider is clocked (they render as a
+    nervous face to whoever detects them) but never hunted, challenged,
+    or rousted. No small-worlding: hiding is not a crime."""
+    from world.director.intel import is_wanted
+    return [rec for rec in records if is_wanted(rec[0])]
+
+
 def _engage(npc, target) -> None:
-    """Reacquired. WHO you are decides what happens next: hiding is
-    suspicious enough to investigate, but the full response is reserved
-    for people security has actual cause against (the wanted record,
-    keyed on the same apparent-uid as awareness). A clean colonist caught
-    lurking gets a move-along, not an incident."""
+    """Reacquired a WANTED target: challenge, hand off to dispatch,
+    propagate. Defensive re-check — a pardon mid-hunt stands the bot
+    down silently (no message; there was never a public incident)."""
     from world.director.intel import is_wanted
     from world.stealth import (
         ALERT, UNAWARE, _target_key, set_awareness,
     )
     key = _target_key(target)
     if not is_wanted(key):
-        # Case closed: no dispatch, no propagation. The zeroed-but-stamped
-        # record rate-limits an immediate re-flag of the same lurker.
         npc.ndb.hunt = None
         set_awareness(npc, target, UNAWARE, roll_stamp=True)
-        try:
-            npc.execute_cmd(f"say {MOVE_ALONG_LINE}")
-        except Exception:  # noqa: BLE001
-            pass
         return
     set_awareness(npc, target, ALERT)
     npc.ndb.hunt = None
@@ -164,7 +165,7 @@ def tick_hunt(npc) -> bool:
     if is_travelling(npc):
         return bool(state)          # en route to a sweep — stay committed
 
-    records = hunt_records(npc)
+    records = _wanted_only(hunt_records(npc))
     best = records[0] if records else None
     if best is None:
         if state:

--- a/world/stealth.py
+++ b/world/stealth.py
@@ -275,6 +275,18 @@ def break_stealth(char, *, quiet=False):
     return True
 
 
+def lurk_placement(room) -> str:
+    """How a DETECTED hidden character reads to whoever sees them (the
+    spec §4 "lurking" tell, crowd-aware): failed concealment in a busy
+    room reads as a nervous face in the throng; in an empty one, as
+    skulking in the shadows. Either way: visibly someone who doesn't
+    want to be seen."""
+    if crowd_hider_bonus(room) >= 2:
+        return ("holding an unconvincing calm — a nervous, somewhat off "
+                "face in the crowd.")
+    return "lurking in the shadows."
+
+
 def is_hidden_from(target, looker) -> bool:
     """The display gate: hidden AND the looker is not yet aware enough to
     place them. Suspicious knows *a* presence, not who/where — still

--- a/world/tests/test_hunt.py
+++ b/world/tests/test_hunt.py
@@ -27,10 +27,16 @@ def _rec(key="uid-prey", level=SEARCHING, last_room=77):
     return [(key, level, last_room, 100.0)]
 
 
+def _all_wanted():
+    """Most machine tests assume the target has cause on file."""
+    return patch("world.director.intel.is_wanted",
+                 return_value={"count": 1})
+
+
 class TestHuntMachine(TestCase):
     def test_no_records_no_hunt(self):
         npc = _npc()
-        with patch("world.stealth.hunt_records", return_value=[]), \
+        with _all_wanted(), patch("world.stealth.hunt_records", return_value=[]), \
                 patch("world.director.travel.is_travelling",
                       return_value=False):
             self.assertFalse(tick_hunt(npc))
@@ -38,7 +44,7 @@ class TestHuntMachine(TestCase):
 
     def test_suspicious_commits_with_orient_beat(self):
         npc = _npc()
-        with patch("world.stealth.hunt_records",
+        with _all_wanted(), patch("world.stealth.hunt_records",
                    return_value=_rec(level=SUSPICIOUS)), \
                 patch("world.director.travel.is_travelling",
                       return_value=False), \
@@ -56,7 +62,7 @@ class TestHuntMachine(TestCase):
         last_room.id = 77
         npc.ndb.hunt = {"key": "uid-prey", "budget": SEARCH_BUDGET,
                         "swept": [], "last_room": 77}
-        with patch("world.stealth.hunt_records", return_value=_rec()), \
+        with _all_wanted(), patch("world.stealth.hunt_records", return_value=_rec()), \
                 patch("world.director.travel.is_travelling",
                       return_value=False), \
                 patch("world.director.travel.travel_to") as travel, \
@@ -71,7 +77,8 @@ class TestHuntMachine(TestCase):
         npc = _npc(room=last_room)
         npc.ndb.hunt = {"key": "uid-prey", "budget": 2,
                         "swept": [], "last_room": 77}
-        with patch("world.stealth.hunt_records", return_value=_rec()), \
+        with _all_wanted(), \
+                patch("world.stealth.hunt_records", return_value=_rec()), \
                 patch("world.director.travel.is_travelling",
                       return_value=False), \
                 patch.object(hunt, "_room_by_id", return_value=last_room), \
@@ -109,7 +116,8 @@ class TestHuntMachine(TestCase):
         npc = _npc()
         npc.ndb.hunt = {"key": "uid-prey", "budget": 0,
                         "swept": [77], "last_room": 77}
-        with patch("world.stealth.hunt_records", return_value=_rec()), \
+        with _all_wanted(), \
+                patch("world.stealth.hunt_records", return_value=_rec()), \
                 patch("world.director.travel.is_travelling",
                       return_value=False), \
                 patch.object(hunt, "_room_by_id", return_value=None), \
@@ -151,31 +159,35 @@ class TestPropagation(TestCase):
 
 
 class TestInnocentLurker(TestCase):
-    """Hiding without a wanted record draws a move-along, not an incident
-    — the full response is reserved for actual cause."""
+    """A hunt requires CAUSE (user-decided): an unwanted hidden presence
+    is silently ignored — no orient, no sweep, no roust. Hiding is not
+    a crime; the detected innocent just reads as a nervous face."""
 
-    def test_clean_colonist_gets_move_along(self):
+    def test_clean_colonist_is_silently_ignored(self):
         npc = _npc()
-        npc.location.id = 55
         prey = MagicMock()
         with patch("world.stealth.hunt_records",
                    return_value=_rec(level=ALERT)), \
                 patch("world.director.travel.is_travelling",
                       return_value=False), \
                 patch.object(hunt, "_present_target", return_value=prey), \
+                patch("world.director.intel.is_wanted",
+                      return_value=None), \
+                patch("world.director.dispatch.raise_event") as raised:
+            self.assertFalse(tick_hunt(npc))     # patrol proceeds normally
+        npc.execute_cmd.assert_not_called()      # no emote, no say, nothing
+        raised.assert_not_called()
+        self.assertFalse(is_hunting(npc))
+
+    def test_pardon_mid_hunt_stands_down_silently(self):
+        npc = _npc()
+        prey = MagicMock()
+        with patch.object(hunt, "propagate_alert"), \
                 patch("world.stealth.set_awareness") as aware, \
                 patch("world.stealth._target_key",
                       return_value="uid-prey"), \
                 patch("world.director.intel.is_wanted",
-                      return_value=None), \
-                patch("world.director.dispatch.raise_event") as raised, \
-                patch.object(hunt, "propagate_alert") as propagate:
-            self.assertTrue(tick_hunt(npc))
-        say = [c.args[0] for c in npc.execute_cmd.call_args_list
-               if c.args[0].startswith("say ")]
-        self.assertTrue(say and "Move along" in say[0])
-        raised.assert_not_called()
-        propagate.assert_not_called()
-        self.assertFalse(is_hunting(npc))
-        # record zeroed but roll-stamped (rate-limits an instant re-flag)
+                      return_value=None):
+            hunt._engage(npc, prey)
+        npc.execute_cmd.assert_not_called()
         self.assertTrue(aware.call_args.kwargs.get("roll_stamp"))

--- a/world/tests/test_stealth.py
+++ b/world/tests/test_stealth.py
@@ -491,3 +491,15 @@ class TestCrowdBonus(TestCase):
         with patch("world.crowd.CrowdSystem.calculate_crowd_level",
                    side_effect=Exception("no crowd")):
             self.assertEqual(crowd_hider_bonus(MagicMock()), 0)
+
+
+class TestLurkPlacement(TestCase):
+    def test_crowd_aware_read(self):
+        from world.stealth import lurk_placement
+        with patch("world.crowd.CrowdSystem.calculate_crowd_level",
+                   return_value=3):
+            self.assertIn("nervous", lurk_placement(MagicMock()))
+        with patch("world.crowd.CrowdSystem.calculate_crowd_level",
+                   return_value=0):
+            self.assertIn("lurking in the shadows",
+                          lurk_placement(MagicMock()))


### PR DESCRIPTION
Closes #989

- silent wanted-check (apparent-uid) gates hunt COMMITMENT: unwanted
  hidden presences are ignored entirely — no orient, sweep, or roust
  (move-along line removed; hiding is not a crime)
- lurk placement is crowd-aware: "a nervous, somewhat off face in the
  crowd" in a throng, "lurking in the shadows" in an empty room
- pardon mid-hunt stands down silently (defensive engage re-check)
- spec: revised stance recorded + flagged for eventual zone-dependent
  reconsideration (user)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
