### PR TITLE
Dispatch room designation — the ear leaves the garage (Closes #1086)

### DIFF
--- a/commands/CmdPatrol.py
+++ b/commands/CmdPatrol.py
@@ -31,6 +31,11 @@ class CmdPatrol(default_cmds.MuxCommand):
                                             base: secbots spawn/post/sync/
                                             respawn here; the heartbeat keeps
                                             <complement> units alive (default 1)
+        @patrol/dispatch                  - designate THIS room the dispatch
+                                            room: the console and the operator
+                                            live here (respawns stay at the
+                                            base); without one, dispatch works
+                                            from the base itself
         @patrol/status [npc]              - show posts and beats
         @patrol/clear <npc>               - take <npc> off patrol (keeps post)
 
@@ -74,6 +79,21 @@ class CmdPatrol(default_cmds.MuxCommand):
                 f"security base: secbots spawn, post, sync, and respawn "
                 f"here; the heartbeat maintains a complement of "
                 f"{complement}.")
+            return
+
+        if "dispatch" in switches:
+            from world.director.population import set_dispatch_room
+            if caller.location is None:
+                caller.msg("You have no location to designate.")
+                return
+            set_dispatch_room(caller.location)
+            ensure_heartbeat()
+            caller.msg(
+                f"{caller.location.get_display_name(caller)} is now the "
+                f"dispatch room: the console and the operator live here "
+                f"(the heartbeat installs them if missing); respawns stay "
+                f"at the security base. Move existing hardware and staff "
+                f"yourself if you want THEM rather than fresh ones.")
             return
 
         if "status" in switches:

