### PR TITLE
Elevator: the car rides a real shaft column (Closes #1098)

### DIFF
--- a/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
+++ b/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
@@ -61,11 +61,18 @@ convenience.
 * **Lift/elevator — THE CAR MODEL (DECIDED 2026-07-10, supersedes the
   warp-exit v1; resolves open question 1).** A real elevator is three
   parts:
-  1. **Landings** — one room per served floor (the Constabulary alcove
-     #4939 and 2F landing #4957 are the prototype pair). Each landing has
-     an `elevator` exit whose destination is always THE CAR — but
-     traversal is gated on the car being AT that floor ("The doors are
-     shut. Press the call button.").
+  1. **Landings** — the ordinary rooms the doors open onto, one per
+     served floor (the Constabulary prototype: the LOBBY #4936 and the
+     2F SECURE CORRIDOR #4960 — the doors sit in their east walls). Each
+     landing has an `elevator` exit whose destination is always THE CAR —
+     but traversal is gated on the car being AT that floor ("The doors
+     are shut. Press the call button."). **The SHAFT is real too
+     (refined 2026-07-10, user call):** a stacked column of sealed rooms
+     (#4939/#4957 at (9,-18,z), joined up/down) that the car physically
+     occupies — `db.shaft_xy` parks the car's grid position at
+     (shaft_x, shaft_y, landing_z), never in a landing's cell. No
+     pedestrian exits touch the shaft; prying the doors to reach it is
+     future B&E texture.
   2. **The CAR** — a real room. Passengers stand in it, talk in it, fight
      in it — a moving room where scenes happen. Its single `out` exit is
      **re-pointed by the controller** to the current landing; it refuses

--- a/typeclasses/elevator.py
+++ b/typeclasses/elevator.py
@@ -51,6 +51,10 @@ class ElevatorCar(IndoorRoom):
         self.db.moving = False
         self.db.target_floor = None
         self.db.floor_locks = {}
+        # The shaft's (x, y) grid column. When set, the car's coordinates
+        # are (shaft_x, shaft_y, landing_z) — the car sits IN the shaft at
+        # its floor's height, never in the threshold room's cell.
+        self.db.shaft_xy = None
 
     def at_init(self):
         super().at_init()
@@ -172,7 +176,12 @@ class ElevatorCar(IndoorRoom):
             from world.spatial import get_xyz, set_xyz
             xyz = get_xyz(landing)
             if xyz:
-                set_xyz(self, *xyz)
+                shaft = self.db.shaft_xy
+                if shaft:
+                    # the car rides its shaft column at the landing's height
+                    set_xyz(self, shaft[0], shaft[1], xyz[2])
+                else:
+                    set_xyz(self, *xyz)
         except Exception:
             pass
         if not quiet:

--- a/world/tests/test_elevator.py
+++ b/world/tests/test_elevator.py
@@ -26,7 +26,7 @@ def _car(floors, current=0, moving=False):
     car = MagicMock(name="car")
     car.db = SimpleNamespace(floors=floors, current_floor=current,
                              moving=moving, target_floor=None,
-                             floor_locks={})
+                             floor_locks={}, shaft_xy=None)
     car.contents = []
     _bind(car, emod.ElevatorCar,
           "floor_index", "current_landing", "is_docked_at",
@@ -98,6 +98,17 @@ class TestRide(TestCase):
         self.assertEqual(self.car.db.current_floor, 1)
         self.assertIs(out.destination, self.l2)
         self.l2.msg_contents.assert_called_once()      # doors open upstairs
+
+    def test_arrival_parks_the_car_in_its_shaft_column(self):
+        # The car never shares a threshold room's grid cell: with a
+        # shaft column set, it sits at (shaft_x, shaft_y, landing_z) —
+        # in the shaft, at the floor's height.
+        self.car.db.shaft_xy = (9, -18)
+        self.car.db.moving = True
+        with patch("world.spatial.get_xyz", return_value=(8, -18, 1)), \
+                patch("world.spatial.set_xyz") as set_xyz:
+            self.car._arrive(1)
+        set_xyz.assert_called_once_with(self.car, 9, -18, 1)
 
     def test_quiet_arrival_snaps_without_messages(self):
         self.car.db.moving = True


### PR DESCRIPTION
User refinement: the stacked dug rooms ARE the shaft; the doors (and
call buttons) belong to the ordinary rooms they open onto. db.shaft_xy
parks the arriving car at (shaft_x, shaft_y, landing_z) so it occupies
the shaft at the floor's height instead of colliding with a threshold
room's grid cell. Spec 1.1 refined to match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
