### PR TITLE
Harden the forum skin swap: retry on navigation, stop swallowing errors

### DIFF
--- a/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
+++ b/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
@@ -107,7 +107,11 @@ export default apiInitializer("1.8.0", (api) => {
       link.dataset.schemeId = id;
       applied = id;
     } catch (e) {
-      // The cookie is already set, so a reload lands on the right palette.
+      // The cookie is already set, so a reload lands on the right palette —
+      // but say so. A silent catch here hid a misdiagnosed seam for hours;
+      // if this path is ever hit again, the evidence belongs in the console.
+      console.warn("[gel-skin] stylesheet swap failed; will retry on next navigation", e);
+      applied = null;
     }
   }
 
@@ -124,4 +128,14 @@ export default apiInitializer("1.8.0", (api) => {
       applySkin(event.data.skin);
     }
   });
+
+  // Belt and braces for the mid-load toggle. In principle the two paths above
+  // cover every ordering — a toggle before boot is caught by the initial
+  // cookie read, one after boot by the listener — and a timing sweep (50ms to
+  // 2.5s) confirms it in Chromium. But a stuck palette was still observed
+  // once in Safari and could not be reproduced in the harness, so: re-read
+  // the cookie on every SPA navigation. If nothing was missed this is a
+  // cheap no-op (applySkin bails when the id already matches); if anything
+  // ever is, it converges one navigation later instead of never.
+  api.onPageChange(() => applySkin(currentSkin()));
 });


### PR DESCRIPTION
A stuck palette was observed once when toggling the skin mid-load in
Safari. A full timing sweep in a headless Chromium harness (message posted
50ms to 2.5s into the load, via a stub gel.monster origin so the
cross-origin listener check is exercised for real) could NOT reproduce it:
every ordering converges, because the boot-time cookie read covers a toggle
before Ember boots and the message listener covers one after.

So this is not a fix for a understood defect — it is containment for one
that is real but unreproduced. Two changes:

applySkin re-runs on every SPA navigation via api.onPageChange, re-reading
the cookie. When nothing was missed it is a no-op (applySkin bails when the
applied id already matches); when something ever is missed, the palette
converges one navigation later instead of never.

The catch around the stylesheet swap logs a console.warn instead of
swallowing silently, and resets `applied` so the next attempt is not
short-circuited. The silent catch cost hours of misdiagnosis tonight; if
this path is hit again the evidence will be in the console.

Rides the next component upload; no behaviour change on the happy path.

Co-Authored-By: Claude <noreply@anthropic.com>
