### PR TITLE
The homepage gets one column, a headline, and somewhere to go

### DIFF
--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -1543,3 +1543,194 @@ h1 { font-size: var(--size-h1); }
 .border-accent {
     border-color: var(--terminal-accent) !important;
 }
+
+/* ====================================================================
+   THE SHARED COLUMN  (2026-07-30)
+   --------------------------------------------------------------------
+   The homepage used to run two measures on one axis: a centred ~85ch
+   text column inside a shell up to 2100px wide, with the widget row
+   filling that shell. Both were centred, neither shared an edge, and
+   the result read as floating rather than composed.
+
+   Everything now resolves to ONE column. `.container` is that column,
+   so Evennia's navbar (which uses it in base.html — never forked) and
+   page content share their left and right edges for free. Prose is
+   limited by MEASURE instead of by centring, so it keeps a readable
+   line length while still starting on the shared left edge.
+
+   Change --page-col to retune every surface at once.
+   ==================================================================== */
+:root {
+    --page-col: min(92vw, 1140px);
+    --measure: 72ch;
+
+    --s1: 8px;  --s2: 16px; --s3: 24px;
+    --s4: 40px; --s5: 64px; --s6: 96px;
+}
+
+.container, .container-sm, .container-md, .container-lg, .container-xl {
+    max-width: var(--page-col);
+}
+
+/* The Atlas is a map — it wants width, not measure. It breaks out of the
+   column back to the old shell size. Negative margin rather than a
+   transform, which would blur the plate's hairlines. */
+.atlas-plate {
+    width: min(96vw, 2100px);
+    margin-left: calc((100% - min(96vw, 2100px)) / 2);
+}
+
+/* --------------------------------------------------------------------
+   Homepage
+   -------------------------------------------------------------------- */
+.eyebrow {
+    font-family: var(--font-data);
+    font-size: 10.5px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--terminal-text-muted);
+}
+.eyebrow.accent { color: var(--terminal-accent); }
+
+.hero { padding-block: var(--s6) var(--s5); }
+
+/* Sentence case, and big — this is the thesis, not chrome. Overrides the
+   global uppercase heading rule deliberately. */
+.hero h1 {
+    font-family: var(--font-display);
+    font-size: clamp(30px, 4.6vw, 54px);
+    font-weight: 500;
+    line-height: 1.1;
+    letter-spacing: -0.015em;
+    text-transform: none;
+    text-wrap: balance;
+    max-width: 22ch;
+    color: var(--terminal-text);
+    margin: var(--s3) 0;
+}
+
+.hero .deck {
+    max-width: var(--measure);
+    font-size: 17px;
+    line-height: 1.7;
+    color: var(--terminal-text);
+}
+
+.actions {
+    display: flex;
+    align-items: center;
+    gap: var(--s3);
+    margin-top: var(--s4);
+    flex-wrap: wrap;
+}
+
+/* One primary action. Everything beside it is visibly quieter. */
+.btn-play {
+    display: inline-block;
+    padding: 11px 26px;
+    font-family: var(--font-data);
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    background: var(--terminal-accent);
+    border: 1px solid var(--terminal-accent);
+    color: var(--terminal-bg-dark);
+    transition: background .18s ease, border-color .18s ease;
+}
+.btn-play:hover,
+.btn-play:focus {
+    background: var(--terminal-text);
+    border-color: var(--terminal-text);
+    color: var(--terminal-bg-dark);
+    text-decoration: none;
+}
+
+.btn-quiet {
+    font-family: var(--font-data);
+    font-size: 11px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--terminal-text-muted);
+    border-bottom: 1px solid var(--terminal-border);
+    padding-bottom: 2px;
+}
+.btn-quiet:hover,
+.btn-quiet:focus {
+    color: var(--terminal-accent);
+    border-color: var(--terminal-accent-dim);
+    text-decoration: none;
+}
+
+.lore {
+    border-top: 1px solid var(--terminal-border);
+    padding-block: var(--s5);
+}
+.lore p {
+    max-width: var(--measure);
+    color: var(--terminal-text-muted);
+}
+.lore p + p { margin-top: var(--s3); }
+.lore strong { color: var(--terminal-text); font-weight: 500; }
+
+/* Owns the pre-alpha state rather than hedging it as a small link. */
+.status-note {
+    border-left: 2px solid var(--terminal-accent-dim);
+    padding: var(--s2) 0 var(--s2) var(--s3);
+    max-width: var(--measure);
+    margin-bottom: var(--s5);
+}
+.status-note p {
+    color: var(--terminal-text-muted);
+    font-size: 14.5px;
+    margin-bottom: 0;
+}
+.status-note .eyebrow { display: block; margin-bottom: var(--s1); }
+
+/* The figures: one quiet band instead of three cards competing with the
+   pitch. Only "connected now" is jade, because it is the only STATE. */
+.status-band {
+    border-top: 1px solid var(--terminal-border);
+    border-bottom: 1px solid var(--terminal-border);
+    padding-block: var(--s3);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: var(--s3) var(--s4);
+}
+.status-band .figure .n {
+    font-family: var(--font-data);
+    font-size: 21px;
+    font-variant-numeric: tabular-nums;
+    color: var(--terminal-text);
+    line-height: 1.2;
+}
+.status-band .figure .n .live { color: var(--terminal-success); }
+.status-band .figure .l {
+    font-family: var(--font-data);
+    font-size: 10px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--terminal-text-muted);
+    margin-top: 2px;
+}
+
+.recent {
+    padding-block: var(--s3) var(--s6);
+    font-size: 13px;
+    color: var(--terminal-text-muted);
+}
+.recent .eyebrow { display: block; margin-bottom: var(--s2); }
+.recent ul {
+    list-style: none;
+    padding-left: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--s1) var(--s4);
+    margin-bottom: 0;
+}
+.recent .who { color: var(--terminal-text); }
+.recent .when { font-style: italic; }
+
+@media (max-width: 600px) {
+    .hero { padding-block: var(--s5) var(--s4); }
+    .actions { gap: var(--s2); }
+}

