### PR TITLE
Specs catch up with the fire escape arc

### DIFF
--- a/specs/BUILDING_PLAYBOOK.md
+++ b/specs/BUILDING_PLAYBOOK.md
@@ -212,6 +212,20 @@ now law:
    (edge audits, contradiction checks, no-gear proofs) and city-scale
    zoning. They do not generate build tasks. Design intent does.
 
+## 2.6 · Build 003's laws (the fire escape, 2026-08-06)
+
+6. **Narrative picks the room.** Communal fixtures wire from communal
+   spaces (every escape window opens from a landing or hall, not a
+   tenant's parlor) — adjacency serves the story, never the reverse.
+7. **Read the mechanism before wiring against it.** Copying an
+   exemplar's attributes is not understanding it: the escape's roof
+   edge shipped without `sky_room` and silently degraded to a walk.
+   Before touching jump/fall/door machinery, read its code path.
+8. **Walk it as a player before handing it over.** Mechanism-level
+   tests pass things only a player's experience catches (findable
+   windows, message registers, ambience). The builder walks the build
+   through real command flow before the owner ever sees a dbref list.
+
 ## 3 · The session ritual
 
 The shape of a build session, in order. Steps compress for small builds;
@@ -240,6 +254,9 @@ none are skipped silently.
 9. **The atlas gate** — verify on the live render; if the build
    introduced a new class or landmark, do the art: rig scene → sprite
    grind → `export_models.py` rebake, in the same arc, not "later."
+9.5. **The player walk** — traverse the build end to end through real
+   command flow (looks, exits, jumps, messages) as a player would,
+   and fix what jars BEFORE delivering the dbref inventory.
 10. **Ship** — the deploy cycle, and if a build taught doctrine, the
     playbook and the source spec get the lesson in the same PR.
 

--- a/specs/JUMP_COMMAND_SPEC.md
+++ b/specs/JUMP_COMMAND_SPEC.md
@@ -4,6 +4,15 @@
 >
 > **⚠ Spec-vs-code corrections — the following claims were FALSE when audited:**
 > - The header claimed "IMPLEMENTATION COMPLETE ✅". Phase 3 (elevated-position combat bonuses, enhanced aim from edges) has **no code**.
+> **FIELD NOTES (2026-08-06, from building the Brackett fire escape):**
+> (1) An edge exit whose destination is air MUST carry `sky_room` (int
+> dbref) — without it the "graceful degradation" fallback turns the jump
+> into a plain walk with no fall and no landing roll. (2) Walking into a
+> sky room never triggers falling; the entire fall experience lives in
+> this command's flow. (3) The landing runs on a delayed callback
+> (0.5s/story): a server reload during that window orphans the jumper in
+> the sky room — do not reload while players are airborne; hardening
+> item: resolve airborne characters at server start.
 > - No dedicated jump test module exists — only incidental coverage in `test_drop_to_room.py` and `test_build_tools.py`.
 
 **Status: IMPLEMENTATION COMPLETE** ✅  

--- a/specs/PARKOUR_TEMPLATE_LIBRARY.md
+++ b/specs/PARKOUR_TEMPLATE_LIBRARY.md
@@ -21,6 +21,16 @@ a number reopens the templates.
 - **Falls**: gravity walks sky cells to ground at **5 damage/story**.
   Risk therefore scales with height automatically — the same gap is a
   scraped knee at z2 and a death sentence at z14.
+- **Field facts (learned building the Brackett escape, 2026-08-06):**
+  an edge exit into air REQUIRES `sky_room` (int dbref) or the jump
+  silently degrades to a plain walk — the full edge-to-air attr set is
+  is_edge / edge_difficulty / sky_room / fall_room / fall_distance /
+  fall_damage. WALKING into a sky room never triggers falling (no
+  gravity-on-entry hook exists; the fall lives in the `jump` flow
+  only). A server reload during the fall delay orphans the jumper in
+  the sky room. Fire-escape rooms are `type: "fire escape"` — their
+  own exit-message list (exits.py) and ambience category
+  (ROOM_TYPE_POOLS) exist; new room types join both registries.
 - **Edges**: any edge is a valid hook anchor. **No authored anchor
   points** — exploration is encouraged, not fenced; the *building
   design* does the fencing, never the mechanic.
@@ -257,13 +267,16 @@ one of four jobs — **on-ramp** (ground/interior → roof), **step**
 one). A build's parkour budget is measured in furniture, and one or
 two pieces per building is plenty.
 
-- **F1 · The fire escape** — the workhorse on-ramp. Hangs in the back
-  alley; **windows open onto it** from the interior floors it passes;
-  it rides plainly up to the roof and down to the alley (drop-ladder
-  at the bottom). Three networks meet on it: street city (the alley),
-  roof city (the top), and the *interior* (every window) — which
-  makes it an escape route, a burglar's front door, and the B&E
-  seam's cheapest expression. Just up/down exits; no mechanics.
+- **F1 · The fire escape** — the workhorse on-ramp, and now a BUILT
+  exemplar: **the Brackett fire escape** (landings (-8,-18) z3-z6).
+  Its as-built laws: windows are **communal** — they open from each
+  floor's landing/hall, never from private units (a unit's security
+  perimeter includes everything of its own); exit key `window`, no
+  aliases; the iron works both ways; the bottom is a **one-way drop**
+  (ascent from below waits for the crank/grapple era); it can end on
+  a ROOF or HULL rather than the ground, feeding the second city
+  directly. Egress always; ingress is the future hidden-exit
+  mechanic. Copy the exemplar, not this paragraph.
 - **F2 · The water tower** — the step-stone crown. Ladder up a leg,
   tank-top platform +1..+2 above its roof with its own edge set: it
   takes a roof HIGHER without a new building, bridges to the taller


### PR DESCRIPTION
The parkour library's kernel gains the field facts — sky_room is
load-bearing, walking into air never falls, reloads orphan jumpers —
and F1 now points at the built Brackett exemplar with its as-built
laws. The playbook gains Build 003's three laws and the player-walk
ritual step. The jump spec gains field notes so the next builder
reads the trap instead of rediscovering it.

Closes #1723

Co-Authored-By: Claude <noreply@anthropic.com>
