### PR TITLE
ShaftRoom: shafts carry their own building-agnostic type (Closes #1116)

### DIFF
--- a/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
+++ b/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
@@ -72,7 +72,10 @@ convenience.
      occupies — `db.shaft_xy` parks the car's grid position at
      (shaft_x, shaft_y, landing_z), never in a landing's cell. No
      pedestrian exits touch the shaft; prying the doors to reach it is
-     future B&E texture.
+     future B&E texture. Shaft rooms carry their OWN room type
+     (`ShaftRoom`, `db.type="shaft"` — decided 2026-07-10): building-
+     agnostic for every future lift, "The shaft continues down" prose,
+     and the anchor for future climb/fall/car-hazard mechanics.
   2. **The CAR** — a real room. Passengers stand in it, talk in it, fight
      in it — a moving room where scenes happen. Its single `out` exit is
      **re-pointed by the controller** to the current landing; it refuses

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -1143,6 +1143,27 @@ class AlleyRoom(Room):
         self.db.type = "alley"
 
 
+class ShaftRoom(Room):
+    """An elevator/service shaft interior — the sealed column a lift
+    car physically travels through (verticality §1.1). Building-
+    agnostic on purpose: every lift's shaft rooms take this type, so
+    prose reads "The shaft continues down" and future shaft mechanics
+    (climbing, falls, the car-arriving hazard) key off ``db.type ==
+    "shaft"`` instead of room lists. No crowd, ever.
+
+    Usage:
+        @tunnel up = Shaft (2F):typeclasses.rooms.ShaftRoom
+    """
+
+    def at_object_creation(self):
+        """Set default attributes for shaft rooms."""
+        super().at_object_creation()
+        self.db.crowd_base_level = 0
+        self.db.outside = False
+        self.db.is_sky_room = False
+        self.db.type = "shaft"
+
+
 class ConstabularyRoom(Room):
     """A room of the Colonial Constabulary — ONE type for the whole
     building (user call 2026-07-10) so crowd flavour reads

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -49,6 +49,7 @@ _SWEEP_LOCALES = {
     "sky": "across the open air",
     "interior": "across the room",
     "constabulary": "across the floor",
+    "shaft": "up the shaft",
 }
 
 

--- a/world/tests/test_constabulary_flavor.py
+++ b/world/tests/test_constabulary_flavor.py
@@ -172,3 +172,12 @@ class TestSearchFindsHiddenExits(TestCase):
         stranger.db = SimpleNamespace(found_exits=[])
         self.assertIn(hidden, room._visible_exits(finder))
         self.assertNotIn(hidden, room._visible_exits(stranger))
+
+
+class TestShaftRoomType(TestCase):
+    def test_sweep_locale(self):
+        self.assertEqual(_sweep_locale(_Room("shaft")), "up the shaft")
+
+    def test_shaft_type_has_no_crowd_modifier(self):
+        # shafts contribute nothing to crowd — absence is the contract
+        self.assertNotIn("shaft", CrowdSystem().room_type_modifiers)


### PR DESCRIPTION
Reusable by every future lift, honest prose (the shaft continues
down), and the anchor for future climb/fall/car-hazard mechanics.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
