### PR TITLE
Radio: the tune dial reads megahertz — bands are numbers (Closes #1055)

### DIFF
--- a/commands/CmdRadio.py
+++ b/commands/CmdRadio.py
@@ -161,12 +161,20 @@ class CmdTune(Command):
             caller.msg(f"You set {device.get_display_name(caller)} sweeping "
                        f"the bands.")
             return
-        # Store the band as typed (clean display); matching is case-insensitive
-        # in world.radio.same_band, so 911mhz and 911MHz are the same channel.
-        device.db.frequency = freq
+        # The dial reads megahertz, not prose: a band is a NUMBER in the
+        # tunable range, stored canonically ('912' -> 912MHz) so every
+        # radio tuned to the same number lands on the same channel.
+        from world.radio import BAND_MAX, BAND_MIN, normalize_band
+        band = normalize_band(freq)
+        if band is None:
+            caller.msg(f"The dial reads megahertz — a number from "
+                       f"{int(BAND_MIN)} to {BAND_MAX} (or 'scan'). "
+                       f"'{freq}' isn't a frequency.")
+            return
+        device.db.frequency = band
         state = "" if is_powered(device) else " (it's switched off)"
         caller.msg(f"You tune {device.get_display_name(caller)} to "
-                   f"{freq}{state}.")
+                   f"{band}{state}.")
 
 
 class CmdToggle(Command):

--- a/specs/proposals/RADIO_COMMS_SPEC.md
+++ b/specs/proposals/RADIO_COMMS_SPEC.md
@@ -177,7 +177,12 @@ loot/frisk/steal path. Witnesses already spawn with an emergency-band walkie
 
 ### 6.3 · Tuning & discovery
 
-`radio/tune <frequency>` — a walkie hears only its tuned band. Discovery is
+`radio/tune <frequency>` — a walkie hears only its tuned band. **The dial
+reads megahertz (DECIDED 2026-07-06):** a band is a NUMBER, 1–999.9 MHz at
+one-decimal resolution (~10k channels — searchable, not infinite), stored
+canonically (`912` → `912MHz`; `normalize_band`); prose is refused ("'banana'
+isn't a frequency"). `same_band` normalizes both sides, so legacy loose
+values keep matching. Discovery is
 **scanning** (sweep bands and listen), **lucky guesses**, and **captured
 walkies** (a lifted security handheld arrives tuned to their band — the
 listening post). Secrecy is procedural, not cryptographic (encryption is a

--- a/world/radio.py
+++ b/world/radio.py
@@ -53,14 +53,46 @@ def is_scanning(device: Any) -> bool:
     return isinstance(freq, str) and freq.strip().lower() == SCAN
 
 
+#: The handheld's tunable range, in megahertz — a bounded spectrum makes
+#: scanning/guessing/jamming meaningful (a band plan exists to be searched).
+BAND_MIN, BAND_MAX = 1.0, 999.9
+
+
+def normalize_band(raw: Any) -> Optional[str]:
+    """Canonicalize a dialed frequency: a NUMBER (optional one decimal),
+    optional ``MHz`` suffix any case, within the tunable range — rendered
+    as ``911MHz`` / ``101.5MHz``. Returns None for anything a dial can't
+    say (``banana`` is not a frequency). ``scan`` is not a band; callers
+    handle it before this."""
+    if raw is None:
+        return None
+    text = str(raw).strip().lower()
+    if text.endswith("mhz"):
+        text = text[:-3].strip()
+    if not text:
+        return None
+    try:
+        value = float(text)
+    except (TypeError, ValueError):
+        return None
+    if not (BAND_MIN <= value <= BAND_MAX):
+        return None
+    value = round(value, 1)
+    shown = str(int(value)) if value == int(value) else f"{value:.1f}"
+    return f"{shown}MHz"
+
+
 def same_band(a: Any, b: Any) -> bool:
-    """Two frequencies are the same band, compared case-insensitively. Players
-    type what a scanner shows them and the ``tune`` command preserves case, but
-    the emergency-band constant and the bot comms-organ specs are mixed-case —
-    so ``911MHz`` typed as ``911mhz`` must still reach dispatch. None never
-    matches (an untuned radio is on no band)."""
+    """Two frequencies are the same band. Both sides normalize through the
+    canonical dial format first — so a legacy loose value (``912``) matches
+    its canonical form (``912MHz``), and case never matters. Non-numeric
+    values fall back to a case-insensitive string compare (future named
+    bands); None never matches (an untuned radio is on no band)."""
     if a is None or b is None:
         return False
+    na, nb = normalize_band(a), normalize_band(b)
+    if na is not None and nb is not None:
+        return na == nb
     return str(a).strip().lower() == str(b).strip().lower()
 
 

--- a/world/tests/test_radio.py
+++ b/world/tests/test_radio.py
@@ -50,6 +50,42 @@ class TestDevicePredicates(TestCase):
         self.assertFalse(same_band(None, "447"))         # untuned = no band
         self.assertFalse(same_band("447", None))
 
+    def test_same_band_normalizes_legacy_loose_values(self):
+        from world.radio import same_band
+        self.assertTrue(same_band("912", "912MHz"))      # pre-dial data
+        self.assertTrue(same_band("101.5", "101.5mhz"))
+        self.assertTrue(same_band("911.0", "911MHz"))    # trailing .0 folds
+
+    def test_normalize_band_is_a_dial_not_prose(self):
+        from world.radio import normalize_band
+        self.assertEqual(normalize_band("912"), "912MHz")
+        self.assertEqual(normalize_band("911mhz"), "911MHz")
+        self.assertEqual(normalize_band(" 101.5 MHz".replace(" MHz", "MHz")),
+                         "101.5MHz")
+        self.assertEqual(normalize_band("101.54"), "101.5MHz")  # one decimal
+        self.assertIsNone(normalize_band("banana"))      # not a frequency
+        self.assertIsNone(normalize_band("0"))           # below the dial
+        self.assertIsNone(normalize_band("1000"))        # above the dial
+        self.assertIsNone(normalize_band(""))
+        self.assertIsNone(normalize_band(None))
+
+    def test_tune_rejects_prose_and_stores_canonical(self):
+        from commands.CmdRadio import CmdTune
+        dev = _radio()
+        # prose refused
+        cmd = CmdTune(); cmd.args = "walkie to banana"
+        cmd.caller = MagicMock(); cmd.caller.ndb.channel = None
+        cmd.caller.search.return_value = dev
+        cmd.parse(); cmd.func()
+        self.assertIn("isn't a frequency", cmd.caller.msg.call_args.args[0])
+        self.assertNotEqual(dev.db.frequency, "banana")
+        # loose number stored canonically
+        cmd2 = CmdTune(); cmd2.args = "walkie to 912"
+        cmd2.caller = MagicMock(); cmd2.caller.ndb.channel = None
+        cmd2.caller.search.return_value = dev
+        cmd2.parse(); cmd2.func()
+        self.assertEqual(dev.db.frequency, "912MHz")
+
     def test_transmit_device_prefers_worn_then_held(self):
         worn, held = _radio(), _radio()
         c = _char(worn=[worn], hands={"r": held})


### PR DESCRIPTION
'tune magpie to banana' worked; a dial should read like a dial.
normalize_band: 1-999.9 MHz at one-decimal resolution (~10k channels,
a bounded searchable spectrum), optional MHz suffix any case, canonical
912MHz/101.5MHz render. tune refuses prose and stores canonical;
same_band normalizes both sides so legacy loose values keep matching.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
