### PR TITLE
Wounds: species prose packs — robots tear, synths bleed cobalt (Closes #1041)

### DIFF
--- a/specs/SPECIES_AUTHORING.md
+++ b/specs/SPECIES_AUTHORING.md
@@ -13,7 +13,7 @@ Two files hold the per-species data; everything else in the codebase consumes th
 
 Two optional secondary places:
 
-- **`world/medical/wounds/messages/*.py`** — per-injury-type wound prose. The existing tables are species-agnostic (humans share them). If a species needs distinct destruction or severance prose, declare a species-keyed overlay on each injury-type module (currently only human prose is shipped).
+- **`world/medical/wounds/messages/*.py`** — per-injury-type wound prose. The existing tables are species-agnostic (humans share them). **Species packs (shipped 2026-07-05):** a species whose wounds must not read as human flesh registers a COMPLETE pack module in `messages.SPECIES_PACKS` (`robot.py` — torn plating, amber hydraulic weep, weld-seam scars; `synth.py` — cobalt blood, pearlescent seam scars). A pack species renders ALL surface-wound prose (every stage, plus `DESTROYED_BY_LOCATION` and `COMPOUND_DESCRIPTIONS`) from its pack — it never falls through to the shared flesh tables, which is the no-leak guarantee (pin new packs with a completeness test like `test_species_wounds.py`). Pack prose should hardcode the species `blood_color` (`world/anatomy/species.py`) and match the register of its `organ_descriptions.py` entries so surface and organ damage read as one body. Humans and pack-less species (rat, ...) keep the shared modules unchanged.
 - **`world/anatomy/organs.py`** — `ORGAN_DISPLAY` for organ-name display. Species-agnostic today; new species reuse the existing mammalian organ names where biologically equivalent.
 
 ## Required tables in `SPECIES_DEFINITIONS[species]`

--- a/world/medical/wounds/longdesc_hooks.py
+++ b/world/medical/wounds/longdesc_hooks.py
@@ -248,7 +248,7 @@ def _compound_phrase(worst_wound, others_count, character=None):
         worst_wound['severity'], worst_wound['severity'].lower()
     )
 
