### PR TITLE
Door spring latch: autolock doors seal on close (Closes #1148)

### DIFF
--- a/commands/CmdDoors.py
+++ b/commands/CmdDoors.py
@@ -106,6 +106,16 @@ class CmdCloseDoor(Command):
         if not door.is_open():
             self.caller.msg("It's already closed.")
             return
+        if door.db.door_autolock is True:
+            # the spring latch: anyone may close it, and closing it
+            # seals it — restoring security needs no authority
+            door._mirror(door_closed=True, door_locked=True)
+            self.caller.msg("You pull the door shut; the lock "
+                            "re-engages with a |rclunk|n.")
+            door._both_rooms_msg("The door swings shut and its lock "
+                                 "re-engages with a clunk.",
+                                 exclude=[self.caller])
+            return
         door._mirror(door_closed=True)
         self.caller.msg("You pull the door shut.")
         door._both_rooms_msg("The door swings shut.", exclude=[self.caller])

--- a/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
+++ b/specs/proposals/VERTICALITY_AND_BUILDINGS_SPEC.md
@@ -150,7 +150,10 @@ door IS the exit, per user call). `typeclasses/doors.py DoorExit`
 requires the door OPEN — open/close are explicit verbs, walking never
 changes state, refined 2026-07-10 per user), player verbs
 `open/close/lock/unlock/knock`, builder `@door` (+/grant /revoke /list
-/force), grant files in `world/access.py`, pathfinder blocked-edge
+/force), **`db.door_autolock` spring latch (2026-07-11, user call:
+closing re-engages the lock, no grant needed — anyone can RESTORE
+security, only granted sleeves can remove it; cube doors ship with
+it)**, grant files in `world/access.py`, pathfinder blocked-edge
 filter live in `world/spatial/pathfind.py`, and the elevator's
 `db.floor_locks` consumes the same grant model. §2.3 sound-muffling
 awaits a cross-room sound layer (none exists yet — closed doors are

--- a/typeclasses/doors.py
+++ b/typeclasses/doors.py
@@ -29,6 +29,10 @@ class DoorExit(Exit):
         self.db.door_closed = True     # a freshly hung door starts shut
         self.db.door_locked = False
         self.db.door_broken = False
+        # spring latch: closing this door re-engages the lock, no
+        # grant needed — anyone can RESTORE security, only granted
+        # sleeves can remove it (the hotel-door standard)
+        self.db.door_autolock = False
         self.db.access_grants = []     # §2.2 grant file: [{sleeve, until, issued_by}]
         if "door" not in self.aliases.all():
             self.aliases.add("door")

--- a/world/tests/test_doors.py
+++ b/world/tests/test_doors.py
@@ -198,3 +198,31 @@ class TestElevatorFloorLock(TestCase):
         with patch.object(emod, "delay") as d:
             self.assertTrue(car.request_floor("1", _sleeve("uid-mallory")))
         d.assert_called_once()
+
+
+class TestAutolock(TestCase):
+    """The spring latch: closing an autolock door seals it — anyone may
+    restore security; only granted sleeves may remove it."""
+
+    def _closer(self, autolock=True, open_=True):
+        from commands.CmdDoors import CmdCloseDoor
+        door = _door_factory(closed=not open_, locked=False)
+        door.db.door_autolock = autolock
+        _bind(door, dmod.DoorExit, "is_open")
+        cmd = CmdCloseDoor()
+        cmd.args = "door"
+        cmd.caller = MagicMock()
+        with patch("commands.CmdDoors.find_door", return_value=door):
+            cmd.func()
+        return door, cmd.caller
+
+    def test_stranger_closing_reseals_the_lock(self):
+        door, caller = self._closer(autolock=True)
+        self.assertTrue(door.db.door_closed)
+        self.assertTrue(door.db.door_locked)           # spring latch
+        self.assertIn("re-engages", caller.msg.call_args.args[0])
+
+    def test_plain_doors_just_close(self):
+        door, caller = self._closer(autolock=False)
+        self.assertTrue(door.db.door_closed)
+        self.assertFalse(door.db.door_locked)


### PR DESCRIPTION
Anyone can restore security; only granted sleeves can remove it. Cube
doors ship with the latch - a passerby shutting a tenant's forgotten
door re-arms it in one motion.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
