### PR TITLE
Use the display: containers widen, the measure holds

### DIFF
--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -16,7 +16,7 @@
   html{background:var(--ink)}
   body{margin:0;background:var(--ink);color:var(--bone);font-family:var(--serif)}
   /* __END_STANDALONE__ */
-  .wrap{max-width:1180px;margin:0 auto;padding:4px 0 24px}
+  .wrap{max-width:100%;margin:0 auto;padding:4px 0 24px}
   header{display:flex;flex-direction:column;align-items:center;gap:6px;
     border-bottom:1px solid var(--line);padding-bottom:12px;text-align:center}
   .title{display:flex;flex-direction:column;gap:3px;align-items:center}

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -1367,3 +1367,27 @@ p, .lore-voice, .card-body {
     border: none !important;
     box-shadow: none !important;
 }
+
+/* ================================================================
+   WIDTH
+
+   Bootstrap 4 caps `.container` at 1140px, which on a wide display
+   leaves most of the screen empty. Two different things were being
+   constrained by that one number, and they want opposite treatment:
+
+   - CONTAINERS (the card row, the Atlas stage) should use the display.
+     A map especially: more width is literally more colony visible.
+   - PROSE should not. At full width on a wide monitor the welcome copy
+     would set ~200 characters per line; the eye loses its place on the
+     return sweep somewhere past 90. The 72ch measure stays, and simply
+     centres inside the roomier container.
+   ================================================================ */
+.container, .container-sm, .container-md, .container-lg, .container-xl {
+    max-width: min(96vw, 2100px);
+}
+
+/* the plate uses whatever the container gives it */
+.atlas-plate {
+    max-width: 100%;
+}
+.atlas-plate .wrap { max-width: 100%; }


### PR DESCRIPTION
Closes #1419

Bootstrap's 1140px cap constrained the card row and the Atlas stage
alongside the prose. Containers go to min(96vw, 2100px); the 72ch prose
measure stays, because ~200 characters a line is not reading.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
