### PR TITLE
Radio: walkie perceived name follows gear schema — AWE Magpie-01 radio (Closes #1017)

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3971,9 +3971,10 @@ HIGH_TOPS = {
 WALKIE_TALKIE = {
     "prototype_key": "WALKIE_TALKIE",
     "typeclass": "typeclasses.items.Radio",
-    "key": "a battered walkie-talkie",
-    "aliases": ["walkie", "walkie-talkie", "radio", "handset", "magpie", "awe"],
-    "desc": ("A knock-around AWE Magpie — a handheld transceiver in scuffed "
+    "key": "AWE Magpie-01 radio",
+    "aliases": ["walkie", "walkie-talkie", "radio", "handset", "magpie",
+                "magpie-01", "awe"],
+    "desc": ("A knock-around AWE Magpie-01 — a handheld transceiver in scuffed "
              "high-impact plastic, its stubby antenna taped at the base and a "
              "rubberised push-to-talk worn pale by a thousand thumbs. The "
              "Ashford Wireless & Electric wordmark and its little etched magpie "


### PR DESCRIPTION
Match the ordnance schema (HDG DX-15 / VECTOR UEM-3 / PAM Model 6):
brand acronym + model code + lowercase noun. Key 'a battered
walkie-talkie' -> 'AWE Magpie-01 radio'; the brand shows in the
perceived name like issued kit now, not only on look. Desc aligned to
Magpie-01; 'magpie-01' alias added.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
