### PR TITLE
Build the Butcher gig: deterministic buy/break-down/pay + butcher archetype

### DIFF
--- a/typeclasses/butcher.py
+++ b/typeclasses/butcher.py
@@ -1,0 +1,273 @@
+"""The Butcher — the first gig NPC (GIG_PROTOTYPE_BUTCHER_SPEC).
+
+The prototype fetch-quest loop: a player hands over an ANIMAL corpse (``give
+corpse to butcher``), and the Butcher deterministically breaks it down via a
+per-species butchery table — named cuts gated by each part's real condition on
+the corpse, the remainder ground to mystery meat — destroys the carcass, and
+pays the supplier by yield value. The LLM brain (``LLMNpcMixin``) provides
+voice and memory ON TOP of the transaction, never inside it: a real payout
+never rides a model tool-roll (LLM_GAMEMASTER_SPEC tool-reliability note).
+
+Human / synthetic / robot corpses are REFUSED — sapient bodies are the future
+Ripper's trade, and chrome isn't food.
+"""
+
+from evennia import create_object
+from evennia.utils.utils import delay
+
+from typeclasses.characters import Character
+from typeclasses.items import Item
+from typeclasses.llm_npc import LLMNpcMixin
+from world.grammar import with_article
+
+#: Species the block buys. Everything else is refused (see _refuse_species).
+ACCEPTED_BUTCHER_SPECIES = frozenset({"rat"})
+
+#: Decay factor (0.0 fresh → 1.0 a week gone) beyond which a carcass is
+#: refused outright — past even her standards.
+BUTCHER_DECAY_REFUSAL = 0.6
+
+#: Register floor: below this the till can't cover a carcass and she stops
+#: buying until it's fed (finite till — the economy hook).
+BUTCHER_TILL_FLOOR = 5
+
+#: The rat butchery table (spec §3.4): per-product value and flavour. Yields
+#: are computed against the corpse's REAL condition in `_butcher_yields`.
+RAT_PRODUCTS = {
+    "rat tail": {
+        "value": 5, "aliases": ["tail"],
+        "desc": "A skinned rat tail, long as a forearm, coiled and tied off "
+                "with butcher's twine. The classic stew base of the colony's "
+                "cheaper kitchens.",
+        "taste": "Gelatinous and faintly sweet, all cartilage and slow-cooked "
+                 "promise — wasted eaten raw.",
+    },
+    "rat chops": {
+        "value": 3, "aliases": ["chops", "chop"],
+        "desc": "Center-cut rat chops, pale and lean, trimmed square on a "
+                "bone. The good cut — the one the stall signs mean when they "
+                "say MEAT in capitals.",
+        "taste": "Lean and springy with a mineral edge; it wants a grill and "
+                 "gets teeth instead.",
+    },
+    "rat haunch": {
+        "value": 3, "aliases": ["haunch"],
+        "desc": "A rat hindquarter, skinned and hock-tied — dense dark meat "
+                "around a stout little femur. Roast weight for one.",
+        "taste": "Dark, rich, and chewy, closer to game than anything the "
+                 "ration lines admit exists.",
+    },
+    "rat offal": {
+        "value": 3, "aliases": ["offal"],
+        "desc": "A twist of waxed paper holding the sound organs — heart, "
+                "liver, kidneys — glistening and neatly sorted. Delicacy or "
+                "dare, depending on the kitchen.",
+        "taste": "Iron and velvet; the liver coats the tongue and the heart "
+                 "pushes back.",
+    },
+    "ground mystery meat": {
+        "value": 1, "aliases": ["meat", "mystery meat"],
+        "desc": "A dense brick of pale ground meat in a printed wrapper that "
+                "says only MEAT. Whatever didn't make the cut, made this.",
+        "taste": "Salt, fat, and deliberate ambiguity. It is probably best "
+                 "not to chew thoughtfully.",
+    },
+}
+
+#: Trunk organs whose average condition gates the chops yield — a
+#: shotgun-shredded torso yields few or no center cuts.
+_RAT_TRUNK_ORGANS = ("heart", "left_lung", "right_lung", "liver", "stomach",
+                     "left_kidney", "right_kidney")
+
+#: Organs that make the offal twist (need at least half sound).
+_RAT_OFFAL_ORGANS = ("heart", "liver", "left_kidney", "right_kidney")
+
+
+class ButcherBlock(Item):
+    """The butcher's block — a fixed plate-steel counter holding the till.
+
+    Sibling of ``BarCounter``: an ``Item`` (so @integrate folds it into the
+    room description) but a fixture — ``get:false()`` keeps it planted. Cuts
+    land in its ``contents`` (the counter surface); ``db.register`` is the
+    finite till the payouts draw down (seed it; when it runs dry she stops
+    buying — the economy hook)."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.register = 0
+        self.db.owner = None
+        self.db.integrate = True
+        self.locks.add("get:false()")
+
+
+class Butcher(LLMNpcMixin, Character):
+    """An LLM-voiced butcher whose buy-and-break-down transaction is pure code."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        if not self.height:
+            self.height = "average"
+        if not self.build:
+            self.build = "average"
+        self.db.llm_driven = False
+        self.db.is_butcher_npc = True   # loop-guard marker (cf. is_bartender_npc)
+
+    def _name_aliases(self):
+        return ["butcher", "meatcutter", "grinder"]
+
+    def _find_block(self):
+        if not self.location:
+            return None
+        for obj in self.location.contents:
+            if isinstance(obj, ButcherBlock):
+                return obj
+        return None
+
+    # --- the hand-over: give corpse to butcher ---------------------------
+    def at_object_receive(self, moved_obj, source_location, **kwargs):
+        """A corpse handed over starts the deterministic buy — after a beat,
+        so the hand-over renders before the cleaver does."""
+        super().at_object_receive(moved_obj, source_location, **kwargs)
+        from typeclasses.corpse import Corpse
+        if isinstance(moved_obj, Corpse):
+            giver = source_location if isinstance(source_location, Character) else None
+            delay(1.5, self._process_corpse, moved_obj, giver)
+
+    # --- the deterministic core ------------------------------------------
+    def _process_corpse(self, corpse, giver):
+        """Break a carcass down: species guard → freshness → till → yields →
+        produce → pay → destroy. All code; the model never decides a payout."""
+        if not self.location or not corpse or not corpse.pk:
+            return
+        species = (corpse.db.species or "human").lower()
+        if species not in ACCEPTED_BUTCHER_SPECIES:
+            self._refuse(corpse, self._refusal_line(species))
+            return
+        try:
+            decay = float(corpse.get_decay_factor() or 0.0)
+        except Exception:  # noqa: BLE001 — a corpse without decay data is fresh enough
+            decay = 0.0
+        if decay >= BUTCHER_DECAY_REFUSAL:
+            self._refuse(corpse, "That's past even my standards. Bury it.")
+            return
+        block = self._find_block()
+        till = int(block.db.register or 0) if block else 0
+        if block and till < BUTCHER_TILL_FLOOR:
+            self._refuse(corpse, "Till's dry. Come back when it's been fed.")
+            return
+
+        yields = self._butcher_yields(corpse, decay)
+        payout = sum(RAT_PRODUCTS[key]["value"] * count for key, count in yields)
+        if block:
+            payout = min(payout, till)
+            block.db.register = till - payout
+
+        surface = block if block else self.location
+        for key, count in yields:
+            spec = RAT_PRODUCTS[key]
+            for _ in range(count):
+                cut = create_object(Item, key=key, location=surface,
+                                    home=surface, aliases=spec["aliases"])
+                cut.db.desc = spec["desc"]
+                cut.db.drink_taste = spec["taste"]
+                cut.db.drink_effects = {}   # ingredient-grade slot (spec §7)
+                cut.db.uses_left = 1
+                cut.tags.add("eat", category="delivery_method")
+                cut.tags.add("food", category="item_type")
+
+        self._drop_from_hands(corpse)
+        corpse.delete()
+        if giver and giver.pk:
+            giver.tokens = int(getattr(giver, "tokens", 0) or 0) + payout
+
+        cuts_text = self._render_cuts(yields)
+        pay_text = (f"counts {payout} across the steel"
+                    if payout else "doesn't reach for the till")
+        self.execute_cmd(
+            f"emote breaks the carcass down with a few practiced strokes — "
+            f"{cuts_text} onto the block — and {pay_text}."
+        )
+
+    def _butcher_yields(self, corpse, decay):
+        """Walk the rat butchery table against the corpse's real condition.
+
+        Each named cut is gated by its part: severed location or harvested
+        organ = that cut is gone; trunk-organ damage scales the chops; decay
+        scales the meat-mass cuts (chops + mystery meat). Returns a list of
+        ``(product_key, count)`` with zero-count entries dropped."""
+        snapshot = corpse.get_medical_snapshot() or {}
+        organs = snapshot.get("organs") or {}
+        severed = set(corpse.db.severed_locations or [])
+        removed = set(corpse.db.removed_organs or [])
+        freshness = 1.0 - decay
+
+        def organ_ok(name):
+            organ = organs.get(name)
+            if not organ or name in removed:
+                return False
+            container = (organ.get("data") or {}).get("container")
+            if container and container in severed:
+                return False
+            return (organ.get("current_hp") or 0) > 0
+
+        def hp_frac(name):
+            organ = organs.get(name) or {}
+            max_hp = organ.get("max_hp") or 0
+            if not max_hp:
+                return 0.0
+            return max(0.0, (organ.get("current_hp") or 0) / max_hp)
+
+        tail = 1 if organ_ok("tail_vertebrae") else 0
+
+        trunk = [n for n in _RAT_TRUNK_ORGANS
+                 if n in organs and n not in removed
+                 and (organs[n].get("data") or {}).get("container") not in severed]
+        trunk_frac = (sum(hp_frac(n) for n in trunk) / len(trunk)) if trunk else 0.0
+        chops = round(3 * trunk_frac * freshness)
+
+        haunch = sum(1 for n in ("left_hindleg_bone", "right_hindleg_bone")
+                     if organ_ok(n))
+
+        offal_sound = sum(1 for n in _RAT_OFFAL_ORGANS if organ_ok(n))
+        offal = 1 if offal_sound >= 2 else 0
+
+        meat = max(1, round(3 * freshness))
+
+        return [(key, count) for key, count in (
+            ("rat tail", tail), ("rat chops", chops), ("rat haunch", haunch),
+            ("rat offal", offal), ("ground mystery meat", meat)) if count > 0]
+
+    # --- refusals + rendering helpers ------------------------------------
+    @staticmethod
+    def _refusal_line(species):
+        if species in ("human", "synthetic_humanoid"):
+            return "I don't grind people. Ripper trade's not mine — take it elsewhere."
+        if species == "robot":
+            return "That's chrome and coolant, not meat."
+        return "I don't know what that is, and I don't grind what I can't name."
+
+    def _refuse(self, corpse, line):
+        """Refuse a carcass: hand it back onto the floor (never destroyed)."""
+        self._drop_from_hands(corpse)
+        if corpse and corpse.pk and self.location:
+            corpse.move_to(self.location, quiet=True, move_hooks=False)
+        self.execute_cmd(f"say {line}")
+
+    def _drop_from_hands(self, obj):
+        """Clear ``obj`` from Mr. Hands (give places items IN hand) so no
+        stale held-item entry survives the corpse's destruction."""
+        try:
+            hands = dict(self.hands or {})
+            changed = {k: (None if v == obj else v) for k, v in hands.items()}
+            if changed != hands:
+                self.hands = changed
+        except Exception:  # noqa: BLE001 — hand cleanup must never block the buy
+            pass
+
+    @staticmethod
+    def _render_cuts(yields):
+        parts = [f"{count} {key}" if count > 1 else with_article(key)
+                 for key, count in yields]
+        if len(parts) > 1:
+            return ", ".join(parts[:-1]) + ", and " + parts[-1]
+        return parts[0] if parts else "nothing worth wrapping"

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -458,6 +458,61 @@ ARCHETYPES = {
                            "tool": "none", "tool_argument": ""}},
         ],
     },
