### PR TITLE
Radio: double render + the mutter — xmit low, 'to <radio>' open (Closes #1062)

### DIFF
--- a/commands/CmdCommunication.py
+++ b/commands/CmdCommunication.py
@@ -115,7 +115,7 @@ class CmdTo(Command):
                 caller.msg(f"You aren't carrying "
                            f"{target.get_display_name(caller)}.")
                 return
-            transmit(caller, speech, target)
+            transmit(caller, speech, target, overt=True)   # spoken openly
             return
 
         # Actor sees their own message; the room hears it through the shared

--- a/commands/CmdRadio.py
+++ b/commands/CmdRadio.py
@@ -38,7 +38,9 @@ class CmdTransmit(Command):
     WEARING first, then one in your HAND; you can't transmit through a radio
     that's only in your pocket.
 
-    Directed speech works too: ``to <radio>, <message>`` transmits the same way.
+    You transmit LOW — people around you must catch what you mutter into
+    the handset (a sharp ear might). To speak into the radio openly so the
+    whole room hears, address it instead: ``to <radio>, <message>``.
     """
 
     key = "transmit"

--- a/specs/proposals/RADIO_COMMS_SPEC.md
+++ b/specs/proposals/RADIO_COMMS_SPEC.md
@@ -161,10 +161,14 @@ channel-per-frequency):
   original text scoped the echo "to its holder"; the physical stance (§2.4
   literally says *speaker grille*) demands more, so:
   1. **Speaker** — `You transmit on 911MHz: "…"` (unchanged).
-  2. **Speaker's ROOM** — transmitting is talking out loud: the words ride
-     the say rails (`says into the radio,`) with full per-observer
-     attribution/hearing/garble/stealth. The witness calling in your
-     assault is audible to whoever stands beside them.
+  2. **Speaker's ROOM** — two registers (playtest-decided 2026-07-07):
+     `xmit` is keying the handset and speaking **LOW** — each bystander
+     rolls to CATCH the words (listener Intellect vs speaker Resonance,
+     the voice-discern pairing); a miss shows only the act ("mutters
+     something into the radio"). `to <radio>, <message>` is **openly**
+     addressing the device — ordinary room speech, everyone hears (the
+     full say rails, `says into the radio,`). Whisper stays contentless
+     to bystanders; the mutter sits between whisper and say.
   3. **Remote listeners** — the crackle line, voice-only attribution,
      scan-tagged (unchanged).
   4. **A receiving walkie's ROOM** — the grille is a speaker: traffic is
@@ -173,8 +177,11 @@ channel-per-frequency):
      nearby crackles…" for non-holders when deaf). Carrying a live radio
      is a stealth liability — as the `toggle` help always promised.
      **Comms ORGANS stay internal** (in the ear = private to the unit).
-     **Same-room suppression:** whoever stands with the speaker heard the
-     words live (perspective 2) — their radio does not double-render.
+     **DOUBLE RENDER (2026-07-07, playtest-decided — replaces the earlier
+     same-room suppression):** a matching radio beside the speaker DOES
+     echo. With xmit's low voice this is load-bearing counter-play: you
+     may fail to catch the mutter, but if your handset repeats it you've
+     just learned you share their band — and heard the content anyway.
 * **Transmitting** — `radio <message>` posts to the channel *through the
   device*, tagged with the device's frequency; every matching-tuned walkie
   echoes it. No device, no voice on the air.

--- a/world/radio.py
+++ b/world/radio.py
@@ -253,8 +253,15 @@ def _render_radio_line(speaker: Any, listener: Any, message: str,
             f'"{message}"')
 
 
-def transmit(speaker: Any, message: str, device: Any) -> bool:
+def transmit(speaker: Any, message: str, device: Any,
+             overt: bool = False) -> bool:
     """Speaker transmits *message* over *device* on its tuned frequency.
+
+    ``overt`` is HOW the words leave the mouth (decided 2026-07-07):
+    ``xmit`` (overt=False) is keying the handset and speaking into it, LOW —
+    bystanders must catch it (opposed hearing check, §_mutter_into);
+    ``to <radio>, <message>`` (overt=True) is openly addressing the device —
+    ordinary room speech everyone present hears.
 
     Returns False (with the speaker messaged) if the device can't send —
     off, or in scan mode (sweeping, not parked on a band). Otherwise posts to
@@ -275,7 +282,10 @@ def transmit(speaker: Any, message: str, device: Any) -> bool:
 
     speaker.msg(f'You transmit on {frequency}: "{message}"')
     _log_to_channel(speaker, message, frequency)
-    _speak_aloud(speaker, message, verb="says into the radio")
+    if overt:
+        _speak_aloud(speaker, message, verb="says into the radio")
+    else:
+        _mutter_into(speaker, message)
     _deliver(speaker, message, frequency, device)
     return True
 
@@ -313,6 +323,60 @@ def transmit_organ(speaker: Any, message: str) -> bool:
     return True
 
 
+def _mutter_into(speaker: Any, message: str) -> None:
+    """The xmit register: a low voice into the handset. Each bystander who
+    can hear rolls to CATCH the words — listener Intellect vs the speaker's
+    Resonance (the voice-discern pairing) — a pass renders the full line, a
+    miss (or deafness) just the act. Sight-only observers see the act. The
+    counter-play is the band: a same-room listener whose radio matches
+    hears the CONTENT off their own handset regardless (perspective 4)."""
+    location = getattr(speaker, "location", None)
+    if location is None:
+        return
+    try:
+        from world.combat.dice import opposed_roll
+        from world.grammar import capitalize_first
+        from world.perception import can_hear, can_see
+        from world.speech import (
+            render_speech_line, speech_payload, visible_voice_flavor,
+        )
+        from world.voice import resolve_speaker_attribution
+        flavor = visible_voice_flavor(speaker)
+        contents = getattr(location, "contents", None)
+        if not isinstance(contents, (list, tuple)):
+            return
+        for observer in contents:
+            if observer is speaker or not hasattr(observer, "msg"):
+                continue
+            heard = can_hear(observer)
+            seen = can_see(observer)
+            if not heard and not seen:
+                continue
+            caught = False
+            if heard:
+                try:
+                    o_roll, s_roll, _ = opposed_roll(
+                        observer, speaker, "intellect", "resonance")
+                    caught = o_roll >= s_roll
+                except Exception:  # noqa: BLE001 — no dice, no eavesdrop
+                    caught = False
+            if caught:
+                text = render_speech_line(
+                    speaker, observer, message, flavor=flavor,
+                    verb="mutters into the radio")
+                payload = speech_payload(observer, speaker, message)
+                observer.msg(text=text, type="say", from_obj=speaker,
+                             **payload)
+            else:
+                who = capitalize_first(
+                    resolve_speaker_attribution(speaker, observer))
+                observer.msg(
+                    f"{who} mutters something into the radio.",
+                    type="say", from_obj=speaker)
+    except Exception:  # noqa: BLE001 — room render never blocks the air
+        pass
+
+
 def _deliver(speaker: Any, message: str, frequency: str,
              exclude_device: Any) -> None:
     """Echo a transmission to every receiver on *frequency*: powered walkies
@@ -329,19 +393,15 @@ def _deliver(speaker: Any, message: str, frequency: str,
     can't raise a chorus."""
     receivers = []          # (listener, tagged, own), deduped, order-stable
     seen = set()
-    speaker_room = getattr(speaker, "location", None)
 
     def _collect(listener, *, tagged, own):
         if listener is None or listener is speaker or id(listener) in seen:
             return
         if not hasattr(listener, "msg"):
             return
-        # Same-room suppression: whoever stands WITH the speaker already
-        # heard the words live (perspective 3, the say rails) — their radio
-        # echoing it back would be double render, not physics worth keeping.
-        if (speaker_room is not None
-                and getattr(listener, "location", None) is speaker_room):
-            return
+        # No same-room suppression (decided 2026-07-07): a matching radio
+        # beside the speaker DOES echo — with xmit's low voice, your own
+        # handset repeating the words is how you learn you share their band.
         seen.add(id(listener))
         receivers.append((listener, tagged, own))
 

--- a/world/tests/test_radio.py
+++ b/world/tests/test_radio.py
@@ -185,20 +185,55 @@ class TestTransmit(TestCase):
         self.assertIn("crackles", line)
         self.assertNotIn("secret", line)
 
-    def test_transmit_is_audible_in_the_speakers_room(self):
-        # Perspective 3 (§2.4 radio is physical): transmitting is talking out
-        # loud — the words ride the say rails to the speaker's room.
+    def test_xmit_mutters_discreetly_in_the_speakers_room(self):
+        # xmit = keying the handset and speaking LOW: the room gets the
+        # mutter render (opposed catch checks), never the open say line.
+        speaker = _char()
+        dev = _radio(freq="447")
+        with self._world([dev]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch.object(radio, "_mutter_into") as mut, \
+                patch("world.speech.broadcast_speech") as bs:
+            transmit(speaker, "cover the back door", dev)
+        mut.assert_called_once_with(speaker, "cover the back door")
+        bs.assert_not_called()
+
+    def test_overt_transmit_speaks_openly(self):
+        # `to <radio>, ...` = openly addressing the device: ordinary room
+        # speech via the say rails, everyone present hears.
         speaker = _char()
         dev = _radio(freq="447")
         with self._world([dev]), \
                 patch.object(radio, "_log_to_channel"), \
                 patch("world.speech.broadcast_speech") as bs:
-            transmit(speaker, "cover the back door", dev)
+            transmit(speaker, "cover the back door", dev, overt=True)
         bs.assert_called_once()
         args, kwargs = bs.call_args
         self.assertEqual(args[1], "cover the back door")
-        self.assertIs(args[2], speaker.location)
         self.assertEqual(kwargs.get("verb"), "says into the radio")
+
+    def test_mutter_catch_is_an_opposed_roll(self):
+        from types import SimpleNamespace
+        speaker = MagicMock()
+        listener_sharp = MagicMock()
+        listener_dull = MagicMock()
+        room = SimpleNamespace(contents=[listener_sharp, listener_dull])
+        speaker.location = room
+        rolls = {id(listener_sharp): (10, 5), id(listener_dull): (2, 9)}
+        with patch("world.combat.dice.opposed_roll",
+                   side_effect=lambda o, s, *a: (*rolls[id(o)], None)), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.perception.can_see", return_value=True), \
+                patch("world.speech.visible_voice_flavor", return_value=None), \
+                patch("world.speech.render_speech_line",
+                      return_value='X mutters into the radio, "plan b"'), \
+                patch("world.voice.resolve_speaker_attribution",
+                      return_value="a lean man"):
+            radio._mutter_into(speaker, "plan b")
+        self.assertIn("plan b", listener_sharp.msg.call_args.kwargs["text"])
+        dull_text = listener_dull.msg.call_args.args[0]
+        self.assertIn("mutters something into the radio", dull_text)
+        self.assertNotIn("plan b", dull_text)
 
     def test_grille_fans_to_the_receiving_radios_room(self):
         # Perspective 4: a walkie has a grille — the whole room hears it,
@@ -226,9 +261,10 @@ class TestTransmit(TestCase):
         bystander.msg.assert_called_once()      # the grille reached them
         self.assertIn("come in", bystander.msg.call_args.args[0])
 
-    def test_same_room_listener_hears_live_voice_not_the_echo(self):
-        # Whoever stands WITH the speaker heard the words live (say rails);
-        # their own radio must not double-render the transmission.
+    def test_same_room_matching_radio_echoes_the_mutter(self):
+        # Decided 2026-07-07 (double render): xmit is a LOW voice — but a
+        # same-room listener whose radio shares the band hears the CONTENT
+        # off their own handset. The echo is how you learn you share a band.
         from types import SimpleNamespace
         speaker = _char()
         dev = _radio(freq="447")
@@ -241,9 +277,14 @@ class TestTransmit(TestCase):
         heard.location = friend
         with self._world([dev, heard]), \
                 patch.object(radio, "_log_to_channel"), \
-                patch("world.speech.broadcast_speech"):
+                patch.object(radio, "_mutter_into"), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern", return_value=None), \
+                patch("world.voice.get_voice_description", return_value="flat"), \
+                patch("world.voice.voice_phrase", return_value=None):
             transmit(speaker, "quiet now", dev)
-        friend.msg.assert_not_called()           # no radio echo in-room
+        friend.msg.assert_called_once()          # the echo arrives
+        self.assertIn("quiet now", friend.msg.call_args.args[0])
 
     def test_ground_radio_fans_to_its_room(self):
         # A walkie left on the floor squawks to whoever's in the room —
@@ -367,7 +408,7 @@ class TestCommands(TestCase):
         with patch("world.stealth.break_stealth"), \
                 patch("world.radio.transmit") as tx:
             cmd.func()
-        tx.assert_called_once_with(caller, "on my way", dev)
+        tx.assert_called_once_with(caller, "on my way", dev, overt=True)
 
 
 class TestCommsOrgan(TestCase):


### PR DESCRIPTION
Playtest: same-room suppression read as a broken receiver (user beside
a witness, tuned right, heard nothing on their handset). Revised:
double render — a matching radio beside the speaker echoes, which with
the new LOW xmit register is counter-play (your handset repeating a
nearby mutter reveals you share their band). Two registers: xmit =
speaking low into the handset, bystanders roll to catch it (Intellect
vs Resonance, the voice-discern pairing; miss = 'mutters something
into the radio'); 'to <radio>, <message>' = openly addressing the
device, full say-rails room speech (overt=True). Whisper stays
contentless; the mutter sits between whisper and say.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
