### PR TITLE
Constabulary room type + institutional crowd + locale-aware sweeps (Closes #1110)

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -14,6 +14,10 @@ from world.crowd import crowd_system
 from .objects import ObjectParent
 
 
+#: Irregular plurals for the exit lister's custom room types.
+TYPE_PLURALS = {"constabulary": "constabularies"}
+
+
 class Room(ObjectParent, DefaultRoom):
     """
     Rooms are like any Object, except their location is None
@@ -944,11 +948,20 @@ class Room(ObjectParent, DefaultRoom):
         for dest_type, exits in exit_groups['custom_types'].items():
             type_dirs = [self.format_direction_with_alias(direction, alias) 
                         for direction, alias in exits]
-            if len(type_dirs) == 1:
+            if dest_type and dest_type == self.db.type:
+                # inside a same-type venue the building CONTINUES rather
+                # than re-announcing itself ("there are constabularies to
+                # the north and south" reads like three police stations)
+                type_desc = (type_dirs[0] if len(type_dirs) == 1
+                             else self.format_direction_list(type_dirs))
+                descriptions.append(
+                    f"The {dest_type} continues to the {type_desc}.")
+            elif len(type_dirs) == 1:
                 descriptions.append(f"There is a {dest_type} to the {type_dirs[0]}.")
             else:
                 type_desc = self.format_direction_list(type_dirs)
-                descriptions.append(f"There are {dest_type}s to the {type_desc}.")
+                plural = TYPE_PLURALS.get(dest_type, f"{dest_type}s")
+                descriptions.append(f"There are {plural} to the {type_desc}.")
         
         # Format edges (grouped)
         if exit_groups['edges']:
@@ -1109,6 +1122,25 @@ class AlleyRoom(Room):
         self.db.outside = True
         self.db.is_sky_room = False
         self.db.type = "alley"
+
+
+class ConstabularyRoom(Room):
+    """A room of the Colonial Constabulary — ONE type for the whole
+    building (user call 2026-07-10) so crowd flavour reads
+    institutional (queue-and-counter, not street crush) and the exit
+    prose treats the building as continuous.
+
+    Usage:
+        @tunnel north = Booking:typeclasses.rooms.ConstabularyRoom
+    """
+
+    def at_object_creation(self):
+        """Set default attributes for constabulary rooms."""
+        super().at_object_creation()
+        self.db.crowd_base_level = 1
+        self.db.outside = False
+        self.db.is_sky_room = False
+        self.db.type = "constabulary"
 
 
 class CorridorRoom(Room):

--- a/world/crowd/crowd_messages.py
+++ b/world/crowd/crowd_messages.py
@@ -562,6 +562,109 @@ CROWD_MESSAGES = {
 
 #: Dance-venue room types — the 'nightclub' pool (floor/bass/lights), a world
 #: apart from the bar-counter 'interior' pool.
+CROWD_MESSAGES['constabulary'] = {
+    'sparse': {
+        'visual': [
+            "a parolee waits under the number board, folding and refolding a summons",
+            "a clerk carries a fan of thermal-print folders from one counter to another",
+            "someone argues quietly with a counter grille and loses",
+            "a mop bucket stands mid-corridor, its owner gone official somewhere",
+        ],
+        'auditory': [
+            "a printer somewhere chews through another form",
+            "the number board clicks over for an empty bench",
+            "a bored voice reads a docket number twice, then gives up",
+        ],
+        'olfactory': [
+            "disinfectant and old paper hold the air in institutional balance",
+            "burnt coffee drifts from somewhere staff-only",
+        ],
+        'tactile': [
+            "the air sits still and processed, every draught filed away",
+            "the floor's fresh polish drags faintly underfoot",
+        ],
+        'atmospheric': [
+            "the room has the patience of a place that outlasts everyone in it",
+            "official quiet — the kind that listens back",
+            "fluorescent light flattens everything to paperwork",
+        ],
+    },
+    'moderate': {
+        'visual': [
+            "a queue shuffles forward one number at a time",
+            "somebody's guardian argues percentages with a clerk through the grille",
+            "a parolee signs in triplicate, the pen chained to the counter",
+            "a courier waits with a sealed evidence pouch and no eye contact",
+        ],
+        'auditory': [
+            "dockets are called in a flat voice that never repeats itself",
+            "a dispute at the counter rises and is stamped flat",
+            "keyboards and stamp-blocks keep an uneven office rhythm",
+        ],
+        'olfactory': [
+            "wet coats and disinfectant argue over the waiting room",
+            "somebody's contraband cigarette died recently and unrepentantly",
+        ],
+        'tactile': [
+            "elbows and folders brush past in the queue",
+            "the benches radiate the warmth of the last hundred waiters",
+        ],
+        'atmospheric': [
+            "processing hums along: names in, numbers out",
+            "everyone here is waiting on somebody official",
+            "the number board rules the room like small, slow weather",
+        ],
+    },
+    'heavy': {
+        'visual': [
+            "the benches are full and the wall is holding up the overflow",
+            "clerks triage a counter three deep in summonses",
+            "a knot of family works out whose fault the fine is, loudly",
+        ],
+        'auditory': [
+            "docket calls fight a room's worth of complaint and lose ground",
+            "somewhere in the press a child recites a case number like a rhyme",
+            "the printers have given up pretending to keep pace",
+        ],
+        'olfactory': [
+            "too many damp coats for the disinfectant to win",
+            "the sweat of long waits soaks into the old plastic seating",
+        ],
+        'tactile': [
+            "the queue compresses; strangers share elbow room and grudges",
+            "the air runs thick with radiator heat and exhaled patience",
+        ],
+        'atmospheric': [
+            "processing day: the whole district owes the counter something",
+            "tempers hold, barely, under fluorescent supervision",
+            "the room runs on the certainty that shouting changes nothing",
+        ],
+    },
+    'packed': {
+        'visual': [
+            "bodies wall-to-wall, folders held overhead like umbrellas",
+            "the number board has stopped meaning anything anyone can act on",
+            "clerks work behind lowered grilles, taking one form at a time",
+        ],
+        'auditory': [
+            "a hundred grievances merge into one institutional roar",
+            "the tannoy repeats an appeal for order nobody can hear",
+        ],
+        'olfactory': [
+            "the crush smells of wet wool, sweat, and defeated disinfectant",
+            "someone in the press has clearly been waiting since yesterday",
+        ],
+        'tactile': [
+            "the crowd moves you; queueing is now a fiction",
+            "shoulder to shoulder, folder to folder, no room to turn",
+        ],
+        'atmospheric': [
+            "the building is over capacity, enforcing calm by mass alone",
+            "riot weather, indoors, on paperwork",
+        ],
+    },
+}
+
 NIGHTCLUB_ROOM_TYPES = {'nightclub', 'club'}
 
 #: Enclosed bar/venue room types that draw on the 'interior' crowd pool rather
@@ -572,8 +675,11 @@ INTERIOR_ROOM_TYPES = {
 
 
 def crowd_profile_for_room_type(room_type):
-    """Map a ``room.type`` to a crowd profile ('default'|'interior'|'nightclub')."""
+    """Map a ``room.type`` to a crowd profile
+    ('default'|'interior'|'nightclub'|'constabulary')."""
     t = str(room_type or "").lower()
+    if t == 'constabulary':
+        return 'constabulary'
     if t in NIGHTCLUB_ROOM_TYPES:
         return 'nightclub'
     if t in INTERIOR_ROOM_TYPES:

--- a/world/crowd/crowd_system.py
+++ b/world/crowd/crowd_system.py
@@ -24,6 +24,7 @@ class CrowdSystem:
             'courier service': 0.3,
             'cube hotel': 0.1,
             'hospital': 0.7,
+            'constabulary': 0.3,
             'stairway': 0.1,
             'dead-end': -0.5,  # Can reduce crowd below base
         }

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -37,6 +37,25 @@ from world.director.travel import is_travelling, travel_to
 
 #: Seconds between heartbeat ticks (also the linger at each waypoint).
 HEARTBEAT_SECONDS = 45
+
+#: Patrol-sweep locale by room type (user note 2026-07-10: the hardcoded
+#: "across the street" read wrong indoors). Unknown types stay ambiguous.
+_SWEEP_LOCALES = {
+    "street": "across the street",
+    "intersection": "across the crossing",
+    "alley": "down the alley",
+    "corridor": "down the corridor",
+    "bridge": "along the span",
+    "sky": "across the open air",
+    "interior": "across the room",
+    "constabulary": "across the floor",
+}
+
+
+def _sweep_locale(room) -> str:
+    """The right patch of world for a sensor sweep to pan across."""
+    rtype = str(getattr(getattr(room, "db", None), "type", "") or "").lower()
+    return _SWEEP_LOCALES.get(rtype, "across its surroundings")
 #: Global script key.
 SCRIPT_KEY = "director_routines"
 
@@ -162,8 +181,8 @@ def at_waypoint(npc: Any) -> None:
                 raise_event(WorldEvent("disturbance", npc.location,
                                        severity=1, source=flagged))
             else:
-                npc.execute_cmd("emote pans a slow sensor sweep across the "
-                                "street and moves on.")
+                npc.execute_cmd("emote pans a slow sensor sweep "
+                                f"{_sweep_locale(npc.location)} and moves on.")
         except Exception:  # noqa: BLE001 — a bad sweep must not stall the beat
             pass
         return

--- a/world/tests/test_constabulary_flavor.py
+++ b/world/tests/test_constabulary_flavor.py
@@ -1,0 +1,63 @@
+"""The constabulary room type: one type for the whole building (user
+call 2026-07-10) — institutional crowd flavour, 'the building
+continues' exit prose, and locale-aware secbot sweeps."""
+
+from unittest import TestCase
+
+from world.crowd.crowd_messages import (
+    CROWD_MESSAGES, crowd_profile_for_room_type, get_crowd_messages)
+from world.crowd.crowd_system import CrowdSystem
+from world.director.routines import _sweep_locale
+from typeclasses.rooms import TYPE_PLURALS
+
+
+class _Room:
+    def __init__(self, rtype):
+        from types import SimpleNamespace
+        self.db = SimpleNamespace(type=rtype)
+
+
+class TestConstabularyCrowd(TestCase):
+    def test_type_maps_to_its_own_profile(self):
+        self.assertEqual(crowd_profile_for_room_type("constabulary"),
+                         "constabulary")
+        self.assertEqual(crowd_profile_for_room_type("street"), "default")
+        self.assertEqual(crowd_profile_for_room_type("bar"), "interior")
+
+    def test_pools_cover_every_tier_and_sense(self):
+        pools = CROWD_MESSAGES["constabulary"]
+        for tier in ("sparse", "moderate", "heavy", "packed"):
+            for sense in ("visual", "auditory", "olfactory",
+                          "tactile", "atmospheric"):
+                self.assertTrue(pools[tier][sense],
+                                f"empty pool: {tier}/{sense}")
+
+    def test_get_messages_serves_the_profile(self):
+        msgs = get_crowd_messages(2, "visual", profile="constabulary")
+        self.assertTrue(any("queue" in m or "counter" in m or "docket" in m
+                            or "parolee" in m or "grille" in m
+                            for m in msgs))
+
+    def test_type_modifier_registered(self):
+        self.assertIn("constabulary", CrowdSystem().room_type_modifiers)
+
+
+class TestSweepLocale(TestCase):
+    def test_room_type_drives_the_sweep(self):
+        self.assertEqual(_sweep_locale(_Room("street")),
+                         "across the street")
+        self.assertEqual(_sweep_locale(_Room("constabulary")),
+                         "across the floor")
+        self.assertEqual(_sweep_locale(_Room("corridor")),
+                         "down the corridor")
+
+    def test_unknown_type_stays_ambiguous(self):
+        self.assertEqual(_sweep_locale(_Room("bathysphere")),
+                         "across its surroundings")
+        self.assertEqual(_sweep_locale(None), "across its surroundings")
+
+
+class TestExitProse(TestCase):
+    def test_irregular_plural_registered(self):
+        self.assertEqual(TYPE_PLURALS.get("constabulary"),
+                         "constabularies")


### PR DESCRIPTION
One room type for the whole building (user call): ConstabularyRoom,
a dedicated crowd profile (queue-and-counter institutional flavour
across four tiers and five senses), a 0.3 type modifier, and exit
prose that lets a same-type building 'continue' rather than
re-announce itself (plus an irregular-plural map). The secbot patrol
sweep now pans across whatever the room actually is - street,
corridor, floor, span - with an ambiguous fallback, instead of
hardcoding 'across the street' indoors.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
