### PR TITLE
Memory across death (spec P3): death-time snapshot + re-sleeve restore

### DIFF
--- a/specs/proposals/NPC_POSTS_AND_REINCARNATION_SPEC.md
+++ b/specs/proposals/NPC_POSTS_AND_REINCARNATION_SPEC.md
@@ -1,6 +1,11 @@
 # NPC Posts & Reincarnation Spec
 
-> **Status:** 🟡 §P1 + §P2 SHIPPED (2026-07-24). §P1: blueprints live for the
+> **Status:** ✅ §P1 + §P2 + §P3 SHIPPED (2026-07-24) — the full ladder.
+> §P3: `snapshot_keeper_memory` hooks the NPC death-deletion branch (dossiers
+> + episodic memory copied onto the POST before the object dies); re-sleeve
+> restores-and-consumes the snapshot, successors never open it (retained as
+> GM archaeology). Remaining: §5 'later' items only (succession rumors,
+> grudges, vacancy crime) + registering more post fixtures in blueprint data. §P1: blueprints live for the
 > nine-strong named roster (`world/npcs/blueprints.py`) with
 > `build_npc`/`build_successor`/`verify_blueprint`, all nine verified MATCH
 > against the live originals. §P2: the posts watcher (`world/npcs/posts.py`)

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -831,6 +831,15 @@ class DeathProgressionScript(DefaultScript):
         # lost player character.
         if account is None:
             if character.db.is_npc is True:
+                # §P3 (NPC_POSTS_AND_REINCARNATION): if this NPC kept a
+                # registered post, snapshot their dossiers/memories onto it
+                # BEFORE the object (and everything on it) is deleted — the
+                # re-sleeve policy restores it; successors never read it.
+                try:
+                    from world.npcs.posts import snapshot_keeper_memory
+                    snapshot_keeper_memory(character)
+                except Exception:  # noqa: BLE001 — never block a death
+                    pass
                 splattercast = get_splattercast()
                 splattercast.msg(f"DEATH_NPC_CLEANUP: deleting dead NPC {getattr(character, 'key', '?')}")
                 character.delete()

--- a/world/npcs/posts.py
+++ b/world/npcs/posts.py
@@ -44,6 +44,35 @@ def _combat_at(room):
                                     exact=False))
 
 
