### PR TITLE
NPC perception of combat: witness-testimony beats (#954, combat slice)

### DIFF
--- a/world/combat/attack.py
+++ b/world/combat/attack.py
@@ -511,6 +511,20 @@ def process_attack(handler, attacker, target, attacker_entry, combatants_list):
         f"{target.key} (roll {target_roll}) with {weapon_name}"
     )
 
+    # NPC perception (#954): being attacked is personal — an LLM target
+    # buffers every swing against it (bystanders get the join/exit/end
+    # summary beats instead). Observe-only; resolution untouched.
+    if getattr(getattr(target, "db", None), "llm_driven", None) is True:
+        try:
+            from world.llm.observation import personal_attack_line
+            line = personal_attack_line(
+                attacker, target, weapon_name,
+                hit=attacker_roll > target_roll)
+            if line and callable(getattr(target, "_observe_action", None)):
+                target._observe_action(attacker, line)
+        except Exception:  # noqa: BLE001 — perception never breaks combat
+            pass
+
     if attacker_roll > target_roll:
         # Hit — calculate damage
         # NOTE: Strict > means ties favor the defender. This is intentional.

--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -248,6 +248,15 @@ class CombatHandler(DefaultScript):
         # 2. Handler was created but never saved to database
         if not self.pk or not self.id:
             return
