### PR TITLE
Whoever boots last asks: query/answer closes the last skin race

### DIFF
--- a/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
+++ b/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
@@ -137,6 +137,15 @@ export default apiInitializer("1.8.0", (api) => {
 
   applySkin(currentSkin());
 
+  // Ask the header what it is wearing. We boot after the iframe's tiny
+  // document, so its listener exists and the reply cannot be lost — this is
+  // what recovers a skin clicked before Ember was listening, whose gel-skin
+  // message died against an unregistered listener. If the iframe is not in
+  // the DOM yet (we booted first), its load-time height message carries the
+  // skin instead: both orderings are covered without retries.
+  document.getElementById("gel-django-header-iframe")
+    ?.contentWindow?.postMessage({ type: "gel-skin-query" }, SITE_ORIGIN);
+
   // The brand mark lives in an iframe served by gel.monster, so a click on it
   // happens cross-origin and cannot reach us any other way. This rides the
   // same postMessage channel the header already uses to report its height.

--- a/web/static/website/js/skins.js
+++ b/web/static/website/js/skins.js
@@ -73,6 +73,12 @@
     if (d && d.type === "gel-skin" && SKINS.indexOf(d.skin) !== -1) {
       apply(d.skin);
     }
+    // The forum asks what we are wearing when IT boots — it boots after us,
+    // so this reply cannot race a listener that does not exist yet. This is
+    // what recovers a click made before Ember was listening.
+    if (d && d.type === "gel-skin-query") {
+      notifyForum(ROOT.getAttribute("data-skin") || SKINS[0]);
+    }
   });
 
   function cycle(ev) {

--- a/web/templates/website/header_only.html
+++ b/web/templates/website/header_only.html
@@ -176,6 +176,15 @@ Uses iframe-specific menu that removes Forum link to prevent double headers.
             subtree: true,
             attributes: true
         });
+
+        // A skin change lands as data-skin on <html> — OUTSIDE body, so the
+        // observer above never fires for it and the skin-carrying height
+        // message was only ever sent pre-click. Watch it explicitly, so every
+        // skin change re-broadcasts what this header is wearing.
+        new MutationObserver(updateHeight).observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['data-skin']
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
The height-piggyback fix verified incomplete in the same Safari harness
that proved the partitioned-jar mechanism: the skin-carrying height
message fired once at load (pre-click, correctly ignored as the default)
and never again — the mutation observer watches body, and a skin change
lands as data-skin on <html>, outside it. A pre-boot click therefore
still had no surviving carrier: its own message raced Ember boot and
died, and nothing later repeated it.

Two additions, one principle: the side that boots last asks.

The component queries the header on boot. The iframe's tiny document
registers its listener long before Ember finishes booting, so the reply
cannot race anything — this recovers a skin clicked before the component
existed. If the component boots first instead, the iframe's load-time
height message carries the skin to a listener that is already ready.
Both orderings covered, no retries, no timers.

And the header watches data-skin on its own root, re-broadcasting the
skin-carrying height message on every change, so post-boot clicks are
carried even if the direct gel-skin message were ever lost.

Co-Authored-By: Claude <noreply@anthropic.com>
