### PR TITLE
Radio gets geography: masts dial to 20 and speak from their steel

### DIFF
--- a/world/radio.py
+++ b/world/radio.py
@@ -236,7 +236,8 @@ def order_reaches(unit: Any, console: Any = None) -> bool:
             return False                   # switched off = no orders
         from world.spatial import get_xyz
         room = _grid_room(console)
-        origin = get_xyz(room) if room is not None else None
+        origin = _antenna_site(console) or (
+            get_xyz(room) if room is not None else None)
         if origin is None:
             return True                    # off-grid console fails open
         reach = _effective_tx_range(console, origin)
@@ -424,8 +425,12 @@ MUTTER_CLARITY_FLOOR = 0.2
 # --- Phase 2 range (RADIO_COMMS_SPEC, decided 2026-07-10) -----------------
 #: Handheld / comms-organ transmit reach, in city grid cells.
 RADIO_TX_RANGE = 12
-#: A base station riding an intact mast: colony-wide.
-MAST_TX_RANGE = 999
+#: A base station riding an intact mast. Dialed from 999 (flat,
+#: geography-free saturation) to 20 on 2026-07-25 (owner call): masts now
+#: have real coverage circles — fringes render through the letter-drop
+#: machinery, multiple masts genuinely union, and wrecking one opens an
+#: audible hole. Refine as the colony grows.
+MAST_TX_RANGE = 20
 #: Inside this fraction of reach the signal is crisp.
 RANGE_CLEAR_FRACTION = 0.7
 #: Between full reach and this fraction: a static wash, existence only.
@@ -454,6 +459,26 @@ def _grid_room(obj):
             return None
         node = getattr(node, "location", None)
     return None
+
+
+def _antenna_site(device):
+    """The grid cell of a base station's linked INTACT antenna — the
+    steel is the station's radio presence (position AND elevation); the
+    cabinet is guts and can live in a basement. None when there is no
+    intact linked antenna, or it's off-grid."""
+    try:
+        db = getattr(device, "db", None)
+        if getattr(db, "is_base_station", None) is not True:
+            return None
+        antenna = getattr(db, "antenna", None)
+        if antenna is None or getattr(
+                getattr(antenna, "db", None), "intact", None) is not True:
+            return None
+        room = _grid_room(antenna)
+        from world.spatial import get_xyz
+        return get_xyz(room) if room is not None else None
+    except Exception:  # noqa: BLE001 — unreadable steel reads as absent
+        return None
 
 
 def _effective_tx_range(device, origin_xyz):
@@ -509,8 +534,10 @@ def _relay_points(frequency, exclude_device, origin_xyz, origin_range):
             if antenna is not None and getattr(
                     getattr(antenna, "db", None), "intact", None) is not True:
                 continue
-            room = _grid_room(radio)
-            xyz = get_xyz(room) if room is not None else None
+            xyz = _antenna_site(radio)
+            if xyz is None:
+                room = _grid_room(radio)
+                xyz = get_xyz(room) if room is not None else None
             if xyz is None:
                 continue
             reach = _effective_tx_range(radio, xyz)
@@ -535,8 +562,10 @@ def _reception_fraction(origin_xyz, origin_range, relays, listener_obj):
     from world.spatial import get_xyz
     if origin_xyz is None:
         return 0.0
-    room = _grid_room(listener_obj)
-    xyz = get_xyz(room) if room is not None else None
+    xyz = _antenna_site(listener_obj)
+    if xyz is None:
+        room = _grid_room(listener_obj)
+        xyz = get_xyz(room) if room is not None else None
     if xyz is None:
         return 0.0
     rx_reach = _effective_tx_range(listener_obj, xyz)
@@ -663,6 +692,11 @@ def _deliver(speaker: Any, message: str, frequency: str,
         origin_xyz = get_xyz(origin_room) if origin_room is not None else None
     except Exception:  # noqa: BLE001
         origin_xyz = None
+    # a mast-linked transmitter speaks FROM its steel, wherever the
+    # cabinet (and its operator) actually sit
+    site = _antenna_site(exclude_device)
+    if site is not None:
+        origin_xyz = site
     origin_range = _effective_tx_range(exclude_device, origin_xyz)
     relays = _relay_points(frequency, exclude_device, origin_xyz,
                            origin_range)

--- a/world/tests/test_radio_range.py
+++ b/world/tests/test_radio_range.py
@@ -84,8 +84,8 @@ class TestReception(TestCase):
             _reception_fraction((0, 0, 0), 12, [], far), 2.0)
 
     def test_relay_saves_the_distant_listener(self):
