### PR TITLE
Civic lane: tighten timeout 10s -> 6s (bounds reload shutdown-wait)

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -267,7 +267,7 @@ LLM_GM_ENABLED = False
 # template dispatcher is the floor either way.
 CIVIC_LLM_ENABLED = False
 CIVIC_LLM_URL = "http://host.docker.internal:8766/v1/chat/completions"
-CIVIC_LLM_TIMEOUT = 10
+CIVIC_LLM_TIMEOUT = 6   # bounds shutdown-wait on in-flight civic threads
 LLM_GM_URL = "http://host.docker.internal:8765/v1/chat/completions"
 LLM_GM_MODEL = ""          # backend-specific model id; blank lets local servers default
 LLM_GM_API_KEY = ""        # Bearer token for cloud backends; blank for local


### PR DESCRIPTION
Three reload incidents on 2026-07-10: two were tooling (deploy script
killed mid-run by an external timeout, orphaning its reload launcher —
the rogue-AMP-peer failure); the third was organic — a reloaded server
whose reactor wedged, prime suspect in-flight civic HTTP holding the
Twisted threadpool at shutdown. 6s still triples the shim's worst
measured round-trip while bounding the shutdown wait.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
