### PR TITLE
The Birdhouse plays the room: shelf radios replace wearables

### DIFF
--- a/world/npcs/blueprints.py
+++ b/world/npcs/blueprints.py
@@ -276,26 +276,7 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                'craft': 'shakes it hard over ice and strains '
                                         'it out',
                                'base_cocktail': 'Espresso Martini'}],
-                     'wardrobe': [{'key': 'AWE Whisperjack earpiece',
-                                   'aliases': ['earpiece', 'whisperjack',
-                                               'bud'],
-                                   'desc': 'An Ashford Wireless & Electric '
-                                           'Whisperjack: a flesh-toned '
-                                           'comms bud with a hairline boom '
-                                           'mic, the little etched magpie '
-                                           'worn almost smooth. A pinhole '
-                                           'light pulses when the band is '
-                                           'live.',
-                                   'worn_desc': 'A |cWhisperjack earpiece|n '
-                                                'sits tucked in {their} '
-                                                'ear, its pinhole light '
-                                                'pulsing with the band.',
-                                   'coverage': ['left_ear'],
-                                   'layer': 2,
-                                   'attrs': [('is_radio', True),
-                                             ('radio_on', True),
-                                             ('frequency', '88.8MHz')]},
-                                  {'key': 'black mesh halter',
+                     'wardrobe': [{'key': 'black mesh halter',
                                    'aliases': [],
                                    'desc': 'A scrap of a halter top: fine '
                                            'black mesh on a chrome '
@@ -1738,26 +1719,7 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                  'scenario': 'working her food cart at the '
                                              'Toe as the market drifts past'},
                      'llm_driven': True,
-                     'wardrobe': [{'key': 'AWE Whisperjack earpiece',
-                                   'aliases': ['earpiece', 'whisperjack',
-                                               'bud'],
-                                   'desc': 'An Ashford Wireless & Electric '
-                                           'Whisperjack: a flesh-toned '
-                                           'comms bud with a hairline boom '
-                                           'mic, the little etched magpie '
-                                           'worn almost smooth. A pinhole '
-                                           'light pulses when the band is '
-                                           'live.',
-                                   'worn_desc': 'A |cWhisperjack earpiece|n '
-                                                'sits tucked in {their} '
-                                                'ear, its pinhole light '
-                                                'pulsing with the band.',
-                                   'coverage': ['left_ear'],
-                                   'layer': 2,
-                                   'attrs': [('is_radio', True),
-                                             ('radio_on', True),
-                                             ('frequency', '88.8MHz')]},
-                                  {'key': 'chainmail apron',
+                     'wardrobe': [{'key': 'chainmail apron',
                                    'aliases': ['apron'],
                                    'desc': "A butcher's apron of fine steel "
                                            'rings, dulled with work and '
@@ -2018,26 +1980,7 @@ BLUEPRINTS = {'bartender_sable': {'name': 'Sable Vane',
                                          'Cinder & Leaf as the Arms '
                                          'settles around them'},
                          'llm_driven': True,
-                         'wardrobe': [{'key': 'AWE Whisperjack earpiece',
-                                   'aliases': ['earpiece', 'whisperjack',
-                                               'bud'],
-                                   'desc': 'An Ashford Wireless & Electric '
-                                           'Whisperjack: a flesh-toned '
-                                           'comms bud with a hairline boom '
-                                           'mic, the little etched magpie '
-                                           'worn almost smooth. A pinhole '
-                                           'light pulses when the band is '
-                                           'live.',
-                                   'worn_desc': 'A |cWhisperjack earpiece|n '
-                                                'sits tucked in {their} '
-                                                'ear, its pinhole light '
-                                                'pulsing with the band.',
-                                   'coverage': ['left_ear'],
-                                   'layer': 2,
-                                   'attrs': [('is_radio', True),
-                                             ('radio_on', True),
-                                             ('frequency', '88.8MHz')]},
-                                  {'key': 'collarless shirt',
+                         'wardrobe': [{'key': 'collarless shirt',
                                        'aliases': ['shirt'],
                                        'desc': 'A crisp collarless shirt '
                                                'in unbleached cotton, '

--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -4353,6 +4353,30 @@ REPEATER_MAST = {
 }
 
 
+#: The band on a shelf: a fixed venue set. The GRILLE rule does the
+#: work — a powered radio fans its band to the whole room it sits in,
+#: so one of these behind a counter puts the Birdhouse in everyone's
+#: ears, keeper and patrons alike. Anyone can ``tune`` it (the mischief
+#: seam); it is bolted against walking off.
+AWE_SHELF_RADIO = {
+    "prototype_key": "AWE_SHELF_RADIO",
+    "typeclass": "typeclasses.items.Radio",
+    "key": "AWE Fireside-12 shelf radio",
+    "aliases": ["radio", "shelf radio", "fireside", "set"],
+    "desc": ("An AWE Fireside-12: a shoebox of scuffed bakelite and brass "
+             "grille-cloth, the etched magpie riding the corner of the "
+             "dial plate. The tuner's had one favourite spot long enough "
+             "to wear a pale arc in the dial."),
+    "locks": "get:false()",
+    "attrs": [
+        ("is_radio", True),
+        ("radio_on", True),
+        ("frequency", "88.8MHz"),
+        ("get_err_msg", "It is screwed down against exactly this idea."),
+    ],
+}
+
+
 #: The Sentinel's head-end: the base-station Radio the mast serves.
 #: Standard radio grammar only — ``toggle``/``tune``; its display renders
 #: dynamically (band when powered, dark when not).


### PR DESCRIPTION
Closes #1321

AWE Fireside-12 prototype (fixed venue set, 88.8, tunable by anyone,
bolted down); keeper earpiece wardrobe entries removed. The grille rule
carries the band to keeper and patrons alike; keepers are ears-only by
design now.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
