### PR TITLE
Cache the rendered atlas plate server-side

### DIFF
--- a/web/website/views/atlas.py
+++ b/web/website/views/atlas.py
@@ -9,7 +9,18 @@ builder's staff-overlay plate still exists only as a generated file
 (scripts/atlas/generate.py) and is not served.
 
 The 'you are here' beacons poll ?feed=here on this same path — the
-edge allowlist admits exact paths only, and query strings pass."""
+edge allowlist admits exact paths only, and query strings pass.
+
+THE PLATE IS CACHED: building it rereads the whole map from the DB and
+embeds ~4MB of baked models per request, identical for every viewer.
+Build it once, account-neutral (empty beacon seed — the client's
+?feed=here poll fills beacons within one tick for logged-in players),
+and reuse for PLATE_TTL. In-game building shows up within the TTL; a
+reload clears the cache instantly (fresh process). Benign build race
+under threads: worst case two identical builds.
+"""
+
+import time
 
 from django.conf import settings
 from django.http import JsonResponse
@@ -18,11 +29,19 @@ from django.utils.safestring import mark_safe
 
 from world.atlas import build_atlas3d_html, player_positions
 
+PLATE_TTL = 120  # seconds
+_plate = {"html": None, "at": 0.0}
+
 
 def atlas_view(request):
     game_dir = getattr(settings, "GAME_DIR", ".")
     if request.GET.get("feed") == "here":
         return JsonResponse({"here": player_positions(request.user)})
-    plate = build_atlas3d_html(game_dir, fragment=True, account=request.user)
+    now = time.monotonic()
+    if _plate["html"] is None or now - _plate["at"] > PLATE_TTL:
+        _plate["html"] = build_atlas3d_html(game_dir, fragment=True,
+                                            account=None)
+        _plate["at"] = now
     return render(request, "website/atlas.html",
-                  {"atlas": mark_safe(plate), "page_title": "Atlas"})
+                  {"atlas": mark_safe(_plate["html"]),
+                   "page_title": "Atlas"})


### PR DESCRIPTION
Every public hit rebuilt the plate — full DB map export plus a ~4MB
models embed — despite identical output for every viewer. Cache the
built plate for 120s, account-neutral: the beacon seed is empty and the
client's ?feed=here poll fills beacons within a tick. Building surfaces
within the TTL; reloads clear the cache by nature.

Closes #1915

Co-Authored-By: Claude <noreply@anthropic.com>