--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -694,7 +694,7 @@ class DispatchConsole(Radio):
     #: automation register: "mechanical, sure, but not a person on the
     #: other side of a radio." This is the person.)
     OPERATOR_INSTRUCTIONS = (
-        "You are Vess: the HUMAN dispatch operator of a colonial security "
+        "You are Petra: the HUMAN dispatch operator of a colonial security "
         "force in a gritty fictional cyberpunk game — a woman with twenty "
         "years on this desk, working the colony's emergency radio band. "
         "You are tired, dry, procedurally exact, and human. You never "

--- a/world/director/population.py
+++ b/world/director/population.py
@@ -14,6 +14,11 @@ A room designated the **security base** (``@patrol/base``, tag
   deleted units simply fall out of the count — no death-hook plumbing,
   the census self-heals.
 
+The **dispatch room** (``@patrol/dispatch``, tag ``("dispatch_room",
+"director")``) is an optional split: the console and the operator live
+there while spawn/sync/respawn stay at the base. Without one, dispatch
+works from the base — the ear and the garage are the same room.
+
 This is deliberately the seed of the spec's population registry (§3):
 role + home + lifecycle, for one role at one base. The general registry
 grows out of it.
@@ -27,6 +32,10 @@ from typing import Any
 #: Room tag marking the security base.
 BASE_TAG = "security_base"
 BASE_TAG_CATEGORY = "director"
+
+#: Room tag marking the dispatch room — where the console and the
+#: operator live. Optional: without one, dispatch works from the base.
+DISPATCH_TAG = "dispatch_room"
 
 
 # --------------------------------------------------------------------------
@@ -49,6 +58,30 @@ def set_security_base(room: Any, complement: int = 1) -> None:
         old.tags.remove(BASE_TAG, category=BASE_TAG_CATEGORY)
     room.tags.add(BASE_TAG, category=BASE_TAG_CATEGORY)
     room.db.security_complement = int(complement)
+
+
+def get_dispatch_room() -> Any | None:
+    """The room dispatch answers from: the ``dispatch_room``-tagged room
+    if one is designated, else the security base. Decouples the ear from
+    the garage — units respawn at the BASE; the console and the operator
+    live HERE."""
+    from evennia.objects.models import ObjectDB
+    room = ObjectDB.objects.filter(
+        db_tags__db_key=DISPATCH_TAG,
+        db_tags__db_category=BASE_TAG_CATEGORY).first()
+    return room if room is not None else get_security_base()
+
+
+def set_dispatch_room(room: Any) -> None:
+    """Designate *room* as THE dispatch room (single room — any previous
+    designation is cleared)."""
+    from evennia.objects.models import ObjectDB
+    old = ObjectDB.objects.filter(
+        db_tags__db_key=DISPATCH_TAG,
+        db_tags__db_category=BASE_TAG_CATEGORY).first()
+    if old is not None and old != room:
+        old.tags.remove(DISPATCH_TAG, category=BASE_TAG_CATEGORY)
+    room.tags.add(DISPATCH_TAG, category=BASE_TAG_CATEGORY)
 
 
 # --------------------------------------------------------------------------
@@ -209,12 +242,12 @@ def ensure_comms_fitted() -> int:
 
 
 def ensure_base_station() -> Any | None:
-    """Upkeep: the security base carries its dispatch console (the
+    """Upkeep: the dispatch room carries its console (the
     RADIO_COMMS_SPEC §2.1 base station — the voice that acknowledges
     reports on 911MHz). Idempotent; in-process (heartbeat at_start).
     Returns the station (existing or newly installed), or None without
-    a designated base."""
-    base = get_security_base()
+    a designated dispatch room or base."""
+    base = get_dispatch_room()
     if base is None:
         return None
     for obj in base.contents:
@@ -241,14 +274,14 @@ def ensure_base_station() -> Any | None:
 
 
 def spawn_dispatch_operator(base: Any) -> Any:
-    """The human at the desk (Operator v1: Vess). Face-to-face she's a
+    """The human at the desk (Operator v1: Petra). Face-to-face she's a
     GM-lane NPC; ON THE AIR the console's civic lane speaks AS her — her
     voice, her register — so the far end of the radio is a person."""
     from evennia import create_object
     from world.llm.personas import DISPATCH_OPERATOR_PERSONA
     op = create_object(
         typeclass="typeclasses.llm_npc.LLMNpc",
-        key="Vess", location=base, home=base,
+        key="Petra", location=base, home=base,
     )
     op.height = "short"
     op.build = "lean"
@@ -271,11 +304,12 @@ def spawn_dispatch_operator(base: Any) -> Any:
 
 
 def ensure_dispatch_operator() -> Any | None:
-    """Upkeep (heartbeat at_start): the base has someone at the desk.
+    """Upkeep (heartbeat at_start): the dispatch room has someone at the
+    desk.
     Idempotent; a dead operator is left to the corpse pipeline and a new
     one is NOT auto-hired here (absence = the console's automation voice —
     the bleak attendant — until staffing recovers at the next reload)."""
-    base = get_security_base()
+    base = get_dispatch_room()
     if base is None:
         return None
     for obj in base.contents:
@@ -293,7 +327,7 @@ def ensure_dispatch_operator() -> Any | None:
 def get_dispatch_operator() -> Any | None:
     """The LIVE operator at the desk, or None (dead, unconscious, absent,
     kidnapped = the automation answers — a difference players can hear)."""
-    base = get_security_base()
+    base = get_dispatch_room()
     if base is None:
         return None
     for obj in base.contents:
@@ -309,11 +343,11 @@ def get_dispatch_operator() -> Any | None:
 
 
 def get_base_station() -> Any | None:
-    """The base's live, powered dispatch console, or None (no base, no
+    """The dispatch room's live, powered console, or None (no room, no
     console, console off/broken = dispatch has no voice — the physical
     gate: sabotage the console and the net goes quiet)."""
     from world.radio import is_powered, is_radio
-    base = get_security_base()
+    base = get_dispatch_room()
     if base is None:
         return None
     for obj in base.contents:

--- a/world/llm/personas.py
+++ b/world/llm/personas.py
@@ -48,7 +48,7 @@ SECURITY_BOT_PERSONA: dict = {
 
 DISPATCH_OPERATOR_PERSONA: dict = {
     "archetype": "colonist",
-    "name": "Vess",
+    "name": "Petra",
     "description": (
         "A woman somewhere past fifty with the posture of someone who has "
         "sat the same chair for twenty years and won it. Headset worn like "

--- a/world/tests/test_director_population.py
+++ b/world/tests/test_director_population.py
@@ -188,7 +188,7 @@ class TestSpawnPostsToBase(TestCase):
 
 
 class TestBaseStation(TestCase):
-    """The base's dispatch console: installed by upkeep, idempotent, and
+    """The dispatch room's console: installed by upkeep, idempotent, and
     only a live powered console counts as dispatch's voice."""
 
     def _station(self, on=True):
@@ -197,12 +197,12 @@ class TestBaseStation(TestCase):
                                radio_on=on, frequency="911MHz")
         return s
 
-    @patch("world.director.population.get_security_base", return_value=None)
+    @patch("world.director.population.get_dispatch_room", return_value=None)
     def test_no_base_no_station(self, _base):
         from world.director.population import ensure_base_station
         self.assertIsNone(ensure_base_station())
 
-    @patch("world.director.population.get_security_base")
+    @patch("world.director.population.get_dispatch_room")
     def test_existing_console_is_kept(self, mock_base):
         from world.director.population import ensure_base_station
         station = self._station()
@@ -212,7 +212,7 @@ class TestBaseStation(TestCase):
             self.assertIs(ensure_base_station(), station)
         sp.assert_not_called()                    # idempotent
 
-    @patch("world.director.population.get_security_base")
+    @patch("world.director.population.get_dispatch_room")
     def test_missing_console_is_installed(self, mock_base):
         from world.director.population import ensure_base_station
         base = MagicMock(); base.contents = []
@@ -223,7 +223,7 @@ class TestBaseStation(TestCase):
             self.assertIs(ensure_base_station(), newborn)
         self.assertIs(newborn.location, base)
 
