### PR TITLE
The memorial becomes a column, not a second table

### DIFF
--- a/specs/STYLING_SPEC.md
+++ b/specs/STYLING_SPEC.md
@@ -179,7 +179,7 @@ Type is assigned **by role**, not globally:
 | reading | Argon | longer reading passages |
 | display | Xenon | headings, plate heads |
 | data | Neon | figures, labels, status chips |
-| hand | Radon | the memorial wall — the one handwritten note |
+| hand | Radon | reserved for human marks; its one user (the memorial wall) was folded into the sleeve listing |
 
 Because these are variable fonts, `@font-face` declares the axes
 (`font-weight: 200 800`, `font-stretch: 100% 125%`, `font-style: oblique 0deg

--- a/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
+++ b/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
@@ -258,6 +258,18 @@ in-game question with an in-game (and gameable) answer. The corpse does **not**
 depend on the DeathRecord; they meet only at `corpse_ref`, which is allowed to go
 null.
 
+> **IMPLEMENTATION NOTE (2026-07-30):** the memorial is **one surface**, not
+> two. It was briefly built as a separate "Memorial Wall" table beneath the
+> sleeve listing, which duplicated it exactly — every death record pointed at a
+> sleeve still listed above it (32/32, 5/5, 1/1 across the accounts holding
+> records), so the page printed the same sleeves twice. The only fact the wall
+> carried that the listing lacked was the **date of death**, which is now a
+> `Died` column on the sleeve row. This matches the table above ("DeathRecord
+> + archived sleeve") and the "keep it minimal" instruction below.
+>
+> Note **archived does not imply dead** — a living sleeve can be shelved from
+> the web — so the column is legitimately empty for some archived rows.
+
 > **On the OOC exception:** the game's flow is relentlessly in-character —
 > perceived identities, obscured sources, IC records. The sleeve memorial is a
 > **rare sanctioned break** from that: an out-of-character tribute to the person

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -16,7 +16,9 @@
                                 long-form reading; unused faces are not
                                 downloaded, so it costs nothing to keep
      Xenon    slab serif     -> headings and brand, brutalist weight
-     Radon    handwriting    -> human marks (the memorial wall)
+     Radon    handwriting    -> human marks (reserved; the memorial wall
+                                     that used it was folded into the
+                                     sleeve listing, see #1452)
 
    Krypton (mechanical, Eurostile/DIN lineage) was tried for data and
    dropped: its flat squarish terminals read almost blackletter in
@@ -1214,14 +1216,6 @@ body {
     letter-spacing: normal;
 }
 
-/* The memorial wall is the one place a person wrote something down, so
-   it gets the handwriting cut. Radon is a mono, so the columns still
-   line up — it just stops sounding like a machine. */
-.memorial-heading,
-.memorial-wall, .memorial-wall td, .memorial-wall .sleeve-epitaph {
-    font-family: var(--font-hand);
-    letter-spacing: 0;
-}
 
 /* ================================================================
    MONASPACE CAPABILITIES
@@ -1285,12 +1279,6 @@ h1, h2, h3, h4, h5, h6, .card-title { font-weight: 600; }
 label, .col-form-label, thead th, .btn { letter-spacing: 0.12em; }
 h1, h2, h3 { letter-spacing: 0.08em; }
 
-/* the dead are lighter than the living: archived sleeves recede on the
-   weight axis, so the memorial wall reads as fading rather than merely
-   grey */
-.memorial-wall td, .memorial-wall th {
-    font-weight: 250;
-}
 
 /* 4. WIDTH AXIS on the brand — 118 of 125 gives the lockup a little
       monumentality without a second typeface. */

--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -21,11 +21,8 @@ Manage Sleeves
 
 <header class="plate-head">
   <h1>Sleeve Inventory</h1>
-  <div class="plate-place">
-    {{ account }} <span>·</span> Sleeve Registry
-  </div>
   <div class="plate-stamp">
-    {{ object_list|length }} on record{% if memorial %} &nbsp;·&nbsp; {{ memorial|length }} remembered{% endif %}
+    {{ object_list|length }} on record
   </div>
 </header>
 
@@ -43,9 +40,10 @@ Manage Sleeves
     <table class="table table-dark table-sm">
       <thead>
         <tr>
-          <th style="width: 40%;">Designation</th>
-          <th style="width: 30%;">Decanted</th>
-          <th style="width: 20%;">Status</th>
+          <th style="width: 32%;">Designation</th>
+          <th style="width: 22%;">Decanted</th>
+          <th style="width: 22%;">Died</th>
+          <th style="width: 14%;">Status</th>
           <th style="width: 10%;"></th>
         </tr>
       </thead>
@@ -59,6 +57,9 @@ Manage Sleeves
           </td>
           <td class="text-muted">
             {{ object.db_date_created|date:"Y-m-d H:i" }}
+          </td>
+          <td class="text-muted">
+            {% if object.died_on %}{{ object.died_on|date:"Y-m-d H:i" }}{% else %}&mdash;{% endif %}
           </td>
           <td>
             {% if object.db.archived %}
@@ -84,29 +85,6 @@ Manage Sleeves
   </div>
   {% endif %}
 
-  {% if memorial %}
-  <h2>Memorial Wall</h2>
-  <div class="table-responsive">
-    <table class="table table-dark table-sm memorial-wall">
-      <thead>
-        <tr>
-          <th style="width: 40%;">Designation</th>
-          <th style="width: 30%;">Born</th>
-          <th style="width: 30%;">Died</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for stone in memorial %}
-        <tr>
-          <td>{{ stone.name }}</td>
-          <td>{% if stone.born %}{{ stone.born|date:"Y-m-d" }}{% else %}&mdash;{% endif %}</td>
-          <td>{% if stone.died %}{{ stone.died|date:"Y-m-d" }}{% else %}&mdash;{% endif %}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  {% endif %}
 
 </div>
 {% endblock %}

--- a/web/website/views/characters.py
+++ b/web/website/views/characters.py
@@ -362,36 +362,47 @@ class CharacterCreateView(EvenniaCharacterCreateView):
 
 class CharacterManageView(EvenniaCharacterManageView):
     """
-    Manage Sleeves + the memorial wall (DEATH_AND_SLEEVE_LIFECYCLE_SPEC §9
-    step 2).
+    Manage Sleeves (DEATH_AND_SLEEVE_LIFECYCLE_SPEC §9 step 2).
 
-    Adds the account's tombstones to the page context: who the sleeve was,
-    born, died — nothing else. This is the game's one sanctioned OOC surface
-    (a tribute to the player); cause and location never appear here, and the
-    internal dbref/corpse keys are deliberately stripped before rendering.
+    The tombstone date is folded INTO the sleeve listing rather than rendered
+    as a second table beneath it. The spec describes this surface as reading
+    "DeathRecord (tombstone: name, born, died) + archived sleeve" — one
+    surface, two sources — and asks that it stay minimal so it remains a
+    tribute rather than an information side-channel.
+
+    A separate memorial wall duplicated the listing exactly: every death
+    record pointed at a sleeve still present above it (32/32, 5/5 and 1/1
+    across the accounts holding records), so the page printed the same
+    sleeves twice. The only fact the wall carried that the listing did not
+    was the date of death, which is now a column.
+
+    Cause and location never appear here, and the internal corpse/sleeve
+    dbrefs are never rendered.
     """
 
     def get_context_data(self, **kwargs):
         from datetime import datetime
         context = super().get_context_data(**kwargs)
-        memorial = []
-        records = self.request.user.db.death_records or []
-        for rec in records:
+
+        # dbref -> date of death. Keyed by dbref rather than name so a
+        # renamed sleeve still matches its own tombstone.
+        died_by_dbref = {}
+        for rec in (self.request.user.db.death_records or []):
             try:
-                if not rec.get("name") and not rec.get("died"):
-                    continue  # a record with neither name nor date is noise
-                born = rec.get("born")
                 died = rec.get("died")
-                memorial.append({
-                    "name": rec.get("name") or "an unnamed sleeve",
-                    "born": datetime.fromtimestamp(born) if born else None,
-                    "died": datetime.fromtimestamp(died) if died else None,
-                })
+                ref = rec.get("sleeve_dbref")
+                if not died or not ref:
+                    continue
+                died_by_dbref[str(ref)] = datetime.fromtimestamp(died)
             except (TypeError, ValueError, OSError, OverflowError):
-                continue  # one malformed record never breaks the wall
-        memorial.sort(key=lambda r: (r["died"] is None,
-                                     r["died"] or datetime.min))
-        context["memorial"] = memorial
+                continue  # one malformed record never breaks the page
+
+        # Annotate for rendering only — transient, never persisted.
+        # NB: archived does NOT imply dead — a living sleeve can be shelved —
+        # so this is legitimately None and the template must tolerate it.
+        for sleeve in context.get("object_list") or []:
+            sleeve.died_on = died_by_dbref.get(str(getattr(sleeve, "dbref", "")))
+
         return context
 
 


### PR DESCRIPTION
Closes #1452

Every death record pointed at a sleeve already listed above it, so the
page printed the same sleeves twice. The wall's only unique fact was the
date of death, which is now a Died column joined by sleeve_dbref rather
than by name.

This is what §9 asks for — one surface reading DeathRecord + archived
sleeve, kept minimal so it stays a tribute. Archived still doesn't imply
dead, so the column tolerates a blank.

Also drops the account/registry line and the "remembered" counter.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
