### PR TITLE
Spec the new-player experience; propose sleeping sleeves

### DIFF
--- a/specs/NEW_PLAYER_EXPERIENCE_SPEC.md
+++ b/specs/NEW_PLAYER_EXPERIENCE_SPEC.md
@@ -1,0 +1,130 @@
+# New-Player Experience Spec
+
+The first thirty minutes of contact: connection screen → account →
+character initialization → decant → first look. This spec records the
+**shipped** flow and, more importantly, the **messaging conventions**
+the owner locked in while polishing it (2026-08-04, #1572–#1591).
+Anything touching chargen, death/respawn, or system-to-player messaging
+should follow these rules.
+
+Related: [`WEB_CHARACTER_CREATION_ALIGNMENT.md`](WEB_CHARACTER_CREATION_ALIGNMENT.md)
+(web/telnet data parity), [`EVMENU_PATTERNS_SPEC.md`](EVMENU_PATTERNS_SPEC.md)
+(menu mechanics), [`TIME_SYSTEM_SPEC.md`](TIME_SYSTEM_SPEC.md) (the clock),
+[`IDENTITY_RECOGNITION_SPEC.md`](IDENTITY_RECOGNITION_SPEC.md) (per-observer
+rendering), and
+[`proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md`](proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md)
+(what happens at the other end).
+
+---
+
+## 1 · The flow
+
+1. **Connection screen** (`server/conf/connection_screens.py`) — the
+   test-pattern broadcast. `YEAR:` is derived from the clock at render
+   time via `world.gametime.tst_now()`. Accounts are **email-keyed**;
+   `create` does **not** auto-login — the player must `connect` after.
+2. **Character initialization** (`commands/charcreate.py`, EvMenu) —
+   protocol-voiced nodes: identity (first/last name), biological sex,
+   height/build/hair (bald skips the style node), G.R.I.M. point
+   distribution, final confirmation. Node furniture (underscore rules)
+   comes from EvMenu's default `node_formatter`.
+3. **Finalize** — the decant. Ordering is load-bearing; see §2.
+4. **First look** — the spawn room (`START_LOCATION`, secret settings)
+   arrives as the payoff of "you open your eyes", *outside* the framed
+   protocol block.
+
+Respawn (template sleeves / flash clone) and web-created characters
+share the same conventions; the flash-clone envelope doubles as a
+morgue tag (§4).
+
+## 2 · Finalize ordering — move BEFORE puppet
+
+All three telnet finalize paths (first character, template respawn,
+flash clone) do, in order:
+
+1. `char.move_to(spawn, quiet=True)` — **before puppeting**. Pre-puppet
+   the character has no session, so nothing renders; the player never
+   sees the Limbo staging area (boilerplate desc, archived sleeves).
+2. Send the framed decant block to the **account** (`caller.msg`).
+3. `caller.puppet_object(...)` last — the puppet-look of the spawn room
+   lands after the narrative (#1572).
+
+**Abandonment:** the menu's `cmd_on_exit` callback disconnects only the
+session that was actually running the abandoned menu, and only while
+that session is still alive (`menu._session`). Kicking the account's
+*current* session locks every reconnect out until a reload — that bug
+shipped and was fixed as #1574. Any future `cmd_on_exit` that
+disconnects must make the same check.
+
+## 3 · Messaging conventions (owner-locked)
+
+- **Standard frame.** Post-menu narrative blocks wear the menus' own
+  furniture: a 66-underscore rule, the box banner, body, closing rule —
+  sent as **one message** so blank lines survive intact and the block
+  lands atomically. The room description always arrives *outside* the
+  frame: the protocol ends, the world begins.
+- **Terminal-informed wrap.** Prose paragraphs are **single unwrapped
+  lines** — the client wraps to its own width, exactly like room
+  descriptions. Never hand-wrap narrative at ~64 columns. Fixed layout
+  is reserved for banners, rules, and label print.
+- **TST dates, never real-world.** Every displayed year/date derives
+  from `world/gametime.py` (Terran Standard Time = real year + 1200;
+  e.g. `DECANTED: 04 AUG 3226`, `YEAR: 3226`). No hardcoded years —
+  everything ticks with the clock.
+- **Informing, not telling.** The world reports; the narrator does not
+  assert. State arrives through labels, consoles, and readouts
+  ("Memory integrity: PARTIAL", "a console ticks through your vitals
+  and finds nothing to flag") — never "You are real." The envelope
+  label is the canonical example: name, numeral, date, prior
+  termination, death count — all fiction-legible facts, zero meta.
+- **Branding.** The sleeve envelope is a **THAWN-HARRISON SINGLE-USE
+  SLEEVE ENVELOPE** (`BIOSTATIC · FRAGILE · DO NOT CONSUME NUTRIGEL`).
+  Imagery homages its inspirations; all print text and marks are ours
+  (world rule: everything branded, nothing lifted).
+
+## 4 · The envelope as record
+
+The yellow print does the informing:
+
+```
+    THAWN-HARRISON SINGLE-USE SLEEVE ENVELOPE
+    CONTENTS: <NAME> <NUMERAL>
+    DECANTED: <DD MON YYYY, TST>
+    PRIOR TERMINATION: <CAUSE>      (flash clone only)
+    DEATH COUNT: <N>                (flash clone only)
+    BIOSTATIC · FRAGILE · DO NOT CONSUME NUTRIGEL
+```
+
+`CONTENTS` is the diegetic name reveal — the sleeve numbering fiction
+doing its own worldbuilding. `PRIOR TERMINATION` reads
+`old_char.db.death_cause`, which the death flow mirrors onto the
+character at corpse construction (#1582).
+
+## 5 · Puppet lifecycle messages
+
+`typeclasses/characters.py` overrides both puppet hooks; **no stock
+Evennia meta lines** ("You become X.", "X has entered/left the game.")
+reach players. All room broadcasts go through
+`world.identity_utils.msg_room_identity` (per-observer recognition;
+capitalization only at genuine sentence starts, #1588).
+
+| Event | Player sees | Room sees |
+|-------|-------------|-----------|
+| First puppet ever | framed decant block, then the room | the tech scene: pod cracked, envelope unzipped, body peeled from the nutrigel (one-shot `db.decant_announce_pending`, set at every creation point incl. web) |
+| Later logins | the room | "{Actor} stirs as consciousness returns." |
+| Logout | — | "{Actor} goes still, eyes emptying to static; the vacant sleeve is quietly gone." (stow-away behavior preserved: `prelogout_location`, body off-grid) |
+
+The logout stow-away is slated to become in-world sleeping persistence
+eventually — see
+[`proposals/SLEEPING_SLEEVES_SPEC.md`](proposals/SLEEPING_SLEEVES_SPEC.md).
+
+## 6 · Testing
+
+End-to-end verification runs a raw-socket telnet probe **inside the
+game container** (port 23; strip IAC negotiation; email-keyed accounts;
+create-then-connect). Walk the full menu, capture every screen, assert
+on the finale (no "Limbo", no stock meta lines, banner before room).
+Throwaway accounts/characters are deleted afterward via the external
+shell **followed by a foreground reload** (idmapper). The probe scripts
+live in session scratch space, not the repo — they are ten lines of
+socket code and this spec is their documentation.

--- a/specs/README.md
+++ b/specs/README.md
@@ -76,6 +76,7 @@ Every spec in those folders carries a `> **Status:**` banner at the top.
 
 | Spec | Description |
 |------|-------------|
+| `NEW_PLAYER_EXPERIENCE_SPEC.md` | Connection → chargen → decant flow and the locked messaging conventions (frame, terminal wrap, TST dates, informing-not-telling, puppet lifecycle) |
 | `EVMENU_PATTERNS_SPEC.md` | EvMenu text-input / multi-source-picker patterns |
 | `STYLING_SPEC.md` | Web client / terminal-brutalist styling |
 | `WEBCLIENT_SCREEN_SIZE_DETECTION_SPEC.md` | Responsive client layout / screen-width detection |

--- a/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
+++ b/specs/proposals/DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md
@@ -157,6 +157,18 @@ PC-only:
 decants a new sleeve: **3 random templates** or a **flash clone** (inherits stats,
 appearance, sex from the archived sleeve). `death_count` sets the numeral.
 
+> **Addendum (2026-08-04, #1572–#1591):** the decant presentation was
+> rebuilt — finalize paths now move the sleeve to the spawn room
+> *before* puppeting (no Limbo leak), the respawn/flash finale is a
+> framed narrative block whose sleeve-envelope label carries the
+> record (`CONTENTS` name+numeral, `DECANTED` TST date, and for flash
+> clones `PRIOR TERMINATION` + `DEATH COUNT`), and `death_cause` is
+> now mirrored onto the **character** at corpse construction (#1582 —
+> previously only the corpse got it, so respawn always read UNKNOWN).
+> Bystanders see the decant as a tech scene; logout reads as the
+> sleeve going vacant. Conventions:
+> [`../NEW_PLAYER_EXPERIENCE_SPEC.md`](../NEW_PLAYER_EXPERIENCE_SPEC.md).
+
 **Archived sleeves are permanent, reviewable records — BY DESIGN.** They live on
 in Limbo; `accounts.py` counts only *non-archived* characters against
 `MAX_NR_CHARACTERS`, and the website surfaces past sleeves ("Decant Sleeve /

--- a/specs/proposals/SLEEPING_SLEEVES_SPEC.md
+++ b/specs/proposals/SLEEPING_SLEEVES_SPEC.md
@@ -1,0 +1,56 @@
+# Sleeping Sleeves — Logout Persistence Proposal
+
+> **Status:** 📋 **PROPOSAL — EXPLICITLY DEFERRED (owner call,
+> 2026-08-04).** Do not build until the mechanisms for players to
+> thrive under the resulting hostility exist. This document exists so
+> the design thesis and its dependencies don't live only in
+> conversation.
+
+## Thesis
+
+Today a logged-out character is stoved off-grid
+(`at_post_unpuppet`: room sees "the vacant sleeve is quietly gone",
+body → `location=None`, `prelogout_location` saved). The intended end
+state is the opposite: **the body stays in the world, asleep.** A
+sleeve is a possession; an unattended possession is exposed.
+
+That exposure is the point, not a side effect:
+
+- A sleeping body can be robbed, moved, harmed, harvested — full
+  contact with the crime systems the world already runs (frisk/trust,
+  grapple, medical, the coming Ripper economy).
+- Which makes **housing load-bearing rather than flavor**: the
+  guaranteed rental credit (Queen of Cups' 25 cubes, the Brackett
+  Arms' 54 leases, spring-latch doors keyed to tenancy) becomes the
+  survival answer — *rent a room or your body is loot*. The housing
+  guarantee shipped first, deliberately.
+
+## Blocking dependencies (why deferred)
+
+The hostility is only good design if a player can realistically live
+with it. Missing today, in the owner's words: "the mechanisms for them
+to thrive with that hostility." Concretely that means things like — to
+be scoped when this revives — meaningful defensive options for the
+sleeping (locked doors are shipped; what else?), consequences/recourse
+for sleeve crime (witnesses, dispatch, the favor/rep loop), and an
+economy where losing pocket contents isn't losing everything.
+
+## The seam
+
+`Character.at_post_unpuppet` (typeclasses/characters.py) is the single
+switch point: replace the stow-away (body off-grid) with a sleeping
+state in place — pose/longdesc to "asleep", the vacant-sleeve line
+retired in favor of the body simply staying. `at_post_puppet`'s stir
+line ("stirs as consciousness returns") already reads correctly for
+waking a persisted body. Everything else — what sleep means to combat,
+medical, frisk, drag — is design work for when this revives.
+
+## Cross-references
+
+- [`../NEW_PLAYER_EXPERIENCE_SPEC.md`](../NEW_PLAYER_EXPERIENCE_SPEC.md)
+  §5 — current puppet lifecycle messaging.
+- [`DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md`](DEATH_AND_SLEEVE_LIFECYCLE_SPEC.md)
+  — what happens when the exposure goes badly.
+- Housing: cube rental + Brackett Arms (shipped; see project history).
+- [`GIG_RIPPER_SPEC.md`](GIG_RIPPER_SPEC.md) — the economy sleeping
+  bodies would feed.


### PR DESCRIPTION
NEW_PLAYER_EXPERIENCE_SPEC records the shipped chargen/decant flow and
the owner-locked messaging conventions from the 2026-08-04 arc
(move-before-puppet ordering, framed finale blocks, terminal-informed
wrap, TST dates, informing-not-telling voice, envelope-as-record,
puppet lifecycle messages, the abandonment-kick rule, and the telnet
probe test method). SLEEPING_SLEEVES_SPEC captures the explicitly
deferred future - logout bodies persisting asleep, hostility by
design, housing as the survival answer - with its blocking
dependencies and the at_post_unpuppet seam. The death lifecycle spec
gains a dated addendum for the decant presentation and the
death-cause mirror fix; README indexes the new spec.

Closes #1592

Co-Authored-By: Claude <noreply@anthropic.com>
