### PR TITLE
Radio Phase 1 core: device-gated voice radio (transmit/tune/toggle)

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -107,6 +107,17 @@ class CmdTo(Command):
         if not target:
             return  # search() already sent the error message
 
+        # `to <radio>, <message>` transmits over the device (RADIO_COMMS_SPEC):
+        # the directed-speech verb, retargeted at a comm device you carry.
+        from world.radio import is_radio, transmit
+        if is_radio(target):
+            if target not in caller.contents:
+                caller.msg(f"You aren't carrying "
+                           f"{target.get_display_name(caller)}.")
+                return
+            transmit(caller, speech, target)
+            return
+
         # Actor sees their own message; the room hears it through the shared
         # speech backbone. `to` is just `say` with a target: the addressee is
         # rendered "you", and the structured payload marks them `addressed` so

--- a/commands/CmdRadio.py
+++ b/commands/CmdRadio.py
@@ -1,0 +1,176 @@
+"""Device comms verbs — ``transmit`` / ``tune`` / ``toggle`` (RADIO_COMMS_SPEC
+Phase 1). Device-general on purpose: radio is the first consumer, but the
+verbs resolve any duck-typed device (``db.is_radio`` today) so future gear
+reuses them. Receiving is command-less — a powered, tuned radio echoes
+matching traffic to its holder (see ``world/radio.py``)."""
+
+from evennia import Command
+
+from world.radio import (
+    SCAN, active_transmit_radio, frequency_of, is_powered, is_radio,
+    is_scanning, transmit,
+)
+
+
+def _resolve_device(caller, phrase, *, require_radio=True):
+    """A device the caller can see. ``require_radio`` filters to comm gear."""
+    obj = caller.search(phrase)
+    if obj is None:
+        return None
+    if require_radio and not is_radio(obj):
+        caller.msg(f"{obj.get_display_name(caller)} isn't a comm device.")
+        return None
+    return obj
+
+
+class CmdTransmit(Command):
+    """
+    Speak over a radio (or other comm device).
+
+    Usage:
+        transmit <message>
+        transmit <message> on <device>
+        xmit <message>            (alias: xm)
+
+    Sends your words over the air on the device's tuned frequency — everyone
+    with a powered radio on that band hears you, recognised by voice (a
+    modulator hides you). With no device named, it uses a radio you're
+    WEARING first, then one in your HAND; you can't transmit through a radio
+    that's only in your pocket.
+
+    Directed speech works too: ``to <radio>, <message>`` transmits the same way.
+    """
+
+    key = "transmit"
+    aliases = ["xmit", "xm"]
+    locks = "cmd:all()"
+    help_category = "Social"
+
+    def parse(self):
+        raw = (self.args or "").strip()
+        self.message = self.device_phrase = ""
+        # "<message> on <device>" — split on the LAST " on " so the message
+        # can contain the word "on".
+        low = raw.lower()
+        idx = low.rfind(" on ")
+        if idx != -1:
+            self.message = raw[:idx].strip()
+            self.device_phrase = raw[idx + 4:].strip()
+        else:
+            self.message = raw
+
+    def func(self):
+        caller = self.caller
+        if not self.message:
+            caller.msg("Transmit what?")
+            return
+        if self.device_phrase:
+            device = _resolve_device(caller, self.device_phrase)
+            if device is None:
+                return
+            if device not in caller.contents:
+                caller.msg(f"You aren't carrying "
+                           f"{device.get_display_name(caller)}.")
+                return
+        else:
+            device = active_transmit_radio(caller)
+            if device is None:
+                caller.msg("You have no radio worn or in hand to transmit "
+                           "with.")
+                return
+        transmit(caller, self.message, device)
+
+
+class CmdTune(Command):
+    """
+    Tune a radio to a frequency — or set it sweeping.
+
+    Usage:
+        tune <device> to <frequency>
+        tune <device> <frequency>
+        tune <device> to scan
+
+    A frequency is any band number. ``scan`` sets the radio sweeping every
+    band — it echoes whatever it catches, tagged with the frequency it caught
+    it on, so you can note the number and tune to it. A sweeping radio can't
+    transmit; tune it to a band first.
+    """
+
+    key = "tune"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def parse(self):
+        raw = (self.args or "").strip()
+        self.device_phrase = self.freq = ""
+        if " to " in raw:
+            dev, _, freq = raw.partition(" to ")
+            self.device_phrase, self.freq = dev.strip(), freq.strip()
+        else:
+            parts = raw.rsplit(None, 1)
+            if len(parts) == 2:
+                self.device_phrase, self.freq = parts[0].strip(), parts[1].strip()
+            else:
+                self.device_phrase = raw
+
+    def func(self):
+        caller = self.caller
+        if not self.device_phrase or not self.freq:
+            caller.msg("Usage: tune <device> to <frequency>")
+            return
+        device = _resolve_device(caller, self.device_phrase)
+        if device is None:
+            return
+        freq = self.freq.lower()
+        if freq == SCAN:
+            device.db.frequency = SCAN
+            caller.msg(f"You set {device.get_display_name(caller)} sweeping "
+                       f"the bands.")
+            return
+        device.db.frequency = freq
+        state = "" if is_powered(device) else " (it's switched off)"
+        caller.msg(f"You tune {device.get_display_name(caller)} to "
+                   f"{freq}{state}.")
+
+
+class CmdToggle(Command):
+    """
+    Switch a device on or off.
+
+    Usage:
+        toggle <device>            (flips it)
+        toggle <device> on
+        toggle <device> off
+
+    A radio must be on to hear traffic or transmit. A powered radio is also
+    audible — worth remembering if you're trying not to be found.
+    """
+
+    key = "toggle"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def parse(self):
+        raw = (self.args or "").strip()
+        self.device_phrase, self.state = raw, None
+        parts = raw.rsplit(None, 1)
+        if len(parts) == 2 and parts[1].lower() in ("on", "off"):
+            self.device_phrase, self.state = parts[0].strip(), parts[1].lower()
+
+    def func(self):
+        caller = self.caller
+        if not self.device_phrase:
+            caller.msg("Toggle what?")
+            return
+        device = _resolve_device(caller, self.device_phrase, require_radio=False)
+        if device is None:
+            return
+        if not hasattr(device.db, "radio_on") and not is_radio(device):
+            caller.msg(f"{device.get_display_name(caller)} has nothing to "
+                       f"switch.")
+            return
+        want_on = (not is_powered(device)) if self.state is None \
+            else (self.state == "on")
+        device.db.radio_on = want_on
+        caller.msg(f"You switch {device.get_display_name(caller)} "
+                   f"{'on' if want_on else 'off'}.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -41,6 +41,7 @@ from commands.CmdFollow import (
 )
 from commands.CmdStealth import CmdHide, CmdSearch, CmdSneak, CmdUnhide
 from commands.CmdTheft import CmdPickpocket, CmdSteal
