### PR TITLE
Skins, cycled by clicking the mark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ web/static/website/css/*
 !web/static/website/fonts/**
 !web/static/website/images/
 !web/static/website/images/**
+!web/static/website/js/
+!web/static/website/js/**
 world/__pycache__/
 typeclasses/__pycache__/
 commands/__pycache__/

--- a/web/static/webclient/css/webclient.css
+++ b/web/static/webclient/css/webclient.css
@@ -345,3 +345,44 @@ html, body {
 .sys-echo {
     color: var(--yellow);
 }
+
+/* ====================================================================
+   SKINS — CHROME ONLY  (2026-08-03)
+   --------------------------------------------------------------------
+   THE PROTOCOL OWNS GAME COLOUR. ansi_up runs with `use_classes = false`
+   (see js/gel.js), so every coloured character the game sends is styled
+   inline from the xterm-256 table and NO stylesheet — including this one
+   — can reach it. A room title is the same cyan here, in Mudlet, and
+   over raw telnet. That is deliberate and must stay true.
+
+   A skin therefore dresses the room around the text: ground, input bar,
+   field, borders, muted status. Not one character of game output.
+
+   Consequence: every skin is DARK. The ANSI palette is fixed, so the
+   ground has to keep it legible — and must not collide with a colour the
+   palette uses (a navy ground eats |b, a maroon one swallows |r).
+   ==================================================================== */
+
+[data-skin="terminal"] {
+    --bg-dark: #1a1a1a;
+    --bg-medium: #2a2a2a;
+    --bg-light: #3a3a3a;
+    --amber: #5fd38d;              /* the old identity: jade, not amber */
+    --amber-dim: #4a9d6d;
+    --amber-glow: rgba(95, 211, 141, 0.3);
+    --text: #e0e0e0;
+    --text-muted: #999999;
+    --border: #404040;
+}
+
+[data-skin="stray"] {
+    --bg-dark: #0d0a12;
+    --bg-medium: #16111c;
+    --bg-light: #201828;
+    --amber: #ff3d9a;              /* neon pink; chrome only, never game text */
+    --amber-dim: #c42d76;
+    --amber-glow: rgba(255, 61, 154, 0.32);
+    --text: #e6dde4;
+    --text-muted: #8d8393;
+    --border: #2c2136;
+}

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -1879,3 +1879,87 @@ h1 { font-size: var(--size-h1); }
 .navbar-brand .media-body {
     line-height: 1.25;
 }
+
+/* ====================================================================
+   SKINS  (2026-08-03)
+   --------------------------------------------------------------------
+   An Easter egg: click the brand mark to cycle. The choice rides in a
+   cookie on `.gel.monster` so the site, the Atlas, the webclient and the
+   forum all agree (see web/static/website/js/skins.js).
+
+   A skin overrides TOKENS ONLY. Nothing here restyles a component,
+   because no component carries a colour of its own — that is the whole
+   reason this is cheap.
+
+   EVERY SKIN IS DARK, and that is a hard rule rather than taste: the
+   webclient renders game output as inline styles straight off the
+   xterm-256 table (the protocol owns game colour, not CSS), so the
+   fixed ANSI palette has to stay legible against whatever ground a skin
+   picks. A light skin would put cyan room titles on cream.
+
+   Related: a ground must not collide with a colour the palette USES.
+   Dark is necessary, not sufficient — a navy ground eats |b blue text,
+   a maroon one swallows |r red.
+   ==================================================================== */
+
+/* ── terminal ─────────────────────────────────────────────────────────
+   The original identity, kept as a period piece: jade on neutral grey,
+   from before the Atlas register. Accent and success are the same green
+   here, which is exactly how it was — and exactly why it was replaced. */
+[data-skin="terminal"] {
+    --terminal-bg-dark: #1a1a1a;
+    --terminal-bg-medium: #2a2a2a;
+    --terminal-bg-light: #3a3a3a;
+    --terminal-accent: #5fd38d;
+    --terminal-accent-dim: #4a9d6d;
+    --terminal-text: #e0e0e0;
+    --terminal-text-muted: #999999;
+    --terminal-border: #404040;
+    --terminal-glow: rgba(95, 211, 141, 0.30);
+}
+
+/* ── stray ────────────────────────────────────────────────────────────
+   Somebody got at the logo. Neon pink over a violet-black ground, and
+   the brand mark wears sprayed-on ears and whiskers (see .tag below).
+   The ground moves off blue-black toward neutral violet so the pink has
+   somewhere to sit without fighting it. */
+[data-skin="stray"] {
+    --terminal-bg-dark: #0d0a12;
+    --terminal-bg-medium: #16111c;
+    --terminal-bg-light: #201828;
+    --terminal-accent: #ff3d9a;
+    --terminal-accent-dim: #c42d76;
+    --terminal-text: #e6dde4;
+    --terminal-text-muted: #8d8393;
+    --terminal-border: #2c2136;
+    --terminal-glow: rgba(255, 61, 154, 0.32);
+}
+
+/* ── the tag ──────────────────────────────────────────────────────────
+   Hidden on every skin but `stray`. Drawn OVER the mark rather than
+   composed into it — round caps, uneven angles, a drip and a little
+   overspray, so it reads as applied by hand rather than designed in. */
+.brand-mark .tag { display: none; }
+
+[data-skin="stray"] .brand-mark .tag {
+    display: block;
+    fill: none;
+    stroke: var(--terminal-accent);
+    stroke-width: 2.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    opacity: 0.92;
+}
+[data-skin="stray"] .brand-mark .tag .spatter {
+    fill: var(--terminal-accent);
+    stroke: none;
+    opacity: 0.75;
+}
+[data-skin="stray"] .brand-mark .tag .drip {
+    stroke-width: 1.6;
+    opacity: 0.7;
+}
+
+/* The mark is a control now; say so on hover without shouting about it. */
+.brand-mark { transition: filter .18s ease; }
+.navbar-brand .brand-mark:hover { filter: brightness(1.25); }

