### PR TITLE
Reader colors: lock flashes red; ANSI door/panel vocabulary (Closes #1122)

### DIFF
--- a/commands/CmdDoors.py
+++ b/commands/CmdDoors.py
@@ -72,11 +72,11 @@ class CmdOpenDoor(Command):
             return
         if door.db.door_locked is True:
             if not is_granted(self.caller, door.db.access_grants):
-                self.caller.msg("The reader beside the door blinks red. "
+                self.caller.msg("The reader beside the door blinks |rred|n. "
                                 "The lock holds.")
                 return
             door._mirror(door_locked=False, door_closed=False)
-            self.caller.msg("The reader flashes green; the lock releases "
+            self.caller.msg("The reader flashes |ggreen|n; the lock releases "
                             "and you swing the door open.")
         else:
             door._mirror(door_closed=False)
@@ -132,16 +132,17 @@ class CmdLockDoor(Command):
                             "to lock.")
             return
         if not is_granted(self.caller, door.db.access_grants):
-            self.caller.msg("The reader blinks red — this lock doesn't "
+            self.caller.msg("The reader blinks |rred|n — this lock doesn't "
                             "answer to your sleeve.")
             return
         if door.db.door_locked is True:
             self.caller.msg("It's already locked.")
             return
         door._mirror(door_closed=True, door_locked=True)
-        self.caller.msg("The reader flashes green; the door seals with a "
+        self.caller.msg("The reader flashes |rred|n; the door seals with a "
                         "solid clunk.")
-        door._both_rooms_msg("The door seals with a solid clunk.",
+        door._both_rooms_msg("The reader flashes |rred|n as the door seals "
+                             "with a solid clunk.",
                              exclude=[self.caller])
 
 
@@ -165,12 +166,13 @@ class CmdUnlockDoor(Command):
             self.caller.msg("It isn't locked.")
             return
         if not is_granted(self.caller, door.db.access_grants):
-            self.caller.msg("The reader blinks red — this lock doesn't "
+            self.caller.msg("The reader blinks |rred|n — this lock doesn't "
                             "answer to your sleeve.")
             return
         door._mirror(door_locked=False)
-        self.caller.msg("The reader flashes green; the lock releases.")
-        door._both_rooms_msg("The lock releases with a click.",
+        self.caller.msg("The reader flashes |ggreen|n; the lock releases.")
+        door._both_rooms_msg("The reader flashes |ggreen|n; the lock "
+                             "releases with a click.",
                              exclude=[self.caller])
 
 

--- a/typeclasses/doors.py
+++ b/typeclasses/doors.py
@@ -103,7 +103,7 @@ class DoorExit(Exit):
         desc = self.db.desc or "A solid door, built to be on the wrong side of."
         if self.db.door_locked is True:
             state = ("It is sealed; a biometric reader sits flush in the "
-                     "frame, idling amber.")
+                     "frame, idling |yamber|n.")
         else:
             state = "It is closed."
         return f"{desc} {state}"
@@ -119,7 +119,7 @@ class DoorExit(Exit):
             return True
         if self.db.door_locked is True:
             traversing_object.msg(
-                "The door is sealed. The reader beside it idles amber.")
+                "The door is sealed. The reader beside it idles |yamber|n.")
         else:
             traversing_object.msg(
                 "The door is closed. You could open it.")

--- a/typeclasses/elevator.py
+++ b/typeclasses/elevator.py
@@ -123,7 +123,7 @@ class ElevatorCar(IndoorRoom):
             return False
         if not self._floor_permitted(idx, presser):
             if presser:
-                presser.msg("The reader beside the panel blinks red. "
+                presser.msg("The reader beside the panel blinks |rred|n. "
                             "The button stays dark.")
             return False
         if self.db.moving:

--- a/world/tests/test_doors.py
+++ b/world/tests/test_doors.py
@@ -183,7 +183,7 @@ class TestElevatorFloorLock(TestCase):
         with patch.object(emod, "delay") as d:
             self.assertFalse(car.request_floor("2", mallory))
         d.assert_not_called()
-        self.assertIn("blinks red", mallory.msg.call_args.args[0])
+        self.assertIn("blinks |rred|n", mallory.msg.call_args.args[0])
 
     def test_secured_floor_lights_for_granted_sleeve(self):
         alice = _sleeve("uid-alice")


### PR DESCRIPTION
Green = grant, red = seal and denial, amber = idle. Locking a door
flashed green (wrong signal, playtest catch); the whole reader
vocabulary is now colored consistently across door verbs, the sealed
appearance, the walk refusal, and the elevator panel denial.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