+def snapshot_keeper_memory(npc):
+    """§P3, the death-side half: called from the death machinery JUST BEFORE
+    a dead NPC object is deleted. If the deceased kept a registered post,
+    their dossiers + episodic memory are copied onto the POST — the estate
+    the policy disposes of: ``resleave`` restores it (insurance covers the
+    self), ``successor`` never reads it (the empty book is the point; the
+    snapshot stays as GM-readable archaeology). Never raises — death must
+    not be blockable by bookkeeping."""
+    try:
+        from evennia.utils.dbserialize import deserialize
+        from world.npcs.blueprints import BLUEPRINTS
+        for key, bp in BLUEPRINTS.items():
+            post = (bp.get("post") or {})
+            if not post.get("fixture"):
+                continue
+            fixture = _resolve(post["fixture"])
+            if not fixture or fixture.db.post_keeper != npc:
+                continue
+            fixture.db.post_memory_snapshot = {
+                "keeper": npc.key,
+                "taken": time.time(),
+                "dossiers": deserialize(npc.db.llm_dossiers) or {},
+                "memories": deserialize(npc.db.llm_memories) or [],
+            }
+            return
+    except Exception:  # noqa: BLE001 — never block a death on bookkeeping
+        pass
+
+
 def maintain_posts(now=None):
     """One sweep over every blueprint-registered post. Never raises — the
     heartbeat guards it, but each post is also isolated so one broken post
@@ -90,6 +119,13 @@ def _sweep_post(blueprint_key, bp, post, now):
     from world.npcs.blueprints import build_npc, build_successor
     if post["policy"] == "resleave":
         npc = build_npc(blueprint_key, room)
+        # continuity of self is what the insurance pays for: the death-time
+        # snapshot comes back with them, then is consumed
+        snapshot = fixture.db.post_memory_snapshot
+        if snapshot:
+            npc.db.llm_dossiers = dict(snapshot.get("dossiers") or {})
+            npc.db.llm_memories = list(snapshot.get("memories") or [])
+            fixture.db.post_memory_snapshot = None
         arrival = post.get(
             "arrival_resleave",
             "{mob} is back at their post, moving like the absence never "

--- a/world/tests/test_npc_posts.py
+++ b/world/tests/test_npc_posts.py
@@ -125,3 +125,63 @@ class TestSuccessorBuild(BaseEvenniaTest):
                              "working the cook-pot behind the food cart.")
         finally:
             npc.delete()
+
+
+class TestMemoryAcrossDeath(TestCase):
+    """§P3: the death-side snapshot and the policy split — re-sleeve restores
+    the book, a successor never opens it."""
+
+    def _dying_keeper(self, is_keeper=True):
+        npc = MagicMock()
+        npc.key = "Ottilie Krug"
+        npc.db.llm_dossiers = {"uid1": {"names": ["the ratcatcher"]}}
+        npc.db.llm_memories = [{"text": "clean kills, always"}]
+        fixture = MagicMock()
+        fixture.db.post_keeper = npc if is_keeper else MagicMock()
+        fixture.db.post_memory_snapshot = None
+        return npc, fixture
+
+    def test_snapshot_taken_for_keeper(self):
+        npc, fixture = self._dying_keeper()
+        with patch.object(postsmod, "_resolve", return_value=fixture):
+            postsmod.snapshot_keeper_memory(npc)
+        snap = fixture.db.post_memory_snapshot
+        self.assertEqual(snap["keeper"], "Ottilie Krug")
+        self.assertEqual(snap["dossiers"], {"uid1": {"names": ["the ratcatcher"]}})
+        self.assertEqual(snap["memories"], [{"text": "clean kills, always"}])
+
+    def test_non_keeper_death_no_snapshot(self):
+        npc, fixture = self._dying_keeper(is_keeper=False)
+        with patch.object(postsmod, "_resolve", return_value=fixture):
+            postsmod.snapshot_keeper_memory(npc)
+        self.assertIsNone(fixture.db.post_memory_snapshot)
+
+    def _reincarnate(self, policy, snapshot):
+        f = _fixture(vacant_since=1000.0)
+        f.db.post_memory_snapshot = snapshot
+        post = dict(POST, policy=policy, delay_hours=1)
+        new_npc = MagicMock()
+        with patch.object(postsmod, "_resolve", return_value=f), \
+             patch.object(postsmod, "_combat_at", return_value=False), \
+             patch("world.npcs.blueprints.build_npc", return_value=new_npc), \
+             patch("world.npcs.blueprints.build_successor",
+                   return_value=new_npc), \
+             patch("world.identity_utils.msg_room_identity"):
+            postsmod._sweep_post("butcher_ottilie", {}, post,
+                                 now=1000.0 + 2 * 3600)
+        return f, new_npc
+
+    def test_resleave_restores_and_consumes_snapshot(self):
+        snap = {"keeper": "X", "dossiers": {"u": {"names": ["pal"]}},
+                "memories": [{"text": "m"}]}
+        f, npc = self._reincarnate("resleave", snap)
+        self.assertEqual(npc.db.llm_dossiers, {"u": {"names": ["pal"]}})
+        self.assertEqual(npc.db.llm_memories, [{"text": "m"}])
+        self.assertIsNone(f.db.post_memory_snapshot)
+
+    def test_successor_never_opens_the_book(self):
+        snap = {"keeper": "X", "dossiers": {"u": {"names": ["pal"]}},
+                "memories": [{"text": "m"}]}
+        f, npc = self._reincarnate("successor", snap)
+        # snapshot retained on the post (archaeology), never loaded
+        self.assertEqual(f.db.post_memory_snapshot, snap)


### PR DESCRIPTION
Closes #1273

snapshot_keeper_memory hooks the death machinery's NPC-deletion branch
(guarded; never blocks a death): a registered post keeper's dossiers and
episodic memories are copied onto the POST before the object is deleted.
Re-sleeve restores and consumes the snapshot; successors never open it —
it stays on the post as GM archaeology.

Tests: snapshot/no-op/restore-consume/successor-never-reads. Full world
suite's only failures reproduce on clean master (pre-existing, unrelated).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
