### PR TITLE
Cleaning channels: solvent takes time, blood needs the dwell (Closes #1068)

### DIFF
--- a/commands/CmdGraffiti.py
+++ b/commands/CmdGraffiti.py
@@ -268,36 +268,107 @@ class CmdGraffiti(Command):
         except Exception:  # noqa: BLE001 — dispatch down ≠ graffiti crash
             pass
     
+    #: Channeled-cleaning rates (CHANNELED_ACTIONS_SPEC §3): shake and prep,
+    #: then a second of scrubbing per solvent unit worked in. Symmetric with
+    #: tagging — undoing the wall costs real public time too.
+    CLEAN_SETUP_SECONDS = 3.0
+    CLEAN_SECONDS_PER_UNIT = 1.0
+
     def _handle_clean_with_solvent(self, solvent_can):
-        """Handle cleaning graffiti and blood stains with a solvent can."""
-        
+        """Cleaning is a CHANNELED act: duration proportional to the solvent
+        worked in. Graffiti scrubs pro-rata on interruption; BLOOD breaks
+        down only at completion — the solvent needs dwell time, so bailing
+        mid-scrub leaves the evidence."""
+
         # Check if solvent can has uses left
         if solvent_can.db.aerosol_level <= 0:
             self.caller.msg(f"{solvent_can.get_display_name(self.caller)} is empty!")
             return
-        
-        # Find both graffiti and blood pool objects
+
+        # Anything to clean? (validated before the channel starts)
+        has_graffiti = has_blood = False
+        for obj in self.caller.location.contents:
+            if isinstance(obj, GraffitiObject) and obj.has_graffiti():
+                has_graffiti = True
+            elif ((isinstance(obj, BloodPool) or obj.db.is_blood_pool)
+                    and obj.db.bleeding_incidents):
+                has_blood = True
+
+        if not has_graffiti and not has_blood:
+            self.caller.msg("There's nothing here to clean.")
+            return
+
+        from world.channeled import begin_channel
+        caller = self.caller
+        planned_units = min(10, solvent_can.db.aerosol_level)
+        duration = (self.CLEAN_SETUP_SECONDS
+                    + planned_units * self.CLEAN_SECONDS_PER_UNIT)
+
+        def _complete():
+            self._apply_solvent(caller, solvent_can, planned_units,
+                                include_blood=True)
+
+        def _interrupted(fraction):
+            worked = fraction * duration - self.CLEAN_SETUP_SECONDS
+            units = int(max(0.0, worked) / self.CLEAN_SECONDS_PER_UNIT)
+            units = min(units, planned_units)
+            if units <= 0:
+                caller.msg("You break off before the solvent bites.")
+                msg_room_identity(
+                    location=caller.location,
+                    template="{actor} breaks off, solvent can in hand, the "
+                             "wall untouched.",
+                    char_refs={"actor": caller},
+                    exclude=[caller],
+                )
+                return
+            # Partial scrub: graffiti loses what you worked in; blood needs
+            # the full dwell — an interrupted scrub leaves the evidence.
+            self._apply_solvent(caller, solvent_can, units,
+                                include_blood=False, interrupted=True)
+
+        started = begin_channel(
+            caller, duration,
+            tell="scrubbing at the wall, solvent fumes sharp.",
+            on_complete=_complete, on_interrupt=_interrupted,
+            key="cleaning")
+        if not started:
+            return
+        caller.msg(f"You shake {solvent_can.get_display_name(caller)} and "
+                   f"set to scrubbing.")
+        msg_room_identity(
+            location=caller.location,
+            template="{actor} shakes a solvent can and sets to scrubbing "
+                     "the wall.",
+            char_refs={"actor": caller},
+            exclude=[caller],
+        )
+
+    def _apply_solvent(self, caller, solvent_can, solvent_used,
+                       include_blood=True, interrupted=False):
+        """Resolve a scrub: deduct the units actually worked in, degrade
+        graffiti by that many characters, break down blood (full dwell
+        only), and message the room."""
+        if not caller.location:
+            return
+        # Re-find targets at resolution (the world may have changed mid-scrub)
         graffiti_obj = None
         blood_pools = []
-        
-        for obj in self.caller.location.contents:
+        for obj in caller.location.contents:
             if isinstance(obj, GraffitiObject):
                 graffiti_obj = obj
             elif isinstance(obj, BloodPool) or obj.db.is_blood_pool:
                 blood_pools.append(obj)
-        
-        # Check if there's anything to clean
         has_graffiti = graffiti_obj and graffiti_obj.has_graffiti()
-        has_blood = any(pool.db.bleeding_incidents for pool in blood_pools)
-        
+        has_blood = (include_blood
+                     and any(p.db.bleeding_incidents for p in blood_pools))
         if not has_graffiti and not has_blood:
-            self.caller.msg("There's nothing here to clean.")
             return
-        
-        # Use solvent (up to 10 units)
-        solvent_used = min(10, solvent_can.db.aerosol_level)
+        solvent_used = min(solvent_used, solvent_can.db.aerosol_level or 0)
+        if solvent_used <= 0:
+            return
         solvent_can.use_solvent(solvent_used)
-        
+
         # Track what was cleaned
         graffiti_cleaned = False
         blood_cleaned = False
@@ -319,7 +390,7 @@ class CmdGraffiti(Command):
                     if solvent_can.db.quality is not None:
                         tool_quality = solvent_can.db.quality
                     
-                    cleaned_volume, clean_result = blood_pool.clean_with_solvent(self.caller, tool_quality)
+                    cleaned_volume, clean_result = blood_pool.clean_with_solvent(caller, tool_quality)
                     if cleaned_volume > 0:
                         blood_cleaned = True
                         cleaned_items.append("|Rblood stains|n")
@@ -342,17 +413,17 @@ class CmdGraffiti(Command):
                 action_desc = "watching the stains break down and fade"
             
             # Immediate action message
-            self.caller.msg(f"You apply solvent to the {item_desc}, {action_desc}.")
+            caller.msg(f"You apply solvent to the {item_desc}, {action_desc}.")
             msg_room_identity(
-                location=self.caller.location,
+                location=caller.location,
                 template=f"{{actor}} applies solvent to the {item_desc}, {action_desc}.",
-                char_refs={"actor": self.caller},
-                exclude=[self.caller],
+                char_refs={"actor": caller},
+                exclude=[caller],
             )
             
             # Delayed atmospheric message to everyone including the player
             def delayed_message():
-                if self.caller.location:  # Make sure location still exists
+                if caller.location:  # Make sure location still exists
                     if graffiti_cleaned and blood_cleaned:
                         evaporate_desc = "The colors break down and the solvent evaporates, taking the stains with it."
                     elif graffiti_cleaned:
@@ -360,7 +431,7 @@ class CmdGraffiti(Command):
                     else:  # blood only
                         evaporate_desc = f"The solvent breaks down the evidence and evaporates, removing the {item_desc}."
                     
-                    self.caller.location.msg_contents(evaporate_desc)
+                    caller.location.msg_contents(evaporate_desc)
             
             delay(3, delayed_message)
             

--- a/specs/proposals/CHANNELED_ACTIONS_SPEC.md
+++ b/specs/proposals/CHANNELED_ACTIONS_SPEC.md
@@ -5,8 +5,11 @@
 > toggle + bare `stop` to abort; BREAKING: take_damage, combat enrollment,
 > grapple establish, unconscious/death, forced movement via at_post_move),
 > graffiti as first consumer (3s + 1s/char, partial-with-ellipsis on
-> interrupt, pro-rata paint, vandalism reports). Solvent cleaning + the
-> wrest/disarm seam are the next consumers. Originally: The game's first
+> interrupt, pro-rata paint, vandalism reports). **Solvent cleaning SHIPPED
+> as second consumer (2026-07-10)**: 3s + 1s/solvent-unit; graffiti scrubs
+> pro-rata on interruption; **blood breaks down only at completion** (the
+> solvent needs dwell time — bailing mid-scrub leaves the evidence). The
+> wrest/disarm seam remains the next consumer. Originally: The game's first
 > generic **timed-act primitive**: an action that occupies its actor for a
 > real duration, shows a visible tell, and resolves to a full result on
 > completion or a **partial result on interruption**. First consumer:

--- a/world/tests/test_channeled.py
+++ b/world/tests/test_channeled.py
@@ -172,6 +172,91 @@ class TestGraffitiChannel(TestCase):
         can.use_paint.assert_not_called()
 
 
+class TestCleaningChannel(TestCase):
+    """Solvent cleaning — the second consumer: per-unit duration, graffiti
+    scrubs pro-rata on interruption, blood needs the full dwell."""
+
+    def _cmd(self):
+        from commands.CmdGraffiti import CmdGraffiti
+        cmd = CmdGraffiti()
+        caller = MagicMock()
+        caller.ndb = SimpleNamespace(channel=None)
+        caller.override_place = None
+        cmd.caller = caller
+        return cmd, caller
+
+    def _solvent(self, level=256):
+        can = MagicMock()
+        can.db.aerosol_level = level
+        can.db.quality = None
+        can.get_display_name = lambda looker=None: "a solvent can"
+        return can
+
+    def _graffiti(self):
+        from typeclasses.objects import GraffitiObject
+        g = MagicMock(spec=GraffitiObject)
+        g.has_graffiti.return_value = True
+        g.db = SimpleNamespace(is_blood_pool=False)
+        g.remove_random_characters.return_value = 5
+        return g
+
+    def test_clean_channels_per_unit(self):
+        cmd, caller = self._cmd()
+        can = self._solvent()
+        wall = self._graffiti()
+        caller.location.contents = [wall]
+        with patch.object(ch, "delay") as d, \
+                patch("commands.CmdGraffiti.msg_room_identity"):
+            cmd._handle_clean_with_solvent(can)
+        self.assertEqual(is_channeling(caller), "cleaning")
+        duration = d.call_args.args[0]
+        self.assertAlmostEqual(duration, 3.0 + 10 * 1.0)   # 10-unit scrub
+        can.use_solvent.assert_not_called()    # cost deducts at RESOLUTION
+
+    def test_completion_scrubs_and_spends(self):
+        cmd, caller = self._cmd()
+        can = self._solvent()
+        wall = self._graffiti()
+        caller.location.contents = [wall]
+        with patch.object(ch, "delay") as d, \
+                patch("commands.CmdGraffiti.msg_room_identity"), \
+                patch("commands.CmdGraffiti.delay"):
+            cmd._handle_clean_with_solvent(can)
+            ch._finish(*d.call_args.args[2:])
+        can.use_solvent.assert_called_once_with(10)
+        wall.remove_random_characters.assert_called_once_with(10)
+
+    def test_interrupt_scrubs_pro_rata_no_blood(self):
+        from typeclasses.objects import BloodPool
+        cmd, caller = self._cmd()
+        can = self._solvent()
+        wall = self._graffiti()
+        blood = MagicMock(spec=BloodPool)
+        blood.db = SimpleNamespace(is_blood_pool=True,
+                                   bleeding_incidents=[1])
+        caller.location.contents = [wall, blood]
+        with patch.object(ch, "delay"), \
+                patch("commands.CmdGraffiti.msg_room_identity"), \
+                patch("commands.CmdGraffiti.delay"), \
+                patch.object(ch, "monotonic", side_effect=[100.0, 107.0]):
+            cmd._handle_clean_with_solvent(can)
+            interrupt_channel(caller)          # 7s in: 4 units worked
+        can.use_solvent.assert_called_once_with(4)
+        wall.remove_random_characters.assert_called_once_with(4)
+        blood.clean_with_solvent.assert_not_called()   # needs full dwell
+
+    def test_nothing_to_clean_never_channels(self):
+        cmd, caller = self._cmd()
+        can = self._solvent()
+        caller.location.contents = []
+        with patch.object(ch, "delay") as d:
+            cmd._handle_clean_with_solvent(can)
+        d.assert_not_called()
+        self.assertIsNone(is_channeling(caller))
+        self.assertIn("nothing here to clean",
+                      caller.msg.call_args.args[0])
+
+
 class TestTaxonomyWiring(TestCase):
     """The BLOCKED gates and BREAKING seams actually call the primitive."""
 


### PR DESCRIPTION
Second consumer of the channeled-action primitive: solvent scrubbing
runs 3s + 1s/unit (a standard 10-unit scrub ~13s — undoing the wall
costs public time, symmetric with tagging). Graffiti degrades pro-rata
on interruption (units worked = characters scrubbed = solvent spent);
blood breaks down only at completion — the solvent needs dwell time,
so bailing mid-scrub leaves the evidence. Costs at resolution, targets
re-found at resolution, validations pre-channel.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
