### PR TITLE
The Atlas comes inside; the sleeve pages come along

### DIFF
--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -8,9 +8,11 @@
     --serif:'Iowan Old Style',Palatino,'Palatino Linotype',Georgia,serif;
     --cond:'Avenir Next Condensed','Helvetica Neue Condensed','Arial Narrow',sans-serif;
   }
+  /* __STANDALONE_ONLY__ */
   html{background:var(--ink)}
   body{margin:0;background:var(--ink);color:var(--bone);font-family:var(--serif)}
-  .wrap{max-width:1180px;margin:0 auto;padding:20px 20px 40px}
+  /* __END_STANDALONE__ */
+  .wrap{max-width:1180px;margin:0 auto;padding:4px 0 24px}
   header{display:flex;align-items:flex-end;gap:16px;flex-wrap:wrap;
     border-bottom:1px solid var(--line);padding-bottom:10px}
   .title{display:flex;flex-direction:column;gap:2px}

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -198,3 +198,36 @@ footer, .footer {
 }
 footer a, .footer a { color: var(--bone-dim); }
 footer a:hover, .footer a:hover { color: var(--amber); }
+
+/* ---------- Bootstrap dark utilities, retuned ----------
+   Pages built with bg-dark / table-dark / border-secondary (Manage
+   Sleeves, character detail) inherit the house style instead of
+   Bootstrap's blue-grey. */
+.bg-dark { background: var(--plate) !important; }
+.bg-secondary { background: var(--plate-hi) !important; }
+.border-secondary { border-color: var(--line) !important; }
+.text-white, .text-light { color: var(--bone) !important; }
+.table-dark {
+    background: transparent;
+    color: var(--bone);
+    font-family: var(--font-mono);
+}
+.table-dark th, .table-dark td, .table-dark thead th {
+    border-color: var(--line) !important;
+    background: transparent;
+}
+.table-dark thead th { color: var(--bone-dim); }
+.table-dark tbody tr:hover { background: var(--plate-hi); }
+.card.bg-dark { border-color: var(--line) !important; }
+.card-title {
+    font-family: var(--font-cond);
+    letter-spacing: .12em;
+    color: var(--bone);
+}
+
+/* Bootstrap's success-green reads as terminal phosphor; in the house
+   style the warm accent carries "live/attested" and green stays for
+   genuine state (connection, health). */
+.text-success { color: var(--amber) !important; }
+.border-success { border-color: var(--line) !important; }
+.card .card-header.bg-dark { background: var(--plate-hi) !important; }

--- a/web/templates/website/atlas.html
+++ b/web/templates/website/atlas.html
@@ -1,0 +1,5 @@
+{% extends "website/base.html" %}
+{% block titleblock %}Atlas{% endblock %}
+{% block content %}
+{{ atlas }}
+{% endblock %}

--- a/web/templates/website/character_detail.html
+++ b/web/templates/website/character_detail.html
@@ -21,7 +21,7 @@ Sleeve Details
           <!-- Stats Column (right) -->
           <div class="col-md-8">
             <!-- Psychophysical Evaluation Report -->
-            <div class="card bg-dark text-success border-success mb-3" style="font-family: 'Courier New', monospace; font-size: 0.9rem;">
+            <div class="card bg-dark border-secondary mb-3" style="font-family: var(--font-mono); font-size: 0.9rem;">
               <div class="card-header bg-dark text-success border-success">
                 <strong>PSYCHOPHYSICAL EVALUATION REPORT</strong>
               </div>

--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -8,15 +8,15 @@ Manage Sleeves
 
 {% load addclass %}
 <style>
-  /* Terminal aesthetic hover effects - Blade Runner edition */
+  /* house style: amber for the live thing, red for the terminal act */
   .sleeve-name-link:hover {
-    color: #5fd38d !important;
-    text-shadow: 0 0 8px rgba(95, 211, 141, 0.3);
+    color: var(--amber) !important;
+    text-shadow: 0 0 8px rgba(224, 168, 111, .35);
   }
-  
+
   .archive-link:hover {
-    color: #e85555 !important;
-    text-shadow: 0 0 8px rgba(232, 85, 85, 0.4);
+    color: var(--bad) !important;
+    text-shadow: 0 0 8px rgba(232, 85, 85, .4);
   }
 </style>
 
@@ -24,12 +24,12 @@ Manage Sleeves
   <div class="col">
     <div class="card bg-dark border-secondary">
       <div class="card-body">
-        <h1 class="card-title text-uppercase" style="font-family: 'Courier New', monospace; letter-spacing: 0.1em;">Sleeve Inventory</h1>
+        <h1 class="card-title text-uppercase">Sleeve Inventory</h1>
         <hr class="border-secondary" />
 
         {% if object_list %}
         <div class="table-responsive">
-          <table class="table table-dark table-sm" style="font-family: 'Courier New', monospace;">
+          <table class="table table-dark table-sm">
             <thead class="border-secondary">
               <tr class="text-uppercase" style="font-size: 0.85rem; letter-spacing: 0.05em;">
                 <th class="border-secondary" style="width: 40%;">Designation</th>
