### PR TITLE
Badge: remove the orphaned drawn-mouth painting the black crescent

### DIFF
--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -95,12 +95,6 @@ folder and edit it to add/remove links to the menu.
             <textPath href="#lm-ring-m" xlink:href="#lm-ring-m" startOffset="50%">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE</textPath>
           </text>
         </g>
-          <g class="eyes" fill="none" stroke-linecap="round">
-            <path d="M 32,66 A 6,6 0 0 1 43,66" stroke-width="5.2"/>
-            <path d="M 57,66 A 6,6 0 0 1 68,66" stroke-width="5.2"/>
-          </g>
-          <path class="mouth" stroke="none"
-                d="M 29,71 A 44,44 0 0 0 71,71 A 23,23 0 0 1 29,71 Z"/>
         </g>
           <g class="smile" fill="none" stroke-linecap="round">
             <path d="M 33,66 A 5,5 0 0 1 43,66" stroke-width="4.6"/>

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -93,12 +93,6 @@ Removes the Forum link to prevent navigation loops and double headers.
             <textPath href="#lm-ring-if" xlink:href="#lm-ring-if" startOffset="50%">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE</textPath>
           </text>
         </g>
-          <g class="eyes" fill="none" stroke-linecap="round">
-            <path d="M 32,66 A 6,6 0 0 1 43,66" stroke-width="5.2"/>
-            <path d="M 57,66 A 6,6 0 0 1 68,66" stroke-width="5.2"/>
-          </g>
-          <path class="mouth" stroke="none"
-                d="M 29,71 A 44,44 0 0 0 71,71 A 23,23 0 0 1 29,71 Z"/>
         </g>
           <g class="smile" fill="none" stroke-linecap="round">
             <path d="M 33,66 A 5,5 0 0 1 43,66" stroke-width="4.6"/>


### PR DESCRIPTION
The mystery black chin was never in the owner's artwork, never the paper,
never the filter — it was our own dead code. The composite-round regex
matched the drawn badge's group only to its first nested close, leaving
the old smile-bowl path and eyes group dangling inside the new group; the
CSS that once coloured them died in the same round, so the crescent
rendered with SVG's default black fill. Found by cropping source against
render side by side after three pixel-grids, a filter exoneration, a
red-paper probe and a hit-test all pointed the wrong way. The instrument
that closed it was eyes, not arithmetic.

Co-Authored-By: Claude <noreply@anthropic.com>
