### PR TITLE
The atlas gets its URL: /atlas/, superuser-gated, never stale

### DIFF
--- a/scripts/atlas/generate.py
+++ b/scripts/atlas/generate.py
@@ -1,74 +1,14 @@
-"""Generate the colony atlas (COLONY_MAPPING_SPEC §M2).
-
-Run inside the game's shell (read-only over the DB):
+"""Generate the colony atlas file (COLONY_MAPPING_SPEC §M2).
 
     evennia shell < scripts/atlas/generate.py
 
-Writes a fully self-contained ``/tmp/atlas.html`` — the §M1 export plus
-live mast coverage, injected into the approved renderer template. Copy
-it wherever you read documents; regenerate any time the world changes.
+Writes self-contained /tmp/atlas.html from the live DB. The website view
+(§M2.5) serves the same builder at /atlas/ for superusers.
 """
 
-import base64
-import json
-import os
-import time
+from world.atlas import build_atlas_html
 
-from world.mapping import export_map
-
-data = export_map()
-
-# the sprite library: stamp wherever a class has art, box everywhere else
-SPRITE_DIR = "scripts/atlas/sprites/final"
-sprites = {}
-if os.path.isdir(SPRITE_DIR):
-    for fname in sorted(os.listdir(SPRITE_DIR)):
-        if fname.endswith(".png"):
-            with open(os.path.join(SPRITE_DIR, fname), "rb") as f:
-                sprites[fname[:-4]] = ("data:image/png;base64,"
-                                       + base64.b64encode(f.read()).decode())
-anchor_path = "scripts/atlas/sprites/anchors.json"
-data["anchor"] = (json.load(open(anchor_path))
-                  if os.path.exists(anchor_path) else None)
-
-# landmark heroes: one sprite spanning many cells, suppressing their tiles
-lm_path = "scripts/atlas/sprites/landmarks.json"
-landmarks = json.load(open(lm_path)) if os.path.exists(lm_path) else []
-for lm in landmarks:
-    lm["uri"] = sprites.pop(lm["sprite"], None)
-data["landmarks"] = [lm for lm in landmarks if lm.get("uri")]
-data["sprites"] = sprites
-
-# live radio coverage annotations — the masts speak from their steel
-masts = []
-try:
-    from world.radio import (_all_powered_radios, _antenna_site,
-                             _effective_tx_range, _grid_room)
-    from world.spatial import get_xyz
-    for radio in _all_powered_radios():
-        if radio.db.is_base_station is not True:
-            continue
-        site = _antenna_site(radio)
-        if site is None:
-            room = _grid_room(radio)
-            site = get_xyz(room) if room is not None else None
-        if site is None:
-            continue
-        reach = _effective_tx_range(radio, site)
-        masts.append({"x": site[0], "y": site[1], "name": radio.key,
-                      "freq": str(radio.db.frequency or ""),
-                      "crisp": round(0.7 * reach, 1),
-                      "reach": round(reach, 1)})
-except Exception as err:  # noqa: BLE001 — coverage is annotation, not truth
-    print(f"mast annotation skipped: {err}")
-data["masts"] = sorted(masts, key=lambda m: m["name"])
-data["edition"] = time.strftime("%Y-%m-%d %H:%M")
-
-template = open("scripts/atlas/template.html").read()
-out = template.replace("/*__DATA__*/null", json.dumps(data))
+html = build_atlas_html(".")
 with open("/tmp/atlas.html", "w") as f:
-    f.write(out)
-print(f"atlas written: /tmp/atlas.html — {len(data['cells'])} cells, "
-      f"{len(sprites)} sprites, "
-      f"{len(data['links'])} links, {len(masts)} masts, "
-      f"edition {data['edition']}")
+    f.write(html)
+print(f"atlas written: /tmp/atlas.html ({len(html)} bytes)")

--- a/web/website/urls.py
+++ b/web/website/urls.py
@@ -26,9 +26,13 @@ from web.website.views.discourse_logout import discourse_logout
 from web.website.views.logout_with_discourse import logout_with_discourse
 from web.website.views.discourse_session_sync import discourse_session_sync
 from web.website.views.header_only import header_only
+from web.website.views.atlas import atlas_view
 
 # Override default character creation, account registration, and other views
 urlpatterns = [
+    # the colony atlas — superuser survey instrument (§M2.5)
+    path("atlas/", atlas_view, name="atlas"),
+
     # robots.txt - served as plain text for search engine crawlers
     path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain"), name="robots-txt"),
 

--- a/web/website/views/atlas.py
+++ b/web/website/views/atlas.py
@@ -1,0 +1,18 @@
+"""The atlas, served (COLONY_MAPPING_SPEC §M2.5): a thin shim over
+world.atlas.build_atlas_html, gated to superusers. The renderer is the
+same self-contained document the generator script writes — served live,
+it is simply never stale."""
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse, HttpResponseForbidden
+
+from world.atlas import build_atlas_html
+
+
+@login_required
+def atlas_view(request):
+    if not request.user.is_superuser:
+        return HttpResponseForbidden("Surveyor access only.")
+    game_dir = getattr(settings, "GAME_DIR", ".")
+    return HttpResponse(build_atlas_html(game_dir))

--- a/world/atlas.py
+++ b/world/atlas.py
@@ -1,0 +1,65 @@
+"""Atlas HTML builder (COLONY_MAPPING_SPEC §M2/§M2.5) — one function,
+two consumers: the offline generator script and the superuser website
+view. Read-only over the DB; paths resolve against *game_dir* so both
+the shell and the Django process find the template and sprite library.
+"""
+
+import base64
+import json
+import os
+import time
+
+from world.mapping import export_map
+
+
+def build_atlas_html(game_dir="."):
+    data = export_map()
+
+    sprite_dir = os.path.join(game_dir, "scripts/atlas/sprites/final")
+    sprites = {}
+    if os.path.isdir(sprite_dir):
+        for fname in sorted(os.listdir(sprite_dir)):
+            if fname.endswith(".png"):
+                with open(os.path.join(sprite_dir, fname), "rb") as f:
+                    sprites[fname[:-4]] = (
+                        "data:image/png;base64,"
+                        + base64.b64encode(f.read()).decode())
+
+    anchor_path = os.path.join(game_dir, "scripts/atlas/sprites/anchors.json")
+    data["anchor"] = (json.load(open(anchor_path))
+                      if os.path.exists(anchor_path) else None)
+
+    lm_path = os.path.join(game_dir, "scripts/atlas/sprites/landmarks.json")
+    landmarks = json.load(open(lm_path)) if os.path.exists(lm_path) else []
+    for lm in landmarks:
+        lm["uri"] = sprites.pop(lm["sprite"], None)
+    data["landmarks"] = [lm for lm in landmarks if lm.get("uri")]
+    data["sprites"] = sprites
+
+    masts = []
+    try:
+        from world.radio import (_all_powered_radios, _antenna_site,
+                                 _effective_tx_range, _grid_room)
+        from world.spatial import get_xyz
+        for radio in _all_powered_radios():
+            if radio.db.is_base_station is not True:
+                continue
+            site = _antenna_site(radio)
+            if site is None:
+                room = _grid_room(radio)
+                site = get_xyz(room) if room is not None else None
+            if site is None:
+                continue
+            reach = _effective_tx_range(radio, site)
+            masts.append({"x": site[0], "y": site[1], "name": radio.key,
+                          "freq": str(radio.db.frequency or ""),
+                          "crisp": round(0.7 * reach, 1),
+                          "reach": round(reach, 1)})
+    except Exception:  # noqa: BLE001 — coverage is annotation, not truth
+        pass
+    data["masts"] = sorted(masts, key=lambda m: m["name"])
+    data["edition"] = time.strftime("%Y-%m-%d %H:%M")
+
+    template = open(os.path.join(game_dir,
+                                 "scripts/atlas/template.html")).read()
+    return template.replace("/*__DATA__*/null", json.dumps(data))


### PR DESCRIPTION
Closes #1341

world/atlas.py builds the document; the generator script and the new
website view both consume it. Served live over the DB behind the
game's own login.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
