### PR TITLE
Combat: charge penalty bites; combatants exit visibly (Closes #306)

### DIFF
--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -19,9 +19,27 @@ from world.combat.capacity import (
 )
 from world.medical.utils import select_hit_location, select_target_organ
 
+
+def _consume_charge_penalty(target):
+    """One-shot dodge multiplier for a failed charge (#306): 0.5 while
+    the off-balance flag is set (consumed on read), 1.0 otherwise."""
+    if getattr(getattr(target, "ndb", None), NDB_CHARGE_PENALTY,
+               None) is not True:
+        return 1.0
+    try:
+        delattr(target.ndb, NDB_CHARGE_PENALTY)
+    except Exception:  # noqa: BLE001 — the penalty still applies this once
+        pass
+    try:
+        target.msg("|rStill off-balance from your failed charge, you "
+                   "struggle to evade!|n")
+    except Exception:  # noqa: BLE001
+        pass
+    return 0.5
+
 from .constants import (
     DB_CHAR, DB_IS_YIELDING,
-    NDB_CHARGE_BONUS,
+    NDB_CHARGE_BONUS, NDB_CHARGE_PENALTY,
     NDB_PROXIMITY,
     WEAPON_TYPE_UNARMED,
     STAGGER_DELAY_INTERVAL, MAX_STAGGER_DELAY,
@@ -435,6 +453,16 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
         splattercast.msg(
             f"DODGE_MOVING: {target.key} moving factor {moving_factor:.2f} — "
             f"motorics {target_skill} -> {effective_dodge:.1f}"
+        )
+
+    # A failed charge leaves you off-balance (#306): the next attack you
+    # must dodge finds you overextended. One-shot — consumed on read.
+    penalty_factor = _consume_charge_penalty(target)
+    if penalty_factor < 1.0:
+        effective_dodge *= penalty_factor
+        splattercast.msg(
+            f"DODGE_CHARGE_PENALTY: {target.key} off-balance — dodge "
+            f"halved to {effective_dodge:.1f}"
         )
 
     # Roll for attack

--- a/world/combat/movement_resolution.py
+++ b/world/combat/movement_resolution.py
@@ -850,9 +850,8 @@ def _resolve_charge_same_room(
                 f"attack triggered."
             )
 
-        # Apply charge failure penalty
-        # TODO: charge_penalty is set but never read — implement penalty
-        # mechanic (e.g., reduced dodge or accuracy next round) or remove
+        # Apply charge failure penalty — consumed by attack.py as a
+        # one-shot halved dodge on the next attack against them (#306)
         char.ndb.charge_penalty = True
         char.msg("|rYour failed charge leaves you off-balance!|n")
         splattercast.msg(
@@ -1016,8 +1015,7 @@ def _resolve_charge_cross_room(
                 f"cross-room charge on {target.key}."
             )
 
-        # Apply charge failure penalty
-        # TODO: charge_penalty is set but never read — implement penalty
-        # mechanic (e.g., reduced dodge or accuracy next round) or remove
+        # Apply charge failure penalty — consumed by attack.py as a
+        # one-shot halved dodge on the next attack against them (#306)
         char.ndb.charge_penalty = True
         char.msg("|rYour failed charge leaves you off-balance!|n")

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -830,7 +830,26 @@ def remove_combatant(handler, char):
         splattercast.msg("RMV_COMB: Updated database directly")
     
     splattercast.msg(f"{char.key} removed from combat.")
-    # TODO: Add narrative combat exit message (weapon lowering, stepping back, etc.)
+    # Narrative exit (#306): the fight visibly lets go of them — but only
+    # if they're leaving on their feet (the dead and unconscious have
+    # their own exits).
+    try:
+        alive = not (callable(getattr(char, "is_dead", None))
+                     and char.is_dead())
+        conscious = not (callable(getattr(char, "is_unconscious", None))
+                         and char.is_unconscious())
+        if alive and conscious and getattr(char, "location", None):
+            from world.identity_utils import msg_room_identity
+            msg_room_identity(
+                location=char.location,
+                template="{actor} lowers their guard and steps back "
+                         "from the fight.",
+                char_refs={"actor": char},
+                exclude=[char],
+            )
+            char.msg("You lower your guard and step back from the fight.")
+    except Exception:  # noqa: BLE001 — flavour never blocks the removal
+        pass
     
     # Stop combat if no combatants remain
     if len(combatants) == 0:

--- a/world/tests/test_combat_todos.py
+++ b/world/tests/test_combat_todos.py
@@ -1,0 +1,72 @@
+"""Issue #306: the charge penalty finally bites, and combatants leave
+the fight with a visible exit."""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from world.combat.attack import _consume_charge_penalty
+
+
+class TestChargePenalty(TestCase):
+    def _char(self, flagged=True):
+        c = MagicMock()
+        c.ndb = SimpleNamespace()
+        if flagged:
+            c.ndb.charge_penalty = True
+        return c
+
+    def test_off_balance_halves_dodge_once(self):
+        char = self._char()
+        self.assertEqual(_consume_charge_penalty(char), 0.5)
+        self.assertFalse(hasattr(char.ndb, "charge_penalty"))  # consumed
+        self.assertEqual(_consume_charge_penalty(char), 1.0)   # one-shot
+        self.assertIn("off-balance", char.msg.call_args_list[0].args[0])
+
+    def test_unflagged_pays_nothing(self):
+        char = self._char(flagged=False)
+        self.assertEqual(_consume_charge_penalty(char), 1.0)
+        char.msg.assert_not_called()
+
+    def test_magic_mock_truthiness_guard(self):
+        # a bare MagicMock ndb attr must not read as flagged
+        char = MagicMock()
+        self.assertEqual(_consume_charge_penalty(char), 1.0)
+
+
+class TestCombatExitNarrative(TestCase):
+    def _leaver(self, dead=False, unconscious=False):
+        char = MagicMock()
+        char.is_dead.return_value = dead
+        char.is_unconscious.return_value = unconscious
+        char.location = MagicMock()
+        return char
+
+    def _remove(self, char):
+        from world.combat.constants import DB_CHAR
+        from world.combat.utils import remove_combatant
+        handler = MagicMock()
+        handler._active_combatants_list = None
+        handler.db.combatants = [{DB_CHAR: char}]
+        with patch("world.identity_utils.msg_room_identity") as broadcast, \
+                patch("world.combat.utils.get_splattercast",
+                      return_value=MagicMock()), \
+                patch("world.combat.utils.cleanup_combatant_state"):
+            remove_combatant(handler, char)
+        return broadcast
+
+    def test_walking_out_is_visible(self):
+        char = self._leaver()
+        broadcast = self._remove(char)
+        broadcast.assert_called_once()
+        self.assertIn("lowers their guard",
+                      broadcast.call_args.kwargs["template"])
+        self.assertIn("step back", char.msg.call_args.args[0])
+
+    def test_the_dead_do_not_lower_their_guard(self):
+        broadcast = self._remove(self._leaver(dead=True))
+        broadcast.assert_not_called()
+
+    def test_the_unconscious_do_not_either(self):
+        broadcast = self._remove(self._leaver(unconscious=True))
+        broadcast.assert_not_called()


### PR DESCRIPTION
A failed charge's off-balance flag is finally consumed: the next
attack the charger must dodge finds their effective dodge halved
(one-shot, MagicMock-truthiness-guarded). And leaving combat on your
feet is visible now - 'lowers their guard and steps back from the
fight' through the identity broadcast; the dead and unconscious keep
their own exits.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
