### PR TITLE
Retired, not Died — and columns that size themselves

### DIFF
--- a/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
+++ b/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
@@ -264,7 +264,9 @@ null.
 > sleeve still listed above it (32/32, 5/5, 1/1 across the accounts holding
 > records), so the page printed the same sleeves twice. The only fact the wall
 > carried that the listing lacked was the **date of death**, which is now a
-> `Died` column on the sleeve row. This matches the table above ("DeathRecord
+> `Retired` column on the sleeve row — "retired" because archiving covers both
+> a dead sleeve and a living one shelved from the web, and only the former
+> stamps a date. This matches the table above ("DeathRecord
 > + archived sleeve") and the "keep it minimal" instruction below.
 >
 > Note **archived does not imply dead** — a living sleeve can be shelved from

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -1761,3 +1761,42 @@ h1 { font-size: var(--size-h1); }
 @media (prefers-reduced-motion: reduce) {
     .brand-mark .ring, .brand-mark .node { transition: none; }
 }
+
+/* --------------------------------------------------------------------
+   Sleeve registry columns
+   --------------------------------------------------------------------
+   Percentage widths stretched the fixed-format columns across the full
+   table, so a timestamp's header sat nowhere near the timestamp under
+   it. These columns hold KNOWN formats — a 16-character date, one of two
+   status words, one link — so they shrink to their content and the name
+   column absorbs the slack. `width: 1%` + `nowrap` is the standard way
+   to say "take exactly what you need" in a full-width table.
+   -------------------------------------------------------------------- */
+.plate-stage .table .col-date,
+.plate-stage .table .col-status,
+.plate-stage .table .col-action {
+    width: 1%;
+    white-space: nowrap;
+}
+
+/* Monaspace is monospaced, but state this anyway: these are figures in
+   columns and must stay in register if the face is ever swapped. */
+.plate-stage .table .col-date {
+    font-variant-numeric: tabular-nums;
+}
+
+.plate-stage .table .col-sleeve { width: auto; }
+
+/* Bootstrap ships .sr-only, but it arrives from a CDN. Defined locally so a
+   visually-hidden label never becomes a visible one if that request fails. */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -40,11 +40,11 @@ Manage Sleeves
     <table class="table table-dark table-sm">
       <thead>
         <tr>
-          <th style="width: 32%;">Designation</th>
-          <th style="width: 22%;">Decanted</th>
-          <th style="width: 22%;">Died</th>
-          <th style="width: 14%;">Status</th>
-          <th style="width: 10%;"></th>
+          <th class="col-sleeve">Sleeve</th>
+          <th class="col-date">Decanted</th>
+          <th class="col-date">Retired</th>
+          <th class="col-status">Status</th>
+          <th class="col-action"><span class="sr-only">Actions</span></th>
         </tr>
       </thead>
       <tbody>
@@ -55,20 +55,20 @@ Manage Sleeves
               {{ object }}
             </a>
           </td>
-          <td class="text-muted">
+          <td class="col-date text-muted">
             {{ object.db_date_created|date:"Y-m-d H:i" }}
           </td>
-          <td class="text-muted">
+          <td class="col-date text-muted">
             {% if object.died_on %}{{ object.died_on|date:"Y-m-d H:i" }}{% else %}&mdash;{% endif %}
           </td>
-          <td>
+          <td class="col-status">
             {% if object.db.archived %}
               <span class="text-warning">Archived</span>
             {% else %}
               <span class="text-accent">Active</span>
             {% endif %}
           </td>
-          <td>
+          <td class="col-action">
             {% if not object.db.archived %}
               <a href="{{ object.web_get_delete_url }}" class="archive-link">Archive</a>
             {% endif %}

--- a/web/website/views/characters.py
+++ b/web/website/views/characters.py
@@ -424,7 +424,12 @@ class CharacterManageView(EvenniaCharacterManageView):
     record pointed at a sleeve still present above it (32/32, 5/5 and 1/1
     across the accounts holding records), so the page printed the same
     sleeves twice. The only fact the wall carried that the listing did not
-    was the date of death, which is now a column.
+    was the date of death, which is now the RETIRED column.
+
+    "Retired" rather than "Died" on purpose: archiving covers both a sleeve
+    that died and a living one shelved from the web, and retirement is the
+    word that spans both. Only death currently stamps a date, so a shelved
+    living sleeve shows an em dash.
 
     Cause and location never appear here, and the internal corpse/sleeve
     dbrefs are never rendered.


### PR DESCRIPTION
Closes #1456

"Died" was wrong for half of what archiving covers: a living sleeve can
be shelved. "Retired" spans both.

The fixed-format columns now take exactly the width they need instead of
percentage shares, so each header sits over its own data. Designation
becomes Sleeve — it was the only header on the page wearing a costume
rather than doing a job.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
