### PR TITLE
Strip session cookies from root icon responses

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -42,6 +42,10 @@ INSTALLED_APPS = INSTALLED_APPS + ["world"]  # type: ignore[name-defined]
 # Prepend Django's SecurityMiddleware (must be near top of chain) and
 # append XFrameOptionsMiddleware + our custom CSP middleware.
 MIDDLEWARE = [
+    # top of stack = last word on the response: strips the session cookie
+    # SharedLoginMiddleware mints on every request from the root icon
+    # paths, or Cloudflare refuses to edge-cache them (see the module)
+    "web.utils.icon_middleware.CookieFreeIconMiddleware",
     "django.middleware.security.SecurityMiddleware",
 ] + MIDDLEWARE + [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",

--- a/web/utils/icon_middleware.py
+++ b/web/utils/icon_middleware.py
@@ -1,0 +1,27 @@
+"""Cookie-free icon responses.
+
+Evennia's SharedLoginMiddleware saves a session on every request that
+arrives without one, so even /favicon.ico responses carry Set-Cookie —
+and Cloudflare refuses to cache any response that sets a cookie
+(cf-cache-status: BYPASS). That single header is why swapping the icon
+files never propagated: the root icon paths could not be edge-cached
+and Safari was never told to revalidate.
+
+This middleware sits at the TOP of the stack (its response pass runs
+LAST, after SessionMiddleware has attached the cookie) and strips all
+cookies from the handful of root icon paths. Nothing about a favicon
+needs a session.
+"""
+
+ICON_PATHS = ("/favicon.ico", "/apple-touch-icon")
+
+
+class CookieFreeIconMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if request.path == ICON_PATHS[0] or request.path.startswith(ICON_PATHS[1]):
+            response.cookies.clear()
+        return response


### PR DESCRIPTION
SharedLoginMiddleware mints a session on every cookie-less request, so
even /favicon.ico carried Set-Cookie — and Cloudflare BYPASSes any
response that sets a cookie. That header is why two rounds of icon
swaps never propagated. CookieFreeIconMiddleware sits at the top of the
stack (its response pass runs last) and clears cookies on the root icon
paths only.

Closes #1906

Co-Authored-By: Claude <noreply@anthropic.com>
