### PR TITLE
Death: delete dead NPCs instead of archiving them to Limbo (Closes #1021)

### DIFF
--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -802,7 +802,20 @@ class DeathProgressionScript(DefaultScript):
             splattercast.msg(f"DEATH_MEDICAL_CLEANUP_FAIL: {getattr(character, 'key', '?')} - {e}")
             import traceback
             splattercast.msg(f"DEATH_MEDICAL_CLEANUP_TRACE: {traceback.format_exc()}")
-        
+
+        # NPCs don't respawn: the corpse created above carries the full
+        # forensic record, so a dead NPC object is DELETED outright instead of
+        # archived to Limbo (the PC-only respawn flow — last_character, new-char
+        # creation). Without this branch every dead NPC accumulates in Limbo
+        # forever as a nameless ghost (a long-standing leak; #4590 cleanup).
+        # Guard on ``account is None`` — only player characters ever carry an
+        # account, so this can never delete a PC.
+        if account is None:
+            splattercast = get_splattercast()
+            splattercast.msg(f"DEATH_NPC_CLEANUP: deleting dead NPC {getattr(character, 'key', '?')}")
+            character.delete()
+            return
+
         # Move character to limbo/OOC room (Evennia's default limbo is #2)
         # Use move_hooks=False to prevent medical script spam on teleport
         try:

--- a/world/tests/test_death_progression_lifecycle.py
+++ b/world/tests/test_death_progression_lifecycle.py
@@ -201,6 +201,19 @@ class TestCompletion(_LifecycleBase):
         self.assertFalse(self.char1.scripts.get("death_progression"))
         self.script = None  # tearDown guard
 
+    def test_dead_npc_is_deleted_not_archived(self):
+        """A dead NPC leaves a corpse, not a Limbo ghost: the transition
+        deletes the accountless character outright rather than archiving it
+        to Limbo (the PC-only respawn flow). Guards the #4590 ghost leak."""
+        from evennia.objects.models import ObjectDB
+        npc = create_object(Character, key="doomed mook", location=self.room1)
+        self.assertIsNone(npc.account)      # NPC: no account
+        npc_id = npc.id
+        self.script._transition_character_to_death(npc)
+        self.assertFalse(
+            ObjectDB.objects.filter(id=npc_id).exists(),
+            "dead NPC should be deleted, not left as a ghost")
+
     def test_corpse_handoff_failure_is_contained_and_loud(self):
         """The deliberate guard: a corpse-creation bug is logged to the
         audit sink AND the server log, does not raise, and therefore


### PR DESCRIPTION
archive_character serves the PC respawn flow only (last_character,
new-char creation). NPCs have no account, so archiving dumped them in
Limbo forever — a ghost leak (dead NPCs as old as ~12 days had piled
up). A dead NPC's corpse already carries the full forensic record, so
_transition_character_to_death now deletes an accountless character
outright and returns, before the Limbo/unpuppet/archive path. Guarded
on 'account is None' so it can never delete a player character.

Surfaced while diagnosing the #4590 husk, whose in-world orphaning was
caused by live-DB index corruption (repaired separately via REINDEX).

Test: test_dead_npc_is_deleted_not_archived.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
