### PR TITLE
Doors + biometric access: the door is the exit (Closes #1108)

### DIFF
--- a/commands/CmdDoors.py
+++ b/commands/CmdDoors.py
@@ -1,0 +1,314 @@
+"""Door verbs (verticality §2.1) — all real player commands, and the
+same verbs NPCs use (the level-playing-field mandate).
+
+    open <door>     - open it (a locked door needs your sleeve granted;
+                      opening it granted UNLOCKS it for real)
+    close <door>    - shut it
+    lock <door>     - shut and seal it (granted sleeves only)
+    unlock <door>   - release the lock (granted sleeves only)
+    knock <door>    - heard on the far side, attributed by sound only
+
+Builders manage the §2.2 grant file with ``@door``:
+
+    @door <exit>                  - hang a door on an exit pair
+    @door/grant <door> = <char>   - add <char>'s sleeve to the grant file
+    @door/revoke <door> = <char>  - remove it
+    @door/list <door>             - read the grant file
+    @door/lock|unlock|open|close <door>  - force state (no sleeve check)
+"""
+
+from evennia import Command, default_cmds
+
+from world.access import is_granted, make_grant, sleeve_uid_of
+
+
+def find_door(caller, arg):
+    """A DoorExit in the caller's room matching *arg* (or the only one)."""
+    location = caller.location
+    if location is None:
+        return None
+    doors = [ex for ex in (getattr(location, "exits", None) or [])
+             if getattr(ex.db, "is_door", None) is True]
+    if not doors:
+        caller.msg("There's no door here.")
+        return None
+    arg = (arg or "").strip().lower()
+    if not arg or arg == "door":
+        if len(doors) == 1:
+            return doors[0]
+        names = ", ".join(d.key for d in doors)
+        caller.msg(f"Which door? ({names})")
+        return None
+    for door in doors:
+        names = [door.key.lower()] + [a.lower() for a in door.aliases.all()]
+        if arg in names:
+            return door
+    caller.msg(f"No door called '{arg}' here.")
+    return None
+
+
+class CmdOpenDoor(Command):
+    """
+    Open a door.
+
+    Usage:
+        open <door>
+
+    A locked door reads your sleeve: granted, it unlocks and opens;
+    otherwise the reader blinks red. With one door in the room, plain
+    ``open door`` works.
+    """
+
+    key = "open"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        door = find_door(self.caller, self.args)
+        if not door:
+            return
+        if door.is_open():
+            self.caller.msg("It's already open.")
+            return
+        if door.db.door_locked is True:
+            if not is_granted(self.caller, door.db.access_grants):
+                self.caller.msg("The reader beside the door blinks red. "
+                                "The lock holds.")
+                return
+            door._mirror(door_locked=False, door_closed=False)
+            self.caller.msg("The reader flashes green; the lock releases "
+                            "and you swing the door open.")
+        else:
+            door._mirror(door_closed=False)
+            self.caller.msg("You swing the door open.")
+        door._both_rooms_msg("The door swings open.", exclude=[self.caller])
+
+
+class CmdCloseDoor(Command):
+    """
+    Close a door.
+
+    Usage:
+        close <door>
+    """
+
+    key = "close"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        door = find_door(self.caller, self.args)
+        if not door:
+            return
+        if door.db.door_broken is True:
+            self.caller.msg("The door hangs broken; it won't close.")
+            return
+        if not door.is_open():
+            self.caller.msg("It's already closed.")
+            return
+        door._mirror(door_closed=True)
+        self.caller.msg("You pull the door shut.")
+        door._both_rooms_msg("The door swings shut.", exclude=[self.caller])
+
+
+class CmdLockDoor(Command):
+    """
+    Lock a door (closes it first if open). Granted sleeves only.
+
+    Usage:
+        lock <door>
+    """
+
+    key = "lock"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        door = find_door(self.caller, self.args)
+        if not door:
+            return
+        if door.db.door_broken is True:
+            self.caller.msg("The door hangs broken; there's nothing left "
+                            "to lock.")
+            return
+        if not is_granted(self.caller, door.db.access_grants):
+            self.caller.msg("The reader blinks red — this lock doesn't "
+                            "answer to your sleeve.")
+            return
+        if door.db.door_locked is True:
+            self.caller.msg("It's already locked.")
+            return
+        door._mirror(door_closed=True, door_locked=True)
+        self.caller.msg("The reader flashes green; the door seals with a "
+                        "solid clunk.")
+        door._both_rooms_msg("The door seals with a solid clunk.",
+                             exclude=[self.caller])
+
+
+class CmdUnlockDoor(Command):
+    """
+    Unlock a door (it stays closed). Granted sleeves only.
+
+    Usage:
+        unlock <door>
+    """
+
+    key = "unlock"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        door = find_door(self.caller, self.args)
+        if not door:
+            return
+        if door.db.door_locked is not True:
+            self.caller.msg("It isn't locked.")
+            return
+        if not is_granted(self.caller, door.db.access_grants):
+            self.caller.msg("The reader blinks red — this lock doesn't "
+                            "answer to your sleeve.")
+            return
+        door._mirror(door_locked=False)
+        self.caller.msg("The reader flashes green; the lock releases.")
+        door._both_rooms_msg("The lock releases with a click.",
+                             exclude=[self.caller])
+
+
+class CmdKnock(Command):
+    """
+    Knock on a door — heard on the far side, attributed by sound only.
+
+    Usage:
+        knock <door>
+    """
+
+    key = "knock"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        door = find_door(self.caller, self.args)
+        if not door:
+            return
+        if door.is_open():
+            self.caller.msg("It's open — just walk through.")
+            return
+        self.caller.msg("You knock on the door.")
+        if door.location:
+            door.location.msg_contents("Someone knocks on the door.",
+                                       exclude=[self.caller])
+        if door.destination:
+            door.destination.msg_contents(
+                "A knock sounds against the door.")
+
+
+class CmdDoorAdmin(default_cmds.MuxCommand):
+    """
+    Hang and administer doors (builder).
+
+    Usage:
+        @door <exit>                    - convert an exit pair into a door
+        @door/grant <door> = <char>     - add <char>'s sleeve to the grant file
+        @door/revoke <door> = <char>    - remove <char>'s sleeve
+        @door/list <door>               - read the grant file
+        @door/lock <door>               - force-lock (no sleeve check)
+        @door/unlock <door>             - force-unlock
+        @door/open <door>               - force-open
+        @door/close <door>              - force-close
+    """
+
+    key = "@door"
+    locks = "cmd:perm(Builders) or perm(Developers)"
+    help_category = "Building"
+
+    def func(self):
+        caller = self.caller
+        if not self.lhs:
+            caller.msg("Usage: @door <exit> (see help @door)")
+            return
+
+        # bare form: hang a door on an existing exit pair
+        if not self.switches:
+            ex = caller.search(self.lhs,
+                               candidates=list(caller.location.exits))
+            if not ex:
+                return
+            if getattr(ex.db, "is_door", None) is True:
+                caller.msg("That exit is already a door.")
+                return
+            back = None
+            for cand in (getattr(ex.destination, "exits", None) or []):
+                if cand.destination is caller.location:
+                    back = cand
+                    break
+            for side in filter(None, (ex, back)):
+                side.swap_typeclass("typeclasses.doors.DoorExit",
+                                    clean_attributes=False,
+                                    run_start_hooks="at_object_creation")
+            if back:
+                ex.db.door_twin = back
+                back.db.door_twin = ex
+            caller.msg(f"Door hung on {ex.key}"
+                       + (f" / {back.key} (both sides)" if back
+                          else " (WARNING: no return exit found — one-sided)")
+                       + ". It starts closed and unlocked; use "
+                         "@door/grant then lock.")
+            return
+
+        door = find_door(caller, self.lhs)
+        if not door:
+            return
+        switch = self.switches[0]
+
+        if switch in ("lock", "unlock", "open", "close"):
+            if switch == "lock":
+                door._mirror(door_closed=True, door_locked=True)
+            elif switch == "unlock":
+                door._mirror(door_locked=False)
+            elif switch == "open":
+                door._mirror(door_closed=False, door_locked=False)
+            else:
+                door._mirror(door_closed=True)
+            caller.msg(f"Door {door.key}: forced {switch}.")
+            return
+
+        if switch == "list":
+            grants = door.db.access_grants or []
+            if not grants:
+                caller.msg("Grant file: empty.")
+                return
+            lines = [f"  sleeve {g.get('sleeve', '?')[:8]}… "
+                     f"issued_by={g.get('issued_by')} until={g.get('until')}"
+                     for g in grants]
+            caller.msg("Grant file:\n" + "\n".join(lines))
+            return
+
+        if switch in ("grant", "revoke"):
+            if not self.rhs:
+                caller.msg(f"Usage: @door/{switch} <door> = <character>")
+                return
+            target = caller.search(self.rhs, global_search=True)
+            if not target:
+                return
+            uid = sleeve_uid_of(target)
+            if not uid:
+                caller.msg(f"{target.key} has no sleeve uid — nothing to "
+                           f"{switch}.")
+                return
+            grants = list(door.db.access_grants or [])
+            if switch == "grant":
+                if any(g.get("sleeve") == uid for g in grants):
+                    caller.msg(f"{target.key} is already on the grant file.")
+                    return
+                grants.append(make_grant(target, issued_by=caller.key))
+                door._mirror(access_grants=grants)
+                caller.msg(f"Granted: {target.key}'s sleeve now opens "
+                           f"{door.key}.")
+            else:
+                kept = [g for g in grants if g.get("sleeve") != uid]
+                door._mirror(access_grants=kept)
+                caller.msg(f"Revoked: {target.key}'s sleeve no longer opens "
+                           f"{door.key}.")
+            return
+
+        caller.msg(f"Unknown switch '/{switch}' (see help @door).")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -50,6 +50,8 @@ from commands.CmdExplosives import (
     CmdClearDetonator,
 )
 from commands.CmdGraffiti import CmdGraffiti, CmdPress
+from commands.CmdDoors import (CmdOpenDoor, CmdCloseDoor, CmdLockDoor,
+                               CmdUnlockDoor, CmdKnock, CmdDoorAdmin)
 from commands.CmdCharacter import CmdDescribe, CmdSkintone, CmdVoice
 from commands.CmdCharacter import CmdRemember, CmdForget, CmdRecall, CmdMemory
 from commands.CmdCommunication import (
@@ -249,6 +251,12 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         
         # Add graffiti system commands
         self.add(CmdGraffiti())
+        self.add(CmdOpenDoor())
+        self.add(CmdCloseDoor())
+        self.add(CmdLockDoor())
+        self.add(CmdUnlockDoor())
+        self.add(CmdKnock())
+        self.add(CmdDoorAdmin())
         self.add(CmdPress())
         
         # Add unified describe command (short desc + keyword + longdesc).

--- a/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
+++ b/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
@@ -141,7 +141,15 @@ special tooling.
 permanently *open* and a missing edge is permanently *barrier*; a door is an
 edge that can be **either, at runtime** — the first operable face.
 
-### 2.1 · The state model
+### 2.1 · The state model — ✅ SHIPPED 2026-07-10 (§2.1 + §2.2; the
+door IS the exit, per user call). `typeclasses/doors.py DoorExit`
+(mirrored pair, open/closed/locked, broken seam reserved), player verbs
+`open/close/lock/unlock/knock`, builder `@door` (+/grant /revoke /list
+/force), grant files in `world/access.py`, pathfinder blocked-edge
+filter live in `world/spatial/pathfind.py`, and the elevator's
+`db.floor_locks` consumes the same grant model. §2.3 sound-muffling
+awaits a cross-room sound layer (none exists yet — closed doors are
+already the gate when it lands); §2.4 breach stays reserved.
 
 `DoorExit(Exit)` with a mirrored twin (Evennia exits are one-way; a door is
 the *pair*, state shared so both sides agree):

--- a/typeclasses/doors.py
+++ b/typeclasses/doors.py
@@ -1,0 +1,133 @@
+"""Doors — the door IS the exit (verticality §2, decided 2026-07-10).
+
+A door is a mirrored PAIR of ``DoorExit``s (Evennia exits are one-way;
+the Evennia contrib door pattern shares state across the pair so both
+sides always agree). States: **open** (free traversal), **closed**
+(walking through auto-opens it), **locked** (blocked unless the
+traverser's sleeve is on the grant file — §2.2 biometric model, via
+``world.access``).
+
+Traversal through a locked door for a GRANTED sleeve is momentary:
+the reader flashes green, the door admits them, and it seals locked
+again behind — passage alone never de-secures a floor. Explicitly
+``open``-ing a locked door (granted) unlocks it for real.
+
+``door_broken`` is the §2.4 breach seam: a broken door hangs open and
+cannot close or lock (reserved; nothing sets it yet).
+
+The pathfinder consults ``door_blocks(traverser)`` so NPC dispatch
+routes around doors the NPC can't pass instead of pathing through
+walls it can't open.
+"""
+
+from typeclasses.exits import Exit
+from world.access import is_granted
+
+READER_DENIED_MSG = "The reader beside the door blinks red. The lock holds."
+DOOR_CLOSED_HINT = "You could knock."
+
+
+class DoorExit(Exit):
+    """One side of a door. State lives mirrored on both sides."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.is_door = True
+        self.db.door_closed = True     # a freshly hung door starts shut
+        self.db.door_locked = False
+        self.db.door_broken = False
+        self.db.access_grants = []     # §2.2 grant file: [{sleeve, until, issued_by}]
+        if "door" not in self.aliases.all():
+            self.aliases.add("door")
+
+    # ------------------------------------------------------------------
+    # the pair
+    # ------------------------------------------------------------------
+
+    def twin(self):
+        """The matching exit on the far side, cached after first lookup."""
+        cached = self.db.door_twin
+        if cached is not None and getattr(cached, "pk", None):
+            return cached
+        dest = self.destination
+        for ex in (getattr(dest, "exits", None) or []):
+            if (getattr(ex.db, "is_door", None) is True
+                    and ex.destination is self.location):
+                self.db.door_twin = ex
+                ex.db.door_twin = self
+                return ex
+        return None
+
+    def _mirror(self, **states):
+        """Set door state attributes on BOTH sides of the pair."""
+        sides = [self]
+        other = self.twin()
+        if other is not None:
+            sides.append(other)
+        for side in sides:
+            for key, value in states.items():
+                setattr(side.db, key, value)
+
+    # ------------------------------------------------------------------
+    # state queries
+    # ------------------------------------------------------------------
+
+    def is_open(self):
+        return self.db.door_broken is True or self.db.door_closed is not True
+
+    def is_locked_for(self, char):
+        """Locked against *char* specifically (grant file consulted)."""
+        if self.db.door_broken is True or self.db.door_locked is not True:
+            return False
+        return not is_granted(char, self.db.access_grants)
+
+    def door_blocks(self, traverser):
+        """Pathfinder hook: is this edge impassable for *traverser*?
+        Closed-but-unlocked doors don't block (traversal auto-opens);
+        only a lock the traverser's sleeve can't answer does."""
+        return self.is_locked_for(traverser)
+
+    # ------------------------------------------------------------------
+    # messaging
+    # ------------------------------------------------------------------
+
+    def _both_rooms_msg(self, text, exclude=None):
+        exclude = exclude or []
+        for room in (self.location, self.destination):
+            if room is not None:
+                room.msg_contents(text, exclude=exclude)
+
+    # ------------------------------------------------------------------
+    # traversal
+    # ------------------------------------------------------------------
+
+    def _traverse_gate(self, traversing_object):
+        """May *traversing_object* pass right now? Handles the door's
+        own state changes and messaging; returns True to proceed."""
+        if self.db.door_broken is True:
+            return True
+        if self.db.door_locked is True:
+            if is_granted(traversing_object, self.db.access_grants):
+                # momentary admission — seals locked again behind them
+                traversing_object.msg(
+                    "The reader flashes green; the lock releases just "
+                    "long enough to let you through, then seals again.")
+                self._both_rooms_msg(
+                    "The door unseals briefly to let someone through, "
+                    "then locks again.", exclude=[traversing_object])
+                return True
+            traversing_object.msg(
+                f"{READER_DENIED_MSG} {DOOR_CLOSED_HINT}")
+            return False
+        if self.db.door_closed is True:
+            # walking through an unlocked door opens it
+            self._mirror(door_closed=False)
+            traversing_object.msg("You push the door open.")
+            self._both_rooms_msg("The door swings open.",
+                                 exclude=[traversing_object])
+        return True
+
+    def at_traverse(self, traversing_object, target_location):
+        if not self._traverse_gate(traversing_object):
+            return
+        super().at_traverse(traversing_object, target_location)

--- a/typeclasses/elevator.py
+++ b/typeclasses/elevator.py
@@ -100,12 +100,31 @@ class ElevatorCar(IndoorRoom):
     # the two requests
     # ------------------------------------------------------------------
 
+    def _floor_permitted(self, idx, presser):
+        """The §2.2 biometric floor gate: ``db.floor_locks`` maps a floor
+        label to a grant file; a secured floor's button only lights for a
+        granted sleeve. Unsecured floors pass free."""
+        floors = self.db.floors or []
+        if not 0 <= idx < len(floors):
+            return False
+        locks = self.db.floor_locks or {}
+        grants = locks.get(str(floors[idx][1]))
+        if grants is None:
+            return True
+        from world.access import is_granted
+        return presser is not None and is_granted(presser, grants)
+
     def request_floor(self, label, presser=None):
         """A panel press inside the car."""
         idx = self.floor_index(label)
         if idx is None:
             if presser:
                 presser.msg("The panel has no such floor.")
+            return False
+        if not self._floor_permitted(idx, presser):
+            if presser:
+                presser.msg("The reader beside the panel blinks red. "
+                            "The button stays dark.")
             return False
         if self.db.moving:
             if presser:

--- a/world/access.py
+++ b/world/access.py
@@ -1,0 +1,59 @@
+"""Biometric access grants — everything is a file (verticality §2.2).
+
+No keys, no codes, no cards: a lock reads the presenter's SLEEVE (the
+identity spine's ``sleeve_uid``) and checks it against its **grant
+file** — a list of ``{"sleeve": uid, "until": epoch-or-None,
+"issued_by": name}`` entries stored as honest attributes on the lock
+until decking makes them hackable. The attack surface is forgery, not
+theft: present someone else's biometrics.
+
+Consumers: ``DoorExit.access_grants`` (typeclasses/doors.py) and the
+elevator's per-floor ``db.floor_locks`` (typeclasses/elevator.py).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+
+def sleeve_uid_of(char: Any) -> Optional[str]:
+    """The presenter's biometric — the sleeve's canonical uid."""
+    try:
+        return getattr(char, "sleeve_uid", None)
+    except Exception:  # noqa: BLE001 — a broken identity reads as no-match
+        return None
+
+
+def make_grant(char: Any, issued_by: Any = None,
+               until: Optional[float] = None) -> dict:
+    """A grant-file entry for *char*'s sleeve (§2.2 record shape)."""
+    return {
+        "sleeve": sleeve_uid_of(char),
+        "until": float(until) if until else None,
+        "issued_by": str(issued_by) if issued_by else None,
+    }
+
+
+def is_granted(char: Any, grants: Any) -> bool:
+    """Does *char*'s sleeve match a live entry in *grants*?
+
+    Fail-closed: no sleeve, no grants, malformed entries, expired
+    entries — all read as not granted. One bad record never grants
+    (or blocks) the rest.
+    """
+    uid = sleeve_uid_of(char)
+    if not uid or not grants:
+        return False
+    now = time.time()
+    for entry in grants:
+        try:
+            if entry.get("sleeve") != uid:
+                continue
+            until = entry.get("until")
+            if until and now > float(until):
+                continue
+            return True
+        except Exception:  # noqa: BLE001
+            continue
+    return False

--- a/world/spatial/pathfind.py
+++ b/world/spatial/pathfind.py
@@ -60,6 +60,15 @@ def _neighbors(room: Any, traverser: Any):
                     continue
             except Exception:  # noqa: BLE001 — never break routing over a lock
                 pass
+            # verticality §2.1: a locked door the traverser's sleeve can't
+            # answer is a blocked edge — dispatch routes around it
+            blocks = getattr(ex, "door_blocks", None)
+            if callable(blocks):
+                try:
+                    if blocks(traverser):
+                        continue
+                except Exception:  # noqa: BLE001
+                    pass
         yield dest, ex
 
 

--- a/world/tests/test_doors.py
+++ b/world/tests/test_doors.py
@@ -1,0 +1,170 @@
+"""Doors + biometric access (verticality §2, the door IS the exit).
+
+A door is a mirrored DoorExit pair; locked traversal is answered by the
+sleeve against the §2.2 grant file (world.access); the pathfinder treats
+locked doors as blocked edges per traverser; the elevator's floor locks
+consume the same grant model.
+"""
+
+import time
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import typeclasses.doors as dmod
+import typeclasses.elevator as emod
+from world.access import is_granted, make_grant
+
+
+def _bind(mock, cls, *names):
+    for name in names:
+        setattr(mock, name, getattr(cls, name).__get__(mock, cls))
+
+
+def _sleeve(uid):
+    char = MagicMock()
+    char.sleeve_uid = uid
+    return char
+
+
+def _door(closed=True, locked=False, grants=None, broken=False):
+    door = MagicMock()
+    door.db = SimpleNamespace(is_door=True, door_closed=closed,
+                              door_locked=locked, door_broken=broken,
+                              access_grants=grants or [], door_twin=None)
+    _bind(door, dmod.DoorExit,
+          "is_open", "is_locked_for", "door_blocks", "_traverse_gate",
+          "_mirror", "_both_rooms_msg", "twin")
+    door.destination.exits = []
+    return door
+
+
+class TestGrantFile(TestCase):
+    def test_matching_live_grant_passes(self):
+        alice = _sleeve("uid-alice")
+        grants = [make_grant(alice, issued_by="Vess")]
+        self.assertTrue(is_granted(alice, grants))
+        self.assertFalse(is_granted(_sleeve("uid-mallory"), grants))
+
+    def test_expired_grant_fails_closed(self):
+        alice = _sleeve("uid-alice")
+        stale = [make_grant(alice, until=time.time() - 10)]
+        self.assertFalse(is_granted(alice, stale))
+        live = [make_grant(alice, until=time.time() + 3600)]
+        self.assertTrue(is_granted(alice, live))
+
+    def test_no_sleeve_or_garbage_never_grants(self):
+        self.assertFalse(is_granted(_sleeve(None), [{"sleeve": None}]))
+        self.assertFalse(is_granted(_sleeve("u"), ["garbage", 42, {}]))
+        self.assertFalse(is_granted(_sleeve("u"), None))
+
+
+class TestDoorGate(TestCase):
+    def test_open_door_passes_silently(self):
+        door = _door(closed=False)
+        walker = MagicMock()
+        self.assertTrue(door._traverse_gate(walker))
+        walker.msg.assert_not_called()
+
+    def test_closed_unlocked_auto_opens_both_sides(self):
+        door = _door(closed=True)
+        twin = _door(closed=True)
+        door.db.door_twin = twin
+        twin.pk = 1
+        walker = MagicMock()
+        self.assertTrue(door._traverse_gate(walker))
+        self.assertFalse(door.db.door_closed)
+        self.assertFalse(twin.db.door_closed)          # mirrored
+        self.assertIn("push the door open", walker.msg.call_args.args[0])
+
+    def test_locked_refuses_the_ungranted(self):
+        door = _door(closed=True, locked=True,
+                     grants=[make_grant(_sleeve("uid-alice"))])
+        mallory = _sleeve("uid-mallory")
+        self.assertFalse(door._traverse_gate(mallory))
+        self.assertTrue(door.db.door_locked)           # unchanged
+        self.assertIn("blinks red", mallory.msg.call_args.args[0])
+
+    def test_locked_admits_granted_momentarily(self):
+        alice = _sleeve("uid-alice")
+        door = _door(closed=True, locked=True, grants=[make_grant(alice)])
+        self.assertTrue(door._traverse_gate(alice))
+        self.assertTrue(door.db.door_locked)           # seals again behind
+        self.assertTrue(door.db.door_closed)
+        self.assertIn("flashes green", alice.msg.call_args.args[0])
+
+    def test_broken_door_never_blocks(self):
+        door = _door(closed=True, locked=True, broken=True)
+        walker = _sleeve("uid-anyone")
+        self.assertTrue(door._traverse_gate(walker))
+        self.assertFalse(door.door_blocks(walker))
+
+
+class TestPathfinderEdges(TestCase):
+    def _room_with(self, exits):
+        room = MagicMock()
+        room.exits = exits
+        return room
+
+    def _plain_exit(self):
+        ex = MagicMock(spec=["destination", "access"])
+        ex.access.return_value = True
+        return ex
+
+    def test_locked_door_is_a_blocked_edge(self):
+        from world.spatial.pathfind import _neighbors
+        alice = _sleeve("uid-alice")
+        blocked = self._plain_exit()
+        blocked.door_blocks = MagicMock(return_value=True)
+        open_door = self._plain_exit()
+        open_door.door_blocks = MagicMock(return_value=False)
+        plain = self._plain_exit()
+        room = self._room_with([blocked, open_door, plain])
+        found = [ex for _, ex in _neighbors(room, alice)]
+        self.assertNotIn(blocked, found)
+        self.assertIn(open_door, found)
+        self.assertIn(plain, found)
+
+    def test_no_traverser_keeps_pure_connectivity(self):
+        from world.spatial.pathfind import _neighbors
+        blocked = self._plain_exit()
+        blocked.door_blocks = MagicMock(return_value=True)
+        room = self._room_with([blocked])
+        self.assertEqual(len(list(_neighbors(room, None))), 1)
+
+
+class TestElevatorFloorLock(TestCase):
+    def _car(self, locks):
+        car = MagicMock()
+        landing1, landing2 = MagicMock(), MagicMock()
+        car.db = SimpleNamespace(
+            floors=[[landing1, "1"], [landing2, "2"]], current_floor=0,
+            moving=False, target_floor=None, floor_locks=locks,
+            shaft_xy=None)
+        _bind(car, emod.ElevatorCar,
+              "floor_index", "request_floor", "_floor_permitted",
+              "_begin_move", "current_landing")
+        return car
+
+    def test_secured_floor_refuses_ungranted_sleeve(self):
+        alice = _sleeve("uid-alice")
+        car = self._car({"2": [make_grant(alice)]})
+        mallory = _sleeve("uid-mallory")
+        with patch.object(emod, "delay") as d:
+            self.assertFalse(car.request_floor("2", mallory))
+        d.assert_not_called()
+        self.assertIn("blinks red", mallory.msg.call_args.args[0])
+
+    def test_secured_floor_lights_for_granted_sleeve(self):
+        alice = _sleeve("uid-alice")
+        car = self._car({"2": [make_grant(alice)]})
+        with patch.object(emod, "delay") as d:
+            self.assertTrue(car.request_floor("2", alice))
+        d.assert_called_once()
+
+    def test_unsecured_floors_stay_free(self):
+        car = self._car({"2": [make_grant(_sleeve("uid-alice"))]})
+        car.db.current_floor = 1
+        with patch.object(emod, "delay") as d:
+            self.assertTrue(car.request_floor("1", _sleeve("uid-mallory")))
+        d.assert_called_once()


### PR DESCRIPTION
DoorExit = a mirrored exit pair sharing open/closed/locked state (the
Evennia contrib door shape, per user call). Locked traversal reads the
sleeve against the 2.2 grant file (world/access.py, fail-closed);
granted passage is momentary - the door seals locked behind; explicit
open unlocks for real. Player verbs open/close/lock/unlock/knock;
builder @door hangs doors on exit pairs and manages grants. The
pathfinder treats locked doors as blocked edges per traverser, and the
elevator's reserved floor_locks seam now consumes the same grant model.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
