### PR TITLE
The Rook was talking to the walls: radio-mode replies air via xmit

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -280,7 +280,7 @@ class LLMNpcMixin:
                                       present=present)
             self._agentic_round(messages, persona, patron, line or "",
                                 speaker_name, on_fail, rounds=0,
-                                subject=subject)
+                                subject=subject, mode=mode)
 
         def _with_query_vec(vec):
             # reactor-side: score this NPC's memories against the line, inject.
@@ -525,7 +525,7 @@ class LLMNpcMixin:
     # --- the agentic tool loop (constrained turn → context tools → reply) ----
 
     def _agentic_round(self, messages, persona, patron, line, speaker_name,
-                       on_fail, rounds, subject=None):
+                       on_fail, rounds, subject=None, mode="directed"):
         """One constrained generation; the reactor-side callback either runs a
         context tool and loops, or renders the final reply + any action tool.
         ``subject`` is the memory-scoping identity for this turn (voice-scoped
@@ -533,13 +533,13 @@ class LLMNpcMixin:
         request_turn(
             messages,
             on_turn=partial(self._on_turn, messages, persona, patron, line,
-                            speaker_name, on_fail, rounds, subject),
+                            speaker_name, on_fail, rounds, subject, mode),
             on_fail=on_fail,
             schema=schema_for(persona),  # tool enum scoped to the archetype
         )
 
     def _on_turn(self, messages, persona, patron, line, speaker_name, on_fail,
-                 rounds, subject, raw):
+                 rounds, subject, mode, raw):
         turn = parse_turn(raw, persona, tool_names(persona))
         # Echo guard: a pose aimed at the NPC sometimes comes straight back
         # as its "own" action (or speech). Parroting reads broken — drop it.
@@ -556,11 +556,22 @@ class LLMNpcMixin:
                 {"role": "user", "content": f"TOOL RESULT ({tool}) — {result}"},
             ]
             self._agentic_round(extended, persona, patron, line, speaker_name,
-                                on_fail, rounds + 1, subject=subject)
+                                on_fail, rounds + 1, subject=subject,
+                                mode=mode)
             return
         # Terminal: render speech/action/thought, route any action tool, remember.
-        rendered = self._render_llm_reply(turn["speech"], turn["action"],
-                                          turn["thought"], patron)
+        # A radio turn answers ON THE AIR (§7.3): the reply speech keys the
+        # NPC's real transmit device via ``xmit`` — never room-say, which
+        # would address the walls (the Rook's sealed studio taught us this).
+        # When the model ALSO called the radio tool, that call carries the
+        # transmission and speech stays room-side flavour.
+        aired = False
+        if (mode in ("radio", "radio_ambient") and turn["speech"]
+                and tool != "radio"):
+            aired = self._transmit_words(turn["speech"])
+        rendered = self._render_llm_reply(
+            None if aired else turn["speech"], turn["action"],
+            turn["thought"], patron)
         # Opt-in tuning log: raw model decision beside the final rendered text,
         # so the game-side transform (conjugation/selfify/second-person) is
         # auditable — the sidecar log sees the prompt but not this step.
@@ -678,9 +689,7 @@ class LLMNpcMixin:
             # walkie first; the command's own fallback covers a built-in comms
             # organ. No device = the command refuses = the NPC stays mute,
             # exactly as it would for a player (§7.5).
-            words = " ".join(str(arg).split()).strip().strip('"').strip()
-            if words:
-                self.execute_cmd(f"xmit {words}")
+            self._transmit_words(arg)
         elif tool == "release":
             # The character has decided the exchange is over: drop the
             # conversation hold so the routine (patrol/drift) resumes on
@@ -688,6 +697,20 @@ class LLMNpcMixin:
             # speech/action channels of this same turn.
             self.ndb.llm_engaged_until = None
             self.ndb.llm_engaged_with = None
+
+    def _transmit_words(self, words):
+        """Key the NPC's real transmit device with *words* (the radio
+        tool's sanitation, shared). Returns True when a transmission was
+        attempted — the command itself refuses without a device (§7.5),
+        exactly as it would for a player."""
+        words = " ".join(str(words).split()).strip().strip('"').strip()
+        if not words:
+            return False
+        from world.radio import active_transmit_radio
+        if active_transmit_radio(self) is None:
+            return False          # no device: stay mute, don't say-leak
+        self.execute_cmd(f"xmit {words}")
+        return True
 
     def _remember_person(self, patron, name):
         """Privately name/nickname the interlocutor via the REAL ``remember``

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -919,7 +919,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         turn = {"speech": None, "action": None, "tool": "look",
                 "tool_argument": "patron"}
         with patch.object(llmnpc, "parse_turn", return_value=turn):
-            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, None, "{}")
+            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, None, "directed", "{}")
         b._agentic_round.assert_called_once()           # looped to gather context
         b.execute_cmd.assert_not_called()               # no terminal render yet
 
