### PR TITLE
Stealth Phases 5-6: ambush + theft

### DIFF
--- a/commands/CmdTheft.py
+++ b/commands/CmdTheft.py
@@ -1,0 +1,205 @@
+"""``steal`` / ``pickpocket`` — applied stealth (STEALTH_AND_DETECTION_SPEC §6.2).
+
+Theft is the hide/search contest (world/stealth.py) pointed at taking things.
+Same room is the only spatial gate — theft is a stealth move, not a combat one,
+so it never requires proximity or an advance. A subdued / unconscious / dead
+mark is free looting (the trust predicate). An awake mark is a contest whose
+whole risk is *getting caught*: a botched lift spikes the victim and every
+witness to Alert (keyed on the thief's apparent-uid — a disguise protects you)
+and raises a sourceless disturbance so the block runs hot.
+"""
+
+from random import choice, randint
+
+from evennia import Command
+
+from world.consent import can_contest
+from world.stealth import (
+    AMBUSH_CONTEST_BONUS, ALERT, contest, is_ambush, set_awareness,
+)
+
+
+def _stealable_inventory(target):
+    """Carried items only — not worn, not held. What a pickpocket's fingers
+    can reach without a struggle."""
+    worn = set()
+    get_worn = getattr(target, "get_worn_items", None)
+    if callable(get_worn):
+        worn = {id(i) for i in (get_worn() or [])}
+    held = {id(i) for i in (getattr(target, "hands", None) or {}).values() if i}
+    return [obj for obj in target.contents
+            if id(obj) not in worn and id(obj) not in held]
+
+
+def _caught(thief, victim):
+    """The lift failed and the mark noticed. Victim + everyone who can see
+    the thief jump to Alert (recognition keys on apparent-uid), and a
+    sourceless disturbance runs the block hot — a witnessed-but-unidentified
+    theft is exactly the situational cause the hunt reads."""
+    from world.perception import can_see
+    room = thief.location
+    set_awareness(victim, thief, ALERT)
+    for obs in (room.contents if room else []):
+        if obs is thief or obs is victim or not hasattr(obs, "get_sdesc"):
+            continue
+        try:
+            if can_see(obs):
+                set_awareness(obs, thief, ALERT)
+        except Exception:  # noqa: BLE001
+            continue
+    try:
+        from world.director.dispatch import WorldEvent, raise_event
+        raise_event(WorldEvent("crime", room, severity=1, source=None))
+    except Exception:  # noqa: BLE001 — dispatch down ≠ theft crash
+        pass
+
+
+class CmdSteal(Command):
+    """
+    Steal from someone — lift an item off them without their notice.
+
+    Usage:
+        steal <target>
+        steal <item> from <target>
+
+    ``steal <target>`` picks something at random from what they're carrying
+    (not worn, not in-hand) — you don't need to know what they've got. If
+    you DO know (you frisked them, someone tipped you, it's in plain sight),
+    ``steal <item> from <target>`` lets you go for that piece specifically.
+
+    Against an awake mark it's a contest — their notice against your nerve,
+    helped by a crowd and by striking from concealment. Fail and they feel
+    it: you're made, and so is anyone watching. A subdued, unconscious, or
+    dead mark is simply looted.
+    """
+
+    key = "steal"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def parse(self):
+        raw = (self.args or "").strip()
+        self.item_name = self.target_name = ""
+        if " from " in raw:
+            item, _, target = raw.partition(" from ")
+            self.item_name, self.target_name = item.strip(), target.strip()
+        else:
+            self.target_name = raw
+
+    def func(self):
+        caller = self.caller
+        if not self.target_name:
+            caller.msg("Steal from whom?")
+            return
+        target = caller.search(self.target_name)
+        if not target:
+            return
+        if target is caller:
+            caller.msg("You pat your own pockets. All present.")
+            return
+        if not hasattr(target, "get_sdesc"):
+            caller.msg("You can't steal from that.")
+            return
+
+        inventory = _stealable_inventory(target)
+        if self.item_name:
+            item = caller.search(self.item_name, location=target, quiet=True)
+            item = item[0] if isinstance(item, list) and item else item
+            if not item or id(item) not in {id(i) for i in inventory}:
+                # The precision path only works on what you can actually
+                # reach — a named item you can't perceive isn't a free tell.
+                caller.msg(f"You can't get at any '{self.item_name}' on "
+                           f"{target.get_display_name(caller)}.")
+                return
+        else:
+            if not inventory:
+                caller.msg(f"{target.get_display_name(caller)} has nothing "
+                           f"loose to lift.")
+                return
+            item = choice(inventory)
+
+        self._lift(caller, target, item)
+
+    def _lift(self, caller, target, item):
+        # Free action on a mark who can't contest (trust predicate).
+        if not can_contest(target):
+            item.move_to(caller, quiet=True)
+            caller.msg(f"You lift {item.get_display_name(caller)} off "
+                       f"{target.get_display_name(caller)}.")
+            return
+        # Awake mark: a contest, ambush + crowd folded in by world.stealth.
+        bonus = AMBUSH_CONTEST_BONUS if is_ambush(caller, target) else 0
+        # Positive margin = the OBSERVER (victim) wins = the thief is caught.
+        if contest(caller, target, hider_bonus=bonus) > 0:
+            caller.msg(f"Your fingers find {item.get_display_name(caller)} — "
+                       f"but {target.get_display_name(caller)} feels it.")
+            target.msg(f"{caller.get_display_name(target)} is stealing "
+                       f"from you!")
+            _caught(caller, target)
+            return
+        item.move_to(caller, quiet=True)
+        caller.msg(f"You lift {item.get_display_name(caller)} off "
+                   f"{target.get_display_name(caller)}, clean.")
+
+
+class CmdPickpocket(Command):
+    """
+    Pick someone's pocket for loose currency.
+
+    Usage:
+        pickpocket <target>
+
+    A blind grab for tokens — you don't choose an amount, you lift what your
+    fingers close on. Lower-stakes and more deniable than lifting a specific
+    item. Same contest, same consequences if you're caught; a crowd and
+    concealment both help.
+    """
+
+    key = "pickpocket"
+    aliases = ["pick"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Pickpocket whom?")
+            return
+        target = caller.search(self.args.strip())
+        if not target:
+            return
+        if target is caller:
+            caller.msg("Your own tokens are right where you left them.")
+            return
+        if not hasattr(target, "get_sdesc"):
+            caller.msg("That has no pockets.")
+            return
+        tokens = int(getattr(target.db, "tokens", 0) or 0)
+        if tokens <= 0:
+            caller.msg(f"{target.get_display_name(caller)} is carrying no "
+                       f"tokens.")
+            return
+
+        lift = min(tokens, randint(1, max(1, tokens // 3)))
+
+        if not can_contest(target):
+            self._transfer(caller, target, lift)
+            caller.msg(f"You lift {lift} tokens off "
+                       f"{target.get_display_name(caller)}.")
+            return
+        bonus = AMBUSH_CONTEST_BONUS if is_ambush(caller, target) else 0
+        if contest(caller, target, hider_bonus=bonus) > 0:
+            caller.msg(f"Your hand's in {target.get_display_name(caller)}'s "
+                       f"pocket when they turn — caught.")
+            target.msg(f"{caller.get_display_name(target)} has a hand in "
+                       f"your pocket!")
+            _caught(caller, target)
+            return
+        self._transfer(caller, target, lift)
+        caller.msg(f"You lift {lift} tokens off "
+                   f"{target.get_display_name(caller)}, clean.")
+
+    @staticmethod
+    def _transfer(caller, target, amount):
+        target.db.tokens = int(getattr(target.db, "tokens", 0) or 0) - amount
+        caller.db.tokens = int(getattr(caller.db, "tokens", 0) or 0) + amount

--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -56,11 +56,6 @@ class CmdAttack(Command):
     def func(self):
         caller = self.caller
         args = self.args.strip()
-        # Attacking gives you away (STEALTH_AND_DETECTION_SPEC §6.4) — the
-        # ambush ADVANTAGE (spec §6.1) lands with the ambush phase; v1 is
-        # just honesty: violence is loud.
-        from world.stealth import break_stealth
-        break_stealth(caller, quiet=True)
         splattercast = get_splattercast()
 
         if not args:
@@ -296,9 +291,19 @@ class CmdAttack(Command):
             if caller_entry_snapshot:
                 original_caller_target_in_handler = final_handler.get_target_obj(caller_entry_snapshot)
 
+        # --- Ambush (STEALTH_AND_DETECTION_SPEC §6.1): striking a target
+        # who can't perceive you is a first-strike. Read BEFORE breaking
+        # stealth (which flips them to Alert), apply as initiative primacy,
+        # THEN attacking gives you away (§6.4). ---
+        from world.stealth import AMBUSH_INITIATIVE_BONUS, break_stealth, is_ambush
+        ambush = AMBUSH_INITIATIVE_BONUS if is_ambush(caller, target) else 0
+        if ambush and not caller_was_in_final_handler:
+            caller.msg("You strike from concealment!")
+        break_stealth(caller, quiet=True)
+
         # --- Add combatants to the final_handler ---
         if not caller_was_in_final_handler:
-            final_handler.add_combatant(caller, target=target)
+            final_handler.add_combatant(caller, target=target, ambush_bonus=ambush)
         else: 
             caller_entry = next((e for e in final_handler.db.combatants if e["char"] == caller), None)
             if caller_entry: # Ensure entry exists

--- a/commands/combat/special_actions.py
+++ b/commands/combat/special_actions.py
@@ -111,9 +111,21 @@ class CmdGrapple(Command):
         caller_is_in_combat = any(e["char"] == caller for e in handler.db.combatants)
         target_is_in_combat = any(e["char"] == target for e in handler.db.combatants)
 
+        # Ambush (STEALTH_AND_DETECTION_SPEC §6.1): grappling a target who
+        # can't perceive you rides the same first-strike primacy as a
+        # strike — the grapple resolves on your turn, and going first means
+        # it lands before they can act. Read BEFORE break_stealth.
+        from world.stealth import (
+            AMBUSH_INITIATIVE_BONUS, break_stealth, is_ambush,
+        )
+        ambush = AMBUSH_INITIATIVE_BONUS if is_ambush(caller, target) else 0
+        if ambush and not caller_is_in_combat:
+            caller.msg("You lunge from concealment!")
+        break_stealth(caller, quiet=True)
+
         if not caller_is_in_combat:
             log_combat_action(caller, "grapple_initiate", target, details="initiating grapple combat")
-            handler.add_combatant(caller) 
+            handler.add_combatant(caller, ambush_bonus=ambush)
             handler.add_combatant(target) 
         elif not target_is_in_combat: 
             log_combat_action(caller, "grapple_join", target, details="attempting to grapple (adding target to combat)")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -40,6 +40,7 @@ from commands.CmdFollow import (
     CmdEscort, CmdFollow, CmdStopEscorting, CmdStopFollowing,
 )
 from commands.CmdStealth import CmdHide, CmdSearch, CmdSneak, CmdUnhide
+from commands.CmdTheft import CmdPickpocket, CmdSteal
 from commands.combat.cmdset_combat import CombatCmdSet
 from commands.combat.special_actions import CmdAim, CmdGrapple
 from commands.CmdThrow import CmdThrow, CmdPull, CmdCatch
@@ -186,6 +187,11 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdUnhide())
         self.add(CmdSneak())
         self.add(CmdSearch())
+
+        # Theft (STEALTH_AND_DETECTION_SPEC §6.2): applied stealth — the
+        # contest pointed at taking things.
+        self.add(CmdSteal())
+        self.add(CmdPickpocket())
         
         # Add aim command for ranged combat preparation
         self.add(CmdAim())

--- a/specs/proposals/DECKING_SPEC.md
+++ b/specs/proposals/DECKING_SPEC.md
@@ -1,0 +1,74 @@
+# Decking Spec — Runs, Traces, and the Net's Game Loop
+
+> **Status:** 📋 **DRAFT FOR DISCUSSION** — not implemented, not yet fully
+> designed. The net's *substrate* is `PHASE_LAYER_SPEC` (net = a phase over
+> the same geography; the two-body model; the single perception gate). This
+> spec designs the **game** that runs on that substrate: what a decker
+> actually does, minute to minute. Primary reference:
+> **uplink-headless-mod** (https://github.com/hosler/uplink-headless-mod) —
+> a reverse-engineered, GUI-stripped *Uplink* whose engine reduces the
+> entire hacking genre to ~40 discrete commands over JSON. That reduction
+> is the proof we need: **Uplink's loop is already a text game.** We adopt
+> its loop (bounce → intrude → work under a trace timer → clean logs →
+> jack out) and implement it on machinery Gelatinous has already built.
+
+---
+
+## 1 · Why Uplink, specifically
+
+The headless mod demonstrates four things that map straight onto a MUD:
+
+1. **A discrete command surface is enough.** Forty operations carry the
+   whole game — connection management, file ops, cracking, tracing, log
+   work, missions, shopping. No GUI required; the interface was always
+   incidental to the loop.
+2. **Timed async operations are the tension.** Cracks and copies take real
+   seconds while a trace advances — tension without twitch. Evennia's
+   `delay` and the director heartbeat already run this shape.
+3. **Layered navigation** (map → node → console) mirrors rooms → objects →
+   commands. We don't need to invent an interface metaphor; the MUD *is*
+   one.
+4. **Missions close the loop** (accept → run → deliver → get paid) — which
+   is Gelatinous's gig/favor direction verbatim.
+
+## 2 · The stack (what's substrate, what's this spec)
+
+| Layer | Owner | Status |
+|---|---|---|
+| Net as a phase; two-body model; perception gate | `PHASE_LAYER_SPEC` | specced |
+| Net topology over real geography (§3) | this spec | draft |
+| The run loop: bounce, intrusion, tools, logs (§4) | this spec | draft |
+| Trace = the hunt, pointed at the net (§5) | this spec ← `world/director/hunt.py` | draft |
+| ICE = deterministic NPCs (§6) | this spec ← robot/mob pattern | draft |
+| Deck & programs = gear (§7) | this spec ← parked-stats stance | draft |
+| Jobs = gigs over the BBS (§8) | this spec ← growth direction | draft |
+| Cross-phase effects (cameras, doors, radio taps) | `PHASE_LAYER_SPEC` §7/§9 | reserved |
+
+## 3 · Topology — hosts live somewhere
+
+Per the phase layer, the net overlays the **same geography**: a corp's host
+is *in its building*, the colony's utility grid is *under its streets*.
+Net-rooms (nodes/hosts) are rooms in `phase = net`, usually anchored to the
+real coordinates of the machine that runs them:
+
+* **Public grid** — the walkable net commons (the bounce fabric): exchange
+  nodes roughly following district geography.
+* **Hosts** — a facility's system: entry node (gate/ICE) → interior nodes
+  (filesystems, controls, logs) — a small "building" in the net whose
+  meat-space twin is a real place. **This is the high-rise dependency
+  shared with radio: corporate towers are where the good hosts live.**
+* **Dark nodes** — unlisted addresses (found, bought, extracted): the
+  net's speakeasies.
+
+Navigation is movement; the map is the room graph; "layered navigation"
+comes free.
+
+## 4 · The run loop (Uplink's, adapted)
+
+1. **Jack in** — from a terminal or a deck (portable item; interior-grade
+   chrome later). Body slumps in meat-space: a **free-action target** (the
+   trust spec's contest predicate already covers this — guard your meat).
+2. **Bounce** — route your entry through public/compromised nodes before
+   the target. Your bounce path is real: it is the literal sequence of
+   net-rooms your connection traverses, and **the trace walks it back**.
+   More hops = longer trace runway;

--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -238,11 +238,23 @@ deterministic**, which is exactly why this scales without LLM cost.
 
 ## 6 · Applied contest — ambush, theft, breaking stealth
 
-### 6.1 · Ambush
+### 6.1 · Ambush — SHIPPED (2026-07-03)
 
-Acting on a target at **Unaware** toward you is an ambush: a first-strike
-advantage routed through the existing aim/initiative systems (`world/combat`),
-not a new combat path.
+Acting on a target who **can't perceive you** is an ambush: the opener lands
+with a first-strike advantage, routed through existing systems, not a new
+combat path. `world.stealth.is_ambush(attacker, target)` = the presence gate
+(`not can_perceive(target, attacker)`), read BEFORE `break_stealth` flips them
+to Alert. Covers **both** the combat and non-combat openers (user-decided):
+
+* **attack / grapple** — `AMBUSH_INITIATIVE_BONUS` (+20) folds into the
+  attacker's combat initiative via `add_combatant(..., ambush_bonus=)`, so
+  from concealment you act first; the grapple resolves on that first turn
+  before the target can contest. "You strike/lunge from concealment!"
+* **theft** — `AMBUSH_CONTEST_BONUS` (+6) on the steal/pickpocket contest
+  (§6.2): a mark who doesn't know you're there is far easier to lift.
+
+v1 scope: initiative primacy (going first IS the ambush). A separate accuracy
+bump is a future tune — deliberately not a stealth-insta-kill.
 
 ### 6.2 · Theft (steal & pickpocket)
 
@@ -250,15 +262,20 @@ not a new combat path.
 risk is *getting caught*. It is the contest engine (§3) and the awareness meter
 (§4) pointed at taking things, not a separate system.
 
-* **`steal <item> from <target>`** — take a *specific, perceivable* item (a
-  visible worn/carried object). Contest: thief vs the victim's awareness, modified
-  by §3.2 (crowd/distraction help; a prominent or worn item is harder than a loose
-  one; a victim in active combat is distracted). **Success** → the item transfers
-  with little awareness gained. **Failure** → *caught*: the victim (and witnesses
-  in LoS) jump toward **Alert** toward the thief, recognition keys on the thief's
-  **apparent-UID** (a mask/disguise protects you — `IDENTITY_RECOGNITION_SPEC`),
-  and a witnessed theft can raise a **dispatch** event (the victim swings, a guard
-  responds).
+**SHIPPED (2026-07-03; user-corrected: no frisk gate).**
+
+* **`steal <target>`** — lift something **at random from what they're
+  carrying** (not worn, not in-hand). No frisk required: theft is accessible
+  to anyone. **`steal <item> from <target>`** is the *precision path* — go for
+  a named piece, but only one you can actually perceive/reach (frisked,
+  tipped, in plain sight); intel lets you CHOOSE, it's never a gate.
+  Contest: thief-vs-victim (world.stealth.contest, crowd + ambush folded in).
+  **Success** → the item transfers, clean. **Failure** → *caught*: the victim
+  and every witness in LoS jump to **Alert** toward the thief, recognition
+  keys on the thief's **apparent-UID** (a mask protects you), and a
+  **sourceless `crime` event** runs the block hot (situational cause — the
+  hunt reads it). Same-room is the ONLY spatial gate — theft is stealth, not
+  combat, so it never requires proximity or an advance.
 * **`pickpocket <target>`** — **tokens (currency) only**: a blind grab for cash,
   lower-stakes and more deniable than targeted theft (you don't choose *what*, you
   lift *some*). Same contest and caught-consequences, tuned lighter. Specific

--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -421,7 +421,7 @@ class CombatHandler(DefaultScript):
         
         splattercast.msg(f"{DEBUG_PREFIX_HANDLER}_MERGE: Merged {other_handler.key} into {self.key}. Now managing {len(our_rooms)} rooms with {len(our_combatants)} combatants.")
 
-    def add_combatant(self, char, target=None, initial_grappling=None, initial_grappled_by=None, initial_is_yielding=False):
+    def add_combatant(self, char, target=None, initial_grappling=None, initial_grappled_by=None, initial_is_yielding=False, ambush_bonus=0):
         """
         Add a character to combat.
         
@@ -432,7 +432,7 @@ class CombatHandler(DefaultScript):
             initial_grappled_by: Optional character grappling this char initially
             initial_is_yielding: Whether the character starts yielding
         """
-        add_combatant(self, char, target, initial_grappling, initial_grappled_by, initial_is_yielding)
+        add_combatant(self, char, target, initial_grappling, initial_grappled_by, initial_is_yielding, ambush_bonus=ambush_bonus)
 
     def remove_combatant(self, char):
         """

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -523,7 +523,7 @@ def clear_mutual_aim(char1, char2):
 # COMBATANT MANAGEMENT (moved from handler.py)
 # ===================================================================
 
-def add_combatant(handler, char, target=None, initial_grappling=None, initial_grappled_by=None, initial_is_yielding=False):
+def add_combatant(handler, char, target=None, initial_grappling=None, initial_grappled_by=None, initial_is_yielding=False, ambush_bonus=0):
     """
     Add a character to combat.
     
@@ -572,6 +572,7 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
             randint(1, 20)
             + get_numeric_stat(char, "motorics", 0)
             + surplus_limb_initiative_bonus(char)
+            + int(ambush_bonus or 0)   # first-strike from an ambush (§6.1)
         ),
         DB_TARGET_DBREF: target_dbref,
         DB_GRAPPLING_DBREF: get_character_dbref(initial_grappling),

--- a/world/stealth.py
+++ b/world/stealth.py
@@ -287,6 +287,27 @@ def lurk_placement(room) -> str:
     return "lurking in the shadows."
 
 
+# --- ambush (spec §6.1): the opener against an unaware target -----------
+AMBUSH_INITIATIVE_BONUS = 20   # first-strike primacy from concealment
+AMBUSH_CONTEST_BONUS = 6       # ambush edge on a theft contest
+
+
+def is_ambush(attacker, target) -> bool:
+    """The opener lands as an AMBUSH when *target* can't perceive
+    *attacker* — they don't know you're there. Reuses the presence gate,
+    so a hidden attacker the target hasn't detected qualifies and a
+    plainly-visible one never does. Drives first-strike combat (initiative
+    primacy), uncontested-because-first grapples, and easier theft. MUST be
+    read BEFORE break_stealth (which flips the target to Alert)."""
+    if attacker is target:
+        return False
+    try:
+        from world.perception import can_perceive
+        return not can_perceive(target, attacker)
+    except Exception:  # noqa: BLE001 — no gate = no ambush
+        return False
+
+
 def is_hidden_from(target, looker) -> bool:
     """The display gate: hidden AND the looker is not yet aware enough to
     place them. Suspicious knows *a* presence, not who/where — still

--- a/world/tests/test_theft.py
+++ b/world/tests/test_theft.py
@@ -1,0 +1,209 @@
+"""Ambush + theft (STEALTH_AND_DETECTION_SPEC §6.1/§6.2).
+
+MagicMock harness; the stealth contest and consent predicate are patched at
+their sources so what's under test is the command logic — random selection,
+same-room-only gating, the caught consequences, the free path.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.stealth import AMBUSH_INITIATIVE_BONUS
+
+
+class TestAmbushPredicate(TestCase):
+    def test_ambush_when_target_cannot_perceive(self):
+        from world.stealth import is_ambush
+        atk, tgt = MagicMock(), MagicMock()
+        with patch("world.perception.can_perceive", return_value=False):
+            self.assertTrue(is_ambush(atk, tgt))
+        with patch("world.perception.can_perceive", return_value=True):
+            self.assertFalse(is_ambush(atk, tgt))
+
+    def test_never_ambush_self(self):
+        from world.stealth import is_ambush
+        c = MagicMock()
+        self.assertFalse(is_ambush(c, c))
+
+    def test_initiative_bonus_threaded(self):
+        # add_combatant must fold ambush_bonus into the initiative roll
+        from world.combat import utils
+        handler = MagicMock()
+        handler.db.combatants = []
+        char = MagicMock()
+        with patch("random.randint", return_value=10), \
+                patch("world.combat.utils.get_numeric_stat", return_value=0), \
+                patch("world.combat.utils.surplus_limb_initiative_bonus",
+                      return_value=0), \
+                patch("world.combat.utils.get_character_dbref",
+                      return_value=None):
+            utils.add_combatant(handler, char,
+                                ambush_bonus=AMBUSH_INITIATIVE_BONUS)
+        entry = handler.db.combatants[0]
+        from world.combat.constants import DB_INITIATIVE
+        self.assertEqual(entry[DB_INITIATIVE], 10 + AMBUSH_INITIATIVE_BONUS)
+
+
+def _target(tokens=0, contents=None, worn=None, hands=None):
+    t = MagicMock()
+    t.get_sdesc = lambda: "a mark"
+    t.get_display_name = lambda looker=None, **k: "a mark"
+    t.contents = contents or []
+    t.get_worn_items = lambda: (worn or [])
+    t.hands = hands or {}
+    t.db.tokens = tokens
+    return t
+
+
+def _item(name):
+    it = MagicMock()
+    it.get_display_name = lambda looker=None, **k: name
+    return it
+
+
+class TestStealableInventory(TestCase):
+    def test_excludes_worn_and_held(self):
+        from commands.CmdTheft import _stealable_inventory
+        loose, worn, held = _item("a chip"), _item("a coat"), _item("a knife")
+        t = _target(contents=[loose, worn, held], worn=[worn],
+                    hands={"r": held})
+        self.assertEqual(_stealable_inventory(t), [loose])
+
+
+class TestSteal(TestCase):
+    def _cmd(self, args, target):
+        from commands.CmdTheft import CmdSteal
+        cmd = CmdSteal()
+        cmd.caller = MagicMock()
+        cmd.caller.get_display_name = lambda looker=None, **k: "a thief"
+        cmd.caller.search.return_value = target
+        cmd.args = args
+        cmd.parse()
+        return cmd
+
+    def test_no_item_picks_random_carried(self):
+        chip = _item("a chip")
+        target = _target(contents=[chip])
+        cmd = self._cmd("mark", target)
+        with patch("commands.CmdTheft.can_contest", return_value=True), \
+                patch("commands.CmdTheft.is_ambush", return_value=False), \
+                patch("commands.CmdTheft.contest", return_value=-5):
+            cmd.func()
+        chip.move_to.assert_called_once()          # clean lift
+        self.assertIn("clean", cmd.caller.msg.call_args.args[0])
+
+    def test_empty_inventory_message(self):
+        cmd = self._cmd("mark", _target(contents=[]))
+        with patch("commands.CmdTheft.can_contest", return_value=True):
+            cmd.func()
+        self.assertIn("nothing loose", cmd.caller.msg.call_args.args[0])
+
+    def test_caught_alerts_and_raises_incident(self):
+        chip = _item("a chip")
+        target = _target(contents=[chip])
+        cmd = self._cmd("mark", target)
+        with patch("commands.CmdTheft.can_contest", return_value=True), \
+                patch("commands.CmdTheft.is_ambush", return_value=False), \
+                patch("commands.CmdTheft.contest", return_value=5), \
+                patch("commands.CmdTheft._caught") as caught:
+            cmd.func()
+        chip.move_to.assert_not_called()           # the lift failed
+        caught.assert_called_once_with(cmd.caller, target)
+
+    def test_subdued_mark_is_free_loot(self):
+        chip = _item("a chip")
+        target = _target(contents=[chip])
+        cmd = self._cmd("mark", target)
+        with patch("commands.CmdTheft.can_contest", return_value=False), \
+                patch("commands.CmdTheft.contest") as roll:
+            cmd.func()
+        chip.move_to.assert_called_once()
+        roll.assert_not_called()                   # no contest when helpless
+
+    def test_specific_item_must_be_reachable(self):
+        chip = _item("a chip")
+        target = _target(contents=[chip])
+        cmd = self._cmd("datajack from mark", target)   # not present
+        cmd.caller.search = MagicMock(side_effect=lambda *a, **k:
+                                      target if a and a[0] == "mark" else None)
+        with patch("commands.CmdTheft.can_contest", return_value=True):
+            cmd.func()
+        self.assertIn("can't get at", cmd.caller.msg.call_args.args[0])
+
+    def test_ambush_bonus_applied_to_contest(self):
+        chip = _item("a chip")
+        target = _target(contents=[chip])
+        cmd = self._cmd("mark", target)
+        with patch("commands.CmdTheft.can_contest", return_value=True), \
+                patch("commands.CmdTheft.is_ambush", return_value=True), \
+                patch("commands.CmdTheft.contest", return_value=-1) as roll:
+            cmd.func()
+        from world.stealth import AMBUSH_CONTEST_BONUS
+        self.assertEqual(roll.call_args.kwargs.get("hider_bonus"),
+                         AMBUSH_CONTEST_BONUS)
+
+
+class TestPickpocket(TestCase):
+    def _cmd(self, target):
+        from commands.CmdTheft import CmdPickpocket
+        cmd = CmdPickpocket()
+        cmd.caller = MagicMock()
+        cmd.caller.db.tokens = 0
+        cmd.caller.get_display_name = lambda looker=None, **k: "a thief"
+        cmd.caller.search.return_value = target
+        cmd.args = "mark"
+        return cmd
+
+    def test_clean_lift_transfers_tokens(self):
+        target = _target(tokens=90)
+        cmd = self._cmd(target)
+        with patch("commands.CmdTheft.can_contest", return_value=True), \
+                patch("commands.CmdTheft.is_ambush", return_value=False), \
+                patch("commands.CmdTheft.contest", return_value=-5), \
+                patch("commands.CmdTheft.randint", return_value=20):
+            cmd.func()
+        self.assertEqual(cmd.caller.db.tokens, 20)
+        self.assertEqual(target.db.tokens, 70)
+
+    def test_no_tokens_message(self):
+        cmd = self._cmd(_target(tokens=0))
+        with patch("commands.CmdTheft.can_contest", return_value=True):
+            cmd.func()
+        self.assertIn("no tokens", cmd.caller.msg.call_args.args[0])
+
+    def test_caught_leaves_tokens_and_raises(self):
+        target = _target(tokens=90)
+        cmd = self._cmd(target)
+        with patch("commands.CmdTheft.can_contest", return_value=True), \
+                patch("commands.CmdTheft.is_ambush", return_value=False), \
+                patch("commands.CmdTheft.contest", return_value=5), \
+                patch("commands.CmdTheft.randint", return_value=20), \
+                patch("commands.CmdTheft._caught") as caught:
+            cmd.func()
+        self.assertEqual(target.db.tokens, 90)     # nothing taken
+        caught.assert_called_once()
+
+
+class TestCaughtConsequences(TestCase):
+    def test_caught_alerts_witnesses_and_raises_sourceless_crime(self):
+        from commands.CmdTheft import _caught
+        thief = MagicMock()
+        thief.get_sdesc = lambda: "a thief"
+        victim = MagicMock()
+        witness, blindfolded = MagicMock(), MagicMock()
+        witness.get_sdesc = blindfolded.get_sdesc = lambda: "x"
+        room = MagicMock()
+        room.contents = [thief, victim, witness, blindfolded]
+        thief.location = room
+        with patch("commands.CmdTheft.set_awareness") as aware, \
+                patch("world.perception.can_see",
+                      side_effect=lambda o: o is witness), \
+                patch("world.director.dispatch.raise_event") as raised:
+            _caught(thief, victim)
+        awared = {c.args[0] for c in aware.call_args_list}
+        self.assertIn(victim, awared)
+        self.assertIn(witness, awared)
+        self.assertNotIn(blindfolded, awared)      # can't see = not alerted
+        event = raised.call_args.args[0]
+        self.assertEqual(event.type, "crime")
+        self.assertIsNone(event.source)            # unidentified -> hot scene


### PR DESCRIPTION
Closes #993

- world.stealth.is_ambush (presence-gate predicate) + AMBUSH_INITIATIVE
  _BONUS/AMBUSH_CONTEST_BONUS
- attack + grapple: ambush read before break_stealth, +20 initiative
  threaded through add_combatant(ambush_bonus=) — first-strike primacy
- CmdSteal: `steal <target>` random carried item (no frisk gate),
  `steal <item> from <target>` precision path (perceivable-only);
  CmdPickpocket tokens-only. Same-room only (no combat proximity).
  Subdued=free loot; awake=contest w/ crowd+ambush; caught -> witnesses
  Alert (apparent-uid) + sourceless crime event runs the block hot
- spec §6.1/§6.2 marked shipped

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
