### PR TITLE
Civilians: reaction escalation ladder — comply→flee, cornered rat (Closes #1037)

### DIFF
--- a/specs/proposals/NPC_DISPATCH_AND_SIMULATION_SPEC.md
+++ b/specs/proposals/NPC_DISPATCH_AND_SIMULATION_SPEC.md
@@ -280,6 +280,26 @@ only question is whether you were *seen*.
   **nature/demeanor/traits axis** on NPCs informs both these deterministic
   reactions *and* the LLM persona when one is puppeted — one personality
   substrate, two consumers.
+
+  **✅ ESCALATION LADDER (shipped 2026-07-04):** reactions are stateful
+  (`ndb.reaction_stage`), not a stateless one-shot — continued violence
+  climbs: **comply → flee** (surrender answered with violence is off the
+  table; the rung persists, so a beaten hawker never re-offers hands-up),
+  **flee → resist when armed** (the *cornered rat*: a scavver denied an
+  exit turns and draws; unarmed keeps retrying the run), **resist is
+  terminal** (no re-reaction, no spam — the old form re-fired the same
+  emote every swing). Dialogue is NEVER scripted: for LLM NPCs the attack +
+  their own mechanical response is *observed into the action buffer*
+  (combat informs the prompt; the model owns the words, no forced turn).
+
+  **Decision (2026-07-04, closes the #1004 revert question):** melee
+  **proximity is positional, not combat membership** — the orphan sweep
+  keeps target/targeted-by/grapple/aim relationships only. An attacker who
+  ever swung holds their victim via target-lock; the sole dissolve case is
+  someone who closed distance but never attacked, and re-attacking simply
+  re-forms combat. Watch item: yield-to-dissolve initiative resets (fix, if
+  ever needed, is re-engage initiative carry-over — not
+  proximity-as-membership).
 * **The report step** — the victim runs the §5.1 witness pipeline on
   themselves: delay (the interdiction window), then report if able.
 

--- a/world/director/civilians.py
+++ b/world/director/civilians.py
@@ -456,11 +456,29 @@ def purge_civilians(role: str | None = None) -> int:
 # --------------------------------------------------------------------------
 
 def react_to_attack(victim: Any, attacker: Any) -> None:
-    """Role-shaped reaction when *victim* is attacked. The combat handler
-    already enrolls victims targeting their attacker (default = fight
-    back), so: **resist** just draws the blade if one is carried;
-    **comply** stops attacking (yields — hands up, in effect); **flee**
-    runs for it. All through real commands, all fail-open."""
+    """Role-shaped reaction when *victim* is attacked — an ESCALATION LADDER,
+    not a stateless one-shot (the old form re-fired the same reaction on
+    every swing: hands thrown up three times in one fight).
+
+    First attack answers with the role's posture; CONTINUED violence climbs:
+
+    * **comply** → hands up. Attacked again → compliance didn't buy safety:
+      **flee**. Attacked still → cornered (armed roles draw — see flee).
+    * **flee** → run. Attacked again: unarmed keeps trying to run (a retry —
+      flee can fail); ARMED turns cornered rat — draws and stands
+      (**resist**). A scavver denied an exit is dangerous.
+    * **resist** → draw once. Terminal: they're already fighting; no
+      re-reaction, no spam.
+
+    The rung persists on the NPC (``ndb.reaction_stage``) for its remaining
+    life — a hawker whose surrender was answered with violence doesn't offer
+    it twice; next time they run straight away. All through real commands,
+    all fail-open.
+
+    LLM NPCs additionally get the event OBSERVED into their action buffer —
+    no forced LLM call, no scripted dialogue; the next turn they take knows
+    they were just attacked and reacts in their own voice (combat informs
+    the prompt, the model owns the words)."""
     from evennia.utils import delay
     reaction = getattr(getattr(victim, "db", None), "reaction", None)
     if not reaction:
@@ -472,15 +490,66 @@ def react_to_attack(victim: Any, attacker: Any) -> None:
         except Exception:  # noqa: BLE001 — a reaction must not break combat
             pass
 
-    if reaction == "resist":
-        weapon = getattr(victim.db, "carried_weapon", None)
-        if weapon:
-            delay(1.0, _cmd, f"wield {weapon}")
-    elif reaction == "comply":
-        delay(1.5, _cmd, "stop attacking")
-        delay(2.0, _cmd, "emote throws both hands up, wanting none of this.")
-    elif reaction == "flee":
+    stage = getattr(victim.ndb, "reaction_stage", None)
+    armed = bool(getattr(victim.db, "carried_weapon", None))
+    if stage == "resisting":
+        return  # already fighting for their life — nothing to escalate
+
+    if stage is None:
+        # First violence: the role's posture.
+        if reaction == "resist":
+            if armed:
+                delay(1.0, _cmd, f"wield {victim.db.carried_weapon}")
+            victim.ndb.reaction_stage = "resisting"
+            _inform_brain(victim, attacker, "drew on them" if armed
+                          else "squared up")
+        elif reaction == "comply":
+            delay(1.5, _cmd, "stop attacking")
+            delay(2.0, _cmd,
+                  "emote throws both hands up, wanting none of this.")
+            victim.ndb.reaction_stage = "complied"
+            _inform_brain(victim, attacker, "threw your hands up")
+        elif reaction == "flee":
+            delay(1.5, _cmd, "flee")
+            victim.ndb.reaction_stage = "fleeing"
+            _inform_brain(victim, attacker, "bolted")
+        return
+
+    if stage == "complied":
+        # Hands up didn't stop it — surrender is off the table now.
         delay(1.5, _cmd, "flee")
+        victim.ndb.reaction_stage = "fleeing"
+        _inform_brain(victim, attacker, "ran for it — surrender bought "
+                      "nothing")
+        return
+
+    if stage == "fleeing":
+        if armed:
+            # Cornered rat: no exit worked, violence keeps coming — draw
+            # and stand. A picker with a box cutter and no way out.
+            delay(1.0, _cmd, f"wield {victim.db.carried_weapon}")
+            victim.ndb.reaction_stage = "resisting"
+            _inform_brain(victim, attacker, "turned, cornered, and drew")
+        else:
+            delay(1.5, _cmd, "flee")   # unarmed: keep trying to get out
+            _inform_brain(victim, attacker, "kept running")
+
+
+def _inform_brain(victim: Any, attacker: Any, what_you_did: str) -> None:
+    """Combat informs the LLM prompt (never scripts it): buffer the attack +
+    this NPC's own mechanical response as a witnessed event, so the next
+    turn the model takes carries it. Cheap — no LLM call is made here."""
+    observe = getattr(victim, "_observe_action", None)
+    if not callable(observe) or getattr(victim.db, "llm_driven", None) is not True:
+        return
+    try:
+        handle = victim._address_handle(attacker)
+    except Exception:  # noqa: BLE001
+        handle = "someone"
+    try:
+        observe(attacker, f"{handle} just attacked you — you {what_you_did}.")
+    except Exception:  # noqa: BLE001 — flavour must never break a reaction
+        pass
 
 
 

--- a/world/tests/test_director_civilians.py
+++ b/world/tests/test_director_civilians.py
@@ -345,12 +345,15 @@ class TestConversationHold(TestCase):
 
 
 class TestReactToAttack(TestCase):
-    """§5.2 victim reactions: resist draws, comply yields, flee runs."""
+    """§5.2 victim reactions: resist draws, comply yields, flee runs —
+    and CONTINUED violence climbs the escalation ladder instead of
+    re-firing the same reaction (the spam guard)."""
 
-    def _victim(self, reaction, weapon=None):
+    def _victim(self, reaction, weapon=None, stage=None):
         return SimpleNamespace(
             db=SimpleNamespace(reaction=reaction, role="x",
                                carried_weapon=weapon),
+            ndb=SimpleNamespace(reaction_stage=stage),
             execute_cmd=MagicMock())
 
     @patch("evennia.utils.delay")
@@ -390,6 +393,73 @@ class TestReactToAttack(TestCase):
         pc = SimpleNamespace(db=SimpleNamespace(reaction=None))
         react_to_attack(pc, MagicMock())
         mock_delay.assert_not_called()
+
+    # --- the escalation ladder -------------------------------------------
+
+    @patch("evennia.utils.delay")
+    def test_complier_attacked_again_flees(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        v = self._victim("comply", stage="complied")
+        react_to_attack(v, MagicMock())
+        cmds = str([c.args for c in mock_delay.call_args_list])
+        self.assertIn("flee", cmds)
+        self.assertNotIn("hands up", cmds)      # surrender not re-offered
+        self.assertEqual(v.ndb.reaction_stage, "fleeing")
+
+    @patch("evennia.utils.delay")
+    def test_armed_flee_cornered_draws(self, mock_delay):
+        # The cornered rat: a fleeing ARMED civilian attacked again turns
+        # and draws instead of re-fleeing forever.
+        from world.director.civilians import react_to_attack
+        v = self._victim("flee", weapon="box cutter", stage="fleeing")
+        react_to_attack(v, MagicMock())
+        cmds = str([c.args for c in mock_delay.call_args_list])
+        self.assertIn("wield box cutter", cmds)
+        self.assertEqual(v.ndb.reaction_stage, "resisting")
+
+    @patch("evennia.utils.delay")
+    def test_unarmed_flee_keeps_running(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        v = self._victim("flee", weapon=None, stage="fleeing")
+        react_to_attack(v, MagicMock())
+        cmds = str([c.args for c in mock_delay.call_args_list])
+        self.assertIn("flee", cmds)              # a retry, not an escalation
+        self.assertEqual(v.ndb.reaction_stage, "fleeing")
+
+    @patch("evennia.utils.delay")
+    def test_resisting_is_terminal_no_spam(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        v = self._victim("resist", weapon="shiv", stage="resisting")
+        react_to_attack(v, MagicMock())
+        mock_delay.assert_not_called()           # already fighting: silence
+
+    @patch("evennia.utils.delay")
+    def test_first_reaction_sets_stage(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        v = self._victim("comply")
+        react_to_attack(v, MagicMock())
+        self.assertEqual(v.ndb.reaction_stage, "complied")
+
+    @patch("evennia.utils.delay")
+    def test_llm_brain_is_informed_not_scripted(self, mock_delay):
+        # Combat informs the prompt: the event lands in the action buffer;
+        # no LLM call is forced and no dialogue is scripted.
+        from world.director.civilians import react_to_attack
+        v = self._victim("comply")
+        v.db.llm_driven = True
+        v._observe_action = MagicMock()
+        v._address_handle = lambda a: "a lean man"
+        react_to_attack(v, MagicMock())
+        observed = v._observe_action.call_args.args[1]
+        self.assertIn("a lean man just attacked you", observed)
+        self.assertIn("threw your hands up", observed)
+
+    @patch("evennia.utils.delay")
+    def test_non_llm_victim_gets_no_brain_call(self, mock_delay):
+        from world.director.civilians import react_to_attack
+        v = self._victim("comply")              # no llm_driven, no buffer
+        react_to_attack(v, MagicMock())         # must not raise
+        self.assertEqual(v.ndb.reaction_stage, "complied")
 
 
 class TestClothingStyles(TestCase):


### PR DESCRIPTION
react_to_attack was stateless: every swing re-fired the same reaction
(hands up three times in one fight). Now an escalation ladder on
ndb.reaction_stage: first attack = the role's posture; continued
violence climbs comply→flee (surrender answered with violence is never
re-offered; the rung persists), flee→resist when armed (the cornered
rat: a scavver denied an exit turns and draws; unarmed keeps retrying
the run), resist terminal (no re-reaction, no spam).

Dialogue is never scripted: LLM NPCs get the attack + their own
mechanical response observed into the action buffer (_inform_brain) so
the next turn reacts in their own voice — combat informs the prompt,
the model owns the words.

Also records the melee-proximity decision (no change: proximity is
positional, not membership; target-lock already holds attacked victims)
in NPC_DISPATCH spec 5.2, closing the #1004 revert question.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
