### PR TITLE
Food layer: cuts join the ingredient catalog; the butcher sells dishes

### DIFF
--- a/typeclasses/butcher.py
+++ b/typeclasses/butcher.py
@@ -31,16 +31,15 @@ BUTCHER_DECAY_REFUSAL = 0.6
 #: buying until it's fed (finite till — the economy hook).
 BUTCHER_TILL_FLOOR = 5
 
-#: The rat butchery pricing (spec §3.4): per-product BUY value (what the
-#: block pays a supplier) and SELL price (what the shop charges — the margin
-#: is what keeps the till solvent). Prose/tags live on the prototypes
-#: (world/prototypes.py RAT_TAIL etc.); `name` is the display form.
+#: The rat butchery BUY values (spec §3.4): what the block pays a supplier
+#: per unit yielded. The SELL side is cooked — dish prices live in
+#: ``world.food.FOOD_RECIPES``; raw-cut prose/tags on the prototypes.
 RAT_PRODUCTS = {
-    "rat_tail":            {"name": "rat tail", "buy": 5, "sell": 8},
-    "rat_chops":           {"name": "rat chops", "buy": 3, "sell": 5},
-    "rat_haunch":          {"name": "rat haunch", "buy": 3, "sell": 5},
-    "rat_offal":           {"name": "rat offal", "buy": 3, "sell": 5},
-    "ground_mystery_meat": {"name": "ground mystery meat", "buy": 1, "sell": 2},
+    "rat_tail":            {"name": "rat tail", "buy": 5},
+    "rat_chops":           {"name": "rat chops", "buy": 3},
+    "rat_haunch":          {"name": "rat haunch", "buy": 3},
+    "rat_offal":           {"name": "rat offal", "buy": 3},
+    "ground_mystery_meat": {"name": "ground mystery meat", "buy": 1},
 }
 
 #: Trunk organs whose average condition gates the chops yield — a
