### PR TITLE
Correct confabulation example in inventory-grounding comment

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -555,9 +555,12 @@ def render_persona(persona: dict) -> str:
                      "weapons, gear, or possessions you aren't carrying.")
     elif carrying is not None:
         # Empty inventory renders EXPLICITLY, not as silence: an unstated
-        # inventory is a vacuum the model fills (it invented an "M88 pistol"
-        # for an unarmed bartender when asked what she carried). Naming the
-        # absence grounds it (#1230).
+        # inventory is a vacuum the model fills (an unarmed bartender, asked
+        # what she carried, invented gear rather than admit she had none).
+        # Naming the absence grounds it (#1230). NB: a SEPARATE failure — the
+        # model confabulating LORE about a REAL item (calling the HDG M88 an
+        # "Italian" gun by a made-up "Capiche") — needs item-lore grounding,
+        # not this; out of scope here.
         lines.append("You are carrying nothing but the clothes you're wearing "
                      "— don't invent weapons, gear, or possessions you don't "
                      "have.")


### PR DESCRIPTION
Follow-up to #1230. The comment claimed the model "invented an M88 pistol",
but the M88 (HDG M88 tactical pistol) is a REAL game item the player named;
the confabulation was LORE about that real gun (a made-up "Capiche" maker /
"Italian" origin, contradicting its real HDG provenance in the prototypes).
That is a distinct failure — item-lore grounding, not inventory presence —
so the comment now says so and marks it out of scope for this change.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
