### PR TITLE
Radio: four-perspective display — speakers audible, grilles are speakers (Closes #1057)

### DIFF
--- a/specs/proposals/RADIO_COMMS_SPEC.md
+++ b/specs/proposals/RADIO_COMMS_SPEC.md
@@ -152,11 +152,29 @@ channel-per-frequency):
   Name, Voice/attribution metadata, and Frequency per line. History,
   persistence, and staff distribution come free from the channel system.
 * **Player view** — players NEVER subscribe. A walkie tuned to a frequency
-  **echoes** only matching traffic to its holder, re-rendered through the
-  say/voice rails: the speaker's **voice phrase**, **voice recognition**
-  (recognisable on the air; a modulator defeats it), **hearing-gated**,
-  attributed **by voice only** (never sight). "A gravelly voice crackles
-  over the walkie: …"
+  **echoes** matching traffic, re-rendered through the say/voice rails: the
+  speaker's **voice phrase**, **voice recognition** (recognisable on the
+  air; a modulator defeats it), **hearing-gated**, attributed **by voice
+  only** (never sight). "A gravelly voice crackles over the walkie: …"
+
+  **AMENDED (2026-07-06) — the four-perspective display model.** The
+  original text scoped the echo "to its holder"; the physical stance (§2.4
+  literally says *speaker grille*) demands more, so:
+  1. **Speaker** — `You transmit on 911MHz: "…"` (unchanged).
+  2. **Speaker's ROOM** — transmitting is talking out loud: the words ride
+     the say rails (`says into the radio,`) with full per-observer
+     attribution/hearing/garble/stealth. The witness calling in your
+     assault is audible to whoever stands beside them.
+  3. **Remote listeners** — the crackle line, voice-only attribution,
+     scan-tagged (unchanged).
+  4. **A receiving walkie's ROOM** — the grille is a speaker: traffic is
+     audible to everyone in the radio's room (carried → the holder's room;
+     lying on the floor → its room), hearing-gated per observer ("A radio
+     nearby crackles…" for non-holders when deaf). Carrying a live radio
+     is a stealth liability — as the `toggle` help always promised.
+     **Comms ORGANS stay internal** (in the ear = private to the unit).
+     **Same-room suppression:** whoever stands with the speaker heard the
+     words live (perspective 2) — their radio does not double-render.
 * **Transmitting** — `radio <message>` posts to the channel *through the
   device*, tagged with the device's frequency; every matching-tuned walkie
   echoes it. No device, no voice on the air.

--- a/world/radio.py
+++ b/world/radio.py
@@ -235,15 +235,17 @@ def radio_voice_handle(speaker: Any, listener: Any) -> str:
 
 
 def _render_radio_line(speaker: Any, listener: Any, message: str,
-                       frequency: str, *, tagged: bool) -> str:
+                       frequency: str, *, tagged: bool, own: bool = True) -> str:
     """A received transmission, VOICE-attributed (never sight — you can't see
     the far end) and hearing-gated. ``tagged`` prefixes the frequency (scanner
-    sweep mode caught it off-band)."""
+    sweep mode caught it off-band); ``own`` distinguishes your handset from
+    a grille you're merely standing near."""
     from world.perception import can_hear
     from world.voice import voice_phrase
     band = f"[{frequency}] " if tagged else ""
     if not can_hear(listener):
-        return f"{band}Your radio crackles, but you can't make out a word."
+        source = "Your radio" if own else "A radio nearby"
+        return f"{band}{source} crackles, but you can't make out a word."
     who = radio_voice_handle(speaker, listener)
     flavour = voice_phrase(speaker)
     flav = f" |x*{flavour}*|n" if flavour else ""
@@ -273,8 +275,25 @@ def transmit(speaker: Any, message: str, device: Any) -> bool:
 
     speaker.msg(f'You transmit on {frequency}: "{message}"')
     _log_to_channel(speaker, message, frequency)
+    _speak_aloud(speaker, message, verb="says into the radio")
     _deliver(speaker, message, frequency, device)
     return True
+
+
+def _speak_aloud(speaker: Any, message: str, verb: str) -> None:
+    """Perspective 3 (§2.4 — radio is PHYSICAL): transmitting is talking,
+    out loud, in a room. The spoken line rides the say rails so bystanders
+    get per-observer attribution, hearing gating, garble, and stealth for
+    free — the witness calling in your assault is audible to the person
+    standing next to them."""
+    location = getattr(speaker, "location", None)
+    if location is None:
+        return
+    try:
+        from world.speech import broadcast_speech
+        broadcast_speech(speaker, message, location, verb=verb)
+    except Exception:  # noqa: BLE001 — room render never blocks the air
+        pass
 
 
 def transmit_organ(speaker: Any, message: str) -> bool:
@@ -289,6 +308,7 @@ def transmit_organ(speaker: Any, message: str) -> bool:
         return False
     speaker.msg(f'You transmit on {frequency}: "{message}"')
     _log_to_channel(speaker, message, frequency)
+    _speak_aloud(speaker, message, verb="says over comms")
     _deliver(speaker, message, frequency, None)
     return True
 
@@ -307,32 +327,47 @@ def _deliver(speaker: Any, message: str, frequency: str,
     LLM-driven receivers is ELECTED (``radio_elected=True``) — the §7.2
     single-answerer for "all units"-style broadcasts, so a band-wide call
     can't raise a chorus."""
-    receivers = []          # (listener, tagged), deduped, order-stable
+    receivers = []          # (listener, tagged, own), deduped, order-stable
     seen = set()
+    speaker_room = getattr(speaker, "location", None)
 
-    def _collect(listener, *, tagged):
+    def _collect(listener, *, tagged, own):
         if listener is None or listener is speaker or id(listener) in seen:
             return
         if not hasattr(listener, "msg"):
             return
+        # Same-room suppression: whoever stands WITH the speaker already
+        # heard the words live (perspective 3, the say rails) — their radio
+        # echoing it back would be double render, not physics worth keeping.
+        if (speaker_room is not None
+                and getattr(listener, "location", None) is speaker_room):
+            return
         seen.add(id(listener))
-        receivers.append((listener, tagged))
+        receivers.append((listener, tagged, own))
 
     for radio in _all_powered_radios():
         if radio is exclude_device:
             continue
         scanning = is_scanning(radio)
         if scanning or same_band(frequency_of(radio), frequency):
-            _collect(radio.location, tagged=scanning)   # holder hears it
+            # Perspective 4: a walkie has a GRILLE — the traffic is audible
+            # to the whole room the radio is in, not just its holder (the
+            # toggle help has promised this since P1). A carried radio fans
+            # to the holder's room; one on the floor fans to its room.
+            holder = radio.location
+            for listener in _grille_audience(holder):
+                _collect(listener, tagged=scanning, own=(listener is holder))
 
     for bot in _comms_bots_on(frequency):
-        _collect(bot, tagged=False)                      # built-in transceiver
+        # A comms ORGAN is internal — in the ear, not on a grille. Private
+        # to the unit; the room hears nothing.
+        _collect(bot, tagged=False, own=True)
 
     # Single-answerer election: deterministic (lowest dbref) among LLM-driven
     # receivers. Range is abstracted in P1, so "nearest" has no meaning yet.
     elected = None
     try:
-        candidates = [l for l, _ in receivers
+        candidates = [l for l, _, _ in receivers
                       if getattr(getattr(l, "db", None), "llm_driven", False)
                       is True]
         if candidates:
@@ -341,16 +376,38 @@ def _deliver(speaker: Any, message: str, frequency: str,
         elected = None
 
     from world.perception import can_hear
-    for listener, tagged in receivers:
+    for listener, tagged, own in receivers:
         try:
             payload = {}
             if can_hear(listener):
                 payload["speech"] = message   # the say-rails contract
             listener.msg(_render_radio_line(
-                speaker, listener, message, frequency, tagged=tagged),
+                speaker, listener, message, frequency, tagged=tagged,
+                own=own),
                 type="radio", from_obj=speaker,
                 radio_frequency=frequency,
                 radio_elected=(listener is elected),
                 **payload)
         except Exception:  # noqa: BLE001 — one bad listener never stops the net
             pass
+
+
+def _grille_audience(holder: Any) -> list:
+    """Who hears a receiving walkie's grille. A radio carried by someone
+    fans to their whole room (holder included); one lying in a room fans to
+    that room's contents. Strictly typed (isinstance list) so a mock or
+    malformed location degrades to holder-only, never to silence."""
+    if holder is None:
+        return []
+    room = getattr(holder, "location", None)
+    contents = getattr(room, "contents", None) if room is not None else None
+    if isinstance(contents, (list, tuple)):          # carried: holder's room
+        audience = list(contents)
+        if holder not in audience:
+            audience.append(holder)
+        return audience
+    contents = getattr(holder, "contents", None)
+    if (isinstance(contents, (list, tuple))
+            and not hasattr(holder, "hands")):       # on the floor of a room
+        return list(contents)
+    return [holder]                                   # fallback: holder only

--- a/world/speech.py
+++ b/world/speech.py
@@ -113,7 +113,8 @@ def render_speech_line(speaker, observer, speech, *, target=None, flavor=None,
     )
 
 
-def broadcast_speech(speaker, speech, location, *, target=None, speech_type="say"):
+def broadcast_speech(speaker, speech, location, *, target=None, speech_type="say",
+                     verb="says"):
     """Render and broadcast a spoken line to a room.
 
     Shared by ``say`` (``target=None``) and ``to`` (``target=<character>``).
@@ -129,7 +130,7 @@ def broadcast_speech(speaker, speech, location, *, target=None, speech_type="say
         if not can_hear(observer) and not can_see(observer):
             continue  # no channel — suppressed
         text = render_speech_line(
-            speaker, observer, speech, target=target, flavor=flavor
+            speaker, observer, speech, target=target, flavor=flavor, verb=verb
         )
         payload = speech_payload(
             observer, speaker, speech, addressed=(observer is target)

--- a/world/tests/test_radio.py
+++ b/world/tests/test_radio.py
@@ -185,6 +185,88 @@ class TestTransmit(TestCase):
         self.assertIn("crackles", line)
         self.assertNotIn("secret", line)
 
+    def test_transmit_is_audible_in_the_speakers_room(self):
+        # Perspective 3 (§2.4 radio is physical): transmitting is talking out
+        # loud — the words ride the say rails to the speaker's room.
+        speaker = _char()
+        dev = _radio(freq="447")
+        with self._world([dev]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.speech.broadcast_speech") as bs:
+            transmit(speaker, "cover the back door", dev)
+        bs.assert_called_once()
+        args, kwargs = bs.call_args
+        self.assertEqual(args[1], "cover the back door")
+        self.assertIs(args[2], speaker.location)
+        self.assertEqual(kwargs.get("verb"), "says into the radio")
+
+    def test_grille_fans_to_the_receiving_radios_room(self):
+        # Perspective 4: a walkie has a grille — the whole room hears it,
+        # not just the holder ('a powered radio is also audible').
+        from types import SimpleNamespace
+        speaker = _char()
+        dev = _radio(freq="447")
+        holder, bystander = MagicMock(), MagicMock()
+        holder.db.llm_driven = False
+        bystander.db.llm_driven = False
+        room = SimpleNamespace(contents=[holder, bystander])
+        holder.location = room
+        bystander.location = room
+        heard = _radio(freq="447")
+        heard.location = holder
+        with self._world([dev, heard]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.speech.broadcast_speech"), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern", return_value=None), \
+                patch("world.voice.get_voice_description", return_value="flat"), \
+                patch("world.voice.voice_phrase", return_value=None):
+            transmit(speaker, "come in", dev)
+        holder.msg.assert_called_once()
+        bystander.msg.assert_called_once()      # the grille reached them
+        self.assertIn("come in", bystander.msg.call_args.args[0])
+
+    def test_same_room_listener_hears_live_voice_not_the_echo(self):
+        # Whoever stands WITH the speaker heard the words live (say rails);
+        # their own radio must not double-render the transmission.
+        from types import SimpleNamespace
+        speaker = _char()
+        dev = _radio(freq="447")
+        friend = MagicMock()
+        friend.db.llm_driven = False
+        room = SimpleNamespace(contents=[])
+        speaker.location = room
+        friend.location = room                   # standing with the speaker
+        heard = _radio(freq="447")
+        heard.location = friend
+        with self._world([dev, heard]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.speech.broadcast_speech"):
+            transmit(speaker, "quiet now", dev)
+        friend.msg.assert_not_called()           # no radio echo in-room
+
+    def test_ground_radio_fans_to_its_room(self):
+        # A walkie left on the floor squawks to whoever's in the room —
+        # a planted/abandoned live radio is a real presence.
+        from types import SimpleNamespace
+        speaker = _char()
+        dev = _radio(freq="447")
+        visitor = MagicMock()
+        visitor.db.llm_driven = False
+        room = SimpleNamespace(contents=[visitor])   # no 'hands': a room
+        ground_radio = _radio(freq="447")
+        ground_radio.location = room
+        with self._world([dev, ground_radio]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.speech.broadcast_speech"), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern", return_value=None), \
+                patch("world.voice.get_voice_description", return_value="flat"), \
+                patch("world.voice.voice_phrase", return_value=None):
+            transmit(speaker, "anyone there?", dev)
+        visitor.msg.assert_called_once()
+        self.assertIn("anyone there?", visitor.msg.call_args.args[0])
+
     def test_off_device_refuses_transmit(self):
         speaker = _char()
         dev = _radio(on=False, freq="447")


### PR DESCRIPTION
Perspectives 3-4 built: transmitting is talking out loud (the words
ride the say rails to the speaker's room — 'says into the radio,' with
per-observer attribution/hearing/garble/stealth), and a receiving
walkie's grille fans to its whole room (carried -> holder's room;
on the floor -> its room; 'A radio nearby crackles...' when deaf and
not yours), making the toggle help's 'a powered radio is also audible'
true at last. Comms organs stay internal (in the ear = private).
Same-room suppression: whoever stands with the speaker heard it live —
no double render. Spec §6.1 amended with the model, explicitly noting
the 'to its holder' extension.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