+from commands.CmdRadio import CmdTransmit, CmdTune, CmdToggle
 from commands.combat.cmdset_combat import CombatCmdSet
 from commands.combat.special_actions import CmdAim, CmdGrapple
 from commands.CmdThrow import CmdThrow, CmdPull, CmdCatch
@@ -192,6 +193,13 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         # contest pointed at taking things.
         self.add(CmdSteal())
         self.add(CmdPickpocket())
+
+        # Comm devices (RADIO_COMMS_SPEC Phase 1): transmit/tune/toggle,
+        # device-general (radio is the first consumer). `to <radio>, msg`
+        # also transmits (CmdTo retarget).
+        self.add(CmdTransmit())
+        self.add(CmdTune())
+        self.add(CmdToggle())
         
         # Add aim command for ranged combat preparation
         self.add(CmdAim())

--- a/specs/proposals/RADIO_COMMS_SPEC.md
+++ b/specs/proposals/RADIO_COMMS_SPEC.md
@@ -1,6 +1,8 @@
 # Radio Comms Spec — The Colony's Primary Communications
 
-> **Status:** 📋 Proposal — not implemented. **PHASE 1 SCOPED & DECIDED
+> **Status:** 🚧 **PHASE 1 CORE SHIPPED (2026-07-04): player-facing radio is LIVE** — `world/radio.py` (single staff-locked channel + device-gated voice echo), `Radio` typeclass + `WALKIE_TALKIE` prototype, `transmit`/`xmit`/`xm` + `to <radio>,` retarget, `tune <device> to <freq|scan>`, `toggle <device> [on/off]`, state-aware look-readout (frequency shown only when powered). Voice-attributed (recognition on the air, modulator-defeatable), hearing-gated, every powered carried radio receives its band (scan catches all, freq-tagged). **NOT YET: the witness/dispatch links ride radio** (next slice — rewire `witness.py`/dispatch to transmit-if-deviced), device acquisition placement (vendor/loot/spawn kit), and all Phase 2 (antennae/range/battery/jamming/encryption). Original scoping below.
+>
+> **PHASE 1 SCOPED & DECIDED
 > (2026-07-03, §7): buildable now, vertical-independent** — devices +
 > channel-system backend + voice-over-radio + the witness-report and
 > dispatch-order links. Phase 2 (range/antennae/coverage) waits on the

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -598,12 +598,45 @@ class Item(DefaultObject):
         super().at_delete()
 
 
