### PR TITLE
Unify food cart + stools: the cart is its own seating

### DIFF
--- a/typeclasses/butcher.py
+++ b/typeclasses/butcher.py
@@ -17,6 +17,7 @@ from evennia.utils.utils import delay
 
 from typeclasses.characters import Character
 from typeclasses.llm_npc import LLMNpcMixin
+from typeclasses.furniture import Seating
 from typeclasses.shopkeeper import ShopContainer
 from world.grammar import with_article
 
@@ -51,8 +52,10 @@ _RAT_TRUNK_ORGANS = ("heart", "left_lung", "right_lung", "liver", "stomach",
 _RAT_OFFAL_ORGANS = ("heart", "liver", "left_kidney", "right_kidney")
 
 
-class FoodCart(ShopContainer):
-    """The butcher's food cart — a parked scrap-built cart that is her SHOP.
+class FoodCart(Seating, ShopContainer):
+    """The butcher's food cart — a parked scrap-built cart that is her SHOP,
+    and its own SEATING (the BarCounter pattern: the plastic stools are part
+    of the cart, so ``sit at cart`` takes one of its slots).
 
     A ``ShopContainer`` in **limited-inventory** mode selling COOKED DISHES:
     the grind's cuts run through ``world.food`` recipes (``stock_cuts`` cooks
@@ -82,6 +85,11 @@ class FoodCart(ShopContainer):
                                       "ceremony.")
         self.db.purchase_msg_room = ("{buyer} counts chits onto the cart and "
                                      "walks off with {item}.")
+        # Seating: the stools ARE the cart (BarCounter pattern) — `sit at
+        # cart` takes one of these slots.
+        self.db.postures = ("sitting",)
+        self.db.capacity = 4
+        self.db.preposition = "at"
 
     def stock_cuts(self, counts):
         """COOK the ground produce and stock the DISHES: raw ingredient counts

--- a/world/tests/test_butcher.py
+++ b/world/tests/test_butcher.py
@@ -301,3 +301,21 @@ class TestFoodLayer(TestCase):
         # empty today, but the summation seam works (spec §7 tier 3)
         from world.food import dish_contributions
         self.assertEqual(dish_contributions("rat_tail_stew"), {})
+
+
+class TestCartSeating(TestCase):
+    """The cart is its own seating (BarCounter pattern): `sit cart` resolves
+    because FoodCart carries the Seating mixin + posture config."""
+
+    def test_cart_is_seating_with_slots(self):
+        from typeclasses.furniture import Seating
+        self.assertTrue(issubclass(butchmod.FoodCart, Seating))
+
+    def test_seating_defaults(self):
+        from unittest.mock import MagicMock
+        cart = MagicMock()
+        cart.db.postures = ("sitting",)
+        cart.db.capacity = 4
+        allows = butchmod.FoodCart.allows.__get__(cart, butchmod.FoodCart)
+        self.assertTrue(allows("sitting"))
+        self.assertFalse(allows("lying"))


### PR DESCRIPTION
Closes #1255

FoodCart gains the Seating mixin (BarCounter pattern): postures sitting,
capacity 4, preposition "at" — the plastic stools are part of the cart, so
"sit at cart" takes one of its slots and CmdSit's isinstance(Seating)
filter resolves it. Live data folds the standalone stools fixture into the
cart's desc/integrate line. 26/26 butcher tests green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
