### PR TITLE
Fix LLM pose bracket leak + base-form verb agreement

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -553,7 +553,7 @@ class LLMNpcMixin:
             extended = messages + [
                 {"role": "assistant",
                  "content": raw if isinstance(raw, str) else json.dumps(raw)},
-                {"role": "user", "content": f"[tool result · {tool}] {result}"},
+                {"role": "user", "content": f"TOOL RESULT ({tool}) — {result}"},
             ]
             self._agentic_round(extended, persona, patron, line, speaker_name,
                                 on_fail, rounds + 1, subject=subject)
@@ -717,12 +717,15 @@ class LLMNpcMixin:
         action = action.strip() if action else None
         thought = thought.strip() if thought else None
         if action:
-            # Deterministic pose backstop: the ACTION renders as "<name>
-            # <action>", so a first-person self-reference ("lowering my voice")
-            # renders broken ("Sable lowering my voice"). The charter + ChatML
-            # system role keep the model third-person almost always, but code —
-            # not the model — GUARANTEES it. Convert self-possessives/objects to
-            # the NPC's third-person pronoun; leave quoted speech alone.
+            # Deterministic pose backstops: the ACTION renders as "<name>
+            # <action>" with NO conjugation, so the model must write a
+            # third-person predicate. Code — not the model — GUARANTEES two
+            # things the charter can only ask for: (1) verb agreement — a
+            # base-form verb ("fill an empty pint") renders "Sable fill an
+            # empty pint"; conjugate the leading verb of each clause →
+            # "fills"; (2) first-person self-refs ("lowering my voice") →
+            # the NPC's pronoun. Small RP models (Rocinante) slip on both.
+            action = self._conjugate_action(action)
             action = self._selfify_action(action)
         if action and patron:
             action = self._resolve_second_person(action, patron)
@@ -739,6 +742,50 @@ class LLMNpcMixin:
             self.execute_cmd(f"say {speech}")
         if thought:
             self.execute_cmd(f"think {thought}")
