### PR TITLE
Atlas: one underline, not two

### DIFF
--- a/scripts/atlas/template3d.html
+++ b/scripts/atlas/template3d.html
@@ -37,9 +37,9 @@
   .stamp{font-family:var(--mono);font-size:11px;letter-spacing:.10em;
     color:var(--bone-dim);text-align:center}
   .stamp b{color:var(--amber);font-weight:400}
-  .lore{margin:14px auto 0;max-width:85ch;font-size:var(--size-body,15.5px);line-height:1.7;
+  .plate-lore{margin:14px auto 0;max-width:85ch;font-size:var(--size-body,15.5px);line-height:1.7;
     color:var(--bone-dim);text-align:center}
-  .lore em{color:var(--bone);font-style:normal}
+  .plate-lore em{color:var(--bone);font-style:normal}
   .stage{position:relative;background:var(--plate);border:1px solid var(--line);border-radius:4px;margin-top:14px}
   #view{position:relative;height:min(72vh,860px);min-height:420px;overflow:hidden}
   .here{position:absolute;transform:translate(-50%,-100%);display:flex;flex-direction:column;
@@ -85,7 +85,7 @@
   </div>
   <div class="stamp" id="stamp"></div>
 </header>
-<p class="lore">A lifetime ago a terraforming mission set down in
+<p class="plate-lore">A lifetime ago a terraforming mission set down in
 this crater to make a waypoint of it: processor stacks, a gate anchor,
 and a manifest that assumed resupply. The work came up crooked. Then the
 system gateway went — a light nobody has explained, and not one ship


### PR DESCRIPTION
The plate's lore paragraph shared its class name with the homepage's
.lore component, whose border-top drew a second rule under the
masthead when the plate is embedded in the site. The plate's class is
now .plate-lore; only the header's own underline remains.

Closes #1647

Co-Authored-By: Claude <noreply@anthropic.com>
