### PR TITLE
You read a watch, not a command

### DIFF
--- a/typeclasses/objects.py
+++ b/typeclasses/objects.py
@@ -25,6 +25,29 @@ class ObjectParent:
 
     """
     
+    def get_display_desc(self, looker, **kwargs):
+        """
+        Render the description, resolving colony-clock tokens.
+
+        A description may carry ``{time}``, ``{time12}``, ``{date}``,
+        ``{cy}``, ``{hour}``, ``{period}`` — see ``world/gametime.py``. This
+        is how the hour is legible in play: you read a watch or a wall clock,
+        not a command. Without a timepiece a character genuinely does not
+        know what time it is, which is correct for this colony.
+
+        Objects may carry ``clock_skew`` (minutes fast/slow) or
+        ``clock_stopped`` (a POSIX stamp it died at), so two timepieces in
+        one room can disagree.
+
+        Descriptions without tokens are returned untouched.
+        """
+        desc = super().get_display_desc(looker, **kwargs)
+        try:
+            from world.gametime import render_time_tokens
+            return render_time_tokens(desc, self)
+        except Exception:  # noqa: BLE001 — a clock fault never hides an item
+            return desc
+
     # Ordinal word mapping for natural language search
     ORDINAL_WORDS = {
         'first': 1, 'second': 2, 'third': 3, 'fourth': 4, 'fifth': 5,

--- a/world/gametime.py
+++ b/world/gametime.py
@@ -150,3 +150,91 @@ def format_now():
     """The current colony time, both reckonings, for display."""
     moment = colony_now()
     return f"{moment.strftime('%Y-%m-%d %H:%M')} TST  (CY {colony_year()})"
+
+
+# -- authored time tokens -----------------------------------------------
+#
+# Time is legible IN-WORLD, through objects, not through a command. A
+# character with no watch does not know the hour — which is the correct
+# answer for a colony where a working timepiece is a possession.
+#
+# Author a description with braces, the way {their} already works:
+#
+#     A scratched chrono, its face reading {time}.
+#     The platform clock stands at {time12}, {date}.
+#
+# Two object attributes make timepieces disagree with each other, which is
+# the point of having more than one:
+#
+#     db.clock_skew     minutes fast (+) or slow (-). Cheap chrome drifts.
+#     db.clock_stopped  a POSIX stamp; the thing died at that moment and
+#                       shows it forever.
+
+import re as _re
+
+#: Tokens an author may write. Case-sensitive, matching {their}/{Their}.
+TIME_TOKENS = ("time", "time12", "date", "datetime", "cy", "hour", "period")
+
+_TOKEN_RE = _re.compile(r"\{(" + "|".join(TIME_TOKENS) + r")\}")
+
+
+def _period_name(hour):
+    """A vague reading, for devices that do not give you a number."""
+    if hour < 5:
+        return "the small hours"
+    if hour < 8:
+        return "early morning"
+    if hour < 12:
+        return "morning"
+    if hour < 14:
+        return "midday"
+    if hour < 18:
+        return "afternoon"
+    if hour < 21:
+        return "evening"
+    return "night"
+
+
+def render_time_tokens(text, obj=None):
+    """
+    Replace ``{time}``-style tokens in *text* with the colony clock.
+
+    *obj* is the thing being read, and may carry ``clock_skew`` or
+    ``clock_stopped`` so two watches in the same room can disagree.
+    Returns *text* unchanged when it holds no tokens, so this is safe to
+    run over every description.
+    """
+    if not text or "{" not in text:
+        return text
+    if not _TOKEN_RE.search(text):
+        return text
+
+    moment = None
+    skew = 0
+    if obj is not None:
+        try:
+            stopped = obj.attributes.get("clock_stopped", None)
+            if stopped:
+                moment = _shift_year(
+                    datetime.fromtimestamp(float(stopped), timezone.utc)
+                    .astimezone(COLONY_TZ))
+            skew = int(obj.attributes.get("clock_skew", 0) or 0)
+        except Exception:  # noqa: BLE001 — a broken prop must still render
+            moment, skew = None, 0
+
+    if moment is None:
+        moment = colony_now()
+    if skew:
+        moment = moment + timedelta(minutes=skew)
+
+    values = {
+        "time": moment.strftime("%H:%M"),
+        "time12": moment.strftime("%I:%M %p").lstrip("0"),
+        "date": moment.strftime("%b %d, %Y"),
+        "datetime": f"{moment.strftime('%b %d, %Y')} "
+                    f"{moment.strftime('%I:%M %p').lstrip('0')}",
+        "cy": f"CY {moment.year - FOUNDING_YEAR_TST}",
+        "hour": moment.strftime("%H"),
+        "period": _period_name(moment.hour),
+    }
+    return _TOKEN_RE.sub(lambda m: values[m.group(1)], text)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -65,6 +65,36 @@ HELP_ENTRY_DICTS = [
                 others see -> A long scar runs down her cheek.
                 you see    -> A long scar runs down your cheek.
 
+            ## time
+
+            Time tokens read the colony clock. They belong on |wtimepieces|n —
+            a worn chrono, a platform clock, an integrated display — and that
+            is deliberate: there is no command that tells you the hour. A
+            character carrying nothing does not know what time it is.
+
+                |w{time}|n      - 24-hour   (19:32)
+                |w{time12}|n    - 12-hour   (7:32 PM)
+                |w{date}|n      - date      (Jul 30, 3226)
+                |w{datetime}|n  - both
+                |w{cy}|n        - colony year (CY 61)
+                |w{hour}|n      - hour alone (19)
+                |w{period}|n    - vague     (the small hours, morning, evening)
+
+            Use |w{period}|n for anything that does not deserve a number — a
+            sun-line, a sky, a device too cheap to be precise.
+
+            Example:
+
+                A scratched field chrono, its face reading {time}.
+
+                you see -> A scratched field chrono, its face reading 19:32.
+
+            Two attributes let timepieces disagree, which is the point of
+            owning more than one:
+
+                |wclock_skew|n     minutes fast (+) or slow (-)
+                |wclock_stopped|n  a timestamp it died at, and shows forever
+
             ## number
 
             Number-flexible tokens let a single description read naturally

--- a/world/tests/test_time_tokens.py
+++ b/world/tests/test_time_tokens.py
@@ -1,0 +1,95 @@
+"""Time is legible through objects, not a command."""
+
+from datetime import datetime, timezone
+from unittest import mock
+
+from evennia.utils.test_resources import EvenniaTest
+
+from world import gametime
+
+
+class TestTimeTokens(EvenniaTest):
+
+    def _at(self, iso_utc):
+        moment = datetime.fromisoformat(iso_utc).replace(tzinfo=timezone.utc)
+        return mock.patch.object(gametime, "_real_utc", return_value=moment)
+
+    def test_time_token_renders_the_colony_clock(self):
+        with self._at("2026-07-31T03:32:00"):          # 19:32 colony
+            self.assertEqual(
+                gametime.render_time_tokens("The face reads {time}."),
+                "The face reads 19:32.")
+
+    def test_twelve_hour_and_date_and_cy(self):
+        with self._at("2026-07-31T03:32:00"):
+            out = gametime.render_time_tokens("{time12} on {date}, {cy}")
+            self.assertEqual(out, "7:32 PM on Jul 30, 3226, CY 61")
+
+    def test_period_is_vague_for_devices_without_a_readout(self):
+        with self._at("2026-07-31T11:00:00"):          # 03:00 colony
+            self.assertEqual(
+                gametime.render_time_tokens("It is {period}."),
+                "It is the small hours.")
+
+    def test_text_without_tokens_is_untouched(self):
+        text = "A scratched chrome bracelet, its face cracked."
+        self.assertIs(gametime.render_time_tokens(text), text)
+
+    def test_unknown_braces_are_left_alone(self):
+        """{their} and friends belong to other renderers."""
+        text = "{Their} wrist bears a chrono."
+        self.assertEqual(gametime.render_time_tokens(text), text)
+
+    def test_empty_and_none_survive(self):
+        self.assertEqual(gametime.render_time_tokens(""), "")
+        self.assertIsNone(gametime.render_time_tokens(None))
+
+
+class TestTimepiecesDisagree(EvenniaTest):
+    """Two watches in a room should be able to tell you different things."""
+
+    def _at(self, iso_utc):
+        moment = datetime.fromisoformat(iso_utc).replace(tzinfo=timezone.utc)
+        return mock.patch.object(gametime, "_real_utc", return_value=moment)
+
+    def test_skew_runs_a_watch_fast(self):
+        self.obj1.db.clock_skew = 11
+        with self._at("2026-07-31T03:32:00"):
+            self.assertEqual(
+                gametime.render_time_tokens("{time}", self.obj1), "19:43")
+
+    def test_skew_runs_a_watch_slow(self):
+        self.obj1.db.clock_skew = -20
+        with self._at("2026-07-31T03:32:00"):
+            self.assertEqual(
+                gametime.render_time_tokens("{time}", self.obj1), "19:12")
+
+    def test_a_stopped_clock_shows_the_moment_it_died(self):
+        self.obj1.db.clock_stopped = datetime(
+            2025, 11, 13, 5, 43, tzinfo=timezone.utc).timestamp()
+        with self._at("2026-07-31T03:32:00"):
+            self.assertEqual(
+                gametime.render_time_tokens("{time} on {date}", self.obj1),
+                "21:43 on Nov 12, 3225")
+
+    def test_a_garbage_skew_does_not_break_the_object(self):
+        self.obj1.db.clock_skew = "eleven"
+        with self._at("2026-07-31T03:32:00"):
+            self.assertEqual(
+                gametime.render_time_tokens("{time}", self.obj1), "19:32")
+
+
+class TestObjectRendersItsOwnDesc(EvenniaTest):
+    """The hook is on ObjectParent, so every object type gets it."""
+
+    def test_looking_at_an_item_resolves_the_token(self):
+        self.obj1.db.desc = "A field chrono reading {time}."
+        with mock.patch.object(gametime, "_real_utc",
+                               return_value=datetime(2026, 7, 31, 3, 32,
+                                                     tzinfo=timezone.utc)):
+            shown = self.obj1.get_display_desc(self.char1)
+        self.assertEqual(shown, "A field chrono reading 19:32.")
+
+    def test_an_ordinary_item_is_unaffected(self):
+        self.obj1.db.desc = "A dented mug."
+        self.assertEqual(self.obj1.get_display_desc(self.char1), "A dented mug.")


### PR DESCRIPTION
Closes #1502

The hour became mechanically decisive tonight and stayed invisible. A
time command would have fixed that and broken the fiction; time tokens
on objects fix it in the world's own terms — {time}, {time12}, {date},
{cy}, {period} — resolved on ObjectParent so every object type inherits
it.

clock_skew and clock_stopped let two watches in one room disagree, which
is the reason to own a second one.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
