### PR TITLE
Carry the skin on height messages, arbitrating across partitioned jars

### DIFF
--- a/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
+++ b/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
@@ -78,8 +78,15 @@ export default apiInitializer("1.8.0", (api) => {
     frame?.contentWindow?.postMessage({ type: "gel-skin", skin }, SITE_ORIGIN);
   }
 
+  // The skin the body is wearing, BY NAME, independent of the cookie — which
+  // in Safari private mode may be unreadable or live in a different jar than
+  // the one the header writes. This is what lets a reloaded header be re-armed
+  // even when no cookie can be read at all.
+  let wearing = null;
+
   async function applySkin(skin) {
     if (skin in PALETTES) {
+      wearing = skin;
       pushToHeader(skin);
     }
     const id = paletteId(skin);
@@ -140,14 +147,33 @@ export default apiInitializer("1.8.0", (api) => {
     if (event.data?.type === "gel-skin") {
       applySkin(event.data.skin);
     }
-    // The header posts its height when it loads — which is also the moment
-    // its own message listener provably exists. Answering with the current
-    // skin closes the race where a push fired before the iframe was ready,
-    // and re-arms a header that reloaded for any reason.
+    // The header posts its height on load, on resize, and on every DOM
+    // mutation — a frequent, unlosable signal, and it now carries the skin
+    // the header is actually wearing. Two jars may be in play: in Safari
+    // private mode the iframe's cookie jar is PARTITIONED from ours, so a
+    // skin clicked in the header lands in a jar we can never read, and the
+    // click's own gel-skin message can race Ember boot and be lost.
+    //
+    // Arbitration: our own cookie wins when we can read one (normal mode,
+    // where both jars are the same and the server rendered from it) — answer
+    // by pushing it down, which also re-arms a header that reloaded. When
+    // our jar says nothing, the header's report is the only record of the
+    // user's intent: adopt it.
     if (event.data?.type === "gel-header-height") {
-      const skin = currentSkin();
-      if (skin in PALETTES) {
-        pushToHeader(skin);
+      const ours = currentSkin();
+      if (ours in PALETTES) {
+        pushToHeader(ours);
+      } else if (wearing) {
+        // Cookie unreadable but we know what we're wearing (adopted via
+        // messages earlier): re-arm the header — it may have reloaded into
+        // an empty partitioned jar and fallen back to the default.
+        pushToHeader(wearing);
+      } else if (event.data.skin in PALETTES && event.data.skin !== "atlas") {
+        // We know nothing; the header's report is the only record of the
+        // user's intent. The atlas exclusion keeps a default-stamped header
+        // from ever overriding anything — atlas is what both sides wear
+        // when nobody has chosen, so adopting it is never necessary.
+        applySkin(event.data.skin);
       }
     }
   });

--- a/web/templates/website/header_only.html
+++ b/web/templates/website/header_only.html
@@ -126,7 +126,15 @@ Uses iframe-specific menu that removes Forum link to prevent double headers.
             if (!TARGET_ORIGIN) return;  // Don't post if no origin configured
             window.parent.postMessage({
                 type: 'gel-header-height',
-                height: measuredHeight()
+                height: measuredHeight(),
+                // The skin rides along. In Safari private mode this iframe's
+                // cookie jar is PARTITIONED from the page around us — a skin
+                // clicked here is written to a jar the forum can never read,
+                // and the click's own gel-skin message can race Ember boot
+                // and be lost. Height messages repeat (load, resize, every
+                // DOM mutation), so carrying the skin on them gives the forum
+                // an unlosable way to learn what this header is wearing.
+                skin: document.documentElement.getAttribute('data-skin') || 'atlas'
             }, TARGET_ORIGIN);
         }
 


### PR DESCRIPTION
Reproduced deterministically in real Safari via safaridriver on the
production host: in ephemeral/private sessions the header iframe's cookie
jar is PARTITIONED from the page around it. Baseline showed the iframe
reading no cookie even though the HTTP request carried one; after a click,
the iframe read back its own write while the top level still saw nothing.
Ten seconds later: header stray, body atlas, stable. Every cookie-based
healing path on the body reads the top jar, so it can never converge on a
skin the header wrote — and the click's own message can race Ember boot
and be lost, which made the state permanent.

The header already posts its height on load, on resize, and on every DOM
mutation. That message now carries the skin the header is wearing —
frequent and unlosable, so no boot race can starve it.

The component arbitrates per message. Its own readable cookie wins, and is
pushed down — normal mode, where the jars are one. Failing that, the skin
the body already adopted via messages is pushed down, re-arming a header
that reloaded into an empty jar and fell back to the default. Failing
that, the header's report is the only record of the user's intent and is
adopted — except a report of the default, which is what both sides wear
when nobody has chosen, and so never needs adopting.

Closes #1534

Co-Authored-By: Claude <noreply@anthropic.com>
