### PR TITLE
Silence beats a rerun: NPCs stop replaying their own remembered quotes

### DIFF
--- a/typeclasses/llm_npc.py
+++ b/typeclasses/llm_npc.py
@@ -550,6 +550,12 @@ class LLMNpcMixin:
         for field in ("action", "speech"):
             if turn[field] and is_echo(turn[field], line):
                 turn[field] = None
+        # Anti-photocopy: a reply that near-copies one of our OWN recent
+        # remembered answers is dropped — retrieval hands small models
+        # their old quotes and they replay them verbatim (Ezra's 'six
+        # blocks that way' era). Silence beats a rerun.
+        if turn["speech"] and self._repeats_self(turn["speech"]):
+            turn["speech"] = None
         tool, arg = turn["tool"], turn["tool_argument"]
         # Context tool: run the real read, feed the result back, loop.
         if tool in CONTEXT_TOOLS and rounds < LLM_MAX_TOOL_ROUNDS:
@@ -723,6 +729,26 @@ class LLMNpcMixin:
                             "the station clock", self._llm_silent,
                             rounds=0, subject=None, mode="broadcast")
         return True
+
+    def _repeats_self(self, speech):
+        """True when *speech* near-copies one of this NPC's own recent
+        remembered answers. Short lines are exempt — re-quoting a price
+        isn't a loop; re-running the whole sales pitch is."""
+        if not speech or len(str(speech)) < 40:
+            return False
+        try:
+            marker = ' — I answered: "'
+            for m in list(self.db.llm_memories or [])[-12:]:
+                text = str((m or {}).get("text", ""))
+                i = text.find(marker)
+                if i < 0:
+                    continue
+                own = text[i + len(marker):].strip().strip('"')
+                if own and is_echo(speech, own):
+                    return True
+        except Exception:  # noqa: BLE001 — the guard never blocks a reply
+            return False
+        return False
 
     def _transmit_words(self, words):
         """Key the NPC's real transmit device with *words* (the radio

--- a/world/tests/test_bar.py
+++ b/world/tests/test_bar.py
@@ -907,7 +907,8 @@ class TestBartenderLLMRouting(BaseEvenniaTest):
         b._hist_key = barmod.Bartender._hist_key
         b._reconstruct_reply = barmod.Bartender._reconstruct_reply
         for name in ("_on_turn", "_run_context_tool", "_render_llm_reply",
-                     "_handle_action_tool", "_remember_turn", "_recent_history"):
+                     "_handle_action_tool", "_remember_turn", "_recent_history",
+                     "_repeats_self"):
             setattr(b, name,
                     getattr(barmod.Bartender, name).__get__(b, barmod.Bartender))
         b.ndb.llm_history = {}

--- a/world/tests/test_llm_npc.py
+++ b/world/tests/test_llm_npc.py
@@ -343,6 +343,36 @@ class TestStyleTool(TestCase):
         b.execute_cmd.assert_called_once_with("remove mesh top")
 
 
+class TestAntiPhotocopy(TestCase):
+    """A reply that near-copies the NPC's own remembered answer drops —
+    retrieval hands small models their old quotes and they replay them."""
+
+    def _npc(self, mems):
+        b = MagicMock()
+        b.db.llm_memories = [{"text": t} for t in mems]
+        _bind(b, "_repeats_self")
+        return b
+
+    def test_own_rerun_dropped(self):
+        b = self._npc(['a voice said: "hi" — I answered: "Drinking is six '
+                       'blocks that way. We keep church and state separate '
+                       'here at Kaspar."'])
+        self.assertTrue(b._repeats_self(
+            "Drinking is six blocks that way. We keep church and state "
+            "separate here at Kaspar."))
+
+    def test_fresh_line_passes(self):
+        b = self._npc(['a voice said: "hi" — I answered: "Drinking is six '
+                       'blocks that way, friend."'])
+        self.assertFalse(b._repeats_self(
+            "Quiet night on Kaspar. The lamp is on and the case is "
+            "honest — come see me before curfew."))
+
+    def test_short_requotes_exempt(self):
+        b = self._npc(['x — I answered: "Fifteen tokens."'])
+        self.assertFalse(b._repeats_self("Fifteen tokens."))
+
+
 class TestRadioRepliesAir(TestCase):
     """A radio-mode turn answers ON THE AIR: reply speech keys the real
     transmit device via xmit, never room-say (the Rook's sealed studio)."""
@@ -352,6 +382,7 @@ class TestRadioRepliesAir(TestCase):
         _bind(b, "_on_turn")
         _bind(b, "_transmit_words")
         _bind(b, "_handle_action_tool")
+        _bind(b, "_repeats_self")
         device = MagicMock() if has_device else None
         with patch.object(llmnpc, "parse_turn", return_value=dict(turn)), \
                 patch.object(llmnpc, "tool_names", return_value=[]), \
@@ -411,6 +442,7 @@ class TestEchoGuard(TestCase):
     def _turn(self, turn, line):
         b = MagicMock()
         _bind(b, "_on_turn")
+        _bind(b, "_repeats_self")
         with patch.object(llmnpc, "parse_turn", return_value=dict(turn)), \
                 patch.object(llmnpc, "tool_names", return_value=[]):
             b._on_turn([], {}, MagicMock(), line, "a man", lambda: None, 0,


### PR DESCRIPTION
Closes #1325

Memory retrieval hands small models their own past answers and they
photocopy them verbatim (Ezra's 'six blocks that way' era). New
_repeats_self guard drops a reply that near-copies any recent
remembered answer; short requotes exempt.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
