### PR TITLE
Revert #1004 (proximity as orphan relationship — overbroad, unvetted)

### DIFF
--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -1140,23 +1140,12 @@ def detect_and_remove_orphaned_combatants(handler):
             and getattr(aimer, "location", None) == char.location
             and getattr(aimer.ndb, NDB_AIMING_AT, None) == char)
 
-        # MELEE PROXIMITY is the close-quarters twin of aim (#1002): proximity
-        # is only ever established by combat (advance/charge/grapple), so
-        # being in someone's face IS being in the fight. A yielder held at
-        # melee range must no more be swept than one held at gunpoint. Live
-        # partner required (proximity is same-room and cleared on move, but
-        # guard against a stale set member all the same).
-        prox = getattr(char.ndb, NDB_PROXIMITY, None)
-        is_in_proximity = bool(
-            prox and any(getattr(o, "location", None) == char.location
-                         for o in prox))
-
         # Yielding status for context logging (but not considered in orphan check)
         is_yielding = entry.get(DB_IS_YIELDING, False)
 
         # If combatant has no combat relationships, they are orphaned
         if not (has_target or is_grappling or is_grappled or is_targeted
-                or is_aiming or is_aimed_at or is_in_proximity):
+                or is_aiming or is_aimed_at):
             yield_context = " (yielding)" if is_yielding else " (not yielding)"
             splattercast.msg(f"ORPHAN_DETECT: {char.key} is orphaned{yield_context} - no target, not grappling, not grappled, not targeted, not aiming/aimed-at")
             orphaned_chars.append(char)

--- a/world/tests/test_orphan_aim.py
+++ b/world/tests/test_orphan_aim.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 
 from world.combat.constants import (
     DB_CHAR, DB_GRAPPLED_BY_DBREF, DB_GRAPPLING_DBREF, DB_TARGET_DBREF,
-    NDB_AIMED_AT_BY, NDB_AIMING_AT, NDB_PROXIMITY,
+    NDB_AIMED_AT_BY, NDB_AIMING_AT,
 )
 import world.combat.utils as cu
 
@@ -26,7 +26,7 @@ def _char(dbref):
     c.key = f"char{dbref}"
     c._dbref = dbref
     # bare ndb: nothing aiming by default
-    for attr in (NDB_AIMING_AT, NDB_AIMED_AT_BY, NDB_PROXIMITY):
+    for attr in (NDB_AIMING_AT, NDB_AIMED_AT_BY):
         setattr(c.ndb, attr, None)
     c.location = "room"
     return c
@@ -92,48 +92,3 @@ class TestOrphanAim(TestCase):
         entries = [_entry(a, target=2), _entry(b, target=None)]
         removed = self._run(self._handler(entries))
         self.assertNotIn(b, removed)       # b is targeted by a
-
-
-class TestOrphanProximity(TestCase):
-    """Melee proximity is a combat relationship (only combat establishes it),
-    so a yielder held at melee range must not be swept — the close-quarters
-    twin of the aim hold."""
-
-    def _run(self, handler):
-        removed = []
-        orig_remove = cu.remove_combatant
-        cu.remove_combatant = lambda h, ch: removed.append(ch)
-        orig_dbref = cu.get_character_dbref
-        cu.get_character_dbref = lambda ch: getattr(ch, "_dbref", None)
-        try:
-            cu.detect_and_remove_orphaned_combatants(handler)
-        finally:
-            cu.remove_combatant = orig_remove
-            cu.get_character_dbref = orig_dbref
-        return removed
-
-    def _handler(self, entries):
-        h = MagicMock(); h.db.combatants = entries
-        return h
-
-    def test_in_melee_proximity_is_held(self):
-        a, b = _char(1), _char(2)
-        setattr(a.ndb, NDB_PROXIMITY, {b})
-        setattr(b.ndb, NDB_PROXIMITY, {a})
-        entries = [_entry(a, target=None), _entry(b, target=None)]
-        removed = self._run(self._handler(entries))
-        self.assertNotIn(b, removed)
-        self.assertNotIn(a, removed)
-
-    def test_stale_proximity_partner_gone_is_orphaned(self):
-        a, b = _char(1), _char(2)
-        b.location = "elsewhere"          # partner not present
-        setattr(a.ndb, NDB_PROXIMITY, {b})
-        removed = self._run(self._handler([_entry(a, target=None)]))
-        self.assertIn(a, removed)
-
-    def test_empty_proximity_set_is_orphaned(self):
-        a = _char(1)
-        setattr(a.ndb, NDB_PROXIMITY, set())
-        removed = self._run(self._handler([_entry(a, target=None)]))
-        self.assertIn(a, removed)


### PR DESCRIPTION
Reverts #1004. Proximity is a muddy multi-source signal (grapple/advance/charge all establish it) and passive/lingering, unlike aim's active deliberate hold — treating it as 'in combat' for orphan detection is overbroad and risks holding zombie handlers open. The change was shipped off a question, not a decision, and wants a proper deep-dive on the combat model before anything like it lands. The authorized aim fix (#1003) stays.