### PR TITLE
Brand all vice items; regrit Bellows for the southwest side

### DIFF
--- a/world/npcs/blueprints.py
+++ b/world/npcs/blueprints.py
@@ -1831,12 +1831,14 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                          'desc': 'Slight, jade-skinned, and visibly '
                                  'delighted to be here: a synthetic '
                                  'humanoid with ember-orange hair slicked '
-                                 'back like a struck match, minding a '
-                                 'smoke shop with the enthusiasm of a '
-                                 'curator. Everything about them is neat, '
-                                 'quick, and faintly theatrical, as if '
-                                 'shopkeeping were a performance they '
-                                 'rehearsed and still love.',
+                                 'back like a struck match, running a '
+                                 'southside smoke shop with the flourish '
+                                 'of a gutter magician. Everything about '
+                                 'them is quick, theatrical, and visibly '
+                                 'repaired — brass fittings where chrome '
+                                 'was specced, solder where there should '
+                                 'be seams, a performance staged entirely '
+                                 'from salvage and staged well.',
                          'longdesc': {
                              'hair': 'Ember-orange hair slicked back hard, '
                                      'a colour no scalp grows — chosen, '
@@ -1865,16 +1867,20 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                            'precise as a card sharp\'s — '
                                            'they wrap, tap, cut, and count '
                                            'like small stage acts.',
-                             'left_arm': 'Jade skin with faint geometric '
-                                         'seams at the joints, kept bare '
-                                         'below rolled sleeves — {they} '
-                                         '{have} nothing to hide and '
-                                         'seem{s} pleased about it.',
-                             'right_arm': 'Jade skin with faint geometric '
-                                          'seams at the joints, kept bare '
-                                          'below rolled sleeves — {they} '
-                                          '{have} nothing to hide and '
-                                          'seem{s} pleased about it.'},
+                             'left_arm': 'Jade skin with geometric seams '
+                                         'at the joints — one forearm '
+                                         'panel is a mismatched salvage '
+                                         'green, riveted rather than '
+                                         'seamed, and {they} wear{s} it '
+                                         'the way other people wear a '
+                                         'good watch.',
+                             'right_arm': 'Jade skin with geometric seams '
+                                          'at the joints — one forearm '
+                                          'panel is a mismatched salvage '
+                                          'green, riveted rather than '
+                                          'seamed, and {they} wear{s} it '
+                                          'the way other people wear a '
+                                          'good watch.'},
                          'look_place': 'behind the counter, beaming.',
                          'temp_place': 'minding the counter with '
                                        'unreasonable cheer.',
@@ -1918,48 +1924,57 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                        'category': 'clothing'},
                                       {'key': 'ember-stitched waistcoat',
                                        'aliases': ['waistcoat', 'vest'],
-                                       'desc': 'A dark waistcoat '
-                                               'embroidered with falling '
-                                               'leaves that smoulder '
-                                               'orange at their edges — '
-                                               'the shop sign, made '
-                                               'wearable. The stitching '
-                                               'catches lamplight like '
-                                               'live coals.',
-                                       'worn_desc': 'A dark waistcoat '
-                                               'embroidered with falling '
-                                               'leaves smouldering orange '
-                                               'at their edges',
+                                       'desc': 'A waistcoat sewn from four '
+                                               'dead garments into one '
+                                               'good one, embroidered '
+                                               'with falling leaves that '
+                                               'smoulder orange at the '
+                                               'edges — most stitched, '
+                                               'two genuinely scorched. '
+                                               'The shop sign made '
+                                               'wearable, then made '
+                                               'honest.',
+                                       'worn_desc': 'A patchwork '
+                                               'waistcoat embroidered '
+                                               'with smouldering leaves, '
+                                               'two of them genuinely '
+                                               'scorched',
                                        'coverage': ['chest', 'back',
                                                     'abdomen'],
                                        'layer': 2, 'color': 'black',
-                                       'material': 'brocade',
+                                       'material': 'patchwork',
                                        'weight': 0.4,
                                        'category': 'clothing'},
