### PR TITLE
Build 005A: re-run safety for the z6 conversions

### DIFF
--- a/scripts/builds/005_brackett_rise.py
+++ b/scripts/builds/005_brackett_rise.py
@@ -106,6 +106,8 @@ Z6 = {
     (-9, -20):  ("South Wing Roof East", f"{B} - Unit 6B (Store Room)"),
 }
 for pos, (old_suffix, new_key) in Z6.items():
+    if ObjectDB.objects.filter(db_key=new_key).first():
+        continue                       # re-run safe: already converted
     r = by_key(f"{B} - {old_suffix}")
     strip_surface(r)
     r.key = new_key


### PR DESCRIPTION
A SQLite lock killed the first run after the z6 conversions; the
renamed rooms would then trip by_key on retry. The conversion loop
now skips rows whose new key already exists, matching the rest of
the script's idempotency.

Closes #1730

Co-Authored-By: Claude <noreply@anthropic.com>
