### PR TITLE
Posts watcher (spec P2): vacancy, shuttering, successor reincarnation

### DIFF
--- a/specs/proposals/NPC_POSTS_AND_REINCARNATION_SPEC.md
+++ b/specs/proposals/NPC_POSTS_AND_REINCARNATION_SPEC.md
@@ -1,10 +1,17 @@
 # NPC Posts & Reincarnation Spec
 
-> **Status:** 🟡 §P1 SHIPPED (2026-07-24) — blueprints live for the nine-strong
-> named roster (`world/npcs/blueprints.py`: Sable, Vesper, Sully, Nikolai,
-> Marta, Del, Ezra, Ottilie, Petra) with `build_npc`/`verify_blueprint` and a
-> full build-from-nothing round-trip test. Posts/watcher/policies (§P2/§P3)
-> not built. Originally: Named NPCs
+> **Status:** 🟡 §P1 + §P2 SHIPPED (2026-07-24). §P1: blueprints live for the
+> nine-strong named roster (`world/npcs/blueprints.py`) with
+> `build_npc`/`build_successor`/`verify_blueprint`, all nine verified MATCH
+> against the live originals. §P2: the posts watcher (`world/npcs/posts.py`)
+> rides the director heartbeat — vacancy stamping + shuttered fixture desc,
+> combat de-confliction, and policy reincarnation. **Owner-decided values:**
+> successor 24h / re-sleeve 8h; the till/stock are the POST's (successors
+> inherit); Del + Sully are INSTITUTIONS (re-sleeve) — the only forgettable
+> posts are Ottilie's cart and Ezra's counter. The cart is the live pilot
+> (fixture-bound, vacant desc, arrival line); other posts activate as their
+> fixtures get registered in blueprint data. §P3 (memory snapshot/restore at
+> death for re-sleeve) not built. Originally: Named NPCs
 > (Ottilie, Del, Marta, Vesper…) currently die **permanently and
 > unreproducibly**: death → corpse → the character object is deleted (#1022),
 > dossiers and memories with it, and the NPC was hand-built in a shell session

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -248,6 +248,11 @@ class DirectorRoutineScript(DefaultScript):
             maintain_security_complement()
         except Exception:  # noqa: BLE001 — respawn must not stall the beats
             pass
+        try:
+            from world.npcs.posts import maintain_posts
+            maintain_posts()
+        except Exception:  # noqa: BLE001 — reincarnation must not stall the beats
+            pass
         # Tick telemetry (DB-backed → visible cross-process; surfaced by
         # @patrol/status as "last tick Ns ago").
         import time

--- a/world/npcs/blueprints.py
+++ b/world/npcs/blueprints.py
@@ -347,7 +347,7 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                      'home_room': '#1968',
                      'post': {'fixture': None,
                               'policy': 'resleave',
-                              'delay_hours': 24}},
+                              'delay_hours': 8}},
  'companion_vesper': {'name': 'Vesper',
                       'typeclass': 'typeclasses.llm_npc.LLMNpc',
                       'identity': {'sex': 'female',
@@ -526,7 +526,7 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                       'home_room': '#1974',
                       'post': {'fixture': None,
                                'policy': 'resleave',
-                               'delay_hours': 24}},
+                               'delay_hours': 8}},
  'bartender_sully': {'name': 'Sully',
                      'typeclass': 'typeclasses.bar.Bartender',
                      'identity': {'sex': 'male',
@@ -829,8 +829,8 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                      'carried_prototypes': ['painkiller'],
                      'home_room': '#1867',
                      'post': {'fixture': None,
-                              'policy': None,
-                              'delay_hours': 72}},
+                              'policy': 'resleave',
+                              'delay_hours': 8}},
  'doctor_nikolai': {'name': 'Nikolai Kasparov',
                     'typeclass': 'typeclasses.clinic.Doctor',
                     'identity': {'sex': 'ambiguous',
@@ -1022,7 +1022,7 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                     'home_room': '#3137',
                     'post': {'fixture': None,
                              'policy': 'resleave',
-                             'delay_hours': 24}},
+                             'delay_hours': 8}},
  'doctor_marta': {'name': 'Marta Okoye',
                   'typeclass': 'typeclasses.clinic.Doctor',
                   'identity': {'sex': 'female',
@@ -1228,7 +1228,7 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                   'home_room': '#5130',
                   'post': {'fixture': None,
                            'policy': 'resleave',
-                           'delay_hours': 24}},
+                           'delay_hours': 8}},
  'bartender_del': {'name': 'Delphine Marchetti',
                    'typeclass': 'typeclasses.bar.Bartender',
                    'identity': {'sex': 'female',
@@ -1454,8 +1454,8 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                    'carried_prototypes': ['break_shotgun'],
                    'home_room': '#5147',
                    'post': {'fixture': None,
-                            'policy': None,
-                            'delay_hours': 72}},
+                            'policy': 'resleave',
+                            'delay_hours': 8}},
  'merchant_ezra': {'name': 'Ezra Vantomme',
                    'typeclass': 'typeclasses.llm_npc.LLMNpc',
                    'identity': {'sex': 'male',
@@ -1632,7 +1632,7 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                    'home_room': '#5157',
                    'post': {'fixture': None,
                             'policy': 'successor',
-                            'delay_hours': 72}},
+                            'delay_hours': 24}},
  'butcher_ottilie': {'name': 'Ottilie Krug',
                      'typeclass': 'typeclasses.butcher.Butcher',
                      'identity': {'sex': 'female',
@@ -1804,7 +1804,18 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                      'home_room': '#5203',
                      'post': {'fixture': '#5221',
                               'policy': 'successor',
-                              'delay_hours': 72}},
+                              'delay_hours': 24,
+                              'vacant_desc':
+                                  'The |chull-plate food cart|n stands cold '
+                                  'against the scar wall, burner ring dark, '
+                                  'a chain run through its wheels.',
+                              'successor_temp_place':
+                                  'working the cook-pot behind the food '
+                                  'cart.',
+                              'arrival_successor':
+                                  '{mob} runs the chain off the cart, fires '
+                                  'the burner ring, and takes up the '
+                                  'cleaver like it was always theirs.'}},
  'dispatch_petra': {'name': 'Petra',
                     'typeclass': 'typeclasses.llm_npc.LLMNpc',
                     'identity': {'sex': 'female',
@@ -1861,7 +1872,7 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                     'home_room': '#4963',
                     'post': {'fixture': None,
                              'policy': 'resleave',
-                             'delay_hours': 24}}}
+                             'delay_hours': 8}}}
 
 
 def build_npc(blueprint_key, location):
