### PR TITLE
Sleeve dates read in colony time

### DIFF
--- a/commands/CmdAdmin.py
+++ b/commands/CmdAdmin.py
@@ -761,7 +761,10 @@ class CmdWeather(Command):
             current_weather = weather_system.get_current_weather()
             intensity = weather_system.get_weather_intensity()
             time_period = get_current_time_period()
-            real_time = time.strftime("%H:%M:%S")
+            # Colony time, not the container's UTC — this readout exists to
+            # explain what the weather system thinks the hour is.
+            from world.gametime import colony_now
+            real_time = colony_now().strftime("%H:%M:%S")
             weather_key = f"{current_weather}_{time_period}"
             
             self.caller.msg("|WWeather System Status:|n")

--- a/web/templates/website/character_detail.html
+++ b/web/templates/website/character_detail.html
@@ -91,7 +91,7 @@ Sleeve Details
                     <span class="text-accent">Active</span>
                   {% endif %}
                 </p>
-                <p class="mb-2"><strong>Decanted on:</strong> {{ object.db_date_created }}</p>
+                <p class="mb-2"><strong>Decanted on:</strong> {{ decanted_display }} TST</p>
               </div>
             </div>
             

--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -54,10 +54,10 @@ Manage Sleeves
             </a>
           </td>
           <td class="col-date text-muted">
-            {{ object.db_date_created|date:"Y-m-d H:i" }}
+            {{ object.decanted_display }}
           </td>
           <td class="col-date text-muted">
-            {% if object.died_on %}{{ object.died_on|date:"Y-m-d H:i" }}{% else %}&mdash;{% endif %}
+            {% if object.retired_display %}{{ object.retired_display }}{% else %}&mdash;{% endif %}
           </td>
           <td class="col-status">
             {% if object.db.archived %}

--- a/web/website/views/characters.py
+++ b/web/website/views/characters.py
@@ -470,8 +470,22 @@ class CharacterManageView(EvenniaCharacterManageView):
         # Annotate for rendering only — transient, never persisted.
         # NB: archived does NOT imply dead — a living sleeve can be shelved —
         # so this is legitimately None and the template must tolerate it.
+        #
+        # Dates render in COLONY time (TST, fixed UTC-8), not the stored real
+        # UTC. The stored values stay real POSIX/UTC on purpose: durations are
+        # subtraction, and a calendar offset must never leak into stored data.
+        from world.gametime import format_stamp
+
         for sleeve in context.get("object_list") or []:
-            sleeve.died_on = died_by_dbref.get(str(getattr(sleeve, "dbref", "")))
+            died = died_by_dbref.get(str(getattr(sleeve, "dbref", "")))
+            sleeve.died_on = died
+            sleeve.retired_display = (
+                format_stamp(died.timestamp()) if died else None
+            )
+            created = getattr(sleeve, "db_date_created", None)
+            sleeve.decanted_display = (
+                format_stamp(created.timestamp()) if created else None
+            )
 
         return context
 
@@ -604,6 +618,14 @@ class OwnerOnlyCharacterDetailView(EvenniaCharacterDetailView):
         # Import the descriptor function
         from commands.CmdCharacter import get_stat_descriptor
         
+        # Decanting date in colony time (TST) rather than raw stored UTC.
+        from world.gametime import format_stamp
+
+        created = getattr(character, "db_date_created", None)
+        context["decanted_display"] = (
+            format_stamp(created.timestamp()) if created else "unrecorded"
+        )
+
         # Get stat descriptors (AttributeProperty with autocreate=True, always exist)
         grit = character.grit
         resonance = character.resonance

--- a/world/tests/test_gametime.py
+++ b/world/tests/test_gametime.py
@@ -157,3 +157,32 @@ class TestWoundTimestamp(EvenniaTest):
         organ.take_damage(5, injury_type="cut")
         self.assertIsNotNone(organ.wound_timestamp)
         self.assertAlmostEqual(organ.wound_timestamp, gametime.stamp(), delta=5)
+
+
+class TestSleeveDatesRenderInColonyTime(EvenniaTest):
+    """
+    The stored values stay real; only the display shifts.
+
+    This is the whole shape of the fix: no migration touched the records,
+    because shifting stored timestamps +1200 years would break every
+    duration in the game.
+    """
+
+    def test_format_stamp_shifts_a_real_stored_time(self):
+        # A real sleeve record: 2025-11-13 05:43 UTC as stored.
+        stored = datetime(2025, 11, 13, 5, 43, tzinfo=timezone.utc).timestamp()
+        shown = gametime.format_stamp(stored)
+        # -> colony local (UTC-8) is the previous evening, year +1200
+        self.assertEqual(shown, "3225-11-12 21:43")
+
+    def test_stored_value_is_untouched_by_display(self):
+        stored = datetime(2025, 11, 13, 5, 43, tzinfo=timezone.utc).timestamp()
+        before = stored
+        gametime.format_stamp(stored)
+        self.assertEqual(stored, before)
+
+    def test_durations_still_work_on_stored_values(self):
+        """The reason we did not migrate: elapsed time must stay sane."""
+        born = datetime(2025, 11, 13, 5, 43, tzinfo=timezone.utc).timestamp()
+        died = datetime(2025, 11, 13, 5, 45, tzinfo=timezone.utc).timestamp()
+        self.assertEqual(gametime.since(born, now=died), 120.0)


### PR DESCRIPTION
Closes #1488

Manage Sleeves, Sleeve Details and the admin weather readout rendered
stored values raw — real year, container UTC. They now go through
gametime.format_stamp: 2025-11-13 05:43 stored reads 3225-11-12 21:43.

Nothing was migrated. Stored time stays real POSIX/UTC because durations
are subtraction — shifting the records would break wound ageing,
recognition decay and every rate limit in the game.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
