### PR TITLE
Dates iOS won't mistake for phone numbers

### DIFF
--- a/web/templates/website/character_detail.html
+++ b/web/templates/website/character_detail.html
@@ -4,6 +4,12 @@
 Sleeve Details
 {% endblock %}
 
+{% block header_ext %}
+{# iOS data detectors turn date-like digit runs into tappable phone links.
+   The dates are already formatted to avoid it; this makes it explicit. #}
+<meta name="format-detection" content="telephone=no">
+{% endblock %}
+
 {% block content %}
 <div class="row">
   <div class="col">

--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -4,6 +4,12 @@
 Manage Sleeves
 {% endblock %}
 
+{% block header_ext %}
+{# iOS data detectors turn date-like digit runs into tappable phone links.
+   The dates are already formatted to avoid it; this makes it explicit. #}
+<meta name="format-detection" content="telephone=no">
+{% endblock %}
+
 {% block content %}
 
 {% load addclass %}

--- a/world/gametime.py
+++ b/world/gametime.py
@@ -125,13 +125,25 @@ def since(stamped, now=None):
 
 
 def format_stamp(stamped, with_time=True):
-    """Render a stored stamp in colony local time, TST calendar."""
+    """
+    Render a stored stamp in colony local time, TST calendar.
+
+    US style with a spelled month — "Nov 12, 3225 9:43 PM". The month name
+    is load-bearing, not decoration: iOS data detectors read a bare
+    ``3225-11-12 21:43`` as a phone number and turn it into a tappable link.
+    An alphabetic month breaks that heuristic.
+    """
     if stamped is None:
         return "unrecorded"
     moment = _shift_year(
         datetime.fromtimestamp(stamped, timezone.utc).astimezone(COLONY_TZ)
     )
-    return moment.strftime("%Y-%m-%d %H:%M" if with_time else "%Y-%m-%d")
+    date_part = moment.strftime("%b %d, %Y")
+    if not with_time:
+        return date_part
+    # %I is zero-padded and there is no portable %-I, so strip it by hand.
+    clock = moment.strftime("%I:%M %p").lstrip("0")
+    return f"{date_part} {clock}"
 
 
 def format_now():

--- a/world/tests/test_gametime.py
+++ b/world/tests/test_gametime.py
@@ -119,7 +119,15 @@ class TestStamps(EvenniaTest):
     def test_format_stamp_renders_in_colony_time_and_tst(self):
         moment = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc).timestamp()
         # 12:00 UTC -> 04:00 colony, year +1200
-        self.assertEqual(gametime.format_stamp(moment), "3226-07-30 04:00")
+        self.assertEqual(gametime.format_stamp(moment), "Jul 30, 3226 4:00 AM")
+
+    def test_format_avoids_a_bare_digit_run(self):
+        """iOS reads 3225-11-12 21:43 as a phone number. A month name does not."""
+        import re
+        shown = gametime.format_stamp(
+            datetime(2025, 11, 13, 5, 43, tzinfo=timezone.utc).timestamp())
+        self.assertIsNone(re.match(r"^\d{4}-\d{2}-\d{2}", shown))
+        self.assertIn("Nov", shown)
 
     def test_format_stamp_tolerates_unstamped(self):
         self.assertEqual(gametime.format_stamp(None), "unrecorded")
@@ -173,7 +181,7 @@ class TestSleeveDatesRenderInColonyTime(EvenniaTest):
         stored = datetime(2025, 11, 13, 5, 43, tzinfo=timezone.utc).timestamp()
         shown = gametime.format_stamp(stored)
         # -> colony local (UTC-8) is the previous evening, year +1200
-        self.assertEqual(shown, "3225-11-12 21:43")
+        self.assertEqual(shown, "Nov 12, 3225 9:43 PM")
 
     def test_stored_value_is_untouched_by_display(self):
         stored = datetime(2025, 11, 13, 5, 43, tzinfo=timezone.utc).timestamp()


### PR DESCRIPTION
Closes #1491

3225-11-12 21:43 matched iOS's phone-number heuristic and rendered as
tappable call links. Dates are now US style with a spelled month —
Nov 12, 3225 9:43 PM — which breaks the digit run, plus a
format-detection meta on both sleeve pages via header_ext.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
