### PR TITLE
Atlas: the live render moves INTO the plate

### DIFF
--- a/scripts/atlas/template3d.html
+++ b/scripts/atlas/template3d.html
@@ -1,25 +1,58 @@
-<!doctype html>
 <meta charset="utf-8">
-<title>Atlas — Live</title>
+<title>Gelatinous — Colony Atlas</title>
 <style>
-  :root{--ink:#0b0e14;--plate:#0d1119;--line:#232a36;--bone:#d8d2c4;--bone-dim:#8f8a7d;
-    --amber:#e0a86f;--cyan:#6fd6e0;--mono:'Monaspace Neon',ui-monospace,monospace}
-  *{margin:0;box-sizing:border-box}
-  html,body{height:100%}
-  body{background:var(--ink);color:var(--bone);font-family:var(--mono);overflow:hidden}
-  #stage{position:fixed;inset:0}
-  canvas{display:block;cursor:grab;touch-action:none}
+  .atlas-plate{font-family:var(--serif) !important}
+  .atlas-plate h1{font-family:var(--cond) !important}
+  .atlas-plate .place,.atlas-plate .stamp,.atlas-plate .controls,
+  .atlas-plate .readout,.atlas-plate .zval,.atlas-plate .tag{font-family:var(--mono) !important}
+  :root{
+    /* Embedded in the site, these resolve to the house tokens so the
+       Atlas and the homepage cannot disagree on colour, face or scale.
+       Opened as a standalone file the fallbacks take over. */
+    --ink:var(--terminal-bg-dark,#0b0e14);
+    --plate:var(--terminal-bg-medium,#11161f);
+    --line:var(--terminal-border,#232c3a);
+    --bone:var(--terminal-text,#d8d3c4);
+    --bone-dim:var(--terminal-text-muted,#8f8d82);
+    --amber:var(--terminal-accent,#e0a86f);
+    --cyan:#6fd6e0;                      /* DATA only, never inherited */
+    --mono:var(--font-data,ui-monospace,'SF Mono',Menlo,Consolas,monospace);
+    --serif:var(--font-prose,'Iowan Old Style',Palatino,Georgia,serif);
+    --cond:var(--font-display,'Avenir Next Condensed','Arial Narrow',sans-serif);
+  }
+  /* __STANDALONE_ONLY__ */
+  html{background:var(--ink)}
+  body{margin:0;background:var(--ink);color:var(--bone);font-family:var(--serif);padding:0 16px}
+  /* __END_STANDALONE__ */
+  .wrap{max-width:100%;margin:0 auto;padding:4px 0 24px}
+  header{display:flex;flex-direction:column;align-items:center;gap:6px;
+    border-bottom:1px solid var(--line);padding-bottom:12px;text-align:center}
+  .title{display:flex;flex-direction:column;gap:3px;align-items:center}
+  h1{font-family:var(--cond);font-weight:600;font-size:var(--size-h1,32px);letter-spacing:.14em;
+    text-transform:uppercase;margin:0;color:var(--bone);line-height:1}
+  .place{font-family:var(--mono);font-size:11px;letter-spacing:.20em;
+    text-transform:uppercase;color:var(--amber)}
+  .place span{color:var(--bone-dim);padding:0 2px}
+  .stamp{font-family:var(--mono);font-size:11px;letter-spacing:.10em;
+    color:var(--bone-dim);text-align:center}
+  .stamp b{color:var(--amber);font-weight:400}
+  .lore{margin:14px auto 0;max-width:85ch;font-size:var(--size-body,15.5px);line-height:1.7;
+    color:var(--bone-dim);text-align:center}
+  .lore em{color:var(--bone);font-style:normal}
+  .stage{position:relative;background:var(--plate);border:1px solid var(--line);border-radius:4px;margin-top:14px}
+  #view{position:relative;height:min(72vh,860px);min-height:420px}
+  #view canvas{position:absolute;inset:0;display:block;cursor:grab;touch-action:none;border-radius:3px 3px 0 0}
   canvas.dragging{cursor:grabbing}
-  .readout{position:absolute;left:12px;top:10px;opacity:0;transition:opacity .12s;
-    font-size:12px;color:var(--cyan);background:rgba(11,14,20,.72);padding:4px 8px;
-    border:1px solid var(--line);border-radius:3px;pointer-events:none;min-height:15px;z-index:3}
+  .readout{position:absolute;left:12px;top:10px;opacity:0;transition:opacity .12s;font-family:var(--mono);font-size:12px;color:var(--cyan);
+    background:rgba(11,14,20,.72);padding:4px 8px;border:1px solid var(--line);border-radius:3px;pointer-events:none;min-height:15px;z-index:3}
   .readout.on{opacity:1}
   .readout .kind{display:block;margin-top:2px;color:var(--amber);
     letter-spacing:.14em;text-transform:uppercase;font-size:10px}
-  .controls{position:absolute;left:0;right:0;bottom:0;display:flex;flex-wrap:wrap;gap:14px;
-    align-items:center;padding:10px 14px;font-size:12px;color:var(--bone-dim);
-    background:rgba(11,14,20,.78);border-top:1px solid var(--line);z-index:3}
-  .zrow{display:flex;gap:10px;align-items:center;flex:1;min-width:200px}
+  .tag{position:absolute;right:12px;top:10px;font-family:var(--mono);font-size:10px;letter-spacing:.14em;
+    color:var(--bone-dim);text-transform:uppercase;z-index:3;pointer-events:none}
+  .controls{display:flex;flex-wrap:wrap;gap:18px;align-items:center;padding:10px 14px;
+    font-family:var(--mono);font-size:12px;color:var(--bone-dim);border-top:1px solid var(--line)}
+  .zrow{display:flex;gap:10px;align-items:center;flex:1;min-width:220px}
   .zrow input[type=range]{flex:1;accent-color:var(--amber)}
   .zval{color:var(--amber);min-width:5ch;font-variant-numeric:tabular-nums}
   .vrow{display:flex;gap:8px;align-items:center}
@@ -29,17 +62,35 @@
   .vrow button:active{background:var(--line)}
   .vlab{color:var(--cyan);min-width:3.5ch;text-align:center;background:none;border:none;
     font-family:var(--mono);font-size:12px;cursor:pointer;padding:5px 2px}
-  .tag{position:absolute;right:12px;top:10px;font-size:10px;letter-spacing:.14em;
-    color:var(--bone-dim);text-transform:uppercase;z-index:3}
+  :focus-visible{outline:2px solid var(--cyan);outline-offset:2px}
 </style>
-<div id="stage">
-  <div class="readout" id="readout">&nbsp;</div>
-  <div class="tag">live render</div>
+
+<div class="wrap atlas-plate">
+<header>
+  <div class="title">
+    <h1>Atlas</h1>
+    <div class="place">Domino's Gambit <span>·</span> Off-World Colony</div>
+  </div>
+  <div class="stamp" id="stamp"></div>
+</header>
+<p class="lore">A lifetime ago a terraforming mission set down in
+this crater to make a waypoint of it: processor stacks, a gate anchor,
+and a manifest that assumed resupply. The work came up crooked. Then the
+system gateway went — a light nobody has explained, and not one ship
+since — and a staging post became a home. What follows is decades of
+making do, seen from above.</p>
+
+<div class="stage">
+  <div id="view">
+    <div class="readout" id="readout">&nbsp;</div>
+    <div class="tag">live render</div>
+  </div>
   <div class="controls">
     <div class="zrow"><span>z-slice</span><input id="zcap" type="range" min="0" max="8" value="8" step="1"><span class="zval" id="zval"></span></div>
-    <span class="vrow"><button id="rotL" type="button" aria-label="rotate left">&#10226;</button><button class="vlab" id="vlab" type="button" title="reset view">NE</button><button id="rotR" type="button" aria-label="rotate right">&#10227;</button></span>
+    <span class="vrow"><button id="rotL" type="button" aria-label="rotate view left">&#10226;</button><button class="vlab" id="vlab" type="button" title="reset view" aria-label="reset view to northeast">NE</button><button id="rotR" type="button" aria-label="rotate view right">&#10227;</button></span>
     <span class="vrow"><button id="skyBtn" type="button" title="day / night" aria-label="toggle day or night">&#9789;</button></span>
   </div>
+</div>
 </div>
 <script>/*__THREE__*/</script>
 <script>
@@ -104,9 +155,12 @@ scene.background=new THREE.Color(0x0b0e14);
 const renderer=new THREE.WebGLRenderer({antialias:true});
 renderer.setPixelRatio(Math.min(devicePixelRatio,2));
 renderer.localClippingEnabled=true;
-document.getElementById('stage').prepend(renderer.domElement);
+const view=document.getElementById('view');
+view.prepend(renderer.domElement);
 const cv=renderer.domElement;
 const readout=document.getElementById('readout');
+document.getElementById('stamp').innerHTML=
+  `<b>${DATA.cells.length}</b> rooms &nbsp;·&nbsp; <b>${(DATA.links||[]).length}</b> ways`;
 
 const ZMAX=Math.max(...CELLS.map(c=>c.z),1);
 const zcapEl=document.getElementById('zcap');
@@ -284,7 +338,7 @@ function aimCamera(){
     cy + d*Math.sin(AZ)*Math.cos(ELEV),
     d*Math.sin(ELEV));
   camera.lookAt(cx, cy, 0);
-  const aspect=innerWidth/innerHeight;
+  const aspect=(view.clientWidth||1)/(view.clientHeight||1);
   const half=26/ZOOM;
   camera.left=-half*aspect; camera.right=half*aspect;
   camera.top=half; camera.bottom=-half;
@@ -298,13 +352,15 @@ function syncLabel(){
   VLAB.textContent=['NE','SE','SW','NW'][q];
 }
 function resize(){
-  renderer.setSize(innerWidth, innerHeight);
+  const w=view.clientWidth||1, h=view.clientHeight||1;
+  renderer.setSize(w, h);
   const pr=Math.min(devicePixelRatio,2);
-  rt.setSize(innerWidth*pr, innerHeight*pr);
-  postMat.uniforms.res.value.set(innerWidth*pr, innerHeight*pr);
+  rt.setSize(w*pr, h*pr);
+  postMat.uniforms.res.value.set(w*pr, h*pr);
   aimCamera(); invalidate();
 }
 addEventListener('resize', resize);
+new ResizeObserver(resize).observe(view);
 
 // ── the darkroom, as a shader: warm pull, split-tone, ordered
 // dither posterization, grain — the sprite grade, at 60fps ─────────

--- a/specs/STYLING_SPEC.md
+++ b/specs/STYLING_SPEC.md
@@ -518,17 +518,19 @@ Bootstrap stays at 4.6 (or the overrides are reviewed against the new version);
 ## Addendum (2026-07-29) — the Atlas, and cache-busting
 
 **The Atlas is a second visual world, on purpose.** `scripts/atlas/` renders
-the colony map in its own register (night plate `#0b0e14`, bone text, amber
-emphasis, cyan reserved for data, condensed / serif / mono type roles).
-Since 2026-08-04 the served atlas at `/atlas/` is the *live render* — the
-self-contained three.js viewer (`template3d.html`), a full standalone page
-outside the site chrome; it carries the register natively and inherits
-nothing. The earlier sprite plate survives only as the builder's generated
-staff instrument (`scripts/atlas/generate.py`), never served, so the
-fragment-embedding notes below are historical. (When it was embedded, the
-site's global `* { font-family: 'Inter' … !important }` forced the plate to
-re-assert its type roles inside `.atlas-plate` — that scoping remains in
-the generated file, deliberate, not a leak.)
+the colony map as a self-contained document in its own register (night plate
+`#0b0e14`, bone text, amber emphasis, cyan reserved for data, condensed /
+serif / mono type roles). It is embedded into the site at `/atlas/` through
+`web/templates/website/atlas.html` in *fragment* mode, so the site's header
+and footer carry through. Since 2026-08-04 the picture inside the plate is
+the *live render* (`template3d.html`, three.js) rather than the painted
+sprite canvas — the plate chrome (title row, place line, stamp, lore, staged
+frame, house-token `:root` mapping) is unchanged; only the stage went 3D.
+The sprite plate survives as the builder's generated staff instrument
+(`scripts/atlas/generate.py`). Because this theme sets a global
+`* { font-family: 'Inter' … !important }`, the plate re-asserts its own type
+roles inside `.atlas-plate` with `!important` — that scoping is deliberate,
+not a leak.
 
 **Two structural additions live at the bottom of `custom.css`:**
 

--- a/web/templates/website/atlas.html
+++ b/web/templates/website/atlas.html
@@ -1,0 +1,5 @@
+{% extends "website/base.html" %}
+{% block titleblock %}Atlas{% endblock %}
+{% block content %}
+{{ atlas }}
+{% endblock %}

--- a/web/website/views/atlas.py
+++ b/web/website/views/atlas.py
@@ -1,13 +1,13 @@
-"""The atlas, served (COLONY_MAPPING_SPEC §M2.5) — the live render IS
-the atlas. One version: the three.js viewer with the Cycles verdict
-baked into its vertices, day and night skies aboard. The builder's
-staff-overlay plate still exists as a generated file (scripts/atlas/
-generate.py); it is an instrument, not a page."""
+"""The atlas, served (COLONY_MAPPING_SPEC §M2.5) — inside the site's own
+page, so the colony's header and footer carry through. The plate chrome
+is the design; only the picture inside it went live-rendered. Any
+logged-in account may read it. The builder's staff-overlay plate still
+exists as a generated file (scripts/atlas/generate.py)."""
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-
-from django.http import HttpResponse
+from django.shortcuts import render
+from django.utils.safestring import mark_safe
 
 from world.atlas import build_atlas3d_html
 
@@ -15,4 +15,6 @@ from world.atlas import build_atlas3d_html
 @login_required
 def atlas_view(request):
     game_dir = getattr(settings, "GAME_DIR", ".")
-    return HttpResponse(build_atlas3d_html(game_dir))
+    plate = build_atlas3d_html(game_dir, fragment=True)
+    return render(request, "website/atlas.html",
+                  {"atlas": mark_safe(plate), "page_title": "Atlas"})

--- a/world/atlas.py
+++ b/world/atlas.py
@@ -95,11 +95,11 @@ def build_atlas_html(game_dir=".", staff=False, fragment=False):
     return html
 
 
-def build_atlas3d_html(game_dir="."):
-    """The live-render atlas (phase one): three.js + exported models.
-
-    A full standalone page — the 3D stage owns the viewport, so it does
-    not embed in the site chrome the way the 2D plate does.
+def build_atlas3d_html(game_dir=".", fragment=False):
+    """The live-render atlas: three.js + exported models, wearing the
+    same plate chrome as the sprite atlas did. In *fragment* mode it
+    embeds in the site's own page (header and footer carry through),
+    exactly the way the 2D plate was served.
     """
     data = export_map()
 
@@ -120,4 +120,11 @@ def build_atlas3d_html(game_dir="."):
     html = html.replace("/*__THREE__*/", three_src)
     html = html.replace("/*__DATA__*/null", json.dumps(data, separators=(",", ":")))
     html = html.replace("/*__MODELS__*/null", models_src)
+    if fragment:
+        # served inside the site's own page: the shell owns <title>,
+        # the charset, and the page background
+        html = re.sub(r"/\* __STANDALONE_ONLY__ \*/.*?/\* __END_STANDALONE__ \*/",
+                      "", html, flags=re.S)
+        html = re.sub(r"<meta charset[^>]*>\s*", "", html)
+        html = re.sub(r"<title>.*?</title>\s*", "", html, flags=re.S)
     return html


### PR DESCRIPTION
The promotion threw out the site integration with the mode switch —
wrong move; the plate chrome was the design. Restored: the ATLAS
masthead, place line, rooms-and-ways stamp, lore paragraph, staged
frame, house-token :root mapping and .atlas-plate type re-assertions
all return around the 3D stage, and the page is served in fragment
mode through website/atlas.html again so the site's header and footer
carry through. The renderer now mounts in the stage and follows it
with a ResizeObserver instead of owning the window; standalone-only
rules (charset, title, body background) strip out in fragment mode
the same way the sprite plate's did.

Closes #1641

Co-Authored-By: Claude <noreply@anthropic.com>
