### PR TITLE
The forum header dropdown works now

### DIFF
--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -56,14 +56,34 @@ Removes the Forum link to prevent navigation loops and double headers.
 
       {% block navbar_user %}
       {% if account %}
-      <li class="nav-item">
-        <span class="nav-link">Logged in as {{ account.username }} <span style="opacity: 0;">▼</span></span>
-      </li>
-      <li>
-        <form method="post" action="{% url 'logout' %}" target="_top" style="display:inline;">
-          {% csrf_token %}
-          <button type="submit" class="nav-link btn btn-link">Log Out</button>
-        </form>
+      {% comment %}
+        A real dropdown, matching the main site. This works inside the iframe
+        only because header_only.html now measures the OPEN menu's bottom edge
+        and asks the Discourse component to grow the iframe to fit — a
+        dropdown is absolutely positioned, so body.scrollHeight never saw it
+        and the menu was silently clipped at 80px.
+
+        Every link needs target="_top": without it, navigation loads the
+        destination INSIDE the 80px header frame.
+      {% endcomment %}
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#"
+           id="user_options_iframe" aria-expanded="false" aria-haspopup="true">
+          Logged in as {{ account.username }} <span class="caret"></span>
+        </a>
+        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="user_options_iframe">
+          {% if not account.at_character_limit %}
+          <a class="dropdown-item" href="{% url 'character-create' %}" target="_top">Decant Sleeve</a>
+          {% endif %}
+          <a class="dropdown-item" href="{% url 'character-manage' %}" target="_top">Manage Sleeves</a>
+          <a class="dropdown-item" href="{% url 'atlas' %}" target="_top">Colony Atlas</a>
+          <div class="dropdown-divider"></div>
+          <a class="dropdown-item" href="{% url 'password_change' %}" target="_top">Change Password</a>
+          <form method="post" action="{% url 'logout' %}" target="_top" style="display:inline;">
+            {% csrf_token %}
+            <button type="submit" class="dropdown-item">Log Out</button>
+          </form>
+        </div>
       </li>
       {% else %}
       <li>

--- a/web/templates/website/header_only.html
+++ b/web/templates/website/header_only.html
@@ -77,20 +77,47 @@ Uses iframe-specific menu that removes Forum link to prevent double headers.
         // Target origin is restricted to the configured Discourse URL
         // to prevent leaking auth state to arbitrary embedding domains.
         const TARGET_ORIGIN = '{{ discourse_url|default:"" }}';
+
+        // Measure what the parent must be tall enough to show.
+        //
+        // body.scrollHeight ALONE IS NOT ENOUGH, and this is why the account
+        // dropdown never worked inside the forum header: a Bootstrap dropdown
+        // is absolutely positioned, so it contributes nothing to scrollHeight.
+        // The observer below fired on open, measured the same 80px, posted
+        // 80px, and the menu stayed clipped by the iframe.
+        //
+        // So: take the lowest edge of any OPEN dropdown as well. The element
+        // has layout even while the iframe visually clips it, which is what
+        // makes this measurable at all.
+        function measuredHeight() {
+            let height = document.body.scrollHeight;
+            document.querySelectorAll('.dropdown-menu.show').forEach(function (menu) {
+                const bottom = Math.ceil(menu.getBoundingClientRect().bottom);
+                height = Math.max(height, bottom + 8);  // 8px breathing room
+            });
+            return height;
+        }
+
         function updateHeight() {
             if (!TARGET_ORIGIN) return;  // Don't post if no origin configured
-            const height = document.body.scrollHeight;
             window.parent.postMessage({
                 type: 'gel-header-height',
-                height: height
+                height: measuredHeight()
             }, TARGET_ORIGIN);
         }
-        
+
         // Send height on load and when window resizes
         window.addEventListener('load', updateHeight);
         window.addEventListener('resize', updateHeight);
-        
-        // Monitor for dynamic content changes (dropdown opens, etc.)
+
+        // Bootstrap fires these once the menu has been positioned, so the
+        // measurement above is taken against final geometry rather than
+        // mid-animation. Collapsing on close returns the header to 80px.
+        $(document).on('shown.bs.dropdown hidden.bs.dropdown', function () {
+            requestAnimationFrame(updateHeight);
+        });
+
+        // Still watch for other dynamic content (login state, flash messages).
         const observer = new MutationObserver(updateHeight);
         observer.observe(document.body, {
             childList: true,


### PR DESCRIPTION
Closes #1466

The resize protocol was complete on both sides all along. It failed
because updateHeight() measured body.scrollHeight, and an absolutely
positioned dropdown never touches scrollHeight — so the observer fired,
measured 80px, posted 80px, and the menu stayed clipped.

Measure the open menu's bottom edge instead, hook Bootstrap's dropdown
events, and give the iframe menu a real dropdown with target="_top".

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