--- a/web/templates/website/homepage/main-content.html
+++ b/web/templates/website/homepage/main-content.html
@@ -1,24 +1,59 @@
-<p>
-    Welcome to Gelatinous Monster, an <a href="https://github.com/daiimus/gelatinous" target="_blank">in-development</a> 
-    online text-based multiplayer game set in an offworld colony where death is more inconvenience than ending. 
-    You're a freelancer. Digitally immortal, physically disposable. Operating on the fringe and traversing in-between disposable "sleeves" 
-    (bodies, for the uninitiated). You chase contracts, financial security, and whatever else passes for meaning 
-    in a place where resurrection is just another service industry.
-</p>
+{% comment %}
+The homepage pitch. Structure carries the hierarchy: thesis, deck, action,
+lore, honest statement of state.
 
-<hr/>
+"Digitally immortal, physically disposable" used to be the third sentence of
+a paragraph. It is the strongest line on the page and the clearest statement
+of what the game is, so it leads.
+{% endcomment %}
 
-<p class="lore-voice">
-    You are the gelatinous monster. Not the sleeve - that's just meat and water, a seventy-percent solution 
-    of saline and bad decisions wrapped in skin. The real horror is you: the ghost in the machine, 
-    the pattern that persists, the signal refusing to degrade. You pour yourself into these bodies like 
-    consciousness is just another bodily fluid, and when they fail - you simply 
-    find another vessel. Another sleeve. Another temporary arrangement of atoms pretending coherence.
-</p>
+<section class="hero">
+  <p class="eyebrow accent">Domino&rsquo;s Gambit &middot; Off-world colony</p>
 
-<p class="lore-voice">
-    The colony doesn't care what you are. It barely cares that you are. Out here past the edge of 
-    polite civilization, identity is as fluid as the water that comprises most of your stolen biology. 
-    Take contracts. Make enemies. Die spectacularly. The sleeve can be replaced. The question is: 
-    can you?
-</p>
+  <h1>Digitally immortal, physically disposable.</h1>
+
+  <p class="deck">
+    A text-based multiplayer game set in an off-world colony where death is
+    more inconvenience than ending. You&rsquo;re a freelancer. You chase
+    contracts, financial security, and whatever else passes for meaning in a
+    place where resurrection is just another service industry.
+  </p>
+
+  <div class="actions">
+    <a class="btn-play" href="/webclient/">Play online</a>
+    <a class="btn-quiet" href="{% url 'character-create' %}">Make a sleeve</a>
+    <a class="btn-quiet" href="{% url 'atlas' %}">Read the atlas</a>
+  </div>
+</section>
+
+<section class="lore">
+  <p>
+    You are the gelatinous monster. Not the sleeve &mdash; that&rsquo;s just meat and
+    water, a seventy-percent solution of saline and bad decisions wrapped in
+    skin. <strong>The real horror is you:</strong> the ghost in the machine, the
+    pattern that persists, the signal refusing to degrade. You pour yourself
+    into these bodies like consciousness is just another bodily fluid, and when
+    they fail &mdash; you simply find another vessel. Another sleeve. Another
+    temporary arrangement of atoms pretending coherence.
+  </p>
+  <p>
+    The colony doesn&rsquo;t care what you are. It barely cares that you are. Out
+    here past the edge of polite civilization, identity is as fluid as the water
+    that comprises most of your stolen biology. Take contracts. Make enemies.
+    Die spectacularly. The sleeve can be replaced.
+    <strong>The question is: can you?</strong>
+  </p>
+</section>
+
+<div class="status-note">
+  <span class="eyebrow accent">Pre-alpha</span>
+  <p>
+    This is in development and it is not finished. Things break, systems change
+    without warning, and sleeves occasionally die for reasons that aren&rsquo;t your
+    fault. If you want a polished game, come back later. If you want to watch one
+    get built &mdash; and say what it should become &mdash;
+    <a href="https://forum.gel.monster/" target="_blank" rel="noopener">the forum is here</a>
+    and
+    <a href="https://github.com/daiimus/gelatinous" target="_blank" rel="noopener">the source is public</a>.
+  </p>
+</div>

