### PR TITLE
Butcher sell side: block becomes a limited shop fed by the grind

### DIFF
--- a/typeclasses/butcher.py
+++ b/typeclasses/butcher.py
@@ -12,12 +12,12 @@ Human / synthetic / robot corpses are REFUSED — sapient bodies are the future
 Ripper's trade, and chrome isn't food.
 """
 
-from evennia import create_object
+from evennia.prototypes.spawner import spawn
 from evennia.utils.utils import delay
 
 from typeclasses.characters import Character
-from typeclasses.items import Item
 from typeclasses.llm_npc import LLMNpcMixin
+from typeclasses.shopkeeper import ShopContainer
 from world.grammar import with_article
 
 #: Species the block buys. Everything else is refused (see _refuse_species).
@@ -31,47 +31,16 @@ BUTCHER_DECAY_REFUSAL = 0.6
 #: buying until it's fed (finite till — the economy hook).
 BUTCHER_TILL_FLOOR = 5
 
-#: The rat butchery table (spec §3.4): per-product value and flavour. Yields
-#: are computed against the corpse's REAL condition in `_butcher_yields`.
+#: The rat butchery pricing (spec §3.4): per-product BUY value (what the
+#: block pays a supplier) and SELL price (what the shop charges — the margin
+#: is what keeps the till solvent). Prose/tags live on the prototypes
+#: (world/prototypes.py RAT_TAIL etc.); `name` is the display form.
 RAT_PRODUCTS = {
-    "rat tail": {
-        "value": 5, "aliases": ["tail"],
-        "desc": "A skinned rat tail, long as a forearm, coiled and tied off "
-                "with butcher's twine. The classic stew base of the colony's "
-                "cheaper kitchens.",
-        "taste": "Gelatinous and faintly sweet, all cartilage and slow-cooked "
-                 "promise — wasted eaten raw.",
-    },
-    "rat chops": {
-        "value": 3, "aliases": ["chops", "chop"],
-        "desc": "Center-cut rat chops, pale and lean, trimmed square on a "
-                "bone. The good cut — the one the stall signs mean when they "
-                "say MEAT in capitals.",
-        "taste": "Lean and springy with a mineral edge; it wants a grill and "
-                 "gets teeth instead.",
-    },
-    "rat haunch": {
-        "value": 3, "aliases": ["haunch"],
-        "desc": "A rat hindquarter, skinned and hock-tied — dense dark meat "
-                "around a stout little femur. Roast weight for one.",
-        "taste": "Dark, rich, and chewy, closer to game than anything the "
-                 "ration lines admit exists.",
-    },
-    "rat offal": {
-        "value": 3, "aliases": ["offal"],
-        "desc": "A twist of waxed paper holding the sound organs — heart, "
-                "liver, kidneys — glistening and neatly sorted. Delicacy or "
-                "dare, depending on the kitchen.",
-        "taste": "Iron and velvet; the liver coats the tongue and the heart "
-                 "pushes back.",
-    },
-    "ground mystery meat": {
-        "value": 1, "aliases": ["meat", "mystery meat"],
-        "desc": "A dense brick of pale ground meat in a printed wrapper that "
-                "says only MEAT. Whatever didn't make the cut, made this.",
-        "taste": "Salt, fat, and deliberate ambiguity. It is probably best "
-                 "not to chew thoughtfully.",
-    },
+    "rat_tail":            {"name": "rat tail", "buy": 5, "sell": 8},
+    "rat_chops":           {"name": "rat chops", "buy": 3, "sell": 5},
+    "rat_haunch":          {"name": "rat haunch", "buy": 3, "sell": 5},
+    "rat_offal":           {"name": "rat offal", "buy": 3, "sell": 5},
+    "ground_mystery_meat": {"name": "ground mystery meat", "buy": 1, "sell": 2},
 }
 
 #: Trunk organs whose average condition gates the chops yield — a
@@ -83,21 +52,54 @@ _RAT_TRUNK_ORGANS = ("heart", "left_lung", "right_lung", "liver", "stomach",
 _RAT_OFFAL_ORGANS = ("heart", "liver", "left_kidney", "right_kidney")
 
 
-class ButcherBlock(Item):
-    """The butcher's block — a fixed plate-steel counter holding the till.
+class ButcherBlock(ShopContainer):
+    """The butcher's block — a fixed counter that is also her SHOP.
 
-    Sibling of ``BarCounter``: an ``Item`` (so @integrate folds it into the
-    room description) but a fixture — ``get:false()`` keeps it planted. Cuts
-    land in its ``contents`` (the counter surface); ``db.register`` is the
-    finite till the payouts draw down (seed it; when it runs dry she stops
-    buying — the economy hook)."""
+    A ``ShopContainer`` in **limited-inventory** mode: the stock is exactly
+    what the grind produced (``stock_cuts``), never spawned from thin air —
+    the gig economy stays real. ``buy rat chops from block`` works like any
+    shop, and the override below credits sale proceeds to ``db.register``,
+    closing the till loop: payouts to hunters drain the till, meat sales
+    refill it. ``db.integrate`` folds it into the room description."""
 
     def at_object_creation(self):
         super().at_object_creation()
+        self.db.is_infinite = False
+        self.db.shop_name = "the butcher's block"
+        self.db.container_type = "block"
         self.db.register = 0
         self.db.owner = None
         self.db.integrate = True
-        self.locks.add("get:false()")
+        self.db.purchase_msg_buyer = ("You count out {price}, and the butcher "
+                                      "hooks down {item} without ceremony.")
+        self.db.purchase_msg_room = ("{buyer} counts chits onto the block and "
+                                     "walks off with {item}.")
+
+    def stock_cuts(self, counts):
+        """Add ground produce to the shop: ``{prototype_key: count}``.
+
+        Registers each prototype at its sell price (idempotent) and
+        accumulates limited-mode quantities."""
+        inventory = dict(self.db.prototype_inventory or {})
+        stock = dict(self.db.item_inventory or {})
+        for proto_key, count in counts.items():
+            spec = RAT_PRODUCTS.get(proto_key)
+            if not spec or count <= 0:
+                continue
+            inventory[proto_key] = spec["sell"]
+            stock[proto_key] = int(stock.get(proto_key, 0)) + int(count)
+        self.db.prototype_inventory = inventory
+        self.db.item_inventory = stock
+        self.db.is_infinite = False
+
+    def purchase_item(self, buyer, prototype_key):
+        """Sales feed the till: on a successful buy, the price lands in
+        ``db.register`` — the fund the butcher pays suppliers from."""
+        price = self.get_price(prototype_key)
+        success, result = super().purchase_item(buyer, prototype_key)
+        if success and price:
+            self.db.register = int(self.db.register or 0) + int(price)
+        return success, result
 
 
 class Butcher(LLMNpcMixin, Character):
@@ -157,23 +159,18 @@ class Butcher(LLMNpcMixin, Character):
             return
 
         yields = self._butcher_yields(corpse, decay)
-        payout = sum(RAT_PRODUCTS[key]["value"] * count for key, count in yields)
+        payout = sum(RAT_PRODUCTS[key]["buy"] * count for key, count in yields)
         if block:
             payout = min(payout, till)
             block.db.register = till - payout
-
-        surface = block if block else self.location
-        for key, count in yields:
-            spec = RAT_PRODUCTS[key]
-            for _ in range(count):
-                cut = create_object(Item, key=key, location=surface,
-                                    home=surface, aliases=spec["aliases"])
-                cut.db.desc = spec["desc"]
-                cut.db.drink_taste = spec["taste"]
-                cut.db.drink_effects = {}   # ingredient-grade slot (spec §7)
-                cut.db.uses_left = 1
-                cut.tags.add("eat", category="delivery_method")
-                cut.tags.add("food", category="item_type")
+            # the produce becomes SHOP STOCK — buyable, finite, real
+            block.stock_cuts(dict(yields))
+        else:
+            # blockless butcher: spawn the cuts loose where she stands
+            for key, count in yields:
+                for _ in range(count):
+                    for cut in spawn(key):
+                        cut.move_to(self.location, quiet=True, move_hooks=False)
 
         self._drop_from_hands(corpse)
         corpse.delete()
@@ -185,7 +182,7 @@ class Butcher(LLMNpcMixin, Character):
                     if payout else "doesn't reach for the till")
         self.execute_cmd(
             f"emote breaks the carcass down with a few practiced strokes — "
-            f"{cuts_text} onto the block — and {pay_text}."
+            f"{cuts_text} into the case — and {pay_text}."
         )
 
     def _butcher_yields(self, corpse, decay):
@@ -234,8 +231,8 @@ class Butcher(LLMNpcMixin, Character):
         meat = max(1, round(3 * freshness))
 
         return [(key, count) for key, count in (
-            ("rat tail", tail), ("rat chops", chops), ("rat haunch", haunch),
-            ("rat offal", offal), ("ground mystery meat", meat)) if count > 0]
+            ("rat_tail", tail), ("rat_chops", chops), ("rat_haunch", haunch),
+            ("rat_offal", offal), ("ground_mystery_meat", meat)) if count > 0]
 
     # --- refusals + rendering helpers ------------------------------------
     @staticmethod
@@ -266,8 +263,10 @@ class Butcher(LLMNpcMixin, Character):
 
     @staticmethod
     def _render_cuts(yields):
-        parts = [f"{count} {key}" if count > 1 else with_article(key)
-                 for key, count in yields]
+        parts = []
+        for key, count in yields:
+            name = RAT_PRODUCTS.get(key, {}).get("name", key)
+            parts.append(f"{count} {name}" if count > 1 else with_article(name))
         if len(parts) > 1:
             return ", ".join(parts[:-1]) + ", and " + parts[-1]
         return parts[0] if parts else "nothing worth wrapping"

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -1866,6 +1866,102 @@ BLOOD_BAG = {
 }
 
 # Injectable Painkiller - Multi-dose pain management
+# ============================================================================
+# BUTCHER CUTS (GIG_PROTOTYPE_BUTCHER_SPEC) — the Butcher's block stocks these
+# as limited shop inventory when a carcass is ground (typeclasses/butcher.py);
+# quantities are REAL (what suppliers brought), never infinite. Ingredient-
+# grade per spec §7: edible now (eat delivery + taste), empty contributions
+# slot for the future food-recipe layer.
+# ============================================================================
+
+RAT_TAIL = {
+    "prototype_key": "rat_tail",
+    "key": "rat tail",
+    "aliases": ["tail"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A skinned rat tail, long as a forearm, coiled and tied off with "
+            "butcher's twine. The classic stew base of the colony's cheaper "
+            "kitchens.",
+    "attrs": [
+        ("drink_taste", "Gelatinous and faintly sweet, all cartilage and "
+                        "slow-cooked promise — wasted eaten raw."),
+        ("drink_effects", {}),
+        ("uses_left", 1),
+        ("value", 8),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
+RAT_CHOPS = {
+    "prototype_key": "rat_chops",
+    "key": "rat chops",
+    "aliases": ["chops", "chop"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Center-cut rat chops, pale and lean, trimmed square on a bone. "
+            "The good cut — the one the stall signs mean when they say MEAT "
+            "in capitals.",
+    "attrs": [
+        ("drink_taste", "Lean and springy with a mineral edge; it wants a "
+                        "grill and gets teeth instead."),
+        ("drink_effects", {}),
+        ("uses_left", 1),
+        ("value", 5),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
+RAT_HAUNCH = {
+    "prototype_key": "rat_haunch",
+    "key": "rat haunch",
+    "aliases": ["haunch"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A rat hindquarter, skinned and hock-tied — dense dark meat "
+            "around a stout little femur. Roast weight for one.",
+    "attrs": [
+        ("drink_taste", "Dark, rich, and chewy, closer to game than anything "
+                        "the ration lines admit exists."),
+        ("drink_effects", {}),
+        ("uses_left", 1),
+        ("value", 5),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
+RAT_OFFAL = {
+    "prototype_key": "rat_offal",
+    "key": "rat offal",
+    "aliases": ["offal"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A twist of waxed paper holding the sound organs — heart, liver, "
+            "kidneys — glistening and neatly sorted. Delicacy or dare, "
+            "depending on the kitchen.",
+    "attrs": [
+        ("drink_taste", "Iron and velvet; the liver coats the tongue and the "
+                        "heart pushes back."),
+        ("drink_effects", {}),
+        ("uses_left", 1),
+        ("value", 5),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
+GROUND_MYSTERY_MEAT = {
+    "prototype_key": "ground_mystery_meat",
+    "key": "ground mystery meat",
+    "aliases": ["meat", "mystery meat"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A dense brick of pale ground meat in a printed wrapper that says "
+            "only MEAT. Whatever didn't make the cut, made this.",
+    "attrs": [
+        ("drink_taste", "Salt, fat, and deliberate ambiguity. It is probably "
+                        "best not to chew thoughtfully."),
+        ("drink_effects", {}),
+        ("uses_left", 1),
+        ("value", 2),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
 PAINKILLER = {
     "key": "painkiller",
     "typeclass": "typeclasses.items.Item",

--- a/world/tests/test_butcher.py
+++ b/world/tests/test_butcher.py
@@ -70,15 +70,15 @@ class TestButcherYields(TestCase):
 
     def test_clean_fresh_rat_full_cuts(self):
         y = self._yields(_corpse(_rat_snapshot()))
-        self.assertEqual(y["rat tail"], 1)
-        self.assertEqual(y["rat chops"], 3)
-        self.assertEqual(y["rat haunch"], 2)
-        self.assertEqual(y["rat offal"], 1)
-        self.assertEqual(y["ground mystery meat"], 3)
+        self.assertEqual(y["rat_tail"], 1)
+        self.assertEqual(y["rat_chops"], 3)
+        self.assertEqual(y["rat_haunch"], 2)
+        self.assertEqual(y["rat_offal"], 1)
+        self.assertEqual(y["ground_mystery_meat"], 3)
 
     def test_severed_tail_no_tail(self):
         y = self._yields(_corpse(_rat_snapshot(), severed=["tail"]))
-        self.assertNotIn("rat tail", y)
+        self.assertNotIn("rat_tail", y)
 
     def test_shredded_trunk_no_chops(self):
         snap = _rat_snapshot(
@@ -87,24 +87,24 @@ class TestButcherYields(TestCase):
             stomach=_organ("abdomen", hp=0), left_kidney=_organ("abdomen", hp=0),
             right_kidney=_organ("abdomen", hp=0))
         y = self._yields(_corpse(snap))
-        self.assertNotIn("rat chops", y)
-        self.assertNotIn("rat offal", y)   # shredded organs are no delicacy
-        self.assertEqual(y["rat haunch"], 2)  # legs untouched
+        self.assertNotIn("rat_chops", y)
+        self.assertNotIn("rat_offal", y)   # shredded organs are no delicacy
+        self.assertEqual(y["rat_haunch"], 2)  # legs untouched
 
     def test_harvested_organs_no_offal(self):
         y = self._yields(_corpse(_rat_snapshot(),
                                  removed=["heart", "liver", "left_kidney"]))
-        self.assertNotIn("rat offal", y)
+        self.assertNotIn("rat_offal", y)
 
     def test_decay_scales_meat_mass(self):
         fresh = self._yields(_corpse(_rat_snapshot()), decay=0.0)
         stale = self._yields(_corpse(_rat_snapshot()), decay=0.5)
-        self.assertLess(stale["rat chops"], fresh["rat chops"])
-        self.assertGreaterEqual(stale["ground mystery meat"], 1)
+        self.assertLess(stale["rat_chops"], fresh["rat_chops"])
+        self.assertGreaterEqual(stale["ground_mystery_meat"], 1)
 
     def test_empty_snapshot_still_minces_something(self):
         y = self._yields(_corpse(None))
-        self.assertEqual(list(y), ["ground mystery meat"])
+        self.assertEqual(list(y), ["ground_mystery_meat"])
 
 
 class TestProcessCorpse(TestCase):
@@ -118,8 +118,8 @@ class TestProcessCorpse(TestCase):
         giver = MagicMock()
         giver.pk = 1
         giver.tokens = 0
-        with patch.object(butchmod, "create_object") as co:
-            co.return_value = MagicMock()
+        with patch.object(butchmod, "spawn") as sp:
+            sp.return_value = [MagicMock()]
             b._process_corpse(corpse, giver)
         return b, block, giver
 
@@ -160,6 +160,7 @@ class TestProcessCorpse(TestCase):
         self.assertEqual(block.db.register, 500 - 26)
         emote = b.execute_cmd.call_args.args[0]
         self.assertTrue(emote.startswith("emote breaks the carcass down"))
+        block.stock_cuts.assert_called_once()
         self.assertIn("counts 26 across the steel", emote)
 
     def test_payout_capped_by_till(self):
@@ -201,8 +202,57 @@ class TestRatAccepted(TestCase):
         for banned in ("human", "synthetic_humanoid", "robot"):
             self.assertNotIn(banned, ACCEPTED_BUTCHER_SPECIES)
 
-    def test_products_have_flavour(self):
+    def test_products_priced_with_margin(self):
+        # sell > buy on every product: the block's margin keeps the till solvent
         for key, spec in RAT_PRODUCTS.items():
-            self.assertTrue(spec["desc"]), key
-            self.assertTrue(spec["taste"]), key
-            self.assertGreater(spec["value"], 0)
+            self.assertGreater(spec["buy"], 0, key)
+            self.assertGreater(spec["sell"], spec["buy"], key)
+
+    def test_prototypes_exist_and_are_edible(self):
+        from evennia.prototypes.prototypes import search_prototype
+        for key in RAT_PRODUCTS:
+            protos = search_prototype(key)
+            self.assertTrue(protos, f"prototype missing: {key}")
+            proto = protos[0]
+            tags = [tuple(t[:2]) for t in proto.get("tags", [])]
+            self.assertIn(("eat", "delivery_method"), tags)
+
+
+class TestBlockShop(TestCase):
+    """The sell side: the block is a limited shop stocked by the grind, and
+    sales credit the till (closing the buy/sell economy loop). Uses real
+    Evennia objects for the purchase path."""
+
+    def test_stock_and_purchase_cycle(self):
+        from evennia.utils.test_resources import BaseEvenniaTest
+        # run inside an Evennia test body for object creation
+        class _T(BaseEvenniaTest):
+            def runTest(self):
+                from evennia import create_object
+                block = create_object("typeclasses.butcher.ButcherBlock",
+                                      key="test block", location=self.room1)
+                block.db.register = 100
+                block.stock_cuts({"rat_chops": 2, "rat_tail": 1})
+                self.assertEqual(block.db.item_inventory["rat_chops"], 2)
+                self.assertEqual(block.db.prototype_inventory["rat_chops"], 5)
+                buyer = self.char1
+                buyer.tokens = 50
+                ok, item = block.purchase_item(buyer, "rat_chops")
+                self.assertTrue(ok)
+                self.assertEqual(item.location, buyer)
+                self.assertEqual(buyer.tokens, 45)               # paid 5
+                self.assertEqual(block.db.register, 105)          # till credited
+                self.assertEqual(block.db.item_inventory["rat_chops"], 1)
+                # the spawned cut is edible, ingredient-grade
+                self.assertTrue(item.tags.has("eat", category="delivery_method"))
+                self.assertEqual(item.db.uses_left, 1)
+                # drain the stock: second buy ok, third refused
+                ok, _ = block.purchase_item(buyer, "rat_chops")
+                self.assertTrue(ok)
+                ok, msg = block.purchase_item(buyer, "rat_chops")
+                self.assertFalse(ok)
+        t = _T("runTest"); t.setUp()
+        try:
+            t.runTest()
+        finally:
+            t.tearDown()


### PR DESCRIPTION
Closes #1249

The butcher bought carcasses but nothing sold. ButcherBlock now subclasses
ShopContainer in limited-inventory mode: the grind stocks the shop
(stock_cuts — quantities += what the carcass actually yielded) instead of
spawning loose items, so her stock is exactly what suppliers brought and
"buy rat chops from block" works like any shop. Five ingredient-grade cut
prototypes added.

The till loop closes: purchase_item override credits sale proceeds to
db.register — the fund payouts draw from. Pays ~26/clean rat, sells the
yield for ~44; the margin keeps the stall solvent. (Base ShopContainer
purchases discard the money.)

Tests: stock/purchase/till-credit/sell-out on real objects; prototype
existence + edibility; sell>buy margin. 266/266 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
