### PR TITLE
Live atlas: 'you are here' beacons

### DIFF
--- a/scripts/atlas/template3d.html
+++ b/scripts/atlas/template3d.html
@@ -4,7 +4,8 @@
   .atlas-plate{font-family:var(--serif) !important}
   .atlas-plate h1{font-family:var(--cond) !important}
   .atlas-plate .place,.atlas-plate .stamp,.atlas-plate .controls,
-  .atlas-plate .readout,.atlas-plate .zval,.atlas-plate .tag{font-family:var(--mono) !important}
+  .atlas-plate .readout,.atlas-plate .zval,.atlas-plate .tag,
+  .atlas-plate .here .who{font-family:var(--mono) !important}
   :root{
     /* Embedded in the site, these resolve to the house tokens so the
        Atlas and the homepage cannot disagree on colour, face or scale.
@@ -40,7 +41,18 @@
     color:var(--bone-dim);text-align:center}
   .lore em{color:var(--bone);font-style:normal}
   .stage{position:relative;background:var(--plate);border:1px solid var(--line);border-radius:4px;margin-top:14px}
-  #view{position:relative;height:min(72vh,860px);min-height:420px}
+  #view{position:relative;height:min(72vh,860px);min-height:420px;overflow:hidden}
+  .here{position:absolute;transform:translate(-50%,-100%);display:flex;flex-direction:column;
+    align-items:center;gap:3px;pointer-events:none;z-index:2}
+  .here .who{font-family:var(--mono);font-size:10px;letter-spacing:.14em;
+    text-transform:uppercase;color:var(--amber);background:rgba(11,14,20,.72);
+    padding:2px 6px;border:1px solid var(--line);border-radius:3px;white-space:nowrap}
+  .here .pip{position:relative;width:9px;height:9px;border-radius:50%;
+    background:var(--amber);box-shadow:0 0 10px 2px rgba(224,168,111,.85)}
+  .here .pip::after{content:'';position:absolute;inset:-7px;border-radius:50%;
+    border:1.5px solid var(--amber);animation:herepulse 2.2s ease-out infinite}
+  @keyframes herepulse{0%{transform:scale(.4);opacity:1}100%{transform:scale(1.8);opacity:0}}
+  @media (prefers-reduced-motion: reduce){.here .pip::after{animation:none}}
   #view canvas{position:absolute;inset:0;display:block;cursor:grab;touch-action:none;border-radius:3px 3px 0 0}
   canvas.dragging{cursor:grabbing}
   .readout{position:absolute;left:12px;top:10px;opacity:0;transition:opacity .12s;font-family:var(--mono);font-size:12px;color:var(--cyan);
@@ -373,6 +385,7 @@ function aimCamera(){
   camera.updateProjectionMatrix();
   // the sun rides the world, not the camera: honest shadow sides
   syncLabel();
+  placeHere();
 }
 const VLAB=document.getElementById('vlab');
 function syncLabel(){
@@ -617,9 +630,37 @@ function syncZ(){
   const v=+zcapEl.value;
   zval.textContent=`z ≤ ${v-1<0?0:v-1}`;
   clipPlane.constant=v+0.6;
+  placeHere();
   invalidate();
 }
 zcapEl.addEventListener('input',syncZ);
+
+// ── you are here: the account's characters, as pulsing beacons ─────
+// DOM markers so the pulse animates in CSS while the render loop
+// stays on-demand; repositioned whenever the camera or slice moves
+const hereMarks=[];
+for (const h of (DATA.here||[])){
+  const el=document.createElement('div');
+  el.className='here';
+  el.innerHTML='<span class="who">'+esc(h.name)+'</span><span class="pip"></span>';
+  view.appendChild(el);
+  hereMarks.push({el, x:h.xyz[0], y:h.xyz[1], z:h.xyz[2]});
+}
+const hereV3=new THREE.Vector3();
+function placeHere(){
+  if (!hereMarks.length) return;
+  const w=view.clientWidth, hh=view.clientHeight;
+  for (const m of hereMarks){
+    if (m.z > +zcapEl.value-1+0.5){ m.el.style.display='none'; continue; }
+    hereV3.set(m.x, m.y, m.z+0.55).project(camera);
+    if (Math.abs(hereV3.x)>1.15 || Math.abs(hereV3.y)>1.15){
+      m.el.style.display='none'; continue;
+    }
+    m.el.style.display='';
+    m.el.style.left=((hereV3.x+1)/2*w)+'px';
+    m.el.style.top=((1-hereV3.y)/2*hh)+'px';
+  }
+}
 
 // ── day / night: crossfade the baked skies ─────────────────────────
 const NIGHT_BG=new THREE.Color(0x0b0e14), DAY_BG=new THREE.Color(0x5d6875);

--- a/web/website/views/atlas.py
+++ b/web/website/views/atlas.py
@@ -15,6 +15,6 @@ from world.atlas import build_atlas3d_html
 @login_required
 def atlas_view(request):
     game_dir = getattr(settings, "GAME_DIR", ".")
-    plate = build_atlas3d_html(game_dir, fragment=True)
+    plate = build_atlas3d_html(game_dir, fragment=True, account=request.user)
     return render(request, "website/atlas.html",
                   {"atlas": mark_safe(plate), "page_title": "Atlas"})

--- a/world/atlas.py
+++ b/world/atlas.py
@@ -95,13 +95,27 @@ def build_atlas_html(game_dir=".", staff=False, fragment=False):
     return html
 
 
-def build_atlas3d_html(game_dir=".", fragment=False):
+def build_atlas3d_html(game_dir=".", fragment=False, account=None):
     """The live-render atlas: three.js + exported models, wearing the
     same plate chrome as the sprite atlas did. In *fragment* mode it
     embeds in the site's own page (header and footer carry through),
-    exactly the way the 2D plate was served.
+    exactly the way the 2D plate was served. When *account* is given,
+    its characters' positions ride along as 'you are here' beacons.
     """
     data = export_map()
+
+    here = []
+    if account is not None:
+        try:
+            from world.spatial import get_xyz
+            for char in (account.characters or []):
+                loc = getattr(char, "location", None)
+                xyz = get_xyz(loc) if loc is not None else None
+                if xyz is not None:
+                    here.append({"name": char.key, "xyz": list(xyz)})
+        except Exception:  # noqa: BLE001 — the beacon is annotation, not truth
+            pass
+    data["here"] = here
 
     lm_path = os.path.join(game_dir, "scripts/atlas/sprites/landmarks.json")
     landmarks = json.load(open(lm_path)) if os.path.exists(lm_path) else []


### PR DESCRIPTION
The atlas is login-only, so the page knows whose map it is. The view
hands the account to build_atlas3d_html, which rides each character's
grid position along as DATA.here — characters without coordinates
(archived husks in Limbo, logged-out sleeves) are naturally skipped.
The viewer plants a pulsing amber pip with the character's name chip
over the cell: a DOM overlay whose pulse animates in CSS, keeping the
render loop on-demand; markers reposition with the camera and the
z-slice, and hide when sliced away or out of frame.

Closes #1645

Co-Authored-By: Claude <noreply@anthropic.com>
