### PR TITLE
Heal dangling worn-item references in get_worn_items

### DIFF
--- a/typeclasses/clothing_mixin.py
+++ b/typeclasses/clothing_mixin.py
@@ -419,6 +419,21 @@ class ClothingMixin:
         if not self.worn_items:
             return []
 
+        # Heal dangling references: deleting an object while it is worn
+        # leaves entries that deserialize to None (or to a deleted object
+        # whose pk is gone). Prune them here so every consumer sees live
+        # items and the stored dict repairs itself on first read.
+        for loc, items in list(self.worn_items.items()):
+            live = [itm for itm in items if itm and itm.pk]
+            if len(live) != len(items):
+                if live:
+                    self.worn_items[loc] = live
+                else:
+                    del self.worn_items[loc]
+
+        if not self.worn_items:
+            return []
+
         if location:
             return self.worn_items.get(location, [])
 


### PR DESCRIPTION
Deleting an object while it is worn leaves entries in the wearer's
worn_items dict that deserialize to None, crashing every command that
walks the worn list (inv, remove). Prune dead entries on read so the
stored dict self-repairs the next time any consumer asks for it.

Closes #1564

Co-Authored-By: Claude <noreply@anthropic.com>
