### PR TITLE
Concealment survives a sideways glance, and the till opens

### DIFF
--- a/specs/BARS_AND_RECIPES_SPEC.md
+++ b/specs/BARS_AND_RECIPES_SPEC.md
@@ -5,7 +5,7 @@
 > **⚠ Spec-vs-code corrections — the following claims were FALSE when audited:**
 > - §9 lists `load <ingredients> into <bar>` as a shipped v1 verb. **No `load` command exists** — bottomless house stock (`derive_bar_stock`) replaced it.
 > - §9 lists `clear <bar>`; the shipped verb is `clean` (alias `wipe`).
-> - `db.register` is initialised but nothing reads or credits it — the till is a stub.
+> - ~~`db.register` is a stub~~ — **wrong**: it *is* credited on every sale (`typeclasses/bar.py:496`). The real gap was that nothing drained it, so bar income accumulated with no way out. Closed 2026-08-03 by `till <bar>` (owner/staff only), mirroring the butcher's block, which was already a closed loop.
 
 ## 0.1 · Implementation status (2026-06-22)
 

--- a/specs/LOOK_COMMAND_SPEC.md
+++ b/specs/LOOK_COMMAND_SPEC.md
@@ -4,7 +4,7 @@
 >
 > **⚠ Spec-vs-code corrections — the following claims were FALSE when audited:**
 > - The header's "Implementation Status: COMPLETED ✅" contradicted its own "12/13 Features Complete". 12/13 is correct.
-> - **§Sensory Focus Commands (`listen`, `smell`, `feel`) do not exist.** The five-sense room layers are real and perception-gated; there is no player-facing focus verb.
+> - **§Sensory Focus Commands (`listen`, `smell`, `feel`) do not exist and will not be built** (owner decision, 2026-08-03): `look` is the time-tested MUD verb and already surfaces every sense layer the room carries, perception-gated. Separate per-sense verbs would be syntax for its own sake. The section is retained as history, not as a plan.
 > - §13 Ambient Message System is confirmed unbuilt — no ticker or interval script emits atmospheric messages; the pools are pulled at `look` time only.
 > - Crowd-aware directional look **is** built (`typeclasses/exits.py:662`), contrary to earlier notes.
 

--- a/specs/TURNSTILE_INTEGRATION_SPEC.md
+++ b/specs/TURNSTILE_INTEGRATION_SPEC.md
@@ -1,9 +1,9 @@
 # Cloudflare Turnstile Integration Guide
 
-> **Status:** ✅ **SHIPPED** — code shipped, but **inactive unless keys are configured**. Verified 2026-08-02.
+> **Status:** ✅ **SHIPPED & LIVE** — verified 2026-08-03: the widget renders on the live registration page and both keys resolve non-empty at runtime.
 >
 > **⚠ Spec-vs-code corrections — the following claims were FALSE when audited:**
-> - `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` are empty strings in committed settings, and empty keys **skip verification** (`views/accounts.py:62-63`). The integration exists; that is not evidence CAPTCHA is live.
+> - An earlier audit called this inactive because `settings.py` holds empty strings. **That was wrong.** The real keys live in `server/conf/secret_settings.py`, which is gitignored — reading the committed repo says nothing about what the deployment is running. Empty keys *would* skip verification (`views/accounts.py:62-63`), so the check is worth keeping in mind, but it does not apply here.
 
 ## Overview
 

--- a/typeclasses/bar.py
+++ b/typeclasses/bar.py
@@ -202,6 +202,77 @@ class CmdBarClear(Command):
         )
 
 
