### PR TITLE
Grenade fuses survive reloads (Closes #505)

### DIFF
--- a/commands/CmdExplosives.py
+++ b/commands/CmdExplosives.py
@@ -506,6 +506,10 @@ class CmdDefuse(Command):
         # Clear countdown state
         setattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0)
         grenade.db.pin_pulled = False  # Grenade is now safe
+        try:
+            grenade.attributes.remove("detonation_deadline")  # #505
+        except Exception:  # noqa: BLE001
+            pass
 
         # Clean up rigging if this was a rigged grenade
         self.cleanup_rigging(grenade)
@@ -667,6 +671,10 @@ class CmdDefuse(Command):
             # Check dud chance
             dud_chance = grenade.db.dud_chance if grenade.db.dud_chance is not None else 0.0
             if random.random() < dud_chance:
+                try:
+                    grenade.attributes.remove("detonation_deadline")
+                except Exception:  # noqa: BLE001 — #505 dud fuse is spent
+                    pass
                 if grenade.location:
                     grenade.location.msg_contents(MSG_GRENADE_DUD_ROOM.format(grenade=grenade.key))
                 return

--- a/commands/explosion_utils.py
+++ b/commands/explosion_utils.py
@@ -177,6 +177,12 @@ def check_rigged_grenade(character, exit_obj):
             # Check dud chance
             dud_chance = rigged_grenade.db.dud_chance if rigged_grenade.db.dud_chance is not None else 0.0
             if random.random() < dud_chance:
+                # #505: a dud's fuse is spent — drop the deadline
+                # or the reload sweep would cook it off again
+                try:
+                    rigged_grenade.attributes.remove('detonation_deadline')
+                except Exception:  # noqa: BLE001
+                    pass
                 if rigged_grenade.location:
                     rigged_grenade.location.msg_contents(MSG_GRENADE_DUD_ROOM.format(grenade=rigged_grenade.key))
                 return
@@ -283,6 +289,15 @@ def check_rigged_grenade(character, exit_obj):
 
 def start_standalone_grenade_ticker(grenade, explosion_callback=None):
     """Start a countdown ticker for grenades outside of CmdPull context."""
+    # #505: persist the DEADLINE — the per-second delay chain dies on
+    # reload, but the timestamp survives for the at_server_start sweep.
+    try:
+        import time as _time
+        _remaining = getattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0) or 0
+        grenade.db.detonation_deadline = _time.time() + float(_remaining)
+    except Exception:  # noqa: BLE001 — a stampless fuse still ticks live
+        pass
+
     def tick():
         try:
             # Check if grenade still exists and has countdown
