### PR TITLE
A brand mark the theme draws itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ web/static/website/css/*
 !web/static/website/css/custom.css
 !web/static/website/fonts/
 !web/static/website/fonts/**
+!web/static/website/images/
+!web/static/website/images/**
 world/__pycache__/
 typeclasses/__pycache__/
 commands/__pycache__/

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -1734,3 +1734,42 @@ h1 { font-size: var(--size-h1); }
     .hero { padding-block: var(--s5) var(--s4); }
     .actions { gap: var(--s2); }
 }
+
+/* ====================================================================
+   BRAND MARK — the GM orbit  (2026-07-30)
+   --------------------------------------------------------------------
+   Inlined in _menu.html / _menu_iframe.html rather than loaded as an
+   image, so it carries NO colour of its own: every stroke and fill
+   reads a theme token. Change --terminal-accent and the mark follows.
+   Inlining also means no extra request and no fork of base.html.
+
+   The monogram is set in the display face, so the mark is built from
+   the same type system as the headings.
+   ==================================================================== */
+.brand-mark {
+    flex-shrink: 0;
+    margin: 0 14px;
+    overflow: visible;
+}
+.brand-mark .ring  { stroke: var(--terminal-accent); }
+.brand-mark .node  { fill: var(--terminal-accent); }
+.brand-mark .knock { fill: var(--terminal-bg-dark); }
+.brand-mark .mono {
+    fill: var(--terminal-text);
+    font-family: var(--font-display);
+    text-anchor: middle;
+    dominant-baseline: central;
+    letter-spacing: 1px;
+}
+
+/* the mark answers when the wordmark is hovered — one gesture, not two */
+.navbar-brand:hover .brand-mark .ring,
+.navbar-brand:focus .brand-mark .ring { stroke: var(--terminal-text); }
+.navbar-brand:hover .brand-mark .node,
+.navbar-brand:focus .brand-mark .node { fill: var(--terminal-text); }
+.brand-mark .ring,
+.brand-mark .node { transition: stroke .18s ease, fill .18s ease; }
+
+@media (prefers-reduced-motion: reduce) {
+    .brand-mark .ring, .brand-mark .node { transition: none; }
+}

--- a/web/static/website/images/gm-orbit.svg
+++ b/web/static/website/images/gm-orbit.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="512" height="512"
+     role="img" aria-label="Gelatinous Monster">
+  <title>Gelatinous Monster</title>
+  <!--
+    The GM orbit mark. Colours read CSS custom properties with literal
+    fallbacks, so this file works standalone (favicon, forum, social) AND
+    inherits the site theme when inlined into a page.
+  -->
+  <rect width="100" height="100" fill="var(--terminal-bg-dark, #0b0e14)"/>
+  <g fill="none" stroke="var(--terminal-accent, #e0a86f)" stroke-width="0.9">
+    <circle cx="50" cy="50" r="46"/>
+    <ellipse cx="50" cy="50" rx="46" ry="15" transform="rotate(-20 50 50)" stroke-opacity="0.5"/>
+    <circle cx="50" cy="50" r="30" stroke-dasharray="1.2 2.6" stroke-opacity="0.75"/>
+    <path d="M50 2 L50 26" stroke-opacity="0.4"/>
+    <path d="M50 74 L50 98" stroke-opacity="0.4"/>
+  </g>
+  <g fill="var(--terminal-accent, #e0a86f)">
+    <circle cx="50" cy="2.5" r="2.4"/>
+    <circle cx="88.5" cy="37" r="3.2"/>
+  </g>
+  <circle cx="50" cy="50" r="16.5" fill="var(--terminal-bg-dark, #0b0e14)"/>
+  <text x="50" y="51" font-size="21" letter-spacing="2" font-weight="500"
+        text-anchor="middle" dominant-baseline="central"
+        font-family="'Monaspace Xenon', ui-monospace, 'SF Mono', Menlo, monospace"
+        fill="var(--terminal-text, #d8d3c4)">GM</text>
+</svg>

--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -12,8 +12,16 @@ folder and edit it to add/remove links to the menu.
 
   <a class="navbar-brand" href="/">
     <div class="media">
-      <img class="d-flex navbar-brand-logo mx-3" src="{% static "website/images/evennia_logo.png" %}"
-        alt="{{game_name}} logo" />
+      <svg class="brand-mark" width="44" height="44" viewBox="0 0 100 100"
+           aria-hidden="true" focusable="false">
+        <g class="ring" fill="none" stroke-width="2.2">
+          <circle cx="50" cy="50" r="43"/>
+          <ellipse cx="50" cy="50" rx="43" ry="15" transform="rotate(-20 50 50)" stroke-opacity="0.55"/>
+        </g>
+        <circle class="node" cx="86" cy="35" r="5"/>
+        <circle class="knock" cx="50" cy="50" r="25"/>
+        <text class="mono" x="50" y="52" font-size="34" font-weight="600" letter-spacing="1">GM</text>
+      </svg>
       <div class="media-body">
         {{ game_name }}<br />
         <small>{{game_slogan}}</small>

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -11,8 +11,16 @@ Removes the Forum link to prevent navigation loops and double headers.
 
   <a class="navbar-brand" href="/" target="_top">
     <div class="media">
-      <img class="d-flex navbar-brand-logo mx-3" src="{% static "website/images/evennia_logo.png" %}"
-        alt="{{game_name}} logo" />
+      <svg class="brand-mark" width="44" height="44" viewBox="0 0 100 100"
+           aria-hidden="true" focusable="false">
+        <g class="ring" fill="none" stroke-width="2.2">
+          <circle cx="50" cy="50" r="43"/>
+          <ellipse cx="50" cy="50" rx="43" ry="15" transform="rotate(-20 50 50)" stroke-opacity="0.55"/>
+        </g>
+        <circle class="node" cx="86" cy="35" r="5"/>
+        <circle class="knock" cx="50" cy="50" r="25"/>
+        <text class="mono" x="50" y="52" font-size="34" font-weight="600" letter-spacing="1">GM</text>
+      </svg>
       <div class="media-body">
         {{ game_name }}<br />
         <small>{{game_slogan}}</small>


### PR DESCRIPTION
Closes #1446

An orbital diagram with a GM monogram, replacing Evennia's stock raster
logo. Inlined in the two menu templates so every stroke reads a theme
token — change --terminal-accent and the mark follows — and so it costs
no request and no base.html fork.

Compact cut for the navbar because the detailed one dies below 60px;
the full mark ships as a standalone SVG for favicon and forum use.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
