### PR TITLE
Ossie in the cab: radio the crane, the container moves

### DIFF
--- a/scripts/builds/032_crane_operator.py
+++ b/scripts/builds/032_crane_operator.py
@@ -1,0 +1,90 @@
+"""Build 032 — the crane operator and the cab console (P3).
+
+    docker exec -i gelatinous bash -lc 'cd /usr/src/game && evennia shell' \
+        < scripts/builds/032_crane_operator.py
+    then a foreground reload.
+
+Puts Ossie Trelane in the operator's cab with a Boiler Run base-station
+console tuned to the work band (27.0). Callers key up on 27.0 and ask
+for a floor; Ossie runs the container there and answers on the air. The
+crane order is deterministic (CraneOperator._hear_radio); the LLM is off
+for now. Re-run-safe.
+"""
+from evennia import create_object
+from evennia.objects.models import ObjectDB
+from world.spatial import get_xyz
+
+BAND = "27.0"
+
+
+def at(xyz):
+    return next((r for r in ObjectDB.objects.filter(db_attributes__db_key="xyz")
+                 if r.destination is None and get_xyz(r) == xyz), None)
+
+
+def in_room(room, key):
+    return next((o for o in room.contents if o.key == key), None)
+
+
+cab = at((-1, -18, 17))
+assert cab is not None, "operator's cab missing at (-1,-18,17)"
+
+# ---- the console: a powered base station on the work band ------------
+console = in_room(cab, "Boiler Run crane console")
+if console is None:
+    console = create_object("typeclasses.items.Radio",
+                            key="Boiler Run crane console", location=cab)
+    console.aliases.add(["console", "crane console", "radio", "base station"])
+    console.db.desc = (
+        "A bolted-down Boiler Run control console — a bank of worn levers, a "
+        "load gauge with a cracked face, and a fixed transceiver whose "
+        "display glows a steady 27.0. This is the voice that runs the "
+        "container.")
+    console.locks.add("get:false()")
+console.db.is_radio = True
+console.db.is_base_station = True
+console.db.is_npc = True             # radio loop-guard: brains observe, never chain
+console.db.radio_on = True
+console.db.frequency = BAND
+
+# ---- the chair: so the operator is 'seated at' the console -----------
+chair = in_room(cab, "operator's chair")
+if chair is None:
+    chair = create_object("typeclasses.furniture.Furniture",
+                          key="operator's chair", location=cab)
+    chair.db.desc = ("A cracked vinyl chair on a pedestal, bolted to the cab "
+                     "floor so it doesn't slide when the mast sways.")
+
+# ---- Ossie Trelane, the operator ------------------------------------
+op = in_room(cab, "Ossie Trelane")
+if op is None:
+    op = create_object("typeclasses.crane.CraneOperator", key="Ossie Trelane",
+                       location=cab)
+    op.aliases.add(["ossie", "operator", "crane operator", "trelane"])
+op.db.desc = (
+    "A broad, weathered crane operator in a Boiler Run hi-viz vest gone grey "
+    "with dust, seated at the console like they've grown into it. They watch "
+    "the load through the long window more than they watch you, one hand "
+    "never far from the levers.")
+op.db.is_npc = True
+op.db.llm_driven = False              # deterministic crane control; LLM off for now
+op.db.voice_description = "gravelly, unhurried"
+op.db.voice_ending = "and signs off with a click of the handset"
+# seat them at the console
+op.db.furniture = chair
+op.db.posture = "sitting"
+
+# ---- point callers at the band --------------------------------------
+if "27.0" not in (cab.db.desc or ""):
+    cab.db.desc = (cab.db.desc or "").rstrip() + (
+        " A grease-pencil scrawl by the window reads: CRANE CONTROL — "
+        "BOILER RUN WORK CHANNEL 27.0.")
+hoard = at((-1, -19, 0))
+if hoard is not None and "27.0" not in (hoard.db.desc or ""):
+    hoard.db.desc = (hoard.db.desc or "").rstrip() + (
+        " A faded sign wired to the fence: DELIVERIES — RAISE THE OPERATOR ON "
+        "27.0.")
+
+print(f"BUILD 032: operator #{op.id} seated at chair #{chair.id}, "
+      f"console #{console.id} on {console.db.frequency} "
+      f"(on={console.db.radio_on}, base={console.db.is_base_station}).")

