### PR TITLE
Nudge laughing badge 1 degree clockwise, center ring text in its band

### DIFF
--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -61,7 +61,7 @@ folder and edit it to add/remove links to the menu.
              skin's CSS swaps them in for the ringed world. Both are
              original drawings in the referenced style, not reproductions —
              and the badge's ring text is the site's own line. -->
-        <g class="alt alt-laughing" transform="rotate(-2 50 50)">
+        <g class="alt alt-laughing" transform="rotate(-1 50 50)">
           <!-- Composite: the owner's text-cleared artwork over a paper-white
                disc — navy on paper, as the original prints — clipped to the
                disc and brim corridor. The site's sentence circles it,
@@ -76,7 +76,7 @@ folder and edit it to add/remove links to the menu.
               <rect x="-10" y="-10" width="130" height="120" fill="white"/>
               <rect x="50" y="37" width="61" height="26" rx="8" fill="black"/>
             </mask>
-            <path id="lm-ring-m" d="M 50,92 A 42,42 0 1 1 50.01,92 Z"/>
+            <path id="lm-ring-m" d="M 50,90 A 40,40 0 1 1 50.01,90 Z"/>
           </defs>
           <g clip-path="url(#lm-clip-m)">
             <rect class="paper" x="-6" y="-6" width="122" height="112"/>
@@ -89,7 +89,7 @@ folder and edit it to add/remove links to the menu.
           </g>
           <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
           <circle cx="50" cy="50" r="36" fill="none" stroke-width="1.6"/>
-          <text class="ringtext" font-size="6.0" font-weight="700" letter-spacing="0.45"
+          <text class="ringtext" font-size="5.8" font-weight="700" letter-spacing="0.40"
                 text-anchor="middle" mask="url(#lm-tmask-m)">
             <textPath href="#lm-ring-m" xlink:href="#lm-ring-m" startOffset="50%">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE</textPath>
           </text>

--- a/web/templates/website/_menu_iframe.html
+++ b/web/templates/website/_menu_iframe.html
@@ -59,7 +59,7 @@ Removes the Forum link to prevent navigation loops and double headers.
              skin's CSS swaps them in for the ringed world. Both are
              original drawings in the referenced style, not reproductions —
              and the badge's ring text is the site's own line. -->
-        <g class="alt alt-laughing" transform="rotate(-2 50 50)">
+        <g class="alt alt-laughing" transform="rotate(-1 50 50)">
           <!-- Composite: the owner's text-cleared artwork over a paper-white
                disc — navy on paper, as the original prints — clipped to the
                disc and brim corridor. The site's sentence circles it,
@@ -74,7 +74,7 @@ Removes the Forum link to prevent navigation loops and double headers.
               <rect x="-10" y="-10" width="130" height="120" fill="white"/>
               <rect x="50" y="37" width="61" height="26" rx="8" fill="black"/>
             </mask>
-            <path id="lm-ring-if" d="M 50,92 A 42,42 0 1 1 50.01,92 Z"/>
+            <path id="lm-ring-if" d="M 50,90 A 40,40 0 1 1 50.01,90 Z"/>
           </defs>
           <g clip-path="url(#lm-clip-if)">
             <rect class="paper" x="-6" y="-6" width="122" height="112"/>
@@ -87,7 +87,7 @@ Removes the Forum link to prevent navigation loops and double headers.
           </g>
           <circle cx="50" cy="50" r="48" fill="none" stroke-width="1.8"/>
           <circle cx="50" cy="50" r="36" fill="none" stroke-width="1.6"/>
-          <text class="ringtext" font-size="6.0" font-weight="700" letter-spacing="0.45"
+          <text class="ringtext" font-size="5.8" font-weight="700" letter-spacing="0.40"
                 text-anchor="middle" mask="url(#lm-tmask-if)">
             <textPath href="#lm-ring-if" xlink:href="#lm-ring-if" startOffset="50%">A TEMPORARY ARRANGEMENT OF ATOMS PRETENDING COHERENCE</textPath>
           </text>


### PR DESCRIPTION
Owner review: tilt reads better at -1 than -2, and the ring sentence
hugged the outer ring (baseline r=42 left 0.9 units outer clearance vs
5.2 inner). Baseline moves to r=40 with font-size 5.8 and letter-spacing
0.40 so the sentence keeps its bottom gap on the smaller circumference.

Closes #1570

Co-Authored-By: Claude <noreply@anthropic.com>
