### PR TITLE
Combat reflex lane: fast-model barks on combat beats (#954 follow-on)

### DIFF
--- a/world/combat/handler.py
+++ b/world/combat/handler.py
@@ -255,6 +255,8 @@ class CombatHandler(DefaultScript):
             observe_event(self.obj,
                           lambda observer: "The fight breaks off.",
                           sound="the sounds of fighting die down")
+            from world.llm.reflex import fire_combat_reflex
+            fire_combat_reflex(self, self.obj, "fight_ended")
         except Exception:  # noqa: BLE001 — perception never breaks combat
             pass
         

--- a/world/combat/utils.py
+++ b/world/combat/utils.py
@@ -543,6 +543,9 @@ def add_combatant(handler, char, target=None, initial_grappling=None, initial_gr
                       combat_join_line(char, target),
                       sound="sudden violence erupts nearby",
                       exclude=(char, target))
+        from world.llm.reflex import fire_combat_reflex
+        fire_combat_reflex(handler, getattr(char, "location", None),
+                           "fight_started", exclude=(char, target))
     except Exception:  # noqa: BLE001 — perception never breaks combat
         pass
 
@@ -859,6 +862,10 @@ def remove_combatant(handler, char):
                           sound=(None if state == "walked"
                                  else "a body hits the floor nearby"),
                           exclude=(char,))
+            if state != "walked":
+                from world.llm.reflex import fire_combat_reflex
+                fire_combat_reflex(handler, getattr(char, "location", None),
+                                   "someone_down", exclude=(char,))
         except Exception:  # noqa: BLE001
             pass
         if alive and conscious and getattr(char, "location", None):

