### PR TITLE
Elevator verbs: 'in' at the doors, 'call' for the button (Closes #1100)

### DIFF
--- a/commands/CmdGraffiti.py
+++ b/commands/CmdGraffiti.py
@@ -462,11 +462,20 @@ class CmdPress(Command):
     """
     
     key = "press"
+    aliases = ["call"]
     locks = "cmd:all()"
     help_category = "General"
-    
+
     def func(self):
         """Execute the press command."""
+        if getattr(self, "cmdstring", "").lower() == "call":
+            # `call` = press the call button here (elevator shorthand);
+            # any trailing words ("call elevator") are just as welcome
+            self.args = "call"
+            if not self._press_pressable():
+                self.caller.msg("There's no call button here.")
+            return
+
         if not self.args:
             self.caller.msg("Usage: press <color> on <spray_can>, or "
                             "press <button> for buttons and panels.")

--- a/typeclasses/elevator.py
+++ b/typeclasses/elevator.py
@@ -192,7 +192,14 @@ class ElevatorCar(IndoorRoom):
 
 class ElevatorDoorExit(Exit):
     """A landing's `elevator` exit. Destination is always the car;
-    traversal only works while the car is docked here, doors open."""
+    traversal only works while the car is docked here, doors open.
+    Answers to `in` as well — the natural verb at the threshold (the
+    car side's exit is keyed `out` to match)."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        if "in" not in self.aliases.all():
+            self.aliases.add("in")
 
     def at_traverse(self, traversing_object, target_location):
         if not car_docked(self.destination, self.location):

--- a/world/tests/test_elevator.py
+++ b/world/tests/test_elevator.py
@@ -232,3 +232,24 @@ class TestPressRouting(TestCase):
         cmd._press_spray_can = MagicMock()
         cmd.func()
         cmd._press_spray_can.assert_called_once_with("blue", "spray can")
+
+    def test_call_is_press_call(self):
+        btn = self._pressable("call button", aliases=["button"])
+        cmd = self._cmd("", [btn])
+        cmd.cmdstring = "call"
+        cmd.func()
+        btn.at_press.assert_called_once_with(cmd.caller, None)
+
+    def test_call_with_trailing_words_still_lands(self):
+        btn = self._pressable("call button")
+        cmd = self._cmd("elevator", [btn])
+        cmd.cmdstring = "call"
+        cmd.func()
+        btn.at_press.assert_called_once_with(cmd.caller, None)
+
+    def test_call_without_a_button_says_so(self):
+        cmd = self._cmd("", [])
+        cmd.cmdstring = "call"
+        cmd.func()
+        self.assertIn("no call button",
+                      cmd.caller.msg.call_args.args[0])


### PR DESCRIPTION
ElevatorDoorExit aliases 'in' at creation (the car side is already
keyed 'out'), and 'call' rides CmdPress as an alias that presses the
room's call button regardless of trailing words.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
