### PR TITLE
Combat: aim is a first-class relationship (orphan sweep held-target fix)

### DIFF
--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -114,9 +114,17 @@ class CmdAttack(Command):
             obj for obj in target_room.contents
             if inherits_from(obj, "typeclasses.characters.Character")
         ]
-        target = resolve_character_target(
-            caller, target_search_name, candidates=potential_targets
-        )
+        # System-driven attacks (the flee/aim-break opportunity attack) hand
+        # us the ALREADY-RESOLVED object — never round-trip a real key
+        # through the player-facing search, which both fails the identity
+        # pipeline and leaks the key in the failure message.
+        target = getattr(self, "pre_resolved_target", None)
+        if target is not None and target.location is not target_room:
+            target = None
+        if target is None:
+            target = resolve_character_target(
+                caller, target_search_name, candidates=potential_targets
+            )
         if not target:
             caller.msg(f"You don't see '{target_search_name}' {(f'in the {aiming_direction} direction' if aiming_direction else 'here')}.")
             return

--- a/commands/combat/movement.py
+++ b/commands/combat/movement.py
@@ -210,10 +210,15 @@ class CmdFlee(Command):
                     # Import and execute the attack command from the aimer's perspective
                     from commands.combat.core_actions import CmdAttack
                     
-                    # Create a temporary attack command instance for the aimer
+                    # Create a temporary attack command instance for the aimer.
+                    # Pass the RESOLVED object — args carries only the aimer's
+                    # perceived name for messages; a raw key would fail the
+                    # identity pipeline AND leak the real name (#1002).
                     attack_cmd = CmdAttack()
                     attack_cmd.caller = current_aimer_for_break_attempt