@@ -362,6 +377,15 @@ def start_grenade_ticker(grenade):
     armor.  Candidates for unification once behavior requirements
     converge.
     """
+    # #505: persist the DEADLINE — the per-second delay chain dies on
+    # reload, but the timestamp survives for the at_server_start sweep.
+    try:
+        import time as _time
+        _remaining = getattr(grenade.ndb, NDB_COUNTDOWN_REMAINING, 0) or 0
+        grenade.db.detonation_deadline = _time.time() + float(_remaining)
+    except Exception:  # noqa: BLE001 — a stampless fuse still ticks live
+        pass
+
     def tick():
         try:
             # Check if grenade still exists and has countdown
@@ -506,6 +530,12 @@ def explode_standalone_grenade(grenade):
         dud_chance = grenade.db.dud_chance if grenade.db.dud_chance is not None else 0.0
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Dud chance: {dud_chance}")
         if random.random() < dud_chance:
+            # #505: a dud's fuse is spent — drop the deadline
+            # or the reload sweep would cook it off again
+            try:
+                grenade.attributes.remove('detonation_deadline')
+            except Exception:  # noqa: BLE001
+                pass
             splattercast.msg(f"{DEBUG_PREFIX_THROW}_DEBUG: Grenade {grenade} is a dud")
             if grenade.location:
                 grenade.location.msg_contents(MSG_GRENADE_DUD_ROOM.format(grenade=grenade.key))
@@ -677,6 +707,39 @@ def explode_standalone_grenade(grenade):
         splattercast = get_splattercast()
         splattercast.msg(f"{DEBUG_PREFIX_THROW}_ERROR: Error in explode_standalone_grenade: {e}")
         raise
+
+
+def sweep_armed_grenades():
+    """#505: fuses don't survive a reload — the per-second utils.delay
+    chains die with the process, freezing armed grenades mid-fuse (and
+    a frozen countdown reads as 'explodes in hand when thrown'). The
+    ticker starters persist ``db.detonation_deadline``; this
+    at_server_start sweep re-arms live fuses at their true remaining
+    time and cooks off overdue ones a beat after start (so the world
+    is fully loaded when the blast resolves). Returns
+    (rearmed, detonated)."""
+    import time as _time
+    from evennia.objects.models import ObjectDB
+    rearmed = detonated = 0
+    for obj in ObjectDB.objects.filter(
+            db_attributes__db_key="detonation_deadline").distinct():
+        try:
+            if obj.db.pin_pulled is not True:
+                obj.attributes.remove("detonation_deadline")
+                continue
+            remaining = float(obj.db.detonation_deadline or 0) - _time.time()
+            if remaining > 0:
+                setattr(obj.ndb, NDB_COUNTDOWN_REMAINING,
+                        max(1, int(remaining)))
+                start_standalone_grenade_ticker(obj)
+                rearmed += 1
+            else:
+                setattr(obj.ndb, NDB_COUNTDOWN_REMAINING, 0)
+                utils.delay(2, explode_standalone_grenade, obj)
+                detonated += 1
+        except Exception:  # noqa: BLE001 — one bad grenade never stops the sweep
+            continue
+    return rearmed, detonated
 
 
 def check_auto_defuse(character):
@@ -872,6 +935,12 @@ def trigger_auto_defuse_explosion(grenade):
         # Check dud chance
         dud_chance = grenade.db.dud_chance if grenade.db.dud_chance is not None else 0.0
         if random.random() < dud_chance:
+            # #505: a dud's fuse is spent — drop the deadline
+            # or the reload sweep would cook it off again
+            try:
+                grenade.attributes.remove('detonation_deadline')
+            except Exception:  # noqa: BLE001
+                pass
             if grenade.location:
                 grenade.location.msg_contents(MSG_GRENADE_DUD_ROOM.format(grenade=grenade.key))
             return

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -30,7 +30,17 @@ def at_server_start():
     This is called every time the server starts up, regardless of
     how it was shut down.
     """
-    pass
+    # #505: re-arm or cook off grenade fuses that crossed the reload
+    try:
+        from commands.explosion_utils import sweep_armed_grenades
+        rearmed, detonated = sweep_armed_grenades()
+        if rearmed or detonated:
+            from evennia.utils import logger
+            logger.log_info(f"Grenade fuse sweep: {rearmed} re-armed, "
+                            f"{detonated} overdue (detonating).")
+    except Exception:  # noqa: BLE001 — a broken sweep must not stop the boot
+        from evennia.utils import logger
+        logger.log_trace("Grenade fuse sweep failed.")
 
 
 def at_server_stop():

--- a/world/combat/constants.py
+++ b/world/combat/constants.py
@@ -278,6 +278,9 @@ NDB_SKIP_ROUND = "skip_combat_round"
 
 # Charge system fields (temporary states)
 NDB_CHARGE_BONUS = "charge_attack_bonus_active"
+#: #306 — set on a failed charge; the next attack the charger must
+#: dodge finds them off-balance (one-shot, consumed in attack.py).
+NDB_CHARGE_PENALTY = "charge_penalty"
 NDB_CHARGE_VULNERABILITY = "charging_vulnerability_active"
 
 # Aiming state fields
@@ -378,6 +381,10 @@ DB_REQUIRES_PIN = "requires_pin"
 DB_DUD_CHANCE = "dud_chance"
 DB_BLAST_RADIUS = "blast_radius"
 DB_PIN_PULLED = "pin_pulled"
+#: #505 — the PERSISTED detonation deadline (epoch seconds). ndb fuse
+#: chains die on reload; this survives, and the at_server_start sweep
+#: re-arms live fuses / cooks off overdue ones from it.
+DB_DETONATION_DEADLINE = "detonation_deadline"
 
 # Exit properties
 DB_IS_EDGE = "is_edge"

