### PR TITLE
Retire Cistern No. 2; No. 1 holds the 5 slot with a straight east line

### DIFF
--- a/scripts/builds/056_greenhaus_cisterns.py
+++ b/scripts/builds/056_greenhaus_cisterns.py
@@ -1,58 +1,40 @@
-"""Build 056 — Greenhaus Cisterns No. 1 and No. 2: the western connectors.
+"""Build 056 — Greenhaus Cistern No. 1: the western connector.
 
     docker exec -i gelatinous bash -lc 'cd /usr/src/game && evennia shell' \
         < scripts/builds/056_greenhaus_cisterns.py
     then a foreground reload.
 
-INTENT (playbook §0): the Verticals' water supply, and the western
-approach that turns the farm towers from an island into a line. Two
-riveted Greenhaus cisterns stand over Shipbreaker Alley's diagonal —
-No. 1 squat at (5,-18), No. 2 taller at (6,-18) — feeding the Fungary's
-riser. The parkour diagonal: alley ladder → No. 1 tank top (5,-19,1) →
-ne edge into the air over the alley's dogleg (6,-18,1) ← south edge
-from No. 2's catwalk (6,-17,1) → ladder → No. 2 lid (6,-17,2) → east
-edge onto the Fungary North Platform (Level 2). Structures keep off
-walkable cells; only air crosses the lane (the Kaspar-connector idiom).
-(Greenhaus Cistern No. 3 already stands at (13,-15) as a landmark —
-this completes the numbered set.)
+FINAL FORM (after 057-061 iterations, owner-settled): ONE cistern — the
+squat No. 1 at (5,-19,1) over the corner off Braddock — with a straight
+east crossing at z1 into the farm:
 
