### PR TITLE
Crane sky room takes the standard name

### DIFF
--- a/scripts/builds/030_marlowe_lot_skeleton.py
+++ b/scripts/builds/030_marlowe_lot_skeleton.py
@@ -148,7 +148,7 @@ exits += mk_exit(uc_roof_n, container, "east", ["e"])
 # ---- 5. transit + fall rooms for the future jump edge ----------------
 # The half-second of the leap toward the Queen of Cups, and the pit you
 # hit if you miss. Placed now so Phase 2 only has to wire the exit.
-sky, new = ensure((0, -17, 12), "Crane Gap (over the Lot)", tc=SKY_TC,
+sky, new = ensure((0, -17, 12), "In the Air", tc=SKY_TC,
     type="sky", outside=True, is_ground=False, is_sky_room=True,
     desc=("Open air over the construction lot, high as the Queen of Cups' "
           "rack roof. The container swings somewhere below or beside you; "

--- a/scripts/builds/034_crane_gap_relocate.py
+++ b/scripts/builds/034_crane_gap_relocate.py
@@ -25,7 +25,8 @@ NEW = (-1, -16, 13)
 sky = at((0, -17, 12)) or at(NEW)
 assert sky is not None, "crane gap sky room not found"
 set_xyz(sky, *NEW)
-sky.key = "Crane Gap (over Kaspar Street)"
+sky.key = "In the Air"          # the standard sky-room name; the leap's
+                               # specifics live in the desc, not the key
 sky.db.desc = (
     "Open air north of the crane, level with the Queen of Cups' rack roof "
     "— the half-second the leap from the container lives in, out over "
@@ -41,5 +42,5 @@ car = ObjectDB.objects.filter(
 if car is not None:
     car.move_to_level(car.db.level or 1, announce=False)
 
-print(f"BUILD 034: crane gap #{sky.id} -> {get_xyz(sky)} {sky.key!r}; "
+print(f"BUILD 034: sky #{sky.id} -> {get_xyz(sky)} {sky.key!r}; "
       f"car level={car.db.level if car else '?'} SKY={type(car).SKY if car else '?'}")


### PR DESCRIPTION
Every SkyRoom in the colony is keyed "In the Air" (73 of them); the
crane's transit room was the one deviation, named for the gap. Conform
the key — the leap's specifics belong in the desc, not the name — and
fix both build scripts so a re-run stays standard.

Co-Authored-By: Claude <noreply@anthropic.com>
