### PR TITLE
The colony draws itself: §M1 export + §M2 atlas generator

### DIFF
--- a/scripts/atlas/generate.py
+++ b/scripts/atlas/generate.py
@@ -1,0 +1,50 @@
+"""Generate the colony atlas (COLONY_MAPPING_SPEC §M2).
+
+Run inside the game's shell (read-only over the DB):
+
+    evennia shell < scripts/atlas/generate.py
+
+Writes a fully self-contained ``/tmp/atlas.html`` — the §M1 export plus
+live mast coverage, injected into the approved renderer template. Copy
+it wherever you read documents; regenerate any time the world changes.
+"""
+
+import json
+import time
+
+from world.mapping import export_map
+
+data = export_map()
+
+# live radio coverage annotations — the masts speak from their steel
+masts = []
+try:
+    from world.radio import (_all_powered_radios, _antenna_site,
+                             _effective_tx_range, _grid_room)
+    from world.spatial import get_xyz
+    for radio in _all_powered_radios():
+        if radio.db.is_base_station is not True:
+            continue
+        site = _antenna_site(radio)
+        if site is None:
+            room = _grid_room(radio)
+            site = get_xyz(room) if room is not None else None
+        if site is None:
+            continue
+        reach = _effective_tx_range(radio, site)
+        masts.append({"x": site[0], "y": site[1], "name": radio.key,
+                      "freq": str(radio.db.frequency or ""),
+                      "crisp": round(0.7 * reach, 1),
+                      "reach": round(reach, 1)})
+except Exception as err:  # noqa: BLE001 — coverage is annotation, not truth
+    print(f"mast annotation skipped: {err}")
+data["masts"] = sorted(masts, key=lambda m: m["name"])
+data["edition"] = time.strftime("%Y-%m-%d %H:%M")
+
+template = open("scripts/atlas/template.html").read()
+out = template.replace("/*__DATA__*/null", json.dumps(data))
+with open("/tmp/atlas.html", "w") as f:
+    f.write(out)
+print(f"atlas written: /tmp/atlas.html — {len(data['cells'])} cells, "
+      f"{len(data['links'])} links, {len(masts)} masts, "
+      f"edition {data['edition']}")

