### PR TITLE
The tower board: press rent <unit> claims a named vacancy

### DIFF
--- a/typeclasses/terminals.py
+++ b/typeclasses/terminals.py
@@ -13,7 +13,7 @@ First citizen: the RENTAL TERMINAL (housing guarantee, spec §2.5).
 
 from typeclasses.items import Item
 from world.rental import (
-    RELOCATION_WINDOW, assign_cube, is_free, residence_of)
+    RELOCATION_WINDOW, assign_cube, is_free, residence_of, unit_matches)
 
 
 class RentalTerminal(Item):
@@ -33,8 +33,12 @@ class RentalTerminal(Item):
     # -- press grammar ---------------------------------------------------
     def at_press(self, presser, arg=None):
         arg = (arg or "").strip().lower()
-        if arg in ("rent", "claim", "here", "confirm"):
-            self._press_rent(presser, confirm=(arg == "confirm"))
+        parts = arg.split(None, 1)
+        verb = parts[0] if parts else ""
+        unit = parts[1].strip() if len(parts) > 1 else None
+        if verb in ("rent", "claim", "here", "confirm"):
+            self._press_rent(presser, unit=unit,
+                             confirm=(verb == "confirm"))
             return True
         if not arg or arg in ("status", "info"):
             self._press_status(presser)
@@ -45,30 +49,45 @@ class RentalTerminal(Item):
         return [c for c in (self.db.cubes or [])
                 if c is not None and getattr(c, "pk", None)]
 
+    @staticmethod
+    def _unit_short(cube):
+        """The board name: "The Brackett Arms - Unit 3B" -> "3B"."""
+        tail = cube.key.split(" - ")[-1]
+        return tail[5:] if tail.lower().startswith("unit ") else tail
+
     def _press_status(self, presser):
         cubes = self._cubes()
-        vacancies = sum(1 for c in cubes if is_free(c))
+        free = [self._unit_short(c) for c in cubes if is_free(c)]
         current = residence_of(presser)
         home = (f"Registered residence: |w{current.key}|n."
                 if current else
                 "No registered residence — your housing credit is unspent.")
+        board = (" Vacant: " + ", ".join(free) + ".") if free else ""
         presser.msg(
             f"The screen wakes under your touch.\n{home}\n"
-            f"Vacant cubes here: {vacancies} of {len(cubes)}. "
-            f"|wpress rent on kiosk|n to register.")
+            f"Vacancies here: {len(free)} of {len(cubes)}.{board}\n"
+            f"|wpress rent on kiosk|n to register, or "
+            f"|wpress rent <unit> on kiosk|n to choose.")
 
-    def _press_rent(self, presser, confirm=False):
+    def _press_rent(self, presser, unit=None, confirm=False):
         current = residence_of(presser)
         cubes = self._cubes()
-        if current is not None and current not in cubes and not confirm:
+        # any claim that would change an existing registration wants an
+        # explicit confirm — cross-building, or naming a different unit
+        # on this very board (in-building moves are real relocations)
+        relocating = current is not None and not (
+            (unit and unit_matches(current, unit))
+            or (not unit and current in cubes))
+        if relocating and not confirm:
             hours = int(RELOCATION_WINDOW // 3600)
+            which = f" {unit}" if unit else ""
             presser.msg(
                 f"You're registered at {current.key}. Claiming here "
                 f"relocates you — the old door answers your sleeve for "
                 f"{hours} more hours, then seals. "
-                f"|wpress confirm on kiosk|n to proceed.")
+                f"|wpress confirm{which} on kiosk|n to proceed.")
             return
-        ok, msg = assign_cube(presser, self)
+        ok, msg = assign_cube(presser, self, unit=unit)
         presser.msg(msg)
         if ok and presser.location:
             presser.location.msg_contents(

--- a/world/rental.py
+++ b/world/rental.py
@@ -153,10 +153,21 @@ def residence_report(char):
     }
 
 
-def assign_cube(char, terminal):
+def unit_matches(cube, want):
+    """Does the name *want* denote this cube? Token match on the key, so
+    "3b" hits "The Brackett Arms - Unit 3B" and "r0-01" hits "R0-01"."""
+    want = (want or "").strip().lower()
+    if not want:
+        return False
+    tokens = [t.strip("().,").lower() for t in cube.key.split()]
+    return want in tokens
+
+
+def assign_cube(char, terminal, unit=None):
     """The terminal transaction. Returns ``(ok, message)``; relocation
     from an existing residence is handled here (old cube released with
-    the window, new cube claimed permanent)."""
+    the window, new cube claimed permanent). *unit* names a specific
+    cube on this terminal's board ("3b"); without it, first-free."""
     if sleeve_uid_of(char) is None:
         return False, ("The terminal's reader passes over you and finds "
                        "no sleeve signature to register.")
@@ -165,13 +176,26 @@ def assign_cube(char, terminal):
     if not cubes:
         return False, "The terminal blinks: NO UNITS CONFIGURED."
     current = residence_of(char)
-    if current in cubes:
-        return False, (f"The terminal blinks green: you are already "
-                       f"registered to {current.key}.")
-    free = [c for c in cubes if is_free(c)]
-    if not free:
-        return False, ("The terminal blinks |rred|n: NO VACANCY. Every "
-                       "cube is registered or in handover.")
+    if unit:
+        named = [c for c in cubes if unit_matches(c, unit)]
+        if not named:
+            return False, (f"The terminal blinks: no unit "
+                           f"'{unit.strip().upper()}' on this board.")
+        if current in named:
+            return False, (f"The terminal blinks green: you are already "
+                           f"registered to {current.key}.")
+        free = [c for c in named if is_free(c)]
+        if not free:
+            return False, (f"The terminal blinks |rred|n: {named[0].key} "
+                           f"is registered or in handover.")
+    else:
+        if current in cubes:
+            return False, (f"The terminal blinks green: you are already "
+                           f"registered to {current.key}.")
+        free = [c for c in cubes if is_free(c)]
+        if not free:
+            return False, ("The terminal blinks |rred|n: NO VACANCY. Every "
+                           "cube is registered or in handover.")
     cube = free[0]
     moved = ""
     if current is not None:

--- a/world/tests/test_cube_rental.py
+++ b/world/tests/test_cube_rental.py
@@ -124,6 +124,52 @@ class TestVacancy(TestCase):
         self.assertFalse(is_free(cube))
 
 
+class TestUnitChoice(TestCase):
+    """`press rent 3b` — claiming a NAMED unit off the board (Brackett
+    Arms; QoC's first-free stays the bare-press behavior)."""
+
+    def _tower(self):
+        a = _cube("The Brackett Arms - Unit 3A")
+        b = _cube("The Brackett Arms - Unit 3B")
+        return a, b, _terminal([a, b])
+
+    def test_named_unit_claimed(self):
+        tenant = _char()
+        a, b, terminal = self._tower()
+        ok, msg = assign_cube(tenant, terminal, unit="3b")
+        self.assertTrue(ok)
+        self.assertIs(tenant.db.residence, b)
+
+    def test_unknown_unit_refused(self):
+        ok, msg = assign_cube(_char(), self._tower()[2], unit="9z")
+        self.assertFalse(ok)
+        self.assertIn("no unit '9Z'", msg)
+
+    def test_taken_unit_refused(self):
+        a, b, terminal = self._tower()
+        assign_cube(_char("uid-first"), terminal, unit="3b")
+        ok, msg = assign_cube(_char("uid-late"), terminal, unit="3b")
+        self.assertFalse(ok)
+        self.assertIn("registered or in handover", msg)
+
+    def test_own_unit_refused(self):
+        tenant = _char()
+        a, b, terminal = self._tower()
+        assign_cube(tenant, terminal, unit="3b")
+        ok, msg = assign_cube(tenant, terminal, unit="3b")
+        self.assertFalse(ok)
+        self.assertIn("already", msg)
+
+    def test_in_building_move_relocates(self):
+        tenant = _char()
+        a, b, terminal = self._tower()
+        assign_cube(tenant, terminal, unit="3a")
+        ok, msg = assign_cube(tenant, terminal, unit="3b")
+        self.assertTrue(ok)
+        self.assertIs(tenant.db.residence, b)
+        self.assertIsNone(a.db.resident)               # old lease released
+
+
 class TestTerminalPressGrammar(TestCase):
     """The kiosk speaks press (user call): press rent on kiosk /
     press confirm on kiosk / bare press = status."""
@@ -138,6 +184,7 @@ class TestTerminalPressGrammar(TestCase):
         for name in ("at_press", "_press_rent", "_press_status", "_cubes"):
             setattr(t, name,
                     getattr(RentalTerminal, name).__get__(t, RentalTerminal))
+        t._unit_short = RentalTerminal._unit_short
         return t
 
     def test_press_rent_claims(self):
@@ -160,6 +207,38 @@ class TestTerminalPressGrammar(TestCase):
                       tenant.msg.call_args.args[0])
         self.assertTrue(new_terminal.at_press(tenant, "confirm"))
         self.assertIs(tenant.db.residence, new)
+
+    def test_press_rent_with_unit_routes_choice(self):
+        tenant = _char()
+        a = _cube("The Brackett Arms - Unit 3A")
+        b = _cube("The Brackett Arms - Unit 3B")
+        terminal = self._terminal_obj([a, b])
+        self.assertTrue(terminal.at_press(tenant, "rent 3b"))
+        self.assertIs(tenant.db.residence, b)
+
+    def test_in_building_move_wants_confirm(self):
+        tenant = _char()
+        a = _cube("The Brackett Arms - Unit 3A")
+        b = _cube("The Brackett Arms - Unit 3B")
+        terminal = self._terminal_obj([a, b])
+        terminal.at_press(tenant, "rent 3a")
+        self.assertTrue(terminal.at_press(tenant, "rent 3b"))
+        self.assertIs(tenant.db.residence, a)          # not yet moved
+        self.assertIn("press confirm 3b on kiosk",
+                      tenant.msg.call_args.args[0])
+        self.assertTrue(terminal.at_press(tenant, "confirm 3b"))
+        self.assertIs(tenant.db.residence, b)
+
+    def test_status_lists_vacant_board(self):
+        tenant = _char()
+        a = _cube("The Brackett Arms - Unit 3A")
+        b = _cube("The Brackett Arms - Unit 3B")
+        terminal = self._terminal_obj([a, b])
+        assign_cube(_char("uid-other"), terminal, unit="3a")
+        terminal.at_press(tenant, "status")
+        status = tenant.msg.call_args.args[0]
+        self.assertIn("1 of 2", status)
+        self.assertIn("Vacant: 3B.", status)
 
     def test_bare_press_reads_status(self):
         tenant = _char()


### PR DESCRIPTION
Closes #1299

assign_cube takes an optional unit name (token-matched against the
board, so "3b" hits "The Brackett Arms - Unit 3B"); bare rent keeps
QoC's first-free behavior. In-building moves are real relocations —
old lease released with the 48h handover, explicit confirm required
for any residence-changing claim. Kiosk status now lists the vacant
board by unit short-name.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
