### PR TITLE
Give LLM NPCs Mr. Hands awareness + a wield/unwield tool

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -629,6 +629,50 @@ class LLMNpcMixin:
                 except Exception:  # noqa: BLE001 — resolution is best-effort
                     pass
                 self.execute_cmd(f"{verb} {garment}")
+        elif tool == "wield" and arg:
+            # Draw/holster/swap through the REAL Mr. Hands commands (wield /
+            # unwield), so the hand state and the fiction stay in agreement.
+            # The model writes natural register ("draw the shotgun", "put the
+            # pistol away"); normalise onto the two commands. wield searches
+            # the stash, unwield searches what's in hand — each does its own
+            # search, so a refusal (no free hand, not carried) reads exactly
+            # as it would for a player.
+            phrase = " ".join(str(arg).split())
+            low = phrase.lower()
+            cmd, item = "wield", phrase
+            # holster/stow family -> unwield; draw/ready family -> wield
+            unwield_leads = ("unwield ", "holster ", "stow ", "sheathe ",
+                             "sheath ", "put away ", "put down ", "lower ",
+                             "rack ", "set down ", "set aside ")
+            wield_leads = ("wield ", "draw ", "hold ", "raise ", "ready ",
+                           "pull ", "level ", "produce ", "grab ", "take up ",
+                           "bring up ", "bring out ", "pull out ")
+            for lead in unwield_leads:
+                if low.startswith(lead):
+                    cmd, item = "unwield", phrase[len(lead):]
+                    break
+            else:
+                for lead in wield_leads:
+                    if low.startswith(lead):
+                        cmd, item = "wield", phrase[len(lead):]
+                        break
+                else:
+                    # trailing "... away/down" (e.g. "put the shotgun away",
+                    # "set the knife down") = stow. Strip the trailing particle
+                    # AND the leading stow-verb the lead-list didn't catch, so
+                    # the middle (the item) is what reaches unwield.
+                    if re.search(r"\s(away|down)$", low):
+                        cmd = "unwield"
+                        item = re.sub(r"\s+(away|down)$", "", phrase, flags=re.I)
+                        item = re.sub(
+                            r"^(?:put|set|lay|tuck|stash|stick|slip|slide)\s+",
+                            "", item.strip(), flags=re.I)
+            # bare item: strip article/possessive lead + any style parenthetical
+            item = re.sub(r"^(?:my|his|her|their|its|the|a|an)\s+", "",
+                          item.strip(), flags=re.I)
+            item = re.sub(r"\s*\([^)]*\)\s*$", "", item).strip()
+            if item:
+                self.execute_cmd(f"{cmd} {item}")
         elif tool == "radio" and arg:
             # Key up for REAL through the transmit command (§7.3) — worn/held
             # walkie first; the command's own fallback covers a built-in comms

--- a/typeclasses/llm_persona.py
+++ b/typeclasses/llm_persona.py
@@ -30,11 +30,14 @@ def _self_pronouns(npc) -> str:
 
 
 def _wardrobe(npc) -> tuple:
-    """(wearing, carrying): worn garments — with their live style state, so the
-    model knows what's zipped/rolled and what the `style` tool can act on — and
-    the loose inventory. This is the NPC's real self-knowledge of its own kit;
-    without it the model invents clothing it isn't wearing."""
-    wearing, carrying = [], []
+    """(wearing, carrying, wielding, hands_free): worn garments — with their
+    live style state, so the model knows what's zipped/rolled and what the
+    `style` tool can act on — the STASHED inventory, what's in the NPC's HANDS
+    right now (Mr. Hands: held-is-wielded), and how many grasping slots are free.
+    This is the NPC's real self-knowledge of its own kit; without it the model
+    invents clothing it isn't wearing or talks about a weapon as if it's already
+    drawn when it's stashed."""
+    wearing, carrying, wielding, hands_free = [], [], [], None
     try:
         worn = list(npc.get_worn_items() or [])
         for item in worn:
@@ -45,10 +48,23 @@ def _wardrobe(npc) -> tuple:
                 entry += f" ({', '.join(states)})"
             wearing.append(entry)
         worn_ids = {id(i) for i in worn}
-        carrying = [obj.key for obj in npc.contents if id(obj) not in worn_ids]
+        # Mr. Hands: `hands` is {container: item_or_None}. Held items are in
+        # hand (wielded), distinct from stashed carry; count the empty slots
+        # so the model knows if it has a free hand to draw INTO.
+        hands = npc.hands or {}
+        held_ids = set()
+        hands_free = 0
+        for container, item in hands.items():
+            if item:
+                wielding.append(f"{item.key} (in {str(container).replace('_', ' ')})")
+                held_ids.add(id(item))
+            else:
+                hands_free += 1
+        carrying = [obj.key for obj in npc.contents
+                    if id(obj) not in worn_ids and id(obj) not in held_ids]
     except Exception:  # noqa: BLE001 — never break persona-building over kit
         pass
