### PR TITLE
Fix reflexive self-gesture mis-attributed to patron; add LLM decision log

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -281,6 +281,9 @@ LLM_GM_TIMEOUT = 120       # seconds; per-round budget. Measured 58.5s/round for
                            # a turn) the wait still lands inside the natural beat.
 LLM_GM_MAX_TOKENS = 220    # a turn = a line + an action + a thought; headroom so
                            # the 3rd channel doesn't truncate (was 120 for 2 fields)
+LLM_GM_DECISION_LOG = False  # opt-in tuning log: raw model output beside the final
+                           # rendered text (server/logs/llm_decisions.log). Flip on
+                           # in secret_settings.py while dialing a model in.
 
 ######################################################################
 # Director (world simulation)

--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -559,8 +559,14 @@ class LLMNpcMixin:
                                 on_fail, rounds + 1, subject=subject)
             return
         # Terminal: render speech/action/thought, route any action tool, remember.
-        self._render_llm_reply(turn["speech"], turn["action"], turn["thought"],
-                               patron)
+        rendered = self._render_llm_reply(turn["speech"], turn["action"],
+                                          turn["thought"], patron)
+        # Opt-in tuning log: raw model decision beside the final rendered text,
+        # so the game-side transform (conjugation/selfify/second-person) is
+        # auditable — the sidecar log sees the prompt but not this step.
+        from world.llm.decision_log import decision_log_enabled, log_decision
+        if decision_log_enabled():
+            log_decision(self, speaker_name, line, turn, rendered)
         self._handle_action_tool(tool, arg, patron)
         self._remember_turn(patron, line, speaker_name, turn["speech"],
                             turn["action"], turn["thought"])