-    @patch("world.director.population.get_security_base")
+    @patch("world.director.population.get_dispatch_room")
     def test_powered_console_is_the_voice_off_is_silence(self, mock_base):
         from world.director.population import get_base_station
         live, dead = self._station(on=True), self._station(on=False)
@@ -246,7 +246,7 @@ class TestDispatchOperator(TestCase):
         op.is_unconscious.return_value = unconscious
         return op
 
-    @patch("world.director.population.get_security_base")
+    @patch("world.director.population.get_dispatch_room")
     def test_live_operator_found(self, mock_base):
         from world.director.population import get_dispatch_operator
         vess = self._op()
@@ -254,7 +254,7 @@ class TestDispatchOperator(TestCase):
         mock_base.return_value = base
         self.assertIs(get_dispatch_operator(), vess)
 
-    @patch("world.director.population.get_security_base")
+    @patch("world.director.population.get_dispatch_room")
     def test_dead_or_unconscious_operator_is_no_operator(self, mock_base):
         from world.director.population import get_dispatch_operator
         base = MagicMock()
@@ -264,7 +264,7 @@ class TestDispatchOperator(TestCase):
         base.contents = [self._op(unconscious=True)]
         self.assertIsNone(get_dispatch_operator())
 
-    @patch("world.director.population.get_security_base")
+    @patch("world.director.population.get_dispatch_room")
     def test_upkeep_is_idempotent(self, mock_base):
         from world.director.population import ensure_dispatch_operator
         vess = self._op()
@@ -273,3 +273,36 @@ class TestDispatchOperator(TestCase):
         with patch("world.director.population.spawn_dispatch_operator") as sp:
             self.assertIs(ensure_dispatch_operator(), vess)
         sp.assert_not_called()
+
+class TestDispatchRoomDesignation(TestCase):
+    """The ear/garage split: dispatch prefers its own tagged room and
+    falls back to the base, so an untagged world behaves as before."""
+
+    @patch("world.director.population.get_security_base")
+    @patch("evennia.objects.models.ObjectDB")
+    def test_tagged_room_wins(self, mock_db, mock_base):
+        from world.director.population import get_dispatch_room
+        upstairs = MagicMock(name="dispatch ops")
+        mock_db.objects.filter.return_value.first.return_value = upstairs
+        self.assertIs(get_dispatch_room(), upstairs)
+        mock_base.assert_not_called()
+
+    @patch("world.director.population.get_security_base")
+    @patch("evennia.objects.models.ObjectDB")
+    def test_untagged_world_falls_back_to_the_base(self, mock_db, mock_base):
+        from world.director.population import get_dispatch_room
+        mock_db.objects.filter.return_value.first.return_value = None
+        base = MagicMock(name="landing pad")
+        mock_base.return_value = base
+        self.assertIs(get_dispatch_room(), base)
+
+    @patch("evennia.objects.models.ObjectDB")
+    def test_redesignation_clears_the_old_tag(self, mock_db):
+        from world.director.population import DISPATCH_TAG, set_dispatch_room
+        old, new = MagicMock(name="old"), MagicMock(name="new")
+        mock_db.objects.filter.return_value.first.return_value = old
+        set_dispatch_room(new)
+        old.tags.remove.assert_called_once_with(DISPATCH_TAG,
+                                                category="director")
+        new.tags.add.assert_called_once_with(DISPATCH_TAG,
+                                             category="director")

--- a/world/tests/test_radio_comprehension.py
+++ b/world/tests/test_radio_comprehension.py
@@ -238,7 +238,7 @@ class TestOperatorObservesNeverReplies(TestCase):
 
     def test_operator_named_on_air_observes_only(self):
         b = MagicMock()
-        b.key = "Vess"
+        b.key = "Petra"
         b.sdesc_keyword = None
         b.db.llm_driven = True
         b.db.dispatch_operator = True
@@ -251,9 +251,9 @@ class TestOperatorObservesNeverReplies(TestCase):
             _bind(b, m)
         with patch.object(llmnpc, "llm_enabled", return_value=True), \
                 patch.object(llmnpc, "delay") as d:
-            b._hear_radio("Vess, you there?", MagicMock(),
+            b._hear_radio("Petra, you there?", MagicMock(),
                           {"type": "radio", "radio_frequency": "911MHz",
                            "radio_elected": True})
         d.assert_not_called()                    # no second brain on the air
         self.assertTrue(b.ndb.action_buffer)     # ...but she heard it
-        self.assertIn("Vess, you there?", b.ndb.action_buffer[0])
+        self.assertIn("Petra, you there?", b.ndb.action_buffer[0])


### PR DESCRIPTION
get_dispatch_room() prefers a dispatch_room-tagged room and falls back
to the security base, so the console and operator can sit behind the
Constabulary's secure floor while units keep respawning from the base
(now the landing pad fiction). New @patrol/dispatch switch designates
the caller's room; untagged worlds behave exactly as before. Operator
renamed Vess -> Petra across persona, spawn, and the on-air register.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