--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -1,0 +1,276 @@
+<title>Gelatinous — Colony Atlas</title>
+<style>
+  :root{
+    --ink:#0b0e14; --plate:#11161f; --line:#232c3a;
+    --bone:#d8d3c4; --bone-dim:#8f8d82;
+    --cyan:#6fd6e0; --amber:#e0a86f;
+    --mono:ui-monospace,'SF Mono',Menlo,Consolas,monospace;
+    --serif:'Iowan Old Style',Palatino,'Palatino Linotype',Georgia,serif;
+    --cond:'Avenir Next Condensed','Helvetica Neue Condensed','Arial Narrow',sans-serif;
+  }
+  html{background:var(--ink)}
+  body{margin:0;background:var(--ink);color:var(--bone);font-family:var(--serif)}
+  .wrap{max-width:1180px;margin:0 auto;padding:28px 20px 60px}
+  header{border-bottom:1px solid var(--line);padding-bottom:14px;margin-bottom:6px}
+  .eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:.22em;color:var(--amber);text-transform:uppercase}
+  h1{font-family:var(--cond);font-weight:600;font-size:clamp(28px,4.5vw,44px);letter-spacing:.02em;margin:.15em 0 .1em;text-wrap:balance}
+  .sub{font-size:15px;color:var(--bone-dim);margin:0;max-width:66ch}
+  .stage{position:relative;background:var(--plate);border:1px solid var(--line);border-radius:4px;margin-top:18px}
+  canvas{display:block;width:100%;height:auto;cursor:crosshair}
+  .readout{position:absolute;left:12px;top:10px;font-family:var(--mono);font-size:12px;color:var(--cyan);
+    background:rgba(11,14,20,.72);padding:4px 8px;border:1px solid var(--line);border-radius:3px;pointer-events:none;min-height:15px}
+  .controls{display:flex;flex-wrap:wrap;gap:18px;align-items:center;padding:12px 14px;border-top:1px solid var(--line);
+    font-family:var(--mono);font-size:12px;color:var(--bone-dim)}
+  .controls label{display:flex;gap:7px;align-items:center;cursor:pointer;user-select:none}
+  .controls input[type=checkbox]{accent-color:var(--cyan)}
+  .zrow{display:flex;gap:10px;align-items:center;flex:1;min-width:220px}
+  .zrow input[type=range]{flex:1;accent-color:var(--amber)}
+  .zval{color:var(--amber);min-width:5ch;font-variant-numeric:tabular-nums}
+  .legend{display:flex;flex-wrap:wrap;gap:8px 14px;margin-top:14px;font-family:var(--mono);font-size:11.5px;color:var(--bone-dim)}
+  .chip{display:inline-flex;gap:6px;align-items:center}
+  .sw{width:11px;height:11px;border-radius:2px;display:inline-block;border:1px solid rgba(255,255,255,.15)}
+  .note{margin-top:22px;font-size:15px;line-height:1.62;color:var(--bone-dim);max-width:70ch}
+  .note b{color:var(--bone);font-weight:600}
+  :focus-visible{outline:2px solid var(--cyan);outline-offset:2px}
+</style>
+
+<div class="wrap">
+<header>
+  <div class="eyebrow">Gelatinous Colony &middot; Atlas — edition <span id="edition"></span></div>
+  <h1>The Colony, Entire</h1>
+  <p class="sub">Every coordinate-seeded room, drawn from the live database by the §M1 export.
+  Hover anything; slice by level; toggle the lattice, the routes, the bands.</p>
+</header>
+
+<div class="stage">
+  <div class="readout" id="readout">&nbsp;</div>
+  <canvas id="cv" aria-label="Isometric atlas of the colony"></canvas>
+  <div class="controls">
+    <div class="zrow"><span>z-slice</span><input id="zcap" type="range" min="0" max="8" value="8" step="1"><span class="zval" id="zval"></span></div>
+    <label><input id="tAir" type="checkbox" checked> air lattice</label>
+    <label><input id="tEdge" type="checkbox" checked> jump routes</label>
+    <label><input id="tRadio" type="checkbox"> radio coverage</label>
+  </div>
+</div>
+
+<div class="legend" id="legend"></div>
+
+<p class="note"><b>Reading the plate:</b> solids are the built colony, colored by what a cell is;
+glass volumes are the air lattice — deliberate negative space where bodies fall and vehicles will
+fly. Neon arcs are wired jump edges, each ending in its landing dot. Radio rings draw each mast's
+crisp range solid and its full reach dashed. This document is generated, not drawn: rerun the
+atlas script and it is current again.</p>
+</div>
+
+<script>
+'use strict';
+const DATA = /*__DATA__*/null;
+
+// ---------- palette & classification ----------
+const P = {
+  street:  ['#4d4852','#3a363f','#2c2930'],
+  market:  ['#a65d3e','#7e422c','#5e301f'],
+  hull:    ['#c8a184','#96725b','#6f5340'],
+  tenement:['#5b7a88','#425964','#31434c'],
+  roof:    ['#cdc6b4','#9a917f','#736b5c'],
+  shop:    ['#c49048','#8f6730','#6b4c22'],
+  hotel:   ['#7a6f96','#584f6e','#413a52'],
+  machine: ['#8b8b84','#63635d','#494943'],
+  generic: ['#6e6a72','#514e57','#3c3a41'],
+};
+const LEGEND_LABEL = {street:'street', market:'market', hull:'hull-top',
+  tenement:'residential', roof:'rooftop', shop:'commerce',
+  hotel:'cube hotel', machine:'machinery', generic:'other', air:'air lattice'};
+function cls(c){
+  if (c.flags.includes('sky')) return 'air';
+  const t=(c.type||'').toLowerCase(), k=c.key||'';
+  if (t==='street'||t==='bridge') return 'street';
+  if (t==='market') return 'market';
+  if (t==='rooftop') return k.startsWith("Hammett's Boot")?'hull':'roof';
+  if (t==='tenement'||t==='residential'||t==='apartment') return 'tenement';
+  if (['shop','corner store','laundromat','bar','clinic','nightclub'].includes(t)) return 'shop';
+  if (k.startsWith('Queen of Cups')||/^R\d-\d\d$/.test(k)) return 'hotel';
+  if (k.toLowerCase().includes('elevator')) return 'machine';
+  if (t==='constabulary') return 'machine';
+  return 'generic';
+}
+
+// ---------- data prep ----------
+const C = DATA.cells.map(c=>({x:c.xyz[0],y:c.xyz[1],z:c.xyz[2],
+  t:cls(c), name:c.key, dbref:c.dbref}));
+const byRef = {}; for (const c of C) byRef[c.dbref]=c;
+const EDGES = DATA.links.filter(l=>l.kind==='edge'||l.kind==='gap').map(l=>{
+  const a=byRef[l.from], b=byRef[l.to]; if(!a||!b) return null;
+  const p=[[a.x,a.y,a.z+0.6]];
+  p.push([(a.x+b.x)/2,(a.y+b.y)/2,Math.max(a.z,b.z)+1.1]);
+  p.push([b.x,b.y,b.z+0.6]);
+  const fr=l.edge&&l.edge.fall_room? byRef['#'+l.edge.fall_room] : null;
+  if (fr && fr.dbref!==b.dbref) p.push([fr.x,fr.y,fr.z+0.6]);
+  return {n:`${a.name} — ${l.key}`, p};
+}).filter(Boolean);
+const MASTS = (DATA.masts||[]);
+const ZMAX = Math.max(...C.map(c=>c.z), 1);
+
+// ---------- projection ----------
+const TW=44, TH=22, ZH=17;
+const isoX=(x,y)=>(x-y)*TW/2, isoY=(x,y,z)=>(x+y)*TH/2 - z*ZH;
+let minX=1e9,maxX=-1e9,minY=1e9,maxY=-1e9;
+for (const c of C){
+  const sx=isoX(c.x,c.y), sy=isoY(c.x,c.y,c.z);
+  minX=Math.min(minX,sx-TW/2); maxX=Math.max(maxX,sx+TW/2);
+  minY=Math.min(minY,sy-TH/2-ZH); maxY=Math.max(maxY,sy+TH/2);
+}
+const PAD=46, W=maxX-minX+PAD*2, H=maxY-minY+PAD*2;
+const OX=-minX+PAD, OY=-minY+PAD;
+C.sort((a,b)=>(a.x+a.y)-(b.x+b.y) || a.z-b.z || b.y-a.y);
+const STREETS=new Set(C.filter(c=>c.t==='street').map(c=>`${c.x},${c.y}`));
+
+const cv=document.getElementById('cv'), ctx=cv.getContext('2d');
+const readout=document.getElementById('readout');
+const ui={zcap:document.getElementById('zcap'), zval:document.getElementById('zval'),
+  air:document.getElementById('tAir'), edge:document.getElementById('tEdge'),
+  radio:document.getElementById('tRadio')};
+ui.zcap.max=ZMAX; ui.zcap.value=ZMAX; ui.zval.textContent=`z ≤ ${ZMAX}`;
+document.getElementById('edition').textContent = DATA.edition || '';
+const DPR=Math.min(window.devicePixelRatio||1,2);
+cv.width=Math.round(W*DPR); cv.height=Math.round(H*DPR);
+cv.style.aspectRatio=`${W} / ${H}`;
+
+// ---------- painting ----------
+function topPath(sx,sy){ctx.beginPath();ctx.moveTo(sx,sy-TH/2);ctx.lineTo(sx+TW/2,sy);
+  ctx.lineTo(sx,sy+TH/2);ctx.lineTo(sx-TW/2,sy);ctx.closePath();}
+function rng(c){let h=(c.x*73856093)^(c.y*19349663)^(c.z*83492791);
+  return ()=>{h=Math.imul(h^h>>>15,2246822519);h=Math.imul(h^h>>>13,3266489917);
+    return ((h^=h>>>16)>>>0)/4294967296;};}
+function facePane(sx,sy,side,u,v,w,h,fill){
+  const dirX=side*TW/2, slope=TH/TW;
+  const bx=sx+dirX*u, by=(sy-ZH)+Math.abs(dirX*u)*slope+v;
+  const wx=dirX*w, wy=Math.abs(dirX*w)*slope;
+  ctx.fillStyle=fill; ctx.beginPath();
+  ctx.moveTo(bx,by); ctx.lineTo(bx+wx,by+wy);
+  ctx.lineTo(bx+wx,by+wy+h); ctx.lineTo(bx,by+h); ctx.closePath(); ctx.fill();
+}
+function detail(c,sx,sy){
+  const r=rng(c);
+  if (c.t==='tenement' && c.z>0){
+    for (const side of [-1,1]) for (let i=0;i<3;i++){
+      const lit=r()<0.38;
+      facePane(sx,sy,side,0.16+i*0.28,ZH*0.28,0.13,ZH*0.34,
+        lit?'rgba(224,168,111,0.85)':'rgba(11,14,20,0.5)');
+    }
+  }
+  if (c.t==='tenement' && c.z===0)
+    facePane(sx,sy,1,0.36,ZH*0.34,0.24,ZH*0.62,'rgba(11,14,20,0.62)');
+  if (c.t==='market'){
+    for (const side of [-1,1]) for (let i=1;i<=2;i++)
+      facePane(sx,sy,side,0.06,ZH*(i/3),0.88,1.2,'rgba(11,14,20,0.28)');
+  }
+  if (c.t==='hull'){
+    ctx.strokeStyle='rgba(11,14,20,0.30)'; ctx.lineWidth=.8;
+    ctx.beginPath(); ctx.moveTo(sx-TW*0.26,sy-ZH); ctx.lineTo(sx+TW*0.10,sy-ZH+TH*0.30);
+    ctx.moveTo(sx-TW*0.06,sy-ZH-TH*0.22); ctx.lineTo(sx+TW*0.30,sy-ZH+TH*0.10); ctx.stroke();
+  }
+  if (c.t==='street'){
+    const ew=STREETS.has(`${c.x+1},${c.y}`)||STREETS.has(`${c.x-1},${c.y}`);
+    ctx.strokeStyle='rgba(216,211,196,0.13)'; ctx.lineWidth=1.1; ctx.beginPath();
+    if (ew){ctx.moveTo(sx-TW*0.32,sy-ZH+TH*0.16);ctx.lineTo(sx+TW*0.10,sy-ZH-TH*0.05);}
+    else   {ctx.moveTo(sx+TW*0.32,sy-ZH+TH*0.16);ctx.lineTo(sx-TW*0.10,sy-ZH-TH*0.05);}
+    ctx.stroke();
+    if (r()<0.15){ctx.fillStyle='rgba(11,14,20,0.4)';
+      ctx.beginPath();ctx.ellipse(sx+(r()-0.5)*10,sy-ZH+2,3.2,1.6,0,0,Math.PI*2);ctx.fill();}
+  }
+  if (c.t==='shop'){
+    facePane(sx,sy,1,0.40,ZH*0.30,0.22,ZH*0.66,'rgba(11,14,20,0.6)');
+    facePane(sx,sy,-1,0.30,ZH*0.35,0.10,ZH*0.22,'rgba(224,168,111,0.9)');
+  }
+  if (c.t==='roof'){
+    if (r()<0.45){ctx.fillStyle='rgba(216,211,196,0.5)';
+      ctx.beginPath();ctx.ellipse(sx-6,sy-ZH-2,3.8,1.9,0,0,Math.PI*2);ctx.fill();}
+  }
+  if (c.t==='hotel'){
+    for (const side of [-1,1]) for (let i=0;i<2;i++) for (let j=0;j<2;j++)
+      facePane(sx,sy,side,0.22+i*0.36,ZH*(0.22+j*0.38),0.10,ZH*0.2,
+        r()<0.3?'rgba(224,168,111,0.7)':'rgba(11,14,20,0.45)');
+  }
+}
+function drawCell(c){
+  const sx=isoX(c.x,c.y)+OX, sy=isoY(c.x,c.y,c.z)+OY;
+  if (c.t==='air'){
+    ctx.fillStyle='rgba(111,214,224,0.05)'; ctx.strokeStyle='rgba(111,214,224,0.2)'; ctx.lineWidth=.7;
+    topPath(sx,sy-ZH); ctx.fill(); ctx.stroke(); return;
+  }
+  const [top,left,right]=P[c.t]||P.generic;
+  ctx.fillStyle=left; ctx.beginPath(); ctx.moveTo(sx-TW/2,sy-ZH); ctx.lineTo(sx,sy+TH/2-ZH);
+  ctx.lineTo(sx,sy+TH/2); ctx.lineTo(sx-TW/2,sy); ctx.closePath(); ctx.fill();
+  ctx.fillStyle=right; ctx.beginPath(); ctx.moveTo(sx+TW/2,sy-ZH); ctx.lineTo(sx,sy+TH/2-ZH);
+  ctx.lineTo(sx,sy+TH/2); ctx.lineTo(sx+TW/2,sy); ctx.closePath(); ctx.fill();
+  ctx.fillStyle=top; topPath(sx,sy-ZH); ctx.fill();
+  ctx.strokeStyle='rgba(11,14,20,0.35)'; ctx.lineWidth=.6; ctx.stroke();
+  detail(c,sx,sy);
+}
+function drawRadio(){
+  for (const m of MASTS){
+    for (const [r,dash] of [[m.crisp,[]],[m.reach,[6,5]]]){
+      ctx.beginPath();
+      for (let i=0;i<=140;i++){const a=i/140*Math.PI*2, wx=m.x+r*Math.cos(a), wy=m.y+r*Math.sin(a);
+        const px=isoX(wx,wy)+OX, py=isoY(wx,wy,0)+OY; i?ctx.lineTo(px,py):ctx.moveTo(px,py);}
+      ctx.setLineDash(dash); ctx.strokeStyle='rgba(224,168,111,0.45)'; ctx.lineWidth=1.3; ctx.stroke();
+    }
+    ctx.setLineDash([]);
+  }
+}
+function drawEdges(zc){
+  ctx.lineWidth=1.6; ctx.strokeStyle='rgba(111,214,224,0.85)';
+  ctx.shadowColor='rgba(111,214,224,0.7)'; ctx.shadowBlur=6;
+  for (const e of EDGES){
+    if (Math.min(...e.p.map(p=>p[2]))>zc) continue;
+    ctx.beginPath();
+    e.p.forEach(([x,y,z],i)=>{const px=isoX(x,y)+OX, py=isoY(x,y,z)+OY; i?ctx.lineTo(px,py):ctx.moveTo(px,py);});
+    ctx.stroke();
+    const [x,y,z]=e.p[e.p.length-1];
+    ctx.beginPath(); ctx.arc(isoX(x,y)+OX, isoY(x,y,z)+OY, 2.4, 0, Math.PI*2);
+    ctx.fillStyle='rgba(111,214,224,0.9)'; ctx.fill();
+  }
+  ctx.shadowBlur=0;
+}
+function draw(){
+  ctx.setTransform(DPR,0,0,DPR,0,0);
+  ctx.clearRect(0,0,W,H);
+  const zc=+ui.zcap.value;
+  if (ui.radio.checked) drawRadio();
+  for (const c of C){
+    if (c.z>zc) continue;
+    if (c.t==='air' && !ui.air.checked) continue;
+    drawCell(c);
+  }
+  if (ui.edge.checked) drawEdges(zc);
+}
+draw();
+
+// ---------- hover ----------
+cv.addEventListener('mousemove',ev=>{
+  const r=cv.getBoundingClientRect();
+  const mx=(ev.clientX-r.left)*(W/r.width), my=(ev.clientY-r.top)*(H/r.height);
+  const zc=+ui.zcap.value; let hit=null;
+  for (let i=C.length-1;i>=0;i--){
+    const c=C[i]; if (c.z>zc || (c.t==='air'&&!ui.air.checked)) continue;
+    const sx=isoX(c.x,c.y)+OX, sy=isoY(c.x,c.y,c.z)+OY-ZH;
+    const dx=Math.abs(mx-sx)/(TW/2), dy=Math.abs(my-sy)/(TH/2);
+    if (dx+dy<=1){hit=c;break;}
+  }
+  readout.innerHTML = hit
+    ? `${hit.name} &nbsp;<span style="color:var(--bone-dim)">(${hit.x}, ${hit.y}, ${hit.z})</span>`
+    : '&nbsp;';
+});
+cv.addEventListener('mouseleave',()=>readout.innerHTML='&nbsp;');
+for (const el of [ui.zcap,ui.air,ui.edge,ui.radio])
+  el.addEventListener('input',()=>{ui.zval.textContent=`z ≤ ${ui.zcap.value}`; draw();});
+
+// ---------- legend (only classes actually present) ----------
+const present=[...new Set(C.map(c=>c.t))];
+document.getElementById('legend').innerHTML =
+  Object.keys(LEGEND_LABEL).filter(t=>present.includes(t)).map(t=>{
+    const bg = t==='air' ? 'rgba(111,214,224,0.18)' : (P[t]||P.generic)[0];
+    return `<span class="chip"><span class="sw" style="background:${bg}"></span>${LEGEND_LABEL[t]}</span>`;
+  }).join('');
+</script>

