### PR TITLE
Radio: brand the walkie as the AWE Magpie (Closes #1015)

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3972,11 +3972,14 @@ WALKIE_TALKIE = {
     "prototype_key": "WALKIE_TALKIE",
     "typeclass": "typeclasses.items.Radio",
     "key": "a battered walkie-talkie",
-    "aliases": ["walkie", "walkie-talkie", "radio", "handset"],
-    "desc": ("A knock-around handheld transceiver in scuffed high-impact "
-             "plastic, its stubby antenna taped at the base and a rubberised "
-             "push-to-talk worn pale by a thousand thumbs. A small monochrome "
-             "display sits above the dial."),
+    "aliases": ["walkie", "walkie-talkie", "radio", "handset", "magpie", "awe"],
+    "desc": ("A knock-around AWE Magpie — a handheld transceiver in scuffed "
+             "high-impact plastic, its stubby antenna taped at the base and a "
+             "rubberised push-to-talk worn pale by a thousand thumbs. The "
+             "Ashford Wireless & Electric wordmark and its little etched magpie "
+             "have half-rubbed off the casing — the same mark you'd find on a "
+             "cheap hotplate — and a small monochrome display sits above the "
+             "dial."),
     "attrs": [
         ("is_radio", True),
         ("radio_on", False),


### PR DESCRIPTION
Ashford Wireless & Electric — a founder-name house that also makes
hotplates; the model is the Magpie, a corvid that hoards shiny things
(apt for a device meant to be looted). Brand + model in the PAM/HDG
voice. Perceived key stays 'a battered walkie-talkie'; the brand lives
in the desc and as 'magpie'/'awe' aliases. Flavour only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