@@ -1942,6 +1953,77 @@ def build_npc(blueprint_key, location):
 
     npc.db.llm_persona = dict(bp.get("persona") or {})
     npc.db.llm_driven = bool(bp.get("llm_driven"))
+    return npc
+
+
+def build_successor(blueprint_key, location):
+    """Construct a SUCCESSOR for a post (spec §1.1 generator mode): a new
+    person — generated name/face/build from the colony pools, generic flavor
+    prose — wearing the same TRADE (archetype, kit, post) as the predecessor.
+    Dossiers start empty by design: the empty book is the consequence.
+    """
+    from random import choice, randint
+    from world.identity import HEIGHTS, BUILDS, HAIR_COLORS, HAIR_STYLES
+    from world.director.civilians import HUMAN_SKINTONES
+    from world.namebank import (
+        FIRST_NAMES_MALE, FIRST_NAMES_FEMALE, FIRST_NAMES_AMBIGUOUS,
+        LAST_NAMES,
+    )
+    from world.mob_flavor import apply_random_flavor
+
+    bp = BLUEPRINTS[blueprint_key]
+    post = bp.get("post") or {}
+
+    sex = choice(["male", "female"])
+    if randint(1, 10) <= 2:
+        sex = "ambiguous"
+    first = {"male": FIRST_NAMES_MALE, "female": FIRST_NAMES_FEMALE}.get(
+        sex, FIRST_NAMES_AMBIGUOUS)
+    name = f"{choice(first)} {choice(LAST_NAMES)}"
+
+    npc = create_object(bp["typeclass"], key=name, location=location,
+                        home=location)
+    npc.db.is_npc = True
+    npc.sex = sex
+    npc.height = choice(HEIGHTS)
+    npc.build = choice(BUILDS)
+    npc.db.skintone = choice(HUMAN_SKINTONES)
+    if randint(1, 5) > 1:
+        npc.hair_color = choice(HAIR_COLORS)
+        npc.hair_style = choice(HAIR_STYLES)
+    ident = bp.get("identity", {})
+    if ident.get("sdesc_keyword"):
+        npc.attributes.add("sdesc_keyword", ident["sdesc_keyword"])
+    for stat in ("grit", "resonance", "intellect", "motorics"):
+        setattr(npc, stat, randint(1, 3))
+    apply_random_flavor(npc)   # generic desc / longdescs / look_place
+
+    if post.get("successor_temp_place"):
+        npc.temp_place = post["successor_temp_place"]
+    if bp.get("menu"):
+        npc.db.menu = bp["menu"]
+
+    # the TRADE survives the person: same kit, same tools of the job
+    for gspec in sorted(bp.get("wardrobe", ()),
+                        key=lambda g: int(g.get("layer", 1) or 1)):
+        garment = create_object("typeclasses.items.Item", key=gspec["key"],
+                                aliases=gspec.get("aliases"), location=npc,
+                                home=npc)
+        for attr in ("desc", "worn_desc", "coverage", "layer", "color",
+                     "material", "weight", "category"):
+            if gspec.get(attr) is not None:
+                garment.attributes.add(attr, gspec[attr])
+        npc.wear_item(garment)
+    for proto in bp.get("carried_prototypes", ()):
+        for item in spawn(proto):
+            item.move_to(npc, quiet=True, move_hooks=False)
+
+    # same ROLE persona, new person: name swapped, person-prose kept only
+    # where it is role-anchored (the seeds were written that way)
+    persona = dict(bp.get("persona") or {})
+    persona["name"] = name
+    npc.db.llm_persona = persona
+    npc.db.llm_driven = True
     return npc
 
 