@@ -929,7 +929,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         turn = {"speech": "Coming up", "action": "grabs a glass", "thought": None,
                 "tool": "prepare_drink", "tool_argument": "Negroni"}
         with patch.object(llmnpc, "parse_turn", return_value=turn):
-            b._on_turn(["m"], {}, patron, "a negroni", "a man", lambda: None, 0, None, "{}")
+            b._on_turn(["m"], {}, patron, "a negroni", "a man", lambda: None, 0, None, "directed", "{}")
         b.execute_cmd.assert_any_call("prepare Negroni")  # the REAL command
         b._agentic_round.assert_not_called()              # terminal, no loop
 
@@ -941,7 +941,7 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         turn = {"speech": "hey", "action": "nods", "thought": None,
                 "tool": "none", "tool_argument": ""}
         with patch.object(llmnpc, "parse_turn", return_value=turn):
-            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, None, "{}")
+            b._on_turn(["m"], {}, patron, "hi", "a man", lambda: None, 0, None, "directed", "{}")
         b.execute_cmd.assert_any_call('emote nods, "hey"')
 
     def test_run_context_tool_look_and_stock(self):

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -343,6 +343,60 @@ class TestStyleTool(TestCase):
         b.execute_cmd.assert_called_once_with("remove mesh top")
 
 
+class TestRadioRepliesAir(TestCase):
+    """A radio-mode turn answers ON THE AIR: reply speech keys the real
+    transmit device via xmit, never room-say (the Rook's sealed studio)."""
+
+    def _turn(self, mode, turn, has_device=True):
+        b = MagicMock()
+        _bind(b, "_on_turn")
+        _bind(b, "_transmit_words")
+        _bind(b, "_handle_action_tool")
+        device = MagicMock() if has_device else None
+        with patch.object(llmnpc, "parse_turn", return_value=dict(turn)), \
+                patch.object(llmnpc, "tool_names", return_value=[]), \
+                patch("world.radio.active_transmit_radio",
+                      return_value=device):
+            b._on_turn([], {}, MagicMock(), "hi", "a voice", lambda: None, 0,
+                       None, mode, "{}")
+        return b
+
+    def test_radio_speech_transmits(self):
+        b = self._turn("radio", {"speech": "You are on the air, caller.",
+                                 "action": None, "thought": None,
+                                 "tool": "none", "tool_argument": ""})
+        b.execute_cmd.assert_any_call("xmit You are on the air, caller.")
+        self.assertIsNone(b._render_llm_reply.call_args.args[0])  # no say
+
+    def test_room_speech_untouched(self):
+        b = self._turn("directed", {"speech": "hey", "action": None,
+                                    "thought": None, "tool": "none",
+                                    "tool_argument": ""})
+        self.assertEqual(b._render_llm_reply.call_args.args[0], "hey")
+        for call in b.execute_cmd.call_args_list:
+            self.assertFalse(str(call.args[0]).startswith("xmit"))
+
+    def test_no_device_stays_mute_not_say(self):
+        b = self._turn("radio", {"speech": "hello?", "action": None,
+                                 "thought": None, "tool": "none",
+                                 "tool_argument": ""}, has_device=False)
+        for call in b.execute_cmd.call_args_list:
+            self.assertFalse(str(call.args[0]).startswith("xmit"))
+        # speech falls back to the room render (harmless in a sealed room,
+        # correct for a device-snatched unit standing in a crowd)
+        self.assertEqual(b._render_llm_reply.call_args.args[0], "hello?")
+
+    def test_radio_tool_carries_it_instead(self):
+        b = self._turn("radio", {"speech": "flavour line",
+                                 "action": None, "thought": None,
+                                 "tool": "radio",
+                                 "tool_argument": "the real broadcast"})
+        b.execute_cmd.assert_any_call("xmit the real broadcast")
+        # speech stays room-side when the tool carried the transmission
+        self.assertEqual(b._render_llm_reply.call_args.args[0],
+                         "flavour line")
+
+
 class TestEchoGuard(TestCase):
     """A pose aimed at the NPC must never come straight back as its reply."""
 
@@ -352,7 +406,7 @@ class TestEchoGuard(TestCase):
         with patch.object(llmnpc, "parse_turn", return_value=dict(turn)), \
                 patch.object(llmnpc, "tool_names", return_value=[]):
             b._on_turn([], {}, MagicMock(), line, "a man", lambda: None, 0,
-                       None, "{}")
+                       None, "directed", "{}")
         return b._render_llm_reply.call_args.args
 
     def test_parroted_pose_dropped_before_render(self):


### PR DESCRIPTION
Closes #1313

A radio turn's caller is not in the room — reply speech now keys the
NPC's real transmit device (xmit) instead of room-say, with the radio
tool still carrying explicit transmissions and deviceless NPCs staying
mute, player-equal. Mode threaded through the agentic chain.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
