### PR TITLE
Fire escape prose pass; exit-type refinements logged

### DIFF
--- a/scripts/builds/003_brackett_fire_escape.py
+++ b/scripts/builds/003_brackett_fire_escape.py
@@ -19,7 +19,8 @@ The design (owner, 2026-08-05):
     that pointed at those air cells (including falls from above) is
     repointed to the landings, so the column still resolves.
 
-Skeleton only: names, coordinates, exits. No descriptions.
+Prose pass applied 2026-08-06 (owner go): descs + sense layers
+ship with the landings on creation; re-runs never stomp live edits.
 """
 from evennia import create_object
 from evennia.objects.models import ObjectDB
@@ -58,6 +59,67 @@ hosts = {
 }
 FLOOR = {3: "Third", 4: "Fourth", 5: "Fifth", 6: "Sixth"}
 
+DESCS = {
+    3: ("The bottom of the old iron: a grated landing bolted to the "
+        "tenement's east wall, paint gone to scale, rivets bleeding rust "
+        "down the brick. The counterweighted ladder hangs below the floor "
+        "hatch, chained short so it stops above the Boot's shin — close "
+        "enough to drop, too far to climb back. Someone has scratched "
+        "tally marks into the rail, dozens of them, meaning unknown.",
+        {"auditory": "The Boot's hull ticks with temperature below; the "
+                     "whole run of iron telegraphs any footstep above.",
+         "olfactory": "Rust, chain grease, and the dead-ship smell rising "
+                      "off the hull beneath — cold metal and old bilge.",
+         "tactile": "The grating gives a half-inch under weight, spring "
+                    "and complaint; the chain runs greasy through its eye.",
+         "atmospheric": "Everything below this landing is one-way — the "
+                        "iron ends here, and the ship begins."}),
+    4: ("A landing like a held breath between ladders — four bolts, a "
+        "rail, and the long view of brick running both directions. The "
+        "fourth-floor window is painted into its frame except for the one "
+        "pane that isn't. Cigarette ends collect where the grating meets "
+        "the wall, all of them the same brand.",
+        {"auditory": "Ladder rungs ring above and below at the smallest "
+                     "shift — nobody arrives here unannounced.",
+         "olfactory": "Stale smoke has soaked into the brick; rain never "
+                      "quite rinses this corner.",
+         "tactile": "The rail wobbles a knuckle's width where one anchor "
+                    "has pulled from the mortar.",
+         "atmospheric": "A between-place — the kind of spot the "
+                        "building's stories pass through and never stop."}),
+    5: ("The top of the code-era run, where the original iron ends in a "
+        "squared-off rail and the view opens: the toe quarter laid out "
+        "roof by roof, the Boot's hull below, the arcade lights of Kaspar "
+        "Street, the crater rim beyond all of it. The fifth-floor window "
+        "sits at chest height, its sill worn smooth by decades of "
+        "climbing through. Above, newer iron continues — different welds, "
+        "different mind.",
+        {"auditory": "Wind first — everything else arrives underneath it, "
+                     "thinned by five stories.",
+         "olfactory": "Clean height: dust and processor ozone, the "
+                      "street's grease burned off by distance.",
+         "tactile": "The updraft finds every seam in your clothes; the "
+                    "rail runs cold even in heat.",
+         "atmospheric": "The highest place boots alone can reach — "
+                        "everything above wants rope, or nerve."}),
+    6: ("The bolt-on: salvage iron in three different greens, welded by "
+        "someone who cared about holding, not looks. It hangs off the "
+        "building a full story above the old escape's end, a scavenged "
+        "ladder lashed across the gap to the code-era run below. The hall "
+        "window behind it has a blanket for a curtain and a jar of "
+        "cigarette ends on the sill. The roofline waits one story up — "
+        "close enough to hear, too far to touch.",
+        {"auditory": "Sixth-floor life bleeds through the window — a "
+                     "radio, a cough, a kettle: the floor that officially "
+                     "isn't.",
+         "olfactory": "Weld scale and fresh rust — this iron is decades "
+                      "younger than the run it hangs from.",
+         "tactile": "The bolt-on flexes more than the old iron: a longer "
+                    "sway, a newer fear.",
+         "atmospheric": "Built by the people it serves, and it feels like "
+                        "it — half fire escape, half statement."}),
+}
+
 landings = {}
 made_rooms = made_exits = repointed = 0
 for z in (3, 4, 5, 6):
@@ -75,6 +137,9 @@ for z in (3, 4, 5, 6):
     landing.db.outside = True
     landing.db.is_ground = True
     landing.db.is_sky_room = False
+    desc, senses = DESCS[z]
+    landing.db.desc = desc
+    landing.db.sense_descs = senses
     made_rooms += 1
     # every exit that pointed at the air cell now points at the iron —
     # including falls from the air above, which land on the escape

--- a/specs/BUILDING_PLAYBOOK.md
+++ b/specs/BUILDING_PLAYBOOK.md
@@ -302,6 +302,11 @@ owner verdict — argue with them.
 - Both are one future system wearing two clothes: **powered,
   hackable furniture that edits the exit graph at runtime**. When
   decking/hacking design begins, start here.
+- **Exit-type refinements (owner go, 2026-08-06)** ride the same
+  arc: drop ladders (one-way until worked), auto-closing windows
+  (egress that shuts behind you), and decking elements surfaced as
+  exit behavior. The fire escape's current exits are the plain-verb
+  rough drafts of all three.
 
 **Candidates (unsettled — owner verdict wanted):**
 - **A true market hall**: stalls exist as street props; a roofed market


### PR DESCRIPTION
The four landings receive their descriptions and sense layers — the
old iron's bottom with its chained ladder and tally marks, the
held-breath fourth, the fifth where the view opens and everything
above wants rope or nerve, and the bolt-on in three greens, half fire
escape, half statement. The build script ships them on creation and
never stomps live edits. The ledger logs the coming exit-type work:
drop ladders, auto-closing windows, decking elements.

Closes #1721

Co-Authored-By: Claude <noreply@anthropic.com>
