### PR TITLE
Derive the forum component's colours from the active palette

### DIFF
--- a/web/discourse-theme/common/common.scss
+++ b/web/discourse-theme/common/common.scss
@@ -42,11 +42,26 @@
     --heading-font-family: "Monaspace Xenon", ui-monospace, "SF Mono",
         Menlo, monospace;
 
-    /* the house accent, for the places Discourse's scheme does not reach */
-    --gg-accent: #e0a86f;
-    --gg-bone: #d8d3c4;
-    --gg-bone-dim: #8f8d82;
-    --gg-line: #232c3a;
+    /* House names for the palette, DERIVED rather than literal.
+     *
+     * These used to be hardcoded Domino's Gambit hex. That was invisible
+     * while there was only one palette, and became a bug the moment the skin
+     * easter egg could swap it: Discourse repainted everything from the new
+     * palette while these stayed amber-and-blue-grey. The most visible
+     * symptom was --gg-line on .d-header's border-bottom, which drew a fixed
+     * blue-grey rule directly under the site header — a seam between the
+     * header and the forum body that appeared on every skin except the
+     * default, and looked like a theme-sync failure rather than a stray
+     * border.
+     *
+     * Discourse compiles --primary/--secondary/--tertiary and their derived
+     * shades from whichever palette is active, so mapping onto them makes the
+     * component follow the skin for free, with nothing to keep in sync.
+     */
+    --gg-accent: var(--tertiary);
+    --gg-bone: var(--primary);
+    --gg-bone-dim: var(--primary-medium);
+    --gg-line: var(--primary-low);
 }
 
 /* texture healing and the slashed zero — the same house characteristics


### PR DESCRIPTION
On any skin but the default, a line sat between the site header and the
forum body. It was not skin-sync: both halves had taken the skin correctly.
The component defined its house colour names as literals —

    --gg-accent: #e0a86f;  --gg-bone: #d8d3c4;
    --gg-bone-dim: #8f8d82;  --gg-line: #232c3a;

and .d-header draws border-bottom: 1px solid var(--gg-line). That is a
fixed blue-grey rule directly under the header, so against Terminal's grey
or Stray's violet it became a seam.

Harmless while there was one palette; a bug the moment the easter egg could
swap them, because Discourse repaints everything from the new palette while
these four stayed behind.

Mapping them onto --tertiary/--primary/--primary-medium/--primary-low makes
the component follow the palette for free, with nothing left to keep in
sync. Verified those recompile per palette: under Terminal --primary-low
resolves to rgb(49.28, 49.28, 49.28) rather than the Domino's Gambit value.

No literal colours remain in the component.

The tell, worth recording: the brand mark's ring was already jade in the
report, so the header HAD taken the skin — which ruled out the timing
explanation and pointed at something painting a fixed colour instead.

Closes #1528

Co-Authored-By: Claude <noreply@anthropic.com>
