### PR TITLE
Cold night: the site moves onto the Atlas's ink

### DIFF
--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -60,9 +60,13 @@
 
 :root {
     /* Terminal Color Palette - Blade Runner Edition */
-    --terminal-bg-dark: #1a1a1a;         /* Softer black background */
-    --terminal-bg-medium: #2a2a2a;       /* Medium dark for cards */
-    --terminal-bg-light: #3a3a3a;        /* Light dark for inputs */
+    /* Surfaces from the Atlas: a blue-biased near-black rather than
+       neutral grey. The bias is what reads as "cold night" instead of
+       "dark mode" — and a neutral grey beside a warm accent looks
+       muddy, where a cool ground makes amber sing. */
+    --terminal-bg-dark: #0b0e14;         /* Atlas ink — the ground */
+    --terminal-bg-medium: #11161f;       /* Atlas plate — cards, raised */
+    --terminal-bg-light: #182030;        /* Atlas plate-hi — inputs, hover */
     /* Palette aligned to the Atlas (2026-07-29): its calm comes from
        bone-cream text and an amber accent rather than white-on-black
        with a jade highlight. */
@@ -77,7 +81,7 @@
     --terminal-success-dim: #4a9d6d;
     --terminal-yellow: #e6c547;          /* Softer warning yellow */
     --terminal-red: #e85555;             /* Softer error red */
-    --terminal-border: #404040;          /* Visible but subtle borders */
+    --terminal-border: #232c3a;          /* Atlas line — cool rule */
     --terminal-glow: rgba(224, 168, 111, 0.30); /* amber glow */
     --terminal-success-glow: rgba(95, 211, 141, 0.3);
 

--- a/web/templates/website/character_confirm_archive.html
+++ b/web/templates/website/character_confirm_archive.html
@@ -10,25 +10,25 @@ Archive Sleeve
 <style>
   /* Caution tape styling for archive confirmation */
   .caution-card {
-    background-color: var(--terminal-bg-medium, #2a2a2a);
+    background-color: var(--terminal-bg-medium, var(--terminal-bg-medium));
     border: none !important;
     padding: 8px;
     background-image: repeating-linear-gradient(
       45deg,
       #e6c547 0px,
       #e6c547 20px,
-      #1a1a1a 20px,
-      #1a1a1a 40px
+      var(--terminal-bg-dark) 20px,
+      var(--terminal-bg-dark) 40px
     );
   }
   
   .caution-card-inner {
-    background-color: var(--terminal-bg-medium, #2a2a2a);
+    background-color: var(--terminal-bg-medium, var(--terminal-bg-medium));
     padding: 2rem;
   }
   
   .archive-danger-btn {
-    background-color: var(--terminal-bg-light, #3a3a3a);
+    background-color: var(--terminal-bg-light, var(--terminal-bg-light));
     border: 2px solid var(--terminal-yellow, #e6c547);
     color: var(--terminal-yellow, #e6c547);
     text-transform: uppercase;
@@ -37,7 +37,7 @@ Archive Sleeve
   }
   
   .archive-danger-btn:hover {
-    background-color: var(--terminal-bg-dark, #1a1a1a);
+    background-color: var(--terminal-bg-dark, var(--terminal-bg-dark));
     border-color: var(--terminal-red, #e85555);
     color: var(--terminal-red, #e85555);
     text-shadow: 0 0 8px rgba(232, 85, 85, 0.6);

--- a/web/templates/website/character_respawn_create.html
+++ b/web/templates/website/character_respawn_create.html
@@ -119,7 +119,7 @@ Respawn Sleeve
 .flash-clone-warning {
   background-color: var(--terminal-bg-medium);
   border-top: 2px solid #e6c547;
-  border-bottom: 1px solid #404040;
+  border-bottom: 1px solid var(--terminal-border);
 }
 
 .flash-clone-warning > div {
@@ -158,8 +158,8 @@ Respawn Sleeve
     45deg,
     #e6c547 0px,
     #e6c547 20px,
-    #1a1a1a 20px,
-    #1a1a1a 40px
+    var(--terminal-bg-dark) 20px,
+    var(--terminal-bg-dark) 40px
   ) 8;
   background-color: var(--terminal-bg-medium);
   cursor: pointer;

--- a/web/templates/website/header_only.html
+++ b/web/templates/website/header_only.html
@@ -14,7 +14,7 @@ Uses iframe-specific menu that removes Forum link to prevent double headers.
     <!-- Critical CSS - renders dark background immediately before external CSS loads -->
     <style>
         html, body {
-            background-color: #1a1a1a !important;
+            background-color: var(--terminal-bg-dark) !important;
             margin: 0;
             padding: 0;
         }


### PR DESCRIPTION
Closes #1415

Surfaces go blue-biased (ink / plate / plate-hi / line) to match the
Atlas, and the last hardcoded greys in three templates follow the
tokens so nothing reads chalky against the new ground.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