+class CmdBarTill(Command):
+    """
+    Take the day's earnings out of the bar.
+
+    Usage:
+        till <bar>
+        till <bar> = <amount>
+
+    Counts what the register holds, and hands it over. With an amount, takes
+    only that much and leaves the rest. For the owner and their staff.
+
+    Money went INTO the register on every sale and had no way back out — the
+    bar accumulated a number nobody could spend. The butcher's block already
+    closed this loop (payouts drain its till); this is the same door on the
+    other side of the counter.
+    """
+
+    key = "till"
+    locks = "cmd:all()"
+    help_category = "Bar"
+
+    def func(self):
+        from world.identity_utils import msg_room_identity
+
+        bar = self.obj
+        caller = self.caller
+
+        owner = bar.db.owner
+        staff = bar.db.staff or []
+        if owner is not None and caller != owner and caller not in staff:
+            caller.msg("That's not your register.")
+            return
+
+        held = int(bar.db.register or 0)
+        if held <= 0:
+            caller.msg("The register's empty.")
+            return
+
+        # NB: this is evennia.commands.command.Command, not MuxCommand — there
+        # is no self.rhs. Parse the "= <amount>" half by hand.
+        take = held
+        amount = ""
+        if "=" in (self.args or ""):
+            amount = self.args.split("=", 1)[1].strip()
+        if amount:
+            try:
+                take = int(amount)
+            except (TypeError, ValueError):
+                caller.msg("Take how much?")
+                return
+            if take <= 0:
+                caller.msg("Take how much?")
+                return
+            take = min(take, held)
+
+        bar.db.register = held - take
+        caller.tokens = int(getattr(caller, "tokens", 0) or 0) + take
+
+        left = bar.db.register
+        caller.msg(
+            f"You count {take} out of the register"
+            + (f", leaving {left}." if left else " and leave it empty.")
+        )
+        msg_room_identity(
+            location=caller.location,
+            template="{actor} counts the register out and pockets the take.",
+            char_refs={"actor": caller},
+            exclude=[caller],
+        )
+
+
 class BarCmdSet(CmdSet):
     key = "bar_cmdset"
 
@@ -210,6 +281,7 @@ class BarCmdSet(CmdSet):
         self.add(CmdBarUse())
         self.add(CmdBarPrepare())
         self.add(CmdBarClear())
+        self.add(CmdBarTill())
 
 
 # ---------------------------------------------------------------------------

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -675,10 +675,20 @@ class Exit(DefaultExit):
         if not destination_room:
             return ""
             
-        # Get characters in destination room (excluding looker if they're somehow there)
-        destination_characters = [char for char in destination_room.contents 
-                                if char.is_typeclass("typeclasses.characters.Character") 
-                                and char != looker]
+        # Get characters in destination room (excluding looker if they're somehow
+        # there). PERCEPTION-GATED, same as rooms.get_adjacent_character_sightings:
+        # without this, a character hidden from the room-level glance was still
+        # named here, and concealment could be defeated by looking at the exit
+        # instead of the room (stealth spec §7 — no leak through the doorway).
+        from world.perception import can_perceive
+
+        destination_characters = [
+            char for char in destination_room.contents
+            if char.is_typeclass("typeclasses.characters.Character")
+            and char != looker
+            and char.access(looker, "view")
+            and can_perceive(looker, char)
+        ]
                           
         if not destination_characters:
             return ""

