### PR TITLE
Badge: black melts to paper, corridor hugs the brim, letters find the band

### DIFF
--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -68,13 +68,17 @@ folder and edit it to add/remove links to the menu.
                centred on the crown, and a mask blanks whichever letters the
                escaping brim crosses, exactly as the source does. -->
           <defs>
+            <filter id="lm-ink-m" color-interpolation-filters="sRGB">
+              <feColorMatrix type="matrix"
+                values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 2.7 0 0"/>
+            </filter>
             <clipPath id="lm-clip-m">
               <circle cx="50" cy="50" r="36.8"/>
-              <rect x="50" y="39.5" width="63" height="21" rx="7"/>
+              <rect x="50" y="39.5" width="59.5" height="21" rx="10.5"/>
             </clipPath>
             <mask id="lm-tmask-m" maskUnits="userSpaceOnUse">
               <rect x="-10" y="-10" width="130" height="120" fill="white"/>
-              <rect x="50" y="37" width="64" height="26" rx="8" fill="black"/>
+              <rect x="50" y="37" width="61" height="26" rx="8" fill="black"/>
             </mask>
             <path id="lm-ring-m" d="M 50,92 A 42,42 0 1 1 50.01,92 Z"/>
           </defs>
@@ -82,11 +86,11 @@ folder and edit it to add/remove links to the menu.
             <rect class="paper" x="-6" y="-6" width="122" height="112"/>
             <image href="{% static 'website/images/laughing-face.png' %}"
                    x="-0.61" y="-0.67" width="112.32" height="101.36"
-                   preserveAspectRatio="xMinYMin meet"/>
+                   preserveAspectRatio="xMinYMin meet" filter="url(#lm-ink-m)"/>
           </g>
           <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
           <circle cx="50" cy="50" r="36" fill="none" stroke-width="1.6"/>
-          <text class="ringtext" font-size="6.7" font-weight="700" letter-spacing="0.3"
+          <text class="ringtext" font-size="6.0" font-weight="700" letter-spacing="0.45"
                 text-anchor="middle" mask="url(#lm-tmask-m)">
             <textPath href="#lm-ring-m" xlink:href="#lm-ring-m" startOffset="50%">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE</textPath>
           </text>

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -66,13 +66,17 @@ Removes the Forum link to prevent navigation loops and double headers.
                centred on the crown, and a mask blanks whichever letters the
                escaping brim crosses, exactly as the source does. -->
           <defs>
+            <filter id="lm-ink-if" color-interpolation-filters="sRGB">
+              <feColorMatrix type="matrix"
+                values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 2.7 0 0"/>
+            </filter>
             <clipPath id="lm-clip-if">
               <circle cx="50" cy="50" r="36.8"/>
-              <rect x="50" y="39.5" width="63" height="21" rx="7"/>
+              <rect x="50" y="39.5" width="59.5" height="21" rx="10.5"/>
             </clipPath>
             <mask id="lm-tmask-if" maskUnits="userSpaceOnUse">
               <rect x="-10" y="-10" width="130" height="120" fill="white"/>
-              <rect x="50" y="37" width="64" height="26" rx="8" fill="black"/>
+              <rect x="50" y="37" width="61" height="26" rx="8" fill="black"/>
             </mask>
             <path id="lm-ring-if" d="M 50,92 A 42,42 0 1 1 50.01,92 Z"/>
           </defs>
@@ -80,11 +84,11 @@ Removes the Forum link to prevent navigation loops and double headers.
             <rect class="paper" x="-6" y="-6" width="122" height="112"/>
             <image href="{% static 'website/images/laughing-face.png' %}"
                    x="-0.61" y="-0.67" width="112.32" height="101.36"
-                   preserveAspectRatio="xMinYMin meet"/>
+                   preserveAspectRatio="xMinYMin meet" filter="url(#lm-ink-if)"/>
           </g>
           <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
           <circle cx="50" cy="50" r="36" fill="none" stroke-width="1.6"/>
-          <text class="ringtext" font-size="6.7" font-weight="700" letter-spacing="0.3"
+          <text class="ringtext" font-size="6.0" font-weight="700" letter-spacing="0.45"
                 text-anchor="middle" mask="url(#lm-tmask-if)">
             <textPath href="#lm-ring-if" xlink:href="#lm-ring-if" startOffset="50%">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE</textPath>
           </text>


### PR DESCRIPTION
The strange black chin was in the source file itself — genuinely opaque
black pixels in the lip region, distinct from the navy art. Black has no
blue; navy is made of it. A sRGB feColorMatrix keys alpha to the blue
channel, so black fades to the paper backing while navy stands — no pixel
of the owner's file edited, just light passed through a lens. The paper
corridor now ends in a round cap at the bar's tip instead of overhanging
white, and the ring sentence steps down to sit centred in its band, clear
of both circles.

Co-Authored-By: Claude <noreply@anthropic.com>
