### PR TITLE
Record death cause on the character; give initiate messages a location

### DIFF
--- a/commands/combat/core_actions.py
+++ b/commands/combat/core_actions.py
@@ -27,6 +27,7 @@ from world.combat.constants import (
 from commands._identity_targeting import resolve_character_target
 from world.combat.handler import get_or_create_combat
 from world.combat.messages import get_combat_message
+from world.medical.utils import select_hit_location
 from world.combat.proximity import establish_proximity
 from world.combat.utils import (
     initialize_proximity_ndb, get_wielded_weapon, get_numeric_stat,
@@ -361,7 +362,9 @@ class CmdAttack(Command):
             splattercast.msg(f"{DEBUG_PREFIX_ATTACK}: Aiming direction attack by {caller.key} towards {aiming_direction} into {target_room.key}.")
 
             # --- ADDITIONAL AIMING DIRECTION LOGIC ---
-            initiate_msg_obj = get_combat_message(weapon_type_for_msg, "initiate", attacker=caller, target=target, item=weapon_obj)
+            initiate_msg_obj = get_combat_message(
+                weapon_type_for_msg, "initiate", attacker=caller, target=target, item=weapon_obj,
+                hit_location=select_hit_location(target, 0, caller))
             
             std_attacker_initiate = ""
             std_victim_initiate = ""
@@ -424,7 +427,9 @@ class CmdAttack(Command):
             
         else:
             # Standard local attack initiation message (use get_combat_message)
-            initiate_msg_obj = get_combat_message(weapon_type_for_msg, "initiate", attacker=caller, target=target, item=weapon_obj)
+            initiate_msg_obj = get_combat_message(
+                weapon_type_for_msg, "initiate", attacker=caller, target=target, item=weapon_obj,
+                hit_location=select_hit_location(target, 0, caller))
             
             attacker_msg = ""
             victim_msg = ""
@@ -480,7 +485,9 @@ class CmdAttack(Command):
                     target_weapon_type = target_weapon.db.weapon_type
                 
                 # Get target's initiate message (defensive reaction)
-                target_initiate_msg_obj = get_combat_message(target_weapon_type, "initiate", attacker=target, target=caller, item=target_weapon)
+                target_initiate_msg_obj = get_combat_message(
+                    target_weapon_type, "initiate", attacker=target, target=caller, item=target_weapon,
+                    hit_location=select_hit_location(caller, 0, target))
                 
                 target_attacker_msg = ""
                 target_victim_msg = ""

--- a/typeclasses/death_progression.py
+++ b/typeclasses/death_progression.py
@@ -617,6 +617,11 @@ class DeathProgressionScript(DefaultScript):
         # Transfer medical/death data if available
         if hasattr(character, 'medical_state') and character.medical_state:
             corpse.db.death_cause = character.get_death_cause()
+            # Mirror onto the character: the respawn flow reads
+            # old_char.db.death_cause for the sleeve envelope's
+            # PRIOR TERMINATION line, and this is the last point the
+            # live medical state is guaranteed readable.
+            character.db.death_cause = corpse.db.death_cause
             corpse.db.medical_conditions = character.medical_state.get_condition_summary()
             corpse.db.blood_type = character.db.blood_type if character.db.blood_type is not None else 'unknown'
 
@@ -885,7 +890,13 @@ class DeathProgressionScript(DefaultScript):
         
         # Archive the dead character (also handles any lingering sessions)
         character.archive_character(reason="death")
-        character.db.death_cause = character.db.death_cause if character.db.death_cause is not None else 'unknown'
+        if character.db.death_cause is None:
+            # Corpse construction usually records the cause; fall back to
+            # reading the medical state directly before giving up.
+            try:
+                character.db.death_cause = character.get_death_cause() or 'unknown'
+            except Exception:
+                character.db.death_cause = 'unknown'
 
     def _initiate_new_character_creation(self, account, old_character, session):
         """Start the character creation process for the account after death."""


### PR DESCRIPTION
Live deathmatch findings. The death flow copied get_death_cause() onto
the corpse but never onto the character, so the respawn envelope's
PRIOR TERMINATION line always read UNKNOWN - mirror it at corpse
construction and try the medical state before the archive-time
'unknown' fallback. Attack-initiate templates across nearly every
weapon reference {hit_location} but the three initiate call sites
never passed one, intermittently printing a formatter error; compute
an intended location via select_hit_location, the same precedent the
miss path uses.

Closes #1582
Closes #1583

Co-Authored-By: Claude <noreply@anthropic.com>
