### PR TITLE
The badge fills its circle; the doodle learns to be happy

### DIFF
--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -2025,7 +2025,7 @@ h1 { font-size: var(--size-h1); }
 /* the doodle: crayon strokes in cream, teeth line in yellow */
 [data-skin="ed"] .brand-mark .alt-ed { stroke: var(--terminal-text); }
 [data-skin="ed"] .brand-mark .alt-ed .dotfill { fill: var(--terminal-text); stroke: none; }
-[data-skin="ed"] .brand-mark .alt-ed .teeth { stroke: var(--quaternary, #ffd23f); stroke: var(--terminal-glow); stroke: #ffd23f; }
+[data-skin="ed"] .brand-mark .alt-ed .tongue { stroke: var(--terminal-accent); }
 
 /* ed's typography: the superfamily mixed the way its makers intended.
    Nav items cycle faces AND crayon colours; heading words get faces from

--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -62,30 +62,36 @@ folder and edit it to add/remove links to the menu.
              original drawings in the referenced style, not reproductions —
              and the badge's ring text is the site's own line. -->
         <g class="alt alt-laughing">
-          <circle cx="50" cy="50" r="46" fill="none" stroke-width="1.6"/>
+          <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
           <defs>
-            <path id="lm-ring-m" d="M 50,89 A 39,39 0 1 1 50.01,89 Z"/>
+            <path id="lm-ring-m" d="M 50,91 A 41,41 0 1 1 50.01,91 Z"/>
           </defs>
-          <text class="ringtext" font-size="6.2" letter-spacing="0.6">
+          <text class="ringtext" font-size="6.4" letter-spacing="0.5">
             <textPath href="#lm-ring-m" xlink:href="#lm-ring-m">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE &#183;</textPath>
           </text>
-          <g fill="none" stroke-width="2.2" stroke-linecap="round">
-            <circle cx="50" cy="52" r="20"/>
-            <path d="M 32,44 A 20,20 0 0 1 68,44 L 70,38 L 30,38 Z" class="cap"/>
-            <path d="M 30,38 L 22,40"/>
-            <path d="M 42,52 L 48,52"/>
-            <circle cx="59" cy="52" r="1.6" class="dotfill"/>
-            <path d="M 38,60 Q 50,70 62,60"/>
+          <g fill="none" stroke-width="2.4" stroke-linecap="round">
+            <!-- the face fills the interior: big head, low cap, wide grin -->
+            <circle cx="50" cy="54" r="28"/>
+            <path d="M 24,46 A 28,28 0 0 1 76,46 L 79,36 L 27,36 Z" class="cap"/>
+            <path d="M 27,36 L 15,39" class="cap"/>
+            <path d="M 38,54 L 46,54"/>
+            <circle cx="61" cy="54" r="2" class="dotfill"/>
+            <path d="M 34,64 Q 50,78 66,64"/>
           </g>
         </g>
         <g class="alt alt-ed" transform="rotate(-7 50 50)">
-          <g fill="none" stroke-width="3.6" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="50" cy="50" r="42"/>
-            <circle cx="38" cy="38" r="2.4" class="dotfill"/>
-            <circle cx="63" cy="36" r="2.4" class="dotfill"/>
-            <path d="M 22,52 Q 50,88 79,50 Q 66,72 50,73 Q 33,72 22,52 Z"/>
-            <path d="M 26,56 L 33,60 L 38,65 L 45,68 L 52,69 L 60,66 L 67,61 L 73,55"
-                  stroke-width="2.4" class="teeth"/>
+          <g fill="none" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="50" cy="52" r="40"/>
+            <!-- wild little hair sprouts -->
+            <path d="M 38,13 Q 36,5 30,4"/>
+            <path d="M 50,11 Q 51,3 46,0"/>
+            <path d="M 62,13 Q 66,6 72,6"/>
+            <!-- happy closed eyes: upward arcs, nothing stares back -->
+            <path d="M 32,44 Q 38,36 44,44"/>
+            <path d="M 57,42 Q 63,34 69,42"/>
+            <!-- enormous joyful smile, a little tongue, zero teeth -->
+            <path d="M 28,58 Q 50,84 73,56"/>
+            <path d="M 44,72 Q 50,78 57,72" class="tongue"/>
           </g>
         </g>
       </svg>

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -60,30 +60,36 @@ Removes the Forum link to prevent navigation loops and double headers.
              original drawings in the referenced style, not reproductions —
              and the badge's ring text is the site's own line. -->
         <g class="alt alt-laughing">
-          <circle cx="50" cy="50" r="46" fill="none" stroke-width="1.6"/>
+          <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
           <defs>
-            <path id="lm-ring-if" d="M 50,89 A 39,39 0 1 1 50.01,89 Z"/>
+            <path id="lm-ring-if" d="M 50,91 A 41,41 0 1 1 50.01,91 Z"/>
           </defs>
-          <text class="ringtext" font-size="6.2" letter-spacing="0.6">
+          <text class="ringtext" font-size="6.4" letter-spacing="0.5">
             <textPath href="#lm-ring-if" xlink:href="#lm-ring-if">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE &#183;</textPath>
           </text>
-          <g fill="none" stroke-width="2.2" stroke-linecap="round">
-            <circle cx="50" cy="52" r="20"/>
-            <path d="M 32,44 A 20,20 0 0 1 68,44 L 70,38 L 30,38 Z" class="cap"/>
-            <path d="M 30,38 L 22,40"/>
-            <path d="M 42,52 L 48,52"/>
-            <circle cx="59" cy="52" r="1.6" class="dotfill"/>
-            <path d="M 38,60 Q 50,70 62,60"/>
+          <g fill="none" stroke-width="2.4" stroke-linecap="round">
+            <!-- the face fills the interior: big head, low cap, wide grin -->
+            <circle cx="50" cy="54" r="28"/>
+            <path d="M 24,46 A 28,28 0 0 1 76,46 L 79,36 L 27,36 Z" class="cap"/>
+            <path d="M 27,36 L 15,39" class="cap"/>
+            <path d="M 38,54 L 46,54"/>
+            <circle cx="61" cy="54" r="2" class="dotfill"/>
+            <path d="M 34,64 Q 50,78 66,64"/>
           </g>
         </g>
         <g class="alt alt-ed" transform="rotate(-7 50 50)">
-          <g fill="none" stroke-width="3.6" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="50" cy="50" r="42"/>
-            <circle cx="38" cy="38" r="2.4" class="dotfill"/>
-            <circle cx="63" cy="36" r="2.4" class="dotfill"/>
-            <path d="M 22,52 Q 50,88 79,50 Q 66,72 50,73 Q 33,72 22,52 Z"/>
-            <path d="M 26,56 L 33,60 L 38,65 L 45,68 L 52,69 L 60,66 L 67,61 L 73,55"
-                  stroke-width="2.4" class="teeth"/>
+          <g fill="none" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="50" cy="52" r="40"/>
+            <!-- wild little hair sprouts -->
+            <path d="M 38,13 Q 36,5 30,4"/>
+            <path d="M 50,11 Q 51,3 46,0"/>
+            <path d="M 62,13 Q 66,6 72,6"/>
+            <!-- happy closed eyes: upward arcs, nothing stares back -->
+            <path d="M 32,44 Q 38,36 44,44"/>
+            <path d="M 57,42 Q 63,34 69,42"/>
+            <!-- enormous joyful smile, a little tongue, zero teeth -->
+            <path d="M 28,58 Q 50,84 73,56"/>
+            <path d="M 44,72 Q 50,78 57,72" class="tongue"/>
           </g>
         </g>
       </svg>


### PR DESCRIPTION
Owner review round two. The laughing badge was timid — face scaled up to
fill the interior, cap low and jutting, grin wide, the ring text riding
the rim. And ed read creepy rather than whimsical: the zigzag teeth are
gone entirely, replaced by happy closed eyes (upward arcs — nothing
stares back), an enormous joyful smile with a small accent-coloured
tongue, and three sprouts of wild hair. Whimsy is arcs, it turns out;
menace was angles.

Co-Authored-By: Claude <noreply@anthropic.com>
