### PR TITLE
Wire Greenhaus gap edges the way the jump engine expects

### DIFF
--- a/scripts/builds/055_greenhaus_verticals.py
+++ b/scripts/builds/055_greenhaus_verticals.py
@@ -277,7 +277,16 @@ for xyz in AIR:
     r.db.desc = AIR_DESC
     R[xyz] = r
 
-# platform/roof edges into the air columns
+# platform/roof edges into the air columns. Gap exits need THREE parts
+# (canon: the Halcyon crossing): destination=air (jump-off descents),
+# gap_destination=the far perch (where jump-across LANDS), sky_room=the
+# air (transit). Destination-only wiring strands jumpers in the air.
+def _wire_gap(loc, key, far, air):
+    for e in loc.exits:
+        if e.key == key and e.db.is_gap:
+            e.db.gap_destination = far.id
+            e.db.sky_room = air.id
+
 for x in TOWERS:
     for z in range(1, 11):
         d = diff(z)
@@ -285,9 +294,13 @@ for x in TOWERS:
             if x in (7, 9):                      # eastward into a gap
                 exits += link(R[(x, y, z)], R[(x + 1, y, z)], "east",
                               edge=d, gap=d)
+                _wire_gap(R[(x, y, z)], "east", R[(x + 2, y, z)],
+                          R[(x + 1, y, z)])
             if x in (9, 11):                     # westward into a gap
                 exits += link(R[(x, y, z)], R[(x - 1, y, z)], "west",
                               edge=d, gap=d)
