### PR TITLE
Drop the import the clock change orphaned

### DIFF
--- a/world/weather/time_system.py
+++ b/world/weather/time_system.py
@@ -5,7 +5,6 @@ Manages game time and provides current time period for weather system.
 Designed to be easily expandable for calendar systems and time-based events.
 """
 
-import time
 
 
 # Time periods for weather variation (12 granular periods)


### PR DESCRIPTION
time_system.py no longer calls time.localtime() — it reads the colony
clock — so the module-level import had no remaining uses.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
