### PR TITLE
Seed `wearing` from the server render, and break the push loop it found

### DIFF
--- a/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
+++ b/web/discourse-theme/javascripts/discourse/api-initializers/skins.gjs
@@ -42,6 +42,16 @@ const PALETTES = {
 const SITE_ORIGIN = "https://gel.monster";
 
 function currentSkin() {
+  // Test hook: Safari private mode can deny script cookie access that the
+  // HTTP layer was granted, and no harness can produce that state on
+  // demand — this flag can. Inert unless deliberately set.
+  try {
+    if (localStorage.getItem("gel-skin-test-blind")) {
+      return null;
+    }
+  } catch (e) {
+    // storage unavailable: fall through to the real read
+  }
   const hit = document.cookie.match(/(?:^|;\s*)gel_skin=([^;]+)/);
   return hit ? decodeURIComponent(hit[1]) : null;
 }
@@ -83,6 +93,18 @@ export default apiInitializer("1.8.0", (api) => {
   // the one the header writes. This is what lets a reloaded header be re-armed
   // even when no cookie can be read at all.
   let wearing = null;
+  // THE SEED: the server may have rendered a non-default palette from a
+  // cookie the script cannot read (Safari private mode). The body knows
+  // what it is wearing — data-scheme-id — it just never told itself.
+  // Without this, `wearing` stays null, the header's honest "atlas" report
+  // is (correctly) never adopted, and nothing ever pushes the real skin
+  // down: the header stays default forever against a skinned body.
+  for (const skin in PALETTES) {
+    if (skin !== "atlas" && paletteId(skin) === applied) {
+      wearing = skin;
+      break;
+    }
+  }
 
   async function applySkin(skin) {
     if (skin in PALETTES) {
@@ -157,6 +179,10 @@ export default apiInitializer("1.8.0", (api) => {
     }
   }
 
+  // Read-only state handle so a harness can see in: this saga's lesson is
+  // that inference dies where instrumentation lives.
+  window.__gelSkinState = () => ({ wearing, applied, ours: currentSkin() });
+
   applySkin(currentSkin());
 
   // Ask the header what it is wearing. We boot after the iframe's tiny
@@ -192,14 +218,18 @@ export default apiInitializer("1.8.0", (api) => {
     // user's intent: adopt it.
     if (event.data?.type === "gel-header-height") {
       const ours = currentSkin();
-      if (ours in PALETTES) {
-        pushToHeader(ours);
-      } else if (wearing) {
-        // Cookie unreadable but we know what we're wearing (adopted via
-        // messages earlier): re-arm the header — it may have reloaded into
-        // an empty partitioned jar and fallen back to the default.
-        pushToHeader(wearing);
-      } else if (event.data.skin in PALETTES && event.data.skin !== "atlas") {
+      // What we would tell the header: our own cookie when readable, else
+      // what the body is wearing (message-adopted or seeded from the
+      // server render).
+      const toPush = ours in PALETTES ? ours : wearing;
+      if (toPush && event.data.skin !== toPush) {
+        // Push ONLY when the header reports something different. An
+        // unconditional push here closed a loop: push -> the header
+        // applies -> its data-skin observer fires -> it reports height
+        // again -> push. The inequality is what breaks the cycle, and it
+        // still re-arms a header that reloaded into the default.
+        pushToHeader(toPush);
+      } else if (!toPush && event.data.skin in PALETTES && event.data.skin !== "atlas") {
         // We know nothing; the header's report is the only record of the
         // user's intent. The atlas exclusion keeps a default-stamped header
         // from ever overriding anything — atlas is what both sides wear

--- a/web/static/website/js/skins.js
+++ b/web/static/website/js/skins.js
@@ -35,8 +35,17 @@
 
   function apply(skin) {
     if (SKINS.indexOf(skin) === -1) skin = SKINS[0];
-    if (skin === SKINS[0]) ROOT.removeAttribute("data-skin");
-    else ROOT.setAttribute("data-skin", skin);
+    // Mutate ONLY on change. setAttribute with an unchanged value still
+    // fires MutationObservers, and the header's observer re-broadcasts the
+    // skin on every data-skin mutation — an unconditional write here turned
+    // push -> apply -> observe -> report -> push into an infinite message
+    // loop between the forum and its own header (caught by the harness as
+    // megabytes of identical pushes in seconds).
+    if (skin === SKINS[0]) {
+      if (ROOT.hasAttribute("data-skin")) ROOT.removeAttribute("data-skin");
+    } else if (ROOT.getAttribute("data-skin") !== skin) {
+      ROOT.setAttribute("data-skin", skin);
+    }
   }
 
   function notifyForum(skin) {


### PR DESCRIPTION
Rigor round, at the owner's insistence, and it earned its keep twice.

THE SEED. The reported state — body server-rendered in a skin, header
stuck on the default, both cookie-blind to script — traced to a variable
nobody initialized: `wearing` was only ever set by applySkin, and a
server-rendered skin never passes through applySkin. The component sat on
a skinned body it did not know it was wearing, and the header's honest
"atlas" report was (correctly) never adopted, so nothing ever pushed the
real skin down. The body knew — data-scheme-id — it just never told
itself. `wearing` now seeds from the rendered palette at boot.

Proven in a purpose-built laboratory: a localStorage flag
(gel-skin-test-blind) makes currentSkin() return null on demand,
reproducing Safari-private cookie blindness that no harness can produce
naturally. Under seeded render + blindness:
  {"wearing":"stray","applied":23,"ours":null}
and a synthetic atlas-reporting height message was answered with a push
of the worn skin. Also adds window.__gelSkinState, a read-only handle,
because this saga's repeated lesson is that inference dies where
instrumentation lives.

THE LOOP. The proof's wiretap then caught the push arriving thousands of
times: push -> the header applies -> setAttribute fires its data-skin
observer even when the value is UNCHANGED -> it reports height -> push.
Live since the observer shipped, invisible except as wasted work. Two
guards break it at both ends: apply() mutates only on actual change, and
the height handler pushes only when the header reports something
different from what we would tell it — which still re-arms a header that
reloaded into the default.

Co-Authored-By: Claude <noreply@anthropic.com>