-    template = _resolve_compound_template(injury_type, stage)
+    template = _resolve_compound_template(injury_type, stage, character)
     if template:
         format_vars = {
             'severity': severity,
@@ -474,7 +474,7 @@ def _pair_base_noun(location):
     return location.replace("_", " ")
 
 
-def _resolve_compound_template(injury_type, stage):
+def _resolve_compound_template(injury_type, stage, character=None):
     """
     Resolve a random compound template for an injury type and stage.
 
@@ -498,17 +498,25 @@ def _resolve_compound_template(injury_type, stage):
     # (sever_character_body sets current_hp/wound_stage but not
     # injury_type).  Fall through to the generic compound table when
     # the injury type is missing or non-string.
-    module = (
-        getattr(messages, injury_type, None)
-        if isinstance(injury_type, str)
-        else None
-    )
-    if module is not None:
-        compound = getattr(module, 'COMPOUND_DESCRIPTIONS', None)
-    if not compound:
-        compound = getattr(messages.generic, 'COMPOUND_DESCRIPTIONS', None)
-    if not compound:
-        return None
+    # Species routing mirrors get_wound_description: a pack species draws
+    # compound prose from its pack only (never human flesh vocabulary).
+    pack = messages.species_pack(character)
+    if pack is not None:
+        compound = getattr(pack, 'COMPOUND_DESCRIPTIONS', None)
+        if not compound:
+            return None   # pack species with no compound set: inline fallback
+    else:
+        module = (
+            getattr(messages, injury_type, None)
+            if isinstance(injury_type, str)
+            else None
+        )
+        if module is not None:
+            compound = getattr(module, 'COMPOUND_DESCRIPTIONS', None)
+        if not compound:
+            compound = getattr(messages.generic, 'COMPOUND_DESCRIPTIONS', None)
+        if not compound:
+            return None
 
     variants = compound.get(stage) or compound.get('fresh')
     if not variants:

--- a/world/medical/wounds/messages/__init__.py
+++ b/world/medical/wounds/messages/__init__.py
@@ -12,3 +12,30 @@ from . import blunt
 from . import generic
 from . import severed
 from . import harvested
+from . import robot
+from . import synth
+
+#: Species wound-prose packs (SPECIES_AUTHORING §wounds): a species listed
+#: here NEVER falls through to human flesh prose — its pack is complete
+#: across all stages. Species not listed (human, rat, ...) use the shared
+#: per-injury-type modules above.
+SPECIES_PACKS = {
+    "robot": robot,
+    "synthetic_humanoid": synth,
+}
+
+
+def species_pack(character):
+    """The wound-prose pack for *character*'s species, or None (human
+    default). Reads ``character.species`` with a ``db.species`` fallback so
+    corpses (which carry species on db) resolve identically."""
+    if character is None:
+        return None
+    species = getattr(character, "species", None)
+    if not isinstance(species, str):
+        species = None
+    species = species or getattr(
+        getattr(character, "db", None), "species", None)
+    if not isinstance(species, str):
+        return None
+    return SPECIES_PACKS.get(species)

--- a/world/medical/wounds/messages/robot.py
+++ b/world/medical/wounds/messages/robot.py
@@ -1,0 +1,89 @@
+"""
+Robot wound descriptions — the species pack (SPECIES_AUTHORING §wounds).
+
+A robot doesn't bleed, bruise, or scar: it tears, dents, shears, sparks, and
+weeps amber hydraulic fluid (the species ``blood_color``: amber ``|y``, dried
+tar-black). "Treated" is field repair — welds, epoxy, clamped lines; "healing"
+is sealant curing and welds dulling; "scarred" is the permanent record of old
+repairs — mismatched plate, buffed-out gouges, weld seams.
+
+This pack is COMPLETE across every stage so a robot never falls through to
+human flesh prose. Vocabulary matches ``world/anatomy/organ_descriptions.py``
+(amber hydraulic fluid, coolant, servos) so organ and surface damage read as
+one machine.
+"""
+
+WOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|ya {severity} gouge torn through the plating of the {location}, weeping amber hydraulic fluid|n",
+        "|ya {severity} shear across the {location}, the metal peeled back in bright curls|n",
+        "|ya {severity} rupture in the {location} housing, servos stuttering beneath|n",
+        "|ya {severity} breach in the {location}, hydraulic lines glistening amber in the gap|n",
+        "|ya {severity} dent crumpling the {location}, its panel seams sprung|n",
+        "|ya {severity} tear in the {location} chassis, loose contacts sparking intermittently|n",
+        "|ya {severity} scorch across the {location}, the plating blued and buckled|n",
+    ],
+
+    "treated": [
+        "a {severity} breach in the {location}, clamped and sealed with a fresh weld bead",
+        "a {severity} gouge in the {location} packed with epoxy, the patch still tacky",
+        "a {severity} rupture in the {location} strapped under a bolted service plate",
+        "a {severity} tear in the {location}, its severed lines crimped off and taped",
+        "a {severity} dent in the {location} hammered roughly true, the seam resealed",
+    ],
+
+    "healing": [
+        "a {severity} weld line along the {location}, its bead still bright from the torch",
+        "a {severity} patch on the {location}, sealant cured to a dull amber rind",
+        "a {severity} repair in the {location}, new plate sitting proud of the old",
+        "a {severity} resealed seam in the {location}, dried fluid staining it tar-black",
+    ],
+
+    "scarred": [
+        "an old weld seam across the {location}, ground smooth but never flush",
+        "a mismatched replacement plate on the {location}, its finish a shade off",
+        "a buffed-out gouge in the {location}, visible only where the light catches",
+        "a lattice of old repair marks on the {location}, story of a working chassis",
+    ],
+
+    "destroyed": [
+        "the {location} is a crushed ruin of plate and servo, tar-black fluid long since bled out",
+        "the {location} has been mangled into scrap, actuators shorn and lines burst",
+        "the {location} is burnt out entirely, its housing slagged and dead",
+    ],
+}
+
+# Sensory surfaces get bespoke destruction prose — optics and acoustic
+# arrays, not eyes and ears (mirrors the human modules' overlay shape).
+DESTROYED_BY_LOCATION = {
+    "left_eye": [
+        "{Their} left optic is a shattered socket, lens glass glittering in the housing",
+        "{Their} left optic assembly is caved in, its aperture dark and dead",
+    ],
+    "right_eye": [
+        "{Their} right optic is a shattered socket, lens glass glittering in the housing",
+        "{Their} right optic assembly is caved in, its aperture dark and dead",
+    ],
+    "left_ear": [
+        "{Their} left acoustic array is sheared away, wiring fanned from the mount",
+    ],
+    "right_ear": [
+        "{Their} right acoustic array is sheared away, wiring fanned from the mount",
+    ],
+}
+
+COMPOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|ya {severity} gouge in the {location}, one of several fresh rents weeping amber|n",
+        "|ythe {location} torn open in more than one place, hydraulic fluid tracking down the plate|n",
+    ],
+    "treated": [
+        "a cluster of patched breaches on the {location}, welds and epoxy shoulder to shoulder",
+    ],
+    "healing": [
+        "a run of curing repairs along the {location}, sealant rinds in every seam",
+    ],
+    "scarred": [
+        "a constellation of old damage on the {location} — dents, weld seams, mismatched plate",
+    ],
+}

--- a/world/medical/wounds/messages/synth.py
+++ b/world/medical/wounds/messages/synth.py
@@ -1,0 +1,74 @@
+"""
+Synthetic-humanoid wound descriptions — the species pack (SPECIES_AUTHORING
+§wounds).
+
+A synth wounds like flesh but never quite like OUR flesh: the dermis is too
+uniform, the blood runs **cobalt** (the species ``blood_color``: ``|B``,
+dried slate), and repair is eerily tidy — wounds knit clean, scars set as
+faint pearlescent seams rather than raised tissue. Human mechanics, alien
+presentation (the species' whole design).
+
+This pack is COMPLETE across every stage so a synth never falls through to
+crimson human prose. ``{skintone}`` still applies — synths carry the alien
+skin palette.
+"""
+
+WOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|Ba {severity} cut across the {location}, welling slow cobalt|n",
+        "|Ba {severity} gash in the {location}, its edges unnaturally clean, blue-dark inside|n",
+        "|Ba {severity} wound on the {location}, cobalt beading along the parted dermis|n",
+        "|Ba {severity} tear through the {location}, the layered dermis peeled too evenly|n",
+        "|Ba {severity} puncture in the {location}, a thin cobalt line tracking from it|n",
+        "|Ba {severity} rent in the {location}, slate-dark where the blue has begun to set|n",
+    ],
+
+    "treated": [
+        "{skintone}a {severity} sutured wound on the {location}, {suture_color}stitches|n{skintone} laid in machine-even rows|n",
+        "{skintone}a {severity} dressed wound on the {location}, slate staining the bandage's edge|n",
+        "{skintone}a {severity} sealed cut on the {location}, its margins already fusing smooth|n",
+        "{skintone}a {severity} bound wound in the {location}, cobalt dried to slate beneath the wrap|n",
+    ],
+
+    "healing": [
+        "{skintone}a {severity} knitting wound on the {location}, closing cleaner than flesh should|n",
+        "{skintone}a {severity} mending cut across the {location}, its seam paling to pearl|n",
+        "{skintone}a {severity} half-healed wound on the {location}, slate flaking from the new dermis|n",
+    ],
+
+    "scarred": [
+        "{skintone}a faint pearlescent seam across the {location}, too regular to be a natural scar|n",
+        "{skintone}an old wound line on the {location}, set smooth and slightly opaline|n",
+        "{skintone}a hairline scar on the {location}, catching the light like lacquer|n",
+    ],
+
+    "destroyed": [
+        "the {location} has been ruined utterly, layered dermis and blue-dark substrate mangled together",
+        "the {location} is destroyed, cobalt long since drained to a slate crust",
+        "the {location} is a wreck of parted dermis and exposed substrate, past any knitting",
+    ],
+}
+
+DESTROYED_BY_LOCATION = {
+    "left_eye": [
+        "{Their} left eye is a ruined socket, its iris-ring dulled to dead glass",
+    ],
+    "right_eye": [
+        "{Their} right eye is a ruined socket, its iris-ring dulled to dead glass",
+    ],
+}
+
+COMPOUND_DESCRIPTIONS = {
+    "fresh": [
+        "|Ba {severity} wound on the {location}, the worst of several seeping cobalt|n",
+    ],
+    "treated": [
+        "{skintone}a cluster of dressed wounds on the {location}, slate shadowing each edge|n",
+    ],
+    "healing": [
+        "{skintone}a spread of knitting wounds across the {location}, each seam paling in step|n",
+    ],
+    "scarred": [
+        "{skintone}a scatter of pearlescent seams across the {location}, an even, unnatural record|n",
+    ],
+}

--- a/world/medical/wounds/wound_descriptions.py
+++ b/world/medical/wounds/wound_descriptions.py
@@ -30,14 +30,24 @@ def get_wound_description(injury_type, location, severity="Moderate", stage="fre
     Returns:
         str: Formatted wound description ready for longdesc integration
     """
-    # Get the appropriate message module for this injury type
-    try:
-        message_module = getattr(messages, injury_type)
-        wound_messages = message_module.WOUND_DESCRIPTIONS
-    except AttributeError:
-        # Fallback to generic wound descriptions
-        message_module = messages.generic
-        wound_messages = message_module.WOUND_DESCRIPTIONS
+    # Species routing (SPECIES_AUTHORING §wounds): a robot doesn't bleed and
+    # a synth doesn't bleed RED — a species with a registered pack renders
+    # ALL its wound prose from that pack (complete across stages, so human
+    # flesh vocabulary can never leak onto the wrong chassis). Humans and
+    # pack-less species (rat, ...) keep the shared per-injury-type modules.
+    pack = messages.species_pack(character)
+    if pack is not None:
+        message_module = pack
+        wound_messages = pack.WOUND_DESCRIPTIONS
+    else:
+        # Get the appropriate message module for this injury type
+        try:
+            message_module = getattr(messages, injury_type)
+            wound_messages = message_module.WOUND_DESCRIPTIONS
+        except AttributeError:
+            # Fallback to generic wound descriptions
+            message_module = messages.generic
+            wound_messages = message_module.WOUND_DESCRIPTIONS
 
     # Issue #347: destroyed-stage overlay keyed by (injury_type, location).
     # Limb-vocabulary doesn't fit sensory destruction ("His left eye

--- a/world/tests/test_species_wounds.py
+++ b/world/tests/test_species_wounds.py
@@ -1,0 +1,135 @@
+"""Species wound-prose packs (SPECIES_AUTHORING §wounds).
+
+A robot tears and weeps amber hydraulic fluid; a synth bleeds cobalt and
+scars to pearlescent seams. A species with a registered pack NEVER falls
+through to human flesh prose, at any stage; humans and pack-less species
+are byte-identical to before.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+from world.medical.wounds import messages
+from world.medical.wounds.wound_descriptions import get_wound_description
+
+#: Human-flesh vocabulary that must never appear on a robot chassis.
+FLESH_WORDS = ("blood", "bleed", "flesh", "tissue", "skin", "bruis",
+               "stitch", "sutur", "scab")
+
+STAGES = ("fresh", "treated", "healing", "scarred", "destroyed")
+
+
+def _char(species=None, skintone=None):
+    return SimpleNamespace(
+        species=species,
+        db=SimpleNamespace(species=species, skintone=skintone),
+    )
+
+
+class TestPackRegistry(TestCase):
+    def test_robot_and_synth_registered(self):
+        self.assertIs(messages.species_pack(_char("robot")), messages.robot)
+        self.assertIs(messages.species_pack(_char("synthetic_humanoid")),
+                      messages.synth)
+
+    def test_human_and_packless_get_none(self):
+        self.assertIsNone(messages.species_pack(_char(None)))
+        self.assertIsNone(messages.species_pack(_char("human")))
+        self.assertIsNone(messages.species_pack(_char("rat")))
+        self.assertIsNone(messages.species_pack(None))
+
+    def test_packs_complete_across_all_stages(self):
+        # The no-leak guarantee rests on completeness — every stage authored.
+        for pack in messages.SPECIES_PACKS.values():
+            for stage in STAGES:
+                self.assertTrue(pack.WOUND_DESCRIPTIONS.get(stage),
+                                f"{pack.__name__} missing stage {stage!r}")
+
+
+class TestRobotProse(TestCase):
+    def test_no_flesh_vocabulary_at_any_stage(self):
+        bot = _char("robot")
+        for stage in STAGES:
+            for injury in ("cut", "bullet", "blunt", "stab"):
+                for _ in range(12):   # cover the random template choices
+                    desc = get_wound_description(
+                        injury, "chest", "Severe", stage, character=bot)
+                    low = desc.lower()
+                    for word in FLESH_WORDS:
+                        self.assertNotIn(
+                            word, low,
+                            f"flesh word {word!r} on a robot ({stage}): {desc}")
+
+    def test_fresh_damage_reads_mechanical(self):
+        bot = _char("robot")
+        seen = " ".join(
+            get_wound_description("cut", "chest", "Severe", "fresh",
+                                  character=bot)
+            for _ in range(20)).lower()
+        self.assertTrue(any(w in seen for w in
+                            ("plating", "servo", "hydraulic", "chassis",
+                             "panel", "scorch")), seen[:200])
+
+    def test_destroyed_eye_is_an_optic(self):
+        bot = _char("robot")
+        desc = get_wound_description("blunt", "left_eye", "Critical",
+                                     "destroyed", character=bot).lower()
+        self.assertIn("optic", desc)
+
+
+class TestSynthProse(TestCase):
+    def test_fresh_blood_is_cobalt_never_crimson(self):
+        synth = _char("synthetic_humanoid")
+        for _ in range(20):
+            desc = get_wound_description("cut", "chest", "Moderate", "fresh",
+                                         character=synth)
+            self.assertNotIn("|R", desc)     # human crimson code
+        seen = " ".join(
+            get_wound_description("cut", "chest", "Moderate", "fresh",
+                                  character=synth)
+            for _ in range(20)).lower()
+        self.assertTrue("cobalt" in seen or "slate" in seen, seen[:200])
+
+    def test_scars_read_engineered(self):
+        synth = _char("synthetic_humanoid")
+        seen = " ".join(
+            get_wound_description("cut", "chest", "Light", "scarred",
+                                  character=synth)
+            for _ in range(20)).lower()
+        self.assertTrue(any(w in seen for w in
+                            ("pearlescent", "opaline", "lacquer")), seen[:200])
+
+
+class TestHumanUnchanged(TestCase):
+    def test_human_fresh_cut_comes_from_the_cut_module(self):
+        human = _char(None)
+        for _ in range(10):
+            desc = get_wound_description("cut", "chest", "Severe", "fresh",
+                                         character=human)
+            self.assertIn("|R", desc)        # human crimson prose intact
+
+    def test_packless_species_uses_shared_modules(self):
+        rat = _char("rat")
+        desc = get_wound_description("cut", "chest", "Severe", "fresh",
+                                     character=rat)
+        self.assertIn("|R", desc)            # falls to the shared tables
+
+
+class TestCompoundRouting(TestCase):
+    def test_robot_compound_is_mechanical(self):
+        from world.medical.wounds.longdesc_hooks import (
+            _resolve_compound_template,
+        )
+        bot = _char("robot")
+        for stage in ("fresh", "treated", "healing", "scarred"):
+            template = _resolve_compound_template("cut", stage, bot)
+            self.assertIsNotNone(template, stage)
+            for word in FLESH_WORDS:
+                self.assertNotIn(word, template.lower(), template)
+
+    def test_human_compound_unchanged(self):
+        from world.medical.wounds.longdesc_hooks import (
+            _resolve_compound_template,
+        )
+        template = _resolve_compound_template("cut", "fresh", _char(None))
+        self.assertIsNotNone(template)


### PR DESCRIPTION
Longdesc damage prose was human-flesh for every species. New species
packs (the SPECIES_AUTHORING-prescribed overlay): messages/robot.py
(torn plating, amber hydraulic weep, weld-seam scars, optics for
destroyed eyes) and messages/synth.py (cobalt blood per the canonical
species blood_color, machine-even sutures, pearlescent seam scars).
messages.SPECIES_PACKS + species_pack() route get_wound_description
and the compound path; packs are COMPLETE across all five stages so a
pack species never falls through to flesh vocabulary (pinned by a
stage x injury sweep test). Humans and pack-less species unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