@@ -712,7 +718,7 @@ class LLMNpcMixin:
         ``execute_cmd('think <thought>')`` — perceived only by the actor and a
         mind-reader, so it never leaks onto the visible stage."""
         if not self.location:
-            return
+            return {}
         speech = speech.strip().strip('"').strip() if speech else None
         action = action.strip() if action else None
         thought = thought.strip() if thought else None
@@ -727,8 +733,10 @@ class LLMNpcMixin:
             # the NPC's pronoun. Small RP models (Rocinante) slip on both.
             action = self._conjugate_action(action)
             action = self._selfify_action(action)
+            action = self._selfify_reflexive_gesture(action)
         if action and patron:
             action = self._resolve_second_person(action, patron)
+        rendered = {"action": None, "speech": None, "thought": thought}
         if action:
             body = action
             if speech and '"' not in body:
@@ -737,11 +745,14 @@ class LLMNpcMixin:
                 # action already carries a quote, that one rides — don't double.
                 sep = "" if body[-1] in ",.!?…" else ","
                 body = f'{body}{sep} "{speech}"'
+            rendered["action"] = body
             self.execute_cmd(f"emote {body}")
         elif speech:
+            rendered["speech"] = speech
             self.execute_cmd(f"say {speech}")
         if thought:
             self.execute_cmd(f"think {thought}")
+        return rendered
 
     #: Words that never START a pose clause as a verb (determiners,
     #: pronouns, prepositions, conjunctions, common adverbs) — skip them
@@ -803,6 +814,44 @@ class LLMNpcMixin:
                 r"\b(my|mine|me|myself)\b",
                 lambda m: transform_pronoun(m.group(0), "third", gender),
                 seg, flags=re.I)
+
+        chunks = action.split('"')
+        chunks[0::2] = [_rewrite(c) for c in chunks[0::2]]
+        return '"'.join(chunks)
+
+    #: Self-gesture verbs + body parts where "<verb> your <part>" is the NPC
+    #: moving its OWN body, never handling the patron's. The model reaches for
+    #: "your" here because the prompt addresses IT as "you" (observed live:
+    #: "cock your head" → the second-person resolver mis-mapped it onto the
+    #: patron, so a bystander would read "cocks the patron's head"). DELIBERATELY
+    #: CONSERVATIVE: only verbs with no plausible directed reading. Ambiguous
+    #: ones (tilt/lower/raise/lift/cup/stroke/take/press) have real patron-
+    #: directed uses — a bartender tilting a patron's chin up — and are LEFT to
+    #: fall through to _resolve_second_person on purpose.
+    _REFLEXIVE_GESTURE_VERBS = ("cock", "crane", "crack", "cant", "bob", "nod",
+        "shake", "roll", "scratch", "jerk", "wag", "duck", "incline", "arch")
+    _REFLEXIVE_GESTURE_PARTS = ("head", "neck", "chin", "jaw", "brow", "brows",
+        "eyebrow", "eyebrows", "shoulder", "shoulders", "temple", "temples",
+        "eye", "eyes", "knuckle", "knuckles")
+
+    def _selfify_reflexive_gesture(self, action):
+        """Rewrite a reflexive self-gesture the model wrote in the second person
+        ("cock your head") to the NPC's own possessive ("cocks his head"), BEFORE
+        _resolve_second_person claims that "your" for the patron. Gated on a tight
+        verb+part matrix so genuinely patron-directed possessives (which the
+        resolver SHOULD map) are untouched. Quoted speech is skipped."""
+        from world.grammar import GENDER_MAP
+        gender = GENDER_MAP.get(getattr(self, "gender", "neutral"), "neutral")
+        poss = {"male": "his", "female": "her"}.get(gender, "their")
+        verbs = "|".join(self._REFLEXIVE_GESTURE_VERBS)
+        parts = "|".join(self._REFLEXIVE_GESTURE_PARTS)
+        # <verb>(s) [one optional adjective] your [one optional adjective] <part>
+        pat = re.compile(
+            rf"\b((?:{verbs})(?:es|s)?\s+(?:\w+\s+)?)your(\s+(?:\w+\s+)?(?:{parts})\b)",
+            re.I)
+
+        def _rewrite(seg):
+            return pat.sub(lambda m: m.group(1) + poss + m.group(2), seg)
 
         chunks = action.split('"')
         chunks[0::2] = [_rewrite(c) for c in chunks[0::2]]

--- a/world/llm/decision_log.py
+++ b/world/llm/decision_log.py
@@ -1,0 +1,53 @@
+"""Opt-in per-turn decision log for the LLM Gamemaster.
+
+Records the RAW model output beside the FINAL rendered text for every NPC turn,
+so the game-side post-processing — verb conjugation, selfify, second-person +
+reflexive-gesture resolution, echo-guard, quote-weaving — is auditable. This is
+the piece the sidecar's ``conversation.log`` can't see: the sidecar logs the
+prompt/context in and the raw JSON out, but the transform from raw output to what
+players actually read happens here in the game.
+
+OFF by default (``settings.LLM_GM_DECISION_LOG``) — a tuning instrument, not a
+production log. Flip it on in ``secret_settings.py`` on the live box while dialing
+a model in; each record is one JSON line under ``server/logs/llm_decisions.log``.
+Never raises: logging must not break a turn.
+"""
+
+import json
+import os
+import time
+
+from django.conf import settings
+
+
+def decision_log_enabled():
+    return bool(getattr(settings, "LLM_GM_DECISION_LOG", False))
+
+
+def _logpath():
+    return os.path.join(getattr(settings, "LOG_DIR", "."), "llm_decisions.log")
+
+
+def log_decision(npc, speaker_name, line, raw_turn, rendered):
+    """Append one turn: what the NPC heard, the raw model decision, and the
+    final rendered channels. ``raw_turn`` is the parsed model dict; ``rendered``
+    is ``{"action", "speech", "thought"}`` as they left the render (None where a
+    channel was empty or woven into another)."""
+    if not decision_log_enabled():
+        return
+    try:
+        room = getattr(getattr(npc, "location", None), "key", None)
+        rec = {
+            "t": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "npc": f"{getattr(npc, 'key', '?')}({getattr(npc, 'dbref', '?')})",
+            "room": room,
+            "heard_from": speaker_name,
+            "heard": line,
+            "raw": {k: (raw_turn or {}).get(k) for k in
+                    ("speech", "action", "thought", "tool", "tool_argument")},
+            "rendered": rendered,
+        }
+        with open(_logpath(), "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    except Exception:  # noqa: BLE001 — logging must never break a turn
+        pass

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -619,3 +619,59 @@ class TestPromptNoBracketBlocks(TestCase):
         # the labels still anchor the blocks
         for label in ("PRESENT", "PERCEPTION", "RECENTLY", "MEMORY"):
             self.assertIn(label, blob)
+
+
+class TestReflexiveGesture(TestCase):
+    """The model writes a self-gesture in the second person ('cock your head')
+    because the prompt addresses IT as 'you'; that must resolve to the NPC's own
+    pronoun BEFORE _resolve_second_person claims the 'your' for the patron.
+    Ambiguous, genuinely patron-directed possessives must be left alone."""
+
+    def _npc(self, gender="male"):
+        b = MagicMock()
+        b.gender = gender
+        b._REFLEXIVE_GESTURE_VERBS = llmnpc.LLMNpcMixin._REFLEXIVE_GESTURE_VERBS
+        b._REFLEXIVE_GESTURE_PARTS = llmnpc.LLMNpcMixin._REFLEXIVE_GESTURE_PARTS
+        _bind(b, "_selfify_reflexive_gesture")
+        return b
+
+    def test_the_live_bug(self):
+        # "cocks your head" (already conjugated) -> the NPC's own head
+        out = self._npc()._selfify_reflexive_gesture(
+            "cocks your head, weathered face ticking")
+        self.assertEqual(out, "cocks his head, weathered face ticking")
+
+    def test_common_self_gestures(self):
+        b = self._npc()
+        cases = {
+            "rolls your shoulders": "rolls his shoulders",
+            "cracks your knuckles": "cracks his knuckles",
+            "shakes your head slow": "shakes his head slow",
+            "arches your brow": "arches his brow",          # -es sibilant form
+            "scratches your jaw": "scratches his jaw",       # -es sibilant form
+            "cock your damn head": "cock his damn head",     # base + adjective
+        }
+        for src, want in cases.items():
+            self.assertEqual(b._selfify_reflexive_gesture(src), want)
+
+    def test_gender_possessive(self):
+        self.assertEqual(
+            self._npc("female")._selfify_reflexive_gesture("cocks your head"),
+            "cocks her head")
+        self.assertEqual(
+            self._npc("nonbinary")._selfify_reflexive_gesture("cocks your head"),
+            "cocks their head")
+
+    def test_patron_directed_left_untouched(self):
+        # ambiguous verbs with real directed uses fall through to the
+        # second-person resolver — a bartender handling the PATRON's body
+        b = self._npc()
+        for src in ("tilts your chin up to meet his eyes",
+                    "cups your jaw", "lifts your head",
+                    "presses your head to the bar", "takes your hand"):
+            self.assertEqual(b._selfify_reflexive_gesture(src), src)
+
+    def test_quoted_speech_skipped(self):
+        b = self._npc()
+        out = b._selfify_reflexive_gesture('grins, "watch your head" and turns')
+        self.assertEqual(out, 'grins, "watch your head" and turns')


### PR DESCRIPTION
Closes #1228

A bartender rendered "cocks your head" at the player. The raw model output
(from the sidecar log) was 'action: cock your head' — the model used "your"
for its OWN head, because the prompt addresses the NPC in second person.
_selfify_action only catches my/mine/me/myself, so "your" fell through to
_resolve_second_person, which maps model you/your onto the interlocutor by
design; a bystander would have read "cocks the patron's head".

_selfify_reflexive_gesture runs before _resolve_second_person and converts
"<self-gesture-verb> your <body-part>" to the NPC's own possessive, gated on
a tight verb+part matrix. Conservative by design: ambiguous verbs with real
patron-directed uses (tilt/lower/raise/cup/stroke/take/press) are left to
fall through so directed gestures still resolve onto the patron.

Adds opt-in world/llm/decision_log.py (settings.LLM_GM_DECISION_LOG, default
OFF): one JSON line per turn pairing the raw model decision with the final
rendered channels — the game-side transform the sidecar log can't see.
_render_llm_reply now returns what it rendered so the terminal can log it.

Regression tests: TestReflexiveGesture. Full LLM suite 139/139 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