+class Radio(Item):
+    """A comm device — a walkie-talkie (RADIO_COMMS_SPEC Phase 1).
+
+    Powered on/off (``db.radio_on``), tuned to a frequency (``db.frequency``,
+    or the special ``"scan"`` sweep). A powered, tuned radio echoes matching
+    traffic to whoever carries it (``world/radio.py``); the ``transmit`` /
+    ``tune`` / ``toggle`` verbs drive it. The state readout is on the FACE —
+    visible only when powered; a dark display tells you nothing.
+    """
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.is_radio = True
+        self.db.radio_on = False
+        self.db.frequency = None
+
+    def return_appearance(self, looker, **kwargs):
+        appearance = super().return_appearance(looker, **kwargs)
+        if getattr(self.db, "radio_on", False):
+            from world.radio import SCAN
+            freq = self.db.frequency
+            if freq == SCAN:
+                readout = "SWEEP — cycling the bands"
+            elif freq:
+                readout = f"{freq}, receiving"
+            else:
+                readout = "on, untuned"
+            appearance += f"\n\n|cThe display glows: {readout}.|n"
+        else:
+            appearance += "\n\n|xThe display is dark.|n"
+        return appearance
+
+
 class SprayCanItem(Item):
     """
     Spray paint can for graffiti system.
     Contains finite paint and selectable colors.
     """
-    
+
     def at_object_creation(self):
         """Initialize spray can with paint and color attributes."""
         super().at_object_creation()

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3962,3 +3962,24 @@ HIGH_TOPS = {
         ("weight", 0.6),
     ],
 }
+
+
+# ==========================================================================
+# COMM DEVICES (RADIO_COMMS_SPEC Phase 1)
+# ==========================================================================
+
+WALKIE_TALKIE = {
+    "prototype_key": "WALKIE_TALKIE",
+    "typeclass": "typeclasses.items.Radio",
+    "key": "a battered walkie-talkie",
+    "aliases": ["walkie", "walkie-talkie", "radio", "handset"],
+    "desc": ("A knock-around handheld transceiver in scuffed high-impact "
+             "plastic, its stubby antenna taped at the base and a rubberised "
+             "push-to-talk worn pale by a thousand thumbs. A small monochrome "
+             "display sits above the dial."),
+    "attrs": [
+        ("is_radio", True),
+        ("radio_on", False),
+        ("frequency", None),
+    ],
+}