--- a/world/npcs/posts.py
+++ b/world/npcs/posts.py
@@ -1,0 +1,116 @@
+"""The posts watcher — NPC reincarnation (NPC_POSTS_AND_REINCARNATION_SPEC §P2).
+
+A **post** is a staffed workplace (the food cart; later the bars, clinics,
+counters). The blueprint registry is the single source of truth — each
+blueprint's ``post`` dict names its fixture, policy, and delay; there is no
+in-game registration (owner's standing rule: no ad-hoc builder commands).
+
+Each director heartbeat, ``maintain_posts()`` sweeps every registered post:
+
+* keeper present → nothing to do (clearing any stale vacancy state);
+* keeper gone (dead NPCs are deleted, #1022) → stamp the vacancy and swap the
+  fixture to its vacant ``integration_desc`` — the room tells the story;
+* vacancy older than the policy delay (and no live combat at the post) →
+  reincarnate: ``resleave`` rebuilds the SAME person from the blueprint;
+  ``successor`` seats a STRANGER (``build_successor``) with an empty book.
+
+The post persists through death by design: stock, till, and prices are the
+cart's property, not the keeper's (owner-decided). Memory snapshot/restore
+for re-sleeve is §P3 — the snapshot must be taken at death-time (the object
+is deleted before this sweep can see it), which needs the death-side hook.
+"""
+
+import time
+
+from evennia.utils.search import search_object
+
+
+def _resolve(dbref):
+    hits = search_object(dbref)
+    return hits[0] if hits else None
+
+
+def _keeper_present(fixture):
+    keeper = fixture.db.post_keeper
+    return bool(keeper and keeper.pk
+                and keeper.location == fixture.location)
+
+
+def _combat_at(room):
+    from world.director.security import _in_combat
+    return any(_in_combat(obj) for obj in room.contents
+               if hasattr(obj, "is_typeclass")
+               and obj.is_typeclass("typeclasses.characters.Character",
+                                    exact=False))
+
+
+def maintain_posts(now=None):
+    """One sweep over every blueprint-registered post. Never raises — the
+    heartbeat guards it, but each post is also isolated so one broken post
+    can't stall the others."""
+    from world.npcs.blueprints import BLUEPRINTS
+    now = now if now is not None else time.time()
+    for key, bp in BLUEPRINTS.items():
+        post = bp.get("post") or {}
+        if not post.get("fixture") or post.get("policy") not in (
+                "resleave", "successor"):
+            continue
+        try:
+            _sweep_post(key, bp, post, now)
+        except Exception:  # noqa: BLE001 — one post must not stall the sweep
+            pass
+
+
+def _sweep_post(blueprint_key, bp, post, now):
+    fixture = _resolve(post["fixture"])
+    if not fixture or not fixture.location:
+        return
+    room = fixture.location
+
+    if _keeper_present(fixture):
+        if fixture.db.post_vacant_since:
+            _restore_desc(fixture)
+            fixture.db.post_vacant_since = None
+        return
+
+    if not fixture.db.post_vacant_since:
+        # the moment the watcher notices: stamp it, shutter the fixture
+        fixture.db.post_vacant_since = now
+        if post.get("vacant_desc"):
+            if fixture.db.post_active_desc is None:
+                fixture.db.post_active_desc = fixture.db.integration_desc
+            fixture.db.integration_desc = post["vacant_desc"]
+        return
+
+    if now - float(fixture.db.post_vacant_since) < post["delay_hours"] * 3600:
+        return
+    if _combat_at(room):
+        return   # never seat anyone into a live firefight
+
+    from world.npcs.blueprints import build_npc, build_successor
+    if post["policy"] == "resleave":
+        npc = build_npc(blueprint_key, room)
+        arrival = post.get(
+            "arrival_resleave",
+            "{mob} is back at their post, moving like the absence never "
+            "happened.")
+    else:
+        npc = build_successor(blueprint_key, room)
+        arrival = post.get(
+            "arrival_successor",
+            "{mob} steps up and takes over the post like it was always "
+            "theirs.")
+
+    fixture.db.post_keeper = npc
+    fixture.db.post_vacant_since = None
+    _restore_desc(fixture)
+
+    from world.identity_utils import msg_room_identity
+    msg_room_identity(location=room, template=arrival,
+                      char_refs={"mob": npc})
+
+
+def _restore_desc(fixture):
+    if fixture.db.post_active_desc is not None:
+        fixture.db.integration_desc = fixture.db.post_active_desc
+        fixture.db.post_active_desc = None

