### PR TITLE
Write down the header contract before we forget it again

### DIFF
--- a/specs/DISCOURSE_INTEGRATION.md
+++ b/specs/DISCOURSE_INTEGRATION.md
@@ -397,6 +397,80 @@ export default apiInitializer("1.8.0", (api) => {
 
 ---
 
+## The header height contract
+
+The header is an iframe, and an iframe **clips its own content**. Anything the
+header needs to draw below its own height — an account dropdown, a flash
+message — is invisible unless the parent is told to grow. That contract spans
+both sides, and every piece of it is load-bearing.
+
+**Site side** (`web/templates/website/header_only.html`):
+
+```js
+window.parent.postMessage({ type: 'gel-header-height', height: measuredHeight() },
+                          TARGET_ORIGIN);
+```
+
+**Forum side** (the theme component's `theme-initializer.gjs`) listens, checks
+the origin, and sets **both** the iframe and its container:
+
+```js
+if (event.origin !== 'https://gel.monster') return;
+iframe.style.height = newHeight;
+container.style.height = newHeight;
+```
+
+### Four things that must all be true
+
+1. **Measure the open menu, not the document.** `document.body.scrollHeight`
+   is not enough: a Bootstrap dropdown is absolutely positioned and never
+   touches it. Take the lowest edge of any `.dropdown-menu.show` via
+   `getBoundingClientRect()`. The element has layout even while the iframe
+   visually clips it, which is what makes it measurable at all.
+2. **Grow the body too.** Asking the parent to resize does not stop the
+   *document* clipping the menu at its own 80px box, and until the body is
+   tall enough the reported height stays wrong. On open, the body takes a
+   `min-height` containing the menu; cleared on close.
+3. **Do not disable dropdowns in CSS.** An earlier attempt shipped
+   `.dropdown-menu { display: none !important }` with the note "they render
+   outside bounds". That was true then, but `display: none` also denies the
+   menu the layout the measurement depends on — with it, the protocol
+   silently measures nothing. **If dropdowns ever need removing, remove the
+   markup, not the layout.**
+4. **Every link needs `target="_top"`.** Without it, navigation loads the
+   destination *inside* the 80px header frame.
+
+### The header must never be cached
+
+`/header-only/` is auth state — it names the logged-in account and renders a
+different menu for anonymous visitors. It was previously
+`Cache-Control: max-age=300, private`, which meant the forum header could keep
+saying "Logged in as X" for five minutes after logout, and made template
+changes appear not to ship. `private` stops shared caches, not the browser's.
+It is now `no_store, no_cache, must_revalidate, private`.
+
+## Forum branding is not inherited
+
+Discourse serves its own icons and does **not** pick anything up from the
+game site. Four settings decide how the forum appears in a tab, a bookmark, a
+phone home screen and a shared link:
+
+| setting | used for |
+|---------|----------|
+| `favicon` | browser tab |
+| `logo_small` | collapsed header |
+| `large_icon` | PWA / manifest |
+| `apple_touch_icon` | iOS home screen |
+
+All four were empty, so the forum showed Discourse's stock icon while the
+game site showed the brand mark. They are uploads, not URLs — set them in
+**Admin → Settings → Branding**, or create an `Upload` and assign it.
+
+> Uploading via `rails runner` fails with `EPERM` if the file was placed with
+> `docker cp`: `image_optim` rewrites the image **in place** and the copied
+> file is not owned by the `discourse` user. `chown discourse:discourse` it
+> first.
+
 ## Testing
 
 ### Test SSO Login

--- a/specs/STYLING_SPEC.md
+++ b/specs/STYLING_SPEC.md
@@ -298,6 +298,17 @@ The standalone SVG uses the same tokens with **literal fallbacks**
 (`var(--terminal-accent, #e0a86f)`), so it renders correctly outside a page —
 verified by rendering it in isolation, not assumed.
 
+**The plate is a disc, not a tile.** Anywhere the mark needs a ground behind
+it (the standalone SVG, the favicon raster) that ground is a circle at the
+ring radius, with transparent corners. A full-bleed `<rect>` renders the mark
+as a dark square in a browser tab and against any non-ink surface. When
+re-exporting the raster, confirm the alpha channel survived (`sips -g
+hasAlpha`) — a flattened render silently re-bakes the square and looks
+identical in a file listing.
+
+The inline navbar mark has no background element at all, which is why it can
+look right on the site while an exported icon looks like a tile.
+
 ### The favicon is named `evennia_logo.png` on purpose
 
 `base.html` hardcodes `rel="icon"` to `website/images/evennia_logo.png`. Rather


### PR DESCRIPTION
Closes #1479

The forum dropdown failed four times, each for a reason that lived only
in a commit message: measure the menu not the document, grow the body,
never disable dropdowns in CSS, target=_top. Plus why the header must
never be cached — it is auth state.

Also records that Discourse serves its own icons, and the disc-plate rule
for the mark.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
