### PR TITLE
Track the skin manifests the previous commit silently dropped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ web/static/*
 !web/static/website/
 web/static/website/*
 !web/static/website/css/
+!web/static/website/skins/
 web/static/website/css/*
 !web/static/website/css/custom.css
 !web/static/website/fonts/

--- a/web/static/website/skins/atlas.ghostty
+++ b/web/static/website/skins/atlas.ghostty
@@ -1,0 +1,38 @@
+# Gelatinous Monster — atlas (the house skin: ink, bone, amber)
+# A valid Ghostty terminal theme; drop into your terminal and it just works.
+# Lines beginning `# gel:` are the game's skin-system extensions.
+palette = 0=#11161f
+palette = 1=#e85555
+palette = 2=#5fd38d
+palette = 3=#e6c547
+palette = 4=#7195c9
+palette = 5=#b48ead
+palette = 6=#6fd6e0
+palette = 7=#d8d3c4
+palette = 8=#6b6f78
+palette = 9=#ef7b7b
+palette = 10=#7fe3a5
+palette = 11=#f0d576
+palette = 12=#8fb3e6
+palette = 13=#caa3d6
+palette = 14=#93e2ea
+palette = 15=#f2efe6
+background = #0b0e14
+foreground = #d8d3c4
+cursor-color = #e0a86f
+selection-background = #182030
+selection-foreground = #d8d3c4
+
+# gel: slug = atlas
+# gel: order = 0
+# gel: palette-name = Domino's Gambit
+# gel: palette-id = 21
+# gel: accent = #e0a86f
+# gel: accent-dim = #b8834f
+# gel: bg-medium = #11161f
+# gel: bg-light = #182030
+# gel: text-muted = #8f8d82
+# gel: border = #232c3a
+# gel: glow-alpha = 0.30
+# gel: quaternary = #6fd6e0
+# gel: primary-low-mid = #6b6f78

--- a/web/static/website/skins/dub.ghostty
+++ b/web/static/website/skins/dub.ghostty
@@ -1,0 +1,39 @@
+# Gelatinous Monster — dub (gold leads; green and red keep the state seats)
+# A valid Ghostty terminal theme; `# gel:` lines are the game's extensions.
+# The tribute reads through use, not decoration: gold is the accent, green
+# means success, red means danger — the slots that already mean something.
+palette = 0=#151b12
+palette = 1=#e85555
+palette = 2=#3fae6a
+palette = 3=#f0c34e
+palette = 4=#5f81a5
+palette = 5=#a06fb5
+palette = 6=#52b3a4
+palette = 7=#e8e0c8
+palette = 8=#6f7563
+palette = 9=#ef7b7b
+palette = 10=#5fd38d
+palette = 11=#f7d76e
+palette = 12=#7fa3c9
+palette = 13=#c395d6
+palette = 14=#7fd0c2
+palette = 15=#f5efdc
+background = #0e120c
+foreground = #e8e0c8
+cursor-color = #f0c34e
+selection-background = #1e2818
+selection-foreground = #e8e0c8
+
+# gel: slug = dub
+# gel: order = 3
+# gel: palette-name = Dub
+# gel: palette-id = 24
+# gel: accent = #f0c34e
+# gel: accent-dim = #c29a34
+# gel: bg-medium = #151b12
+# gel: bg-light = #1e2818
+# gel: text-muted = #979274
+# gel: border = #2a3324
+# gel: glow-alpha = 0.30
+# gel: quaternary = #3fae6a
+# gel: primary-low-mid = #6f7563

--- a/web/static/website/skins/prism.ghostty
+++ b/web/static/website/skins/prism.ghostty
@@ -1,0 +1,48 @@
+# Gelatinous Monster — prism (a readable rainbow, and the Monaspace showcase)
+# A valid Ghostty terminal theme; `# gel:` lines are the game's extensions.
+# One lead accent (violet) keeps "what's clickable" unambiguous; the
+# spectrum lives on non-semantic zones via the --prism-* tokens, consumed
+# by handwritten flourish CSS. Static — a rainbow you can read.
+# Type is the show: display set in Radon's handwriting, data in Xenon slab.
+palette = 0=#17171e
+palette = 1=#ff5f6e
+palette = 2=#4fd66f
+palette = 3=#ffd75f
+palette = 4=#5f9fff
+palette = 5=#c46fff
+palette = 6=#4fd6d0
+palette = 7=#dcdce4
+palette = 8=#8f8f9c
+palette = 9=#ff8b96
+palette = 10=#7fe39a
+palette = 11=#ffe38b
+palette = 12=#8bb9ff
+palette = 13=#d69bff
+palette = 14=#8be3de
+palette = 15=#f2f2f7
+background = #101014
+foreground = #dcdce4
+cursor-color = #9d7bff
+selection-background = #20202a
+selection-foreground = #dcdce4
+
+# gel: slug = prism
+# gel: order = 4
+# gel: palette-name = Prism
+# gel: palette-id = 25
+# gel: accent = #9d7bff
+# gel: accent-dim = #7a5fd0
+# gel: bg-medium = #17171e
+# gel: bg-light = #20202a
+# gel: text-muted = #8f8f9c
+# gel: border = #2a2a38
+# gel: glow-alpha = 0.32
+# gel: quaternary = #4fd6d0
+# gel: primary-low-mid = #74747f
+# gel: font-display = radon
+# gel: font-data = xenon
+# gel: css-prism-r = #ff5f6e
+# gel: css-prism-g = #4fd66f
+# gel: css-prism-y = #ffd75f
+# gel: css-prism-b = #5f9fff
+# gel: css-prism-c = #4fd6d0

--- a/web/static/website/skins/stray.ghostty
+++ b/web/static/website/skins/stray.ghostty
@@ -1,0 +1,38 @@
+# Gelatinous Monster — stray (somebody got at the logo; neon pink, violet-black)
+# A valid Ghostty terminal theme; `# gel:` lines are the game's extensions.
+# The sprayed-on cat ears are handwritten CSS, not data — see custom.css.
+palette = 0=#16111c
+palette = 1=#e85555
+palette = 2=#5fd38d
+palette = 3=#e6c547
+palette = 4=#7a71c9
+palette = 5=#ff3d9a
+palette = 6=#6fd6e0
+palette = 7=#e6dde4
+palette = 8=#6b6470
+palette = 9=#ef7b7b
+palette = 10=#7fe3a5
+palette = 11=#f0d576
+palette = 12=#9a90e0
+palette = 13=#ff6ab3
+palette = 14=#93e2ea
+palette = 15=#f5eef4
+background = #0d0a12
+foreground = #e6dde4
+cursor-color = #ff3d9a
+selection-background = #201828
+selection-foreground = #e6dde4
+
+# gel: slug = stray
+# gel: order = 2
+# gel: palette-name = Stray
+# gel: palette-id = 23
+# gel: accent = #ff3d9a
+# gel: accent-dim = #c42d76
+# gel: bg-medium = #16111c
+# gel: bg-light = #201828
+# gel: text-muted = #8d8393
+# gel: border = #2c2136
+# gel: glow-alpha = 0.32
+# gel: quaternary = #6fd6e0
+# gel: primary-low-mid = #6b6470

--- a/web/static/website/skins/terminal.ghostty
+++ b/web/static/website/skins/terminal.ghostty
@@ -1,0 +1,37 @@
+# Gelatinous Monster — terminal (the old identity: jade on neutral grey)
+# A valid Ghostty terminal theme; `# gel:` lines are the game's extensions.
+palette = 0=#2a2a2a
+palette = 1=#e85555
+palette = 2=#5fd38d
+palette = 3=#e6c547
+palette = 4=#6a9fb5
+palette = 5=#b48ead
+palette = 6=#75b5aa
+palette = 7=#e0e0e0
+palette = 8=#666666
+palette = 9=#ef7b7b
+palette = 10=#7fe3a5
+palette = 11=#f0d576
+palette = 12=#8ab7cc
+palette = 13=#c9a6c9
+palette = 14=#93cfc4
+palette = 15=#f5f5f5
+background = #1a1a1a
+foreground = #e0e0e0
+cursor-color = #5fd38d
+selection-background = #3a3a3a
+selection-foreground = #e0e0e0
+
+# gel: slug = terminal
+# gel: order = 1
+# gel: palette-name = Terminal
+# gel: palette-id = 22
+# gel: accent = #5fd38d
+# gel: accent-dim = #4a9d6d
+# gel: bg-medium = #2a2a2a
+# gel: bg-light = #3a3a3a
+# gel: text-muted = #999999
+# gel: border = #404040
+# gel: glow-alpha = 0.30
+# gel: quaternary = #4a9d6d
+# gel: primary-low-mid = #6b6f78


### PR DESCRIPTION
web/static/website/* is ignored with per-directory exceptions, and the new
skins/ directory had none — so #1542 merged the generator while gitignore
ate its inputs. The single source of truth was untracked; a fresh clone
would have had a generator with nothing to generate from. Caught because
git said so in the push output, verified by add --dry-run rather than
check-ignore (whose -v output misleads on negated rules — July's lesson).

Co-Authored-By: Claude <noreply@anthropic.com>
