### PR TITLE
The badge's ring text leaves a gap at the seam instead of colliding

### DIFF
--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -66,7 +66,7 @@ folder and edit it to add/remove links to the menu.
           <defs>
             <path id="lm-ring-m" d="M 50,91 A 41,41 0 1 1 50.01,91 Z"/>
           </defs>
-          <text class="ringtext" font-size="6.4" letter-spacing="0.5">
+          <text class="ringtext" font-size="5.9" letter-spacing="0.35">
             <textPath href="#lm-ring-m" xlink:href="#lm-ring-m">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE &#183;</textPath>
           </text>
           <g fill="none" stroke-width="2.4" stroke-linecap="round">

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -64,7 +64,7 @@ Removes the Forum link to prevent navigation loops and double headers.
           <defs>
             <path id="lm-ring-if" d="M 50,91 A 41,41 0 1 1 50.01,91 Z"/>
           </defs>
-          <text class="ringtext" font-size="6.4" letter-spacing="0.5">
+          <text class="ringtext" font-size="5.9" letter-spacing="0.35">
             <textPath href="#lm-ring-if" xlink:href="#lm-ring-if">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE &#183;</textPath>
           </text>
           <g fill="none" stroke-width="2.4" stroke-linecap="round">


### PR DESCRIPTION
Sized so the sentence under-fills the circumference: circular badge text
that meets itself must either be measured to the letter or leave daylight,
and daylight is the honest choice for a monospace ring.

Co-Authored-By: Claude <noreply@anthropic.com>
