### PR TITLE
Elevator: the CAR model — car room, gated landings, press controller (Closes #1084)

### DIFF
--- a/commands/CmdGraffiti.py
+++ b/commands/CmdGraffiti.py
@@ -468,15 +468,49 @@ class CmdPress(Command):
     def func(self):
         """Execute the press command."""
         if not self.args:
-            self.caller.msg("Usage: press <color> on <spray_can>")
+            self.caller.msg("Usage: press <color> on <spray_can>, or "
+                            "press <button> for buttons and panels.")
             return
-        
+
         if " on " not in self.args:
-            self.caller.msg("Usage: press <color> on <spray_can>")
+            # no "on" — a wall button or panel (elevators etc.), not a can
+            if self._press_pressable():
+                return
+            self.caller.msg("Usage: press <color> on <spray_can>, or "
+                            "press <button> for buttons and panels.")
             return
         
         # Split color and can name
         color_part, can_part = self.args.rsplit(" on ", 1)
+        return self._press_spray_can(color_part, can_part)
+
+    def _press_pressable(self):
+        """Route `press <arg>` to a pressable object in the room.
+
+        Match by the object's name/aliases first (`press call button`),
+        then offer the raw arg to each pressable's `at_press` as a label
+        (`press 2` on an elevator panel). Returns True when handled.
+        """
+        arg = self.args.strip()
+        location = self.caller.location
+        if not location:
+            return False
+        pressables = [obj for obj in location.contents
+                      if obj.db.pressable is True
+                      and hasattr(obj, "at_press")]
+        if not pressables:
+            return False
+        low = arg.lower()
+        for obj in pressables:
+            names = [obj.key.lower()] + [a.lower() for a in obj.aliases.all()]
+            if low in names or any(low in name for name in names):
+                return bool(obj.at_press(self.caller, None))
+        for obj in pressables:
+            if obj.at_press(self.caller, arg):
+                return True
+        return False
+
+    def _press_spray_can(self, color_part, can_part):
         new_color = color_part.strip().lower()
         can_name = can_part.strip()
         

--- a/typeclasses/elevator.py
+++ b/typeclasses/elevator.py
@@ -1,0 +1,259 @@
+"""The elevator: landings, a car that is a real room, and a controller.
+
+The CAR model (VERTICALITY_AND_BUILDINGS_SPEC §1.1, decided 2026-07-10):
+the car's position is honest world-state. Landings keep a permanent
+``elevator`` exit whose destination is always the car, but traversal is
+gated on the car being docked there with its doors open. The car's single
+``out`` exit is re-pointed to the current landing on arrival and refuses
+mid-travel. A call button at each landing summons the car; a panel inside
+selects floors. Both are pressed through the ordinary ``press`` command.
+
+The car is a room — riders stay free while it moves (no channeled action;
+the CAR moves, not the actor), so scenes can happen in it.
+
+Security seam (not yet consumed): ``db.floor_locks`` is reserved for the
+§2.2 biometric grant-file check on secured floors.
+"""
+
+from evennia.utils.utils import delay
+
+from typeclasses.exits import Exit
+from typeclasses.items import Item
+from typeclasses.rooms import IndoorRoom
+
+DOOR_SECONDS = 3
+RIDE_SECONDS_PER_FLOOR = 6
+
+DOORS_SHUT_MSG = "The elevator doors are shut. Press the call button."
+CAR_MOVING_MSG = "The car is moving. Best wait for the doors."
+
+
+def car_docked(car, landing):
+    """True when `car` sits at `landing` with its doors open."""
+    if car is None or landing is None:
+        return False
+    is_docked = getattr(car, "is_docked_at", None)
+    return bool(is_docked and is_docked(landing))
+
+
+class ElevatorCar(IndoorRoom):
+    """The moving room.
+
+    - ``db.floors``: ordered shaft, ``[[landing_room, label], ...]``
+    - ``db.current_floor``: index into floors (where the car sits)
+    - ``db.moving`` / ``db.target_floor``: in-flight state
+    """
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.floors = []
+        self.db.current_floor = 0
+        self.db.moving = False
+        self.db.target_floor = None
+        self.db.floor_locks = {}
+
+    def at_init(self):
+        super().at_init()
+        # delays don't survive a reload — a car caught mid-ride snaps
+        # to where it was headed, doors open, no messages
+        if self.db.moving:
+            target = self.db.target_floor
+            if target is None:
+                target = self.db.current_floor
+            self._arrive(target, quiet=True)
+
+    # ------------------------------------------------------------------
+    # state
+    # ------------------------------------------------------------------
+
+    def floor_index(self, room_or_label):
+        """Resolve a landing room or a panel label to a floors index."""
+        for i, entry in enumerate(self.db.floors or []):
+            landing, label = entry[0], entry[1]
+            if room_or_label is landing:
+                return i
+            if str(room_or_label).strip().lower() == str(label).lower():
+                return i
+        return None
+
+    def current_landing(self):
+        floors = self.db.floors or []
+        idx = self.db.current_floor
+        if idx is None or not 0 <= idx < len(floors):
+            return None
+        return floors[idx][0]
+
+    def is_docked_at(self, landing):
+        return not self.db.moving and self.current_landing() is landing
+
+    def _out_exit(self):
+        for obj in self.contents:
+            if getattr(obj, "destination", None) or obj.db_destination_id:
+                return obj
+        return None
+
+    # ------------------------------------------------------------------
+    # the two requests
+    # ------------------------------------------------------------------
+
+    def request_floor(self, label, presser=None):
+        """A panel press inside the car."""
+        idx = self.floor_index(label)
+        if idx is None:
+            if presser:
+                presser.msg("The panel has no such floor.")
+            return False
+        if self.db.moving:
+            if presser:
+                presser.msg("The car is already in motion.")
+            return False
+        if idx == self.db.current_floor:
+            if presser:
+                presser.msg("The doors are already open on that floor.")
+            return False
+        self._begin_move(idx)
+        return True
+
+    def call_to(self, landing, presser=None):
+        """A call-button press at a landing."""
+        idx = self.floor_index(landing)
+        if idx is None:
+            if presser:
+                presser.msg("The button clicks, dead. This shaft doesn't "
+                            "serve this floor.")
+            return False
+        if self.db.moving:
+            if presser:
+                presser.msg("Behind the doors, the mechanism is already "
+                            "in motion.")
+            return False
+        if idx == self.db.current_floor:
+            if presser:
+                presser.msg("The doors are already open.")
+            return False
+        self._begin_move(idx)
+        return True
+
+    # ------------------------------------------------------------------
+    # motion
+    # ------------------------------------------------------------------
+
+    def _begin_move(self, target_idx):
+        old_landing = self.current_landing()
+        going_up = target_idx > (self.db.current_floor or 0)
+        distance = abs(target_idx - (self.db.current_floor or 0))
+        self.db.moving = True
+        self.db.target_floor = target_idx
+        word = "upward" if going_up else "downward"
+        shaft = "up" if going_up else "down"
+        self.msg_contents(
+            f"The doors slide shut; the car shudders and hums {word}.")
+        if old_landing:
+            old_landing.msg_contents(
+                "The elevator doors slide shut. The car hums away "
+                f"{shaft} the shaft.")
+        delay(DOOR_SECONDS + RIDE_SECONDS_PER_FLOOR * distance,
+              self._arrive, target_idx)
+
+    def _arrive(self, target_idx, quiet=False):
+        floors = self.db.floors or []
+        if not 0 <= target_idx < len(floors):
+            self.db.moving = False
+            self.db.target_floor = None
+            return
+        landing = floors[target_idx][0]
+        self.db.current_floor = target_idx
+        self.db.moving = False
+        self.db.target_floor = None
+        out = self._out_exit()
+        if out:
+            out.destination = landing
+        try:
+            from world.spatial import get_xyz, set_xyz
+            xyz = get_xyz(landing)
+            if xyz:
+                set_xyz(self, *xyz)
+        except Exception:
+            pass
+        if not quiet:
+            self.msg_contents("The car settles; the doors slide open.")
+            landing.msg_contents("The elevator doors slide open with a "
+                                 "pneumatic sigh.")
+
+
+class ElevatorDoorExit(Exit):
+    """A landing's `elevator` exit. Destination is always the car;
+    traversal only works while the car is docked here, doors open."""
+
+    def at_traverse(self, traversing_object, target_location):
+        if not car_docked(self.destination, self.location):
+            traversing_object.msg(DOORS_SHUT_MSG)
+            return
+        super().at_traverse(traversing_object, target_location)
+
+
+class ElevatorCarExit(Exit):
+    """The car's `out` exit. Its destination is re-pointed on arrival;
+    it refuses while the car is between floors."""
+
+    def at_traverse(self, traversing_object, target_location):
+        car = self.location
+        if getattr(car.db, "moving", False) or not target_location:
+            traversing_object.msg(CAR_MOVING_MSG)
+            return
+        super().at_traverse(traversing_object, target_location)
+
+
+class ElevatorCallButton(Item):
+    """A landing's call button. `press button` summons the car.
+    ``db.elevator`` points at the car."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.pressable = True
+        self.locks.add("get:false()")
+        self.db.get_err_msg = "The button is set into the wall."
+
+    def at_press(self, presser, arg=None):
+        if arg:
+            # only answers to its own name — labels belong to the panel
+            return False
+        car = self.db.elevator
+        if not car:
+            presser.msg("You press the button. Nothing. It's dead.")
+            return True
+        presser.msg("You press the call button.")
+        if presser.location:
+            presser.location.msg_contents(
+                "The call button clicks under a fingertip.",
+                exclude=[presser])
+        car.call_to(self.location, presser)
+        return True
+
+
+class ElevatorPanel(Item):
+    """The floor panel inside the car. `press <floor>` selects a floor;
+    `press panel` reads the buttons. ``db.elevator`` points at the car."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.pressable = True
+        self.locks.add("get:false()")
+        self.db.get_err_msg = "The panel is bolted to the car."
+
+    def at_press(self, presser, arg=None):
+        car = self.db.elevator or self.location
+        floors = getattr(car.db, "floors", None) or []
+        if not arg:
+            labels = ", ".join(str(entry[1]) for entry in floors)
+            presser.msg(f"Worn buttons, one per floor: {labels or 'none'}.")
+            return True
+        if car.floor_index(arg) is None:
+            return False
+        presser.msg(f"You press {arg}.")
+        if presser.location:
+            presser.location.msg_contents(
+                "A panel button lights under a fingertip.",
+                exclude=[presser])
+        car.request_floor(arg, presser)
+        return True

--- a/world/tests/test_elevator.py
+++ b/world/tests/test_elevator.py
@@ -1,0 +1,223 @@
+"""The elevator car model (VERTICALITY_AND_BUILDINGS_SPEC §1.1).
+
+The car's position is world-state: landings gate on the car being docked,
+the car's out exit is re-pointed on arrival and refuses mid-travel, and
+both buttons ride the ordinary ``press`` command.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import typeclasses.elevator as emod
+from typeclasses.elevator import (
+    DOOR_SECONDS,
+    RIDE_SECONDS_PER_FLOOR,
+    car_docked,
+)
+
+
+def _bind(mock, cls, *names):
+    for name in names:
+        setattr(mock, name, getattr(cls, name).__get__(mock, cls))
+
+
+def _car(floors, current=0, moving=False):
+    car = MagicMock(name="car")
+    car.db = SimpleNamespace(floors=floors, current_floor=current,
+                             moving=moving, target_floor=None,
+                             floor_locks={})
+    car.contents = []
+    _bind(car, emod.ElevatorCar,
+          "floor_index", "current_landing", "is_docked_at",
+          "request_floor", "call_to", "_begin_move", "_arrive",
+          "_out_exit")
+    return car
+
+
+def _landing(name):
+    room = MagicMock(name=name)
+    return room
+
+
+class TestFloorState(TestCase):
+    def setUp(self):
+        self.l1, self.l2 = _landing("alcove"), _landing("2F landing")
+        self.car = _car([[self.l1, "1"], [self.l2, "2"]])
+
+    def test_floor_index_by_label_and_room(self):
+        self.assertEqual(self.car.floor_index("2"), 1)
+        self.assertEqual(self.car.floor_index(" 2 "), 1)   # forgiving
+        self.assertEqual(self.car.floor_index(self.l1), 0)
+        self.assertIsNone(self.car.floor_index("13"))
+
+    def test_docked_means_here_and_not_moving(self):
+        self.assertIs(self.car.current_landing(), self.l1)
+        self.assertTrue(self.car.is_docked_at(self.l1))
+        self.assertFalse(self.car.is_docked_at(self.l2))
+        self.car.db.moving = True
+        self.assertFalse(self.car.is_docked_at(self.l1))
+        self.assertFalse(car_docked(self.car, self.l1))
+        self.assertFalse(car_docked(None, self.l1))
+
+
+class TestRide(TestCase):
+    def setUp(self):
+        self.l1, self.l2 = _landing("alcove"), _landing("2F landing")
+        self.car = _car([[self.l1, "1"], [self.l2, "2"]])
+
+    def test_panel_press_starts_the_ride(self):
+        with patch.object(emod, "delay") as d:
+            self.assertTrue(self.car.request_floor("2", MagicMock()))
+        self.assertTrue(self.car.db.moving)
+        self.assertEqual(self.car.db.target_floor, 1)
+        seconds = d.call_args.args[0]
+        self.assertEqual(seconds, DOOR_SECONDS + RIDE_SECONDS_PER_FLOOR)
+        # doors close at both ends
+        self.car.msg_contents.assert_called_once()
+        self.l1.msg_contents.assert_called_once()
+
+    def test_bad_floor_and_double_press_refuse(self):
+        rider = MagicMock()
+        with patch.object(emod, "delay") as d:
+            self.assertFalse(self.car.request_floor("13", rider))
+            self.assertFalse(self.car.request_floor("1", rider))  # already here
+            self.car.db.moving = True
+            self.assertFalse(self.car.request_floor("2", rider))  # in motion
+        d.assert_not_called()
+        self.assertEqual(rider.msg.call_count, 3)
+
+    def test_arrival_repoints_the_out_exit(self):
+        out = MagicMock(name="out")
+        out.destination = self.l1
+        self.car.contents = [out]
+        self.car.db.moving = True
+        self.car.db.target_floor = 1
+        self.car._arrive(1)
+        self.assertFalse(self.car.db.moving)
+        self.assertEqual(self.car.db.current_floor, 1)
+        self.assertIs(out.destination, self.l2)
+        self.l2.msg_contents.assert_called_once()      # doors open upstairs
+
+    def test_quiet_arrival_snaps_without_messages(self):
+        self.car.db.moving = True
+        self.car._arrive(1, quiet=True)
+        self.assertEqual(self.car.db.current_floor, 1)
+        self.car.msg_contents.assert_not_called()
+        self.l2.msg_contents.assert_not_called()
+
+    def test_call_button_summons_or_reports(self):
+        caller = MagicMock()
+        with patch.object(emod, "delay"):
+            self.assertFalse(self.car.call_to(self.l1, caller))   # already open
+            self.assertTrue(self.car.call_to(self.l2, caller))    # summons
+        self.assertTrue(self.car.db.moving)
+        caller2 = MagicMock()
+        self.assertFalse(self.car.call_to(self.l1, caller2))      # mid-ride
+        self.assertIn("in motion", caller2.msg.call_args.args[0])
+
+
+class TestExitsGate(TestCase):
+    def test_landing_exit_refuses_until_docked(self):
+        door = MagicMock()
+        _bind(door, emod.ElevatorDoorExit, "at_traverse")
+        car = _car([[door.location, "1"]], current=0)
+        car.db.moving = True
+        door.destination = car
+        walker = MagicMock()
+        door.at_traverse(walker, car)
+        self.assertIn("shut", walker.msg.call_args.args[0])
+
+    def test_car_exit_refuses_mid_travel(self):
+        out = MagicMock()
+        _bind(out, emod.ElevatorCarExit, "at_traverse")
+        out.location.db = SimpleNamespace(moving=True)
+        walker = MagicMock()
+        out.at_traverse(walker, MagicMock())
+        self.assertIn("moving", walker.msg.call_args.args[0])
+
+
+class TestButtons(TestCase):
+    def _button(self, cls):
+        btn = MagicMock()
+        _bind(btn, cls, "at_press")
+        return btn
+
+    def test_call_button_presses_through_to_the_car(self):
+        btn = self._button(emod.ElevatorCallButton)
+        presser = MagicMock()
+        self.assertTrue(btn.at_press(presser))
+        btn.db.elevator.call_to.assert_called_once_with(btn.location, presser)
+
+    def test_dead_button_is_dead(self):
+        btn = self._button(emod.ElevatorCallButton)
+        btn.db.elevator = None
+        presser = MagicMock()
+        self.assertTrue(btn.at_press(presser))
+        self.assertIn("dead", presser.msg.call_args.args[0])
+
+    def test_panel_lists_floors_on_bare_press(self):
+        panel = self._button(emod.ElevatorPanel)
+        panel.db.elevator.db = SimpleNamespace(
+            floors=[[MagicMock(), "1"], [MagicMock(), "2"]])
+        presser = MagicMock()
+        self.assertTrue(panel.at_press(presser, None))
+        self.assertIn("1, 2", presser.msg.call_args.args[0])
+
+    def test_panel_declines_labels_it_does_not_own(self):
+        panel = self._button(emod.ElevatorPanel)
+        panel.db.elevator.floor_index.return_value = None
+        self.assertFalse(panel.at_press(MagicMock(), "13"))
+
+    def test_panel_selects_a_floor(self):
+        panel = self._button(emod.ElevatorPanel)
+        car = panel.db.elevator
+        car.floor_index.return_value = 1
+        presser = MagicMock()
+        self.assertTrue(panel.at_press(presser, "2"))
+        car.request_floor.assert_called_once_with("2", presser)
+
+
+class TestPressRouting(TestCase):
+    """`press` without " on " reaches pressables; spray syntax untouched."""
+
+    def _cmd(self, args, contents):
+        from commands.CmdGraffiti import CmdPress
+        cmd = CmdPress()
+        cmd.args = args
+        cmd.caller = MagicMock()
+        cmd.caller.location.contents = contents
+        return cmd
+
+    def _pressable(self, key, aliases=(), handles=True):
+        obj = MagicMock()
+        obj.key = key
+        obj.db.pressable = True
+        obj.aliases.all.return_value = list(aliases)
+        obj.at_press.return_value = handles
+        return obj
+
+    def test_name_match_presses_the_object(self):
+        btn = self._pressable("call button", aliases=["button"])
+        cmd = self._cmd("call button", [btn])
+        self.assertTrue(cmd._press_pressable())
+        btn.at_press.assert_called_once_with(cmd.caller, None)
+
+    def test_label_falls_through_to_the_panel(self):
+        panel = self._pressable("floor panel")
+        cmd = self._cmd("2", [panel])
+        self.assertTrue(cmd._press_pressable())
+        panel.at_press.assert_called_once_with(cmd.caller, "2")
+
+    def test_nothing_pressable_defers_to_usage(self):
+        stranger = MagicMock()
+        stranger.db.pressable = None       # MagicMock-truthiness guard
+        cmd = self._cmd("2", [stranger])
+        self.assertFalse(cmd._press_pressable())
+        stranger.at_press.assert_not_called()
+
+    def test_spray_syntax_still_routes_to_the_can(self):
+        cmd = self._cmd("blue on spray can", [])
+        cmd._press_spray_can = MagicMock()
+        cmd.func()
+        cmd._press_spray_can.assert_called_once_with("blue", "spray can")


### PR DESCRIPTION
The car is a real room whose position is world-state (verticality 1.1,
decided in #1082): landings keep a permanent elevator exit gated on the
car being docked; the car's out exit is re-pointed on arrival and
refuses mid-travel; a call button per landing and a floor panel in the
car both answer the ordinary press command (CmdPress grows a pressable
route for args without ' on '; spray-can syntax untouched). Motion is
script-timed (3s doors + 6s/floor) with door messages at both ends; a
reload mid-ride snaps the car to its target quietly. db.floor_locks
reserved for the 2.2 biometric floor-grant seam.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
