### PR TITLE
Doors: passage requires OPEN; walking never changes state (Closes #1120)

### DIFF
--- a/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
+++ b/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
@@ -146,7 +146,9 @@ edge that can be **either, at runtime** — the first operable face.
 
 ### 2.1 · The state model — ✅ SHIPPED 2026-07-10 (§2.1 + §2.2; the
 door IS the exit, per user call). `typeclasses/doors.py DoorExit`
-(mirrored pair, open/closed/locked, broken seam reserved), player verbs
+(mirrored pair, open/closed/locked, broken seam reserved; passage
+requires the door OPEN — open/close are explicit verbs, walking never
+changes state, refined 2026-07-10 per user), player verbs
 `open/close/lock/unlock/knock`, builder `@door` (+/grant /revoke /list
 /force), grant files in `world/access.py`, pathfinder blocked-edge
 filter live in `world/spatial/pathfind.py`, and the elevator's

--- a/typeclasses/doors.py
+++ b/typeclasses/doors.py
@@ -3,14 +3,11 @@
 A door is a mirrored PAIR of ``DoorExit``s (Evennia exits are one-way;
 the Evennia contrib door pattern shares state across the pair so both
 sides always agree). States: **open** (free traversal), **closed**
-(walking through auto-opens it), **locked** (blocked unless the
-traverser's sleeve is on the grant file — §2.2 biometric model, via
-``world.access``).
-
-Traversal through a locked door for a GRANTED sleeve is momentary:
-the reader flashes green, the door admits them, and it seals locked
-again behind — passage alone never de-secures a floor. Explicitly
-``open``-ing a locked door (granted) unlocks it for real.
+and **locked** (both block passage outright). The door is a physical
+state machine, not an auth check (user call 2026-07-10): passage
+requires the door OPEN — ``open`` opens it (a locked door needs your
+sleeve granted, and opening it unlocks it), ``close`` closes it,
+``lock`` seals it, and walking never changes the state.
 
 ``door_broken`` is the §2.4 breach seam: a broken door hangs open and
 cannot close or lock (reserved; nothing sets it yet).
@@ -22,10 +19,6 @@ walls it can't open.
 
 from typeclasses.exits import Exit
 from world.access import is_granted
-
-READER_DENIED_MSG = "The reader beside the door blinks red. The lock holds."
-DOOR_CLOSED_HINT = "You could knock."
-
 
 class DoorExit(Exit):
     """One side of a door. State lives mirrored on both sides."""
