### PR TITLE
Designation goes back

### DIFF
--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -40,7 +40,7 @@ Manage Sleeves
     <table class="table table-dark table-sm">
       <thead>
         <tr>
-          <th class="col-sleeve">Sleeve</th>
+          <th class="col-sleeve">Designation</th>
           <th class="col-date">Decanted</th>
           <th class="col-date">Retired</th>
           <th class="col-status">Status</th>


### PR DESCRIPTION
It is the name, and it is a valid column header in a registry — the
argument for replacing it was thin and the owner rejected it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
