### PR TITLE
Prism keeps the house faces; the gradient carries the rainbow alone

### DIFF
--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -1956,8 +1956,6 @@ h1 { font-size: var(--size-h1); }
     --terminal-text-muted: #8f8f9c;
     --terminal-border: #2a2a38;
     --terminal-glow: rgba(157, 123, 255, 0.32);
-    --font-display: 'Monaspace Radon', ui-monospace, 'SF Mono', Menlo, monospace;
-    --font-data: 'Monaspace Xenon', ui-monospace, 'SF Mono', Menlo, monospace;
     --prism-r: #ff5f6e;
     --prism-g: #4fd66f;
     --prism-y: #ffd75f;

--- a/web/static/website/skins/prism.ghostty
+++ b/web/static/website/skins/prism.ghostty
@@ -3,7 +3,6 @@
 # One lead accent (violet) keeps "what's clickable" unambiguous; the
 # spectrum lives on non-semantic zones via the --prism-* tokens, consumed
 # by handwritten flourish CSS. Static — a rainbow you can read.
-# Type is the show: display set in Radon's handwriting, data in Xenon slab.
 palette = 0=#17171e
 palette = 1=#ff5f6e
 palette = 2=#4fd66f
@@ -39,8 +38,6 @@ selection-foreground = #dcdce4
 # gel: glow-alpha = 0.32
 # gel: quaternary = #4fd6d0
 # gel: primary-low-mid = #74747f
-# gel: font-display = radon
-# gel: font-data = xenon
 # gel: css-prism-r = #ff5f6e
 # gel: css-prism-g = #4fd66f
 # gel: css-prism-y = #ffd75f


### PR DESCRIPTION
Owner review: the Radon display remap was one flourish too many. The
spectrum h1 stays — now set in the same Xenon the other skins wear — and
the skin differs by colour only, like its siblings. One manifest edit,
one regenerate: the factory working as intended.

Co-Authored-By: Claude <noreply@anthropic.com>
