### PR TITLE
Amber for sleeve chrome, and spaces around the Recently Connected dash

### DIFF
--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -1519,12 +1519,27 @@ h1 { font-size: var(--size-h1); }
     color: var(--terminal-text-muted);
 }
 
-/* status reads as state, not decoration: jade for living, amber-warn
-   for archived — and both in the machine voice at label scale */
+/* status reads as state, not decoration — in the machine voice at label
+   scale, whichever colour it carries */
+.plate-stage .text-accent,
 .plate-stage .text-success,
 .plate-stage .text-warning {
     font-family: var(--font-data);
     font-size: 10.5px;
     letter-spacing: 0.14em;
     text-transform: uppercase;
+}
+
+/* ── accent utilities ────────────────────────────────────────────────
+   Bootstrap's .text-success / .border-success carry MEANING here: jade
+   is reserved for state. The sleeve pages had been using them as plain
+   chrome — plate borders, rules, a report heading — which is what put
+   green on pages that have nothing to report. These give that chrome the
+   house accent and leave the semantic classes to mean what they say. */
+.text-accent {
+    color: var(--terminal-accent) !important;
+}
+
+.border-accent {
+    border-color: var(--terminal-accent) !important;
 }

--- a/web/templates/website/character_detail.html
+++ b/web/templates/website/character_detail.html
@@ -21,11 +21,11 @@ Sleeve Details
           <!-- Stats Column (right) -->
           <div class="col-md-8">
             <!-- Psychophysical Evaluation Report -->
-            <div class="card bg-dark text-success border-success mb-3" style="font-size: 0.9rem;">
-              <div class="card-header bg-dark text-success border-success">
+            <div class="card bg-dark text-accent border-accent mb-3" style="font-size: 0.9rem;">
+              <div class="card-header bg-dark text-accent border-accent">
                 <strong>PSYCHOPHYSICAL EVALUATION REPORT</strong>
               </div>
-              <div class="card-body bg-dark text-success" style="padding: 1rem;">
+              <div class="card-body bg-dark text-accent" style="padding: 1rem;">
                 <div class="mb-2">
                   <strong>Subject:</strong> <span class="text-white">{{ object.db_key }}</span>
                 </div>
@@ -33,7 +33,7 @@ Sleeve Details
                   <strong>File Reference:</strong> <span class="text-white">GEL-MST/PR-{{ object.id }}</span>
                 </div>
                 
-                <hr class="border-success" />
+                <hr class="border-accent" />
                 
                 <div class="mt-3" style="display: table; width: 100%;">
                   <div style="display: table-row;">
@@ -70,7 +70,7 @@ Sleeve Details
                   </div>
                 </div>
                 
-                <hr class="border-success" />
+                <hr class="border-accent" />
                 
                 <div class="mt-3">
                   <strong>Notes:</strong>
@@ -88,7 +88,7 @@ Sleeve Details
                   {% if object.db.archived %}
                     <span class="text-warning">Archived</span>
                   {% else %}
-                    <span class="text-success">Active</span>
+                    <span class="text-accent">Active</span>
                   {% endif %}
                 </p>
                 <p class="mb-2"><strong>Decanted on:</strong> {{ object.db_date_created }}</p>

--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -64,7 +64,7 @@ Manage Sleeves
             {% if object.db.archived %}
               <span class="text-warning">Archived</span>
             {% else %}
-              <span class="text-success">Active</span>
+              <span class="text-accent">Active</span>
             {% endif %}
           </td>
           <td>

--- a/web/templates/website/homepage/recently-connected-widget.html
+++ b/web/templates/website/homepage/recently-connected-widget.html
@@ -1,0 +1,19 @@
+{% comment %}
+Overrides Evennia's stock widget for one reason: upstream runs the name
+straight into the timestamp — `Drivel&mdash;50 minutes ago`. At Monaspace's
+tracking that reads as a single hyphenated word. Spaces around the dash.
+
+Kept structurally identical to upstream otherwise, so the card matches its
+neighbours (accounts / database stats) and picks up the same house styling.
+{% endcomment %}
+<div class="card">
+    <h4 class="card-header text-center">Recently Connected</h4>
+
+    <div class="card-body px-0 py-0">
+        <ul class="list-group">
+            {% for account in accounts_connected_recent %}
+            <li class="list-group-item">{{ account.username }} &mdash; <em>{{ account.last_login|timesince }} ago</em></li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>


### PR DESCRIPTION
Closes #1432

Jade is reserved for state, so the evaluation-report plate stops
borrowing .text-success for its border and rules. Adds .text-accent /
.border-accent for chrome that just wants the house accent.

The Recently Connected widget is overridden locally rather than patched
upstream, purely to put spaces around the em dash.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
