### PR TITLE
The colony gets a clock

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -325,3 +325,11 @@ STORAGES = {
         "BACKEND": "web.utils.staticfiles.ForgivingManifestStaticFilesStorage",
     },
 }
+
+# ---------------------------------------------------------------------------
+# Time
+# ---------------------------------------------------------------------------
+# The colony runs 1:1 with real time (TIME_SYSTEM_SPEC). Evennia ships 2.0,
+# which would have run the world at double speed the moment anything started
+# using its gametime helpers. The canonical clock is world/gametime.py.
+TIME_FACTOR = 1.0

--- a/specs/TIME_SYSTEM_SPEC.md
+++ b/specs/TIME_SYSTEM_SPEC.md
@@ -1,6 +1,8 @@
 # Time System Specification
 
-> **Status:** 📋 Proposal — not implemented (tracking #301). The TST real-time clock is the future-clock seam the cadence system already references; current TIME_FACTOR is unchanged.
+> **Status:** ✅ **IMPLEMENTED 2026-07-30** (#301). Canonical clock is
+> `world/gametime.py`; `TIME_FACTOR` is now 1.0. Weather, director broadcasts
+> and the admin readout all read the colony hour from it.
 
 ## Overview
 
@@ -11,7 +13,48 @@ The Gelatinous Monster universe operates on Terran Standard Time (TST) - Earth's
 ### Base Configuration
 - **Time Factor**: 1.0 (real-time synchronization)
 - **Base Standard**: UTC/Terran Standard Time
-- **Implementation**: Evennia's native gametime system with real-world alignment
+- **Implementation**: `world/gametime.py` — the single source of truth.
+  Nothing else may call `time.localtime()`; the container runs UTC and the
+  colony does not.
+
+### The three decisions
+
+| | | why |
+|---|---|---|
+| **1:1 with real time** | no acceleration | an hour is an hour; `TIME_FACTOR = 1.0` (Evennia ships 2.0) |
+| **Fixed UTC−8, no DST** | colony local time | matches the owner's winter clock; a stranded colony has no reason to shift clocks twice a year, and no authority left to tell it to |
+| **Year = real + 1200** | today is **3226 TST** | see below |
+
+**Why 1200 and not a rounder 1000.** The Gregorian calendar repeats on a
+**400-year cycle**, so only multiples of 400 preserve the day of the week.
++1000 keeps the month and day but shifts every weekday — which breaks the
+moment anything is scheduled (a Friday night at the bar that is not Friday for
+the people playing). 1200 keeps month, day **and** weekday, so a real date and
+its TST date are the same day in every sense.
+
+It also makes leap years line up: leap rules depend on the year mod 4, 100 and
+400, so a 400-aligned offset cannot change whether a year is leap. Feb 29
+always has a Feb 29 to land on.
+
+**The offset must stay a multiple of 400.** The constant carries that warning,
+and `test_weekday_alignment_depends_on_the_offset` pins the fact.
+
+### Two reckonings
+
+- **TST** — Terran Standard Time, the network's calendar. Institutional: gate
+  manifests, salvaged paperwork, anything official.
+- **CY** — Colony Year, zero at **3165 TST** (planetfall). Currently **CY 61**.
+  What people actually say.
+
+Anything the colony wrote itself tends to be CY; anything from before or
+outside is TST. Free texture — use the split.
+
+### Timestamps
+
+`gametime.stamp()` returns **real POSIX seconds**, deliberately unshifted and
+unlocalised, so durations stay subtraction and nothing depends on a calendar
+offset. Shift on the way out with `format_stamp()`. `wound_timestamp` in
+`world/medical/core.py` uses this.
 
 ### Justification Framework
 

--- a/world/director/broadcasts.py
+++ b/world/director/broadcasts.py
@@ -39,7 +39,10 @@ def _cue():
     except Exception:  # noqa: BLE001 — a broken clock still runs a station
         pass
     if not period:
-        hour = time.localtime().tm_hour
+        # Fallback path — still the COLONY hour, not the container's UTC.
+        # This is the seam the weather system reads from too.
+        from world.gametime import colony_hour
+        hour = colony_hour()
         period = ("the small hours" if hour < 5 else
                   "morning" if hour < 12 else
                   "afternoon" if hour < 18 else "night")

--- a/world/gametime.py
+++ b/world/gametime.py
@@ -1,0 +1,140 @@
+"""
+The colony clock — canonical time for Domino's Gambit.
+
+Single source of truth. Anything that needs the hour, the date, or a
+timestamp asks here; nothing else should call ``time.localtime()``, because
+the container runs UTC and the colony does not.
+
+THREE FACTS, and they are all the spec:
+
+1. **Time runs 1:1 with real time.** No acceleration. An hour is an hour.
+   ``TIME_FACTOR = 1.0`` in settings backs this up for Evennia's own
+   ``gametime`` helpers.
+
+2. **The colony sits at a fixed UTC-8, and does not observe DST.** It matches
+   the owner's winter clock exactly and drifts an hour in summer. That is
+   deliberate: a stranded colony has no reason to shift its clocks twice a
+   year, and no authority left to tell it to.
+
+3. **The year is real year + 1200.** Today is 3226. Terran Standard Time is
+   the Earth calendar the wider network still runs on, and the colony keeps
+   it.
+
+   The offset is 1200 rather than a rounder 1000 for one reason: the
+   Gregorian calendar repeats on a **400-year cycle**, so only multiples of
+   400 preserve the day of the week. +1000 would have kept the month and day
+   but silently shifted every weekday, which breaks the moment anything is
+   scheduled — a Friday night at the bar that is not Friday for the people
+   playing. 1200 keeps month, day AND weekday, so a real date and its TST
+   date are the same day in every sense.
+
+Locally, people count from the landing instead: **CY** (Colony Year), zero at
+3165 TST. Anything institutional is dated TST; anything the colony wrote
+itself tends to be CY. That split is free texture — use it.
+"""
+
+from datetime import datetime, timedelta, timezone
+import time
+
+# -- the three constants above, in code ---------------------------------
+
+#: Colony offset from UTC. Fixed. No daylight saving, ever.
+COLONY_UTC_OFFSET = timedelta(hours=-8)
+
+#: Terran Standard Time is the real calendar, plus this many years.
+#: MUST stay a multiple of 400 or weekdays stop matching real ones —
+#: see the module docstring, and test_weekday_alignment_depends_on_the_offset.
+TST_YEAR_OFFSET = 1200
+
+#: TST year the colony made planetfall — CY 0.
+FOUNDING_YEAR_TST = 3165
+
+COLONY_TZ = timezone(COLONY_UTC_OFFSET, name="TST-8")
+
+
+# -- the clock ----------------------------------------------------------
+
+def _real_utc():
+    """Real wall-clock UTC. The one place we read the host clock."""
+    return datetime.now(timezone.utc)
+
+
+def _shift_year(moment):
+    """
+    Move a datetime forward by the TST offset.
+
+    Uses ``replace`` rather than arithmetic so the month, day, hour and
+    weekday are preserved exactly. Feb 29 is the one date that cannot
+    survive a year shift onto a non-leap year, so it lands on Mar 1 — the
+    alternative (Feb 28) would silently repeat a date.
+    """
+    try:
+        return moment.replace(year=moment.year + TST_YEAR_OFFSET)
+    except ValueError:
+        return moment.replace(month=3, day=1, year=moment.year + TST_YEAR_OFFSET)
+
+
+def tst_now():
+    """Terran Standard Time — the network's clock. UTC, shifted."""
+    return _shift_year(_real_utc())
+
+
+def colony_now():
+    """
+    Local time in the colony: TST at a fixed UTC-8.
+
+    This is what a character experiences — what "evening" means, when the
+    market opens, whether it is dark.
+    """
+    return _shift_year(_real_utc().astimezone(COLONY_TZ))
+
+
+def colony_hour():
+    """Current colony hour, 0-23. The hour every other system should use."""
+    return colony_now().hour
+
+
+def colony_year():
+    """
+    Years since planetfall — CY. Currently 61.
+
+    Returns the *local* reckoning, not TST.
+    """
+    return tst_now().year - FOUNDING_YEAR_TST
+
+
+# -- timestamps ---------------------------------------------------------
+
+def stamp():
+    """
+    A timestamp for storage: real POSIX seconds, UTC.
+
+    Deliberately NOT shifted and NOT localised. Stored time should be a
+    plain monotonic number so durations are subtraction and nothing depends
+    on a timezone that might change. Shift it on the way out, for display,
+    with :func:`format_stamp`.
+    """
+    return time.time()
+
+
+def since(stamped, now=None):
+    """Seconds elapsed since a :func:`stamp`. Negative clamps to zero."""
+    if stamped is None:
+        return None
+    return max(0.0, (now if now is not None else time.time()) - stamped)
+
+
+def format_stamp(stamped, with_time=True):
+    """Render a stored stamp in colony local time, TST calendar."""
+    if stamped is None:
+        return "unrecorded"
+    moment = _shift_year(
+        datetime.fromtimestamp(stamped, timezone.utc).astimezone(COLONY_TZ)
+    )
+    return moment.strftime("%Y-%m-%d %H:%M" if with_time else "%Y-%m-%d")
+
+
+def format_now():
+    """The current colony time, both reckonings, for display."""
+    moment = colony_now()
+    return f"{moment.strftime('%Y-%m-%d %H:%M')} TST  (CY {colony_year()})"

--- a/world/medical/core.py
+++ b/world/medical/core.py
@@ -273,7 +273,10 @@ class Organ:
         if old_hp == self.max_hp:  # First damage to this organ
             self.injury_type = injury_type
             self.wound_stage = 'fresh'
-            # TODO: Set wound_timestamp when time system is implemented
+            # Real POSIX seconds, not colony time — wound age is a duration,
+            # and durations should not depend on a calendar offset.
+            from world.gametime import stamp
+            self.wound_timestamp = stamp()
         elif not hasattr(self, 'injury_type') or self.injury_type == "generic":
             # Update injury type if this is more specific than previous
             self.injury_type = injury_type

--- a/world/tests/test_gametime.py
+++ b/world/tests/test_gametime.py
@@ -1,0 +1,159 @@
+"""Tests for the colony clock (TIME_SYSTEM_SPEC)."""
+
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+from evennia.utils.test_resources import EvenniaTest
+
+from world import gametime
+
+
+class TestColonyClock(EvenniaTest):
+    """The three facts: 1:1, fixed UTC-8, +1200 years."""
+
+    def _at(self, iso_utc):
+        """Pin real UTC to a known instant."""
+        moment = datetime.fromisoformat(iso_utc).replace(tzinfo=timezone.utc)
+        return mock.patch.object(gametime, "_real_utc", return_value=moment)
+
+    def test_year_is_offset(self):
+        with self._at("2026-07-30T12:00:00"):
+            self.assertEqual(gametime.tst_now().year, 3226)
+
+    def test_offset_preserves_month_and_day(self):
+        """Same calendar date, so conversion is one field and never drifts."""
+        with self._at("2026-07-30T12:00:00"):
+            real = datetime(2026, 7, 30, 12, tzinfo=timezone.utc)
+            tst = gametime.tst_now()
+            self.assertEqual((tst.month, tst.day), (real.month, real.day))
+
+    def test_weekday_alignment_depends_on_the_offset(self):
+        """
+        The Gregorian calendar repeats every 400 years, so ONLY multiples of
+        400 keep the weekday. +1000 does not; +1200 would. Nothing in the game
+        would, so this pins the fact. The offset is 1200 precisely so this
+        passes the aligned branch; if someone changes it to a non-multiple of
+        400 this test still passes, but the game quietly loses weekday
+        alignment — which is why the constant carries a warning too.
+        """
+        from datetime import date
+        aligned = date(2026, 7, 30).weekday() == date(
+            2026 + gametime.TST_YEAR_OFFSET, 7, 30).weekday()
+        self.assertEqual(aligned, gametime.TST_YEAR_OFFSET % 400 == 0)
+
+    def test_colony_is_utc_minus_eight(self):
+        with self._at("2026-07-30T12:00:00"):
+            self.assertEqual(gametime.colony_hour(), 4)
+
+    def test_colony_date_rolls_back_across_midnight_utc(self):
+        """03:00 UTC is still the previous evening in the colony."""
+        with self._at("2026-07-31T03:00:00"):
+            local = gametime.colony_now()
+            self.assertEqual(local.hour, 19)
+            self.assertEqual(local.day, 30)
+
+    def test_no_daylight_saving(self):
+        """Midsummer and midwinter share the same offset. That is the point."""
+        with self._at("2026-01-15T12:00:00"):
+            winter = gametime.colony_hour()
+        with self._at("2026-07-15T12:00:00"):
+            summer = gametime.colony_hour()
+        self.assertEqual(winter, summer)
+
+    def test_colony_year_counts_from_planetfall(self):
+        with self._at("2026-07-30T12:00:00"):
+            self.assertEqual(gametime.colony_year(), 3226 - 3165)
+
+    def test_leap_day_passes_straight_through(self):
+        """Feb 29 stays Feb 29 — see the leap-status test below for why."""
+        for instant in ("2028-02-29T12:00:00", "2000-02-29T12:00:00"):
+            with self.subTest(instant=instant), self._at(instant):
+                moment = gametime.tst_now()
+                self.assertEqual((moment.month, moment.day), (2, 29))
+
+    def test_a_400_multiple_offset_also_preserves_leap_years(self):
+        """
+        Falling out of the 400-year cycle: leap rules depend on the year mod
+        4, 100 and 400, so an offset divisible by 400 cannot change whether a
+        year is leap. With 1200, Feb 29 always has a Feb 29 to land on and the
+        fallback in _shift_year is unreachable.
+        """
+        import calendar
+        self.assertEqual(gametime.TST_YEAR_OFFSET % 400, 0)
+        for year in (2000, 2024, 2028, 2100, 2200, 2400):
+            self.assertEqual(
+                calendar.isleap(year),
+                calendar.isleap(year + gametime.TST_YEAR_OFFSET),
+                f"{year} and {year + gametime.TST_YEAR_OFFSET} disagree",
+            )
+
+    def test_fallback_protects_a_non_aligned_offset(self):
+        """
+        The fallback is dead code today, but it is the difference between a
+        crash and a sane date if the offset is ever changed. 2000 is leap,
+        3000 is not.
+        """
+        with mock.patch.object(gametime, "TST_YEAR_OFFSET", 1000), \
+             self._at("2000-02-29T12:00:00"):
+            moment = gametime.tst_now()
+            self.assertEqual((moment.month, moment.day), (3, 1))
+
+
+class TestStamps(EvenniaTest):
+    """Stored time is a plain duration-friendly number."""
+
+    def test_stamp_is_real_posix_seconds_not_shifted(self):
+        """A stamp a thousand years in the future would break every duration."""
+        now = datetime.now(timezone.utc).timestamp()
+        self.assertAlmostEqual(gametime.stamp(), now, delta=5)
+
+    def test_since_measures_elapsed(self):
+        self.assertAlmostEqual(gametime.since(1000.0, now=1060.0), 60.0)
+
+    def test_since_never_returns_negative(self):
+        self.assertEqual(gametime.since(2000.0, now=1000.0), 0.0)
+
+    def test_since_tolerates_unstamped(self):
+        self.assertIsNone(gametime.since(None))
+
+    def test_format_stamp_renders_in_colony_time_and_tst(self):
+        moment = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc).timestamp()
+        # 12:00 UTC -> 04:00 colony, year +1200
+        self.assertEqual(gametime.format_stamp(moment), "3226-07-30 04:00")
+
+    def test_format_stamp_tolerates_unstamped(self):
+        self.assertEqual(gametime.format_stamp(None), "unrecorded")
+
+
+class TestWeatherUsesTheColonyClock(EvenniaTest):
+    """Weather, broadcasts and the admin readout must not keep their own clock."""
+
+    def test_weather_hour_is_the_colony_hour(self):
+        from world.weather.time_system import TimeSystem
+
+        with mock.patch.object(gametime, "_real_utc",
+                               return_value=datetime(2026, 7, 30, 12, 0,
+                                                     tzinfo=timezone.utc)):
+            self.assertEqual(TimeSystem().get_current_hour(), 4)
+
+    def test_period_follows_the_colony_hour_not_utc(self):
+        from world.weather.time_system import get_current_time_period
+
+        # 06:00 UTC is 22:00 in the colony — night, not morning.
+        with mock.patch.object(gametime, "_real_utc",
+                               return_value=datetime(2026, 7, 30, 6, 0,
+                                                     tzinfo=timezone.utc)):
+            self.assertNotIn(get_current_time_period(), ("dawn", "morning"))
+
+
+class TestWoundTimestamp(EvenniaTest):
+    """The TODO this work was tracked against."""
+
+    def test_first_damage_stamps_the_wound(self):
+        from world.medical.core import Organ
+
+        organ = Organ("heart")
+        self.assertIsNone(organ.wound_timestamp)
+        organ.take_damage(5, injury_type="cut")
+        self.assertIsNotNone(organ.wound_timestamp)
+        self.assertAlmostEqual(organ.wound_timestamp, gametime.stamp(), delta=5)

--- a/world/weather/time_system.py
+++ b/world/weather/time_system.py
@@ -60,10 +60,12 @@ class TimeSystem:
         Returns:
             int: Current hour in 24-hour format
         """
-        # For now, use real-world time
-        # Future: implement accelerated game time
-        current_time = time.localtime()
-        return current_time.tm_hour
+        # Delegates to the colony clock. This used to call time.localtime(),
+        # which is the CONTAINER's clock — UTC — so "night" ran eight hours
+        # away from the colony's own night, and weather, director broadcasts
+        # and the admin readout all inherited the error.
+        from world.gametime import colony_hour
+        return colony_hour()
         
     def get_current_time_period(self):
         """


### PR DESCRIPTION
Closes #301

world/gametime.py is the canonical time source: 1:1 with real time, a
fixed UTC-8 with no DST, and Terran Standard Time at real year + 1200 —
today is 3226 TST, CY 61 since planetfall in 3165.

The offset is 1200 rather than 1000 because the Gregorian calendar
repeats every 400 years, so only multiples of 400 keep the day of the
week. +1000 would have shifted every weekday, which breaks the moment
anything is scheduled. It also makes leap years line up, so Feb 29
always has a Feb 29 to land on.

Two real bugs found on the way in:

- world/weather/time_system.py read time.localtime(), i.e. the
  CONTAINER's clock — UTC. Weather, director broadcasts and the admin
  readout were running the colony's day/night eight hours out.
- TIME_FACTOR was Evennia's default 2.0, so anything using Evennia's own
  gametime would have run at double speed. Spec says 1.0.

wound_timestamp is wired (the TODO this issue tracked). Stamps are stored
as plain POSIX seconds, unshifted, so durations stay subtraction.

19 tests. Two pre-existing failures elsewhere (test_build_tools air-fill
fixture, radio xmit routing) confirmed failing on clean master too.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
