### PR TITLE
Radio mutter: margin-graded fragments, not a binary catch (Closes #1064)

### DIFF
--- a/specs/proposals/RADIO_COMMS_SPEC.md
+++ b/specs/proposals/RADIO_COMMS_SPEC.md
@@ -163,9 +163,13 @@ channel-per-frequency):
   1. **Speaker** — `You transmit on 911MHz: "…"` (unchanged).
   2. **Speaker's ROOM** — two registers (playtest-decided 2026-07-07):
      `xmit` is keying the handset and speaking **LOW** — each bystander
-     rolls to CATCH the words (listener Intellect vs speaker Resonance,
-     the voice-discern pairing); a miss shows only the act ("mutters
-     something into the radio"). `to <radio>, <message>` is **openly**
+     rolls to catch it (listener Intellect vs speaker Resonance, the
+     voice-discern pairing) and the MARGIN grades comprehension
+     (playtest-refined 2026-07-07): a clean win hears every word, an even
+     ear catches letter-dropped fragments ("c-ver the b-ck d--r" — shape
+     and punctuation intact, letters lost), a bad miss gets only the act
+     ("mutters something into the radio"). An NPC brain's speech payload
+     carries exactly the fragments that listener heard, not the secret. `to <radio>, <message>` is **openly**
      addressing the device — ordinary room speech, everyone hears (the
      full say rails, `says into the radio,`). Whisper stays contentless
      to bystanders; the mutter sits between whisper and say.

--- a/world/radio.py
+++ b/world/radio.py
@@ -19,6 +19,7 @@ generalise to any future comm gear.
 
 from __future__ import annotations
 
+import random
 from typing import Any, Optional
 
 RADIO_CHANNEL_KEY = "Radio"
@@ -323,13 +324,32 @@ def transmit_organ(speaker: Any, message: str) -> bool:
     return True
 
 
+#: The mutter-catch curve: an even roll hears half the letters; each point
+#: of margin swings comprehension by this much. Below the floor the words
+#: are just noise (the act-only line).
+MUTTER_CLARITY_STEP = 0.15
+MUTTER_CLARITY_FLOOR = 0.2
+
+
+def _obscure_heard(message: str, clarity: float) -> str:
+    """Drop letters the listener didn't catch: each letter survives with
+    probability *clarity*, the rest render as ``-`` — fragments of a low
+    voice ("c-ver the b-ck d--r"), spacing and punctuation intact so the
+    SHAPE of the sentence stays audible."""
+    drop = 1.0 - max(0.0, min(1.0, clarity))
+    return "".join("-" if ch.isalpha() and random.random() < drop else ch
+                   for ch in message)
+
+
 def _mutter_into(speaker: Any, message: str) -> None:
-    """The xmit register: a low voice into the handset. Each bystander who
-    can hear rolls to CATCH the words — listener Intellect vs the speaker's
-    Resonance (the voice-discern pairing) — a pass renders the full line, a
-    miss (or deafness) just the act. Sight-only observers see the act. The
-    counter-play is the band: a same-room listener whose radio matches
-    hears the CONTENT off their own handset regardless (perspective 4)."""
+    """The xmit register: a low voice into the handset. Each hearing
+    bystander rolls to catch it — listener Intellect vs the speaker's
+    Resonance (the voice-discern pairing) — and the MARGIN sets how much
+    survives: a clean win hears every word, an even ear catches fragments
+    ("c-ver the b-ck d--r"), a bad miss (or deafness) gets only the act.
+    Sight-only observers see the act. The counter-play is the band: a
+    same-room listener whose radio matches hears the CONTENT off their own
+    handset regardless (perspective 4)."""
     location = getattr(speaker, "location", None)
     if location is None:
         return
@@ -352,19 +372,24 @@ def _mutter_into(speaker: Any, message: str) -> None:
             seen = can_see(observer)
             if not heard and not seen:
                 continue
-            caught = False
+            clarity = 0.0
             if heard:
                 try:
                     o_roll, s_roll, _ = opposed_roll(
                         observer, speaker, "intellect", "resonance")
-                    caught = o_roll >= s_roll
+                    clarity = max(0.0, min(1.0, 0.5 + (o_roll - s_roll)
+                                           * MUTTER_CLARITY_STEP))
                 except Exception:  # noqa: BLE001 — no dice, no eavesdrop
-                    caught = False
-            if caught:
+                    clarity = 0.0
+            if clarity >= MUTTER_CLARITY_FLOOR:
+                caught = (message if clarity >= 1.0
+                          else _obscure_heard(message, clarity))
                 text = render_speech_line(
-                    speaker, observer, message, flavor=flavor,
+                    speaker, observer, caught, flavor=flavor,
                     verb="mutters into the radio")
-                payload = speech_payload(observer, speaker, message)
+                # The payload carries exactly what THIS listener heard —
+                # an NPC brain reacts to the fragments, not the secret.
+                payload = speech_payload(observer, speaker, caught)
                 observer.msg(text=text, type="say", from_obj=speaker,
                              **payload)
             else:

--- a/world/tests/test_radio.py
+++ b/world/tests/test_radio.py
@@ -212,28 +212,51 @@ class TestTransmit(TestCase):
         self.assertEqual(args[1], "cover the back door")
         self.assertEqual(kwargs.get("verb"), "says into the radio")
 
-    def test_mutter_catch_is_an_opposed_roll(self):
+    def test_mutter_clarity_grades_with_the_roll_margin(self):
+        # Margin sets comprehension: a clean win hears every word, an even
+        # ear catches fragments, a bad miss gets only the act.
         from types import SimpleNamespace
         speaker = MagicMock()
-        listener_sharp = MagicMock()
-        listener_dull = MagicMock()
-        room = SimpleNamespace(contents=[listener_sharp, listener_dull])
+        sharp, even, dull = MagicMock(), MagicMock(), MagicMock()
+        room = SimpleNamespace(contents=[sharp, even, dull])
         speaker.location = room
-        rolls = {id(listener_sharp): (10, 5), id(listener_dull): (2, 9)}
+        rolls = {id(sharp): (10, 5),    # margin +5 -> clarity 1.0: verbatim
+                 id(even): (5, 5),      # margin  0 -> clarity 0.5: fragments
+                 id(dull): (2, 9)}      # margin -7 -> below floor: act only
+        rendered = []
+        def _render(spk, obs, msg, **kw):
+            rendered.append((obs, msg))
+            return f'X mutters into the radio, "{msg}"'
         with patch("world.combat.dice.opposed_roll",
                    side_effect=lambda o, s, *a: (*rolls[id(o)], None)), \
                 patch("world.perception.can_hear", return_value=True), \
                 patch("world.perception.can_see", return_value=True), \
                 patch("world.speech.visible_voice_flavor", return_value=None), \
                 patch("world.speech.render_speech_line",
-                      return_value='X mutters into the radio, "plan b"'), \
+                      side_effect=_render), \
                 patch("world.voice.resolve_speaker_attribution",
                       return_value="a lean man"):
