### PR TITLE
Alleys are alleys by name: no live room carries type 'alley'

### DIFF
--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -87,6 +87,7 @@ const LEGEND_LABEL = {street:'street', alley:'alley', market:'market', hull:'hul
 function cls(c){
   if (c.flags.includes('sky')) return 'air';
   const t=(c.type||'').toLowerCase(), k=c.key||'';
+  if (k.toLowerCase().includes('alley')) return 'alley';
   if (t==='street'||t==='bridge') return 'street';
   if (t==='alley') return 'alley';
   if (t==='market') return 'market';


### PR DESCRIPTION
Shipbreaker Alley is typed market and Dark Alley street (correct for
their crowd pools); the atlas classifies by key so presentation gets
the gnarly sprite without touching game behavior.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
