### PR TITLE
Radio §7: LLM NPC radio comprehension — hear, gate, key up (Closes #1033)

### DIFF
--- a/commands/CmdRadio.py
+++ b/commands/CmdRadio.py
@@ -75,6 +75,14 @@ class CmdTransmit(Command):
         else:
             device = active_transmit_radio(caller)
             if device is None:
+                # Built-in comms organ fallback (a security unit's ear module,
+                # or any future implanted transceiver): same command, no
+                # handheld required. world.radio.transmit_organ gates on the
+                # organ being intact.
+                from world.radio import comms_organ_frequency, transmit_organ
+                if comms_organ_frequency(caller):
+                    transmit_organ(caller, self.message)
+                    return
                 caller.msg("You have no radio worn or in hand to transmit "
                            "with.")
                 return

--- a/specs/proposals/RADIO_COMMS_SPEC.md
+++ b/specs/proposals/RADIO_COMMS_SPEC.md
@@ -201,7 +201,24 @@ Antennae/repeaters/coverage holes, real coordinate range, the Drifts-dark
 rule, jamming devices, **power/battery**, encryption/scrambling, and the
 robot built-in-transceiver attacks (ride the robot-component work).
 
-## 7 · NPC radio comprehension — the next slice (📋 designed, not built)
+## 7 · NPC radio comprehension — ✅ SHIPPED (2026-07-04)
+
+> **Shipped as designed, all six sub-sections.** Delivery attaches the
+> say-rails structured payload (`speech=` for hearing listeners only) +
+> `radio_frequency`/`radio_elected`; `LLMNpcMixin._hear_radio` gates exactly
+> like room speech (named → answer; broadcast → elected unit only —
+> deterministic lowest-dbref election in `_deliver`; NPC-sourced →
+> observe-only loop guard; chatter → buffer + rare `radio_ambient`
+> volunteer). Radio turns attribute by VOICE (`radio_voice_handle`, shared
+> with the echo render), carry no visual perception, and scope memory to the
+> VOICE identity (`voice:<uid>` subject threaded through storage so nothing
+> cross-sensory leaks). Transmit = the `radio` action tool (granted to
+> `security`; withheld from `colonist`) → the REAL `xmit` command, whose new
+> no-handheld fallback keys a built-in comms organ (`transmit_organ`) — so
+> bots and any future implanted player transmit through the identical
+> command. Persona card advertises the device + band. Turn framing makes
+> air-vs-room unambiguous (§7.6). Physical gates hold throughout: delivery
+> is the hearing gate, the command refusal is the mute gate.
 
 Phase 1 built the physical medium and a scripted witness one-shot, but radio
 does **not** yet reach the NPC brains. Today: an LLM NPC with a powered walkie

--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -63,6 +63,13 @@ class LLMNpcMixin:
         # on the next reply. This is what keeps the single-threaded model from
         # saturating: poses cost nothing until they ride a turn we're making.
         speech = kwargs.get("speech")
+        # Radio traffic (RADIO_COMMS_SPEC §7): delivery already enforced the
+        # physical gate (powered tuned device / intact comms organ) and the
+        # hearing gate (a deaf listener gets no ``speech``). Distinct from
+        # room speech — the source is the AIR, not someone beside us.
+        if kwargs.get("type") == "radio":
+            self._hear_radio(speech, speaker, kwargs)
+            return True
         if kwargs.get("type") == "pose" and not speech:
             if self.db.llm_driven:
                 self._observe_action(speaker, text)
@@ -111,6 +118,68 @@ class LLMNpcMixin:
             return "directed"
         return "ambient"
 
+    # --- radio comprehension (RADIO_COMMS_SPEC §7) ------------------------
+
+    #: Band-wide address forms — "answer whoever's out there". Only the
+    #: ELECTED unit answers these (§7.2 de-confliction).
+    _RADIO_BROADCAST_PHRASES = ("all units", "any unit", "all stations",
+                                "anyone on this band", "anyone copy",
+                                "does anyone copy")
+
+    def _hear_radio(self, speech, speaker, kwargs):
+        """A transmission reached this NPC's device. Gate exactly like room
+        speech so a busy band can't saturate the model (§7.2):
+
+        * named directly → answer (directed cooldown);
+        * band-wide broadcast → only the elected receiver answers;
+        * NPC-sourced (witness reports, bot chatter) → observe-only, ever —
+          the loop guard that keeps two NPCs from ping-ponging on the air;
+        * everything else → observe into the buffer + the rare gated
+          volunteer, mirroring ambient room chatter."""
+        if not self.db.llm_driven or not speech:
+            return   # no brain to reach, or deaf (delivery sent no words)
+        voice = self._radio_voice_handle(speaker)
+        freq = kwargs.get("radio_frequency") or "the air"
+        overheard = f'Over the radio ({freq}), {voice} said: "{speech}"'
+        if not llm_enabled() or self._is_npc_speaker(speaker):
+            self._observe_action(speaker, overheard)
+            return
+        low = speech.lower()
+        broadcast = any(p in low for p in self._RADIO_BROADCAST_PHRASES)
+        if self._mentions_self(speech):
+            mode = "radio"                    # named: answer, cooldown-gated
+        elif broadcast and kwargs.get("radio_elected"):
+            mode = "radio"                    # "all units": we're the answerer
+        elif broadcast:
+            self._observe_action(speaker, overheard)
+            return                            # someone else's call to take
+        else:
+            # General chatter: buffer it (colours the next turn), and pass
+            # through the ambient gates for the rare volunteer.
+            self._observe_action(speaker, overheard)
+            mode = "radio_ambient"
+        delay(1.5, self._try_llm_reply, speech, speaker, mode)
+
+    def _radio_voice_handle(self, speaker):
+        """How this NPC knows the voice on the air — voice-only attribution
+        (shared with the player echo render; a modulator defeats it)."""
+        try:
+            from world.radio import radio_voice_handle
+            return radio_voice_handle(speaker, self)
+        except Exception:  # noqa: BLE001 — attribution is never load-bearing
+            return "an unfamiliar voice"
+
+    def _radio_subject(self, patron):
+        """Memory scoping for a voice on the air: the VOICE identity, never
+        the visual one — over radio this NPC has never SEEN the speaker, so
+        dossier/memory must not leak cross-sensory identity."""
+        try:
+            from world.voice import get_apparent_voice_uid
+            uid = get_apparent_voice_uid(patron)
+            return f"voice:{uid}" if uid else self._hist_key(patron)
+        except Exception:  # noqa: BLE001
+            return self._hist_key(patron)
+
     def _is_engaged_with(self, speaker):
         """Whether the conversation hold is active AND held for this speaker."""
         until = self.ndb.llm_engaged_until
@@ -149,13 +218,18 @@ class LLMNpcMixin:
         """
         if not self.db.llm_driven or not llm_enabled():
             return False
-        if (not self.location
+        radio = mode in ("radio", "radio_ambient")
+        # Radio is the one channel that legitimately crosses rooms — the
+        # device is the gate (§7.5), already enforced at delivery. Everything
+        # else requires sharing the room.
+        if not radio and (
+                not self.location
                 or getattr(patron, "location", None) is not self.location):
             return False
 
         now = monotonic()
         last = self.ndb.last_llm or 0
-        if mode in ("ambient", "arrival"):
+        if mode in ("ambient", "arrival", "radio_ambient"):
             # Volunteering into the room (overheard chatter or someone walking
             # in) is rate-limited and probabilistic so the NPC doesn't pounce.
             if now - last < LLM_AMBIENT_COOLDOWN:
@@ -176,11 +250,16 @@ class LLMNpcMixin:
 
         # Capture everything reactor-side BEFORE threading (SQLite/Evennia-thread
         # contract). The agentic loop re-calls from the reactor-side callback.
+        # Radio turns attribute by VOICE and carry no visual perception — the
+        # speaker isn't in front of us (§7.1); memory scopes to the voice
+        # identity so nothing cross-sensory leaks.
         persona = build_persona(self)
-        speaker_name = self._address_handle(patron)
-        perception = self._perceive(patron)
+        speaker_name = (self._radio_voice_handle(patron) if radio
+                        else self._address_handle(patron))
+        perception = None if radio else self._perceive(patron)
         history = self._recent_history(patron)
-        subject = self._memory_subject(patron)
+        subject = (self._radio_subject(patron) if radio
+                   else self._memory_subject(patron))
         relationship = self._relationship_line(subject, patron)
         events = self._drain_actions()  # what we've witnessed since last reply
         present = self._present_others(patron)  # who else is in the room now
@@ -192,7 +271,8 @@ class LLMNpcMixin:
                                       relationship=relationship, events=events,
                                       present=present)
             self._agentic_round(messages, persona, patron, line or "",
-                                speaker_name, on_fail, rounds=0)
+                                speaker_name, on_fail, rounds=0,
+                                subject=subject)
 
         def _with_query_vec(vec):
             # reactor-side: score this NPC's memories against the line, inject.
@@ -380,16 +460,18 @@ class LLMNpcMixin:
         d[subject] = entry
         self.db.llm_dossiers = d
 
-    def _store_memory(self, patron, speaker_name, line, speech):
+    def _store_memory(self, patron, speaker_name, line, speech, subject=None):
         """Remember this exchange: embed it off-reactor, then write a record
         (scoped to the interlocutor) and prune. Fire-and-forget — runs after the
-        reply has already rendered, so it never delays the NPC."""
+        reply has already rendered, so it never delays the NPC. ``subject``
+        overrides the scoping identity (voice-scoped on radio turns) so
+        storage always matches what retrieval will look under."""
         if not line:
             return
         text = f'{speaker_name} said: "{line}"'
         if speech:
             text += f' — I answered: "{speech}"'
-        subject = self._memory_subject(patron)
+        subject = subject or self._memory_subject(patron)
 
         def _save(vec):
             recs = self._load_memories()
@@ -435,19 +517,21 @@ class LLMNpcMixin:
     # --- the agentic tool loop (constrained turn → context tools → reply) ----
 
     def _agentic_round(self, messages, persona, patron, line, speaker_name,
-                       on_fail, rounds):
+                       on_fail, rounds, subject=None):
         """One constrained generation; the reactor-side callback either runs a
-        context tool and loops, or renders the final reply + any action tool."""
+        context tool and loops, or renders the final reply + any action tool.
+        ``subject`` is the memory-scoping identity for this turn (voice-scoped
+        on radio turns) — threaded through so storage matches retrieval."""
         request_turn(
             messages,
             on_turn=partial(self._on_turn, messages, persona, patron, line,
-                            speaker_name, on_fail, rounds),
+                            speaker_name, on_fail, rounds, subject),
             on_fail=on_fail,
             schema=schema_for(persona),  # tool enum scoped to the archetype
         )
 
     def _on_turn(self, messages, persona, patron, line, speaker_name, on_fail,
-                 rounds, raw):
+                 rounds, subject, raw):
         turn = parse_turn(raw, persona, tool_names(persona))
         # Echo guard: a pose aimed at the NPC sometimes comes straight back
         # as its "own" action (or speech). Parroting reads broken — drop it.
@@ -464,7 +548,7 @@ class LLMNpcMixin:
                 {"role": "user", "content": f"[tool result · {tool}] {result}"},
             ]
             self._agentic_round(extended, persona, patron, line, speaker_name,
-                                on_fail, rounds + 1)
+                                on_fail, rounds + 1, subject=subject)
             return
         # Terminal: render speech/action/thought, route any action tool, remember.
         self._render_llm_reply(turn["speech"], turn["action"], turn["thought"],
@@ -473,7 +557,8 @@ class LLMNpcMixin:
         self._remember_turn(patron, line, speaker_name, turn["speech"],
                             turn["action"], turn["thought"])
         # Long-term memory: persist what was learned (async, post-render).
-        self._store_memory(patron, speaker_name, line, turn["speech"])
+        self._store_memory(patron, speaker_name, line, turn["speech"],
+                           subject=subject)
 
     def _run_context_tool(self, tool, arg, patron):
         """Run a read-only context tool and return its result for the model.
