### PR TITLE
Revert the favicon URL routes — the OG method already covers it

### DIFF
--- a/web/urls.py
+++ b/web/urls.py
@@ -13,37 +13,13 @@ Search the Django documentation for "URL dispatcher" for more help.
 
 """
 
-from django.shortcuts import redirect
-from django.templatetags.static import static
 from django.urls import include, path
 
 # default evennia patterns
 from evennia.web.urls import urlpatterns as evennia_default_urlpatterns
 
-
-def favicon(request):
-    """
-    Serve the brand mark at /favicon.ico.
-
-    Evennia routes this to ``/media/images/favicon.ico``, which does not exist
-    here — the root probe 404s. Browsers still ask for it regardless of the
-    ``<link rel="icon">`` in the page: Safari in particular uses it for tab
-    icons, bookmarks and the reading list, which is why a correct link tag was
-    not enough to make the new mark appear.
-
-    Resolved per request rather than at import, so the hashed filename stays
-    correct after the mark is restyled and re-collected.
-    """
-    return redirect(static("website/images/evennia_logo.png"))
-
-
 # add patterns
 urlpatterns = [
-    # Ours must precede Evennia's, which points these at /media paths that
-    # do not exist in this deployment.
-    path("favicon.ico", favicon),
-    path("apple-touch-icon.png", favicon),
-    path("apple-touch-icon-precomposed.png", favicon),
     # website
     path("", include("web.website.urls")),
     # webclient


### PR DESCRIPTION
Reverts #1475.

The original approach is commit `60393c0` ("Image updates"): replace `web/static/website/images/evennia_logo.png` so it shadows Evennia's, because `base.html` links **that file** as `rel="icon"`. No routes, no extra files.

That method is already in place from #1449, and it demonstrably works — the origin and the edge both serve our mark (`cf-polished: ok, orig_size=25722`, our exact byte count). Adding `/favicon.ico` and `apple-touch-icon` routes was solving a problem the existing approach already handles.

Note `favicon.ico` is referenced by nothing — not our templates, not Evennia's. It is a vestigial file that gets collected and never requested.