### PR TITLE
Strip multi-line pseudo-comments leaking into page output

### DIFF
--- a/web/templates/website/base.html
+++ b/web/templates/website/base.html
@@ -8,17 +8,7 @@
     <meta name="generator" content="Evennia" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    {# type must match the actual file (PNG) — the stock x-icon/PNG MIME
-       mismatch gives WebKit licence to ignore the declaration and keep its
-       stored icon forever (observed: devices never fetched this URL). #}
     <link rel="icon" type="image/png" sizes="256x256" href="{% static "website/images/evennia_logo.png" %}" />
-    {# iOS ignores rel=icon and keeps a stored touch icon forever unless the
-       page DECLARES a touch-icon URL it hasn't seen — the declaration is the
-       only reliable trigger to make it refetch (live-verified via edge logs:
-       the webclient's declared link fetched instantly through a stale icon
-       store; undeclared pages never fetched at all). Shadowed from Evennia's
-       base.html for this one addition — resync on Evennia upgrades. #}
     <link rel="apple-touch-icon" href="{% static "website/images/apple-touch-icon.png" %}" />
 
     <!-- Bootstrap CSS -->


### PR DESCRIPTION
Django's {# #} comment syntax is single-line only; the multi-line
blocks added to the shadowed base.html rendered as literal text on
every website page. Remove them — the rationale lives in the commit
history and styling spec.

Co-Authored-By: Claude <noreply@anthropic.com>
