### PR TITLE
Dispatch transmission mast: the first antenna (Closes #1124)

### DIFF
--- a/typeclasses/items.py
+++ b/typeclasses/items.py
@@ -859,6 +859,12 @@ class DispatchConsole(Radio):
             line = " ".join(str(line).split())[:200]
             if not line or not is_powered(self):
                 return
+            # the transmission mast (roof antenna) is part of the voice:
+            # linked and wrecked = no carrier, honestly (sabotage seam)
+            antenna = self.db.antenna
+            if antenna is not None and getattr(
+                    getattr(antenna, "db", None), "intact", None) is not True:
+                return
             who = speaker if speaker is not None else self._operator()
             if who is not None:
                 try:

--- a/world/director/population.py
+++ b/world/director/population.py
@@ -353,6 +353,10 @@ def get_base_station() -> Any | None:
     for obj in base.contents:
         if (getattr(getattr(obj, "db", None), "is_base_station", None) is True
                 and is_radio(obj) and is_powered(obj)):
+            antenna = getattr(obj.db, "antenna", None)
+            if antenna is not None and getattr(
+                    getattr(antenna, "db", None), "intact", None) is not True:
+                return None   # mast down = dispatch has no voice
             return obj
     return None
 

--- a/world/tests/test_director_population.py
+++ b/world/tests/test_director_population.py
@@ -306,3 +306,45 @@ class TestDispatchRoomDesignation(TestCase):
                                                 category="director")
         new.tags.add.assert_called_once_with(DISPATCH_TAG,
                                              category="director")
+
+
+class TestDispatchAntenna(TestCase):
+    """The transmission mast is part of dispatch's voice: a linked,
+    wrecked antenna silences the station (first antenna in the game —
+    the roof sabotage seam). No linked antenna = old behaviour."""
+
+    def _station(self, antenna=None):
+        s = MagicMock()
+        s.db = SimpleNamespace(is_base_station=True, is_radio=True,
+                               radio_on=True, frequency="911MHz",
+                               antenna=antenna)
+        return s
+
+    def _antenna(self, intact=True):
+        a = MagicMock()
+        a.db = SimpleNamespace(intact=intact, dispatch_antenna=True)
+        return a
+
+    @patch("world.director.population.get_dispatch_room")
+    def test_intact_mast_keeps_the_voice(self, mock_room):
+        from world.director.population import get_base_station
+        station = self._station(antenna=self._antenna(intact=True))
+        base = MagicMock(); base.contents = [station]
+        mock_room.return_value = base
+        self.assertIs(get_base_station(), station)
+
+    @patch("world.director.population.get_dispatch_room")
+    def test_wrecked_mast_silences_dispatch(self, mock_room):
+        from world.director.population import get_base_station
+        station = self._station(antenna=self._antenna(intact=False))
+        base = MagicMock(); base.contents = [station]
+        mock_room.return_value = base
+        self.assertIsNone(get_base_station())
+
+    @patch("world.director.population.get_dispatch_room")
+    def test_no_mast_linked_is_old_behaviour(self, mock_room):
+        from world.director.population import get_base_station
+        station = self._station(antenna=None)
+        base = MagicMock(); base.contents = [station]
+        mock_room.return_value = base
+        self.assertIs(get_base_station(), station)


### PR DESCRIPTION
The console's voice depends on its linked roof mast: wrecked antenna
= no carrier at both transmit paths (station lookup for acks, console
answer path). Unlinked consoles keep old behaviour. The secret-hatch
roof chain gains a live objective; the intact flag awaits the 2.4
breach mechanic for its in-game attack path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