--- a/world/radio.py
+++ b/world/radio.py
@@ -1,0 +1,211 @@
+"""Radio — the colony's primary comms (RADIO_COMMS_SPEC Phase 1).
+
+Radio is PHYSICAL and DEVICE-GATED (Option A): a transmission reaches every
+powered walkie tuned to its frequency (the network is assumed present until
+Phase 2 makes range/antennae geography). No device — snatched, off, wrong
+band — no signal.
+
+**Backend (§6.1): one channel, the walkie sorts it out.** A single staff-
+locked Evennia Channel ("Radio") carries ALL traffic tagged with frequency —
+the admin's whole-grid monitor and single chronological log. Players never
+subscribe: a tuned, powered walkie **echoes** matching traffic to its holder,
+re-rendered through the voice rails (voice recognition on the air; a modulator
+defeats it; hearing-gated; attributed by VOICE only — you can't see who's on
+the far end).
+
+Devices are duck-typed (`db.is_radio`), so the transmit/tune/toggle verbs
+generalise to any future comm gear.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+RADIO_CHANNEL_KEY = "Radio"
+#: The special "frequency" that receives every band (scanner sweep mode).
+SCAN = "scan"
+
+
+# --------------------------------------------------------------------------
+# Device predicates & state
+# --------------------------------------------------------------------------
+
+def is_radio(obj: Any) -> bool:
+    """Duck-typed: a comm device that transmits/receives on a frequency.
+    Strict ``is True`` — the flag is only ever written as a literal, so a
+    non-radio's absent/mock attribute never reads as one."""
+    return getattr(getattr(obj, "db", None), "is_radio", False) is True
+
+
+def is_powered(device: Any) -> bool:
+    return getattr(getattr(device, "db", None), "radio_on", False) is True
+
+
+def frequency_of(device: Any) -> Optional[str]:
+    return getattr(getattr(device, "db", None), "frequency", None)
+
+
+def is_scanning(device: Any) -> bool:
+    return frequency_of(device) == SCAN
+
+
+# --------------------------------------------------------------------------
+# Which device a character uses (worn first, then held)
+# --------------------------------------------------------------------------
+
+def _worn_radios(char: Any) -> list:
+    get_worn = getattr(char, "get_worn_items", None)
+    worn = get_worn() if callable(get_worn) else []
+    return [i for i in (worn or []) if is_radio(i)]
+
+
+def _held_radios(char: Any) -> list:
+    hands = getattr(char, "hands", None) or {}
+    seen, out = set(), []
+    for item in hands.values():
+        if is_radio(item) and id(item) not in seen:
+            seen.add(id(item))
+            out.append(item)
+    return out
+
+
+def active_transmit_radio(char: Any) -> Optional[Any]:
+    """The device a ``transmit`` defaults to: a WORN radio first, then a HELD
+    one. Returns None if the character has neither worn nor held — a radio
+    merely carried in a pocket can receive but not be spoken through
+    (spec: 'unable to use the command unless it's worn or held')."""
+    worn = _worn_radios(char)
+    if worn:
+        return worn[0]
+    held = _held_radios(char)
+    return held[0] if held else None
+
+
+def carried_radios(char: Any) -> list:
+    """Every radio in the character's possession (worn, held, or pocketed) —
+    all of them receive, so a captured second walkie on another band is a
+    listening post for free."""
+    out, seen = [], set()
+    for item in getattr(char, "contents", []) or []:
+        if is_radio(item) and id(item) not in seen:
+            seen.add(id(item))
+            out.append(item)
+    return out
+
+
+# --------------------------------------------------------------------------
+# The channel (staff monitor + log)
+# --------------------------------------------------------------------------
+
+def get_radio_channel() -> Optional[Any]:
+    """The single staff-locked channel carrying all traffic. Created on first
+    use; players never subscribe (they hear via a walkie echo)."""
+    try:
+        from evennia.comms.models import ChannelDB
+        from evennia import create_channel
+        chan = ChannelDB.objects.get_channel(RADIO_CHANNEL_KEY)
+        if not chan:
+            chan = create_channel(
+                RADIO_CHANNEL_KEY,
+                locks=("control:perm(Admin);listen:perm(Builder);"
+                       "send:false()"),
+                desc="Colony radio grid — all frequencies (staff monitor).",
+            )
+        return chan
+    except Exception:  # noqa: BLE001 — the log is a convenience, never load-bearing
+        return None
+
+
+def _log_to_channel(speaker: Any, message: str, frequency: str) -> None:
+    chan = get_radio_channel()
+    if chan is None:
+        return
+    try:
+        from world.voice import get_voice_description
+        voice = get_voice_description(speaker) or "unknown voice"
+        name = getattr(speaker, "key", "?")
+        chan.msg(f"[{frequency}] {name} ({voice}): \"{message}\"")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# --------------------------------------------------------------------------
+# Transmit + echo
+# --------------------------------------------------------------------------
+
+def _all_powered_radios():
+    """Every powered radio in the world (attribute-scoped query). Range is
+    abstracted in P1, so a transmission reaches all of them on-band."""
+    from evennia.objects.models import ObjectDB
+    return [o for o in ObjectDB.objects.filter(
+        db_attributes__db_key="is_radio").distinct()
+        if is_radio(o) and is_powered(o)]
+
+
+def _render_radio_line(speaker: Any, listener: Any, message: str,
+                       frequency: str, *, tagged: bool) -> str:
+    """A received transmission, VOICE-attributed (never sight — you can't see
+    the far end) and hearing-gated. ``tagged`` prefixes the frequency (scanner
+    sweep mode caught it off-band)."""
+    from world.perception import can_hear
+    from world.voice import (
+        attempt_voice_discern, get_voice_description, voice_phrase,
+    )
+    band = f"[{frequency}] " if tagged else ""
+    if not can_hear(listener):
+        return f"{band}Your radio crackles, but you can't make out a word."
+    # Attribution: a known voice names them; else the voice descriptor; else
+    # a bare "someone". Mirrors resolve_speaker_attribution's voice branch.
+    known = attempt_voice_discern(listener, speaker)
+    if known:
+        who = known
+    else:
+        desc = get_voice_description(speaker)
+        who = f"a {desc} voice" if desc else "an unfamiliar voice"
+    flavour = voice_phrase(speaker)
+    flav = f" |x*{flavour}*|n" if flavour else ""
+    return (f'{band}{who[:1].upper()}{who[1:]} crackles over the radio{flav}: '
+            f'"{message}"')
+
+
+def transmit(speaker: Any, message: str, device: Any) -> bool:
+    """Speaker transmits *message* over *device* on its tuned frequency.
+
+    Returns False (with the speaker messaged) if the device can't send —
+    off, or in scan mode (sweeping, not parked on a band). Otherwise posts to
+    the staff channel and echoes to every powered radio tuned to that
+    frequency (plus any radio in scan mode, which catches all bands)."""
+    if not is_powered(device):
+        speaker.msg(f"{device.get_display_name(speaker)} is switched off.")
+        return False
+    if is_scanning(device):
+        speaker.msg(f"{device.get_display_name(speaker)} is sweeping — "
+                    f"tune it to a frequency before you transmit.")
+        return False
+    frequency = frequency_of(device)
+    if not frequency:
+        speaker.msg(f"{device.get_display_name(speaker)} isn't tuned to "
+                    f"anything.")
+        return False
+
+    speaker.msg(f'You transmit on {frequency}: "{message}"')
+    _log_to_channel(speaker, message, frequency)
+
+    for radio in _all_powered_radios():
+        if radio is device:
+            continue
+        scanning = is_scanning(radio)
+        if not scanning and frequency_of(radio) != frequency:
+            continue
+        holder = radio.location
+        if holder is None or not hasattr(holder, "msg"):
+            continue  # a radio on the ground squawks to nobody in P1
+        if holder is speaker:
+            continue
+        try:
+            holder.msg(_render_radio_line(
+                speaker, holder, message, frequency, tagged=scanning),
+                type="radio", from_obj=speaker)
+        except Exception:  # noqa: BLE001 — one bad listener never stops the net
+            continue
+    return True

