### PR TITLE
The forum pushes the skin into the header, which stops guessing

### DIFF
--- a/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
+++ b/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
@@ -68,7 +68,20 @@ export default apiInitializer("1.8.0", (api) => {
     return schemes.find((s) => s.name === name)?.id ?? null;
   }
 
+  function pushToHeader(skin) {
+    // The header iframe cannot always read the cookie itself: Safari private
+    // mode denies a cross-origin iframe document.cookie access that this
+    // top-level, first-party page is granted. We know the skin; tell it.
+    // Runs on every application, INCLUDING the already-applied no-op path,
+    // because the header can disagree even when the body already matches.
+    const frame = document.getElementById("gel-django-header-iframe");
+    frame?.contentWindow?.postMessage({ type: "gel-skin", skin }, SITE_ORIGIN);
+  }
+
   async function applySkin(skin) {
+    if (skin in PALETTES) {
+      pushToHeader(skin);
+    }
     const id = paletteId(skin);
     // An unknown skin, or a palette that has been deleted, leaves the forum
     // wearing whatever it already had. Failing to the default is correct: a
@@ -126,6 +139,16 @@ export default apiInitializer("1.8.0", (api) => {
     }
     if (event.data?.type === "gel-skin") {
       applySkin(event.data.skin);
+    }
+    // The header posts its height when it loads — which is also the moment
+    // its own message listener provably exists. Answering with the current
+    // skin closes the race where a push fired before the iframe was ready,
+    // and re-arms a header that reloaded for any reason.
+    if (event.data?.type === "gel-header-height") {
+      const skin = currentSkin();
+      if (skin in PALETTES) {
+        pushToHeader(skin);
+      }
     }
   });
 

--- a/web/static/website/js/skins.js
+++ b/web/static/website/js/skins.js
@@ -53,7 +53,27 @@
     }
   }
 
-  apply(readCookie() || SKINS[0]);
+  // Apply only when the cookie is actually READABLE. Safari private mode can
+  // deny a cross-origin iframe document.cookie access that the HTTP request
+  // itself was granted — the header arrives server-stamped with the right
+  // data-skin, and `apply(readCookie() || default)` was then REVERTING it to
+  // the default on the strength of a cookie this document simply cannot see.
+  // No cookie read → leave the server's stamp alone; on bare site pages there
+  // is no stamp and no cookie, which is the default anyway.
+  var initial = readCookie();
+  if (initial) apply(initial);
+
+  // And accept the skin FROM the forum page around us. The forum is top-level
+  // and first-party, so its cookie read always works; when the component
+  // applies a skin it pushes it down here, which keeps the header correct
+  // even when this document's own cookie and storage access are dead.
+  window.addEventListener("message", function (ev) {
+    if (ev.origin !== "https://forum.gel.monster") return;
+    var d = ev.data;
+    if (d && d.type === "gel-skin" && SKINS.indexOf(d.skin) !== -1) {
+      apply(d.skin);
+    }
+  });
 
   function cycle(ev) {
     // The mark sits inside the brand link; cycling must not navigate home.


### PR DESCRIPTION
Reproduced in a fresh private-mode session with cleared cache, which ruled
out stale tabs, stale JS, and every timing theory at once: body Terminal,
header atlas, persistent. The state requires the top-level page to read
gel_skin while the iframe cannot — Safari private mode denying a
cross-origin iframe document.cookie access that the HTTP request itself
was granted. The header arrived correctly server-stamped; then
apply(readCookie() || default) treated the unreadable cookie as "default"
and reverted the stamp. The JS clobbered a correct answer with an
inference.

Principle of the fix: the forum page is top-level and first-party, so its
cookie read always works — the header should never have to guess.

skins.js applies at load only when a cookie was actually READ; otherwise
the server's stamp stands. It also accepts gel-skin messages from
forum.gel.monster, the reverse of the channel that already existed.

The component pushes the skin into the iframe on every application,
including the already-applied no-op path, because the header can disagree
while the body matches. And it answers the header's own height
announcement with the current skin: that message is posted on the
header's load, which is the moment its listener provably exists — closing
the race where a push fires before the iframe is ready, and re-arming a
header that reloaded for any reason.

Cookie for server paint, messages both directions for runtime. No path
remains that depends on the iframe reading state Safari will not show it.

Closes #1534

Co-Authored-By: Claude <noreply@anthropic.com>
