### PR TITLE
Only capitalize identity placeholders at genuine sentence starts

### DIFF
--- a/world/identity_utils.py
+++ b/world/identity_utils.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import re
+
 from world.grammar import capitalize_first
 
 if TYPE_CHECKING:
@@ -88,6 +90,15 @@ def msg_room_identity(
         if pos != -1 and pos < first_pos:
             first_pos = pos
             first_placeholder = placeholder
+
+    # Only capitalize when the placeholder actually sits at a sentence
+    # start. A template like "... techs peel {actor} out of the gel"
+    # must render "an average man", not "An average man". Colour codes
+    # before the placeholder don't count as prose.
+    if first_placeholder is not None:
+        prefix = re.sub(r"\|\[?\w{1,3}", "", template[:first_pos]).strip()
+        if prefix and prefix[-1] not in ".!?":
+            first_placeholder = None
 
     for observer in location.contents:
         if observer in exclude_set:


### PR DESCRIPTION
msg_room_identity capitalized whichever placeholder appeared first in
the template, assuming actor-first templates; the decant scene rendered
"peel An average man out of the nutrigel". Capitalize only when the
prose before the placeholder is empty (colour codes aside) or ends a
sentence, so mid-sentence references keep their lowercase article.

Closes #1588

Co-Authored-By: Claude <noreply@anthropic.com>
