### PR TITLE
Atlas cosmetic skins; the Brackett wears its seam band

### DIFF
--- a/scripts/atlas/template.html
+++ b/scripts/atlas/template.html
@@ -142,6 +142,8 @@ const SKINS = [
 ];
 function cls(c){
   if (c.flags.includes('sky')) return 'air';
+  // atlas_skin: cosmetic override, mirrors the 3D atlas
+  if (c.skin && FILL[c.skin]) return c.skin;
   const t=(c.type||'').toLowerCase(), k=c.key||'';
   if (k.toLowerCase().includes('alley')) return 'alley';
   // type=rooftop is authoritative (the lid standard sets it); the name

--- a/scripts/atlas/template3d.html
+++ b/scripts/atlas/template3d.html
@@ -152,6 +152,9 @@ const SKINS = [["The Brackett Arms","tenement"],["Colonial Constabulary","consta
   ["Shuttered Storefront","shuttered"]];
 function cls(c){
   if ((c.flags||[]).includes('sky')) return 'air';
+  // atlas_skin: a cosmetic override — dresses the cell's map look
+  // without touching the gameplay type (the seam-band mechanism)
+  if (c.skin && MODELS[c.skin]) return c.skin;
   const t=(c.type||'').toLowerCase(), k=c.key||'';
   if (k.toLowerCase().includes('alley')) return 'alley';
   if (t==='fire escape') return 'fire_escape';

--- a/scripts/builds/008_brackett_seam_band.py
+++ b/scripts/builds/008_brackett_seam_band.py
@@ -1,0 +1,24 @@
+"""Build 008 — the seam band (owner: keep the atlas look post-007).
+
+    evennia shell < scripts/builds/008_brackett_seam_band.py
+    then foreground reload (mapping.py changed anyway).
+
+Floor 6 standardized as housing but remains the building's seam —
+the top of the old pour. The owner liked the glass band the loggia
+motif gave the flank, so the look survives as pure map cosmetics:
+`db.atlas_skin = "loggia"` on every floor-6 cell wraps the whole
+sixth storey in the banded look, a ring at the seam line. atlas_skin
+is the new cosmetic override (export_map ships it; both atlases
+check it first) — it never touches the gameplay `type`.
+"""
+from evennia.objects.models import ObjectDB
+
+B = "The Brackett Arms"
+stamped = 0
+for r in ObjectDB.objects.filter(db_key__contains=B):
+    xyz = r.attributes.get("xyz")
+    if (xyz and xyz[2] == 6 and -11 <= xyz[0] <= -9
+            and -20 <= xyz[1] <= -16 and r.destination is None):
+        r.db.atlas_skin = "loggia"
+        stamped += 1
+print(f"BUILD 008: seam band stamped on {stamped} floor-6 cells.")

--- a/specs/COLONY_MAPPING_SPEC.md
+++ b/specs/COLONY_MAPPING_SPEC.md
@@ -228,6 +228,14 @@ Two consumers exist today, both fed by `export_map()`:
   `scripts/atlas/generate.py` (staff=True) writes the standalone file,
   and the staff overlays — air lattice, jump routes, radio coverage —
   live only there. It is never served.
+- **Cosmetic skins (2026-08-07)**: `db.atlas_skin = "<class>"` on a
+  room overrides its atlas class in both renderers WITHOUT touching the
+  gameplay `type` (which drives crowd routing, exit phrasing, ambience).
+  The export ships it as `skin`; `cls()` honors it first, guarded on the
+  class existing in the model/fill library. First use: the Brackett
+  seam band — the whole sixth storey wears the `loggia` glass band as a
+  ring at the old-pour/rebuild seam line (Build 008), map charm marking
+  a structural truth after the floor standardized as housing.
 - **Pipeline discipline**: `models.json` is baked art. Any change to a
   rig model or hero script requires re-running `export_models.py`
   alongside the sprite grind, or the live render serves stale geometry.

--- a/world/mapping.py
+++ b/world/mapping.py
@@ -58,6 +58,7 @@ def export_map():
             "key": room.key,
             "xyz": list(xyz),
             "type": str(room.db.type or ""),
+            "skin": str(room.db.atlas_skin or ""),
             "flags": _flags(room),
             "crowd": int(room.db.crowd_base_level or 0),
         })


### PR DESCRIPTION
db.atlas_skin overrides a cell's map class in both renderers without
touching the gameplay type — map dress as its own layer. Build 008
stamps the whole sixth storey with the loggia band: a glass ring at
the seam between the old pour and the rebuild, keeping the look the
owner liked now that the floor itself is standard housing.

Closes #1747

Co-Authored-By: Claude <noreply@anthropic.com>
