### PR TITLE
Badge: SVG-native whitener and single tilt

### DIFF
--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -2015,9 +2015,6 @@ h1 { font-size: var(--size-h1); }
 /* the badge: the owner's artwork lifted to white by filter; our rings
    white, our ring sentence accent blue */
 [data-skin="laughing"] .brand-mark .alt-laughing { stroke: var(--terminal-text); }
-[data-skin="laughing"] .brand-mark .alt-laughing image {
-    filter: brightness(0) invert(1);
-}
 [data-skin="laughing"] .brand-mark .alt-laughing .ringtext {
     fill: var(--terminal-accent);
     stroke: none;

--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -61,13 +61,17 @@ folder and edit it to add/remove links to the menu.
              skin's CSS swaps them in for the ringed world. Both are
              original drawings in the referenced style, not reproductions —
              and the badge's ring text is the site's own line. -->
-        <g class="alt alt-laughing" transform="rotate(-8 50 50)">
+        <g class="alt alt-laughing" transform="rotate(-2 50 50)">
           <!-- Composite: the owner's own text-cleared artwork, clipped to
                the face disc and the brim corridor so the erased band never
                renders; the site's sentence circles it in our own type. The
                file is served exactly as supplied — the crop is presentation,
                not editing. -->
           <defs>
+            <filter id="lm-white-m">
+              <feColorMatrix type="matrix"
+                values="0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 1 0"/>
+            </filter>
             <clipPath id="lm-clip-m">
               <circle cx="50" cy="50" r="36.8"/>
               <rect x="50" y="40" width="62" height="22" rx="7"/>
@@ -77,7 +81,7 @@ folder and edit it to add/remove links to the menu.
           <image href="{% static 'website/images/laughing-face.png' %}"
                  x="0.3" y="1.7" width="109.9" height="97"
                  preserveAspectRatio="xMinYMin meet"
-                 clip-path="url(#lm-clip-m)"/>
+                 clip-path="url(#lm-clip-m)" filter="url(#lm-white-m)"/>
           <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
           <circle cx="50" cy="50" r="36" fill="none" stroke-width="1.6"/>
           <text class="ringtext" font-size="6.7" font-weight="700" letter-spacing="0.3">

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -59,13 +59,17 @@ Removes the Forum link to prevent navigation loops and double headers.
              skin's CSS swaps them in for the ringed world. Both are
              original drawings in the referenced style, not reproductions —
              and the badge's ring text is the site's own line. -->
-        <g class="alt alt-laughing" transform="rotate(-8 50 50)">
+        <g class="alt alt-laughing" transform="rotate(-2 50 50)">
           <!-- Composite: the owner's own text-cleared artwork, clipped to
                the face disc and the brim corridor so the erased band never
                renders; the site's sentence circles it in our own type. The
                file is served exactly as supplied — the crop is presentation,
                not editing. -->
           <defs>
+            <filter id="lm-white-if">
+              <feColorMatrix type="matrix"
+                values="0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 1 0"/>
+            </filter>
             <clipPath id="lm-clip-if">
               <circle cx="50" cy="50" r="36.8"/>
               <rect x="50" y="40" width="62" height="22" rx="7"/>
@@ -75,7 +79,7 @@ Removes the Forum link to prevent navigation loops and double headers.
           <image href="{% static 'website/images/laughing-face.png' %}"
                  x="0.3" y="1.7" width="109.9" height="97"
                  preserveAspectRatio="xMinYMin meet"
-                 clip-path="url(#lm-clip-if)"/>
+                 clip-path="url(#lm-clip-if)" filter="url(#lm-white-if)"/>
           <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
           <circle cx="50" cy="50" r="36" fill="none" stroke-width="1.6"/>
           <text class="ringtext" font-size="6.7" font-weight="700" letter-spacing="0.3">


### PR DESCRIPTION
Safari ignores CSS filter on SVG child elements — the recolor silently
no-opped and the face rendered navy on ink. An feColorMatrix filter
primitive does the same lift natively everywhere. And the supplied art
carries its own tilt; the group rotation now only adds a nudge instead of
doubling it.

Co-Authored-By: Claude <noreply@anthropic.com>
