### PR TITLE
Web: memorial wall on Manage Sleeves — the account's tombstones (Closes #1029)

### DIFF
--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -80,7 +80,39 @@ Manage Sleeves
           </p>
         </div>
         {% endif %}
-          
+
+        {% if memorial %}
+        <hr class="border-secondary mt-4" />
+        <h2 class="text-uppercase text-muted" style="font-family: 'Courier New', monospace; letter-spacing: 0.1em; font-size: 1rem;">Memorial Wall</h2>
+        <div class="table-responsive">
+          <table class="table table-dark table-sm" style="font-family: 'Courier New', monospace;">
+            <thead class="border-secondary">
+              <tr class="text-uppercase" style="font-size: 0.85rem; letter-spacing: 0.05em;">
+                <th class="border-secondary" style="width: 40%;">Designation</th>
+                <th class="border-secondary" style="width: 30%;">Born</th>
+                <th class="border-secondary" style="width: 30%;">Died</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for stone in memorial %}
+              <tr class="border-secondary" style="font-size: 0.85rem;">
+                <td class="border-secondary text-white" style="width: 40%;">{{ stone.name }}</td>
+                <td class="border-secondary text-muted" style="width: 30%;">
+                  {% if stone.born %}{{ stone.born|date:"Y-m-d" }}{% else %}&mdash;{% endif %}
+                </td>
+                <td class="border-secondary text-muted" style="width: 30%;">
+                  {% if stone.died %}{{ stone.died|date:"Y-m-d" }}{% else %}&mdash;{% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="text-muted" style="font-family: 'Courier New', monospace; font-size: 0.75rem;">
+          {{ memorial|length }} sleeve(s) remembered
+        </div>
+        {% endif %}
+
       </div>
     </div>
   </div>

--- a/web/website/urls.py
+++ b/web/website/urls.py
@@ -12,8 +12,9 @@ from django.conf import settings
 
 from evennia.web.website.urls import urlpatterns as evennia_website_urlpatterns
 from web.website.views.characters import (
-    CharacterCreateView, 
+    CharacterCreateView,
     CharacterArchiveView,
+    CharacterManageView,
     StaffCharacterListView,
     OwnerOnlyCharacterDetailView,
     OwnerOnlyCharacterUpdateView
@@ -57,6 +58,9 @@ urlpatterns = [
     
     # Custom character creation with GRIM stats
     path("characters/create/", CharacterCreateView.as_view(), name="character-create"),
+
+    # Manage Sleeves with the memorial wall (tombstones — spec §9 step 2)
+    path("characters/manage/", CharacterManageView.as_view(), name="character-manage"),
     
     # Custom archive (instead of delete) - preserves Stack data
     path(

--- a/web/website/views/characters.py
+++ b/web/website/views/characters.py
@@ -17,6 +17,7 @@ from evennia.web.website.views.characters import (
     CharacterListView as EvenniaCharacterListView,
     CharacterDetailView as EvenniaCharacterDetailView,
     CharacterUpdateView as EvenniaCharacterUpdateView,
+    CharacterManageView as EvenniaCharacterManageView,
     CharacterMixin
 )
 
@@ -366,6 +367,41 @@ class CharacterCreateView(EvenniaCharacterCreateView):
         else:
             messages.error(self.request, "Character creation failed.")
             return self.form_invalid(form)
+
+
+class CharacterManageView(EvenniaCharacterManageView):
+    """
+    Manage Sleeves + the memorial wall (DEATH_AND_SLEEVE_LIFECYCLE_SPEC §9
+    step 2).
+
+    Adds the account's tombstones to the page context: who the sleeve was,
+    born, died — nothing else. This is the game's one sanctioned OOC surface
+    (a tribute to the player); cause and location never appear here, and the
+    internal dbref/corpse keys are deliberately stripped before rendering.
+    """
+
+    def get_context_data(self, **kwargs):
+        from datetime import datetime
+        context = super().get_context_data(**kwargs)
+        memorial = []
+        records = self.request.user.db.death_records or []
+        for rec in records:
+            try:
+                if not rec.get("name") and not rec.get("died"):
+                    continue  # a record with neither name nor date is noise
+                born = rec.get("born")
+                died = rec.get("died")
+                memorial.append({
+                    "name": rec.get("name") or "an unnamed sleeve",
+                    "born": datetime.fromtimestamp(born) if born else None,
+                    "died": datetime.fromtimestamp(died) if died else None,
+                })
+            except (TypeError, ValueError, OSError, OverflowError):
+                continue  # one malformed record never breaks the wall
+        memorial.sort(key=lambda r: (r["died"] is None,
+                                     r["died"] or datetime.min))
+        context["memorial"] = memorial
+        return context
 
 
 class CharacterArchiveView(LoginRequiredMixin, CharacterMixin, View):


### PR DESCRIPTION
Spec §9 step 2. CharacterManageView subclass injects 'memorial' from
account.db.death_records — name, born, died only (internal keys
stripped; cause/location never present by design). URL override keeps
the character-manage route name so existing redirects work. Template
gains a Memorial Wall section in the terminal aesthetic; unknown
decant dates (reconstructed tombstones) render as an em dash.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
