### PR TITLE
Resolve terraces, courtyards, and elevators ahead of building skins

### DIFF
--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -137,8 +137,11 @@ function cls(c){
   // type=rooftop is authoritative (the lid standard sets it); the name
   // regex only rescues legacy cells. Checked BEFORE the skins so a
   // building prefix can never dress a roof as another storey.
-  if (t==='rooftop' || /rooftop|- roof/i.test(k))
+  if (t==='rooftop' || t==='balcony' || t==='terrace' || /rooftop|- roof/i.test(k))
     return k.startsWith("Hammett's Boot")?'hull':'roof';
+  // open ground and machinery outrank building skins too
+  if (/courtyard/i.test(k)) return 'street';
+  if (k.toLowerCase().includes('elevator')) return 'machine';
   for (const [prefix, skin] of SKINS)
     if (k.startsWith(prefix)) return skin;
   if (t==='street'||t==='bridge') return 'street';


### PR DESCRIPTION
Companion template fixes for lid sweep c3: balcony/terrace types
resolve to roof class (Helix Balcony rendered as lounge mass),
courtyards resolve to open ground (Thawn's rendered as cryo building),
and the elevator->machine check moves ahead of the skins (the Brackett
Elevator Car snapshot rendered as a tenement cell).

Closes #1602

Co-Authored-By: Claude <noreply@anthropic.com>