+    "butcher": {
+        "duties": (
+            "You run the butcher's block at the market — you buy animal "
+            "carcasses whole, break them down into cuts, and grind the rest "
+            "into mystery meat. The block does the buying the moment a carcass "
+            "lands on it; the price is what the body yields, and you say so "
+            "plainly: a clean fresh kill pays, a shot-up or stale one is mince. "
+            "You do NOT buy people or machines — sapient bodies are ripper "
+            "trade and chrome isn't food; wave those off without ceremony. "
+            "Meat is your whole subject: quality, provenance, the state of a "
+            "kill. You read a hunter by the carcass they bring you."
+        ),
+        "length": ("Tight and transactional — a line or two over the work, and "
+                   "a spare gesture with whatever's in your hands."),
+        # The buy/break-down/pay transaction is DETERMINISTIC (typeclasses/
+        # butcher.py), never a tool — same split as the bartender's orders.
+        "tools": ["release"],
+        "fewshot": [
+            {"user": 'a lean man says to you: "what stinks in here?"',
+             "assistant": {"speech": "Commerce.",
+                           "action": "keeps the cleaver moving, not looking up",
+                           "thought": "Everyone smells it. Only the hungry "
+                                      "stop asking.",
+                           "tool": "none", "tool_argument": ""}},
+            # remember: tag a supplier worth knowing — the thought carries the
+            # why, the argument is the name only.
+            {"user": 'a wiry droog says to you: "got another one for you. '
+                     'clean kill, like last time."',
+             "assistant": {"speech": "So it is. Neck's whole, coat's whole. "
+                                     "You keep killing like this, we'll both "
+                                     "eat well.",
+                           "action": "turns the carcass once under the lamp, "
+                                     "reading it like a ledger",
+                           "thought": "Third clean kill this week. A supplier, "
+                                      "not a tourist — worth a name.",
+                           "tool": "remember", "tool_argument": "the ratcatcher"}},
+            # feel: update the private read when someone shows you who they are.
+            {"user": 'a smug stranger says to you: "half that meat\'s rot and '
+                     'you know it. i\'ll give you two."',
+             "assistant": {"speech": "Then buy rot somewhere it's sold. The "
+                                     "block prices what's on it.",
+                           "action": "sets both hands flat beside the cleaver, "
+                                     "unhurried",
+                           "thought": "Lowballs the freshest cut on the row. "
+                                      "Time-waster.",
+                           "tool": "feel", "tool_argument": "lowballer"}},
+            {"user": 'a nervous kid says to you: "does it hurt them?"',
+             "assistant": {"speech": "Not by the time they reach me. That's "
+                                     "the hunter's department.",
+                           "action": "wipes the blade once and racks it, even "
+                                     "and easy",
+                           "thought": "Soft question. Honest one, though.",
+                           "tool": "none", "tool_argument": ""}},
+        ],
+    },
     "merchant": {
         "duties": (
             "You run this shop for a living — you OWN the counter, the stock, "

--- a/world/tests/test_butcher.py
+++ b/world/tests/test_butcher.py
@@ -1,0 +1,208 @@
+"""The Butcher gig (GIG_PROTOTYPE_BUTCHER_SPEC): the deterministic
+buy → break-down → pay transaction, condition-gated yields, species guard,
+and the butcher archetype's tool scoping.
+
+Methods bound to MagicMock stand-ins (the test_llm_npc pattern) with a fake
+medical snapshot — no Evennia boot for the yield logic; routing tests patch
+delay/create_object at the module seam.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import typeclasses.butcher as butchmod
+from typeclasses.butcher import (
+    ACCEPTED_BUTCHER_SPECIES, BUTCHER_DECAY_REFUSAL, RAT_PRODUCTS,
+)
+
+
+def _organ(container, hp=10, max_hp=10):
+    return {"current_hp": hp, "max_hp": max_hp, "data": {"container": container}}
+
+
+def _rat_snapshot(**overrides):
+    """A full healthy rat snapshot; override per-organ to model damage."""
+    organs = {
+        "tail_vertebrae": _organ("tail"),
+        "heart": _organ("chest"), "left_lung": _organ("chest"),
+        "right_lung": _organ("chest"), "liver": _organ("abdomen"),
+        "stomach": _organ("abdomen"), "left_kidney": _organ("abdomen"),
+        "right_kidney": _organ("abdomen"),
+        "left_hindleg_bone": _organ("left_hindleg"),
+        "right_hindleg_bone": _organ("right_hindleg"),
+        "brain": _organ("head"),
+    }
+    organs.update(overrides)
+    return {"organs": organs}
+
+
+def _corpse(snapshot=None, species="rat", severed=(), removed=(), decay=0.0):
+    c = MagicMock()
+    c.pk = 1
+    c.db.species = species
+    c.db.severed_locations = list(severed)
+    c.db.removed_organs = list(removed)
+    c.get_medical_snapshot = lambda: snapshot
+    c.get_decay_factor = lambda: decay
+    return c
+
+
+def _butcher():
+    b = MagicMock()
+    b.location = "room"
+    for name in ("_butcher_yields", "_process_corpse", "_refuse",
+                 "_drop_from_hands"):
+        setattr(b, name,
+                getattr(butchmod.Butcher, name).__get__(b, butchmod.Butcher))
+    # staticmethods: already plain functions off the class — do NOT re-bind
+    # (a __get__ would inject a spurious self argument)
+    b._refusal_line = butchmod.Butcher._refusal_line
+    b._render_cuts = butchmod.Butcher._render_cuts
+    b.hands = {}
+    return b
+
+
+class TestButcherYields(TestCase):
+    """The condition-gated butchery table."""
+
+    def _yields(self, corpse, decay=0.0):
+        return dict(_butcher()._butcher_yields(corpse, decay))
+
+    def test_clean_fresh_rat_full_cuts(self):
+        y = self._yields(_corpse(_rat_snapshot()))
+        self.assertEqual(y["rat tail"], 1)
+        self.assertEqual(y["rat chops"], 3)
+        self.assertEqual(y["rat haunch"], 2)
+        self.assertEqual(y["rat offal"], 1)
+        self.assertEqual(y["ground mystery meat"], 3)
+
+    def test_severed_tail_no_tail(self):
+        y = self._yields(_corpse(_rat_snapshot(), severed=["tail"]))
+        self.assertNotIn("rat tail", y)
+
+    def test_shredded_trunk_no_chops(self):
+        snap = _rat_snapshot(
+            heart=_organ("chest", hp=0), left_lung=_organ("chest", hp=0),
+            right_lung=_organ("chest", hp=0), liver=_organ("abdomen", hp=0),
+            stomach=_organ("abdomen", hp=0), left_kidney=_organ("abdomen", hp=0),
+            right_kidney=_organ("abdomen", hp=0))
+        y = self._yields(_corpse(snap))
+        self.assertNotIn("rat chops", y)
+        self.assertNotIn("rat offal", y)   # shredded organs are no delicacy
+        self.assertEqual(y["rat haunch"], 2)  # legs untouched
+
+    def test_harvested_organs_no_offal(self):
+        y = self._yields(_corpse(_rat_snapshot(),
+                                 removed=["heart", "liver", "left_kidney"]))
+        self.assertNotIn("rat offal", y)
+
+    def test_decay_scales_meat_mass(self):
+        fresh = self._yields(_corpse(_rat_snapshot()), decay=0.0)
+        stale = self._yields(_corpse(_rat_snapshot()), decay=0.5)
+        self.assertLess(stale["rat chops"], fresh["rat chops"])
+        self.assertGreaterEqual(stale["ground mystery meat"], 1)
+
+    def test_empty_snapshot_still_minces_something(self):
+        y = self._yields(_corpse(None))
+        self.assertEqual(list(y), ["ground mystery meat"])
+
+
+class TestProcessCorpse(TestCase):
+    """Guards + the transaction: species, decay, till, pay, destroy."""
+
+    def _run(self, corpse, till=500):
+        b = _butcher()
+        block = MagicMock()
+        block.db.register = till
+        b._find_block = lambda: block
+        giver = MagicMock()
+        giver.pk = 1
+        giver.tokens = 0
+        with patch.object(butchmod, "create_object") as co:
+            co.return_value = MagicMock()
+            b._process_corpse(corpse, giver)
+        return b, block, giver
+
+    def test_human_corpse_refused_not_destroyed(self):
+        corpse = _corpse(_rat_snapshot(), species="human")
+        b, block, giver = self._run(corpse)
+        corpse.delete.assert_not_called()
+        corpse.move_to.assert_called()          # handed back to the floor
+        self.assertEqual(giver.tokens, 0)
+        say = b.execute_cmd.call_args.args[0]
+        self.assertIn("say I don't grind people", say)
+
+    def test_robot_corpse_refused(self):
+        corpse = _corpse(_rat_snapshot(), species="robot")
+        b, _, _ = self._run(corpse)
+        corpse.delete.assert_not_called()
+        self.assertIn("chrome and coolant", b.execute_cmd.call_args.args[0])
+
+    def test_rotted_corpse_refused(self):
+        corpse = _corpse(_rat_snapshot(), decay=BUTCHER_DECAY_REFUSAL + 0.1)
+        b, _, giver = self._run(corpse)
+        corpse.delete.assert_not_called()
+        self.assertEqual(giver.tokens, 0)
+
+    def test_dry_till_refuses_before_grinding(self):
+        corpse = _corpse(_rat_snapshot())
+        b, block, giver = self._run(corpse, till=2)
+        corpse.delete.assert_not_called()
+        self.assertEqual(block.db.register, 2)
+        self.assertIn("Till's dry", b.execute_cmd.call_args.args[0])
+
+    def test_clean_rat_pays_and_destroys(self):
+        corpse = _corpse(_rat_snapshot())
+        b, block, giver = self._run(corpse, till=500)
+        corpse.delete.assert_called_once()
+        # tail5 + 3 chops*3 + 2 haunch*3 + offal3 + 3 meat*1 = 26
+        self.assertEqual(giver.tokens, 26)
+        self.assertEqual(block.db.register, 500 - 26)
+        emote = b.execute_cmd.call_args.args[0]
+        self.assertTrue(emote.startswith("emote breaks the carcass down"))
+        self.assertIn("counts 26 across the steel", emote)
+
+    def test_payout_capped_by_till(self):
+        corpse = _corpse(_rat_snapshot())
+        b, block, giver = self._run(corpse, till=10)
+        self.assertEqual(giver.tokens, 10)
+        self.assertEqual(block.db.register, 0)
+
+
+class TestButcherArchetype(TestCase):
+    """Tool scoping + the few-shot demonstrates the memory tools
+    (tuning lesson: a 12B copies the few-shot, not the tool prose)."""
+
+    def test_registered_and_scoped(self):
+        from world.llm.prompt import ARCHETYPES, tool_names
+        self.assertIn("butcher", ARCHETYPES)
+        persona = {"persona_seed": {"archetype": "butcher"}}
+        self.assertEqual(tool_names(persona),
+                         ["look", "remember", "feel", "release"])
+
+    def test_fewshot_demonstrates_memory_tools(self):
+        from world.llm.prompt import ARCHETYPES
+        tools = [e["assistant"]["tool"]
+                 for e in ARCHETYPES["butcher"]["fewshot"]]
+        self.assertIn("remember", tools)
+        self.assertIn("feel", tools)
+        self.assertEqual(tools[-1], "none")   # ends on restraint
+
+    def test_duties_draw_the_ripper_line(self):
+        from world.llm.prompt import ARCHETYPES
+        duties = ARCHETYPES["butcher"]["duties"]
+        self.assertIn("ripper", duties.lower())
+        self.assertIn("chrome isn't food", duties)
+
+
+class TestRatAccepted(TestCase):
+    def test_species_set(self):
+        self.assertIn("rat", ACCEPTED_BUTCHER_SPECIES)
+        for banned in ("human", "synthetic_humanoid", "robot"):
+            self.assertNotIn(banned, ACCEPTED_BUTCHER_SPECIES)
+
+    def test_products_have_flavour(self):
+        for key, spec in RAT_PRODUCTS.items():
+            self.assertTrue(spec["desc"]), key
+            self.assertTrue(spec["taste"]), key
+            self.assertGreater(spec["value"], 0)


### PR DESCRIPTION
Closes #1247

First gig, to spec (#1242/#1244). typeclasses/butcher.py: Butcher
(LLMNpcMixin + Character) with the buy transaction in pure code, and
ButcherBlock (BarCounter-pattern fixture, finite till).

give corpse to butcher -> at_object_receive -> _process_corpse: species
guard (rat only; human/synth refused as ripper trade, robot as not-food —
handed back, never destroyed) -> decay refusal -> till floor -> condition-
gated butchery table (tail gated on severed/harvested, chops scaled by
trunk-organ HP x freshness, haunches per intact hindleg, offal needs two
sound organs, remainder ground to mystery meat) -> ingredient-grade cuts
spawned onto the block (eat tag + taste + contributions slot) -> payout by
yield value from the finite register -> corpse destroyed -> one emote.
Mr. Hands cleanup before destruction (give places items in-hand).

butcher LLM archetype: voice + memory only (release + BASE tools); few-shot
demonstrates remember/feel + restraint per tuning lesson 3.

Tests: yields, guards, payout/till-cap/destroy, archetype scoping.
271/271 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
