### PR TITLE
Tests: fix 6 pre-existing failures surfaced by the 6.1.0 sweep (Closes #1039)

### DIFF
--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -908,7 +908,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         turn = {"speech": None, "action": None, "tool": "look",
                 "tool_argument": "patron"}
         with patch.object(llmnpc, "parse_turn", return_value=turn):
-            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, "{}")
+            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, None, "{}")
         b._agentic_round.assert_called_once()           # looped to gather context
         b.execute_cmd.assert_not_called()               # no terminal render yet
 
@@ -918,7 +918,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         turn = {"speech": "Coming up", "action": "grabs a glass", "thought": None,
                 "tool": "prepare_drink", "tool_argument": "Negroni"}
         with patch.object(llmnpc, "parse_turn", return_value=turn):
-            b._on_turn(["m"], {}, patron, "a negroni", "a man", lambda: None, 0, "{}")
+            b._on_turn(["m"], {}, patron, "a negroni", "a man", lambda: None, 0, None, "{}")
         b.execute_cmd.assert_any_call("prepare Negroni")  # the REAL command
         b._agentic_round.assert_not_called()              # terminal, no loop
 
@@ -930,7 +930,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         turn = {"speech": "hey", "action": "nods", "thought": None,
                 "tool": "none", "tool_argument": ""}
         with patch.object(llmnpc, "parse_turn", return_value=turn):
-            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, "{}")
+            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, None, "{}")
         b.execute_cmd.assert_any_call('emote nods, "hey"')
 
     def test_run_context_tool_look_and_stock(self):

--- a/world/tests/test_security_persona.py
+++ b/world/tests/test_security_persona.py
@@ -17,7 +17,7 @@ class TestSecurityArchetype(TestCase):
             self.assertIn(key, arch)
         # combat/detain stays deterministic; `release` (end a chat) is the
         # one conversational action it owns.
-        self.assertEqual(arch["tools"], ["release"])
+        self.assertEqual(arch["tools"], ["release", "radio"])
 
     def test_fewshot_is_machine_register(self):
         shots = ARCHETYPES["security"]["fewshot"]

--- a/world/tests/test_substances.py
+++ b/world/tests/test_substances.py
@@ -542,6 +542,7 @@ class TestDeliveryWiring(TestCase):
 
         item = MagicMock()
         item.db = _FakeDB(substance="alcohol")
+        item.key = "bottle of rotgut"
         item.get_display_name = lambda looker=None: "bottle of rotgut"
         target = MagicMock()
         cmd, parse_result = self._drink_cmd(item, target)
@@ -579,6 +580,7 @@ class TestDeliveryWiring(TestCase):
 
         item = MagicMock()
         item.db = _FakeDB()  # no substance, no uses
+        item.key = "mystery snack"
         item.get_display_name = lambda looker=None: "mystery snack"
         cmd, parse_result = self._drink_cmd(item, None)
         parse_result["target"] = cmd.caller


### PR DESCRIPTION
All six reproduce on 6.0.0 — no update regressions. test_bar's
_on_turn calls updated for the subject param (#1034 miss);
test_security_persona pins the radio grant; test_substances mocks
set item.key (broken since #688 — with_article got a MagicMock,
the recurring trap).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
