### PR TITLE
Fix sdesc_keyword category bug in blueprint builders

### DIFF
--- a/world/npcs/blueprints.py
+++ b/world/npcs/blueprints.py
@@ -1930,7 +1930,8 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                                'embroidered with falling '
                                                'leaves smouldering orange '
                                                'at their edges',
-                                       'coverage': ['chest', 'back'],
+                                       'coverage': ['chest', 'back',
+                                                    'abdomen'],
                                        'layer': 2, 'color': 'black',
                                        'material': 'brocade',
                                        'weight': 0.4,
@@ -2096,7 +2097,9 @@ def build_npc(blueprint_key, location):
     if ident.get("skintone"):
         npc.db.skintone = ident["skintone"]
     if ident.get("sdesc_keyword"):
-        npc.attributes.add("sdesc_keyword", ident["sdesc_keyword"])
+        # AttributeProperty(category="identity") — a plain attributes.add
+        # lands in the wrong category and the property never sees it
+        npc.sdesc_keyword = ident["sdesc_keyword"]
 
     for stat, val in (bp.get("stats") or {}).items():
         setattr(npc, stat, val)
@@ -2174,7 +2177,7 @@ def build_successor(blueprint_key, location):
         npc.hair_style = choice(HAIR_STYLES)
     ident = bp.get("identity", {})
     if ident.get("sdesc_keyword"):
-        npc.attributes.add("sdesc_keyword", ident["sdesc_keyword"])
+        npc.sdesc_keyword = ident["sdesc_keyword"]
     for stat in ("grit", "resonance", "intellect", "motorics"):
         setattr(npc, stat, randint(1, 3))
     apply_random_flavor(npc)   # generic desc / longdescs / look_place

--- a/world/tests/test_npc_blueprints.py
+++ b/world/tests/test_npc_blueprints.py
@@ -65,6 +65,11 @@ class TestBuildRoundTrip(BaseEvenniaTest):
             diffs = verify_blueprint(key, npc)
             self.assertEqual(diffs, [], f"{key}: {diffs}")
             self.assertTrue(npc.db.llm_driven, key)
+            want_kw = BLUEPRINTS[key].get("identity", {}).get("sdesc_keyword")
+            if want_kw:
+                # the category-bug regression: the PROPERTY must see it
+                self.assertEqual(npc.sdesc_keyword, want_kw, key)
+                self.assertIn(want_kw, npc.get_sdesc(), key)
             npc.delete()
 
     def test_invalid_identity_refused_before_write(self):


### PR DESCRIPTION
Closes #1285

sdesc_keyword is AttributeProperty(category='identity'); the builders wrote
it via plain attributes.add so the property never saw it — blueprint-born
NPCs rendered 'person'. Both builders assign through the property now.
Bellows' waistcoat gains abdomen coverage (the sdesc feature garment is the
outermost item at the alphabetically-first covered location). Regression
test asserts keywords land in live sdescs. 20/20 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
