### PR TITLE
Voice: 'in an icy monotone' — article via with_article (#1059)

### DIFF
--- a/world/voice.py
+++ b/world/voice.py
@@ -157,12 +157,13 @@ def voice_phrase(char: Any, language: str = "Common") -> str | None:
     """
     desc = get_voice_description(char)
     ending = get_voice_ending(char)
+    from world.grammar import with_article
     if desc and ending:
-        body = f"in a {desc} {ending}"
+        body = f"in {with_article(f'{desc} {ending}')}"
     elif desc:
-        body = f"in a {desc} voice"
+        body = f"in {with_article(f'{desc} voice')}"
     elif ending:
-        body = f"in a {ending}"
+        body = f"in {with_article(ending)}"
     else:
         return None
     return f"speaking {language}, {body}"


### PR DESCRIPTION
The voice_phrase composer hardcoded 'in a', rendering 'a icy monotone'
on vowel-initial descriptors. Route through world.grammar.with_article.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