-            radio._mutter_into(speaker, "plan b")
-        self.assertIn("plan b", listener_sharp.msg.call_args.kwargs["text"])
-        dull_text = listener_dull.msg.call_args.args[0]
+            radio._mutter_into(speaker, "cover the back door")
+        by_obs = {id(o): m for o, m in rendered}
+        self.assertEqual(by_obs[id(sharp)], "cover the back door")  # verbatim
+        fragments = by_obs[id(even)]
+        self.assertIn("-", fragments)                # some letters lost...
+        self.assertNotEqual(fragments, "cover the back door")
+        self.assertEqual(len(fragments), len("cover the back door"))
+        self.assertTrue(any(c.isalpha() for c in fragments))  # ...not all
+        dull_text = dull.msg.call_args.args[0]
         self.assertIn("mutters something into the radio", dull_text)
-        self.assertNotIn("plan b", dull_text)
+        self.assertNotIn("cover", dull_text)
+
+    def test_obscure_heard_keeps_shape_loses_letters(self):
+        from world.radio import _obscure_heard
+        msg = "meet at the docks, nine."
+        self.assertEqual(_obscure_heard(msg, 1.0), msg)      # perfect ear
+        blanked = _obscure_heard(msg, 0.0)
+        self.assertEqual(len(blanked), len(msg))             # shape intact
+        self.assertNotIn("m", blanked)                       # letters gone
+        self.assertIn(",", blanked)                          # punctuation stays
+        self.assertIn(" ", blanked)
 
     def test_grille_fans_to_the_receiving_radios_room(self):
         # Perspective 4: a walkie has a grille — the whole room hears it,


### PR DESCRIPTION
The opposed roll's margin grades comprehension (clarity = 0.5 +
margin x 0.15): a clean win hears every word, an even ear catches
letter-dropped fragments ('c-ver the b-ck d--r' — spacing and
punctuation intact so the sentence's shape survives), below the floor
only the act renders. The speech payload carries exactly what that
listener heard, so an NPC brain reacts to its own fragments, never
the secret.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
