### PR TITLE
Specs: the atlas paperwork catches up

### DIFF
--- a/scripts/atlas/README.md
+++ b/scripts/atlas/README.md
@@ -1,18 +1,44 @@
 # The Atlas
 
 The colony draws itself. `world/mapping.py` exports the coordinate
-substrate; everything here renders it.
+substrate; everything here renders it. Two renderers share that truth:
 
-## Running it
+- **The live render** (`template3d.html` + `sprites/models.json` +
+  `vendor/three.min.js`) is what `gel.monster/atlas` serves to any
+  logged-in account (`world/atlas.py:build_atlas3d_html`, embedded in
+  the site page by `web/website/views/atlas.py`). Free camera, day and
+  night baked in, the cockpit HUD, live 'you are here' beacons.
+- **The sprite plate** (`template.html` + `sprites/final/`) is the
+  builder's staff instrument — air lattice, jump routes, radio
+  coverage live only here. Generated file, never served.
+
+## The builder's plate
 
 ```
-# regenerate the map from the live database (inside the game container)
+# regenerate from the live database (inside the game container)
 evennia shell < scripts/atlas/generate.py     # writes /tmp/atlas.html
 ```
 
-The same builder serves `gel.monster/atlas` live to superusers
-(`web/website/views/atlas.py`), so the served page is never stale. The
-file version is for reading offline.
+## The live-render bake
+
+```
+blender --background --python scripts/atlas/sprites/export_models.py
+```
+
+Monkeypatches `rig.render` so every sprite scene — classes and heroes —
+is captured instead of photographed: joined, subdivided toward bake
+resolution, and COMBINED-baked in Cycles into POINT-domain vertex
+colors **twice** (the rig's night lights, then a day sky), written to
+`sprites/models.json` as parallel `c`/`d` color arrays. The viewer
+crossfades them; it runs no lights of its own.
+
+- **models.json is baked art.** Any model or hero change requires this
+  rerun alongside the sprite grind, or the live render serves stale
+  geometry (the 2D and 3D atlases are baked independently — keep them
+  in step when models change).
+- **Denoiser OFF for vertex bakes** (it needs pixels; vertices aren't).
+- three.js is **vendored and pinned** (r147 UMD — the last build that
+  works as a plain script tag; do not "upgrade" it casually).
 
 ## The sprite pipeline
 

--- a/specs/COLONY_MAPPING_SPEC.md
+++ b/specs/COLONY_MAPPING_SPEC.md
@@ -1,6 +1,15 @@
 # Colony Mapping — the export, the builder's volume, the player's chart
 
-> **Status:** 📋 PROPOSAL (2026-07-25) — design only, nothing built.
+> **Status:** ✅ SHIPPED through §M2.5 — and past it (2026-08-04).
+> §M1 export, the sprite atlas, and the website view went live 2026-07-28;
+> the *served* atlas has since evolved into a **live 3D render** and is
+> player-facing — see **§7 · The atlas as shipped**, which supersedes the
+> §M2.5 details below where they differ. The sprite plate survives as the
+> builder's generated instrument. §M3 (player chart: vague-not-false,
+> visited sets, GMCP) and §M4 (paper maps, decking exposure, planner)
+> remain 📋 deferred with their design unchanged.
+>
+> *Original proposal framing follows.*
 > **SCOPE REFOCUS (owner, same day): the v1 consumer is the OWNER alone.**
 > The player/builder audience split and everything serving it (vagueness
 > dial, visited-sets, GMCP) is deferred to §M3/M4 unchanged; v1 = §M1
@@ -187,3 +196,39 @@ the live style study beside procedural cells for an A/B.
    emission per the vagueness dial. Mudlet draws the rest.
 4. **§M4 — later.** Paper map items; decking exposure; interactive
    planner. Each is a new consumer of §M1, none reopens it.
+
+## 7 · The atlas as shipped (2026-08-04) — the live render
+
+"One export, many renderers" held; the renderers just outgrew the plan.
+Two consumers exist today, both fed by `export_map()`:
+
+- **The served atlas** (`/atlas/`, login-only, linked in the account
+  dropdown) is a **live 3D render**, embedded in the site page in the
+  same plate chrome the sprite atlas wore (`web/templates/website/
+  atlas.html` fragment mode; STYLING_SPEC addendum). The stage is a
+  three.js orthographic free camera over models captured from the *same
+  Blender rig* that shot the sprites: `scripts/atlas/sprites/
+  export_models.py` monkeypatches `rig.render`, joins and subdivides
+  each scene, and **bakes the full Cycles verdict into vertex colors** —
+  twice, once under the rig's night lights and once under a day sky —
+  shipped as parallel color attributes that the viewer crossfades. No
+  live lights; a post shader carries the darkroom grade at 60fps.
+- **Cockpit HUD**: a compass dial (needle tracks the true screen
+  direction of north; tap = home reset, which re-centers and fits the
+  city flush to the stage from per-cell projection), a translucent
+  altitude tape driving the z-slice clipping plane, and a sky-instrument
+  toggle (crescent/sun glyph). Rotation is gestural (twist, shift-drag,
+  bracket keys). Hover/tap raycasts to the room readout.
+- **'You are here'**: `player_positions(account)` rides the logged-in
+  account's character positions into the page and a 5-second poll of
+  `?feed=here` (same allowlisted path; query strings pass the edge)
+  keeps the pulsing beacons honest while you play. Characters without a
+  place in the world simply don't report.
+- **The builder instrument** is still the §M2/§3.5 sprite plate:
+  `scripts/atlas/generate.py` (staff=True) writes the standalone file,
+  and the staff overlays — air lattice, jump routes, radio coverage —
+  live only there. It is never served.
+- **Pipeline discipline**: `models.json` is baked art. Any change to a
+  rig model or hero script requires re-running `export_models.py`
+  alongside the sprite grind, or the live render serves stale geometry.
+  three.js is vendored (r147 UMD, pinned — the last non-ESM build).

--- a/specs/README.md
+++ b/specs/README.md
@@ -79,6 +79,7 @@ Every spec in those folders carries a `> **Status:**` banner at the top.
 | `NEW_PLAYER_EXPERIENCE_SPEC.md` | Connection → chargen → decant flow and the locked messaging conventions (frame, terminal wrap, TST dates, informing-not-telling, puppet lifecycle) |
 | `EVMENU_PATTERNS_SPEC.md` | EvMenu text-input / multi-source-picker patterns |
 | `STYLING_SPEC.md` | Web client / terminal-brutalist styling |
+| `COLONY_MAPPING_SPEC.md` | The colony atlas: canonical map export + the live 3D render at `/atlas/` (Cycles-baked vertices, day/night, HUD, 'you are here') + the builder's sprite plate; §M3 player chart deferred inline |
 | `WEBCLIENT_SCREEN_SIZE_DETECTION_SPEC.md` | Responsive client layout / screen-width detection |
 | `WEB_CHARACTER_CREATION_ALIGNMENT.md` | Web/game character-creation parity |
 | `WEB_RESPAWN_CHARACTER_CREATION_SPEC.md` | Web respawn flow |

--- a/specs/STYLING_SPEC.md
+++ b/specs/STYLING_SPEC.md
@@ -524,7 +524,7 @@ serif / mono type roles). It is embedded into the site at `/atlas/` through
 `web/templates/website/atlas.html` in *fragment* mode, so the site's header
 and footer carry through. Since 2026-08-04 the picture inside the plate is
 the *live render* (`template3d.html`, three.js) rather than the painted
-sprite canvas — the plate chrome (title row, place line, stamp, lore, staged
+sprite canvas — the plate chrome (title row, place line, lore, staged
 frame, house-token `:root` mapping) is unchanged; only the stage went 3D.
 The sprite plate survives as the builder's generated staff instrument
 (`scripts/atlas/generate.py`). Because this theme sets a global


### PR DESCRIPTION
COLONY_MAPPING_SPEC still read "design only, nothing built" while the
atlas shipped, went 3D, gained two skies, a cockpit HUD, and live
beacons. It moves to the top level as a shipped system with a truthful
banner and a §7 as-shipped addendum that supersedes §M2.5 where they
differ; §M3/§M4 stay deferred inline with their design unchanged, and
specs/README indexes it. scripts/atlas/README now documents both
renderers and the live-render bake (models.json is baked art, denoiser
off for vertex bakes, three.js pinned). STYLING_SPEC's plate-chrome
list drops the retired stamp.

Closes #1663

Co-Authored-By: Claude <noreply@anthropic.com>
