### PR TITLE
search finds hidden exits, per-searcher (Closes #1114)

### DIFF
--- a/commands/CmdStealth.py
+++ b/commands/CmdStealth.py
@@ -188,7 +188,9 @@ class CmdSearch(Command):
             exclude=[caller],
         )
         found_chars, found_objs = active_search(caller)
-        if not found_chars and not found_objs:
+        from world.stealth import search_hidden_exits
+        found_exits = search_hidden_exits(caller)
+        if not found_chars and not found_objs and not found_exits:
             caller.msg("You search the area and find nothing out of place.")
             return
         for char in found_chars:
@@ -204,3 +206,6 @@ class CmdSearch(Command):
                 f"You turn up {obj.get_display_name(caller)}, "
                 f"stashed out of sight."
             )
+        for ex in found_exits:
+            caller.msg(ex.db.search_found_msg
+                       or f"You uncover a hidden way out: {ex.key}.")

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -820,10 +820,14 @@ class Room(ObjectParent, DefaultRoom):
         the standard secret-door mechanism, e.g. the rooftop hatch) stays
         out of the exit prose entirely; it can still be traversed by
         name by anyone who knows it's there."""
+        try:
+            found = list(getattr(looker.db, "found_exits", None) or [])
+        except Exception:  # noqa: BLE001 — no db, no discoveries
+            found = []
         out = []
         for ex in (self.exits or []):
             try:
-                if not ex.access(looker, "view"):
+                if not ex.access(looker, "view") and ex not in found:
                     continue
             except Exception:  # noqa: BLE001 — a broken lock stays visible
                 pass

--- a/world/stealth.py
+++ b/world/stealth.py
@@ -235,6 +235,41 @@ def active_search(searcher, room=None) -> tuple:
     return found_chars, found_objs
 
 
+#: Default difficulty for finding a view-locked (secret) exit — harder
+#: than a stashed object (10): a secret door is built to stay secret.
+SECRET_EXIT_DIFFICULTY = 14
+
+
+def search_hidden_exits(searcher, room=None) -> list:
+    """The hidden-exit arm of an active search: roll (stash idiom —
+    d20 + Resonance + the search bonus) against each view-locked exit's
+    ``db.search_difficulty``. Unlike stashed objects, a found exit
+    reveals PER SEARCHER: it lands in ``searcher.db.found_exits`` and
+    only that character's exit prose gains it. Returns newly found
+    exits."""
+    room = room or searcher.location
+    if room is None:
+        return []
+    already = list(searcher.db.found_exits or [])
+    found = []
+    for ex in (getattr(room, "exits", None) or []):
+        try:
+            if ex.access(searcher, "view"):
+                continue                      # not hidden (from them)
+        except Exception:  # noqa: BLE001 — broken lock reads visible
+            continue
+        if ex in already:
+            continue
+        difficulty = int(getattr(ex.db, "search_difficulty", None)
+                         or SECRET_EXIT_DIFFICULTY)
+        if randint(1, 20) + _stat(searcher, "resonance")                 + ACTIVE_SEARCH_BONUS > difficulty:
+            already.append(ex)
+            found.append(ex)
+    if found:
+        searcher.db.found_exits = already
+    return found
+
+
 def break_stealth(char, *, quiet=False):
     """Acting loudly (speaking, attacking, walking off openly) drops the
     hidden state and makes everyone present fully aware (spec §6.4 —

--- a/world/tests/test_constabulary_flavor.py
+++ b/world/tests/test_constabulary_flavor.py
@@ -92,3 +92,83 @@ class TestSecretExits(TestCase):
         cursed.access.side_effect = RuntimeError("lock exploded")
         room.exits = [cursed]
         self.assertEqual(room._visible_exits(MagicMock()), [cursed])
+
+
+class TestSearchFindsHiddenExits(TestCase):
+    """`search` rolls against view-locked exits (stash idiom) and a
+    find is PER SEARCHER: it lands in db.found_exits and only that
+    character's exit prose gains the exit."""
+
+    def _searcher(self, found=None):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+        s = MagicMock()
+        s.db = SimpleNamespace(found_exits=list(found or []))
+        return s
+
+    def _hidden_exit(self, difficulty=None):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+        ex = MagicMock()
+        ex.access.return_value = False        # view-locked
+        ex.db = SimpleNamespace(search_difficulty=difficulty,
+                                search_found_msg=None)
+        return ex
+
+    def test_good_roll_finds_and_remembers(self):
+        from unittest.mock import MagicMock, patch
+        import world.stealth as st
+        searcher = self._searcher()
+        hatch = self._hidden_exit()
+        room = MagicMock(); room.exits = [hatch]
+        with patch.object(st, "randint", return_value=20), \
+                patch.object(st, "_stat", return_value=3):
+            found = st.search_hidden_exits(searcher, room)
+        self.assertEqual(found, [hatch])
+        self.assertIn(hatch, searcher.db.found_exits)
+
+    def test_bad_roll_finds_nothing(self):
+        from unittest.mock import MagicMock, patch
+        import world.stealth as st
+        searcher = self._searcher()
+        room = MagicMock(); room.exits = [self._hidden_exit()]
+        with patch.object(st, "randint", return_value=1), \
+                patch.object(st, "_stat", return_value=0):
+            self.assertEqual(st.search_hidden_exits(searcher, room), [])
+        self.assertEqual(searcher.db.found_exits, [])
+
+    def test_already_found_is_not_refound(self):
+        from unittest.mock import MagicMock, patch
+        import world.stealth as st
+        hatch = self._hidden_exit()
+        searcher = self._searcher(found=[hatch])
+        room = MagicMock(); room.exits = [hatch]
+        with patch.object(st, "randint", return_value=20), \
+                patch.object(st, "_stat", return_value=3):
+            self.assertEqual(st.search_hidden_exits(searcher, room), [])
+
+    def test_visible_exits_are_ignored(self):
+        from unittest.mock import MagicMock, patch
+        import world.stealth as st
+        plain = MagicMock()
+        plain.access.return_value = True
+        room = MagicMock(); room.exits = [plain]
+        with patch.object(st, "randint", return_value=20):
+            self.assertEqual(st.search_hidden_exits(self._searcher(), room),
+                             [])
+
+    def test_discovered_exit_appears_in_prose(self):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+        from typeclasses.rooms import Room
+        room = MagicMock()
+        room._visible_exits = Room._visible_exits.__get__(room, Room)
+        hidden = MagicMock()
+        hidden.access.return_value = False
+        room.exits = [hidden]
+        finder = MagicMock()
+        finder.db = SimpleNamespace(found_exits=[hidden])
+        stranger = MagicMock()
+        stranger.db = SimpleNamespace(found_exits=[])
+        self.assertIn(hidden, room._visible_exits(finder))
+        self.assertNotIn(hidden, room._visible_exits(stranger))


### PR DESCRIPTION
The active search sweeps view-locked exits with the stash roll idiom
(d20 + Resonance + bonus vs db.search_difficulty, default 14). Unlike
stashes, a found exit reveals per searcher: it joins their
db.found_exits and only their exit prose gains it — a secret door
stays secret to everyone who hasn't earned it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
