### PR TITLE
Civic lane: prompting practices — few-shot, labels, echo guard (Closes #1075)

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -651,18 +651,40 @@ class DispatchConsole(Radio):
     #: Seconds between answered lines — the console is terse, not chatty.
     ANSWER_COOLDOWN = 10.0
     #: The register. Instructions live game-side so the backend stays dumb.
-    #: EVERYTHING on this band is dispatch's traffic (it is the emergency
-    #: channel) — hails get procedure, chatter gets channel discipline.
+    #: Small-model practices (the 19:15 misfires taught this): EXAMPLES over
+    #: adjectives — a 3B parrots unlabeled scaffolding and inverts roles
+    #: without exemplars showing exactly what "your reply" means. Context is
+    #: labeled, the traffic is labeled, and the output contract is explicit:
+    #: only the spoken line, nothing else.
     INSTRUCTIONS = (
-        "You are the dispatch operator of a colonial security force in a "
-        "gritty fictional cyberpunk game, monitoring the colony's EMERGENCY "
-        "radio band. Everything you hear arrives on that band. Answer in "
-        "ONE short, flat, procedural line — no exclamation marks, no "
-        "warmth, no questions unless operationally necessary. Acknowledge "
-        "genuine reports and hails; state unit availability when asked; "
-        "direct callers to give a location. If the traffic is idle chatter, "
-        "greetings, or non-emergency use of the band, tell them curtly to "
-        "keep this channel clear. Stay strictly in-world."
+        "You are DISPATCH: the radio dispatch operator of a colonial "
+        "security force in a gritty fictional cyberpunk game, monitoring "
+        "the colony's emergency band. You never identify as anything else "
+        "and you never speak for callers.\n"
+        "You receive [CONTEXT] (facts for you alone — never repeat it) and "
+        "[TRAFFIC] (what the caller said). Reply with ONLY the words you "
+        "speak on the air: one short, flat, procedural line. No exclamation "
+        "marks, no warmth, no brackets, no labels, no narration. Never "
+        "repeat or paraphrase the caller's words back to them.\n"
+        "Acknowledge genuine reports and hails; state unit availability "
+        "when asked; direct callers to give a location. Idle chatter or "
+        "non-emergency use of the band gets told curtly to keep the "
+        "channel clear.\n"
+        "EXAMPLES:\n"
+        "[CONTEXT] Units available: 3. [TRAFFIC] a husky voice: "
+        "\"Dispatch, shots fired on Volta Street!\"\n"
+        "Copy, shots fired on Volta Street. Units responding. Stay off "
+        "the street.\n"
+        "[CONTEXT] Units available: 0. [TRAFFIC] a reedy voice: "
+        "\"Anyone there? I need help at the docks.\"\n"
+        "Copy, docks. No units available. Shelter in place and keep this "
+        "channel open.\n"
+        "[CONTEXT] Units available: 2. [TRAFFIC] an unfamiliar voice: "
+        "\"How's your day going?\"\n"
+        "Keep this channel clear.\n"
+        "[CONTEXT] Units available: 4. [TRAFFIC] a flat voice: "
+        "\"Dispatch, do you copy?\"\n"
+        "Dispatch copies. Go ahead."
     )
     FALLBACK_LINE = "Dispatch copies. State your traffic and location."
 
@@ -708,13 +730,47 @@ class DispatchConsole(Radio):
             voice = radio_voice_handle(speaker, self)
         except Exception:  # noqa: BLE001
             voice = "an unknown voice"
-        prompt = (f"Units available: {units}. Radio traffic from {voice}: "
-                  f'"{speech}"')
+        prompt = (f'[CONTEXT] Units available: {units}. '
+                  f'[TRAFFIC] {voice}: "{speech}"')
         request_civic_line(
             self.INSTRUCTIONS, prompt,
-            on_reply=self._answer,
+            on_reply=lambda text: self._answer(
+                self._clean_reply(text, heard=speech)),
             on_fail=lambda: self._answer(self.FALLBACK_LINE),
         )
+
+    def _clean_reply(self, text, heard=None):
+        """Reply sanitation (the GM lane's practices, scaled down): the model
+        must return ONLY a spoken line. First line only; quotes/labels
+        stripped; brackets (stage directions) removed; any echo of the
+        prompt scaffolding (the exact 19:15 misfire) OR of the caller's own
+        words (the GM lane's echo guard — 'Copy, how's your day going?')
+        rejects the reply in favour of the template fallback."""
+        import re
+        line = " ".join(str(text or "").split())
+        line = line.split("\n")[0].strip().strip('"').strip()
+        line = re.sub(r"^(dispatch|operator|you)\s*:\s*", "", line,
+                      flags=re.I)
+        line = re.sub(r"\[[^\]]*\]", "", line).strip()   # stage directions
+        line = line.strip().strip('"').strip()
+        low = line.lower()
+        scaffolding = ("units available:", "[context]", "[traffic]",
+                       "radio traffic from")
+        if not line or len(line) > 200 or any(s in low for s in scaffolding):
+            return self.FALLBACK_LINE
+        if heard:
+            try:
+                from world.llm.prompt import is_echo
+                # Strip the procedural lead ('Copy, ...') before the echo
+                # check so a legitimate acknowledgment that RESTATES a
+                # report isn't punished — only naked parroting is.
+                bare = re.sub(r"^(copy|roger|acknowledged)[,.\s]*", "",
+                              low).strip()
+                if bare and is_echo(bare, heard):
+                    return self.FALLBACK_LINE
+            except Exception:  # noqa: BLE001 — the guard is best-effort
+                pass
+        return line
 
     def _units_available(self):
         try:

--- a/world/tests/test_director_dispatch.py
+++ b/world/tests/test_director_dispatch.py
@@ -197,6 +197,7 @@ class TestDispatchConsoleAnswers(TestCase):
         c.INSTRUCTIONS = DispatchConsole.INSTRUCTIONS
         c.FALLBACK_LINE = DispatchConsole.FALLBACK_LINE
         c._units_available = lambda: 2
+        c._clean_reply = lambda text, heard=None: text   # sanitizer has its own suite
         return c
 
     def _player(self):
@@ -273,3 +274,48 @@ class TestDispatchConsoleAnswers(TestCase):
             c._maybe_answer(self._player(), self._kwargs("Dispatch, copy?"))
             c._maybe_answer(self._player(), self._kwargs("Dispatch, copy?!"))
         self.assertEqual(c._answer.call_count, 1)   # second inside cooldown
+
+
+class TestConsoleReplySanitation(TestCase):
+    """The civic lane's reply guards (the GM lane's practices, scaled
+    down): scaffolding echoes, stage directions, and caller-parroting all
+    degrade to the template fallback — never onto the air."""
+
+    def _console(self):
+        from typeclasses.items import DispatchConsole
+        return DispatchConsole.__new__(DispatchConsole)
+
+    def test_scaffolding_echo_rejected(self):
+        # The literal 19:15 misfire, on tape in the radio log.
+        c = self._console()
+        bad = ('Units available: 5. Radio traffic from an unfamiliar '
+               'voice: "How\'s your day going?" [Radio traffic is dead.]')
+        self.assertEqual(c._clean_reply(bad, heard="How's your day going?"),
+                         c.FALLBACK_LINE)
+
+    def test_caller_parrot_rejected(self):
+        c = self._console()
+        self.assertEqual(
+            c._clean_reply("Copy, how's your day going?",
+                           heard="How's your day going?"),
+            c.FALLBACK_LINE)
+
+    def test_legitimate_restatement_passes(self):
+        c = self._console()
+        good = "Copy, shots fired on Volta Street. Units responding."
+        self.assertEqual(
+            c._clean_reply(good, heard="Dispatch, shots fired on Volta Street!"),
+            good)
+
+    def test_stage_directions_and_labels_stripped(self):
+        c = self._console()
+        self.assertEqual(
+            c._clean_reply('Dispatch: "Copy. Go ahead." [static]',
+                           heard="hello dispatch"),
+            "Copy. Go ahead.")
+
+    def test_empty_or_overlong_falls_back(self):
+        c = self._console()
+        self.assertEqual(c._clean_reply("", heard="x"), c.FALLBACK_LINE)
+        self.assertEqual(c._clean_reply("y" * 300, heard="x"),
+                         c.FALLBACK_LINE)


### PR DESCRIPTION
Two on-air misfires (on tape): scaffolding parroted onto the air and
role inversion. The civic lane shipped v1-thin; this applies the GM
lane's practices scaled to a 3B: labeled [CONTEXT]/[TRAFFIC] prompt
with an explicit only-the-spoken-line contract, four few-shot
exemplars in the instructions (examples over adjectives), and reply
sanitation — first-line-only, label/quote/stage-direction stripping,
scaffolding-echo rejection, and the GM lane's echo guard so a reply
that parrots the caller degrades to the procedural fallback while a
legitimate report restatement passes. Replayed the literal misfire
traffic against the live shim: clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
