### PR TITLE
Operator: valid build vocab + spawn seats her on the real chair (#1077)

### DIFF
--- a/world/director/population.py
+++ b/world/director/population.py
@@ -251,7 +251,7 @@ def spawn_dispatch_operator(base: Any) -> Any:
         key="Vess", location=base, home=base,
     )
     op.height = "short"
-    op.build = "wiry"
+    op.build = "lean"
     op.sex = "female"
     op.db.is_npc = True
     op.db.dispatch_operator = True
@@ -261,6 +261,12 @@ def spawn_dispatch_operator(base: Any) -> Any:
     op.db.llm_driven = True
     op.look_place = ("seated at the dispatch console, headset on, one eye "
                      "on the board.")
+    # Take the actual chair when the base has one (real posture, not just
+    # the placement line) — fail-open: she stands if the furniture's gone.
+    try:
+        op.execute_cmd("sit dispatch chair")
+    except Exception:  # noqa: BLE001
+        pass
     return op
 
 


### PR DESCRIPTION
The audit the user's instinct triggered found spawn_dispatch_operator
setting build='wiry' — not in the identity vocabulary — so Vess's
get_sdesc() raised for any onlooker. Storage takes canonical keys
(short+lean composes to the 'wiry woman' display anyway). Spawn also
now takes the actual dispatch chair via the real sit command when the
base has one (fail-open: she stands if the furniture's gone).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
