### PR TITLE
Radio Phase 1: witness report rides a real walkie + bot transceivers

### DIFF
--- a/world/director/population.py
+++ b/world/director/population.py
@@ -76,6 +76,20 @@ def factory_fit_armament(mob: Any, side: str = "right") -> None:
     mob.save_medical_state()
 
 
+def factory_fit_comms(mob: Any, side: str = "left") -> None:
+    """Seat the built-in comms module (transceiver) in an ear/antenna —
+    factory equipment like the riot gun. Tuned to the emergency band; the
+    radio receiver reads it via world.radio.comms_organ_frequency, so the
+    unit hears the net until the ear is destroyed/harvested."""
+    from world.medical.core import Organ
+    from world.prototypes import ROBOT_COMMS_MODULE_SPEC
+    spec = {k: (v.replace("{side}", side) if isinstance(v, str) else v)
+            for k, v in dict(ROBOT_COMMS_MODULE_SPEC).items()}
+    state = mob.medical_state
+    state.organs["comms_module"] = Organ("comms_module", organ_data=spec)
+    mob.save_medical_state()
+
+
 def spawn_secbot(location: Any, name: str | None = None) -> Any:
     """Build a complete security unit at *location*: robot species +
     LLMNpc brain + persona + role + factory armament, **posted to the
@@ -120,6 +134,10 @@ def spawn_secbot(location: Any, name: str | None = None) -> Any:
     try:
         factory_fit_armament(mob)
     except Exception:  # noqa: BLE001 — an unarmed unit still functions
+        pass
+    try:
+        factory_fit_comms(mob)   # built-in transceiver (one ear)
+    except Exception:  # noqa: BLE001 — a deaf unit still patrols
         pass
     # Belong to the base: post there; adopt the base's standing beat.
     base = get_security_base()

--- a/world/director/witness.py
+++ b/world/director/witness.py
@@ -75,6 +75,20 @@ def spawn_witness(location: Any) -> Any | None:
     # The visible tell — this is who saw you, and what they're about to do.
     witness.look_place = ("edging away from the scene, one hand on a "
                           "battered walkie-talkie.")
+    # The report rides a REAL device now (RADIO_COMMS_SPEC): a walkie tuned to
+    # the emergency band. Snatch or break it before the window closes and the
+    # report never goes out — a physical interdiction beside killing them. And
+    # robbing the witness nets you a walkie already tuned to the cop channel.
+    try:
+        from evennia.prototypes.spawner import spawn
+        from world.prototypes import WALKIE_TALKIE
+        from world.radio import EMERGENCY_BAND
+        walkie = spawn(WALKIE_TALKIE)[0]
+        walkie.location = witness
+        walkie.db.radio_on = True
+        walkie.db.frequency = EMERGENCY_BAND
+    except Exception:  # noqa: BLE001 — no device = they can't call it in
+        pass
     try:
         witness.execute_cmd(
             "emote flinches back from the scene, fumbling for a "
@@ -82,6 +96,21 @@ def spawn_witness(location: Any) -> Any | None:
     except Exception:  # noqa: BLE001
         pass
     return witness
+
+
+def _witness_walkie(witness: Any) -> Any | None:
+    """The witness's own working walkie — powered, on the emergency band, and
+    still in their possession. None once it's snatched or broken."""
+    try:
+        from world.radio import (
+            EMERGENCY_BAND, carried_radios, frequency_of, is_powered,
+        )
+        for radio in carried_radios(witness):
+            if is_powered(radio) and frequency_of(radio) == EMERGENCY_BAND:
+                return radio
+    except Exception:  # noqa: BLE001
+        pass
+    return None
 
 
 def can_report(witness: Any) -> bool:
@@ -106,7 +135,10 @@ def witness_report(witness: Any, event: Any) -> bool:
     whether the report went out."""
     from world.director.dispatch import raise_event
     reported = False
-    if can_report(witness):
+    walkie = _witness_walkie(witness)
+    # The report needs BOTH a live witness AND a working radio (§3): the force
+    # never learns if the witness is silenced OR the walkie is gone/broken.
+    if can_report(witness) and walkie is not None:
         try:
             witness.execute_cmd(
                 "emote raises the walkie-talkie and calls it in, voice "
@@ -114,16 +146,29 @@ def witness_report(witness: Any, event: Any) -> bool:
         except Exception:  # noqa: BLE001
             pass
         try:
-            raise_event(event)
+            from world.radio import transmit
+            transmit(witness, _report_line(witness), walkie)  # real air-traffic
+        except Exception:  # noqa: BLE001 — the transmission is best-effort...
+            pass
+        try:
+            raise_event(event)   # ...the dispatch response is what matters
             reported = True
         except Exception:  # noqa: BLE001 — a broken dispatch must not strand us
             pass
         flee_and_cower(witness)
     elif witness is not None:
-        # Silenced (dead/unconscious) — cleanup only; the dead belong to
-        # the corpse pipeline, the downed get hauled off eventually.
+        # Silenced — dead/unconscious OR the walkie snatched/broken. No report
+        # goes out; cleanup only (the dead belong to the corpse pipeline).
         delay(WITNESS_DESPAWN_DELAY, despawn_witness, witness)
     return reported
+
+
+def _report_line(witness: Any) -> str:
+    """What the witness says over the air — a rattled, unhelpful call-in
+    (no perp detail; the BOLO the force acts on rides the dispatch event)."""
+    where = getattr(getattr(witness, "location", None), "key", "the street")
+    return (f"Someone call it in — there's trouble on {where}, get a unit "
+            f"down here!")
 
 
 #: How far (straight-line rooms) the witness will run to find a corner.

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3983,3 +3983,18 @@ WALKIE_TALKIE = {
         ("frequency", None),
     ],
 }
+
+
+#: The security unit's built-in transceiver (RADIO_COMMS_SPEC §2.1): a comms
+#: module seated in an ear/antenna, factory-fit like the riot gun. Carries
+#: the radio metadata the receiver reads (`radio_frequency`); intact + on-band
+#: = the unit hears the net. Destroy/harvest the ear (medical hit-location)
+#: and the bot goes deaf — the EMP/mute seam, for free.
+ROBOT_COMMS_MODULE_SPEC = {
+    "container": "{side}_ear", "max_hp": 6, "hit_weight": "rare",
+    "inorganic": True, "prosthetic_frame": True,
+    "radio_frequency": "911MHz",   # the emergency band (world.radio)
+    "longdesc": ("Where the {side} ear should be, a mesh-grilled comms pod "
+                 "sits flush to the chassis, a stub antenna folded along the "
+                 "skull line."),
+}

--- a/world/radio.py
+++ b/world/radio.py
@@ -24,6 +24,9 @@ from typing import Any, Optional
 RADIO_CHANNEL_KEY = "Radio"
 #: The special "frequency" that receives every band (scanner sweep mode).
 SCAN = "scan"
+#: The colony's distress channel — witnesses call it in here, security
+#: monitors it. No band plan yet, so a real-world emergency band stands in.
+EMERGENCY_BAND = "911MHz"
 
 
 # --------------------------------------------------------------------------
@@ -142,6 +145,38 @@ def _all_powered_radios():
         if is_radio(o) and is_powered(o)]
 
 
+def comms_organ_frequency(char: Any) -> Optional[str]:
+    """The band a character's BUILT-IN comms organ is tuned to, if it has a
+    functional one (a security bot's ear/antenna module — §2.1). None when
+    the organ is absent or destroyed (the EMP/shoot-the-ear mute seam falls
+    out of the medical hit-location system for free)."""
+    state = getattr(char, "medical_state", None)
+    if state is None:
+        return None
+    for organ in (getattr(state, "organs", None) or {}).values():
+        try:
+            freq = (getattr(organ, "data", None) or {}).get("radio_frequency")
+            if freq and not organ.is_destroyed():
+                return freq
+        except Exception:  # noqa: BLE001 — a broken organ record just doesn't hear
+            continue
+    return None
+
+
+def _comms_bots_on(frequency: str) -> list:
+    """Security units whose built-in comms organ is tuned to *frequency* and
+    intact — role-scoped so it's a bounded query, not a full character scan."""
+    from evennia.objects.models import ObjectDB
+    out = []
+    for char in ObjectDB.objects.filter(
+            db_attributes__db_key="role").distinct():
+        if getattr(char.db, "role", None) != "security":
+            continue
+        if comms_organ_frequency(char) == frequency:
+            out.append(char)
+    return out
+
+
 def _render_radio_line(speaker: Any, listener: Any, message: str,
                        frequency: str, *, tagged: bool) -> str:
     """A received transmission, VOICE-attributed (never sight — you can't see
@@ -190,22 +225,37 @@ def transmit(speaker: Any, message: str, device: Any) -> bool:
 
     speaker.msg(f'You transmit on {frequency}: "{message}"')
     _log_to_channel(speaker, message, frequency)
+    _deliver(speaker, message, frequency, device)
+    return True
 
-    for radio in _all_powered_radios():
-        if radio is device:
-            continue
-        scanning = is_scanning(radio)
-        if not scanning and frequency_of(radio) != frequency:
-            continue
-        holder = radio.location
-        if holder is None or not hasattr(holder, "msg"):
-            continue  # a radio on the ground squawks to nobody in P1
-        if holder is speaker:
-            continue
+
+def _deliver(speaker: Any, message: str, frequency: str,
+             exclude_device: Any) -> None:
+    """Echo a transmission to every receiver on *frequency*: powered walkies
+    (tuned or scanning) held by a character, and security units with a live
+    built-in comms organ. Deduped per receiver so a bot holding a walkie AND
+    wearing a comms organ hears it once."""
+    delivered = set()
+
+    def _send(listener, *, tagged):
+        if listener is None or listener is speaker or id(listener) in delivered:
+            return
+        if not hasattr(listener, "msg"):
+            return
+        delivered.add(id(listener))
         try:
-            holder.msg(_render_radio_line(
-                speaker, holder, message, frequency, tagged=scanning),
+            listener.msg(_render_radio_line(
+                speaker, listener, message, frequency, tagged=tagged),
                 type="radio", from_obj=speaker)
         except Exception:  # noqa: BLE001 — one bad listener never stops the net
+            pass
+
+    for radio in _all_powered_radios():
+        if radio is exclude_device:
             continue
-    return True
+        scanning = is_scanning(radio)
+        if scanning or frequency_of(radio) == frequency:
+            _send(radio.location, tagged=scanning)   # holder hears it
+
+    for bot in _comms_bots_on(frequency):
+        _send(bot, tagged=False)                      # built-in transceiver

--- a/world/tests/test_radio.py
+++ b/world/tests/test_radio.py
@@ -197,3 +197,71 @@ class TestCommands(TestCase):
                 patch("world.radio.transmit") as tx:
             cmd.func()
         tx.assert_called_once_with(caller, "on my way", dev)
+
+
+class TestCommsOrgan(TestCase):
+    """Security bots hear via a built-in comms organ (ear module), not a
+    carried walkie — and go deaf when it's destroyed (the EMP/mute seam)."""
+
+    def _bot(self, freq="911MHz", destroyed=False):
+        bot = MagicMock()
+        bot.db.role = "security"
+        organ = MagicMock()
+        organ.data = {"radio_frequency": freq}
+        organ.is_destroyed = lambda: destroyed
+        bot.medical_state.organs = {"comms_module": organ}
+        return bot
+
+    def test_intact_organ_reports_frequency(self):
+        from world.radio import comms_organ_frequency
+        self.assertEqual(comms_organ_frequency(self._bot()), "911MHz")
+
+    def test_destroyed_organ_is_deaf(self):
+        from world.radio import comms_organ_frequency
+        self.assertIsNone(comms_organ_frequency(
+            self._bot(destroyed=True)))
+
+    def test_no_medical_state_is_deaf(self):
+        from world.radio import comms_organ_frequency
+        c = MagicMock(); c.medical_state = None
+        self.assertIsNone(comms_organ_frequency(c))
+
+    def test_bot_receives_emergency_transmission(self):
+        from world.radio import EMERGENCY_BAND, transmit
+        speaker = _char()
+        dev = _radio(freq=EMERGENCY_BAND)
+        bot = self._bot(freq=EMERGENCY_BAND)
+        with patch.object(radio, "_all_powered_radios", return_value=[dev]), \
+                patch.object(radio, "_comms_bots_on", return_value=[bot]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern", return_value=None), \
+                patch("world.voice.get_voice_description", return_value="tinny"), \
+                patch("world.voice.voice_phrase", return_value=None):
+            transmit(speaker, "unit down", dev)
+        bot.msg.assert_called_once()
+        self.assertIn("unit down", bot.msg.call_args.args[0])
+
+
+class TestWitnessGating(TestCase):
+    def _witness(self, walkie=None):
+        w = MagicMock()
+        w.contents = [walkie] if walkie else []
+        return w
+
+    def test_walkie_present_and_tuned_gates_report_true(self):
+        from world.director.witness import _witness_walkie
+        from world.radio import EMERGENCY_BAND
+        walkie = _radio(freq=EMERGENCY_BAND)
+        self.assertIs(_witness_walkie(self._witness(walkie)), walkie)
+
+    def test_snatched_walkie_no_report(self):
+        from world.director.witness import _witness_walkie
+        self.assertIsNone(_witness_walkie(self._witness(None)))
+
+    def test_off_or_wrong_band_walkie_no_report(self):
+        from world.director.witness import _witness_walkie
+        off = _radio(on=False, freq="911MHz")
+        self.assertIsNone(_witness_walkie(self._witness(off)))
+        wrong = _radio(on=True, freq="447")
+        self.assertIsNone(_witness_walkie(self._witness(wrong)))


### PR DESCRIPTION
Closes #1008

- EMERGENCY_BAND (911MHz); witness spawns with a real WALKIE_TALKIE
  tuned to it; witness_report gates on _witness_walkie (live witness
  AND working radio) — snatch/break/KO = no report. On fire, witness
  transmits on-air AND raises the dispatch event.
- security bots get a built-in comms organ (ROBOT_COMMS_MODULE_SPEC,
  factory_fit_comms — the riot-gun pattern) in an ear, tuned to
  911MHz; radio receiver reads it via comms_organ_frequency; destroy/
  harvest the ear -> deaf bot (EMP/mute seam via hit-location)
- radio receiver unified into _deliver (walkies + comms bots, deduped)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