--- a/world/tests/test_bar_till.py
+++ b/world/tests/test_bar_till.py
@@ -1,0 +1,77 @@
+"""The register can be emptied — money in, money out.
+
+Uses Evennia's command-test helper (`self.call`) rather than
+`execute_cmd`: the bar's commands live on an OBJECT cmdset, and driving
+them through the cmdset router in a test harness silently no-ops.
+"""
+
+from evennia import create_object
+from evennia.utils.test_resources import EvenniaCommandTest
+
+from typeclasses.bar import CmdBarTill
+
+
+class TestBarTill(EvenniaCommandTest):
+
+    def setUp(self):
+        super().setUp()
+        self.bar = create_object("typeclasses.bar.BarCounter", key="bar",
+                                 location=self.room1)
+        self.char1.location = self.room1
+        self.char1.tokens = 0
+
+    def _till(self, args=""):
+        self.call(CmdBarTill(), args, obj=self.bar, caller=self.char1)
+
+    def test_owner_takes_the_whole_register(self):
+        self.bar.db.owner = self.char1
+        self.bar.db.register = 120
+        self._till()
+        self.assertEqual(self.bar.db.register, 0)
+        self.assertEqual(self.char1.tokens, 120)
+
+    def test_partial_take_leaves_the_rest(self):
+        self.bar.db.owner = self.char1
+        self.bar.db.register = 120
+        self._till("bar = 50")
+        self.assertEqual(self.bar.db.register, 70)
+        self.assertEqual(self.char1.tokens, 50)
+
+    def test_cannot_take_more_than_is_there(self):
+        self.bar.db.owner = self.char1
+        self.bar.db.register = 30
+        self._till("bar = 500")
+        self.assertEqual(self.bar.db.register, 0)
+        self.assertEqual(self.char1.tokens, 30)
+
+    def test_staff_may_take(self):
+        self.bar.db.owner = self.char2
+        self.bar.db.staff = [self.char1]
+        self.bar.db.register = 40
+        self._till()
+        self.assertEqual(self.char1.tokens, 40)
+
+    def test_a_stranger_may_not(self):
+        self.bar.db.owner = self.char2
+        self.bar.db.register = 40
+        self._till()
+        self.assertEqual(self.bar.db.register, 40)
+        self.assertEqual(self.char1.tokens, 0)
+
+    def test_unowned_bar_is_open_to_anyone(self):
+        self.bar.db.register = 15
+        self._till()
+        self.assertEqual(self.char1.tokens, 15)
+
+    def test_empty_register_pays_nothing(self):
+        self.bar.db.owner = self.char1
+        self.bar.db.register = 0
+        self._till()
+        self.assertEqual(self.char1.tokens, 0)
+
+    def test_a_nonsense_amount_takes_nothing(self):
+        self.bar.db.owner = self.char1
+        self.bar.db.register = 60
+        self._till("bar = lots")
+        self.assertEqual(self.bar.db.register, 60)
+        self.assertEqual(self.char1.tokens, 0)

--- a/world/tests/test_exit_stealth.py
+++ b/world/tests/test_exit_stealth.py
@@ -1,0 +1,32 @@
+"""Concealment must survive a directional glance (#1506)."""
+
+from unittest import mock
+
+from evennia.utils.test_resources import EvenniaTest
+
+
+class TestExitLookRespectsPerception(EvenniaTest):
+    """
+    rooms.get_adjacent_character_sightings gated through can_perceive;
+    exits._get_exit_character_display did not, so looking at the exit
+    named people who were hidden from the room.
+    """
+
+    def test_hidden_character_is_not_named_through_the_exit(self):
+        self.char2.location = self.room2          # next door
+        with mock.patch("world.perception.can_perceive", return_value=False):
+            shown = self.exit._get_exit_character_display(self.char1)
+        self.assertNotIn(self.char2.key, shown or "")
+
+    def test_visible_character_still_shows(self):
+        self.char2.location = self.room2
+        with mock.patch("world.perception.can_perceive", return_value=True):
+            shown = self.exit._get_exit_character_display(self.char1)
+        self.assertTrue(shown)
+
+    def test_empty_destination_is_silent(self):
+        for obj in list(self.room2.contents):
+            if obj.is_typeclass("typeclasses.characters.Character"):
+                obj.location = self.room1
+        with mock.patch("world.perception.can_perceive", return_value=True):
+            self.assertEqual(self.exit._get_exit_character_display(self.char1), "")


### PR DESCRIPTION
Closes #1506, #1515

_get_exit_character_display named characters that can_perceive would
have hidden, so looking at the exit defeated concealment the room-level
glance respected. Same gate as rooms.get_adjacent_character_sightings —
whose comment already said "no leak through the doorway".

The bar register was credited on every sale and never drained; `till`
gives the owner and staff a way to collect, mirroring the butcher's
block.

Also corrects two audit claims that were wrong: Turnstile IS live (its
keys are in gitignored secret_settings, not the committed file), and the
register was never a stub. Owner ruled out listen/smell/feel — look does
the job — and the spec now records that as a decision.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
