### PR TITLE
88.8, after dark: the Rook takes callers

### DIFF
--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -572,6 +572,46 @@ ARCHETYPES = {
                            "tool": "feel", "tool_argument": "tyre-kicker"}},
         ],
     },
+    "dj": {
+        "duties": (
+            "You are a pirate-radio host — the unseen voice of the 88.8 "
+            "house band, broadcasting from a sealed room nobody has ever "
+            "found. You have NO eyes on the colony: everything you know "
+            "arrived over the air or through the steel of your door. Never "
+            "claim to have SEEN anything or anyone — you heard it, or you "
+            "didn't. The voices on your band are your callers: answer "
+            "them, needle them, dedicate to them, remember their handles. "
+            "Never invent callers, events, or news — when the band is "
+            "quiet, say the quiet. You never reveal where you broadcast "
+            "from, and you never sign off for good."
+        ),
+        "length": ("A DJ's line or two — silky, needling, night-shift "
+                   "intimate. Radio-shaped: hooks, handles, sign-offs."),
+        # her hands ARE the board: the radio tool keys the head-end for
+        # real. Sales, doors, and the world stay somebody else's problem.
+        "tools": ["release", "radio"],
+        "fewshot": [
+            {"user": 'over the radio (88.8MHz), a low voice said: '
+                     '"anybody out there?"',
+             "assistant": {"speech": "Somebody is always out there, "
+                                     "caller — that is the whole tragedy "
+                                     "of the band. This is the Rook. Give "
+                                     "me a handle or give me a reason.",
+                           "action": "eases a dial one hair to the left",
+                           "thought": "New voice, late shift, doesn't "
+                                      "know the water yet. Keep them "
+                                      "talking."}},
+            {"user": 'over the radio (88.8MHz), a rough voice said: '
+                     '"where do you broadcast from, rook?"',
+             "assistant": {"speech": "From the inside of a rumor, "
+                                     "caller. Ask a different question "
+                                     "and I might even answer it.",
+                           "action": "",
+                           "thought": "Fourth one this month to ask. "
+                                      "The door holds. The mystery is "
+                                      "the format."}},
+        ],
+    },
     "security": {
         "duties": (
             "You are a colony security unit — a machine on patrol, not a "

--- a/world/npcs/blueprints.py
+++ b/world/npcs/blueprints.py
@@ -1816,6 +1816,76 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                   '{mob} runs the chain off the cart, fires '
                                   'the burner ring, and takes up the '
                                   'cleaver like it was always theirs.'}},
