### PR TITLE
Deterministic conversational drink orders + remember/feel few-shot

### DIFF
--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -342,6 +342,28 @@ ACK_EMOTES = (
 #: Minimum seconds between acknowledgements, so a chatty room doesn't spam them.
 ACK_COOLDOWN = 6.0
 
+#: Imperative cues that mark spoken words as a drink ORDER (vs a casual mention).
+#: A DETERMINISTIC conversational order — spoken to the bartender in open speech,
+#: not just the formal `to del, whiskey` form — routes to the real serve path so
+#: a real order never rides on the model's flaky prepare_drink tool roll.
+ORDER_CUES = (
+    "pour", "gimme", "give me", "get me", "make me", "fix me", "grab me",
+    "i'll have", "i'll take", "i will have", "lemme get", "let me get",
+    "let me have", "hit me with", "set me up", "line me up", "can i get",
+    "can i have", "i'd like", "i would like", "i want", "i need a", "another",
+)
+
+#: Throwaway words around a BARE order ("whiskey, neat") — strip these and the
+#: drink's own keywords; if nothing meaningful is left, the whole line WAS the
+#: order (so "whiskey ruined me" — remainder "ruined" — is correctly NOT one).
+ORDER_FILLER = frozenset((
+    "a", "an", "the", "one", "some", "of", "glass", "mug", "shot", "shots",
+    "pint", "double", "single", "neat", "straight", "up", "rocks", "on",
+    "cold", "chilled", "stiff", "tall", "please", "thanks", "cheers", "and",
+    "with", "ice", "make", "it", "me", "just", "yeah", "gimme", "another",
+    "round",
+))
+
 
 class Bartender(LLMNpcMixin, Character):
     """An NPC that takes drink orders by being spoken to (the `to` command).
@@ -390,7 +412,43 @@ class Bartender(LLMNpcMixin, Character):
         if kwargs.get("addressed"):
             delay(1.5, self._fulfil_order, speech, speaker)
             return True
+        # DETERMINISTIC conversational order (reliability lever): a clear spoken
+        # order goes to the real serve path instead of the model's flaky
+        # prepare_drink — but only when it's plausibly aimed at THIS bartender
+        # (engaged/alone/named), so an order overheard across the room doesn't
+        # get served. Anything ambiguous still flows to the LLM as the backstop.
+        if (self._is_conversational_order(speech)
+                and self._classify_speech(speech, speaker) == "directed"):
+            delay(1.5, self._fulfil_order, speech, speaker)
+            return True
         return False
+
+    def _is_conversational_order(self, speech):
+        """Deterministic drink-order detector. Conservative by design — a
+        question or a casual drink mention is NOT an order. It's an order only
+        when a servable drink resolves AND either an imperative cue is present
+        ("pour me a rotgut") OR the whole line is just that drink plus filler
+        ("whiskey, neat")."""
+        import re
+        low = " ".join((speech or "").lower().split())
+        if not low or "?" in low:
+            return False
+        bar = self._find_bar()
+        recipe, _off = (resolve_drink(low, bar) if bar
+                        else (match_recipe(low, self.db.menu or []), False))
+        if not recipe:
+            return False
+        if any(cue in low for cue in ORDER_CUES):
+            return True
+        # Bare order: strip the matched drink's keywords + its name + filler;
+        # an empty remainder means the line WAS the order and nothing else.
+        kws = set()
+        for kw in recipe.get("order_keywords", (recipe.get("name", ""),)):
+            kws.update(kw.lower().split())
+        kws.update(recipe.get("name", "").lower().split())
+        remainder = [w for w in re.findall(r"[a-z']+", low)
+                     if w not in kws and w not in ORDER_FILLER]
+        return not remainder
 
     def _name_aliases(self):
         return ["bartender", "barkeep", "barkeeper"]

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -287,6 +287,23 @@ ARCHETYPES = {
                                      "clean glass in front of the scarred woman",
                            "thought": "No small talk. My kind of customer.",
                            "tool": "prepare_drink", "tool_argument": "whiskey"}},
+            # remember: coin a private nickname for someone worth tagging — the
+            # thought carries the WHY, the argument is the name only (no pronoun).
+            {"user": 'a twitchy man says to you: "you didn\'t see me here '
+                     'tonight, yeah?"',
+             "assistant": {"speech": "I see a lot of nothing. It's a talent.",
+                           "action": "keeps wiping the same spot on the bar, not "
+                                     "looking up",
+                           "thought": "Third time this week he's asked me to "
+                                      "forget him. A man that careful earns a name.",
+                           "tool": "remember", "tool_argument": "the ghost"}},
+            # feel: update the private read when someone's behaviour shifts how
+            # you regard them — a short plain word, not every turn.
+            {"user": 'a smug suit says to you: "keep the change, sweetheart."',
+             "assistant": {"speech": "Generous of you.",
+                           "action": "rakes the coins off the bar without a glance",
+                           "thought": "Talks to me like I'm furniture. That sticks.",
+                           "tool": "feel", "tool_argument": "condescending"}},
             {"user": 'a cocky droog says to you: "you always this slow?"',
              "assistant": {"speech": "Only for the ones worth making wait.",
                            "action": "slides the glass over slow, holding the "

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -631,6 +631,9 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
             setattr(b, name, bound)
         # default: not alone (so ambient stays ambient); override per test
         b._is_alone_with = lambda speaker: False
+        # these routing tests use non-order speech; the deterministic order
+        # detector is exercised in its own test class, off here.
+        b._is_conversational_order = lambda s: False
         # real _resolve_second_person needs a concrete handle
         b._address_handle = lambda t: "a lean man"
         # The pose sub-helpers (conjugation, selfify, reflexive-gesture) each
@@ -961,3 +964,75 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         self.assertTrue(b._mentions_self("yo bartender"))
         self.assertTrue(b._mentions_self("nice catgirl ears"))
         self.assertFalse(b._mentions_self("this whole place is dead"))
+
+
+class TestConversationalOrderDetection(BaseEvenniaTest):
+    """Deterministic conversational-order detection (reliability lever): a clear
+    spoken order routes to the real serve path instead of the model's flaky
+    prepare_drink tool; a question or a casual drink mention does NOT."""
+
+    MENU = [{"name": "rotgut", "order_keywords": ("rotgut", "whiskey")},
+            {"name": "gin", "order_keywords": ("gin",)},
+            {"name": "beer", "order_keywords": ("beer",)}]
+
+    def _bartender(self):
+        b = MagicMock()
+        b._find_bar = lambda: None          # no bar obj → match against db.menu
+        b.db.menu = self.MENU
+        b._is_conversational_order = barmod.Bartender._is_conversational_order.__get__(
+            b, barmod.Bartender)
+        return b
+
+    def test_orders_detected(self):
+        b = self._bartender()
+        for s in ("pour me a rotgut", "whiskey, neat", "rotgut.", "gimme a beer",
+                  "another gin", "a beer", "one whiskey please", "i'll have a gin",
+                  "set me up with a gin"):
+            self.assertTrue(b._is_conversational_order(s), f"should be order: {s!r}")
+
+    def test_non_orders_ignored(self):
+        b = self._bartender()
+        for s in ("is it safe to talk in here?", "i need to forget today",
+                  "you always work alone?", "i had a whiskey earlier",
+                  "whiskey ruined me", "is the gin any good",
+                  "this beer belly's killing me", "nice place", ""):
+            self.assertFalse(b._is_conversational_order(s), f"not an order: {s!r}")
+
+
+class TestConversationalOrderRouting(BaseEvenniaTest):
+    """_handle_directed_speech routes a detected order to _fulfil_order ONLY when
+    it's plausibly aimed at this bartender (directed), never on ambient chatter."""
+
+    def _bartender(self, order=True, kind="directed"):
+        b = MagicMock()
+        b._is_gratitude = lambda s: False
+        b._is_conversational_order = lambda s: order
+        b._classify_speech = lambda s, spk: kind
+        b._handle_directed_speech = barmod.Bartender._handle_directed_speech.__get__(
+            b, barmod.Bartender)
+        return b
+
+    def test_directed_order_routes_to_serve(self):
+        b = self._bartender(order=True, kind="directed")
+        with patch.object(barmod, "delay") as d:
+            handled = b._handle_directed_speech("pour me a rotgut", MagicMock(),
+                                                {"addressed": False})
+        self.assertTrue(handled)
+        # delay(1.5, self._fulfil_order, speech, speaker) — arg[1] is the callback
+        self.assertEqual(d.call_args.args[1], b._fulfil_order)
+
+    def test_ambient_order_not_served(self):
+        # same order words, but overheard (not aimed at us) → falls through to LLM
+        b = self._bartender(order=True, kind="ambient")
+        with patch.object(barmod, "delay") as d:
+            handled = b._handle_directed_speech("pour me a rotgut", MagicMock(),
+                                                {"addressed": False})
+        self.assertFalse(handled)
+        d.assert_not_called()
+
+    def test_non_order_falls_through(self):
+        b = self._bartender(order=False, kind="directed")
+        with patch.object(barmod, "delay") as d:
+            handled = b._handle_directed_speech("rough night?", MagicMock(),
+                                                {"addressed": False})
+        self.assertFalse(handled)


### PR DESCRIPTION
Closes #1235

Narrow the 12B to what it's good at (voice, discretionary reads) and route
the transaction it's weak at (drink orders) deterministically.

_is_conversational_order detects a spoken order in open speech — a servable
drink resolves AND either an imperative cue ("pour me a rotgut") or the whole
line is just that drink plus filler ("whiskey, neat") — and routes it to the
real _fulfil_order serve path instead of the model's flaky prepare_drink.
Conservative (a question or casual mention like "whiskey ruined me" is not an
order) and gated on directedness so an order overheard across the room isn't
served. prepare_drink stays as a backstop. 16/16 on the case set.

remember/feel few-shot: the memory tools were firing zero (she named nobody
despite forming clear reads). A remember/feel demonstration in the bartender
few-shot (ending on a restraint example) gets them firing on sensible targets
with prepare_drink accuracy within noise — and moot for real orders now that
those are deterministic. Lights up the dormant dossier/recognition layer.

Tests: TestConversationalOrderDetection + TestConversationalOrderRouting.
237/237 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
