### PR TITLE
Resolve the header skin server-side, killing the seam against the forum

### DIFF
--- a/web/discourse-theme/README.md
+++ b/web/discourse-theme/README.md
@@ -21,8 +21,35 @@ one and the forum loses its header; a component layers on top of it.
    add it under *Included components*.
 4. Select the **Domino's Gambit** colour scheme on the parent theme.
 
-Re-uploading a newer zip updates the component in place, and the parent
-theme keeps its header either way.
+### Updating it later
+
+**A zip install always creates a NEW component — it does not update the
+existing one in place.** Uploading a newer zip leaves you with two
+components of the same name, one attached to the parent theme and one
+`Unused`, distinguishable only by that column.
+
+To update:
+
+1. Upload the new zip. Note which entry says `Unused` — that is the new
+   one.
+2. Rename the *old* one (the one marked `Used on Foundation`) so the two
+   can be told apart.
+3. On the parent theme, **add the new component first, then remove the
+   old one.** Doing it in that order matters: removing the last component
+   silently strips the forum's typography with no warning, and the
+   palette keeps looking correct because the parent theme points at the
+   colour scheme directly.
+4. Verify the forum, then delete the renamed old component.
+
+Deleting a component never deletes a colour scheme — the palettes are
+standalone records (`theme_id` null) and survive independently.
+
+Installing **from a git repository** instead would give proper in-place
+updates via *Check for updates*, which is Discourse's real upgrade path.
+The obstacle is that its importer expects `about.json` at the repository
+root, and this lives in a subdirectory of the game monorepo, so it would
+need its own repository or a dedicated branch. Worth doing if component
+changes become frequent.
 
 ### If the header has already disappeared
 

--- a/web/templates/website/header_only.html
+++ b/web/templates/website/header_only.html
@@ -5,7 +5,7 @@ Uses iframe-specific menu that removes Forum link to prevent double headers.
 {% endcomment %}
 {% load static %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en"{% if skin %} data-skin="{{ skin }}"{% endif %}>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,10 +15,15 @@ Uses iframe-specific menu that removes Forum link to prevent double headers.
          loads. MUST be a literal: --terminal-bg-dark is defined in custom.css,
          which has not arrived yet, and an undefined custom property makes the
          whole declaration invalid — which is exactly the flash this prevents.
-         Keep in sync with --terminal-bg-dark. -->
+
+         The literal is chosen server-side from the skin cookie (SKIN_INK in
+         views/header_only.py). Hardcoding the default ink here meant that on
+         any other skin the header painted the wrong ground until skins.js
+         ran, which read as a colour seam against the already-skinned forum
+         body. Keep SKIN_INK in sync with --terminal-bg-dark per skin. -->
     <style>
         html, body {
-            background-color: #0b0e14 !important;
+            background-color: {{ skin_ink }} !important;
             margin: 0;
             padding: 0;
         }

--- a/web/website/views/header_only.py
+++ b/web/website/views/header_only.py
@@ -14,6 +14,39 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.conf import settings
 
 
+# The skin has to be resolved SERVER-SIDE for this view, unlike everywhere
+# else, because the header is an iframe sitting directly against the forum
+# body — and Discourse renders its own palette server-side from a cookie.
+# Letting skins.js apply the skin after load meant the header painted the
+# default ground while the body was already skinned, showing a seam along the
+# join until the script ran. A fresh forum page replays that every time; an
+# in-forum click does not reload the iframe, which is why it looked like it
+# healed itself.
+#
+# Values are the `--terminal-bg-dark` of each skin in custom.css. They must be
+# LITERALS here for the same reason the critical CSS block in the template
+# uses literals: custom.css has not arrived at first paint, and an undefined
+# custom property invalidates the whole declaration. Keep the two in sync.
+SKIN_INK = {
+    "atlas": "#0b0e14",
+    "terminal": "#1a1a1a",
+    "stray": "#0d0a12",
+}
+DEFAULT_SKIN = "atlas"
+
+
+def _requested_skin(request):
+    """
+    The skin named by the `gel_skin` cookie, or the default.
+
+    Whitelisted against SKIN_INK rather than trusted: the value reaches a
+    template attribute and a stylesheet, and it is set by client-side script
+    on a domain-scoped cookie, so anyone can put anything in it.
+    """
+    skin = request.COOKIES.get("gel_skin", DEFAULT_SKIN)
+    return skin if skin in SKIN_INK else DEFAULT_SKIN
+
+
 # NOT cached. This response is auth state: it names the logged-in account and
 # renders a different menu for anonymous visitors. A five-minute cache meant
 # the forum header could keep saying "Logged in as X" for five minutes after
@@ -38,7 +71,13 @@ def header_only(request):
 
     Optional: Only useful if you're embedding the header elsewhere (e.g., forum).
     """
+    skin = _requested_skin(request)
+
     context = {
+        # Only stamped when it is not the default, matching what skins.js does
+        # to the <html> element so the two agree about what "no skin" means.
+        'skin': '' if skin == DEFAULT_SKIN else skin,
+        'skin_ink': SKIN_INK[skin],
         'game_name': 'Gelatinous Monster',
         'game_slogan': 'An abomination to behold',
         'account': request.user if request.user.is_authenticated else None,


### PR DESCRIPTION
On any skin but the default, arriving at the forum from the site showed a
colour line between the header iframe and the forum body. Clicking Forum
from inside Discourse did not, which made it look like it healed itself.

The two halves were resolving the skin by different means at different
times. Discourse reads its palette cookie server-side and gets the right
palette in the first paint. /header-only/ was served with no skin
information at all, and skins.js only sets data-skin after the document
and two CDN scripts have loaded — so the header wore the default ground
while the body was already skinned.

Two things held it there. The critical CSS block hardcoded the atlas ink
as a literal to prevent a flash before custom.css arrives, which is simply
the wrong colour on another skin. And once custom.css does arrive and win
the cascade, it resolves var(--terminal-bg-dark), which still needs the
data-skin that only script was setting.

An in-forum click is an Ember transition that never reloads the iframe, so
the already-skinned header survives it. That asymmetry was the tell.

Now the view resolves the skin from the cookie and passes both the name
and the ink literal, the template stamps data-skin on <html>, and the
critical block emits the matching colour. Correct at first paint, no
script involved. The cookie is whitelisted rather than trusted: it is
client-set on a domain-scoped cookie and the value reaches both an HTML
attribute and a stylesheet.

The ink literals are necessarily duplicated between SKIN_INK and
--terminal-bg-dark, because custom properties do not exist at first paint
— which is the entire reason the critical block exists. Both sides carry a
comment saying so.

Also corrects the component README, which claimed re-uploading a zip
updates the component in place. It does not; it creates a second
identically-named component, which is exactly what happened. The real
procedure, including the order that avoids silently stripping the forum's
typography, is now written down.

Closes #1521

Co-Authored-By: Claude <noreply@anthropic.com>
