### PR TITLE
Channeled actions: graffiti per-letter timer + interrupt taxonomy (Closes #1053)

### DIFF
--- a/commands/CmdGraffiti.py
+++ b/commands/CmdGraffiti.py
@@ -112,80 +112,161 @@ class CmdGraffiti(Command):
         else:
             self.caller.msg(f"You can't use {can.get_display_name(self.caller)} for spraying - unknown contents: {aerosol_contents}.")
     
+    #: Channeled-tagging rates (CHANNELED_ACTIONS_SPEC §3): the can-rattle
+    #: setup, then one second of exposure per letter. Length IS risk — a
+    #: 10-char throw-up is ~13s; a 100-char manifesto stands you in public
+    #: past the whole witness window.
+    SPRAY_SETUP_SECONDS = 3.0
+    SPRAY_SECONDS_PER_CHAR = 1.0
+
     def _handle_spray_paint_with_spraypaint(self, spray_can, message):
-        """Handle spray painting with a spray paint can."""
+        """Spray painting is a CHANNELED act: duration proportional to the
+        letter count, visible tell, interruptible. The full tag lands at
+        completion; an interruption lands the letters finished so far with
+        the ellipsis truncation (an interrupted tag is evidence). Paint
+        deducts at resolution, pro-rata."""
         if not message:
             self.caller.msg("You need to specify a message to spray.")
             return
-        
+
         if len(message) > 100:
             self.caller.msg("Your message is too long! Keep it under 100 characters.")
             return
-        
+
         # Check if spray can has paint
         if spray_can.db.aerosol_level <= 0:
             self.caller.msg(f"{spray_can.get_display_name(self.caller)} is empty!")
             return
-        
-        # Calculate paint needed (1 paint per character)
-        paint_needed = len(message)
-        paint_available = spray_can.db.aerosol_level
-        
-        # Determine actual message length based on available paint
+
+        from world.channeled import begin_channel
+        caller = self.caller
+        duration = (self.SPRAY_SETUP_SECONDS
+                    + len(message) * self.SPRAY_SECONDS_PER_CHAR)
+
+        def _complete():
+            self._land_tag(caller, spray_can, message)
+
+        def _interrupted(fraction):
+            worked = fraction * duration - self.SPRAY_SETUP_SECONDS
+            letters = int(max(0.0, worked) / self.SPRAY_SECONDS_PER_CHAR)
+            letters = min(letters, len(message))
+            if letters <= 0:
+                caller.msg("You break off before the nozzle ever touches "
+                           "the wall.")
+                msg_room_identity(
+                    location=caller.location,
+                    template="{actor} breaks off, spray can still rattling, "
+                             "the wall untouched.",
+                    char_refs={"actor": caller},
+                    exclude=[caller],
+                )
+                return
+            # The letters finished so far land — with the ellipsis the
+            # paint-out path already renders. Evidence of interruption.
+            self._land_tag(caller, spray_can, message[:letters] + "...",
+                           interrupted=True)
+
+        started = begin_channel(
+            caller, duration,
+            tell="crouched at the wall, spray can hissing.",
+            on_complete=_complete, on_interrupt=_interrupted,
+            key="spraying")
+        if not started:
+            return
+        caller.msg(f"You shake {spray_can.get_display_name(caller)}, the "
+                   f"rattle sharp, and set to work on the wall.")
+        msg_room_identity(
+            location=caller.location,
+            template="{actor} shakes a rattling spray can and sets to work "
+                     "on the wall.",
+            char_refs={"actor": caller},
+            exclude=[caller],
+        )
+
+    def _land_tag(self, caller, spray_can, message, interrupted=False):
+        """Resolve a tag onto the wall (full or partial): deduct paint for
+        the characters actually sprayed, write the graffiti, message the
+        room, and file the vandalism report — tagging is a crime the
+        crowd-gated witness pipeline can now fairly see (the act occupied
+        real, public time)."""
+        if not caller.location:
+            return
+        # Paint deducts at resolution (1/char actually sprayed, ellipsis
+        # free); the can may have less left than the tag needs.
+        paint_needed = len(message.rstrip(".")) if interrupted else len(message)
+        paint_available = spray_can.db.aerosol_level or 0
         ran_out_mid_message = False
         if paint_needed > paint_available:
-            message = message[:paint_available] + "..."  # Add ellipsis to show it was cut off
+            message = message[:paint_available] + "..."
             paint_used = paint_available
             ran_out_mid_message = True
         else:
             paint_used = paint_needed
-        
+
         # Get the current color and name before using paint (in case can gets deleted)
         current_color = spray_can.db.current_color or "white"  # Default fallback
-        can_name_for_message = spray_can.get_display_name(self.caller)
-        
+        can_name_for_message = spray_can.get_display_name(caller)
+
         # Use the paint
         spray_can.use_paint(paint_used)
-        
+
         # Find or create the room's graffiti object
         graffiti_obj = None
-        for obj in self.caller.location.contents:
+        for obj in caller.location.contents:
             if isinstance(obj, GraffitiObject):
                 graffiti_obj = obj
                 break
-        
+
         if not graffiti_obj:
             # Create new graffiti object for this room
             graffiti_obj = create_object(
                 typeclass=GraffitiObject,
                 key="graffiti",
-                location=self.caller.location
+                location=caller.location
             )
-        
+
         # Add the graffiti message to the object
-        graffiti_obj.add_graffiti(message, current_color, self.caller)
-        
+        graffiti_obj.add_graffiti(message, current_color, caller)
+
         # Messages - using proper Evennia color formatting
         color_code = GRAFFITI_COLOR_MAP.get(current_color.lower() if current_color else 'white', 'w')
         colored_message = f"|{color_code}{message}|n"
-        
-        # Create appropriate message based on whether can ran out
-        if ran_out_mid_message:
-            self.caller.msg(f"You start to spray on the wall with a {can_name_for_message}, but it runs out of paint mid-message! You manage to spray '{colored_message}' before the can crumples up and becomes useless.")
+
+        if interrupted:
+            caller.msg(f"Your hand jerks away mid-letter — '{colored_message}' "
+                       f"is all that made it onto the wall.")
             msg_room_identity(
-                location=self.caller.location,
+                location=caller.location,
+                template=f"{{actor}} breaks off mid-tag, leaving "
+                         f"'{colored_message}' half-finished on the wall.",
+                char_refs={"actor": caller},
+                exclude=[caller],
+            )
+        elif ran_out_mid_message:
+            caller.msg(f"You start to spray on the wall with a {can_name_for_message}, but it runs out of paint mid-message! You manage to spray '{colored_message}' before the can crumples up and becomes useless.")
+            msg_room_identity(
+                location=caller.location,
                 template=f"{{actor}} starts to spray on the wall, but their can runs out of paint mid-message, managing only '{colored_message}' before tossing the empty can aside.",
-                char_refs={"actor": self.caller},
-                exclude=[self.caller],
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
         else:
-            self.caller.msg(f"You spray '{colored_message}' on the wall with a {can_name_for_message}.")
+            caller.msg(f"You spray '{colored_message}' on the wall with a {can_name_for_message}.")
             msg_room_identity(
-                location=self.caller.location,
+                location=caller.location,
                 template=f"{{actor}} sprays '{colored_message}' on the wall.",
-                char_refs={"actor": self.caller},
-                exclude=[self.caller],
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
+
+        # Vandalism is a crime (dispatch §5.2 taxonomy — carried the entry
+        # since the crime slice; this is its first caller). Crowd-gated
+        # witness, real walkie, interdiction window: all the real rails.
+        try:
+            from world.director.crime import report_crime
+            report_crime("vandalism", caller.location, perp=caller)
+        except Exception:  # noqa: BLE001 — dispatch down ≠ graffiti crash
+            pass
     
     def _handle_clean_with_solvent(self, solvent_can):
         """Handle cleaning graffiti and blood stains with a solvent can."""

--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -40,6 +40,9 @@ class CmdWield(Command):
 
     def func(self):
         caller = self.caller
+        from world.channeled import refuse_if_channeling
+        if refuse_if_channeling(caller):
+            return  # BLOCKED (CHANNELED_ACTIONS_SPEC §2.2): hands are busy
         args = self.args.strip().lower()
 
         if not args:

--- a/commands/CmdRadio.py
+++ b/commands/CmdRadio.py
@@ -81,6 +81,9 @@ class CmdTransmit(Command):
         return None
 
     def func(self):
+        from world.channeled import refuse_if_channeling
+        if refuse_if_channeling(self.caller):
+            return  # BLOCKED (CHANNELED_ACTIONS_SPEC §2.2): device work is hands-work
         caller = self.caller
         if not self.raw_message:
             caller.msg("Transmit what?")
@@ -142,6 +145,9 @@ class CmdTune(Command):
                 self.device_phrase = raw
 
     def func(self):
+        from world.channeled import refuse_if_channeling
+        if refuse_if_channeling(self.caller):
+            return  # BLOCKED (CHANNELED_ACTIONS_SPEC §2.2): device work is hands-work
         caller = self.caller
         if not self.device_phrase or not self.freq:
             caller.msg("Usage: tune <device> to <frequency>")
@@ -188,6 +194,9 @@ class CmdToggle(Command):
             self.device_phrase, self.state = parts[0].strip(), parts[1].lower()
 
     def func(self):
+        from world.channeled import refuse_if_channeling
+        if refuse_if_channeling(self.caller):
+            return  # BLOCKED (CHANNELED_ACTIONS_SPEC §2.2): device work is hands-work
         caller = self.caller
         if not self.device_phrase:
             caller.msg("Toggle what?")

--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -54,6 +54,9 @@ class CmdAttack(Command):
     help_category = "Combat"
 
     def func(self):
+        from world.channeled import refuse_if_channeling
+        if refuse_if_channeling(self.caller):
+            return  # BLOCKED (CHANNELED_ACTIONS_SPEC §2.2)
         caller = self.caller
         args = self.args.strip()
         splattercast = get_splattercast()
@@ -547,7 +550,15 @@ class CmdStop(Command):
     def func(self):
         caller = self.caller
         args = self.args.strip().lower()
-        
+
+        # Channeled act (CHANNELED_ACTIONS_SPEC §2.2): bare `stop`, or
+        # `stop <act>` naming it, aborts deliberately — you keep the partial.
+        from world.channeled import is_channeling, stop_channel
+        channel_key = is_channeling(caller)
+        if channel_key and (not args or args == channel_key):
+            stop_channel(caller)
+            return
+
         if not args:
             caller.msg(MSG_STOP_WHAT)
             return

--- a/specs/GRAFFITI_SYSTEM_SPEC.md
+++ b/specs/GRAFFITI_SYSTEM_SPEC.md
@@ -219,11 +219,15 @@ Unified graffiti system providing player-driven street expression through spray 
 
 ### Known Limitations
 - No message persistence across server restarts for graffiti objects
-- No built-in anti-spam protection beyond resource limits
 - Color palette fixed to 7 standard ANSI colors
 
 ### Future Enhancement Opportunities
-- **Action delays** - spray painting/cleaning takes time, prevents movement during action
+- ~~Action delays~~ — ✅ SHIPPED (2026-07-06, CHANNELED_ACTIONS_SPEC):
+  spraying is a channeled act (3s setup + 1s/letter — duration proportional
+  to tag length, the anti-spam that is also the fiction); movement blocked,
+  violence interrupts (partial tag lands with ellipsis, pro-rata paint), and
+  tagging files a real `vandalism` crime report (crowd-gated witness).
+  Cleaning delays: next consumer.
 - **Identical tag stacking** - repeated messages get consolidated with quantity descriptors
   - Single: "Scrawled in red paint: WAKKA RULES"  
   - Multiple colors: "Scrawled in |rp|ba|gi|yn|mt obsessively: WAKKA RULES"

--- a/specs/proposals/CHANNELED_ACTIONS_SPEC.md
+++ b/specs/proposals/CHANNELED_ACTIONS_SPEC.md
@@ -1,6 +1,12 @@
 # Channeled Actions Spec — timed, interruptible acts
 
-> **Status:** 📋 **PROPOSAL (2026-07-06) — design only.** The game's first
+> **Status:** ✅ **SHIPPED (2026-07-06)** — `world/channeled.py` (the
+> primitive), taxonomy wired (BLOCKED: movement/wield/attack/xmit-tune-
+> toggle + bare `stop` to abort; BREAKING: take_damage, combat enrollment,
+> grapple establish, unconscious/death, forced movement via at_post_move),
+> graffiti as first consumer (3s + 1s/char, partial-with-ellipsis on
+> interrupt, pro-rata paint, vandalism reports). Solvent cleaning + the
+> wrest/disarm seam are the next consumers. Originally: The game's first
 > generic **timed-act primitive**: an action that occupies its actor for a
 > real duration, shows a visible tell, and resolves to a full result on
 > completion or a **partial result on interruption**. First consumer:

--- a/typeclasses/armor_mixin.py
+++ b/typeclasses/armor_mixin.py
@@ -43,6 +43,13 @@ class ArmorMixin:
             tuple: (died: bool, actual_damage: int) - Whether character died
                 and actual damage applied after armor
         """
+        # BREAKING (CHANNELED_ACTIONS_SPEC §2.3): contact ends a channel.
+        try:
+            from world.channeled import interrupt_channel
+            interrupt_channel(self)
+        except Exception:
+            pass
+
         if not isinstance(amount, int) or amount <= 0:
             return (False, 0)
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -654,6 +654,13 @@ class Character(
             splattercast.msg(f"AT_DEATH_SKIP: {self.key} already processed death (db flag), skipping")
             return
             
+        # BREAKING (CHANNELED_ACTIONS_SPEC §2.3): dying ends any channel.
+        try:
+            from world.channeled import interrupt_channel
+            interrupt_channel(self)
+        except Exception:  # noqa: BLE001
+            pass
+
         # Mark death as processed IMMEDIATELY using db (persistent) to prevent ANY race conditions
         self.db.death_processed = True
         
@@ -719,6 +726,12 @@ class Character(
         """
         if not force_test and not self.is_unconscious():
             return
+        # BREAKING (CHANNELED_ACTIONS_SPEC §2.3): collapsing ends a channel.
+        try:
+            from world.channeled import interrupt_channel
+            interrupt_channel(self)
+        except Exception:  # noqa: BLE001
+            pass
             
         # Check if character has builder/developer permissions
         if not force_test and self.locks.check(self, "perm(Builder)"):
@@ -1364,6 +1377,14 @@ class Character(
             **kwargs: Forwarded to the parent hook (e.g. ``move_type``).
         """
         super().at_post_move(source_location, **kwargs)
+        # BREAKING (CHANNELED_ACTIONS_SPEC §2.3): a move that happened while
+        # channeling was FORCED (voluntary moves are blocked at at_pre_move) —
+        # dragged, thrown, gravity. The act breaks with a partial.
+        try:
+            from world.channeled import interrupt_channel
+            interrupt_channel(self)
+        except Exception:  # noqa: BLE001
+            pass
         # You can't carry a seat between rooms — moving puts you on your feet
         # (FURNITURE_AND_POSTURE; silent, the move messages already narrate it).
         if self.db.furniture or (self.db.posture and self.db.posture != "standing"):
@@ -1393,6 +1414,11 @@ class Character(
         off openly while hidden gives you away (stealth spec §6.4) —
         ``sneak`` sets the ndb flag that keeps concealment through a move."""
         if not super().at_pre_move(destination, **kwargs):
+            return False
+        # BLOCKED (CHANNELED_ACTIONS_SPEC §2.2): channels prevent movement —
+        # leaving requires an explicit 'stop'. Never a silent cancel.
+        from world.channeled import refuse_if_channeling
+        if refuse_if_channeling(self):
             return False
         if self.db.hidden is True and not self.ndb.sneaking:
             from world.stealth import break_stealth

--- a/world/channeled.py
+++ b/world/channeled.py
@@ -1,0 +1,131 @@
+"""Channeled actions — timed, interruptible acts (CHANNELED_ACTIONS_SPEC).
+
+The stillness primitive: an act that occupies its actor for a real duration,
+shows a visible tell, and resolves to a full result on completion or a
+PARTIAL result on interruption. One channel per character, ndb-backed (a
+reload silently kills the act: nothing lands, nothing is spent — costs
+deduct at resolution, never up front).
+
+The interrupt taxonomy (spec §2) lives at the call sites, not here:
+
+* FREE   — perception/speech never call into this module.
+* BLOCKED— hands/attention verbs call :func:`refuse_if_channeling` and back
+           off with a message; the actor exits deliberately via ``stop``
+           (:func:`stop_channel`).
+* BREAKING — the world's contact seams (damage, grapple, combat enrollment,
+           unconsciousness/death, wrest/disarm, forced movement) call
+           :func:`interrupt_channel`.
+"""
+
+from __future__ import annotations
+
+from time import monotonic
+from typing import Any, Callable, Optional
+
+from evennia.utils import delay
+
+
+def channel_of(actor: Any) -> Optional[dict]:
+    """The actor's live channel record, or None. Strictly typed — only a
+    dict this module wrote counts (the MagicMock-truthiness lesson: a mock
+    actor's auto-attribute must never read as a live channel)."""
+    chan = getattr(getattr(actor, "ndb", None), "channel", None)
+    return chan if isinstance(chan, dict) else None
+
+
+def is_channeling(actor: Any) -> Optional[str]:
+    """The channel's key ("spraying") when the actor is mid-act, else None."""
+    chan = channel_of(actor)
+    return chan.get("key") if chan else None
+
+
+def refuse_if_channeling(actor: Any) -> bool:
+    """The BLOCKED-class gate: True (and a refusal message) when the actor is
+    mid-channel. Blocked verbs call this first and return — never a silent
+    cancel; deliberate exit is the ``stop`` command."""
+    key = is_channeling(actor)
+    if not key:
+        return False
+    actor.msg(f"You're busy {key} — 'stop' first.")
+    return True
+
+
+def begin_channel(actor: Any, duration: float, tell: str,
+                  on_complete: Callable, on_interrupt: Callable,
+                  key: str = "working") -> bool:
+    """Begin a channeled act. Refuses (False, with message) if one is
+    already running. ``on_complete()`` fires after *duration* seconds;
+    ``on_interrupt(fraction)`` fires instead if the act is stopped or
+    broken, with the elapsed fraction (0.0–1.0)."""
+    if refuse_if_channeling(actor):
+        return False
+    token = object()   # invalidates the pending completion on interrupt
+    actor.ndb.channel = {
+        "key": key,
+        "started": monotonic(),
+        "duration": max(0.1, float(duration)),
+        "on_complete": on_complete,
+        "on_interrupt": on_interrupt,
+        "token": token,
+        "prior_place": getattr(actor, "override_place", None),
+    }
+    try:
+        actor.override_place = tell   # the act is PUBLIC time — visible tell
+    except Exception:  # noqa: BLE001 — a tell failure never blocks the act
+        pass
+    delay(duration, _finish, actor, token)
+    return True
+
+
+def _clear(actor: Any) -> Optional[dict]:
+    """Tear down the channel state (tell restored). Returns the record."""
+    chan = channel_of(actor)
+    if not chan:
+        return None
+    actor.ndb.channel = None
+    try:
+        actor.override_place = chan.get("prior_place")
+    except Exception:  # noqa: BLE001
+        pass
+    return chan
+
+
+def _finish(actor: Any, token: object) -> None:
+    """Timer landing: complete the act — unless the channel was already
+    interrupted (token mismatch) or died with the server (ndb gone)."""
+    chan = channel_of(actor)
+    if not chan or chan.get("token") is not token:
+        return
+    chan = _clear(actor)
+    try:
+        chan["on_complete"]()
+    except Exception:  # noqa: BLE001 — a consumer bug never leaks upward
+        pass
+
+
+def stop_channel(actor: Any) -> bool:
+    """Voluntary exit (the ``stop`` verb): abort with the current fraction.
+    You keep what you finished. Returns True if a channel was stopped."""
+    return _interrupt(actor, voluntary=True)
+
+
+def interrupt_channel(actor: Any, reason: str | None = None) -> bool:
+    """BREAKING-class exit: the world made contact (damage, grapple, combat
+    enrollment, collapse, wrest, forced movement). Fail-open and cheap when
+    the actor isn't channeling — seams may call this unconditionally."""
+    return _interrupt(actor, voluntary=False, reason=reason)
+
+
+def _interrupt(actor: Any, voluntary: bool, reason: str | None = None) -> bool:
+    chan = channel_of(actor)
+    if not chan:
+        return False
+    now = monotonic()
+    elapsed = now - chan.get("started", now)
+    fraction = max(0.0, min(1.0, elapsed / chan["duration"]))
+    _clear(actor)
+    try:
+        chan["on_interrupt"](fraction)
+    except Exception:  # noqa: BLE001
+        pass
+    return True

--- a/world/combat/grappling.py
+++ b/world/combat/grappling.py
@@ -69,6 +69,12 @@ def establish_grapple(combat_handler, grappler, victim):
     """
     if grappler == victim:
         return False, MSG_CANNOT_GRAPPLE_SELF
+    # BREAKING (CHANNELED_ACTIONS_SPEC §2.3): being seized ends a channel.
+    try:
+        from world.channeled import interrupt_channel
+        interrupt_channel(victim)
+    except Exception:  # noqa: BLE001
+        pass
     
     # Get combatant entries
     grappler_entry = None

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -535,6 +535,13 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
         initial_grappled_by: Optional character grappling this char initially
         initial_is_yielding: Whether the character starts yielding
     """
+    # BREAKING (CHANNELED_ACTIONS_SPEC §2.3): entering combat ends a
+    # channel, even before the first hit lands.
+    try:
+        from world.channeled import interrupt_channel
+        interrupt_channel(char)
+    except Exception:  # noqa: BLE001
+        pass
     from .constants import (
         DB_COMBATANTS, DB_CHAR, DB_TARGET_DBREF,
         DB_GRAPPLING_DBREF, DB_GRAPPLED_BY_DBREF, DB_IS_YIELDING, 

--- a/world/tests/test_channeled.py
+++ b/world/tests/test_channeled.py
@@ -1,0 +1,221 @@
+"""Channeled actions (world/channeled.py + graffiti consumer) —
+CHANNELED_ACTIONS_SPEC.
+
+The stillness primitive: duration + tell + on_complete/on_interrupt(frac).
+The taxonomy: FREE never touches it, BLOCKED verbs refuse with 'stop first',
+BREAKING seams (damage/grapple/enrollment/collapse/forced move) land the
+partial. Graffiti: per-letter timer, interrupted tags land with ellipsis,
+vandalism finally reports.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.channeled as ch
+from world.channeled import (
+    begin_channel, interrupt_channel, is_channeling, refuse_if_channeling,
+    stop_channel,
+)
+
+
+def _actor():
+    a = MagicMock()
+    a.ndb = SimpleNamespace(channel=None)
+    a.override_place = None
+    return a
+
+
+class TestPrimitive(TestCase):
+    def test_begin_sets_tell_and_schedules(self):
+        a = _actor()
+        with patch.object(ch, "delay") as d:
+            ok = begin_channel(a, 10, "at the wall", lambda: None,
+                               lambda f: None, key="spraying")
+        self.assertTrue(ok)
+        self.assertEqual(is_channeling(a), "spraying")
+        self.assertEqual(a.override_place, "at the wall")
+        d.assert_called_once()
+
+    def test_second_channel_refused(self):
+        a = _actor()
+        with patch.object(ch, "delay"):
+            begin_channel(a, 10, "t", lambda: None, lambda f: None, key="spraying")
+            ok = begin_channel(a, 5, "t2", lambda: None, lambda f: None)
+        self.assertFalse(ok)
+        self.assertIn("busy spraying", a.msg.call_args.args[0])
+
+    def test_completion_fires_and_restores_tell(self):
+        a = _actor()
+        a.override_place = "leaning on the bar."
+        done = MagicMock()
+        with patch.object(ch, "delay") as d:
+            begin_channel(a, 10, "tagging", done, lambda f: None)
+        # fire the scheduled completion with the real token
+        _, args = d.call_args.args[1], d.call_args.args[2:]
+        ch._finish(*args)
+        done.assert_called_once()
+        self.assertIsNone(is_channeling(a))
+        self.assertEqual(a.override_place, "leaning on the bar.")
+
+    def test_interrupt_lands_fraction_and_stale_timer_noops(self):
+        a = _actor()
+        got = {}
+        with patch.object(ch, "delay") as d, \
+                patch.object(ch, "monotonic", side_effect=[100.0, 104.0]):
+            begin_channel(a, 10, "t", MagicMock(),
+                          lambda f: got.update(frac=f))
+            interrupt_channel(a)
+        self.assertAlmostEqual(got["frac"], 0.4)
+        self.assertIsNone(is_channeling(a))
+        # the pending completion is now stale: firing it must do nothing
+        args = d.call_args.args[2:]
+        ch._finish(*args)   # token mismatch -> no-op, no crash
+
+    def test_stop_is_voluntary_interrupt(self):
+        a = _actor()
+        got = {}
+        with patch.object(ch, "delay"), \
+                patch.object(ch, "monotonic", side_effect=[100.0, 101.0]):
+            begin_channel(a, 10, "t", MagicMock(), lambda f: got.update(f=f))
+            self.assertTrue(stop_channel(a))
+        self.assertIn("f", got)
+
+    def test_interrupt_without_channel_is_free(self):
+        self.assertFalse(interrupt_channel(_actor()))
+
+    def test_refuse_gate_strict_on_mocks(self):
+        # The MagicMock trap: a bare mock actor must NOT read as channeling.
+        self.assertFalse(refuse_if_channeling(MagicMock()))
+
+    def test_consumer_exception_never_leaks(self):
+        a = _actor()
+        with patch.object(ch, "delay") as d:
+            begin_channel(a, 10, "t", MagicMock(side_effect=RuntimeError),
+                          lambda f: None)
+        ch._finish(*d.call_args.args[2:])   # must not raise
+        self.assertIsNone(is_channeling(a))
+
+
+class TestGraffitiChannel(TestCase):
+    def _cmd(self):
+        from commands.CmdGraffiti import CmdGraffiti
+        cmd = CmdGraffiti()
+        caller = MagicMock()
+        caller.ndb = SimpleNamespace(channel=None)
+        caller.override_place = None
+        cmd.caller = caller
+        return cmd, caller
+
+    def _can(self, paint=256, color="red"):
+        can = MagicMock()
+        can.db.aerosol_level = paint
+        can.db.current_color = color
+        can.get_display_name = lambda looker=None: "a battered spray can"
+        return can
+
+    def test_spray_channels_with_per_letter_duration(self):
+        cmd, caller = self._cmd()
+        can = self._can()
+        with patch.object(ch, "delay") as d, \
+                patch("commands.CmdGraffiti.msg_room_identity"):
+            cmd._handle_spray_paint_with_spraypaint(can, "KRAKEN RULES")
+        self.assertEqual(is_channeling(caller), "spraying")
+        duration = d.call_args.args[0]
+        self.assertAlmostEqual(duration, 3.0 + len("KRAKEN RULES") * 1.0)
+        can.use_paint.assert_not_called()      # cost deducts at RESOLUTION
+
+    def test_completion_lands_full_tag_and_reports_vandalism(self):
+        cmd, caller = self._cmd()
+        can = self._can()
+        with patch.object(ch, "delay") as d, \
+                patch("commands.CmdGraffiti.msg_room_identity"), \
+                patch("commands.CmdGraffiti.create_object") as co, \
+                patch("world.director.crime.report_crime") as report:
+            caller.location.contents = []
+            cmd._handle_spray_paint_with_spraypaint(can, "KRAKEN")
+            ch._finish(*d.call_args.args[2:])
+        can.use_paint.assert_called_once_with(6)
+        graffiti = co.return_value
+        graffiti.add_graffiti.assert_called_once()
+        self.assertEqual(graffiti.add_graffiti.call_args.args[0], "KRAKEN")
+        report.assert_called_once()
+        self.assertEqual(report.call_args.args[0], "vandalism")
+
+    def test_interruption_lands_partial_with_ellipsis(self):
+        cmd, caller = self._cmd()
+        can = self._can()
+        with patch.object(ch, "delay"), \
+                patch("commands.CmdGraffiti.msg_room_identity"), \
+                patch("commands.CmdGraffiti.create_object") as co, \
+                patch("world.director.crime.report_crime") as report, \
+                patch.object(ch, "monotonic", side_effect=[100.0, 107.0]):
+            caller.location.contents = []
+            # 10 letters -> duration 13s; interrupted at 7s = 4 letters done
+            cmd._handle_spray_paint_with_spraypaint(can, "KRAKENRULE")
+            interrupt_channel(caller)
+        landed = co.return_value.add_graffiti.call_args.args[0]
+        self.assertEqual(landed, "KRAK...")
+        can.use_paint.assert_called_once_with(4)   # pro-rata, ellipsis free
+        report.assert_called_once()                # caught mid-crime still reports
+
+    def test_interruption_before_first_letter_lands_nothing(self):
+        cmd, caller = self._cmd()
+        can = self._can()
+        with patch.object(ch, "delay"), \
+                patch("commands.CmdGraffiti.msg_room_identity"), \
+                patch("commands.CmdGraffiti.create_object") as co, \
+                patch.object(ch, "monotonic", side_effect=[100.0, 101.0]):
+            cmd._handle_spray_paint_with_spraypaint(can, "KRAKEN")
+            interrupt_channel(caller)      # 1s in: still shaking the can
+        co.assert_not_called()
+        can.use_paint.assert_not_called()
+
+
+class TestTaxonomyWiring(TestCase):
+    """The BLOCKED gates and BREAKING seams actually call the primitive."""
+
+    def _busy(self):
+        a = MagicMock()
+        a.ndb = SimpleNamespace(channel=None)
+        a.override_place = None
+        with patch.object(ch, "delay"):
+            begin_channel(a, 60, "t", MagicMock(), MagicMock(),
+                          key="spraying")
+        return a
+
+    def test_wield_blocked_while_channeling(self):
+        from commands.CmdInventory import CmdWield
+        cmd = CmdWield()
+        cmd.caller = self._busy()
+        cmd.args = "shiv"
+        cmd.func()
+        self.assertIn("busy spraying", cmd.caller.msg.call_args.args[0])
+        self.assertEqual(is_channeling(cmd.caller), "spraying")  # intact
+
+    def test_xmit_blocked_while_channeling(self):
+        from commands.CmdRadio import CmdTransmit
+        cmd = CmdTransmit()
+        cmd.caller = self._busy()
+        cmd.args = "hello"
+        cmd.parse()
+        cmd.func()
+        self.assertIn("busy spraying", cmd.caller.msg.call_args.args[0])
+
+    def test_combat_enrollment_breaks_channel(self):
+        from world.combat.utils import add_combatant
+        a = self._busy()
+        try:
+            add_combatant(MagicMock(), a)
+        except Exception:  # noqa: BLE001 — mock handler dies later; fine
+            pass
+        self.assertIsNone(is_channeling(a))   # the channel broke FIRST
+
+    def test_stop_verb_aborts_channel(self):
+        from commands.combat.core_actions import CmdStop
+        a = self._busy()
+        cmd = CmdStop()
+        cmd.caller = a
+        cmd.args = ""
+        cmd.func()
+        self.assertIsNone(is_channeling(a))


### PR DESCRIPTION
world/channeled.py: the stillness primitive — one channel per
character, visible tell, on_complete at duration, on_interrupt(frac)
otherwise, stale-timer token, costs at resolution. Taxonomy wired:
BLOCKED verbs refuse with 'stop first' (movement/wield/attack/radio;
bare stop aborts keeping the partial), BREAKING seams land the partial
(take_damage, combat enrollment, grapple establish, collapse, death,
forced movement). Graffiti channels 3s + 1s/char: interruption lands
finished letters with the existing ellipsis truncation, pro-rata
paint, and tagging files report_crime('vandalism') — the taxonomy
entry's first caller. Length = exposure = risk.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
