### PR TITLE
Play the decant scene to bystanders on a character's first puppet

### DIFF
--- a/commands/charcreate.py
+++ b/commands/charcreate.py
@@ -323,6 +323,11 @@ def create_character_from_template(account, template, sex="ambiguous"):
     # death_count starts at 1 via AttributeProperty in Character class
     char.unarchive_character()   # attribute + sleeve-tag index in sync
     
+    # One-shot: the first puppet plays the decant scene to the room
+    # (at_post_puppet consumes this). Covers web-created characters too,
+    # whose first puppet happens at first login.
+    char.db.decant_announce_pending = True
+    
     return char
 
 
@@ -429,6 +434,7 @@ def create_flash_clone(account, old_character):
         # Create new stack ID if old char didn't have one
         import uuid
         char.db.stack_id = str(uuid.uuid4())
+    char.db.decant_announce_pending = True
     
     # Reset state
     char.unarchive_character()   # attribute + sleeve-tag index in sync
@@ -1488,6 +1494,7 @@ def first_char_finalize(caller, raw_string, **kwargs):
         # Generate unique Stack ID
         import uuid
         char.db.stack_id = str(uuid.uuid4())
+        char.db.decant_announce_pending = True
         char.db.original_creation = time.time()
         char.db.current_sleeve_birth = time.time()
         

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -1237,9 +1237,23 @@ class Character(
         if self.location:
             from world.identity_utils import msg_room_identity
 
+            if self.attributes.get("decant_announce_pending"):
+                # One-shot, set at character creation: the first puppet is
+                # the decant itself, so bystanders get the whole scene.
+                self.attributes.remove("decant_announce_pending")
+                template = (
+                    "A pair of Thawn-Harrison techs crack open a decanting "
+                    "pod, unzip the sleeve envelope inside tooth by tooth, "
+                    "and peel {actor} out of the nutrigel. One strips the "
+                    "breather free and logs the decant at a console; they "
+                    "move on without a word."
+                )
+            else:
+                template = "{actor} stirs as consciousness returns."
+
             msg_room_identity(
                 self.location,
-                "{actor} stirs as consciousness returns.",
+                template,
                 {"actor": self},
                 exclude=[self],
             )


### PR DESCRIPTION
A one-shot decant_announce_pending attribute is set at character
creation (template helper, flash clone, first-character finalize - the
shared helpers cover web-created characters at first login too).
at_post_puppet consumes it and broadcasts the tech scene - pod cracked,
envelope unzipped, body peeled out of the nutrigel - via
msg_room_identity; ordinary logins keep the subtle stir line.

Closes #1586

Co-Authored-By: Claude <noreply@anthropic.com>