+
+    #: Words that never START a pose clause as a verb (determiners,
+    #: pronouns, prepositions, conjunctions, common adverbs) — skip them
+    #: so "the glass", "her eyes", "slowly turns" aren't mis-conjugated.
+    _NOT_A_LEADING_VERB = frozenset((
+        "the a an this that these those her his their its my your our",
+        "one both all some no every each either neither",
+        "and then but so or nor as like with without into onto over under",
+        "at on in to for from before after through across around",
+        "still slowly slow quietly quiet just already almost barely",
+    ).__str__().split())
+
+    def _conjugate_action(self, action):
+        """Guarantee verb agreement in a pose. The action renders as
+        "<name> <action>" with no conjugation, so a base-form verb
+        ("fill an empty pint") renders wrong ("Sable fill ..."). Conjugate
+        the FIRST word of each clause (split on and/then/comma) to third-
+        person singular when it looks like a base verb — skipping words
+        already conjugated (-s), participles (-ing), past tense (-ed), and
+        non-verb clause-openers. Quoted speech is left alone. Small RP
+        models (Rocinante) write base-form pose verbs where a 24B wrote
+        '-s' forms; code fixes it either way."""
+        from world.grammar import conjugate_third_person
+
+        def _fix_clause(clause):
+            m = re.match(r"(\s*)([A-Za-z]+)(.*)$", clause, re.S)
+            if not m:
+                return clause
+            lead, word, rest = m.group(1), m.group(2), m.group(3)
+            lw = word.lower()
+            if (lw in self._NOT_A_LEADING_VERB
+                    or lw.endswith(("s", "ing", "ed"))):
+                return clause
+            return lead + conjugate_third_person(word) + rest
+
+        def _fix(seg):
+            # split on clause boundaries, KEEPING the delimiters
+            parts = re.split(r"(\s+and\s+|\s+then\s+|,\s+)", seg)
+            parts[0::2] = [_fix_clause(c) for c in parts[0::2]]
+            return "".join(parts)
+
+        chunks = action.split('"')
+        chunks[0::2] = [_fix(c) for c in chunks[0::2]]
+        return '"'.join(chunks)
 
     def _selfify_action(self, action):
         """Convert first-person SELF references in an action to the NPC's

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -133,7 +133,7 @@ def _tools_block(tools) -> str:
         if entry:
             lines.append(f'- "{name}": {entry["desc"]}')
     lines.append('- "none": no tool this turn.')
-    lines.append("After a context tool you get a [tool result]; then reply for real.")
+    lines.append("After a context tool you get a TOOL RESULT line; then reply for real.")
     if "style" in tools:
         lines.append('Your clothing only REALLY changes when you call "style" — '
                      "a pose alone doesn't remove, put on, or open anything. "
@@ -640,24 +640,30 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
 
     speaker = speaker or "someone"
     line = line or ""
-    who = f"[WHO — {relationship}]\n\n" if relationship else ""
+    # Context blocks are labelled but NOT [bracket]-wrapped: a small RP model
+    # copies an inline `[gloss]` shape straight into its dialogue (observed:
+    # a bartender said 'Lotta GANES [a nightrunner] beneath the ice' — it had
+    # learned from these blocks that characters wear bracketed descriptors).
+    # An UPPERCASE label + em-dash gives the same structural boundary without
+    # a token pattern the model will reproduce in prose.
+    who = f"WHO — {relationship}\n\n" if relationship else ""
     seen = ""
     if events:
-        seen = ("[RECENTLY — what you've just seen happen around you (it colours "
+        seen = ("RECENTLY — what you've just seen happen around you (it colours "
                 "how you feel, react if it warrants):\n"
-                + "\n".join(f"- {e}" for e in events if e) + "]\n\n")
+                + "\n".join(f"- {e}" for e in events if e) + "\n\n")
     mem = ""
     if memories:
-        mem = ("[MEMORY — what you recall (use it naturally, don't recite it):\n"
-               + "\n".join(f"- {m}" for m in memories if m) + "]\n\n")
+        mem = ("MEMORY — what you recall (use it naturally, don't recite it):\n"
+               + "\n".join(f"- {m}" for m in memories if m) + "\n\n")
     here = ""
     if present:
-        here = ("[PRESENT — others in the room with you right now; to act toward "
+        here = ("PRESENT — others in the room with you right now; to act toward "
                 "any of them, name them by the description shown here so the world "
                 "renders it right:\n"
-                + "\n".join(f"- {p}" for p in present if p) + "]\n\n")
+                + "\n".join(f"- {p}" for p in present if p) + "\n\n")
     mem = who + seen + here + mem
-    perc = f"[PERCEPTION — when you look at {speaker} you see: {perception}]\n\n" \
+    perc = f"PERCEPTION — when you look at {speaker} you see: {perception}\n\n" \
         if perception else ""
     if mode == "radio":
         # `speaker` is a VOICE handle — the far end is NOT in the room. The

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -552,3 +552,70 @@ class TestRememberNameGuard(TestCase):
             b._remember_person(patron, "the negotiating ninja.")
         b.execute_cmd.assert_called_once_with(
             "remember a lean man as the negotiating ninja")
+
+
+class TestActionConjugation(TestCase):
+    """A small RP model writes base-form pose verbs ('fill an empty pint');
+    the action renders as '<name> <action>' with no conjugation, so the verb
+    must be agreed to third-person singular in code (#1224 follow-up)."""
+
+    def _npc(self):
+        b = MagicMock()
+        b._NOT_A_LEADING_VERB = llmnpc.LLMNpcMixin._NOT_A_LEADING_VERB
+        _bind(b, "_conjugate_action")
+        return b
+
+    def test_leading_base_verb_agreed(self):
+        self.assertEqual(self._npc()._conjugate_action("fill an empty pint"),
+                         "fills an empty pint")
+
+    def test_each_clause_verb_agreed(self):
+        b = self._npc()
+        self.assertEqual(
+            b._conjugate_action(
+                "dry a glass with a rag and decant a brassy pint alongside"),
+            "dries a glass with a rag and decants a brassy pint alongside")
+
+    def test_then_and_comma_clauses(self):
+        b = self._npc()
+        self.assertEqual(
+            b._conjugate_action("move the half-pint into place then polish it"),
+            "moves the half-pint into place then polishes it")
+
+    def test_already_conjugated_left_alone(self):
+        b = self._npc()
+        self.assertEqual(b._conjugate_action("wipes the bar, tracking the man"),
+                         "wipes the bar, tracking the man")
+
+    def test_quoted_speech_untouched(self):
+        b = self._npc()
+        out = b._conjugate_action('nods slow, "fill it yourself" and turns away')
+        self.assertEqual(out, 'nods slow, "fill it yourself" and turns away')
+
+    def test_non_verb_openers_skipped(self):
+        # a clause that opens on a determiner/adverb, not a verb
+        b = self._npc()
+        self.assertEqual(b._conjugate_action("slowly leans in"), "slowly leans in")
+
+
+class TestPromptNoBracketBlocks(TestCase):
+    """Context blocks must NOT be [bracket]-wrapped: a small RP model copies an
+    inline `[gloss]` shape into dialogue ('Lotta GANES [a nightrunner]…')."""
+
+    def test_context_blocks_have_no_enclosing_brackets(self):
+        import re as _re
+        from world.llm import prompt as P
+        persona = {"persona_seed": {"archetype": "bartender", "name": "Del",
+                                    "pronouns": "she/her", "description": "keeper",
+                                    "personality": "warm"}}
+        msgs = P.build_messages(
+            persona, "a lean man", "how's your day?", "directed",
+            perception="a lean man in a scuffed jacket",
+            present=["a wiry woman with a shaved head"],
+            events=["a droog knocked over a stool"],
+            memories=["the lean man tips well"])
+        blob = "\n".join(m["content"] for m in msgs)
+        self.assertEqual(_re.findall(r"\[[^\]]{1,40}\]", blob), [])
+        # the labels still anchor the blocks
+        for label in ("PRESENT", "PERCEPTION", "RECENTLY", "MEMORY"):
+            self.assertIn(label, blob)


### PR DESCRIPTION
Closes #1226

Two pose-quality backstops around Rocinante-12B GM output, mirroring the
existing _selfify_action / _resolve_second_person deterministic guards.

Bracket leak: the turn prompt wrapped context in [bracket] blocks (PRESENT/
PERCEPTION/WHO/RECENTLY/MEMORY/tool result). A small RP model imitates that
inline-gloss shape in dialogue — live a bartender said "Lotta GANES [a
nightrunner] beneath the ice" (no such entity; the model invented a bracketed
descriptor because the prompt taught it characters wear [brackets]). Drop the
enclosing brackets, keep uppercase labels + em-dash for the same structural
boundary without a token pattern the model reproduces.

Verb agreement: the action renders as "<name> <action>" with no conjugation,
so a base-form model verb ("fill an empty pint") reads "A bartender fill an
empty pint". _conjugate_action agrees the leading verb of each clause (split
on and/then/comma) to third-person singular via conjugate_third_person,
skipping already-conjugated words, participles, non-verb clause-openers, and
quoted speech.

Regression tests: TestActionConjugation + TestPromptNoBracketBlocks. Full
LLM suite 134/134 green in the throwaway container.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