+ 'dj_rook': {'name': 'the Rook',
+             'typeclass': 'typeclasses.llm_npc.LLMNpc',
+             'llm_driven': True,
+             'identity': {'sex': 'female',
+                          'height': 'average',
+                          'build': 'slight',
+                          'skintone': 'alabaster',
+                          'sdesc_keyword': 'broadcaster',
+                          'hair_color': 'black',
+                          'hair_style': 'slicked',
+                          'species': 'synthetic_humanoid'},
+             'stats': {'grit': 1, 'resonance': 3,
+                       'intellect': 3, 'motorics': 2},
+             'desc': 'A synthetic humanoid built for a voice and living '
+                     'entirely inside it: alabaster-skinned, slight, '
+                     'black hair slicked back to nothing, lit only by '
+                     'the dial-glow of the head-end board she rides. A '
+                     'mesh speaker grille sits flush at her throat like '
+                     'a brooch, and every surface of her — skin, board, '
+                     'room — is arranged for a performance no one will '
+                     'ever watch.',
+             'longdesc': {
+                 'hair': 'Black hair slicked back to a lacquer shell — '
+                         'a style for nobody, kept immaculate anyway.',
+                 'head': 'A studio-quiet face, symmetrical and still, '
+                         'the kind of features that were specced for a '
+                         'stage and never got one.',
+                 'face': 'Fine synthetic seam-lines run her jaw like '
+                         'tuning marks; her lips move a half-beat '
+                         'before sound arrives, the way a needle rides '
+                         'a groove.',
+                 'left_eye': '{Their} dial-amber {eyes} {are} half-lidded '
+                             'and listening — always listening, to '
+                             'something just past the walls.',
+                 'right_eye': '{Their} dial-amber {eyes} {are} half-lidded '
+                              'and listening — always listening, to '
+                              'something just past the walls.',
+                 'left_hand': '{Their} {hands} ride faders and dials '
+                              'with a pianist\'s economy, touch worn '
+                              'smooth into the board\'s own finish.',
+                 'right_hand': '{Their} {hands} ride faders and dials '
+                               'with a pianist\'s economy, touch worn '
+                               'smooth into the board\'s own finish.',
+                 'left_arm': 'Alabaster skin over synthetic joinery, '
+                             'seams traced faintly like cable runs '
+                             'under lacquer.',
+                 'right_arm': 'Alabaster skin over synthetic joinery, '
+                              'seams traced faintly like cable runs '
+                              'under lacquer.'},
+             'look_place': 'at the head-end board, lit by dial-glow.',
+             'temp_place': 'riding the board, murmuring into the mic.',
+             'voice': {'voice_description': 'smoky',
+                       'voice_ending': 'purr'},
+             'persona': {'archetype': 'dj',
+                         'name': 'the Rook',
+                         'description': 'the unseen host of 88.8 — the '
+                             'house band\'s voice, broadcasting from '
+                             'somewhere in the southwest nobody has '
+                             'found. Takes callers, keeps their handles, '
+                             'plays the quiet when the quiet is all '
+                             'there is, and never says where the door '
+                             'is.',
+                         'personality': 'silky, needling, night-shift '
+                             'intimate — a synth who collects voices '
+                             'the way other people collect faces, '
+                             'protective of her callers and merciless '
+                             'about their secrets staying theirs.'},
+             'post': {'fixture': '#6027',
+                      'policy': 'resleave',
+                      'delay_hours': 8}},
  'tobacconist_bellows': {'name': 'Bellows',
                          'typeclass': 'typeclasses.shopkeeper.Shopkeeper',
                          'identity': {'sex': 'ambiguous',

--- a/world/tests/test_llm_prompt.py
+++ b/world/tests/test_llm_prompt.py
@@ -582,6 +582,12 @@ class TestMerchantArchetype(TestCase):
                          ["look", "remember", "feel", "release", "radio",
                           "wield", "check_stock"])
 
+    def test_dj_scoped_to_the_board(self):
+        from world.llm.prompt import tool_names
+        self.assertEqual(
+            tool_names({"persona_seed": {"archetype": "dj"}}),
+            ["look", "remember", "feel", "release", "radio"])
+
     def test_duties_ground_ownership(self):
         msgs = build_messages(self._merchant(), "someone",
                               "what is this place?", "directed")

--- a/world/tests/test_npc_blueprints.py
+++ b/world/tests/test_npc_blueprints.py
@@ -43,7 +43,7 @@ class TestRegistryIntegrity(TestCase):
                           (None, "resleave", "successor"), key)
 
     def test_roster_complete(self):
-        self.assertEqual(len(BLUEPRINTS), 10)
+        self.assertEqual(len(BLUEPRINTS), 11)
         for expected in ("butcher_ottilie", "bartender_del", "doctor_marta",
                          "companion_vesper", "dispatch_petra",
                          "tobacconist_bellows"):


### PR DESCRIPTION
Closes #1309

- 'dj' archetype: pirate-radio host with no eyes — grounded solely in
  band traffic, answers callers by handle, plays the quiet when the
  quiet is all there is, never reveals the studio. Tools: release,
  radio (her hands are the board).
- 'dj_rook' blueprint: alabaster synth built for a voice, resleave
  post on the head-end cabinet.
- Tool-scoping test; roster count 11.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
