### PR TITLE
The badge learns its grammar: brim as escaping bar, crown, smile bowl

### DIFF
--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -2012,15 +2012,17 @@ h1 { font-size: var(--size-h1); }
 [data-skin="laughing"] .brand-mark .alt-laughing { display: block; }
 [data-skin="ed"] .brand-mark .alt-ed { display: block; }
 
-/* the badge: white line-work, blue ring text, blue cap */
+/* the badge: white rings and smile, blue cap and ring text */
 [data-skin="laughing"] .brand-mark .alt-laughing { stroke: var(--terminal-text); }
 [data-skin="laughing"] .brand-mark .alt-laughing .ringtext {
     fill: var(--terminal-accent);
     stroke: none;
     font-family: var(--font-prose);
 }
-[data-skin="laughing"] .brand-mark .alt-laughing .cap { stroke: var(--terminal-accent); }
-[data-skin="laughing"] .brand-mark .alt-laughing .dotfill { fill: var(--terminal-text); stroke: none; }
+[data-skin="laughing"] .brand-mark .alt-laughing .cap { stroke: var(--terminal-accent); fill: var(--terminal-accent); }
+[data-skin="laughing"] .brand-mark .alt-laughing .cap rect { stroke: none; }
+[data-skin="laughing"] .brand-mark .alt-laughing .facefill { fill: var(--terminal-text); }
+[data-skin="laughing"] .brand-mark .alt-laughing .smile { stroke: var(--terminal-text); }
 
 /* the doodle: crayon strokes in cream, teeth line in yellow */
 [data-skin="ed"] .brand-mark .alt-ed { stroke: var(--terminal-text); }

--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -61,23 +61,28 @@ folder and edit it to add/remove links to the menu.
              skin's CSS swaps them in for the ringed world. Both are
              original drawings in the referenced style, not reproductions —
              and the badge's ring text is the site's own line. -->
-        <g class="alt alt-laughing">
+        <g class="alt alt-laughing" transform="rotate(-8 50 50)">
+          <!-- the badge grammar: text band between two rings, the cap's brim
+               a capsule bar bisecting the disc and escaping past the ring,
+               crown arc above, laughing eyes and a smile bowl below. Drawn
+               fresh; the ring speaks the site's own sentence. -->
           <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
+          <circle cx="50" cy="50" r="36" fill="none" stroke-width="1.6"/>
           <defs>
-            <path id="lm-ring-m" d="M 50,91 A 41,41 0 1 1 50.01,91 Z"/>
+            <path id="lm-ring-m" d="M 50,92 A 42,42 0 1 1 50.01,92 Z"/>
           </defs>
-          <text class="ringtext" font-size="5.9" letter-spacing="0.35">
-            <textPath href="#lm-ring-m" xlink:href="#lm-ring-m">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE &#183;</textPath>
+          <text class="ringtext" font-size="6.7" font-weight="700" letter-spacing="0.3">
+            <textPath href="#lm-ring-m" xlink:href="#lm-ring-m">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE</textPath>
           </text>
-          <g fill="none" stroke-width="2.4" stroke-linecap="round">
-            <!-- the face fills the interior: big head, low cap, wide grin -->
-            <circle cx="50" cy="54" r="28"/>
-            <path d="M 24,46 A 28,28 0 0 1 76,46 L 79,36 L 27,36 Z" class="cap"/>
-            <path d="M 27,36 L 15,39" class="cap"/>
-            <path d="M 38,54 L 46,54"/>
-            <circle cx="61" cy="54" r="2" class="dotfill"/>
-            <path d="M 34,64 Q 50,78 66,64"/>
+          <g class="cap">
+            <path d="M 17,46 A 34,34 0 0 1 83,46" fill="none" stroke-width="7"/>
+            <rect x="15" y="45" width="82" height="13" rx="6.5"/>
           </g>
