### PR TITLE
Open the atlas to the public

### DIFF
--- a/web/website/urls.py
+++ b/web/website/urls.py
@@ -30,7 +30,7 @@ from web.website.views.atlas import atlas_view
 
 # Override default character creation, account registration, and other views
 urlpatterns = [
-    # the colony atlas — superuser survey instrument (§M2.5)
+    # the colony atlas — public shop window (§M2.5); staff plate stays offline
     path("atlas/", atlas_view, name="atlas"),
 
     # robots.txt - served as plain text for search engine crawlers

--- a/web/website/views/atlas.py
+++ b/web/website/views/atlas.py
@@ -1,14 +1,17 @@
 """The atlas, served (COLONY_MAPPING_SPEC §M2.5) — inside the site's own
 page, so the colony's header and footer carry through. The plate chrome
-is the design; only the picture inside it went live-rendered. Any
-logged-in account may read it. The builder's staff-overlay plate still
-exists as a generated file (scripts/atlas/generate.py).
+is the design; only the picture inside it went live-rendered. PUBLIC:
+anyone with the link may view it (owner call, 2026-08-23 — it's the
+colony's shop window). The 'you are here' beacons still require a
+login by nature: player_positions() only ever reports the requesting
+account's own characters, and returns empty for anonymous viewers. The
+builder's staff-overlay plate still exists only as a generated file
+(scripts/atlas/generate.py) and is not served.
 
 The 'you are here' beacons poll ?feed=here on this same path — the
 edge allowlist admits exact paths only, and query strings pass."""
 
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.utils.safestring import mark_safe
@@ -16,7 +19,6 @@ from django.utils.safestring import mark_safe
 from world.atlas import build_atlas3d_html, player_positions
 
 
-@login_required
 def atlas_view(request):
     game_dir = getattr(settings, "GAME_DIR", ".")
     if request.GET.get("feed") == "here":


### PR DESCRIPTION
The live 3D atlas becomes the colony's shop window: drop the login gate
on /atlas/ so the link can be handed out directly. Beacons degrade
safely for anonymous viewers (own-characters-only, empty for anon); the
staff 2D plate stays offline-only. Stale 'superuser instrument' comment
corrected.

Closes #1913

Co-Authored-By: Claude <noreply@anthropic.com>
