### PR TITLE
Harden the atlas against strings it does not control yet

### DIFF
--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -90,6 +90,8 @@ making do, seen from above.</p>
 <script>
 'use strict';
 const DATA = /*__DATA__*/null;
+const esc = s => String(s).replace(/[&<>"']/g,
+  c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 
 // ---------- palette & classification ----------
 const P = {
@@ -425,10 +427,13 @@ cv.addEventListener('mousemove',ev=>{
     if (dx+dy<=1){hit=c;break;}
   }
   readout.className = hit ? 'readout on' : 'readout';
+  // Room names are game data, written into HTML — escape them. Currently
+  // only builders can name a room, so this is hardening rather than a hole,
+  // but the sink is one keystroke away from being player-reachable.
   readout.innerHTML = hit
-    ? `${hit.name} &nbsp;<span style="color:var(--bone-dim)">(${hit.x}, `
+    ? `${esc(hit.name)} &nbsp;<span style="color:var(--bone-dim)">(${hit.x}, `
       + `${hit.y}, ${hit.z})</span>`
-      + `<span class="kind">${LEGEND_LABEL[hit.t] || hit.t}</span>`
+      + `<span class="kind">${esc(LEGEND_LABEL[hit.t] || hit.t)}</span>`
     : '&nbsp;';
 });
 cv.addEventListener('mouseleave',()=>{readout.className='readout';readout.innerHTML='&nbsp;';});

--- a/world/atlas.py
+++ b/world/atlas.py
@@ -62,7 +62,18 @@ def build_atlas_html(game_dir=".", staff=False, fragment=False):
 
     template = open(os.path.join(game_dir,
                                  "scripts/atlas/template.html")).read()
-    html = template.replace("/*__DATA__*/null", json.dumps(data))
+    # json.dumps does NOT escape "</script>", so a string containing it would
+    # close the script element and everything after it would parse as markup.
+    # Escaping "<" (plus the two line separators JS treats as newlines) is the
+    # standard hardening — \u003c is a valid escape inside a JS string, and
+    # "<" only ever occurs inside string values in JSON.
+    payload = (
+        json.dumps(data)
+        .replace("<", "\\u003c")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+    html = template.replace("/*__DATA__*/null", payload)
     if fragment:
         # served inside the site's own page: the shell owns <title> and
         # the page background, and Evennia's sticky footer needs the


### PR DESCRIPTION
Closes #1482

json.dumps does not escape </script>, and the payload is written into a
script element; the hover readout wrote room names into innerHTML. Room
names are builder-authored today, so neither is player-reachable — but
both are one feature away from taking player text.

Rest of the security pass came back clean: DEBUG off, hosts scoped,
secure cookies, HSTS, secrets gitignored, auth on the sensitive views,
and the frame-ancestors exemption limited to /header-only/.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
