### PR TITLE
The same comment bug, again

### DIFF
--- a/web/templates/website/character_detail.html
+++ b/web/templates/website/character_detail.html
@@ -5,8 +5,10 @@ Sleeve Details
 {% endblock %}
 
 {% block header_ext %}
-{# iOS data detectors turn date-like digit runs into tappable phone links.
-   The dates are already formatted to avoid it; this makes it explicit. #}
+{% comment %}
+  iOS data detectors turn date-like digit runs into tappable phone links.
+  The dates are already formatted to avoid it; this makes it explicit.
+{% endcomment %}
 <meta name="format-detection" content="telephone=no">
 {% endblock %}
 

--- a/web/templates/website/character_manage_list.html
+++ b/web/templates/website/character_manage_list.html
@@ -5,8 +5,10 @@ Manage Sleeves
 {% endblock %}
 
 {% block header_ext %}
-{# iOS data detectors turn date-like digit runs into tappable phone links.
-   The dates are already formatted to avoid it; this makes it explicit. #}
+{% comment %}
+  iOS data detectors turn date-like digit runs into tappable phone links.
+  The dates are already formatted to avoid it; this makes it explicit.
+{% endcomment %}
 <meta name="format-detection" content="telephone=no">
 {% endblock %}
 


### PR DESCRIPTION
I shipped a two-line {# #} into both sleeve templates hours after fixing
exactly this on the homepage (#1444) and writing the warning into
STYLING_SPEC. It rendered as body copy on Manage Sleeves.

{% comment %} now, and the repo-wide sweep is clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