--- a/world/llm/reflex.py
+++ b/world/llm/reflex.py
@@ -1,0 +1,181 @@
+"""The combat reflex lane (#954 follow-on, user call 2026-07-11).
+
+The big model plays conversation tempo (17-85s a turn); the civic
+lane's small on-device model answers in under a second — the only
+model that can honestly play a FLINCH. When a combat beat lands, one
+elected bystander LLM NPC may bark a single in-character line seconds
+later, through the civic lane and the real ``say`` command.
+
+**Input shaping is the load-bearing wall.** The small model's
+guardrails pattern-match graphic PHRASING, not events (probed live
+2026-07-11: a murder passed; "bleeding heavily... not moving"
+refused). So the reflex prompt never sees the witness-detail beat
+lines at all — it gets a fixed, category-mapped, deliberately bloodless
+rendition from ``REFLEX_BEATS``. The full-detail lines still go where
+they always went: the NPC's action buffer, which only the GM lane
+reads. No fidelity is lost anywhere that matters, and the guardrail
+has nothing to catch.
+
+**Failure mode is silence**, at every layer: refusal, timeout,
+nonsense output, cooldown, no eligible bystander — nothing renders.
+An NPC that doesn't comment on a fight is indistinguishable from one
+choosing not to.
+
+Discipline ledger: deterministic combat stays authoritative (the
+reflex is downstream flavour, exception-contained); output through a
+real command; bystanders only (combatants have a deterministic combat
+AI and a model can't play 6-second rounds); election = lowest dbref
+(the radio precedent — no chorus); one reflex per fight (handler
+flag) plus a per-NPC time gate; strict ``is True`` checks throughout.
+"""
+
+from __future__ import annotations
+
+import time
+from random import uniform
+
+from evennia.utils.utils import delay
+
+#: Guardrail-safe beat renditions — the ONLY text the small model sees.
+REFLEX_BEATS = {
+    "fight_started": "A fight just broke out nearby between two people.",
+    "someone_down": ("Someone just went down hard in the fight and "
+                     "isn't getting up."),
+    "fight_ended": "The fight nearby just broke off.",
+}
+
+#: A single NPC won't reflex again within this many seconds.
+REFLEX_NPC_COOLDOWN = 90.0
+
+#: The human beat between the event and the bark.
+REFLEX_DELAY_MIN, REFLEX_DELAY_MAX = 1.5, 3.0
+
+REFLEX_INSTRUCTIONS = (
+    "You are {name}, {identity} in a gritty fictional cyberpunk "
+    "roleplaying game. Something just happened near you. React with "
+    "ONE short spoken line, in character — a bark, a curse, a warning, "
+    "a call for order. No narration, no asterisks, no quotation marks. "
+    "If your character would stay silent, reply with exactly: NOTHING"
+)
+
+
+def _clean_reflex(text):
+    """One spoken line or None: first line, stage directions and quote
+    marks stripped, declines honoured, length capped."""
+    if not text:
+        return None
+    line = str(text).splitlines()[0].strip()
+    # strip *stage directions* wherever they appear
+    while "*" in line:
+        head, _, rest = line.partition("*")
+        _, _, tail = rest.partition("*")
+        line = (head + " " + tail).strip()
+    line = line.strip().strip('"').strip()
+    if not line or line.upper() in ("NOTHING", "NOTHING."):
+        return None
+    if line.startswith("[") or line.lower().startswith(("as an ai", "i cannot", "i can't")):
+        return None
+    return line[:160]
+
+
+def _combatants_of(handler):
+    """Everyone currently in the fight (excluded from reflexing)."""
+    out = set()
+    try:
+        from world.combat.constants import DB_CHAR
+        for entry in (handler.db.combatants or []):
+            char = entry.get(DB_CHAR)
+            if char is not None:
+                out.add(char)
+    except Exception:  # noqa: BLE001
+        pass
+    return out
+
+
+def _elect_bystander(location, excluded):
+    """The one LLM-driven, conscious, perceiving bystander who reacts —
+    lowest dbref (the radio election precedent), off cooldown."""
+    from world.perception import can_hear, can_see
+    candidates = []
+    try:
+        contents = list(getattr(location, "contents", None) or [])
+    except Exception:  # noqa: BLE001
+        return None
+    now = time.time()
+    for obj in contents:
+        try:
+            if obj in excluded:
+                continue
+            if getattr(getattr(obj, "db", None), "llm_driven",
+                       None) is not True:
+                continue
+            if callable(getattr(obj, "is_dead", None)) and obj.is_dead():
+                continue
+            if (callable(getattr(obj, "is_unconscious", None))
+                    and obj.is_unconscious()):
+                continue
+            if not (can_see(obj) or can_hear(obj)):
+                continue
+            last = getattr(obj.ndb, "last_combat_reflex", None) or 0
+            if now - float(last) < REFLEX_NPC_COOLDOWN:
+                continue
+            candidates.append(obj)
+        except Exception:  # noqa: BLE001
+            continue
+    if not candidates:
+        return None
+    return min(candidates, key=lambda o: getattr(o, "id", 0) or 0)
+
+
+def fire_combat_reflex(handler, location, category, exclude=()):
+    """Maybe bark: one elected bystander, one reflex per fight, the
+    guardrail-safe beat only, silence on every failure."""
+    try:
+        from world.llm.client import civic_enabled, request_civic_line
+        if not civic_enabled():
+            return
+        beat = REFLEX_BEATS.get(category)
+        if not beat or location is None:
+            return
+        if handler is not None:
+            if getattr(getattr(handler, "ndb", None), "combat_reflex_done",
+                       None) is True:
+                return
+        excluded = set(exclude) | _combatants_of(handler)
+        npc = _elect_bystander(location, excluded)
+        if npc is None:
+            return
+        if handler is not None:
+            handler.ndb.combat_reflex_done = True
+        npc.ndb.last_combat_reflex = time.time()
+
+        persona = dict(getattr(npc.db, "llm_persona", None) or {})
+        instructions = REFLEX_INSTRUCTIONS.format(
+            name=persona.get("name") or npc.key,
+            identity=(persona.get("description")
+                      or "a bystander")[:160])
+
+        def _deliver():
+            try:
+                # re-check at speak time: downed mid-beat = silence
+                if (callable(getattr(npc, "is_dead", None)) and npc.is_dead()) \
+                        or (callable(getattr(npc, "is_unconscious", None))
+                            and npc.is_unconscious()):
+                    return
+
+                def on_reply(text):
+                    line = _clean_reflex(text)
+                    if line:
+                        try:
+                            npc.execute_cmd(f"say {line}")
+                        except Exception:  # noqa: BLE001
+                            pass
+
+                request_civic_line(instructions, beat, on_reply,
+                                   lambda: None)
+            except Exception:  # noqa: BLE001 — silence
+                pass
+
+        delay(uniform(REFLEX_DELAY_MIN, REFLEX_DELAY_MAX), _deliver)
+    except Exception:  # noqa: BLE001 — the reflex lane never breaks combat
+        pass

