### PR TITLE
Butcher's block becomes a food cart

### DIFF
--- a/typeclasses/butcher.py
+++ b/typeclasses/butcher.py
@@ -51,28 +51,36 @@ _RAT_TRUNK_ORGANS = ("heart", "left_lung", "right_lung", "liver", "stomach",
 _RAT_OFFAL_ORGANS = ("heart", "liver", "left_kidney", "right_kidney")
 
 
-class ButcherBlock(ShopContainer):
-    """The butcher's block — a fixed counter that is also her SHOP.
+class FoodCart(ShopContainer):
+    """The butcher's food cart — a parked scrap-built cart that is her SHOP.
 
     A ``ShopContainer`` in **limited-inventory** mode selling COOKED DISHES:
     the grind's cuts run through ``world.food`` recipes (``stock_cuts`` cooks
     them 1:1) and the menu is stew, chops, and skewers — never spawned from
-    thin air, so the gig economy stays real. ``buy stew from block`` works
+    thin air, so the gig economy stays real. ``buy stew from cart`` works
     like any shop, and the override below credits sale proceeds to
     ``db.register``, closing the till loop: payouts to hunters drain the
-    till, dish sales refill it. ``db.integrate`` folds it into the room."""
+    till, dish sales refill it.
+
+    A FIXTURE with wheels only in the fiction (``get:false``; the desc shows
+    them chocked) — if roaming vendors ever become a mechanic, the cart is
+    already the right object for it. ``db.integrate`` folds it into the room
+    via the short ``db.integration_desc`` line (the full desc stays on
+    ``look cart`` — the jukebox lesson)."""
 
     def at_object_creation(self):
         super().at_object_creation()
         self.db.is_infinite = False
-        self.db.shop_name = "the butcher's block"
-        self.db.container_type = "block"
+        self.db.shop_name = "the food cart"
+        self.db.container_type = "cart"
         self.db.register = 0
         self.db.owner = None
         self.db.integrate = True
+        self.db.integration_priority = 8
         self.db.purchase_msg_buyer = ("You count out {price}, and the butcher "
-                                      "hooks down {item} without ceremony.")
-        self.db.purchase_msg_room = ("{buyer} counts chits onto the block and "
+                                      "hands {item} across the cart without "
+                                      "ceremony.")
+        self.db.purchase_msg_room = ("{buyer} counts chits onto the cart and "
                                      "walks off with {item}.")
 
     def stock_cuts(self, counts):
@@ -123,10 +131,11 @@ class Butcher(LLMNpcMixin, Character):
         return ["butcher", "meatcutter", "grinder"]
 
     def _find_block(self):
+        """The cart she works from (name kept for the give-flow history)."""
         if not self.location:
             return None
         for obj in self.location.contents:
-            if isinstance(obj, ButcherBlock):
+            if isinstance(obj, FoodCart):
                 return obj
         return None
 
@@ -275,3 +284,8 @@ class Butcher(LLMNpcMixin, Character):
         if len(parts) > 1:
             return ", ".join(parts[:-1]) + ", and " + parts[-1]
         return parts[0] if parts else "nothing worth wrapping"
+
+
+#: Back-compat alias — live objects created before the cart redesign carry
+#: ``typeclasses.butcher.ButcherBlock`` as their stored typeclass path.
+ButcherBlock = FoodCart

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -460,13 +460,13 @@ ARCHETYPES = {
     },
     "butcher": {
         "duties": (
-            "You run the butcher's block at the market — you buy animal "
+            "You run a scrap-built food cart at the market — you buy animal "
             "carcasses whole, break them down, and cook the cuts into the "
             "dishes on your board: rat tail stew, grilled chops, roast "
-            "haunch, the skewers. The block does the buying the moment a "
+            "haunch, the skewers. The cart does the buying the moment a "
             "carcass lands on it; the price is what the body yields, and you "
             "say so plainly: a clean fresh kill pays, a shot-up or stale one "
-            "is mince. Customers buy the finished dishes off the block. "
+            "is mince. Customers buy the finished dishes off the cart. "
             "You do NOT buy people or machines — sapient bodies are ripper "
             "trade and chrome isn't food; wave those off without ceremony. "
             "Meat is your whole subject: quality, provenance, the state of a "
@@ -500,7 +500,7 @@ ARCHETYPES = {
             {"user": 'a smug stranger says to you: "half that meat\'s rot and '
                      'you know it. i\'ll give you two."',
              "assistant": {"speech": "Then buy rot somewhere it's sold. The "
-                                     "block prices what's on it.",
+                                     "cart prices what's on it.",
                            "action": "sets both hands flat beside the cleaver, "
                                      "unhurried",
                            "thought": "Lowballs the freshest cut on the row. "

--- a/world/tests/test_butcher.py
+++ b/world/tests/test_butcher.py
@@ -232,8 +232,8 @@ class TestBlockShop(TestCase):
         class _T(BaseEvenniaTest):
             def runTest(self):
                 from evennia import create_object
-                block = create_object("typeclasses.butcher.ButcherBlock",
-                                      key="test block", location=self.room1)
+                block = create_object("typeclasses.butcher.FoodCart",
+                                      key="test cart", location=self.room1)
                 block.db.register = 100
                 # raw cuts in -> COOKED DISHES on the menu (world.food recipes)
                 block.stock_cuts({"rat_chops": 2, "rat_tail": 1})


### PR DESCRIPTION
Closes #1253

ButcherBlock -> FoodCart (compat alias for live stored typeclass paths): a
parked scrap-built vendor cart — wheels chocked in the fiction, still a
get:false fixture, the right object if roaming vendors ever become real.
Cart-voiced purchase messages, shop_name/container_type updated, default
integration_priority 8 + the db.integration_desc short-line pattern (full
desc stays on look — the jukebox lesson). Butcher archetype wording updated.

Live data (cart re-key/descs, plastic-stool seating, Toe desc handoff)
follows separately. 261/261 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
