### PR TITLE
Builder plate: map fire escape to the roof class

### DIFF
--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -146,6 +146,7 @@ function cls(c){
   // type=rooftop is authoritative (the lid standard sets it); the name
   // regex only rescues legacy cells. Checked BEFORE the skins so a
   // building prefix can never dress a roof as another storey.
+  if (t==='fire escape') return 'roof';
   if (t==='rooftop' || t==='terrace' || /rooftop|- roof/i.test(k))
     return k.startsWith("Hammett's Boot")?'hull':'roof';
   // open ground and machinery outrank building skins too


### PR DESCRIPTION
The 2D builder template's cls() differs textually from the live
render's, so the earlier mapping pass silently missed it. Fire-escape
cells now paint as roof silhouettes on the staff plate too.

Closes #1716

Co-Authored-By: Claude <noreply@anthropic.com>
