### PR TITLE
Ground LLM persona on real inventory so NPCs stop inventing gear

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -550,7 +550,17 @@ def render_persona(persona: dict) -> str:
         lines.append("You are wearing nothing.")
     carrying = persona.get("carrying")
     if carrying:
-        lines.append("You are carrying: " + ", ".join(carrying) + ".")
+        lines.append("You are carrying: " + ", ".join(carrying)
+                     + ". That is everything you have on you — don't invent "
+                     "weapons, gear, or possessions you aren't carrying.")
+    elif carrying is not None:
+        # Empty inventory renders EXPLICITLY, not as silence: an unstated
+        # inventory is a vacuum the model fills (it invented an "M88 pistol"
+        # for an unarmed bartender when asked what she carried). Naming the
+        # absence grounds it (#1230).
+        lines.append("You are carrying nothing but the clothes you're wearing "
+                     "— don't invent weapons, gear, or possessions you don't "
+                     "have.")
     if persona.get("radio"):
         lines.append(f"You have {persona['radio']} — the 'radio' tool "
                      f"transmits over it; everyone on that band hears you.")

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -74,6 +74,22 @@ class TestBuildMessages(TestCase):
         self.assertNotIn("refer to yourself",
                          render_persona({"persona_seed": {"name": "N"}}).lower())
 
+    def test_carrying_grounds_against_invented_gear(self):
+        # Inventory awareness (#1230): a listed item + an anti-invention clause,
+        # so the model cites what it HAS instead of confabulating (an unarmed
+        # bartender invented an "M88 pistol" when asked what she carried).
+        seed = {"persona_seed": {"name": "Del"}}
+        has = render_persona({**seed, "carrying": ["PAM Reaper shotgun"]})
+        self.assertIn("PAM Reaper shotgun", has)
+        self.assertIn("don't invent", has.lower())
+        # Empty inventory renders EXPLICITLY (not silence — that's the vacuum
+        # the model fills): named absence + the same grounding.
+        empty = render_persona({**seed, "carrying": []})
+        self.assertIn("carrying nothing", empty.lower())
+        self.assertIn("don't invent", empty.lower())
+        # Key wholly absent (defensive fixture) -> no carrying line, no crash.
+        self.assertNotIn("carrying", render_persona(seed).lower())
+
     def test_memories_injected_before_turn(self):
         msgs = build_messages(_PERSONA, "a man", "remember me?", "directed",
                               memories=["he stiffed you on a tab last week",


### PR DESCRIPTION
Closes #1230

An unarmed bartender, asked what she carried, invented an "M88 pistol".
render_persona surfaced 'carrying' only when non-empty, so an empty
inventory rendered as silence — a vacuum the model fills.

render_persona now grounds inventory both ways: with items it lists them
plus "that is everything you have on you — don't invent weapons, gear, or
possessions you aren't carrying"; empty renders explicitly ("carrying
nothing but the clothes you're wearing — don't invent…"). Mirrors the
existing anti-confabulation clauses on the wearing and surroundings lines,
and grounds every LLM NPC.

Content (live DB): racked a PAM Reaper coach gun in Del Marchetti's
inventory so the Last Shift bartender cites a real behind-the-bar shotgun
instead of confabulating one.

Regression test: render_persona carrying (has/empty/absent). 140/140 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
