### PR TITLE
Exit prose: paren hint is the shortest alias (Closes #1102)

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -839,7 +839,9 @@ class Room(ObjectParent, DefaultRoom):
         for exit_obj in exits:
             direction = exit_obj.key
             aliases = exit_obj.aliases.all()
-            alias = aliases[0] if aliases else None
+            # the paren hint is the tersest way to type the exit — pick the
+            # SHORTEST alias, not the first ("elevator (in)", not "(car)")
+            alias = min(aliases, key=len) if aliases else None
             destination = exit_obj.destination
             
             # Check if exit leads to a sky room (skip unless edge/gap)


### PR DESCRIPTION
The hint is the tersest way to type the exit — 'elevator (in)', not
'(car)'. Cardinals unchanged (single alias).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
