### PR TITLE
Operator observes the band, never radio-replies (#1077)

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -144,6 +144,14 @@ class LLMNpcMixin:
         if not llm_enabled() or self._is_npc_speaker(speaker):
             self._observe_action(speaker, overheard)
             return
+        # The dispatch operator OBSERVES the band, never radio-replies —
+        # the console speaks for her on the air (civic lane, her voice);
+        # a second brain answering the same call would double-render at
+        # the base. The buffer means the traffic still colours her
+        # face-to-face turns: she KNOWS what's been on the band tonight.
+        if getattr(self.db, "dispatch_operator", None) is True:
+            self._observe_action(speaker, overheard)
+            return
         low = speech.lower()
         broadcast = any(p in low for p in self._RADIO_BROADCAST_PHRASES)
         if self._mentions_self(speech):

--- a/world/tests/test_radio_comprehension.py
+++ b/world/tests/test_radio_comprehension.py
@@ -229,3 +229,31 @@ class TestRadioTool(TestCase):
         msgs2 = build_messages({}, "a flat voice", "quiet night",
                                "radio_ambient")
         self.assertIn("Radio chatter", msgs2[-1]["content"])
+
+
+class TestOperatorObservesNeverReplies(TestCase):
+    """The dispatch operator's own brain never radio-replies (the console
+    is her radio voice) — but the traffic lands in her buffer, so her
+    face-to-face turns know what's been on the band."""
+
+    def test_operator_named_on_air_observes_only(self):
+        b = MagicMock()
+        b.key = "Vess"
+        b.sdesc_keyword = None
+        b.db.llm_driven = True
+        b.db.dispatch_operator = True
+        b.ndb.action_buffer = None
+        b._is_npc_speaker = lambda s: False
+        b._radio_voice_handle = lambda s: "a husky voice"
+        b._name_aliases = lambda: []
+        b._RADIO_BROADCAST_PHRASES = llmnpc.LLMNpcMixin._RADIO_BROADCAST_PHRASES
+        for m in ("_hear_radio", "_observe_action", "_mentions_self"):
+            _bind(b, m)
+        with patch.object(llmnpc, "llm_enabled", return_value=True), \
+                patch.object(llmnpc, "delay") as d:
+            b._hear_radio("Vess, you there?", MagicMock(),
+                          {"type": "radio", "radio_frequency": "911MHz",
+                           "radio_elected": True})
+        d.assert_not_called()                    # no second brain on the air
+        self.assertTrue(b.ndb.action_buffer)     # ...but she heard it
+        self.assertIn("Vess, you there?", b.ndb.action_buffer[0])


### PR DESCRIPTION
Vess is llm_driven AND stands where the console's grille fans every
911MHz transmission — so her own GM-lane brain could answer radio
traffic naming her, colliding with the console's civic-lane answer
(remote hears one reply; the base watches her answer twice in two
registers, 15s apart). One rule closes it: the dispatch operator
OBSERVES the band (traffic buffers into her face-to-face context — she
knows what's been on the air tonight) and never radio-replies; the
console IS her radio voice.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
