### PR TITLE
Manage Sleeves becomes a plate

### DIFF
--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -1402,3 +1402,125 @@ p, .lore-voice, .card-body {
    these tokens with standalone fallbacks). */
 body { font-size: var(--size-body); }
 h1 { font-size: var(--size-h1); }
+
+/* ================================================================
+   THE PLATE PATTERN
+
+   Promoted out of the Atlas so any page can be a survey plate: a
+   centred masthead (title, designation, stamp, rule), an optional
+   in-fiction caption at the shared measure, then the content in a
+   raised panel. Same tokens, same scale — the Atlas remains the
+   reference implementation, these are the house classes.
+   ================================================================ */
+.plate-head {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    text-align: center;
+    border-bottom: 1px solid var(--terminal-border);
+    padding-bottom: 12px;
+}
+
+.plate-head h1 {
+    font-family: var(--font-display);
+    font-size: var(--size-h1);
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--terminal-text);
+    margin: 0;
+    line-height: 1;
+}
+
+.plate-place {
+    font-family: var(--font-data);
+    font-size: 11px;
+    letter-spacing: 0.20em;
+    text-transform: uppercase;
+    color: var(--terminal-accent);
+}
+.plate-place span { color: var(--terminal-text-muted); padding: 0 2px; }
+
+.plate-stamp {
+    font-family: var(--font-data);
+    font-size: 11px;
+    letter-spacing: 0.10em;
+    color: var(--terminal-text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.plate-lore {
+    max-width: 85ch;
+    margin: 14px auto 0;
+    font-size: var(--size-body);
+    line-height: 1.7;
+    text-align: center;
+    color: var(--terminal-text-muted);
+}
+
+.plate-stage {
+    margin-top: 18px;
+    background: var(--terminal-bg-medium);
+    border: 1px solid var(--terminal-border);
+    border-radius: 4px;
+    padding: 4px 16px 12px;
+}
+
+/* section headings inside a plate sit quietly, like the Atlas's
+   control strip rather than a second masthead */
+.plate-stage h2 {
+    font-family: var(--font-data);
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--terminal-text-muted);
+    margin: 22px 0 8px;
+}
+
+/* the empty state speaks plainly rather than shouting in brackets */
+.plate-empty {
+    padding: 26px 4px;
+    text-align: center;
+    color: var(--terminal-text-muted);
+    font-size: var(--size-body);
+}
+.plate-empty p { margin: 0 0 6px; }
+.plate-empty p:last-child { margin: 0; }
+
+/* tables inside a plate: no boxed cells, just rules — the Atlas's
+   control-strip restraint applied to data */
+.plate-stage .table th {
+    border-top: 0;
+    border-bottom: 1px solid var(--terminal-border);
+    font-family: var(--font-data);
+    font-size: 10.5px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--terminal-text-muted);
+    padding-top: 14px;
+}
+.plate-stage .table td {
+    border-top: 1px solid var(--terminal-border);
+    vertical-align: middle;
+}
+.plate-stage .table tbody tr:hover { background: var(--terminal-bg-light); }
+.plate-stage .table a { text-decoration: none; }
+.plate-stage .table .sleeve-name-link { color: var(--terminal-text); }
+.plate-stage .table .archive-link {
+    font-family: var(--font-data);
+    font-size: 10.5px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--terminal-text-muted);
+}
+
+/* status reads as state, not decoration: jade for living, amber-warn
+   for archived — and both in the machine voice at label scale */
+.plate-stage .text-success,
+.plate-stage .text-warning {
+    font-family: var(--font-data);
+    font-size: 10.5px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}

--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -8,113 +8,105 @@ Manage Sleeves
 
 {% load addclass %}
 <style>
-  /* Terminal aesthetic hover effects - Blade Runner edition */
   .sleeve-name-link:hover {
     color: var(--terminal-accent) !important;
     text-shadow: 0 0 8px var(--terminal-glow);
   }
-  
+
   .archive-link:hover {
-    color: #e85555 !important;
+    color: var(--terminal-red) !important;
     text-shadow: 0 0 8px rgba(232, 85, 85, 0.4);
   }
 </style>
 
