### PR TITLE
Dispatch gets a voice: base console acks on 911MHz, no LLM (Closes #1070)

### DIFF
--- a/specs/proposals/RADIO_COMMS_SPEC.md
+++ b/specs/proposals/RADIO_COMMS_SPEC.md
@@ -43,7 +43,7 @@ makes it useful makes it attackable.
 | Device | What it is | Notes |
 |---|---|---|
 | **Walkie-talkie** | handheld transceiver item | carried/held; **snatchable** (grab/steal/disarm play); tunable to a channel; limited range without the antenna network |
-| **Base station** | fixed room object | strong range; where an org's traffic converges (security base = the intel-sync point) |
+| **Base station** | fixed room object | strong range; where an org's traffic converges (security base = the intel-sync point). **✅ FIRST BUILD (2026-07-10):** `BASE_STATION` console at the security base (heartbeat-installed, idempotent) — **dispatch's voice**: deterministic template acks on 911MHz for every event (`Dispatch copies — an assault at Cobb Street. Unit responding.` / `No units available.` when the pool drains — the finite pool made audible). Switch it off or wreck it and dispatch goes silent (the sabotage seam, live). No LLM — the RAM-gated AFM civic lane may voice the long tail someday |
 | **Rooftop antenna / repeater** | fixed infrastructure object, placed high (`Z > 0` rooftops) | extends channel coverage across the city; **breakable** (climb up and smash it) and **repairable** — a physical target for sabotage |
 | **Built-in transceiver** | a robot component (chassis organ) | security bots report/receive via an internal radio — destroying that component (or EMP) mutes the bot without destroying it |
 

--- a/world/director/dispatch.py
+++ b/world/director/dispatch.py
@@ -80,18 +80,68 @@ def dispatch(event: WorldEvent) -> list:
     the list of dispatched NPCs."""
     from world.director.assignment import assign, is_assigned
     ranked = find_responders(event)
-    if not ranked:
-        return []
-    count = max(1, int(event.severity))
     dispatched = []
-    for _steps, npc in ranked:
-        if len(dispatched) >= count:
-            break
-        if is_assigned(npc):
-            continue  # committed to another incident
-        if assign(npc, event):
-            dispatched.append(npc)
+    if ranked:
+        count = max(1, int(event.severity))
+        for _steps, npc in ranked:
+            if len(dispatched) >= count:
+                break
+            if is_assigned(npc):
+                continue  # committed to another incident
+            if assign(npc, event):
+                dispatched.append(npc)
+    _ack_on_air(event, dispatched)
     return dispatched
+
+
+#: The dispatcher's phrasebook — deterministic templates, no LLM (the
+#: RAM-gated AFM "civic lane" may voice the long tail someday; the core
+#: acknowledgment is three slots and needs no model).
+_EVENT_PHRASES = {
+    "assault": "an assault",
+    "disturbance": "a disturbance",
+    "pickpocketing": "a reported theft",
+    "vandalism": "vandalism in progress",
+    "crime": "a reported incident",
+}
+
+
+def _ack_on_air(event: WorldEvent, dispatched: list) -> None:
+    """Dispatch acknowledges on 911MHz — through the base's REAL console
+    (RADIO_COMMS_SPEC §2.1 base station; no console, or console off/broken,
+    = no voice: the physical gate players can sabotage). Deterministic
+    template, delayed a beat so it lands after the report it answers.
+    A drained pool is announced too — "no units available" on a scanner
+    tells a listening crew the force is overwhelmed, which is the finite
+    pool made audible."""
+    try:
+        from evennia.utils import delay
+        what = _EVENT_PHRASES.get(event.type, f"a reported {event.type}")
+        where = getattr(event.location, "key", "an unknown location")
+        if dispatched:
+            n = len(dispatched)
+            units = "Unit" if n == 1 else f"{n} units"
+            line = f"Dispatch copies — {what} at {where}. {units} responding."
+        else:
+            line = (f"Dispatch copies — {what} at {where}. "
+                    f"No units available.")
+        delay(2.0, _transmit_ack, line)
+    except Exception:  # noqa: BLE001 — the ack is flavour; dispatch is done
+        pass
+
+
+def _transmit_ack(line: str) -> None:
+    """Key the base console. Late-bound so the console can die (or be
+    switched off) between the event and the ack — silence, honestly."""
+    try:
+        from world.director.population import get_base_station
+        from world.radio import transmit
+        station = get_base_station()
+        if station is None:
+            return
+        transmit(station, line, station, overt=True)
+    except Exception:  # noqa: BLE001
+        pass
 
 
 #: How long an incident scene stays HOT (situational cause for the hunt).

--- a/world/director/population.py
+++ b/world/director/population.py
@@ -208,6 +208,43 @@ def ensure_comms_fitted() -> int:
     return fitted
 
 
+def ensure_base_station() -> Any | None:
+    """Upkeep: the security base carries its dispatch console (the
+    RADIO_COMMS_SPEC §2.1 base station — the voice that acknowledges
+    reports on 911MHz). Idempotent; in-process (heartbeat at_start).
+    Returns the station (existing or newly installed), or None without
+    a designated base."""
+    base = get_security_base()
+    if base is None:
+        return None
+    for obj in base.contents:
+        if getattr(getattr(obj, "db", None), "is_base_station", None) is True:
+            return obj
+    try:
+        from evennia.prototypes.spawner import spawn
+        from world.prototypes import BASE_STATION
+        station = spawn(BASE_STATION)[0]
+        station.location = base
+        return station
+    except Exception:  # noqa: BLE001 — a mute base still dispatches
+        return None
+
+
+def get_base_station() -> Any | None:
+    """The base's live, powered dispatch console, or None (no base, no
+    console, console off/broken = dispatch has no voice — the physical
+    gate: sabotage the console and the net goes quiet)."""
+    from world.radio import is_powered, is_radio
+    base = get_security_base()
+    if base is None:
+        return None
+    for obj in base.contents:
+        if (getattr(getattr(obj, "db", None), "is_base_station", None) is True
+                and is_radio(obj) and is_powered(obj)):
+            return obj
+    return None
+
+
 def maintain_security_complement() -> Any | None:
     """One heartbeat of the respawn loop: if living posted units fall
     short of the base's complement, cycle ONE replacement out of the

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -211,8 +211,11 @@ class DirectorRoutineScript(DefaultScript):
         idmapper). Today: factory-fit the comms module into any security
         unit spawned before the transceiver existed (#1009). Idempotent."""
         try:
-            from world.director.population import ensure_comms_fitted
+            from world.director.population import (
+                ensure_base_station, ensure_comms_fitted,
+            )
             ensure_comms_fitted()
+            ensure_base_station()
         except Exception:  # noqa: BLE001 — upkeep must not stall the beats
             pass
 

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -3989,6 +3989,33 @@ WALKIE_TALKIE = {
 }
 
 
+#: The security base's fixed transceiver (RADIO_COMMS_SPEC §2.1: "base
+#: station") — the voice of dispatch. A powered, 911MHz-locked console that
+#: acknowledges reports on the air (deterministic template lines, no LLM).
+#: PHYSICAL: switch it off or wreck it and dispatch goes silent. The is_npc
+#: marker is the radio loop-guard (LLM units observe its traffic, never
+#: reply-chain on it).
+BASE_STATION = {
+    "prototype_key": "BASE_STATION",
+    "typeclass": "typeclasses.items.Radio",
+    "key": "a dispatch console",
+    "aliases": ["console", "station", "base station", "dispatch"],
+    "desc": ("A hard-wired dispatch console bolted to the wall, all worn "
+             "toggles and a fat coiled mic on a hook. A band readout burns "
+             "steady at 911MHz; the cooling fan never quite stops."),
+    "locks": "get:false()",
+    "attrs": [
+        ("is_radio", True),
+        ("radio_on", True),
+        ("frequency", "911MHz"),
+        ("is_base_station", True),
+        ("is_npc", True),
+        ("voice_description", "clipped"),
+        ("voice_ending", "monotone"),
+    ],
+}
+
+
 #: The security unit's built-in transceiver (RADIO_COMMS_SPEC §2.1): a comms
 #: module seated in an ear/antenna, factory-fit like the riot gun. Carries
 #: the radio metadata the receiver reads (`radio_frequency`); intact + on-band

--- a/world/tests/test_director_dispatch.py
+++ b/world/tests/test_director_dispatch.py
@@ -122,3 +122,58 @@ class TestDispatchWiring(TestCase):
         cs = CharacterCmdSet()
         cs.at_cmdset_creation()
         self.assertIn("@dispatch", [c.key for c in cs.commands])
+
+
+class TestDispatcherAck(TestCase):
+    """The dispatcher's voice: deterministic template acks on 911MHz via
+    the base's REAL console — no console = no voice (the physical gate)."""
+
+    def _event(self, etype="assault", where="Cobb Street"):
+        ev = MagicMock()
+        ev.type = etype
+        ev.location = MagicMock()
+        ev.location.key = where
+        return ev
+
+    @patch("evennia.utils.delay")
+    def test_ack_names_the_crime_place_and_count(self, mock_delay):
+        from world.director.dispatch import _ack_on_air
+        _ack_on_air(self._event(), [MagicMock(), MagicMock()])
+        line = mock_delay.call_args.args[2]
+        self.assertIn("an assault at Cobb Street", line)
+        self.assertIn("2 units responding", line)
+
+    @patch("evennia.utils.delay")
+    def test_single_unit_reads_singular(self, mock_delay):
+        from world.director.dispatch import _ack_on_air
+        _ack_on_air(self._event("vandalism"), [MagicMock()])
+        line = mock_delay.call_args.args[2]
+        self.assertIn("vandalism in progress", line)
+        self.assertIn("Unit responding", line)
+
+    @patch("evennia.utils.delay")
+    def test_drained_pool_is_announced(self, mock_delay):
+        # 'No units available' on a scanner = the finite pool made audible.
+        from world.director.dispatch import _ack_on_air
+        _ack_on_air(self._event("disturbance"), [])
+        line = mock_delay.call_args.args[2]
+        self.assertIn("No units available", line)
+
+    def test_transmit_rides_the_real_console(self):
+        from world.director.dispatch import _transmit_ack
+        station = MagicMock()
+        with patch("world.director.population.get_base_station",
+                   return_value=station), \
+                patch("world.radio.transmit") as tx:
+            _transmit_ack("Dispatch copies.")
+        tx.assert_called_once_with(station, "Dispatch copies.", station,
+                                   overt=True)
+
+    def test_no_console_no_voice(self):
+        # Sabotage seam: console gone/off = dispatch has no voice.
+        from world.director.dispatch import _transmit_ack
+        with patch("world.director.population.get_base_station",
+                   return_value=None), \
+                patch("world.radio.transmit") as tx:
+            _transmit_ack("Dispatch copies.")
+        tx.assert_not_called()

--- a/world/tests/test_director_population.py
+++ b/world/tests/test_director_population.py
@@ -185,3 +185,51 @@ class TestSpawnPostsToBase(TestCase):
                 spawn_secbot(MagicMock(name="room"))
                 key = mock_create.call_args.kwargs["key"]
                 self.assertIn("security robot", key)
+
+
+class TestBaseStation(TestCase):
+    """The base's dispatch console: installed by upkeep, idempotent, and
+    only a live powered console counts as dispatch's voice."""
+
+    def _station(self, on=True):
+        s = MagicMock()
+        s.db = SimpleNamespace(is_base_station=True, is_radio=True,
+                               radio_on=on, frequency="911MHz")
+        return s
+
+    @patch("world.director.population.get_security_base", return_value=None)
+    def test_no_base_no_station(self, _base):
+        from world.director.population import ensure_base_station
+        self.assertIsNone(ensure_base_station())
+
+    @patch("world.director.population.get_security_base")
+    def test_existing_console_is_kept(self, mock_base):
+        from world.director.population import ensure_base_station
+        station = self._station()
+        base = MagicMock(); base.contents = [station]
+        mock_base.return_value = base
+        with patch("evennia.prototypes.spawner.spawn") as sp:
+            self.assertIs(ensure_base_station(), station)
+        sp.assert_not_called()                    # idempotent
+
+    @patch("world.director.population.get_security_base")
+    def test_missing_console_is_installed(self, mock_base):
+        from world.director.population import ensure_base_station
+        base = MagicMock(); base.contents = []
+        mock_base.return_value = base
+        newborn = MagicMock()
+        with patch("evennia.prototypes.spawner.spawn",
+                   return_value=[newborn]):
+            self.assertIs(ensure_base_station(), newborn)
+        self.assertIs(newborn.location, base)
+
+    @patch("world.director.population.get_security_base")
+    def test_powered_console_is_the_voice_off_is_silence(self, mock_base):
+        from world.director.population import get_base_station
+        live, dead = self._station(on=True), self._station(on=False)
+        base = MagicMock()
+        mock_base.return_value = base
+        base.contents = [live]
+        self.assertIs(get_base_station(), live)
+        base.contents = [dead]                    # switched off: no voice
+        self.assertIsNone(get_base_station())


### PR DESCRIPTION
BASE_STATION prototype (the radio spec's fixed device, first build): a
dispatch console at the security base, heartbeat-installed, loop-guard
marked. Every dispatched event is acknowledged over the REAL console
(transmit overt) with deterministic template lines — 'Dispatch copies
— an assault at Cobb Street. Unit responding.' — and a drained pool
announces 'No units available', making the finite force audible to
anyone scanning. Physical gate: console off/gone/destroyed = dispatch
goes silent (the sabotage seam). The AFM civic lane stays parked,
RAM-gated; the core acknowledgment needed three template slots, not a
model.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