--- a/world/mapping.py
+++ b/world/mapping.py
@@ -1,0 +1,88 @@
+"""The colony map export (COLONY_MAPPING_SPEC §M1).
+
+One canonical, deterministic, READ-ONLY walk of the coordinate substrate:
+``export_map()`` returns cells (every coord-seeded room) and links (every
+exit between two seeded rooms), with edge flight-plans and door state
+riding along. Everything that draws a map — the atlas, the portrait
+plates, someday the decking layer's wayfinding files — is a consumer of
+this one structure. The exporter stamps nothing (no timestamps, no
+randomness): callers date their own editions.
+"""
+
+from evennia.objects.models import ObjectDB
+
+from world.spatial import get_xyz
+
+
+def _flags(room):
+    flags = []
+    db = room.db
+    if db.outside is True:
+        flags.append("outside")
+    if db.is_sky_room is True:
+        flags.append("sky")
+    if db.is_ground is True:
+        flags.append("ground")
+    return flags
+
+
+def _link_kind(ex, src):
+    db = ex.db
+    if db.is_door is True:
+        return "door"
+    if db.is_edge is True:
+        return "edge"
+    if db.is_gap is True:
+        return "gap"
+    if src.db.is_sky_room is True and ex.key in ("down", "d"):
+        return "fall"
+    return "walk"
+
+
+def export_map():
+    """The whole seeded world as one deterministic structure."""
+    rooms = {}
+    for obj in ObjectDB.objects.filter(
+            db_attributes__db_key="xyz").distinct():
+        if obj.destination is not None:
+            continue                      # exits never carry cells
+        xyz = get_xyz(obj)
+        if xyz is None:
+            continue
+        rooms[obj.id] = (obj, xyz)
+
+    cells = []
+    for _, (room, xyz) in rooms.items():
+        cells.append({
+            "dbref": f"#{room.id}",
+            "key": room.key,
+            "xyz": list(xyz),
+            "type": str(room.db.type or ""),
+            "flags": _flags(room),
+        })
+    cells.sort(key=lambda c: (c["xyz"], c["dbref"]))
+
+    links = []
+    for ex in ObjectDB.objects.exclude(db_destination=None):
+        src, dst = ex.location, ex.destination
+        if src is None or src.id not in rooms or dst.id not in rooms:
+            continue                      # off-grid ends are absent by design
+        kind = _link_kind(ex, src)
+        entry = {"from": f"#{src.id}", "to": f"#{dst.id}",
+                 "key": ex.key, "kind": kind}
+        if kind in ("edge", "gap"):
+            edge = {}
+            for attr in ("sky_room", "fall_room", "fall_distance",
+                         "fall_damage", "edge_difficulty",
+                         "gap_destination"):
+                val = ex.attributes.get(attr)
+                if val is not None:
+                    edge[attr] = int(val) if not isinstance(val, str) \
+                        else val
+            entry["edge"] = edge
+        elif kind == "door":
+            entry["door"] = {"locked": ex.db.door_locked is True}
+        links.append(entry)
+    links.sort(key=lambda l: (l["from"], l["to"], l["key"]))
+
+    return {"cells": cells, "links": links}

