### PR TITLE
Live atlas: flush home framing

### DIFF
--- a/scripts/atlas/template3d.html
+++ b/scripts/atlas/template3d.html
@@ -335,38 +335,37 @@ for (const [model, spots] of propPlacements){
 }
 
 // ── the camera: free-angle orthographic isometric ──────────────────
-// home = the city's bounding box, framed to fill the stage
-let bx0=1e9,bx1=-1e9,by0=1e9,by1=-1e9,bz1=1;
-for (const c of CELLS){
-  if (c.t==='air') continue;
-  if (c.x<bx0)bx0=c.x; if (c.x>bx1)bx1=c.x;
-  if (c.y<by0)by0=c.y; if (c.y>by1)by1=c.y;
-  if (c.z>bz1)bz1=c.z;
-}
 const HOME_AZ=Math.PI/4*3;            // NE view to match the 2D atlas
 const ELEV=Math.atan(0.5);
-let cx=(bx0+bx1)/2, cy=(by0+by1)/2;   // world center of interest
+let cx=0, cy=0;                       // world center of interest
 let AZ=HOME_AZ, ZOOM=1;
-function fitZoom(az){
-  // the zoom that fills the stage with the city at azimuth `az`:
-  // project the bounding box onto the screen axes, size to the extents
+function frameCity(az){
+  // flush framing at azimuth `az`: project every cell onto the screen
+  // axes, then solve for the world center and zoom that make those
+  // extents fill the stage
   const ca=Math.cos(az), sa=Math.sin(az), ce=Math.cos(ELEV), se=Math.sin(ELEV);
-  const d=[-ca*ce,-sa*ce,-se], r=[-sa,ca,0];
-  const u=[r[1]*d[2]-r[2]*d[1], r[2]*d[0]-r[0]*d[2], r[0]*d[1]-r[1]*d[0]];
-  let ex=0, ey=0;
-  for (const x of [bx0-0.6-cx, bx1+0.6-cx])
-    for (const y of [by0-0.6-cy, by1+0.6-cy])
-      for (const z of [-0.5, bz1+0.8]){
-        ex=Math.max(ex, Math.abs(x*r[0]+y*r[1]));
-        ey=Math.max(ey, Math.abs(x*u[0]+y*u[1]+z*u[2]));
-      }
+  const r=[-sa,ca], u=[-ca*se,-sa*se,ce];
+  let x0=1e9,x1=-1e9,y0=1e9,y1=-1e9;
+  for (const c of CELLS){
+    if (c.t==='air') continue;
+    const px=c.x*r[0]+c.y*r[1];
+    const py=c.x*u[0]+c.y*u[1]+(c.z+0.5)*u[2];
+    if (px<x0)x0=px; if (px>x1)x1=px;
+    if (py<y0)y0=py; if (py>y1)y1=py;
+  }
+  x0-=0.8; x1+=0.8; y0-=0.7; y1+=0.9;  // cell footprint + prop/mast slack
+  const mx=(x0+x1)/2, my=(y0+y1)/2;
+  // (r, forward) is an orthonormal ground basis: r recenters screen-x,
+  // a forward-ground shift recenters screen-y (scaled by the elevation)
+  const B=-my/se;
+  const fcx=B*ca-mx*sa, fcy=B*sa+mx*ca;
   const aspect=(view.clientWidth||1)/(view.clientHeight||1);
-  const half=Math.max(ey, ex/aspect)*1.06;
-  return Math.min(8, Math.max(0.35, 26/half));
+  const half=Math.max((y1-y0)/2, (x1-x0)/2/aspect)*1.01;
+  return {cx:fcx, cy:fcy, zoom:Math.min(8, Math.max(0.35, 26/half))};
 }
 function goHome(){
-  cx=(bx0+bx1)/2; cy=(by0+by1)/2;
-  ZOOM=fitZoom(HOME_AZ);
+  const f=frameCity(HOME_AZ);
+  cx=f.cx; cy=f.cy; ZOOM=f.zoom;
   spinBy(((HOME_AZ-AZ)%(2*Math.PI)));
 }
 const camera=new THREE.OrthographicCamera(-1,1,1,-1,-200,400);
@@ -681,5 +680,7 @@ skyBtn.addEventListener('click',()=>{
     if (t<1) requestAnimationFrame(step);
   })(performance.now());
 });
-syncZ(); resize(); ZOOM=fitZoom(AZ); aimCamera(); tick();
+syncZ(); resize();
+{ const f=frameCity(AZ); cx=f.cx; cy=f.cy; ZOOM=f.zoom; }
+aimCamera(); tick();
 </script>


### PR DESCRIPTION
The bounding-box fit was conservative: no building is tall at the
box's far corners, so their projected headroom bought dead margin,
and the frame center was the box middle rather than the visual one.
frameCity(az) projects every cell onto the screen axes and solves for
both the world center — r recenters screen-x, a forward-ground shift
recenters screen-y — and the zoom that put the true extents flush
against the stage, with only footprint slack in hand.

Closes #1649

Co-Authored-By: Claude <noreply@anthropic.com>
