### PR TITLE
No keeper, no commerce: post-bound counters close during a vacancy

### DIFF
--- a/typeclasses/shopkeeper.py
+++ b/typeclasses/shopkeeper.py
@@ -141,6 +141,17 @@ class ShopContainer(DefaultObject):
                 - (True, item_obj) on success
                 - (False, error_message) on failure
         """
+        # A counter bound to a post only sells while its keeper is minding
+        # it — a dead or absent shopkeeper closes the shop (the community
+        # feels the vacancy). Counters with no keeper binding vend freely:
+        # that IS the vending-machine tier.
+        keeper = self.db.post_keeper
+        if keeper is not None and not (
+                keeper.pk and keeper.location == self.location):
+            return False, (self.db.post_closed_msg
+                           or "Nobody's minding the counter. No coin changes "
+                              "hands here until somebody's back behind it.")
+
         # Check if item exists in shop
         if prototype_key not in self.db.prototype_inventory:
             return False, "That item isn't sold here."

--- a/world/tests/test_shopkeeper.py
+++ b/world/tests/test_shopkeeper.py
@@ -131,6 +131,43 @@ class TestPurchaseHandDelivery(BaseEvenniaTest):
         self.assertIsNone(counter.db.register)
 
 
+@override_settings(PROTOTYPE_MODULES=["world.prototypes"])
+class TestVacancyClosesShop(BaseEvenniaTest):
+    """A post-bound counter only sells while its keeper is minding it;
+    unbound counters vend freely (the vending-machine tier)."""
+
+    def _counter(self):
+        from evennia import create_object
+        counter = create_object("typeclasses.shopkeeper.ShopContainer",
+                                key="post counter", location=self.room1)
+        counter.db.is_infinite = True
+        counter.db.prototype_inventory = {"cigarette_pack_noir": 6}
+        return counter
+
+    def test_absent_keeper_closes_the_till(self):
+        from evennia import create_object
+        counter = self._counter()
+        keeper = create_object("typeclasses.characters.Character",
+                               key="keeper", location=self.room1)
+        counter.db.post_keeper = keeper
+        self.char1.tokens = 50
+
+        ok, _ = counter.purchase_item(self.char1, "cigarette_pack_noir")
+        self.assertTrue(ok)                       # keeper present: open
+
+        keeper.location = self.room2
+        ok, msg = counter.purchase_item(self.char1, "cigarette_pack_noir")
+        self.assertFalse(ok)                      # keeper gone: closed
+        self.assertIn("Nobody's minding the counter", msg)
+        self.assertEqual(self.char1.tokens, 44)   # only the open sale paid
+
+    def test_unbound_counter_vends_freely(self):
+        counter = self._counter()                 # post_keeper never set
+        self.char1.tokens = 20
+        ok, _ = counter.purchase_item(self.char1, "cigarette_pack_noir")
+        self.assertTrue(ok)
+
+
 class TestBuyRoutesThroughKeeper(TestCase):
     """The buy command: a keeper minding the counter serves the sale in
     person; unmanned counters stay self-service."""


### PR DESCRIPTION
Closes #1297

A counter bound to a post (db.post_keeper) refuses purchase_item while
its keeper is dead or out of the room — the community feels the
vacancy at the till, not at a locked door. Unbound counters vend
freely, which is the vending-machine tier by construction. The food
cart inherits the guard. Per-fixture message via db.post_closed_msg.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
