### PR TITLE
Serve root favicon.ico directly with cache headers

### DIFF
--- a/web/urls.py
+++ b/web/urls.py
@@ -13,20 +13,49 @@ Search the Django documentation for "URL dispatcher" for more help.
 
 """
 
+import os
+
+from django.conf import settings
+from django.http import FileResponse, Http404
 from django.urls import include, path
-from django.views.generic import RedirectView
+from django.views.decorators.cache import cache_control
 
 # default evennia patterns
 from evennia.web.urls import urlpatterns as evennia_default_urlpatterns
 
-# iOS/iPadOS probe these ROOT paths on their own whenever a page doesn't
-# declare an apple-touch-icon link (ours mostly don't — Evennia's base.html
-# isn't forked). Without these routes the probes 404 (and the Cloudflare
-# path allowlist blocked them outright), so Apple devices improvised their
-# tab/home-screen icons. Same redirect pattern Evennia uses for favicon.ico.
-_TOUCH_ICON = RedirectView.as_view(
-    url="/static/website/images/apple-touch-icon.png", permanent=False
-)
+# Safari (macOS and iOS) largely ignores rel=icon and lives off the ROOT
+# /favicon.ico; iOS additionally probes root /apple-touch-icon*.png paths.
+# Evennia's default is a 302 into /media/, but a redirect through Django
+# session middleware sets a cookie, which makes Cloudflare BYPASS the cache
+# and gives Safari a hop it caches badly — icon swaps never propagated.
+# Serve the bytes DIRECTLY at the root with explicit cache headers instead:
+# edge-cacheable, cookie-free, and must-revalidate so a replaced icon
+# actually reaches devices. (These routes shadow Evennia's favicon redirect
+# because our urlpatterns are matched first.)
+
+
+def _icon(relpath, content_type):
+    @cache_control(public=True, max_age=86400, must_revalidate=True)
+    def view(request):
+        candidates = [os.path.join(settings.STATIC_ROOT or "", relpath)]
+        try:
+            from django.contrib.staticfiles import finders
+
+            found = finders.find(relpath)
+            if found:
+                candidates.insert(0, found)
+        except Exception:
+            pass
+        for p in candidates:
+            if p and os.path.isfile(p):
+                return FileResponse(open(p, "rb"), content_type=content_type)
+        raise Http404(relpath)
+
+    return view
+
+
+_FAVICON = _icon("website/images/favicon.ico", "image/vnd.microsoft.icon")
+_TOUCH_ICON = _icon("website/images/apple-touch-icon.png", "image/png")
 
 # add patterns
 urlpatterns = [
@@ -36,7 +65,8 @@ urlpatterns = [
     path("webclient/", include("web.webclient.urls")),
     # web admin
     path("admin/", include("web.admin.urls")),
-    # apple-touch-icon probe targets (see note above)
+    # root icon paths Safari/iOS actually use (see note above)
+    path("favicon.ico", _FAVICON),
     path("apple-touch-icon.png", _TOUCH_ICON),
     path("apple-touch-icon-precomposed.png", _TOUCH_ICON),
     path("apple-touch-icon-120x120.png", _TOUCH_ICON),


### PR DESCRIPTION
Evennia's root favicon is a 302 through session middleware that sets a
cookie — Cloudflare BYPASSes it, no cache headers exist anywhere, and
Safari (which ignores rel=icon and lives off root /favicon.ico) never
got told to revalidate its cached icon: swapping the files never fully
propagated. Serve the bytes directly at the root, cookie-free, with
Cache-Control public/max-age=86400/must-revalidate; same treatment for
the apple-touch probe paths.

Closes #1904

Co-Authored-By: Claude <noreply@anthropic.com>
