### PR TITLE
Grow the ears out of the rim, and push the whiskers clear

### DIFF
--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -34,24 +34,26 @@ folder and edit it to add/remove links to the menu.
           <circle class="node" cx="24.5" cy="-6.2" r="3.0"/>
         </g>
         <g class="tag">
-          <!-- Ears straddle the rim and break the silhouette — sprayed ON the
-               sign, not drawn into it. They sit apart rather than meeting at
-               the crown, which at 44px otherwise reads as a bow tie. The tips
-               run above the viewBox on purpose; .brand-mark allows overflow. -->
-          <path d="M 19,21 L 26,-8 L 42,6 Z"/>
-          <path d="M 81,20 L 75,-9 L 59,5 Z"/>
+          <!-- Ears grow OUT of the rim: both base points of each triangle lie
+               exactly on the r=49 circle, so the ear reads as part of the head
+               rather than a triangle pasted over it. That single constraint is
+               what makes the silhouette legible as a cat. Tips run above the
+               viewBox on purpose; .brand-mark allows overflow. The right ear is
+               not a mirror of the left — sprayed, not printed. -->
+          <path d="M 36.5,2.9 L 8.6,-11.3 L 11.4,19.8 Z"/>
+          <path d="M 65.1,3.4 L 91.7,-7.4 L 90.1,21.9 Z"/>
           <!-- Whiskers sit BELOW the ring. On the old monogram mark they could
                cross the middle harmlessly; the ring now occupies that band and
                they fought it. -->
-          <path d="M 33,70 L 6,65"/>
-          <path d="M 33,75 L 4,79"/>
-          <path d="M 35,79 L 11,90"/>
-          <path d="M 67,70 L 94,65"/>
-          <path d="M 67,75 L 96,79"/>
-          <path d="M 65,79 L 89,90"/>
+          <path d="M 29,69 L 1,63"/>
+          <path d="M 29,75 L -1,79"/>
+          <path d="M 31,79 L 6,91"/>
+          <path d="M 71,69 L 99,63"/>
+          <path d="M 71,75 L 101,79"/>
+          <path d="M 69,79 L 94,91"/>
           <!-- a drip off the left ear, and overspray -->
-          <path class="drip" d="M 24,-3 L 24,6"/>
-          <circle class="spatter" cx="15" cy="3" r="1.5"/>
+          <path class="drip" d="M 13,0 L 13,9"/>
+          <circle class="spatter" cx="20" cy="6" r="1.5"/>
           <circle class="spatter" cx="87" cy="-3" r="1.2"/>
           <circle class="spatter" cx="8" cy="70" r="1.1"/>
         </g>

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -32,24 +32,26 @@ Removes the Forum link to prevent navigation loops and double headers.
           <circle class="node" cx="24.5" cy="-6.2" r="3.0"/>
         </g>
         <g class="tag">
-          <!-- Ears straddle the rim and break the silhouette — sprayed ON the
-               sign, not drawn into it. They sit apart rather than meeting at
-               the crown, which at 44px otherwise reads as a bow tie. The tips
-               run above the viewBox on purpose; .brand-mark allows overflow. -->
-          <path d="M 19,21 L 26,-8 L 42,6 Z"/>
-          <path d="M 81,20 L 75,-9 L 59,5 Z"/>
+          <!-- Ears grow OUT of the rim: both base points of each triangle lie
+               exactly on the r=49 circle, so the ear reads as part of the head
+               rather than a triangle pasted over it. That single constraint is
+               what makes the silhouette legible as a cat. Tips run above the
+               viewBox on purpose; .brand-mark allows overflow. The right ear is
+               not a mirror of the left — sprayed, not printed. -->
+          <path d="M 36.5,2.9 L 8.6,-11.3 L 11.4,19.8 Z"/>
+          <path d="M 65.1,3.4 L 91.7,-7.4 L 90.1,21.9 Z"/>
           <!-- Whiskers sit BELOW the ring. On the old monogram mark they could
                cross the middle harmlessly; the ring now occupies that band and
                they fought it. -->
-          <path d="M 33,70 L 6,65"/>
-          <path d="M 33,75 L 4,79"/>
-          <path d="M 35,79 L 11,90"/>
-          <path d="M 67,70 L 94,65"/>
-          <path d="M 67,75 L 96,79"/>
-          <path d="M 65,79 L 89,90"/>
+          <path d="M 29,69 L 1,63"/>
+          <path d="M 29,75 L -1,79"/>
+          <path d="M 31,79 L 6,91"/>
+          <path d="M 71,69 L 99,63"/>
+          <path d="M 71,75 L 101,79"/>
+          <path d="M 69,79 L 94,91"/>
           <!-- a drip off the left ear, and overspray -->
-          <path class="drip" d="M 24,-3 L 24,6"/>
-          <circle class="spatter" cx="15" cy="3" r="1.5"/>
+          <path class="drip" d="M 13,0 L 13,9"/>
+          <circle class="spatter" cx="20" cy="6" r="1.5"/>
           <circle class="spatter" cx="87" cy="-3" r="1.2"/>
           <circle class="spatter" cx="8" cy="70" r="1.1"/>
         </g>


### PR DESCRIPTION
The ears were triangles overlapping the disc, which read as horns — or at
44px, as a bow. Both base points of each triangle now lie exactly on the
r=49 rim, so the ear appears to grow out of the head instead of sitting on
top of it. That one constraint is what makes the silhouette legible as a
cat; size and angle barely mattered by comparison.

The right ear is deliberately not a mirror of the left. Sprayed, not
printed.

Whiskers move outward, away from the body, where they read as whiskers
rather than as lines crossing a logo. The drip follows the left ear to its
new position.

Verified at 44px, the size the header actually renders.

Co-Authored-By: Claude <noreply@anthropic.com>
