### PR TITLE
The Birdhouse gets programming: station-clock segments + an audience

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -570,8 +570,8 @@ class LLMNpcMixin:
         # When the model ALSO called the radio tool, that call carries the
         # transmission and speech stays room-side flavour.
         aired = False
-        if (mode in ("radio", "radio_ambient") and turn["speech"]
-                and tool != "radio"):
+        if (mode in ("radio", "radio_ambient", "broadcast")
+                and turn["speech"] and tool != "radio"):
             aired = self._transmit_words(turn["speech"])
         rendered = self._render_llm_reply(
             None if aired else turn["speech"], turn["action"],
@@ -583,8 +583,9 @@ class LLMNpcMixin:
         if decision_log_enabled():
             log_decision(self, speaker_name, line, turn, rendered)
         self._handle_action_tool(tool, arg, patron)
-        self._remember_turn(patron, line, speaker_name, turn["speech"],
-                            turn["action"], turn["thought"])
+        if patron is not None:            # broadcasts have no caller
+            self._remember_turn(patron, line, speaker_name, turn["speech"],
+                                turn["action"], turn["thought"])
         # Long-term memory: persist what was learned (async, post-render).
         self._store_memory(patron, speaker_name, line, turn["speech"],
                            subject=subject)
@@ -702,6 +703,27 @@ class LLMNpcMixin:
             self.ndb.llm_engaged_until = None
             self.ndb.llm_engaged_with = None
 
+    def llm_broadcast(self, cue):
+        """An unprompted on-air segment (ambient broadcaster, DJ P2): the
+        director heartbeat hands us a station-clock *cue*; the reply airs
+        through the real transmit device like any radio turn. No caller —
+        no history, no dossier, no memory writes."""
+        if not self.db.llm_driven or not llm_enabled():
+            return False
+        from world.radio import active_transmit_radio
+        if active_transmit_radio(self) is None:
+            return False              # off the air is off the air
+        persona = build_persona(self)
+        events = self._drain_actions()     # whatever the band gave us
+        messages = build_messages(persona, "the station clock", cue,
+                                  "broadcast", None, None, memories=None,
+                                  relationship=None, events=events,
+                                  present=None)
+        self._agentic_round(messages, persona, None, cue,
+                            "the station clock", self._llm_silent,
+                            rounds=0, subject=None, mode="broadcast")
+        return True
+
     def _transmit_words(self, words):
         """Key the NPC's real transmit device with *words* (the radio
         tool's sanitation, shared). Returns True when a transmission was
@@ -721,6 +743,8 @@ class LLMNpcMixin:
         command (NPC_MEMORY_AND_IDENTITY_SPEC §4) — keyed on their apparent_uid
         in this NPC's recognition memory. Skips a no-op re-name so the LLM can't
         churn the same nickname every turn."""
+        if patron is None:
+            return
         name = " ".join(str(name).split())[:40].strip(" .,!?;:'\"")
         if not name or " as " in name.lower():
             return

--- a/world/director/broadcasts.py
+++ b/world/director/broadcasts.py
@@ -1,0 +1,69 @@
+"""Ambient broadcasters — scheduled on-air segments (the Rook's P2).
+
+An NPC flagged ``db.ambient_broadcaster`` cuts an unprompted segment on
+the director heartbeat cadence: every ``db.broadcast_interval`` seconds
+(default 30 minutes), jittered so the station never feels metronomic.
+The cue hands the model only what the world actually knows — the hour,
+the weather — and whatever the band gave the NPC's observation buffer;
+the segment airs through the NPC's real transmit device or not at all.
+"""
+
+import random
+import time
+
+from evennia.objects.models import ObjectDB
+
+#: Seconds between segments when the NPC doesn't set its own cadence.
+DEFAULT_INTERVAL = 1800
+
+
+def _due(npc, now):
+    """Fire only past the stored deadline; a first sighting schedules
+    ahead instead of firing on boot (a reload isn't a cue)."""
+    nxt = npc.db.next_broadcast_at
+    if nxt is None:
+        interval = float(npc.db.broadcast_interval or DEFAULT_INTERVAL)
+        npc.db.next_broadcast_at = now + interval * random.uniform(0.2, 1.0)
+        return False
+    return now >= float(nxt)
+
+
+def _cue():
+    """The station clock: hour and weather from the live systems, with a
+    real-clock fallback — the cue never invents more than the world knows."""
+    period, weather = None, None
+    try:
+        from world.weather import time_system, weather_system
+        period = time_system.get_current_time_period()
+        weather = weather_system.get_current_weather()
+    except Exception:  # noqa: BLE001 — a broken clock still runs a station
+        pass
+    if not period:
+        hour = time.localtime().tm_hour
+        period = ("the small hours" if hour < 5 else
+                  "morning" if hour < 12 else
+                  "afternoon" if hour < 18 else "night")
+    line = f"It is {period} in the colony"
+    if weather:
+        line += f"; the weather is {weather}"
+    return line + (". Recent band traffic, if any, appears above — "
+                   "there may be none.")
+
+
+def maintain_broadcasts(now=None):
+    """One heartbeat sweep over every flagged broadcaster. Never raises;
+    each NPC is isolated so one broken station can't stall the beats."""
+    now = now if now is not None else time.time()
+    for npc in ObjectDB.objects.filter(
+            db_attributes__db_key="ambient_broadcaster"):
+        try:
+            if npc.db.ambient_broadcaster is not True:
+                continue
+            if not npc.db.llm_driven or not _due(npc, now):
+                continue
+            interval = float(npc.db.broadcast_interval or DEFAULT_INTERVAL)
+            npc.db.next_broadcast_at = now + interval * random.uniform(
+                0.75, 1.25)
+            npc.llm_broadcast(_cue())
+        except Exception:  # noqa: BLE001 — one station never stalls the sweep
+            continue

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -253,6 +253,11 @@ class DirectorRoutineScript(DefaultScript):
             maintain_posts()
         except Exception:  # noqa: BLE001 — reincarnation must not stall the beats
             pass
+        try:
+            from world.director.broadcasts import maintain_broadcasts
+            maintain_broadcasts()
+        except Exception:  # noqa: BLE001 — the station must not stall the beats
+            pass
         # Tick telemetry (DB-backed → visible cross-process; surfaced by
         # @patrol/status as "last tick Ns ago").
         import time

--- a/world/llm/prompt.py
+++ b/world/llm/prompt.py
@@ -966,6 +966,13 @@ def build_messages(persona: dict, speaker: str, line: str, mode: str,
                 f"(Not addressed to you; the speaker is somewhere else. Key "
                 f"up — the radio tool — only if your character truly would; "
                 f"staying silent is normal.)")
+    elif mode == "broadcast":
+        turn = (f"{mem}STATION CLOCK — {line}\n\n"
+                f"Cut a short on-air segment in your own voice — a DJ "
+                f"break, not a reply. Use only what the hours and the "
+                f"band actually gave you (recent traffic, if any, appears "
+                f"above); when nothing did, make the quiet itself the "
+                f"segment. Never invent callers, events, or news.")
     elif mode == "ambient":
         turn = f'{mem}{perc}You overhear {speaker} say: "{line}"'
     elif mode == "arrival":

--- a/world/npcs/blueprints.py
+++ b/world/npcs/blueprints.py
@@ -276,7 +276,26 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                'craft': 'shakes it hard over ice and strains '
                                         'it out',
                                'base_cocktail': 'Espresso Martini'}],
