### PR TITLE
Crowds that know the hour, civilians that come back

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -333,3 +333,8 @@ STORAGES = {
 # which would have run the world at double speed the moment anything started
 # using its gametime helpers. The canonical clock is world/gametime.py.
 TIME_FACTOR = 1.0
+
+# Ceiling on the ambient civilian population maintained by the director
+# heartbeat (world/director/population.py). The loop trickles ONE civilian
+# per beat toward this number and never exceeds it. 0 disables respawning.
+CIVILIAN_POOL_MAX = 40

--- a/world/crowd/crowd_system.py
+++ b/world/crowd/crowd_system.py
@@ -54,6 +54,26 @@ class CrowdSystem:
             'flashstorm': -2.5,
         }
     
+    # How the hour thins or swells a street.
+    #
+    # This is not only flavour: crowd level feeds witness chance
+    # (world/director/witness.py) and the stealth concealment bonus
+    # (world/stealth.py), so the hour now changes whether a crime is seen
+    # and whether a body can disappear into a crowd. Deep night is the
+    # quietest and the most exposed — fewer eyes, but nowhere to stand.
+    #
+    # Shaped like a shift colony rather than an office one: two shift
+    # changes carry the peaks, and the small hours are genuinely empty.
+    time_modifiers = {
+        0: -2.0, 1: -2.2, 2: -2.2, 3: -2.0, 4: -1.6,   # the small hours
+        5: -1.0, 6: -0.3,                               # first movement
+        7: 0.6, 8: 0.7, 9: 0.4,                         # morning shift change
+        10: 0.0, 11: 0.1, 12: 0.3, 13: 0.1,             # working day
+        14: 0.0, 15: 0.0, 16: 0.2,
+        17: 0.7, 18: 0.8, 19: 0.5,                      # evening shift change
+        20: 0.2, 21: 0.0, 22: -0.6, 23: -1.3,           # winding down
+    }
+
     def calculate_crowd_level(self, room):
         """
         Calculate total crowd level for a room based on multiple factors.
@@ -90,6 +110,14 @@ class CrowdSystem:
             # Weather system not available, no modifier
             pass
         
+        # Add the hour. The colony clock is the canonical source; a broken
+        # clock must not empty the streets, so a failure here is a no-op.
+        try:
+            from world.gametime import colony_hour
+            total_level += self.time_modifiers.get(colony_hour(), 0.0)
+        except Exception:  # noqa: BLE001
+            pass
+
         # Ensure minimum of 0
         final_level = max(0, int(round(total_level)))
         

--- a/world/director/population.py
+++ b/world/director/population.py
@@ -380,3 +380,82 @@ def maintain_security_complement() -> Any | None:
     except Exception:  # noqa: BLE001
         pass
     return unit
+
+
+# ---------------------------------------------------------------------------
+# Civilian population
+# ---------------------------------------------------------------------------
+# Secbots have had a respawn loop since the security slice shipped; civilians
+# never did. They were spawned by hand (`@civilians/populate`) and every one
+# that died stayed dead, so the streets drained monotonically and the only
+# cure was a builder remembering to top them up.
+#
+# This is the same shape as maintain_security_complement: ONE per heartbeat,
+# so a massacre is made good over minutes rather than instantly, and the
+# colony never appears to teleport a crowd into a room someone is standing in.
+
+#: Ceiling on the ambient civilian population. Not a target to rush to — the
+#: loop trickles toward it. Override in settings as CIVILIAN_POOL_MAX.
+CIVILIAN_POOL_DEFAULT = 40
+
+
+def civilian_pool_max() -> int:
+    """The ceiling, from settings if set, else :data:`CIVILIAN_POOL_DEFAULT`."""
+    from django.conf import settings
+    try:
+        return max(0, int(getattr(settings, "CIVILIAN_POOL_MAX",
+                                  CIVILIAN_POOL_DEFAULT)))
+    except (TypeError, ValueError):
+        return CIVILIAN_POOL_DEFAULT
+
+
+def living_civilians() -> list:
+    """Every civilian currently on the grid."""
+    from evennia.utils.search import search_tag
+    return [npc for npc in search_tag("civilian", category="director") if npc]
+
+
+def _spawnable_rooms() -> list:
+    """
+    Where a civilian may appear.
+
+    Two rules, both about not being seen to pop into existence:
+    somewhere with a reason to have people (`crowd_base_level > 0`), and
+    nowhere a player is standing.
+    """
+    from world.spatial.coordinates import all_coordinate_rooms
+    rooms = []
+    for room in all_coordinate_rooms():
+        if "Room" not in getattr(room, "typeclass_path", ""):
+            continue
+        if getattr(room.db, "is_sky_room", False):
+            continue
+        if not (getattr(room, "crowd_base_level", 0) or 0):
+            continue
+        if any(getattr(o, "has_account", False) for o in room.contents):
+            continue
+        rooms.append(room)
+    return rooms
+
+
+def maintain_civilian_population():
+    """
+    One heartbeat of the civilian respawn loop.
+
+    Spawns at most ONE civilian, and only while the living population is
+    under :func:`civilian_pool_max`. Returns the new civilian or ``None``.
+    """
+    from random import choice
+
+    ceiling = civilian_pool_max()
+    if ceiling <= 0:
+        return None
+    if len(living_civilians()) >= ceiling:
+        return None
+
+    rooms = _spawnable_rooms()
+    if not rooms:
+        return None
+
+    from world.director.civilians import CIVILIAN_ROLES, spawn_civilian
+    return spawn_civilian(choice(sorted(CIVILIAN_ROLES)), choice(rooms))

--- a/world/director/routines.py
+++ b/world/director/routines.py
@@ -246,6 +246,12 @@ class DirectorRoutineScript(DefaultScript):
         try:
             from world.director.population import maintain_security_complement
             maintain_security_complement()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            # Civilians drain over time; top the pool up one per beat.
+            from world.director.population import maintain_civilian_population
+            maintain_civilian_population()
         except Exception:  # noqa: BLE001 — respawn must not stall the beats
             pass
         try:

--- a/world/tests/test_population_pool.py
+++ b/world/tests/test_population_pool.py
@@ -1,0 +1,80 @@
+"""The civilian pool ceiling and the hour's effect on crowds."""
+
+from unittest import mock
+
+from evennia.utils.test_resources import EvenniaTest
+
+from world.director import population
+
+
+class TestCivilianPoolCeiling(EvenniaTest):
+    """A respawn loop without a ceiling is how you get 4,000 NPCs."""
+
+    def test_ceiling_comes_from_settings(self):
+        with self.settings(CIVILIAN_POOL_MAX=7):
+            self.assertEqual(population.civilian_pool_max(), 7)
+
+    def test_ceiling_falls_back_to_the_default(self):
+        with mock.patch.object(population, "CIVILIAN_POOL_DEFAULT", 12):
+            with self.settings():
+                # no override present in test settings -> default applies
+                self.assertIsInstance(population.civilian_pool_max(), int)
+
+    def test_garbage_ceiling_does_not_crash_the_heartbeat(self):
+        with self.settings(CIVILIAN_POOL_MAX="not a number"):
+            self.assertEqual(population.civilian_pool_max(),
+                             population.CIVILIAN_POOL_DEFAULT)
+
+    def test_zero_ceiling_disables_respawn(self):
+        with self.settings(CIVILIAN_POOL_MAX=0):
+            self.assertIsNone(population.maintain_civilian_population())
+
+    def test_no_spawn_when_pool_is_full(self):
+        with self.settings(CIVILIAN_POOL_MAX=2), \
+             mock.patch.object(population, "living_civilians",
+                               return_value=["a", "b"]):
+            self.assertIsNone(population.maintain_civilian_population())
+
+    def test_spawns_at_most_one_per_beat(self):
+        """Losses are made good at a walking pace, not instantly."""
+        room = self.room1
+        with self.settings(CIVILIAN_POOL_MAX=40), \
+             mock.patch.object(population, "living_civilians", return_value=[]), \
+             mock.patch.object(population, "_spawnable_rooms", return_value=[room]), \
+             mock.patch("world.director.civilians.spawn_civilian",
+                        return_value="npc") as spawner:
+            population.maintain_civilian_population()
+            self.assertEqual(spawner.call_count, 1)
+
+
+class TestCrowdKnowsTheHour(EvenniaTest):
+    """Crowd level feeds witness chance and stealth, so the hour is mechanical."""
+
+    def _level_at(self, hour):
+        from world.crowd.crowd_system import CrowdSystem
+        room = self.room1
+        room.crowd_base_level = 3
+        with mock.patch("world.gametime.colony_hour", return_value=hour):
+            return CrowdSystem().calculate_crowd_level(room)
+
+    def test_deep_night_is_emptier_than_the_evening_rush(self):
+        self.assertLess(self._level_at(3), self._level_at(18))
+
+    def test_shift_changes_are_the_peaks(self):
+        self.assertGreaterEqual(self._level_at(8), self._level_at(14))
+        self.assertGreaterEqual(self._level_at(18), self._level_at(14))
+
+    def test_level_never_goes_negative(self):
+        room = self.room1
+        room.crowd_base_level = 0
+        from world.crowd.crowd_system import CrowdSystem
+        with mock.patch("world.gametime.colony_hour", return_value=2):
+            self.assertGreaterEqual(CrowdSystem().calculate_crowd_level(room), 0)
+
+    def test_a_broken_clock_does_not_empty_the_streets(self):
+        from world.crowd.crowd_system import CrowdSystem
+        room = self.room1
+        room.crowd_base_level = 3
+        with mock.patch("world.gametime.colony_hour",
+                        side_effect=RuntimeError("clock is out")):
+            self.assertGreater(CrowdSystem().calculate_crowd_level(room), 0)


### PR DESCRIPTION
Closes #1500

Crowd level ignored the clock, so 4am and noon were mechanically the
same street — same witness chance, same place to hide. A 24-hour
modifier table shaped like a shift colony fixes that; the saturating
witness formula means it mostly differentiates night, which is the
interesting case anyway: fewer eyes and less cover at once.

Civilians had no respawn loop, so the population only ever fell. Same
one-per-beat shape as the secbot complement, with a CIVILIAN_POOL_MAX
ceiling, spawning only where people have a reason to be and never in
front of a player.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
