### PR TITLE
One Log Out, not two

### DIFF
--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -82,12 +82,6 @@ folder and edit it to add/remove links to the menu.
           </form>
         </div>
       </li>
-      <li>
-        <form method="post" action="{% url 'logout' %}" style="display:inline;">
-          {% csrf_token %}
-          <button type="submit" class="nav-link btn btn-link">Log Out</button>
-        </form>
-      </li>
       {% else %}
       <li>
         <a class="nav-link" href="{% url 'login' %}?next={{ request.path }}">Log In</a>


### PR DESCRIPTION
Closes #1464

The user dropdown already contains Log Out, so the standalone link beside
it was a second control for the same function in the tightest row on the
page. Log In and Register still show for anonymous visitors.

Left the forum iframe menu alone: it has no dropdown, so its Log Out is
the only one there.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