-                    attack_cmd.args = caller.key  # Target is the caller who failed to flee
+                    attack_cmd.pre_resolved_target = caller
+                    attack_cmd.args = caller.get_display_name(
+                        current_aimer_for_break_attempt)
                     attack_cmd.cmdstring = "attack"
                     
                     # Display messages about the aimer's opportunity attack

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1225,9 +1225,23 @@ class Character(
         dest_name = (
             destination.get_display_name(self) if destination else "somewhere"
         )
-        template = (
-            f"{{actor}} is leaving {origin_name}, heading for {dest_name}."
-        )
+        if dest_name == origin_name:
+            # Adjacent rooms sharing a display name (street segments) read
+            # absurd as "leaving X, heading for X" — name the DIRECTION.
+            direction = None
+            for ex in getattr(self.location, "exits", []) or []:
+                if getattr(ex, "destination", None) == destination:
+                    direction = ex.key
+                    break
+            template = (
+                f"{{actor}} is leaving {origin_name}, heading {direction}."
+                if direction else
+                f"{{actor}} is moving on down {origin_name}."
+            )
+        else:
+            template = (
+                f"{{actor}} is leaving {origin_name}, heading for {dest_name}."
+            )
         exclude = [self]
         if self.db.hidden is True:
             # A hidden mover's departure only reaches those tracking them —
@@ -1276,9 +1290,23 @@ class Character(
             else "somewhere"
         )
         dest_name = self.location.get_display_name(self)
-        template = (
-            f"{{actor}} arrives to {dest_name} from {origin_name}."
-        )
+        if origin_name == dest_name:
+            # Same-named street segments: name the direction they came
+            # from (the exit here that leads back the way they came).
+            direction = None
+            for ex in getattr(self.location, "exits", []) or []:
+                if getattr(ex, "destination", None) == source_location:
+                    direction = ex.key
+                    break
+            template = (
+                f"{{actor}} arrives from the {direction}."
+                if direction else
+                f"{{actor}} arrives, moving along {dest_name}."
+            )
+        else:
+            template = (
+                f"{{actor}} arrives to {dest_name} from {origin_name}."
+            )
         exclude = [self]
         if self.db.hidden is True:
             # A sneaking arrival isn't announced — the fresh hide contest in

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -1116,14 +1116,38 @@ def detect_and_remove_orphaned_combatants(handler):
         is_grappling = entry.get(DB_GRAPPLING_DBREF) is not None
         is_grappled = entry.get(DB_GRAPPLED_BY_DBREF) is not None
         is_targeted = char_dbref in targeted_dbrefs
-        
+
+        # AIM is a first-class combat relationship (#1002): someone with a
+        # bead drawn — or someone under another's bead — is engaged and must
+        # NOT be swept. Without this, a target who yields (comply reaction ->
+        # no target) or whose attacker switches aim reads as "orphaned" and
+        # is ejected + un-aim-locked, so it strolls out of a fight it's very
+        # much still in. Aiming/aimed-at keeps it held.
+        #
+        # LIVENESS-CHECKED, not just present: clear_aim_state clears a
+        # character's own fields but NOT the reciprocal on the other party,
+        # so a bare `aimed_at_by`/`aiming_at` can go stale (aimer gone, or
+        # switched targets). A stale ref must NOT make a combatant
+        # un-orphanable forever — so we require the relationship to be
+        # mutually live (both present, same room, reciprocally pointed).
+        aim_target = getattr(char.ndb, NDB_AIMING_AT, None)
+        is_aiming = bool(
+            aim_target is not None
+            and getattr(aim_target, "location", None) == char.location)
+        aimer = getattr(char.ndb, NDB_AIMED_AT_BY, None)
+        is_aimed_at = bool(
+            aimer is not None
+            and getattr(aimer, "location", None) == char.location
+            and getattr(aimer.ndb, NDB_AIMING_AT, None) == char)
+
         # Yielding status for context logging (but not considered in orphan check)
         is_yielding = entry.get(DB_IS_YIELDING, False)
-        
+
         # If combatant has no combat relationships, they are orphaned
-        if not (has_target or is_grappling or is_grappled or is_targeted):
+        if not (has_target or is_grappling or is_grappled or is_targeted
+                or is_aiming or is_aimed_at):
             yield_context = " (yielding)" if is_yielding else " (not yielding)"
-            splattercast.msg(f"ORPHAN_DETECT: {char.key} is orphaned{yield_context} - no target, not grappling, not grappled, not targeted")
+            splattercast.msg(f"ORPHAN_DETECT: {char.key} is orphaned{yield_context} - no target, not grappling, not grappled, not targeted, not aiming/aimed-at")
             orphaned_chars.append(char)
     
     # Remove all orphaned combatants

--- a/world/tests/test_orphan_aim.py
+++ b/world/tests/test_orphan_aim.py
@@ -1,0 +1,94 @@
+"""Orphan sweep respects AIM as a combat relationship (#1002).
+
+The perfect storm: comply/flee reactions drop a target's target_dbref, so the
+per-round orphan sweep ejected them (clearing combat + aim-lock) and they
+walked out of a fight they were still in. Aim now holds them — but only when
+the aim is LIVE (no immortal handlers from stale refs).
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from world.combat.constants import (
+    DB_CHAR, DB_GRAPPLED_BY_DBREF, DB_GRAPPLING_DBREF, DB_TARGET_DBREF,
+    NDB_AIMED_AT_BY, NDB_AIMING_AT,
+)
+import world.combat.utils as cu
+
+
+def _entry(char, target=None):
+    return {DB_CHAR: char, DB_TARGET_DBREF: target,
+            DB_GRAPPLING_DBREF: None, DB_GRAPPLED_BY_DBREF: None}
+
+
+def _char(dbref):
+    c = MagicMock()
+    c.key = f"char{dbref}"
+    c._dbref = dbref
+    # bare ndb: nothing aiming by default
+    for attr in (NDB_AIMING_AT, NDB_AIMED_AT_BY):
+        setattr(c.ndb, attr, None)
+    c.location = "room"
+    return c
+
+
+class TestOrphanAim(TestCase):
+    def _run(self, handler):
+        """Call the real detector with dbref plumbing patched to our fakes."""
+        removed = []
+        orig_remove = cu.remove_combatant
+        cu.remove_combatant = lambda h, ch: removed.append(ch)
+        orig_dbref = cu.get_character_dbref
+        cu.get_character_dbref = lambda ch: getattr(ch, "_dbref", None)
+        try:
+            cu.detect_and_remove_orphaned_combatants(handler)
+        finally:
+            cu.remove_combatant = orig_remove
+            cu.get_character_dbref = orig_dbref
+        return removed
+
+    def _handler(self, entries):
+        h = MagicMock()
+        h.db.combatants = entries
+        return h
+
+    def test_yielding_no_target_is_orphaned_without_aim(self):
+        # baseline: the storm as-was — a complied NPC (no target, not
+        # targeted, no aim) is swept.
+        a = _char(1)
+        removed = self._run(self._handler([_entry(a, target=None)]))
+        self.assertIn(a, removed)
+
+    def test_aimed_at_target_is_held(self):
+        # aggressor A aims at B; B yields (no target). B must NOT be swept.
+        a, b = _char(1), _char(2)
+        setattr(a.ndb, NDB_AIMING_AT, b)
+        setattr(b.ndb, NDB_AIMED_AT_BY, a)
+        entries = [_entry(a, target=None), _entry(b, target=None)]
+        removed = self._run(self._handler(entries))
+        self.assertNotIn(b, removed)      # held at gunpoint
+        self.assertNotIn(a, removed)      # aiming = engaged
+
+    def test_stale_aimed_at_is_still_orphaned(self):
+        # B thinks it's aimed at by A, but A is gone (not reciprocally
+        # aiming) — must NOT become immortal.
+        a, b = _char(1), _char(2)
+        setattr(b.ndb, NDB_AIMED_AT_BY, a)   # stale: A doesn't aim back
+        setattr(a.ndb, NDB_AIMING_AT, None)
+        removed = self._run(self._handler([_entry(b, target=None)]))
+        self.assertIn(b, removed)
+
+    def test_aimer_in_other_room_does_not_hold(self):
+        a, b = _char(1), _char(2)
+        a.location = "elsewhere"
+        setattr(a.ndb, NDB_AIMING_AT, b)
+        setattr(b.ndb, NDB_AIMED_AT_BY, a)
+        removed = self._run(self._handler([_entry(b, target=None)]))
+        self.assertIn(b, removed)          # aimer not present -> not live
+
+    def test_targeted_combatant_still_safe(self):
+        # regression: normal targeting still prevents orphaning.
+        a, b = _char(1), _char(2)
+        entries = [_entry(a, target=2), _entry(b, target=None)]
+        removed = self._run(self._handler(entries))
+        self.assertNotIn(b, removed)       # b is targeted by a


### PR DESCRIPTION
Closes #1002

- detect_and_remove_orphaned_combatants no longer ejects a combatant
  that is aiming at someone or under someone's LIVE bead (both present,
  same room, reciprocally pointed) — so a surrendered-at-gunpoint target
  stays in combat and keeps its aim-lock instead of being swept +
  un-aim-locked and strolling off via dispatch. Liveness-checked to
  avoid immortal handlers from stale aim refs (clear_aim_state doesn't
  clear the reciprocal).
- rider: flee opportunity-attack passes the RESOLVED target, not the raw
  key (fixes the "Neil DeMarco" identity leak/failure)
- rider: same-named adjacent street segments announce the DIRECTION, not
  "leaving X, heading for X"

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
