### PR TITLE
The live render becomes the Atlas

### DIFF
--- a/specs/STYLING_SPEC.md
+++ b/specs/STYLING_SPEC.md
@@ -518,14 +518,17 @@ Bootstrap stays at 4.6 (or the overrides are reviewed against the new version);
 ## Addendum (2026-07-29) — the Atlas, and cache-busting
 
 **The Atlas is a second visual world, on purpose.** `scripts/atlas/` renders
-the colony map as a self-contained document in its own register (night plate
-`#0b0e14`, bone text, amber emphasis, cyan reserved for data, condensed /
-serif / mono type roles). It is embedded into the site at `/atlas/` through
-`web/templates/website/atlas.html` in *fragment* mode, so the site's header
-and footer carry through. Because this theme sets a global
-`* { font-family: 'Inter' … !important }`, the plate re-asserts its own type
-roles inside `.atlas-plate` with `!important` — that scoping is deliberate,
-not a leak.
+the colony map in its own register (night plate `#0b0e14`, bone text, amber
+emphasis, cyan reserved for data, condensed / serif / mono type roles).
+Since 2026-08-04 the served atlas at `/atlas/` is the *live render* — the
+self-contained three.js viewer (`template3d.html`), a full standalone page
+outside the site chrome; it carries the register natively and inherits
+nothing. The earlier sprite plate survives only as the builder's generated
+staff instrument (`scripts/atlas/generate.py`), never served, so the
+fragment-embedding notes below are historical. (When it was embedded, the
+site's global `* { font-family: 'Inter' … !important }` forced the plate to
+re-assert its type roles inside `.atlas-plate` — that scoping remains in
+the generated file, deliberate, not a leak.)
 
 **Two structural additions live at the bottom of `custom.css`:**
 

--- a/web/templates/website/atlas.html
+++ b/web/templates/website/atlas.html
@@ -1,5 +1,0 @@
-{% extends "website/base.html" %}
-{% block titleblock %}Atlas{% endblock %}
-{% block content %}
-{{ atlas }}
-{% endblock %}

--- a/web/website/views/atlas.py
+++ b/web/website/views/atlas.py
@@ -1,26 +1,18 @@
-"""The atlas, served (COLONY_MAPPING_SPEC §M2.5) — inside the site's own
-page, so the colony's header and footer carry through. Any logged-in
-account may read the plate; the analytical overlays are staff
-instruments and only render their controls for staff."""
+"""The atlas, served (COLONY_MAPPING_SPEC §M2.5) — the live render IS
+the atlas. One version: the three.js viewer with the Cycles verdict
+baked into its vertices, day and night skies aboard. The builder's
+staff-overlay plate still exists as a generated file (scripts/atlas/
+generate.py); it is an instrument, not a page."""
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render
-from django.utils.safestring import mark_safe
 
 from django.http import HttpResponse
 
-from world.atlas import build_atlas3d_html, build_atlas_html
+from world.atlas import build_atlas3d_html
 
 
 @login_required
 def atlas_view(request):
     game_dir = getattr(settings, "GAME_DIR", ".")
-    if request.GET.get("mode") == "3d":
-        # the live-render atlas rides the SAME path (the edge allowlist
-        # admits exact paths only; query strings pass freely)
-        return HttpResponse(build_atlas3d_html(game_dir))
-    staff = bool(request.user.is_superuser or request.user.is_staff)
-    plate = build_atlas_html(game_dir, staff=staff, fragment=True)
-    return render(request, "website/atlas.html",
-                  {"atlas": mark_safe(plate), "page_title": "Atlas"})
+    return HttpResponse(build_atlas3d_html(game_dir))


### PR DESCRIPTION
One atlas, not two. /atlas/ now serves the three.js live render
outright — the mode switch and the embedded 2D sprite fragment retire,
and the website/atlas.html template goes with them. The builder's
staff-overlay plate keeps living as a generated file via
scripts/atlas/generate.py; it is an instrument, not a page. The
STYLING_SPEC addendum now records the fragment-embedding notes as
historical.

Closes #1639

Co-Authored-By: Claude <noreply@anthropic.com>