-<div class="row">
-  <div class="col">
-    <div class="card bg-dark border-secondary">
-      <div class="card-body">
-        <h1 class="card-title text-uppercase" style="letter-spacing: 0.1em;">Sleeve Inventory</h1>
-        <hr class="border-secondary" />
-
-        {% if object_list %}
-        <div class="table-responsive">
-          <table class="table table-dark table-sm">
-            <thead class="border-secondary">
-              <tr class="text-uppercase" style="font-size: 0.85rem; letter-spacing: 0.05em;">
-                <th class="border-secondary" style="width: 40%;">Designation</th>
-                <th class="border-secondary" style="width: 30%;">Decanted</th>
-                <th class="border-secondary" style="width: 20%;">Status</th>
-                <th class="border-secondary" style="width: 10%;"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for object in object_list %}
-              <tr class="border-secondary">
-                <td class="border-secondary">
-                  <a href="{{ object.web_get_detail_url }}" class="text-white sleeve-name-link" style="text-decoration: none;">
-                    {{ object }}
-                  </a>
-                </td>
-                <td class="border-secondary text-muted">
-                  {{ object.db_date_created|date:"Y-m-d H:i" }}
-                </td>
-                <td class="border-secondary">
-                  {% if object.db.archived %}
-                    <span class="text-warning">ARCHIVED</span>
-                  {% else %}
-                    <span class="text-success">ACTIVE</span>
-                  {% endif %}
-                </td>
-                <td class="border-secondary">
-                  {% if not object.db.archived %}
-                    <a href="{{ object.web_get_delete_url }}" class="text-warning archive-link" style="font-size: 0.85rem; text-decoration: none;">
-                      [ARCHIVE]
-                    </a>
-                  {% endif %}
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-        
-        <div class="mt-3 text-muted" style="font-size: 0.85rem;">
-          {{ object_list|length }} sleeve(s) on record
-        </div>
-        {% else %}
-        <div class="alert alert-dark border-secondary">
-          <p class="mb-0">NO SLEEVES ON RECORD</p>
-          <p class="mb-0 mt-2">
-            <a href="{% url 'character-create' %}" class="text-warning">[INITIATE DECANTING PROCESS]</a>
-          </p>
-        </div>
-        {% endif %}
-
-        {% if memorial %}
-        <hr class="border-secondary mt-4" />
-        <h2 class="text-uppercase text-muted memorial-heading" style="letter-spacing: 0.1em; font-size: 1rem;">Memorial Wall</h2>
-        <div class="table-responsive">
-          <table class="table table-dark table-sm memorial-wall">
-            <thead class="border-secondary">
-              <tr class="text-uppercase" style="font-size: 0.85rem; letter-spacing: 0.05em;">
-                <th class="border-secondary" style="width: 40%;">Designation</th>
-                <th class="border-secondary" style="width: 30%;">Born</th>
-                <th class="border-secondary" style="width: 30%;">Died</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for stone in memorial %}
-              <tr class="border-secondary" style="font-size: 0.85rem;">
-                <td class="border-secondary text-white" style="width: 40%;">{{ stone.name }}</td>
-                <td class="border-secondary text-muted" style="width: 30%;">
-                  {% if stone.born %}{{ stone.born|date:"Y-m-d" }}{% else %}&mdash;{% endif %}
-                </td>
-                <td class="border-secondary text-muted" style="width: 30%;">
-                  {% if stone.died %}{{ stone.died|date:"Y-m-d" }}{% else %}&mdash;{% endif %}
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-        <div class="text-muted" style="font-size: 0.75rem;">
-          {{ memorial|length }} sleeve(s) remembered
-        </div>
-        {% endif %}
-
-      </div>
-    </div>
+<header class="plate-head">
+  <h1>Sleeve Inventory</h1>
+  <div class="plate-place">
+    {{ account }} <span>·</span> Sleeve Registry
   </div>
+  <div class="plate-stamp">
+    {{ object_list|length }} on record{% if memorial %} &nbsp;·&nbsp; {{ memorial|length }} remembered{% endif %}
+  </div>
+</header>
+
+<p class="plate-lore">
+  Every body you have worn, on file. The registry does not care which one
+  you are using — only that the pattern persisted long enough to be
+  recorded. Archive a sleeve and it stops being yours; it does not stop
+  having been you.
+</p>
+
+<div class="plate-stage">
+
+  {% if object_list %}
+  <div class="table-responsive">
+    <table class="table table-dark table-sm">
+      <thead>
+        <tr>
+          <th style="width: 40%;">Designation</th>
+          <th style="width: 30%;">Decanted</th>
+          <th style="width: 20%;">Status</th>
+          <th style="width: 10%;"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for object in object_list %}
+        <tr>
+          <td>
+            <a href="{{ object.web_get_detail_url }}" class="sleeve-name-link">
+              {{ object }}
+            </a>
+          </td>
+          <td class="text-muted">
+            {{ object.db_date_created|date:"Y-m-d H:i" }}
+          </td>
+          <td>
+            {% if object.db.archived %}
+              <span class="text-warning">Archived</span>
+            {% else %}
+              <span class="text-success">Active</span>
+            {% endif %}
+          </td>
+          <td>
+            {% if not object.db.archived %}
+              <a href="{{ object.web_get_delete_url }}" class="archive-link">Archive</a>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <div class="plate-empty">
+    <p>No sleeves on record.</p>
+    <p><a href="{% url 'character-create' %}">Initiate decanting</a></p>
+  </div>
+  {% endif %}
+
+  {% if memorial %}
+  <h2>Memorial Wall</h2>
+  <div class="table-responsive">
+    <table class="table table-dark table-sm memorial-wall">
+      <thead>
+        <tr>
+          <th style="width: 40%;">Designation</th>
+          <th style="width: 30%;">Born</th>
+          <th style="width: 30%;">Died</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for stone in memorial %}
+        <tr>
+          <td>{{ stone.name }}</td>
+          <td>{% if stone.born %}{{ stone.born|date:"Y-m-d" }}{% else %}&mdash;{% endif %}</td>
+          <td>{% if stone.died %}{{ stone.died|date:"Y-m-d" }}{% else %}&mdash;{% endif %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+
 </div>
 {% endblock %}


### PR DESCRIPTION
Closes #1423

Promotes the Atlas's masthead/stage pattern into house classes and
rebuilds the sleeve registry on it: centred masthead, in-fiction
caption at the shared measure, tables in a raised stage with rules
instead of boxed cells and status in the machine voice.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