-                     'wardrobe': [{'key': 'black mesh halter',
+                     'wardrobe': [{'key': 'AWE Whisperjack earpiece',
+                                   'aliases': ['earpiece', 'whisperjack',
+                                               'bud'],
+                                   'desc': 'An Ashford Wireless & Electric '
+                                           'Whisperjack: a flesh-toned '
+                                           'comms bud with a hairline boom '
+                                           'mic, the little etched magpie '
+                                           'worn almost smooth. A pinhole '
+                                           'light pulses when the band is '
+                                           'live.',
+                                   'worn_desc': 'A |cWhisperjack earpiece|n '
+                                                'sits tucked in {their} '
+                                                'ear, its pinhole light '
+                                                'pulsing with the band.',
+                                   'coverage': ['left_ear'],
+                                   'layer': 2,
+                                   'attrs': [('is_radio', True),
+                                             ('radio_on', True),
+                                             ('frequency', '88.8MHz')]},
+                                  {'key': 'black mesh halter',
                                    'aliases': [],
                                    'desc': 'A scrap of a halter top: fine '
                                            'black mesh on a chrome '
@@ -1719,7 +1738,26 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                  'scenario': 'working her food cart at the '
                                              'Toe as the market drifts past'},
                      'llm_driven': True,
-                     'wardrobe': [{'key': 'chainmail apron',
+                     'wardrobe': [{'key': 'AWE Whisperjack earpiece',
+                                   'aliases': ['earpiece', 'whisperjack',
+                                               'bud'],
+                                   'desc': 'An Ashford Wireless & Electric '
+                                           'Whisperjack: a flesh-toned '
+                                           'comms bud with a hairline boom '
+                                           'mic, the little etched magpie '
+                                           'worn almost smooth. A pinhole '
+                                           'light pulses when the band is '
+                                           'live.',
+                                   'worn_desc': 'A |cWhisperjack earpiece|n '
+                                                'sits tucked in {their} '
+                                                'ear, its pinhole light '
+                                                'pulsing with the band.',
+                                   'coverage': ['left_ear'],
+                                   'layer': 2,
+                                   'attrs': [('is_radio', True),
+                                             ('radio_on', True),
+                                             ('frequency', '88.8MHz')]},
+                                  {'key': 'chainmail apron',
                                    'aliases': ['apron'],
                                    'desc': "A butcher's apron of fine steel "
                                            'rings, dulled with work and '
@@ -1884,6 +1922,8 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                              'the way other people collect faces, '
                              'protective of her callers and merciless '
                              'about their secrets staying theirs.'},
+             'db_attrs': {'ambient_broadcaster': True,
+                          'broadcast_interval': 1800},
              'post': {'fixture': '#6027',
                       'policy': 'resleave',
                       'delay_hours': 8}},
@@ -1978,7 +2018,26 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                          'Cinder & Leaf as the Arms '
                                          'settles around them'},
                          'llm_driven': True,
-                         'wardrobe': [{'key': 'collarless shirt',
+                         'wardrobe': [{'key': 'AWE Whisperjack earpiece',
+                                   'aliases': ['earpiece', 'whisperjack',
+                                               'bud'],
+                                   'desc': 'An Ashford Wireless & Electric '
+                                           'Whisperjack: a flesh-toned '
+                                           'comms bud with a hairline boom '
+                                           'mic, the little etched magpie '
+                                           'worn almost smooth. A pinhole '
+                                           'light pulses when the band is '
+                                           'live.',
+                                   'worn_desc': 'A |cWhisperjack earpiece|n '
+                                                'sits tucked in {their} '
+                                                'ear, its pinhole light '
+                                                'pulsing with the band.',
+                                   'coverage': ['left_ear'],
+                                   'layer': 2,
+                                   'attrs': [('is_radio', True),
+                                             ('radio_on', True),
+                                             ('frequency', '88.8MHz')]},
+                                  {'key': 'collarless shirt',
                                        'aliases': ['shirt'],
                                        'desc': 'A crisp collarless shirt '
                                                'in unbleached cotton, '
@@ -2219,11 +2278,16 @@ def build_npc(blueprint_key, location):
                      "material", "weight", "category"):
             if gspec.get(attr) is not None:
                 garment.attributes.add(attr, gspec[attr])
+        for k, v in (gspec.get("attrs") or ()):
+            garment.attributes.add(k, v)     # e.g. a worn earpiece IS a radio
         npc.wear_item(garment)
 
     for proto in bp.get("carried_prototypes", ()):
         for item in spawn(proto):
             item.move_to(npc, quiet=True, move_hooks=False)
+
+    for k, v in (bp.get("db_attrs") or {}).items():
+        npc.attributes.add(k, v)             # blueprint-owned flags (P2 etc.)
 
     npc.db.llm_persona = dict(bp.get("persona") or {})
     npc.db.llm_driven = bool(bp.get("llm_driven"))
@@ -2287,6 +2351,8 @@ def build_successor(blueprint_key, location):
                      "material", "weight", "category"):
             if gspec.get(attr) is not None:
                 garment.attributes.add(attr, gspec[attr])
+        for k, v in (gspec.get("attrs") or ()):
+            garment.attributes.add(k, v)     # e.g. a worn earpiece IS a radio
         npc.wear_item(garment)
     for proto in bp.get("carried_prototypes", ()):
         for item in spawn(proto):

--- a/world/tests/test_broadcasts.py
+++ b/world/tests/test_broadcasts.py
@@ -1,0 +1,73 @@
+"""Ambient broadcasters: the station-clock sweep (the Rook's P2)."""
+
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import world.director.broadcasts as bc
+
+
+def _npc(flag=True, llm=True, nxt=None, interval=None):
+    n = MagicMock()
+    n.db = SimpleNamespace(ambient_broadcaster=flag, llm_driven=llm,
+                           next_broadcast_at=nxt, broadcast_interval=interval)
+    return n
+
+
+class TestDue(TestCase):
+    def test_first_sighting_schedules_ahead_not_fires(self):
+        n = _npc()
+        self.assertFalse(bc._due(n, now=1000.0))
+        self.assertGreater(n.db.next_broadcast_at, 1000.0)
+
+    def test_past_deadline_fires(self):
+        self.assertTrue(bc._due(_npc(nxt=900.0), now=1000.0))
+        self.assertFalse(bc._due(_npc(nxt=1100.0), now=1000.0))
+
+
+class TestSweep(TestCase):
+    def _sweep(self, npcs, now=1000.0):
+        with patch.object(bc.ObjectDB.objects, "filter",
+                          return_value=npcs):
+            bc.maintain_broadcasts(now=now)
+
+    def test_due_station_airs_and_reschedules(self):
+        n = _npc(nxt=900.0, interval=100)
+        self._sweep([n])
+        n.llm_broadcast.assert_called_once()
+        cue = n.llm_broadcast.call_args.args[0]
+        self.assertIn("in the colony", cue)
+        self.assertGreaterEqual(n.db.next_broadcast_at, 1075.0)  # 100*0.75
+        self.assertLessEqual(n.db.next_broadcast_at, 1125.0)     # 100*1.25
+
+    def test_not_due_stays_quiet(self):
+        n = _npc(nxt=1100.0)
+        self._sweep([n])
+        n.llm_broadcast.assert_not_called()
+
+    def test_unflagged_and_brainless_skipped(self):
+        a = _npc(flag=False, nxt=900.0)
+        b = _npc(llm=False, nxt=900.0)
+        self._sweep([a, b])
+        a.llm_broadcast.assert_not_called()
+        b.llm_broadcast.assert_not_called()
+
+    def test_one_broken_station_never_stalls_the_sweep(self):
+        bad = _npc(nxt=900.0)
+        bad.llm_broadcast.side_effect = RuntimeError("boom")
+        good = _npc(nxt=900.0)
+        self._sweep([bad, good])
+        good.llm_broadcast.assert_called_once()
+
+
+class TestBroadcastFraming(TestCase):
+    def test_station_clock_turn(self):
+        from world.llm.prompt import build_messages
+        msgs = build_messages({"persona_seed": {"archetype": "dj",
+                                                "name": "the Rook"}},
+                              "the station clock", "It is night.",
+                              "broadcast", None, None)
+        turn = msgs[-1]["content"]
+        self.assertIn("STATION CLOCK", turn)
+        self.assertIn("Cut a short on-air segment", turn)
+        self.assertIn("Never invent callers", turn)

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -386,6 +386,14 @@ class TestRadioRepliesAir(TestCase):
         # correct for a device-snatched unit standing in a crowd)
         self.assertEqual(b._render_llm_reply.call_args.args[0], "hello?")
 
+    def test_broadcast_speech_airs_too(self):
+        b = self._turn("broadcast", {"speech": "It is night in the colony "
+                                               "and the band is quiet.",
+                                     "action": None, "thought": None,
+                                     "tool": "none", "tool_argument": ""})
+        b.execute_cmd.assert_any_call(
+            "xmit It is night in the colony and the band is quiet.")
+
     def test_radio_tool_carries_it_instead(self):
         b = self._turn("radio", {"speech": "flavour line",
                                  "action": None, "thought": None,


### PR DESCRIPTION
Closes #1319

- world/director/broadcasts.py: heartbeat sweep fires flagged
  broadcasters on a jittered persisted cadence; cue = live hour +
  weather + the band's own recent traffic; 'broadcast' prompt mode
  cuts a grounded DJ break that airs via the real transmit device.
- Keeper earpieces: AWE Whisperjack (worn 88.8 radios) in Sable,
  Bellows, and Ottilie's blueprint wardrobes; builder passes wardrobe
  attrs through (a worn earpiece IS a radio) and applies blueprint
  db_attrs so the Rook's broadcaster flag survives resleeve.
- Tests: due/reschedule/skip/isolation, broadcast framing, broadcast
  speech airs via xmit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
