### PR TITLE
Radio Phase 1: walkie acquisition — armory stock + ganger loot (Closes #1013)

### DIFF
--- a/specs/proposals/RADIO_COMMS_SPEC.md
+++ b/specs/proposals/RADIO_COMMS_SPEC.md
@@ -1,6 +1,6 @@
 # Radio Comms Spec — The Colony's Primary Communications
 
-> **Status:** 🚧 **PHASE 1 CORE SHIPPED (2026-07-04): player-facing radio is LIVE** — `world/radio.py` (single staff-locked channel + device-gated voice echo), `Radio` typeclass + `WALKIE_TALKIE` prototype, `transmit`/`xmit`/`xm` + `to <radio>,` retarget, `tune <device> to <freq|scan>`, `toggle <device> [on/off]`, state-aware look-readout (frequency shown only when powered). Voice-attributed (recognition on the air, modulator-defeatable), hearing-gated, every powered carried radio receives its band (scan catches all, freq-tagged). **WITNESS LINK + BOT TRANSCEIVERS ALSO SHIPPED (#1009):** the witness spawns with a real `WALKIE_TALKIE` on the **emergency band (911MHz)** and `witness_report` gates on it — snatch/break/KO = no report (a physical interdiction beside killing them; robbing them nets a walkie pre-tuned to the cop channel). Security bots carry a built-in **comms module** (ear/antenna augment organ, `factory_fit_comms`, like the riot gun) tuned to 911MHz — they hear the net via `comms_organ_frequency`; destroy/harvest the ear and the bot goes deaf (EMP/mute seam via medical hit-location). **REMAINING P1:** player device acquisition placement (vendor/loot/spawn kit). **PHASE 2:** antennae/range/coverage, battery, jamming, encryption (gated on verticality). Original scoping below.
+> **Status:** 🚧 **PHASE 1 CORE SHIPPED (2026-07-04): player-facing radio is LIVE** — `world/radio.py` (single staff-locked channel + device-gated voice echo), `Radio` typeclass + `WALKIE_TALKIE` prototype, `transmit`/`xmit`/`xm` + `to <radio>,` retarget, `tune <device> to <freq|scan>`, `toggle <device> [on/off]`, state-aware look-readout (frequency shown only when powered). Voice-attributed (recognition on the air, modulator-defeatable), hearing-gated, every powered carried radio receives its band (scan catches all, freq-tagged). **WITNESS LINK + BOT TRANSCEIVERS ALSO SHIPPED (#1009):** the witness spawns with a real `WALKIE_TALKIE` on the **emergency band (911MHz)** and `witness_report` gates on it — snatch/break/KO = no report (a physical interdiction beside killing them; robbing them nets a walkie pre-tuned to the cop channel). Security bots carry a built-in **comms module** (ear/antenna augment organ, `factory_fit_comms`, like the riot gun) tuned to 911MHz — they hear the net via `comms_organ_frequency`; destroy/harvest the ear and the bot goes deaf (EMP/mute seam via medical hit-location). **ACQUISITION PLACED (2026-07-04):** the Colonial Armory stocks `WALKIE_TALKIE` at 0 tokens (live shop object) and ~1-in-3 gangers carry one (`chance_stock`) — Phase 1 is now player-obtainable end to end. **PHASE 2:** antennae/range/coverage, battery, jamming, encryption (gated on verticality). Original scoping below.
 >
 > **PHASE 1 SCOPED & DECIDED
 > (2026-07-03, §7): buildable now, vertical-independent** — devices +
@@ -167,6 +167,13 @@ The **walkie-talkie item**: held/carried, powered, tuned to one frequency.
 Acquisition = **all three**: vendor purchase (the store), loot (gangers /
 security units carry them), and spawn kit where role-appropriate. Snatchable
 via the existing theft/wrest machinery; breakable via ordinary damage.
+
+**Shipped placement (2026-07-04):** the **Colonial Armory** stocks
+`WALKIE_TALKIE` at **0 tokens** (a live builder change to the hand-built shop
+object, not a prototype), and the **ganger** civilian role carries one on a
+**~1-in-3** roll (`chance_stock` in `world/director/civilians.py`) — a
+loot/frisk/steal path. Witnesses already spawn with an emergency-band walkie
+(#1009). Broader vendor/loot spread waits on Phase 2 geography.
 
 ### 6.3 · Tuning & discovery
 

--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -16,7 +16,7 @@ layer is being refined — refinement is the point right now.
 
 from __future__ import annotations
 
-from random import choice, randint, sample
+from random import choice, randint, random, sample
 from typing import Any
 
 #: Management tag — every spawned civilian carries it; purge is scoped to it.
@@ -130,6 +130,9 @@ CIVILIAN_ROLES: dict[str, dict] = {
         "reaction": "resist", "armed": True, "reports": "never",
         "weapon_pool": ["SHIV", "TIRE_IRON", "BRASS_KNUCKLES", "HEAVY_CHAIN",
                         "BASEBALL_BAT", "BOX_CUTTER"],
+        # The set runs on comms: some gangers carry a walkie (loot/frisk/steal
+        # path). Each entry rolls independently — see the chance_stock loop.
+        "chance_stock": [("WALKIE_TALKIE", 0.33)],
         "ambient": [
             "posts up against the wall like the wall should be grateful.",
             "sizes up a passerby, files the number away, looks elsewhere.",
@@ -375,6 +378,15 @@ def spawn_civilian(role: str, anchor: Any) -> Any | None:
     # Stock (a hawker sells something real — and muggable) + a blade for
     # armed roles (carried, not wielded: they DRAW it when it comes to that).
     for proto in spec.get("stock", []):
+        try:
+            proto_spawn(proto)[0].move_to(npc, quiet=True)
+        except Exception:  # noqa: BLE001
+            continue
+    # Probabilistic kit: (prototype_key, chance) rolled per item, so only some
+    # of a role's members carry it (e.g. a walkie on ~1-in-3 gangers).
+    for proto, chance in spec.get("chance_stock", []):
+        if random() >= chance:
+            continue
         try:
             proto_spawn(proto)[0].move_to(npc, quiet=True)
         except Exception:  # noqa: BLE001

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -62,6 +62,18 @@ class TestRoles(TestCase):
             if spec.get("armed"):
                 self.assertTrue(spec.get("weapon_pool"), f"{role} armed, no pool")
 
+    def test_chance_stock_references_real_prototypes(self):
+        from world import prototypes as protos
+        for role, spec in CIVILIAN_ROLES.items():
+            for key, chance in spec.get("chance_stock", []):
+                self.assertTrue(hasattr(protos, key), f"{role}: {key}")
+                self.assertTrue(0.0 < chance <= 1.0, f"{role}: {key} {chance}")
+
+    def test_ganger_carries_a_walkie(self):
+        self.assertIn(
+            ("WALKIE_TALKIE", 0.33),
+            CIVILIAN_ROLES["ganger"].get("chance_stock", []))
+
     def test_colonist_archetype_registered(self):
         from world.llm.prompt import ARCHETYPES
         self.assertIn("colonist", ARCHETYPES)
@@ -142,6 +154,38 @@ class TestRoles(TestCase):
             mock_create.return_value = npc2
             _c.spawn_civilian("miner", _Room("street"))
             self.assertNotIn("register", npc2.db.llm_persona)
+
+    def _spawn_ganger_with_roll(self, roll):
+        """Spawn a ganger with civilians.random pinned to *roll*; return the
+        list of prototype keys that were actually spawned."""
+        from unittest.mock import patch as _patch
+        import world.director.civilians as _c
+        spawned = []
+
+        def _fake_spawn(proto):
+            spawned.append(proto)
+            item = MagicMock(); item.key = str(proto); item.layer = 2
+            return [item]
+
+        with _patch("evennia.create_object") as mock_create, \
+             _patch("evennia.prototypes.spawner.spawn", side_effect=_fake_spawn), \
+             _patch("world.mob_flavor.apply_random_flavor"), \
+             _patch("world.anatomy.get_species_default_longdesc_locations",
+                    return_value={}), \
+             _patch("world.medical.core.MedicalState"), \
+             _patch("world.spatial.rooms_within", return_value=[]), \
+             _patch("world.spatial.is_reachable", return_value=True), \
+             _patch.object(_c, "random", return_value=roll):
+            npc = MagicMock(); npc.db = SimpleNamespace()
+            mock_create.return_value = npc
+            _c.spawn_civilian("ganger", _Room("alley"))
+        return spawned
+
+    def test_chance_stock_roll_gates_the_walkie(self):
+        # roll below the 0.33 threshold → the walkie spawns...
+        self.assertIn("WALKIE_TALKIE", self._spawn_ganger_with_roll(0.1))
+        # ...at or above it → no walkie.
+        self.assertNotIn("WALKIE_TALKIE", self._spawn_ganger_with_roll(0.9))
 
     def test_ambient_beat_by_role(self):
         npc = SimpleNamespace(db=SimpleNamespace(role="miner"))


### PR DESCRIPTION
Add a `chance_stock` field to civilian roles: (prototype_key, chance)
tuples rolled per item at spawn. The ganger carries a WALKIE_TALKIE on
a ~1-in-3 roll, making walkies obtainable via the loot/frisk/steal path.

The Colonial Armory stock (0 tokens) is a live builder change to the
hand-built shop object, applied separately from this code.

Spec: RADIO_COMMS_SPEC §6.2 acquisition placement recorded; status
banner updated — Phase 1 now player-obtainable end to end.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
