### PR TITLE
Serve the mark at /favicon.ico

### DIFF
--- a/web/urls.py
+++ b/web/urls.py
@@ -13,13 +13,37 @@ Search the Django documentation for "URL dispatcher" for more help.
 
 """
 
+from django.shortcuts import redirect
+from django.templatetags.static import static
 from django.urls import include, path
 
 # default evennia patterns
 from evennia.web.urls import urlpatterns as evennia_default_urlpatterns
 
+
+def favicon(request):
+    """
+    Serve the brand mark at /favicon.ico.
+
+    Evennia routes this to ``/media/images/favicon.ico``, which does not exist
+    here — the root probe 404s. Browsers still ask for it regardless of the
+    ``<link rel="icon">`` in the page: Safari in particular uses it for tab
+    icons, bookmarks and the reading list, which is why a correct link tag was
+    not enough to make the new mark appear.
+
+    Resolved per request rather than at import, so the hashed filename stays
+    correct after the mark is restyled and re-collected.
+    """
+    return redirect(static("website/images/evennia_logo.png"))
+
+
 # add patterns
 urlpatterns = [
+    # Ours must precede Evennia's, which points these at /media paths that
+    # do not exist in this deployment.
+    path("favicon.ico", favicon),
+    path("apple-touch-icon.png", favicon),
+    path("apple-touch-icon-precomposed.png", favicon),
     # website
     path("", include("web.website.urls")),
     # webclient


### PR DESCRIPTION
Closes #1474

Evennia routes /favicon.ico to /media/images/favicon.ico, which 404s
here, so every browser probing the root got nothing — Safari leans on
that path for tabs and bookmarks even when the link tag is right.

Cloudflare was innocent: cf-polished reports orig_size=25722, our exact
file, just recompressed at the edge.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