@@ -69,11 +69,11 @@ Manage Sleeves
           </table>
         </div>
         
-        <div class="mt-3 text-muted" style="font-family: 'Courier New', monospace; font-size: 0.85rem;">
+        <div class="mt-3 text-muted" style="font-family: var(--font-mono); font-size: 0.85rem;">
           {{ object_list|length }} sleeve(s) on record
         </div>
         {% else %}
-        <div class="alert alert-dark border-secondary" style="font-family: 'Courier New', monospace;">
+        <div class="alert alert-dark border-secondary">
           <p class="mb-0">NO SLEEVES ON RECORD</p>
           <p class="mb-0 mt-2">
             <a href="{% url 'character-create' %}" class="text-warning">[INITIATE DECANTING PROCESS]</a>
@@ -83,9 +83,9 @@ Manage Sleeves
 
         {% if memorial %}
         <hr class="border-secondary mt-4" />
-        <h2 class="text-uppercase text-muted" style="font-family: 'Courier New', monospace; letter-spacing: 0.1em; font-size: 1rem;">Memorial Wall</h2>
+        <h2 class="text-uppercase text-muted" style="font-family: var(--font-mono); letter-spacing: 0.1em; font-size: 1rem;">Memorial Wall</h2>
         <div class="table-responsive">
-          <table class="table table-dark table-sm" style="font-family: 'Courier New', monospace;">
+          <table class="table table-dark table-sm">
             <thead class="border-secondary">
               <tr class="text-uppercase" style="font-size: 0.85rem; letter-spacing: 0.05em;">
                 <th class="border-secondary" style="width: 40%;">Designation</th>
@@ -108,7 +108,7 @@ Manage Sleeves
             </tbody>
           </table>
         </div>
-        <div class="text-muted" style="font-family: 'Courier New', monospace; font-size: 0.75rem;">
+        <div class="text-muted" style="font-family: var(--font-mono); font-size: 0.75rem;">
           {{ memorial|length }} sleeve(s) remembered
         </div>
         {% endif %}

--- a/web/website/views/atlas.py
+++ b/web/website/views/atlas.py
@@ -1,11 +1,12 @@
-"""The atlas, served (COLONY_MAPPING_SPEC §M2.5). Any logged-in
-account may read the plate; the analytical overlays (air lattice, jump
-routes, radio coverage) are staff instruments and only render their
-controls for staff."""
+"""The atlas, served (COLONY_MAPPING_SPEC §M2.5) — inside the site's own
+page, so the colony's header and footer carry through. Any logged-in
+account may read the plate; the analytical overlays are staff
+instruments and only render their controls for staff."""
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse
+from django.shortcuts import render
+from django.utils.safestring import mark_safe
 
 from world.atlas import build_atlas_html
 
@@ -14,4 +15,6 @@ from world.atlas import build_atlas_html
 def atlas_view(request):
     game_dir = getattr(settings, "GAME_DIR", ".")
     staff = bool(request.user.is_superuser or request.user.is_staff)
-    return HttpResponse(build_atlas_html(game_dir, staff=staff))
+    plate = build_atlas_html(game_dir, staff=staff, fragment=True)
+    return render(request, "website/atlas.html",
+                  {"atlas": mark_safe(plate), "page_title": "Atlas"})

--- a/world/atlas.py
+++ b/world/atlas.py
@@ -7,11 +7,12 @@ the shell and the Django process find the template and sprite library.
 import base64
 import json
 import os
+import re
 
 from world.mapping import export_map
 
 
-def build_atlas_html(game_dir=".", staff=False):
+def build_atlas_html(game_dir=".", staff=False, fragment=False):
     data = export_map()
 
     sprite_dir = os.path.join(game_dir, "scripts/atlas/sprites/final")
@@ -61,4 +62,12 @@ def build_atlas_html(game_dir=".", staff=False):
 
     template = open(os.path.join(game_dir,
                                  "scripts/atlas/template.html")).read()
-    return template.replace("/*__DATA__*/null", json.dumps(data))
+    html = template.replace("/*__DATA__*/null", json.dumps(data))
+    if fragment:
+        # served inside the site's own page: the shell owns <title> and
+        # the page background, and Evennia's sticky footer needs the
+        # body margin the standalone rules would clear
+        html = re.sub(r"/\* __STANDALONE_ONLY__ \*/.*?/\* __END_STANDALONE__ \*/",
+                      "", html, flags=re.S)
+        html = re.sub(r"<title>.*?</title>\s*", "", html, flags=re.S)
+    return html


### PR DESCRIPTION
Closes #1391

Atlas renders through the site shell in fragment mode (header and
footer carry through, standalone mode preserved for the file). Bootstrap
dark utilities, Courier, and terminal-green retuned to the house style
so Manage Sleeves and character detail match the plate.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
