### PR TITLE
Atlas: the 'you are here' beacon goes live

### DIFF
--- a/scripts/atlas/template3d.html
+++ b/scripts/atlas/template3d.html
@@ -728,20 +728,55 @@ for (const t of ['touchstart','touchmove'])
 
 // ── you are here: the account's characters, as pulsing beacons ─────
 // DOM markers so the pulse animates in CSS while the render loop
-// stays on-demand; repositioned whenever the camera or slice moves
-const hereMarks=[];
-for (const h of (DATA.here||[])){
-  const el=document.createElement('div');
-  el.className='here';
-  el.innerHTML='<span class="who">'+esc(h.name)+'</span><span class="pip"></span>';
-  view.appendChild(el);
-  hereMarks.push({el, x:h.xyz[0], y:h.xyz[1], z:h.xyz[2]});
+// stays on-demand; repositioned whenever the camera or slice moves.
+// A slow poll on this same path keeps them honest while you play.
+const hereMarks=new Map();            // name -> marker
+function setHereMarks(list){
+  const seen=new Set();
+  for (const h of (list||[])){
+    seen.add(h.name);
+    const m=hereMarks.get(h.name);
+    if (!m){
+      const el=document.createElement('div');
+      el.className='here';
+      el.innerHTML='<span class="who">'+esc(h.name)+'</span><span class="pip"></span>';
+      view.appendChild(el);
+      hereMarks.set(h.name, {el, x:h.xyz[0], y:h.xyz[1], z:h.xyz[2]});
+    } else if (m.x!==h.xyz[0]||m.y!==h.xyz[1]||m.z!==h.xyz[2]){
+      tweenMark(m, h.xyz);
+    }
+  }
+  for (const [name,m] of hereMarks)
+    if (!seen.has(name)){ m.el.remove(); hereMarks.delete(name); }
+  placeHere();
 }
+function tweenMark(m, xyz){
+  const fx=m.x, fy=m.y, fz=m.z, t0=performance.now();
+  (function step(now){
+    const t=Math.min(1,(now-t0)/700);
+    const e=t<0.5?2*t*t:1-Math.pow(-2*t+2,2)/2;
+    m.x=fx+(xyz[0]-fx)*e; m.y=fy+(xyz[1]-fy)*e; m.z=fz+(xyz[2]-fz)*e;
+    placeHere();
+    if (t<1) requestAnimationFrame(step);
+  })(performance.now());
+}
+let hereFails=0;
+const hereTimer=setInterval(async ()=>{
+  if (document.hidden) return;
+  try{
+    const r=await fetch('?feed=here',{headers:{'Accept':'application/json'}});
+    if (!r.ok) throw new Error(r.status);
+    setHereMarks((await r.json()).here);
+    hereFails=0;
+  }catch(e){                     // standalone file or auth lapse: give up
+    if (++hereFails>=3) clearInterval(hereTimer);
+  }
+}, 5000);
 const hereV3=new THREE.Vector3();
 function placeHere(){
-  if (!hereMarks.length) return;
+  if (!hereMarks.size) return;
   const w=view.clientWidth, hh=view.clientHeight;
-  for (const m of hereMarks){
+  for (const m of hereMarks.values()){
     if (m.z > ZCAP-0.5){ m.el.style.display='none'; continue; }
     hereV3.set(m.x, m.y, m.z+0.55).project(camera);
     if (Math.abs(hereV3.x)>1.15 || Math.abs(hereV3.y)>1.15){
@@ -772,6 +807,7 @@ skyBtn.addEventListener('click',()=>{
     if (t<1) requestAnimationFrame(step);
   })(performance.now());
 });
+setHereMarks(DATA.here);
 syncZ(); resize();
 { const f=frameCity(AZ); cx=f.cx; cy=f.cy; ZOOM=f.zoom; }
 aimCamera(); tick();

--- a/web/website/views/atlas.py
+++ b/web/website/views/atlas.py
@@ -2,19 +2,25 @@
 page, so the colony's header and footer carry through. The plate chrome
 is the design; only the picture inside it went live-rendered. Any
 logged-in account may read it. The builder's staff-overlay plate still
-exists as a generated file (scripts/atlas/generate.py)."""
+exists as a generated file (scripts/atlas/generate.py).
+
+The 'you are here' beacons poll ?feed=here on this same path — the
+edge allowlist admits exact paths only, and query strings pass."""
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
 from django.shortcuts import render
 from django.utils.safestring import mark_safe
 
-from world.atlas import build_atlas3d_html
+from world.atlas import build_atlas3d_html, player_positions
 
 
 @login_required
 def atlas_view(request):
     game_dir = getattr(settings, "GAME_DIR", ".")
+    if request.GET.get("feed") == "here":
+        return JsonResponse({"here": player_positions(request.user)})
     plate = build_atlas3d_html(game_dir, fragment=True, account=request.user)
     return render(request, "website/atlas.html",
                   {"atlas": mark_safe(plate), "page_title": "Atlas"})

--- a/world/atlas.py
+++ b/world/atlas.py
@@ -95,6 +95,25 @@ def build_atlas_html(game_dir=".", staff=False, fragment=False):
     return html
 
 
+def player_positions(account):
+    """The 'you are here' feed: grid positions of the account's
+    characters. Characters without a place in the world (archived
+    husks, the unspawned) simply don't report."""
+    here = []
+    if account is None:
+        return here
+    try:
+        from world.spatial import get_xyz
+        for char in (account.characters or []):
+            loc = getattr(char, "location", None)
+            xyz = get_xyz(loc) if loc is not None else None
+            if xyz is not None:
+                here.append({"name": char.key, "xyz": list(xyz)})
+    except Exception:  # noqa: BLE001 — the beacon is annotation, not truth
+        pass
+    return here
+
+
 def build_atlas3d_html(game_dir=".", fragment=False, account=None):
     """The live-render atlas: three.js + exported models, wearing the
     same plate chrome as the sprite atlas did. In *fragment* mode it
@@ -103,19 +122,7 @@ def build_atlas3d_html(game_dir=".", fragment=False, account=None):
     its characters' positions ride along as 'you are here' beacons.
     """
     data = export_map()
-
-    here = []
-    if account is not None:
-        try:
-            from world.spatial import get_xyz
-            for char in (account.characters or []):
-                loc = getattr(char, "location", None)
-                xyz = get_xyz(loc) if loc is not None else None
-                if xyz is not None:
-                    here.append({"name": char.key, "xyz": list(xyz)})
-        except Exception:  # noqa: BLE001 — the beacon is annotation, not truth
-            pass
-    data["here"] = here
+    data["here"] = player_positions(account)
 
     lm_path = os.path.join(game_dir, "scripts/atlas/sprites/landmarks.json")
     landmarks = json.load(open(lm_path)) if os.path.exists(lm_path) else []


### PR DESCRIPTION
The beacon was baked at page build — walk across town and the pip
stayed home. player_positions() factors out of the builder, the view
answers ?feed=here on the same allowlisted path with current
positions as JSON, and the viewer polls it every five seconds while
the tab is visible: markers glide to their new cells, appear and
retire as characters gain or lose a place in the world, and the poll
gives up quietly after three failures (standalone file, auth lapse).

Closes #1659

Co-Authored-By: Claude <noreply@anthropic.com>
