### PR TITLE
Secbots: fit comms modules into pre-#1009 units at heartbeat start (Closes #1035)

### DIFF
--- a/world/director/population.py
+++ b/world/director/population.py
@@ -168,6 +168,32 @@ def count_posted_secbots(base: Any) -> int:
     return n
 
 
+def ensure_comms_fitted() -> int:
+    """Upkeep: factory-fit the comms module into any LIVE security unit that
+    never got one (units spawned before the transceiver shipped, #1009).
+    Idempotent — a unit whose organs already carry the module (even a
+    DESTROYED one: an EMP'd ear stays dead, we don't magically re-arm it)
+    is a dict-key check, no write. Runs in-process from the heartbeat's
+    at_start, so the running server's idmapper stays authoritative."""
+    from evennia.objects.models import ObjectDB
+    fitted = 0
+    for bot in ObjectDB.objects.filter(
+            db_attributes__db_key="role").distinct():
+        if getattr(bot.db, "role", None) != "security":
+            continue
+        state = getattr(bot, "medical_state", None)
+        if state is None:
+            continue
+        if "comms_module" in (getattr(state, "organs", None) or {}):
+            continue
+        try:
+            factory_fit_comms(bot)
+            fitted += 1
+        except Exception:  # noqa: BLE001 — one odd unit never stops the sweep
+            continue
+    return fitted
+
+
 def maintain_security_complement() -> Any | None:
     """One heartbeat of the respawn loop: if living posted units fall
     short of the base's complement, cycle ONE replacement out of the

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -194,6 +194,17 @@ class DirectorRoutineScript(DefaultScript):
         self.interval = HEARTBEAT_SECONDS
         self.persistent = True
 
+    def at_start(self):
+        """Once per server start/reload: upkeep that must be true of the
+        standing population, applied in-process (never via external shell —
+        idmapper). Today: factory-fit the comms module into any security
+        unit spawned before the transceiver existed (#1009). Idempotent."""
+        try:
+            from world.director.population import ensure_comms_fitted
+            ensure_comms_fitted()
+        except Exception:  # noqa: BLE001 — upkeep must not stall the beats
+            pass
+
     def at_repeat(self):
         counts = tick_all()
         try:

--- a/world/tests/test_director_population.py
+++ b/world/tests/test_director_population.py
@@ -43,6 +43,39 @@ class TestComplementCount(TestCase):
         self.assertEqual(count_posted_secbots(base), 1)
 
 
+class TestEnsureCommsFitted(TestCase):
+    """The reload-time upkeep sweep: fit the comms module into pre-#1009
+    units, never touch a unit that already has one (even destroyed)."""
+
+    def _unit(self, organs):
+        bot = MagicMock(name="bot")
+        bot.db = SimpleNamespace(role="security")
+        bot.medical_state = SimpleNamespace(organs=organs)
+        return bot
+
+    @patch("world.director.population.factory_fit_comms")
+    @patch("evennia.objects.models.ObjectDB")
+    def test_fits_only_units_missing_the_module(self, mock_db, mock_fit):
+        from world.director.population import ensure_comms_fitted
+        bare = self._unit({})                              # pre-#1009: fit
+        fitted = self._unit({"comms_module": MagicMock()})  # has one: skip
+        destroyed = self._unit({"comms_module": MagicMock()})  # EMP'd: skip
+        civilian = MagicMock(); civilian.db = SimpleNamespace(role="miner")
+        mock_db.objects.filter.return_value.distinct.return_value = [
+            bare, fitted, destroyed, civilian]
+        self.assertEqual(ensure_comms_fitted(), 1)
+        mock_fit.assert_called_once_with(bare)
+
+    @patch("world.director.population.factory_fit_comms",
+           side_effect=RuntimeError("bad unit"))
+    @patch("evennia.objects.models.ObjectDB")
+    def test_one_bad_unit_never_stops_the_sweep(self, mock_db, _fit):
+        from world.director.population import ensure_comms_fitted
+        units = [self._unit({}), self._unit({})]
+        mock_db.objects.filter.return_value.distinct.return_value = units
+        self.assertEqual(ensure_comms_fitted(), 0)   # both failed, no raise
+
+
 class TestMaintain(TestCase):
     @patch("world.director.population.spawn_secbot")
     @patch("world.director.population.count_posted_secbots", return_value=2)


### PR DESCRIPTION
Live verification of #1033 found the 5 standing units predate
factory_fit_comms — no organ, so radio can't reach them. Fix is
self-healing in-process upkeep, not external-shell surgery (idmapper):
ensure_comms_fitted() sweeps live security units once per server start
(heartbeat at_start) and fits any unit MISSING the module. A unit that
already carries one — including a DESTROYED one (an EMP'd ear stays
dead) — is a dict-key check, never a write.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
