### PR TITLE
Build 003: the edge needs its sky_room

### DIFF
--- a/scripts/builds/003_brackett_fire_escape.py
+++ b/scripts/builds/003_brackett_fire_escape.py
@@ -124,7 +124,8 @@ for ex in east_roof.exits:
     if dest and dest.attributes.get("xyz") == (COL_X, COL_Y, 7):
         ex.db.is_edge = True
         ex.db.edge_difficulty = 8
-        ex.db.fall_room = landings[6].id
+        ex.db.sky_room = dest.id      # REQUIRED: without it the jump
+        ex.db.fall_room = landings[6].id   # degrades to a plain walk
         ex.db.fall_distance = 1
         ex.db.fall_damage = 5
         edge_fixed = True


### PR DESCRIPTION
Owner test: falling did nothing in the air room. An edge jump only
enters the fall flow when the exit carries sky_room — without it the
code gracefully degrades to direct movement, leaving the jumper
standing in the sky. The East Roof edge now names its air room, live
and in the script.

Closes #1709

Co-Authored-By: Claude <noreply@anthropic.com>
