### PR TITLE
Console answers ALL band traffic — it's the emergency channel (#1072)

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -648,18 +648,21 @@ class DispatchConsole(Radio):
     never reply-chain on IT), must name dispatch, cooldown between answers.
     """
 
-    #: Traffic must name dispatch to get an answer (not every squawk).
-    ADDRESS_WORDS = ("dispatch", "control", "base")
     #: Seconds between answered lines — the console is terse, not chatty.
     ANSWER_COOLDOWN = 10.0
     #: The register. Instructions live game-side so the backend stays dumb.
+    #: EVERYTHING on this band is dispatch's traffic (it is the emergency
+    #: channel) — hails get procedure, chatter gets channel discipline.
     INSTRUCTIONS = (
         "You are the dispatch operator of a colonial security force in a "
-        "gritty fictional cyberpunk game. You answer radio traffic in ONE "
-        "short, flat, procedural line — no exclamation marks, no warmth, "
-        "no questions unless operationally necessary. You acknowledge, "
-        "state unit availability when asked, and direct callers to report "
-        "incidents with a location. Stay strictly in-world."
+        "gritty fictional cyberpunk game, monitoring the colony's EMERGENCY "
+        "radio band. Everything you hear arrives on that band. Answer in "
+        "ONE short, flat, procedural line — no exclamation marks, no "
+        "warmth, no questions unless operationally necessary. Acknowledge "
+        "genuine reports and hails; state unit availability when asked; "
+        "direct callers to give a location. If the traffic is idle chatter, "
+        "greetings, or non-emergency use of the band, tell them curtly to "
+        "keep this channel clear. Stay strictly in-world."
     )
     FALLBACK_LINE = "Dispatch copies. State your traffic and location."
 
@@ -683,9 +686,10 @@ class DispatchConsole(Radio):
                 or getattr(db, "llm_driven", None) is True
                 or getattr(db, "is_base_station", None) is True):
             return
-        low = speech.lower()
-        if not any(word in low for word in self.ADDRESS_WORDS):
-            return
+        # No address gate (playtest-decided 2026-07-10): this is the
+        # EMERGENCY band — everything a player says on it is dispatch's
+        # traffic. Idle chatter gets channel discipline from the register
+        # ("keep this channel clear"), not silence.
         from time import monotonic
         last = getattr(self.ndb, "last_answer", None) or 0
         now = monotonic()

--- a/world/tests/test_director_dispatch.py
+++ b/world/tests/test_director_dispatch.py
@@ -193,7 +193,6 @@ class TestDispatchConsoleAnswers(TestCase):
         for m in ("_maybe_answer",):
             setattr(c, m, DispatchConsole._maybe_answer.__get__(
                 c, DispatchConsole))
-        c.ADDRESS_WORDS = DispatchConsole.ADDRESS_WORDS
         c.ANSWER_COOLDOWN = DispatchConsole.ANSWER_COOLDOWN
         c.INSTRUCTIONS = DispatchConsole.INSTRUCTIONS
         c.FALLBACK_LINE = DispatchConsole.FALLBACK_LINE
@@ -256,13 +255,17 @@ class TestDispatchConsoleAnswers(TestCase):
         req.assert_not_called()
         c._answer.assert_not_called()
 
-    def test_unaddressed_traffic_is_ignored(self):
+    def test_all_band_traffic_is_answered_even_chatter(self):
+        # It's the EMERGENCY band: everything on it is dispatch's traffic.
+        # Idle chatter gets channel discipline (register-level), not silence.
         c = self._console()
         with patch("world.llm.client.civic_enabled", return_value=True), \
-                patch("world.llm.client.request_civic_line") as req:
-            c._maybe_answer(self._player(), self._kwargs(
-                "meet me at the docks, nine sharp"))
-        req.assert_not_called()
+                patch("world.llm.client.request_civic_line") as req, \
+                patch("world.radio.radio_voice_handle",
+                      return_value="a voice"):
+            c._maybe_answer(self._player(), self._kwargs("Hey there."))
+        req.assert_called_once()
+        self.assertIn("Hey there.", req.call_args.args[1])
 
     def test_cooldown_gates_repeat_answers(self):
         c = self._console()


### PR DESCRIPTION
Playtest: 'Hey there.' on 911MHz got silence — the address-word gate
working as shipped and wrong anyway. Everything a player says on the
EMERGENCY band is dispatch's traffic: the gate is gone; genuine hails
get procedure, idle chatter gets channel discipline from the register
('keep this channel clear'), never silence. Cooldown and loop guards
unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
