### PR TITLE
The Sentinel goes up: AWE repeater mast + basement head-end breaker

### DIFF
--- a/typeclasses/terminals.py
+++ b/typeclasses/terminals.py
@@ -93,3 +93,46 @@ class RentalTerminal(Item):
             presser.location.msg_contents(
                 "The rental terminal chirps its registration jingle.",
                 exclude=[presser])
+
+
+class RepeaterBreaker(Item):
+    """A repeater's power isolator — the head-end cabinet, floors away
+    from the mast it feeds. ``press breaker`` toggles the linked
+    repeater's power: district infrastructure you can reach with a
+    boot instead of a ladder (tampering stays in players' sphere; the
+    mast up top is the violent seam)."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.pressable = True
+        self.locks.add("get:false()")
+        self.db.get_err_msg = "It is conduit-fed and bolted to the wall."
+        if "breaker" not in self.aliases.all():
+            self.aliases.add("breaker")
+
+    def at_press(self, presser, arg=None):
+        mast = self.db.linked_repeater
+        if mast is None or not getattr(mast, "pk", None):
+            presser.msg("The breaker throws with a dead clack — nothing "
+                        "answers on the other end of the conduit.")
+            return True
+        going_on = getattr(mast.db, "radio_on", False) is not True
+        mast.db.radio_on = going_on
+        if going_on:
+            presser.msg("You haul the breaker closed. The conduit "
+                        "overhead picks up a live hum.")
+            room_line = "The head-end breaker slams closed; the conduit hums."
+            mast_line = ("The repeater mast's cabinet clicks, and its "
+                         "patient hum resumes.")
+        else:
+            presser.msg("You haul the breaker open. Somewhere far "
+                        "overhead, a hum you'd stopped hearing spins down.")
+            room_line = "The head-end breaker bangs open; the conduit goes dead."
+            mast_line = ("The repeater mast's hum spins down; its status "
+                         "lamp fades to nothing.")
+        if presser.location:
+            presser.location.msg_contents(room_line, exclude=[presser])
+        mast_room = getattr(mast, "location", None)
+        if mast_room is not None and mast_room != presser.location:
+            mast_room.msg_contents(mast_line)
+        return True

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -4325,6 +4325,49 @@ BASE_STATION = {
 }
 
 
+#: District radio infrastructure: a mast-top repeater. Mechanically a
+#: powered base station (world.radio one-hop relay) whose room's elevation
+#: sets its reach — site it HIGH. Powered from a remote head-end breaker
+#: (RepeaterBreaker, db.linked_repeater), so killing the district's signal
+#: is a basement job, not a climb.
+REPEATER_MAST = {
+    "prototype_key": "REPEATER_MAST",
+    "typeclass": "typeclasses.items.Radio",
+    "key": "AWE Sentinel-9 repeater mast",
+    "aliases": ["mast", "repeater", "sentinel", "sentinel-9"],
+    "desc": ("A lattice-steel repeater mast in Ashford Wireless & Electric "
+             "grey, guyed to the deck at three points and crowned with a "
+             "folded-dipole array that creaks when the wind changes its "
+             "mind. The equipment cabinet at its base hums patiently behind "
+             "a service door stencilled with the AWE magpie; a band readout "
+             "burns steady at 911MHz, and a conduit as thick as a wrist "
+             "dives straight down into the building's bones."),
+    "locks": "get:false()",
+    "attrs": [
+        ("is_radio", True),
+        ("radio_on", True),
+        ("frequency", "911MHz"),
+        ("is_base_station", True),
+        ("get_err_msg", "It is guyed, bolted, and taller than your ambition."),
+    ],
+}
+
+
+#: The mast's power isolator — lives floors away from the mast it feeds.
+REPEATER_BREAKER = {
+    "prototype_key": "REPEATER_BREAKER",
+    "typeclass": "typeclasses.terminals.RepeaterBreaker",
+    "key": "head-end breaker cabinet",
+    "aliases": ["cabinet", "head-end", "isolator"],
+    "desc": ("A wall cabinet in Ashford Wireless & Electric grey, its "
+             "service tag gone brittle under the shop lamp. Inside, one "
+             "fist-sized breaker lever feeds a conduit that climbs into "
+             "the dark of the riser and doesn't come back. A yellowed "
+             "card behind plastic reads: SENTINEL HEAD-END — DO NOT "
+             "THROW UNDER LOAD."),
+}
+
+
 #: The security unit's built-in transceiver (RADIO_COMMS_SPEC §2.1): a comms
 #: module seated in an ear/antenna, factory-fit like the riot gun. Carries
 #: the radio metadata the receiver reads (`radio_frequency`); intact + on-band

--- a/world/tests/test_radio_range.py
+++ b/world/tests/test_radio_range.py
@@ -289,3 +289,44 @@ class TestOrderReach(TestCase):
                           return_value=[repeater]):
             self.assertTrue(order_reaches(self._unit_at(40, 40),
                                           console=console))
+
+
+class TestRepeaterBreaker(TestCase):
+    """The head-end breaker: district infrastructure's power switch,
+    floors away from the mast it feeds."""
+
+    def _breaker(self, mast):
+        from typeclasses.terminals import RepeaterBreaker
+        b = MagicMock()
+        b.db = SimpleNamespace(pressable=True, linked_repeater=mast)
+        b.location = MagicMock()
+        b.at_press = RepeaterBreaker.at_press.__get__(b, RepeaterBreaker)
+        return b
+
+    def _mast_obj(self, on=True):
+        m = MagicMock()
+        m.pk = 1
+        m.db = SimpleNamespace(radio_on=on)
+        m.location = MagicMock()
+        return m
+
+    def test_press_toggles_power_both_ways(self):
+        mast = self._mast_obj(on=True)
+        breaker = self._breaker(mast)
+        self.assertTrue(breaker.at_press(MagicMock()))
+        self.assertFalse(mast.db.radio_on)         # thrown open: dead
+        self.assertTrue(breaker.at_press(MagicMock()))
+        self.assertTrue(mast.db.radio_on)          # closed again: live
+
+    def test_mast_room_hears_the_state_change(self):
+        mast = self._mast_obj(on=True)
+        breaker = self._breaker(mast)
+        breaker.at_press(MagicMock())
+        line = mast.location.msg_contents.call_args.args[0]
+        self.assertIn("spins down", line)
+
+    def test_unlinked_breaker_is_safe(self):
+        breaker = self._breaker(None)
+        presser = MagicMock()
+        self.assertTrue(breaker.at_press(presser))
+        self.assertIn("dead clack", presser.msg.call_args.args[0])


### PR DESCRIPTION
Closes #1301

- REPEATER_MAST prototype: AWE-branded lattice mast, a powered 911MHz
  base station — the radio layer's one-hop relay machinery makes it
  regenerate emergency-band traffic and back up the constabulary's
  own mast for free.
- RepeaterBreaker terminal + REPEATER_BREAKER prototype: the power
  isolator sited floors from the mast (db.linked_repeater); press
  toggles the mast's power, and the mast's room hears the hum change.
- Tests: toggle both ways, remote room messaging, unlinked safety.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
