### PR TITLE
Spec: DeathRecord carries no location either — pure existence tribute (#1023)

### DIFF
--- a/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
+++ b/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
@@ -213,17 +213,19 @@ Two concerns share the death moment but want opposite lifetimes:
   reminisce).
 
 The fix: one small, immutable **DeathRecord**, written at permanent death (§3),
-that marks the death's *existence* — nothing more. **It does not carry cause of
-death.** The player isn't owed an explanation; the record is a **tribute**, not a
-report.
+that marks the death's *existence* — nothing more. **It carries neither cause of
+death nor location.** The player isn't owed an explanation, and a location is
+actionable intelligence ("go check where I died"); the record is a **tribute**,
+not a report. This sleeve was, and ended — a name and a date.
 
 ```
 DeathRecord {                     # tiny, permanent; survives corpse removal
     id                            # stable key
     sleeve / account              # who died (null account = NPC → skip for web)
-    when / where                  # death_time, room name at death
+    when                          # death_time — a date on a memorial, nothing more
     corpse_ref                    # -> Corpse while it exists; null once a gig
-                                  #   hauls the body away
+                                  #   hauls the body away (internal key, never
+                                  #   surfaced on the web view)
 }
 ```
 
@@ -272,7 +274,7 @@ persist — which is the desired behavior now, and doubles as free playtesting o
    id onto the corpse (`corpse_ref` back on it) and, for PCs, the archived sleeve.
    Purely additive; changes nothing play-facing.
 2. **Web nostalgia review** — point "Manage Sleeves" at the DeathRecord's
-   existence facts (who/when/where — no cause of death, no autopsy coupling).
+   existence facts (who/when only — no cause, no location, no autopsy coupling).
 3. **Tag/index archived sleeves** — convert the account/website sleeve listing off
    the Limbo scan.
 4. **Corpse cleanup gig** — *deferred*, built atop the NPC-faction gig/freelancer


### PR DESCRIPTION
Location is actionable intelligence ('go check where I died'), the same
side-channel problem as cause of death. The record collapses to a name
and a date: sleeve/account + death_time + internal corpse_ref (never
surfaced on the web view). Amends #1024.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