--- a/world/tests/test_grenade_fuse_persistence.py
+++ b/world/tests/test_grenade_fuse_persistence.py
@@ -1,0 +1,87 @@
+"""Grenade fuses survive reloads (#505).
+
+The per-second delay chains die with the process; the ticker starters
+persist ``db.detonation_deadline`` and the at_server_start sweep
+re-arms live fuses / cooks off overdue ones. Duds and defuses drop
+the deadline so a reload never re-detonates a spent grenade.
+"""
+
+import time
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import commands.explosion_utils as xu
+
+
+def _grenade(pin_pulled=True, deadline=None):
+    g = MagicMock()
+    g.db = SimpleNamespace(pin_pulled=pin_pulled,
+                           detonation_deadline=deadline)
+    g.ndb = SimpleNamespace()
+    return g
+
+
+class TestFuseSweep(TestCase):
+    def _sweep_with(self, grenades):
+        mock_qs = MagicMock()
+        mock_qs.distinct.return_value = grenades
+        with patch("evennia.objects.models.ObjectDB") as db, \
+                patch.object(xu, "start_standalone_grenade_ticker") as tick, \
+                patch.object(xu.utils, "delay") as delay:
+            db.objects.filter.return_value = mock_qs
+            result = xu.sweep_armed_grenades()
+        return result, tick, delay
+
+    def test_live_fuse_rearms_at_true_remaining(self):
+        g = _grenade(deadline=time.time() + 8)
+        (rearmed, detonated), tick, delay = self._sweep_with([g])
+        self.assertEqual((rearmed, detonated), (1, 0))
+        tick.assert_called_once_with(g)
+        self.assertIn(g.ndb.countdown_remaining, (7, 8))
+        delay.assert_not_called()
+
+    def test_overdue_fuse_cooks_off_after_start(self):
+        g = _grenade(deadline=time.time() - 30)
+        (rearmed, detonated), tick, delay = self._sweep_with([g])
+        self.assertEqual((rearmed, detonated), (0, 1))
+        tick.assert_not_called()
+        delay.assert_called_once_with(2, xu.explode_standalone_grenade, g)
+
+    def test_defused_before_reload_is_left_alone(self):
+        g = _grenade(pin_pulled=False, deadline=time.time() + 5)
+        (rearmed, detonated), tick, delay = self._sweep_with([g])
+        self.assertEqual((rearmed, detonated), (0, 0))
+        g.attributes.remove.assert_called_once_with("detonation_deadline")
+        tick.assert_not_called()
+
+    def test_one_bad_grenade_never_stops_the_sweep(self):
+        cursed = MagicMock()
+        cursed.db = property(lambda s: (_ for _ in ()).throw(RuntimeError))
+        good = _grenade(deadline=time.time() + 5)
+        (rearmed, _), tick, _ = self._sweep_with([cursed, good])
+        self.assertEqual(rearmed, 1)
+
+
+class TestDeadlineStamp(TestCase):
+    def test_standalone_ticker_stamps_the_deadline(self):
+        g = _grenade()
+        g.ndb.countdown_remaining = 6
+        before = time.time()
+        with patch.object(xu.utils, "delay"), \
+                patch.object(xu, "get_splattercast",
+                             return_value=MagicMock()):
+            xu.start_standalone_grenade_ticker(g)
+        self.assertAlmostEqual(g.db.detonation_deadline, before + 6,
+                               delta=2)
+
+    def test_sticky_ticker_stamps_the_deadline(self):
+        g = _grenade()
+        g.ndb.countdown_remaining = 4
+        before = time.time()
+        with patch.object(xu.utils, "delay"), \
+                patch.object(xu, "get_splattercast",
+                             return_value=MagicMock()):
+            xu.start_grenade_ticker(g)
+        self.assertAlmostEqual(g.db.detonation_deadline, before + 4,
+                               delta=2)


### PR DESCRIPTION
Both ticker starters persist db.detonation_deadline; the
at_server_start sweep re-arms live fuses at their true remaining time
and cooks off overdue ones a beat after boot. Duds and defuses drop
the deadline so a reload never re-detonates a spent grenade; stale
deadlines on unpulled grenades are cleaned. A reload can no longer
freeze an armed grenade into a throw-trap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
