### PR TITLE
Swap stylesheets without awaiting a preload Safari never resolves

### DIFF
--- a/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
+++ b/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
@@ -112,19 +112,25 @@ export default apiInitializer("1.8.0", (api) => {
         return;
       }
 
-      // Preload before swapping, or the page renders unstyled for a beat
-      // while the new sheet is fetched.
+      // Swap by inserting a real stylesheet and waiting for ITS load, not a
+      // rel=preload probe: Safari does not reliably fire load/error on
+      // preload links, and awaiting one hung this function forever — the
+      // fetch succeeded, the swap never ran, and every retry piled into the
+      // same silent hang (observed live: thirty fetches, zero swaps). A real
+      // stylesheet's load event is dependable everywhere, and the timeout
+      // guarantees convergence even if no event ever fires — the cost is a
+      // one-frame flash in a case that otherwise never converges at all.
+      const next = document.createElement("link");
+      next.rel = "stylesheet";
+      next.className = "light-scheme";
+      next.dataset.schemeId = id;
       await new Promise((resolve) => {
-        const pre = document.createElement("link");
-        pre.rel = "preload";
-        pre.as = "style";
-        pre.href = new_href;
-        pre.onload = pre.onerror = resolve;
-        document.head.appendChild(pre);
+        next.onload = next.onerror = resolve;
+        setTimeout(resolve, 3000);
+        next.href = new_href;
+        link.insertAdjacentElement("afterend", next);
       });
-
-      link.href = new_href;
-      link.dataset.schemeId = id;
+      link.remove();
       applied = id;
     } catch (e) {
       // The cookie is already set, so a reload lands on the right palette —


### PR DESCRIPTION
Instrumentation on real Safari finally caught the stuck half in the act:
thirty successful swap fetches, zero applied swaps. The component received
every message, resolved the palette, fetched the stylesheet — and awaited
a rel=preload link whose load/error events Safari does not reliably fire.
The promise never resolved, the href never changed, `applied` never
updated, and each retry piled into the same silent hang. Chromium fires
those events, which is why every Chromium harness run converged and the
hang stayed invisible until the harness ran Safari itself.

Swap by inserting a real stylesheet link and waiting for ITS load —
dependable everywhere — with a timeout backstop so this function can never
hang again. Worst case is a one-frame flash in a case that previously
never converged at all.

Closes #1534

Co-Authored-By: Claude <noreply@anthropic.com>