--- a/world/tests/test_combat_reflex.py
+++ b/world/tests/test_combat_reflex.py
@@ -1,0 +1,136 @@
+"""The combat reflex lane (#954 follow-on): one elected bystander, one
+guardrail-safe beat, one real say command — silence on every failure."""
+
+import time
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.llm.reflex as rx
+from world.llm.reflex import (
+    REFLEX_BEATS, _clean_reflex, _elect_bystander, fire_combat_reflex)
+
+
+def _npc(dbref=10, llm=True, cooldown_ago=9999):
+    npc = MagicMock()
+    npc.id = dbref
+    npc.key = "Sable"
+    npc.db = SimpleNamespace(llm_driven=llm,
+                             llm_persona={"name": "Sable",
+                                          "description": "a bartender"})
+    npc.ndb = SimpleNamespace(
+        last_combat_reflex=time.time() - cooldown_ago)
+    npc.is_dead.return_value = False
+    npc.is_unconscious.return_value = False
+    return npc
+
+
+def _handler(fired=False, combatants=()):
+    from world.combat.constants import DB_CHAR
+    h = MagicMock()
+    h.ndb = SimpleNamespace(
+        combat_reflex_done=True if fired else None)
+    h.db.combatants = [{DB_CHAR: c} for c in combatants]
+    return h
+
+
+def _room(contents):
+    room = MagicMock()
+    room.contents = list(contents)
+    return room
+
+
+class TestBeatSafety(TestCase):
+    def test_no_beat_carries_gore_phrasing(self):
+        # the probe-mapped tripwires stay out of the small model's input
+        for text in REFLEX_BEATS.values():
+            for word in ("blood", "bleeding", "knife", "wound", "stab",
+                         "dead", "kill", "corpse", "not moving"):
+                self.assertNotIn(word, text.lower())
+
+
+class TestCleanReflex(TestCase):
+    def test_strips_stage_directions_and_quotes(self):
+        self.assertEqual(
+            _clean_reflex('*Eyes widen* "What the hell?"'),
+            "What the hell?")
+
+    def test_declines_and_meta_are_silence(self):
+        self.assertIsNone(_clean_reflex("NOTHING"))
+        self.assertIsNone(_clean_reflex("I cannot respond to that."))
+        self.assertIsNone(_clean_reflex(""))
+        self.assertIsNone(_clean_reflex("**"))
+
+
+class TestElection(TestCase):
+    def _see_hear(self):
+        return (patch("world.perception.can_see", return_value=True),
+                patch("world.perception.can_hear", return_value=True))
+
+    def test_lowest_dbref_wins_fighters_excluded(self):
+        see, hear = self._see_hear()
+        low, high, fighter = _npc(5), _npc(9), _npc(1)
+        with see, hear:
+            winner = _elect_bystander(_room([high, low, fighter]),
+                                      {fighter})
+        self.assertIs(winner, low)
+
+    def test_cooldown_and_non_llm_are_ineligible(self):
+        see, hear = self._see_hear()
+        cooling = _npc(3, cooldown_ago=5)          # reflexed recently
+        plain = _npc(4, llm=False)
+        ready = _npc(8)
+        with see, hear:
+            winner = _elect_bystander(_room([cooling, plain, ready]), set())
+        self.assertIs(winner, ready)
+
+    def test_imperceptive_room_elects_nobody(self):
+        with patch("world.perception.can_see", return_value=False), \
+                patch("world.perception.can_hear", return_value=False):
+            self.assertIsNone(_elect_bystander(_room([_npc()]), set()))
+
+
+class TestFire(TestCase):
+    def _fire(self, handler, room, category="fight_started"):
+        calls = {}
+        def fake_request(instructions, prompt, on_reply, on_fail):
+            calls["instructions"] = instructions
+            calls["prompt"] = prompt
+            on_reply('*ducks* "Hey! Take it outside!"')
+        with patch("world.llm.client.civic_enabled", return_value=True), \
+                patch("world.llm.client.request_civic_line",
+                      side_effect=fake_request), \
+                patch.object(rx, "delay",
+                             side_effect=lambda t, fn: fn()), \
+                patch("world.perception.can_see", return_value=True), \
+                patch("world.perception.can_hear", return_value=True):
+            fire_combat_reflex(handler, room, category)
+        return calls
+
+    def test_full_path_barks_through_the_real_command(self):
+        npc = _npc()
+        handler = _handler()
+        calls = self._fire(handler, _room([npc]))
+        self.assertEqual(calls["prompt"], REFLEX_BEATS["fight_started"])
+        self.assertIn("Sable", calls["instructions"])
+        npc.execute_cmd.assert_called_once_with(
+            "say Hey! Take it outside!")
+        self.assertIs(handler.ndb.combat_reflex_done, True)
+
+    def test_one_reflex_per_fight(self):
+        npc = _npc()
+        calls = self._fire(_handler(fired=True), _room([npc]))
+        self.assertEqual(calls, {})
+        npc.execute_cmd.assert_not_called()
+
+    def test_combatants_never_reflex(self):
+        fighter = _npc(2)
+        handler = _handler(combatants=(fighter,))
+        self._fire(handler, _room([fighter]))
+        fighter.execute_cmd.assert_not_called()
+
+    def test_civic_lane_off_is_silence(self):
+        npc = _npc()
+        with patch("world.llm.client.civic_enabled", return_value=False):
+            fire_combat_reflex(_handler(), _room([npc]), "fight_started")
+        npc.execute_cmd.assert_not_called()


### PR DESCRIPTION
The civic lane's sub-second on-device model plays the only tempo it
honestly can: a flinch. One elected bystander LLM NPC (lowest dbref,
combatants excluded, per-NPC cooldown, ONE reflex per fight) barks a
single in-character line 1.5-3s after a combat beat, through the real
say command. Input shaping is the load-bearing wall: the small model
only ever sees fixed guardrail-safe beat renditions (probed live:
guardrails match gore PHRASING, not events) - full-detail witness
lines stay in the buffer only the GM lane reads. Failure mode is
silence at every layer: refusal, timeout, decline, nonsense, no
eligible bystander, lane disabled.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
