### PR TITLE
DeathRecord: engrave the sleeve tombstone on the account at archive (Closes #1027)

### DIFF
--- a/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
+++ b/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
@@ -9,9 +9,18 @@
 > [`HEALTH_AND_SUBSTANCE_SYSTEM_SPEC`](../HEALTH_AND_SUBSTANCE_SYSTEM_SPEC.md)
 > (corpse/forensics), and
 > [`WEB_RESPAWN_CHARACTER_CREATION_SPEC`](../WEB_RESPAWN_CHARACTER_CREATION_SPEC.md)
-> (decant/sleeve). §8 (rough edges) and §9 (**optimization proposal — the
-> DeathRecord spine**) are NOT yet built. **Recent change folded in:** dead NPCs
-> are now **deleted**, not archived (#1022) — see §4.
+> (decant/sleeve). **§9 STEP 1 SHIPPED (2026-07-04): the DeathRecord tombstone
+> is LIVE** — `world/death_records.py` engraves `{name, born, died, corpse_ref}`
+> on the owning account (`account.db.death_records`) from `archive_character`;
+> the death path stamps the corpse ref post-archive. **Scope decision: EVERY
+> archived sleeve gets a tombstone** (death or manual retirement; `died` = the
+> archive moment). Legacy sleeves backfilled (39 archived + reconstructions
+> from account-linked corpses). The NPC-delete guard (#1022) hardened to a
+> DOUBLE guard (`account is None` AND canonical `db.is_npc`) — an accountless
+> unflagged character archives with a warning, never deletes. §9 steps 2–3
+> (web view, sleeve tag/index) and 4–5 (cleanup gig, morgue IC records) remain
+> unbuilt. **Recent change folded in:** dead NPCs are **deleted**, not archived
+> (#1022) — see §4.
 
 ---
 
@@ -275,9 +284,14 @@ persist — which is the desired behavior now, and doubles as free playtesting o
 
 **Suggested build order (each shippable alone, additive, low-risk):**
 
-1. **DeathRecord object** — write it in `_create_corpse_from_character`; stamp its
-   id onto the corpse (`corpse_ref` back on it) and, for PCs, the archived sleeve.
-   Purely additive; changes nothing play-facing.
+1. ✅ **DeathRecord object** (SHIPPED 2026-07-04) — `world/death_records.py`;
+   engraved from `archive_character` (covers death AND manual retirement — the
+   all-archives scope decision), corpse ref stamped post-archive in
+   `_handle_corpse_creation_and_transition`. Stored as
+   `account.db.death_records` (plain attribute list — no new typeclass, the
+   web view already reads the account). `born` falls back to the object's
+   creation date for legacy sleeves. Legacy backfill: all archived sleeves +
+   tombstones reconstructed from account-linked corpses whose husks are gone.
 2. **Web nostalgia review** — point "Manage Sleeves" at the DeathRecord's
    tombstone (name, born, died — no cause, no location, no autopsy coupling).
 3. **Tag/index archived sleeves** — convert the account/website sleeve listing off

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -480,7 +480,18 @@ class Character(
         self.db.archived = True
         self.db.archived_reason = reason
         self.db.archived_date = time.time()
-        
+
+        # Engrave the OOC tombstone on the owning account — who the sleeve
+        # was, born, died (DEATH_AND_SLEEVE_LIFECYCLE_SPEC §9). Every archive
+        # gets one (death or manual retirement); idempotent per sleeve.
+        # Guarded: a memorial bug must never block the archive itself.
+        try:
+            from world.death_records import add_record
+            add_record(self, died=self.db.archived_date)
+        except Exception as e:
+            splattercast = get_splattercast()
+            splattercast.msg(f"ARCHIVE_RECORD_ERROR: {self.key} - {e}")
+
         # Move character to Limbo to prevent appearing as NPC in game world
         from evennia import search_object
         limbo = search_object("#2")  # Limbo is always dbref #2

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -486,7 +486,18 @@ class DeathProgressionScript(DefaultScript):
             
             # 3. Transition character out of play (includes unpuppeting now)
             self._transition_character_to_death(character)
-            
+
+            # 3b. Link the tombstone to the body (spec §9): the archive above
+            # engraved the record; the corpse ref is an internal key that goes
+            # stale once the world removes the body — by design. Account is
+            # the pre-unpuppet capture; NPCs (account None) no-op inside.
+            try:
+                from world.death_records import stamp_corpse
+                stamp_corpse(character, corpse, account=account)
+            except Exception:  # noqa: BLE001 — the memorial never blocks death
+                pass
+
+
             # 4. Initiate character creation for account
             if account and session:
                 self._initiate_new_character_creation(account, character, session)
@@ -808,13 +819,22 @@ class DeathProgressionScript(DefaultScript):
         # archived to Limbo (the PC-only respawn flow — last_character, new-char
         # creation). Without this branch every dead NPC accumulates in Limbo
         # forever as a nameless ghost (a long-standing leak; #4590 cleanup).
-        # Guard on ``account is None`` — only player characters ever carry an
-        # account, so this can never delete a PC.
+        # DOUBLE guard: ``account is None`` AND the canonical ``db.is_npc``
+        # marker (every spawn path sets it; PCs never carry it) — so a PC that
+        # somehow dies accountless (offline death, half-wiped state) can never
+        # be deleted. The failure direction is a flagged Limbo ghost, not a
+        # lost player character.
         if account is None:
+            if character.db.is_npc is True:
+                splattercast = get_splattercast()
+                splattercast.msg(f"DEATH_NPC_CLEANUP: deleting dead NPC {getattr(character, 'key', '?')}")
+                character.delete()
+                return
             splattercast = get_splattercast()
-            splattercast.msg(f"DEATH_NPC_CLEANUP: deleting dead NPC {getattr(character, 'key', '?')}")
-            character.delete()
-            return
+            splattercast.msg(
+                f"DEATH_TRANSITION_WARN: {getattr(character, 'key', '?')} is "
+                f"accountless but not flagged is_npc — archiving instead of "
+                f"deleting (investigate)")
 
         # Move character to limbo/OOC room (Evennia's default limbo is #2)
         # Use move_hooks=False to prevent medical script spam on teleport

--- a/world/death_records.py
+++ b/world/death_records.py
@@ -1,0 +1,85 @@
+"""Death records — the OOC tombstone (DEATH_AND_SLEEVE_LIFECYCLE_SPEC §9).
+
+A sleeve's permanent memorial: **who the sleeve was, born, died.** Engraved on
+the OWNING ACCOUNT (``account.db.death_records``) the moment the sleeve is
+archived, so it survives everything the mortal loop later does to the body
+(cleanup gigs, corpse removal) and everything the sleeve loop does to the
+husk. Deliberately minimal — no cause, no location (that's actionable
+intelligence and belongs in-game): a name and two dates, everything a
+headstone says and everything it doesn't.
+
+Scope: EVERY archived sleeve gets a record (death or manual retirement —
+``died`` is simply the archive moment). NPCs get no tombstone: no account,
+no player to reminisce. The web "Manage Sleeves" view reads this list;
+``corpse_dbref`` is an internal key only, never surfaced, and goes stale
+by design once the world removes the body.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+
+def get_records(account: Any) -> list:
+    """The account's tombstones (a copy — mutate via the helpers)."""
+    return list(getattr(getattr(account, "db", None), "death_records", None) or [])
+
+
+def _sleeve_born(character: Any) -> Optional[float]:
+    """The sleeve's decant moment: ``current_sleeve_birth`` when charcreate
+    stamped it, else the object's creation timestamp (true for every sleeve
+    ever made — covers pre-charcreate legacy sleeves)."""
+    born = getattr(getattr(character, "db", None), "current_sleeve_birth", None)
+    if born is not None:
+        return born
+    created = getattr(character, "date_created", None)
+    try:
+        return created.timestamp() if created else None
+    except (AttributeError, OSError, OverflowError, ValueError):
+        return None
+
+
+def add_record(character: Any, account: Any = None,
+               died: Optional[float] = None) -> Optional[dict]:
+    """Engrave a tombstone for *character* on its owning account.
+
+    Idempotent per sleeve — re-archiving can never double-engrave. Returns
+    the record, or None when there's no account (an NPC: by design, no
+    tombstone). ``account`` may be passed explicitly for callers that
+    captured it before an unpuppet."""
+    account = account or getattr(character, "account", None)
+    if account is None:
+        return None
+    dbref = getattr(character, "dbref", None)
+    records = get_records(account)
+    for rec in records:
+        if rec.get("sleeve_dbref") == dbref:
+            return rec
+    record = {
+        "sleeve_dbref": dbref,
+        "name": getattr(character, "key", None),
+        "born": _sleeve_born(character),
+        "died": died if died is not None else time.time(),
+        "corpse_dbref": None,
+    }
+    records.append(record)
+    account.db.death_records = records
+    return record
+
+
+def stamp_corpse(character: Any, corpse: Any, account: Any = None) -> bool:
+    """Link the sleeve's tombstone to its body (internal key only). The link
+    goes stale once a cleanup gig removes the corpse — by design; the record
+    itself never depends on it."""
+    account = account or getattr(character, "account", None)
+    if account is None or corpse is None:
+        return False
+    dbref = getattr(character, "dbref", None)
+    records = get_records(account)
+    for rec in records:
+        if rec.get("sleeve_dbref") == dbref:
+            rec["corpse_dbref"] = getattr(corpse, "dbref", None)
+            account.db.death_records = records
+            return True
+    return False

--- a/world/tests/test_death_progression_lifecycle.py
+++ b/world/tests/test_death_progression_lifecycle.py
@@ -207,12 +207,48 @@ class TestCompletion(_LifecycleBase):
         to Limbo (the PC-only respawn flow). Guards the #4590 ghost leak."""
         from evennia.objects.models import ObjectDB
         npc = create_object(Character, key="doomed mook", location=self.room1)
+        npc.db.is_npc = True                # the canonical NPC marker
         self.assertIsNone(npc.account)      # NPC: no account
         npc_id = npc.id
         self.script._transition_character_to_death(npc)
         self.assertFalse(
             ObjectDB.objects.filter(id=npc_id).exists(),
             "dead NPC should be deleted, not left as a ghost")
+
+    def test_accountless_without_npc_marker_is_never_deleted(self):
+        """The double guard's failure direction: accountless but NOT flagged
+        is_npc (an offline PC death, a half-wiped husk) must archive, never
+        delete — a flagged Limbo ghost beats a lost player character."""
+        from evennia.objects.models import ObjectDB
+        mystery = create_object(Character, key="unflagged husk",
+                                location=self.room1)
+        self.assertIsNone(mystery.account)
+        mystery_id = mystery.id
+        self.script._transition_character_to_death(mystery)
+        self.assertTrue(
+            ObjectDB.objects.filter(id=mystery_id).exists(),
+            "accountless-but-unflagged character must never be deleted")
+        mystery.delete()  # test cleanup
+
+    def test_pc_death_engraves_tombstone_with_corpse_ref(self):
+        """The sleeve loop's memorial (spec §9): permanent death of a PC
+        writes {name, born, died, corpse_dbref} onto the owning account."""
+        from world.death_records import get_records
+        self.char1.msg = MagicMock()
+        self.account.db.death_records = []
+        with patch("world.identity_utils.msg_room_identity"), \
+                patch.object(self.char1, "apply_final_death_state",
+                             create=True):
+            self.script._complete_death_progression()
+        records = get_records(self.account)
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec["sleeve_dbref"], self.char1.dbref)
+        self.assertEqual(rec["name"], self.char1.key)
+        self.assertIsNotNone(rec["born"])       # date_created fallback
+        self.assertIsNotNone(rec["died"])
+        self.assertIsNotNone(rec["corpse_dbref"])   # linked to the body
+        self.script = None  # completion deleted the script; tearDown guard
 
     def test_corpse_handoff_failure_is_contained_and_loud(self):
         """The deliberate guard: a corpse-creation bug is logged to the

--- a/world/tests/test_death_records.py
+++ b/world/tests/test_death_records.py
@@ -1,0 +1,86 @@
+"""Death records (world/death_records.py) — DEATH_AND_SLEEVE_LIFECYCLE_SPEC §9.
+
+The OOC tombstone: who the sleeve was, born, died. Engraved on the owning
+account at archive time; idempotent; NPCs (no account) get none; the corpse
+link is internal and allowed to go stale.
+"""
+
+from datetime import datetime
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from world.death_records import add_record, get_records, stamp_corpse
+
+
+def _account(records=None):
+    acct = MagicMock()
+    acct.db.death_records = records if records is not None else []
+    return acct
+
+
+def _sleeve(dbref="#42", key="Jorge Calderon II", birth=1000.0, account=None):
+    ch = MagicMock()
+    ch.dbref = dbref
+    ch.key = key
+    ch.db.current_sleeve_birth = birth
+    ch.account = account
+    ch.date_created = datetime(2025, 10, 14, 12, 0, 0)
+    return ch
+
+
+class TestAddRecord(TestCase):
+    def test_engraves_name_and_two_dates(self):
+        acct = _account()
+        rec = add_record(_sleeve(account=acct), died=2000.0)
+        self.assertEqual(rec["name"], "Jorge Calderon II")
+        self.assertEqual(rec["born"], 1000.0)
+        self.assertEqual(rec["died"], 2000.0)
+        self.assertIsNone(rec["corpse_dbref"])       # stamped separately
+        self.assertEqual(acct.db.death_records, [rec])
+
+    def test_no_cause_no_location_ever(self):
+        # The tombstone's whole design: a name and two dates, nothing else.
+        rec = add_record(_sleeve(account=_account()), died=2000.0)
+        self.assertEqual(
+            set(rec), {"sleeve_dbref", "name", "born", "died", "corpse_dbref"})
+
+    def test_npc_gets_no_tombstone(self):
+        self.assertIsNone(add_record(_sleeve(account=None)))
+
+    def test_idempotent_per_sleeve(self):
+        acct = _account()
+        sleeve = _sleeve(account=acct)
+        first = add_record(sleeve, died=2000.0)
+        again = add_record(sleeve, died=9999.0)     # re-archive: no double
+        self.assertEqual(again, first)
+        self.assertEqual(len(get_records(acct)), 1)
+
+    def test_born_falls_back_to_creation_date(self):
+        # Legacy sleeves predating current_sleeve_birth still get a born date.
+        sleeve = _sleeve(birth=None, account=_account())
+        rec = add_record(sleeve, died=2000.0)
+        self.assertEqual(rec["born"],
+                         datetime(2025, 10, 14, 12, 0, 0).timestamp())
+
+    def test_explicit_account_overrides_lost_link(self):
+        # Death path captures the account pre-unpuppet and passes it in.
+        acct = _account()
+        rec = add_record(_sleeve(account=None), account=acct, died=2000.0)
+        self.assertIsNotNone(rec)
+        self.assertEqual(len(get_records(acct)), 1)
+
+
+class TestStampCorpse(TestCase):
+    def test_links_record_to_body(self):
+        acct = _account()
+        sleeve = _sleeve(account=acct)
+        add_record(sleeve, died=2000.0)
+        corpse = MagicMock(); corpse.dbref = "#777"
+        self.assertTrue(stamp_corpse(sleeve, corpse))
+        self.assertEqual(get_records(acct)[0]["corpse_dbref"], "#777")
+
+    def test_no_record_or_account_is_a_noop(self):
+        corpse = MagicMock(); corpse.dbref = "#777"
+        self.assertFalse(stamp_corpse(_sleeve(account=None), corpse))
+        acct = _account()
+        self.assertFalse(stamp_corpse(_sleeve(account=acct), corpse))


### PR DESCRIPTION
Spec §9 step 1. world/death_records.py: add_record (idempotent per
sleeve, NPC → none by design, born falls back to date_created for
legacy sleeves), stamp_corpse (internal link, goes stale by design),
get_records. Written from archive_character — every archived sleeve
gets one (death or manual retirement; died = archive moment). The
death path stamps the corpse ref post-archive using the pre-unpuppet
account capture.

Also hardens the #1022 NPC-delete to a DOUBLE guard: account is None
AND canonical db.is_npc — accountless-but-unflagged archives with a
loud warning instead of deleting; the failure direction is a Limbo
ghost, never a lost player character.

Tombstone shape pinned by test: exactly {sleeve_dbref, name, born,
died, corpse_dbref} — no cause, no location.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
