### PR TITLE
Only kick the menu's own live session when chargen is abandoned

### DIFF
--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -495,13 +495,17 @@ def _charcreate_exit_callback(caller, menu):
         # They completed creation - just close menu, don't disconnect
         return
     
-    # No active characters - they exited without completing
-    # Disconnect them so they restart character creation on reconnect
-    sessions = caller.sessions.all()
-    if not sessions:
-        # Already disconnected (e.g. connection dropped during menu)
-        return
-    sessions[0].sessionhandler.disconnect(sessions[0], reason="|ySleeve decantation incomplete. Please reconnect to try again.|n")
+    # No active characters - the menu was abandoned. Disconnect the session
+    # that was RUNNING this menu so it restarts creation on reconnect — but
+    # only if that session is still alive. When a connection drops mid-menu,
+    # the stale menu is closed by EvMenu.__init__ at the NEXT login; kicking
+    # the account's current (fresh) session there would boot every reconnect
+    # in an endless "decantation incomplete" loop until a server reload.
+    menu_session = getattr(menu, "_session", None)
+    if menu_session and menu_session in caller.sessions.all():
+        menu_session.sessionhandler.disconnect(
+            menu_session,
+            reason="|ySleeve decantation incomplete. Please reconnect to try again.|n")
 
 
 def start_character_creation(account, is_respawn=False, old_character=None):


### PR DESCRIPTION
A dropped connection mid-chargen left a stale menu on the account; the
next login's fresh menu displaced it via EvMenu.__init__ -> close_menu
-> cmd_on_exit, and the callback disconnected the account's current
session - the brand-new login. Each kicked login left its own stale
menu, looping "decantation incomplete" until a server reload cleared
ndb. Now the callback only disconnects the session that was actually
running the abandoned menu, and only while that session is still alive,
so displacement-at-login is a no-op and genuine abandons still kick.

Closes #1574

Co-Authored-By: Claude <noreply@anthropic.com>
