### PR TITLE
The decant button's hover wash follows the amber accent

### DIFF
--- a/web/templates/website/character_respawn_create.html
+++ b/web/templates/website/character_respawn_create.html
@@ -196,9 +196,9 @@ Respawn Sleeve
 }
 
 #decant-button:hover {
-  background-color: rgba(95, 211, 141, 0.1);
+  background-color: rgba(224, 168, 111, 0.10);
   box-shadow: 0 0 12px var(--terminal-glow);
-  text-shadow: 0 0 8px rgba(95, 211, 141, 0.6);
+  text-shadow: 0 0 8px rgba(224, 168, 111, 0.55);
 }
 
 /* Red hover for submit button when flash clone selected */


### PR DESCRIPTION
Two rgba() jade values survived tokenisation on #decant-button:hover
(a background wash and a text glow, both needing alpha rather than a
solid token). Recoloured to amber.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
