### PR TITLE
Replace meta puppet messages with the decant narrative

### DIFF
--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -733,9 +733,10 @@ def respawn_finalize_template(caller, raw_string, **kwargs):
         caller.msg("|g╚════════════════════════════════════════════════════════════════╝|n")
         caller.msg("")
         caller.msg(f"|wWelcome back, |c{char.key}|w.|n")
-        caller.msg(f"|wClone Generation:|n |w1|n")
         caller.msg("")
-        caller.msg("|yYou open your eyes in an unfamiliar body.|n")
+        caller.msg("|wThe envelope unseals around an unfamiliar body. The same yellow|n")
+        caller.msg("|wprint slides past your face: DO NOT CONSUME NUTRIGEL.|n")
+        caller.msg("")
         caller.msg("|yThe memories feel... borrowed. But they're yours now.|n")
         caller.msg("")
 
@@ -1478,13 +1479,24 @@ def first_char_finalize(caller, raw_string, **kwargs):
         if spawn_location and spawn_location != char.location:
             char.move_to(spawn_location, quiet=True)
 
-        # Welcome banner before the puppet-look, so the spawn room
-        # description lands as the payoff of "you open your eyes".
+        # Decant narrative before the puppet-look, so the spawn room
+        # description lands as the payoff of "you open your eyes". The
+        # character's name (numeral and all) is revealed diegetically as
+        # the sleeve envelope's CONTENTS line.
         caller.msg("|g╔════════════════════════════════════════════════════════════════╗")
         caller.msg("|g║  CONSCIOUSNESS UPLOAD COMPLETE                                 ║")
         caller.msg("|g╚════════════════════════════════════════════════════════════════╝|n")
         caller.msg("")
-        caller.msg(f"|wWelcome to Gelatinous Monster, |c{char.key}|w.|n")
+        caller.msg("|wPressure equalizes with a hiss. Nutrigel drains in slow pulses,|n")
+        caller.msg("|wand the envelope's seam parts tooth by tooth along its zipper.|n")
+        caller.msg("|wYellow print slides past your face:|n")
+        caller.msg("")
+        caller.msg("|y    THAWN-HARRISON SINGLE-USE SLEEVE ENVELOPE|n")
+        caller.msg(f"|y    CONTENTS: {char.key.upper()}|n")
+        caller.msg("|y    BIOSTATIC · FRAGILE · DO NOT CONSUME NUTRIGEL|n")
+        caller.msg("")
+        caller.msg("|wGloved hands peel the breather from your face. Your first breath|n")
+        caller.msg("|win this body tastes of refrigerant and copper.|n")
         caller.msg("")
         caller.msg("|wThe static clears. You open your eyes.|n")
         caller.msg("|wThe year is 198█. The broadcast continues.|n")

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1224,6 +1224,26 @@ class Character(
 
         return f"{name} ({with_article(sdesc)})"
 
+    def at_post_puppet(self, **kwargs):
+        """Look at the room and announce our waking, without the meta lines.
+
+        Overrides Evennia's default, which sends "You become <name>." to
+        the player and "<name> has entered the game." to the room. The
+        chargen/respawn flows narrate the decant themselves, and bystanders
+        see a sleeve waking rather than an out-of-character login notice.
+        """
+        self.msg((self.at_look(self.location), {"type": "look"}), options=None)
+
+        if self.location:
+            from world.identity_utils import msg_room_identity
+
+            msg_room_identity(
+                self.location,
+                "{actor} stirs as consciousness returns.",
+                {"actor": self},
+                exclude=[self],
+            )
+
     def announce_move_from(
         self, destination, msg=None, mapping=None, **kwargs
     ):


### PR DESCRIPTION
Drop Evennia's stock "You become <name>." and "<name> has entered the
game." via an at_post_puppet override: the player gets the room look,
bystanders see the sleeve stir awake (identity-aware). The first-
character finalize now narrates the decant - nutrigel, the envelope
unzipping, Thawn-Harrison yellow print revealing the character's name
as the CONTENTS line - before the room look pays off "you open your
eyes". Template respawns get the envelope beat and lose the hardcoded
"Clone Generation: 1" line.

Closes #1576

Co-Authored-By: Claude <noreply@anthropic.com>