+
+        # NPC perception (#954): closure for bystander brains
+        try:
+            from world.llm.observation import observe_event
+            observe_event(self.obj,
+                          lambda observer: "The fight breaks off.",
+                          sound="the sounds of fighting die down")
+        except Exception:  # noqa: BLE001 — perception never breaks combat
+            pass
         
         splattercast = get_splattercast()
         

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -535,6 +535,17 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
         initial_grappled_by: Optional character grappling this char initially
         initial_is_yielding: Whether the character starts yielding
     """
+    # NPC perception (#954): bystander LLM brains learn who started on
+    # whom — observe-only, exception-contained, resolution untouched.
+    try:
+        from world.llm.observation import combat_join_line, observe_event
+        observe_event(getattr(char, "location", None),
+                      combat_join_line(char, target),
+                      sound="sudden violence erupts nearby",
+                      exclude=(char, target))
+    except Exception:  # noqa: BLE001 — perception never breaks combat
+        pass
+
     # BREAKING (CHANNELED_ACTIONS_SPEC §2.3): entering combat ends a
     # channel, even before the first hit lands.
     try:
@@ -838,6 +849,18 @@ def remove_combatant(handler, char):
                      and char.is_dead())
         conscious = not (callable(getattr(char, "is_unconscious", None))
                          and char.is_unconscious())
+        # NPC perception (#954): bystander brains remember how they left
+        try:
+            from world.llm.observation import combat_exit_line, observe_event
+            state = ("dead" if not alive
+                     else "unconscious" if not conscious else "walked")
+            observe_event(getattr(char, "location", None),
+                          combat_exit_line(char, state),
+                          sound=(None if state == "walked"
+                                 else "a body hits the floor nearby"),
+                          exclude=(char,))
+        except Exception:  # noqa: BLE001
+            pass
         if alive and conscious and getattr(char, "location", None):
             from world.identity_utils import msg_room_identity
             msg_room_identity(

--- a/world/llm/observation.py
+++ b/world/llm/observation.py
@@ -1,0 +1,117 @@
+"""Third-party event perception for LLM NPCs (#954, combat-first slice).
+
+LLM NPCs perceive speech and poses; everything else in a room — combat
+above all — broadcasts through ``msg_room_identity``, whose perf gate
+deliberately skips session-less observers (#462). That gate's design
+note points here: hook the ACTION SOURCE, not the broadcast.
+
+``observe_event`` renders ONE summary line per significant event into
+each LLM-driven bystander's action buffer (the same ``[RECENTLY]``
+rails poses ride): a reactor-side string append — no LLM call, no DB
+write, no change to resolution or player-facing messages. Latency
+shapes the design: a model turn runs far longer than a combat round,
+so events are MEMORY expressed at the next social beat, never
+combat-time reactions.
+
+The best-practice contract this module keeps:
+
+* **Deterministic layer stays authoritative** — taps are observe-only
+  and exception-contained (#469 pattern: flavour never breaks combat).
+* **Perceived identity** — every line renders per observer via
+  ``get_display_name`` (a stranger is "a wiry man", never their key).
+* **Perception-gated** — the sighted get the scene, the blind get the
+  sound of it (when the event has one), the deaf-and-blind get
+  nothing (five-senses rails).
+* **Strict truthiness** — ``db.llm_driven is True`` (mock discipline).
+"""
+
+from __future__ import annotations
+
+
+def observe_event(location, render, *, sound=None, exclude=()):
+    """Buffer a perceived event for every LLM-driven observer here.
+
+    Args:
+        location: the room the event happens in.
+        render (callable): ``render(observer) -> str|None`` — the line a
+            SIGHTED observer buffers, rendered from their point of view.
+        sound (str): what a blind-but-hearing observer gets instead
+            (``None`` = the event is sight-only).
+        exclude: participants who already know (the doer; a target that
+            received its own personal line).
+    """
+    if location is None or not callable(render):
+        return
+    try:
+        contents = list(getattr(location, "contents", None) or [])
+    except Exception:  # noqa: BLE001 — a broken room observes nothing
+        return
+    from world.perception import can_hear, can_see
+    for observer in contents:
+        try:
+            if observer in exclude:
+                continue
+            if getattr(getattr(observer, "db", None), "llm_driven",
+                       None) is not True:
+                continue
+            buffer = getattr(observer, "_observe_action", None)
+            if not callable(buffer):
+                continue
+            line = None
+            if can_see(observer):
+                line = render(observer)
+            elif sound and can_hear(observer):
+                line = sound
+            if line:
+                buffer(None, line)
+        except Exception:  # noqa: BLE001 — one odd bystander never
+            continue      # silences the room
+
+
+# ---------------------------------------------------------------------------
+# Combat event renderers — the witness-testimony altitude: who started
+# it, who went down, how it ended. Never the per-swing fire-hose.
+# ---------------------------------------------------------------------------
+
+def combat_join_line(char, target=None):
+    """Someone enters the fight (with their opening target if known)."""
+    def render(observer):
+        try:
+            who = char.get_display_name(observer)
+            if target is not None and target is observer:
+                return f"{who} comes straight at you!"
+            if target is not None:
+                return (f"{who} attacks "
+                        f"{target.get_display_name(observer)}!")
+            return f"{who} joins the fight."
+        except Exception:  # noqa: BLE001
+            return None
+    return render
+
+
+def combat_exit_line(char, state):
+    """Someone leaves the fight: 'walked' | 'unconscious' | 'dead'."""
+    def render(observer):
+        try:
+            who = char.get_display_name(observer)
+        except Exception:  # noqa: BLE001
+            return None
+        if state == "dead":
+            return f"{who} goes down and doesn't move."
+        if state == "unconscious":
+            return f"{who} collapses, out cold."
+        return f"{who} lowers their guard and steps back from the fight."
+    return render
+
+
+def personal_attack_line(attacker, target, weapon_name, hit):
+    """An attack ON an LLM NPC — personal enough to buffer every swing.
+    Rendered from the TARGET's point of view; call only for
+    ``target.db.llm_driven is True``."""
+    try:
+        who = attacker.get_display_name(target)
+    except Exception:  # noqa: BLE001
+        return None
+    verb = "hits you" if hit else "attacks you and misses"
+    with_what = f" with {weapon_name}" if weapon_name else ""
+    return f"{who} {verb}{with_what}!"

--- a/world/tests/test_npc_combat_perception.py
+++ b/world/tests/test_npc_combat_perception.py
@@ -1,0 +1,134 @@
+"""NPC perception of combat (#954, combat-first slice).
+
+Bystander LLM brains buffer witness-testimony beats — who started on
+whom, who went down, how it ended — through the same [RECENTLY] rails
+poses ride. Perception-gated, perceived-identity rendered, observe-only.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.llm.observation as obs
+from world.llm.observation import (
+    combat_exit_line, combat_join_line, observe_event,
+    personal_attack_line)
+
+
+def _npc(llm=True):
+    npc = MagicMock()
+    npc.db = SimpleNamespace(llm_driven=llm)
+    npc._observe_action = MagicMock()
+    return npc
+
+
+def _room(contents):
+    room = MagicMock()
+    room.contents = contents
+    return room
+
+
+class TestObserveEvent(TestCase):
+    def test_sighted_llm_bystander_buffers_the_rendered_line(self):
+        npc = _npc()
+        with patch("world.perception.can_see", return_value=True):
+            observe_event(_room([npc]),
+                          lambda o: "a wiry man attacks a heavyset woman!")
+        npc._observe_action.assert_called_once()
+        self.assertIn("wiry man", npc._observe_action.call_args.args[1])
+
+    def test_blind_bystander_gets_the_sound_only(self):
+        npc = _npc()
+        with patch("world.perception.can_see", return_value=False), \
+                patch("world.perception.can_hear", return_value=True):
+            observe_event(_room([npc]), lambda o: "the visual line",
+                          sound="sudden violence erupts nearby")
+        self.assertEqual(npc._observe_action.call_args.args[1],
+                         "sudden violence erupts nearby")
+
+    def test_deaf_and_blind_get_nothing(self):
+        npc = _npc()
+        with patch("world.perception.can_see", return_value=False), \
+                patch("world.perception.can_hear", return_value=False):
+            observe_event(_room([npc]), lambda o: "line", sound="sound")
+        npc._observe_action.assert_not_called()
+
+    def test_non_llm_and_excluded_are_skipped(self):
+        plain = MagicMock()
+        plain.db = SimpleNamespace(llm_driven=None)   # strict is True
+        fighter = _npc()
+        watcher = _npc()
+        with patch("world.perception.can_see", return_value=True):
+            observe_event(_room([plain, fighter, watcher]),
+                          lambda o: "line", exclude=(fighter,))
+        plain._observe_action.assert_not_called()
+        fighter._observe_action.assert_not_called()
+        watcher._observe_action.assert_called_once()
+
+    def test_magicmock_truthiness_guard(self):
+        impostor = MagicMock()   # bare mock: db.llm_driven is a Mock
+        with patch("world.perception.can_see", return_value=True):
+            observe_event(_room([impostor]), lambda o: "line")
+        impostor._observe_action.assert_not_called()
+
+
+class TestRenderers(TestCase):
+    def _seen_as(self, name):
+        char = MagicMock()
+        char.get_display_name.return_value = name
+        return char
+
+    def test_join_names_the_opening_target(self):
+        char = self._seen_as("a wiry man")
+        target = self._seen_as("a heavyset woman")
+        observer = MagicMock()
+        self.assertEqual(combat_join_line(char, target)(observer),
+                         "a wiry man attacks a heavyset woman!")
+
+    def test_join_addresses_the_observer_when_targeted(self):
+        char = self._seen_as("a wiry man")
+        observer = MagicMock()
+        line = combat_join_line(char, observer)(observer)
+        self.assertEqual(line, "a wiry man comes straight at you!")
+
+    def test_exit_states(self):
+        char = self._seen_as("a wiry man")
+        observer = MagicMock()
+        self.assertIn("doesn't move",
+                      combat_exit_line(char, "dead")(observer))
+        self.assertIn("out cold",
+                      combat_exit_line(char, "unconscious")(observer))
+        self.assertIn("steps back",
+                      combat_exit_line(char, "walked")(observer))
+
+    def test_personal_attack_renders_from_target_pov(self):
+        attacker = MagicMock()
+        attacker.get_display_name.return_value = "a scarred woman"
+        target = _npc()
+        hit = personal_attack_line(attacker, target, "a knife", hit=True)
+        miss = personal_attack_line(attacker, target, None, hit=False)
+        self.assertEqual(hit, "a scarred woman hits you with a knife!")
+        self.assertEqual(miss, "a scarred woman attacks you and misses!")
+        attacker.get_display_name.assert_called_with(target)
+
+
+class TestCombatWiring(TestCase):
+    def test_remove_combatant_feeds_bystander_memory(self):
+        from world.combat.constants import DB_CHAR
+        from world.combat.utils import remove_combatant
+        char = MagicMock()
+        char.is_dead.return_value = True
+        char.is_unconscious.return_value = False
+        char.location = MagicMock()
+        handler = MagicMock()
+        handler._active_combatants_list = None
+        handler.db.combatants = [{DB_CHAR: char}]
+        with patch("world.llm.observation.observe_event") as tap, \
+                patch("world.identity_utils.msg_room_identity"), \
+                patch("world.combat.utils.get_splattercast",
+                      return_value=MagicMock()), \
+                patch("world.combat.utils.cleanup_combatant_state"):
+            remove_combatant(handler, char)
+        tap.assert_called_once()
+        self.assertEqual(tap.call_args.kwargs.get("sound"),
+                         "a body hits the floor nearby")


### PR DESCRIPTION
LLM bystanders finally learn what happened around them: who started
on whom (join beat), who went down and how (exit beats: walked/out
cold/dead), and that the fight broke off - one summary line per beat
into the same [RECENTLY] buffer poses ride, never the per-swing
fire-hose. Attacks ON an LLM NPC buffer every swing, rendered from
the target's own point of view. All taps hook the action source per
the 462 gate's design note: observe-only, exception-contained,
perceived-identity rendered, perception-gated (the blind get the
sound of it), strict-truthiness guarded. Latency keeps this
memory-first: brains speak at the next social beat, not combat time.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
