### PR TITLE
Voices for witnesses and secbots — no anonymous snitches (Closes #1059)

### DIFF
--- a/world/director/population.py
+++ b/world/director/population.py
@@ -126,6 +126,11 @@ def spawn_secbot(location: Any, name: str | None = None) -> Any:
     # authoritative. Chassis renders via its robot key, not the humanoid
     # descriptor table (LLMNpc's safety-net seeds height/build).
     mob.db.is_npc = True   # the canonical NPC marker (absence = PC)
+    # A voice in the MECHANICAL register of the curated vocab — the unit's
+    # radio traffic ("Unit engaging — backup to ...") should read machine.
+    from random import choice as _choice
+    mob.db.voice_description = _choice(("clipped", "flinty", "icy"))
+    mob.db.voice_ending = _choice(("monotone", "hum"))
     mob.db.role = "security"
     mob.db.llm_persona = dict(SECURITY_BOT_PERSONA)
     mob.db.llm_driven = True
@@ -181,6 +186,15 @@ def ensure_comms_fitted() -> int:
             db_attributes__db_key="role").distinct():
         if getattr(bot.db, "role", None) != "security":
             continue
+        # Voice self-heal (same upkeep spirit): a pre-voice unit's radio
+        # traffic rendered "an unfamiliar voice" — give it the mechanical
+        # register its factory now ships with. Idempotent.
+        if getattr(bot.db, "voice_description", None) is None:
+            try:
+                bot.db.voice_description = choice(("clipped", "flinty", "icy"))
+                bot.db.voice_ending = choice(("monotone", "hum"))
+            except Exception:  # noqa: BLE001
+                pass
         state = getattr(bot, "medical_state", None)
         if state is None:
             continue

--- a/world/director/witness.py
+++ b/world/director/witness.py
@@ -69,6 +69,15 @@ def spawn_witness(location: Any) -> Any | None:
         return None
     witness.height = choice(HEIGHTS)
     witness.build = choice(BUILDS)
+    # A voice (like spawn_civilian rolls) — the witness's whole purpose is
+    # being HEARD on the emergency band; without a descriptor every report
+    # rendered as "an unfamiliar voice" (uniformly anonymous snitches).
+    try:
+        from world.voice import get_voice_descriptions, get_voice_endings
+        witness.db.voice_description = choice(sorted(get_voice_descriptions()))
+        witness.db.voice_ending = choice(sorted(get_voice_endings()))
+    except Exception:  # noqa: BLE001 — flavour never blocks the spawn
+        pass
     witness.db.is_npc = True   # the canonical NPC marker (absence = PC)
     witness.db.tokens = randint(*WITNESS_TOKENS)          # §5.2 pockets
     witness.db.is_witness = True

--- a/world/tests/test_director_population.py
+++ b/world/tests/test_director_population.py
@@ -66,6 +66,17 @@ class TestEnsureCommsFitted(TestCase):
         self.assertEqual(ensure_comms_fitted(), 1)
         mock_fit.assert_called_once_with(bare)
 
+    @patch("world.director.population.factory_fit_comms")
+    @patch("evennia.objects.models.ObjectDB")
+    def test_sweep_heals_missing_voices(self, mock_db, _fit):
+        from world.director.population import ensure_comms_fitted
+        mute = self._unit({"comms_module": MagicMock()})
+        mute.db.voice_description = None
+        mock_db.objects.filter.return_value.distinct.return_value = [mute]
+        ensure_comms_fitted()
+        self.assertIn(mute.db.voice_description, ("clipped", "flinty", "icy"))
+        self.assertIn(mute.db.voice_ending, ("monotone", "hum"))
+
     @patch("world.director.population.factory_fit_comms",
            side_effect=RuntimeError("bad unit"))
     @patch("evennia.objects.models.ObjectDB")

--- a/world/tests/test_director_witness.py
+++ b/world/tests/test_director_witness.py
@@ -73,6 +73,11 @@ class TestSpawnWitness(TestCase):
         self.assertTrue(w.db.is_witness)
         self.assertTrue(w.db.is_npc)   # canonical marker (absence = PC)
         self.assertIn("walkie-talkie", w.look_place)  # the visible tell
+        # A voice: the snitch's whole purpose is being HEARD on the air —
+        # without a descriptor every report was "an unfamiliar voice".
+        from world.voice import get_voice_descriptions, get_voice_endings
+        self.assertIn(w.db.voice_description, get_voice_descriptions())
+        self.assertIn(w.db.voice_ending, get_voice_endings())
         # Readies the walkie the PLAYER way — real commands, no backdoor.
         cmds = [c.args[0] for c in w.execute_cmd.call_args_list]
         self.assertIn("wield magpie", cmds)


### PR DESCRIPTION
get_voice_description is @voice/spawn-set only and the witness spawner
predates the civilian voice roll, so every witness report rendered 'an
unfamiliar voice'. Witnesses now roll a voice from the curated vocab at
spawn (the snitch's whole purpose is being HEARD); secbots get the
mechanical register (clipped/flinty/icy + monotone/hum); the heartbeat
upkeep sweep self-heals the live pre-voice units. PC voice flavour
stays @voice opt-in by design; recognition itself always worked.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