+          <g class="facefill" stroke="none">
+            <path d="M 30,63 A 7.5,7.5 0 0 1 45,63 L 42,63 A 4.5,4.5 0 0 0 33,63 Z"/>
+            <path d="M 55,63 A 7.5,7.5 0 0 1 70,63 L 67,63 A 4.5,4.5 0 0 0 58,63 Z"/>
+          </g>
+          <path class="smile" d="M 27,64 A 26,26 0 0 0 73,64" fill="none" stroke-width="6.5" stroke-linecap="round"/>
         </g>
         <g class="alt alt-ed" transform="rotate(-7 50 50)">
           <g fill="none" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round">

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -59,23 +59,28 @@ Removes the Forum link to prevent navigation loops and double headers.
              skin's CSS swaps them in for the ringed world. Both are
              original drawings in the referenced style, not reproductions —
              and the badge's ring text is the site's own line. -->
-        <g class="alt alt-laughing">
+        <g class="alt alt-laughing" transform="rotate(-8 50 50)">
+          <!-- the badge grammar: text band between two rings, the cap's brim
+               a capsule bar bisecting the disc and escaping past the ring,
+               crown arc above, laughing eyes and a smile bowl below. Drawn
+               fresh; the ring speaks the site's own sentence. -->
           <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
+          <circle cx="50" cy="50" r="36" fill="none" stroke-width="1.6"/>
           <defs>
-            <path id="lm-ring-if" d="M 50,91 A 41,41 0 1 1 50.01,91 Z"/>
+            <path id="lm-ring-if" d="M 50,92 A 42,42 0 1 1 50.01,92 Z"/>
           </defs>
-          <text class="ringtext" font-size="5.9" letter-spacing="0.35">
-            <textPath href="#lm-ring-if" xlink:href="#lm-ring-if">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE &#183;</textPath>
+          <text class="ringtext" font-size="6.7" font-weight="700" letter-spacing="0.3">
+            <textPath href="#lm-ring-if" xlink:href="#lm-ring-if">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE</textPath>
           </text>
-          <g fill="none" stroke-width="2.4" stroke-linecap="round">
-            <!-- the face fills the interior: big head, low cap, wide grin -->
-            <circle cx="50" cy="54" r="28"/>
-            <path d="M 24,46 A 28,28 0 0 1 76,46 L 79,36 L 27,36 Z" class="cap"/>
-            <path d="M 27,36 L 15,39" class="cap"/>
-            <path d="M 38,54 L 46,54"/>
-            <circle cx="61" cy="54" r="2" class="dotfill"/>
-            <path d="M 34,64 Q 50,78 66,64"/>
+          <g class="cap">
+            <path d="M 17,46 A 34,34 0 0 1 83,46" fill="none" stroke-width="7"/>
+            <rect x="15" y="45" width="82" height="13" rx="6.5"/>
           </g>
+          <g class="facefill" stroke="none">
+            <path d="M 30,63 A 7.5,7.5 0 0 1 45,63 L 42,63 A 4.5,4.5 0 0 0 33,63 Z"/>
+            <path d="M 55,63 A 7.5,7.5 0 0 1 70,63 L 67,63 A 4.5,4.5 0 0 0 58,63 Z"/>
+          </g>
+          <path class="smile" d="M 27,64 A 26,26 0 0 0 73,64" fill="none" stroke-width="6.5" stroke-linecap="round"/>
         </g>
         <g class="alt alt-ed" transform="rotate(-7 50 50)">
           <g fill="none" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
Owner review: the mark it honours is famous precisely for its silhouette,
and the first drawing missed it — a timid left-brim cap on a small face.
The recognisable grammar is structural: a capsule bar bisecting the disc
and escaping past the ring entirely, a heavy crown arc above, laughing
arc-eyes and a wide smile bowl below, the whole badge tilted a few
degrees. Redrawn fresh in that grammar, white and blue, with the ring
still speaking the site's own sentence.

Co-Authored-By: Claude <noreply@anthropic.com>