--- a/world/tests/test_npc_posts.py
+++ b/world/tests/test_npc_posts.py
@@ -1,0 +1,127 @@
+"""The posts watcher (NPC_POSTS_AND_REINCARNATION_SPEC §P2): vacancy
+stamping, delay gating, policy dispatch, and the successor generator."""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+from evennia.utils.test_resources import BaseEvenniaTest
+
+import world.npcs.posts as postsmod
+
+
+def _fixture(keeper=None, vacant_since=None, room=None):
+    f = MagicMock()
+    f.location = room or MagicMock()
+    f.db.post_keeper = keeper
+    f.db.post_vacant_since = vacant_since
+    f.db.post_active_desc = None
+    f.db.integration_desc = "active line"
+    return f
+
+
+POST = {"fixture": "#999", "policy": "successor", "delay_hours": 24,
+        "vacant_desc": "shuttered line"}
+
+
+class TestSweep(TestCase):
+    def _run(self, fixture, now, post=None, combat=False):
+        with patch.object(postsmod, "_resolve", return_value=fixture), \
+             patch.object(postsmod, "_combat_at", return_value=combat), \
+             patch("world.npcs.blueprints.build_npc") as bn, \
+             patch("world.npcs.blueprints.build_successor") as bs, \
+             patch("world.identity_utils.msg_room_identity"):
+            bs.return_value = MagicMock()
+            bn.return_value = MagicMock()
+            postsmod._sweep_post("butcher_ottilie", {}, post or POST, now)
+        return bn, bs
+
+    def test_staffed_post_untouched(self):
+        keeper = MagicMock(); keeper.pk = 1
+        f = _fixture(keeper=keeper)
+        keeper.location = f.location
+        bn, bs = self._run(f, now=1000.0)
+        bn.assert_not_called(); bs.assert_not_called()
+        self.assertIsNone(f.db.post_vacant_since)
+
+    def test_vacancy_stamped_and_shuttered(self):
+        f = _fixture(keeper=None)
+        self._run(f, now=1000.0)
+        self.assertEqual(f.db.post_vacant_since, 1000.0)
+        self.assertEqual(f.db.integration_desc, "shuttered line")
+        self.assertEqual(f.db.post_active_desc, "active line")
+
+    def test_before_delay_nothing_happens(self):
+        f = _fixture(vacant_since=1000.0)
+        bn, bs = self._run(f, now=1000.0 + 23 * 3600)
+        bn.assert_not_called(); bs.assert_not_called()
+
+    def test_after_delay_successor_seated(self):
+        f = _fixture(vacant_since=1000.0)
+        f.db.post_active_desc = "active line"
+        bn, bs = self._run(f, now=1000.0 + 25 * 3600)
+        bs.assert_called_once()
+        bn.assert_not_called()
+        self.assertIsNone(f.db.post_vacant_since)
+        self.assertEqual(f.db.integration_desc, "active line")
+        self.assertIsNotNone(f.db.post_keeper)
+
+    def test_resleave_policy_rebuilds_same_person(self):
+        f = _fixture(vacant_since=1000.0)
+        post = dict(POST, policy="resleave", delay_hours=8)
+        bn, bs = self._run(f, now=1000.0 + 9 * 3600, post=post)
+        bn.assert_called_once()
+        bs.assert_not_called()
+
+    def test_combat_blocks_seating(self):
+        f = _fixture(vacant_since=1000.0)
+        bn, bs = self._run(f, now=1000.0 + 25 * 3600, combat=True)
+        bn.assert_not_called(); bs.assert_not_called()
+        self.assertEqual(f.db.post_vacant_since, 1000.0)
+
+
+class TestPolicyData(TestCase):
+    def test_decided_delays(self):
+        from world.npcs.blueprints import BLUEPRINTS
+        for key, bp in BLUEPRINTS.items():
+            post = bp["post"]
+            if post["policy"] == "successor":
+                self.assertEqual(post["delay_hours"], 24, key)
+            elif post["policy"] == "resleave":
+                self.assertEqual(post["delay_hours"], 8, key)
+
+    def test_roster_split(self):
+        from world.npcs.blueprints import BLUEPRINTS
+        successors = {k for k, bp in BLUEPRINTS.items()
+                      if bp["post"]["policy"] == "successor"}
+        self.assertEqual(successors, {"butcher_ottilie", "merchant_ezra"})
+        # Del and Sully are institutions (owner-decided 2026-07-24)
+        for inst in ("bartender_del", "bartender_sully"):
+            self.assertEqual(BLUEPRINTS[inst]["post"]["policy"], "resleave")
+
+
+@override_settings(PROTOTYPE_MODULES=["world.prototypes"])
+class TestSuccessorBuild(BaseEvenniaTest):
+    """A real successor: new person, same trade."""
+
+    def test_successor_is_a_new_person_with_the_trade(self):
+        from world.npcs.blueprints import BLUEPRINTS, build_successor
+        npc = build_successor("butcher_ottilie", self.room1)
+        try:
+            self.assertNotEqual(npc.key, "Ottilie Krug")
+            self.assertTrue(npc.db.llm_driven)
+            persona = dict(npc.db.llm_persona)
+            self.assertEqual(persona["name"], npc.key)
+            self.assertEqual(persona["archetype"], "butcher")
+            # the trade kit transferred
+            want = sorted(g["key"] for g in
+                          BLUEPRINTS["butcher_ottilie"]["wardrobe"])
+            have = sorted(i.key for i in npc.get_worn_items())
+            self.assertEqual(want, have)
+            # the empty book: no dossiers, no memories
+            self.assertFalse(npc.db.llm_dossiers)
+            self.assertFalse(npc.db.llm_memories)
+            self.assertEqual(npc.temp_place,
+                             "working the cook-pot behind the food cart.")
+        finally:
+            npc.delete()


### PR DESCRIPTION
Closes #1271

world/npcs/posts.py rides the director heartbeat (the security-complement
shape): per-post sweep -> keeper check -> vacancy stamp + shuttered
integration_desc -> delay gate (successor 24h / resleave 8h, owner-decided)
-> combat de-confliction -> policy reincarnation. resleave rebuilds the
same person from the blueprint; successor seats a stranger
(build_successor: generated identity + generic flavor, same trade kit and
archetype, EMPTY dossiers — murder deletes social capital, not commerce).
Till/stock persist through death (the post's property). Del + Sully are
institutions; only Ottilie and Ezra get successors. The cart is the live
pilot. P3 (death-time memory snapshot for resleave) remains.

Tests: sweep logic, policy data, real successor build. 288/288 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