+                _wire_gap(R[(x, y, z)], "west", R[(x - 2, y, z)],
+                          R[(x - 1, y, z)])
 
 # ── the lawns ──────────────────────────────────────────────────────────
 LAWN = {(8, -17, 0): "Greenhaus Grounds - West Lawn (North)",
@@ -311,21 +324,15 @@ for gx in (8, 10):
         exits += link(R[(gx + 1, y, 0)], R[(gx, y, 0)], "west")
 
 # ── the way in: over the cop shop ──────────────────────────────────────
-conn = at((8, -16, 2))
-if conn is None:
-    conn = create_object(SKY_TC, key="In the Air")
-    conn.db.xyz = (8, -16, 2)
-    made += 1
-conn.key = "In the Air"
-conn.db.type = "sky"
-conn.db.is_sky_room = True
-conn.db.outside = True
-conn.db.desc = CONNECTOR_DESC
+# entry: a pure DESCENT from the cop roof over the fence, landing by
+# gravity on the West Lawn — destination is the farm's own airspace
+# (build 060 lesson: a straight south line from the roof has no same-z
+# perch, so this cannot be a gap crossing).
 constab = next((r for r in ObjectDB.objects.filter(
     db_key="Colonial Constabulary Rooftop (South)")
     if r.destination is None), None)
 if constab is not None:
-    exits += link(constab, conn, "south", edge=10, gap=10)
+    exits += link(constab, R[(8, -17, 2)], "south", edge=10)
 
 print(f"BUILD 055: Greenhaus Verticals — {made} rooms touched, "
       f"{exits} exits created. Entry: Constabulary roof, south edge.")

--- a/scripts/builds/056_greenhaus_cisterns.py
+++ b/scripts/builds/056_greenhaus_cisterns.py
@@ -118,6 +118,13 @@ if air is None:
     made += 1
 exits += link(rooms[C1_TOP], air, "northeast", edge=7, gap=7)
 exits += link(rooms[C2_WALK], air, "southwest", edge=7, gap=7)
+# gap exits land at the FAR PERCH; the air is transit only (build 060)
+for room, key, far in ((rooms[C1_TOP], "northeast", rooms[C2_WALK]),
+                       (rooms[C2_WALK], "southwest", rooms[C1_TOP])):
+    for e in room.exits:
+        if e.key == key and e.db.is_gap:
+            e.db.gap_destination = far.id
+            e.db.sky_room = air.id
 # No. 2's own ladder, catwalk to lid
 exits += link(rooms[C2_WALK], rooms[C2_TOP], "up")
 exits += link(rooms[C2_TOP], rooms[C2_WALK], "down")

--- a/scripts/builds/060_gap_wiring.py
+++ b/scripts/builds/060_gap_wiring.py
@@ -1,0 +1,110 @@
+"""Build 060 — wire the Greenhaus gap jumps the way the engine expects.
+
+    docker exec -i gelatinous bash -lc 'cd /usr/src/game && evennia shell' \
+        < scripts/builds/060_gap_wiring.py
+    then a foreground reload.
+
+Owner report: jumping the cistern crossing left them stuck in the air
+cell. Root cause (canon read from the Halcyon↔Antenna crossing): a gap
+exit needs THREE pieces — `destination` = the air cell (used by
+`jump off` descents), `db.gap_destination` = the far perch dbref (where
+`jump across` actually lands), `db.sky_room` = the air cell dbref (the
+transit hop). Builds 055/056 set only destination, so a SUCCESSFUL
+crossing "landed" in the air. This wires gap_destination + sky_room on
+every Greenhaus gap edge:
+
+  - cistern diagonal: C1 lid <-> C2 catwalk through the air (5,-18,1)
+  - every farm platform/roof lateral: x7<->x9<->x11 through the air
+    columns at x8/x10, same y, same z
+  - the Constabulary entry becomes a pure DESCENT over the fence:
+    destination retargeted to the farm's own air (8,-17,2) so the fall
+    lands on the West Lawn INSIDE the fence (it previously fell to
+    Kaspar Street outside); is_gap removed, the orphan connector air
+    over Kaspar is deleted.
+
+Re-run-safe.
+"""
+from evennia.objects.models import ObjectDB
+from world.spatial import get_xyz
+
+
+def by_key(key):
+    return next((r for r in ObjectDB.objects.filter(db_key=key)
+                 if r.destination is None), None)
+
+
+def at(xyz):
+    return next((r for r in ObjectDB.objects.filter(db_attributes__db_key="xyz")
+                 if r.destination is None and get_xyz(r) == xyz), None)
+
+
+def wire(room, key, far, air):
+    for e in room.exits:
+        if e.key == key and e.db.is_gap:
+            e.db.gap_destination = far.id
+            e.db.sky_room = air.id
+            return 1
+    return 0
+
+
+wired = 0
+
+# ── the cistern diagonal ───────────────────────────────────────────────
+c1 = by_key("Greenhaus Cistern No. 1 - Tank Top")
+walk = by_key("Greenhaus Cistern No. 2 - Service Catwalk")
+air = at((5, -18, 1))
+wired += wire(c1, "northeast", walk, air)
+wired += wire(walk, "southwest", c1, air)
+
+# ── the farm laterals: platforms and roof greens ───────────────────────
+TOWERS = {7: "The Fungary", 9: "The Leafworks", 11: "The Fruiting House"}
+
+
+def perch(x, y, z):
+    name = TOWERS[x]
+    if z == 10:
+        side = "North" if y == -17 else "South"
+        return by_key(f"{name} - Roof Green ({side})")
+    side = "North" if y == -17 else "South"
+    return by_key(f"{name} - {side} Platform (Level {z})")
+
+
+for x in TOWERS:
+    for y in (-17, -19):
+        for z in range(1, 11):
+            me = perch(x, y, z)
+            if me is None:
+                continue
+            if x in (7, 9):                      # east across the gap
+                gap_air = at((x + 1, y, z))
+                far = perch(x + 2, y, z)
+                if gap_air and far:
+                    wired += wire(me, "east", far, gap_air)
+            if x in (9, 11):                     # west across the gap
+                gap_air = at((x - 1, y, z))
+                far = perch(x - 2, y, z)
+                if gap_air and far:
+                    wired += wire(me, "west", far, gap_air)
+
+# ── the Constabulary entry: descent over the fence, landing inside ─────
+constab = by_key("Colonial Constabulary Rooftop (South)")
+farm_air = at((8, -17, 2))
+old_conn = at((8, -16, 2))
+retargeted = 0
+for e in constab.exits:
+    if e.key == "south" and e.db.is_edge:
+        if e.destination != farm_air:
+            e.destination = farm_air
+            retargeted += 1
+        e.db.is_gap = None
+        e.db.gap_difficulty = None
+        e.db.sky_room = None
+        e.db.gap_destination = None
+if old_conn is not None:
+    inbound = [x for x in ObjectDB.objects.filter(db_destination=old_conn.id)]
+    if not inbound:
+        old_conn.delete()
+
+print(f"BUILD 060: {wired} gap edges wired (gap_destination + sky_room), "
+      f"constab entry retargeted={retargeted} to the fenced airspace, "
+      f"orphan connector removed.")


### PR DESCRIPTION
Gap exits need three parts (canon: the Halcyon crossing): destination=
the air cell for jump-off descents, gap_destination=the far perch where
jump-across lands, sky_room=the air for transit. Builds 055/056 set
destination only, stranding successful jumpers in bare SkyRooms — 83
edges affected. Build 060 wires the cistern diagonal and every farm
lateral, converts the Constabulary entry to a pure descent landing
inside the fence, and deletes the orphan connector. 055/056 patched
for fresh replays.

Closes #1927

Co-Authored-By: Claude <noreply@anthropic.com>