--- a/typeclasses/crane.py
+++ b/typeclasses/crane.py
@@ -1,0 +1,124 @@
+"""The Boiler Run crane operator — radio control of the container car.
+
+The operator sits in the cab at the top of the mast with a base-station
+console tuned to the work band. A caller keys up on that band and asks
+for a floor; the operator runs the container there (the P2 seam,
+``CraneContainer.move_to_level``) and keys back a confirmation.
+
+The crane order is DETERMINISTIC — it does not depend on the LLM being
+up, because a hoist answering "take it to twelve" shouldn't hinge on a
+warm model. Anything that ISN'T a crane order falls through to the LLM
+persona (when enabled) for flavour, exactly the ``_handle_directed_speech``
+/ radio split the brain was built around.
+"""
+import re
+
+from typeclasses.llm_npc import LLMNpc
+
+
+class CraneOperator(LLMNpc):
+    """An LLM-capable NPC whose radio ear is wired to the crane first."""
+
+    #: The Boiler Run work band. Callers tune here to reach the cab.
+    CRANE_BAND = "27.0"
+
+    #: house floor -> the container's z is (floor - 1); travel is 2..17.
+    MIN_FLOOR = 2
+    MAX_FLOOR = 17
+    QOC_FLOOR = 13          # level with the Queen of Cups rack roof
+
+    _NUMBER_WORDS = {
+        "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7,
+        "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12,
+        "thirteen": 13, "fourteen": 14, "fifteen": 15, "sixteen": 16,
+        "seventeen": 17,
+    }
+
+    # -- finding the car -------------------------------------------------
+    def _find_car(self):
+        from evennia.objects.models import ObjectDB
+        return ObjectDB.objects.filter(
+            db_typeclass_path="typeclasses.rooms.CraneContainer").first()
+
+    # -- reading the order -----------------------------------------------
+    def _parse_floor(self, speech, car):
+        """Pull a target floor (2..17) out of a transmission, or None if it
+        isn't a crane order at all."""
+        low = speech.lower()
+
+        # named destinations first — these are the ones players will reach for
+        if any(w in low for w in ("dock", "docked", "ground", "street level",
+                                  "bottom", "second", "2nd", "boarding")):
+            return self.MIN_FLOOR
+        if any(w in low for w in ("top", "topmost", "highest", "the top",
+                                  "seventeenth", "seventeen", "17th")):
+            return self.MAX_FLOOR
+        if "queen" in low or "crossing" in low or "the level" in low:
+            return self.QOC_FLOOR
+
+        # an explicit floor number: digits 2..17
+        m = re.search(r"\b(1[0-7]|[2-9])\b", low)
+        if m:
+            return int(m.group(1))
+        # or a spelled-out number
+        for word, n in self._NUMBER_WORDS.items():
+            if re.search(rf"\b{word}\b", low):
+                return n
+
+        # relative nudges (only when clearly a movement word, not chatter)
+        cur_floor = (car.db.level or 1) + 1
+        if re.search(r"\b(up|raise|higher|lift)\b", low):
+            return cur_floor + 1
+        if re.search(r"\b(down|lower|drop)\b", low):
+            return cur_floor - 1
+        return None
+
+    # -- radio ear: crane order first, persona second --------------------
+    def _hear_radio(self, speech, speaker, kwargs):
+        from world.radio import same_band
+
+        if (speech and not self._is_npc_speaker(speaker)
+                and same_band(kwargs.get("radio_frequency"), self.CRANE_BAND)):
+            car = self._find_car()
+            if car is not None:
+                floor = self._parse_floor(speech, car)
+                if floor is not None:
+                    self._run_crane(floor, speaker, car)
+                    return
+        # not a crane order — let the LLM brain handle it (if enabled)
+        super()._hear_radio(speech, speaker, kwargs)
+
+    # -- doing it --------------------------------------------------------
+    def _run_crane(self, floor, caller, car):
+        from evennia.utils import delay
+
+        floor = max(self.MIN_FLOOR, min(self.MAX_FLOOR, int(floor)))
+        target_z = floor - 1
+        old_z = car.db.level or 1
+
+        if target_z == old_z:
+            self._reply(f"Copy. She's already sitting at the {floor}th.")
+            return
+
+        rising = target_z > old_z
+        # a beat of chatter, then the car actually moves
+        self._reply(f"Copy, the {floor}th. Bringing her "
+                    f"{'up' if rising else 'down'} — mind the swing.")
+        delay(2.0, self._drive, car, target_z, floor)
+
+    def _drive(self, car, target_z, floor):
+        car.move_to_level(target_z)
+        if floor == self.QOC_FLOOR:
+            self._reply(f"The {floor}th — level with the Queen's roof. "
+                        f"Step lively.")
+        else:
+            self._reply(f"Held at the {floor}th. Watch your footing.")
+
+    def _reply(self, message):
+        """Key the cab console and answer on the band."""
+        from world.radio import active_transmit_radio, transmit, transmit_organ
+        device = active_transmit_radio(self)
+        if device is not None:
+            transmit(self, message, device=device)
+        else:
+            transmit_organ(self, message)


### PR DESCRIPTION
The operator sits at a Boiler Run console tuned to the work band. Key up
on 27.0 and ask for a floor — a number, a name ("top", "dock", "the
queen"), or "up"/"down" — and Ossie runs the container there and answers
on the air. The crane order is deterministic: CraneOperator._hear_radio
catches it before the LLM, so the hoist works whether or not the model
is warm; anything that isn't a crane order falls through to the persona.
Signs on the hoarding and in the cab point callers at 27.0.

Closes #1809

Co-Authored-By: Claude <noreply@anthropic.com>
