### PR TITLE
Radio render: drop the voice-flavour sprinkle (Closes #1090)

### DIFF
--- a/world/radio.py
+++ b/world/radio.py
@@ -264,17 +264,19 @@ def _render_radio_line(speaker: Any, listener: Any, message: str,
     """A received transmission, VOICE-attributed (never sight — you can't see
     the far end) and hearing-gated. ``tagged`` prefixes the frequency (scanner
     sweep mode caught it off-band); ``own`` distinguishes your handset from
-    a grille you're merely standing near."""
+    a grille you're merely standing near.
+
+    No voice-flavour sprinkle here (dropped 2026-07-10): the sprinkle exists
+    for SAY, where the handle is a visual sdesc and the italics add voice
+    info. Radio attribution IS the voice — "A smoky voice ... *in a smoky
+    rasp*" described itself twice."""
     from world.perception import can_hear
-    from world.voice import voice_phrase
     band = f"[{frequency}] " if tagged else ""
     if not can_hear(listener):
         source = "Your radio" if own else "A radio nearby"
         return f"{band}{source} crackles, but you can't make out a word."
     who = radio_voice_handle(speaker, listener)
-    flavour = voice_phrase(speaker)
-    flav = f" |x*{flavour}*|n" if flavour else ""
-    return (f'{band}{who[:1].upper()}{who[1:]} crackles over the radio{flav}: '
+    return (f'{band}{who[:1].upper()}{who[1:]} crackles over the radio: '
             f'"{message}"')
 
 

--- a/world/tests/test_radio.py
+++ b/world/tests/test_radio.py
@@ -121,6 +121,28 @@ class TestTransmit(TestCase):
         self.assertIn("A gravelly voice crackles over the radio", line)
         self.assertIn("rendezvous at the docks", line)
 
+    def test_no_voice_flavour_sprinkle_on_the_air(self):
+        # The handle IS the voice — "A smoky voice ... *in a smoky rasp*"
+        # described itself twice (playtest, 2026-07-10). Say keeps the
+        # sprinkle; radio must not, even when the composer has one.
+        speaker = _char()
+        dev, heard = _radio(freq="447"), _radio(freq="447")
+        listener = MagicMock(); heard.location = listener
+        with self._world([dev, heard]), \
+                patch.object(radio, "_log_to_channel"), \
+                patch("world.perception.can_hear", return_value=True), \
+                patch("world.voice.attempt_voice_discern",
+                      return_value=None), \
+                patch("world.voice.get_voice_description",
+                      return_value="smoky"), \
+                patch("world.voice.voice_phrase",
+                      return_value="speaking Common, in a smoky rasp"):
+            transmit(speaker, "long day", dev)
+        line = listener.msg.call_args.args[0]
+        self.assertIn("A smoky voice crackles over the radio", line)
+        self.assertNotIn("rasp*", line)
+        self.assertNotIn("speaking Common", line)
+
     def test_known_voice_names_the_speaker(self):
         speaker = _char()
         dev, heard = _radio(freq="447"), _radio(freq="447")


### PR DESCRIPTION
'A smoky voice crackles over the radio *in a smoky rasp*' described
itself twice (playtest). The sprinkle exists for say, where the handle
is a visual sdesc and the italics add voice info; radio attribution IS
the voice, so the handle rides alone. Say unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
