### PR TITLE
Reflex instructions: no example-noun lists for the small model

### DIFF
--- a/world/llm/reflex.py
+++ b/world/llm/reflex.py
@@ -52,10 +52,13 @@ REFLEX_DELAY_MIN, REFLEX_DELAY_MAX = 1.5, 3.0
 
 REFLEX_INSTRUCTIONS = (
     "You are {name}, {identity} in a gritty fictional cyberpunk "
-    "roleplaying game. Something just happened near you. React with "
-    "ONE short spoken line, in character — a bark, a curse, a warning, "
-    "a call for order. No narration, no asterisks, no quotation marks. "
-    "If your character would stay silent, reply with exactly: NOTHING"
+    "roleplaying game. Something just happened near you. Reply with "
+    "the ONE short line your character says out loud, in their own "
+    "voice. No narration, no asterisks, no quotation marks, no "
+    "examples. If your character would stay silent, reply with "
+    "exactly: NOTHING"
+    # (No example-noun lists: the 3B model parrots them — a probe
+    # literally answered "*Bark*". Small models get plain orders.)
 )
 
 


### PR DESCRIPTION
Probe: the 3B model parroted the instruction's 'a bark, a curse...'
list as literal output (*Bark*). The sanitizer already silenced it;
this stops wasting the reflexes. Plain orders only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
