### PR TITLE
Ground the butcher's persona in her real trade

### DIFF
--- a/specs/proposals/GIG_PROTOTYPE_BUTCHER_SPEC.md
+++ b/specs/proposals/GIG_PROTOTYPE_BUTCHER_SPEC.md
@@ -1,15 +1,19 @@
 # Gig Prototype — The Butcher
 
-> **Status:** 📋 PROPOSAL (2026-07-20) — design only, nothing built. The **first
-> gig**: a prototype fetch-quest that proves the loop the faction/favor/rep
-> capstone will hang off — *an NPC wants something → a player delivers it → the
-> NPC pays*. Deliberately minimal and self-contained. It builds **entirely on
-> shipped systems** (corpse/anatomy, the LLM NPC brain, tokens, `give`); the only
-> new code is the Butcher herself. Sibling gig — the **Ripper** (sapient organs,
-> black-market) — is a later doc; this one is **animal meat only**. Ties into
-> `LLM_GAMEMASTER_SPEC` (the NPC brain + the deterministic-transaction pattern),
-> `HEALTH_AND_SUBSTANCE_SYSTEM_SPEC` (corpses/organs/substances), and
-> `NPC_MEMORY_AND_IDENTITY_SPEC` (she remembers her suppliers).
+> **Status:** ✅ SHIPPED & LIVE (built 2026-07-24; spec'd #1242/#1244; built
+> #1247/#1249/#1251/#1253/#1255). **As built, the design EVOLVED past this doc:**
+> the block became a **hull-plate FOOD CART** (`typeclasses/butcher.py FoodCart` —
+> ShopContainer + Seating: limited-inventory shop, till-crediting sales, 4 stool
+> slots, `sit at cart`); the sell side is **COOKED DISHES**, not raw cuts — the
+> grind's cuts are consumed as `world/food.py` catalog ingredients through
+> `FOOD_RECIPES` (rat tail stew 12₮ … mystery skewer 3₮), so the §7 tier-2
+> cook/menu layer shipped WITH the prototype. The buy side is exactly §3: give a
+> corpse → condition-gated butchery table → payout by yield from the finite till;
+> dish sales refill the till (closed economy loop). Live: **Ottilie Krug #5222**
+> + cart #5221 at the Toe of Hammett's Boot (#5203); rats via `@spawnmob/rat`
+> (ambient sewer spawn still deferred). Her persona grounds the cart's LIVE board
+> + what she buys (anti-invention). Remaining from §5: ambient rat supply, rep-
+> scaled rates, tier-3 provenance, the Ripper.
 
 ---
 

--- a/typeclasses/llm_persona.py
+++ b/typeclasses/llm_persona.py
@@ -125,6 +125,33 @@ def build_persona(npc) -> dict:
         bar_menu = (bar.db.menu if bar else None) or npc.db.menu or []
         menu = [r.get("name") for r in bar_menu if r.get("name")] or None
 
+    # The butcher's real trade, same grounding principle: the cart's ACTUAL
+    # board (live shop stock + prices) and what she buys — without these the
+    # model invents stock ("sushi pork") and meats she's never carried.
+    cart_menu = None
+    buys = None
+    find_block = getattr(npc, "_find_block", None)
+    if callable(find_block):
+        try:
+            from typeclasses.butcher import ACCEPTED_BUTCHER_SPECIES
+            buys = sorted(ACCEPTED_BUTCHER_SPECIES)
+            block = find_block()
+            if block is not None:
+                stock = block.db.item_inventory or {}
+                prices = block.db.prototype_inventory or {}
+                from evennia.prototypes.prototypes import search_prototype
+                entries = []
+                for proto_key, count in stock.items():
+                    if int(count or 0) <= 0:
+                        continue
+                    protos = search_prototype(proto_key)
+                    name = (protos[0].get("key") if protos else None) or proto_key
+                    price = prices.get(proto_key)
+                    entries.append(f"{name} ({price} tokens, {count} left)")
+                cart_menu = entries   # [] = sold out; rendered explicitly
+        except Exception:  # noqa: BLE001 — persona building never breaks on trade
+            cart_menu, buys = None, None
+
     wearing, carrying, wielding, hands_free = _wardrobe(npc)
 
     # Radio state (RADIO_COMMS_SPEC §7.3): what the brain can key up with —
@@ -167,6 +194,8 @@ def build_persona(npc) -> dict:
         "voice_ending": get_voice_ending(npc),
         "location": location,
         "menu": menu,
+        "cart_menu": cart_menu,
+        "buys": buys,
         # deserialize → plain dict/list (the seed's nested mes_example is a
         # _SaverDict/_SaverList off the DB, which json.dumps can't serialize).
         "persona_seed": deserialize(npc.db.llm_persona) or {},

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -780,6 +780,21 @@ def render_persona(persona: dict) -> str:
     if menu:
         lines.append("Your bar serves ONLY: " + ", ".join(menu) + " (no beer, no "
                      "off-list). The bar makes them, not you.")
+    cart_menu = persona.get("cart_menu")
+    if cart_menu:
+        lines.append("On your cart's board RIGHT NOW: " + ", ".join(cart_menu)
+                     + ". That is your COMPLETE stock — never invent dishes, "
+                     "meats, or stock you don't have. Prices are the board's, "
+                     "flat; customers buy off the cart themselves.")
+    elif cart_menu is not None:
+        lines.append("Your cart is SOLD OUT — nothing on the board until "
+                     "someone brings you a carcass. Don't invent stock.")
+    buys = persona.get("buys")
+    if buys:
+        lines.append("You buy ANIMAL carcasses only — " + ", ".join(buys)
+                     + ", these days — handed over at the cart and priced by "
+                     "what the body yields. People and machines you refuse: "
+                     "sapient bodies are ripper trade, chrome isn't food.")
     return "\n".join(lines)
 
 

--- a/world/tests/test_butcher.py
+++ b/world/tests/test_butcher.py
@@ -319,3 +319,32 @@ class TestCartSeating(TestCase):
         allows = butchmod.FoodCart.allows.__get__(cart, butchmod.FoodCart)
         self.assertTrue(allows("sitting"))
         self.assertFalse(allows("lying"))
+
+
+class TestButcherPersonaGrounding(TestCase):
+    """The butcher's card grounds her REAL trade: the cart's live board and
+    what she buys — without it the model invents stock ('sushi pork')."""
+
+    def test_board_rendered_with_anti_invention(self):
+        from world.llm.prompt import render_persona
+        card = render_persona({
+            "persona_seed": {"archetype": "butcher", "name": "Ottilie"},
+            "cart_menu": ["bowl of rat tail stew (12 tokens, 1 left)"],
+            "buys": ["rat"]})
+        self.assertIn("bowl of rat tail stew (12 tokens, 1 left)", card)
+        self.assertIn("never invent dishes", card)
+        self.assertIn("ANIMAL carcasses only — rat", card)
+        self.assertIn("ripper trade", card)
+
+    def test_sold_out_rendered_explicitly(self):
+        from world.llm.prompt import render_persona
+        card = render_persona({
+            "persona_seed": {"archetype": "butcher", "name": "Ottilie"},
+            "cart_menu": [], "buys": ["rat"]})
+        self.assertIn("SOLD OUT", card)
+
+    def test_absent_keys_no_cart_lines(self):
+        from world.llm.prompt import render_persona
+        card = render_persona({"persona_seed": {"archetype": "bartender",
+                                                "name": "Del"}})
+        self.assertNotIn("cart", card.lower())


### PR DESCRIPTION
Closes #1259

Asked what carcasses she buys, Ottilie invented "sushi pork" — her card had
zero trade grounding. build_persona now reads the cart's LIVE board (stock +
prices) and ACCEPTED_BUTCHER_SPECIES; render_persona emits the complete-stock
board with an anti-invention clause (explicit SOLD OUT when empty) and the
buys line (animal carcasses only; people/machines refused). Same grounding
principle as the bartender's menu.

Spec banner updated to SHIPPED & LIVE with the as-built evolution (food cart,
cooked dishes, food layer, seating). 266/266 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
