### PR TITLE
Weather ambience: room-type categories, fire escape first

### DIFF
--- a/world/weather/weather_messages.py
+++ b/world/weather/weather_messages.py
@@ -1094,3 +1094,44 @@ def _build_weather_messages():
 WEATHER_MESSAGES = {
     'default': _build_weather_messages(),
 }
+
+# ---------------------------------------------------------------------------
+# Per-ROOM-TYPE ambience pools. These MIX INTO the weather draw for rooms
+# whose ``type`` has an entry here, so a room's character seeps into the
+# ambience alongside the weather truth. Any room type may join the registry;
+# lines are DRAFT prose, owner-editable, same register as the weather pools.
+ROOM_TYPE_POOLS = {
+    'fire escape': {
+        # the street's crowd-activity line reads wrong from one story up;
+        # suppress it and let the height-distanced lines below carry it
+        '_suppress_street_activity': True,
+        'visual': [
+            "heads and cart-tops pass below, foreshortened",
+            "rust streaks bleed down the brickwork under the landing",
+            "the ground shows through the grated floor, a long way down",
+            "the rail wears a hand-polish decades of grips have left",
+            "flaking paint maps continents across the iron",
+        ],
+        'auditory': [
+            "the whole escape hums faintly when the wind leans on it",
+            "bolts tick and settle somewhere in the brick",
+            "the grating rings softly underfoot with every shift",
+        ],
+        'olfactory': [
+            "rust and old paint give off a dry metal smell",
+            "cooking grease drifts thin from a cracked window",
+            "the brick at your back breathes out the day's dust",
+        ],
+        'tactile': [
+            "the grating flexes underfoot, spring and complaint",
+            "the rail comes away gritty with scale under the hand",
+            "an updraft threads through the open floor",
+        ],
+        'atmospheric': [
+            "the street's noise arrives one story removed, thinned by height",
+            "the landing feels borrowed - a place to pass through, not stay",
+            "pigeon wire and mismatched bolts say someone maintains this, barely",
+            "the wall radiates the building's held warmth into the open air",
+        ],
+    },
+}

--- a/world/weather/weather_system.py
+++ b/world/weather/weather_system.py
@@ -52,6 +52,23 @@ class WeatherSystem:
         if not weather_messages:
             return ""
 
+        # Mix in the room-type ambience pool, if this room's type has one —
+        # the location's character interleaves with the weather truth.
+        from .weather_messages import ROOM_TYPE_POOLS
+        room_type = (getattr(room, 'type', None) or "")
+        type_pool = ROOM_TYPE_POOLS.get(str(room_type).lower())
+        if type_pool:
+            base = dict(weather_messages)
+            if type_pool.get('_suppress_street_activity') and base.get('atmospheric'):
+                # the diurnal street-activity line is atmospheric[0] by
+                # construction; a type that suppresses it speaks for itself
+                base['atmospheric'] = base['atmospheric'][1:] or base['atmospheric']
+            weather_messages = {
+                sense: list(base.get(sense, [])) + list(type_pool.get(sense, []))
+                for sense in (set(base) | set(type_pool))
+                if not sense.startswith('_')
+            }
+
         # Pick one line each from DISTINCT perceivable senses, so the lines we
         # show never echo each other (a visual + a smell, not two near-identical
         # visuals). Senses gate per CAPACITY_CONSUMERS spec §5: sight -> visual,


### PR DESCRIPTION
The escape landings spoke street ambience from one story up. The
weather system gains ROOM_TYPE_POOLS: a room whose type has an entry
mixes its own sense lines into the weather draw and may suppress the
diurnal street-activity line to speak for itself. First member: the
fire escape — iron, rust, grating, updraft, the street's noise
arriving one story removed. Draft prose, owner-editable; any room
type can join the registry.

Closes #1719

Co-Authored-By: Claude <noreply@anthropic.com>
