### PR TITLE
Dispatch: no magic radios — theft snitch + security net ride real devices (Closes #1047)

### DIFF
--- a/commands/CmdTheft.py
+++ b/commands/CmdTheft.py
@@ -47,9 +47,15 @@ def _caught(thief, victim):
                 set_awareness(obs, thief, ALERT)
         except Exception:  # noqa: BLE001
             continue
+    # The report rides the REAL pipeline (RADIO_COMMS_SPEC / dispatch §5.1):
+    # report_crime rolls the crowd-gated witness, who calls it in over an
+    # actual walkie after the interdiction window — no magic radio. Empty
+    # alley = no witness = the force never learns; and the thief gets the
+    # window to silence the snitch. perp stays None by design: the theft is
+    # witnessed-but-unidentified (the situational cause the hunt reads).
     try:
-        from world.director.dispatch import WorldEvent, raise_event
-        raise_event(WorldEvent("crime", room, severity=1, source=None))
+        from world.director.crime import report_crime
+        report_crime("pickpocketing", room, perp=None)
     except Exception:  # noqa: BLE001 — dispatch down ≠ theft crash
         pass
 

--- a/specs/proposals/NPC_DISPATCH_AND_SIMULATION_SPEC.md
+++ b/specs/proposals/NPC_DISPATCH_AND_SIMULATION_SPEC.md
@@ -23,7 +23,7 @@
 >
 > **Identification design RESOLVED (§5.1, 2026-06-30); crime taxonomy + heat
 > (§5.2, 2026-06-30).** Chain status: BOLO ✅ · tiered confidence ✅ (detain
-> deferred to the trust gate) · combat auto-raise ✅ #871 (45s→witness window, per-scene debounce, crime-time BOLO) · witness spawn ✅ #873 (crowd-gated, interdictable, first flash-temp ephemeral; flees to cower via director travel #888) · base intel-sync ✅ #876 (per-bot sightings → force-wide wanted record only on return-to-post; latency window real; repeat-offender counts; @dispatch/wanted) · radio report ⬜
+> deferred to the trust gate) · combat auto-raise ✅ #871 (45s→witness window, per-scene debounce, crime-time BOLO) · witness spawn ✅ #873 (crowd-gated, interdictable, first flash-temp ephemeral; flees to cower via director travel #888) · base intel-sync ✅ #876 (per-bot sightings → force-wide wanted record only on return-to-post; latency window real; repeat-offender counts; @dispatch/wanted) · radio report ✅ (2026-07-05: NO magic radios left on the crime chain — witness calls ride a real walkie via wield/xmit (#1009/#1020); a caught theft routes through report_crime's crowd-gated witness instead of a raw raise_event; patrol wanted-flags and hunt challenges key the unit's comms organ on 911MHz (xmit fallback) before the deterministic raise — the security net is audible to anyone tuned in. Explosions stay direct: a detonation is its own broadcast)
 > (`RADIO_COMMS_SPEC` drafted #859; magic placeholder until built) ·
 > no-trace window ⬜. Population/identity presentation layer
 > still open — see §10.

--- a/world/director/hunt.py
+++ b/world/director/hunt.py
@@ -123,6 +123,13 @@ def _engage(npc, target) -> None:
         npc.execute_cmd(f"say {CHALLENGE_LINE}")
     except Exception:  # noqa: BLE001
         pass
+    # Backup request rides the REAL air (comms organ via xmit's fallback) —
+    # audible to anyone on 911MHz. Flavour only; the raise stays authoritative.
+    try:
+        where = getattr(npc.location, "key", "position")
+        npc.execute_cmd(f"xmit Unit engaging — backup to {where}.")
+    except Exception:  # noqa: BLE001 — a mute unit still raises
+        pass
     try:
         from world.director.dispatch import WorldEvent, raise_event
         raise_event(WorldEvent("disturbance", npc.location, severity=2,

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -148,6 +148,17 @@ def at_waypoint(npc: Any) -> None:
             from world.director.security import _scan_wanted
             _uid, flagged, _entry = _scan_wanted(npc)
             if flagged is not None:
+                # Call it in over the REAL air first (the unit's comms
+                # organ; xmit's no-handheld fallback) — anyone tuned to
+                # 911MHz hears the net light up. Best-effort flavour; the
+                # deterministic raise below is what dispatch acts on.
+                try:
+                    where = getattr(npc.location, "key", "position")
+                    npc.execute_cmd(
+                        f"xmit Dispatch — flagged match on {where}, "
+                        f"moving to challenge.")
+                except Exception:  # noqa: BLE001 — a mute unit still raises
+                    pass
                 raise_event(WorldEvent("disturbance", npc.location,
                                        severity=1, source=flagged))
             else:

--- a/world/tests/test_director_routines.py
+++ b/world/tests/test_director_routines.py
@@ -86,6 +86,10 @@ class TestWaypointSweep(TestCase):
         self.assertEqual(event.type, "disturbance")
         self.assertIs(event.source, felon)
         self.assertEqual(event.location, npc.location)
+        # ...and the unit called it in over the REAL air first (comms organ
+        # via xmit's no-handheld fallback) — no magic radio.
+        cmds = [c.args[0] for c in npc.execute_cmd.call_args_list]
+        self.assertTrue(any(c.startswith("xmit ") for c in cmds), cmds)
 
     @patch("world.director.security._scan_wanted",
            return_value=(None, None, None))

--- a/world/tests/test_hunt.py
+++ b/world/tests/test_hunt.py
@@ -108,6 +108,10 @@ class TestHuntMachine(TestCase):
         say = [c.args[0] for c in npc.execute_cmd.call_args_list
                if c.args[0].startswith("say ")]
         self.assertTrue(say and "Halt, Colonist" in say[0])
+        # Backup request rides the real air (comms organ) — no magic radio.
+        xmit = [c.args[0] for c in npc.execute_cmd.call_args_list
+                if c.args[0].startswith("xmit ")]
+        self.assertTrue(xmit and "backup" in xmit[0].lower())
         raised.assert_called_once()
         propagate.assert_called_once_with(npc, "uid-prey", 55)
         self.assertFalse(is_hunting(npc))     # dispatch owns it now

--- a/world/tests/test_theft.py
+++ b/world/tests/test_theft.py
@@ -110,6 +110,25 @@ class TestSteal(TestCase):
         chip.move_to.assert_not_called()           # the lift failed
         caught.assert_called_once_with(cmd.caller, target)
 
+    def test_caught_report_rides_the_witness_pipeline(self):
+        # No magic radio: the botched lift routes through report_crime
+        # (crowd-gated witness + real walkie), never a raw raise_event.
+        from commands.CmdTheft import _caught
+        thief = MagicMock()
+        room = MagicMock(); room.contents = []
+        thief.location = room
+        victim = MagicMock()
+        with patch("commands.CmdTheft.set_awareness"), \
+                patch("world.director.crime.report_crime") as report, \
+                patch("world.director.dispatch.raise_event") as raw:
+            _caught(thief, victim)
+        report.assert_called_once()
+        args, kwargs = report.call_args
+        self.assertEqual(args[0], "pickpocketing")
+        self.assertIs(args[1], room)
+        self.assertIsNone(kwargs.get("perp"))   # witnessed-but-unidentified
+        raw.assert_not_called()
+
     def test_subdued_mark_is_free_loot(self):
         chip = _item("a chip")
         target = _target(contents=[chip])
@@ -198,12 +217,10 @@ class TestCaughtConsequences(TestCase):
         with patch("commands.CmdTheft.set_awareness") as aware, \
                 patch("world.perception.can_see",
                       side_effect=lambda o: o is witness), \
-                patch("world.director.dispatch.raise_event") as raised:
+                patch("world.director.crime.report_crime") as report:
             _caught(thief, victim)
         awared = {c.args[0] for c in aware.call_args_list}
         self.assertIn(victim, awared)
         self.assertIn(witness, awared)
         self.assertNotIn(blindfolded, awared)      # can't see = not alerted
-        event = raised.call_args.args[0]
-        self.assertEqual(event.type, "crime")
-        self.assertIsNone(event.source)            # unidentified -> hot scene
+        report.assert_called_once()                # the real pipeline, no raw raise


### PR DESCRIPTION
Audit of every raise_event caller found three paths bypassing the
radio: a caught theft raised dispatch directly (no witness, no device,
worked in an empty alley) — now routes through report_crime's
crowd-gated witness + real walkie + interdiction window (taxonomy:
pickpocketing; perp None by design, witnessed-but-unidentified). The
patrol wanted-flag and the hunt challenge now key the unit's comms
organ on the air (xmit's no-handheld fallback) before the
deterministic raise — the security net is audible to anyone tuned to
911MHz. Explosions stay direct: a detonation is its own broadcast.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
