### PR TITLE
A manned counter is never self-service: buy routes through the keeper

### DIFF
--- a/commands/shop.py
+++ b/commands/shop.py
@@ -84,10 +84,19 @@ class CmdBuy(Command):
         # Get price for messaging
         price = container.get_price(prototype_key)
         from world.shop.utils import format_currency
-        
-        # Give item to buyer using proper hands integration
-        self._give_item_to_buyer(caller, item)
-        
+
+        # Hand placement happens inside purchase_item (or the shop's own
+        # override — bars/carts land items on the counter/board instead).
+
+        # A keeper minding THIS counter serves the sale in person — the
+        # self-service messages below are for unmanned shelves only.
+        keeper = self._find_keeper(caller, container)
+        if keeper:
+            caller.msg(f"You pay {format_currency(price)}.")
+            keeper.serve_purchase(caller, item, price)
+            self._notify_merchant(caller, item, price, container)
+            return
+
         # Get custom messages from shop or use defaults
         msg_buyer = container.db.purchase_msg_buyer or "You purchase {item} for {price}."
         msg_room = container.db.purchase_msg_room or "{buyer} purchases {item} from {shop}."
@@ -173,27 +182,22 @@ class CmdBuy(Command):
         
         return None
     
-    def _give_item_to_buyer(self, buyer, item):
-        """
-        Give purchased item to buyer, using wield if hands available.
-        
-        Args:
-            buyer: Character who bought the item
-            item: Item to give
-        """
-        # Item location is set to buyer in purchase_item.
-        # PR-H2: ``hands`` is now anatomy-derived with canonical keys
-        # ("left_hand" / "right_hand").  Walk the derived view and
-        # pick the first empty slot — handles severed-hand buyers
-        # automatically (their derived view won't include the
-        # severed slot, so we won't try to wield into thin air).
-        hands = buyer.hands
-        for hand_key, held in hands.items():
-            if held is None:
-                buyer.wield_item(item, hand=hand_key)
-                return
-        # All slots full — item stays in inventory.
-    
+    def _find_keeper(self, buyer, container):
+        """The shopkeeper minding this counter, if one is present — an
+        ``is_merchant`` character in the room whose own counter lookup
+        resolves to this container (so a keeper never serves a stranger's
+        shelf)."""
+        for obj in buyer.location.contents:
+            if not getattr(obj, "is_merchant", False):
+                continue
+            serve = getattr(obj, "serve_purchase", None)
+            find_counter = getattr(obj, "_find_counter", None)
+            if not (callable(serve) and callable(find_counter)):
+                continue
+            if find_counter() == container:
+                return obj
+        return None
+
     def _notify_merchant(self, buyer, item, price, container):
         """
         Send transaction message to merchant if present.

--- a/typeclasses/shopkeeper.py
+++ b/typeclasses/shopkeeper.py
@@ -440,6 +440,14 @@ class Shopkeeper(LLMNpcMixin, Character):
             self.execute_cmd("say Counter says no. Take it up with the "
                              "counter.")
             return
+        self.serve_purchase(patron, item, price)
+
+    def serve_purchase(self, patron, item, price):
+        """The handover — the keeper physically presses the purchase into
+        the buyer's hand. Fired after a spoken order, and by the ``buy``
+        command whenever this keeper is minding the counter (a manned shop
+        is never self-service)."""
+        from world.grammar import with_article
         handle = None
         try:
             handle = self._address_handle(patron)

--- a/world/tests/test_shopkeeper.py
+++ b/world/tests/test_shopkeeper.py
@@ -63,6 +63,8 @@ class TestShopOrderFulfilment(TestCase):
         patron = MagicMock(); patron.location = "room"; patron.tokens = tokens
         b._fulfil_shop_order = shopmod.Shopkeeper._fulfil_shop_order.__get__(
             b, shopmod.Shopkeeper)
+        b.serve_purchase = shopmod.Shopkeeper.serve_purchase.__get__(
+            b, shopmod.Shopkeeper)
         return b, counter, patron
 
     def test_serve_hands_item_over(self):
@@ -127,6 +129,52 @@ class TestPurchaseHandDelivery(BaseEvenniaTest):
         ok, _ = counter.purchase_item(buyer, "cigarette_pack_noir")
         self.assertTrue(ok)
         self.assertIsNone(counter.db.register)
+
+
+class TestBuyRoutesThroughKeeper(TestCase):
+    """The buy command: a keeper minding the counter serves the sale in
+    person; unmanned counters stay self-service."""
+
+    def _cmd(self, room_contents):
+        from commands.shop import CmdBuy
+        cmd = CmdBuy()
+        buyer = MagicMock()
+        buyer.location.contents = room_contents
+        return cmd, buyer
+
+    def _keeper(self, counter, merchant=True):
+        keeper = MagicMock()
+        keeper.is_merchant = merchant
+        keeper._find_counter = lambda: counter
+        return keeper
+
+    def test_keeper_at_this_counter_found(self):
+        counter = MagicMock()
+        keeper = self._keeper(counter)
+        cmd, buyer = self._cmd([keeper, counter])
+        self.assertIs(cmd._find_keeper(buyer, counter), keeper)
+
+    def test_strangers_counter_not_served(self):
+        counter, other = MagicMock(), MagicMock()
+        keeper = self._keeper(other)          # minds a different fixture
+        cmd, buyer = self._cmd([keeper, counter])
+        self.assertIsNone(cmd._find_keeper(buyer, counter))
+
+    def test_non_merchant_ignored(self):
+        counter = MagicMock()
+        bystander = self._keeper(counter, merchant=False)
+        cmd, buyer = self._cmd([bystander, counter])
+        self.assertIsNone(cmd._find_keeper(buyer, counter))
+
+    def test_serve_purchase_emote(self):
+        b = MagicMock()
+        b._address_handle = lambda p: "the lean man"
+        item = MagicMock(); item.key = "syringe of guttervenom"
+        shopmod.Shopkeeper.serve_purchase.__get__(
+            b, shopmod.Shopkeeper)(MagicMock(), item, 15)
+        emote = b.execute_cmd.call_args.args[0]
+        self.assertIn("presses it into the lean man's hand", emote)
+        self.assertIn("sweeps 15 into the till", emote)
 
 
 class TestShelfGrounding(TestCase):


### PR DESCRIPTION
Closes #1295

- CmdBuy finds the keeper minding THIS counter (is_merchant +
  _find_counter() == container) and hands the sale to
  Shopkeeper.serve_purchase — the same pluck/press/sweep emote as a
  spoken order; buyer gets a flat "You pay N₮." receipt. Unmanned
  counters keep their custom self-service messages.
- serve_purchase factored out of _fulfil_shop_order.
- Redundant CmdBuy._give_item_to_buyer removed — hand placement is
  purchase_item's job (or the fixture override's, for counter/board
  landings), ending the double wield.
- Tests: keeper routing (right counter / stranger's counter /
  non-merchant), serve emote unit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