--- a/web/templates/website/homepage/recently-connected-widget.html
+++ b/web/templates/website/homepage/recently-connected-widget.html
@@ -1,19 +1,23 @@
 {% comment %}
-Overrides Evennia's stock widget for one reason: upstream runs the name
-straight into the timestamp — `Drivel&mdash;50 minutes ago`. At Monaspace's
-tracking that reads as a single hyphenated word. Spaces around the dash.
+Overrides Evennia's stock widget twice over:
 
-Kept structurally identical to upstream otherwise, so the card matches its
-neighbours (accounts / database stats) and picks up the same house styling.
+1. Upstream runs the name into the timestamp — `Drivel&mdash;50 minutes ago`.
+   At Monaspace's tracking that reads as one hyphenated word, so the dash gets
+   spaces around it.
+2. It is no longer a card. It sits under the figures band as a quiet inline
+   list, because who logged in recently is context for regulars, not a headline
+   for a first-time reader.
 {% endcomment %}
-<div class="card">
-    <h4 class="card-header text-center">Recently Connected</h4>
-
-    <div class="card-body px-0 py-0">
-        <ul class="list-group">
-            {% for account in accounts_connected_recent %}
-            <li class="list-group-item">{{ account.username }} &mdash; <em>{{ account.last_login|timesince }} ago</em></li>
-            {% endfor %}
-        </ul>
-    </div>
-</div>
+<section class="recent">
+  <span class="eyebrow">Recently connected</span>
+  <ul>
+    {% for account in accounts_connected_recent %}
+    <li>
+      <span class="who">{{ account.username }}</span> &mdash;
+      <span class="when">{{ account.last_login|timesince }} ago</span>
+    </li>
+    {% empty %}
+    <li class="when">Nobody yet.</li>
+    {% endfor %}
+  </ul>
+</section>

--- a/web/templates/website/index.html
+++ b/web/templates/website/index.html
@@ -1,0 +1,58 @@
+{% extends "website/base.html" %}
+
+{% comment %}
+Overrides Evennia's homepage layout.
+
+Upstream stacks a centred card for the pitch and then three equal-weight
+widget cards. That gave the page three different alignments — a narrow
+centred text column inside a much wider shell, with full-width cards below
+— so nothing shared an edge and the page read as floating.
+
+This version puts everything on the single `.container` column: masthead,
+hero, lore, status, figures, footer. The prose is limited by MEASURE
+(max-width in ch) rather than by centring, so it keeps its readable line
+length while still starting on the shared left edge.
+
+The three widget cards are replaced by one quiet band of figures. They are
+for us and the regulars, not for a first-time reader, so they no longer
+compete with the pitch. `num_others` ("1116 other objects") is deliberately
+dropped — it is a builder's metric and means nothing to a visitor.
+{% endcomment %}
+
+{% block titleblock %}Home{% endblock %}
+
+{% block header_ext %}
+{% endblock %}
+
+{% block content %}
+
+{% include "website/homepage/main-content.html" %}
+
+<div class="status-band">
+  <div class="figure">
+    <div class="n">{% if num_accounts_connected %}<span class="live">{{ num_accounts_connected }}</span>{% else %}0{% endif %}</div>
+    <div class="l">Connected now</div>
+  </div>
+  <div class="figure">
+    <div class="n">{{ num_accounts_registered }}</div>
+    <div class="l">Accounts</div>
+  </div>
+  <div class="figure">
+    <div class="n">{{ num_characters }}</div>
+    <div class="l">Sleeves</div>
+  </div>
+  <div class="figure">
+    <div class="n">{{ num_rooms }}</div>
+    <div class="l">Rooms</div>
+  </div>
+  <div class="figure">
+    <div class="n">{{ num_accounts_connected_recent }}</div>
+    <div class="l">Active this week</div>
+  </div>
+</div>
+
+{% include "website/homepage/recently-connected-widget.html" %}
+
+{% include "website/homepage/evennia-widget.html" %}
+
+{% endblock %}


### PR DESCRIPTION
Closes #1440

The page ran two measures on one axis — centred prose inside a much
wider centred shell — so nothing shared an edge. .container is now the
single column, which aligns Evennia's navbar to the content without
forking base.html, and prose is bounded by measure instead of centring.

The thesis line is promoted out of paragraph three into a headline, one
primary action replaces none at all, pre-alpha is stated rather than
hedged, and the three stat cards become a quiet band of figures.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
