### PR TITLE
The fire escape becomes a type of its own

### DIFF
--- a/scripts/atlas/template3d.html
+++ b/scripts/atlas/template3d.html
@@ -154,6 +154,7 @@ function cls(c){
   if ((c.flags||[]).includes('sky')) return 'air';
   const t=(c.type||'').toLowerCase(), k=c.key||'';
   if (k.toLowerCase().includes('alley')) return 'alley';
+  if (t==='fire escape') return 'roof';
   if (t==='rooftop'||t==='terrace'||/rooftop|- roof/i.test(k))
     return k.startsWith("Hammett's Boot")?'hull':'roof';
   if (/courtyard/i.test(k)) return 'street';

--- a/scripts/builds/003_brackett_fire_escape.py
+++ b/scripts/builds/003_brackett_fire_escape.py
@@ -71,7 +71,7 @@ for z in (3, 4, 5, 6):
         f"expected air cell at ({COL_X},{COL_Y},{z})"
     landing = create_object(ROOM_TC, key=name)
     landing.db.xyz = (COL_X, COL_Y, z)
-    landing.db.type = "rooftop"
+    landing.db.type = "fire escape"
     landing.db.outside = True
     landing.db.is_ground = True
     landing.db.is_sky_room = False

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -497,6 +497,11 @@ class Exit(DefaultExit):
         street_context = self._analyze_street_context()
         if street_context:
             return street_context
+
+        # Fire-escape destinations get their own message set
+        fire_escape_context = self._analyze_fire_escape_context()
+        if fire_escape_context:
+            return fire_escape_context
             
         # Generate directional atmospheric defaults (with weather integration)
         directional_desc = self._get_directional_atmospheric(looker)
@@ -506,6 +511,35 @@ class Exit(DefaultExit):
         # Fallback atmospheric description
         return "The passage stretches into shadows and uncertainty."
         
+    #: Exit-look messages for fire-escape destinations, keyed by exit key.
+    #: DRAFT prose — owner-editable; the mechanism is the point.
+    FIRE_ESCAPE_MESSAGES = {
+        "window": "Through the window: grated iron and a drop, the fire "
+                  "escape clinging to the wall outside.",
+        "up": "The ladder climbs to the next landing, rust flaking off "
+              "every rung.",
+        "down": "The ladder descends to the landing below, its bolts "
+                "groaning in the brick.",
+        "drop": "The counterweighted ladder hangs above open air — one "
+                "way down, no way back.",
+    }
+    FIRE_ESCAPE_DEFAULT = ("Iron landings cling to the wall, promising a "
+                           "rattling descent.")
+
+    def _analyze_fire_escape_context(self):
+        """
+        Fire-escape destinations get their own message list (the street
+        pattern, applied to the colony's ironmongery). Triggers when the
+        destination room's ``type`` is ``fire escape``.
+        """
+        destination = self.destination
+        if not destination:
+            return ""
+        if getattr(destination, 'type', None) != 'fire escape':
+            return ""
+        return self.FIRE_ESCAPE_MESSAGES.get(self.key.lower(),
+                                             self.FIRE_ESCAPE_DEFAULT)
+
     def _analyze_street_context(self):
         """
         Analyze destination room type and exit count for street-specific descriptions.


### PR DESCRIPTION
The landings read as rooftops in every message. They are now type
fire escape: the exit list says so, the exits carry their own message
set — window, up, down, drop, and a default, draft prose on the
street-context pattern — and the atlas renders the plates with the
roof silhouette. Applied live and in the build script.

Closes #1716

Co-Authored-By: Claude <noreply@anthropic.com>