-Re-run-safe. Rollback: delete the three rooms keyed "Greenhaus Cistern
-No. 1/No. 2 - …" plus the alley's up exit and the core hatch edge.
+    Braddock (5,-20) --ladder--> C1 lid (5,-19,1)
+      --east gap--> In the Air over Shipbreaker (6,-19,1)
+      --lands--> The Fungary - South Platform (Level 1)
+
+Cistern No. 2 was built and then retired the same day (its numeral
+returns elsewhere later); No. 3 stands as a landmark at (13,-15). Gap
+exits carry the three-part wiring (destination=air for descents,
+gap_destination=the far perch, sky_room=the air) — build 060's law.
+Re-run-safe.
 """
 from evennia import create_object
 from evennia.objects.models import ObjectDB
 from world.spatial import get_xyz
 
 ROOM_TC = "typeclasses.rooms.Room"
+SKY_TC = "typeclasses.rooms.SkyRoom"
 EXIT_TC = "typeclasses.exits.Exit"
-ALIAS = {"north": ["n"], "south": ["s"], "east": ["e"], "west": ["w"],
-         "up": ["u"], "down": ["d"], "northeast": ["ne"], "southwest": ["sw"]}
 
-C1_TOP = (4, -19, 1)   # off Braddock; one straight diagonal to C2 (059 fix)
-C2_WALK = (6, -17, 1)  # over the block corner NORTH of the alley (058 fix)
-C2_TOP = (6, -17, 2)
+C1_TOP = (5, -19, 1)
 
-DESCS = {
-    C1_TOP: ("The lid of Greenhaus Cistern No. 1 — the runt of the numbered "
-             "set, a squat riveted drum on splayed legs over Shipbreaker's "
-             "bend. The deck plate is dished with age and slick where the "
-             "fill valve weeps; the Greenhaus band has gone verdigris "
-             "except where the numeral is repainted, annually, by someone "
-             "who clearly hates ladders. East, its taller sibling's "
-             "catwalk hangs a committed leap away."),
-    C2_WALK: ("Cistern No. 2's service catwalk — a mesh ring around the "
-              "drum's waist, bolted to legs that straddle the alley below. "
-              "Feed pipes as thick as thighs leave the tank eastward, "
-              "shouldering through a junction collar toward the farm "
-              "towers. The ladder to the lid is cold, wet, and "
-              "load-rated for exactly one honest person."),
-    C2_TOP: ("The lid of Greenhaus Cistern No. 2 — a wide riveted deck "
-             "behind a rail that stops meaning it halfway round. The "
-             "Greenhaus band below is fresh, the level gauge ticking "
-             "green; the whole drum thrums faintly as the risers drink. "
-             "East, flush in the Fungary's concrete flank, a service "
-             "hatch stencilled GH-RISER 01 stands a hard jump away."),
-}
+DESC = ("The lid of Greenhaus Cistern No. 1 — the sole survivor of the "
+        "numbered set on this block, a squat riveted drum on splayed legs "
+        "over the corner off Braddock. The deck plate is dished with age "
+        "and slick where the fill valve weeps; the numeral is repainted "
+        "annually by someone who clearly hates ladders. The ladder rides "
+        "the south leg down to the avenue. East, across the alley's air, "
+        "the Fungary's first-level platform rail waits for the committed.")
 
 
 def at(xyz):
@@ -65,73 +47,54 @@ def by_key(key):
                  if r.destination is None), None)
 
 
-def has_exit(loc, key):
-    return any(e.key == key for e in loc.exits)
-
-
-def link(loc, dest, key, edge=None, gap=None):
-    if loc is None or dest is None or has_exit(loc, key):
+def link(loc, dest, key, alias, edge=None):
+    if loc is None or dest is None or any(e.key == key for e in loc.exits):
         return 0
-    e = create_object(EXIT_TC, key=key, aliases=ALIAS.get(key, []),
+    e = create_object(EXIT_TC, key=key, aliases=[alias],
                       location=loc, destination=dest)
     if edge is not None:
         e.db.is_edge = True
         e.db.edge_difficulty = edge
-    if gap is not None:
         e.db.is_gap = True
-        e.db.gap_difficulty = gap
+        e.db.gap_difficulty = edge
     return 1
 
 
 made = exits = 0
-rooms = {}
-SPEC = {C1_TOP: ("Greenhaus Cistern No. 1 - Tank Top", "cistern_solo"),
-        C2_WALK: ("Greenhaus Cistern No. 2 - Service Catwalk", "cistern_walk"),
-        C2_TOP: ("Greenhaus Cistern No. 2 - Tank Top", "cistern_top")}
-for xyz, (key, skin) in SPEC.items():
-    r = at(xyz)
-    if r is None:
-        r = create_object(ROOM_TC, key=key)
-        r.db.xyz = xyz
-        made += 1
-    r.key = key
-    r.db.desc = DESCS[xyz]
-    r.db.type = "cistern"
-    r.db.atlas_skin = skin
-    r.db.outside = True
-    rooms[xyz] = r
-
-braddock = at((4, -20, 0))
-core2 = by_key("The Fungary - Stair Core (Level 2)")
-
-# the ladder up No. 1 from Braddock (public climb, both ways)
-exits += link(braddock, rooms[C1_TOP], "up")
-exits += link(rooms[C1_TOP], braddock, "down")
-# the crossing: both lids edge into the air over the alley dogleg
-air = at((5, -18, 1))
-if air is None:
-    air = create_object("typeclasses.rooms.SkyRoom", key="In the Air")
-    air.db.xyz = (5, -18, 1)
-    air.db.type = "sky"
-    air.db.is_sky_room = True
-    air.db.outside = True
+c1 = at(C1_TOP)
+if c1 is None:
+    c1 = create_object(ROOM_TC, key="Greenhaus Cistern No. 1 - Tank Top")
+    c1.db.xyz = C1_TOP
     made += 1
-exits += link(rooms[C1_TOP], air, "northeast", edge=7, gap=7)
-exits += link(rooms[C2_WALK], air, "southwest", edge=7, gap=7)
-# gap exits land at the FAR PERCH; the air is transit only (build 060)
-for room, key, far in ((rooms[C1_TOP], "northeast", rooms[C2_WALK]),
-                       (rooms[C2_WALK], "southwest", rooms[C1_TOP])):
+c1.key = "Greenhaus Cistern No. 1 - Tank Top"
+c1.db.desc = DESC
+c1.db.type = "cistern"
+c1.db.atlas_skin = "cistern_solo"
+c1.db.outside = True
+
+air = at((6, -19, 1))
+if air is None:
+    air = create_object(SKY_TC, key="In the Air")
+    air.db.xyz = (6, -19, 1)
+    made += 1
+air.db.type = "sky"
+air.db.is_sky_room = True
+air.db.outside = True
+air.db.desc = ("Open air over Shipbreaker Alley, on the straight line "
+               "between Cistern No. 1's lid and the Fungary's first-level "
+               "rail. The lane's awnings sag below.")
+
+braddock = at((5, -20, 0))
+plat_s1 = by_key("The Fungary - South Platform (Level 1)")
+exits += link(braddock, c1, "up", "u")
+exits += link(c1, braddock, "down", "d")
+exits += link(c1, air, "east", "e", edge=7)
+exits += link(plat_s1, air, "west", "w", edge=7)
+for room, key, far in ((c1, "east", plat_s1), (plat_s1, "west", c1)):
     for e in room.exits:
         if e.key == key and e.db.is_gap:
             e.db.gap_destination = far.id
             e.db.sky_room = air.id
-# No. 2's own ladder, catwalk to lid
-exits += link(rooms[C2_WALK], rooms[C2_TOP], "up")
-exits += link(rooms[C2_TOP], rooms[C2_WALK], "down")
-# entry: No. 2 lid <-> the Fungary North Platform (Level 2)
-plat2 = by_key("The Fungary - North Platform (Level 2)")
-exits += link(rooms[C2_TOP], plat2, "east", edge=8, gap=8)
-exits += link(plat2, rooms[C2_TOP], "west", edge=8, gap=8)
 
-print(f"BUILD 056: Greenhaus Cisterns No. 1 & 2 — {made} rooms, "
-      f"{exits} exits. Route: Shipbreaker ladder → C1 → C2 → Fungary core L2.")
+print(f"BUILD 056: Cistern No. 1 — {made} rooms, {exits} exits. "
+      f"Route: Braddock ladder -> C1 -> east over the alley -> South Platform L1.")

--- a/scripts/builds/061_cistern_simplify.py
+++ b/scripts/builds/061_cistern_simplify.py
@@ -1,0 +1,135 @@
+"""Build 061 — retire Cistern No. 2 (for now); No. 1 to the 5 slot.
+
+    docker exec -i gelatinous bash -lc 'cd /usr/src/game && evennia shell' \
+        < scripts/builds/061_cistern_simplify.py
+    then a foreground reload.
+
+Owner call: Cistern No. 2 comes down entirely — the numeral returns
+elsewhere later — and No. 1 moves to (5,-19,1), where the crossing
+becomes one straight EAST line at z1:
+
+    Braddock (5,-20) --ladder--> C1 lid (5,-19,1)
+      --east gap--> In the Air over the alley (6,-19,1)
+      --lands--> The Fungary - South Platform (Level 1) (7,-19,1)
+
+Demolition manifest: both No. 2 rooms (occupants relocated to Braddock
+first), the North Platform (Level 2) west edge into them, the old
+crossing air at (5,-18,1), and C1's old ladder/edges. Re-run-safe.
+"""
+from evennia import create_object
+from evennia.objects.models import ObjectDB
+from world.spatial import get_xyz
+
+EXIT_TC = "typeclasses.exits.Exit"
+SKY_TC = "typeclasses.rooms.SkyRoom"
+
+
+def by_key(key):
+    return next((r for r in ObjectDB.objects.filter(db_key=key)
+                 if r.destination is None), None)
+
+
+def at(xyz):
+    return next((r for r in ObjectDB.objects.filter(db_attributes__db_key="xyz")
+                 if r.destination is None and get_xyz(r) == xyz), None)
+
+
+c1 = by_key("Greenhaus Cistern No. 1 - Tank Top")
+walk = by_key("Greenhaus Cistern No. 2 - Service Catwalk")
+top = by_key("Greenhaus Cistern No. 2 - Tank Top")
+plat_n2 = by_key("The Fungary - North Platform (Level 2)")
+plat_s1 = by_key("The Fungary - South Platform (Level 1)")
+braddock_old = at((4, -20, 0))
+braddock_new = at((5, -20, 0))
+
+# 0. evacuate the doomed rooms
+moved = 0
+for room in (walk, top):
+    if room is None:
+        continue
+    for o in list(room.contents):
+        if o.destination is None and not o.db_typeclass_path.endswith("Exit"):
+            if "character" in (o.db_typeclass_path or "").lower():
+                o.move_to(braddock_new, quiet=True)
+                o.msg("|yGreenhaus crews wave you off the tank — the whole "
+                      "drum is coming down for relocation. You climb clear "
+                      "to Braddock.|n")
+                moved += 1
+
+# 1. demolition
+removed = 0
+if plat_n2 is not None:
+    for e in list(plat_n2.exits):
+        if e.key == "west" and e.destination in (walk, top):
+            e.delete()
+            removed += 1
+old_air = at((5, -18, 1))
+for room in (walk, top, old_air):
+    if room is not None:
+        room.delete()
+        removed += 1
+
+# 2. C1 to the 5 slot; strip its stale exits
+if c1 is not None and get_xyz(c1) != (5, -19, 1):
+    c1.db.xyz = (5, -19, 1)
+for e in list(c1.exits):
+    e.delete()
+    removed += 1
+if braddock_old is not None:
+    for e in list(braddock_old.exits):
+        if e.destination == c1:
+            e.delete()
+            removed += 1
+c1.db.desc = ("The lid of Greenhaus Cistern No. 1 — the sole survivor of "
+              "the numbered set on this block, a squat riveted drum on "
+              "splayed legs over the corner off Braddock. The deck plate "
+              "is dished with age and slick where the fill valve weeps; "
+              "the numeral is repainted annually by someone who clearly "
+              "hates ladders. The ladder rides the south leg down to the "
+              "avenue. East, across the alley's air, the Fungary's "
+              "first-level platform rail waits for the committed.")
+
+# 3. the straight east crossing
+air = at((6, -19, 1))
+if air is None:
+    air = create_object(SKY_TC, key="In the Air")
+    air.db.xyz = (6, -19, 1)
+air.key = "In the Air"
+air.db.type = "sky"
+air.db.is_sky_room = True
+air.db.outside = True
+air.db.desc = ("Open air over Shipbreaker Alley, on the straight line "
+               "between Cistern No. 1's lid and the Fungary's first-level "
+               "rail. The lane's awnings sag below.")
+
+
+def link(loc, dest, key, alias, edge=None):
+    if loc is None or dest is None or any(e.key == key for e in loc.exits):
+        return 0
+    e = create_object(EXIT_TC, key=key, aliases=[alias],
+                      location=loc, destination=dest)
+    if edge is not None:
+        e.db.is_edge = True
+        e.db.edge_difficulty = edge
+        e.db.is_gap = True
+        e.db.gap_difficulty = edge
+    return 1
+
+
+def wire(room, key, far, sky):
+    for e in room.exits:
+        if e.key == key and e.db.is_gap:
+            e.db.gap_destination = far.id
+            e.db.sky_room = sky.id
+
+
+added = link(braddock_new, c1, "up", "u")
+added += link(c1, braddock_new, "down", "d")
+added += link(c1, air, "east", "e", edge=7)
+added += link(plat_s1, air, "west", "w", edge=7)
+wire(c1, "east", plat_s1, air)
+wire(plat_s1, "west", c1, air)
+
+print(f"BUILD 061: No. 2 demolished, No. 1 -> {get_xyz(c1)}; {moved} occupants "
+      f"evacuated, {removed} pieces removed, {added} exits laid. "
+      f"Route: Braddock ladder -> C1 -> east over the alley -> South Platform L1.")


### PR DESCRIPTION
Owner simplification: No. 2 comes down (its numeral returns elsewhere
later) and No. 1 moves to (5,-19,1). The crossing becomes one straight
east gap at z1 — Braddock ladder, cistern lid, air over Shipbreaker,
landing on the Fungary South Platform (Level 1) — with the three-part
gap wiring throughout. Demolition evacuates occupants first. 056
rewritten to the final minimal form; 061 migrates the live world.

Closes #1929

Co-Authored-By: Claude <noreply@anthropic.com>