--- a/world/tests/test_mapping.py
+++ b/world/tests/test_mapping.py
@@ -1,0 +1,71 @@
+"""The §M1 map export: deterministic, read-only, classified links."""
+
+from evennia import create_object
+from evennia.utils.test_resources import BaseEvenniaTest
+
+from world.mapping import export_map
+
+
+class TestExportMap(BaseEvenniaTest):
+    def _room(self, key, xyz, **db):
+        r = create_object("typeclasses.rooms.Room", key=key, location=None)
+        r.db.xyz = xyz
+        for k, v in db.items():
+            r.attributes.add(k, v)
+        return r
+
+    def _exit(self, key, src, dst, **db):
+        ex = create_object("typeclasses.exits.Exit", key=key,
+                          location=src, destination=dst)
+        for k, v in db.items():
+            ex.attributes.add(k, v)
+        return ex
+
+    def _world(self):
+        street = self._room("Test Street", (0, 0, 0), type="street",
+                            outside=True, is_ground=True)
+        roof = self._room("Test Roof", (0, 1, 1), type="rooftop",
+                          outside=True)
+        sky = self._room("In the Air", (1, 0, 1), is_sky_room=True,
+                         outside=True)
+        offgrid = create_object("typeclasses.rooms.Room",
+                                key="Interior", location=None)
+        self._exit("north", street, roof)
+        self._exit("south", roof, street, is_door=True, door_locked=True)
+        self._exit("east", roof, sky, is_edge=True, sky_room=sky.id,
+                   fall_room=street.id, fall_distance=1, fall_damage=10,
+                   edge_difficulty=8)
+        self._exit("down", sky, street)
+        self._exit("in", street, offgrid)      # off-grid end: absent
+        return street, roof, sky
+
+    def test_cells_flags_and_offgrid_absence(self):
+        self._world()
+        data = export_map()
+        keys = {c["key"] for c in data["cells"]}
+        self.assertIn("Test Street", keys)
+        self.assertNotIn("Interior", keys)
+        street = next(c for c in data["cells"]
+                      if c["key"] == "Test Street")
+        self.assertEqual(street["xyz"], [0, 0, 0])
+        self.assertEqual(sorted(street["flags"]), ["ground", "outside"])
+        air = next(c for c in data["cells"] if c["key"] == "In the Air")
+        self.assertIn("sky", air["flags"])
+
+    def test_link_classification(self):
+        street, roof, sky = self._world()
+        kinds = {(l["key"], l["kind"]): l for l in export_map()["links"]
+                 if l["from"] in (f"#{street.id}", f"#{roof.id}",
+                                  f"#{sky.id}")}
+        self.assertIn(("north", "walk"), kinds)
+        self.assertIn(("south", "door"), kinds)
+        self.assertTrue(kinds[("south", "door")]["door"]["locked"])
+        self.assertIn(("east", "edge"), kinds)
+        edge = kinds[("east", "edge")]["edge"]
+        self.assertEqual(edge["fall_distance"], 1)
+        self.assertEqual(edge["fall_room"], street.id)
+        self.assertIn(("down", "fall"), kinds)   # one-way out of the sky
+
+    def test_deterministic(self):
+        self._world()
+        self.assertEqual(export_map(), export_map())


### PR DESCRIPTION
Closes #1331

world/mapping.py exports every seeded cell and classified link,
deterministically, read-only. scripts/atlas renders it as the approved
night plate — self-contained HTML with z-slice, hover, air lattice,
jump routes, and live mast coverage, stamped by edition.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
