### PR TITLE
Route 'tenement' rooms to the residential crowd pool

### DIFF
--- a/world/crowd/crowd_messages.py
+++ b/world/crowd/crowd_messages.py
@@ -884,6 +884,7 @@ NIGHTCLUB_ROOM_TYPES = {'nightclub', 'club'}
 
 RESIDENTIAL_ROOM_TYPES = {
     'cube hotel',
+    'tenement',      # the Brackett Arms and whatever housing follows
 }
 
 #: Enclosed bar/venue room types that draw on the 'interior' crowd pool rather

--- a/world/crowd/crowd_system.py
+++ b/world/crowd/crowd_system.py
@@ -24,6 +24,7 @@ class CrowdSystem:
             'laundromat': 0.2,
             'courier service': 0.3,
             'cube hotel': 0.1,
+            'tenement': 0.1,
             'hospital': 0.7,
             'constabulary': 0.3,
             'stairwell': 0.1,

--- a/world/tests/test_crowd.py
+++ b/world/tests/test_crowd.py
@@ -57,6 +57,8 @@ class TestResidentialProfile(TestCase):
         from world.crowd.crowd_messages import crowd_profile_for_room_type
         self.assertEqual(crowd_profile_for_room_type("cube hotel"),
                          "residential")
+        self.assertEqual(crowd_profile_for_room_type("tenement"),
+                         "residential")
         self.assertEqual(crowd_profile_for_room_type("CUBE HOTEL"),
                          "residential")
 


### PR DESCRIPTION
Closes #1279

Prep for the Brackett Arms: 'tenement' joins RESIDENTIAL_ROOM_TYPES (+0.1
modifier, the cube-hotel tier) so its halls draw tenant life. Tests extended.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