@@ -55,12 +54,13 @@ _RAT_OFFAL_ORGANS = ("heart", "liver", "left_kidney", "right_kidney")
 class ButcherBlock(ShopContainer):
     """The butcher's block — a fixed counter that is also her SHOP.
 
-    A ``ShopContainer`` in **limited-inventory** mode: the stock is exactly
-    what the grind produced (``stock_cuts``), never spawned from thin air —
-    the gig economy stays real. ``buy rat chops from block`` works like any
-    shop, and the override below credits sale proceeds to ``db.register``,
-    closing the till loop: payouts to hunters drain the till, meat sales
-    refill it. ``db.integrate`` folds it into the room description."""
+    A ``ShopContainer`` in **limited-inventory** mode selling COOKED DISHES:
+    the grind's cuts run through ``world.food`` recipes (``stock_cuts`` cooks
+    them 1:1) and the menu is stew, chops, and skewers — never spawned from
+    thin air, so the gig economy stays real. ``buy stew from block`` works
+    like any shop, and the override below credits sale proceeds to
+    ``db.register``, closing the till loop: payouts to hunters drain the
+    till, dish sales refill it. ``db.integrate`` folds it into the room."""
 
     def at_object_creation(self):
         super().at_object_creation()
@@ -76,17 +76,22 @@ class ButcherBlock(ShopContainer):
                                      "walks off with {item}.")
 
     def stock_cuts(self, counts):
-        """Add ground produce to the shop: ``{prototype_key: count}``.
-
-        Registers each prototype at its sell price (idempotent) and
-        accumulates limited-mode quantities."""
+        """COOK the ground produce and stock the DISHES: raw ingredient counts
+        (``{catalog_id: count}``) run through ``world.food.cook_yields`` — the
+        cuts are consumed as recipe ingredients, and what the shop sells is the
+        cooked menu (rat tail stew, grilled chops…) at recipe prices. The raw
+        cuts stay real in ``FOOD_INGREDIENT_CATALOG`` for the future grocery /
+        player-kitchen layer; today the butcher IS the whole chain."""
+        from world.food import FOOD_RECIPES, cook_yields
+        dishes = cook_yields(counts)
         inventory = dict(self.db.prototype_inventory or {})
         stock = dict(self.db.item_inventory or {})
-        for proto_key, count in counts.items():
-            spec = RAT_PRODUCTS.get(proto_key)
-            if not spec or count <= 0:
+        for recipe_id, count in dishes.items():
+            recipe = FOOD_RECIPES.get(recipe_id)
+            if not recipe or count <= 0:
                 continue
-            inventory[proto_key] = spec["sell"]
+            proto_key = recipe["prototype"]
+            inventory[proto_key] = recipe["price"]
             stock[proto_key] = int(stock.get(proto_key, 0)) + int(count)
         self.db.prototype_inventory = inventory
         self.db.item_inventory = stock
@@ -182,7 +187,7 @@ class Butcher(LLMNpcMixin, Character):
                     if payout else "doesn't reach for the till")
         self.execute_cmd(
             f"emote breaks the carcass down with a few practiced strokes — "
-            f"{cuts_text} into the case — and {pay_text}."
+            f"{cuts_text} to the cook-pot — and {pay_text}."
         )
 
     def _butcher_yields(self, corpse, decay):

--- a/world/food.py
+++ b/world/food.py
@@ -1,0 +1,115 @@
+"""The food layer — the bar's ingredient pattern applied to eating.
+
+Mirrors ``world/bar.py``: a **FOOD_INGREDIENT_CATALOG** (ingredient id →
+role / substance contributions / flavour, the same shape as
+``INGREDIENT_CATALOG``) and **FOOD_RECIPES** (dish → the ingredients it
+consumes + a price). The butcher's grind produces catalog ingredients; her
+block cooks them 1:1 into dishes and sells THOSE (GIG_PROTOTYPE_BUTCHER_SPEC
+§7 tier 2). When player kitchens / grocery buying arrive, the raw ingredients
+start circulating through this same catalog — the recipes and contributions
+are already waiting.
+
+Contributions are empty for now (no nutrition substance is registered yet);
+the slots are the point — a future toxin-traced or drugged carcass flows its
+substances through the ingredient into the dish (spec §7 tier 3).
+"""
+
+#: Food component role (the ``ROLE_SPIRIT`` analogue).
+ROLE_PROTEIN = "protein"
+
+#: The butcher's cuts as REAL ingredients (bar-catalog shape). ``prototype``
+#: names the spawnable raw-item form (world/prototypes.py).
+FOOD_INGREDIENT_CATALOG = {
+    "rat_tail": {
+        "name": "rat tail", "role": ROLE_PROTEIN, "contributions": {},
+        "flavour": "gelatinous slow-cook richness",
+        "desc": "a skinned rat tail, coiled and tied with butcher's twine",
+        "keywords": ("tail",), "prototype": "rat_tail",
+    },
+    "rat_chops": {
+        "name": "rat chops", "role": ROLE_PROTEIN, "contributions": {},
+        "flavour": "lean, mineral-edged meat",
+        "desc": "center-cut rat chops, pale and lean on the bone",
+        "keywords": ("chops", "chop"), "prototype": "rat_chops",
+    },
+    "rat_haunch": {
+        "name": "rat haunch", "role": ROLE_PROTEIN, "contributions": {},
+        "flavour": "dark, gamey roast meat",
+        "desc": "a skinned, hock-tied rat hindquarter",
+        "keywords": ("haunch",), "prototype": "rat_haunch",
+    },
+    "rat_offal": {
+        "name": "rat offal", "role": ROLE_PROTEIN, "contributions": {},
+        "flavour": "iron-rich organ meat",
+        "desc": "a waxed-paper twist of sound rat organs",
+        "keywords": ("offal",), "prototype": "rat_offal",
+    },
+    "ground_mystery_meat": {
+        "name": "ground mystery meat", "role": ROLE_PROTEIN, "contributions": {},
+        "flavour": "salt, fat, and ambiguity",
+        "desc": "a dense brick of pale ground meat, wrapper stamped MEAT",
+        "keywords": ("meat", "mystery"), "prototype": "ground_mystery_meat",
+    },
+}
+
+#: Dishes: what a kitchen makes of the catalog. ``ingredients`` maps catalog
+#: ids to quantities consumed; ``prototype`` is the servable item
+#: (world/prototypes.py); ``price`` is the cooked sell price (the butcher's
+#: value-add margin over the raw cut lives here).
+FOOD_RECIPES = {
+    "rat_tail_stew": {
+        "name": "rat tail stew", "ingredients": {"rat_tail": 1},
+        "price": 12, "prototype": "rat_tail_stew",
+        "keywords": ("stew",),
+    },
+    "grilled_rat_chops": {
+        "name": "grilled rat chops", "ingredients": {"rat_chops": 1},
+        "price": 8, "prototype": "grilled_rat_chops",
+        "keywords": ("grilled", "chops"),
+    },
+    "roast_rat_haunch": {
+        "name": "roast rat haunch", "ingredients": {"rat_haunch": 1},
+        "price": 8, "prototype": "roast_rat_haunch",
+        "keywords": ("roast", "haunch"),
+    },
+    "butchers_breakfast": {
+        "name": "butcher's breakfast", "ingredients": {"rat_offal": 1},
+        "price": 8, "prototype": "butchers_breakfast",
+        "keywords": ("breakfast", "offal", "fry"),
+    },
+    "mystery_skewer": {
+        "name": "mystery skewer", "ingredients": {"ground_mystery_meat": 1},
+        "price": 3, "prototype": "mystery_skewer",
+        "keywords": ("skewer",),
+    },
+}
+
+
+def cook_yields(ingredient_counts):
+    """Convert raw-ingredient counts into dish counts, greedily.
+
+    ``{catalog_id: count}`` → ``{recipe_id: count}``. Each recipe consumes its
+    declared ingredients; with the current 1:1 recipes every cut becomes its
+    dish. Ingredients no recipe wants are left uncooked (dropped)."""
+    remaining = dict(ingredient_counts or {})
+    dishes = {}
+    for recipe_id, recipe in FOOD_RECIPES.items():
+        needs = recipe["ingredients"]
+        while all(remaining.get(k, 0) >= q for k, q in needs.items()):
+            for k, q in needs.items():
+                remaining[k] = remaining.get(k, 0) - q
+            dishes[recipe_id] = dishes.get(recipe_id, 0) + 1
+    return dishes
+
+
+def dish_contributions(recipe_id):
+    """Sum a dish's substance contributions from its ingredients — the same
+    additive model as ``world.bar.project_mix``. Empty today; the seam the
+    provenance tier (spec §7 tier 3) flows through."""
+    recipe = FOOD_RECIPES.get(recipe_id) or {}
+    total = {}
+    for ing_id, qty in (recipe.get("ingredients") or {}).items():
+        contribs = (FOOD_INGREDIENT_CATALOG.get(ing_id) or {}).get("contributions") or {}
+        for substance, doses in contribs.items():
+            total[substance] = total.get(substance, 0) + doses * qty
+    return total

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -461,10 +461,12 @@ ARCHETYPES = {
     "butcher": {
         "duties": (
             "You run the butcher's block at the market — you buy animal "
-            "carcasses whole, break them down into cuts, and grind the rest "
-            "into mystery meat. The block does the buying the moment a carcass "
-            "lands on it; the price is what the body yields, and you say so "
-            "plainly: a clean fresh kill pays, a shot-up or stale one is mince. "
+            "carcasses whole, break them down, and cook the cuts into the "
+            "dishes on your board: rat tail stew, grilled chops, roast "
+            "haunch, the skewers. The block does the buying the moment a "
+            "carcass lands on it; the price is what the body yields, and you "
+            "say so plainly: a clean fresh kill pays, a shot-up or stale one "
+            "is mince. Customers buy the finished dishes off the block. "
             "You do NOT buy people or machines — sapient bodies are ripper "
             "trade and chrome isn't food; wave those off without ceremony. "
             "Meat is your whole subject: quality, provenance, the state of a "

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -1962,6 +1962,97 @@ GROUND_MYSTERY_MEAT = {
     "tags": [("eat", "delivery_method"), ("food", "item_type")],
 }
 
+# --- cooked dishes (world/food.py FOOD_RECIPES; the butcher's block sells
+# these — the raw cuts above are the INGREDIENTS they consume) ---------------
+
+RAT_TAIL_STEW = {
+    "prototype_key": "rat_tail_stew",
+    "key": "bowl of rat tail stew",
+    "aliases": ["stew", "rat tail stew"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A dented tin bowl of dark, glossy stew, a whole rat tail coiled "
+            "through it like a question mark. The colony's honest comfort "
+            "food — nobody asks the rat's opinion.",
+    "attrs": [
+        ("drink_taste", "Rich, gelatinous, and deeply savoury — the tail gives "
+                        "up everything it has, slow and complete."),
+        ("drink_effects", {}),
+        ("uses_left", 2),
+        ("value", 12),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
+GRILLED_RAT_CHOPS = {
+    "prototype_key": "grilled_rat_chops",
+    "key": "plate of grilled rat chops",
+    "aliases": ["grilled chops", "chops plate"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Grill-striped rat chops on a scoured steel plate, bones frenched "
+            "with more care than the venue strictly deserves.",
+    "attrs": [
+        ("drink_taste", "Char and clean lean meat with a mineral finish — the "
+                        "good cut, treated with respect."),
+        ("drink_effects", {}),
+        ("uses_left", 2),
+        ("value", 8),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
+ROAST_RAT_HAUNCH = {
+    "prototype_key": "roast_rat_haunch",
+    "key": "roast rat haunch",
+    "aliases": ["roast", "roast haunch"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A whole rat hindquarter roasted to a lacquered brown, the skin "
+            "crisped and the little femur left as a handle.",
+    "attrs": [
+        ("drink_taste", "Dark and gamey under crackled skin — eats like a "
+                        "meal that used to be somebody's whole day of hunting."),
+        ("drink_effects", {}),
+        ("uses_left", 2),
+        ("value", 8),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
+BUTCHERS_BREAKFAST = {
+    "prototype_key": "butchers_breakfast",
+    "key": "butcher's breakfast",
+    "aliases": ["breakfast", "offal fry"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "A shallow pan of flash-fried rat offal — heart, liver, kidneys — "
+            "glistening in rendered fat with a fist of ration crackers on the "
+            "side. The trade's own meal.",
+    "attrs": [
+        ("drink_taste", "Iron and velvet, seared fast — the liver melts, the "
+                        "heart argues, the fat forgives everything."),
+        ("drink_effects", {}),
+        ("uses_left", 1),
+        ("value", 8),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
+MYSTERY_SKEWER = {
+    "prototype_key": "mystery_skewer",
+    "key": "mystery skewer",
+    "aliases": ["skewer"],
+    "typeclass": "typeclasses.items.Item",
+    "desc": "Cubes of seasoned mystery meat char-grilled on a filed-down "
+            "spoke. Street food in its purest colony form: hot, cheap, and "
+            "unexaminable.",
+    "attrs": [
+        ("drink_taste", "Salt, char, and fat — delicious precisely as long as "
+                        "you keep your curiosity holstered."),
+        ("drink_effects", {}),
+        ("uses_left", 1),
+        ("value", 3),
+    ],
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+}
+
 PAINKILLER = {
     "key": "painkiller",
     "typeclass": "typeclasses.items.Item",

--- a/world/tests/test_butcher.py
+++ b/world/tests/test_butcher.py
@@ -202,11 +202,14 @@ class TestRatAccepted(TestCase):
         for banned in ("human", "synthetic_humanoid", "robot"):
             self.assertNotIn(banned, ACCEPTED_BUTCHER_SPECIES)
 
-    def test_products_priced_with_margin(self):
-        # sell > buy on every product: the block's margin keeps the till solvent
-        for key, spec in RAT_PRODUCTS.items():
-            self.assertGreater(spec["buy"], 0, key)
-            self.assertGreater(spec["sell"], spec["buy"], key)
+    def test_dishes_priced_with_margin(self):
+        # every dish sells above the buy cost of its ingredients — the
+        # cooked margin is what keeps the till solvent
+        from world.food import FOOD_RECIPES
+        for rid, recipe in FOOD_RECIPES.items():
+            cost = sum(RAT_PRODUCTS[i]["buy"] * q
+                       for i, q in recipe["ingredients"].items())
+            self.assertGreater(recipe["price"], cost, rid)
 
     def test_prototypes_exist_and_are_edible(self):
         from evennia.prototypes.prototypes import search_prototype
@@ -232,27 +235,69 @@ class TestBlockShop(TestCase):
                 block = create_object("typeclasses.butcher.ButcherBlock",
                                       key="test block", location=self.room1)
                 block.db.register = 100
+                # raw cuts in -> COOKED DISHES on the menu (world.food recipes)
                 block.stock_cuts({"rat_chops": 2, "rat_tail": 1})
-                self.assertEqual(block.db.item_inventory["rat_chops"], 2)
-                self.assertEqual(block.db.prototype_inventory["rat_chops"], 5)
+                self.assertEqual(block.db.item_inventory["grilled_rat_chops"], 2)
+                self.assertEqual(block.db.item_inventory["rat_tail_stew"], 1)
+                self.assertEqual(block.db.prototype_inventory["grilled_rat_chops"], 8)
+                self.assertEqual(block.db.prototype_inventory["rat_tail_stew"], 12)
+                self.assertNotIn("rat_chops", block.db.item_inventory)  # raw not sold
                 buyer = self.char1
                 buyer.tokens = 50
-                ok, item = block.purchase_item(buyer, "rat_chops")
+                ok, item = block.purchase_item(buyer, "grilled_rat_chops")
                 self.assertTrue(ok)
                 self.assertEqual(item.location, buyer)
-                self.assertEqual(buyer.tokens, 45)               # paid 5
-                self.assertEqual(block.db.register, 105)          # till credited
-                self.assertEqual(block.db.item_inventory["rat_chops"], 1)
+                self.assertEqual(buyer.tokens, 42)               # paid 8
+                self.assertEqual(block.db.register, 108)          # till credited
+                self.assertEqual(block.db.item_inventory["grilled_rat_chops"], 1)
                 # the spawned cut is edible, ingredient-grade
                 self.assertTrue(item.tags.has("eat", category="delivery_method"))
-                self.assertEqual(item.db.uses_left, 1)
+                self.assertEqual(item.db.uses_left, 2)   # a plated dish is two bites
                 # drain the stock: second buy ok, third refused
-                ok, _ = block.purchase_item(buyer, "rat_chops")
+                ok, _ = block.purchase_item(buyer, "grilled_rat_chops")
                 self.assertTrue(ok)
-                ok, msg = block.purchase_item(buyer, "rat_chops")
+                ok, msg = block.purchase_item(buyer, "grilled_rat_chops")
                 self.assertFalse(ok)
         t = _T("runTest"); t.setUp()
         try:
             t.runTest()
         finally:
             t.tearDown()
+
+
+class TestFoodLayer(TestCase):
+    """world/food.py: the ingredient catalog + recipes are coherent, and the
+    cook step maps cuts to dishes."""
+
+    def test_recipes_reference_real_ingredients(self):
+        from world.food import FOOD_INGREDIENT_CATALOG, FOOD_RECIPES
+        for rid, recipe in FOOD_RECIPES.items():
+            for ing in recipe["ingredients"]:
+                self.assertIn(ing, FOOD_INGREDIENT_CATALOG, f"{rid} -> {ing}")
+            self.assertGreater(recipe["price"], 0)
+
+    def test_dish_prototypes_exist_and_are_edible(self):
+        from evennia.prototypes.prototypes import search_prototype
+        from world.food import FOOD_RECIPES
+        for rid, recipe in FOOD_RECIPES.items():
+            protos = search_prototype(recipe["prototype"])
+            self.assertTrue(protos, f"dish prototype missing: {rid}")
+            tags = [tuple(t[:2]) for t in protos[0].get("tags", [])]
+            self.assertIn(("eat", "delivery_method"), tags)
+
+    def test_cook_yields_full_grind(self):
+        from world.food import cook_yields
+        dishes = cook_yields({"rat_tail": 1, "rat_chops": 3, "rat_haunch": 2,
+                              "rat_offal": 1, "ground_mystery_meat": 3})
+        self.assertEqual(dishes, {"rat_tail_stew": 1, "grilled_rat_chops": 3,
+                                  "roast_rat_haunch": 2, "butchers_breakfast": 1,
+                                  "mystery_skewer": 3})
+
+    def test_cook_yields_ignores_unknown(self):
+        from world.food import cook_yields
+        self.assertEqual(cook_yields({"mystery_gland": 4}), {})
+
+    def test_contributions_seam(self):
+        # empty today, but the summation seam works (spec §7 tier 3)
+        from world.food import dish_contributions
+        self.assertEqual(dish_contributions("rat_tail_stew"), {})


### PR DESCRIPTION
Closes #1251

world/food.py applies the bar's ingredient pattern to eating:
FOOD_INGREDIENT_CATALOG (the five cuts as real catalog ingredients, same
shape as INGREDIENT_CATALOG) + FOOD_RECIPES (rat tail stew, grilled chops,
roast haunch, butcher's breakfast, mystery skewer) + cook_yields +
dish_contributions (the additive substance seam — empty today, tier-3
provenance flows through it later).

The block now COOKS: stock_cuts runs the grind's yield through the recipes
and stocks the cooked menu at recipe prices; raw cuts are consumed as
ingredients and never sold. Dish prototypes added (plated 2-bite meals).
Every dish prices above its ingredients' buy cost so the till stays solvent.

When the grocery/player-kitchen layer arrives, raw cuts circulate through
this same catalog — the butcher just stops being the only kitchen.

Tests: cook mapping, catalog coherence, dish edibility, margins, full
stock/buy/till cycle. 261/261 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
