### PR TITLE
get honours get:false() fixtures (masts, console, boombox stay put) (Closes #1220)

### DIFF
--- a/commands/CmdInventory.py
+++ b/commands/CmdInventory.py
@@ -468,7 +468,26 @@ class CmdGet(Command):
             caller.msg(f"You can't pick up {item.get_display_name(caller)}.")
             return
 
+        # Honour the get lock + at_pre_get — a bolted-down fixture (a mast,
+        # a dispatch console, a wired boombox) carries get:false() and MUST
+        # stay put. The custom command used to skip this, so every fixture
+        # was liftable.
+        if not self._can_be_taken(caller, item):
+            return
+
         self._give_item_to_character(caller, item)
+
+    def _can_be_taken(self, caller, item):
+        """True if *item* may be picked up: the ``get`` lock passes and
+        ``at_pre_get`` allows it. Fixtures (``get:false()``) are refused
+        with their ``get_err_msg`` (or a default)."""
+        if not item.access(caller, "get"):
+            caller.msg(item.db.get_err_msg
+                       or f"You can't pick up {item.get_display_name(caller)}.")
+            return False
+        if item.at_pre_get(caller) is False:
+            return False
+        return True
 
     def _get_from_container(self, caller, item_name, container_name):
         """Get an item from a container."""
@@ -535,7 +554,11 @@ class CmdGet(Command):
             if not isinstance(item, Item):
                 caller.msg(f"You can't take {item.get_display_name(caller)} from the {container.get_display_name(caller)}.")
                 return None
-                
+
+            # Same fixture guard as room-get (get lock + at_pre_get).
+            if not self._can_be_taken(caller, item):
+                return None
+
             return item
         
         caller.msg(f"You don't see a '{item_name}' in the {container.get_display_name(caller)}.")

--- a/world/tests/test_get_fixture_lock.py
+++ b/world/tests/test_get_fixture_lock.py
@@ -1,0 +1,47 @@
+"""The get command honours get:false() fixtures (2026-07-14): a mast,
+console, or wired boombox stays bolted down. Regression for a custom
+CmdGet that skipped the lock check entirely."""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from commands.CmdInventory import CmdGet
+
+
+def _cmd():
+    cmd = CmdGet()
+    cmd.caller = MagicMock()
+    return cmd
+
+
+class TestFixtureGetGuard(TestCase):
+    def _item(self, allowed, pre_get=True, err=None):
+        item = MagicMock()
+        item.access.return_value = allowed
+        item.at_pre_get.return_value = pre_get
+        item.db.get_err_msg = err
+        item.get_display_name.return_value = "the boombox"
+        return item
+
+    def test_locked_fixture_refused_with_its_message(self):
+        cmd = _cmd()
+        item = self._item(allowed=False, err="It's wired to the wall. It stays.")
+        self.assertFalse(cmd._can_be_taken(cmd.caller, item))
+        cmd.caller.msg.assert_called_once_with("It's wired to the wall. It stays.")
+
+    def test_locked_fixture_default_message(self):
+        cmd = _cmd()
+        item = self._item(allowed=False, err=None)
+        self.assertFalse(cmd._can_be_taken(cmd.caller, item))
+        self.assertIn("can't pick up", cmd.caller.msg.call_args.args[0])
+
+    def test_pre_get_veto_cancels_silently(self):
+        cmd = _cmd()
+        item = self._item(allowed=True, pre_get=False)
+        self.assertFalse(cmd._can_be_taken(cmd.caller, item))
+
+    def test_free_item_passes(self):
+        cmd = _cmd()
+        item = self._item(allowed=True, pre_get=True)
+        self.assertTrue(cmd._can_be_taken(cmd.caller, item))


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