@@ -514,6 +599,14 @@ class LLMNpcMixin:
             if verb in ("zip", "unzip", "button", "unbutton",
                         "rollup", "unroll", "remove", "wear") and garment:
                 self.execute_cmd(f"{verb} {garment}")
+        elif tool == "radio" and arg:
+            # Key up for REAL through the transmit command (§7.3) — worn/held
+            # walkie first; the command's own fallback covers a built-in comms
+            # organ. No device = the command refuses = the NPC stays mute,
+            # exactly as it would for a player (§7.5).
+            words = " ".join(str(arg).split()).strip().strip('"').strip()
+            if words:
+                self.execute_cmd(f"xmit {words}")
         elif tool == "release":
             # The character has decided the exchange is over: drop the
             # conversation hold so the routine (patrol/drift) resumes on

--- a/typeclasses/llm_persona.py
+++ b/typeclasses/llm_persona.py
@@ -111,7 +111,29 @@ def build_persona(npc) -> dict:
 
     wearing, carrying = _wardrobe(npc)
 
+    # Radio state (RADIO_COMMS_SPEC §7.3): what the brain can key up with —
+    # a worn/held powered walkie, or a built-in comms organ. None = no way
+    # onto the air (the radio tool would refuse, so don't advertise it).
+    radio = None
+    try:
+        from world.radio import (
+            active_transmit_radio, comms_organ_frequency, frequency_of,
+            is_powered,
+        )
+        device = active_transmit_radio(npc)
+        if device is not None and is_powered(device):
+            band = frequency_of(device)
+            radio = (f"a radio tuned to {band}" if band
+                     else "a radio tuned to nothing")
+        else:
+            band = comms_organ_frequency(npc)
+            if band:
+                radio = f"a built-in comms module tuned to {band}"
+    except Exception:  # noqa: BLE001 — persona building never breaks on comms
+        radio = None
+
     return {
+        "radio": radio,
         "sdesc": npc.get_sdesc(),
         "wearing": wearing,
         "carrying": carrying,

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -55,6 +55,14 @@ TOOLS = {
                         "said your piece, or you'd simply rather move on; "
                         "your speech/action this turn are your goodbye "
                         "(argument: '')"},
+    "radio": {"kind": "action",
+              "desc": "key up your radio and speak over the air — everyone "
+                      "tuned to your band hears it, wherever they are, and "
+                      "your device transmits for REAL. Use it to answer a "
+                      "radio call or raise someone who is NOT in the room; "
+                      "to talk to someone standing in front of you, just "
+                      "speak (argument: exactly the words you say on the "
+                      "air)"},
     "check_stock": {"kind": "context",
                     "desc": "list exactly what the bar can serve right now "
                             "(argument: '')"},
@@ -360,7 +368,9 @@ ARCHETYPES = {
         ),
         "length": ("One or two clipped lines, machine-cadence. No warmth, no "
                    "filler. A short mechanical pose at most."),
-        "tools": ["release"],  # may end an exchange; combat/detain stays deterministic
+        # radio: the unit's comms organ keys up for real (§7.4) — flavour on
+        # the air; combat/detain/dispatch stay deterministic.
+        "tools": ["release", "radio"],
         "fewshot": [
             {"user": 'a bystander says to you: "what happened here?"',
              "assistant": {"speech": "Incident under review. Details are "
@@ -485,6 +495,9 @@ def render_persona(persona: dict) -> str:
     carrying = persona.get("carrying")
     if carrying:
         lines.append("You are carrying: " + ", ".join(carrying) + ".")
+    if persona.get("radio"):
+        lines.append(f"You have {persona['radio']} — the 'radio' tool "
+                     f"transmits over it; everyone on that band hears you.")
     loc = persona.get("location") or {}
     if loc.get("name"):
         # Neutral placement — what the NPC *does* here comes from its archetype
@@ -552,7 +565,8 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
         charter += "\n\nLENGTH: " + arch["length"]
     charter += "\n\n" + _tools_block(tool_names(persona))
     charter += "\n" + CHARTER_POSE_IDENTITY
-    charter += (CHARTER_AMBIENT if mode in ("ambient", "arrival") else "")
+    charter += (CHARTER_AMBIENT
+                if mode in ("ambient", "arrival", "radio_ambient") else "")
     system = charter + "\n\n" + render_persona(persona)
     # A persona may carry a `register` — an imperative directive placed LAST
     # (most salient) to steer tone/explicitness. Lives in the NPC's DB persona,
@@ -589,7 +603,21 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
     mem = who + seen + here + mem
     perc = f"[PERCEPTION — when you look at {speaker} you see: {perception}]\n\n" \
         if perception else ""
-    if mode == "ambient":
+    if mode == "radio":
+        # `speaker` is a VOICE handle — the far end is NOT in the room. The
+        # framing must be unambiguous (§7.6) or the model answers a remote
+        # call face-to-face, or mutters at the air to a present patron.
+        turn = (f'{mem}Over your radio you hear {speaker} say: "{line}"\n\n'
+                f"(That came over the AIR — the speaker is somewhere else, "
+                f"not in the room with you. To answer THEM, use the radio "
+                f"tool; anything in speech/action happens here in the room, "
+                f"seen only by those present.)")
+    elif mode == "radio_ambient":
+        turn = (f'{mem}Radio chatter on your band — {speaker}: "{line}" '
+                f"(Not addressed to you; the speaker is somewhere else. Key "
+                f"up — the radio tool — only if your character truly would; "
+                f"staying silent is normal.)")
+    elif mode == "ambient":
         turn = f'{mem}{perc}You overhear {speaker} say: "{line}"'
     elif mode == "arrival":
         # No speech — `speaker` just entered the room. React only if the

--- a/world/radio.py
+++ b/world/radio.py
@@ -189,26 +189,30 @@ def _comms_bots_on(frequency: str) -> list:
     return out
 
 
+def radio_voice_handle(speaker: Any, listener: Any) -> str:
+    """How *listener* knows the voice on the air: a recognised voice names
+    them (voice memory; a modulator defeats it), else the voice descriptor,
+    else "an unfamiliar voice". Attribution is VOICE-ONLY — you can't see the
+    far end. Shared by the echo render and the NPC brain (§7.1)."""
+    from world.voice import attempt_voice_discern, get_voice_description
+    known = attempt_voice_discern(listener, speaker)
+    if known:
+        return known
+    desc = get_voice_description(speaker)
+    return f"a {desc} voice" if desc else "an unfamiliar voice"
+
+
 def _render_radio_line(speaker: Any, listener: Any, message: str,
                        frequency: str, *, tagged: bool) -> str:
     """A received transmission, VOICE-attributed (never sight — you can't see
     the far end) and hearing-gated. ``tagged`` prefixes the frequency (scanner
     sweep mode caught it off-band)."""
     from world.perception import can_hear
-    from world.voice import (
-        attempt_voice_discern, get_voice_description, voice_phrase,
-    )
+    from world.voice import voice_phrase
     band = f"[{frequency}] " if tagged else ""
     if not can_hear(listener):
         return f"{band}Your radio crackles, but you can't make out a word."
-    # Attribution: a known voice names them; else the voice descriptor; else
-    # a bare "someone". Mirrors resolve_speaker_attribution's voice branch.
-    known = attempt_voice_discern(listener, speaker)
-    if known:
-        who = known
-    else:
-        desc = get_voice_description(speaker)
-        who = f"a {desc} voice" if desc else "an unfamiliar voice"
+    who = radio_voice_handle(speaker, listener)
     flavour = voice_phrase(speaker)
     flav = f" |x*{flavour}*|n" if flavour else ""
     return (f'{band}{who[:1].upper()}{who[1:]} crackles over the radio{flav}: '
@@ -241,33 +245,80 @@ def transmit(speaker: Any, message: str, device: Any) -> bool:
     return True
 
 
+def transmit_organ(speaker: Any, message: str) -> bool:
+    """Key up a BUILT-IN comms organ — the transceiver a security unit wears
+    in its ear (§2.1). No handheld needed; the organ's intactness is the
+    physical gate (destroyed ear = mute, same as deaf). Same air, same log,
+    same delivery as a walkie. ``transmit``'s no-device fallback routes here,
+    so a bot keys up through the identical player command."""
+    frequency = comms_organ_frequency(speaker)
+    if not frequency:
+        speaker.msg("You have no working comms module to transmit with.")
+        return False
+    speaker.msg(f'You transmit on {frequency}: "{message}"')
+    _log_to_channel(speaker, message, frequency)
+    _deliver(speaker, message, frequency, None)
+    return True
+
+
 def _deliver(speaker: Any, message: str, frequency: str,
              exclude_device: Any) -> None:
     """Echo a transmission to every receiver on *frequency*: powered walkies
     (tuned or scanning) held by a character, and security units with a live
     built-in comms organ. Deduped per receiver so a bot holding a walkie AND
-    wearing a comms organ hears it once."""
-    delivered = set()
+    wearing a comms organ hears it once.
 
-    def _send(listener, *, tagged):
-        if listener is None or listener is speaker or id(listener) in delivered:
+    Each hearing listener also gets the STRUCTURED speech payload the say
+    rails use (``speech=<words>``, world.speech) plus radio kwargs — so an NPC
+    brain reads one shape regardless of the carrying verb (§7.1). A deaf
+    listener gets the static line and no words. One listener among the
+    LLM-driven receivers is ELECTED (``radio_elected=True``) — the §7.2
+    single-answerer for "all units"-style broadcasts, so a band-wide call
+    can't raise a chorus."""
+    receivers = []          # (listener, tagged), deduped, order-stable
+    seen = set()
+
+    def _collect(listener, *, tagged):
+        if listener is None or listener is speaker or id(listener) in seen:
             return
         if not hasattr(listener, "msg"):
             return
-        delivered.add(id(listener))
-        try:
-            listener.msg(_render_radio_line(
-                speaker, listener, message, frequency, tagged=tagged),
-                type="radio", from_obj=speaker)
-        except Exception:  # noqa: BLE001 — one bad listener never stops the net
-            pass
+        seen.add(id(listener))
+        receivers.append((listener, tagged))
 
     for radio in _all_powered_radios():
         if radio is exclude_device:
             continue
         scanning = is_scanning(radio)
         if scanning or same_band(frequency_of(radio), frequency):
-            _send(radio.location, tagged=scanning)   # holder hears it
+            _collect(radio.location, tagged=scanning)   # holder hears it
 
     for bot in _comms_bots_on(frequency):
-        _send(bot, tagged=False)                      # built-in transceiver
+        _collect(bot, tagged=False)                      # built-in transceiver
+
+    # Single-answerer election: deterministic (lowest dbref) among LLM-driven
+    # receivers. Range is abstracted in P1, so "nearest" has no meaning yet.
+    elected = None
+    try:
+        candidates = [l for l, _ in receivers
+                      if getattr(getattr(l, "db", None), "llm_driven", False)
+                      is True]
+        if candidates:
+            elected = min(candidates, key=lambda l: getattr(l, "id", 0) or 0)
+    except Exception:  # noqa: BLE001 — election is best-effort flavour
+        elected = None
+
+    from world.perception import can_hear
+    for listener, tagged in receivers:
+        try:
+            payload = {}
+            if can_hear(listener):
+                payload["speech"] = message   # the say-rails contract
+            listener.msg(_render_radio_line(
+                speaker, listener, message, frequency, tagged=tagged),
+                type="radio", from_obj=speaker,
+                radio_frequency=frequency,
+                radio_elected=(listener is elected),
+                **payload)
+        except Exception:  # noqa: BLE001 — one bad listener never stops the net
+            pass

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -351,7 +351,8 @@ class TestEchoGuard(TestCase):
         _bind(b, "_on_turn")
         with patch.object(llmnpc, "parse_turn", return_value=dict(turn)), \
                 patch.object(llmnpc, "tool_names", return_value=[]):
-            b._on_turn([], {}, MagicMock(), line, "a man", lambda: None, 0, "{}")
+            b._on_turn([], {}, MagicMock(), line, "a man", lambda: None, 0,
+                       None, "{}")
         return b._render_llm_reply.call_args.args
 
     def test_parroted_pose_dropped_before_render(self):

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -301,7 +301,7 @@ class TestParseTurn(TestCase):
     def test_schema_tool_enum(self):
         self.assertEqual(TURN_SCHEMA["properties"]["tool"]["enum"],
                          ["none", "look", "remember", "feel", "style",
-                          "release", "check_stock", "prepare_drink",
+                          "release", "radio", "check_stock", "prepare_drink",
                           "diagnose", "treat", "install"])
 
 

--- a/world/tests/test_radio_comprehension.py
+++ b/world/tests/test_radio_comprehension.py
@@ -1,0 +1,231 @@
+"""NPC radio comprehension (RADIO_COMMS_SPEC §7).
+
+Radio reaches the LLM brain as heard-over-the-air words (say-rails speech
+payload), gated like room speech: named → answer; "all units" → only the
+elected unit; NPC-sourced → observe-only (the loop guard); chatter → buffer +
+rare volunteer. Transmit rides the real ``xmit`` command, with the built-in
+comms organ as the command's own no-handheld fallback.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import typeclasses.llm_npc as llmnpc
+import world.radio as radio
+from world.radio import transmit, transmit_organ
+
+
+def _bind(b, name):
+    setattr(b, name,
+            getattr(llmnpc.LLMNpcMixin, name).__get__(b, llmnpc.LLMNpcMixin))
+
+
+def _radio(on=True, freq="447", holder=None, holder_id=1):
+    r = MagicMock()
+    r.db.is_radio = True
+    r.db.radio_on = on
+    r.db.frequency = freq
+    listener = MagicMock()
+    listener.id = holder_id
+    listener.db.llm_driven = False
+    r.location = holder if holder is not None else listener
+    return r
+
+
+def _speaker():
+    c = MagicMock()
+    c.get_worn_items = lambda: []
+    c.hands = {}
+    c.contents = []
+    return c
+
+
+class TestDeliveryPayload(TestCase):
+    def _tx(self, listeners_radios, message="unit 7, report in"):
+        speaker = _speaker()
+        dev = _radio(freq="447")
+        dev.location = speaker
+        with patch.object(radio, "_all_powered_radios",
+                          return_value=[dev] + listeners_radios), \
+                patch.object(radio, "_comms_bots_on", return_value=[]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern", return_value=None), \
+                patch("world.voice.get_voice_description", return_value="flat"), \
+                patch("world.voice.voice_phrase", return_value=None):
+            transmit(speaker, message, dev)
+
+    def test_hearing_listener_gets_speech_payload(self):
+        heard = _radio(freq="447")
+        self._tx([heard], "rendezvous at the docks")
+        kwargs = heard.location.msg.call_args.kwargs
+        self.assertEqual(kwargs["speech"], "rendezvous at the docks")
+        self.assertEqual(kwargs["type"], "radio")
+        self.assertEqual(kwargs["radio_frequency"], "447")
+
+    def test_deaf_listener_gets_no_words(self):
+        speaker = _speaker()
+        dev = _radio(freq="447"); dev.location = speaker
+        heard = _radio(freq="447")
+        with patch.object(radio, "_all_powered_radios",
+                          return_value=[dev, heard]), \
+                patch.object(radio, "_comms_bots_on", return_value=[]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.perception.can_hear", return_value=False):
+            transmit(speaker, "secret", dev)
+        kwargs = heard.location.msg.call_args.kwargs
+        self.assertNotIn("speech", kwargs)   # static, no content to react to
+
+    def test_exactly_one_llm_listener_is_elected(self):
+        a, b = _radio(freq="447", holder_id=10), _radio(freq="447", holder_id=20)
+        a.location.db.llm_driven = True
+        b.location.db.llm_driven = True
+        self._tx([a, b])
+        elected = [r.location.msg.call_args.kwargs["radio_elected"]
+                   for r in (a, b)]
+        self.assertEqual(sorted(elected), [False, True])
+        # deterministic: the lowest id answers
+        self.assertTrue(a.location.msg.call_args.kwargs["radio_elected"])
+
+
+class TestTransmitOrgan(TestCase):
+    def test_intact_organ_transmits(self):
+        bot = _speaker()
+        with patch.object(radio, "comms_organ_frequency",
+                          return_value="911MHz"), \
+                patch.object(radio, "_log_to_channel"), \
+                patch.object(radio, "_deliver") as deliver:
+            self.assertTrue(transmit_organ(bot, "unit responding"))
+        deliver.assert_called_once_with(bot, "unit responding", "911MHz", None)
+
+    def test_no_organ_refuses(self):
+        char = _speaker()
+        with patch.object(radio, "comms_organ_frequency", return_value=None):
+            self.assertFalse(transmit_organ(char, "hello?"))
+        self.assertIn("no working comms", char.msg.call_args.args[0])
+
+    def test_xmit_command_falls_back_to_organ(self):
+        from commands.CmdRadio import CmdTransmit
+        cmd = CmdTransmit()
+        caller = MagicMock()
+        caller.get_worn_items = lambda: []
+        caller.hands = {}
+        cmd.caller = caller
+        cmd.args = "unit responding, en route"
+        cmd.parse()
+        with patch("world.radio.comms_organ_frequency",
+                   return_value="911MHz"), \
+                patch("world.radio.transmit_organ") as org:
+            cmd.func()
+        org.assert_called_once_with(caller, "unit responding, en route")
+
+
+class TestHearRadio(TestCase):
+    def _npc(self, elected=False, llm=True):
+        b = MagicMock()
+        b.key = "Unit 7"
+        b.sdesc_keyword = None
+        b.db.llm_driven = llm
+        b.ndb.action_buffer = None
+        b._is_npc_speaker = lambda s: False
+        b._radio_voice_handle = lambda s: "a flat voice"
+        b._name_aliases = lambda: []
+        # class constant — a bare MagicMock would swallow it into a Mock
+        b._RADIO_BROADCAST_PHRASES = llmnpc.LLMNpcMixin._RADIO_BROADCAST_PHRASES
+        for m in ("_hear_radio", "_observe_action", "_mentions_self"):
+            _bind(b, m)
+        return b
+
+    def _kwargs(self, elected=False):
+        return {"type": "radio", "radio_frequency": "911MHz",
+                "radio_elected": elected}
+
+    def test_named_directly_answers(self):
+        b = self._npc()
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as d:
+            b._hear_radio("Unit 7, report in.", MagicMock(), self._kwargs())
+        d.assert_called_once()
+        self.assertIn("radio", d.call_args.args)      # directed radio mode
+
+    def test_broadcast_only_elected_answers(self):
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as d:
+            self._npc()._hear_radio("all units, check in.", MagicMock(),
+                                    self._kwargs(elected=True))
+        d.assert_called_once()
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as d2:
+            b2 = self._npc()
+            b2._hear_radio("all units, check in.", MagicMock(),
+                           self._kwargs(elected=False))
+        d2.assert_not_called()                         # someone else's call
+        self.assertTrue(b2.ndb.action_buffer)          # ...but still heard
+
+    def test_npc_sourced_is_observed_never_answered(self):
+        b = self._npc()
+        b._is_npc_speaker = lambda s: True             # witness / bot chatter
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as d:
+            b._hear_radio("Unit 7, trouble on Cobb Street!", MagicMock(),
+                          self._kwargs(elected=True))
+        d.assert_not_called()                          # the loop guard holds
+        self.assertIn('a flat voice said: "Unit 7, trouble on Cobb Street!"',
+                      b.ndb.action_buffer[0])
+
+    def test_chatter_buffers_and_volunteers_ambient(self):
+        b = self._npc()
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as d:
+            b._hear_radio("quiet night out there.", MagicMock(),
+                          self._kwargs())
+        self.assertTrue(b.ndb.action_buffer)           # colours the next turn
+        d.assert_called_once()
+        self.assertIn("radio_ambient", d.call_args.args)
+
+    def test_deaf_or_brainless_hears_nothing(self):
+        b = self._npc()
+        with patch.object(llmnpc, "delay") as d:
+            b._hear_radio(None, MagicMock(), self._kwargs())   # deaf: no words
+        d.assert_not_called()
+        self.assertFalse(b.ndb.action_buffer)
+        b2 = self._npc(llm=False)
+        with patch.object(llmnpc, "delay") as d2:
+            b2._hear_radio("hello?", MagicMock(), self._kwargs())
+        d2.assert_not_called()
+
+    def test_at_msg_receive_routes_radio(self):
+        b = self._npc()
+        b._hear_radio = MagicMock()
+        _bind(b, "at_msg_receive")
+        b.at_msg_receive(text="[447] A flat voice crackles...",
+                         from_obj=MagicMock(), type="radio",
+                         speech="come in", radio_frequency="447")
+        b._hear_radio.assert_called_once()
+
+
+class TestRadioTool(TestCase):
+    def test_registered_and_granted_to_security(self):
+        from world.llm.prompt import ARCHETYPES, TOOLS
+        self.assertIn("radio", TOOLS)
+        self.assertEqual(TOOLS["radio"]["kind"], "action")
+        self.assertIn("radio", ARCHETYPES["security"]["tools"])
+        self.assertNotIn("radio", ARCHETYPES["colonist"]["tools"])
+
+    def test_tool_routes_to_real_xmit_command(self):
+        b = MagicMock()
+        _bind(b, "_handle_action_tool")
+        b._handle_action_tool("radio", '"Unit responding, en route."',
+                              MagicMock())
+        b.execute_cmd.assert_called_once_with(
+            "xmit Unit responding, en route.")
+
+    def test_radio_turn_framing_is_unambiguous(self):
+        from world.llm.prompt import build_messages
+        msgs = build_messages({}, "a flat voice", "report in", "radio")
+        turn = msgs[-1]["content"]
+        self.assertIn("Over your radio", turn)
+        self.assertIn("not in the room", turn)
+        msgs2 = build_messages({}, "a flat voice", "quiet night",
+                               "radio_ambient")
+        self.assertIn("Radio chatter", msgs2[-1]["content"])


### PR DESCRIPTION
Delivery attaches the say-rails speech payload (hearing-gated) plus
radio_frequency/radio_elected; _hear_radio gates like room speech:
named -> answer, broadcast -> elected unit only (deterministic
lowest-dbref election), NPC-sourced -> observe-only loop guard,
chatter -> buffer + rare radio_ambient volunteer. Radio turns
attribute by voice (radio_voice_handle, shared with the echo render),
no visual perception, memory scoped to the voice identity and threaded
through storage so nothing cross-sensory leaks.

Transmit: 'radio' action tool (security yes, colonist no) -> the REAL
xmit command; CmdTransmit falls back to an intact built-in comms organ
(transmit_organ) so bots key up through the identical player command.
Persona card advertises the device + band; turn framing keeps
air-vs-room unambiguous.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
