### PR TITLE
Shelf radios integrate after the venue's primary fixture

### DIFF
--- a/world/prototypes.py
+++ b/world/prototypes.py
@@ -4372,6 +4372,7 @@ AWE_SHELF_RADIO = {
         ("is_radio", True),
         ("radio_on", True),
         ("frequency", "88.8MHz"),
+        ("integration_priority", 7),   # after the venue's primary fixture
         ("get_err_msg", "It is screwed down against exactly this idea."),
     ],
 }


### PR DESCRIPTION
The Fireside-12 defaulted to integration_priority 5, rendering ahead
of the cart/counter it sits on. Priority 7 seats it after.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
