### PR TITLE
Radio render: A voice crackles over the radio: *accent* "Words" (Closes #1092)

### DIFF
--- a/world/radio.py
+++ b/world/radio.py
@@ -266,18 +266,27 @@ def _render_radio_line(speaker: Any, listener: Any, message: str,
     sweep mode caught it off-band); ``own`` distinguishes your handset from
     a grille you're merely standing near.
 
-    No voice-flavour sprinkle here (dropped 2026-07-10): the sprinkle exists
-    for SAY, where the handle is a visual sdesc and the italics add voice
-    info. Radio attribution IS the voice — "A smoky voice ... *in a smoky
-    rasp*" described itself twice."""
+    The voice is described ONCE (playtest, 2026-07-10): a GENERIC handle —
+    "A voice", or the name when the listener knows it — with the accent
+    carried in italics before the words:
+
+        A voice crackles over the radio: *speaking Common, in a smoky
+        rasp* "Long day."
+
+    (The descriptive handle + accent-suffix arrangement described the same
+    voice twice. The NPC brain's buffer handle — ``radio_voice_handle`` —
+    keeps the descriptor: prose for a reader, not a render.)"""
     from world.perception import can_hear
+    from world.voice import attempt_voice_discern, voice_phrase
     band = f"[{frequency}] " if tagged else ""
     if not can_hear(listener):
         source = "Your radio" if own else "A radio nearby"
         return f"{band}{source} crackles, but you can't make out a word."
-    who = radio_voice_handle(speaker, listener)
+    who = attempt_voice_discern(listener, speaker) or "a voice"
+    accent = voice_phrase(speaker)
+    acc = f"|x*{accent}*|n " if accent else ""
     return (f'{band}{who[:1].upper()}{who[1:]} crackles over the radio: '
-            f'"{message}"')
+            f'{acc}"{message}"')
 
 
 def transmit(speaker: Any, message: str, device: Any,

--- a/world/tests/test_radio.py
+++ b/world/tests/test_radio.py
@@ -118,13 +118,13 @@ class TestTransmit(TestCase):
             ok = transmit(speaker, "rendezvous at the docks", dev)
         self.assertTrue(ok)
         line = listener.msg.call_args.args[0]
-        self.assertIn("A gravelly voice crackles over the radio", line)
+        self.assertIn("A voice crackles over the radio", line)
         self.assertIn("rendezvous at the docks", line)
 
-    def test_no_voice_flavour_sprinkle_on_the_air(self):
-        # The handle IS the voice — "A smoky voice ... *in a smoky rasp*"
-        # described itself twice (playtest, 2026-07-10). Say keeps the
-        # sprinkle; radio must not, even when the composer has one.
+    def test_voice_described_once_accent_before_the_words(self):
+        # Playtest shape (2026-07-10): generic handle, accent in italics
+        # between the colon and the quote — the voice is described ONCE.
+        # "A smoky voice ... *in a smoky rasp*" described itself twice.
         speaker = _char()
         dev, heard = _radio(freq="447"), _radio(freq="447")
         listener = MagicMock(); heard.location = listener
@@ -133,15 +133,15 @@ class TestTransmit(TestCase):
                 patch("world.perception.can_hear", return_value=True), \
                 patch("world.voice.attempt_voice_discern",
                       return_value=None), \
-                patch("world.voice.get_voice_description",
-                      return_value="smoky"), \
                 patch("world.voice.voice_phrase",
                       return_value="speaking Common, in a smoky rasp"):
             transmit(speaker, "long day", dev)
         line = listener.msg.call_args.args[0]
-        self.assertIn("A smoky voice crackles over the radio", line)
-        self.assertNotIn("rasp*", line)
-        self.assertNotIn("speaking Common", line)
+        self.assertIn('A voice crackles over the radio: '
+                      '|x*speaking Common, in a smoky rasp*|n "long day"',
+                      line)
+        self.assertNotIn("smoky voice", line)   # descriptor stays out of
+                                                # the handle
 
     def test_known_voice_names_the_speaker(self):
         speaker = _char()


### PR DESCRIPTION
Playtest-decided shape: generic handle (A voice / the known name via
voice memory), accent in italics once, between the colon and the
words. The descriptor-handle arrangement described the same voice
twice however it was ordered; this says it once, where the ear meets
the words. radio_voice_handle keeps the descriptor for the NPC
brain buffer (prose for a reader, not a render).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
