### PR TITLE
Build 012 fix: xyz on the roof-proper tiles too

### DIFF
--- a/scripts/builds/012_brackett_roof_fill.py
+++ b/scripts/builds/012_brackett_roof_fill.py
@@ -71,7 +71,7 @@ VIEW = {
 }
 roof = {}
 for pos, suffix in ROOF.items():
-    roof[pos] = room_at(f"{B} - {suffix}")
+    roof[pos] = room_at(f"{B} - {suffix}", (pos[0], pos[1], 16))
 for pos, where in VIEW.items():
     r = roof[pos]
     if not r.db.desc:


### PR DESCRIPTION
The roof loop passed no coordinates either; the six new perimeter
tiles need them. Now every room_at call carries its xyz.

Closes #1760

Co-Authored-By: Claude <noreply@anthropic.com>