--- a/world/tests/test_radio.py
+++ b/world/tests/test_radio.py
@@ -1,0 +1,199 @@
+"""Radio Phase 1 (world/radio.py + commands/CmdRadio.py) — RADIO_COMMS_SPEC.
+
+The device-gated echo: powered walkie tuned to a frequency hears matching
+traffic, voice-attributed and hearing-gated; transmit defaults worn→held;
+scan catches all bands; the `to`-retarget transmits.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.radio as radio
+from world.radio import (
+    SCAN, active_transmit_radio, is_radio, is_scanning, transmit,
+)
+
+
+def _radio(on=True, freq="447"):
+    r = MagicMock()
+    r.db.is_radio = True
+    r.db.radio_on = on
+    r.db.frequency = freq
+    return r
+
+
+def _char(worn=None, hands=None, contents=None):
+    c = MagicMock()
+    c.get_worn_items = lambda: (worn or [])
+    c.hands = hands or {}
+    c.contents = contents if contents is not None else []
+    c.get_display_name = lambda looker=None, **k: "a lean man"
+    return c
+
+
+class TestDevicePredicates(TestCase):
+    def test_is_radio(self):
+        self.assertTrue(is_radio(_radio()))
+        plain = MagicMock(); plain.db.is_radio = False
+        self.assertFalse(is_radio(plain))
+
+    def test_scan_mode(self):
+        self.assertTrue(is_scanning(_radio(freq=SCAN)))
+        self.assertFalse(is_scanning(_radio(freq="447")))
+
+    def test_transmit_device_prefers_worn_then_held(self):
+        worn, held = _radio(), _radio()
+        c = _char(worn=[worn], hands={"r": held})
+        self.assertIs(active_transmit_radio(c), worn)      # worn wins
+        c2 = _char(worn=[], hands={"r": held})
+        self.assertIs(active_transmit_radio(c2), held)     # else held
+        c3 = _char(worn=[], hands={})
+        self.assertIsNone(active_transmit_radio(c3))       # pocketed != usable
+
+
+class TestTransmit(TestCase):
+    def _world(self, listeners):
+        return patch.object(radio, "_all_powered_radios",
+                            return_value=listeners)
+
+    def test_matching_frequency_hears_voice_attributed(self):
+        speaker = _char()
+        dev = _radio(freq="447")
+        heard_radio = _radio(freq="447")
+        listener = MagicMock()
+        heard_radio.location = listener
+        with self._world([dev, heard_radio]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern",
+                      return_value=None), \
+                patch("world.voice.get_voice_description",
+                      return_value="gravelly"), \
+                patch("world.voice.voice_phrase", return_value=None):
+            ok = transmit(speaker, "rendezvous at the docks", dev)
+        self.assertTrue(ok)
+        line = listener.msg.call_args.args[0]
+        self.assertIn("A gravelly voice crackles over the radio", line)
+        self.assertIn("rendezvous at the docks", line)
+
+    def test_known_voice_names_the_speaker(self):
+        speaker = _char()
+        dev, heard = _radio(freq="447"), _radio(freq="447")
+        listener = MagicMock(); heard.location = listener
+        with self._world([dev, heard]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern",
+                      return_value="Roony"), \
+                patch("world.voice.voice_phrase", return_value=None):
+            transmit(speaker, "hi", dev)
+        self.assertIn("Roony crackles over the radio",
+                      listener.msg.call_args.args[0])
+
+    def test_off_band_radio_does_not_hear(self):
+        speaker = _char()
+        dev, off_band = _radio(freq="447"), _radio(freq="891")
+        listener = MagicMock(); off_band.location = listener
+        with self._world([dev, off_band]), \
+                patch.object(radio, "_log_to_channel"):
+            transmit(speaker, "hi", dev)
+        listener.msg.assert_not_called()
+
+    def test_scanning_radio_catches_all_bands_tagged(self):
+        speaker = _char()
+        dev, scanner = _radio(freq="447"), _radio(freq=SCAN)
+        listener = MagicMock(); scanner.location = listener
+        with self._world([dev, scanner]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern", return_value=None), \
+                patch("world.voice.get_voice_description",
+                      return_value="flat"), \
+                patch("world.voice.voice_phrase", return_value=None):
+            transmit(speaker, "come in", dev)
+        self.assertIn("[447]", listener.msg.call_args.args[0])   # freq-tagged
+
+    def test_deaf_listener_gets_static(self):
+        speaker = _char()
+        dev, heard = _radio(freq="447"), _radio(freq="447")
+        listener = MagicMock(); heard.location = listener
+        with self._world([dev, heard]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.perception.can_hear", return_value=False):
+            transmit(speaker, "secret", dev)
+        line = listener.msg.call_args.args[0]
+        self.assertIn("crackles", line)
+        self.assertNotIn("secret", line)
+
+    def test_off_device_refuses_transmit(self):
+        speaker = _char()
+        dev = _radio(on=False, freq="447")
+        with patch.object(radio, "_all_powered_radios", return_value=[]):
+            self.assertFalse(transmit(speaker, "hi", dev))
+        self.assertIn("switched off", speaker.msg.call_args.args[0])
+
+    def test_scanning_device_refuses_transmit(self):
+        speaker = _char()
+        dev = _radio(freq=SCAN)
+        self.assertFalse(transmit(speaker, "hi", dev))
+        self.assertIn("sweeping", speaker.msg.call_args.args[0])
+
+
+class TestCommands(TestCase):
+    def test_transmit_parses_on_device(self):
+        from commands.CmdRadio import CmdTransmit
+        cmd = CmdTransmit()
+        cmd.args = "meet at the docks on the black handset"
+        cmd.parse()
+        self.assertEqual(cmd.message, "meet at the docks")
+        self.assertEqual(cmd.device_phrase, "the black handset")
+
+    def test_transmit_no_radio_worn_or_held(self):
+        from commands.CmdRadio import CmdTransmit
+        cmd = CmdTransmit()
+        cmd.caller = _char(worn=[], hands={})
+        cmd.args = "hello"
+        cmd.parse()
+        cmd.func()
+        self.assertIn("no radio worn or in hand",
+                      cmd.caller.msg.call_args.args[0])
+
+    def test_tune_parses_to_and_bare(self):
+        from commands.CmdRadio import CmdTune
+        for args in ("walkie to 447", "walkie 447"):
+            cmd = CmdTune(); cmd.args = args; cmd.parse()
+            self.assertEqual(cmd.device_phrase, "walkie")
+            self.assertEqual(cmd.freq, "447")
+
+    def test_tune_to_scan(self):
+        from commands.CmdRadio import CmdTune
+        dev = _radio()
+        cmd = CmdTune(); cmd.args = "walkie to scan"
+        cmd.caller = MagicMock(); cmd.caller.search.return_value = dev
+        cmd.parse(); cmd.func()
+        self.assertEqual(dev.db.frequency, SCAN)
+
+    def test_toggle_flip_and_explicit(self):
+        from commands.CmdRadio import CmdToggle
+        dev = _radio(on=False)
+        cmd = CmdToggle(); cmd.args = "walkie"
+        cmd.caller = MagicMock(); cmd.caller.search.return_value = dev
+        cmd.parse(); cmd.func()
+        self.assertTrue(dev.db.radio_on)          # flipped on
+        cmd2 = CmdToggle(); cmd2.args = "walkie off"
+        cmd2.caller = MagicMock(); cmd2.caller.search.return_value = dev
+        cmd2.parse(); cmd2.func()
+        self.assertFalse(dev.db.radio_on)         # explicit off
+
+    def test_to_retarget_transmits(self):
+        from commands.CmdCommunication import CmdTo
+        dev = _radio(freq="447")
+        caller = MagicMock()
+        caller.location = MagicMock()
+        caller.contents = [dev]
+        caller.search.return_value = dev
+        cmd = CmdTo(); cmd.caller = caller; cmd.args = "walkie, on my way"
+        with patch("world.stealth.break_stealth"), \
+                patch("world.radio.transmit") as tx:
+            cmd.func()
+        tx.assert_called_once_with(caller, "on my way", dev)


### PR DESCRIPTION
Closes #1006

- world/radio.py: staff-locked channel + device-gated echo; every
  powered carried walkie receives its band (scan = all, freq-tagged),
  voice-attributed (recognition/modulator) + hearing-gated; range
  abstracted (Option A)
- typeclasses.items.Radio + WALKIE_TALKIE prototype; look-readout
  visible only when powered
- device-general verbs: transmit/xmit/xm (worn->held default),
  tune <dev> to <freq|scan>, toggle <dev> [on/off]; `to <radio>,`
  retarget in CmdTo
- strict is-True device flags (mock/junk-data safe)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