-        far = _radio_at(_room(30, 0))
-        relay = ((10, 0, 0), MAST_TX_RANGE)   # heard the origin, colony reach
+        far = _radio_at(_room(11, 0))         # fringe of the direct link
+        relay = ((10, 0, 0), MAST_TX_RANGE)   # heard the origin, mast reach
         frac = _reception_fraction((0, 0, 0), 12, [relay], far)
         self.assertLess(frac, 0.1)            # crisp via the repeater
 
@@ -159,14 +159,14 @@ class TestDeliveryByRange(TestCase):
                          len("cover the back door before they run"))
         self.assertIn("-", heard)                       # letter-dropped
 
-    def test_repeater_carries_the_band_colony_wide(self):
+    def test_repeater_carries_the_band_across_town(self):
         origin = _room(0, 0)
         speaker = self._speaker_at(origin)
         dev = _radio_at(None, freq="911MHz"); dev.location = speaker
         console = _radio_at(_room(8, 0), base_station=True,
                             antenna=_mast(True), freq="911MHz")
         console.location.contents = []                  # empty dispatch room
-        far_r, far_holder = self._held_by_char_at(_room(30, 0),
+        far_r, far_holder = self._held_by_char_at(_room(20, 0),
                                                   freq="911MHz")
         with self._world([dev, console, far_r]), \
                 patch.object(radio, "_comms_bots_on", return_value=[]), \
@@ -207,8 +207,9 @@ class TestReciprocity(TestCase):
     def test_console_hears_the_distant_witness(self):
         console = _radio_at(_room(0, 0), base_station=True,
                             antenna=_mast(True))
-        frac = _reception_fraction((30, 0, 0), RADIO_TX_RANGE, [], console)
-        self.assertLess(frac, 0.1)                     # clear at the desk
+        # beyond the walkie's own 12 — only the mast's ears close the link
+        frac = _reception_fraction((13, 0, 0), RADIO_TX_RANGE, [], console)
+        self.assertLess(frac, 0.7)                     # clear at the desk
 
     def test_wrecked_mast_deafens_the_console_too(self):
         console = _radio_at(_room(0, 0), base_station=True,
@@ -223,7 +224,7 @@ class TestReciprocity(TestCase):
                             antenna=_mast(True), freq="911MHz")
         with patch.object(radio, "_all_powered_radios",
                           return_value=[console]):
-            relays = radio._relay_points("911MHz", None, (30, 0, 0),
+            relays = radio._relay_points("911MHz", None, (18, 0, 0),
                                          RADIO_TX_RANGE)
         self.assertEqual(len(relays), 1)               # heard the far call
 
@@ -244,11 +245,14 @@ class TestOrderReach(TestCase):
         c.db.radio_on = on
         return c
 
-    def test_intact_mast_commands_the_colony(self):
+    def test_intact_mast_commands_the_district(self):
         from world.radio import order_reaches
         with patch.object(radio, "_all_powered_radios", return_value=[]):
-            self.assertTrue(order_reaches(self._unit_at(200, 200),
+            self.assertTrue(order_reaches(self._unit_at(18, 18),
                                           console=self._console()))
+            # ...but not the far side of the crater (dialed to 20)
+            self.assertFalse(order_reaches(self._unit_at(200, 200),
+                                           console=self._console()))
 
     def test_wrecked_mast_collapses_to_walkie_range(self):
         from world.radio import order_reaches
@@ -287,6 +291,6 @@ class TestOrderReach(TestCase):
                              antenna=_mast(True))
         with patch.object(radio, "_all_powered_radios",
                           return_value=[repeater]):
-            self.assertTrue(order_reaches(self._unit_at(40, 40),
+            self.assertTrue(order_reaches(self._unit_at(30, 30),
                                           console=console))
 


### PR DESCRIPTION
Closes #1311

MAST_TX_RANGE 999 -> 20 (owner call, refine as the colony grows) and
_antenna_site() at all four seams — transmit origin, relay position,
reception, order reach — so a mast-linked station's presence is its
antenna's cell, not its cabinet's basement. Coverage circles are real:
fringes letter-drop, masts union, wrecked steel opens audible holes.
Tests recalibrated from the 999 era.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