-                                      {'key': 'striped sleeve garters',
-                                       'aliases': ['garters', 'sleeve '
-                                                   'garters'],
-                                       'desc': 'Elasticated sleeve garters '
-                                               'in ember-and-ash stripes, '
-                                               'worn above the elbow — '
-                                               'pure shopkeeper theatre, '
-                                               'and they know it.',
-                                       'worn_desc': 'Striped sleeve '
-                                               'garters in ember-and-ash, '
-                                               'pure shopkeeper theatre',
+                                      {'key': 'salvage sleeve garters',
+                                       'aliases': ['garters',
+                                                   'sleeve garters'],
+                                       'desc': 'Sleeve garters cut from '
+                                               'inner-tube rubber and '
+                                               'closed with polished '
+                                               'brass pipe-clips — '
+                                               'shopkeeper theatre built '
+                                               'from what the gutter '
+                                               'provided, worn with '
+                                               'complete conviction.',
+                                       'worn_desc': 'Inner-tube sleeve '
+                                               'garters closed with '
+                                               'polished brass '
+                                               'pipe-clips',
                                        'coverage': ['left_arm',
                                                     'right_arm'],
-                                       'layer': 2, 'color': 'orange',
-                                       'material': 'elastic',
+                                       'layer': 2, 'color': 'black',
+                                       'material': 'rubber',
                                        'weight': 0.1,
                                        'category': 'clothing'},
                                       {'key': 'pinstripe trousers',
                                        'aliases': ['trousers'],
                                        'desc': 'Narrow pinstripe trousers '
-                                               'pressed to a blade edge, '
-                                               'a size too formal for the '
-                                               'district and entirely on '
-                                               'purpose.',
+                                               'pressed to a blade edge — '
+                                               'the stripes gone shiny at '
+                                               'the knees, the hems '
+                                               'singed, the formality '
+                                               'entirely on purpose and '
+                                               'entirely secondhand.',
                                        'worn_desc': 'Narrow pinstripe '
                                                'trousers pressed to a '
                                                'blade edge',
@@ -1971,22 +1986,24 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                        'material': 'wool',
                                        'weight': 0.6,
                                        'category': 'clothing'},
-                                      {'key': 'embroidered velvet slippers',
-                                       'aliases': ['slippers'],
-                                       'desc': 'House slippers in bottle-'
-                                               'green velvet, each '
-                                               'embroidered with a tiny '
-                                               'genie lamp trailing gold '
-                                               'smoke. Absurd. Immaculate. '
-                                               'Non-negotiable.',
-                                       'worn_desc': 'Bottle-green velvet '
-                                               'slippers embroidered with '
-                                               'tiny smoking genie lamps',
+                                      {'key': 'brass-toed boots',
+                                       'aliases': ['boots'],
+                                       'desc': 'Scuffed black work boots '
+                                               'with brass toecaps '
+                                               'polished to parade shine '
+                                               '— the only part of the '
+                                               'outfit that gets daily '
+                                               'maintenance, because an '
+                                               'audience looks down when '
+                                               'you tap your foot.',
+                                       'worn_desc': 'Scuffed black boots, '
+                                               'brass toecaps polished '
+                                               'to parade shine',
                                        'coverage': ['left_foot',
                                                     'right_foot'],
-                                       'layer': 1, 'color': 'green',
-                                       'material': 'velvet',
-                                       'weight': 0.2,
+                                       'layer': 1, 'color': 'black',
+                                       'material': 'leather',
+                                       'weight': 0.8,
                                        'category': 'clothing'}],
                          'carried_prototypes': [],
                          'home_room': None,

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -2931,10 +2931,10 @@ PAIN_RELIEF_CIGARETTE = {
 
 PRE_ROLLED_JOINT = {
     "prototype_key": "pre_rolled_joint",
-    "key": "pre-rolled joint",
+    "key": "Greenhaus pre-rolled joint",
     "typeclass": "typeclasses.items.Item",
     "aliases": ["joint", "spliff"],
-    "desc": "A factory-rolled joint, machine-perfect: crimped ends, a "
+    "desc": "A Greenhaus-brand factory joint, machine-perfect: crimped ends, a "
             "pressed filter plug, and a seam so straight it looks printed. "
             "Uniform as ammunition — nobody's hands were involved. (One "
             "day the colony will roll its own; this is what came before.)",
@@ -2949,10 +2949,10 @@ PRE_ROLLED_JOINT = {
 
 ROPE_CIGAR = {
     "prototype_key": "rope_cigar",
-    "key": "rope cigar",
+    "key": "Old Mule rope cigar",
     "typeclass": "typeclasses.items.Item",
     "aliases": ["cigar", "cheap cigar"],
-    "desc": "A short, dark cigar of the kind sold by the box to men who "
+    "desc": "An Old Mule — the short, dark cigar sold by the box to men who "
             "have stopped tasting things: dense, crooked, and dependable. "
             "Burns slow, bites hard, costs little.",
     "tags": [("smoke", "delivery_method")],
@@ -2966,12 +2966,12 @@ ROPE_CIGAR = {
 
 MACHINE_ROLLED_CIGAR = {
     "prototype_key": "machine_rolled_cigar",
-    "key": "machine-rolled corona",
+    "key": "Silverband corona",
     "typeclass": "typeclasses.items.Item",
     "aliases": ["corona", "good cigar"],
-    "desc": "A machine-rolled corona in dark Noir leaf, its band a strip "
-            "of embossed foil pretending to a heritage the colony never "
-            "had. The draw is engineered; the ash holds an inch.",
+    "desc": "A Silverband corona in dark Noir leaf, named for its band — "
+            "a strip of embossed foil pretending to a heritage the colony "
+            "never had. The draw is engineered; the ash holds an inch.",
     "tags": [("smoke", "delivery_method")],
     "attrs": [
         ("substance", "tobacco_noir"),
@@ -2983,10 +2983,10 @@ MACHINE_ROLLED_CIGAR = {
 
 CHEWING_TOBACCO_PLUG = {
     "prototype_key": "chewing_tobacco_plug",
-    "key": "plug of chewing tobacco",
+    "key": "plug of Anchor chewing tobacco",
     "typeclass": "typeclasses.items.Item",
     "aliases": ["plug", "chew", "chaw"],
-    "desc": "A pressed plug of cured leaf and molasses, dense as a hockey "
+    "desc": "An Anchor-brand plug of cured leaf and molasses, dense as a hockey "
             "puck and about as subtle. The working man's smoke-free vice — "
             "no flame, no ash, no witnesses.",
     "tags": [("eat", "delivery_method"), ("food", "item_type")],
@@ -3000,11 +3000,13 @@ CHEWING_TOBACCO_PLUG = {
 }
 
 ROTGUT_BOTTLE = {
-    "key": "bottle of rotgut",
+    "key": "bottle of Boiler Run rotgut",
     "typeclass": "typeclasses.items.Item",
     "aliases": ["rotgut", "bottle", "booze"],
-    "desc": "An unlabeled glass bottle of harsh colonial liquor. It "
-            "smells like fuel and bad decisions, in that order.",
+    "desc": "A squat bottle of Boiler Run, the colony's licensed rotgut — "
+            "the label is a woodcut of a bursting boiler, which is either "
+            "a warning or a promise. Smells like fuel and bad decisions, "
+            "in that order.",
     "tags": [("drink", "delivery_method")],
     "attrs": [
         ("substance", "alcohol"),
@@ -3014,11 +3016,12 @@ ROTGUT_BOTTLE = {
 }
 
 OPIUM_CIGARETTE = {
-    "key": "tar-black opium cigarette",
+    "key": "tar-black Slowboat opium cigarette",
     "typeclass": "typeclasses.items.Item",
     "aliases": ["opium cigarette", "opium", "tar cigarette"],
-    "desc": "A thin cigarette rolled around tar-black resin. Heavy, "
-            "sweet, and patient — it will wait as long as you can.",
+    "desc": "A Slowboat: thin paper rolled around tar-black resin, the "
+            "brand a tiny steamer stamped near the tip. Heavy, sweet, and "
+            "patient — it will wait as long as you can.",
     "tags": [("smoke", "delivery_method")],
     "attrs": [
         ("substance", "opium"),
@@ -3378,8 +3381,10 @@ CIGARETTE_BASE = {
 
 CIGARETTE_NEUTRAL = {
     "prototype_parent": "CIGARETTE_BASE",
-    "key": "cigarette",
-    "desc": "A standard filtered cigarette, mild tobacco wrapped in white paper.",
+    "key": "Longhaul cigarette",
+    "desc": "A Longhaul — the workman's filtered cigarette, mild tobacco in "
+            "white paper, the brand's little hauler logo printed at the "
+            "filter. Ubiquitous as grit.",
     "attrs": [
         ("substance", "tobacco_neutral"),
     ],
@@ -3416,7 +3421,7 @@ CIGARETTE_PACK_BASE = {
 
 CIGARETTE_PACK_NEUTRAL = {
     "prototype_parent": "CIGARETTE_PACK_BASE",
-    "key": "pack of cigarettes",
+    "key": "pack of Longhaul cigarettes",
     "desc": (
         "A cardboard pack of filtered cigarettes.  The brand "
         "lettering is generic block print, no logo, no flourish."


### PR DESCRIPTION
Closes #1287

World rule: everything sold is branded unless handmade or ubiquitous —
Longhaul, Noir, Greenhaus, Old Mule, Silverband, Anchor, Boiler Run,
Slowboat; guttervenom's scraped label is the deliberate anti-brand.
Prototype_keys stable. Bellows reworked gutterpunk-meets-steampunk:
patchwork scorched waistcoat, inner-tube garters with brass pipe-clips,
singed secondhand pinstripes, brass-toed boots; velvet slippers removed.
82/82 green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
