### PR TITLE
Spec freshness sweep (Closes #1140)

### DIFF
--- a/specs/COMBAT_AUDIT_LOGGING_SPEC.md
+++ b/specs/COMBAT_AUDIT_LOGGING_SPEC.md
@@ -48,9 +48,14 @@ object everywhere.
 Every `.msg()` on the router does up to two things:
 
 1. **Audit file — always on.** The message is appended to
-   `server/logs/combat_audit.log` via Evennia's async file logger
-   (`evennia.utils.logger.log_file`). Writes happen on the logger's
-   thread pool, never blocking the Twisted reactor. This is the
+   `server/logs/combat_audit.log` via a **module-owned stdlib
+   `logging.RotatingFileHandler`** (changed #1106, 2026-07-10:
+   Evennia's `logger.log_file` recycles its cached handle every 500th
+   access on the reactor while queued thread writes still hold it —
+   every recycle boundary silently dropped the queue, 7.9k lines
+   rendered as `NoneType: None` until #1094 unmasked it). The stdlib
+   handler locks per write and rotates safely; writes are buffered
+   microsecond appends. This is the
    durable record for investigating bug reports, cheating
    accusations, and combat disputes.
 

--- a/specs/CONDITION_CADENCE_SPEC.md
+++ b/specs/CONDITION_CADENCE_SPEC.md
@@ -86,6 +86,10 @@ revision:
   rule §6.1.
 * **`utils.delay` timers do not survive reload**: a live grenade
   mid-fuse across a reload freezes into a hand-explosion trap.
+  **✅ FIXED (#505, 2026-07-11):** both ticker starters persist
+  `db.detonation_deadline`; the `at_server_start` sweep re-arms live
+  fuses at true remaining time and cooks off overdue ones; duds and
+  defuses clear the deadline.
   Out of scope here; tracked as its own issue (§6.3).
 
 ## 3 · Effect taxonomy

--- a/specs/proposals/LLM_GAMEMASTER_SPEC.md
+++ b/specs/proposals/LLM_GAMEMASTER_SPEC.md
@@ -878,3 +878,32 @@ ends with PROJECTED agents.
   form with a face.
 * The broken automaton **#4951 stays** as set-dressing fossil (its
   OUT OF ORDER grille clicks on).
+
+
+## Third-Party Perception + The Reflex Lane — ✅ SHIPPED 2026-07-11
+
+**Combat perception (#954 combat slice, #1135):**
+`world/llm/observation.py observe_event` — witness-testimony beats
+(join w/ opening target, exits walked/out-cold/dead, fight end, plus
+per-swing personal attacks on LLM targets from their own POV) land in
+LLM bystanders' action buffers via per-observer identity rendering,
+perception-gated (blind hear the sound of it), exception-contained,
+observe-only. Buffer-only by design: model tempo (17–85s) can never
+honestly play a 6s combat round — brains speak at the next social
+beat. Remaining #954 scope: clothing/transfer perception + directed
+reactions.
+
+**The reflex lane (#1136):** the TWO-LANE DOCTRINE completed — the
+GM lane (24B) plays conversation tempo; the CIVIC lane's on-device
+small model (~0.65s) plays the FLINCH. On fight beats, ONE elected
+bystander (lowest dbref, combatants excluded, 90s NPC cooldown, one
+reflex per fight) barks a single line through `say`. **Input shaping
+is the wall:** the small model only ever sees fixed bloodless
+`REFLEX_BEATS` renditions — probed live: its guardrails match gore
+PHRASING, not events ("bleeding heavily… not moving" refused; a
+murder passed; profanity passes). Full-detail witness lines stay in
+the GM-lane buffer. Failure mode is silence at every layer. Persona
+steering confirmed at archetype level (bartender/dispatcher/robot
+probes produced three distinct registers from one identity clause);
+small models get plain orders — example-noun lists get parroted
+(#1137).

--- a/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
+++ b/specs/proposals/STEALTH_AND_DETECTION_SPEC.md
@@ -19,7 +19,7 @@
 > move announcements, whisper bystanders, and speech attribution
 > (stealth-aware `resolve_speaker_attribution` — hidden speakers attribute
 > by VOICE). Leak-completeness tests drive each real path. Deliberate
-> bypasses hold: AoE, area sound, `search`. **PHASE 4 (THE HUNT) SHIPPED
+> bypasses hold: AoE, area sound, `search`. **`search` GREW HIDDEN-EXIT DISCOVERY (#1114, 2026-07-10): view-locked (secret) exits roll the stash idiom (d20 + Resonance + search bonus vs `db.search_difficulty`, default 14 > stashes' 10) — a find is PER SEARCHER (`db.found_exits`; the exit joins THEIR exit prose forever, everyone else keeps seeing nothing; custom `db.search_found_msg`). First consumer: the Constabulary roof hatch.** **PHASE 4 (THE HUNT) SHIPPED
 > (2026-07-03):** `world/director/hunt.py` — the deterministic state
 > machine off the awareness meter, ticked by the director heartbeat
 > before the patrol beat: Suspicious → orient beat (the player's audible


### PR DESCRIPTION
Audit sink reality (#1106), grenade deadline fix (#505), search's
hidden-exit discovery (#1114), and the perception + reflex-lane
doctrine (#1135-#1137) land in their owning specs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
