### PR TITLE
Sleeves: archive tag index — one-query split, self-healing (Closes #1031)

### DIFF
--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -319,7 +319,7 @@ def create_character_from_template(account, template, sex="ambiguous"):
     
     # Set defaults
     # death_count starts at 1 via AttributeProperty in Character class
-    char.db.archived = False
+    char.unarchive_character()   # attribute + sleeve-tag index in sync
     
     return char
 
@@ -429,7 +429,7 @@ def create_flash_clone(account, old_character):
         char.db.stack_id = str(uuid.uuid4())
     
     # Reset state
-    char.db.archived = False
+    char.unarchive_character()   # attribute + sleeve-tag index in sync
     char.db.current_sleeve_birth = time.time()
     
     return char
@@ -488,8 +488,8 @@ def _charcreate_exit_callback(caller, menu):
     Called when the character creation menu exits.
     Only disconnects if character creation was NOT completed.
     """
-    # Check if they have any ACTIVE (non-archived) characters
-    active_characters = [char for char in caller.characters if not char.db.archived]
+    # Check if they have any ACTIVE (non-archived) characters (tag-indexed)
+    active_characters = caller.active_sleeves
     
     if active_characters:
         # They completed creation - just close menu, don't disconnect
@@ -1448,7 +1448,7 @@ def first_char_finalize(caller, raw_string, **kwargs):
         
         # Set defaults
         # death_count starts at 1 via AttributeProperty in Character class
-        char.db.archived = False
+        char.unarchive_character()   # attribute + sleeve-tag index in sync
         
         # Generate unique Stack ID
         import uuid

--- a/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
+++ b/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
@@ -294,8 +294,15 @@ persist — which is the desired behavior now, and doubles as free playtesting o
    tombstones reconstructed from account-linked corpses whose husks are gone.
 2. **Web nostalgia review** — point "Manage Sleeves" at the DeathRecord's
    tombstone (name, born, died — no cause, no location, no autopsy coupling).
-3. **Tag/index archived sleeves** — convert the account/website sleeve listing off
-   the Limbo scan.
+3. ✅ **Tag/index archived sleeves** (SHIPPED 2026-07-04) — `archive_character`
+   adds the `archived` tag (category `sleeve`) as the query index;
+   `Account._sleeves_split` / `active_sleeves` / `archived_sleeves` split the
+   account's characters in ONE tag query (self-healing: a legacy
+   `db.archived=True` without the tag is healed into the index on read, so an
+   archived husk can never auto-puppet as active). All account/web/charcreate
+   scans converted; `Character.is_archived` (tag-first) + `unarchive_character`
+   (keeps attribute and tag in sync) are the canonical accessors. Legacy
+   sleeves backfilled live.
 4. **Corpse cleanup gig** — *deferred*, built atop the NPC-faction gig/freelancer
    loop. Removal nulls `corpse_ref`; the record persists. Until then, remains are
    intentional world-tells.

--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -136,6 +136,48 @@ class Account(DefaultAccount):
 
     """
 
+    def _sleeves_split(self):
+        """Split this account's characters into (active, archived) using the
+        ``archived`` tag index (spec §9 step 3) — ONE database query for the
+        whole split instead of a ``db.archived`` attribute read per character
+        (accounts accumulate archived sleeves forever; actives are capped by
+        MAX_NR_CHARACTERS). Order of ``self.characters`` is preserved.
+
+        Self-healing: the few tag-active sleeves are verified against the
+        legacy ``db.archived`` attribute — a True without the tag (pre-index
+        sleeve, stray staff @py) is healed into the index on the spot, so an
+        archived husk can never read as active (at_post_login auto-puppets
+        actives)."""
+        chars = [c for c in self.characters if c]
+        if not chars:
+            return [], []
+        from evennia.objects.models import ObjectDB
+        archived_ids = set(ObjectDB.objects.filter(
+            id__in=[c.id for c in chars],
+            db_tags__db_key="archived",
+            db_tags__db_category="sleeve",
+        ).values_list("id", flat=True))
+        active, archived = [], []
+        for char in chars:
+            if char.id in archived_ids:
+                archived.append(char)
+            elif char.db.archived is True:      # legacy flag, no tag: heal
+                char.tags.add("archived", category="sleeve")
+                archived.append(char)
+            else:
+                active.append(char)
+        return active, archived
+
+    @property
+    def active_sleeves(self):
+        """This account's non-archived characters (tag-indexed, one query)."""
+        return self._sleeves_split()[0]
+
+    @property
+    def archived_sleeves(self):
+        """This account's archived sleeves (tag-indexed, one query)."""
+        return self._sleeves_split()[1]
+
     def check_available_slots(self, **kwargs):
         """
         Override Evennia's default to exclude archived characters from slot count.
@@ -148,20 +190,16 @@ class Account(DefaultAccount):
                will halt character creation. If not, character creation can proceed.
         """
         from django.conf import settings
-        
+
         # Get max allowed characters
         max_slots = settings.MAX_NR_CHARACTERS
         if max_slots is None:
             # No limit
             return None
-        
+
         # Count only active (non-archived) characters
-        active_count = 0
-        for char in self.characters:
-            if char.db.archived:
-                continue
-            active_count += 1
-        
+        active_count = len(self.active_sleeves)
+
         # Check if we have slots available
         available_slots = max(0, max_slots - active_count)
         
@@ -188,17 +226,9 @@ class Account(DefaultAccount):
         max_slots = settings.MAX_NR_CHARACTERS
         if max_slots is None:
             return False
-        
-        # Count active (non-archived) characters - defensive coding
-        active_count = 0
-        for char in self.characters:
-            if not char:
-                continue
-            if char.db.archived:
-                continue
-            active_count += 1
-        
-        return active_count >= max_slots
+
+        # Count active (non-archived) characters via the tag index
+        return len(self.active_sleeves) >= max_slots
 
     def at_post_login(self, session=None, **kwargs):
         """
@@ -209,18 +239,10 @@ class Account(DefaultAccount):
         - Starting character creation for new accounts
         - Handling archived characters
         """
-        # Use Evennia's account.characters (the _playable_characters list) - this is the authoritative source
-        all_characters = self.characters.all()
-        
-        # Filter for active (non-archived) characters
-        # Be defensive: only treat explicitly archived=True as archived
-        active_chars = []
-        for char in all_characters:
-            # Only exclude if explicitly archived
-            if char.db.archived is True:
-                continue
-            active_chars.append(char)
-        
+        # Split the account's sleeves on the tag index — one query, and the
+        # archived list is reused below for the last_character restore.
+        active_chars, archived_sleeves = self._sleeves_split()
+
         # CRITICAL: Only start character creation if there are ZERO active characters
         if not active_chars:
             # No active characters - start character creation
@@ -230,18 +252,11 @@ class Account(DefaultAccount):
                 
                 # Restore last_character if it's missing but we have archived characters
                 # This handles cases where last_character was cleared or lost
-                if not self.db.last_character:
-                    # Find most recently archived character
-                    archived_chars = []
-                    for char in all_characters:
-                        if char.db.archived is True:
-                            archived_date = char.db.archived_date or 0
-                            archived_chars.append((archived_date, char))
-                    
-                    # Sort by archive date (most recent first) and use the newest
-                    if archived_chars:
-                        archived_chars.sort(reverse=True, key=lambda x: x[0])
-                        self.db.last_character = archived_chars[0][1]
+                if not self.db.last_character and archived_sleeves:
+                    # Most recently archived sleeve (tag-indexed split above)
+                    self.db.last_character = max(
+                        archived_sleeves,
+                        key=lambda c: c.db.archived_date or 0)
                 
                 # Check if they have a last_character (from death or manual archival)
                 # If so, use respawn flow with flash clone + template options

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -453,6 +453,20 @@ class Character(
         except Exception as e:
             return f"Error in death analysis: {e}"
     
+    @property
+    def is_archived(self):
+        """Whether this sleeve is archived. Reads the tag index first (fast,
+        tag-cached), falling back to the legacy ``db.archived`` attribute for
+        sleeves archived before the tag existed."""
+        return bool(self.tags.has("archived", category="sleeve")
+                    or self.db.archived is True)
+
+    def unarchive_character(self):
+        """Clear archive state (attribute AND tag) — the single place both
+        stores are kept in sync when a sleeve is marked active."""
+        self.db.archived = False
+        self.tags.remove("archived", category="sleeve")
+
     def archive_character(self, reason="manual", disconnect_msg=None):
         """
         Archive this character and disconnect any active sessions.
@@ -476,10 +490,14 @@ class Character(
         # (This ensures "Jorge Jackson" -> "Jorge Jackson II" etc.)
         self.death_count += 1
         
-        # Set archive flags
+        # Set archive flags. The db attributes are the display/audit record;
+        # the TAG is the query index (spec §9 step 3) — account/website sleeve
+        # listings filter on it in one query instead of reading db.archived
+        # off every character.
         self.db.archived = True
         self.db.archived_reason = reason
         self.db.archived_date = time.time()
+        self.tags.add("archived", category="sleeve")
 
         # Engrave the OOC tombstone on the owning account — who the sleeve
         # was, born, died (DEATH_AND_SLEEVE_LIFECYCLE_SPEC §9). Every archive

--- a/web/website/views/characters.py
+++ b/web/website/views/characters.py
@@ -52,8 +52,9 @@ class CharacterCreateView(EvenniaCharacterCreateView):
                 # Check if character still exists and is accessible
                 _ = old_char.key
                 
-                # Check if character is actually archived/dead (default False for legacy)
-                is_archived = old_char.db.archived or False
+                # Check if character is actually archived/dead (tag-first, with
+                # legacy db.archived fallback inside the property)
+                is_archived = old_char.is_archived
                 
                 # If not archived, they're alive - clear last_character and proceed to normal creation
                 if not is_archived:
@@ -66,16 +67,10 @@ class CharacterCreateView(EvenniaCharacterCreateView):
                 # last_character reference is broken/invalid, clear it
                 account.db.last_character = None
         
-        # Check if account has reached max character limit
-        active_characters = []
-        for char in account.characters:
-            # Defensive check - ensure character is accessible
-            if not char:
-                continue
-            archived = char.db.archived or False
-            if not archived:
-                active_characters.append(char)
-        
+        # Check if account has reached max character limit (tag-indexed split,
+        # one query — spec §9 step 3)
+        active_characters = account.active_sleeves
+
         from django.conf import settings
         max_chars = settings.MAX_NR_CHARACTERS
         
@@ -126,7 +121,8 @@ class CharacterCreateView(EvenniaCharacterCreateView):
                 
                 # Ensure archived attribute exists (db attribute, not AttributeProperty)
                 if old_character.db.archived is None:
-                    old_character.db.archived = False  # Legacy characters were active when they died
+                    # Legacy characters were active when they died
+                    old_character.unarchive_character()
                     
             except (AttributeError, TypeError, Exception) as e:
                 # Old character reference is invalid/deleted - clear it
@@ -267,13 +263,8 @@ class CharacterCreateView(EvenniaCharacterCreateView):
         # Note: Account.check_available_slots() override in typeclasses/accounts.py
         # handles the primary slot checking. This view-level check provides additional
         # user-friendly validation before the character creation attempt.
-        active_characters = []
-        for char in account.characters:
-            # Access archived status via db.archived (returns None if unset)
-            archived = char.db.archived or False
-            if not archived:
-                active_characters.append(char)
-        
+        active_characters = account.active_sleeves   # tag-indexed, one query
+
         from django.conf import settings
         max_chars = settings.MAX_NR_CHARACTERS
         
@@ -337,7 +328,7 @@ class CharacterCreateView(EvenniaCharacterCreateView):
             character.db.stack_id = str(uuid.uuid4())
             character.db.original_creation = time.time()
             character.db.current_sleeve_birth = time.time()
-            character.db.archived = False
+            character.unarchive_character()   # attribute + sleeve-tag index in sync
             # death_count defaults to 1 via AttributeProperty in Character class
             
             # WEB-CREATED CHARACTERS: Make invisible until puppeted

--- a/world/tests/test_sleeve_archive_index.py
+++ b/world/tests/test_sleeve_archive_index.py
@@ -1,0 +1,76 @@
+"""Sleeve archive tag index (DEATH_AND_SLEEVE_LIFECYCLE_SPEC §9 step 3).
+
+Archived sleeves carry the ``archived`` tag (category ``sleeve``) as the query
+index; account listings split active/archived in one tag query instead of a
+``db.archived`` attribute read per character. Legacy flag-without-tag sleeves
+are self-healed into the index so an archived husk can never read as active.
+"""
+
+from evennia import create_object
+from evennia.utils.test_resources import EvenniaTest
+
+from typeclasses.characters import Character
+
+
+class TestArchiveTagIndex(EvenniaTest):
+    character_typeclass = Character
+
+    def setUp(self):
+        super().setUp()
+        # EvenniaTest links char1 to the account but does not register it in
+        # account.characters (the _playable_characters list) — do so, since
+        # the split reads that list.
+        self.account.characters.add(self.char1)
+
+    def _adopt(self, key):
+        """A second character on the test account."""
+        char = create_object(Character, key=key, location=self.room1)
+        char.db_account = self.account
+        char.save()
+        self.account.characters.add(char)
+        return char
+
+    def test_archive_adds_tag_and_unarchive_clears_both(self):
+        self.char1.archive_character(reason="manual")
+        self.assertTrue(self.char1.tags.has("archived", category="sleeve"))
+        self.assertTrue(self.char1.db.archived)
+        self.assertTrue(self.char1.is_archived)
+        self.char1.unarchive_character()
+        self.assertFalse(self.char1.tags.has("archived", category="sleeve"))
+        self.assertFalse(self.char1.db.archived)
+        self.assertFalse(self.char1.is_archived)
+
+    def test_is_archived_falls_back_to_legacy_attribute(self):
+        self.char1.db.archived = True          # pre-index sleeve: flag only
+        self.assertTrue(self.char1.is_archived)
+
+    def test_sleeves_split_by_tag(self):
+        retired = self._adopt("old sleeve")
+        retired.archive_character(reason="death")
+        active, archived = self.account._sleeves_split()
+        self.assertIn(self.char1, active)
+        self.assertNotIn(retired, active)
+        self.assertIn(retired, archived)
+        self.assertEqual(self.account.active_sleeves, active)
+        self.assertEqual(self.account.archived_sleeves, archived)
+
+    def test_split_self_heals_legacy_flag_without_tag(self):
+        legacy = self._adopt("legacy husk")
+        legacy.db.archived = True              # flag set, tag never written
+        active, archived = self.account._sleeves_split()
+        self.assertNotIn(legacy, active,
+                         "archived husk must never read as active")
+        self.assertIn(legacy, archived)
+        # ...and the index healed itself for next time.
+        self.assertTrue(legacy.tags.has("archived", category="sleeve"))
+
+    def test_at_character_limit_counts_only_active(self):
+        from django.test import override_settings
+        retired = self._adopt("dead weight")
+        retired.archive_character(reason="death")
+        with override_settings(MAX_NR_CHARACTERS=1):
+            # one active (char1) + one archived -> at the limit of 1, and the
+            # archived sleeve does not push us over
+            self.assertTrue(self.account.at_character_limit)
+        with override_settings(MAX_NR_CHARACTERS=2):
+            self.assertFalse(self.account.at_character_limit)


### PR DESCRIPTION
Spec §9 step 3. archive_character adds the 'archived' tag (category
'sleeve') as the query index; Account._sleeves_split/active_sleeves/
archived_sleeves split the account's characters in one tag query
instead of a db.archived read per character (archived sleeves
accumulate forever; actives are capped). Self-healing: a legacy
flag-without-tag sleeve is healed into the index on read, so an
archived husk can never read as active (at_post_login auto-puppets
actives — safety, not just perf). All account/web/charcreate scans
converted; Character.is_archived (tag-first) + unarchive_character
(attribute+tag in sync) are the canonical accessors.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
