### PR TITLE
Exit prose respects view locks — secret exits (Closes #1112)

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -815,6 +815,21 @@ class Room(ObjectParent, DefaultRoom):
             
         return final
     
+    def _visible_exits(self, looker):
+        """Exits *looker* may see. A view-locked exit (``view:false()`` —
+        the standard secret-door mechanism, e.g. the rooftop hatch) stays
+        out of the exit prose entirely; it can still be traversed by
+        name by anyone who knows it's there."""
+        out = []
+        for ex in (self.exits or []):
+            try:
+                if not ex.access(looker, "view"):
+                    continue
+            except Exception:  # noqa: BLE001 — a broken lock stays visible
+                pass
+            out.append(ex)
+        return out
+
     def get_custom_exit_display(self, looker):
         """
         Get smart exit display using natural language based on destination room types.
@@ -825,8 +840,8 @@ class Room(ObjectParent, DefaultRoom):
         # Sky rooms don't display exits
         if self.is_sky_room:
             return ""
-            
-        exits = self.exits
+
+        exits = self._visible_exits(looker)
         if not exits:
             return ""
         

--- a/world/tests/test_constabulary_flavor.py
+++ b/world/tests/test_constabulary_flavor.py
@@ -61,3 +61,34 @@ class TestExitProse(TestCase):
     def test_irregular_plural_registered(self):
         self.assertEqual(TYPE_PLURALS.get("constabulary"),
                          "constabularies")
+
+
+class TestSecretExits(TestCase):
+    """View-locked exits stay out of the exit prose (the standard
+    Evennia secret-door mechanism; first consumer: the rooftop hatch)."""
+
+    def test_view_locked_exit_is_filtered(self):
+        from unittest.mock import MagicMock
+        from typeclasses.rooms import Room
+        room = MagicMock()
+        room._visible_exits = Room._visible_exits.__get__(room, Room)
+        visible = MagicMock()
+        visible.access.return_value = True
+        hidden = MagicMock()
+        hidden.access.return_value = False
+        room.exits = [visible, hidden]
+        looker = MagicMock()
+        result = room._visible_exits(looker)
+        self.assertIn(visible, result)
+        self.assertNotIn(hidden, result)
+        hidden.access.assert_called_with(looker, "view")
+
+    def test_broken_lock_stays_visible(self):
+        from unittest.mock import MagicMock
+        from typeclasses.rooms import Room
+        room = MagicMock()
+        room._visible_exits = Room._visible_exits.__get__(room, Room)
+        cursed = MagicMock()
+        cursed.access.side_effect = RuntimeError("lock exploded")
+        room.exits = [cursed]
+        self.assertEqual(room._visible_exits(MagicMock()), [cursed])


### PR DESCRIPTION
_visible_exits(looker) filters view-locked exits out of the custom
exit display (the standard Evennia secret-door mechanism); they stay
traversable by name. First consumer: the Constabulary rooftop hatch
into the sealed elevator shaft.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
