### PR TITLE
Honor type=rooftop before building skins in the atlas classifier

### DIFF
--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -134,7 +134,10 @@ function cls(c){
   if (c.flags.includes('sky')) return 'air';
   const t=(c.type||'').toLowerCase(), k=c.key||'';
   if (k.toLowerCase().includes('alley')) return 'alley';
-  if (/rooftop|- roof/i.test(k))
+  // type=rooftop is authoritative (the lid standard sets it); the name
+  // regex only rescues legacy cells. Checked BEFORE the skins so a
+  // building prefix can never dress a roof as another storey.
+  if (t==='rooftop' || /rooftop|- roof/i.test(k))
     return k.startsWith("Hammett's Boot")?'hull':'roof';
   for (const [prefix, skin] of SKINS)
     if (k.startsWith(prefix)) return skin;


### PR DESCRIPTION
Lids named without a literal '- roof' ('Northwest Roof', 'North Wing
Roof West') slipped past the name regex into the SKINS prefix table
and rendered as tenement storeys - the Brackett visually gained
floors; Thawn's condenser decks rendered as cryo mass. type=rooftop
is authoritative since the lid-standard conformance pass, so check it
before the skins; the name regex stays as legacy rescue. Class-diff
verified: 18 cells reclassify, all corrections.

Closes #1600

Co-Authored-By: Claude <noreply@anthropic.com>