-    return wearing, carrying
+    return wearing, carrying, wielding, hands_free
 
 
 def _room_desc(npc) -> str | None:
@@ -109,7 +125,7 @@ def build_persona(npc) -> dict:
         bar_menu = (bar.db.menu if bar else None) or npc.db.menu or []
         menu = [r.get("name") for r in bar_menu if r.get("name")] or None
 
-    wearing, carrying = _wardrobe(npc)
+    wearing, carrying, wielding, hands_free = _wardrobe(npc)
 
     # Radio state (RADIO_COMMS_SPEC §7.3): what the brain can key up with —
     # a worn/held powered walkie, or a built-in comms organ. None = no way
@@ -137,6 +153,8 @@ def build_persona(npc) -> dict:
         "sdesc": npc.get_sdesc(),
         "wearing": wearing,
         "carrying": carrying,
+        "wielding": wielding,
+        "hands_free": hands_free,
         "longdescs": longdescs,
         "skintone": getattr(npc.db, "skintone", None),
         "height": npc.height,

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -55,6 +55,15 @@ TOOLS = {
                         "said your piece, or you'd simply rather move on; "
                         "your speech/action this turn are your goodbye "
                         "(argument: '')"},
+    "wield": {"kind": "action",
+              "desc": "draw a weapon or item from your stash into your hands, "
+                      "holster/put one away, or swap — for REAL (what you're "
+                      "carrying and what's already in your hands is in your "
+                      "card). Drawing or stowing HAPPENS through this tool; a "
+                      "pose alone doesn't move it. Pose the gesture AND call it "
+                      "the same turn. Argument: the verb and the item, e.g. "
+                      "'draw the shotgun', 'holster the pistol', 'put away the "
+                      "knife'"},
     "radio": {"kind": "action",
               "desc": "key up your radio and speak over the air — everyone "
                       "tuned to your band hears it, wherever they are, and "
@@ -139,6 +148,11 @@ def _tools_block(tools) -> str:
                      "a pose alone doesn't remove, put on, or open anything. "
                      "Whenever your action involves your own clothing, pose the "
                      "gesture AND call the tool in the same turn.")
+    if "wield" in tools:
+        lines.append('What\'s in your hands only REALLY changes when you call '
+                     '"wield" — a pose alone doesn\'t draw, holster, or swap '
+                     "anything. Whenever your action puts something in or out of "
+                     "your hands, pose the gesture AND call the tool that turn.")
     return "\n".join(lines)
 
 
@@ -250,7 +264,7 @@ ARCHETYPES = {
         ),
         "length": ("Keep it tight — a line or two of speech and a short pose. "
                    "This is banter, not a monologue."),
-        "tools": ["check_stock", "prepare_drink"],  # + BASE_TOOLS (look)
+        "tools": ["check_stock", "prepare_drink", "wield"],  # + BASE_TOOLS (look)
         # The few-shot IS how a small model learns the register (it copies the
         # last assistant turns far more than it obeys prose rules). Every
         # example here demonstrates the contract: TIGHT (one line + a short
