### PR TITLE
No gloss on the air: radio context lines drop the parenthetical shape

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -140,7 +140,11 @@ class LLMNpcMixin:
             return   # no brain to reach, or deaf (delivery sent no words)
         voice = self._radio_voice_handle(speaker)
         freq = kwargs.get("radio_frequency") or "the air"
-        overheard = f'Over the radio ({freq}), {voice} said: "{speech}"'
+        # No parenthetical gloss — small RP models copy the "(...)" shape
+        # straight into their dialogue (the Rook greeted a caller as
+        # "caller (Rook)" after learning it here).
+        band = f" on {freq}" if freq != "the air" else ""
+        overheard = f'Over the radio{band}, {voice} said: "{speech}"'
         if not llm_enabled() or self._is_npc_speaker(speaker):
             self._observe_action(speaker, overheard)
             return

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -591,7 +591,7 @@ ARCHETYPES = {
         # real. Sales, doors, and the world stay somebody else's problem.
         "tools": ["release", "radio"],
         "fewshot": [
-            {"user": 'over the radio (88.8MHz), a low voice said: '
+            {"user": 'Over your radio you hear a low voice say: '
                      '"anybody out there?"',
              "assistant": {"speech": "Somebody is always out there, "
                                      "caller — that is the whole tragedy "
@@ -601,7 +601,7 @@ ARCHETYPES = {
                            "thought": "New voice, late shift, doesn't "
                                       "know the water yet. Keep them "
                                       "talking."}},
-            {"user": 'over the radio (88.8MHz), a rough voice said: '
+            {"user": 'Over your radio you hear a rough voice say: '
                      '"where do you broadcast from, rook?"',
              "assistant": {"speech": "From the inside of a rumor, "
                                      "caller. Ask a different question "


### PR DESCRIPTION
Closes #1317

The Rook learned "caller (Rook)" from 'Over the radio (88.8MHz), ...' —
the documented copy-the-bracket failure mode of small RP models. The
observe line reads 'on <band>' now, and the dj few-shot mirrors the
real radio turn framing verbatim.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
