### PR TITLE
The Atlas stops counting the years

### DIFF
--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -65,11 +65,11 @@
   </div>
   <div class="stamp" id="stamp"></div>
 </header>
-<p class="lore">Sixty-one years ago a terraforming mission set down in
+<p class="lore">A lifetime ago a terraforming mission set down in
 this crater to make a waypoint of it: processor stacks, a gate anchor,
 and a manifest that assumed resupply. The work came up crooked. Then the
 system gateway went — a light nobody has explained, and not one ship
-since — and a staging post became a home. What follows is six decades of
+since — and a staging post became a home. What follows is decades of
 making do, seen from above.</p>
 
 <div class="stage">


### PR DESCRIPTION
"Sixty-one years ago" and "six decades" pinned a date the colony has no
business being certain about. "A lifetime ago" and "decades" leave it
where it belongs — a place that lost its gate, its resupply and a good
deal of its record-keeping.

The precise reckoning still exists in the systems (CY 61, 3226 TST); the
prose no longer recites it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