@@ -83,9 +76,10 @@ class DoorExit(Exit):
 
     def door_blocks(self, traverser):
         """Pathfinder hook: is this edge impassable for *traverser*?
-        Closed-but-unlocked doors don't block (traversal auto-opens);
-        only a lock the traverser's sleeve can't answer does."""
-        return self.is_locked_for(traverser)
+        Any not-open door blocks — passage requires the door open, and
+        no NPC behaviour opens doors yet. (When granted NPCs learn the
+        open verb, this refines to a lock-vs-grant check.)"""
+        return not self.is_open()
 
     # ------------------------------------------------------------------
     # messaging
@@ -119,30 +113,17 @@ class DoorExit(Exit):
     # ------------------------------------------------------------------
 
     def _traverse_gate(self, traversing_object):
-        """May *traversing_object* pass right now? Handles the door's
-        own state changes and messaging; returns True to proceed."""
-        if self.db.door_broken is True:
+        """May *traversing_object* pass right now? Passage requires the
+        door OPEN — walking never opens, unlocks, or closes anything."""
+        if self.is_open():
             return True
         if self.db.door_locked is True:
-            if is_granted(traversing_object, self.db.access_grants):
-                # momentary admission — seals locked again behind them
-                traversing_object.msg(
-                    "The reader flashes green; the lock releases just "
-                    "long enough to let you through, then seals again.")
-                self._both_rooms_msg(
-                    "The door unseals briefly to let someone through, "
-                    "then locks again.", exclude=[traversing_object])
-                return True
             traversing_object.msg(
-                f"{READER_DENIED_MSG} {DOOR_CLOSED_HINT}")
-            return False
-        if self.db.door_closed is True:
-            # walking through an unlocked door opens it
-            self._mirror(door_closed=False)
-            traversing_object.msg("You push the door open.")
-            self._both_rooms_msg("The door swings open.",
-                                 exclude=[traversing_object])
-        return True
+                "The door is sealed. The reader beside it idles amber.")
+        else:
+            traversing_object.msg(
+                "The door is closed. You could open it.")
+        return False
 
     def at_traverse(self, traversing_object, target_location):
         if not self._traverse_gate(traversing_object):

--- a/world/tests/test_doors.py
+++ b/world/tests/test_doors.py
@@ -66,38 +66,41 @@ class TestDoorGate(TestCase):
         self.assertTrue(door._traverse_gate(walker))
         walker.msg.assert_not_called()
 
-    def test_closed_unlocked_auto_opens_both_sides(self):
+    def test_closed_door_refuses_until_opened(self):
+        # the door is a state machine: walking never opens it (user
+        # call 2026-07-10) — passage requires the open command first
         door = _door_factory(closed=True)
-        twin = _door_factory(closed=True)
-        door.db.door_twin = twin
-        twin.pk = 1
         walker = MagicMock()
-        self.assertTrue(door._traverse_gate(walker))
-        self.assertFalse(door.db.door_closed)
-        self.assertFalse(twin.db.door_closed)          # mirrored
-        self.assertIn("push the door open", walker.msg.call_args.args[0])
+        self.assertFalse(door._traverse_gate(walker))
+        self.assertTrue(door.db.door_closed)           # untouched
+        self.assertIn("closed", walker.msg.call_args.args[0])
+        self.assertIn("open it", walker.msg.call_args.args[0])
 
-    def test_locked_refuses_the_ungranted(self):
-        door = _door_factory(closed=True, locked=True,
-                     grants=[make_grant(_sleeve("uid-alice"))])
-        mallory = _sleeve("uid-mallory")
-        self.assertFalse(door._traverse_gate(mallory))
-        self.assertTrue(door.db.door_locked)           # unchanged
-        self.assertIn("blinks red", mallory.msg.call_args.args[0])
-
-    def test_locked_admits_granted_momentarily(self):
+    def test_locked_refuses_everyone_even_granted(self):
         alice = _sleeve("uid-alice")
-        door = _door_factory(closed=True, locked=True, grants=[make_grant(alice)])
-        self.assertTrue(door._traverse_gate(alice))
-        self.assertTrue(door.db.door_locked)           # seals again behind
+        door = _door_factory(closed=True, locked=True,
+                             grants=[make_grant(alice)])
+        for walker in (alice, _sleeve("uid-mallory")):
+            self.assertFalse(door._traverse_gate(walker))
+            self.assertIn("sealed", walker.msg.call_args.args[0])
+        self.assertTrue(door.db.door_locked)           # unchanged
         self.assertTrue(door.db.door_closed)
-        self.assertIn("flashes green", alice.msg.call_args.args[0])
 
     def test_broken_door_never_blocks(self):
         door = _door_factory(closed=True, locked=True, broken=True)
         walker = _sleeve("uid-anyone")
         self.assertTrue(door._traverse_gate(walker))
         self.assertFalse(door.door_blocks(walker))
+
+    def test_any_closed_door_blocks_the_pathfinder(self):
+        # no NPC behaviour opens doors yet: a not-open door is a
+        # blocked edge regardless of grants
+        alice = _sleeve("uid-alice")
+        closed = _door_factory(closed=True,
+                               grants=[make_grant(alice)])
+        self.assertTrue(closed.door_blocks(alice))
+        open_door = _door_factory(closed=False)
+        self.assertFalse(open_door.door_blocks(alice))
 
 
 class TestClosedDoorBlocksSight(TestCase):


### PR DESCRIPTION
The door is a physical state machine, not an auth check (user call):
closed blocks everyone politely, locked blocks everyone including
granted sleeves, and open is the only way through - open/close/lock
are the explicit verbs that change state. Removes auto-open-on-walk
and momentary admission; pathfinder treats any not-open door as a
blocked edge until NPCs learn the open verb. Restores the original
2.1 table.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
