### PR TITLE
Sleeve Registry, in the registry's own voice

### DIFF
--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -20,17 +20,15 @@ Manage Sleeves
 </style>
 
 <header class="plate-head">
-  <h1>Sleeve Inventory</h1>
+  <h1>Sleeve Registry</h1>
   <div class="plate-stamp">
     {{ object_list|length }} on record
   </div>
 </header>
 
 <p class="plate-lore">
-  Every body you have worn, on file. The registry does not care which one
-  you are using — only that the pattern persisted long enough to be
-  recorded. Archive a sleeve and it stops being yours; it does not stop
-  having been you.
+  Every sleeve issued to this account, as the registry holds it. Archiving
+  removes a sleeve from your roster; the record of it stays on file.
 </p>
 
 <div class="plate-stage">


### PR DESCRIPTION
The page is a registry, so the headline says so. The blurb drops the
knowing edge and states what the page is — a clerk's description, not a
manifesto. The site's voice outside the homepage should be plainly
in-world, and the lore that would justify anything more ornate does not
exist yet.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
