### PR TITLE
Smoke-form messaging, tobacco expansion, pre-rolled joint, shop crowd pool

### DIFF
--- a/commands/CmdSmoke.py
+++ b/commands/CmdSmoke.py
@@ -31,6 +31,7 @@ from world.identity_utils import msg_room_identity
 from world.consumables import consume_use
 from world.substances import apply_substance
 from world.smoke import (
+    get_smoke_noun,
     find_held_lighter,
     find_held_smokable,
     get_substance,
@@ -152,7 +153,7 @@ class CmdLight(Command):
             return
 
         set_lit(cigarette, True)
-        self_msg, room_template = pick_light_self_message()
+        self_msg, room_template = pick_light_self_message(get_smoke_noun(cigarette))
         caller.msg(self_msg)
         if caller.location is not None:
             msg_room_identity(
@@ -185,7 +186,7 @@ class CmdLight(Command):
             return
 
         set_lit(cigarette, True)
-        caller_msg, target_msg, room_template = pick_light_other_message()
+        caller_msg, target_msg, room_template = pick_light_other_message(get_smoke_noun(cigarette))
         caller.msg(
             caller_msg.format(
                 target=target.get_display_name(caller),
@@ -275,7 +276,8 @@ class CmdSmoke(Command):
             return
 
         substance = get_substance(cigarette)
-        self_msg, room_template = pick_smoke_message(substance)
+        self_msg, room_template = pick_smoke_message(
+            substance, form=getattr(cigarette.db, 'smoke_form', None))
         caller.msg(self_msg)
         if caller.location is not None:
             msg_room_identity(
@@ -299,7 +301,7 @@ class CmdSmoke(Command):
         # the burnout broadcast on that transition.
         outcome = consume_use(cigarette)
         if outcome.get("destroyed"):
-            burnt_self, burnt_room = pick_burnt_out_message()
+            burnt_self, burnt_room = pick_burnt_out_message(get_smoke_noun(cigarette))
             caller.msg(burnt_self)
             if caller.location is not None:
                 msg_room_identity(
@@ -351,7 +353,7 @@ class CmdSnuff(Command):
             return
 
         set_lit(cigarette, False)
-        self_msg, room_template = pick_snuff_message()
+        self_msg, room_template = pick_snuff_message(get_smoke_noun(cigarette))
         caller.msg(self_msg)
         if caller.location is not None:
             msg_room_identity(

--- a/world/crowd/crowd_messages.py
+++ b/world/crowd/crowd_messages.py
@@ -877,6 +877,93 @@ CROWD_MESSAGES['market'] = {
     },
 }
 
+# 'shop' — small enclosed storefronts (a smoke shop, a corner store, the
+# pawn counter): browsers and till-trade at intimate scale. Distinct from
+# 'market' (stall crowds), 'interior' (bar murmur), and 'default' (street).
+CROWD_MESSAGES['shop'] = {
+    'sparse': {
+        'visual': [
+            "the shop sits empty but for the stock, shelves keeping their own counsel",
+            "a lone browser drifts the shelves, picking things up mostly to put them down",
+            "someone stands too long over one item, arithmetic visible in their face",
+        ],
+        'auditory': [
+            "the door sits quiet long enough that the shop's own small sounds surface — a fan, a tick, a settling shelf",
+            "a single customer murmurs a question and gets a shorter answer",
+        ],
+        'olfactory': [
+            "with nobody in, the shop smells only of itself and its stock",
+        ],
+        'tactile': [
+            "the air in the empty shop sits still and close",
+        ],
+        'atmospheric': [
+            "an off-hours hush holds the shop, the stock outnumbering the customers",
+        ],
+    },
+    'moderate': {
+        'visual': [
+            "a steady trickle of customers works the shelves, most knowing what they came for",
+            "someone counts chits at the counter while the next in line pretends not to watch the total",
+            "a regular exchanges a nod with the counter and goes straight to their usual shelf",
+        ],
+        'auditory': [
+            "the door announces customers at comfortable intervals",
+            "chits click the glass; a price is spoken once and not argued",
+            "two customers trade shelf-side small talk in shop voices",
+        ],
+        'olfactory': [
+            "passing customers stir the stock's smell loose from the shelves",
+        ],
+        'tactile': [
+            "browsers edge past one another in the narrow aisle with practiced economy",
+        ],
+        'atmospheric': [
+            "the shop runs at its comfortable working rhythm — trade without hurry",
+        ],
+    },
+    'heavy': {
+        'visual': [
+            "the narrow floor is crowded, browsers queuing sideways between the shelves",
+            "the counter works a short line, hands and chits moving in steady rotation",
+        ],
+        'auditory': [
+            "the door barely settles between arrivals; the counter talk overlaps",
+            "somebody at the back calls a question over the heads of the queue",
+        ],
+        'olfactory': [
+            "packed bodies compete with the stock for the shop's air",
+        ],
+        'tactile': [
+            "elbows and shoulders negotiate the aisle, mostly politely",
+        ],
+        'atmospheric': [
+            "the shop is at capacity, trade brisk and the till warm",
+        ],
+    },
+    'packed': {
+        'visual': [
+            "the shop is jammed wall to wall, the queue folded back on itself between the shelves",
+            "the counter serves whoever's hand reaches it first",
+        ],
+        'auditory': [
+            "the room is one continuous transaction — orders, totals, and the door never quite closing",
+        ],
+        'olfactory': [
+            "there's no air in the little shop that hasn't queued for the counter itself",
+        ],
+        'tactile': [
+            "the crowd moves you whether you're in the queue or not",
+        ],
+        'atmospheric': [
+            "a run on the shop — whatever's driving it, the shelves are emptying visibly",
+        ],
+    },
+}
+
+#: Small enclosed storefronts — counter trade at intimate scale.
+SHOP_ROOM_TYPES = {'shop', 'corner store'}
+
 #: Covered/enclosed market galleries — stall commerce, not street crush.
 MARKET_ROOM_TYPES = {'market'}
 
@@ -896,10 +983,12 @@ INTERIOR_ROOM_TYPES = {
 
 def crowd_profile_for_room_type(room_type):
     """Map a ``room.type`` to a crowd profile
-    ('default'|'interior'|'market'|'nightclub'|'constabulary'|'residential')."""
+    ('default'|'interior'|'shop'|'market'|'nightclub'|'constabulary'|'residential')."""
     t = str(room_type or "").lower()
     if t == 'constabulary':
         return 'constabulary'
+    if t in SHOP_ROOM_TYPES:
+        return 'shop'
     if t in MARKET_ROOM_TYPES:
         return 'market'
     if t in NIGHTCLUB_ROOM_TYPES:

--- a/world/crowd/crowd_system.py
+++ b/world/crowd/crowd_system.py
@@ -21,6 +21,7 @@ class CrowdSystem:
             'intersection': 1.0,
             'corner store': 0.5,
             'market': 0.5,
+            'shop': 0.3,
             'laundromat': 0.2,
             'courier service': 0.3,
             'cube hotel': 0.1,

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2929,15 +2929,71 @@ PAIN_RELIEF_CIGARETTE = {
 # Substance pharmacology lives in world/substances/registry.py; these
 # items just carry the substance id + delivery tag (spec §1/§2).
 
-HAND_ROLLED_JOINT = {
-    "key": "hand-rolled joint",
+PRE_ROLLED_JOINT = {
+    "prototype_key": "pre_rolled_joint",
+    "key": "pre-rolled joint",
     "typeclass": "typeclasses.items.Item",
     "aliases": ["joint", "spliff"],
-    "desc": "A crooked hand-rolled joint, packed with sweet-smelling "
-            "resinous flower. The paper crackles when squeezed.",
+    "desc": "A factory-rolled joint, machine-perfect: crimped ends, a "
+            "pressed filter plug, and a seam so straight it looks printed. "
+            "Uniform as ammunition — nobody's hands were involved. (One "
+            "day the colony will roll its own; this is what came before.)",
     "tags": [("smoke", "delivery_method")],
     "attrs": [
         ("substance", "cannabis"),
+        ("smoke_form", "joint"),
+        ("uses_left", 4),
+        ("max_uses", 4),
+    ],
+}
+
+ROPE_CIGAR = {
+    "prototype_key": "rope_cigar",
+    "key": "rope cigar",
+    "typeclass": "typeclasses.items.Item",
+    "aliases": ["cigar", "cheap cigar"],
+    "desc": "A short, dark cigar of the kind sold by the box to men who "
+            "have stopped tasting things: dense, crooked, and dependable. "
+            "Burns slow, bites hard, costs little.",
+    "tags": [("smoke", "delivery_method")],
+    "attrs": [
+        ("substance", "tobacco_neutral"),
+        ("smoke_form", "cigar"),
+        ("uses_left", 6),
+        ("max_uses", 6),
+    ],
+}
+
+MACHINE_ROLLED_CIGAR = {
+    "prototype_key": "machine_rolled_cigar",
+    "key": "machine-rolled corona",
+    "typeclass": "typeclasses.items.Item",
+    "aliases": ["corona", "good cigar"],
+    "desc": "A machine-rolled corona in dark Noir leaf, its band a strip "
+            "of embossed foil pretending to a heritage the colony never "
+            "had. The draw is engineered; the ash holds an inch.",
+    "tags": [("smoke", "delivery_method")],
+    "attrs": [
+        ("substance", "tobacco_noir"),
+        ("smoke_form", "cigar"),
+        ("uses_left", 8),
+        ("max_uses", 8),
+    ],
+}
+
+CHEWING_TOBACCO_PLUG = {
+    "prototype_key": "chewing_tobacco_plug",
+    "key": "plug of chewing tobacco",
+    "typeclass": "typeclasses.items.Item",
+    "aliases": ["plug", "chew", "chaw"],
+    "desc": "A pressed plug of cured leaf and molasses, dense as a hockey "
+            "puck and about as subtle. The working man's smoke-free vice — "
+            "no flame, no ash, no witnesses.",
+    "tags": [("eat", "delivery_method"), ("food", "item_type")],
+    "attrs": [
+        ("drink_effects", {"tobacco_neutral": 1}),
+        ("drink_taste", "Bitter leaf-juice and molasses, strong enough to "
+                        "make the eyes water — spit or commit."),
         ("uses_left", 4),
         ("max_uses", 4),
     ],

--- a/world/smoke.py
+++ b/world/smoke.py
@@ -40,6 +40,32 @@ ITEM_ROLE_CATEGORY = "item_role"  # Lighter still uses item_role.
 #: ``is_smokable`` migrates that automatically on first access.
 SMOKE_DELIVERY = "smoke"
 
+#: Optional per-item smoke FORM (``db.smoke_form``: "cigarette" | "joint" |
+#: "cigar" | ...). Drives the noun in light/snuff/burnout messages and can
+#: select a form-specific drag bank — a cigar must never render as "your
+#: cigarette". Items without it fall back by substance (cannabis → joint).
+SMOKE_FORM_ATTR = "smoke_form"
+
+_SUBSTANCE_DEFAULT_FORM = {
+    "cannabis": "joint",
+}
+
+
+def get_smoke_noun(item) -> str:
+    """The word this smokable is called in messages."""
+    form = getattr(item.db, SMOKE_FORM_ATTR, None) if item is not None else None
+    if form:
+        return str(form)
+    substance = getattr(item.db, "substance", None) if item is not None else None
+    return _SUBSTANCE_DEFAULT_FORM.get(str(substance or ""), "cigarette")
+
+
+def _sub_noun(entry, noun):
+    """Substitute the {smoke} placeholder across a message tuple, leaving
+    the {actor} identity token for msg_room_identity to render."""
+    return tuple(part.replace("{smoke}", noun) for part in entry)
+
+
 #: Item-role tag for lighters.  Distinct axis from delivery method.
 LIGHTER_ROLE = "lighter"
 
@@ -252,6 +278,26 @@ SMOKE_MESSAGES: dict[str, list[tuple[str, str]]] = {
             "arranging themselves like things set down gently.",
         ),
     ],
+    "cigar": [
+        (
+            "You roll the cigar's smoke slow across your tongue and "
+            "let it go in a flat, unhurried sheet.",
+            "{actor} draws on a thick cigar and releases the smoke "
+            "in a flat, unhurried sheet that means to stay a while.",
+        ),
+        (
+            "You turn the cigar a quarter as it burns, keeping the "
+            "coal even — somebody taught you that once.",
+            "{actor} turns their cigar a quarter as it burns, "
+            "keeping the coal even with practiced patience.",
+        ),
+        (
+            "The cigar's ash holds a full inch before you tap it "
+            "loose. Quality control, of a kind.",
+            "{actor} taps a full inch of ash from their cigar and "
+            "looks quietly satisfied about it.",
+        ),
+    ],
     SUBSTANCE_TOBACCO_NOIR: [
         (
             "You drag on your cigarette, the smoke curling around "
@@ -407,66 +453,66 @@ SMOKE_MESSAGES: dict[str, list[tuple[str, str]]] = {
 LIGHT_SELF_MESSAGES: list[tuple[str, str]] = [
     (
         "You flick open your lighter, the flame catching the tip of "
-        "the cigarette. A soft glow blooms in the dark.",
+        "the {smoke}. A soft glow blooms in the dark.",
         "{actor} flicks open their lighter, the flame catching the "
-        "tip of the cigarette. A soft glow blooms in the dark.",
+        "tip of the {smoke}. A soft glow blooms in the dark.",
     ),
     (
-        "You strike a flame and bring it to the cigarette, the "
+        "You strike a flame and bring it to the {smoke}, the "
         "paper catching with a quiet hiss.",
-        "{actor} strikes a flame and brings it to their cigarette, "
+        "{actor} strikes a flame and brings it to their {smoke}, "
         "the paper catching with a quiet hiss.",
     ),
     (
-        "Your thumb works the lighter; the cigarette tip catches and "
+        "Your thumb works the lighter; the {smoke} tip catches and "
         "glows alive.",
-        "{actor}'s thumb works the lighter; the cigarette tip "
+        "{actor}'s thumb works the lighter; the {smoke} tip "
         "catches and glows alive.",
     ),
 ]
 
-#: Cross-character light (caller lights target's cigarette).  Uses
+#: Cross-character light (caller lights target's {smoke}).  Uses
 #: ``{target}`` placeholder in addition to ``{actor}``.
 LIGHT_OTHER_MESSAGES: list[tuple[str, str, str]] = [
     # (caller_self, target_self, room_template)
     (
-        "You lean in and light {target}'s cigarette, the flame "
+        "You lean in and light {target}'s {smoke}, the flame "
         "briefly painting their face.",
-        "{actor} leans in and lights your cigarette, the flame "
+        "{actor} leans in and lights your {smoke}, the flame "
         "briefly painting your face.",
-        "{actor} leans in and lights {target}'s cigarette, the "
+        "{actor} leans in and lights {target}'s {smoke}, the "
         "flame briefly painting their face.",
     ),
     (
-        "You cup the lighter and bring it to {target}'s cigarette; "
+        "You cup the lighter and bring it to {target}'s {smoke}; "
         "the tip catches.",
         "{actor} cups their lighter and brings it to your "
-        "cigarette; the tip catches.",
+        "{smoke}; the tip catches.",
         "{actor} cups their lighter and brings it to {target}'s "
-        "cigarette; the tip catches.",
+        "{smoke}; the tip catches.",
     ),
     (
         "Your lighter sparks; you offer the flame to {target}'s "
-        "cigarette and it takes.",
+        "{smoke} and it takes.",
         "{actor}'s lighter sparks; they offer the flame to your "
-        "cigarette and it takes.",
+        "{smoke} and it takes.",
         "{actor}'s lighter sparks; they offer the flame to "
-        "{target}'s cigarette and it takes.",
+        "{target}'s {smoke} and it takes.",
     ),
 ]
 
-#: Snuff flavor (caller extinguishes their own cigarette).
+#: Snuff flavor (caller extinguishes their own {smoke}).
 SNUFF_MESSAGES: list[tuple[str, str]] = [
     (
-        "You crush the cigarette out, the ember dying with a faint "
+        "You crush the {smoke} out, the ember dying with a faint "
         "hiss.",
-        "{actor} crushes their cigarette out, the ember dying with "
+        "{actor} crushes their {smoke} out, the ember dying with "
         "a faint hiss.",
     ),
     (
-        "You stub the cigarette against a hard surface; the smoke "
+        "You stub the {smoke} against a hard surface; the smoke "
         "thins to nothing.",
-        "{actor} stubs their cigarette against a hard surface; the "
+        "{actor} stubs their {smoke} against a hard surface; the "
         "smoke thins to nothing.",
     ),
     (
@@ -475,22 +521,22 @@ SNUFF_MESSAGES: list[tuple[str, str]] = [
     ),
 ]
 
-#: Burnout flavor — cigarette consumed and discarded.
+#: Burnout flavor — {smoke} consumed and discarded.
 BURNT_OUT_MESSAGES: list[tuple[str, str]] = [
     (
-        "You take the last drag, then flick the spent cigarette "
+        "You take the last drag, then flick the spent {smoke} "
         "away.",
         "{actor} takes the last drag, then flicks the spent "
-        "cigarette away.",
+        "{smoke} away.",
     ),
     (
-        "The cigarette burns down to the filter; you toss it.",
-        "{actor}'s cigarette burns down to the filter; they toss it.",
+        "The {smoke} burns down to the filter; you toss it.",
+        "{actor}'s {smoke} burns down to the filter; they toss it.",
     ),
     (
-        "A final pull, then the dead end of the cigarette tumbles "
+        "A final pull, then the dead end of the {smoke} tumbles "
         "from your fingers.",
-        "A final pull, then the dead end of {actor}'s cigarette "
+        "A final pull, then the dead end of {actor}'s {smoke} "
         "tumbles from their fingers.",
     ),
 ]
@@ -500,7 +546,7 @@ BURNT_OUT_MESSAGES: list[tuple[str, str]] = [
 # Pickers
 # ---------------------------------------------------------------------
 
-def pick_smoke_message(substance: str | None) -> tuple[str, str]:
+def pick_smoke_message(substance=None, form=None):
     """Return a random ``(self, room_template)`` for ``substance``.
 
     Honours legacy brand keys (``"neutral"`` / ``"noir"``) via the
@@ -508,26 +554,28 @@ def pick_smoke_message(substance: str | None) -> tuple[str, str]:
     pre-#456 still render flavor.  Unknown / missing substance
     falls back to :data:`SUBSTANCE_TOBACCO_NEUTRAL`.
     """
+    if form and form in SMOKE_MESSAGES:
+        return random.choice(SMOKE_MESSAGES[form])
     key = substance or SUBSTANCE_TOBACCO_NEUTRAL
     key = _LEGACY_BRAND_MAP.get(key, key)
     bank = SMOKE_MESSAGES.get(key) or SMOKE_MESSAGES[SUBSTANCE_TOBACCO_NEUTRAL]
     return random.choice(bank)
 
 
-def pick_light_self_message() -> tuple[str, str]:
-    return random.choice(LIGHT_SELF_MESSAGES)
+def pick_light_self_message(noun="cigarette") -> tuple[str, str]:
+    return _sub_noun(random.choice(LIGHT_SELF_MESSAGES), noun)
 
 
-def pick_light_other_message() -> tuple[str, str, str]:
-    return random.choice(LIGHT_OTHER_MESSAGES)
+def pick_light_other_message(noun="cigarette") -> tuple[str, str, str]:
+    return _sub_noun(random.choice(LIGHT_OTHER_MESSAGES), noun)
 
 
-def pick_snuff_message() -> tuple[str, str]:
-    return random.choice(SNUFF_MESSAGES)
+def pick_snuff_message(noun="cigarette") -> tuple[str, str]:
+    return _sub_noun(random.choice(SNUFF_MESSAGES), noun)
 
 
-def pick_burnt_out_message() -> tuple[str, str]:
-    return random.choice(BURNT_OUT_MESSAGES)
+def pick_burnt_out_message(noun="cigarette") -> tuple[str, str]:
+    return _sub_noun(random.choice(BURNT_OUT_MESSAGES), noun)
 
 
 # ---------------------------------------------------------------------

--- a/world/tests/test_crowd.py
+++ b/world/tests/test_crowd.py
@@ -114,3 +114,29 @@ class TestMarketProfile(TestCase):
                           for msgs in tier.values() for m in msgs).lower()
         for banned in ("drone", "gutter", "sky", "bartender", "bar counter"):
             self.assertNotIn(banned, market)
+
+
+class TestShopProfile(TestCase):
+    """The shop pool: small storefront trade — no street crush, no bar."""
+
+    def test_shop_routes_shop(self):
+        from world.crowd.crowd_messages import crowd_profile_for_room_type
+        self.assertEqual(crowd_profile_for_room_type("shop"), "shop")
+        self.assertEqual(crowd_profile_for_room_type("corner store"), "shop")
+
+    def test_all_intensities_populated(self):
+        from world.crowd.crowd_messages import CROWD_MESSAGES
+        pool = CROWD_MESSAGES["shop"]
+        for intensity in ("sparse", "moderate", "heavy", "packed"):
+            self.assertIn(intensity, pool)
+            self.assertTrue(pool[intensity].get("visual"))
+            self.assertTrue(pool[intensity].get("auditory"))
+
+    def test_shop_pool_is_distinct(self):
+        from world.crowd.crowd_messages import CROWD_MESSAGES
+        shop = {m for tier in CROWD_MESSAGES["shop"].values()
+                for msgs in tier.values() for m in msgs}
+        for other in ("default", "interior", "market", "residential"):
+            other_msgs = {m for tier in CROWD_MESSAGES[other].values()
+                          for msgs in tier.values() for m in msgs}
+            self.assertFalse(shop & other_msgs)

--- a/world/tests/test_smoke.py
+++ b/world/tests/test_smoke.py
@@ -556,3 +556,47 @@ class TestDisposableLighterDepletes(TestCase):
         CmdLight._spend_lighter(caller, lighter)
         self.assertFalse(lighter.deleted)
         self.assertIsNone(getattr(lighter.db, "uses_left", None))
+
+
+class TestFormAwareMessaging(TestCase):
+    """Light/snuff/burnout messages name the smokable's FORM — a joint or
+    cigar must never render as 'your cigarette'."""
+
+    def _item(self, form=None, substance=None):
+        from unittest.mock import MagicMock
+        it = MagicMock()
+        it.db.smoke_form = form
+        it.db.substance = substance
+        return it
+
+    def test_noun_from_form_then_substance(self):
+        from world.smoke import get_smoke_noun
+        self.assertEqual(get_smoke_noun(self._item(form="cigar")), "cigar")
+        self.assertEqual(get_smoke_noun(self._item(substance="cannabis")),
+                         "joint")
+        self.assertEqual(get_smoke_noun(self._item(substance="opium")),
+                         "cigarette")
+        self.assertEqual(get_smoke_noun(None), "cigarette")
+
+    def test_banks_substitute_noun(self):
+        from world.smoke import (pick_light_self_message, pick_snuff_message,
+                                 pick_burnt_out_message,
+                                 pick_light_other_message)
+        for picker in (pick_light_self_message, pick_snuff_message,
+                       pick_burnt_out_message, pick_light_other_message):
+            entry = picker("joint")
+            joined = " ".join(entry)
+            self.assertNotIn("cigarette", joined)
+            self.assertNotIn("{smoke}", joined)
+            self.assertIn("joint", joined)
+
+    def test_cigar_drag_bank_selected_by_form(self):
+        from world.smoke import pick_smoke_message
+        for _ in range(6):
+            self_msg, room = pick_smoke_message("tobacco_noir", form="cigar")
+            self.assertIn("cigar", self_msg + room)
+
+    def test_substance_bank_fallback_unchanged(self):
+        from world.smoke import pick_smoke_message
+        self_msg, room = pick_smoke_message("cannabis")
+        self.assertTrue(self_msg)


### PR DESCRIPTION
Closes #1281

Light/snuff/burnout messages hardcoded "cigarette" for every smokable:
db.smoke_form + get_smoke_noun now drive a {smoke} placeholder in those
banks, and pick_smoke_message prefers a form-keyed drag bank (new cigar
bank) before the substance fallback. New tobacco: rope cigar, machine-
rolled corona, chewing plug (eat-delivery tobacco). The joint is
explicitly machine-made (PRE_ROLLED_JOINT) pending the crafting element.
New 'shop' crowd profile + routing for small storefronts.

180/180 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