@@ -395,7 +409,7 @@ ARCHETYPES = {
         # radio: a shop with a counter set can key up the civilian band and
         # poke into chatter — only fires when there's a device to key (a
         # merchant with no radio stays mute, xmit refusing, as a player would).
-        "tools": ["release", "radio"],  # buying/pawning is player-driven; + BASE tools
+        "tools": ["release", "radio", "wield"],  # buying/pawning is player-driven; + BASE tools
         "fewshot": [
             {"user": 'a stranger leans on the counter: "what kind of place is this?"',
              "assistant": {"speech": "The kind that buys what you can't keep and "
@@ -548,9 +562,31 @@ def render_persona(persona: dict) -> str:
                      + ", ".join(wearing) + ".")
     elif persona.get("wearing") is not None:
         lines.append("You are wearing nothing.")
+    # Hands (Mr. Hands): what's actually IN HAND right now, distinct from
+    # stashed carry — so the model doesn't talk about a weapon as if it's drawn
+    # when it's tucked away, and knows whether a hand is free to draw into. The
+    # "use the wield tool" nudge only shows if the archetype actually grants it.
+    has_wield = "wield" in tool_names(persona)
+    wield_nudge = (" To draw, holster, or swap what's in your hands, use the "
+                   "'wield' tool — a pose alone doesn't move it.") if has_wield else ""
+    wielding = persona.get("wielding")
+    if wielding:
+        line = "In your hands right now: " + ", ".join(wielding) + "."
+        free = persona.get("hands_free")
+        if free:
+            line += (" Your other hand is free." if free == 1
+                     else f" You have {free} free hands.")
+        lines.append(line + wield_nudge)
+    elif persona.get("hands_free"):
+        empty = "Your hands are empty."
+        if has_wield:
+            empty += (" To draw something you're carrying into your hands, use "
+                      "the 'wield' tool — narrating it in a pose alone doesn't "
+                      "actually draw it.")
+        lines.append(empty)
     carrying = persona.get("carrying")
     if carrying:
-        lines.append("You are carrying: " + ", ".join(carrying)
+        lines.append("You are carrying (stashed, not in hand): " + ", ".join(carrying)
                      + ". That is everything you have on you — don't invent "
                      "weapons, gear, or possessions you aren't carrying.")
     elif carrying is not None:

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -633,6 +633,14 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         b._is_alone_with = lambda speaker: False
         # real _resolve_second_person needs a concrete handle
         b._address_handle = lambda t: "a lean man"
+        # The pose sub-helpers (conjugation, selfify, reflexive-gesture) each
+        # have their own test classes; here they pass through so the render
+        # assertions pin the ORCHESTRATION (weaving + command routing), not the
+        # grammar transforms. Without this they'd return MagicMocks (they read
+        # class-attr matrices off `self` that a bare mock doesn't carry).
+        b._conjugate_action = lambda a: a
+        b._selfify_action = lambda a: a
+        b._selfify_reflexive_gesture = lambda a: a
         # default: no long-term memories → _try_llm_reply skips the embed round-
         # trip and goes straight to generation (Phase 2; override per test)
         b._load_memories = lambda: []

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -675,3 +675,41 @@ class TestReflexiveGesture(TestCase):
         b = self._npc()
         out = b._selfify_reflexive_gesture('grins, "watch your head" and turns')
         self.assertEqual(out, 'grins, "watch your head" and turns')
+
+
+class TestWieldTool(TestCase):
+    """The wield action tool routes natural draw/holster phrasing onto the REAL
+    Mr. Hands commands (wield / unwield), so hand state and fiction agree."""
+
+    def _npc(self):
+        b = MagicMock()
+        b.location = "room"
+        _bind(b, "_handle_action_tool")
+        return b
+
+    def _wield(self, arg):
+        b = self._npc()
+        b._handle_action_tool("wield", arg, MagicMock())
+        return b.execute_cmd.call_args.args[0] if b.execute_cmd.called else None
+
+    def test_draw_family_routes_to_wield(self):
+        for arg, want in (("draw the shotgun", "wield shotgun"),
+                          ("the boomstick", "wield boomstick"),
+                          ("bring out my coach gun", "wield coach gun"),
+                          ("wield reaper in right", "wield reaper in right")):
+            self.assertEqual(self._wield(arg), want)
+
+    def test_holster_family_routes_to_unwield(self):
+        for arg, want in (("holster the pistol", "unwield pistol"),
+                          ("unwield shotgun", "unwield shotgun"),
+                          ("put the shotgun away", "unwield shotgun"),
+                          ("set the knife down", "unwield knife")):
+            self.assertEqual(self._wield(arg), want)
+
+    def test_empty_arg_no_command(self):
+        b = self._npc()
+        b._handle_action_tool("wield", "", MagicMock())
+        b.execute_cmd.assert_not_called()
+
+    def test_style_parenthetical_stripped(self):
+        self.assertEqual(self._wield("draw the shotgun (loaded)"), "wield shotgun")

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -90,6 +90,27 @@ class TestBuildMessages(TestCase):
         # Key wholly absent (defensive fixture) -> no carrying line, no crash.
         self.assertNotIn("carrying", render_persona(seed).lower())
 
+    def test_hands_awareness_and_wield_tool_grant(self):
+        # Mr. Hands awareness: what's IN HAND now vs stashed, gated wield nudge.
+        drawn = render_persona({"persona_seed": {"archetype": "bartender", "name": "Del"},
+                                "wielding": ["PAM Reaper shotgun (in right hand)"],
+                                "hands_free": 1, "carrying": []})
+        self.assertIn("In your hands right now", drawn)
+        self.assertIn("other hand is free", drawn)
+        self.assertIn("'wield' tool", drawn)  # bartender HAS the tool
+        stashed = render_persona({"persona_seed": {"archetype": "bartender", "name": "Del"},
+                                  "wielding": [], "hands_free": 2,
+                                  "carrying": ["PAM Reaper shotgun"]})
+        self.assertIn("hands are empty", stashed.lower())
+        self.assertIn("stashed, not in hand", stashed.lower())
+        # A companion has NO wield tool — state is shown, but no wield nudge.
+        comp = render_persona({"persona_seed": {"archetype": "companion", "name": "V"},
+                               "wielding": [], "hands_free": 2, "carrying": []})
+        self.assertIn("hands are empty", comp.lower())
+        self.assertNotIn("wield", comp.lower())
+        self.assertIn("wield", tool_names({"persona_seed": {"archetype": "bartender"}}))
+        self.assertNotIn("wield", tool_names({"persona_seed": {"archetype": "companion"}}))
+
     def test_memories_injected_before_turn(self):
         msgs = build_messages(_PERSONA, "a man", "remember me?", "directed",
                               memories=["he stiffed you on a tab last week",
@@ -237,7 +258,7 @@ class TestToolScoping(TestCase):
     def test_bartender_grants_its_job_tools_plus_base(self):
         names = tool_names(_PERSONA)  # bartender archetype
         self.assertEqual(names, ["look", "remember", "feel",
-                                 "check_stock", "prepare_drink"])
+                                 "check_stock", "prepare_drink", "wield"])
 
     def test_schema_scoped_to_archetype(self):
         # the social archetype gets the base tools (look/remember/feel) but
@@ -317,8 +338,8 @@ class TestParseTurn(TestCase):
     def test_schema_tool_enum(self):
         self.assertEqual(TURN_SCHEMA["properties"]["tool"]["enum"],
                          ["none", "look", "remember", "feel", "style",
-                          "release", "radio", "check_stock", "prepare_drink",
-                          "diagnose", "treat", "install"])
+                          "release", "wield", "radio", "check_stock",
+                          "prepare_drink", "diagnose", "treat", "install"])
 
 
 class TestActionNormalization(TestCase):
@@ -443,7 +464,7 @@ class TestWardrobeCard(TestCase):
         text = render_persona({"wearing": ["mesh top (unzipped)", "slit skirt"],
                                "carrying": ["heeled boots"]})
         self.assertIn("mesh top (unzipped), slit skirt", text)
-        self.assertIn("carrying: heeled boots", text)
+        self.assertIn("carrying (stashed, not in hand): heeled boots", text)
 
     def test_stripped_reads_naked(self):
         # an empty (but present) wardrobe means undressed — the model must
@@ -472,7 +493,7 @@ class TestStyleAdoption(TestCase):
     def test_style_rule_absent_when_not_granted(self):
         msgs = build_messages({"persona_seed": {"archetype": "bartender"}},
                               "a man", "hi", "directed")
-        self.assertNotIn("REALLY changes", msgs[0]["content"])
+        self.assertNotIn("clothing only REALLY changes", msgs[0]["content"])
 
 
 class TestSurroundings(TestCase):
@@ -558,7 +579,7 @@ class TestMerchantArchetype(TestCase):
         self.assertIn("merchant", ARCHETYPES)
         # no fake buy/sell tool — transactions go through the shop command
         self.assertEqual(tool_names(self._merchant()),
-                         ["look", "remember", "feel", "release", "radio"])
+                         ["look", "remember", "feel", "release", "radio", "wield"])
 
     def test_duties_ground_ownership(self):
         msgs = build_messages(self._merchant(), "someone",


### PR DESCRIPTION
Closes #1233

After Del got a shotgun (#1230) the model fixated on it, narrating handling
of a STASHED weapon turn after turn (decision log: "rake the barrel of the
shotgun", a garbled "puts away the shotgun rag ... double boilermaker"). The
persona listed the shotgun under carrying but gave no sense of in-hand vs
put-away, and no way to actually draw or holster it.

Awareness (universal): build_persona reads npc.hands and splits inventory
into wielding (in-hand, with which hand) vs carrying (stashed), plus a
free-hand count; render_persona states it plainly so the model stops
treating a put-away weapon as drawn.

Agency (scoped): new wield action tool routes natural draw/holster phrasing
onto the real wield/unwield commands (same execute_cmd pattern as style/
radio). Granted to bartender + merchant; security stays deterministic;
companion/doctor/colonist don't get it. The card's wield nudge shows only
when the tool is granted.

Also fixes pre-existing test_bar breakage: TestBartenderLLMRouting render
tests fed MagicMocks through the pose sub-helpers (_conjugate_action #1226,
_selfify_reflexive_gesture) — uncaught because those suites weren't in the
#1226/#1228 sweeps. Fixture now passes the sub-helpers through.

Tests: TestWieldTool + hands-awareness render. 232/232 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
