### PR TITLE
Radio: xmit on-split only honored for a carried radio (Closes #1049)

### DIFF
--- a/commands/CmdRadio.py
+++ b/commands/CmdRadio.py
@@ -48,9 +48,13 @@ class CmdTransmit(Command):
 
     def parse(self):
         raw = (self.args or "").strip()
+        self.raw_message = raw
         self.message = self.device_phrase = ""
-        # "<message> on <device>" — split on the LAST " on " so the message
-        # can contain the word "on".
+        # "<message> on <device>" — split on the LAST " on " as a CANDIDATE.
+        # The split is only honored if the trailing phrase resolves to a
+        # carried radio (func) — otherwise the " on " belonged to the message
+        # ("there's trouble on Cobb Street") and the whole line transmits.
+        # This grammar ambiguity silently ate every witness report (#1049).
         low = raw.lower()
         idx = low.rfind(" on ")
         if idx != -1:
@@ -59,20 +63,36 @@ class CmdTransmit(Command):
         else:
             self.message = raw
 
+    def _carried_radio_named(self, caller, phrase):
+        """The carried radio *phrase* names, or None — resolved QUIETLY (no
+        error spam: a failed match just means the words were message, not a
+        device clause)."""
+        try:
+            matches = caller.search(phrase, candidates=list(caller.contents),
+                                    quiet=True)
+        except Exception:  # noqa: BLE001
+            return None
+        if not matches:
+            return None
+        matches = matches if isinstance(matches, list) else [matches]
+        for obj in matches:
+            if is_radio(obj):
+                return obj
+        return None
+
     def func(self):
         caller = self.caller
-        if not self.message:
+        if not self.raw_message:
             caller.msg("Transmit what?")
             return
+        device = None
         if self.device_phrase:
-            device = _resolve_device(caller, self.device_phrase)
+            device = self._carried_radio_named(caller, self.device_phrase)
             if device is None:
-                return
-            if device not in caller.contents:
-                caller.msg(f"You aren't carrying "
-                           f"{device.get_display_name(caller)}.")
-                return
-        else:
+                # No carried radio by that name — the " on " was part of the
+                # message itself. Transmit the whole line on the default.
+                self.message = self.raw_message
+        if device is None:
             device = active_transmit_radio(caller)
             if device is None:
                 # Built-in comms organ fallback (a security unit's ear module,

--- a/world/tests/test_radio.py
+++ b/world/tests/test_radio.py
@@ -172,6 +172,35 @@ class TestCommands(TestCase):
         self.assertEqual(cmd.message, "meet at the docks")
         self.assertEqual(cmd.device_phrase, "the black handset")
 
+    def test_message_containing_on_transmits_whole_line(self):
+        # THE witness bug (#1049): "there's trouble on Cobb Street" parsed
+        # "Cobb Street..." as a device name and silently ate every report.
+        # The on-split is only honored when it names a carried radio.
+        from commands.CmdRadio import CmdTransmit
+        dev = _radio(freq="911MHz")
+        caller = _char(worn=[dev], contents=[dev])
+        caller.search = lambda phrase, **kw: []   # no device by that name
+        line = ("Someone call it in — there's trouble on Cobb Street, "
+                "get a unit down here!")
+        cmd = CmdTransmit(); cmd.caller = caller
+        cmd.args = line
+        cmd.parse()
+        with patch("commands.CmdRadio.transmit") as tx:
+            cmd.func()
+        tx.assert_called_once_with(caller, line, dev)   # FULL line, default dev
+
+    def test_on_split_still_honored_for_a_carried_radio(self):
+        from commands.CmdRadio import CmdTransmit
+        worn, named = _radio(freq="447"), _radio(freq="911MHz")
+        caller = _char(worn=[worn], contents=[worn, named])
+        caller.search = lambda phrase, **kw: [named]    # resolves the handset
+        cmd = CmdTransmit(); cmd.caller = caller
+        cmd.args = "meet at the docks on the black handset"
+        cmd.parse()
+        with patch("commands.CmdRadio.transmit") as tx:
+            cmd.func()
+        tx.assert_called_once_with(caller, "meet at the docks", named)
+
     def test_transmit_no_radio_worn_or_held(self):
         from commands.CmdRadio import CmdTransmit
         cmd = CmdTransmit()


### PR DESCRIPTION
The last-' on '-split for 'xmit <message> on <device>' ate every
witness report ever made: "there's trouble on Cobb Street..." parsed
'Cobb Street...' as a device name, found nothing, and died silently
(NPC feedback goes nowhere; raise_event still fired, so dispatch
answered with zero air traffic). Ground truth: the live radio channel
log holds only the user's own two test lines.

Fix: the split is a candidate — honored only when the trailing phrase
quietly resolves to a carried radio; otherwise the whole line is the
message and the default device (worn -> held -> comms organ) carries
it. Fixes players ('xmit meet me on the roof') and the patrol-flag
xmit identically. Verified end-to-end: the witness's full prep + the
literal report line now transmits on 911MHz.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
