### PR TITLE
Fix the action-tool demonstration gap across LLM archetypes

### DIFF
--- a/typeclasses/clinic.py
+++ b/typeclasses/clinic.py
@@ -11,6 +11,8 @@ This is the brain + job hooks only; the persona's ``archetype`` ('doctor', in
 ``world/llm/prompt``) is the role. Opt in per-NPC via ``db.llm_driven``.
 """
 
+from evennia.utils import delay
+
 from typeclasses.characters import Character
 from typeclasses.furniture import AutoDoc
 from typeclasses.llm_npc import LLMNpcMixin
@@ -44,6 +46,24 @@ CLINIC_CYBERWARE = {
     "heart": ("CYBERNETIC_HEART", False),
     "tail": ("CYBERNETIC_TAIL", False),
 }
+
+#: Deterministic medical-request vocab (parity with the bartender's order parser,
+#: #1235): an EXPLICIT patient request for a procedure runs for real instead of
+#: riding the model's flaky treat/install roll. The sim-DRIVEN treatment a doctor
+#: decides from a diagnosis still flows to the LLM — that need is in the sim, not
+#: the words, so it can't be parsed away.
+CYBER_WORDS = ("arm", "eye", "ear", "kidney", "jaw", "heart", "tail")
+SUPPLY_WORDS = ("painkiller", "morphine", "bandage", "gauze", "dressing", "blood",
+                "transfusion", "stim", "stimpak", "splint", "pain")
+#: chrome qualifiers on a body part → an install request ("chrome arm", "cyber eye")
+CHROME_QUALIFIERS = ("cyber", "chrome", "bionic", "prosthetic", "mechanical")
+#: verbs that mark an install request even without a chrome word ("replace my arm")
+INSTALL_CUES = ("install", "fit me", "fit a", "put in", "wire me", "chrome me",
+                "replace my", "swap in", "swap out", "give me a new",
+                "i want a new", "hook me up with", "put a")
+#: verbs that mark a supply request ("gimme a painkiller", "something for the pain")
+TREAT_CUES = ("gimme", "give me", "i need", "i want", "hit me with", "hook me up",
+              "can i get", "shoot me", "get me", "i could use", "something for")
 
 
 class Doctor(LLMNpcMixin, Character):
@@ -80,6 +100,44 @@ class Doctor(LLMNpcMixin, Character):
 
     def _name_aliases(self):
         return ["doctor", "doc", "medic", "surgeon", "ripperdoc"]
+
+    # --- deterministic medical requests (reliability lever) --------------
+    def _handle_directed_speech(self, speech, speaker, kwargs):
+        """An EXPLICIT patient request for a procedure runs deterministically —
+        'put a chrome arm on me' / 'gimme a painkiller' go straight to the real
+        install/treat path instead of the model's flaky tool roll (parity with
+        the bartender's order parser). Gated on directedness so a complaint
+        overheard across the room isn't acted on. Diagnosis-DRIVEN treatment
+        still flows to the LLM (the need is in the sim, not the words)."""
+        req = self._parse_medical_request(speech)
+        if req and self._classify_speech(speech, speaker) == "directed":
+            kind, arg = req
+            patient = self._patient(speaker)
+            runner = self._install_cyber if kind == "install" else self._treat
+            delay(1.5, runner, patient, arg)
+            return True
+        return False
+
+    def _parse_medical_request(self, speech):
+        """('install', speech) | ('treat', speech) | None. Conservative — a
+        question or a bare symptom mention ('my arm hurts', 'my heart's racing')
+        is NOT a request: an install needs a cyberware part AND a chrome word or
+        install verb; a treat needs a supply word AND a request cue."""
+        import re
+        low = " ".join((speech or "").lower().split())
+        if not low or "?" in low:
+            return None
+        words = re.findall(r"[a-z]+", low)   # whole words, punctuation stripped
+        # INSTALL: a cyberware part (whole word) + a chrome qualifier or install verb
+        if any(w in words for w in CYBER_WORDS) and (
+                any(q in low for q in CHROME_QUALIFIERS)
+                or any(c in low for c in INSTALL_CUES)):
+            return ("install", speech)
+        # TREAT: a supply word + an explicit request cue
+        if (any(w in low for w in SUPPLY_WORDS)
+                and any(c in low for c in TREAT_CUES)):
+            return ("treat", speech)
+        return None
 
     # --- tool routing over the shared LLM brain --------------------------
     def _run_context_tool(self, tool, arg, patron):

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -339,6 +339,25 @@ ARCHETYPES = {
                            "thought": "Nervous hands. He'll talk a big game and "
                                       "fold the second I lean in.",
                            "tool": "none", "tool_argument": ""}},
+            # remember: reading people IS the trade — coin a private name for a
+            # client worth knowing (the thought carries the why, name only).
+            {"user": 'a patron says to you: "you probably don\'t even remember me."',
+             "assistant": {"speech": "I remember what matters, sweetheart. The "
+                                     "rest is just noise.",
+                           "action": "traces a slow line down the lean man's "
+                                     "lapel, holding his eyes",
+                           "thought": "Third time back, same nerves he tries to "
+                                      "hide. He wants to be known.",
+                           "tool": "remember", "tool_argument": "the regular"}},
+            # feel: let a client's behaviour update your private read on them.
+            {"user": 'a patron says to you: "just sit there and look pretty."',
+             "assistant": {"speech": "For you? I can do decorative. Costs the "
+                                     "same either way.",
+                           "action": "settles back, the smile cooling half a "
+                                     "degree",
+                           "thought": "Talks down when he's nervous. Not cruel — "
+                                      "scared. Worth remembering how he softens.",
+                           "tool": "feel", "tool_argument": "guarded, all front"}},
             {"user": 'a patron says to you: "rough day. i just need to forget it."',
              "assistant": {"speech": "Then leave it at the door, sweetheart. In "
                                      "here it's just you and me and however long "
@@ -383,6 +402,37 @@ ARCHETYPES = {
                            "thought": "Pale, sweating. That's not a man who's "
                                       "fine. Blood loss, maybe worse.",
                            "tool": "diagnose", "tool_argument": ""}},
+            # The FOLLOW-THROUGH: after diagnose hands back the read, TREAT for
+            # real with the right supply — don't just narrate mending it. This
+            # 2-step (diagnose → treat) is the move a small model drops.
+            {"user": "TOOL RESULT (diagnose) — Deep laceration, right forearm. "
+                     "Bleeding: moderate. Blood loss 25%. Pain: high.",
+             "assistant": {"speech": "Hold still. Pressure first — the rest can "
+                                     "wait.",
+                           "action": "packs the gash and winds a bandage tight "
+                                     "around the forearm",
+                           "thought": "Clean edges, no tendon in it. Bandage "
+                                      "holds this.",
+                           "tool": "treat", "tool_argument": "bandage"}},
+            # Chrome they ask for: fit it for real (install), don't narrate it.
+            {"user": 'a hard woman says to you: "right arm\'s dead weight. put a '
+                     'chrome one on."',
+             "assistant": {"speech": "Sit. Sleeve off, chrome on — let the 'doc "
+                                     "do the cutting.",
+                           "action": "clamps the cybernetic arm into the mount "
+                                     "and keys the AutoDoc's incision arc",
+                           "thought": "Stump's healed clean. Good candidate.",
+                           "tool": "install", "tool_argument": "cyber arm right"}},
+            # Restraint: someone just talking is not a patient — don't diagnose
+            # a man making conversation.
+            {"user": 'a lean man says to you: "slow night, doc?"',
+             "assistant": {"speech": "Slow's good. Slow means nobody's bleeding "
+                                     "on my floor.",
+                           "action": "wipes down the instrument tray, not looking "
+                                     "up",
+                           "thought": "Just talk. Nothing to read, nothing to "
+                                      "fix.",
+                           "tool": "none", "tool_argument": ""}},
         ],
     },
     "colonist": {
@@ -438,6 +488,24 @@ ARCHETYPES = {
                            "thought": "Empty hands, restless eyes. Browser, not "
                                       "a seller. We'll see if he has credits.",
                            "tool": "none", "tool_argument": ""}},
+            # remember: a shopkeeper KNOWS their faces — tag one worth watching.
+            {"user": 'a stranger says to you: "just browsing. don\'t mind me."',
+             "assistant": {"speech": "Browse all you want. Good stuff's behind "
+                                     "glass, and the glass is watching.",
+                           "action": "keeps a quarter-eye on the lean man's hands, "
+                                     "not his face",
+                           "thought": "Says browsing, cases the shelves like he's "
+                                      "pricing a job. That one gets a name.",
+                           "tool": "remember", "tool_argument": "the caser"}},
+            # feel: update the private read when they show you who they are.
+            {"user": 'a stranger says to you: "this all you got? figured a real '
+                     'shop."',
+             "assistant": {"speech": "Real enough to turn away tyre-kickers. You "
+                                     "buying, or just appraising my patience?",
+                           "action": "rests both hands flat on the counter, "
+                                     "unhurried",
+                           "thought": "Mouth first, credits never. Time-waster.",
+                           "tool": "feel", "tool_argument": "tyre-kicker"}},
         ],
     },
     "security": {
@@ -476,6 +544,27 @@ ARCHETYPES = {
                            "thought": "Subject is talking instead of running. "
                                       "Probability of flight: reduced.",
                            "tool": "none", "tool_argument": ""}},
+            # remember: designate a repeat/evasive subject for tracking (the
+            # machine's version of coining a private handle).
+            {"user": 'a man says to you: "i already told your buddy everything. '
+                     'now back off."',
+             "assistant": {"speech": "Statement on file. Remain available for "
+                                     "follow-up. Do not leave the district.",
+                           "action": "logs the man's face against the open "
+                                     "incident record",
+                           "thought": "Second contact, same evasion. Designate "
+                                      "for tracking.",
+                           "tool": "remember", "tool_argument": "the evasive "
+                                             "subject"}},
+            # feel: flag a subject's disposition for the record (§ note it).
+            {"user": 'a man says to you: "you tin cans don\'t scare me. i\'m not '
+                     'moving."',
+             "assistant": {"speech": "Compliance is not fear. Second instruction: "
+                                     "clear the walkway.",
+                           "action": "holds position, optics locked, servos "
+                                     "idling",
+                           "thought": "Non-compliant, escalating. Flag it.",
+                           "tool": "feel", "tool_argument": "uncooperative"}},
         ],
     },
 }

--- a/world/tests/test_clinic.py
+++ b/world/tests/test_clinic.py
@@ -123,3 +123,82 @@ class TestDoctorInstall(BaseEvenniaTest):
         self.assertIn("organ_item_key", install["args"])
         self.assertTrue(install["args"]["location"])      # an anchor was resolved
         self.assertIsNotNone(chart_lib.get_chart(patient))  # saved on the patient
+
+
+class TestMedicalRequestParser(BaseEvenniaTest):
+    """Deterministic medical-request detection (reliability lever, parity with the
+    bartender's order parser): an EXPLICIT install/treat request runs for real; a
+    question or bare symptom mention does NOT."""
+
+    def _doctor(self):
+        d = MagicMock()
+        d._parse_medical_request = clinicmod.Doctor._parse_medical_request.__get__(
+            d, clinicmod.Doctor)
+        return d
+
+    def test_install_requests(self):
+        d = self._doctor()
+        for s in ("put a chrome arm on me. i got the creds.",
+                  "i want a cyber eye. left side.", "install a new kidney",
+                  "replace my heart", "give me a new arm",
+                  "right arm's dead weight. put a chrome one on."):
+            self.assertEqual((d._parse_medical_request(s) or (None,))[0],
+                             "install", f"install: {s!r}")
+
+    def test_treat_requests(self):
+        d = self._doctor()
+        for s in ("gimme a painkiller", "need something for the pain",
+                  "i need a stim", "hit me with the blood"):
+            self.assertEqual((d._parse_medical_request(s) or (None,))[0],
+                             "treat", f"treat: {s!r}")
+
+    def test_not_requests(self):
+        d = self._doctor()
+        for s in ("my arm hurts", "my heart's racing", "keep an eye out for trouble",
+                  "blood everywhere, help", "something's broke in here",
+                  "just patch me up doc", "can you fix my eye?",
+                  "i had a stim earlier", ""):
+            self.assertIsNone(d._parse_medical_request(s), f"not a request: {s!r}")
+
+
+class TestMedicalRequestRouting(BaseEvenniaTest):
+    """_handle_directed_speech routes an explicit request to the real install/
+    treat path — only when directed at this doctor, never on ambient chatter."""
+
+    def _doctor(self, req, kind="directed"):
+        d = MagicMock()
+        d._parse_medical_request = lambda s: req
+        d._classify_speech = lambda s, spk: kind
+        d._patient = lambda spk: "patient"
+        d._handle_directed_speech = clinicmod.Doctor._handle_directed_speech.__get__(
+            d, clinicmod.Doctor)
+        return d
+
+    def test_directed_install_routes(self):
+        d = self._doctor(("install", "put a chrome arm on me"))
+        with patch.object(clinicmod, "delay") as dl:
+            handled = d._handle_directed_speech("put a chrome arm on me",
+                                                MagicMock(), {})
+        self.assertTrue(handled)
+        self.assertEqual(dl.call_args.args[1], d._install_cyber)
+
+    def test_directed_treat_routes(self):
+        d = self._doctor(("treat", "gimme a painkiller"))
+        with patch.object(clinicmod, "delay") as dl:
+            handled = d._handle_directed_speech("gimme a painkiller", MagicMock(), {})
+        self.assertTrue(handled)
+        self.assertEqual(dl.call_args.args[1], d._treat)
+
+    def test_ambient_request_not_acted(self):
+        d = self._doctor(("install", "put a chrome arm on me"), kind="ambient")
+        with patch.object(clinicmod, "delay") as dl:
+            handled = d._handle_directed_speech("put a chrome arm on me",
+                                                MagicMock(), {})
+        self.assertFalse(handled)
+        dl.assert_not_called()
+
+    def test_non_request_falls_through(self):
+        d = self._doctor(None)
+        handled = d._handle_directed_speech("something's broke in here",
+                                            MagicMock(), {})
+        self.assertFalse(handled)


### PR DESCRIPTION
Closes #1237

Generalizing the bartender finding: every archetype's action tools must be
DEMONSTRATED in its few-shot, not just described — a 12B copies the few-shot.

Doctor (live + broken): bench showed treat firing 1/5 even after diagnosis
(narrated treatment instead of calling treat), install 0/6. Added a
treat/install/none few-shot (the diagnose->treat follow-through) -> treat
after diagnose 1/5 -> 6/7. Added _parse_medical_request: an explicit patient
request ("put a chrome arm on me", "gimme a painkiller") routes to the real
install/treat path deterministically (parity with the drink-order parser),
directed-gated, conservative. That is the install path — install is always
patient-requested, so the LLM never firing install no longer matters.

Companion/merchant/security: all grant remember/feel but demonstrated
neither, leaving the recognition layer cold. Added archetype-voiced
remember/feel demos; companion spot-bench confirms remember now fires (was
zero). Colonist left minimal by design.

Tests: TestMedicalRequestParser + TestMedicalRequestRouting. 258/258 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
