### PR TITLE
Specs: bank hologram parole agents + door follow-on (Closes #1138)

### DIFF
--- a/specs/proposals/LLM_GAMEMASTER_SPEC.md
+++ b/specs/proposals/LLM_GAMEMASTER_SPEC.md
@@ -855,3 +855,26 @@ sourced as `mlx-community` 4-bit quants, scored with the §4.1 rubric on the
 target Mac mini, and bound behind the §9 Model adapter so swapping is a config
 change, not a code change. Re-evaluate every release cycle; uncensored
 creative-writing tunes move fast.
+
+
+## Holographic Parole Agents — DESIGN BANKED (user, 2026-07-10; NOT BUILT)
+
+The Constabulary lobby's public face (lobby #4936): the automaton era
+ends with PROJECTED agents.
+
+* **Seats 4 → 3**; each remaining seat gets a **PROJECTOR** — a
+  physical object, **hackable** (decking seam) and **vandalizable**
+  (damage seam). Break the projector, kill the service.
+* **SITTING in a seat auto-boots a holographic LLM parole agent
+  assigned to the sitter; leaving the seat kills it.** Sit-triggered
+  engagement replaces automaton logic entirely — dynamic on/off for
+  free, no idle brains burning tokens at an empty bench.
+* **Register:** civic — fines, parole check-ins, civic requests. The
+  HOLOGRAPHIC_MERCHANT precedent covers projected-being presentation.
+* **Lane (2026-07-11 doctrine):** the CIVIC/fast lane is the natural
+  fit — clerk-register, single-purpose dialogue at sub-second tempo,
+  structural fallback lines, guardrail-compatible content. The GM lane
+  stays reserved for characters with souls; a parole hologram is a
+  form with a face.
+* The broken automaton **#4951 stays** as set-dressing fossil (its
+  OUT OF ORDER grille clicks on).

--- a/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
+++ b/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
@@ -155,6 +155,10 @@ filter live in `world/spatial/pathfind.py`, and the elevator's
 `db.floor_locks` consumes the same grant model. §2.3 sound-muffling
 awaits a cross-room sound layer (none exists yet — closed doors are
 already the gate when it lands); §2.4 breach stays reserved.
+Follow-on owed: **NPCs learn the `open` verb** — refines the
+pathfinder's any-not-open-door blocked edge back to a grant check and
+lets granted NPCs (Petra) badge into their own offices; the seam is
+commented in `DoorExit.door_blocks`.
 
 `DoorExit(Exit)` with a mirrored twin (Evennia exits are one-way; a door is
 the *pair*, state shared so both sides agree):


### PR DESCRIPTION
Specs are where designs live (user convention; issues are for bugs).
The hologram lobby design moves from session memory into
LLM_GAMEMASTER_SPEC with its civic-lane doctrine fit; verticality 2.1
records the NPCs-learn-open follow-on.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