--- a/web/static/website/js/skins.js
+++ b/web/static/website/js/skins.js
@@ -1,0 +1,66 @@
+/*
+ * Skins — an Easter egg, cycled by clicking the brand mark.
+ *
+ * The choice rides in a cookie scoped to `.gel.monster` rather than
+ * localStorage, because localStorage is per-origin and the forum is a
+ * different origin. One cookie, four surfaces: site, atlas, webclient, and
+ * the Discourse theme component that reads it on load.
+ *
+ * WHAT A SKIN MAY TOUCH: chrome only. On the webclient the game's own output
+ * is inline-styled by ansi_up straight off the xterm-256 table, and it stays
+ * that way — a room title is the same cyan here, in Mudlet, and over raw
+ * telnet. The protocol is the source of truth for game text; skins dress the
+ * room around it. Every skin is therefore DARK, so the fixed ANSI palette
+ * stays legible on all of them.
+ */
+(function () {
+  "use strict";
+
+  var SKINS = ["atlas", "terminal", "stray"];
+  var COOKIE = "gel_skin";
+  var ROOT = document.documentElement;
+
+  function readCookie() {
+    var hit = document.cookie.match(/(?:^|;\s*)gel_skin=([^;]+)/);
+    return hit ? decodeURIComponent(hit[1]) : null;
+  }
+
+  function writeCookie(skin) {
+    // Domain-scoped so forum.gel.monster sees it too. A year, because an
+    // Easter egg that forgets itself is just a flicker.
+    var domain = location.hostname.endsWith("gel.monster") ? "; domain=.gel.monster" : "";
+    document.cookie = "gel_skin=" + encodeURIComponent(skin) +
+      "; path=/; max-age=31536000; samesite=lax" + domain;
+  }
+
+  function apply(skin) {
+    if (SKINS.indexOf(skin) === -1) skin = SKINS[0];
+    if (skin === SKINS[0]) ROOT.removeAttribute("data-skin");
+    else ROOT.setAttribute("data-skin", skin);
+  }
+
+  apply(readCookie() || SKINS[0]);
+
+  function cycle(ev) {
+    // The mark sits inside the brand link; cycling must not navigate home.
+    if (ev) { ev.preventDefault(); ev.stopPropagation(); }
+    var current = readCookie() || SKINS[0];
+    var next = SKINS[(SKINS.indexOf(current) + 1 + SKINS.length) % SKINS.length];
+    writeCookie(next);
+    apply(next);
+  }
+
+  function wire() {
+    var marks = document.querySelectorAll(".brand-mark");
+    for (var i = 0; i < marks.length; i++) {
+      marks[i].style.cursor = "pointer";
+      marks[i].addEventListener("click", cycle);
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", wire);
+  } else {
+    wire();
+  }
+})();

--- a/web/templates/webclient/webclient.html
+++ b/web/templates/webclient/webclient.html
@@ -35,6 +35,10 @@
     <span id="reconnect-detail" class="reconnect-detail"></span>
 </div>
 
+<!-- Skins: reads the same .gel.monster cookie as the site and applies
+     data-skin. CHROME ONLY — gel.js keeps ansi_up on inline styles so the
+     protocol still owns game colour. -->
+<script src="{% static 'website/js/skins.js' %}"></script>
 <script src="{% static 'webclient/js/gel.js' %}"></script>
 
 {% endblock %}

--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -21,6 +21,24 @@ folder and edit it to add/remove links to the menu.
         <circle class="node" cx="86" cy="35" r="5"/>
         <circle class="knock" cx="50" cy="50" r="25"/>
         <text class="mono" x="50" y="52" font-size="34" font-weight="600" letter-spacing="1">GM</text>
+        <g class="tag">
+          <!-- ears: uneven on purpose, and overlapping the ring rather than
+               tucked behind it — sprayed ON the sign, not drawn into it -->
+          <path d="M29 17 L34 2 L45 11 Z"/>
+          <path d="M71 16 L67 1 L56 10 Z"/>
+          <!-- whiskers, crossing the ring on both sides -->
+          <path d="M27 55 L5 50"/>
+          <path d="M26 60 L4 62"/>
+          <path d="M28 65 L8 72"/>
+          <path d="M73 55 L95 51"/>
+          <path d="M74 60 L96 62"/>
+          <path d="M72 65 L92 73"/>
+          <!-- a drip off the left ear, and overspray -->
+          <path class="drip" d="M33 4 L33 12"/>
+          <circle class="spatter" cx="26" cy="8" r="1.3"/>
+          <circle class="spatter" cx="80" cy="15" r="1"/>
+          <circle class="spatter" cx="12" cy="57" r="0.9"/>
+        </g>
       </svg>
       <div class="media-body">
         {{ game_name }}<br />
@@ -96,3 +114,6 @@ folder and edit it to add/remove links to the menu.
     </ul>
   </div>
 </nav>
+
+{# Skins: click the brand mark to cycle. See web/static/website/js/skins.js #}
+<script src="{% static 'website/js/skins.js' %}"></script>

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -20,6 +20,24 @@ Removes the Forum link to prevent navigation loops and double headers.
         <circle class="node" cx="86" cy="35" r="5"/>
         <circle class="knock" cx="50" cy="50" r="25"/>
         <text class="mono" x="50" y="52" font-size="34" font-weight="600" letter-spacing="1">GM</text>
+        <g class="tag">
+          <!-- ears: uneven on purpose, and overlapping the ring rather than
+               tucked behind it — sprayed ON the sign, not drawn into it -->
+          <path d="M29 17 L34 2 L45 11 Z"/>
+          <path d="M71 16 L67 1 L56 10 Z"/>
+          <!-- whiskers, crossing the ring on both sides -->
+          <path d="M27 55 L5 50"/>
+          <path d="M26 60 L4 62"/>
+          <path d="M28 65 L8 72"/>
+          <path d="M73 55 L95 51"/>
+          <path d="M74 60 L96 62"/>
+          <path d="M72 65 L92 73"/>
+          <!-- a drip off the left ear, and overspray -->
+          <path class="drip" d="M33 4 L33 12"/>
+          <circle class="spatter" cx="26" cy="8" r="1.3"/>
+          <circle class="spatter" cx="80" cy="15" r="1"/>
+          <circle class="spatter" cx="12" cy="57" r="0.9"/>
+        </g>
       </svg>
       <div class="media-body">
         {{ game_name }}<br />

--- a/web/templates/website/header_only.html
+++ b/web/templates/website/header_only.html
@@ -83,6 +83,9 @@ Uses iframe-specific menu that removes Forum link to prevent double headers.
 </head>
 <body>
     {% include "website/_menu_iframe.html" %}
+
+    <!-- Skins: the forum header cycles too, and shares the cookie. -->
+    <script src="{% static 'website/js/skins.js' %}"></script>
     
     <!-- jQuery and Bootstrap JS -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK" crossorigin="anonymous"></script>


### PR DESCRIPTION
Closes #1517

Three dark skins — atlas, terminal, stray — as token overrides, carried
across surfaces by a cookie on .gel.monster because localStorage would
never reach the forum.

The client gets chrome only. ansi_up stays on inline styles so the
protocol keeps owning game colour; a room title reads the same here, in
Mudlet, and over telnet. That is why every skin is dark.

stray sprays cat ears and whiskers over the mark — closed triangles
perched on the ring after the first attempt read as X-scribbles.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
