### PR TITLE
Situational cause: hidden presences near unresolved incidents

### DIFF
--- a/commands/explosion_utils.py
+++ b/commands/explosion_utils.py
@@ -46,6 +46,16 @@ def notify_adjacent_rooms_of_explosion(explosion_room):
     if not explosion_room:
         return
 
+    # An explosion is an INCIDENT: raise a sourceless disturbance so
+    # security responds and the scene runs hot (situational cause — a
+    # hidden presence near a fresh blast is reasonable suspicion).
+    try:
+        from world.director.dispatch import WorldEvent, raise_event
+        raise_event(WorldEvent("disturbance", explosion_room, severity=2,
+                               source=None))
+    except Exception:  # noqa: BLE001 — dispatch down must not mute the blast
+        pass
+
     # Get all exits from the explosion room
     exits = explosion_room.exits
 

--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -43,11 +43,19 @@
 > detected innocent simply reads as visibly furtive via the crowd-aware
 > lurk placement ("a nervous, somewhat off face in the crowd" in a
 > throng; "lurking in the shadows" in an empty room). A pardon mid-hunt
-> stands the bot down silently. **Marked for eventual reconsideration
-> (user):** whether/where loitering itself warrants a response — e.g.
-> zone-dependent (corporate blocks vs the sprawl) — revisit with the
-> faction/zone work. NOT yet built: ambush advantage (§6.1), theft
-> (§6.2), light/cover modifiers.
+> stands the bot down silently. **SITUATIONAL CAUSE (user-decided, same
+> day):** cause has two axes — STATUS (the wanted record) and SITUATION:
+> every `raise_event` logs an incident (ServerConfig, rolling, 10-min
+> window); a **sourceless** event (an explosion — detonations now raise
+> a severity-2 sourceless `disturbance` — an anonymous crime) runs the
+> scene HOT in its room + adjacents, and a hidden presence near a hot
+> scene IS reasonable suspicion: the hunt commits and the reacquire
+> challenge applies even without a wanted record. Known-source events
+> don't heat the scene (that perp is hunted by uid). **Marked for
+> eventual reconsideration (user):** whether/where loitering itself
+> warrants a response — e.g. zone-dependent (corporate blocks vs the
+> sprawl) — revisit with the faction/zone work. NOT yet built: ambush
+> advantage (§6.1), theft (§6.2), light/cover modifiers.
 > Original abstract: designs the **presence-concealment**
 > layer: `hide` (self or object) vs `search` (a room), resolved as an opposed
 > **Resonance/Motorics** contest, surfaced as a **per-observer graded awareness

--- a/world/director/dispatch.py
+++ b/world/director/dispatch.py
@@ -94,7 +94,58 @@ def dispatch(event: WorldEvent) -> list:
     return dispatched
 
 
+#: How long an incident scene stays HOT (situational cause for the hunt).
+INCIDENT_WINDOW = 600.0
+_INCIDENT_KEY = "director_incidents"
+
+
+def _log_incident(event: WorldEvent) -> None:
+    """Roll the incident log (ServerConfig, capped): every raised event
+    marks its room; entries expire after INCIDENT_WINDOW."""
+    if event.location is None:
+        return
+    import time
+    from evennia.server.models import ServerConfig
+    now = time.time()
+    log = [entry for entry in (ServerConfig.objects.conf(_INCIDENT_KEY) or [])
+           if now - float(entry.get("t", 0)) < INCIDENT_WINDOW]
+    log.append({"room": getattr(event.location, "id", None), "t": now,
+                "type": event.type,
+                "known_source": event.source is not None})
+    ServerConfig.objects.conf(_INCIDENT_KEY, log[-50:])
+
+
+def incident_context(room, *, window: float = INCIDENT_WINDOW) -> bool:
+    """Reasonable suspicion (stealth spec, user-decided 2026-07-03): an
+    UNRESOLVED incident (no known instigator) is hot in or adjacent to
+    *room*. Context, not status: near a fresh sourceless disturbance —
+    an explosion, an anonymous crime — a hidden presence IS cause."""
+    if room is None:
+        return False
+    import time
+    from evennia.server.models import ServerConfig
+    ids = {getattr(room, "id", None)}
+    for exit_obj in getattr(room, "exits", []) or []:
+        dest = getattr(exit_obj, "destination", None)
+        if dest is not None:
+            ids.add(dest.id)
+    now = time.time()
+    for entry in ServerConfig.objects.conf(_INCIDENT_KEY) or []:
+        if entry.get("known_source"):
+            continue  # a known perp is hunted by uid, not by vicinity
+        if now - float(entry.get("t", 0)) >= window:
+            continue
+        if entry.get("room") in ids:
+            return True
+    return False
+
+
 def raise_event(event: WorldEvent) -> list:
-    """Raise *event* onto the director. Currently routes straight to the
-    dispatcher; the seam where a full event bus / monitor lands later."""
+    """Raise *event* onto the director. Logs the incident (situational
+    cause for the hunt), then routes to the dispatcher; the seam where a
+    full event bus / monitor lands later."""
+    try:
+        _log_incident(event)
+    except Exception:  # noqa: BLE001 — logging must not block dispatch
+        pass
     return dispatch(event)

--- a/world/director/hunt.py
+++ b/world/director/hunt.py
@@ -77,26 +77,43 @@ def _give_up(npc, target_key) -> None:
         pass
 
 
-def _wanted_only(records) -> list:
-    """The silent uid check (user-decided 2026-07-03): a hunt requires
-    CAUSE. Awareness records whose apparent-uid isn't on the wanted
-    record are ignored — an innocent hider is clocked (they render as a
-    nervous face to whoever detects them) but never hunted, challenged,
-    or rousted. No small-worlding: hiding is not a crime."""
+def _has_cause(npc, record) -> bool:
+    """A hunt requires CAUSE (user-decided 2026-07-03), from either axis:
+
+    * **Status** — the presence's apparent-uid is on the wanted record
+      (silent check).
+    * **Situation** — an UNRESOLVED incident (sourceless disturbance: an
+      explosion, an anonymous crime) is hot in/adjacent to where the
+      presence was sensed, or where the bot stands. Reasonable
+      suspicion: near a fresh blast, a hidden person IS the lead.
+
+    Without either, the presence is ignored — an innocent hider is
+    clocked (the nervous-face render) but never hunted or rousted."""
+    from world.director.dispatch import incident_context
     from world.director.intel import is_wanted
-    return [rec for rec in records if is_wanted(rec[0])]
+    key, _level, last_room_id, _t = record
+    if is_wanted(key):
+        return True
+    if incident_context(npc.location):
+        return True
+    return incident_context(_room_by_id(last_room_id))
+
+
+def _with_cause(npc, records) -> list:
+    return [rec for rec in records if _has_cause(npc, rec)]
 
 
 def _engage(npc, target) -> None:
-    """Reacquired a WANTED target: challenge, hand off to dispatch,
+    """Reacquired a target WITH CAUSE: challenge, hand off to dispatch,
     propagate. Defensive re-check — a pardon mid-hunt stands the bot
     down silently (no message; there was never a public incident)."""
+    from world.director.dispatch import incident_context
     from world.director.intel import is_wanted
     from world.stealth import (
         ALERT, UNAWARE, _target_key, set_awareness,
     )
     key = _target_key(target)
-    if not is_wanted(key):
+    if not is_wanted(key) and not incident_context(npc.location):
         npc.ndb.hunt = None
         set_awareness(npc, target, UNAWARE, roll_stamp=True)
         return
@@ -165,7 +182,7 @@ def tick_hunt(npc) -> bool:
     if is_travelling(npc):
         return bool(state)          # en route to a sweep — stay committed
 
-    records = _wanted_only(hunt_records(npc))
+    records = _with_cause(npc, hunt_records(npc))
     best = records[0] if records else None
     if best is None:
         if state:

--- a/world/tests/test_hunt.py
+++ b/world/tests/test_hunt.py
@@ -191,3 +191,127 @@ class TestInnocentLurker(TestCase):
             hunt._engage(npc, prey)
         npc.execute_cmd.assert_not_called()
         self.assertTrue(aware.call_args.kwargs.get("roll_stamp"))
+
+
+class TestSituationalCause(TestCase):
+    """Reasonable suspicion (user-decided): near a fresh UNRESOLVED
+    incident, a hidden presence is cause even without a wanted record."""
+
+    def test_unwanted_hider_hunted_near_hot_incident(self):
+        npc = _npc()
+        with patch("world.stealth.hunt_records",
+                   return_value=_rec(level=SUSPICIOUS)), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False), \
+                patch.object(hunt, "_present_target", return_value=None), \
+                patch("world.director.intel.is_wanted",
+                      return_value=None), \
+                patch("world.director.dispatch.incident_context",
+                      return_value=True):
+            self.assertTrue(tick_hunt(npc))
+        self.assertTrue(is_hunting(npc))
+
+    def test_unwanted_hider_ignored_when_scene_is_cold(self):
+        npc = _npc()
+        with patch("world.stealth.hunt_records",
+                   return_value=_rec(level=SUSPICIOUS)), \
+                patch("world.director.travel.is_travelling",
+                      return_value=False), \
+                patch("world.director.intel.is_wanted",
+                      return_value=None), \
+                patch("world.director.dispatch.incident_context",
+                      return_value=False), \
+                patch.object(hunt, "_room_by_id", return_value=None):
+            self.assertFalse(tick_hunt(npc))
+        npc.execute_cmd.assert_not_called()
+
+    def test_engage_allows_incident_cause(self):
+        npc = _npc()
+        npc.location.id = 55
+        prey = MagicMock()
+        with patch.object(hunt, "propagate_alert") as propagate, \
+                patch("world.stealth.set_awareness"), \
+                patch("world.stealth._target_key",
+                      return_value="uid-prey"), \
+                patch("world.director.intel.is_wanted",
+                      return_value=None), \
+                patch("world.director.dispatch.incident_context",
+                      return_value=True), \
+                patch("world.director.dispatch.raise_event"):
+            hunt._engage(npc, prey)
+        say = [c.args[0] for c in npc.execute_cmd.call_args_list
+               if c.args[0].startswith("say ")]
+        self.assertTrue(say and "Halt, Colonist" in say[0])
+        propagate.assert_called_once()
+
+
+class TestIncidentLog(TestCase):
+    """The dispatch-side incident store: sourceless events run a scene hot
+    in the room and its adjacents; known-source events don't; heat fades."""
+
+    def _clear(self):
+        from evennia.server.models import ServerConfig
+        ServerConfig.objects.conf("director_incidents", delete=True)
+
+    def test_sourceless_event_heats_room_and_adjacents(self):
+        from world.director.dispatch import (
+            WorldEvent, incident_context, raise_event,
+        )
+        self._clear()
+        scene = MagicMock()
+        scene.id = 900
+        scene.exits = []
+        with patch("world.director.dispatch.dispatch", return_value=[]):
+            raise_event(WorldEvent("disturbance", scene, source=None))
+        self.assertTrue(incident_context(scene))
+        adjacent = MagicMock()
+        adjacent.id = 901
+        exit_obj = MagicMock()
+        exit_obj.destination = scene
+        adjacent.exits = [exit_obj]
+        self.assertTrue(incident_context(adjacent))
+        far = MagicMock()
+        far.id = 999
+        far.exits = []
+        self.assertFalse(incident_context(far))
+        self._clear()
+
+    def test_known_source_event_is_not_situational_cause(self):
+        from world.director.dispatch import (
+            WorldEvent, incident_context, raise_event,
+        )
+        self._clear()
+        scene = MagicMock()
+        scene.id = 902
+        scene.exits = []
+        with patch("world.director.dispatch.dispatch", return_value=[]):
+            raise_event(WorldEvent("disturbance", scene,
+                                   source=MagicMock()))
+        self.assertFalse(incident_context(scene))
+        self._clear()
+
+    def test_heat_fades_with_the_window(self):
+        from world.director.dispatch import (
+            WorldEvent, incident_context, raise_event,
+        )
+        self._clear()
+        scene = MagicMock()
+        scene.id = 903
+        scene.exits = []
+        with patch("world.director.dispatch.dispatch", return_value=[]):
+            raise_event(WorldEvent("disturbance", scene, source=None))
+        self.assertFalse(incident_context(scene, window=0.0))
+        self._clear()
+
+    def test_explosions_raise_sourceless_incidents(self):
+        from commands.explosion_utils import (
+            notify_adjacent_rooms_of_explosion,
+        )
+        room = MagicMock()
+        room.exits = []
+        with patch("world.director.dispatch.raise_event") as raised:
+            notify_adjacent_rooms_of_explosion(room)
+        event = raised.call_args.args[0]
+        self.assertEqual(event.type, "disturbance")
+        self.assertIsNone(event.source)
+        self.assertIs(event.location, room)


### PR DESCRIPTION
Closes #991

- dispatch: raise_event logs incidents (ServerConfig rolling store,
  10-min window); incident_context(room) = a sourceless event is hot
  in room/adjacents (known-source events don't heat — that perp is
  hunted by uid)
- hunt cause = wanted(uid) OR incident_context at the bot's room or
  the presence's last-known room; engage gate matches
- detonations raise a severity-2 sourceless disturbance (security now
  responds to explosions; blast sites run hot)
- spec updated (two-axis cause model recorded)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
