### PR TITLE
Log-storm hardening: owned audit sink, debug prune, script guard, launcher-kill (Closes #1106)

### DIFF
--- a/scripts/deploy-reload.sh
+++ b/scripts/deploy-reload.sh
@@ -47,8 +47,13 @@ if [ "$(status_server)" -ge 1 ]; then
     echo "--- reload clean, server running ---"
 else
     echo "--- server did not come back: recovering lingering process ---"
+    # Kill BOTH failure shapes: a wedged server process AND a hung
+    # `evennia reload` launcher — the launcher outlives the timed-out
+    # host-side docker exec and lingers as a rogue AMP peer on the
+    # portal (the "Unhandled Command: MsgPortal2Server" spam; needed
+    # manual kills on all three 2026-07-10 wedges).
     docker exec "$CONTAINER" bash -lc '
-        pids=$(ps -o pid=,args= -e | grep "server/server.py" | grep -v grep | awk "{print \$1}")
+        pids=$(ps -o pid=,args= -e | grep -E "server/server\.py|evennia reload" | grep -v grep | awk "{print \$1}")
         for p in $pids; do kill "$p" 2>/dev/null; done
         sleep 4
         for p in $pids; do kill -9 "$p" 2>/dev/null; done

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -465,9 +465,14 @@ class DeathProgressionScript(DefaultScript):
         splattercast.msg(f"DEATH_PROGRESSION: {character.key} completed - corpse created, character transitioned")
         splattercast.msg(f"DEATH_SCRIPT_CLEANUP: Stopping and deleting death progression script for {character.key}")
             
-        # Stop and delete the script to clean up completely
-        self.stop()
-        self.delete()
+        # Stop and delete the script to clean up completely. Corpse
+        # creation/character transition can cascade-delete this script
+        # first, and stopping an already-deleted script raises on its
+        # id-less attribute handler (seen live 2026-07-06/07) — guard
+        # on pk, the same idiom Evennia core uses in Script.delete().
+        if self.pk:
+            self.stop()
+            self.delete()
 
     def _handle_corpse_creation_and_transition(self, character):
         """

--- a/world/combat/debug.py
+++ b/world/combat/debug.py
@@ -8,10 +8,16 @@ its own channel lookups.
 Two destinations, one entry point:
 
 * **Audit file** (always on) — every message is appended to
-  ``server/logs/combat_audit.log`` via Evennia's async file logger.
-  This is the long-term record for investigating player bug reports,
-  cheating accusations, and combat disputes.  File writes happen on
-  the logger's thread pool, never blocking the reactor.
+  ``server/logs/combat_audit.log`` via a stdlib ``logging`` rotating
+  file handler owned by this module.  This is the long-term record
+  for investigating player bug reports, cheating accusations, and
+  combat disputes.  (Previously Evennia's threaded ``logger.log_file``
+  carried these writes; its cached handle is closed on the reactor
+  every 500th access while queued thread writes still hold it, so
+  every recycle boundary silently dropped the queue — 7.9k lost lines
+  rendered as ``NoneType: None`` before #1094 unmasked it.  The
+  stdlib handler locks per-write and rotates safely; Evennia core
+  stays untouched.)
 * **Splattercast channel** (gated) — live in-game broadcast for
   active debugging sessions.  Off by default; enable by setting
   ``SPLATTERCAST_LIVE = True`` in ``server/conf/settings.py``.
@@ -32,16 +38,49 @@ Functions:
 
 from __future__ import annotations
 
+import logging
+import logging.handlers
+import os
+
 from django.conf import settings
 from django.core.exceptions import AppRegistryNotReady
 from django.db import Error as DatabaseError
 
 from evennia.comms.models import ChannelDB
-from evennia.utils import logger
 
 from .constants import SPLATTERCAST_CHANNEL
 
 COMBAT_AUDIT_FILENAME = "combat_audit.log"
+
+# Per-process audit logger cache (mirrors _CHANNEL_CACHE below).
+_AUDIT_LOGGER: list = []
+
+
+def _get_audit_logger():
+    """The stdlib logger writing ``combat_audit.log``.
+
+    Thread-safe (the logging module locks per handler), rotation-safe
+    (rollover happens under that same lock), and reactor-friendly: the
+    handler buffers through the OS page cache, so a write is
+    microseconds — the same synchronous discipline twisted uses for
+    server.log itself.  Rotation size follows the existing
+    CHANNEL_LOG_ROTATE_SIZE convention."""
+    if _AUDIT_LOGGER:
+        return _AUDIT_LOGGER[0]
+    log = logging.getLogger("gelatinous.combat_audit")
+    if not log.handlers:
+        handler = logging.handlers.RotatingFileHandler(
+            os.path.join(settings.LOG_DIR, COMBAT_AUDIT_FILENAME),
+            maxBytes=max(1000, getattr(settings, "CHANNEL_LOG_ROTATE_SIZE",
+                                       10_000_000)),
+            backupCount=100, encoding="utf-8")
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s [-] %(message)s", datefmt="%y-%m-%d %H:%M:%S"))
+        log.addHandler(handler)
+        log.setLevel(logging.INFO)
+        log.propagate = False
+    _AUDIT_LOGGER.append(log)
+    return log
 
 class _NullChannel:
     """No-op message sink.
@@ -89,7 +128,7 @@ class _AuditRouter:
         # break combat for players, so the (and only the) expected I/O
         # failure mode is swallowed; anything else surfaces.
         try:
-            logger.log_file(str(message), filename=COMBAT_AUDIT_FILENAME)
+            _get_audit_logger().info(str(message))
         except OSError:
             pass
         # Opt-in live mirror.  A developer who set SPLATTERCAST_LIVE is

--- a/world/medical/conditions.py
+++ b/world/medical/conditions.py
@@ -128,16 +128,12 @@ class MedicalCondition:
             return
         
         if not self.requires_ticker:
-            splattercast.msg(f"CONDITION_START: {self.condition_type} for {character.key} doesn't require ticker")
             return
             
-        splattercast.msg(f"CONDITION_START: Adding {self.condition_type} severity {self.severity} to {character.key}")
         
         # Ensure character has medical script running
         medical_script = start_medical_script(character)
-        if medical_script:
-            splattercast.msg(f"CONDITION_START: Medical script active for {character.key}")
-        else:
+        if not medical_script:
             splattercast.msg(f"CONDITION_START: Failed to start medical script for {character.key}")
             
     def tick_effect(self, character, elapsed_minutes=1.0):
@@ -296,7 +292,6 @@ class BleedingCondition(MedicalCondition):
                 clot_hazard *= 2
             if hazard_fires(clot_hazard, elapsed_minutes):
                 self.severity = max(0, self.severity - 1)
-                splattercast.msg(f"BLEEDING_HEAL: {character.key} bleeding severity reduced to {self.severity}")
 
     def _location_tourniqueted(self, medical_state) -> bool:
         """True when any organ at this location carries an applied
@@ -405,7 +400,6 @@ class PainCondition(MedicalCondition):
         # Natural pain reduction — per-minute hazard over elapsed.
         if hazard_fires(PAIN_DECAY_HAZARD_PER_MINUTE, elapsed_minutes):
             self.severity = max(0, self.severity - 1)
-            splattercast.msg(f"PAIN_HEAL: {character.key} pain severity reduced to {self.severity}")
             
         # Note: Individual pain messages removed - now handled by consolidated messaging in medical script
             
@@ -471,7 +465,6 @@ class InfectionCondition(MedicalCondition):
                 heal_hazard *= max(BLOOD_FILTRATION_HEAL_FLOOR, filtration)
             if hazard_fires(heal_hazard, elapsed_minutes):
                 self.severity = max(0, self.severity - 1)
-                splattercast.msg(f"INFECTION_HEAL: {character.key} infection severity reduced to {self.severity}")
         else:
             worsen_hazard = INFECTION_WORSEN_HAZARD_PER_MINUTE * self.environmental_modifier
             if filtration is not None:
@@ -616,7 +609,6 @@ class ConsciousnessSuppressionCondition(MedicalCondition):
             self.severity = max(0, self.severity - 1)
             # Recalculate consciousness penalty
             self.consciousness_penalty = min(1.0, self.severity * 0.15)
-            splattercast.msg(f"CONSCIOUSNESS_RECOVERY: {character.key} {self.suppression_type} severity reduced to {self.severity} (penalty: {self.consciousness_penalty:.2f})")
             
     def should_end(self):
         """Consciousness suppression ends when severity reaches 0."""

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -1080,7 +1080,6 @@ class MedicalState:
                 if character:
                     from world.combat.debug import get_splattercast
                     splattercast = get_splattercast()
-                    splattercast.msg(f"ADD_CONDITION: Starting ticker for {condition.condition_type} on {character.key}")
                     condition.start_condition(character)
                 else:
                     from world.combat.debug import get_splattercast

--- a/world/medical/script.py
+++ b/world/medical/script.py
@@ -171,7 +171,6 @@ class MedicalScript(DefaultScript):
                 self.delete()
                 return
                 
-            splattercast.msg(f"MEDICAL_SCRIPT: Processing {len(conditions)} conditions for {self.obj.key}")
             
             # Process each condition
             conditions_to_remove = []
@@ -182,7 +181,6 @@ class MedicalScript(DefaultScript):
             for condition in conditions:
                 try:
                     if hasattr(condition, 'requires_ticker') and condition.requires_ticker:
-                        splattercast.msg(f"MEDICAL_SCRIPT: Ticking {condition.condition_type} severity {condition.severity}")
                         condition.process(self.obj)
                         
                         # Track bleeding severity for consolidated messaging
@@ -200,7 +198,6 @@ class MedicalScript(DefaultScript):
                         # Check if condition should be removed (e.g., severity reached 0)
                         if hasattr(condition, 'should_end') and condition.should_end():
                             conditions_to_remove.append(condition)
-                            splattercast.msg(f"MEDICAL_SCRIPT: {condition.condition_type} marked for removal")
                             
                 except Exception as e:
                     splattercast.msg(f"MEDICAL_SCRIPT_ERROR: Error processing {condition.condition_type}: {e}")
@@ -464,32 +461,19 @@ def start_medical_script(character):
     Returns:
         MedicalScript: The active medical script
     """
-    splattercast = get_splattercast()
-    splattercast.msg(f"START_MEDICAL_SCRIPT: Checking for existing script on {character.key}")
-        
     # Don't create scripts for dead characters
     if hasattr(character, 'medical_state') and character.medical_state.is_dead():
-        splattercast = get_splattercast()
-        splattercast.msg(f"START_MEDICAL_SCRIPT: {character.key} is dead, not creating medical script")
+        get_splattercast().msg(f"START_MEDICAL_SCRIPT: {character.key} is dead, not creating medical script")
         return None
-        
+
     # Check if script already exists
     existing_script = character.scripts.get("medical_script")
     if existing_script:
-        splattercast = get_splattercast()
-        splattercast.msg(f"START_MEDICAL_SCRIPT: Found existing script for {character.key}")
         return existing_script.first() if existing_script else None
-    
+
     # Create new script
-    splattercast = get_splattercast()
-    splattercast.msg(f"START_MEDICAL_SCRIPT: Creating new script for {character.key}")
-        
-    script = character.scripts.add(MedicalScript)
-    
-    splattercast = get_splattercast()
-    splattercast.msg(f"START_MEDICAL_SCRIPT: Script created: {script}")
-        
-    return script
+    get_splattercast().msg(f"START_MEDICAL_SCRIPT: Creating new script for {character.key}")
+    return character.scripts.add(MedicalScript)
 
 
 def stop_medical_script(character):
@@ -499,17 +483,10 @@ def stop_medical_script(character):
     Args:
         character: The character to stop medical script for
     """
-    splattercast = get_splattercast()
-    splattercast.msg(f"STOP_MEDICAL_SCRIPT: Looking for medical scripts on {character.key}")
-    
     # Find and delete all medical scripts (active or stopped)
     existing_scripts = character.scripts.get("medical_script")
     if existing_scripts:
         for script in existing_scripts:
-            splattercast = get_splattercast()
-            splattercast.msg(f"STOP_MEDICAL_SCRIPT: Found script {script}, deleting it")
+            get_splattercast().msg(f"STOP_MEDICAL_SCRIPT: Deleting script for {character.key}")
             script.stop()
             script.delete()
-    else:
-        splattercast = get_splattercast()
-        splattercast.msg(f"STOP_MEDICAL_SCRIPT: No medical scripts found on {character.key}")

--- a/world/tests/test_combat_audit_sink.py
+++ b/world/tests/test_combat_audit_sink.py
@@ -1,0 +1,42 @@
+"""The combat-audit sink writes through a module-owned stdlib logger.
+
+Evennia's threaded ``logger.log_file`` recycles its cached handle every
+500th access on the reactor while queued thread writes still hold it —
+every recycle boundary silently dropped the queue (7.9k lines rendered
+as ``NoneType: None`` until #1094 unmasked it). The sink now owns a
+stdlib rotating handler: per-write locking, safe rollover, Evennia core
+untouched.
+"""
+
+import logging
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.combat.debug as dbg
+
+
+class TestAuditSink(TestCase):
+    def tearDown(self):
+        dbg._AUDIT_LOGGER.clear()
+
+    def test_msg_writes_through_the_owned_logger(self):
+        fake = MagicMock()
+        with patch.object(dbg, "_get_audit_logger", return_value=fake), \
+                patch.object(dbg, "_get_live_channel", return_value=None):
+            dbg.get_splattercast().msg("CONDITION_START: test line")
+        fake.info.assert_called_once_with("CONDITION_START: test line")
+
+    def test_logger_is_cached_and_rotating(self):
+        dbg._AUDIT_LOGGER.clear()
+        log = dbg._get_audit_logger()
+        self.assertIs(dbg._get_audit_logger(), log)     # per-process cache
+        self.assertFalse(log.propagate)                  # never up to root
+        self.assertTrue(any(
+            isinstance(h, logging.handlers.RotatingFileHandler)
+            for h in log.handlers))
+
+    def test_io_failure_never_breaks_combat(self):
+        fake = MagicMock()
+        fake.info.side_effect = OSError("disk full")
+        with patch.object(dbg, "_get_audit_logger", return_value=fake):
+            dbg.get_splattercast().msg("boom")           # must not raise


### PR DESCRIPTION
The combat-audit sink now writes through a module-owned stdlib
RotatingFileHandler: Evennia's threaded log_file recycles its cached
handle every 500th access while queued thread writes still hold it,
silently dropping the queue (the NoneType: None saga, unmasked by
1094). Medical debug loses its 16 per-tick/bookkeeping Splattercast
lines (state changes, errors, and death events stay) — ~90 percent of
audit volume. DeathProgressionScript guards its final stop/delete on
pk (corpse transition can cascade-delete the script first; the core
idiom). deploy-reload.sh recovery kills hung reload launchers too —
the rogue AMP peer behind all three 2026-07-10 wedges.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
